### PR TITLE
feat(ee): bulk action dispatch pipeline + batch approval persistence for RFC 03 v2

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -9,6 +9,12 @@
 #   RFC 03 v2 template-level approval queue. Emitted by
 #   ``instinct_approvals.service`` on every state-mutating function per
 #   the EE cloud rule 9 (``emit on every write``).
+# Updated: 2026-05-28 (feat/wave-3b-action-pipeline) — added
+#   ``BulkActionDispatched`` (type="pocket.bulk_action.dispatched"),
+#   emitted by ``pockets.service.dispatch_bulk_action`` after a bulk
+#   fan-out completes. Carries the dispatch summary (counts + optional
+#   batch approval id) so downstream listeners (audit, analytics) can
+#   key off a single event per dispatch call.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -518,3 +524,17 @@ class InstinctApprovalApproved(Event):
 @dataclass
 class InstinctApprovalRejected(Event):
     EVENT_TYPE: ClassVar[str] = "instinct.approval.rejected"
+
+
+# Bulk action dispatch (RFC 03 v2 / Wave 3b). Emitted by
+# ``pockets.service.dispatch_bulk_action`` after a fan-out call resolves —
+# one event per dispatch, regardless of how many rows were processed.
+# ``data`` carries: ``workspace_id``, ``pocket_id``, ``action_name``,
+# ``total_rows``, ``executed`` (count of EXECUTE / NOTIFY_AND_EXECUTE
+# rows fired), ``blocked`` (count of BLOCK rows), ``approval_needed``
+# (count of rows that escalated into the batch approval), and an
+# optional ``batch_approval_id`` (str | None) — set when ``approval_needed``
+# is non-zero.
+@dataclass
+class BulkActionDispatched(Event):
+    EVENT_TYPE: ClassVar[str] = "pocket.bulk_action.dispatched"

