### PR TITLE
feat(fabric): tier:registered enforcement + FabricResolver for RFC 03 v2

### DIFF
--- a/src/pocketpaw/bundled_templates/__init__.py
+++ b/src/pocketpaw/bundled_templates/__init__.py
@@ -24,6 +24,13 @@
 # temporal trigger sweeper (``sweep_temporal_triggers``, ``SweepResult``,
 # ``TemporalRisingEdge``, ``TemporalSweepError``). PR 2f is the pure
 # OSS-side decision function the EE sweeper calls on each tick.
+# Modified 2026-05-28 (feat/rfc-03-v2-fabric): re-exports the Fabric
+# tier-registered surface — ``FabricRegistry`` Protocol +
+# ``NullFabricRegistry`` no-op default, ``FabricResolver`` (strict
+# runtime resolver), ``FabricValidationError`` and
+# ``validate_template_with_registry`` (lint entry point). The concrete
+# EE-side ``FabricRegistry`` implementation lives in ``ee/fabric/`` and
+# is supplied at wiring time; PR 2g is OSS library-only.
 """Built-in pocket templates bundled and auto-installed by PocketPaw.
 
 Third sibling to ``pocketpaw.bundled_skills`` and ``pocketpaw.bundled_kb``.
@@ -67,10 +74,20 @@ directories via iteration — no installer code changes needed.
 
 from pocketpaw.bundled_templates.cel_runtime import (
     CelEvaluationError,
+    collect_free_identifiers,
     evaluate_cel,
 )
 from pocketpaw.bundled_templates.compile import compile_template
 from pocketpaw.bundled_templates.errors import TemplateValidationError
+from pocketpaw.bundled_templates.fabric_registry import (
+    FabricRegistry,
+    NullFabricRegistry,
+)
+from pocketpaw.bundled_templates.fabric_resolver import FabricResolver
+from pocketpaw.bundled_templates.fabric_validator import (
+    FabricValidationError,
+    validate_template_with_registry,
+)
 from pocketpaw.bundled_templates.identifier_resolver import (
     IdentifierResolver,
     TemplateIdentifierResolver,
@@ -115,6 +132,9 @@ __all__ = [
     "ColumnDef",
     "ConfirmDef",
     "DataSourceDef",
+    "FabricRegistry",
+    "FabricResolver",
+    "FabricValidationError",
     "IdentifierResolver",
     "InstinctDecision",
     "InstinctResolutionError",
@@ -122,6 +142,7 @@ __all__ = [
     "InstinctRulesDef",
     "InstinctVerdict",
     "JoinedEntity",
+    "NullFabricRegistry",
     "PermissionsDef",
     "PocketTemplate",
     "SavedView",
@@ -133,10 +154,12 @@ __all__ = [
     "TemporalRisingEdge",
     "TemporalSweepError",
     "TriggerDef",
+    "collect_free_identifiers",
     "compile_template",
     "evaluate_cel",
     "install_bundled_templates",
     "load_template",
     "resolve_instinct",
     "sweep_temporal_triggers",
+    "validate_template_with_registry",
 ]

--- a/src/pocketpaw/bundled_templates/cel_runtime.py
+++ b/src/pocketpaw/bundled_templates/cel_runtime.py
@@ -280,7 +280,34 @@ def _to_python(value: Any) -> Any:
     return value
 
 
+def collect_free_identifiers(expression: str) -> list[str]:
+    """Parse ``expression`` as CEL and return its leftmost-segment
+    free identifiers in source order, deduplicated.
+
+    Public helper for lint-side consumers (PR 2g's
+    :func:`fabric_validator.validate_template_with_registry`) that need
+    the same identifier set the evaluator walks at runtime — without
+    having to import any celpy types or duplicate the AST walker.
+
+    Returns an empty list for expressions that fail to parse; the
+    schema chokepoint (:class:`pocketpaw.bundled_templates.expressions.CelExpression`)
+    already rejects malformed CEL at validation time, so a parse error
+    here means a caller has fed in an unvalidated string and shouldn't
+    block validation on that case.
+    """
+    # Lazy import — same rationale as in ``evaluate_cel``.
+    import celpy  # noqa: PLC0415
+
+    env = celpy.Environment()
+    try:
+        ast = env.compile(expression)
+    except Exception:  # noqa: BLE001 — celpy raises a wide hierarchy
+        return []
+    return _collect_free_identifiers(ast)
+
+
 __all__ = [
     "CelEvaluationError",
+    "collect_free_identifiers",
     "evaluate_cel",
 ]

--- a/src/pocketpaw/bundled_templates/fabric_registry.py
+++ b/src/pocketpaw/bundled_templates/fabric_registry.py
@@ -1,0 +1,128 @@
+# src/pocketpaw/bundled_templates/fabric_registry.py
+# Created: 2026-05-28 (feat/rfc-03-v2-fabric) — Protocol for the Fabric
+# ObjectType / FabricLink registry. RFC 03 v2's ``tier: registered``
+# enforcement gates schema references through this Protocol; the
+# concrete registry lives in ``ee/fabric/`` and is supplied at runtime
+# wiring time. PR 2g ships the OSS-side library + the ``NullFabricRegistry``
+# no-op default; the EE-side concrete implementation is a separate,
+# out-of-tree change.
+"""Protocol seam between RFC 03 v2 OSS-side enforcement and the EE
+Fabric ObjectType registry.
+
+The pattern
+-----------
+
+PocketPaw is an open-core project. The Fabric ObjectType / FabricLink
+registry — the source of truth for which entity types exist and which
+links connect them — lives in the enterprise package (``ee/fabric/``)
+and is not part of the OSS wheel. The OSS schema layer still needs to
+ask *some* registry "does this entity type exist? does this link
+exist?" so RFC 03 v2's ``tier: registered`` enforcement can fail
+templates loudly at lint / runtime time.
+
+The :class:`FabricRegistry` Protocol is that seam:
+
+* OSS code (the validator and the :class:`FabricResolver`) **consumes**
+  the Protocol — never imports a concrete registry.
+* EE code provides a concrete implementation that walks the live
+  ObjectType graph.
+* For OSS-only environments (developer machines, library tests,
+  CLI ``template lint`` with no Fabric wired), :class:`NullFabricRegistry`
+  is a no-op default that returns ``False`` for every query. Templates
+  that don't declare joins (synthetic-tier) stay clean; templates that
+  declare joins get flagged — which is the right behaviour, since you
+  can't satisfy ``tier: registered`` without a registry to register
+  against.
+
+Surface area
+------------
+
+The Protocol is deliberately minimal. Three methods cover every check
+RFC 03 v2's library layer needs today:
+
+* :meth:`entity_type_exists` — does the registry know ``name``?
+* :meth:`link_exists` — does a link ``link_name`` connect ``from_type``
+  to ``to_type``?
+* :meth:`get_entity_properties` — which property names does the entity
+  type declare? (Reserved for a future property-level lint that PR 2g
+  does not enable yet — it ships so EE implementations can populate
+  the data without another Protocol change later.)
+
+Adding methods is a Protocol change. Keep the surface small until a
+real consumer needs more.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class FabricRegistry(Protocol):
+    """Read-only view of the Fabric ObjectType / FabricLink registry.
+
+    Implementations are supplied at wiring time. The OSS-side
+    :func:`validate_template_with_registry` and :class:`FabricResolver`
+    both consume the Protocol but never import a concrete class.
+
+    The Protocol is :func:`typing.runtime_checkable` so callers can
+    assert ``isinstance(reg, FabricRegistry)`` in tests / wiring code
+    without pulling in a concrete dependency.
+    """
+
+    def entity_type_exists(self, name: str) -> bool:
+        """Return True iff the registry knows an ObjectType called
+        ``name``."""
+        ...
+
+    def link_exists(self, from_type: str, to_type: str, link_name: str) -> bool:
+        """Return True iff a FabricLink called ``link_name`` connects
+        ``from_type`` -> ``to_type``."""
+        ...
+
+    def get_entity_properties(self, name: str) -> set[str]:
+        """Return the declared property names of the ObjectType
+        ``name``. Implementations that don't track properties may
+        return an empty set; PR 2g does not require property-level
+        lint, so the validator tolerates ``set()`` everywhere."""
+        ...
+
+
+class NullFabricRegistry:
+    """No-op :class:`FabricRegistry` — the default when no Fabric is
+    wired.
+
+    Every query returns ``False`` / ``set()``. Consequences:
+
+    * Synthetic-tier templates (no dot-paths, no joined_entities) lint
+      clean — there is nothing to register, so a "miss" is not raised.
+    * Registered-tier templates fail every check. That is the correct
+      diagnostic: a template that demands joins cannot satisfy
+      ``tier: registered`` without a real registry behind it.
+
+    Using ``NullFabricRegistry`` as a placeholder lets the rest of the
+    stack (CLI, runtime composer, tests) keep a single Protocol type
+    in their signatures regardless of whether Fabric is wired.
+    """
+
+    __slots__ = ()
+
+    def entity_type_exists(self, name: str) -> bool:  # noqa: ARG002
+        return False
+
+    def link_exists(  # noqa: ARG002
+        self,
+        from_type: str,
+        to_type: str,
+        link_name: str,
+    ) -> bool:
+        return False
+
+    def get_entity_properties(self, name: str) -> set[str]:  # noqa: ARG002
+        return set()
+
+
+__all__ = [
+    "FabricRegistry",
+    "NullFabricRegistry",
+]

