### PR TITLE
feat(cel): runtime evaluator + IdentifierResolver for RFC 03 v2

### DIFF
--- a/src/pocketpaw/bundled_templates/__init__.py
+++ b/src/pocketpaw/bundled_templates/__init__.py
@@ -10,6 +10,12 @@
 # ``compile_template`` — the OSS-side template-to-runtime translation
 # seam. PR 2b implements ``data_sources[]`` only; other top-level
 # fields passthrough until PRs 2c-2g land their runtime executors.
+# Modified 2026-05-28 (feat/rfc-03-v2-cel-eval): re-exports the CEL
+# runtime evaluator (``evaluate_cel``, ``CelEvaluationError``) and the
+# identifier-resolver Protocol (``IdentifierResolver``,
+# ``TemplateIdentifierResolver``). PR 2c lays the foundation that
+# PR 2d (Instinct 5-step composer), PR 2f (temporal trigger sweeper),
+# and PR 2g (Fabric ``tier: registered`` linter) all consume.
 """Built-in pocket templates bundled and auto-installed by PocketPaw.
 
 Third sibling to ``pocketpaw.bundled_skills`` and ``pocketpaw.bundled_kb``.
@@ -51,8 +57,16 @@ files and register it in ``_bundled/index.json``. The installer discovers
 directories via iteration — no installer code changes needed.
 """
 
+from pocketpaw.bundled_templates.cel_runtime import (
+    CelEvaluationError,
+    evaluate_cel,
+)
 from pocketpaw.bundled_templates.compile import compile_template
 from pocketpaw.bundled_templates.errors import TemplateValidationError