--- a/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
@@ -1,0 +1,430 @@
+# ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
+# Created: 2026-05-28 (feat/wave-3b-action-pipeline) — EE-side library
+# wrapper around the OSS ``plan_bulk_execution`` planner. Implements the
+# RFC 03 v2 §"Bulk action execution model" invariant: a ``kind: bulk``
+# action fans out across N selected rows, and ANY rows that need
+# approval consolidate into ONE InstinctApproval row carrying every
+# row_id — not N separate rows.
+#
+# Wave 3b scope (locked by the architect brief):
+#
+# * Calls the pure OSS ``plan_bulk_execution`` once per dispatch.
+# * Persists exactly ONE ``InstinctApproval`` row when the plan
+#   surfaces an ``approval_request``, with a ``batch=True`` flag and
+#   the full per-row payload mapped under ``row_data[<row_id>]``.
+# * Fires EACH ``RowExecution`` through ``action_executor.run_action``.
+#   The OSS composer already produced the EXECUTE / NOTIFY_AND_EXECUTE
+#   verdict, so this wrapper does NOT re-thread ``template`` into the
+#   per-row call — that would re-evaluate the gate and risk creating a
+#   second approval row on a flapping rule. The brief's "fast-path
+#   EXECUTE" hint is realised by skipping the gate entirely on the
+#   re-entry.
+# * Tenant-isolated via ``pockets_service.get`` — a cross-workspace
+#   pocket_id surfaces as ``NotFound`` (Forbidden gets mapped to the
+#   same shape so a foreign-workspace pocket is treated as if it does
+#   not exist; this matches the existing approvals_service pattern).
+#
+# Out of scope (and explicitly NOT here):
+#
+# * Approver re-entry: when ``approve(batch_approval_id)`` lands later,
+#   a follow-up PR will iterate ``row_data`` and re-run each row with
+#   ``from_instinct=True``. THIS module ships the persistence so the
+#   re-run code has data to work with.
+# * Outcome event emission per executed row (Wave 3c).
+# * UI for triggering bulk runs (paw-enterprise concern).
+# * Per-agent concurrency / rate-limiting (production hardening).
+# * Idempotency keys for retried bulk batches.
+#
+# Import-linter posture: this module is Beanie-PURE. It calls
+# ``instinct_approvals.service.create_approval`` (a permitted writer)
+# and ``pockets.service`` (a permitted reader/writer) but never imports
+# a Beanie document class. The ee/pyproject.toml import-linter contract
+# adds this module to the ``pockets`` source_modules list to lock the
+# invariant.
+
+"""Bulk action dispatch — fan-out across N rows with ONE batch approval."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pocketpaw.bundled_templates import PocketTemplate
+from pocketpaw.bundled_templates.bulk_executor import (
+    BulkExecutionError,
+    plan_bulk_execution,
+)
+from pocketpaw.bundled_templates.identifier_resolver import IdentifierResolver
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+
+# ---------------------------------------------------------------------------
+# Result models — frozen so the caller (service / router) cannot mutate
+# in-flight; one event per dispatch keys off these counts.
+# ---------------------------------------------------------------------------
+
+
+class ExecutionResult(BaseModel):
+    """One row's execution outcome — what ``run_action`` returned for it.
+
+    ``response`` is the raw executor dict (``ok``, ``status``,
+    ``response``, ``error``, etc.) so the caller can serialize it
+    onto the wire without re-shaping. ``row_id`` is the stable
+    identifier used in audit / batch_approval contexts.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    row_id: str
+    verdict: str
+    """Composer verdict — ``EXECUTE`` or ``NOTIFY_AND_EXECUTE``."""
+    response: dict[str, Any]
+    """The full ``action_executor.run_action`` result dict for this row."""
+
+
+class BlockedRowResult(BaseModel):
+    """One row that the Instinct composer blocked.
+
+    Mirrors the OSS ``BlockedRow`` but flattened for wire-friendly
+    serialization. ``reason`` is the composer's typed reason
+    string (e.g. ``operator_overlay_blocked``); ``rule_when`` is the
+    CEL expression of the first block rule that matched.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    row_id: str
+    reason: str
+    rule_when: str
+
+
+class BulkDispatchResult(BaseModel):
+    """Frozen summary of a bulk dispatch call.
+
+    Sum invariant: ``len(executions) + len(blocked) + approval_needed
+    == total_rows``, where ``approval_needed`` is
+    ``len(approval_row_ids)`` when ``batch_approval_id`` is set, else
+    zero. The service-emitted event carries these counts directly.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    pocket_id: str
+    action_name: str
+    total_rows: int
+    executions: list[ExecutionResult] = Field(default_factory=list)
+    blocked: list[BlockedRowResult] = Field(default_factory=list)
+    batch_approval_id: str | None = None
+    approval_row_ids: list[str] = Field(default_factory=list)
+    """Stable row ids that were consolidated into ``batch_approval_id``.
+    Empty when no row needed approval."""
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_bulk(
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    template: PocketTemplate,
+    action_name: str,
+    selected_rows: list[dict[str, Any]],
+    *,
+    resolver: IdentifierResolver | None = None,
+    now: datetime | None = None,
+) -> BulkDispatchResult:
+    """Fan out a ``kind: bulk`` action across ``selected_rows``.
+
+    Walks the OSS planner once, persists ONE batch approval if any row
+    escalated, fires each ready-to-execute row through
+    ``action_executor.run_action``, and returns a frozen summary.
+
+    Tenant isolation is enforced via ``pockets_service.get`` — a
+    pocket_id that doesn't resolve in the caller's workspace surfaces
+    as ``NotFound`` (or is mapped to ``NotFound`` from ``Forbidden``)
+    so the endpoint is not a cross-tenant existence oracle.
+
+    Raises
+    ------
+    NotFound
+        Pocket doesn't exist or is in another workspace.
+    ValidationError
+        ``action_name`` is unknown on the template, or it exists but
+        has ``kind != "bulk"``. Both map onto
+        ``bulk_action.invalid_action`` so the caller sees one typed
+        rejection.
+    """
+    # Lazy import — pockets.service is the only Beanie-writer in scope
+    # for pocket docs, and it sits in the same package. Lazy-imported
+    # to keep this module's static import graph free of pocket model
+    # references (the import-linter contract treats this module as
+    # Beanie-pure).
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.cloud.pockets import action_executor
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    # ── 1. tenant-checked pocket fetch ─────────────────────────────
+    # ``pockets_service.get`` checks owner / shared_with / workspace
+    # visibility. A foreign-workspace pocket raises Forbidden which we
+    # remap to NotFound so the dispatch endpoint is not a cross-tenant
+    # existence oracle (mirrors the pattern in
+    # ``instinct_approvals.service.get_approval``).
+    try:
+        pocket = await pockets_service.get(pocket_id, user_id)
+    except Forbidden as exc:
+        raise NotFound("pocket", pocket_id) from exc
+
+    if pocket.get("workspace") != workspace_id:
+        # Defense in depth — if the pocket resolved but lives in a
+        # different workspace context, treat as not found rather than
+        # leaking existence.
+        raise NotFound("pocket", pocket_id)
+
+    # ── 2. plan the fan-out via the pure OSS planner ───────────────
+    try:
+        plan = plan_bulk_execution(
+            template,
+            action_name,
+            selected_rows,
+            resolver=resolver,
+            now=now,
+        )
+    except BulkExecutionError as exc:
+        # Unknown action OR non-bulk action — both are typed pre-flight
+        # failures the OSS planner raises before any row work. Map to
+        # a single typed CloudError so the route surfaces 400.
+        raise ValidationError("bulk_action.invalid_action", str(exc)) from exc
+
+    # ── 3. persist ONE batch approval when the plan needs it ───────
+    batch_approval_id: str | None = None
+    approval_row_ids: list[str] = []
+    if plan.approval_request is not None:
+        approval_row_ids = list(plan.approval_request.row_ids)
+        batch_approval_id = await _persist_batch_approval(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            plan=plan,
+        )
+
+    # ── 4. fire each ready execution through the executor ──────────
+    # NOTE: we deliberately do NOT thread ``template`` into ``run_action``
+    # here. The composer already evaluated the gate; re-threading would
+    # cause an idempotent re-eval at minimum and a race-created duplicate
+    # approval at worst. Wave 3a wired the gate at the per-row entry; the
+    # bulk path runs the gate ONCE per row via the planner instead.
+    executions: list[ExecutionResult] = await _fire_executions(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        plan=plan,
+        pocket=pocket,
+        action_executor=action_executor,
+        pockets_service=pockets_service,
+    )
+
+    # ── 5. flatten blocked rows for the wire ───────────────────────
+    blocked = [
+        BlockedRowResult(
+            row_id=br.row_id,
+            reason=br.decision.reason,
+            rule_when=br.blocked_by_rule.when,
+        )
+        for br in plan.blocked
+    ]
+
+    return BulkDispatchResult(
+        pocket_id=pocket_id,
+        action_name=action_name,
+        total_rows=plan.total_rows,
+        executions=executions,
+        blocked=blocked,
+        batch_approval_id=batch_approval_id,
+        approval_row_ids=approval_row_ids,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+async def _persist_batch_approval(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    plan: Any,  # bulk_executor.BulkPlan — kept Any to dodge a re-import cycle
+) -> str:
+    """Persist exactly ONE InstinctApproval row that authorises every
+    approval-needing row in the batch.
+
+    Per the RFC: even 50 approval-needing rows produce ONE row in the
+    approvals queue with all ``row_ids`` listed. The downstream
+    approver UI groups by this single id; the future re-entry pipeline
+    iterates ``row_data`` to replay each row.
+
+    The wire shape carried on the approval doc:
+
+    * ``row_id`` — empty (this is a batch approval; individual ids are
+      under ``row_data``).
+    * ``row_data`` — ``{"batch": True, "<row_id>": <row_dict>, ...}``
+      so the future re-entry can iterate (excluding the ``batch`` key
+      sentinel).
+    * ``reason`` — the consolidated reason from the OSS planner
+      (``operator_overlay_escalated`` / ``author_floor`` /
+      ``mixed_approval_reasons``).
+    * ``matched_rules`` — the union of overlay rules that participated
+      across all rows (already deduplicated by the planner).
+    * ``park`` — the batch shape carrying the action_name + the
+      ordered list of row_ids the re-entry will replay. Per-row paths
+      are NOT pre-resolved here; Wave 3c's re-entry will use the
+      pocket's rippleSpec at approval time.
+    """
+    request = plan.approval_request
+
+    row_data: dict[str, Any] = {"batch": True}
+    for rid, payload in request.rows_data.items():
+        # Avoid colliding with the ``batch`` sentinel key. If a row id
+        # is literally "batch", prefix it so the sentinel stays
+        # unambiguous; the planner stringifies all ids upstream so this
+        # is a rare edge case but worth handling.
+        if rid == "batch":
+            row_data["row:batch"] = payload
+        else:
+            row_data[rid] = payload
+
+    park = {
+        "kind": "bulk",
+        "action_name": request.action_name,
+        "row_ids": list(request.row_ids),
+    }
+
+    body = {
+        "pocket_id": pocket_id,
+        "action_name": request.action_name,
+        "row_id": "",  # batch — individual ids live under row_data
+        "row_data": row_data,
+        "verdict": "ESCALATE_APPROVAL",
+        "reason": request.reason,
+        "matched_rules": [rule.model_dump() for rule in request.matched_rules],
+        "park": park,
+    }
+    wire = await approvals_service.create_approval(workspace_id, user_id, body)
+    return wire["id"]
+
+
+async def _fire_executions(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    plan: Any,
+    pocket: dict,
+    action_executor: Any,
+    pockets_service: Any,
+) -> list[ExecutionResult]:
+    """Invoke ``action_executor.run_action`` for each ready row.
+
+    Each row's executor call is independent — a failure on row N does
+    not block rows N+1..N+M. Aggregating per-row results into one
+    ``ExecutionResult`` per row keeps the caller's view symmetric with
+    the planner's bucketing.
+
+    When the pocket has no configured backend, every execution slot
+    yields an ``ok:false`` result with code ``pocket_backend.not_configured``
+    instead of raising — the planner already ran, and the approval rows
+    (if any) are already persisted; raising would lose that work.
+    """
+    if not plan.executions:
+        return []
+
+    spec = pocket.get("rippleSpec") or {}
+    actions = spec.get("actions") if isinstance(spec.get("actions"), dict) else {}
+    raw_action = actions.get(plan.action_name) if isinstance(actions, dict) else None
+
+    if not isinstance(raw_action, dict):
+        # The action is declared on the template but not in the pocket's
+        # rippleSpec — the bulk path needs a write binding to fire.
+        # Yield a per-row error so the caller still sees the batch
+        # approval that was already persisted.
+        return [
+            ExecutionResult(
+                row_id=row.row_id,
+                verdict=row.verdict,
+                response={
+                    "ok": False,
+                    "action": plan.action_name,
+                    "error": (f"no rippleSpec.actions[{plan.action_name!r}] binding on pocket"),
+                    "code": "action_not_found",
+                    "on_error": [],
+                },
+            )
+            for row in plan.executions
+        ]
+
+    creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, pocket_id)
+    if creds is None:
+        return [
+            ExecutionResult(
+                row_id=row.row_id,
+                verdict=row.verdict,
+                response={
+                    "ok": False,
+                    "action": plan.action_name,
+                    "error": "This pocket has no backend configured",
+                    "code": "pocket_backend.not_configured",
+                    "on_error": [],
+                },
+            )
+            for row in plan.executions
+        ]
+    base_url, auth_type, auth_header, token, allowed_writes, _approval_route = creds
+
+    # Per-row path/params: the OSS planner does not resolve Ripple
+    # ``{...}`` expressions — that's a frontend / executor concern. For
+    # Wave 3b's library wiring we pass the raw_action's static path +
+    # params unchanged. A future PR can add row-context substitution.
+    raw_path = raw_action.get("path") or "/"
+    raw_params = raw_action.get("params") if isinstance(raw_action.get("params"), dict) else {}
+
+    results: list[ExecutionResult] = []
+    for row in plan.executions:
+        result_dict = await action_executor.run_action(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            action=plan.action_name,
+            raw_action=raw_action,
+            path=raw_path,
+            params=dict(raw_params),
+            base_url=base_url,
+            auth_type=auth_type,
+            auth_header=auth_header,
+            token=token,
+            allowed_writes=allowed_writes,
+            # Gate is intentionally NOT re-evaluated for these rows —
+            # the planner already produced the verdict. See the comment
+            # block in ``dispatch_bulk`` for the reasoning.
+        )
+        results.append(
+            ExecutionResult(
+                row_id=row.row_id,
+                verdict=row.verdict,
+                response=dict(result_dict),
+            )
+        )
+    return results
+
+
+__all__ = [
+    "BlockedRowResult",
+    "BulkDispatchResult",
+    "ExecutionResult",
+    "dispatch_bulk",
+]

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -42,6 +42,13 @@ RunActionResponse is now ``extra="forbid"`` so an executor-internal key
 (``_park``, ``outcome``) that the router fails to strip raises on
 construction instead of leaking the resolved write path/params onto the
 wire.
