### PR TITLE
feat(bulk): fan-out planner with batch-approval consolidation for RFC 03 v2

### DIFF
--- a/src/pocketpaw/bundled_templates/__init__.py
+++ b/src/pocketpaw/bundled_templates/__init__.py
@@ -31,6 +31,12 @@
 # ``validate_template_with_registry`` (lint entry point). The concrete
 # EE-side ``FabricRegistry`` implementation lives in ``ee/fabric/`` and
 # is supplied at wiring time; PR 2g is OSS library-only.
+# Modified 2026-05-28 (feat/rfc-03-v2-bulk): re-exports the bulk
+# fan-out planner (``plan_bulk_execution``, ``BulkPlan``,
+# ``RowExecution``, ``BlockedRow``, ``BulkApprovalRequest``,
+# ``BulkExecutionError``). PR 2e is the LAST library-layer piece —
+# composes the per-row composer (PR 2d) into the batch-approval
+# contract from RFC §"Bulk action execution model".
 """Built-in pocket templates bundled and auto-installed by PocketPaw.
 
 Third sibling to ``pocketpaw.bundled_skills`` and ``pocketpaw.bundled_kb``.
@@ -72,6 +78,15 @@ files and register it in ``_bundled/index.json``. The installer discovers
 directories via iteration — no installer code changes needed.
 """
 