+from pocketpaw.bundled_templates.identifier_resolver import (
+    IdentifierResolver,
+    TemplateIdentifierResolver,
+)
 from pocketpaw.bundled_templates.installer import (
     TemplateInstallResult,
     install_bundled_templates,
@@ -77,9 +91,11 @@ from pocketpaw.bundled_templates.schema import (
 __all__ = [
     "ActionDef",
     "AgentDef",
+    "CelEvaluationError",
     "ColumnDef",
     "ConfirmDef",
     "DataSourceDef",
+    "IdentifierResolver",
     "InstinctRule",
     "InstinctRulesDef",
     "JoinedEntity",
@@ -87,10 +103,12 @@ __all__ = [
     "PocketTemplate",
     "SavedView",
     "StateBinding",
+    "TemplateIdentifierResolver",
     "TemplateInstallResult",
     "TemplateValidationError",
     "TriggerDef",
     "compile_template",
+    "evaluate_cel",
     "install_bundled_templates",
     "load_template",
 ]

--- a/src/pocketpaw/bundled_templates/cel_runtime.py
+++ b/src/pocketpaw/bundled_templates/cel_runtime.py
@@ -1,0 +1,286 @@
+# src/pocketpaw/bundled_templates/cel_runtime.py
+# Created: 2026-05-28 (feat/rfc-03-v2-cel-eval) — runtime CEL evaluator
+# that pairs with the parse-only ``expressions.CelExpression`` field
+# already on the chokepoint. Foundation for PR 2d (Instinct 5-step
+# composer), PR 2f (temporal trigger sweeper), and PR 2g (Fabric
+# ``tier: registered`` enforcement). Pure library function — OSS-side,
+# no ``pocketpaw_ee`` imports, no I/O, deterministic given a fixed
+# ``now``.
+"""Runtime evaluator for the RFC 03 v2 CEL expression grammar.
+
+The schema chokepoint (``expressions.CelExpression``) parses every
+``filter`` / ``when`` field on a template at validation time. It does
+*not* evaluate — there is no row context at validation time. This
+module is the runtime side: given a parsed expression, an
+:class:`IdentifierResolver`, and a row context, it returns the
+evaluated value.
+
+Design notes
+------------
+
+* Pure / referentially transparent given the same ``now``. No I/O,
+  no global mutable state.
+* The custom ``within(field, duration)`` function is the only CEL
+  function the runtime registers on top of the celpy built-ins. Per
+  RFC 03 v2 ("Expression grammar"), no other custom functions ship.
+* ``now`` is injected per-call so tests can be deterministic; the
+  default uses ``datetime.now(UTC)``. Production callers can override
+  this once a workspace-wide clock abstraction lands.
+* Identifier resolution flows through the
+  :class:`~pocketpaw.bundled_templates.identifier_resolver.IdentifierResolver`
+  Protocol. We pre-walk the parsed AST for top-level free identifiers
+  and resolve each one *before* handing the activation to celpy — that
+  way an undeclared joined-entity root (a Fabric ``tier: registered``
+  miss) surfaces as a typed :class:`CelEvaluationError` instead of an
+  opaque ``CELEvalError`` from inside celpy.
+* All failure modes raise :class:`CelEvaluationError`. The chokepoint
+  loader has its own typed error
+  (:class:`pocketpaw.bundled_templates.errors.TemplateValidationError`)
+  for *parse*-time issues; this class covers *eval*-time issues. They
+  are deliberately separate — a caller catching parse errors should
+  not silently swallow eval errors.
+
+Out of scope for PR 2c
+----------------------
+
+* Fabric ``via_link`` enforcement (PR 2g).
+* Instinct 5-step execution (PR 2d) — that consumes this evaluator but
+  is not built here.
+* Temporal trigger sweeper rising-edge state (PR 2f).
+* Any CLI surface change (e.g. extending ``template lint`` to evaluate
+  against a synthetic context).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pocketpaw.bundled_templates.identifier_resolver import IdentifierResolver
+
+
+class CelEvaluationError(Exception):
+    """Raised when :func:`evaluate_cel` cannot produce a value.
+
+    Wraps both parse-time and eval-time failures with a single typed
+    exception so callers (Instinct composer, temporal sweeper, future
+    linters) can ``except CelEvaluationError`` without reaching into
+    celpy's internal hierarchy.
+
+    Attributes
+    ----------
+    expression:
+        The original expression text.
+    cause:
+        The underlying exception, if any.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        expression: str | None = None,
+        cause: BaseException | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.expression = expression
+        self.cause = cause
+
+
+def evaluate_cel(
+    expression: str,
+    context: dict[str, Any],
+    resolver: IdentifierResolver,
+    *,
+    now: datetime | None = None,
+) -> Any:
+    """Evaluate a CEL ``expression`` against a row ``context``.
+
+    Parameters
+    ----------
+    expression:
+        Raw CEL text. Re-parsed here on every call — the chokepoint's
+        parse-side cache is keyed off the Pydantic model so we cannot
+        rely on it. Cheap (lark is fast) and keeps this function
+        stateless.
+    context:
+        Per-row dict — e.g. ``{"days_remaining": 25, "tenant":
+        {"late_payment_count_12mo": 4}}``. Keys are CEL identifier
+        names; values are plain Python (the evaluator converts to
+        celpy types via :func:`celpy.json_to_cel`).
+    resolver:
+        Implements :class:`IdentifierResolver`. The evaluator pulls
+        the leftmost segment of every free identifier from the
+        parsed AST and asks the resolver to validate + supply it.
+        ``KeyError`` from the resolver becomes
+        :class:`CelEvaluationError` carrying the identifier name.
+    now:
+        Injected wall-clock time. Used by the custom ``within(field,
+        duration)`` function. Defaults to :func:`datetime.now` in UTC.
+        Tests should pass a fixed value to stay deterministic.
+
+    Returns
+    -------
+    The Python-typed result: ``bool`` for boolean expressions, ``int``
+    for integers, ``float`` for doubles, ``str`` for strings, ``None``
+    for null. CEL list / map results are returned as plain Python
+    ``list`` / ``dict``.
+
+    Raises
+    ------
+    CelEvaluationError:
+        Any failure mode. The original celpy exception is exposed on
+        the ``.cause`` attribute for callers that want richer
+        diagnostics.
+    """
+    # Lazy import: matches the chokepoint pattern (``expressions.py``)
+    # and keeps celpy off the module-load hot path. The runtime only
+    # imports it once per process — Python caches the import — so the
+    # per-call cost is negligible.
+    import celpy  # noqa: PLC0415 — lazy import by design
+    from celpy import celtypes  # noqa: PLC0415
+    from celpy.evaluation import CELEvalError  # noqa: PLC0415
+
+    if now is None:
+        now = datetime.now(UTC)
+
+    env = celpy.Environment()
+
+    # Parse → AST. Surface parse errors as CelEvaluationError so the
+    # caller never sees raw ``CELParseError`` types leaking from
+    # celpy's internals.
+    try:
+        ast = env.compile(expression)
+    except Exception as exc:  # noqa: BLE001 — celpy raises a wide hierarchy
+        raise CelEvaluationError(
+            f"failed to parse CEL expression: {exc}",
+            expression=expression,
+            cause=exc,
+        ) from exc
+
+    # Walk the AST for top-level free identifiers, gate each one
+    # through the resolver, and build the celpy activation. We resolve
+    # via the protocol so dotted roots that don't match a declared
+    # joined entity raise immediately (PR 2g will plug a richer
+    # resolver in here without changing this code path).
+    free_idents = _collect_free_identifiers(ast)
+    activation: dict[str, Any] = {}
+    for ident in free_idents:
+        try:
+            value = resolver.resolve(ident, context)
+        except KeyError as exc:
+            raise CelEvaluationError(
+                f"identifier {ident!r} could not be resolved: {exc}",
+                expression=expression,
+                cause=exc,
+            ) from exc
+        activation[ident] = celpy.json_to_cel(value)
+
+    # Register the one custom function the v2 schema exposes. ``now``
+    # is captured in the closure so callers control determinism.
+    def within(field: Any, duration: Any) -> Any:
+        now_ts = celtypes.TimestampType(now)
+        return celtypes.BoolType((now_ts - duration) <= field <= (now_ts + duration))
+
+    try:
+        program = env.program(ast, functions={"within": within})
+    except Exception as exc:  # noqa: BLE001
+        raise CelEvaluationError(
+            f"failed to compile CEL program: {exc}",
+            expression=expression,
+            cause=exc,
+        ) from exc
+
+    try:
+        result = program.evaluate(activation)
+    except CELEvalError as exc:
+        # celpy stuffs a useful structured payload into the args
+        # tuple; surface it inline so authors can debug without
+        # decoding ``exc.args``.
+        raise CelEvaluationError(
+            f"CEL evaluation failed: {exc}",
+            expression=expression,
+            cause=exc,
+        ) from exc
+    except Exception as exc:  # noqa: BLE001 — defensive belt-and-braces
+        raise CelEvaluationError(
+            f"unexpected error during CEL evaluation: {exc}",
+            expression=expression,
+            cause=exc,
+        ) from exc
+
+    return _to_python(result)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _collect_free_identifiers(ast: Any) -> list[str]:
+    """Walk a celpy / lark AST and return the leftmost-segment
+    identifiers in source order, deduplicated.
+
+    We pick up identifiers from ``Tree('ident')`` nodes — those are
+    the standalone variable references the CEL grammar emits. Member
+    access (``foo.bar.baz``) shows up as a tree of ``member_dot`` /
+    ``member`` nodes whose leftmost child eventually hits a ``Tree
+    ('ident')``, so the same walk catches dotted-path roots without
+    duplicating them.
+    """
+    seen: set[str] = set()
+    found: list[str] = []
+
+    def walk(node: Any) -> None:
+        # Tokens are leaves; trees have ``data`` + ``children``.
+        if hasattr(node, "data"):
+            if node.data == "ident":
+                # ``Tree('ident', [Token('IDENT', 'name')])``.
+                for child in node.children:
+                    name = getattr(child, "value", None) or str(child)
+                    if name not in seen:
+                        seen.add(name)
+                        found.append(name)
+                # No need to recurse further inside an ``ident`` node.
+                return
+            for child in node.children:
+                walk(child)
+
+    walk(ast)
+    return found
+
+
+def _to_python(value: Any) -> Any:
+    """Convert a celpy result back to a plain Python value.
+
+    The runtime contract promises Python-typed results so downstream
+    code (the Instinct composer, the temporal sweeper, the policy
+    linter) doesn't have to import celpy types just to read a boolean.
+    """
+    # Lazy import — same rationale as in ``evaluate_cel``.
+    from celpy import celtypes  # noqa: PLC0415
+
+    if value is None:
+        return None
+    if isinstance(value, celtypes.BoolType):
+        return bool(value)
+    if isinstance(value, celtypes.IntType | celtypes.UintType):
+        return int(value)
+    if isinstance(value, celtypes.DoubleType):
+        return float(value)
+    if isinstance(value, celtypes.StringType):
+        return str(value)
+    if isinstance(value, celtypes.ListType):
+        return [_to_python(v) for v in value]
+    if isinstance(value, celtypes.MapType):
+        return {_to_python(k): _to_python(v) for k, v in value.items()}
+    # TimestampType, DurationType, BytesType: pass through. Callers
+    # that need them will recognise the celpy type.
+    return value
+
+
+__all__ = [
+    "CelEvaluationError",
+    "evaluate_cel",
+]

--- a/src/pocketpaw/bundled_templates/identifier_resolver.py
+++ b/src/pocketpaw/bundled_templates/identifier_resolver.py
@@ -1,0 +1,146 @@
+# src/pocketpaw/bundled_templates/identifier_resolver.py
+# Created: 2026-05-28 (feat/rfc-03-v2-cel-eval) — Protocol the CEL
+# runtime evaluator (``cel_runtime.evaluate_cel``) uses to look up
+# top-level free identifiers from an expression. The reference
+# implementation (``TemplateIdentifierResolver``) gates dotted paths
+# against the template's declared ``state.joined_entities[]`` so
+# undeclared joins fail loudly instead of silently passing.
+"""Identifier resolution for CEL evaluation.
+
+The RFC 03 v2 expression grammar treats free identifiers in CEL as
+references to:
+
+* **Flat names** — properties of the primary entity (also surfaced as
+  ``state.columns[].field`` entries with no dot).
+* **Dot-paths** — properties of a joined entity reached through a
+  declared ``state.joined_entities[].via_link`` FabricLink.
+
+The runtime evaluator never reaches into either source directly. It
+asks a resolver that implements :class:`IdentifierResolver`. This keeps
+the evaluator pure and lets future PRs swap in richer implementations
+(e.g. a ``FabricResolver`` in PR 2g that actually walks a registered
+FabricLink when the row context doesn't carry the joined entity inline).
+
+This PR ships the Protocol + a single reference implementation that
+resolves against the in-memory row context only.
+
+Fabric live-link traversal is intentionally out of scope here. The
+reference resolver's docstring repeats that boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from pocketpaw.bundled_templates.schema import PocketTemplate, StateBinding
+
+
+@runtime_checkable
+class IdentifierResolver(Protocol):
+    """Look up a top-level identifier from a CEL expression.
+
+    Implementations decide what counts as a legitimate identifier; the
+    reference impl gates dotted roots against the template's declared
+    joined entities, but a future Fabric-backed implementation may
+    accept any registered link and lazy-load the joined row.
+
+    The contract is intentionally minimal:
+
+    * ``path`` is the *leftmost segment* of the identifier the
+      evaluator pulled from the parsed CEL AST. For a free identifier
+      ``days_remaining`` that is the whole name. For a dotted path
+      ``tenant.late_payment_count_12mo`` that is just ``"tenant"``;
+      CEL's evaluator walks the rest of the path against whatever
+      value the resolver returns.
+    * ``context`` is the per-row dict the caller passed to
+      :func:`pocketpaw.bundled_templates.cel_runtime.evaluate_cel`.
+    * On success: return the looked-up value. The evaluator wraps it
+      in a celpy type via ``celpy.json_to_cel``.
+    * On failure: raise :class:`KeyError`. The evaluator catches
+      ``KeyError`` and surfaces it as a typed
+      :class:`pocketpaw.bundled_templates.cel_runtime.CelEvaluationError`.
+    """
+
+    def resolve(self, path: str, context: dict[str, Any]) -> Any:
+        """Resolve ``path`` against ``context``; raise ``KeyError`` if it
+        cannot be resolved."""
+        ...
+
+
+class TemplateIdentifierResolver:
+    """Reference :class:`IdentifierResolver` keyed off a
+    :class:`PocketTemplate`.
+
+    Resolution rules:
+
+    * **Flat names** (no leading segment / no dot): look up ``path`` in
+      ``context``. Raise ``KeyError`` if absent.
+    * **Dotted roots** (the leftmost segment of a dot-path, passed in
+      as ``path`` by the evaluator): the segment must match a
+      ``state.joined_entities[].name`` declared on the template *and*
+      the row context must carry the joined value inline. Both checks
+      raise ``KeyError`` on miss.
+
+    What this resolver does **not** do (out of scope for PR 2c):
+
+    * It does not call into Fabric to fetch a joined row when the
+      context lacks it inline. PR 2g adds a ``FabricResolver`` that
+      walks ``via_link`` against a live :class:`FabricLinkRegistry`.
+    * It does not enforce that the primary entity is
+      ``tier: registered``. PR 2g adds the linter that pairs with
+      that policy.
+
+    The constructor accepts either a full :class:`PocketTemplate` or
+    just its inner :class:`StateBinding` — handy when the caller has
+    only the inner block (the runtime composer in PR 2d, for example).
+    """
+
+    __slots__ = ("_declared_join_names",)
+
+    def __init__(self, template_or_state: PocketTemplate | StateBinding) -> None:
+        if isinstance(template_or_state, PocketTemplate):
+            state = template_or_state.state
+        else:
+            state = template_or_state
+        self._declared_join_names: frozenset[str] = frozenset(j.name for j in state.joined_entities)
+
+    def resolve(self, path: str, context: dict[str, Any]) -> Any:
+        """Resolve a leftmost-segment identifier against the per-row
+        ``context``. See class docstring for rules."""
+        # The evaluator hands us only the *leftmost* segment by
+        # construction — so ``path`` itself never carries a dot.
+        if "." in path:
+            # Defensive: a misbehaving evaluator might pass a full
+            # path. Reject so the bug surfaces immediately rather
+            # than silently doing the wrong thing.
+            raise KeyError(
+                f"TemplateIdentifierResolver expects leftmost segments, "
+                f"not full dot-paths; got {path!r}"
+            )
+
+        if path in self._declared_join_names:
+            # Dotted-root case. Drill into the row context. The
+            # evaluator handles the rest of the path natively via CEL
+            # member-access semantics.
+            if path not in context:
+                raise KeyError(
+                    f"identifier {path!r} is a declared joined entity but "
+                    f"is missing from the row context"
+                )
+            return context[path]
+
+        # Flat case. Pure context lookup. We deliberately don't accept
+        # an undeclared dotted root even if it happens to be in the
+        # context — see the rationale in the class docstring.
+        if path not in context:
+            raise KeyError(
+                f"identifier {path!r} is not declared on the template "
+                f"and is not present in the row context"
+            )
+        return context[path]
+
+
+__all__ = [
+    "IdentifierResolver",
+    "TemplateIdentifierResolver",
+]

--- a/tests/unit/test_cel_runtime.py
+++ b/tests/unit/test_cel_runtime.py
@@ -1,0 +1,222 @@
+# tests/unit/test_cel_runtime.py
+# Created: 2026-05-28 (feat/rfc-03-v2-cel-eval) — unit tests for the
+# CEL runtime evaluator (``cel_runtime.evaluate_cel``) plus the
+# ``CelEvaluationError`` exception path. Targets the PR 2c scope from
+# RFC 03 v2 — parse-side (``expressions.CelExpression``) already lives
+# in main; this is the runtime layer that the Instinct 5-step
+# composer (PR 2d), the temporal trigger sweeper (PR 2f), and the
+# Fabric ``tier: registered`` linter (PR 2g) will all consume.
+"""Tests for the CEL runtime evaluator.
+
+Covered cases (per the PR 2c brief):
+
+* Numeric comparison: ``days_remaining <= 30``.
+* String equality: ``renewal_stage == 'sent'``.
+* Null compare: ``privilege_flag == null``.
+* Arithmetic + comparison (RFC worked example A):
+  ``rent_proposed < rent_current * 0.95``.
+* Joined-entity dot-path declared on the template:
+  ``tenant.late_payment_count_12mo >= 3``.
+* Joined-entity NOT declared on the template → ``CelEvaluationError``
+  naming the undeclared root.
+* Custom temporal function: ``within(expires_at, duration('60d'))``
+  with deterministic ``now`` injected.
+* Missing identifier → ``CelEvaluationError`` with the identifier name.
+* Type error (string < int) → ``CelEvaluationError``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from pocketpaw.bundled_templates import (
+    CelEvaluationError,
+    PocketTemplate,
+    TemplateIdentifierResolver,
+    evaluate_cel,
+)
+
+# ---------------------------------------------------------------------------
+# Template fixtures (minimal — only the bits the resolver inspects)
+# ---------------------------------------------------------------------------
+
+
+def _lease_template() -> PocketTemplate:
+    """A skinny template that declares the ``tenant`` joined entity so
+    dot-paths in CEL resolve through ``TemplateIdentifierResolver``."""
+    return PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "lease-renewal-test",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "property-management",
+            "display_name": "Lease Renewal (test)",
+            "description": "Skinny lease-renewal fixture for CEL runtime tests.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "Lease",
+                "id_field": "id",
+                "joined_entities": [
+                    {"name": "tenant", "entity_type": "Tenant", "via_link": "lease_tenant"},
+                ],
+                "columns": [
+                    {"field": "id", "widget": "text"},
+                    {"field": "days_remaining", "widget": "trend"},
+                    {"field": "renewal_stage", "widget": "status_dot"},
+                    {"field": "rent_proposed", "widget": "currency_editable"},
+                    {"field": "rent_current", "widget": "currency"},
+                    {"field": "privilege_flag", "widget": "text"},
+                    {"field": "expires_at", "widget": "date"},
+                    {"field": "tenant.late_payment_count_12mo", "widget": "trend"},
+                ],
+            },
+        }
+    )
+
+
+def _flat_template() -> PocketTemplate:
+    """A template with NO joined entities — used to prove that a
+    dotted path against an undeclared root raises."""
+    return PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "flat-only",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "general",
+            "display_name": "Flat only",
+            "description": "Template without joined entities.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "Thing",
+                "columns": [{"field": "id", "widget": "text"}],
+            },
+        }
+    )
+
+
+@pytest.fixture
+def resolver() -> TemplateIdentifierResolver:
+    return TemplateIdentifierResolver(_lease_template())
+
+
+# ---------------------------------------------------------------------------
+# Plain comparisons & arithmetic
+# ---------------------------------------------------------------------------
+
+
+def test_days_remaining_le_30_true(resolver: TemplateIdentifierResolver) -> None:
+    result = evaluate_cel("days_remaining <= 30", {"days_remaining": 25}, resolver)
+    assert result is True
+
+
+def test_days_remaining_le_30_false(resolver: TemplateIdentifierResolver) -> None:
+    result = evaluate_cel("days_remaining <= 30", {"days_remaining": 60}, resolver)
+    assert result is False
+
+
+def test_renewal_stage_equality(resolver: TemplateIdentifierResolver) -> None:
+    assert evaluate_cel("renewal_stage == 'sent'", {"renewal_stage": "sent"}, resolver) is True
+    assert evaluate_cel("renewal_stage == 'sent'", {"renewal_stage": "draft"}, resolver) is False
+
+
+def test_null_compare(resolver: TemplateIdentifierResolver) -> None:
+    assert evaluate_cel("privilege_flag == null", {"privilege_flag": None}, resolver) is True
+    assert evaluate_cel("privilege_flag == null", {"privilege_flag": "x"}, resolver) is False
+
+
+def test_lease_renewal_block_rule_worked_example_a(
+    resolver: TemplateIdentifierResolver,
+) -> None:
+    # RFC 03 v2 worked example A: rent_proposed < rent_current * 0.95
+    # is the "block 5%+ rent cut" Instinct rule.
+    context = {"rent_proposed": 1800.0, "rent_current": 2000.0}
+    assert evaluate_cel("rent_proposed < rent_current * 0.95", context, resolver) is True
+    context_ok = {"rent_proposed": 1950.0, "rent_current": 2000.0}
+    assert evaluate_cel("rent_proposed < rent_current * 0.95", context_ok, resolver) is False
+
+
+# ---------------------------------------------------------------------------
+# Joined-entity dot-paths
+# ---------------------------------------------------------------------------
+
+
+def test_joined_entity_dot_path_true(resolver: TemplateIdentifierResolver) -> None:
+    context = {"tenant": {"late_payment_count_12mo": 4, "name": "alice"}}
+    assert evaluate_cel("tenant.late_payment_count_12mo >= 3", context, resolver) is True
+
+
+def test_joined_entity_dot_path_false(resolver: TemplateIdentifierResolver) -> None:
+    context = {"tenant": {"late_payment_count_12mo": 1, "name": "alice"}}
+    assert evaluate_cel("tenant.late_payment_count_12mo >= 3", context, resolver) is False
+
+
+def test_undeclared_joined_entity_raises() -> None:
+    """``vendor`` is NOT declared on the template; the resolver gates
+    the lookup and ``evaluate_cel`` surfaces a typed error."""
+    flat_resolver = TemplateIdentifierResolver(_flat_template())
+    with pytest.raises(CelEvaluationError) as exc:
+        evaluate_cel("vendor.foo == 1", {}, flat_resolver)
+    assert "vendor" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# within() custom function — deterministic via injected ``now``
+# ---------------------------------------------------------------------------
+
+
+def test_within_inside_window(resolver: TemplateIdentifierResolver) -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    expires_at = now + timedelta(days=30)
+    context = {"expires_at": expires_at}
+    assert evaluate_cel("within(expires_at, duration('60d'))", context, resolver, now=now) is True
+
+
+def test_within_outside_window(resolver: TemplateIdentifierResolver) -> None:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    expires_at = now + timedelta(days=100)
+    context = {"expires_at": expires_at}
+    assert evaluate_cel("within(expires_at, duration('60d'))", context, resolver, now=now) is False
+
+
+def test_within_past_inside_window(resolver: TemplateIdentifierResolver) -> None:
+    """within(field, d) is symmetric: now() - d <= field <= now() + d."""
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    expires_at = now - timedelta(days=30)
+    context = {"expires_at": expires_at}
+    assert evaluate_cel("within(expires_at, duration('60d'))", context, resolver, now=now) is True
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_missing_identifier_raises(resolver: TemplateIdentifierResolver) -> None:
+    with pytest.raises(CelEvaluationError) as exc:
+        evaluate_cel("days_remaining <= 30", {}, resolver)
+    # Error message must name the missing identifier so authors can fix
+    # it without re-running with a debugger.
+    assert "days_remaining" in str(exc.value)
+
+
+def test_type_error_raises(resolver: TemplateIdentifierResolver) -> None:
+    # string < int — celpy raises CELEvalError; the runtime wraps it.
+    with pytest.raises(CelEvaluationError):
+        evaluate_cel(
+            "renewal_stage < 5",
+            {"renewal_stage": "sent"},
+            resolver,
+        )
+
+
+def test_malformed_expression_raises(resolver: TemplateIdentifierResolver) -> None:
+    # Parse failure at eval time (the chokepoint catches most syntax
+    # errors earlier, but evaluate_cel is also called directly with raw
+    # strings — it must surface a CelEvaluationError, not a stray
+    # celpy ``CELParseError``.)
+    with pytest.raises(CelEvaluationError):
+        evaluate_cel("days_remaining <=", {"days_remaining": 1}, resolver)