--- a/src/pocketpaw/bundled_templates/fabric_resolver.py
+++ b/src/pocketpaw/bundled_templates/fabric_resolver.py
@@ -1,0 +1,163 @@
+# src/pocketpaw/bundled_templates/fabric_resolver.py
+# Created: 2026-05-28 (feat/rfc-03-v2-fabric) — strict
+# :class:`IdentifierResolver` for RFC 03 v2's ``tier: registered``
+# enforcement. Drop-in replacement for the PR 2c reference resolver
+# (:class:`TemplateIdentifierResolver`) that additionally validates
+# every declared join against a :class:`FabricRegistry`. The CEL
+# evaluator (``cel_runtime.evaluate_cel``) consumes both resolvers
+# through the shared Protocol — no evaluator change needed.
+"""Strict :class:`IdentifierResolver` keyed off a
+:class:`FabricRegistry`.
+
+Compared to PR 2c's :class:`TemplateIdentifierResolver`, this resolver
+layers two extra gates:
+
+* A leading segment is recognised as a *dotted root* either because
+  it appears in ``state.joined_entities[].name`` OR because it shows
+  up as the leading-segment of any ``state.columns[].field`` dot-path.
+  Dotted roots that aren't declared in ``joined_entities`` raise
+  ``KeyError`` naming the undeclared join — context fallback is
+  rejected for them.
+* Declared joins that ARE in ``joined_entities`` are still gated by
+  the registry: the resolver calls ``registry.link_exists(state.entity_type,
+  joined.entity_type, joined.via_link)`` and raises if the registry
+  says no.
+
+Flat identifiers (those that aren't recognised as dotted roots by
+either signal) fall through to plain context lookup — same loose
+behaviour as the PR 2c reference resolver. This keeps free-variable
+CEL helpers (e.g. ``within(field, duration)`` whose first argument is
+a property name not declared as a column) working without false
+positives.
+
+This is the runtime-side enforcement. The lint-side complement is
+:func:`validate_template_with_registry` in :mod:`fabric_validator` —
+same Protocol, different call site, broader coverage (entity types,
+column fields, every CEL expression on the template).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pocketpaw.bundled_templates.fabric_registry import FabricRegistry
+from pocketpaw.bundled_templates.schema import PocketTemplate, StateBinding
+
+
+def _collect_column_dot_roots(state: StateBinding) -> frozenset[str]:
+    """Leading-segment set extracted from ``state.columns[].field``
+    entries that contain a dot. Used to recognise dotted-root usage
+    even when the join isn't declared — that mismatch is the canonical
+    ``tier: registered`` lint failure surfacing at runtime."""
+    roots: set[str] = set()
+    for col in state.columns:
+        if "." in col.field:
+            roots.add(col.field.split(".", 1)[0])
+    return frozenset(roots)
+
+
+class FabricResolver:
+    """Strict :class:`IdentifierResolver` gated by a
+    :class:`FabricRegistry`.
+
+    Constructor accepts either a full :class:`PocketTemplate` or just
+    its inner :class:`StateBinding` (the latter is convenient for the
+    runtime composer that only carries the state block).
+
+    Raises
+    ------
+    KeyError
+        For every failure mode — undeclared join, unregistered link,
+        missing context. The CEL evaluator catches ``KeyError`` and
+        wraps it in a typed
+        :class:`pocketpaw.bundled_templates.cel_runtime.CelEvaluationError`,
+        so callers see consistent diagnostics regardless of resolver.
+
+    Notes
+    -----
+    The registry is consulted on **every** dotted-root lookup. For
+    long-running runtimes (the Instinct sweeper, the temporal trigger
+    loop), implementations of :class:`FabricRegistry` should cache
+    internally — this class deliberately does not cache because the
+    registry may swap out under it (a workspace re-mount, an EE
+    feature flag toggle).
+    """
+
+    __slots__ = ("_column_dot_roots", "_entity_type", "_joins_by_name", "_registry")
+
+    def __init__(
+        self,
+        template_or_state: PocketTemplate | StateBinding,
+        registry: FabricRegistry,
+    ) -> None:
+        state = (
+            template_or_state.state
+            if isinstance(template_or_state, PocketTemplate)
+            else template_or_state
+        )
+        self._entity_type: str = state.entity_type
+        # Index by name once — the resolver fires on every expression
+        # evaluation, so the O(1) lookup matters under the temporal
+        # sweeper / instinct loops.
+        self._joins_by_name = {j.name: j for j in state.joined_entities}
+        self._column_dot_roots = _collect_column_dot_roots(state)
+        self._registry: FabricRegistry = registry
+
+    def resolve(self, path: str, context: dict[str, Any]) -> Any:
+        """Resolve a leftmost-segment identifier.
+
+        Contract matches the
+        :class:`~pocketpaw.bundled_templates.identifier_resolver.IdentifierResolver`
+        Protocol so this class drops into ``evaluate_cel`` wherever
+        :class:`TemplateIdentifierResolver` does.
+        """
+        # Defensive guard mirroring the reference resolver — a
+        # misbehaving evaluator might pass a full dot-path; surface
+        # the bug rather than silently doing the wrong thing.
+        if "." in path:
+            raise KeyError(
+                f"FabricResolver expects leftmost segments, not full dot-paths; got {path!r}"
+            )
+
+        join = self._joins_by_name.get(path)
+        if join is not None:
+            # Declared-join case. Validate via the registry FIRST so
+            # an unregistered link surfaces even when the row context
+            # happens to carry the join inline (lint-time strictness
+            # at runtime).
+            if not self._registry.link_exists(self._entity_type, join.entity_type, join.via_link):
+                raise KeyError(
+                    f"via_link not registered: {join.via_link!r} on "
+                    f"{self._entity_type}->{join.entity_type}"
+                )
+            if path not in context:
+                raise KeyError(
+                    f"declared joined entity {path!r} (via {join.via_link!r}) "
+                    f"is missing from the row context"
+                )
+            return context[path]
+
+        if path in self._column_dot_roots:
+            # The template uses ``path`` as a dotted root somewhere
+            # (a column field like ``vendor.name``), but never
+            # declared a matching ``joined_entities`` entry. That's
+            # the canonical ``tier: registered`` runtime miss.
+            raise KeyError(
+                f"undeclared join: {path!r} is used as a dotted root in "
+                f"state.columns[] but is not declared in state.joined_entities[]"
+            )
+
+        # Flat case. Fall through to plain context lookup — same loose
+        # behaviour as PR 2c's reference resolver. Keeps free-variable
+        # CEL helpers working without false positives.
+        if path not in context:
+            raise KeyError(
+                f"identifier {path!r} is not declared on the template and "
+                f"is absent from the row context"
+            )
+        return context[path]
+
+
+__all__ = [
+    "FabricResolver",
+]

--- a/src/pocketpaw/bundled_templates/fabric_validator.py
+++ b/src/pocketpaw/bundled_templates/fabric_validator.py
@@ -1,0 +1,338 @@
+# src/pocketpaw/bundled_templates/fabric_validator.py
+# Created: 2026-05-28 (feat/rfc-03-v2-fabric) — lint-time
+# ``tier: registered`` enforcement for RFC 03 v2 templates. Public entry
+# point ``validate_template_with_registry`` collects every miss as a
+# typed :class:`FabricValidationError` and returns them to the caller
+# (CLI ``template lint`` in a follow-up PR) instead of raising — the
+# caller renders all problems at once. Pure / referentially transparent
+# function — no I/O, no module state. The runtime-side complement is
+# :class:`fabric_resolver.FabricResolver`.
+"""Lint-time enforcement of RFC 03 v2 ``tier: registered`` policies.
+
+The validator answers two questions about a :class:`PocketTemplate`:
+
+1. Does the registry know every entity type and every via_link the
+   template references?
+2. Does every dotted identifier in the template's CEL expressions and
+   column fields trace back to a declared ``state.joined_entities[]``
+   entry?
+
+Templates that demand none of the above — no dot-paths in columns, no
+joined entities, no dotted CEL roots — are treated as synthetic-tier
+and pass through cleanly even against an empty / null registry.
+
+Why return a list, not raise
+----------------------------
+
+A real lint surface (CLI, IDE, CI) wants to render every problem at
+once. Raising on the first miss makes authors play whack-a-mole. The
+:func:`validate_template_with_registry` function returns
+``list[FabricValidationError]`` — empty on success — so the caller can
+sort / group / link to docs and render the whole batch.
+
+Severity surface
+----------------
+
+Every error currently ships ``severity='error'``. The
+:class:`FabricValidationError` model carries the field so a future
+extension (e.g. warning when a registered entity exists but a property
+is unrecognised) can land without rewriting the contract.
+
+Public surface
+--------------
+
+* :class:`FabricValidationError` — frozen Pydantic v2 model with
+  ``message``, ``path``, ``severity``, and ``data``.
+* :func:`validate_template_with_registry` — lint entry point.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pocketpaw.bundled_templates.cel_runtime import collect_free_identifiers
+from pocketpaw.bundled_templates.fabric_registry import FabricRegistry
+from pocketpaw.bundled_templates.schema import PocketTemplate
+
+Severity = Literal["error", "warning"]
+
+
+class FabricValidationError(BaseModel):
+    """One Fabric-tier lint finding.
+
+    Frozen so callers can put findings in sets / sort keys without
+    accidentally mutating them mid-render. ``data`` is a typed-loose
+    dict to keep the schema additive — new payload fields (column
+    index, expression source span, registry suggestion) can land
+    without bumping the contract.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    message: str = Field(..., description="Human-readable lint message.")
+    path: str = Field(
+        ...,
+        description="Dotted JSON-path into the template where the miss applies.",
+    )
+    severity: Severity = Field(default="error")
+    data: dict[str, Any] = Field(default_factory=dict)
+
+
+def validate_template_with_registry(
+    template: PocketTemplate,
+    registry: FabricRegistry,
+) -> list[FabricValidationError]:
+    """Return every Fabric-tier lint finding for ``template`` against
+    ``registry``.
+
+    Empty list = clean. The function never raises on a lint miss —
+    only on programmer errors (e.g. passing in something that isn't a
+    :class:`PocketTemplate`, which Pydantic will catch at the boundary
+    of any caller that respects the type hint).
+    """
+    state = template.state
+    errors: list[FabricValidationError] = []
+
+    # ------------------------------------------------------------------
+    # Step 1 — collect every CEL expression on the template AND identify
+    # the leading segments each one uses. Walk once so the synthetic-tier
+    # detection and the per-expression lint share the same data.
+    # ------------------------------------------------------------------
+    cel_sites = _collect_cel_sites(template)
+
+    # Combine: any expression that uses a dotted root? Plus any column
+    # that uses a dotted field. Plus any declared joined entity. Any of
+    # these signals registered-tier intent.
+    column_dot_roots: set[str] = {c.field.split(".", 1)[0] for c in state.columns if "." in c.field}
+    declared_joins: set[str] = {j.name for j in state.joined_entities}
+    cel_dot_roots: set[str] = set()
+    for site in cel_sites:
+        for ident in site.identifiers:
+            # CEL identifiers are returned as leftmost segments only —
+            # we can't tell from the identifier alone whether the
+            # expression used it as a dot-root or as a flat name. But
+            # combined with the structural signals (column dot-paths,
+            # joined entities), we have enough to tag "registered-tier
+            # intent."
+            if ident in column_dot_roots or ident in declared_joins:
+                cel_dot_roots.add(ident)
+
+    uses_dot_paths = bool(column_dot_roots) or bool(declared_joins) or bool(cel_dot_roots)
+
+    # ------------------------------------------------------------------
+    # Step 2 — primary state.entity_type check.
+    # Only fires for registered-tier templates so synthetic ones (no
+    # dots, no joins) don't trip on a Null / empty registry.
+    # ------------------------------------------------------------------
+    if uses_dot_paths and not registry.entity_type_exists(state.entity_type):
+        errors.append(
+            FabricValidationError(
+                message=(
+                    f"unknown entity_type: {state.entity_type!r} is not "
+                    f"registered in the Fabric registry"
+                ),
+                path="state.entity_type",
+                severity="error",
+                data={"entity_type": state.entity_type},
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Step 3 — joined_entities[]: entity_type known + via_link registered.
+    # ------------------------------------------------------------------
+    for i, je in enumerate(state.joined_entities):
+        path_prefix = f"state.joined_entities[{i}]"
+        if not registry.entity_type_exists(je.entity_type):
+            errors.append(
+                FabricValidationError(
+                    message=(
+                        f"unknown joined entity_type: {je.entity_type!r} on "
+                        f"joined_entities[{i}] (name={je.name!r})"
+                    ),
+                    path=f"{path_prefix}.entity_type",
+                    severity="error",
+                    data={
+                        "name": je.name,
+                        "entity_type": je.entity_type,
+                        "index": i,
+                    },
+                )
+            )
+        # via_link check fires independently — even if the entity_type
+        # is known, the link between primary and join may not be.
+        if not registry.link_exists(state.entity_type, je.entity_type, je.via_link):
+            errors.append(
+                FabricValidationError(
+                    message=(
+                        f"via_link not registered: {je.via_link!r} on "
+                        f"{state.entity_type}->{je.entity_type} "
+                        f"(joined_entities[{i}].name={je.name!r})"
+                    ),
+                    path=f"{path_prefix}.via_link",
+                    severity="error",
+                    data={
+                        "name": je.name,
+                        "via_link": je.via_link,
+                        "from_type": state.entity_type,
+                        "to_type": je.entity_type,
+                        "index": i,
+                    },
+                )
+            )
+
+    # ------------------------------------------------------------------
+    # Step 4 — column ``field`` dot-paths: leading segment must be in
+    # ``joined_entities``.
+    # ------------------------------------------------------------------
+    for i, col in enumerate(state.columns):
+        if "." not in col.field:
+            continue
+        leading = col.field.split(".", 1)[0]
+        if leading not in declared_joins:
+            errors.append(
+                FabricValidationError(
+                    message=(
+                        f"undeclared dotted root {leading!r} in "
+                        f"state.columns[{i}].field={col.field!r}; declare it "
+                        f"in state.joined_entities[]"
+                    ),
+                    path=f"state.columns[{i}].field",
+                    severity="error",
+                    data={
+                        "leading_segment": leading,
+                        "field": col.field,
+                        "index": i,
+                    },
+                )
+            )
+
+    # ------------------------------------------------------------------
+    # Step 5 — every CEL expression on the template: each free identifier
+    # that is NOT a declared join AND not present in the column-field
+    # set could be either a flat field or an undeclared dotted root.
+    # We use a conservative rule: emit a lint error only when the
+    # identifier is *also* mentioned as a dotted root somewhere on the
+    # template (i.e. either a column with ``ident.X`` OR a CEL expression
+    # uses it as a dotted root by virtue of appearing in another column).
+    # That cross-signal keeps false positives low for plain flat CEL
+    # references like ``days_remaining``.
+    #
+    # In practice the validator surfaces *most* undeclared-root cases
+    # via the column-field path (Step 4). The CEL pass is the safety
+    # net for expressions like ``ghost.attribute`` where the dotted
+    # usage lives only inside the expression.
+    # ------------------------------------------------------------------
+    flat_column_names = {c.field for c in state.columns if "." not in c.field}
+    for site in cel_sites:
+        for ident in site.identifiers:
+            if ident in declared_joins:
+                continue
+            if ident in flat_column_names:
+                continue
+            # Heuristic for "ident is used as a dotted root in this
+            # expression": parse the raw expression text for ``ident.``
+            # — the CEL grammar guarantees the dot must directly follow
+            # the identifier with no whitespace in member access.
+            if f"{ident}." in site.expression:
+                errors.append(
+                    FabricValidationError(
+                        message=(
+                            f"undeclared dotted root {ident!r} used in "
+                            f"{site.path}={site.expression!r}; declare it in "
+                            f"state.joined_entities[]"
+                        ),
+                        path=site.path,
+                        severity="error",
+                        data={
+                            "leading_segment": ident,
+                            "expression": site.expression,
+                        },
+                    )
+                )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+class _CelSite(BaseModel):
+    """One CEL expression collected from the template, with its parsed
+    identifier set and the dotted JSON-path back to its source."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    expression: str
+    path: str
+    identifiers: tuple[str, ...]
+
+
+def _collect_cel_sites(template: PocketTemplate) -> list[_CelSite]:
+    """Walk every CEL-bearing field on the template and return one
+    :class:`_CelSite` per expression. The order matches the JSON-path
+    order so error rendering is deterministic."""
+    sites: list[_CelSite] = []
+
+    # state.columns[].filter
+    for i, col in enumerate(template.state.columns):
+        if col.filter is not None:
+            sites.append(
+                _CelSite(
+                    expression=col.filter,
+                    path=f"state.columns[{i}].filter",
+                    identifiers=tuple(collect_free_identifiers(col.filter)),
+                )
+            )
+
+    # state.saved_views[].filter
+    for i, sv in enumerate(template.state.saved_views):
+        if sv.filter is not None:
+            sites.append(
+                _CelSite(
+                    expression=sv.filter,
+                    path=f"state.saved_views[{i}].filter",
+                    identifiers=tuple(collect_free_identifiers(sv.filter)),
+                )
+            )
+
+    # triggers[].when, triggers[].filter
+    for i, trig in enumerate(template.triggers):
+        if trig.when is not None:
+            sites.append(
+                _CelSite(
+                    expression=trig.when,
+                    path=f"triggers[{i}].when",
+                    identifiers=tuple(collect_free_identifiers(trig.when)),
+                )
+            )
+        if trig.filter is not None:
+            sites.append(
+                _CelSite(
+                    expression=trig.filter,
+                    path=f"triggers[{i}].filter",
+                    identifiers=tuple(collect_free_identifiers(trig.filter)),
+                )
+            )
+
+    # instinct_rules.rules[].when
+    if template.instinct_rules is not None:
+        for i, rule in enumerate(template.instinct_rules.rules):
+            sites.append(
+                _CelSite(
+                    expression=rule.when,
+                    path=f"instinct_rules.rules[{i}].when",
+                    identifiers=tuple(collect_free_identifiers(rule.when)),
+                )
+            )
+
+    return sites
+
+
+__all__ = [
+    "FabricValidationError",
+    "validate_template_with_registry",
+]