+from pocketpaw.bundled_templates.bulk_executor import (
+    BlockedRow,
+    BulkApprovalRequest,
+    BulkExecutionError,
+    BulkPlan,
+    ExecutionVerdict,
+    RowExecution,
+    plan_bulk_execution,
+)
 from pocketpaw.bundled_templates.cel_runtime import (
     CelEvaluationError,
     collect_free_identifiers,
@@ -128,10 +143,15 @@ from pocketpaw.bundled_templates.temporal_sweeper import (
 __all__ = [
     "ActionDef",
     "AgentDef",
+    "BlockedRow",
+    "BulkApprovalRequest",
+    "BulkExecutionError",
+    "BulkPlan",
     "CelEvaluationError",
     "ColumnDef",
     "ConfirmDef",
     "DataSourceDef",
+    "ExecutionVerdict",
     "FabricRegistry",
     "FabricResolver",
     "FabricValidationError",
@@ -145,6 +165,7 @@ __all__ = [
     "NullFabricRegistry",
     "PermissionsDef",
     "PocketTemplate",
+    "RowExecution",
     "SavedView",
     "StateBinding",
     "SweepResult",
@@ -159,6 +180,7 @@ __all__ = [
     "evaluate_cel",
     "install_bundled_templates",
     "load_template",
+    "plan_bulk_execution",
     "resolve_instinct",
     "sweep_temporal_triggers",
     "validate_template_with_registry",

--- a/src/pocketpaw/bundled_templates/bulk_executor.py
+++ b/src/pocketpaw/bundled_templates/bulk_executor.py
@@ -1,0 +1,550 @@
+# src/pocketpaw/bundled_templates/bulk_executor.py
+# Created: 2026-05-28 (feat/rfc-03-v2-bulk) — pure-library
+# implementation of the RFC 03 v2 bulk-action fan-out planner. Given a
+# template, a ``kind: bulk`` action name, and a list of selected rows,
+# returns an immutable ``BulkPlan`` describing what should happen per
+# row PLUS the single-batch approval contract from the RFC. The
+# planner is the seam between the Instinct composer (per-row, PR 2d)
+# and the EE runtime that actually invokes actions / emits outcomes
+# (lives in ``ee/cloud/pockets/``, wired in a follow-up PR).
+#
+# This module ships the LAST library-layer piece needed before RFC 03
+# v2 integration returns to dev. PRs 2c (CEL), 2d (Instinct composer),
+# 2e (bulk planner) compose into a single pure-Python pipeline the EE
+# runtime consumes; no I/O, no Beanie, no ``pocketpaw_ee`` imports.
+"""Bulk-action fan-out planner for RFC 03 v2 templates.
+
+Public surface
+--------------
+
+* :class:`BulkPlan` — frozen Pydantic v2 model returned by the
+  planner. Carries the resolved action, the per-row executions ready
+  to fire, the blocked rows (with the rule that fired), and an
+  optional :class:`BulkApprovalRequest` consolidating every row that
+  needs approval.
+* :class:`RowExecution` — frozen per-row execution descriptor (verdict
+  ``EXECUTE`` or ``NOTIFY_AND_EXECUTE``, the full underlying
+  :class:`InstinctDecision`, and the notify rules to dispatch in
+  parallel).
+* :class:`BlockedRow` — frozen per-row block descriptor (the decision
+  + the block rule that won).
+* :class:`BulkApprovalRequest` — frozen consolidated approval payload.
+  ONE request covers ALL approval-needing rows from a single
+  ``plan_bulk_execution`` call. The EE runtime enqueues exactly one
+  Instinct approval, not N.
+* :func:`plan_bulk_execution` — the pure entry point. No I/O, no
+  side effects; safe to call from anywhere, including unit tests.
+* :class:`BulkExecutionError` — raised for pre-flight failures
+  (unknown action, non-bulk action kind). Per-row CEL evaluation
+  failures bubble out of :func:`resolve_instinct` as
+  :class:`InstinctResolutionError` and are not re-wrapped — the caller
+  already has typed error coverage for those.
+
+The RFC contract
+----------------
+
+From RFC 03 v2 §"Bulk action execution model"::
+
+    A ``kind: bulk`` action fans out one execution per selected row.
+    Each row execution emits its own outcome events. ... If the action
+    has ``instinct_policy: require_approval`` (or a top-level approval
+    rule matched), the Instinct queue gets ONE approval request that
+    authorizes the whole batch — not N requests.
+
+That is the seam this planner ships. The planner does NOT invoke
+actions, agents, or HTTP calls; those live in the EE runtime and are
+wired separately.
+
+Bucketing rules
+---------------
+
+Per-row verdicts from :func:`resolve_instinct` route as follows:
+
+* ``BLOCK`` → :attr:`BulkPlan.blocked`. Carries the matched rule for
+  the audit log. Blocked rows NEVER enter :attr:`BulkPlan.executions`
+  or the approval request — ``block always wins`` (RFC invariant).
+* ``ESCALATE_APPROVAL`` → consolidated into a single
+  :class:`BulkApprovalRequest`. Approval-needing rows are deduplicated
+  into ONE request regardless of count.
+* ``EXECUTE`` → :attr:`BulkPlan.executions` with verdict EXECUTE.
+* ``NOTIFY_AND_EXECUTE`` → :attr:`BulkPlan.executions` with verdict
+  NOTIFY_AND_EXECUTE and the matched notify rules carried on the
+  row's :attr:`RowExecution.notify_rules`.
+
+Reason codes on :class:`BulkApprovalRequest`
+-------------------------------------------
+
+* ``operator_overlay_escalated`` — every approval-needing row in this
+  batch escalated via a top-level ``instinct_rules`` rule. No row hit
+  the per-action floor.
+* ``author_floor`` — every approval-needing row escalated via the
+  action's own ``instinct_policy: require_approval``. No overlay
+  rule fired.
+* ``mixed_approval_reasons`` — some rows escalated via overlay, some
+  via author floor. Single typed string keeps the contract
+  observable; the per-row decisions live on
+  :attr:`BulkApprovalRequest.per_row_decisions` for fine-grained
+  audit.
+
+Scope (locked by the PR brief)
+------------------------------
+
+* Library / pure function. No I/O, no Beanie, no ``pocketpaw_ee``
+  imports. The OSS import-linter contract enforces this.
+* Result models are **immutable** (``ConfigDict(frozen=True)``).
+* Side effects are *planned* (returned in the structure) but not
+  *fired* — the EE runtime owns dispatch, approval queue submission,
+  agent invocation, HTTP action calls, and outcome event emission.
+* Single-row + global action runtimes live in different code paths;
+  only ``kind: bulk`` is in scope here.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pocketpaw.bundled_templates.identifier_resolver import (
+    IdentifierResolver,
+)
+from pocketpaw.bundled_templates.instinct_composer import (
+    InstinctDecision,
+    resolve_instinct,
+)
+from pocketpaw.bundled_templates.schema import (
+    ActionDef,
+    InstinctRule,
+    PocketTemplate,
+)
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+ExecutionVerdict = Literal["EXECUTE", "NOTIFY_AND_EXECUTE"]
+"""Subset of :class:`~pocketpaw.bundled_templates.InstinctVerdict` that
+indicates the row should proceed to action invocation.
+
+``BLOCK`` and ``ESCALATE_APPROVAL`` are routed to their own buckets
+and do not appear on :attr:`RowExecution.verdict`.
+"""
+
+
+class RowExecution(BaseModel):
+    """A single row ready to fire — verdict is either ``EXECUTE`` or
+    ``NOTIFY_AND_EXECUTE``.
+
+    Frozen so the EE runtime can pass the row through audit and
+    serialization layers without worrying about downstream mutation.
+    The original :class:`InstinctDecision` is preserved on
+    :attr:`decision` so callers always have the full per-row rationale.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    row_id: str
+    """Row identifier resolved from the row dict via
+    ``row_id_field``. Stable for the lifetime of the plan."""
+
+    row: dict[str, Any]
+    """The original row dict, untouched. The EE runtime invokes the
+    action against this exact payload."""
+
+    verdict: ExecutionVerdict
+    """``EXECUTE`` — invoke the action directly. ``NOTIFY_AND_EXECUTE``
+    — invoke AND ping the escalation target via the carried
+    ``notify_rules``."""
+
+    decision: InstinctDecision
+    """The underlying per-row decision. Carries the verdict, reason,
+    matched rules, and audit data; mirrored here for downstream
+    inspection."""
+
+    notify_rules: list[InstinctRule] = Field(default_factory=list)
+    """Top-level ``notify`` rules whose ``when`` matched for this row.
+    Empty on plain ``EXECUTE``; populated on ``NOTIFY_AND_EXECUTE``
+    AND on any row whose ``auto`` policy still surfaced a matching
+    notify rule (top-level notify can fire alongside auto execute)."""
+
+
+class BlockedRow(BaseModel):
+    """A single row blocked by a top-level rule — does NOT enter
+    ``executions`` and does NOT enter the approval request.
+
+    Per RFC ``block always wins``: the EE runtime emits a
+    ``blocked_by_rule`` audit-log entry and skips invocation entirely
+    for this row.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    row_id: str
+    row: dict[str, Any]
+    decision: InstinctDecision
+    """Full underlying decision — verdict is always ``BLOCK`` here."""
+
+    blocked_by_rule: InstinctRule
+    """The first block rule whose ``when`` matched. Carried separately
+    for the audit log even though it is also on
+    ``decision.matched_rules``."""
+
+
+class BulkApprovalRequest(BaseModel):
+    """Single consolidated approval request covering every
+    approval-needing row in the batch.
+
+    Per RFC: ONE approval request authorises the entire batch — never
+    N. Even if 50 rows escalate, the Instinct queue receives this one
+    object. On approval, the EE runtime re-runs the per-row action
+    invocations for every row in :attr:`row_ids`.
+
+    Frozen — the runtime must not edit an in-flight approval. If the
+    batch needs to change, produce a fresh request.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    action_name: str
+    """The bulk action the request authorises (same for every row)."""
+
+    row_ids: list[str]
+    """Stable row identifiers, ordered as they appeared in
+    ``selected_rows``. May be a subset of the total selection if some
+    rows blocked or proceeded clean."""
+
+    rows_data: dict[str, dict[str, Any]]
+    """``row_id → row`` map, for the audit log. The EE runtime
+    serializes this onto the approval queue so reviewers see the exact
+    payload that will be invoked on approval."""
+
+    reason: str
+    """One of ``operator_overlay_escalated``, ``author_floor``, or
+    ``mixed_approval_reasons``. See module docstring."""
+
+    matched_rules: list[InstinctRule] = Field(default_factory=list)
+    """Union (by identity) of every overlay approval rule that
+    participated across all rows in the batch. Empty when the entire
+    batch escalated via author_floor."""
+
+    per_row_decisions: dict[str, InstinctDecision]
+    """``row_id → InstinctDecision`` for fine-grained audit. The
+    consolidated ``reason`` collapses some detail; this field
+    preserves the per-row truth."""
+
+
+class BulkPlan(BaseModel):
+    """Frozen result of :func:`plan_bulk_execution`.
+
+    Carries every bucket the EE runtime needs for dispatch — ready
+    executions, blocked rows, and (optionally) the single batch
+    approval request. The resolved :class:`ActionDef` is also exposed
+    so the runtime does not have to look it up again.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    action_name: str
+    """The bulk action that was planned (matches the caller's input)."""
+
+    action: ActionDef
+    """The resolved action — pre-validated, frozen at template-load
+    time."""
+
+    total_rows: int
+    """``len(selected_rows)``. Useful for sanity checks: the sum of
+    ``len(executions)`` + ``len(blocked)`` + (
+    ``len(approval_request.row_ids)`` if present else 0) equals
+    ``total_rows``."""
+
+    executions: list[RowExecution] = Field(default_factory=list)
+    """Rows ready to fire (verdict ``EXECUTE`` or
+    ``NOTIFY_AND_EXECUTE``)."""
+
+    blocked: list[BlockedRow] = Field(default_factory=list)
+    """Rows blocked by a top-level block rule."""
+
+    approval_request: BulkApprovalRequest | None = None
+    """Single consolidated approval request, or ``None`` when no row
+    needed approval."""
+
+
+class BulkExecutionError(Exception):
+    """Raised by :func:`plan_bulk_execution` for pre-flight failures.
+
+    Two failure modes:
+
+    1. **Unknown action** — ``action_name`` is not declared on
+       ``template.actions[].name``. Surfaces BEFORE any row evaluation
+       runs so the caller fails fast on a typo.
+    2. **Non-bulk action** — the named action exists but its ``kind``
+       is ``single-row`` or ``global``. The bulk planner is for
+       ``kind: bulk`` only; routing the wrong action here would
+       silently mis-execute.
+
+    Per-row evaluation failures (CEL errors, identifier misses) bubble
+    out of :func:`resolve_instinct` as :class:`InstinctResolutionError`
+    and are NOT re-wrapped — callers already have typed coverage for
+    those exceptions.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Public function
+# ---------------------------------------------------------------------------
+
+
+def plan_bulk_execution(
+    template: PocketTemplate,
+    action_name: str,
+    selected_rows: list[dict[str, Any]],
+    *,
+    workspace_context: dict[str, Any] | None = None,
+    resolver: IdentifierResolver | None = None,
+    row_id_field: str | None = None,
+    now: datetime | None = None,
+) -> BulkPlan:
+    """Plan the fan-out for a ``kind: bulk`` action against N rows.
+
+    Walks every selected row through the RFC 03 v2 Instinct composer,
+    buckets per-row verdicts (BLOCK, ESCALATE_APPROVAL, EXECUTE,
+    NOTIFY_AND_EXECUTE), and consolidates every approval-needing row
+    into ONE :class:`BulkApprovalRequest`.
+
+    Parameters
+    ----------
+    template:
+        The fully-validated :class:`PocketTemplate` carrying
+        ``actions[]`` and optional ``instinct_rules``.
+    action_name:
+        Name of the bulk action to plan for. Must exist on the
+        template AND have ``kind == "bulk"``; otherwise
+        :class:`BulkExecutionError` is raised.
+    selected_rows:
+        Per-row dicts the EE runtime collected from the user's
+        selection. Empty list is valid (returns an empty plan).
+    workspace_context:
+        Optional workspace-scoped defaults threaded into every per-row
+        Instinct composition call. Row context wins on collision per
+        the composer's documented contract.
+    resolver:
+        Optional :class:`IdentifierResolver` reused for every row.
+        Defaults to a single
+        :class:`TemplateIdentifierResolver` constructed inside
+        :func:`resolve_instinct` per call when ``None``; passing one
+        explicitly avoids re-constructing it N times.
+    row_id_field:
+        Field name on each row dict used to derive ``row_id``.
+        Resolution order: explicit argument → ``template.state.id_field``
+        → ``"id"`` literal. A row missing the chosen field raises
+        :class:`BulkExecutionError`.
+    now:
+        Optional wall-clock for the CEL ``within(...)`` function.
+        Defaults to ``datetime.now(UTC)``. Tests should pass a fixed
+        value for determinism.
+
+    Returns
+    -------
+    :class:`BulkPlan`
+        Immutable. See class docstring for field semantics.
+
+    Raises
+    ------
+    BulkExecutionError
+        On unknown action or non-bulk action kind.
+    InstinctResolutionError
+        Bubbles up unchanged from :func:`resolve_instinct` when a
+        per-row CEL evaluation fails. Callers should handle both
+        exception types.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    # Resolve action up-front so typos surface BEFORE any row work.
+    action = _find_bulk_action(template, action_name)
+
+    # ``row_id_field`` resolution per the brief: explicit arg →
+    # template.state.id_field → "id" literal. The template default is
+    # already ``"id"`` so the chain collapses to the same value in
+    # the common case; we keep the explicit lookup for clarity.
+    effective_id_field = row_id_field or template.state.id_field or "id"
+
+    executions: list[RowExecution] = []
+    blocked: list[BlockedRow] = []
+    approval_rows: list[tuple[str, dict[str, Any], InstinctDecision]] = []
+
+    for row in selected_rows:
+        row_id = _row_id_for(row, effective_id_field)
+        decision = resolve_instinct(
+            template,
+            action_name,
+            row,
+            workspace_context,
+            resolver=resolver,
+            now=now,
+        )
+
+        if decision.verdict == "BLOCK":
+            # ``block always wins`` — never enters executions or the
+            # approval request. The first block rule that matched is
+            # already on decision.matched_rules[0]; we expose it
+            # separately for the audit log.
+            blocked.append(
+                BlockedRow(
+                    row_id=row_id,
+                    row=row,
+                    decision=decision,
+                    blocked_by_rule=decision.matched_rules[0],
+                )
+            )
+            continue
+
+        if decision.verdict == "ESCALATE_APPROVAL":
+            # Consolidate later — collect now and emit one request
+            # for the whole batch.
+            approval_rows.append((row_id, row, decision))
+            continue
+
+        # EXECUTE or NOTIFY_AND_EXECUTE — verdict matches the
+        # ExecutionVerdict Literal exactly.
+        executions.append(
+            RowExecution(
+                row_id=row_id,
+                row=row,
+                verdict=decision.verdict,
+                decision=decision,
+                notify_rules=list(decision.notify_rules),
+            )
+        )
+
+    approval_request = _consolidate_approval(action_name, approval_rows)
+
+    return BulkPlan(
+        action_name=action_name,
+        action=action,
+        total_rows=len(selected_rows),
+        executions=executions,
+        blocked=blocked,
+        approval_request=approval_request,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _find_bulk_action(template: PocketTemplate, action_name: str) -> ActionDef:
+    """Look up an action by name and confirm it is ``kind: bulk``.
+
+    Two failure modes per :class:`BulkExecutionError`:
+
+    1. Unknown action — name not present on the template.
+    2. Non-bulk action — name present, but ``kind`` is ``single-row``
+       or ``global``. Routing the wrong kind through the bulk planner
+       would silently mis-execute (e.g., single-row actions don't
+       expect fan-out semantics); fail loudly.
+    """
+    for action in template.actions:
+        if action.name == action_name:
+            if action.kind != "bulk":
+                raise BulkExecutionError(
+                    f"not a bulk action: action {action_name!r} has "
+                    f"kind={action.kind!r}; expected 'bulk'"
+                )
+            return action
+    raise BulkExecutionError(
+        f"unknown action: {action_name!r} is not declared on template "
+        f"{template.name!r} (available: "
+        f"{sorted(a.name for a in template.actions)})"
+    )
+
+
+def _row_id_for(row: dict[str, Any], id_field: str) -> str:
+    """Pull the row identifier and stringify it.
+
+    Per the brief, we stringify (the approval queue serializes row_ids
+    as JSON; coercing here keeps the contract narrow). Missing field
+    surfaces as a typed :class:`BulkExecutionError` so callers can
+    distinguish "bad data" from "bad expression".
+    """
+    if id_field not in row:
+        raise BulkExecutionError(
+            f"row is missing id field {id_field!r}; available keys: {sorted(row.keys())}"
+        )
+    return str(row[id_field])
+
+
+def _consolidate_approval(
+    action_name: str,
+    approval_rows: list[tuple[str, dict[str, Any], InstinctDecision]],
+) -> BulkApprovalRequest | None:
+    """Collapse N per-row approval decisions into one batch request.
+
+    Returns ``None`` when no row needs approval. Otherwise builds a
+    single :class:`BulkApprovalRequest` per the RFC contract.
+
+    The consolidated ``reason`` reflects the mix of per-row reasons:
+
+    * All rows ``operator_overlay_escalated`` → ``operator_overlay_escalated``.
+    * All rows ``author_floor`` → ``author_floor``.
+    * Mixed → ``mixed_approval_reasons``.
+
+    The union of matched rules is built by *identity*: an
+    :class:`InstinctRule` is a Pydantic value object, so equal-by-value
+    rules from two rows collapse to one entry in the union. This
+    keeps the contract observable without requiring callers to
+    deduplicate themselves.
+    """
+    if not approval_rows:
+        return None
+
+    row_ids: list[str] = []
+    rows_data: dict[str, dict[str, Any]] = {}
+    per_row_decisions: dict[str, InstinctDecision] = {}
+    union_rules: list[InstinctRule] = []
+    reasons: set[str] = set()
+
+    for row_id, row, decision in approval_rows:
+        row_ids.append(row_id)
+        rows_data[row_id] = row
+        per_row_decisions[row_id] = decision
+        reasons.add(decision.reason)
+        for rule in decision.matched_rules:
+            # Deduplicate by value. ``InstinctRule`` is Pydantic; its
+            # equality compares fields. ``in`` on the list of values
+            # walks linearly — fine for the small N of rules in any
+            # realistic template.
+            if rule not in union_rules:
+                union_rules.append(rule)
+
+    if reasons == {"operator_overlay_escalated"}:
+        consolidated_reason = "operator_overlay_escalated"
+    elif reasons == {"author_floor"}:
+        consolidated_reason = "author_floor"
+    else:
+        # Any other mix (e.g. {operator_overlay_escalated, author_floor})
+        # consolidates to a single typed string per the brief.
+        consolidated_reason = "mixed_approval_reasons"
+
+    return BulkApprovalRequest(
+        action_name=action_name,
+        row_ids=row_ids,
+        rows_data=rows_data,
+        reason=consolidated_reason,
+        matched_rules=union_rules,
+        per_row_decisions=per_row_decisions,
+    )
+
+
+__all__ = [
+    "BlockedRow",
+    "BulkApprovalRequest",
+    "BulkExecutionError",
+    "BulkPlan",
+    "ExecutionVerdict",
+    "RowExecution",
+    "plan_bulk_execution",
+]

--- a/tests/unit/test_bulk_executor.py
+++ b/tests/unit/test_bulk_executor.py
@@ -1,0 +1,647 @@
+# tests/unit/test_bulk_executor.py
+# Created: 2026-05-28 (feat/rfc-03-v2-bulk) — unit tests for the bulk
+# fan-out planner (``bulk_executor.plan_bulk_execution``). Pins the
+# RFC 03 v2 bulk-action execution model: per-row Instinct composition,
+# block / approval / execute / notify_and_execute bucketing, and the
+# core invariant that ONE ``BulkApprovalRequest`` blesses the entire
+# batch (not N requests). Worked-example coverage uses the bundled
+# ``lease-renewal-v2.yaml`` fixture against the ``bulk_draft`` action;
+# synthetic templates cover edge cases.
+"""Tests for the bulk fan-out planner (RFC 03 v2 PR 2e).
+
+The planner is a pure library function: given a template, a bulk
+action name, and a list of selected rows, it returns a frozen
+``BulkPlan`` describing what should happen per row PLUS the
+single-batch approval contract from the RFC.
+
+These tests pin:
+
+* The core RFC contract — ONE ``BulkApprovalRequest`` covers ALL rows
+  that need approval. Even if 50 rows escalate, one request goes on
+  the queue, not 50.
+* Per-row verdict bucketing — BLOCK rows go to ``blocked``,
+  EXECUTE / NOTIFY_AND_EXECUTE rows go to ``executions`` (with
+  ``notify_rules`` carried on the row), ESCALATE_APPROVAL rows
+  consolidate into ``approval_request``.
+* The ``mixed_approval_reasons`` consolidation — when one row
+  escalates via overlay rules (``operator_overlay_escalated``) and
+  another via author floor (``author_floor``), the consolidated
+  ``BulkApprovalRequest.reason`` becomes ``"mixed_approval_reasons"``.
+* Pre-flight validation — unknown action name and non-bulk action
+  kind both raise ``BulkExecutionError``.
+* Edge cases — empty selection, all-blocked batches, custom
+  ``row_id_field``, deterministic ``now`` injection, resolver
+  threading, and frozen-model immutability.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from pocketpaw.bundled_templates import (
+    ActionDef,
+    BlockedRow,
+    BulkApprovalRequest,
+    BulkExecutionError,
+    IdentifierResolver,
+    InstinctDecision,
+    PocketTemplate,
+    TemplateIdentifierResolver,
+    plan_bulk_execution,
+)
+
+# ---------------------------------------------------------------------------
+# Constants & helpers
+# ---------------------------------------------------------------------------
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent.parent / "fixtures" / "templates" / "lease-renewal-v2.yaml"
+)
+
+# Fixed clock so the CEL ``within(...)`` helper is deterministic across
+# the suite. Same wall-clock value tests/unit/test_instinct_composer.py
+# uses so the two suites can share intuition.
+FROZEN_NOW = datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC)
+
+
+def _load_lease_template() -> PocketTemplate:
+    """Load the canonical worked-example fixture."""
+    raw = yaml.safe_load(FIXTURE_PATH.read_text())
+    return PocketTemplate.model_validate(raw)
+
+
+def _clean_row(row_id: str, **overrides: Any) -> dict[str, Any]:
+    """Return a lease row that matches NO instinct rule on the
+    lease-renewal fixture. Tests override the bits they want to flip.
+
+    The fixture's four rules reference ``rent_proposed``,
+    ``rent_current``, ``rent_proposed_delta_pct``,
+    ``tenant.late_payment_count_12mo``, ``expires_at``, and
+    ``renewal_stage``. We populate every identifier so the resolver
+    never trips ``KeyError`` mid-evaluation.
+    """
+    base: dict[str, Any] = {
+        "id": row_id,
+        "rent_current": 2000.0,
+        "rent_proposed": 2050.0,
+        "rent_proposed_delta_pct": 2.5,
+        "renewal_stage": "draft",
+        "days_remaining": 60,
+        "expires_at": datetime(2026, 12, 1, tzinfo=UTC),
+        "tenant": {"late_payment_count_12mo": 0},
+    }
+    base.update(overrides)
+    return base
+
+
+def _minimal_template(
+    *,
+    actions: list[dict[str, Any]] | None = None,
+    rules: list[dict[str, str]] | None = None,
+) -> PocketTemplate:
+    """Build a tiny synthetic template that satisfies the schema. Used
+    by edge-case tests that don't need the full lease fixture."""
+    payload: dict[str, Any] = {
+        "schema_version": "2",
+        "name": "bulk-test",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "synthetic fixture for bulk executor tests",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "default_view": "list",
+            "columns": [
+                {"field": "id", "widget": "text"},
+                {"field": "score", "widget": "number"},
+            ],
+        },
+        "outcomes": ["thing_done"],
+        "actions": actions
+        or [
+            {
+                "name": "bulk_op",
+                "label": "Bulk op",
+                "kind": "bulk",
+                "instinct_policy": "auto",
+                "outcomes_emitted": ["thing_done"],
+            }
+        ],
+    }
+    if rules is not None:
+        payload["instinct_rules"] = {"rules": rules}
+    return PocketTemplate.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# Worked example — bulk_draft against lease-renewal-v2.yaml
+# ---------------------------------------------------------------------------
+
+
+def test_worked_example_all_clean_require_approval_consolidates_to_one_request() -> None:
+    """All 3 rows clean against a ``require_approval`` policy → 1 batch
+    approval covers all 3. This is the RFC's core promise: N rows, 1
+    approval. The bulk_draft action carries
+    ``instinct_policy: require_approval``."""
+    template = _load_lease_template()
+    rows = [
+        _clean_row("lease-1"),
+        _clean_row("lease-2"),
+        _clean_row("lease-3"),
+    ]
+    plan = plan_bulk_execution(template, "bulk_draft", rows, now=FROZEN_NOW)
+
+    assert plan.total_rows == 3
+    assert plan.executions == []
+    assert plan.blocked == []
+    assert plan.approval_request is not None
+    assert plan.approval_request.row_ids == ["lease-1", "lease-2", "lease-3"]
+    # ``require_approval`` floor (no overlay rule matched) → author_floor.
+    assert plan.approval_request.reason == "author_floor"
+    # The approval request carries the full row data for audit.
+    assert set(plan.approval_request.rows_data) == {"lease-1", "lease-2", "lease-3"}
+    # No overlay rules fired, so matched_rules is empty.
+    assert plan.approval_request.matched_rules == []
+
+
+def test_worked_example_mixed_block_approval_clean() -> None:
+    """Three rows, three buckets: lease-1 clean (→ approval via floor),
+    lease-2 hits an overlay rule (→ approval via overlay), lease-3
+    triggers the block rule (→ blocked). With bulk_draft's
+    ``require_approval`` floor, NO row ever lands in ``executions``.
+    The blocked row never enters the approval request — ``block always
+    wins`` per RFC."""
+    template = _load_lease_template()
+    rows = [
+        _clean_row("lease-1"),  # nothing matches → author_floor → approval
+        _clean_row(
+            "lease-2",
+            # overlay: rent_proposed_delta_pct > 8 → require_approval
+            rent_proposed_delta_pct=15.0,
+        ),
+        _clean_row(
+            "lease-3",
+            # block rule: rent_proposed < rent_current * 0.95
+            rent_proposed=1700.0,
+        ),
+    ]
+    plan = plan_bulk_execution(template, "bulk_draft", rows, now=FROZEN_NOW)
+
+    assert plan.total_rows == 3
+    assert plan.executions == []
+    assert [b.row_id for b in plan.blocked] == ["lease-3"]
+    assert plan.blocked[0].decision.verdict == "BLOCK"
+    assert plan.blocked[0].blocked_by_rule.action == "block"
+
+    assert plan.approval_request is not None
+    # Blocked row excluded from approval ids.
+    assert plan.approval_request.row_ids == ["lease-1", "lease-2"]
+    # One row escalates via overlay, one via author_floor → mixed.
+    assert plan.approval_request.reason == "mixed_approval_reasons"
+    # The overlay-matched rule shows up in the union.
+    assert any("rent_proposed_delta_pct" in r.when for r in plan.approval_request.matched_rules)
+
+
+# ---------------------------------------------------------------------------
+# Pure-bucket scenarios on a synthetic template
+# ---------------------------------------------------------------------------
+
+
+def test_all_clean_auto_policy_yields_executions_no_approval() -> None:
+    """``auto`` policy + no rules → every row in ``executions`` with
+    verdict EXECUTE. No approval request, no blocks."""
+    template = _minimal_template()
+    rows = [
+        {"id": "r1", "score": 1},
+        {"id": "r2", "score": 2},
+        {"id": "r3", "score": 3},
+    ]
+    plan = plan_bulk_execution(template, "bulk_op", rows, now=FROZEN_NOW)
+
+    assert plan.total_rows == 3
+    assert [r.row_id for r in plan.executions] == ["r1", "r2", "r3"]
+    assert all(r.verdict == "EXECUTE" for r in plan.executions)
+    assert all(r.notify_rules == [] for r in plan.executions)
+    assert plan.blocked == []
+    assert plan.approval_request is None
+
+
+def test_all_rows_blocked_yields_empty_executions_and_no_approval() -> None:
+    """Every row trips a block rule → all rows in ``blocked``, zero
+    executions, no approval request. Blocks must never sneak into the
+    approval queue."""
+    template = _minimal_template(
+        rules=[{"when": "score < 100", "action": "block"}],
+    )
+    rows = [
+        {"id": "r1", "score": 1},
+        {"id": "r2", "score": 5},
+    ]
+    plan = plan_bulk_execution(template, "bulk_op", rows, now=FROZEN_NOW)
+
+    assert plan.total_rows == 2
+    assert plan.executions == []
+    assert [b.row_id for b in plan.blocked] == ["r1", "r2"]
+    assert plan.approval_request is None
+    for blocked in plan.blocked:
+        assert blocked.decision.verdict == "BLOCK"
+        assert blocked.blocked_by_rule.action == "block"
+
+
+def test_notify_only_policy_routes_rows_into_executions_with_notify_rules() -> None:
+    """``notify_only`` policy + a matching notify rule → every row
+    lands in ``executions`` with verdict NOTIFY_AND_EXECUTE and the
+    matched notify rule carried on the row."""
+    template = _minimal_template(
+        actions=[
+            {
+                "name": "bulk_op",
+                "label": "Bulk op",
+                "kind": "bulk",
+                "instinct_policy": "notify_only",
+                "outcomes_emitted": ["thing_done"],
+            }
+        ],
+        rules=[{"when": "score > 0", "action": "notify"}],
+    )
+    rows = [
+        {"id": "r1", "score": 1},
+        {"id": "r2", "score": 2},
+    ]
+    plan = plan_bulk_execution(template, "bulk_op", rows, now=FROZEN_NOW)
+
+    assert plan.total_rows == 2
+    assert [r.row_id for r in plan.executions] == ["r1", "r2"]
+    assert all(r.verdict == "NOTIFY_AND_EXECUTE" for r in plan.executions)
+    # Notify rule captured on each row's RowExecution.
+    for row_exec in plan.executions:
+        assert len(row_exec.notify_rules) == 1
+        assert row_exec.notify_rules[0].action == "notify"
+    assert plan.blocked == []
+    assert plan.approval_request is None
+
+
+def test_empty_selected_rows_returns_empty_plan() -> None:
+    """Empty selection is valid — returns a fully-empty plan. Caller
+    likely produced an empty filter result; do not crash."""
+    template = _minimal_template()
+    plan = plan_bulk_execution(template, "bulk_op", [], now=FROZEN_NOW)
+
+    assert plan.total_rows == 0
+    assert plan.executions == []
+    assert plan.blocked == []
+    assert plan.approval_request is None
+    assert plan.action_name == "bulk_op"
+    # The looked-up action is still carried for downstream inspection.
+    assert plan.action.kind == "bulk"
+
+
+# ---------------------------------------------------------------------------
+# Approval-request consolidation semantics
+# ---------------------------------------------------------------------------
+
+
+def test_pure_author_floor_approval_reason_is_author_floor() -> None:
+    """All rows clean, action floor is ``require_approval`` → reason
+    ``author_floor`` (no overlay involvement)."""
+    template = _minimal_template(
+        actions=[
+            {
+                "name": "bulk_op",
+                "label": "Bulk op",
+                "kind": "bulk",
+                "instinct_policy": "require_approval",
+                "outcomes_emitted": ["thing_done"],
+            }
+        ],
+    )
+    rows = [{"id": "r1", "score": 1}, {"id": "r2", "score": 2}]
+    plan = plan_bulk_execution(template, "bulk_op", rows, now=FROZEN_NOW)
+
+    assert plan.approval_request is not None
+    assert plan.approval_request.reason == "author_floor"
+    assert plan.approval_request.matched_rules == []
+    assert plan.approval_request.row_ids == ["r1", "r2"]
+
+
+def test_pure_overlay_approval_reason_is_operator_overlay() -> None:
+    """Every row matches an overlay approval rule under ``auto`` policy
+    → reason ``operator_overlay_escalated`` (no author_floor in the
+    mix)."""
+    template = _minimal_template(
+        rules=[{"when": "score > 0", "action": "require_approval"}],
+    )
+    rows = [{"id": "r1", "score": 1}, {"id": "r2", "score": 2}]
+    plan = plan_bulk_execution(template, "bulk_op", rows, now=FROZEN_NOW)
+
+    assert plan.approval_request is not None
+    assert plan.approval_request.reason == "operator_overlay_escalated"
+    assert plan.approval_request.row_ids == ["r1", "r2"]
+    # Union carries one rule (same rule matched twice → still one in
+    # the union).
+    assert len(plan.approval_request.matched_rules) == 1
+    assert plan.approval_request.matched_rules[0].action == "require_approval"
+
+
+def test_mixed_approval_reasons_when_some_overlay_some_floor() -> None:
+    """Action floor is ``require_approval``. Row r1 hits an overlay
+    rule (operator-escalated); row r2 matches nothing (author_floor).
+    The consolidated request flips to ``mixed_approval_reasons``."""
+    template = _minimal_template(
+        actions=[
+            {
+                "name": "bulk_op",
+                "label": "Bulk op",
+                "kind": "bulk",
+                "instinct_policy": "require_approval",
+                "outcomes_emitted": ["thing_done"],
+            }
+        ],
+        rules=[{"when": "score > 10", "action": "require_approval"}],
+    )
+    rows = [
+        {"id": "r1", "score": 20},  # overlay matches → operator_overlay
+        {"id": "r2", "score": 1},  # no overlay → author_floor
+    ]
+    plan = plan_bulk_execution(template, "bulk_op", rows, now=FROZEN_NOW)
+
+    assert plan.approval_request is not None
+    assert plan.approval_request.reason == "mixed_approval_reasons"
+    assert plan.approval_request.row_ids == ["r1", "r2"]
+    # Audit trail preserves per-row decisions for the approval queue.
+    assert set(plan.approval_request.per_row_decisions) == {"r1", "r2"}
+    assert plan.approval_request.per_row_decisions["r1"].reason == "operator_overlay_escalated"
+    assert plan.approval_request.per_row_decisions["r2"].reason == "author_floor"
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_action_raises_bulk_execution_error() -> None:
+    """Action name not declared on the template → BulkExecutionError
+    with ``unknown action`` in the message. The error must surface
+    BEFORE any row evaluation runs."""
+    template = _minimal_template()
+    with pytest.raises(BulkExecutionError, match="unknown action"):
+        plan_bulk_execution(template, "does_not_exist", [{"id": "r1"}], now=FROZEN_NOW)
+
+
+def test_non_bulk_action_raises_bulk_execution_error() -> None:
+    """Action exists but ``kind`` is ``single-row`` → BulkExecutionError.
+    The planner is for ``kind: bulk`` only; routing the wrong action
+    here would silently mis-execute."""
+    template = _minimal_template(
+        actions=[
+            {
+                "name": "row_op",
+                "label": "Row op",
+                "kind": "single-row",
+                "instinct_policy": "auto",
+                "outcomes_emitted": ["thing_done"],
+            },
+            {
+                "name": "global_op",
+                "label": "Global op",
+                "kind": "global",
+                "instinct_policy": "auto",
+                "outcomes_emitted": ["thing_done"],
+            },
+        ],
+    )
+    with pytest.raises(BulkExecutionError, match="not a bulk action"):
+        plan_bulk_execution(template, "row_op", [{"id": "r1"}], now=FROZEN_NOW)
+    with pytest.raises(BulkExecutionError, match="not a bulk action"):
+        plan_bulk_execution(template, "global_op", [{"id": "r1"}], now=FROZEN_NOW)
+
+
+# ---------------------------------------------------------------------------
+# Row-ID resolution
+# ---------------------------------------------------------------------------
+
+
+def test_row_id_field_defaults_to_template_state_id_field() -> None:
+    """When no override is passed, the planner uses
+    ``template.state.id_field`` (which itself defaults to ``"id"``)."""
+    template = _minimal_template()
+    rows = [{"id": "r1", "score": 1}, {"id": "r2", "score": 2}]
+    plan = plan_bulk_execution(template, "bulk_op", rows, now=FROZEN_NOW)
+    assert [r.row_id for r in plan.executions] == ["r1", "r2"]
+
+
+def test_row_id_field_override_uses_caller_supplied_field() -> None:
+    """Passing ``row_id_field`` overrides the template's default. The
+    approval request's row_ids derive from the override."""
+    template = _minimal_template(
+        actions=[
+            {
+                "name": "bulk_op",
+                "label": "Bulk op",
+                "kind": "bulk",
+                "instinct_policy": "require_approval",
+                "outcomes_emitted": ["thing_done"],
+            }
+        ],
+    )
+    rows = [
+        {"id": "ignored-1", "score": 1, "external_id": "ext-A"},
+        {"id": "ignored-2", "score": 2, "external_id": "ext-B"},
+    ]
+    plan = plan_bulk_execution(
+        template, "bulk_op", rows, row_id_field="external_id", now=FROZEN_NOW
+    )
+    assert plan.approval_request is not None
+    assert plan.approval_request.row_ids == ["ext-A", "ext-B"]
+
+
+def test_row_id_field_uses_template_state_id_field_when_declared() -> None:
+    """Template declares ``state.id_field: lease_id`` → planner picks
+    it up automatically, no override needed."""
+    payload = {
+        "schema_version": "2",
+        "name": "id-field-test",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "synthetic",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Lease",
+            "id_field": "lease_id",
+            "default_view": "list",
+            "columns": [
+                {"field": "lease_id", "widget": "text"},
+                {"field": "score", "widget": "number"},
+            ],
+        },
+        "outcomes": ["done"],
+        "actions": [
+            {
+                "name": "bulk_op",
+                "label": "Bulk op",
+                "kind": "bulk",
+                "instinct_policy": "auto",
+                "outcomes_emitted": ["done"],
+            }
+        ],
+    }
+    template = PocketTemplate.model_validate(payload)
+    rows = [
+        {"lease_id": "L-1", "score": 1, "id": "ignored"},
+        {"lease_id": "L-2", "score": 2, "id": "ignored"},
+    ]
+    plan = plan_bulk_execution(template, "bulk_op", rows, now=FROZEN_NOW)
+    assert [r.row_id for r in plan.executions] == ["L-1", "L-2"]
+
+
+# ---------------------------------------------------------------------------
+# Determinism, resolver injection, immutability
+# ---------------------------------------------------------------------------
+
+
+def test_plan_is_deterministic_for_same_now_and_rows() -> None:
+    """Two calls with the same template, same rows, same ``now`` →
+    identical plans. Pure-function invariant."""
+    template = _load_lease_template()
+    rows = [_clean_row("lease-1"), _clean_row("lease-2", rent_proposed=1700.0)]
+    plan_a = plan_bulk_execution(template, "bulk_draft", rows, now=FROZEN_NOW)
+    plan_b = plan_bulk_execution(template, "bulk_draft", rows, now=FROZEN_NOW)
+    assert plan_a == plan_b
+
+
+def test_custom_resolver_is_threaded_into_resolve_instinct() -> None:
+    """Passing a custom resolver routes through to ``resolve_instinct``
+    for every row. We assert observable behaviour: a resolver that
+    raises ``KeyError`` for a needed identifier surfaces as a
+    BulkExecutionError-or-CEL-failure (composer raises
+    InstinctResolutionError, which we expose by letting it bubble)."""
+
+    class _CountingResolver:
+        """Records every ``resolve()`` call to confirm threading."""
+
+        def __init__(self, inner: IdentifierResolver) -> None:
+            self.inner = inner
+            self.calls: list[str] = []
+
+        def resolve(self, path: str, context: dict[str, Any]) -> Any:
+            self.calls.append(path)
+            return self.inner.resolve(path, context)
+
+    template = _minimal_template(
+        rules=[{"when": "score > 0", "action": "require_approval"}],
+    )
+    counting = _CountingResolver(TemplateIdentifierResolver(template))
+    rows = [{"id": "r1", "score": 1}, {"id": "r2", "score": 2}]
+    plan = plan_bulk_execution(template, "bulk_op", rows, resolver=counting, now=FROZEN_NOW)
+
+    # The rule references ``score``; the resolver fired at least
+    # once per row.
+    assert plan.total_rows == 2
+    assert counting.calls.count("score") >= 2
+
+
+def test_bulk_plan_is_frozen() -> None:
+    """``BulkPlan`` must be immutable so callers can pass it through
+    audit / serialization layers without worrying about mutation."""
+    template = _minimal_template()
+    plan = plan_bulk_execution(template, "bulk_op", [{"id": "r1", "score": 1}], now=FROZEN_NOW)
+    with pytest.raises(ValidationError):
+        plan.total_rows = 99  # type: ignore[misc]
+
+
+def test_row_execution_is_frozen() -> None:
+    """``RowExecution`` must be immutable too."""
+    template = _minimal_template()
+    plan = plan_bulk_execution(template, "bulk_op", [{"id": "r1", "score": 1}], now=FROZEN_NOW)
+    row_exec = plan.executions[0]
+    with pytest.raises(ValidationError):
+        row_exec.row_id = "mutated"  # type: ignore[misc]
+
+
+def test_bulk_approval_request_is_frozen() -> None:
+    """``BulkApprovalRequest`` must be immutable so the EE runtime
+    can't accidentally rewrite an in-flight approval."""
+    template = _minimal_template(
+        actions=[
+            {
+                "name": "bulk_op",
+                "label": "Bulk op",
+                "kind": "bulk",
+                "instinct_policy": "require_approval",
+                "outcomes_emitted": ["thing_done"],
+            }
+        ],
+    )
+    plan = plan_bulk_execution(template, "bulk_op", [{"id": "r1", "score": 1}], now=FROZEN_NOW)
+    assert plan.approval_request is not None
+    with pytest.raises(ValidationError):
+        plan.approval_request.row_ids = []  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Type-shape sanity
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_plan_carries_action_def_for_downstream_dispatch() -> None:
+    """The plan exposes the resolved ``ActionDef`` so the EE runtime
+    doesn't have to look it up again. This is the only non-frozen-list
+    field we sanity-check here; the action object itself comes from
+    Pydantic and is already validated upstream."""
+    template = _minimal_template()
+    plan = plan_bulk_execution(template, "bulk_op", [], now=FROZEN_NOW)
+    assert isinstance(plan.action, ActionDef)
+    assert plan.action.name == "bulk_op"
+    assert plan.action.kind == "bulk"
+
+
+def test_executions_carry_full_instinct_decision() -> None:
+    """Each ``RowExecution`` carries the underlying ``InstinctDecision``
+    so callers can audit *why* a row landed in ``executions``."""
+    template = _minimal_template()
+    plan = plan_bulk_execution(template, "bulk_op", [{"id": "r1", "score": 1}], now=FROZEN_NOW)
+    row_exec = plan.executions[0]
+    assert isinstance(row_exec.decision, InstinctDecision)
+    assert row_exec.decision.verdict == "EXECUTE"
+    assert row_exec.decision.reason == "auto"
+
+
+def test_blocked_row_carries_full_instinct_decision_and_rule() -> None:
+    """Each ``BlockedRow`` carries the full decision *and* the first
+    block rule that fired — both are needed for the audit log."""
+    template = _minimal_template(
+        rules=[{"when": "score < 100", "action": "block"}],
+    )
+    plan = plan_bulk_execution(template, "bulk_op", [{"id": "r1", "score": 1}], now=FROZEN_NOW)
+    blocked = plan.blocked[0]
+    assert isinstance(blocked, BlockedRow)
+    assert isinstance(blocked.decision, InstinctDecision)
+    assert blocked.decision.verdict == "BLOCK"
+    assert blocked.blocked_by_rule.action == "block"
+    assert blocked.row == {"id": "r1", "score": 1}
+
+
+def test_bulk_approval_request_type_check() -> None:
+    """Sanity: the approval request is a ``BulkApprovalRequest``
+    instance, not a dict or a plain Decision."""
+    template = _minimal_template(
+        actions=[
+            {
+                "name": "bulk_op",
+                "label": "Bulk op",
+                "kind": "bulk",
+                "instinct_policy": "require_approval",
+                "outcomes_emitted": ["thing_done"],
+            }
+        ],
+    )
+    plan = plan_bulk_execution(template, "bulk_op", [{"id": "r1", "score": 1}], now=FROZEN_NOW)
+    assert isinstance(plan.approval_request, BulkApprovalRequest)


### PR DESCRIPTION
## Summary

PR 2e ships the **bulk fan-out planner** — the **last library-layer
piece** before RFC 03 v2 integration returns to dev. Given a template,
a `kind: bulk` action name, and N selected rows, `plan_bulk_execution`
returns a frozen `BulkPlan` describing per-row fan-out plus the
single-batch approval contract from RFC §"Bulk action execution
model":

> "A `kind: bulk` action fans out one execution per selected row. ...
> If the action has `instinct_policy: require_approval` (or a
> top-level approval rule matched), the Instinct queue gets ONE
> approval request that authorizes the whole batch — not N requests."

That seam is what this PR ships. The EE runtime that actually invokes
actions, submits to the approval queue, and emits outcome events
lives in `ee/cloud/pockets/` and wires up in a follow-up PR.

## What's in scope

- **`src/pocketpaw/bundled_templates/bulk_executor.py`** (new) — pure
  library module. `plan_bulk_execution(template, action_name,
  selected_rows, *, workspace_context, resolver, row_id_field, now)`.
  Per-row Instinct composition via PR 2d's composer; verdict
  bucketing (BLOCK → `blocked`, ESCALATE_APPROVAL → consolidated
  `approval_request`, EXECUTE/NOTIFY_AND_EXECUTE → `executions`);
  pre-flight validation (unknown action / non-bulk kind →
  `BulkExecutionError`).
- **`src/pocketpaw/bundled_templates/__init__.py`** — re-exports the
  new public surface (`plan_bulk_execution`, `BulkPlan`,
  `RowExecution`, `BlockedRow`, `BulkApprovalRequest`,
  `ExecutionVerdict`, `BulkExecutionError`).
- **`tests/unit/test_bulk_executor.py`** (new, 23 tests) — worked
  example against the `lease-renewal-v2.yaml` fixture; pure-bucket
  cases (all-clean auto, all-blocked, all notify-only); the three
  approval reason codes (`operator_overlay_escalated`, `author_floor`,
  `mixed_approval_reasons`); pre-flight validation; `row_id_field`
  resolution chain (explicit → `state.id_field` → `"id"`);
  determinism via fixed `now`; custom-resolver threading; frozen-
  model immutability across all three result models.

## What's NOT in scope (follow-up PR)

- Actual approval-queue submission, agent invocation, HTTP action
  call, outcome event emission — all live in `ee/cloud/pockets/`.
- Single-row + global action runtimes — different code paths; only
  `kind: bulk` is in scope here.
- Per-agent concurrency limits + idempotency keys for retried
  batches — EE runtime concerns, not planning.

## Key architectural decisions (locked, observable)

1. **ONE approval blesses the whole batch.** Even 50 approval-needing
   rows produce one `BulkApprovalRequest`. `row_ids` carries the full
   list; `rows_data` carries per-row payloads for audit;
   `per_row_decisions` preserves the per-row truth that the
   consolidated `reason` field collapses.
2. **`mixed_approval_reasons`** is the typed string used when some
   rows escalate via overlay rules and others via the author floor.
   Single observable contract; per-row detail still recoverable via
   `per_row_decisions`.
3. **Blocked rows are excluded** from both `executions` AND the
   approval request — per RFC `block always wins`. They get their own
   bucket carrying both the full `InstinctDecision` and the first
   block rule that fired (for the audit log).
4. **`NOTIFY_AND_EXECUTE` rows go into `executions`** with `notify_rules`
   carried on the row — not a separate bucket. This keeps the runtime's
   dispatch loop single-pass.
5. **All result models are frozen** (`ConfigDict(frozen=True)`) so the
   plan can flow through audit / serialization layers without
   mid-flight mutation.

## Test plan

- [x] `uv run pytest tests/unit/test_bulk_executor.py -xvs` — 23/23 pass.
- [x] Adjacent suites green (`test_instinct_composer.py`,
      `test_cel_runtime.py`, `test_identifier_resolver.py`,
      `test_template_schema.py`, `test_bundled_templates.py`) —
      no regression, 124/124 pass.
- [x] Full unit suite — 205 passed, 13 skipped.
- [x] `uv run ruff check && uv run ruff format` clean on touched
      files.
- [x] Smoke test against the bundled lease-renewal fixture: 3 rows
      (lease-3 trips the block rule `rent_proposed < rent_current *
      0.95`), `bulk_draft` action with `require_approval` floor →
      `total_rows=3, executions=0, blocked=1, approval_request`
      covers lease-1 + lease-2 with `reason=author_floor`. Matches
      the spec narrative end-to-end.
- [ ] EE integration smoke (deferred to follow-up PR).

## Branch

`feat/rfc-03-v2-bulk` off `feat/rfc-03-v2-integration` (transitive
merge of PR 2c CEL evaluator + PR 2d Instinct composer landed in
Phase 0).
