### PR TITLE
feat(ee): Instinct dispatch gate + approval queue for RFC 03 v2

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -205,6 +205,7 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(pockets_journal_stream_router, prefix="/api/v1")
 
     from pocketpaw_ee.cloud.decisions.router import router as decisions_router
+    from pocketpaw_ee.cloud.instinct_approvals.router import router as instinct_approvals_router
     from pocketpaw_ee.cloud.kb.router import router as kb_router
     from pocketpaw_ee.cloud.livekit.router import router as livekit_router
     from pocketpaw_ee.cloud.mission_control.router import router as mission_control_router
@@ -231,6 +232,11 @@ def mount_cloud(app: FastAPI) -> None:
     # the real REST surface (get/find/trace/downstream/timeline/explain)
     # lands in RFC 07 Slice 2.
     app.include_router(decisions_router, prefix="/api/v1")
+    # Instinct approvals — RFC 03 v2 template-level approval queue
+    # (Wave 3a). The dispatch wrapper persists rows when the OSS
+    # ``resolve_instinct`` returns ``ESCALATE_APPROVAL``; this router
+    # exposes the operator-facing read + decision surface.
+    app.include_router(instinct_approvals_router, prefix="/api/v1")
 
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
     # inline (instead of via build_router's ctx_factory) so the routes can

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -4,6 +4,11 @@
 # Updated: 2026-05-22 (RFC 05 M2b.2) — added PocketOutcomeEvent
 #   (type="pocket.outcome"), emitted after a successful write action whose
 #   binding declared a named `outcome`. Feeds the outcomes JSONL ledger.
+# Updated: 2026-05-28 (feat/wave-3a-instinct-dispatch) — added the three
+#   instinct.approval.* events (created / approved / rejected) for the
+#   RFC 03 v2 template-level approval queue. Emitted by
+#   ``instinct_approvals.service`` on every state-mutating function per
+#   the EE cloud rule 9 (``emit on every write``).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -492,3 +497,24 @@ class ComposioConnectionVerified(Event):
 @dataclass
 class ComposioConnectionMismatch(Event):
     EVENT_TYPE: ClassVar[str] = "composio.connection.mismatch"
