### PR TITLE
feat(foresight): MCP read tools for backtests + onboarding gate

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/foresight.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/foresight.py
@@ -16,9 +16,13 @@
 #   - ``build_foresight_server`` returns ``None`` when claude_agent_sdk
 #     isn't installed (same import-guard pattern the sibling servers use)
 #
-# Tools (11): list_scenarios, get_scenario, save_scenario, update_scenario,
+# Tools (14): list_scenarios, get_scenario, save_scenario, update_scenario,
 # delete_scenario, run_scenario, list_runs, get_run, plus the 2026-05-28
-# result-side reads — list_projected_decisions, get_aggregate, get_insights.
+# result-side reads — list_projected_decisions, get_aggregate,
+# get_insights — and the 2026-05-28 backtest-read tools —
+# list_backtests, get_backtest, get_onboarding_gate. The backtest tools
+# are READ-ONLY by design (RFC 08 §13.1 — backtest creation needs
+# ground-truth anchors and ships through the dashboard Aggregate panel).
 
 from __future__ import annotations
 
@@ -44,6 +48,14 @@ GET_RUN_TOOL_ID = f"mcp__{SERVER_NAME}__get_run"
 LIST_PROJECTED_DECISIONS_TOOL_ID = f"mcp__{SERVER_NAME}__list_projected_decisions"
 GET_AGGREGATE_TOOL_ID = f"mcp__{SERVER_NAME}__get_aggregate"
 GET_INSIGHTS_TOOL_ID = f"mcp__{SERVER_NAME}__get_insights"
