### PR TITLE
feat(instinct): 5-step resolution composer for RFC 03 v2

### DIFF
--- a/src/pocketpaw/bundled_templates/__init__.py
+++ b/src/pocketpaw/bundled_templates/__init__.py
@@ -16,6 +16,10 @@
 # ``TemplateIdentifierResolver``). PR 2c lays the foundation that
 # PR 2d (Instinct 5-step composer), PR 2f (temporal trigger sweeper),
 # and PR 2g (Fabric ``tier: registered`` linter) all consume.
+# Modified 2026-05-28 (feat/rfc-03-v2-instinct-exec): re-exports the
+# Instinct 5-step composer (``resolve_instinct``, ``InstinctDecision``,
+# ``InstinctResolutionError``). PR 2d builds the pure decision
+# function; the EE runtime invokes it per row and dispatches.
 """Built-in pocket templates bundled and auto-installed by PocketPaw.
 
 Third sibling to ``pocketpaw.bundled_skills`` and ``pocketpaw.bundled_kb``.
@@ -71,6 +75,12 @@ from pocketpaw.bundled_templates.installer import (
     TemplateInstallResult,
     install_bundled_templates,
 )
+from pocketpaw.bundled_templates.instinct_composer import (
+    InstinctDecision,
+    InstinctResolutionError,
+    InstinctVerdict,
+    resolve_instinct,
+)
 from pocketpaw.bundled_templates.loader import load_template
 from pocketpaw.bundled_templates.schema import (
     ActionDef,
@@ -96,8 +106,11 @@ __all__ = [
     "ConfirmDef",
     "DataSourceDef",
     "IdentifierResolver",
+    "InstinctDecision",
+    "InstinctResolutionError",
     "InstinctRule",
     "InstinctRulesDef",
+    "InstinctVerdict",
     "JoinedEntity",
     "PermissionsDef",
     "PocketTemplate",
@@ -111,4 +124,5 @@ __all__ = [
     "evaluate_cel",
     "install_bundled_templates",
     "load_template",
+    "resolve_instinct",
 ]

--- a/src/pocketpaw/bundled_templates/instinct_composer.py
+++ b/src/pocketpaw/bundled_templates/instinct_composer.py
@@ -1,0 +1,400 @@
+# src/pocketpaw/bundled_templates/instinct_composer.py
+# Created: 2026-05-28 (feat/rfc-03-v2-instinct-exec) — pure-library
+# implementation of the RFC 03 v2 5-step Instinct resolution order.
+# Consumes the PR 2c CEL evaluator + identifier resolver. Produces an
+# immutable ``InstinctDecision`` value object describing what the EE
+# runtime should do next (BLOCK / ESCALATE_APPROVAL / EXECUTE /
+# NOTIFY_AND_EXECUTE). The runtime side — approval queue, action
+# invocation, outcome emission — lives in ``ee/cloud/pockets/`` and is
+# wired in a follow-up PR. Bulk fan-out (PR 2e), temporal trigger
+# sweeper (PR 2f), and Fabric ``tier: registered`` enforcement (PR 2g)
+# all consume this composer; their per-row decision shape is the
+# same.
+"""5-step Instinct resolution composer for RFC 03 v2 templates.
+
+Public surface
+--------------
+
+* :class:`InstinctDecision` — frozen Pydantic v2 model describing the
+  composed verdict, the rules that participated, the reason code, and
+  any notify rules to fire as side effects.
+* :func:`resolve_instinct` — the pure function that walks the 5-step
+  order from the RFC §"Instinct resolution order" and returns an
+  ``InstinctDecision``.
+* :class:`InstinctResolutionError` — raised for action lookup misses
+  and for rule evaluation failures. CEL eval failures wrap the
+  underlying ``CelEvaluationError`` on ``.__cause__`` so callers can
+  reach the original diagnostic.
+
+Resolution order (verbatim from the RFC)
+----------------------------------------
+
+1. **block rules** — first match → ``BLOCK``, short-circuit.
+2. **approval rules** — any match → ``ESCALATE_APPROVAL`` with reason
+   ``operator_overlay_escalated``.
+3. **per-action policy** — ``auto`` falls through; ``require_approval``
+   escalates with reason ``author_floor``; ``notify_only`` falls
+   through and flips the final verdict to ``NOTIFY_AND_EXECUTE``.
+4. **execute** — this PR returns the verdict; the EE runtime dispatches.
+5. **side effects** — notify rules whose ``when`` matches are returned
+   on the decision so the EE runtime can fan them out in parallel
+   with the action invocation.
+
+Two RFC invariants are pinned in tests and enforced by the early-return
+structure of :func:`resolve_instinct`:
+
+* ``block always wins`` — step 1's first match returns immediately. No
+  step 2-5 work is done. Tests pin both the simple case and the
+  block+approval-simultaneous case.
+* ``the operator overlay can only escalate, never demote`` — step 2
+  can only return ``ESCALATE_APPROVAL``; it never returns ``EXECUTE``.
+  Step 3's ``require_approval`` per-action floor is reached only if
+  step 2 returned no match, so the floor is never lowered.
+
+Scope (locked by the PR brief)
+------------------------------
+
+* Library / pure function. No I/O, no Beanie, no ``pocketpaw_ee``
+  imports. The OSS import-linter contract enforces this.
+* ``InstinctDecision`` is **immutable** (``ConfigDict(frozen=True)``).
+* Side effects are *described* (returned in ``notify_rules``) but not
+  *fired* — the EE runtime owns dispatch.
+* Bulk fan-out is the consumer's job (PR 2e).
+
+Workspace + row context merging
+-------------------------------
+
+The composer merges ``workspace_context`` and ``row_context`` into a
+single activation for CEL evaluation. **Row context wins on
+collision** — per-row data should never be silently shadowed by
+workspace defaults. The merge happens once and is reused for every
+rule the composer evaluates.
+
+Resolver injection
+------------------
+
+If the caller passes no ``resolver``, the composer constructs a
+default :class:`TemplateIdentifierResolver` keyed off
+``template.state``. Tests and the future ``FabricResolver`` (PR 2g)
+can swap in a richer implementation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pocketpaw.bundled_templates.cel_runtime import (
+    CelEvaluationError,
+    evaluate_cel,
+)
+from pocketpaw.bundled_templates.identifier_resolver import (
+    IdentifierResolver,
+    TemplateIdentifierResolver,
+)
+from pocketpaw.bundled_templates.schema import (
+    ActionDef,
+    InstinctRule,
+    PocketTemplate,
+)
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+InstinctVerdict = Literal["BLOCK", "ESCALATE_APPROVAL", "EXECUTE", "NOTIFY_AND_EXECUTE"]
+"""Set of terminal verdicts the composer can produce.
+
+* ``BLOCK`` — step 1 matched. The runtime must abort the action and
+  emit a ``blocked_by_rule`` audit-log entry.
+* ``ESCALATE_APPROVAL`` — step 2 matched or step 3's
+  ``require_approval`` floor fired. The runtime must enqueue the
+  action on the Instinct approval queue.
+* ``EXECUTE`` — step 3 picked ``auto`` and no overlay escalated. The
+  runtime invokes the action directly.
+* ``NOTIFY_AND_EXECUTE`` — step 3 picked ``notify_only``. The runtime
+  invokes the action AND pings the escalation target.
+"""
+
+
+class InstinctDecision(BaseModel):
+    """Immutable result of composing a per-action ``instinct_policy``
+    against the top-level ``instinct_rules.rules[]``.
+
+    Frozen so callers can pass the decision through audit /
+    serialization layers without worrying about downstream mutation.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    verdict: InstinctVerdict
+    action_name: str
+    matched_rules: list[InstinctRule] = Field(default_factory=list)
+    """Rules that *participated in the decision* — the block rule that
+    fired (BLOCK), or the approval rules that escalated
+    (ESCALATE_APPROVAL via overlay). Empty when the verdict came from
+    the per-action floor / fallback."""
+
+    notify_rules: list[InstinctRule] = Field(default_factory=list)
+    """Top-level ``notify`` rules whose ``when`` matched. Fire in
+    parallel with the action invocation per RFC §"Instinct resolution
+    order" step 5. Empty on BLOCK (step 1 short-circuits notify
+    gathering)."""
+
+    reason: str
+    """Short code explaining the verdict: ``blocked_by_rule``,
+    ``operator_overlay_escalated``, ``author_floor``, ``auto``, or
+    ``notify_only``."""
+
+    audit_data: dict[str, Any] = Field(default_factory=dict)
+    """Extra diagnostic data for the audit log — currently carries the
+    action name and the rule ``when`` text(s) that participated.
+    Callers should treat this as opaque metadata."""
+
+
+class InstinctResolutionError(Exception):
+    """Raised by :func:`resolve_instinct`.
+
+    Two failure modes:
+
+    1. **Unknown action** — ``action_name`` is not present on
+       ``template.actions[].name``. The runtime cannot dispatch
+       something that doesn't exist; this is a programming error in
+       the caller (template / action-name mismatch) and surfaces
+       loudly.
+    2. **CEL evaluation failure inside a rule** — the underlying
+       :class:`CelEvaluationError` is preserved on ``__cause__`` via
+       ``raise ... from exc``. The wrapping exception carries the
+       rule and action names so the audit log has enough context to
+       point at the offending rule.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Public function
+# ---------------------------------------------------------------------------
+
+
+def resolve_instinct(
+    template: PocketTemplate,
+    action_name: str,
+    row_context: dict[str, Any],
+    workspace_context: dict[str, Any] | None = None,
+    *,
+    resolver: IdentifierResolver | None = None,
+    now: datetime | None = None,
+) -> InstinctDecision:
+    """Walk the RFC 03 v2 5-step Instinct resolution order for one row.
+
+    Parameters
+    ----------
+    template:
+        The fully-validated :class:`PocketTemplate` carrying
+        ``actions[]`` and (optionally) ``instinct_rules``.
+    action_name:
+        Stable slug from ``ActionDef.name``. Must exist on the
+        template; otherwise :class:`InstinctResolutionError` is raised.
+    row_context:
+        Per-row dict — every identifier referenced by every rule that
+        needs evaluating must be present (the resolver enforces
+        ``KeyError`` → :class:`CelEvaluationError` →
+        :class:`InstinctResolutionError`).
+    workspace_context:
+        Optional workspace-scoped defaults — typically things like
+        the current user's role, the workspace's risk-tolerance
+        setting, etc. Merged with ``row_context``; **row wins on
+        collision**.
+    resolver:
+        Optional :class:`IdentifierResolver`. Defaults to
+        ``TemplateIdentifierResolver(template.state)``.
+    now:
+        Optional wall-clock for the CEL ``within(...)`` function.
+        Defaults to ``datetime.now(UTC)``. Tests should pass a fixed
+        value.
+
+    Returns
+    -------
+    :class:`InstinctDecision`
+        Immutable. See class docstring for field semantics.
+
+    Raises
+    ------
+    InstinctResolutionError
+        On unknown action or rule-eval failure.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    # Resolve the action up-front so a typo on ``action_name`` surfaces
+    # before we evaluate any rules.
+    action = _find_action(template, action_name)
+
+    # Default resolver — same lookup the CEL primitive uses everywhere
+    # else in the runtime. PR 2g will swap in a Fabric-backed resolver.
+    if resolver is None:
+        resolver = TemplateIdentifierResolver(template.state)
+
+    # Merge once. ``workspace_context`` first so ``row_context`` keys
+    # overwrite on collision (row wins). This matches the brief and
+    # keeps per-row data from being shadowed by workspace defaults.
+    merged_context: dict[str, Any] = {}
+    if workspace_context:
+        merged_context.update(workspace_context)
+    merged_context.update(row_context)
+
+    rules = list(template.instinct_rules.rules) if template.instinct_rules else []
+
+    # -------------------------------------------------------------------
+    # STEP 1 — block rules. First match wins; short-circuit immediately.
+    # The ``block always wins`` invariant lives here: returning early
+    # means steps 2-5 never run, even when an approval rule would also
+    # match the same row.
+    # -------------------------------------------------------------------
+    for rule in rules:
+        if rule.action != "block":
+            continue
+        if _eval_rule(rule, merged_context, resolver, now, action_name):
+            return InstinctDecision(
+                verdict="BLOCK",
+                action_name=action_name,
+                matched_rules=[rule],
+                notify_rules=[],
+                reason="blocked_by_rule",
+                audit_data={"action_name": action_name, "rule_when": rule.when},
+            )
+
+    # -------------------------------------------------------------------
+    # STEP 2 — approval rules. ANY match escalates. The overlay can
+    # only escalate; the step 3 ``require_approval`` floor is reached
+    # only when nothing matches here, so the floor is never demoted.
+    # -------------------------------------------------------------------
+    matched_approval: list[InstinctRule] = [
+        rule
+        for rule in rules
+        if rule.action == "require_approval"
+        and _eval_rule(rule, merged_context, resolver, now, action_name)
+    ]
+    # -------------------------------------------------------------------
+    # STEP 5 (gathered now, returned later) — notify rules. We collect
+    # them up-front so the same merged context + resolver is reused for
+    # every rule evaluation in this composer call. They are returned
+    # alongside the verdict (not fired here — the EE runtime owns
+    # dispatch).
+    # -------------------------------------------------------------------
+    notify_rules: list[InstinctRule] = [
+        rule
+        for rule in rules
+        if rule.action == "notify" and _eval_rule(rule, merged_context, resolver, now, action_name)
+    ]
+
+    if matched_approval:
+        return InstinctDecision(
+            verdict="ESCALATE_APPROVAL",
+            action_name=action_name,
+            matched_rules=matched_approval,
+            notify_rules=notify_rules,
+            reason="operator_overlay_escalated",
+            audit_data={
+                "action_name": action_name,
+                "rule_whens": [r.when for r in matched_approval],
+            },
+        )
+
+    # -------------------------------------------------------------------
+    # STEP 3 — per-action policy floor. ``auto`` falls through to step
+    # 4; ``require_approval`` escalates with reason ``author_floor``;
+    # ``notify_only`` falls through and tags the verdict for the
+    # ``NOTIFY_AND_EXECUTE`` path.
+    # -------------------------------------------------------------------
+    if action.instinct_policy == "require_approval":
+        return InstinctDecision(
+            verdict="ESCALATE_APPROVAL",
+            action_name=action_name,
+            matched_rules=[],
+            notify_rules=notify_rules,
+            reason="author_floor",
+            audit_data={"action_name": action_name},
+        )
+
+    # -------------------------------------------------------------------
+    # STEP 4 — execute. The composer does not invoke the action; the
+    # caller dispatches off the verdict.
+    # -------------------------------------------------------------------
+    if action.instinct_policy == "notify_only":
+        return InstinctDecision(
+            verdict="NOTIFY_AND_EXECUTE",
+            action_name=action_name,
+            matched_rules=[],
+            notify_rules=notify_rules,
+            reason="notify_only",
+            audit_data={"action_name": action_name},
+        )
+
+    # ``auto`` — plain execute. Notify rules still flow through (a
+    # top-level notify rule can fire alongside an auto execute).
+    return InstinctDecision(
+        verdict="EXECUTE",
+        action_name=action_name,
+        matched_rules=[],
+        notify_rules=notify_rules,
+        reason="auto",
+        audit_data={"action_name": action_name},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _find_action(template: PocketTemplate, action_name: str) -> ActionDef:
+    """Look up an action by name. Raises :class:`InstinctResolutionError`
+    if not found — the caller passed a bad name and we want that to
+    surface loudly, not silently no-op."""
+    for action in template.actions:
+        if action.name == action_name:
+            return action
+    raise InstinctResolutionError(
+        f"action {action_name!r} is not declared on template "
+        f"{template.name!r} (available: "
+        f"{sorted(a.name for a in template.actions)})"
+    )
+
+
+def _eval_rule(
+    rule: InstinctRule,
+    context: dict[str, Any],
+    resolver: IdentifierResolver,
+    now: datetime,
+    action_name: str,
+) -> bool:
+    """Evaluate a single rule's ``when`` against ``context``.
+
+    Wraps :class:`CelEvaluationError` into
+    :class:`InstinctResolutionError` so callers have a single typed
+    exception to handle. Original cause is preserved on ``__cause__``
+    via the ``from exc`` chain.
+
+    A non-boolean result is coerced to ``bool`` — CEL ``when``
+    expressions are documented as predicates, so a truthy non-bool is
+    almost certainly an author mistake. We still accept it (the RFC
+    says nothing stricter) but downstream linters can flag it.
+    """
+    try:
+        result = evaluate_cel(rule.when, context, resolver, now=now)
+    except CelEvaluationError as exc:
+        raise InstinctResolutionError(
+            f"rule {rule.when!r} failed to evaluate while resolving action {action_name!r}: {exc}"
+        ) from exc
+    return bool(result)
+
+
+__all__ = [
+    "InstinctDecision",
+    "InstinctResolutionError",
+    "InstinctVerdict",
+    "resolve_instinct",
+]

--- a/tests/unit/test_instinct_composer.py
+++ b/tests/unit/test_instinct_composer.py
@@ -1,0 +1,474 @@
+# tests/unit/test_instinct_composer.py
+# Created: 2026-05-28 (feat/rfc-03-v2-instinct-exec) — unit tests for
+# the 5-step Instinct resolution composer
+# (``instinct_composer.resolve_instinct``). Pins the RFC 03 v2
+# resolution order, the ``block always wins`` invariant, and the
+# ``operator overlay can only escalate`` invariant. Worked examples A,
+# B, C from the RFC are pinned against the bundled
+# ``lease-renewal-v2.yaml`` fixture; synthetic templates cover edge
+# cases (no instinct_rules, action lookup miss, CEL eval failure).
+"""Tests for the Instinct 5-step resolution composer (RFC 03 v2 PR 2d).
+
+The composer is a pure library function: given a template, an action
+name, a row context, and (optionally) a workspace context, it returns
+a frozen ``InstinctDecision`` describing what the EE runtime should do
+next — BLOCK, ESCALATE_APPROVAL, EXECUTE, or NOTIFY_AND_EXECUTE.
+
+These tests pin:
+
+* The three RFC worked examples (A, B, C) end-to-end against the real
+  ``lease-renewal-v2.yaml`` fixture so the composer stays honest to
+  the spec's narrative.
+* The two RFC invariants:
+    - ``block always wins`` — a matching block rule short-circuits steps
+      2-5 even when an approval rule would also match.
+    - ``operator overlay can only escalate`` — top-level approval rules
+      can promote ``auto`` to ``ESCALATE_APPROVAL`` but cannot demote a
+      per-action ``require_approval`` floor.
+* Edge cases — missing action, CEL eval failure, empty / absent
+  ``instinct_rules``, notify rule capture, ``notify_only`` policy.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from pocketpaw.bundled_templates import (
+    InstinctDecision,
+    InstinctResolutionError,
+    PocketTemplate,
+    TemplateIdentifierResolver,
+    resolve_instinct,
+)
+
+# ---------------------------------------------------------------------------
+# Constants & helpers
+# ---------------------------------------------------------------------------
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent / "fixtures" / "templates" / "lease-renewal-v2.yaml"
+)
+
+# Fixed clock so ``within(...)`` is deterministic across the suite.
+FROZEN_NOW = datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC)
+
+
+def _load_lease_template() -> PocketTemplate:
+    """Load the canonical worked-example fixture."""
+    raw = yaml.safe_load(FIXTURE_PATH.read_text())
+    return PocketTemplate.model_validate(raw)
+
+
+def _row_with_all_rule_fields(**overrides: Any) -> dict[str, Any]:
+    """Return a row dict that satisfies every identifier referenced by
+    the fixture's ``instinct_rules.rules[]``. Tests override the bits
+    they care about.
+
+    The fixture's four rules reference ``rent_proposed``,
+    ``rent_current``, ``rent_proposed_delta_pct``,
+    ``tenant.late_payment_count_12mo``, ``expires_at``, and
+    ``renewal_stage``. Without every one of these present, step 2 (or
+    even step 1) will trip ``CelEvaluationError`` on a missing
+    identifier — that is the resolver's contract, not a composer bug.
+    """
+    base: dict[str, Any] = {
+        "rent_current": 2000.0,
+        "rent_proposed": 2050.0,
+        "rent_proposed_delta_pct": 2.5,
+        "renewal_stage": "draft",
+        "days_remaining": 60,
+        "expires_at": datetime(2026, 12, 1, tzinfo=UTC),
+        "tenant": {"late_payment_count_12mo": 0},
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# RFC worked examples — A, B, C
+# ---------------------------------------------------------------------------
+
+
+def test_worked_example_a_block_wins_over_auto() -> None:
+    """Example A — auto action ``mark_renewed`` blocked by top-level
+    rule ``rent_proposed < rent_current * 0.95``.
+
+    NOTE: the bundled fixture declares ``mark_renewed`` as
+    ``notify_only`` (not ``auto`` as in the RFC narrative). The block
+    rule fires in step 1 regardless of the per-action floor; this is
+    the ``block always wins`` invariant.
+    """
+    template = _load_lease_template()
+    row = _row_with_all_rule_fields(rent_proposed=1800.0, rent_current=2000.0)
+    decision = resolve_instinct(template, "mark_renewed", row, now=FROZEN_NOW)
+
+    assert decision.verdict == "BLOCK"
+    assert decision.reason == "blocked_by_rule"
+    assert decision.action_name == "mark_renewed"
+    assert len(decision.matched_rules) == 1
+    assert decision.matched_rules[0].action == "block"
+    # Side effects are not collected on BLOCK — step 1 short-circuits
+    # all later steps including notify gathering.
+    assert decision.notify_rules == []
+
+
+def test_worked_example_b_operator_overlay_escalates_auto() -> None:
+    """Example B — ``send_to_tenant`` declared ``require_approval`` in
+    the fixture; using a synthetic template that flips it to ``auto``
+    so the operator-overlay-escalates path is exercised independently
+    of the per-action floor."""
+    template = _load_lease_template()
+    # The fixture's send_to_tenant is require_approval (which is a
+    # FLOOR, not the path we want to exercise here). Mutate the
+    # in-memory model copy to auto so we exercise the overlay-promotes
+    # path cleanly.
+    actions = list(template.actions)
+    sti = next(i for i, a in enumerate(actions) if a.name == "send_to_tenant")
+    actions[sti] = actions[sti].model_copy(update={"instinct_policy": "auto"})
+    template = template.model_copy(update={"actions": actions})
+
+    row = _row_with_all_rule_fields(tenant={"late_payment_count_12mo": 4})
+    decision = resolve_instinct(template, "send_to_tenant", row, now=FROZEN_NOW)
+
+    assert decision.verdict == "ESCALATE_APPROVAL"
+    assert decision.reason == "operator_overlay_escalated"
+    # The matched rule is the second require_approval rule on the
+    # fixture (the first one is the rent-delta one which row B does
+    # not trigger).
+    assert any("late_payment_count_12mo" in r.when for r in decision.matched_rules), (
+        f"expected late-payment rule in matched_rules, got {decision.matched_rules}"
+    )
+
+
+def test_worked_example_c_require_approval_floor() -> None:
+    """Example C — ``bulk_draft`` declares ``instinct_policy:
+    require_approval``. No top-level rule matches. The per-action
+    floor escalates."""
+    template = _load_lease_template()
+    row = _row_with_all_rule_fields(
+        rent_proposed=2050.0,
+        rent_current=2000.0,
+        rent_proposed_delta_pct=2.5,
+        renewal_stage=None,
+        tenant={"late_payment_count_12mo": 1},
+    )
+    decision = resolve_instinct(template, "bulk_draft", row, now=FROZEN_NOW)
+
+    assert decision.verdict == "ESCALATE_APPROVAL"
+    assert decision.reason == "author_floor"
+    # No rule participated — step 2 matched nothing.
+    assert decision.matched_rules == []
+
+
+# ---------------------------------------------------------------------------
+# Per-action policy paths
+# ---------------------------------------------------------------------------
+
+
+def test_auto_action_no_rules_match_executes() -> None:
+    """``draft_renewal`` is auto. With a clean row, no rules match →
+    EXECUTE, reason ``auto``."""
+    template = _load_lease_template()
+    row = _row_with_all_rule_fields()
+    decision = resolve_instinct(template, "draft_renewal", row, now=FROZEN_NOW)
+
+    assert decision.verdict == "EXECUTE"
+    assert decision.reason == "auto"
+    assert decision.matched_rules == []
+
+
+def test_notify_only_policy_emits_notify_and_execute() -> None:
+    """``mark_renewed`` is notify_only. With a clean row (no block rule
+    matches, no approval rule matches) → step 3 picks notify_only →
+    verdict NOTIFY_AND_EXECUTE."""
+    template = _load_lease_template()
+    row = _row_with_all_rule_fields()
+    decision = resolve_instinct(template, "mark_renewed", row, now=FROZEN_NOW)
+
+    assert decision.verdict == "NOTIFY_AND_EXECUTE"
+    assert decision.reason == "notify_only"
+
+
+def test_notify_rule_matches_alongside_execute() -> None:
+    """A row that triggers the fixture's notify rule (within 7d of
+    expiry AND renewal_stage == null) and uses an auto action should
+    EXECUTE with notify_rules captured. Block / approval rules do not
+    match this row."""
+    template = _load_lease_template()
+    # within(expires_at, 7d) at FROZEN_NOW => expires_at must be inside
+    # 2026-05-21..2026-06-04. Pick a stage-null row.
+    row = _row_with_all_rule_fields(
+        expires_at=datetime(2026, 5, 30, tzinfo=UTC),
+        renewal_stage=None,
+        rent_proposed=2050.0,
+        rent_current=2000.0,
+        rent_proposed_delta_pct=2.5,
+        tenant={"late_payment_count_12mo": 0},
+    )
+    decision = resolve_instinct(template, "draft_renewal", row, now=FROZEN_NOW)
+
+    assert decision.verdict == "EXECUTE"
+    assert decision.reason == "auto"
+    # The notify rule on the fixture is rule index 3:
+    #   when: "within(expires_at, duration('7d')) && renewal_stage == null"
+    assert any(r.action == "notify" for r in decision.notify_rules), (
+        f"expected at least one notify rule, got {decision.notify_rules}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# RFC invariants
+# ---------------------------------------------------------------------------
+
+
+def test_block_always_wins_over_simultaneous_approval_rule() -> None:
+    """Row that matches BOTH the block rule AND an approval rule must
+    still return BLOCK. Step 1 short-circuits all later steps."""
+    template = _load_lease_template()
+    # rent_proposed < rent_current * 0.95 matches (block) AND
+    # tenant.late_payment_count_12mo >= 3 matches (approval).
+    row = _row_with_all_rule_fields(
+        rent_proposed=1800.0,
+        rent_current=2000.0,
+        tenant={"late_payment_count_12mo": 5},
+    )
+    decision = resolve_instinct(template, "draft_renewal", row, now=FROZEN_NOW)
+
+    assert decision.verdict == "BLOCK"
+    assert decision.reason == "blocked_by_rule"
+    # Only the block rule participates — approval rule must not show up
+    # in matched_rules because step 2 never ran.
+    assert all(r.action == "block" for r in decision.matched_rules)
+
+
+def test_operator_overlay_cannot_demote_require_approval_floor() -> None:
+    """``require_approval`` per-action policy with a clean row that
+    matches no top-level rule must still ESCALATE — the overlay never
+    runs (no match), so the per-action floor fires in step 3.
+
+    This pins the half of the invariant that says ``the overlay can
+    only escalate, never demote``. If a no-op step-2 silently
+    short-circuited to EXECUTE, this test would fail.
+    """
+    template = _load_lease_template()
+    row = _row_with_all_rule_fields()
+    decision = resolve_instinct(template, "send_to_tenant", row, now=FROZEN_NOW)
+
+    assert decision.verdict == "ESCALATE_APPROVAL"
+    assert decision.reason == "author_floor"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_action_raises_resolution_error() -> None:
+    template = _load_lease_template()
+    row = _row_with_all_rule_fields()
+    with pytest.raises(InstinctResolutionError) as excinfo:
+        resolve_instinct(template, "does_not_exist", row, now=FROZEN_NOW)
+    assert "does_not_exist" in str(excinfo.value)
+
+
+def test_cel_eval_failure_in_rule_raises_resolution_error() -> None:
+    """Missing identifier in a rule's ``when`` -> the underlying
+    ``CelEvaluationError`` is wrapped in ``InstinctResolutionError``
+    so callers have a single typed exception to handle."""
+    template = _load_lease_template()
+    # Omit ``rent_proposed_delta_pct`` so the first approval rule
+    # fails to resolve at eval time.
+    row = {
+        "rent_current": 2000.0,
+        "rent_proposed": 2050.0,
+        "renewal_stage": "draft",
+        "expires_at": datetime(2026, 12, 1, tzinfo=UTC),
+        "tenant": {"late_payment_count_12mo": 0},
+    }
+    with pytest.raises(InstinctResolutionError) as excinfo:
+        resolve_instinct(template, "draft_renewal", row, now=FROZEN_NOW)
+    # The original CelEvaluationError should be reachable.
+    assert excinfo.value.__cause__ is not None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def _minimal_template(**overrides: Any) -> PocketTemplate:
+    """Synthetic minimal template — no joined entities, single auto
+    action, optional instinct_rules override."""
+    data: dict[str, Any] = {
+        "schema_version": "2",
+        "name": "min-template",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "display_name": "Minimal",
+        "description": "Minimal template for composer tests.",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "id_field": "id",
+            "columns": [{"field": "id", "widget": "text"}, {"field": "flag", "widget": "text"}],
+        },
+        "actions": [
+            {"name": "go", "label": "Go", "kind": "single-row", "instinct_policy": "auto"},
+            {
+                "name": "require_go",
+                "label": "Require go",
+                "kind": "single-row",
+                "instinct_policy": "require_approval",
+            },
+            {
+                "name": "notify_go",
+                "label": "Notify go",
+                "kind": "single-row",
+                "instinct_policy": "notify_only",
+            },
+        ],
+    }
+    data.update(overrides)
+    return PocketTemplate.model_validate(data)
+
+
+def test_template_without_instinct_rules_flows_to_per_action_policy() -> None:
+    """When ``instinct_rules`` is None, steps 1 and 2 are skipped and
+    the decision is driven entirely by the per-action policy."""
+    template = _minimal_template()
+    # No row fields needed — no rules to evaluate.
+    decision = resolve_instinct(template, "go", {}, now=FROZEN_NOW)
+    assert decision.verdict == "EXECUTE"
+    assert decision.reason == "auto"
+
+    decision_req = resolve_instinct(template, "require_go", {}, now=FROZEN_NOW)
+    assert decision_req.verdict == "ESCALATE_APPROVAL"
+    assert decision_req.reason == "author_floor"
+
+    decision_notify = resolve_instinct(template, "notify_go", {}, now=FROZEN_NOW)
+    assert decision_notify.verdict == "NOTIFY_AND_EXECUTE"
+    assert decision_notify.reason == "notify_only"
+
+
+def test_template_with_empty_instinct_rules_list_behaves_like_none() -> None:
+    """``instinct_rules: { rules: [] }`` is the explicit-empty case —
+    same observable behaviour as the absent case."""
+    template = _minimal_template(
+        instinct_rules={"escalation": "lead", "rules": []},
+    )
+    decision = resolve_instinct(template, "go", {}, now=FROZEN_NOW)
+    assert decision.verdict == "EXECUTE"
+    assert decision.reason == "auto"
+
+
+def test_bulk_action_decision_shape_matches_single_row() -> None:
+    """``kind: bulk`` does not change the composer's shape — PR 2e
+    handles fan-out; PR 2d just answers ``what would happen for this
+    row``."""
+    template = _load_lease_template()
+    row = _row_with_all_rule_fields(
+        rent_proposed=2050.0,
+        rent_current=2000.0,
+        rent_proposed_delta_pct=2.5,
+        renewal_stage="draft",
+        tenant={"late_payment_count_12mo": 1},
+    )
+    decision = resolve_instinct(template, "bulk_draft", row, now=FROZEN_NOW)
+
+    assert decision.verdict == "ESCALATE_APPROVAL"
+    assert decision.reason == "author_floor"
+    assert decision.action_name == "bulk_draft"
+
+
+def test_workspace_context_merge_row_wins_on_collision() -> None:
+    """Workspace context is merged in; row context wins on a collision
+    so per-row data is never silently shadowed by workspace defaults."""
+    template = _minimal_template(
+        instinct_rules={
+            "escalation": "lead",
+            "rules": [{"when": "flag == 'block_me'", "action": "block"}],
+        },
+    )
+
+    # workspace says flag='ok'; row overrides flag='block_me'.
+    decision = resolve_instinct(
+        template,
+        "go",
+        {"flag": "block_me"},
+        workspace_context={"flag": "ok"},
+        now=FROZEN_NOW,
+    )
+    assert decision.verdict == "BLOCK"
+
+    # workspace says block; row says ok → row wins, no block.
+    decision_ok = resolve_instinct(
+        template,
+        "go",
+        {"flag": "ok"},
+        workspace_context={"flag": "block_me"},
+        now=FROZEN_NOW,
+    )
+    assert decision_ok.verdict == "EXECUTE"
+
+
+def test_decision_is_frozen() -> None:
+    """``InstinctDecision`` is immutable — callers cannot mutate fields
+    in place. Pins the design choice in the brief."""
+    template = _minimal_template()
+    decision = resolve_instinct(template, "go", {}, now=FROZEN_NOW)
+    assert isinstance(decision, InstinctDecision)
+    with pytest.raises((TypeError, ValueError)):
+        decision.verdict = "BLOCK"  # type: ignore[misc]
+
+
+def test_custom_resolver_can_be_injected() -> None:
+    """Callers can override the default resolver (e.g. PR 2g's future
+    Fabric resolver). Pin by passing a stub that returns a constant."""
+    sentinel = "stub"
+
+    class _StubResolver:
+        def resolve(self, path: str, context: dict[str, Any]) -> Any:  # noqa: ARG002
+            # Return ``sentinel`` for any identifier — the test
+            # expression ``flag == 'stub'`` becomes True.
+            return sentinel
+
+    template_with_rule = _minimal_template(
+        instinct_rules={
+            "escalation": "lead",
+            "rules": [{"when": "flag == 'stub'", "action": "require_approval"}],
+        },
+    )
+    decision = resolve_instinct(
+        template_with_rule,
+        "go",
+        {},
+        resolver=_StubResolver(),
+        now=FROZEN_NOW,
+    )
+    assert decision.verdict == "ESCALATE_APPROVAL"
+    assert decision.reason == "operator_overlay_escalated"
+
+
+def test_default_resolver_used_when_none_passed() -> None:
+    """If ``resolver`` is None, the composer constructs a default
+    ``TemplateIdentifierResolver(template.state)``. Pin by exercising
+    a row that depends on the resolver's column-aware logic."""
+    template = _minimal_template()
+    # ``flag`` is a declared column on the minimal template, so the
+    # default resolver looks it up in the row dict.
+    template_with_rule = _minimal_template(
+        instinct_rules={
+            "escalation": "lead",
+            "rules": [{"when": "flag == 'go'", "action": "block"}],
+        },
+    )
+    decision = resolve_instinct(template_with_rule, "go", {"flag": "go"}, now=FROZEN_NOW)
+    assert decision.verdict == "BLOCK"
+    # And the default resolver class is TemplateIdentifierResolver.
+    assert isinstance(TemplateIdentifierResolver(template.state), TemplateIdentifierResolver)


### PR DESCRIPTION
# PR 2d: Instinct 5-step resolution composer (RFC 03 v2)

## Summary

Adds the RFC 03 v2 Instinct resolution composer as an OSS-side pure library function. Given a `PocketTemplate`, an action name, and a row context, `resolve_instinct(...)` walks the 5-step order from RFC §"Instinct resolution order" and returns a frozen `InstinctDecision` the EE runtime can dispatch on (`BLOCK` / `ESCALATE_APPROVAL` / `EXECUTE` / `NOTIFY_AND_EXECUTE`).

This PR ships the decision logic only. The actual approval-queue plumbing, action invocation, and outcome emission live in `ee/cloud/pockets/` and are wired in a follow-up PR. PR 2d is the pure function that the EE runtime calls.

## Why it matters

RFC 03 v2's Instinct policy is the single contract that holds the template's author intent and the operator's runtime overlay together. The composer is what makes that contract observable: every action fire goes through the same 5 steps, every row gets the same deterministic verdict, and the two RFC invariants (`block always wins` and `operator overlay can only escalate`) are enforced by the early-return shape of `resolve_instinct`. Not by ad-hoc checks sprinkled across the runtime.

## Scope

INCLUDED:

- `src/pocketpaw/bundled_templates/instinct_composer.py`. New module. Implements `resolve_instinct(...)`, `InstinctDecision` (frozen Pydantic v2 model), `InstinctResolutionError`.
- `src/pocketpaw/bundled_templates/__init__.py`. Re-exports.
- `tests/unit/test_instinct_composer.py`. 17 unit tests covering the three RFC worked examples, both invariants, all per-action policies, error paths, and edge cases.

EXCLUDED (separate PRs):

- Bulk action fan-out runtime → PR 2e. The composer's decision shape is the same for bulk actions; fan-out is the consumer's job.
- Temporal trigger sweeper → PR 2f. The same composer is what the sweeper consumes per row.
- Actual approval-queue plumbing / action invocation / outcome emission → lives in `ee/cloud/pockets/`. Wired in a follow-up PR.
- Fabric `tier: registered` enforcement → PR 2g. The composer accepts any `IdentifierResolver`; PR 2g's resolver does the strict check without changing this code path.

## Resolution order (verbatim)

1. **block rules**: first match returns `BLOCK` and short-circuits.
2. **approval rules**: any match returns `ESCALATE_APPROVAL` with reason `operator_overlay_escalated`.
3. **per-action policy**: `auto` falls through; `require_approval` escalates with reason `author_floor`; `notify_only` falls through and flips the final verdict to `NOTIFY_AND_EXECUTE`.
4. **execute**: the composer returns the verdict; the EE runtime dispatches.
5. **side effects**: notify rules whose `when` matches are returned on the decision so the EE runtime can fan them out in parallel with the action invocation.

## Design notes

- **Pure, no I/O.** Stays OSS-side. No `pocketpaw_ee` imports. The OSS import-linter contract enforces it.
- **`InstinctDecision` is immutable** via `ConfigDict(frozen=True)`. Callers can pass decisions through audit and serialization layers without worrying about downstream mutation.
- **Row context wins on collision** with workspace context when the two are merged for CEL evaluation. Per-row data is never silently shadowed by workspace defaults.
- **CEL eval failures wrap as `InstinctResolutionError`**, preserving the original `CelEvaluationError` on `__cause__`. Single typed exception for callers, full diagnostic chain intact.
- **Default resolver** is `TemplateIdentifierResolver(template.state)`. Callers can override (PR 2g's future `FabricResolver`).

## Dependencies

Depends on PR 2c (CEL evaluator + `IdentifierResolver`, pocketpaw#1269). PR 2c is brought into this branch via merge of `origin/feat/rfc-03-v2-cel-eval` so the composer can consume `evaluate_cel`. Once PR 2c lands on integration, this PR's base auto-rebases cleanly.

## Tests

```
$ uv run pytest tests/unit/test_instinct_composer.py
17 passed in 0.20s

$ uv run pytest tests/unit/test_instinct_composer.py \
                tests/unit/test_cel_runtime.py \
                tests/unit/test_identifier_resolver.py
38 passed in 0.37s
```

The three RFC worked examples are pinned end-to-end against the real `lease-renewal-v2.yaml` fixture:

- **A**: an auto / notify_only action blocked by a top-level rule `rent_proposed < rent_current * 0.95` returns `BLOCK` with reason `blocked_by_rule`.
- **B**: an auto action promoted to approval by overlay rule `tenant.late_payment_count_12mo >= 3` returns `ESCALATE_APPROVAL` with reason `operator_overlay_escalated`.
- **C**: a `require_approval` per-action floor with no rule match returns `ESCALATE_APPROVAL` with reason `author_floor`.

Plus dedicated tests for both RFC invariants (`block always wins` even when an approval rule would also match; the `require_approval` floor is never demoted by a no-match step 2), the three per-action policies, the unknown-action and CEL-eval-failure error paths, empty or absent `instinct_rules`, workspace-vs-row context merge, frozen decision shape, and custom-resolver injection.

## Test plan

- [x] All 17 new unit tests pass locally
- [x] PR 2c's 14 CEL-runtime tests still pass as adjacent regression
- [x] PR 2c's 7 identifier-resolver tests still pass
- [x] Broader bundled_templates suite (113 tests) still passes
- [x] ruff check + ruff format --check both pass
- [x] mypy clean on the new module
- [x] Smoke-tested the three RFC worked examples end-to-end against the lease-renewal-v2.yaml fixture

## Follow-ups

- PR 2e: bulk action fan-out runtime (consumes this composer per row; one approval blesses the whole batch per RFC §"Bulk action execution model").
- PR 2f: temporal trigger sweeper (consumes this composer per row on cron + per-row state).
- PR 2g: Fabric `tier: registered` enforcement (swaps in a Fabric-backed `IdentifierResolver`; no composer change needed).
- EE-side wiring (approval queue persistence, action invocation, outcome emission). Tracked separately.