+
+
+# Instinct approval queue (RFC 03 v2 / Wave 3a). Fires on every
+# ``instinct_approvals.service`` state-mutating call. Created on the
+# initial gate-result persistence; approved / rejected on operator
+# decision. ``data`` carries the approval id + workspace + pocket
+# context so a downstream WS fan-out can target the right operator
+# inbox without re-reading the doc.
+@dataclass
+class InstinctApprovalCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "instinct.approval.created"
+
+
+@dataclass
+class InstinctApprovalApproved(Event):
+    EVENT_TYPE: ClassVar[str] = "instinct.approval.approved"
+
+
+@dataclass
+class InstinctApprovalRejected(Event):
+    EVENT_TYPE: ClassVar[str] = "instinct.approval.rejected"

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/__init__.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/__init__.py
@@ -1,0 +1,5 @@
+# ee/pocketpaw_ee/cloud/instinct_approvals/__init__.py
+# Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — package marker
+# for the RFC 03 v2 template-level approval queue entity. The 4-file
+# shape lives under ``domain.py``, ``dto.py``, ``service.py``,
+# ``router.py`` — copy of the canonical ``pockets/`` layout.

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/domain.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/domain.py
@@ -1,0 +1,47 @@
+# ee/pocketpaw_ee/cloud/instinct_approvals/domain.py
+# Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — domain value
+# object for the RFC 03 v2 template-level approval queue. Pure-Python
+# frozen dataclass with REQUIRED tenancy fields (workspace_id has no
+# default) — constructing an ``InstinctApproval`` domain object without
+# tenancy is a type error. EE rule 3.
+
+"""Domain value object for ``instinct_approvals``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class InstinctApproval:
+    """One pending / decided template-level Instinct approval.
+
+    Frozen so downstream readers (UI / audit / cross-service callers)
+    cannot mutate the object after the service hands it back. Tenancy
+    fields (``workspace_id``) are required positional so the type
+    system catches a missing tenancy at construction time — the EE
+    cloud rule 3 invariant.
+    """
+
+    id: str
+    workspace_id: str
+    pocket_id: str
+    action_name: str
+    row_id: str
+    row_data: dict[str, Any]
+    verdict: str
+    reason: str
+    matched_rules: list[dict[str, Any]]
+    requested_at: datetime
+    requested_by: str
+    status: str
+    decided_at: datetime | None = None
+    decided_by: str | None = None
+    park: dict[str, Any] | None = None
+    created_at: datetime | None = None
+    notify_rules: list[dict[str, Any]] = field(default_factory=list)
+
+
+__all__ = ["InstinctApproval"]

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/dto.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/dto.py
@@ -1,0 +1,124 @@
+# ee/pocketpaw_ee/cloud/instinct_approvals/dto.py
+# Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — wire-format
+# DTOs for the RFC 03 v2 template-level approval queue. Distinct
+# request and response classes per EE cloud rule 4 — never reuse one
+# model for input and output.
+
+"""Wire-format DTOs for the ``instinct_approvals`` entity."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pocketpaw_ee.cloud._core.time import iso_utc
+from pocketpaw_ee.cloud.instinct_approvals.domain import InstinctApproval
+
+
+class CreateApprovalRequest(BaseModel):
+    """Persist a new pending approval row.
+
+    Called by ``pockets.instinct_dispatch.gate_action`` when the
+    composer returns ``ESCALATE_APPROVAL``. The route is internal —
+    operators do not POST approvals directly; they approve / reject
+    existing ones via the decision endpoints.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    pocket_id: str = Field(min_length=1)
+    action_name: str = Field(min_length=1)
+    row_id: str = ""
+    row_data: dict[str, Any] = Field(default_factory=dict)
+    verdict: str = "ESCALATE_APPROVAL"
+    reason: str = ""
+    matched_rules: list[dict[str, Any]] = Field(default_factory=list)
+    park: dict[str, Any] | None = None
+
+
+class ListApprovalsRequest(BaseModel):
+    """Filter parameters for the list endpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: str | None = None
+    pocket_id: str | None = None
+    limit: int = Field(default=50, ge=1, le=200)
+
+
+class ApprovalDecisionRequest(BaseModel):
+    """Approve or reject an existing pending approval.
+
+    Empty body — the route parameter carries the id, the caller's
+    workspace + user come from the request context. Kept as a typed
+    model so future fields (e.g. reviewer note, batch decision id)
+    don't break the wire.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    note: str | None = None
+
+
+class ApprovalResponse(BaseModel):
+    """Wire response for one approval row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    workspace_id: str
+    pocket_id: str
+    action_name: str
+    row_id: str
+    row_data: dict[str, Any]
+    verdict: str
+    reason: str
+    matched_rules: list[dict[str, Any]]
+    requested_at: str | None
+    requested_by: str
+    status: str
+    decided_at: str | None
+    decided_by: str | None
+    created_at: str | None
+
+
+def approval_to_dto(a: InstinctApproval) -> ApprovalResponse:
+    """Map a domain ``InstinctApproval`` to its wire DTO.
+
+    ``park`` is deliberately not serialized on the wire — it's an
+    executor-internal blob (resolved write path / params /
+    idempotency_key) that the approval queue UI does not need to see
+    and that a future post-approval re-entry consumes server-side.
+    """
+    return ApprovalResponse(
+        id=a.id,
+        workspace_id=a.workspace_id,
+        pocket_id=a.pocket_id,
+        action_name=a.action_name,
+        row_id=a.row_id,
+        row_data=a.row_data,
+        verdict=a.verdict,
+        reason=a.reason,
+        matched_rules=a.matched_rules,
+        requested_at=iso_utc(a.requested_at) if a.requested_at else None,
+        requested_by=a.requested_by,
+        status=a.status,
+        decided_at=iso_utc(a.decided_at) if a.decided_at else None,
+        decided_by=a.decided_by,
+        created_at=iso_utc(a.created_at) if a.created_at else None,
+    )
+
+
+def approval_to_wire_dict(a: InstinctApproval) -> dict:
+    return approval_to_dto(a).model_dump()
+
+
+__all__ = [
+    "ApprovalDecisionRequest",
+    "ApprovalResponse",
+    "CreateApprovalRequest",
+    "ListApprovalsRequest",
+    "approval_to_dto",
+    "approval_to_wire_dict",
+]

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/router.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/router.py
@@ -1,0 +1,94 @@
+# ee/pocketpaw_ee/cloud/instinct_approvals/router.py
+# Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — REST surface
+# for the RFC 03 v2 template-level approval queue. Routes are thin:
+# they parse the request, delegate to the service, and return the wire
+# dict the service produced. Errors propagate via ``CloudError``; the
+# central ``cloud_error_handler`` maps to JSON. Never raises
+# ``HTTPException`` (rule 10).
+
+"""FastAPI router for ``instinct_approvals``."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+from pocketpaw_ee.cloud.instinct_approvals.dto import (
+    ApprovalDecisionRequest,
+    CreateApprovalRequest,
+    ListApprovalsRequest,
+)
+
+router = APIRouter(prefix="/instinct-approvals", tags=["InstinctApprovals"])
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    if not ctx.workspace_id:
+        raise ValidationError(
+            "instinct_approval.workspace_required",
+            "no active workspace on this request",
+        )
+    return ctx.workspace_id
+
+
+@router.post("")
+async def create(
+    body: CreateApprovalRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    """Persist a new pending approval row.
+
+    Internal route — the dispatch wrapper
+    (``pockets.instinct_dispatch.gate_action``) calls
+    ``approvals_service.create_approval`` directly when the composer
+    returns ``ESCALATE_APPROVAL``. The endpoint exists so tooling and
+    tests can exercise the same path.
+    """
+    workspace_id = _require_workspace(ctx)
+    return await approvals_service.create_approval(workspace_id, ctx.user_id, body)
+
+
+@router.get("")
+async def list_approvals(
+    status: str | None = None,
+    pocket_id: str | None = None,
+    limit: int = 50,
+    ctx: RequestContext = Depends(request_context),
+) -> list[dict]:
+    workspace_id = _require_workspace(ctx)
+    body = ListApprovalsRequest(status=status, pocket_id=pocket_id, limit=limit)
+    return await approvals_service.list_approvals(workspace_id, ctx.user_id, body)
+
+
+@router.get("/{approval_id}")
+async def get(
+    approval_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    workspace_id = _require_workspace(ctx)
+    return await approvals_service.get_approval(workspace_id, ctx.user_id, approval_id)
+
+
+@router.post("/{approval_id}/approve")
+async def approve(
+    approval_id: str,
+    body: ApprovalDecisionRequest | None = None,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    workspace_id = _require_workspace(ctx)
+    return await approvals_service.approve(workspace_id, ctx.user_id, approval_id, body)
+
+
+@router.post("/{approval_id}/reject")
+async def reject(
+    approval_id: str,
+    body: ApprovalDecisionRequest | None = None,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    workspace_id = _require_workspace(ctx)
+    return await approvals_service.reject(workspace_id, ctx.user_id, approval_id, body)
+
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
@@ -1,0 +1,251 @@
+# ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+# Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — sole Beanie
+# writer for the ``InstinctApproval`` collection (RFC 03 v2). Module-
+# level ``async def`` API per EE cloud rule 5. Every state-mutating
+# function:
+#   * validates at entry via ``<Request>.model_validate(body)`` (rule 6)
+#   * filters reads by ``workspace=workspace_id`` (rule 7)
+#   * raises ``CloudError`` subclasses, never ``HTTPException`` (rule 10)
+#   * emits an event on the way out (rule 9)
+#
+# Errors:
+#   * unknown approval id → ``NotFound("instinct_approval", id)``
+#   * tenant mismatch on read → returns ``None`` (no oracle); on
+#     decision attempt → ``NotFound`` (treat as if it does not exist)
+#   * already-decided approval → ``ConflictError("instinct_approval.already_decided", ...)``
+
+"""Service for ``instinct_approvals``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from beanie import PydanticObjectId
+
+from pocketpaw_ee.cloud._core.errors import ConflictError, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import (
+    InstinctApprovalApproved,
+    InstinctApprovalCreated,
+    InstinctApprovalRejected,
+)
+from pocketpaw_ee.cloud.instinct_approvals.domain import InstinctApproval
+from pocketpaw_ee.cloud.instinct_approvals.dto import (
+    ApprovalDecisionRequest,
+    CreateApprovalRequest,
+    ListApprovalsRequest,
+    approval_to_wire_dict,
+)
+from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval as _ApprovalDoc
+
+# ---------------------------------------------------------------------------
+# Private mapping helper — Beanie doc → domain
+# ---------------------------------------------------------------------------
+
+
+def _to_domain(doc: _ApprovalDoc) -> InstinctApproval:
+    return InstinctApproval(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        pocket_id=doc.pocket_id,
+        action_name=doc.action_name,
+        row_id=doc.row_id,
+        row_data=dict(doc.row_data or {}),
+        verdict=doc.verdict,
+        reason=doc.reason,
+        matched_rules=list(doc.matched_rules or []),
+        requested_at=doc.requested_at,
+        requested_by=doc.requested_by,
+        status=doc.status,
+        decided_at=doc.decided_at,
+        decided_by=doc.decided_by,
+        park=dict(doc.park) if doc.park else None,
+        created_at=getattr(doc, "createdAt", None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def create_approval(
+    workspace_id: str, user_id: str, body: dict | CreateApprovalRequest
+) -> dict:
+    """Persist a new pending approval row.
+
+    Called by ``pockets.instinct_dispatch.gate_action`` when the
+    template-level composer returns ``ESCALATE_APPROVAL``. Re-validates
+    the body (FastAPI parsed it; internal callers re-parse so the
+    schema is enforced uniformly — rule 6).
+    """
+    body = CreateApprovalRequest.model_validate(body)
+
+    if not workspace_id:
+        raise ValidationError(
+            "instinct_approval.workspace_required",
+            "workspace_id is required to create an approval row",
+        )
+    if not user_id:
+        raise ValidationError(
+            "instinct_approval.user_required",
+            "user_id is required to create an approval row",
+        )
+
+    now = datetime.now(UTC)
+    doc = _ApprovalDoc(
+        workspace=workspace_id,
+        pocket_id=body.pocket_id,
+        action_name=body.action_name,
+        row_id=body.row_id,
+        row_data=body.row_data,
+        verdict=body.verdict,
+        reason=body.reason,
+        matched_rules=body.matched_rules,
+        requested_at=now,
+        requested_by=user_id,
+        status="pending",
+        park=body.park,
+    )
+    await doc.insert()
+    domain = _to_domain(doc)
+    wire = approval_to_wire_dict(domain)
+    await emit(InstinctApprovalCreated(data=dict(wire)))
+    return wire
+
+
+async def list_approvals(
+    workspace_id: str, user_id: str, body: dict | ListApprovalsRequest
+) -> list[dict]:
+    """List approvals scoped to ``workspace_id``. ``user_id`` is the
+    viewer; current behaviour is workspace-wide read (no per-user
+    filtering) — a future PR adds approver-scoped filtering."""
+    body = ListApprovalsRequest.model_validate(body)
+    # `user_id` carries viewer context for future per-approver filtering.
+    _ = user_id
+
+    query: dict[str, Any] = {"workspace": workspace_id}
+    if body.status:
+        query["status"] = body.status
+    if body.pocket_id:
+        query["pocket_id"] = body.pocket_id
+    cursor = (
+        _ApprovalDoc.find(query).sort(-_ApprovalDoc.createdAt).limit(body.limit)  # type: ignore[operator]
+    )
+    return [approval_to_wire_dict(_to_domain(doc)) async for doc in cursor]
+
+
+async def get_approval(workspace_id: str, user_id: str, approval_id: str) -> dict:
+    """Return one approval row by id, scoped to ``workspace_id``.
+
+    Raises ``NotFound`` when the id does not resolve in the caller's
+    workspace — treating a foreign-workspace hit as a 404 keeps the
+    endpoint from being a cross-tenant existence oracle.
+    """
+    _ = user_id  # viewer context unused on the read path today
+    try:
+        oid = PydanticObjectId(approval_id)
+    except Exception as exc:
+        raise NotFound("instinct_approval", approval_id) from exc
+
+    doc = await _ApprovalDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise NotFound("instinct_approval", approval_id)
+    return approval_to_wire_dict(_to_domain(doc))
+
+
+async def approve(
+    workspace_id: str,
+    user_id: str,
+    approval_id: str,
+    body: dict | ApprovalDecisionRequest | None = None,
+) -> dict:
+    """Mark a pending approval as ``approved``. Emits ``InstinctApprovalApproved``.
+
+    Out of scope for Wave 3a: this PR persists the decision only. The
+    follow-up wave wires the post-approval re-entry into
+    ``action_executor.run_action(from_instinct=True)``.
+    """
+    body = ApprovalDecisionRequest.model_validate(body or {})
+    return await _decide(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        approval_id=approval_id,
+        new_status="approved",
+        event_cls=InstinctApprovalApproved,
+        note=body.note,
+    )
+
+
+async def reject(
+    workspace_id: str,
+    user_id: str,
+    approval_id: str,
+    body: dict | ApprovalDecisionRequest | None = None,
+) -> dict:
+    """Mark a pending approval as ``rejected``. Emits ``InstinctApprovalRejected``."""
+    body = ApprovalDecisionRequest.model_validate(body or {})
+    return await _decide(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        approval_id=approval_id,
+        new_status="rejected",
+        event_cls=InstinctApprovalRejected,
+        note=body.note,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+async def _decide(
+    *,
+    workspace_id: str,
+    user_id: str,
+    approval_id: str,
+    new_status: str,
+    event_cls: type,
+    note: str | None,
+) -> dict:
+    if not user_id:
+        raise ValidationError(
+            "instinct_approval.user_required",
+            "user_id is required to decide an approval",
+        )
+    try:
+        oid = PydanticObjectId(approval_id)
+    except Exception as exc:
+        raise NotFound("instinct_approval", approval_id) from exc
+
+    doc = await _ApprovalDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise NotFound("instinct_approval", approval_id)
+    if doc.status != "pending":
+        raise ConflictError(
+            "instinct_approval.already_decided",
+            f"approval {approval_id} is already {doc.status!r}",
+        )
+
+    doc.status = new_status  # type: ignore[assignment]
+    doc.decided_at = datetime.now(UTC)
+    doc.decided_by = user_id
+    await doc.save()
+    domain = _to_domain(doc)
+    wire = approval_to_wire_dict(domain)
+    payload = dict(wire)
+    if note:
+        payload["note"] = note
+    await emit(event_cls(data=payload))
+    return wire
+
+
+__all__ = [
+    "approve",
+    "create_approval",
+    "get_approval",
+    "list_approvals",
+    "reject",
+]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -19,6 +19,7 @@ from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
 from pocketpaw_ee.cloud.models.cycle import Cycle, CycleDailyPoint
 from pocketpaw_ee.cloud.models.file import FileObj
 from pocketpaw_ee.cloud.models.group import Group, GroupAgent
+from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval
 from pocketpaw_ee.cloud.models.invite import Invite
 from pocketpaw_ee.cloud.models.message import Attachment, Mention, Message, Reaction
 from pocketpaw_ee.cloud.models.notification import Notification, NotificationSource
@@ -84,6 +85,7 @@ __all__ = [
     "FileUpload",
     "Group",
     "GroupAgent",
+    "InstinctApproval",
     "Invite",
     "Mention",
     "Message",
@@ -130,6 +132,7 @@ def get_all_documents():
         ComposioConnection,
         Invite,
         Group,
+        InstinctApproval,
         Message,
         ReadState,
         Task,

--- a/ee/pocketpaw_ee/cloud/models/instinct_approval.py
+++ b/ee/pocketpaw_ee/cloud/models/instinct_approval.py
@@ -1,0 +1,103 @@
+# ee/pocketpaw_ee/cloud/models/instinct_approval.py
+# Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — Beanie document
+# backing the EE-side approval queue for RFC 03 v2 template-level
+# Instinct decisions. The pure ``resolve_instinct`` composer in OSS
+# returns an ``InstinctDecision`` per row; when the verdict is
+# ``ESCALATE_APPROVAL`` the dispatch wrapper persists one row of this
+# doc via ``instinct_approvals.service.create_approval`` and the
+# action_executor returns a ``code:instinct_pending`` sentinel carrying
+# the approval id.
+#
+# Tenancy: ``workspace`` is required + indexed. Every read in
+# ``instinct_approvals/service.py`` filters by it, so an approval row in
+# workspace A is invisible to workspace B.
+#
+# ``_park``: the executor parks the resolved write blob (method / path /
+# params / idempotency_key) here so a future post-approval re-entry can
+# replay the write without re-resolving the row. This sibling of the
+# M2b.1 ``_park`` field on ``pocketpaw.instinct.models.Action`` is
+# scoped to the RFC 03 v2 template flow only — the M2b.1 binding-level
+# park remains for backward compatibility.
+
+"""Beanie document for the Instinct approval queue (RFC 03 v2)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+ApprovalStatusT = Literal["pending", "approved", "rejected", "expired"]
+
+
+class InstinctApproval(TimestampedDocument):
+    """One pending / decided template-level Instinct approval row.
+
+    A row is created when the RFC 03 v2 dispatch wrapper evaluates a
+    template-level ``resolve_instinct`` and the verdict is
+    ``ESCALATE_APPROVAL``. The action_executor returns the parked write
+    to the caller as ``code:instinct_pending`` carrying ``approval_id``;
+    the operator approves / rejects via the
+    ``/instinct-approvals/{id}/{approve,reject}`` endpoints.
+
+    Fields:
+        workspace: tenant id. Indexed; every read filters by it.
+        pocket_id: pocket the action fired from.
+        action_name: ``ActionDef.name`` slug.
+        row_id: identifier of the row the action targeted (free-form).
+        row_data: snapshot of the row at decision time. Stored so the
+            approval queue UI can render context without re-fetching.
+        verdict: copied from the composer's ``InstinctDecision.verdict``.
+            Always ``ESCALATE_APPROVAL`` at creation; the field is
+            retained for audit symmetry.
+        reason: the composer's machine-readable reason code
+            (``operator_overlay_escalated`` / ``author_floor``).
+        matched_rules: dump of the composer's ``matched_rules`` (when /
+            action pairs) so the approval UI can show why.
+        requested_at: datetime the gate ran. Distinct from ``createdAt``
+            (which Beanie set on insert) so a future migration that moves
+            persistence off the request path keeps the timeline accurate.
+        requested_by: user id that triggered the action.
+        status: ``pending`` on insert; flipped to ``approved`` /
+            ``rejected`` on operator decision; ``expired`` reserved for a
+            future temporal sweeper.
+        decided_at / decided_by: set when an operator approves or
+            rejects. ``None`` while pending.
+        _park: the resolved write blob the executor parked (method,
+            path, params, idempotency_key, outcome, workspace_id,
+            requested_by). Re-loaded by a future post-approval re-entry
+            into ``run_action(from_instinct=True)``. ``None`` when the
+            executor was not threaded through a write (e.g. a future
+            non-write action surface).
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    pocket_id: Indexed(str)  # type: ignore[valid-type]
+    action_name: str
+    row_id: str = ""
+    row_data: dict[str, Any] = Field(default_factory=dict)
+    verdict: str = "ESCALATE_APPROVAL"
+    reason: str = ""
+    matched_rules: list[dict[str, Any]] = Field(default_factory=list)
+    requested_at: datetime
+    requested_by: str
+    status: ApprovalStatusT = "pending"
+    decided_at: datetime | None = None
+    decided_by: str | None = None
+    park: dict[str, Any] | None = Field(default=None, alias="_park")
+
+    model_config = {"populate_by_name": True}
+
+    class Settings:
+        name = "instinct_approvals"
+        indexes = [
+            [("workspace", 1), ("status", 1), ("createdAt", -1)],
+            [("workspace", 1), ("pocket_id", 1), ("status", 1)],
+        ]
+
+
+__all__ = ["ApprovalStatusT", "InstinctApproval"]

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -31,6 +31,21 @@
 #   keys are swept opportunistically under the existing lock. Previously
 #   the map grew one permanent entry per `(pocket, user)` pair that ever
 #   ran a write — an unbounded memory leak in a long-running worker.
+# Updated: 2026-05-28 (feat/wave-3a-instinct-dispatch) — RFC 03 v2
+#   template-level Instinct gate. `run_action` accepts an optional
+#   `template` parameter; when present and `from_instinct=False` the
+#   executor calls `instinct_dispatch.gate_action(...)` BEFORE any of
+#   the existing security guards (it's the cheapest possible failure
+#   point — pure CEL evaluation, no I/O, no HTTP). The gate returns
+#   one of three branches:
+#     * blocked → return the new `instinct_blocked` sentinel; NO call.
+#     * pending_approval → persist an `InstinctApproval` row via the
+#       new EE-side service, return `instinct_pending` carrying the
+#       `approval_id`; NO call.
+#     * proceed → fall through into the existing gate stack (rate
+#       limit / base-URL / SSRF / allowlist / DNS / M2b.1 park / HTTP).
+#   When no template is passed (all current callers; backward-compat)
+#   the gate is skipped — every existing flow is byte-identical.
 #
 # A write has blast radius a read does not, so this executor adds three
 # concerns on TOP of the shared SSRF guards:
@@ -70,7 +85,7 @@ import logging
 import time
 import urllib.parse
 import uuid
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 from pydantic import BaseModel, Field, ValidationError, model_validator
@@ -85,6 +100,12 @@ from pocketpaw_ee.cloud.pockets._http_guard import (
     _resolve_url,
     _strip_query,
 )
+
+if TYPE_CHECKING:
+    # ``PocketTemplate`` ships in OSS (no EE import here, just typing).
+    # Importing under TYPE_CHECKING keeps the runtime import graph
+    # unchanged for callers that don't thread a template through.
+    from pocketpaw.bundled_templates import PocketTemplate
 
 logger = logging.getLogger(__name__)
 
@@ -325,6 +346,10 @@ async def run_action(
     allowed_writes: list[dict[str, Any]],
     idempotency_key: str | None = None,
     from_instinct: bool = False,
+    template: PocketTemplate | None = None,
+    row_context: dict[str, Any] | None = None,
+    workspace_context: dict[str, Any] | None = None,
+    row_id: str = "",
 ) -> dict:
     """Run ONE pocket write action against its configured backend.
 
@@ -392,6 +417,79 @@ async def run_action(
 
     on_error = binding.on_error
     method = binding.method
+
+    # ── 1.5. RFC 03 v2 template-level Instinct gate ─────────────────────
+    # When a template is threaded through (and we're not re-entering
+    # post-approval), evaluate `resolve_instinct` via the dispatch
+    # wrapper. The wrapper is the only impure layer that talks to the
+    # `instinct_approvals` Beanie collection — this module stays pure
+    # of Beanie imports (import-linter contract).
+    #
+    # The gate is the CHEAPEST failure mode in the stack: pure CEL eval
+    # on the row + workspace context, no HTTP, no SSRF resolve, no DNS
+    # lookup. A BLOCK / ESCALATE_APPROVAL verdict short-circuits every
+    # downstream guard.
+    if template is not None and not from_instinct:
+        from pocketpaw_ee.cloud.pockets import instinct_dispatch
+
+        park = {
+            "action": action,
+            "method": method,
+            "path": path,
+            "params": params,
+            "idempotency_key": idempotency_key,
+            "outcome": binding.outcome,
+        }
+        gate = await instinct_dispatch.gate_action(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            template=template,
+            action_name=action,
+            row_context=row_context or {},
+            workspace_context=workspace_context,
+            row_id=row_id,
+            park=park,
+        )
+        if gate.next_step == "blocked":
+            _audit_action_run(
+                actor=user_id,
+                workspace_id=workspace_id,
+                pocket_id=pocket_id,
+                action=action,
+                status="instinct-blocked",
+                base_url=base_url,
+            )
+            return {
+                "ok": False,
+                "code": "instinct_blocked",
+                "action": action,
+                "error": "action blocked by Instinct rule",
+                "reason": gate.decision.reason,
+                "on_error": on_error,
+            }
+        if gate.next_step == "pending_approval":
+            _audit_action_run(
+                actor=user_id,
+                workspace_id=workspace_id,
+                pocket_id=pocket_id,
+                action=action,
+                status="instinct-pending",
+                base_url=base_url,
+            )
+            return {
+                "ok": True,
+                "code": "instinct_pending",
+                "action": action,
+                "approval_id": gate.approval_id,
+                "reason": gate.decision.reason,
+                "_park": park,
+                "on_success": [],
+                "on_error": [],
+            }
+        # gate.next_step == "proceed" — fall through into the existing
+        # gate stack. Notify rules are dropped on the floor here; Wave
+        # 3c wires the side-effect dispatcher.
 
     # ── 2. write rate limit ─────────────────────────────────────────────
     if await _action_rate_limited(pocket_id, user_id):

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
@@ -1,0 +1,180 @@
+# ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+# Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — single entry
+# point from the runtime into the RFC 03 v2 template-level Instinct.
+# Wraps the OSS-side ``resolve_instinct`` pure function with the EE-
+# side persistence (``instinct_approvals.service``) and returns a
+# typed ``InstinctGateResult`` the action_executor branches on.
+#
+# Why a separate module: ``action_executor`` is import-linter-pure
+# (no Beanie / no models). This wrapper is the impure layer that may
+# call ``instinct_approvals.service.create_approval`` (a Beanie writer
+# under the import-linter contract for that entity).
+#
+# Single entry point: future bulk fan-out (Wave 3b) + temporal sweeper
+# (Wave 3d) call ``gate_action`` per-row too, so all dispatch flows
+# share the same persistence + audit shape.
+#
+# Hard constraint: this module DOES NOT touch the M2b.1 binding-level
+# ``requires_instinct`` flag / ``_park`` sentinel. That flow stays
+# intact for backward compatibility — Wave 3a layers a NEW
+# template-level gate that runs BEFORE the M2b.1 gate.
+
+"""Dispatch wrapper around OSS ``resolve_instinct`` + EE persistence."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from pocketpaw.bundled_templates import (
+    InstinctDecision,
+    InstinctResolutionError,
+    InstinctRule,
+    PocketTemplate,
+    resolve_instinct,
+)
+from pocketpaw.bundled_templates.identifier_resolver import IdentifierResolver
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+
+logger = logging.getLogger(__name__)
+
+NextStepT = Literal["proceed", "blocked", "pending_approval"]
+
+
+class InstinctGateResult(BaseModel):
+    """Outcome of a single ``gate_action`` call.
+
+    Frozen so the executor cannot mutate it. The four-fielded shape
+    matches what the runtime needs to dispatch:
+
+    * ``decision`` — the pure OSS composer's verdict + audit data.
+    * ``next_step`` — collapsed branch for the executor (proceed /
+      blocked / pending_approval).
+    * ``approval_id`` — set only when ``next_step == "pending_approval"``;
+      the action_executor returns it on the ``instinct_pending``
+      sentinel response.
+    * ``notify_rules`` — top-level ``notify`` rules whose ``when``
+      matched the row. Carried through for the future notify side-
+      effect dispatcher (Wave 3c). Empty on BLOCK.
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    decision: InstinctDecision
+    next_step: NextStepT
+    approval_id: str | None = None
+    notify_rules: list[InstinctRule] = []
+
+
+def _matched_rules_payload(decision: InstinctDecision) -> list[dict[str, Any]]:
+    """Serialize matched rules to plain dicts so they can ride a
+    Beanie ``list[dict]`` field. ``InstinctRule.model_dump`` is the
+    canonical serializer."""
+    return [r.model_dump() for r in decision.matched_rules]
+
+
+async def gate_action(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    template: PocketTemplate,
+    action_name: str,
+    row_context: dict[str, Any],
+    workspace_context: dict[str, Any] | None = None,
+    row_id: str = "",
+    park: dict[str, Any] | None = None,
+    resolver: IdentifierResolver | None = None,
+    now: datetime | None = None,
+) -> InstinctGateResult:
+    """Resolve the template-level Instinct verdict for one action+row.
+
+    Calls the pure OSS composer (``resolve_instinct``) first, then
+    branches:
+
+    * ``BLOCK`` → persist nothing. Return ``next_step="blocked"``.
+    * ``ESCALATE_APPROVAL`` → persist one ``InstinctApproval`` row via
+      ``instinct_approvals.service.create_approval``. Return
+      ``next_step="pending_approval"`` with the new approval id.
+    * ``EXECUTE`` → no persistence. Return ``next_step="proceed"``.
+    * ``NOTIFY_AND_EXECUTE`` → no persistence. Return
+      ``next_step="proceed"`` with ``notify_rules`` populated for the
+      side-effect dispatcher.
+
+    Errors:
+        ``InstinctResolutionError`` from the composer (unknown action
+        on the template, or a CEL eval failure on a rule) is mapped to
+        ``NotFound("instinct_action", action_name)``. The brief locks
+        ``NotFound`` for unknown action; an eval failure is structurally
+        the same shape (an undeclared identifier or a malformed rule is
+        a programming/authoring error, not a permissions issue).
+    """
+    try:
+        decision = resolve_instinct(
+            template,
+            action_name,
+            row_context,
+            workspace_context,
+            resolver=resolver,
+            now=now,
+        )
+    except InstinctResolutionError as exc:
+        # The runtime cannot dispatch an action the template does not
+        # declare, and it cannot continue past a rule that does not
+        # evaluate cleanly. Either is a 404 on "the action the caller
+        # asked for is not (currently) runnable" — never echo the
+        # internal exception text to the wire.
+        logger.warning(
+            "instinct gate failed for action=%s pocket=%s: %s",
+            action_name,
+            pocket_id,
+            exc,
+        )
+        raise NotFound("instinct_action", action_name) from exc
+
+    if decision.verdict == "BLOCK":
+        return InstinctGateResult(
+            decision=decision,
+            next_step="blocked",
+            approval_id=None,
+            notify_rules=[],
+        )
+
+    if decision.verdict == "ESCALATE_APPROVAL":
+        # Persist + tag the approval id back onto the result. The
+        # executor returns this on the ``instinct_pending`` sentinel
+        # so the caller (and the eventual approver UI) can address
+        # the row.
+        body = {
+            "pocket_id": pocket_id,
+            "action_name": action_name,
+            "row_id": row_id,
+            "row_data": row_context,
+            "verdict": decision.verdict,
+            "reason": decision.reason,
+            "matched_rules": _matched_rules_payload(decision),
+            "park": park,
+        }
+        wire = await approvals_service.create_approval(workspace_id, user_id, body)
+        return InstinctGateResult(
+            decision=decision,
+            next_step="pending_approval",
+            approval_id=wire["id"],
+            notify_rules=list(decision.notify_rules),
+        )
+
+    # EXECUTE / NOTIFY_AND_EXECUTE — proceed. Notify rules carry
+    # through (top-level notify can fire alongside an auto execute).
+    return InstinctGateResult(
+        decision=decision,
+        next_step="proceed",
+        approval_id=None,
+        notify_rules=list(decision.notify_rules),
+    )
+
+
+__all__ = ["InstinctGateResult", "NextStepT", "gate_action"]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -194,12 +194,27 @@ source_modules = [
     # through `pockets.service` and the Instinct store; it never touches
     # Beanie document classes directly.
     "pocketpaw_ee.cloud.pockets.instinct_bridge",
+    # RFC 03 v2 Wave 3a — the template-level instinct dispatch wrapper.
+    # Calls the pure OSS composer and the `instinct_approvals.service`
+    # Beanie writer; never imports the pockets/session/backend docs.
+    "pocketpaw_ee.cloud.pockets.instinct_dispatch",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",
     "pocketpaw_ee.cloud.models.pocket_backend",
     "pocketpaw_ee.cloud.models.session",
 ]
+
+[[tool.importlinter.contracts]]
+name = "InstinctApprovals — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.instinct_approvals.router",
+    "pocketpaw_ee.cloud.instinct_approvals.dto",
+    "pocketpaw_ee.cloud.instinct_approvals.domain",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.instinct_approval"]
 
 [[tool.importlinter.contracts]]
 name = "Notifications — Beanie writes only from service.py"

--- a/tests/cloud/test_instinct_approvals_service.py
+++ b/tests/cloud/test_instinct_approvals_service.py
@@ -1,0 +1,161 @@
+# tests/cloud/test_instinct_approvals_service.py
+# Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — CRUD tests for
+# the `instinct_approvals` 4-file shape. Pins:
+#   * the create / list / get / approve / reject happy paths
+#   * tenant-filter regression on every read
+#   * emit-on-write regression for every state-mutating function
+#   * Pydantic validation regression on missing required fields
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import (
+    ConflictError,
+    NotFound,
+    ValidationError,
+)
+from pocketpaw_ee.cloud._core.realtime.events import (
+    InstinctApprovalApproved,
+    InstinctApprovalCreated,
+    InstinctApprovalRejected,
+)
+from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _create_body(**overrides) -> dict:
+    body: dict = {
+        "pocket_id": "p1",
+        "action_name": "do_thing",
+        "row_id": "r1",
+        "row_data": {"value": 1},
+        "verdict": "ESCALATE_APPROVAL",
+        "reason": "operator_overlay_escalated",
+        "matched_rules": [{"when": "value > 0", "action": "require_approval"}],
+        "park": {"method": "POST", "path": "/items"},
+    }
+    body.update(overrides)
+    return body
+
+
+async def test_create_persists_and_emits(recording_bus) -> None:
+    out = await approvals_service.create_approval("w1", "u1", _create_body())
+    assert out["workspace_id"] == "w1"
+    assert out["pocket_id"] == "p1"
+    assert out["action_name"] == "do_thing"
+    assert out["status"] == "pending"
+    assert out["requested_by"] == "u1"
+
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert len(created) == 1
+    assert created[0].data["id"] == out["id"]
+
+
+async def test_create_requires_workspace_id() -> None:
+    with pytest.raises(ValidationError):
+        await approvals_service.create_approval("", "u1", _create_body())
+
+
+async def test_create_requires_user_id() -> None:
+    with pytest.raises(ValidationError):
+        await approvals_service.create_approval("w1", "", _create_body())
+
+
+async def test_create_validates_pocket_id() -> None:
+    body = _create_body(pocket_id="")
+    # Pydantic min_length=1 raises a Pydantic ValidationError here —
+    # which is *not* the CloudError ValidationError. Either fail mode
+    # is acceptable; both indicate the body was rejected at entry.
+    with pytest.raises(Exception):
+        await approvals_service.create_approval("w1", "u1", body)
+
+
+async def test_list_filters_by_workspace() -> None:
+    await approvals_service.create_approval("wA", "u1", _create_body(pocket_id="pA"))
+    await approvals_service.create_approval("wB", "u1", _create_body(pocket_id="pB"))
+
+    in_a = await approvals_service.list_approvals("wA", "u1", {})
+    assert len(in_a) == 1
+    assert in_a[0]["pocket_id"] == "pA"
+
+    in_b = await approvals_service.list_approvals("wB", "u1", {})
+    assert len(in_b) == 1
+    assert in_b[0]["pocket_id"] == "pB"
+
+
+async def test_list_filters_by_status_and_pocket() -> None:
+    a1 = await approvals_service.create_approval("w1", "u1", _create_body(pocket_id="p1"))
+    await approvals_service.create_approval("w1", "u1", _create_body(pocket_id="p2"))
+    await approvals_service.approve("w1", "u_approver", a1["id"], None)
+
+    only_pending = await approvals_service.list_approvals("w1", "u1", {"status": "pending"})
+    assert len(only_pending) == 1
+    assert only_pending[0]["pocket_id"] == "p2"
+
+    only_p1 = await approvals_service.list_approvals("w1", "u1", {"pocket_id": "p1"})
+    assert len(only_p1) == 1
+    assert only_p1[0]["id"] == a1["id"]
+
+
+async def test_get_returns_row() -> None:
+    created = await approvals_service.create_approval("w1", "u1", _create_body())
+    out = await approvals_service.get_approval("w1", "u1", created["id"])
+    assert out["id"] == created["id"]
+
+
+async def test_get_cross_workspace_not_found() -> None:
+    created = await approvals_service.create_approval("wA", "u1", _create_body())
+    with pytest.raises(NotFound):
+        await approvals_service.get_approval("wB", "u1", created["id"])
+
+
+async def test_get_bad_id_not_found() -> None:
+    with pytest.raises(NotFound):
+        await approvals_service.get_approval("w1", "u1", "not-an-objectid")
+
+
+async def test_approve_state_transition_and_event(recording_bus) -> None:
+    created = await approvals_service.create_approval("w1", "u1", _create_body())
+    recording_bus.events.clear()
+
+    out = await approvals_service.approve("w1", "u_approver", created["id"], None)
+    assert out["status"] == "approved"
+    assert out["decided_by"] == "u_approver"
+    assert out["decided_at"] is not None
+
+    approved = [e for e in recording_bus.events if isinstance(e, InstinctApprovalApproved)]
+    assert len(approved) == 1
+
+
+async def test_reject_state_transition_and_event(recording_bus) -> None:
+    created = await approvals_service.create_approval("w1", "u1", _create_body())
+    recording_bus.events.clear()
+
+    out = await approvals_service.reject("w1", "u_approver", created["id"], None)
+    assert out["status"] == "rejected"
+
+    rejected = [e for e in recording_bus.events if isinstance(e, InstinctApprovalRejected)]
+    assert len(rejected) == 1
+
+
+async def test_approve_already_decided_conflicts() -> None:
+    created = await approvals_service.create_approval("w1", "u1", _create_body())
+    await approvals_service.approve("w1", "u_approver", created["id"], None)
+
+    with pytest.raises(ConflictError):
+        await approvals_service.approve("w1", "u_approver", created["id"], None)
+
+
+async def test_reject_already_decided_conflicts() -> None:
+    created = await approvals_service.create_approval("w1", "u1", _create_body())
+    await approvals_service.reject("w1", "u_approver", created["id"], None)
+
+    with pytest.raises(ConflictError):
+        await approvals_service.reject("w1", "u_approver", created["id"], None)
+
+
+async def test_decide_requires_user_id() -> None:
+    created = await approvals_service.create_approval("w1", "u1", _create_body())
+    with pytest.raises(ValidationError):
+        await approvals_service.approve("w1", "", created["id"], None)

--- a/tests/cloud/test_instinct_dispatch.py
+++ b/tests/cloud/test_instinct_dispatch.py
@@ -1,0 +1,465 @@
+# tests/cloud/test_instinct_dispatch.py
+# Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — pins the
+# RFC 03 v2 template-level Instinct gate as wired into the EE
+# action_executor.
+#
+# What this pins:
+#   * BLOCK path: a row tripping a block rule → no approval row, no
+#     HTTP call, the executor returns the `instinct_blocked` sentinel.
+#   * ESCALATE_APPROVAL path: a row tripping an approval rule → one
+#     `InstinctApproval` row persisted under the right workspace,
+#     the executor returns `instinct_pending` carrying `approval_id`,
+#     no HTTP call.
+#   * EXECUTE path: auto policy + no rules → gate returns `proceed`;
+#     when called without HTTP wiring the executor still walks the
+#     security gates and ultimately makes a request — verified by
+#     observing a populated `instinct-pending`-FREE result.
+#   * NOTIFY_AND_EXECUTE path: notify_only policy → gate returns
+#     `proceed` with `notify_rules` populated.
+#   * Unknown action surfaces as a `CloudError` (`NotFound`).
+#   * Workspace isolation: an approval row in workspace A is invisible
+#     to a workspace-B read.
+#   * Audit emit: every state-mutating service function emits its event.
+#
+# The executor's HTTP path is exercised indirectly: a BLOCK / pending
+# result must short-circuit BEFORE the HTTP request, so the test does
+# not need a fake transport — if the gate ever fell through into the
+# HTTP stack on a BLOCK row the test would explode on socket lookup
+# (the bogus base_url has no resolver).
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import (
+    InstinctApprovalApproved,
+    InstinctApprovalCreated,
+    InstinctApprovalRejected,
+)
+from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+from pocketpaw_ee.cloud.pockets import action_executor, instinct_dispatch
+
+from pocketpaw.bundled_templates import PocketTemplate
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+FROZEN_NOW = datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — minimal valid v2 PocketTemplate dicts. Every test
+# builds its own so the rule shape is visible inline. ``shape=data-grid``
+# needs at least one column; we declare a `value` column so the row's
+# `value` identifier resolves through the default ``TemplateIdentifierResolver``.
+# ---------------------------------------------------------------------------
+
+
+def _template(
+    *,
+    instinct_policy: str = "auto",
+    rules: list[dict] | None = None,
+    action_name: str = "do_thing",
+) -> PocketTemplate:
+    raw: dict = {
+        "schema_version": "2",
+        "name": "test-template",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "test fixture",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [{"field": "value", "widget": "number"}],
+        },
+        "actions": [
+            {
+                "name": action_name,
+                "label": "Do Thing",
+                "kind": "single-row",
+                "instinct_policy": instinct_policy,
+            }
+        ],
+    }
+    if rules is not None:
+        raw["instinct_rules"] = {"rules": rules}
+    return PocketTemplate.model_validate(raw)
+
+
+def _raw_action() -> dict:
+    """A minimal `ActionBinding`-parseable raw action — used so the
+    executor's binding-parse step passes. We never let the executor
+    reach an HTTP call in this test file; the BLOCK / pending paths
+    short-circuit beforehand."""
+    return {"kind": "write_binding", "method": "POST", "path": "/items"}
+
+
+# ---------------------------------------------------------------------------
+# gate_action — direct tests against the wrapper (no executor)
+# ---------------------------------------------------------------------------
+
+
+async def test_gate_block_persists_nothing(recording_bus) -> None:
+    template = _template(
+        instinct_policy="auto",
+        rules=[{"when": "value > 100", "action": "block"}],
+    )
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 999},
+        now=FROZEN_NOW,
+    )
+
+    assert result.next_step == "blocked"
+    assert result.approval_id is None
+    assert result.decision.verdict == "BLOCK"
+    # No InstinctApprovalCreated event for a block.
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert created == []
+
+
+async def test_gate_escalate_persists_approval_and_emits(recording_bus) -> None:
+    template = _template(
+        instinct_policy="auto",
+        rules=[{"when": "value > 100", "action": "require_approval"}],
+    )
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 200},
+        row_id="row-42",
+        park={"action": "do_thing", "method": "POST", "path": "/items", "params": {"x": 1}},
+        now=FROZEN_NOW,
+    )
+
+    assert result.next_step == "pending_approval"
+    assert result.approval_id is not None
+    assert result.decision.verdict == "ESCALATE_APPROVAL"
+
+    # Approval row persisted under workspace=w1.
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+    assert approvals[0]["id"] == result.approval_id
+    assert approvals[0]["workspace_id"] == "w1"
+    assert approvals[0]["pocket_id"] == "p1"
+    assert approvals[0]["action_name"] == "do_thing"
+    assert approvals[0]["row_id"] == "row-42"
+    assert approvals[0]["row_data"] == {"value": 200}
+    assert approvals[0]["status"] == "pending"
+
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert len(created) == 1
+    assert created[0].data["id"] == result.approval_id
+    assert created[0].data["workspace_id"] == "w1"
+
+
+async def test_gate_execute_proceeds() -> None:
+    template = _template(instinct_policy="auto")
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        now=FROZEN_NOW,
+    )
+
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+    assert result.notify_rules == []
+
+
+async def test_gate_notify_only_proceeds_with_notify_rules() -> None:
+    template = _template(
+        instinct_policy="notify_only",
+        rules=[{"when": "value > 100", "action": "notify"}],
+    )
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 999},
+        now=FROZEN_NOW,
+    )
+
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "NOTIFY_AND_EXECUTE"
+    assert len(result.notify_rules) == 1
+    assert result.notify_rules[0].when == "value > 100"
+
+
+async def test_gate_unknown_action_raises_not_found() -> None:
+    template = _template(action_name="known_action")
+
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    with pytest.raises(NotFound) as excinfo:
+        await instinct_dispatch.gate_action(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id="p1",
+            template=template,
+            action_name="unknown_action",
+            row_context={"value": 1},
+            now=FROZEN_NOW,
+        )
+    assert "unknown_action" in str(excinfo.value)
+
+
+async def test_gate_workspace_isolation_on_list() -> None:
+    template = _template(
+        rules=[{"when": "value > 0", "action": "require_approval"}],
+    )
+
+    # Persist in workspace A
+    await instinct_dispatch.gate_action(
+        workspace_id="wA",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        now=FROZEN_NOW,
+    )
+
+    # Workspace B sees no rows
+    in_b = await approvals_service.list_approvals("wB", "u_other", {})
+    assert in_b == []
+    in_a = await approvals_service.list_approvals("wA", "u1", {})
+    assert len(in_a) == 1
+
+
+# ---------------------------------------------------------------------------
+# action_executor wiring — gate_action is called BEFORE the HTTP path
+# ---------------------------------------------------------------------------
+
+
+async def test_executor_blocked_short_circuits_before_http() -> None:
+    template = _template(
+        rules=[{"when": "value > 100", "action": "block"}],
+    )
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="do_thing",
+        raw_action=_raw_action(),
+        path="/items",
+        params={},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"value": 999},
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "instinct_blocked"
+    assert result["action"] == "do_thing"
+
+
+async def test_executor_pending_approval_short_circuits_before_http(recording_bus) -> None:
+    template = _template(
+        rules=[{"when": "value > 100", "action": "require_approval"}],
+    )
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="do_thing",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"value": 200},
+        row_id="r1",
+    )
+
+    assert result["ok"] is True
+    assert result["code"] == "instinct_pending"
+    assert result["approval_id"]
+    # The park blob carries the resolved write so a future post-approval
+    # re-entry can replay it.
+    assert result["_park"]["method"] == "POST"
+    assert result["_park"]["path"] == "/items"
+
+    # Persisted under w1 with the right shape.
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+    assert approvals[0]["id"] == result["approval_id"]
+
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert len(created) == 1
+
+
+async def test_executor_from_instinct_bypasses_gate(recording_bus) -> None:
+    """A post-approval re-entry (`from_instinct=True`) must NOT call
+    the gate again — otherwise an approval would create a second
+    approval row in a loop. This pins the bypass."""
+    template = _template(
+        rules=[{"when": "value > 100", "action": "require_approval"}],
+    )
+
+    # We expect this to fall through into the HTTP-path gates; the
+    # bogus base_url will reject (rate-limit or DNS), but crucially NO
+    # `instinct_pending` and NO new approval row.
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="do_thing",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"value": 200},
+        from_instinct=True,
+    )
+
+    assert result.get("code") != "instinct_pending"
+    # No approval persisted.
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert approvals == []
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert created == []
+
+
+async def test_executor_without_template_is_backward_compatible() -> None:
+    """When no template is threaded through (every existing caller),
+    the gate is skipped. The executor falls into its existing gate
+    stack — the bogus base_url here triggers an SSRF/DNS reject."""
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="do_thing",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+    )
+    assert result.get("code") != "instinct_pending"
+    assert result.get("code") != "instinct_blocked"
+
+
+# ---------------------------------------------------------------------------
+# Approval lifecycle — approve / reject emit + state transitions
+# ---------------------------------------------------------------------------
+
+
+async def test_approve_flips_status_and_emits(recording_bus) -> None:
+    template = _template(
+        rules=[{"when": "value > 0", "action": "require_approval"}],
+    )
+    gate = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        now=FROZEN_NOW,
+    )
+    recording_bus.events.clear()
+
+    out = await approvals_service.approve("w1", "u_approver", gate.approval_id, {"note": "ok"})
+    assert out["status"] == "approved"
+    assert out["decided_by"] == "u_approver"
+    approved = [e for e in recording_bus.events if isinstance(e, InstinctApprovalApproved)]
+    assert len(approved) == 1
+    assert approved[0].data["id"] == gate.approval_id
+
+
+async def test_reject_flips_status_and_emits(recording_bus) -> None:
+    template = _template(
+        rules=[{"when": "value > 0", "action": "require_approval"}],
+    )
+    gate = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        now=FROZEN_NOW,
+    )
+    recording_bus.events.clear()
+
+    out = await approvals_service.reject("w1", "u_approver", gate.approval_id, {"note": "nope"})
+    assert out["status"] == "rejected"
+    rejected = [e for e in recording_bus.events if isinstance(e, InstinctApprovalRejected)]
+    assert len(rejected) == 1
+
+
+async def test_double_decide_conflicts() -> None:
+    from pocketpaw_ee.cloud._core.errors import ConflictError
+
+    template = _template(
+        rules=[{"when": "value > 0", "action": "require_approval"}],
+    )
+    gate = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        now=FROZEN_NOW,
+    )
+    await approvals_service.approve("w1", "u_approver", gate.approval_id, None)
+
+    with pytest.raises(ConflictError):
+        await approvals_service.reject("w1", "u_approver", gate.approval_id, None)
+
+
+async def test_decide_cross_workspace_not_found() -> None:
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    template = _template(
+        rules=[{"when": "value > 0", "action": "require_approval"}],
+    )
+    gate = await instinct_dispatch.gate_action(
+        workspace_id="wA",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        now=FROZEN_NOW,
+    )
+
+    with pytest.raises(NotFound):
+        await approvals_service.approve("wB", "u_approver", gate.approval_id, None)


### PR DESCRIPTION
# feat(ee): Instinct dispatch gate + approval queue for RFC 03 v2

## Summary

Wave 3a wires the OSS-side `resolve_instinct` composer (RFC 03 v2, shipped on `dev` in #1228) into the EE action executor and lays down the persistence skeleton for the approval queue.

- **New EE entity `instinct_approvals/`** in the canonical 4-file shape — `domain.py`, `dto.py`, `service.py`, `router.py` — plus a Beanie doc at `ee/pocketpaw_ee/cloud/models/instinct_approval.py`. Every read filters by workspace; every state-mutating service function emits an event.
- **New dispatch wrapper** `ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py` — the single entry point from the runtime into Instinct. Calls the pure OSS `resolve_instinct`, branches on the verdict (BLOCK / ESCALATE_APPROVAL / EXECUTE / NOTIFY_AND_EXECUTE), and persists exactly one approval row when the verdict escalates.
- **Minimal touch to `action_executor.py`** — accepts an optional `template` parameter; when present and `from_instinct=False` it calls `gate_action(...)` before any HTTP / SSRF / allowlist guard. Existing callers continue to work unchanged because the template parameter defaults to `None`.

Out of scope for 3a: approval queue UI (3e), batch / bulk approvals (3b), outcome event emission (3c), temporal sweep (3d), per-action gate in `source_executor` (3e). Touching OSS code stays off-limits — the OSS library layer landed on `dev` in #1228 and this PR consumes it.

## Architecture decisions

- **Single entry point**. `gate_action` is the only seam from the runtime into Instinct; future bulk fan-out and the temporal sweeper call it per-row too, so every dispatch flow shares one persistence + audit shape.
- **Backward-compat at the executor**. `template` is an optional kwarg on `run_action`. The three existing callers (router, instinct_bridge, agent/pocket_router) keep working byte-identically; the gate is skipped on the no-template path.
- **Errors via CloudError**. Unknown action surfaces as `NotFound("instinct_action", ...)`. Tenant mismatch on read → `NotFound` (no oracle). Already-decided approval → `ConflictError`. Empty workspace / user → `ValidationError`. No `HTTPException`.
- **Events in the central registry**. `InstinctApprovalCreated / Approved / Rejected` defined in `ee/pocketpaw_ee/cloud/_core/realtime/events.py` alongside every other cloud event. The three events fire from the three state-mutating service functions per EE cloud rule 9.
- **M2b.1 binding-level park kept intact**. The new template-level gate runs *before* the existing M2b.1 `requires_instinct` flow. Either gate can independently park a write; the old sentinel shape (`code:instinct_pending` + `_park`) is preserved for `instinct_bridge.py` callers.
- **Import-linter contract added** for `instinct_approvals` — `router.py`, `dto.py`, `domain.py` may not import the new `InstinctApproval` Beanie doc. Only `service.py` may.

## Files changed

NEW
- `ee/pocketpaw_ee/cloud/models/instinct_approval.py` — Beanie doc.
- `ee/pocketpaw_ee/cloud/instinct_approvals/{__init__,domain,dto,service,router}.py` — 4-file entity shape.
- `ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py` — dispatch wrapper.
- `tests/cloud/test_instinct_dispatch.py` — gate paths + executor wiring + approval lifecycle.
- `tests/cloud/test_instinct_approvals_service.py` — service-level CRUD + tenancy + emit regressions.

MODIFIED
- `ee/pocketpaw_ee/cloud/pockets/action_executor.py` — added `template` / `row_context` / `workspace_context` / `row_id` kwargs and the gate call between binding-parse and rate-limit. +99 / -1.
- `ee/pocketpaw_ee/cloud/_core/realtime/events.py` — 3 new event subclasses.
- `ee/pocketpaw_ee/cloud/models/__init__.py` — register `InstinctApproval` in `ALL_DOCUMENTS`.
- `ee/pocketpaw_ee/cloud/__init__.py` — mount `instinct_approvals_router` at `/api/v1`.
- `ee/pyproject.toml` — add `instinct_dispatch` to the Pockets contract; add a new `InstinctApprovals` import-linter contract.

## Test plan

- [x] 28 new tests (14 dispatch + executor wiring, 14 approvals service) — pass.
- [x] OSS-side `tests/unit/test_instinct_composer.py` — 17 tests pass (no regression).
- [x] Adjacent EE tests `tests/cloud/test_pocket_action_executor.py` (33) + `test_pocket_instinct_bridge.py` (9) + `test_instinct_approval_security.py` (8) — all pass.
- [x] `uv run ruff check` + `ruff format --check` clean on all touched files.
- [x] `uv run lint-imports --config ee/pyproject.toml` — 18 contracts kept, 0 broken.
- [ ] Captain review.