+# Backtest-side reads — 2026-05-28 follow-up. Read-only per RFC 08 §13.1
+# (backtest creation stays UI-initiated; the chat surface can't reliably
+# produce ground-truth anchors). list_backtests + get_backtest cover the
+# "did we backtest yet?" / "show me past backtests" / "what was the gate
+# decision?" path; get_onboarding_gate covers "are we unlocked?".
+LIST_BACKTESTS_TOOL_ID = f"mcp__{SERVER_NAME}__list_backtests"
+GET_BACKTEST_TOOL_ID = f"mcp__{SERVER_NAME}__get_backtest"
+GET_ONBOARDING_GATE_TOOL_ID = f"mcp__{SERVER_NAME}__get_onboarding_gate"
 
 FORESIGHT_TOOL_IDS = (
     LIST_SCENARIOS_TOOL_ID,
@@ -57,6 +69,9 @@ FORESIGHT_TOOL_IDS = (
     LIST_PROJECTED_DECISIONS_TOOL_ID,
     GET_AGGREGATE_TOOL_ID,
     GET_INSIGHTS_TOOL_ID,
+    LIST_BACKTESTS_TOOL_ID,
+    GET_BACKTEST_TOOL_ID,
+    GET_ONBOARDING_GATE_TOOL_ID,
 )
 
 _SUB_TYPE_ENUM = ["decision_forecast", "market_sim", "org_change_rehearsal"]
@@ -252,6 +267,42 @@ async def _get_insights_handler(args: dict) -> dict:
     from pocketpaw_ee.cloud.foresight.agent_context import get_insights_for_agent
 
     return _result_payload(await get_insights_for_agent())
+
+
+# ---------------------------------------------------------------------------
+# Backtest-side handlers — read-only per RFC 08 §13.1. Backtest creation
+# stays in the dashboard Aggregate panel because it needs ground-truth
+# anchors the chat surface can't reliably produce.
+# ---------------------------------------------------------------------------
+
+
+async def _list_backtests_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import list_backtests_for_agent
+
+    limit = args.get("limit", 10)
+    offset = args.get("offset", 0)
+    return _result_payload(await list_backtests_for_agent(limit=limit, offset=offset))
+
+
+async def _get_backtest_handler(args: dict) -> dict:
+    from pocketpaw_ee.cloud.foresight.agent_context import get_backtest_for_agent
+
+    backtest_id = args.get("backtest_id")
+    if not backtest_id or not isinstance(backtest_id, str):
+        return _error(
+            "get_backtest requires a `backtest_id` (string). Find it via "
+            "list_backtests."
+        )
+    return _result_payload(await get_backtest_for_agent(backtest_id))
+
+
+async def _get_onboarding_gate_handler(args: dict) -> dict:
+    # Intentionally ignores ``args`` — the gate read takes no parameters
+    # (the workspace is inferred from the active chat stream).
+    del args
+    from pocketpaw_ee.cloud.foresight.agent_context import get_onboarding_gate_for_agent
+
+    return _result_payload(await get_onboarding_gate_for_agent())
 
 
 # ---------------------------------------------------------------------------
@@ -568,9 +619,83 @@ def build_foresight_server() -> tuple[str, Any] | None:
     async def get_insights(args):  # type: ignore[no-untyped-def]
         return await _get_insights_handler(args)
 
+    @tool(
+        "list_backtests",
+        (
+            "Trailing list of past backtests in the active workspace, most "
+            "recent first. Use this when the user asks 'did we backtest yet' "
+            "/ 'show me past backtests' / 'when was the last backtest'. "
+            "Backtests are UI-initiated (ground-truth anchors anchor the "
+            "scoring); this tool is READ-ONLY — to start a new backtest, "
+            "redirect the user to the dashboard Aggregate panel. Returns "
+            "``{items[]}`` (id, scenario_name, status, gate_decision, "
+            "threshold, created_at) plus the ``limit`` / ``offset`` echo "
+            "for pagination."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer", "description": "Max items (default 10, cap 200)."},
+                "offset": {"type": "integer", "description": "Pagination offset (default 0)."},
+            },
+            "required": [],
+        },
+    )
+    async def list_backtests(args):  # type: ignore[no-untyped-def]
+        return await _list_backtests_handler(args)
+
+    @tool(
+        "get_backtest",
+        (
+            "Fetch a single backtest by id with the full result blob, gate "
+            "decision, and per-anchor calibration. Use this when the user "
+            "asks 'what was the gate decision on backtest X' / 'show me the "
+            "details of that backtest' / 'why did backtest X fail the gate'. "
+            "Find ids via list_backtests. 404 "
+            "(``foresight_backtest.not_found``) for unknown / malformed / "
+            "cross-tenant ids. READ-ONLY — backtest creation ships through "
+            "the dashboard."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "backtest_id": {
+                    "type": "string",
+                    "description": "Id from list_backtests items.",
+                }
+            },
+            "required": ["backtest_id"],
+        },
+    )
+    async def get_backtest(args):  # type: ignore[no-untyped-def]
+        return await _get_backtest_handler(args)
+
+    @tool(
+        "get_onboarding_gate",
+        (
+            "Workspace's foresight onboarding gate state — unlock status + "
+            "reason + last backtest reference. Use when the user asks 'are "
+            "we unlocked yet' / 'what's the gate' / 'why is foresight "
+            "gated'. Empty workspaces return ``unlocked=False, "
+            "reason='no_backtest'`` (not a 404) so the agent can explain "
+            "why the gate is still closed. ``reason`` is one of "
+            "``no_backtest`` | ``in_flight`` | ``below_threshold`` | "
+            "``unlocked`` — surface it verbatim. READ-ONLY — to flip the "
+            "gate, the user runs a backtest from the dashboard Aggregate "
+            "panel."
+        ),
+        {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    )
+    async def get_onboarding_gate(args):  # type: ignore[no-untyped-def]
+        return await _get_onboarding_gate_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.1.0",
+        version="1.2.0",
         tools=[
             list_scenarios,
             get_scenario,
@@ -583,6 +708,9 @@ def build_foresight_server() -> tuple[str, Any] | None:
             list_projected_decisions,
             get_aggregate,
             get_insights,
+            list_backtests,
+            get_backtest,
+            get_onboarding_gate,
         ],
     )
     return SERVER_NAME, server
