### PR TITLE
feat(foresight): surface synth_source on insights wire envelope

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/foresight.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/foresight.py
@@ -608,7 +608,9 @@ def build_foresight_server() -> tuple[str, Any] | None:
             "workspace config (wire shape unchanged). Empty workspaces yield "
             "``items=[]`` — the synthesizer fires no rows when no patterns "
             "match. Surface ``severity`` (info | warning | critical) verbatim "
-            "so the user sees the same colour the dashboard does."
+            "so the user sees the same colour the dashboard does. Response "
+            "carries `synth_source` ('pattern' | 'llm') so the agent can "
+            "disclose which synthesizer produced the rows."
         ),
         {
             "type": "object",

--- a/ee/pocketpaw_ee/cloud/foresight/dto.py
+++ b/ee/pocketpaw_ee/cloud/foresight/dto.py
@@ -770,11 +770,26 @@ class InsightsResponse(BaseModel):
     (pagination lands in v1.0 once the LLM synthesizer can fan
     finer-grained rules). Items are sorted by severity descending
     (critical > warning > info) then ``generated_at`` descending.
+
+    ``synth_source`` reports which synthesizer ACTUALLY produced the
+    rows the caller is reading:
+
+      - ``"pattern"`` (default) — the deterministic v0.5 five-rule
+        synthesizer ran. This is the default for any workspace that
+        hasn't opted into the LLM synth, AND for the fallback path
+        when an LLM run returned empty / failed.
+      - ``"llm"`` — the v1.0 LLM synthesizer produced the rows.
+
+    Dashboard + chat agent surfaces this so users can tell whether
+    they're reading deterministic rule output or an LLM narrative.
+    Defaulting to ``"pattern"`` keeps existing callers / fixtures
+    that construct ``InsightsResponse`` without the field working.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     items: list[InsightResponse]
+    synth_source: Literal["pattern", "llm"] = "pattern"
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -2989,6 +2989,11 @@ async def get_insights(ctx: RequestContext) -> InsightsResponse:
     config_view = await _load_insights_config_view(workspace_id)
 
     raw_insights: list[Any]
+    # Track which synthesizer ACTUALLY produced the wire output so the
+    # response envelope can disclose it. Default "pattern" covers the
+    # untoggled workspace + the LLM-empty fallback path; only a
+    # non-empty LLM run flips this to "llm".
+    actual_source: Literal["pattern", "llm"] = "pattern"
     if config_view.synthesizer == "llm":
         # Try LLM. On ANY failure (timeout, malformed output, rate
         # limit, missing backend) fall back to the pattern synthesizer
@@ -3008,10 +3013,13 @@ async def get_insights(ctx: RequestContext) -> InsightsResponse:
         )
         if llm_insights:
             raw_insights = list(llm_insights)
+            actual_source = "llm"
         else:
             # Empty LLM output — likely a failure or a quiet workspace.
             # Either way the pattern rules are the safe default; if
             # they also produce nothing the response is correctly empty.
+            # ``actual_source`` stays "pattern" — the user is reading
+            # pattern-synthesizer rows regardless of the config toggle.
             logger.warning(
                 "foresight.insights.llm_empty_falling_back_to_pattern",
                 extra={"workspace_id": workspace_id},
@@ -3052,7 +3060,7 @@ async def get_insights(ctx: RequestContext) -> InsightsResponse:
         )
         for insight in raw_insights
     ]
-    return InsightsResponse(items=items)
+    return InsightsResponse(items=items, synth_source=actual_source)
 
 
 # ── LLM insights (Team 3 wave 3) ──────────────────────────────────────────

--- a/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/foresight-create-sim/SKILL.md
@@ -123,7 +123,10 @@ stream's workspace id; no env vars, no headers).
     workspaces yield ``items=[]`` — the synthesizer fires no rows when
     no patterns match. Each item carries ``severity`` (``info`` |
     ``warning`` | ``critical``) — surface it verbatim so the user sees
-    the same colour the dashboard renders.
+    the same colour the dashboard renders. Response carries
+    ``synth_source`` (``"pattern"`` | ``"llm"``) — surface this when
+    reporting findings so the user knows whether they came from the
+    deterministic five-rule synthesizer or the v1.0 LLM synth.
 
     **When to use:** "what mattered in the last run", "explain the
     insights", "anything worth flagging".

--- a/tests/cloud/test_foresight_service_insights_llm.py
+++ b/tests/cloud/test_foresight_service_insights_llm.py
@@ -319,6 +319,83 @@ async def test_get_insights_with_llm_caches_repeat_calls() -> None:
     assert len(backend.calls) == 1
 
 