+Updated: 2026-05-28 (feat/wave-3b-action-pipeline) — added
+DispatchBulkRequest / BulkDispatchResponse / BulkExecutionResultDTO /
+BulkBlockedRowDTO for the new
+``POST /pockets/{id}/actions/{action}/dispatch-bulk`` endpoint. The
+request carries ``rows`` (per-row dicts); the response surfaces the
+RFC 03 v2 bucketing — ``executions`` / ``blocked`` /
+``batch_approval_id`` — plus the consolidated ``approval_row_ids``.
 """
 
 from __future__ import annotations
@@ -349,6 +356,82 @@ class SetApprovalRouteRequest(BaseModel):
     """
 
     route: ApprovalRouteDTO | None = None
+
+
+# ---------------------------------------------------------------------------
+# Bulk action dispatch (RFC 03 v2 / Wave 3b)
+# ---------------------------------------------------------------------------
+
+
+class DispatchBulkRequest(BaseModel):
+    """Body for ``POST /pockets/{id}/actions/{action}/dispatch-bulk``.
+
+    ``rows`` is the per-row payloads the operator selected. Each entry
+    is a free-form dict — the OSS planner threads it through
+    ``resolve_instinct`` per-row, so the keys the template's CEL rules
+    reference must be present.
+
+    ``pocket_id`` and ``action_name`` are mirrored from the URL onto
+    the body to make the service-level call shape symmetric with
+    other entries in this module (rule 5 — every service takes a
+    typed ``body``). The router fills them in from the path
+    parameters; internal callers (jobs, MCP tools) pass them directly.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    pocket_id: str = Field(min_length=1)
+    action_name: str = Field(min_length=1)
+    rows: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class BulkExecutionResultDTO(BaseModel):
+    """One row's execution slot on the wire.
+
+    ``response`` is the executor's full result dict for that row — the
+    same shape ``RunActionResponse`` carries for single-row calls,
+    serialized as a plain dict so the wire surface stays narrow.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    row_id: str
+    verdict: str
+    response: dict[str, Any]
+
+
+class BulkBlockedRowDTO(BaseModel):
+    """One row that the Instinct composer blocked.
+
+    Block reasons + the offending rule's ``when`` expression travel
+    on the wire so the operator can see WHY a row didn't run, without
+    leaking the full ``InstinctDecision`` audit blob.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    row_id: str
+    reason: str
+    rule_when: str
+
+
+class BulkDispatchResponse(BaseModel):
+    """Wire response for ``POST /pockets/{id}/actions/{action}/dispatch-bulk``.
+
+    Mirrors the ``BulkDispatchResult`` library shape. ``batch_approval_id``
+    is set when ANY row escalated to approval — exactly ONE id covers
+    every approval-needing row in the batch (RFC mandate).
+    """
+
+    model_config = {"extra": "forbid"}
+
+    pocket_id: str
+    action_name: str
+    total_rows: int
+    executions: list[BulkExecutionResultDTO] = Field(default_factory=list)
+    blocked: list[BulkBlockedRowDTO] = Field(default_factory=list)
+    batch_approval_id: str | None = None
+    approval_row_ids: list[str] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -83,7 +83,9 @@ from pocketpaw_ee.cloud.pockets import service as pockets_service
 from pocketpaw_ee.cloud.pockets.dto import (
     AddCollaboratorRequest,
     AddWidgetRequest,
+    BulkDispatchResponse,
     CreatePocketRequest,
+    DispatchBulkRequest,
     HomePocketResponse,
     PocketBackendConfigRequest,
     PocketBackendConfigResponse,
@@ -745,6 +747,67 @@ async def run_pocket_action(
     wire = {k: v for k, v in result.items() if k not in ("_park", "outcome")}
     assert "_park" not in wire, "executor `_park` blob must be stripped before the wire response"
     return RunActionResponse(**wire)
+
+
+@router.post(
+    "/{pocket_id}/actions/{action_name}/dispatch-bulk",
+    dependencies=[Depends(require_pocket_action_run)],
+)
+async def dispatch_bulk_action_route(
+    pocket_id: str,
+    action_name: str,
+    body: DispatchBulkRequest | None = None,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> BulkDispatchResponse:
+    """Fan out a ``kind: bulk`` action across the rows in ``body.rows``
+    (RFC 03 v2 Wave 3b).
+
+    The path parameters carry the pocket id + the bulk action name;
+    ``body.rows`` carries the per-row payloads the operator selected.
+    Bucketing follows the RFC contract:
+
+    * ``executions`` — rows ready to fire (verdict ``EXECUTE`` or
+      ``NOTIFY_AND_EXECUTE``). Fired through the action executor with
+      the gate skipped (the OSS planner already evaluated it).
+    * ``blocked`` — rows the Instinct composer blocked.
+    * ``batch_approval_id`` — set when ANY row escalated to approval;
+      exactly ONE InstinctApproval row covers every approval-needing
+      row in the batch (RFC mandate — never N approvals).
+
+    Out of scope for this PR: the per-pocket template resolver. The
+    paw-enterprise UI / a follow-up PR will resolve the
+    :class:`PocketTemplate` from the pocket's persisted template
+    reference; this route surfaces ``400`` until that lookup lands so
+    the contract is observable but the endpoint is not yet
+    silently-broken.
+    """
+    body = body or DispatchBulkRequest(
+        pocket_id=pocket_id,
+        action_name=action_name,
+        rows=[],
+    )
+    # Mirror the URL params onto the body (the body model carries them
+    # so internal callers can hit the service directly).
+    body_dict = body.model_dump()
+    body_dict["pocket_id"] = pocket_id
+    body_dict["action_name"] = action_name
+
+    # Template resolution is a follow-up: the pocket needs a stable
+    # ``template_slug`` field plus a service-level loader that maps
+    # slug → :class:`PocketTemplate`. Returning 400 here keeps the
+    # endpoint observable in OpenAPI without leaking a half-wired
+    # behaviour onto the wire.
+    raise CloudError(
+        400,
+        "bulk_action.template_resolver_pending",
+        (
+            "Bulk dispatch HTTP route requires the per-pocket template "
+            "resolver (Wave 3b follow-up); call "
+            "pockets.service.dispatch_bulk_action(..., template=...) "
+            "directly from library / job callers."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -3093,6 +3093,90 @@ async def rotate_webhook_secret(workspace_id: str, user_id: str, pocket_id: str)
     return doc.webhook_secret
 
 
+# ---------------------------------------------------------------------------
+# Bulk action dispatch (RFC 03 v2 / Wave 3b)
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_bulk_action(
+    workspace_id: str,
+    user_id: str,
+    body: dict | Any,
+    *,
+    template: Any | None = None,
+    now: Any | None = None,
+) -> dict:
+    """Fan out a ``kind: bulk`` action across the rows in ``body.rows``.
+
+    Service-level entry point that:
+
+    1. Re-validates the body via ``DispatchBulkRequest.model_validate``
+       (rule 6 — internal callers re-parse the schema).
+    2. Delegates the orchestration to ``bulk_dispatch.dispatch_bulk``,
+       which calls the pure OSS planner, persists ONE batch approval
+       if any row escalated, and fires each ready-to-run row through
+       ``action_executor.run_action``.
+    3. Emits a ``BulkActionDispatched`` event with the dispatch
+       summary (counts + optional batch approval id) — rule 9.
+
+    ``template`` is threaded through for internal callers (the future
+    paw-enterprise UI fetches the template from its pocket and passes
+    it here). Library tests pass it explicitly. A missing template
+    raises ``ValidationError`` — we cannot fan out a bulk action
+    without the template-level rules to evaluate.
+
+    Returns a wire dict (rule 5) so the router can construct
+    ``BulkDispatchResponse`` directly.
+    """
+    from pocketpaw_ee.cloud._core.realtime.events import BulkActionDispatched
+    from pocketpaw_ee.cloud.pockets import bulk_dispatch
+    from pocketpaw_ee.cloud.pockets.dto import DispatchBulkRequest
+
+    body = DispatchBulkRequest.model_validate(body)
+
+    if template is None:
+        raise ValidationError(
+            "bulk_action.template_required",
+            "dispatch_bulk_action requires the resolved PocketTemplate",
+        )
+
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=body.pocket_id,
+        template=template,
+        action_name=body.action_name,
+        selected_rows=body.rows,
+        now=now,
+    )
+
+    # Wire-friendly dict — frozen Pydantic models serialize cleanly.
+    wire = result.model_dump()
+    # Emit ONE event per dispatch call. Per EE rule 9, every state-
+    # mutating service function emits its event on the way out. The
+    # batch approval write inside ``dispatch_bulk`` already fired its
+    # own ``InstinctApprovalCreated``; this event summarises the bulk
+    # call so downstream audit / analytics listeners can key off a
+    # single event per dispatch.
+    approval_needed = len(result.approval_row_ids)
+    await emit(
+        BulkActionDispatched(
+            data={
+                "workspace_id": workspace_id,
+                "pocket_id": body.pocket_id,
+                "action_name": body.action_name,
+                "total_rows": result.total_rows,
+                "executed": len(result.executions),
+                "blocked": len(result.blocked),
+                "approval_needed": approval_needed,
+                "batch_approval_id": result.batch_approval_id,
+                "actor": user_id,
+            }
+        )
+    )
+    return wire
+
+
 __all__ = [
     "access_via_share_link",
     "add_agent",
@@ -3123,6 +3207,7 @@ __all__ = [
     "create_from_ripple_spec",
     "create_pocket_and_session",
     "delete",
+    "dispatch_bulk_action",
     "generate_share_link",
     "get",
     "get_pocket_backend",

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -198,6 +198,12 @@ source_modules = [
     # Calls the pure OSS composer and the `instinct_approvals.service`
     # Beanie writer; never imports the pockets/session/backend docs.
     "pocketpaw_ee.cloud.pockets.instinct_dispatch",
+    # RFC 03 v2 Wave 3b — the bulk fan-out dispatcher. Calls the pure
+    # OSS ``plan_bulk_execution`` planner and the
+    # ``instinct_approvals.service`` writer; orchestrates per-row
+    # ``action_executor.run_action`` calls. Never imports a Beanie
+    # document class directly.
+    "pocketpaw_ee.cloud.pockets.bulk_dispatch",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",

--- a/tests/cloud/test_bulk_dispatch.py
+++ b/tests/cloud/test_bulk_dispatch.py
@@ -1,0 +1,434 @@
+# tests/cloud/test_bulk_dispatch.py
+# Created: 2026-05-28 (feat/wave-3b-action-pipeline) — pins the
+# Wave 3b bulk action dispatch pipeline. This is the EE-side library
+# wrapper around the OSS ``plan_bulk_execution`` planner.
+#
+# What this pins (RFC 03 v2 §"Bulk action execution model"):
+#   * ONE approval blesses the whole batch — N approval-needing rows
+#     yield exactly ONE InstinctApproval row carrying every row_id.
+#   * Mixed verdict bucketing: block rows go to ``blocked``, execute
+#     rows go to ``executions``, approval rows consolidate into a
+#     single ``batch_approval_id``.
+#   * All-block / all-execute / all-approval / empty paths.
+#   * Tenant isolation: workspace A cannot dispatch a workspace B
+#     pocket's bulk action.
+#   * Non-bulk action raises ``ValidationError``.
+#   * Emit-on-write: ``BulkActionDispatched`` event fires exactly
+#     once per dispatch_bulk_action call.
+#
+# Out of scope for Wave 3b (and therefore NOT pinned here):
+#   * The approver re-entry that re-runs each row with
+#     from_instinct=True after the batch approval lands. Wave 3c.
+#   * Outcome event emission per executed row. Wave 3c.
+#   * UI for triggering bulk runs.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.events import (
+    BulkActionDispatched,
+    InstinctApprovalCreated,
+)
+from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+from pocketpaw_ee.cloud.models.pocket_backend import (
+    AllowedWrite as _AllowedWriteDoc,
+)
+from pocketpaw_ee.cloud.models.pocket_backend import (
+    PocketBackendCredential as _BackendCredentialDoc,
+)
+from pocketpaw_ee.cloud.pockets import bulk_dispatch
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+from pocketpaw.bundled_templates import PocketTemplate
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+FROZEN_NOW = datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — minimal valid v2 PocketTemplate with a bulk action,
+# plus a real Beanie Pocket + PocketBackendCredential so the service
+# wrapper's pocket fetch + creds lookup find them.
+# ---------------------------------------------------------------------------
+
+
+def _template(
+    *,
+    instinct_policy: str = "auto",
+    rules: list[dict] | None = None,
+    action_name: str = "mark_done",
+    kind: str = "bulk",
+) -> PocketTemplate:
+    raw: dict[str, Any] = {
+        "schema_version": "2",
+        "name": "test-template",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "test fixture",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [{"field": "value", "widget": "number"}],
+            "id_field": "id",
+        },
+        "actions": [
+            {
+                "name": action_name,
+                "label": "Do Thing",
+                "kind": kind,
+                "instinct_policy": instinct_policy,
+            }
+        ],
+    }
+    if rules is not None:
+        raw["instinct_rules"] = {"rules": rules}
+    return PocketTemplate.model_validate(raw)
+
+
+def _ripple_spec_with_action(action_name: str = "mark_done") -> dict[str, Any]:
+    """RippleSpec with a single ``write_binding`` action keyed by name."""
+    return {
+        "actions": {
+            action_name: {
+                "kind": "write_binding",
+                "method": "POST",
+                "path": "/items",
+            }
+        }
+    }
+
+
+async def _make_pocket(
+    *,
+    workspace: str = "w1",
+    owner: str = "u1",
+    action_name: str = "mark_done",
+    visibility: str = "workspace",
+) -> str:
+    """Insert a real Pocket Beanie doc and return its id."""
+    doc = _PocketDoc(
+        workspace=workspace,
+        name="test pocket",
+        owner=owner,
+        rippleSpec=_ripple_spec_with_action(action_name),
+        visibility=visibility,
+        widgets=[],
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _make_backend(
+    *,
+    pocket_id: str,
+    workspace_id: str = "w1",
+) -> None:
+    """Insert a PocketBackendCredential with allowlisted POST /items*."""
+    await _BackendCredentialDoc(
+        pocket_id=pocket_id,
+        workspace_id=workspace_id,
+        base_url="https://example.test",
+        auth_type="none",
+        auth_header=None,
+        encrypted_token=None,
+        nonce=None,
+        salt=None,
+        allowed_writes=[
+            _AllowedWriteDoc.model_validate({"method": "POST", "path_pattern": "/items*"})
+        ],
+    ).insert()
+
+
+@pytest.fixture
+def stub_run_action(monkeypatch):
+    """Stub ``action_executor.run_action`` to return a fake ok response.
+
+    The bulk-dispatch unit tests pin orchestration logic, not the
+    HTTP path. Wave 3a already pins ``run_action`` end-to-end against
+    the gate; this fixture short-circuits the call so the EXECUTE
+    branch returns a known value and never touches the network.
+
+    Returns a list ``calls`` the test can introspect for assertions.
+    """
+    calls: list[dict] = []
+
+    async def _stub(**kwargs: Any) -> dict:
+        calls.append(kwargs)
+        return {
+            "ok": True,
+            "action": kwargs["action"],
+            "status": 200,
+            "response": {"ok": True},
+            "on_success": [],
+            "on_error": [],
+        }
+
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    monkeypatch.setattr(action_executor, "run_action", _stub)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# dispatch_bulk — direct library calls
+# ---------------------------------------------------------------------------
+
+
+async def test_all_execute_rows_fan_out(stub_run_action) -> None:
+    """3 rows, all auto-policy, no rules → 3 executions, no approval, no blocked."""
+    pocket_id = await _make_pocket()
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(instinct_policy="auto")
+
+    rows = [
+        {"id": "r1", "value": 1},
+        {"id": "r2", "value": 2},
+        {"id": "r3", "value": 3},
+    ]
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+        now=FROZEN_NOW,
+    )
+
+    assert result.total_rows == 3
+    assert len(result.executions) == 3
+    assert result.blocked == []
+    assert result.batch_approval_id is None
+    # All three rows actually fired (stub recorded the calls).
+    assert len(stub_run_action) == 3
+    # Each execution carries the row_id.
+    fired_ids = {e.row_id for e in result.executions}
+    assert fired_ids == {"r1", "r2", "r3"}
+
+
+async def test_mixed_bucketing_block_execute_approval(stub_run_action) -> None:
+    """3 rows: 1 blocks, 1 executes, 1 needs approval. ONE batch approval."""
+    pocket_id = await _make_pocket()
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(
+        instinct_policy="auto",
+        rules=[
+            # Block wins. Then approval. Then plain execute.
+            {"when": "value > 900", "action": "block"},
+            {"when": "value > 100", "action": "require_approval"},
+        ],
+    )
+
+    rows = [
+        {"id": "rb", "value": 999},  # BLOCK
+        {"id": "re", "value": 1},  # EXECUTE
+        {"id": "ra", "value": 200},  # ESCALATE_APPROVAL
+    ]
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+        now=FROZEN_NOW,
+    )
+
+    assert result.total_rows == 3
+    assert len(result.executions) == 1
+    assert result.executions[0].row_id == "re"
+    assert len(result.blocked) == 1
+    assert result.blocked[0].row_id == "rb"
+    assert result.batch_approval_id is not None
+    # ONE approval doc, carrying the one approval row.
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+    assert approvals[0]["id"] == result.batch_approval_id
+    # Only the execute row fired through run_action.
+    assert len(stub_run_action) == 1
+
+
+async def test_all_approval_rows_consolidate_to_one_batch(stub_run_action, recording_bus) -> None:
+    """3 rows all needing approval → ONE batch_approval_id with all 3 row_ids."""
+    pocket_id = await _make_pocket()
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(
+        instinct_policy="require_approval",  # author floor
+    )
+
+    rows = [
+        {"id": "r1", "value": 1},
+        {"id": "r2", "value": 2},
+        {"id": "r3", "value": 3},
+    ]
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+        now=FROZEN_NOW,
+    )
+
+    assert result.total_rows == 3
+    assert result.executions == []
+    assert result.blocked == []
+    assert result.batch_approval_id is not None
+    # Exactly ONE approval row created for the batch.
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+    approval = approvals[0]
+    assert approval["id"] == result.batch_approval_id
+    # row_data carries the per-row data for all three rows + batch flag.
+    rd = approval["row_data"]
+    assert rd.get("batch") is True
+    # Every row's data is reachable via its id.
+    for row in rows:
+        rid = row["id"]
+        assert rid in rd, f"missing row {rid} in row_data: {rd!r}"
+    # No HTTP fired.
+    assert stub_run_action == []
+    # Exactly ONE InstinctApprovalCreated event.
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert len(created) == 1
+
+
+async def test_all_blocked_rows(stub_run_action) -> None:
+    """3 rows all blocking → 0 executions, 3 blocked, no approval."""
+    pocket_id = await _make_pocket()
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(
+        instinct_policy="auto",
+        rules=[{"when": "value > 0", "action": "block"}],
+    )
+
+    rows = [
+        {"id": "r1", "value": 1},
+        {"id": "r2", "value": 2},
+        {"id": "r3", "value": 3},
+    ]
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+        now=FROZEN_NOW,
+    )
+
+    assert result.total_rows == 3
+    assert result.executions == []
+    assert len(result.blocked) == 3
+    assert result.batch_approval_id is None
+    assert stub_run_action == []
+    # No approval persisted.
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert approvals == []
+
+
+async def test_empty_rows(stub_run_action) -> None:
+    """Empty selected_rows → total_rows=0, all lists empty, no approval."""
+    pocket_id = await _make_pocket()
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(instinct_policy="auto")
+
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=[],
+        now=FROZEN_NOW,
+    )
+
+    assert result.total_rows == 0
+    assert result.executions == []
+    assert result.blocked == []
+    assert result.batch_approval_id is None
+    assert stub_run_action == []
+
+
+async def test_non_bulk_action_raises_validation_error(stub_run_action) -> None:
+    """A ``kind: single-row`` action must not route through the bulk path."""
+    pocket_id = await _make_pocket(action_name="single_action")
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(action_name="single_action", kind="single-row")
+
+    with pytest.raises(ValidationError):
+        await bulk_dispatch.dispatch_bulk(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            template=template,
+            action_name="single_action",
+            selected_rows=[{"id": "r1", "value": 1}],
+            now=FROZEN_NOW,
+        )
+
+
+async def test_tenant_isolation_other_workspace_not_found(stub_run_action) -> None:
+    """Workspace A cannot dispatch a workspace-B pocket — surfaces as NotFound."""
+    pocket_id = await _make_pocket(workspace="wA", owner="uA", visibility="private")
+    await _make_backend(pocket_id=pocket_id, workspace_id="wA")
+    template = _template(instinct_policy="auto")
+
+    with pytest.raises(NotFound):
+        await bulk_dispatch.dispatch_bulk(
+            workspace_id="wB",
+            user_id="uB",
+            pocket_id=pocket_id,
+            template=template,
+            action_name="mark_done",
+            selected_rows=[{"id": "r1", "value": 1}],
+            now=FROZEN_NOW,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Service wrapper — dispatch_bulk_action validates + emits the event
+# ---------------------------------------------------------------------------
+
+
+async def test_service_emits_bulk_action_dispatched_once(stub_run_action, recording_bus) -> None:
+    """The service-level entry point fires exactly one
+    BulkActionDispatched event per call, per EE rule 9."""
+    pocket_id = await _make_pocket()
+    await _make_backend(pocket_id=pocket_id)
+    template = _template(instinct_policy="auto")
+
+    body = {
+        "pocket_id": pocket_id,
+        "action_name": "mark_done",
+        "rows": [
+            {"id": "r1", "value": 1},
+            {"id": "r2", "value": 2},
+        ],
+    }
+    # Service wrapper threads the template — for the test we pass it
+    # via the keyword argument the service exposes to internal callers.
+    result = await pockets_service.dispatch_bulk_action(
+        workspace_id="w1",
+        user_id="u1",
+        body=body,
+        template=template,
+        now=FROZEN_NOW,
+    )
+
+    assert result["total_rows"] == 2
+    dispatched = [e for e in recording_bus.events if isinstance(e, BulkActionDispatched)]
+    assert len(dispatched) == 1
+    payload = dispatched[0].data
+    assert payload["pocket_id"] == pocket_id
+    assert payload["action_name"] == "mark_done"
+    assert payload["total_rows"] == 2
+    assert payload["workspace_id"] == "w1"


### PR DESCRIPTION
# Wave 3b — Bulk action dispatch pipeline + batch approval persistence

Stacks on Wave 3a (#1275). Target `dev` after 3a merges; the
architect retargets if needed.

## Summary

- Wires the OSS `plan_bulk_execution` planner into the EE runtime so a
  `kind: bulk` action fans out across N selected rows with ONE
  approval blessing the whole batch — per RFC 03 v2 §"Bulk action
  execution model".
- New library entry point `pockets.bulk_dispatch.dispatch_bulk` calls
  the pure OSS planner once, persists exactly one `InstinctApproval`
  row covering every approval-needing row, and fires each ready row
  through `action_executor.run_action` (gate skipped on re-entry; the
  composer already produced the verdict).
- New service function `pockets.service.dispatch_bulk_action`
  re-validates the body and emits a single `BulkActionDispatched`
  event with the dispatch summary — rule 9.
- New route `POST /pockets/{id}/actions/{name}/dispatch-bulk` is
  declared in OpenAPI but currently surfaces
  `bulk_action.template_resolver_pending` until paw-enterprise wires
  the per-pocket template resolver (explicitly out of scope here).
- Import-linter contract extended: `pockets.bulk_dispatch` joins the
  Beanie-pure source_modules list alongside `instinct_dispatch`.

## What's in / what's out

In:

- `pockets/bulk_dispatch.py` — `dispatch_bulk(...) -> BulkDispatchResult`
  plus the frozen `ExecutionResult` / `BlockedRowResult` /
  `BulkDispatchResult` models.
- `pockets/service.py` — `dispatch_bulk_action(workspace_id, user_id, body, *, template, now)`.
- `pockets/dto.py` — `DispatchBulkRequest` / `BulkDispatchResponse` /
  `BulkExecutionResultDTO` / `BulkBlockedRowDTO`.
- `pockets/router.py` — new endpoint (stubbed until the template
  resolver lands).
- `_core/realtime/events.py` — `BulkActionDispatched`
  (`pocket.bulk_action.dispatched`).
- `tests/cloud/test_bulk_dispatch.py` — 8 tests covering the 7 brief
  scenarios + the service-level emit gate.

Out (separate PRs, called out in the module docstring):

- Approver re-entry: the path that iterates `row_data` and re-runs
  each row with `from_instinct=True` after the batch approval lands.
  This PR ships the persistence so the re-run code has data to work
  with.
- Outcome event emission per executed row — Wave 3c.
- UI for triggering bulk dispatches — paw-enterprise concern.
- Per-pocket template resolver — needed before the HTTP route is
  callable end-to-end.
- Per-agent concurrency / rate-limiting + idempotency keys for retry.

## Architecture notes

- **ONE approval per batch.** Even 50 escalating rows produce a single
  `InstinctApproval` doc. `row_data` is `{"batch": True, "<row_id>":
  <row dict>, ...}` so the future re-entry can iterate without
  reshaping. The consolidated reason (`operator_overlay_escalated` /
  `author_floor` / `mixed_approval_reasons`) and the union of overlay
  rules ride on the approval doc unchanged from the OSS planner.
- **Gate skipped on per-row re-entry.** The OSS composer already
  produced the verdict for every execute / notify row; re-threading
  `template` into `run_action` would re-evaluate the gate and risk a
  duplicate approval row on a flapping rule. The bulk path runs the
  composer ONCE per row via the planner.
- **Tenant-isolated.** `dispatch_bulk` calls `pockets_service.get`,
  which checks owner / shared_with / workspace visibility; a
  cross-workspace pocket_id raises `NotFound` (Forbidden gets
  remapped) so the endpoint is not a cross-tenant existence oracle.
- **Beanie-pure.** `bulk_dispatch` calls
  `instinct_approvals.service.create_approval` (a permitted writer)
  and `pockets.service` (orchestration) but imports no Beanie
  document class directly. Locked by the import-linter contract.

## Test plan

- [x] `uv run pytest tests/cloud/test_bulk_dispatch.py tests/cloud/test_instinct_dispatch.py tests/cloud/test_instinct_approvals_service.py` — 36 pass.
- [x] `uv run ruff check` + `uv run ruff format` clean on every
  touched file.
- [x] `uv run lint-imports --config ee/pyproject.toml` — 18 contracts
  kept, 0 broken.
- [x] Pocket-adjacent suite (`test_pocket_action_executor.py`,
  `test_pocket_instinct_bridge.py`, `test_pocket_actions_ops.py`) —
  67 pass; no regressions.
- [ ] Captain reviews the PR body + diff.

## Pinned by the new tests

- 3 rows all execute → 3 executions, no approval, no blocked, 3
  executor calls.
- 3 rows mixed (block + execute + approval) → 1 execution, 1 blocked,
  1 batch approval id covering the one approval row.
- 3 rows all needing approval (author_floor) → 0 executions, 0
  blocked, ONE batch approval id; `row_data` carries all three rows
  + `batch=True`.
- 3 rows all blocked → 0 executions, 3 blocked, no approval row.
- Empty selection → `total_rows=0`, all lists empty.
- Non-bulk action (`kind: single-row`) → `ValidationError`.
- Cross-workspace pocket_id → `NotFound`.
- Emit-on-write: `BulkActionDispatched` fires exactly once per
  service call.