--- a/tests/unit/test_fabric_resolver.py
+++ b/tests/unit/test_fabric_resolver.py
@@ -1,0 +1,311 @@
+# tests/unit/test_fabric_resolver.py
+# Created: 2026-05-28 (feat/rfc-03-v2-fabric) — unit tests for
+# ``FabricResolver``, the strict :class:`IdentifierResolver`
+# implementation that gates dotted paths against a ``FabricRegistry``.
+# Companion to ``test_identifier_resolver.py`` (which covers the loose,
+# template-only reference resolver shipped in PR 2c).
+"""Tests for ``FabricResolver``.
+
+The resolver layers two extra gates on top of the PR 2c reference
+resolver:
+
+* A dotted root must be declared in ``state.joined_entities[]`` AND
+  registered in the supplied ``FabricRegistry`` (``link_exists`` returns
+  True for the ``(state.entity_type, joined.entity_type, joined.via_link)``
+  triple). Otherwise raise ``KeyError`` naming the unregistered link.
+* Drilling into the resolved joined value still respects the row
+  context: missing fields raise ``KeyError`` (same contract the CEL
+  evaluator already understands).
+
+Flat identifiers behave the same as the reference resolver.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pocketpaw.bundled_templates import (
+    FabricRegistry,
+    FabricResolver,
+    NullFabricRegistry,
+    PocketTemplate,
+)
+
+# ---------------------------------------------------------------------------
+# Mock registries
+# ---------------------------------------------------------------------------
+
+
+class _MockRegistry:
+    """Configurable in-memory :class:`FabricRegistry` for tests."""
+
+    def __init__(
+        self,
+        *,
+        entities: set[str] | None = None,
+        links: set[tuple[str, str, str]] | None = None,
+        properties: dict[str, set[str]] | None = None,
+    ) -> None:
+        self._entities = entities or set()
+        self._links = links or set()
+        self._properties = properties or {}
+
+    def entity_type_exists(self, name: str) -> bool:
+        return name in self._entities
+
+    def link_exists(self, from_type: str, to_type: str, link_name: str) -> bool:
+        return (from_type, to_type, link_name) in self._links
+
+    def get_entity_properties(self, name: str) -> set[str]:
+        return self._properties.get(name, set())
+
+
+def _lease_template() -> PocketTemplate:
+    """Skinny lease template that declares two joins."""
+    return PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "fabric-resolver-test",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "property-management",
+            "display_name": "Fabric Resolver Test",
+            "description": "Fixture for FabricResolver tests.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "Lease",
+                "joined_entities": [
+                    {"name": "tenant", "entity_type": "Tenant", "via_link": "lease_tenant"},
+                    {
+                        "name": "property",
+                        "entity_type": "Property",
+                        "via_link": "lease_property",
+                    },
+                ],
+                "columns": [
+                    {"field": "id", "widget": "text"},
+                    {"field": "days_remaining", "widget": "trend"},
+                ],
+            },
+        }
+    )
+
+
+def _full_registry() -> _MockRegistry:
+    return _MockRegistry(
+        entities={"Lease", "Tenant", "Property"},
+        links={
+            ("Lease", "Tenant", "lease_tenant"),
+            ("Lease", "Property", "lease_property"),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol shape — the Mock satisfies the Protocol structurally
+# ---------------------------------------------------------------------------
+
+
+def test_mock_registry_satisfies_protocol() -> None:
+    """A duck-typed registry implementing the three methods must satisfy
+    the :class:`FabricRegistry` runtime-checkable Protocol."""
+    registry: FabricRegistry = _full_registry()  # type-check assignment
+    assert isinstance(registry, FabricRegistry)
+
+
+def test_null_registry_satisfies_protocol() -> None:
+    null: FabricRegistry = NullFabricRegistry()
+    assert isinstance(null, FabricRegistry)
+
+
+# ---------------------------------------------------------------------------
+# Flat identifiers — same contract as TemplateIdentifierResolver
+# ---------------------------------------------------------------------------
+
+
+def test_flat_identifier_resolves_from_context() -> None:
+    resolver = FabricResolver(_lease_template().state, _full_registry())
+    assert resolver.resolve("days_remaining", {"days_remaining": 25}) == 25
+
+
+def test_flat_identifier_missing_raises_keyerror() -> None:
+    resolver = FabricResolver(_lease_template().state, _full_registry())
+    with pytest.raises(KeyError):
+        resolver.resolve("days_remaining", {})
+
+
+# ---------------------------------------------------------------------------
+# Dotted-root happy path — declared join + registered link
+# ---------------------------------------------------------------------------
+
+
+def test_declared_join_with_registered_link_resolves() -> None:
+    resolver = FabricResolver(_lease_template().state, _full_registry())
+    context = {"tenant": {"name": "alice", "late_payment_count_12mo": 4}}
+    assert resolver.resolve("tenant", context) == {
+        "name": "alice",
+        "late_payment_count_12mo": 4,
+    }
+
+
+def test_both_declared_joins_resolve() -> None:
+    """Sanity — the resolver is not hard-coded to ``tenant``."""
+    resolver = FabricResolver(_lease_template().state, _full_registry())
+    context = {"property": {"address": "123 Main St"}}
+    assert resolver.resolve("property", context) == {"address": "123 Main St"}
+
+
+# ---------------------------------------------------------------------------
+# Strict failures — undeclared root, unregistered link, missing context
+# ---------------------------------------------------------------------------
+
+
+def _template_with_undeclared_column_root() -> PocketTemplate:
+    """Template that uses ``vendor.name`` as a column dot-path but
+    never declares a ``vendor`` join — the canonical
+    ``tier: registered`` mismatch."""
+    return PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "undeclared-vendor",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "procurement",
+            "display_name": "Undeclared Vendor",
+            "description": "Fixture with an undeclared dotted root in columns.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "PurchaseOrder",
+                "columns": [
+                    {"field": "id", "widget": "text"},
+                    {"field": "vendor.name", "widget": "text"},
+                ],
+            },
+        }
+    )
+
+
+def test_undeclared_join_raises_keyerror_with_name() -> None:
+    """``vendor`` appears as a column dotted root but isn't in
+    ``joined_entities`` — strict resolver rejects even when the row
+    context carries it. This is the canonical ``tier: registered``
+    failure mode."""
+    resolver = FabricResolver(
+        _template_with_undeclared_column_root().state,
+        _MockRegistry(entities={"PurchaseOrder"}),
+    )
+    with pytest.raises(KeyError) as exc:
+        resolver.resolve("vendor", {"vendor": {"foo": 1}})
+    assert "vendor" in str(exc.value)
+    assert "undeclared" in str(exc.value).lower()
+
+
+def test_truly_flat_identifier_falls_through_to_context() -> None:
+    """If the identifier doesn't look like a dotted root (no matching
+    join, no matching column dot-prefix), the resolver falls through
+    to plain context lookup — matching PR 2c's loose runtime behaviour
+    for free CEL helpers (e.g. ``within(some_property, duration)``)."""
+    resolver = FabricResolver(_lease_template().state, _full_registry())
+    assert resolver.resolve("expires_at", {"expires_at": 42}) == 42
+
+
+def test_link_not_registered_raises_keyerror() -> None:
+    """The join is declared on the template, but the registry says the
+    ``via_link`` doesn't exist between ``Lease`` and ``Tenant``."""
+    registry = _MockRegistry(
+        entities={"Lease", "Tenant"},
+        links=set(),  # nothing registered
+    )
+    resolver = FabricResolver(_lease_template().state, registry)
+    context = {"tenant": {"name": "alice"}}
+    with pytest.raises(KeyError) as exc:
+        resolver.resolve("tenant", context)
+    msg = str(exc.value).lower()
+    assert "lease_tenant" in msg
+    assert "via_link" in msg or "link" in msg
+
+
+def test_declared_join_missing_from_context_raises() -> None:
+    """Declared + registered, but the per-row context lacks the join
+    payload. Resolver raises ``KeyError`` — the CEL evaluator surfaces
+    it as a typed evaluation error."""
+    resolver = FabricResolver(_lease_template().state, _full_registry())
+    with pytest.raises(KeyError) as exc:
+        resolver.resolve("tenant", {})
+    assert "tenant" in str(exc.value)
+
+
+def test_full_dot_path_passed_in_is_defensive_error() -> None:
+    """Same defensive guard as the reference resolver — the evaluator
+    only ever hands us leftmost segments. A full dot-path is a caller
+    bug; surface it loudly."""
+    resolver = FabricResolver(_lease_template().state, _full_registry())
+    with pytest.raises(KeyError):
+        resolver.resolve("tenant.name", {"tenant": {"name": "alice"}})
+
+
+# ---------------------------------------------------------------------------
+# NullFabricRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_null_registry_rejects_every_dotted_root() -> None:
+    """``NullFabricRegistry`` treats nothing as registered — any declared
+    join will fail the ``link_exists`` check. This is the right
+    behaviour for a no-Fabric default: a template that declares joins
+    without a real registry to back them is broken, not silently
+    permitted."""
+    resolver = FabricResolver(_lease_template().state, NullFabricRegistry())
+    with pytest.raises(KeyError):
+        resolver.resolve("tenant", {"tenant": {"name": "alice"}})
+
+
+def test_null_registry_passes_flat_identifiers() -> None:
+    """Flat identifiers bypass the registry entirely — same passthrough
+    semantics as the reference resolver."""
+    resolver = FabricResolver(_lease_template().state, NullFabricRegistry())
+    assert resolver.resolve("days_remaining", {"days_remaining": 25}) == 25
+
+
+# ---------------------------------------------------------------------------
+# Constructor overloads — PocketTemplate or StateBinding
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_accepts_full_template() -> None:
+    template = _lease_template()
+    resolver = FabricResolver(template, _full_registry())
+    assert resolver.resolve("tenant", {"tenant": {"name": "alice"}}) == {"name": "alice"}
+
+
+def test_constructor_accepts_state_binding() -> None:
+    template = _lease_template()
+    resolver = FabricResolver(template.state, _full_registry())
+    assert resolver.resolve("tenant", {"tenant": {"name": "alice"}}) == {"name": "alice"}
+
+
+# ---------------------------------------------------------------------------
+# Drop-in compatibility with the CEL evaluator
+# ---------------------------------------------------------------------------
+
+
+def test_works_with_evaluate_cel_for_declared_dotted_path() -> None:
+    """End-to-end sanity: ``FabricResolver`` plugs into ``evaluate_cel``
+    exactly where ``TemplateIdentifierResolver`` would. CEL expressions
+    referencing declared joined entities evaluate correctly."""
+    from pocketpaw.bundled_templates import evaluate_cel
+
+    resolver = FabricResolver(_lease_template().state, _full_registry())
+    context: dict[str, Any] = {"tenant": {"late_payment_count_12mo": 4}}
+    result = evaluate_cel("tenant.late_payment_count_12mo >= 3", context, resolver)
+    assert result is True
+
+
+def test_works_with_evaluate_cel_for_flat_identifier() -> None:
+    from pocketpaw.bundled_templates import evaluate_cel
+
+    resolver = FabricResolver(_lease_template().state, _full_registry())
+    result = evaluate_cel("days_remaining <= 30", {"days_remaining": 25}, resolver)
+    assert result is True