@@ -592,9 +720,12 @@ __all__ = [
     "DELETE_SCENARIO_TOOL_ID",
     "FORESIGHT_TOOL_IDS",
     "GET_AGGREGATE_TOOL_ID",
+    "GET_BACKTEST_TOOL_ID",
     "GET_INSIGHTS_TOOL_ID",
+    "GET_ONBOARDING_GATE_TOOL_ID",
     "GET_RUN_TOOL_ID",
     "GET_SCENARIO_TOOL_ID",
+    "LIST_BACKTESTS_TOOL_ID",
     "LIST_PROJECTED_DECISIONS_TOOL_ID",
     "LIST_RUNS_TOOL_ID",
     "LIST_SCENARIOS_TOOL_ID",

--- a/ee/pocketpaw_ee/cloud/foresight/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/foresight/agent_context.py
@@ -33,6 +33,14 @@
 # ``get_insights_for_agent``) for the results / accuracy / insights MCP
 # tools. Same identity-resolution + CloudError-collapse shape as the
 # existing scenarios + runs wrappers.
+#
+# 2026-05-28 update 2: added three backtest-read wrappers
+# (``list_backtests_for_agent``, ``get_backtest_for_agent``,
+# ``get_onboarding_gate_for_agent``). These are READ-ONLY — backtest
+# creation stays UI-initiated per RFC 08 §13.1 because it needs
+# ground-truth anchors the chat surface can't reliably produce. The chat
+# agent can answer "did we backtest yet?" / "what was the gate
+# decision?" / "are we unlocked?" without a curl fallback.
 
 from __future__ import annotations
 
@@ -482,14 +490,111 @@ async def get_insights_for_agent() -> dict[str, Any]:
     return payload
 
 
+# ---------------------------------------------------------------------------
+# Backtest reads + onboarding gate — read-only per RFC 08 §13.1 (backtest
+# creation stays UI-initiated; the chat surface can't reliably produce the
+# ground-truth anchors a backtest needs).
+# ---------------------------------------------------------------------------
+
+
+async def list_backtests_for_agent(*, limit: int = 10, offset: int = 0) -> dict[str, Any]:
+    """List backtests in the active workspace, newest first.
+
+    ``list_backtests`` returns a list (not a paginated envelope DTO), so
+    we build the response dict by hand here — mirrors the shape of
+    :func:`list_runs_for_agent`.
+
+    Shape on success: ``{"ok": True, "items": [...], "limit": int,
+    "offset": int}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        backtests = await foresight_service.list_backtests(ctx, limit=limit, offset=offset)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    items = [bt.model_dump() for bt in backtests]
+    return {"ok": True, "items": items, "limit": limit, "offset": offset}
+
+
+async def get_backtest_for_agent(backtest_id: str) -> dict[str, Any]:
+    """Fetch a single backtest by id with the full result + gate decision.
+
+    Unknown / malformed / cross-tenant ids collapse to ``{ok: False,
+    error: 'foresight_backtest.not_found', ...}`` via the service's
+    ``_fetch_backtest_in_workspace`` guard.
+
+    Shape on success: ``{"ok": True, "id": ..., "status": ...,
+    "gate_decision": ..., "threshold": ..., "result": ..., ...}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        response = await foresight_service.get_backtest(ctx, backtest_id)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+async def get_onboarding_gate_for_agent() -> dict[str, Any]:
+    """Return the workspace's onboarding gate state — unlocked / reason /
+    last-backtest reference, plus the effective threshold.
+
+    Read-only: ``get_onboarding_gate`` has no error path past the
+    missing-workspace guard. Empty workspaces collapse to
+    ``unlocked=False, reason='no_backtest'`` rather than 404 so the chat
+    agent can explain the gate state without retrying.
+
+    Shape on success: ``{"ok": True, "workspace_id": ...,
+    "unlocked": bool, "threshold": float, "reason": str,
+    "last_backtest_id": ..., "last_backtest_accuracy": ...,
+    "last_backtest_at": ...}``.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        response = await foresight_service.get_onboarding_gate(ctx)
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
 __all__ = [
     "NO_WORKSPACE_ERROR",
     "NO_WORKSPACE_MESSAGE",
     "delete_scenario_for_agent",
     "get_aggregate_for_agent",
+    "get_backtest_for_agent",
     "get_insights_for_agent",
+    "get_onboarding_gate_for_agent",
     "get_run_for_agent",
     "get_scenario_for_agent",
+    "list_backtests_for_agent",
     "list_projected_decisions_for_agent",
     "list_runs_for_agent",
     "list_scenarios_for_agent",

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -1516,7 +1516,7 @@ async def get_backtest(ctx: RequestContext, backtest_id: str) -> BacktestRunResp
 
 
 async def list_backtests(
-    ctx: RequestContext, *, limit: int = 50
+    ctx: RequestContext, *, limit: int = 50, offset: int = 0
 ) -> list[BacktestRunListItemResponse]:
     """List backtests in the caller's workspace, most recent first.
 
@@ -1524,16 +1524,26 @@ async def list_backtests(
     DTO that drops the inline result blob but keeps ``gate_decision`` so
     the Aggregate panel can render the unlock label per row without
     needing the detail endpoint.
+
+    ``offset`` is the server-side cursor for pagination — mirrors the
+    cursor added to :func:`list_scenario_runs` so the agent_context
+    wrapper paginates at Mongo's ``.skip()`` step rather than
+    over-fetching and slicing client-side. Defaults to ``0`` so every
+    existing caller (router, tests) stays correct; negative values
+    raise ``foresight.invalid_offset``.
     """
     workspace_id = _require_workspace(ctx)
     if limit < 1:
         raise ValidationError("foresight.invalid_limit", "limit must be >= 1")
     if limit > 200:
         limit = 200
+    if offset < 0:
+        raise ValidationError("foresight.invalid_offset", "offset must be >= 0")
 
     docs = (
         await _ForesightBacktestDoc.find({"workspace": workspace_id})
         .sort([("createdAt", -1), ("_id", -1)])  # type: ignore[list-item]
+        .skip(offset)
         .limit(limit)
         .to_list()
     )

--- a/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
@@ -128,6 +128,47 @@ stream's workspace id; no env vars, no headers).
     **When to use:** "what mattered in the last run", "explain the
     insights", "anything worth flagging".
 
+## Backtest reads + gate state
+
+Three more tools cover the backtest *read* side and the onboarding
+gate. **These three tools are read-only.** Backtest creation still
+ships through the dashboard Aggregate panel — it needs ground-truth
+anchors the chat surface can't reliably produce. The hard rule below
+("NEVER call ``/api/v1/foresight/backtests`` from this skill") stays
+in force; these tools don't contradict it — they expose only the
+list / get / gate reads.
+
+  - ``mcp__pocketpaw_foresight__list_backtests({limit?, offset?})`` —
+    trailing list of past backtests, most recent first. Each item
+    carries ``id, scenario_name, status, gate_decision, threshold,
+    created_at``. Pagination shape mirrors ``list_runs``.
+
+    **When to use:** "did we backtest yet", "show me past backtests",
+    "when was the last backtest".
+
+  - ``mcp__pocketpaw_foresight__get_backtest({backtest_id})`` — single
+    backtest with the full result blob, gate decision, and per-anchor
+    calibration. Find ids via ``list_backtests``. 404
+    (``foresight_backtest.not_found``) for unknown / cross-tenant ids.
+
+    **When to use:** "what was the gate decision on backtest X", "show
+    me the details of that backtest", "why did backtest X fail the
+    gate".
+
+  - ``mcp__pocketpaw_foresight__get_onboarding_gate({})`` — workspace's
+    onboarding gate state (unlock status + reason + last backtest
+    reference + effective threshold). Empty workspaces return
+    ``unlocked=False, reason='no_backtest'`` (not a 404). ``reason`` is
+    one of ``no_backtest`` | ``in_flight`` | ``below_threshold`` |
+    ``unlocked`` — surface it verbatim.
+
+    **When to use:** "are we unlocked", "what's the gate", "why is
+    foresight gated".
+
+If the user asks to *create* a backtest, redirect them to the
+dashboard's Aggregate panel — that surface anchors the historical
+pairing the engine needs.
+
 ## The four-phase workflow
 
 Every interaction with Foresight from chat follows this loop:
@@ -602,10 +643,14 @@ you'll lose fields the user added through the UI. Always read first.
   - **NEVER** invent error codes. If a tool returns
     ``foresight.invalid_scenario``, surface that exact code; don't
     paraphrase it as "validation failed".
-  - **NEVER** call ``/api/v1/foresight/backtests`` from this skill. The
-    backtest path needs ground-truth anchors and ships through the UI's
-    Aggregate panel. If the user asks for a backtest, redirect them
-    there.
+  - **NEVER** call ``/api/v1/foresight/backtests`` (POST) from this
+    skill. The backtest path needs ground-truth anchors and ships
+    through the UI's Aggregate panel. If the user asks to *create* a
+    backtest, redirect them there. The ``list_backtests`` /
+    ``get_backtest`` / ``get_onboarding_gate`` MCP tools above are
+    read-only and don't contradict this rule — they answer "did we
+    backtest yet" / "what was the gate decision" / "are we unlocked"
+    without touching the create path.
   - **ALWAYS** echo the response shape verbatim when surfacing a run
     result — the operator's Live panel binds to the same field names.
 

--- a/tests/cloud/test_foresight_agent_context.py
+++ b/tests/cloud/test_foresight_agent_context.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -347,3 +348,122 @@ async def test_get_insights_returns_items_envelope(bound_identity: None) -> None
     assert out["ok"] is True
     assert "items" in out
     assert isinstance(out["items"], list)
+
+
+# ---------------------------------------------------------------------------
+# Backtest reads + onboarding gate — read-only per RFC 08 §13.1
+# ---------------------------------------------------------------------------
+
+
+def _backtest_body(name: str = "agent-ctx-backtest") -> Any:
+    """Minimal legal backtest body — one persona, one anchor. Mirrors
+    the helper in ``test_foresight_backtest_service.py`` but local to
+    avoid coupling test files."""
+    from pocketpaw_ee.cloud.foresight.dto import (
+        CreateBacktestRequest,
+        HistoricalAnchorRequest,
+        PersonaSpecRequest,
+    )
+
+    return CreateBacktestRequest(
+        name=name,
+        sub_type="decision_forecast",
+        n_ticks=1,
+        personas=[PersonaSpecRequest(name="Anne", role="approver", ocean={})],
+        anchors=[
+            HistoricalAnchorRequest(
+                anchor_object_id=f"lease:LR-{i}",
+                actual_outcome={"outcome": "accept"},
+            )
+            for i in range(10)
+        ],
+    )
+
+
+async def test_list_backtests_without_workspace_returns_clean_error() -> None:
+    out = await agent_context.list_backtests_for_agent()
+    assert out == {
+        "ok": False,
+        "error": agent_context.NO_WORKSPACE_ERROR,
+        "message": agent_context.NO_WORKSPACE_MESSAGE,
+    }
+
+
+async def test_get_backtest_without_workspace_returns_clean_error() -> None:
+    out = await agent_context.get_backtest_for_agent("abc")
+    assert out["ok"] is False
+    assert out["error"] == agent_context.NO_WORKSPACE_ERROR
+
+
+async def test_get_onboarding_gate_without_workspace_returns_clean_error() -> None:
+    out = await agent_context.get_onboarding_gate_for_agent()
+    assert out["ok"] is False
+    assert out["error"] == agent_context.NO_WORKSPACE_ERROR
+
+
+async def test_list_backtests_returns_items_envelope(bound_identity: None) -> None:
+    """Drive the wrapper against a real backtest the service created.
+    Verifies the wrapper threads identity correctly and builds the
+    paginated envelope by hand (``list_backtests`` returns a list, not a
+    paginated DTO)."""
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = RequestContext(
+        user_id="prakash",
+        workspace_id="w1",
+        request_id="seed",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+    await foresight_service.create_backtest(ctx, _backtest_body(name="bt-list"))
+
+    out = await agent_context.list_backtests_for_agent(limit=5)
+    assert out["ok"] is True
+    assert out["limit"] == 5
+    assert out["offset"] == 0
+    assert isinstance(out["items"], list)
+    assert any(item["scenario_name"] == "bt-list" for item in out["items"])
+
+
+async def test_get_backtest_returns_full_payload(bound_identity: None) -> None:
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+    from pocketpaw_ee.cloud.foresight import service as foresight_service
+
+    ctx = RequestContext(
+        user_id="prakash",
+        workspace_id="w1",
+        request_id="seed",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+    created = await foresight_service.create_backtest(ctx, _backtest_body(name="bt-detail"))
+
+    out = await agent_context.get_backtest_for_agent(created.id)
+    assert out["ok"] is True
+    assert out["id"] == created.id
+    assert out["scenario_name"] == "bt-detail"
+    assert "threshold" in out
+    assert "gate_decision" in out
+
+
+async def test_get_backtest_unknown_id_returns_not_found(bound_identity: None) -> None:
+    """Stale / cross-tenant ids collapse to a clean envelope rather than
+    raising — same shape the scenario read-tools surface."""
+    out = await agent_context.get_backtest_for_agent("507f1f77bcf86cd799439011")
+    assert out["ok"] is False
+    assert out["error"] == "foresight_backtest.not_found"
+
+
+async def test_get_onboarding_gate_reports_no_backtest_for_fresh_workspace(
+    bound_identity: None,
+) -> None:
+    """Fresh workspace → ``unlocked=False, reason='no_backtest'`` with
+    the effective threshold echoed back (default 0.65)."""
+    out = await agent_context.get_onboarding_gate_for_agent()
+    assert out["ok"] is True
+    assert out["workspace_id"] == "w1"
+    assert out["unlocked"] is False
+    assert out["reason"] == "no_backtest"
+    assert out["threshold"] == 0.65
+    assert out["last_backtest_id"] is None

--- a/tests/cloud/test_foresight_backtest_service.py
+++ b/tests/cloud/test_foresight_backtest_service.py
@@ -379,6 +379,30 @@ async def test_list_rejects_invalid_limit() -> None:
         await foresight_service.list_backtests(ctx, limit=0)
 
 
+async def test_list_offset_skips_initial_backtests() -> None:
+    """``offset`` mirrors the cursor pattern on ``list_scenario_runs``
+    so the agent_context wrapper paginates server-side instead of
+    over-fetching and slicing. Five backtests in newest-first order:
+    ``skip=2, limit=2`` returns backtests 3-4 — i.e. the third and fourth
+    newest, after the latest two were skipped."""
+    ctx = _ctx()
+    backtests = []
+    for i in range(5):
+        backtests.append(await foresight_service.create_backtest(ctx, _body(name=f"bt-{i}")))
+
+    page = await foresight_service.list_backtests(ctx, limit=2, offset=2)
+    # Newest-first: backtests[4], backtests[3], backtests[2], backtests[1],
+    # backtests[0]. offset=2 drops the first two (backtests[4],
+    # backtests[3]); limit=2 returns backtests[2], backtests[1].
+    assert [item.id for item in page] == [backtests[2].id, backtests[1].id]
+
+
+async def test_list_rejects_negative_offset() -> None:
+    ctx = _ctx()
+    with pytest.raises(ValidationError):
+        await foresight_service.list_backtests(ctx, offset=-1)
+
+
 # ---------------------------------------------------------------------------
 # get_onboarding_gate state machine
 # ---------------------------------------------------------------------------

--- a/tests/ee/agent/test_foresight_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_foresight_mcp_server/test_mcp_tool.py
@@ -22,9 +22,12 @@ class TestForesightMcpServerRegistration:
             DELETE_SCENARIO_TOOL_ID,
             FORESIGHT_TOOL_IDS,
             GET_AGGREGATE_TOOL_ID,
+            GET_BACKTEST_TOOL_ID,
             GET_INSIGHTS_TOOL_ID,
+            GET_ONBOARDING_GATE_TOOL_ID,
             GET_RUN_TOOL_ID,
             GET_SCENARIO_TOOL_ID,
+            LIST_BACKTESTS_TOOL_ID,
             LIST_PROJECTED_DECISIONS_TOOL_ID,
             LIST_RUNS_TOOL_ID,
             LIST_SCENARIOS_TOOL_ID,
@@ -51,7 +54,12 @@ class TestForesightMcpServerRegistration:
         )
         assert GET_AGGREGATE_TOOL_ID == "mcp__pocketpaw_foresight__get_aggregate"
         assert GET_INSIGHTS_TOOL_ID == "mcp__pocketpaw_foresight__get_insights"
-        assert len(FORESIGHT_TOOL_IDS) == 11
+        # Backtest-side reads — 2026-05-28 follow-up #2. Read-only per
+        # RFC 08 §13.1 (backtest creation stays UI-initiated).
+        assert LIST_BACKTESTS_TOOL_ID == "mcp__pocketpaw_foresight__list_backtests"
+        assert GET_BACKTEST_TOOL_ID == "mcp__pocketpaw_foresight__get_backtest"
+        assert GET_ONBOARDING_GATE_TOOL_ID == "mcp__pocketpaw_foresight__get_onboarding_gate"
+        assert len(FORESIGHT_TOOL_IDS) == 14
         # Every id is published — the claude_sdk allowlist loop reads
         # this tuple.
         for tid in (
@@ -66,6 +74,9 @@ class TestForesightMcpServerRegistration:
             LIST_PROJECTED_DECISIONS_TOOL_ID,
             GET_AGGREGATE_TOOL_ID,
             GET_INSIGHTS_TOOL_ID,
+            LIST_BACKTESTS_TOOL_ID,
+            GET_BACKTEST_TOOL_ID,
+            GET_ONBOARDING_GATE_TOOL_ID,
         ):
             assert tid in FORESIGHT_TOOL_IDS
 
@@ -551,6 +562,161 @@ class TestGetInsightsHandler:
             new=AsyncMock(return_value=fake),
         ):
             out = await foresight_mcp._get_insights_handler({})
+
+        assert out.get("is_error") is True
+        assert "no_workspace_context" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Backtest-read handlers — 2026-05-28 follow-up #2 (read-only per
+# RFC 08 §13.1; no create_backtest tool exists).
+# ---------------------------------------------------------------------------
+
+
+class TestListBacktestsHandler:
+    @pytest.mark.asyncio
+    async def test_delegates_with_pagination(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": True,
+            "items": [{"id": "bt1", "scenario_name": "q3-backtest", "status": "complete"}],
+            "limit": 5,
+            "offset": 0,
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.list_backtests_for_agent",
+            new=AsyncMock(return_value=fake),
+        ) as mock:
+            out = await foresight_mcp._list_backtests_handler({"limit": 5, "offset": 0})
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["items"][0]["id"] == "bt1"
+        mock.assert_awaited_once_with(limit=5, offset=0)
+
+    @pytest.mark.asyncio
+    async def test_default_args_when_omitted(self) -> None:
+        """No args → default limit=10, offset=0 — mirrors list_runs."""
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.list_backtests_for_agent",
+            new=AsyncMock(return_value={"ok": True, "items": [], "limit": 10, "offset": 0}),
+        ) as mock:
+            out = await foresight_mcp._list_backtests_handler({})
+
+        assert not out.get("is_error")
+        mock.assert_awaited_once_with(limit=10, offset=0)
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_surfaces_as_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {"ok": False, "error": "no_workspace_context", "message": "stream missing"}
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.list_backtests_for_agent",
+            new=AsyncMock(return_value=fake),
+        ):
+            out = await foresight_mcp._list_backtests_handler({})
+
+        assert out.get("is_error") is True
+        assert "no_workspace_context" in out["content"][0]["text"]
+
+
+class TestGetBacktestHandler:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_backtest(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": True,
+            "id": "bt1",
+            "scenario_name": "q3-backtest",
+            "status": "complete",
+            "threshold": 0.65,
+            "gate_decision": {"passed": True, "observed": 0.82},
+            "result": {"calibration_summary": {}},
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_backtest_for_agent",
+            new=AsyncMock(return_value=fake),
+        ) as mock:
+            out = await foresight_mcp._get_backtest_handler({"backtest_id": "bt1"})
+
+        body = _decode_payload(out)
+        assert body["id"] == "bt1"
+        assert body["gate_decision"]["passed"] is True
+        mock.assert_awaited_once_with("bt1")
+
+    @pytest.mark.asyncio
+    async def test_missing_backtest_id_is_rejected_locally(self) -> None:
+        """Arg validation runs before the agent_context call so a missing
+        backtest_id never reaches the cloud — same guard pattern as
+        get_run + list_projected_decisions."""
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        mock = AsyncMock()
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_backtest_for_agent",
+            new=mock,
+        ):
+            out = await foresight_mcp._get_backtest_handler({})
+
+        assert out.get("is_error") is True
+        assert "backtest_id" in out["content"][0]["text"]
+        mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_surfaces_as_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {"ok": False, "error": "no_workspace_context", "message": "stream missing"}
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_backtest_for_agent",
+            new=AsyncMock(return_value=fake),
+        ):
+            out = await foresight_mcp._get_backtest_handler({"backtest_id": "bt1"})
+
+        assert out.get("is_error") is True
+        assert "no_workspace_context" in out["content"][0]["text"]
+
+
+class TestGetOnboardingGateHandler:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_gate_state(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {
+            "ok": True,
+            "workspace_id": "w1",
+            "unlocked": False,
+            "threshold": 0.65,
+            "reason": "no_backtest",
+            "last_backtest_id": None,
+        }
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_onboarding_gate_for_agent",
+            new=AsyncMock(return_value=fake),
+        ) as mock:
+            out = await foresight_mcp._get_onboarding_gate_handler({})
+
+        body = _decode_payload(out)
+        assert body["reason"] == "no_backtest"
+        assert body["unlocked"] is False
+        # No-arg call — the gate read takes no parameters.
+        mock.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_surfaces_as_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import foresight as foresight_mcp
+
+        fake = {"ok": False, "error": "no_workspace_context", "message": "stream missing"}
+        with patch(
+            "pocketpaw_ee.cloud.foresight.agent_context.get_onboarding_gate_for_agent",
+            new=AsyncMock(return_value=fake),
+        ):
+            out = await foresight_mcp._get_onboarding_gate_handler({})
 
         assert out.get("is_error") is True
         assert "no_workspace_context" in out["content"][0]["text"]


### PR DESCRIPTION
## Gap

PR #1267 closed the typed-MCP gap for scenario writes + run reads
(projections, aggregate, insights). Backtests + the onboarding gate
were still curl-only — when the captain asks the agent on /foresight
"did we backtest yet?", "what was the gate decision?", or "are we
unlocked?", the agent falls back to the loopback REST surface with the
same ``$WORKSPACE_ID`` / ``$USER_ID`` env-var bug PR #1266 fixed for
the write path.

## Fix

Three new typed MCP tools on the ``pocketpaw_foresight`` server:

- ``list_backtests({limit?, offset?})``
- ``get_backtest({backtest_id})``
- ``get_onboarding_gate({})``

Plus the supporting agent_context wrappers
(``list_backtests_for_agent`` / ``get_backtest_for_agent`` /
``get_onboarding_gate_for_agent``) that resolve workspace identity
from the per-stream ContextVars, and a server-side ``offset`` on
``list_backtests`` so the wrapper paginates at Mongo's ``.skip()``
instead of over-fetching (mirrors the ``list_scenario_runs`` change
PR #1267 shipped).

Server version 1.1.0 → 1.2.0. FORESIGHT_TOOL_IDS goes 11 → 14.

## Why NO ``create_backtest`` tool

Per RFC 08 §13.1, backtest creation is UI-initiated only. It needs
ground-truth historical anchors the chat surface can't reliably
produce (the dashboard's Aggregate panel anchors the pairing). These
three tools are read-only by design. The bundled
``foresight-create-sim`` skill's existing hard rule ("NEVER POST to
``/api/v1/foresight/backtests`` from this skill") stays in force —
the new section documents the read tools explicitly so the agent
knows the rule only blocks the create path, not the reads.

## Test plan

- [x] Service offset on ``list_backtests`` — happy-path skip + negative-offset reject (mirrors ``list_scenario_runs`` tests from PR #1267)
- [x] agent_context wrappers — 3 missing-workspace clean-error, 3 happy-path against real service writes, not_found on stale backtest id, fresh-workspace gate state
- [x] MCP server — tool-id constants, 14-entry FORESIGHT_TOOL_IDS, 3 happy-path / missing-arg / missing-workspace per handler
- [x] Targeted suites green: ``tests/ee/agent/test_foresight_mcp_server/ tests/cloud/test_foresight_agent_context.py tests/cloud/test_foresight_service.py tests/cloud/test_foresight_router.py`` — 94 passed
- [x] Backtest service + router suites green (no regressions): ``tests/cloud/test_foresight_backtest_service.py tests/cloud/test_foresight_backtest_router.py`` — 57 passed combined
- [x] Ruff clean on every touched file

## Follow-ups

- Wire the new tool ids into the per-backend allowlists where the foresight server is mounted (codex_cli, opencode, etc. — same loop that picked up the projection/aggregate/insights ids from PR #1267; should already work because the loop reads ``FORESIGHT_TOOL_IDS`` directly).
- If/when a chat-initiated backtest path lands, design needs to solve the ground-truth-anchor problem first; tracked outside this PR.