+# ---------------------------------------------------------------------------
+# synth_source wire field — tracks the synthesizer that ACTUALLY produced
+# the rows the caller is reading. Default "pattern" covers the untoggled
+# workspace + the LLM-empty fallback path; only a non-empty LLM run flips
+# it to "llm".
+# ---------------------------------------------------------------------------
+
+
+async def test_get_insights_default_synth_source_is_pattern() -> None:
+    """No config doc → response advertises ``synth_source = "pattern"``."""
+    response = await foresight_service.get_insights(_ctx())
+    assert response.synth_source == "pattern"
+
+
+async def test_get_insights_pattern_when_config_pattern() -> None:
+    """Config explicitly set to "pattern" → ``synth_source = "pattern"``."""
+    await foresight_service.set_insights_config(
+        _ctx(),
+        SetForesightInsightsConfigRequest(synthesizer="pattern"),
+    )
+    response = await foresight_service.get_insights(_ctx())
+    assert response.synth_source == "pattern"
+
+
+async def test_get_insights_llm_source_when_llm_produces_output() -> None:
+    """Config "llm" + LLM returns non-empty → ``synth_source = "llm"``."""
+    # Seed records so the LLM helper has something to summarize. The
+    # canned payload is what determines the response items; the seeds
+    # just keep the helper from short-circuiting on empty input.
+    captured_at = datetime.now(UTC) - timedelta(days=1)
+    for i in range(3):
+        await _seed_record(
+            persona_id="alice",
+            confidence=0.4,
+            run_id=f"r-{i}",
+            tick_id=i,
+            captured_at=captured_at,
+        )
+
+    await foresight_service.set_insights_config(
+        _ctx(),
+        SetForesightInsightsConfigRequest(synthesizer="llm"),
+    )
+    backend = _StubLLMBackend(responses=[_valid_llm_payload()])
+    foresight_service._set_llm_backend_for_testing(backend)
+
+    response = await foresight_service.get_insights(_ctx())
+    assert response.synth_source == "llm"
+    # Sanity: an item with the llm_ id prefix is in there — proves the
+    # LLM path ran, not just the toggle reading.
+    assert any(i.id.startswith("llm_") for i in response.items)
+
+
+async def test_get_insights_pattern_source_when_llm_returns_empty() -> None:
+    """Config "llm" + LLM returns ``[]`` → fallback → ``synth_source = "pattern"``.
+
+    The user is reading pattern-synthesizer rows (or none, if both
+    paths are empty) regardless of the config toggle; the wire source
+    has to match what the user actually sees.
+    """
+    await foresight_service.set_insights_config(
+        _ctx(),
+        SetForesightInsightsConfigRequest(synthesizer="llm"),
+    )
+    # LLM helper collapses `{"insights": []}` into an empty list,
+    # which the service then treats as "fallback to pattern".
+    backend = _StubLLMBackend(responses=[json.dumps({"insights": []})])
+    foresight_service._set_llm_backend_for_testing(backend)
+
+    response = await foresight_service.get_insights(_ctx())
+    assert response.synth_source == "pattern"
+    # Items reflect the pattern synthesizer. With no seeded records the
+    # pattern path also produces nothing — the response is correctly
+    # empty AND correctly labelled as the pattern source.
+    assert all(not i.id.startswith("llm_") for i in response.items)
+
+
 async def test_get_insights_requires_workspace_under_llm_path() -> None:
     """The tenancy guard still fires on the LLM branch."""
     from pocketpaw_ee.cloud._core.errors import Forbidden


### PR DESCRIPTION
## Gap

`InsightsResponse` (the wire shape returned by `GET /api/v1/foresight/insights` and the `get_insights` MCP tool) carried no marker for which synthesizer produced the rows. A workspace on the pattern synth and a workspace on the LLM synth returned indistinguishable JSON. Dashboard and chat agent had no way to label the source so users could tell whether they were reading deterministic five-rule output or an LLM narrative.

## Fix

Three thin changes, additive only, default-safe.

- **DTO** — `InsightsResponse.synth_source: Literal["pattern", "llm"] = "pattern"`. Default keeps every existing caller / fixture correct without migration.
- **Service** — `get_insights` tracks the synthesizer that actually produced the rows the user sees. The label flips to `"llm"` only when a non-empty LLM run feeds the response; empty-LLM-falls-back-to-pattern keeps the label as `"pattern"` because that is what the user sees.
- **Docs** — `get_insights` MCP tool description and the `foresight-create-sim` SKILL.md both call out the new field so the chat agent discloses the source when reporting findings.

`get_insights_for_agent` already forwards the full `response.model_dump()` to MCP callers, so the new field flows through without any agent-context code change.

## Backward compatibility

- Field default `"pattern"` means existing JSON consumers continue to parse. Frontends that ignore unknown fields keep working.
- `model_config = ConfigDict(extra="forbid")` on `InsightsResponse` is preserved.
- Workspaces on the LLM synth that hit a fallback (empty / failed / malformed) now correctly label the response as `"pattern"` — they are reading pattern rows.

## Test plan

New cases in `tests/cloud/test_foresight_service_insights_llm.py`:

- [x] `test_get_insights_default_synth_source_is_pattern` — no config doc → `"pattern"`.
- [x] `test_get_insights_pattern_when_config_pattern` — config `"pattern"` → `"pattern"`.
- [x] `test_get_insights_llm_source_when_llm_produces_output` — config `"llm"` + valid stub LLM → `"llm"`, items carry `llm_` ids.
- [x] `test_get_insights_pattern_source_when_llm_returns_empty` — config `"llm"` + stub LLM returns `[]` → fallback path, `"pattern"`, items reflect the pattern synth.

Targeted runs (all green):

- `tests/cloud/test_foresight_service_insights_llm.py` — 13 passed
- `tests/cloud/test_foresight_service_insights.py` — covers existing items shape
- `tests/cloud/test_foresight_insights_config.py` — config CRUD regression
- `tests/cloud/test_foresight_agent_context.py` — MCP forwarding regression
- `tests/ee/agent/test_foresight_mcp_server/` — MCP server regression
- Combined: 93 passed.

Ruff clean on `ee/pocketpaw_ee/cloud/foresight/`, `ee/pocketpaw_ee/agent/mcp_servers/foresight.py`, and the touched test + skill paths.