--- a/tests/unit/test_fabric_validator.py
+++ b/tests/unit/test_fabric_validator.py
@@ -1,0 +1,443 @@
+# tests/unit/test_fabric_validator.py
+# Created: 2026-05-28 (feat/rfc-03-v2-fabric) — unit tests for
+# ``validate_template_with_registry``, the lint-time Fabric
+# ``tier: registered`` enforcement entry point. Pairs with
+# ``test_fabric_resolver.py`` (runtime side) — same Protocol, different
+# call site. Validator returns a list of typed errors so callers
+# (CLI ``template lint``, future tools) can render all of them at once
+# instead of stopping on the first miss.
+"""Tests for ``validate_template_with_registry``.
+
+The validator is the lint-time complement to ``FabricResolver``:
+
+* For ``state.entity_type`` — error when the registry doesn't know the
+  type AND the template uses dot-paths (synthetic-tier templates with
+  no dots stay clean).
+* For each ``state.joined_entities[i]`` — error when ``entity_type`` is
+  not registered, or when ``via_link`` isn't registered between
+  primary and join.
+* For each CEL expression on the template (``saved_views[].filter``,
+  ``columns[].filter``, ``triggers[].when`` / ``.filter``,
+  ``instinct_rules.rules[].when``) and for column ``field``-side
+  dot-paths — error when the leading segment isn't a declared join.
+
+Multiple errors collect in a single call. ``NullFabricRegistry`` is
+the no-Fabric default: it returns clean for synthetic templates (no
+dots) and surfaces errors for any template that demands joins.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from pocketpaw.bundled_templates import (
+    FabricValidationError,
+    NullFabricRegistry,
+    PocketTemplate,
+    validate_template_with_registry,
+)
+
+# Repo-root anchor — tests run from anywhere in the worktree, so we
+# resolve fixtures relative to this file rather than ``cwd``.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LEASE_FIXTURE = _REPO_ROOT / "tests" / "fixtures" / "templates" / "lease-renewal-v2.yaml"
+_TODO_FIXTURE = (
+    _REPO_ROOT
+    / "src"
+    / "pocketpaw"
+    / "bundled_templates"
+    / "_bundled"
+    / "todo-task-tracker"
+    / "template.pocket.yaml"
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock registry
+# ---------------------------------------------------------------------------
+
+
+class _MockRegistry:
+    """Configurable mock — built once per test, immutable thereafter."""
+
+    def __init__(
+        self,
+        *,
+        entities: set[str] | None = None,
+        links: set[tuple[str, str, str]] | None = None,
+        properties: dict[str, set[str]] | None = None,
+    ) -> None:
+        self._entities = entities or set()
+        self._links = links or set()
+        self._properties = properties or {}
+
+    def entity_type_exists(self, name: str) -> bool:
+        return name in self._entities
+
+    def link_exists(self, from_type: str, to_type: str, link_name: str) -> bool:
+        return (from_type, to_type, link_name) in self._links
+
+    def get_entity_properties(self, name: str) -> set[str]:
+        return self._properties.get(name, set())
+
+
+# ---------------------------------------------------------------------------
+# Template loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_lease_template() -> PocketTemplate:
+    data = yaml.safe_load(_LEASE_FIXTURE.read_text())
+    return PocketTemplate.model_validate(data)
+
+
+def _load_todo_template() -> PocketTemplate:
+    data = yaml.safe_load(_TODO_FIXTURE.read_text())
+    return PocketTemplate.model_validate(data)
+
+
+def _clean_lease_registry() -> _MockRegistry:
+    return _MockRegistry(
+        entities={"Lease", "Tenant", "Property"},
+        links={
+            ("Lease", "Tenant", "lease_tenant"),
+            ("Lease", "Property", "lease_property"),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error model contract
+# ---------------------------------------------------------------------------
+
+
+def test_validation_error_is_frozen_pydantic() -> None:
+    err = FabricValidationError(
+        message="boom",
+        path="state.entity_type",
+        severity="error",
+        data={"entity_type": "Foo"},
+    )
+    assert err.message == "boom"
+    # ``frozen=True`` raises ``pydantic.ValidationError`` on mutation
+    # — we catch the generic ``Exception`` to avoid coupling to the
+    # exact subclass while still asserting immutability.
+    try:
+        err.message = "different"  # type: ignore[misc]
+    except Exception:
+        pass
+    else:
+        raise AssertionError("FabricValidationError should be frozen")
+
+
+# ---------------------------------------------------------------------------
+# Clean path — full registry, all references resolve
+# ---------------------------------------------------------------------------
+
+
+def test_lease_with_clean_registry_returns_empty() -> None:
+    """lease-renewal-v2 + registry that knows everything → no errors."""
+    template = _load_lease_template()
+    errors = validate_template_with_registry(template, _clean_lease_registry())
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# state.entity_type unknown
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_primary_entity_type_flagged_when_dots_used() -> None:
+    """If the template references joined entities but the registry
+    doesn't know the primary type, that's a registered-tier error."""
+    template = _load_lease_template()
+    registry = _MockRegistry(entities=set(), links=set())
+    errors = validate_template_with_registry(template, registry)
+    # At least one error pointing at state.entity_type.
+    entity_errors = [e for e in errors if e.path == "state.entity_type"]
+    assert len(entity_errors) == 1
+    assert "Lease" in entity_errors[0].message
+
+
+# ---------------------------------------------------------------------------
+# joined_entities errors — unknown type + missing link
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_joined_entity_type_flagged() -> None:
+    """Registry knows the primary but not one of the joined entity
+    types → typed error per missing join."""
+    template = _load_lease_template()
+    registry = _MockRegistry(
+        entities={"Lease", "Property"},  # missing Tenant
+        links={("Lease", "Property", "lease_property")},
+    )
+    errors = validate_template_with_registry(template, registry)
+    messages = [e.message for e in errors]
+    # Exactly one ``unknown joined entity_type: Tenant`` style error.
+    assert any("Tenant" in m and "joined" in m.lower() for m in messages)
+
+
+def test_unregistered_via_link_flagged() -> None:
+    """Registry knows both ends but not the link between them."""
+    template = _load_lease_template()
+    registry = _MockRegistry(
+        entities={"Lease", "Tenant", "Property"},
+        links={("Lease", "Property", "lease_property")},  # missing lease_tenant
+    )
+    errors = validate_template_with_registry(template, registry)
+    link_errors = [e for e in errors if "lease_tenant" in e.message]
+    assert len(link_errors) == 1
+    msg = link_errors[0].message
+    assert "Lease" in msg
+    assert "Tenant" in msg
+
+
+def test_multiple_errors_collected_in_single_call() -> None:
+    """Validator returns a *list* — it doesn't raise — so the CLI can
+    render every problem at once."""
+    template = _load_lease_template()
+    registry = _MockRegistry(entities={"Lease"}, links=set())
+    errors = validate_template_with_registry(template, registry)
+    # Expect at least: Tenant unknown, Property unknown, lease_tenant
+    # missing, lease_property missing. Four typed errors minimum.
+    assert len(errors) >= 4
+    # Each error carries a structured path so callers can sort / group.
+    paths = {e.path for e in errors}
+    assert any(p.startswith("state.joined_entities") for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# CEL identifier collection — undeclared dotted roots in expressions
+# ---------------------------------------------------------------------------
+
+
+def test_undeclared_dot_path_in_cel_filter_flagged() -> None:
+    """A saved_view filter references ``vendor.foo`` but no
+    ``vendor`` join is declared → flagged as an undeclared dot-path."""
+    template = PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "vendor-test",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "procurement",
+            "display_name": "Vendor Test",
+            "description": "Fixture with an undeclared dot-path.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "PurchaseOrder",
+                "columns": [{"field": "id", "widget": "text"}],
+                "saved_views": [
+                    {"name": "Vendor Alpha", "filter": "vendor.foo == 1"},
+                ],
+            },
+        }
+    )
+    registry = _MockRegistry(entities={"PurchaseOrder"}, links=set())
+    errors = validate_template_with_registry(template, registry)
+    # Find the dot-path lint error — message names ``vendor``.
+    dot_errors = [e for e in errors if "vendor" in e.message.lower()]
+    assert len(dot_errors) >= 1
+
+
+def test_declared_dot_path_in_cel_filter_passes() -> None:
+    """Same shape as above but with the join declared — passes."""
+    template = PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "vendor-test-ok",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "procurement",
+            "display_name": "Vendor Test OK",
+            "description": "Fixture with a declared dot-path.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "PurchaseOrder",
+                "joined_entities": [
+                    {"name": "vendor", "entity_type": "Vendor", "via_link": "po_vendor"},
+                ],
+                "columns": [{"field": "id", "widget": "text"}],
+                "saved_views": [
+                    {"name": "Vendor Alpha", "filter": "vendor.foo == 1"},
+                ],
+            },
+        }
+    )
+    registry = _MockRegistry(
+        entities={"PurchaseOrder", "Vendor"},
+        links={("PurchaseOrder", "Vendor", "po_vendor")},
+    )
+    errors = validate_template_with_registry(template, registry)
+    assert errors == []
+
+
+def test_undeclared_dot_path_in_instinct_rule_when_flagged() -> None:
+    """Same lint applies to ``instinct_rules.rules[].when``."""
+    template = PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "instinct-undecl",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "test",
+            "display_name": "Instinct undecl",
+            "description": "Fixture with an undeclared root in instinct rule.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "Thing",
+                "columns": [{"field": "id", "widget": "text"}],
+            },
+            "instinct_rules": {
+                "rules": [{"when": "ghost.attribute == true", "action": "block"}],
+            },
+        }
+    )
+    registry = _MockRegistry(entities={"Thing"})
+    errors = validate_template_with_registry(template, registry)
+    assert any("ghost" in e.message.lower() for e in errors)
+
+
+def test_undeclared_dot_path_in_trigger_when_flagged() -> None:
+    """Same lint applies to ``triggers[].when``."""
+    template = PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "trigger-undecl",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "test",
+            "display_name": "Trigger undecl",
+            "description": "Fixture with an undeclared root in a trigger.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "Thing",
+                "columns": [{"field": "id", "widget": "text"}],
+            },
+            "triggers": [
+                {"type": "temporal", "when": "ghost.attribute == true"},
+            ],
+        }
+    )
+    registry = _MockRegistry(entities={"Thing"})
+    errors = validate_template_with_registry(template, registry)
+    assert any("ghost" in e.message.lower() for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Column field dot-paths — also gated
+# ---------------------------------------------------------------------------
+
+
+def test_undeclared_dot_path_in_column_field_flagged() -> None:
+    """A column ``field`` like ``vendor.name`` is a dot-path too — the
+    leading segment must be declared. (RFC 03 v2 lines 170-179.)"""
+    template = PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "col-undecl",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "test",
+            "display_name": "Column undecl",
+            "description": "Column with an undeclared dot root.",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "Thing",
+                "columns": [
+                    {"field": "id", "widget": "text"},
+                    {"field": "vendor.name", "widget": "text"},
+                ],
+            },
+        }
+    )
+    registry = _MockRegistry(entities={"Thing"})
+    errors = validate_template_with_registry(template, registry)
+    assert any("vendor" in e.message.lower() for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-tier passthrough — no dots, no enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_template_with_null_registry_returns_empty() -> None:
+    """``todo-task-tracker`` is synthetic-tier: ``Task`` is not in any
+    Fabric registry, the template has zero dot-paths. The validator
+    must treat it as a passthrough — zero errors against
+    ``NullFabricRegistry``."""
+    template = _load_todo_template()
+    errors = validate_template_with_registry(template, NullFabricRegistry())
+    assert errors == []
+
+
+def test_synthetic_template_with_empty_registry_returns_empty() -> None:
+    """Same passthrough with a non-Null but empty mock registry."""
+    template = _load_todo_template()
+    errors = validate_template_with_registry(template, _MockRegistry())
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# NullFabricRegistry behaviour for registered-tier shapes
+# ---------------------------------------------------------------------------
+
+
+def test_lease_with_null_registry_flags_everything() -> None:
+    """``NullFabricRegistry`` knows nothing; a template that demands
+    joins should surface errors. This is the right behaviour for the
+    'no Fabric wired yet' default — silent passthrough would let a
+    registered-tier template ship broken."""
+    template = _load_lease_template()
+    errors = validate_template_with_registry(template, NullFabricRegistry())
+    # Many errors expected: primary entity_type, both joins, all
+    # via_links, plus any dotted CEL roots.
+    assert len(errors) >= 4
+
+
+# ---------------------------------------------------------------------------
+# Severity surface
+# ---------------------------------------------------------------------------
+
+
+def test_all_emitted_errors_are_error_severity() -> None:
+    """PR 2g emits ``severity='error'`` for every miss — the validator
+    has no warning path yet. Lock that in so a future tweak adding
+    warnings is an intentional, reviewed change."""
+    template = _load_lease_template()
+    errors = validate_template_with_registry(template, NullFabricRegistry())
+    for e in errors:
+        assert e.severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# Data payload — callers can sort / group / link to docs
+# ---------------------------------------------------------------------------
+
+
+def test_errors_carry_structured_data_payload() -> None:
+    """Each error should carry a ``data`` dict the CLI / IDE can use to
+    surface remediation hints — at minimum, the offending name."""
+    template = _load_lease_template()
+    registry = _MockRegistry(entities={"Lease"}, links=set())
+    errors = validate_template_with_registry(template, registry)
+    assert any(isinstance(e.data, dict) and e.data for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Repeat calls are pure
+# ---------------------------------------------------------------------------
+
+
+def test_validator_is_pure() -> None:
+    """Re-running the validator with the same inputs returns the same
+    output — no hidden state on the registry, template, or function."""
+    template = _load_lease_template()
+    reg = _clean_lease_registry()
+    first: list[Any] = validate_template_with_registry(template, reg)
+    second: list[Any] = validate_template_with_registry(template, reg)
+    assert first == second


### PR DESCRIPTION
## Summary

PR 2g of the RFC 03 v2 split. Fabric `tier:registered` enforcement and the strict `FabricResolver`. Last runtime sub-PR for the library layer; PR 2e (bulk fan-out) is the only follow-up before `feat/rfc-03-v2-integration` returns to `dev`.

The Fabric ObjectType / FabricLink registry is the seam between OSS-side RFC 03 v2 enforcement and the EE Fabric module. This PR ships the OSS side: a `FabricRegistry` Protocol the rest of the stack consumes, a no-op `NullFabricRegistry` default, a strict `FabricResolver` that drops into `evaluate_cel` wherever PR 2c's reference resolver does, and a lint-time `validate_template_with_registry` entry point. The concrete registry implementation lives in `ee/fabric/` and is supplied at wiring time. Out of scope here.

## What lands

- **`fabric_registry.py`**: `FabricRegistry` Protocol (3 methods: `entity_type_exists`, `link_exists`, `get_entity_properties`) plus `NullFabricRegistry` no-op. Runtime-checkable Protocol so wiring code can `isinstance`-check without a concrete dependency.
- **`fabric_resolver.py`**: strict `IdentifierResolver`. Recognises dotted-root usage via both `state.joined_entities[].name` AND any column whose `field` starts with `<ident>.` so undeclared joins are rejected even when the row context happens to carry them. Falls through to plain context for genuine flat names (`within(expires_at, ...)` and similar free-variable helpers) so the existing fixture templates still resolve.
- **`fabric_validator.py`**: `validate_template_with_registry` returns `list[FabricValidationError]` instead of raising. Walks every CEL site (`columns[].filter`, `saved_views[].filter`, `triggers[].when` / `.filter`, `instinct_rules.rules[].when`), every column dot-path, every joined entity, and the primary `state.entity_type`. Collects misses with a JSON-path back to the source so a future CLI lint can render them grouped.
- **`cel_runtime.py`**: added a public `collect_free_identifiers(text)` helper. Promoted from the private `_collect_free_identifiers` so the validator doesn't duplicate the AST walker. `evaluate_cel`'s signature is unchanged.
- **`__init__.py`**: re-exports `FabricRegistry`, `NullFabricRegistry`, `FabricResolver`, `FabricValidationError`, `validate_template_with_registry`, `collect_free_identifiers`.

## Scope LOCKED

- OSS-side library + tests only. No EE-side concrete `FabricRegistry` (separate, out-of-tree change). No CLI `template lint` wiring (follow-up). No schema `tier` field (RFC defers). No changes to PR 2c's `IdentifierResolver` Protocol or `TemplateIdentifierResolver`.
- No edits to `ee/cloud/pockets/` or `ee/fabric/`. No `pocketpaw_ee.*` imports anywhere in production code.

## Test plan

- [x] 17 `test_fabric_resolver` cases. Flat, declared, undeclared, unregistered, null-registry, constructor overloads, Protocol-shape, end-to-end through `evaluate_cel`.
- [x] 17 `test_fabric_validator` cases. Clean, unknown primary, unknown joined, missing via_link, multi-error collection, synthetic passthrough, CEL undeclared roots in saved_views, instinct rules, triggers, column dot-paths, severity, data payload, purity.
- [x] PR 2c regression check (`test_cel_runtime`, `test_identifier_resolver`). All 21 prior tests still green.
- [x] Full local unit scope: `199 passed, 13 skipped`.
- [x] `ruff check --fix && ruff format` clean on new + touched files.
- [x] Smoke test against the lease-renewal fixture and the bundled `todo-task-tracker`. Clean registry: 0 errors. Broken registry: 4 errors (both joined entity types unknown + both via_links missing). Synthetic + `NullFabricRegistry`: 0 errors.

## Smoke test output

```
  lease-renewal + clean registry: 0 errors
  lease-renewal + broken registry: 4 errors
    error: unknown joined entity_type: 'Tenant' on joined_entities[0] (name='tenant')  @ state.joined_entities[0].entity_type
    error: via_link not registered: 'lease_tenant' on Lease->Tenant (joined_entities[0].name='tenant')  @ state.joined_entities[0].via_link
    error: unknown joined entity_type: 'Property' on joined_entities[1] (name='property')  @ state.joined_entities[1].entity_type
    error: via_link not registered: 'lease_property' on Lease->Property (joined_entities[1].name='property')  @ state.joined_entities[1].via_link
  todo-task-tracker + NullRegistry: 0 errors (synthetic passthrough)
```

## Architectural decisions worth a second look

- **Strict resolver, but how strict?** The brief asked for "undeclared join" rejection on dotted roots. The resolver only ever sees leftmost segments, so it cannot distinguish `vendor.foo` from a bare `vendor` on signature alone. The resolver pre-indexes `state.columns[].field` for any field with a dot. If `vendor` appears as a column dot-prefix but isn't in `joined_entities`, the resolver rejects. Otherwise it falls through to context. This preserves PR 2c's loose runtime behaviour for free CEL helpers while still catching the canonical `tier:registered` mismatch.
- **`NullFabricRegistry` is non-passthrough for registered-tier templates.** Its `link_exists` returns False for everything, so templates that declare joins will surface lint / runtime errors. This is the right default: a template that demands joins can't satisfy `tier:registered` without a real registry. Synthetic templates (no joins, no dots) lint clean against `NullFabricRegistry`.
- **Validator returns a list, not raises.** A real lint surface wants every finding rendered at once. `FabricValidationError` carries a dotted JSON-path so consumers can sort, group, or link.
- **CEL AST walker reused, not duplicated.** Promoted the private `_collect_free_identifiers` helper from PR 2c's `cel_runtime.py` to a public `collect_free_identifiers(expression)` so the validator consumes the same walker the evaluator uses. PR 2c's exported surface is additive. No breaking change.

## Follow-ups (out of scope for this PR)

- EE-side concrete `FabricRegistry` implementation (lives in `ee/fabric/`).
- CLI `template lint` wiring (`validate_template_with_registry` feed into the lint output).
- Property-level validation using `get_entity_properties` (Protocol surface exists; no consumer wired yet).

Closes part of RFC 03 v2 §"Synthetic Fabric tier" + §"Resolution against Fabric". PR 2e (bulk fan-out) is the only remaining sub-PR before integration → dev.