--- a/tests/unit/test_identifier_resolver.py
+++ b/tests/unit/test_identifier_resolver.py
@@ -1,0 +1,142 @@
+# tests/unit/test_identifier_resolver.py
+# Created: 2026-05-28 (feat/rfc-03-v2-cel-eval) — unit tests for the
+# ``IdentifierResolver`` Protocol's reference implementation
+# (``TemplateIdentifierResolver``). The Protocol itself is checked by
+# structural typing; only the reference impl carries observable
+# behavior.
+"""Tests for ``TemplateIdentifierResolver``.
+
+The reference resolver covers two cases:
+
+* Flat identifier (no dot) → look up directly in the context.
+* Dotted identifier — the leading segment must match a
+  ``state.joined_entities[].name`` declared on the template. If it
+  does, drill into the context at that key. If not, raise
+  ``KeyError`` with a clear message.
+
+Fabric live-link traversal (calling out to a registered FabricLink
+when the context lacks the joined entity inline) is out of scope for
+PR 2c and lives in PR 2g.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.bundled_templates import (
+    PocketTemplate,
+    TemplateIdentifierResolver,
+)
+
+
+def _template_with_tenant_join() -> PocketTemplate:
+    return PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "resolver-test",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "property-management",
+            "display_name": "Resolver Test",
+            "description": "Skinny fixture for identifier-resolver tests.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "Lease",
+                "joined_entities": [
+                    {"name": "tenant", "entity_type": "Tenant", "via_link": "lease_tenant"},
+                    {
+                        "name": "property",
+                        "entity_type": "Property",
+                        "via_link": "lease_property",
+                    },
+                ],
+                "columns": [
+                    {"field": "id", "widget": "text"},
+                    {"field": "days_remaining", "widget": "trend"},
+                ],
+            },
+        }
+    )
+
+
+def _template_without_joins() -> PocketTemplate:
+    return PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "no-joins",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "general",
+            "display_name": "No Joins",
+            "description": "Skinny fixture without joined entities.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "Thing",
+                "columns": [{"field": "id", "widget": "text"}],
+            },
+        }
+    )
+
+
+def test_flat_identifier_resolves_against_context() -> None:
+    resolver = TemplateIdentifierResolver(_template_with_tenant_join())
+    assert resolver.resolve("days_remaining", {"days_remaining": 25}) == 25
+
+
+def test_flat_identifier_missing_raises_keyerror() -> None:
+    resolver = TemplateIdentifierResolver(_template_with_tenant_join())
+    with pytest.raises(KeyError):
+        resolver.resolve("days_remaining", {})
+
+
+def test_dotted_path_resolves_when_join_declared() -> None:
+    resolver = TemplateIdentifierResolver(_template_with_tenant_join())
+    # The resolver returns the top-level joined object — the CEL
+    # evaluator (or any caller) then walks the rest of the path.
+    context = {"tenant": {"name": "alice", "late_payment_count_12mo": 4}}
+    value = resolver.resolve("tenant", context)
+    assert value == {"name": "alice", "late_payment_count_12mo": 4}
+
+
+def test_dotted_root_undeclared_raises_keyerror() -> None:
+    resolver = TemplateIdentifierResolver(_template_with_tenant_join())
+    # ``vendor`` is not a declared joined entity AND is not in the
+    # context — should raise KeyError. The error message should name
+    # ``vendor`` so the surrounding evaluator can surface it.
+    with pytest.raises(KeyError) as exc:
+        resolver.resolve("vendor", {})
+    assert "vendor" in str(exc.value)
+
+
+def test_undeclared_root_with_context_resolves_to_value() -> None:
+    """If the row context carries ``vendor`` (e.g. an unjoined flat
+    field that happens to share a name authors might use as a
+    dotted root), the resolver returns the value. Whether the CEL
+    expression *should* be using ``vendor`` at all is a lint-time
+    concern (PR 2g's Fabric ``tier: registered`` enforcement) — at
+    runtime, an entry in the row context is a legitimate lookup.
+
+    This codifies the open boundary between PR 2c (runtime, loose)
+    and PR 2g (lint, strict). Other resolvers (e.g. ``FabricResolver``
+    in PR 2g) may layer extra gates.
+    """
+    resolver = TemplateIdentifierResolver(_template_without_joins())
+    assert resolver.resolve("vendor", {"vendor": {"foo": 1}}) == {"foo": 1}
+
+
+def test_property_join_also_resolves() -> None:
+    """Both declared joins resolve. Sanity check that the lookup is
+    not hardcoded to ``tenant``."""
+    resolver = TemplateIdentifierResolver(_template_with_tenant_join())
+    context = {"property": {"address": "123 Main St"}}
+    assert resolver.resolve("property", context) == {"address": "123 Main St"}
+
+
+def test_state_binding_constructor_overload() -> None:
+    """The resolver should also accept a ``StateBinding`` directly —
+    useful when the caller already has the inner block and doesn't
+    want to round-trip through the full template."""
+    template = _template_with_tenant_join()
+    resolver = TemplateIdentifierResolver(template.state)
+    context = {"tenant": {"name": "alice"}}
+    assert resolver.resolve("tenant", context) == {"name": "alice"}


### PR DESCRIPTION
## Summary

Adds the RFC 03 v2 runtime CEL evaluator and `IdentifierResolver` Protocol on top of the parse-only chokepoint shipped in PR #1225. This is the eval foundation PR 2d (Instinct 5-step composer), PR 2f (temporal trigger sweeper), and PR 2g (Fabric `tier: registered` linter) all consume.

- New `cel_runtime.evaluate_cel(expression, context, resolver, *, now=None) -> Any`. Pure library function. Parses, walks the AST for free identifiers, gates each one through the resolver, registers the `within(field, duration)` custom function with an injected (deterministic) `now`, evaluates, and returns a Python-typed result.
- New `cel_runtime.CelEvaluationError`. Single typed exception wrapping both parse- and eval-time failures. Carries `.expression` and `.cause`.
- New `identifier_resolver.IdentifierResolver` Protocol and `TemplateIdentifierResolver` reference impl. The reference impl gates dotted roots against `state.joined_entities[]`. PR 2g layers a Fabric-backed resolver on the same Protocol.

## RFC 03 v2 compliance

- §"Expression grammar": `within(field, duration)` is the only custom function in v2. This PR registers exactly that and nothing else. `duration()`, `timestamp()`, and CEL built-ins flow through unchanged.
- §"Resolution against Fabric": identifier lookups flow through `IdentifierResolver`, so swapping the resolver swaps the resolution backend. Live `via_link` traversal is intentionally deferred to PR 2g.
- §"actions[] sub-schema, worked example A": `rent_proposed < rent_current * 0.95` evaluates correctly with `float` inputs. Covered by `test_lease_renewal_block_rule_worked_example_a`.

## Files changed

| State    | Path                                                       | LOC |
|----------|------------------------------------------------------------|-----|
| NEW      | `src/pocketpaw/bundled_templates/cel_runtime.py`           | 286 |
| NEW      | `src/pocketpaw/bundled_templates/identifier_resolver.py`   | 146 |
| MODIFIED | `src/pocketpaw/bundled_templates/__init__.py`              | +18 |
| NEW      | `tests/unit/test_cel_runtime.py`                           | 222 |
| NEW      | `tests/unit/test_identifier_resolver.py`                   | 142 |

## Test plan

- `uv run pytest tests/unit/test_cel_runtime.py tests/unit/test_identifier_resolver.py -v` → 21 passed.
- Re-ran the chokepoint suite (`test_bundled_templates.py`, `test_template_schema.py`, `test_template_compile.py`, `test_cli_template.py`) → 113 passed, 7 skipped. No regression.
- `uv run ruff check` + `uv run ruff format --check` both clean on the touched files.
- Smoke test against the real `tests/fixtures/templates/lease-renewal-v2.yaml`:
  ```
  'days_remaining <= 30'                                       -> True  (expected True)
  'rent_proposed < rent_current * 0.95'                        -> True  (expected True)
  'tenant.late_payment_count_12mo >= 3'                        -> True  (expected True)
  smoke OK
  ```

## Out of scope (handed off)

- **PR 2d** Instinct 5-step composer (block / approval / per-action / execute / side-effects) will call `evaluate_cel` for each rule's `when` predicate.
- **PR 2f** Temporal trigger sweeper will call `evaluate_cel` per row with a `now` from the sweep cadence.
- **PR 2g** Fabric `tier: registered` linter plus a `FabricResolver` implementing the same Protocol that walks live `via_link` registrations when the row context lacks the joined entity inline. The linter rejects dotted paths against undeclared joins at parse time; this PR's reference resolver only rejects them when they're absent from the row context.
- CLI extension that wires `template lint` to evaluate expressions against a synthetic context. Deferred until the eval surface is exercised in production by PRs 2d / 2f / 2g.

## Decisions made where the brief was ambiguous

- `CelEvaluationError` lives in `cel_runtime.py` (next to `evaluate_cel`) rather than `errors.py`. Rationale: `errors.py` currently holds `TemplateValidationError`, a parse-time concern; co-locating the eval-time exception with the evaluator keeps cohesion higher than a cross-module split. Re-exported from the package root.
- `within(field, duration)` is registered per-call via `Environment.program(ast, functions={"within": _within_fn})`. The closure captures the injected `now`, which keeps `evaluate_cel` referentially transparent given the same `now`. No global state.
- `TemplateIdentifierResolver` is loose: an entry in the row context resolves even when the root isn't declared as a joined entity. Strict enforcement is a lint-time concern (PR 2g), not a runtime concern. The runtime should be tolerant so it can be reused by tools that ship synthetic contexts.
- Constructor overload: `TemplateIdentifierResolver` accepts a `PocketTemplate` OR a `StateBinding` directly. The runtime composer (PR 2d) often holds only the inner block and shouldn't have to round-trip through the full template.

## Note on celpy types

The RFC's `rent_proposed < rent_current * 0.95` example only works if the inputs are typed as Python `float` (celpy's `DoubleType`). `IntType * DoubleType` has no overload in celpy. The activation builder uses `json_to_cel` which preserves int-as-int and float-as-double, so production callers must coerce numeric columns to `float` before passing them in. Tests pin this behaviour. PR 2d's composer is the natural place to add the coercion (or to surface a typed CelEvaluationError if it ever mismatches).
