### PR TITLE
feat(ee): outcome event emission on action success for RFC 03 v2

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -15,6 +15,15 @@
 #   fan-out completes. Carries the dispatch summary (counts + optional
 #   batch approval id) so downstream listeners (audit, analytics) can
 #   key off a single event per dispatch call.
+# Updated: 2026-05-28 (feat/wave-3c-outcomes) — added ``OutcomeEmitted``
+#   (type="pocket.outcome_emitted"), emitted by
+#   ``pockets.outcomes_emitter.emit_outcomes`` for EACH name declared in
+#   an action's ``outcomes_emitted[]`` after a successful write. RFC 03
+#   v2's template-driven outcomes catalog is distinct from M2b.2's
+#   binding-driven ``PocketOutcomeEvent``: the template-level emit fires
+#   per declared catalog event (multiple per action allowed), the M2b.2
+#   binding-level emit fires the single ``binding.outcome`` name. Both
+#   coexist on the bus under different EVENT_TYPE strings.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -538,3 +547,35 @@ class InstinctApprovalRejected(Event):
 @dataclass
 class BulkActionDispatched(Event):
     EVENT_TYPE: ClassVar[str] = "pocket.bulk_action.dispatched"
+
+
+# Outcome event emission (RFC 03 v2 / Wave 3c). Fires AFTER a write
+# action's ``run_action`` returns ``ok:true`` on the HTTP 2xx success
+# path AND the action's ``outcomes_emitted[]`` declares one or more
+# names. One event per declared name (bulk emits per row). Feeds the
+# downstream Outcomes meter (out of scope for Wave 3c — bus emit is
+# the seam).
+#
+# Payload (``data``):
+#   event_name             — the declared outcome name (str), one of
+#                            ``actions[].outcomes_emitted``.
+#   workspace_id           — tenancy.
+#   pocket_id              — the pocket the action ran on.
+#   action_name            — the action that fired.
+#   row_id                 — the stable row identifier (empty when the
+#                            action does not bind to a row, e.g. a
+#                            page-level action).
+#   row_context_snapshot   — the row dict at emit time. Captures
+#                            payload state for downstream audit.
+#   emitted_at             — ISO-8601 UTC timestamp.
+#   template_name          — pocket template name (provenance for the
+#                            outcomes catalog).
+#   template_version       — pocket template version.
+#
+# Distinct from ``PocketOutcomeEvent`` (M2b.2): the M2b.2 event is
+# binding-driven (single ``binding.outcome`` field), this event is
+# template-driven (per-action ``outcomes_emitted[]`` list — multiple
+# emits per action allowed). Both coexist.
+@dataclass
+class OutcomeEmitted(Event):
+    EVENT_TYPE: ClassVar[str] = "pocket.outcome_emitted"

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -46,6 +46,20 @@
 #       limit / base-URL / SSRF / allowlist / DNS / M2b.1 park / HTTP).
 #   When no template is passed (all current callers; backward-compat)
 #   the gate is skipped — every existing flow is byte-identical.
+# Updated: 2026-05-28 (feat/wave-3c-outcomes) — RFC 03 v2 template-level
+#   outcome event emission. On the HTTP 2xx SUCCESS path, AFTER the
+#   success audit and BEFORE the return, if a `template` is threaded
+#   through the executor calls `outcomes_emitter.emit_outcomes(...)`.
+#   The emitter fires one bus event per name declared in the action's
+#   `outcomes_emitted[]`. Failure / blocked / pending-approval / from-
+#   instinct paths do NOT emit — outcomes are billable, so only
+#   confirmed direct success counts (the post-approval re-entry that
+#   actually fires the HTTP call also emits, since `template` is
+#   threaded through `instinct_bridge.execute_approved_write` callers
+#   that pass it).
+#   Emitter failures must never break the executor's return — the call
+#   is wrapped so a bus or audit hiccup logs a warning but the
+#   action's success result still propagates to the caller.
 #
 # A write has blast radius a read does not, so this executor adds three
 # concerns on TOP of the shared SSRF guards:
@@ -691,6 +705,35 @@ async def run_action(
         status="success",
         base_url=base_url,
     )
+
+    # ── RFC 03 v2 outcome event emission ────────────────────────────────
+    # On a confirmed HTTP 2xx success, fire one ``OutcomeEmitted`` event
+    # per name declared in the action's ``outcomes_emitted[]``. Wave 3c.
+    # Emission is gated on a threaded ``template`` — every legacy caller
+    # that doesn't pass one is byte-identical (zero events emitted).
+    # The emit is wrapped so a bus / audit hiccup never propagates back
+    # into the caller's success path; the action genuinely succeeded.
+    if template is not None:
+        from pocketpaw_ee.cloud.pockets import outcomes_emitter
+
+        try:
+            await outcomes_emitter.emit_outcomes(
+                workspace_id=workspace_id,
+                user_id=user_id,
+                pocket_id=pocket_id,
+                template=template,
+                action_name=action,
+                row_id=row_id,
+                row_context=row_context or {},
+            )
+        except Exception:  # noqa: BLE001 — emission must never break the success path
+            logger.warning(
+                "outcome emission failed for action=%s pocket=%s",
+                action,
+                pocket_id,
+                exc_info=True,
+            )
+
     return {
         "ok": True,
         "action": action,

--- a/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
@@ -30,10 +30,18 @@
 #   a follow-up PR will iterate ``row_data`` and re-run each row with
 #   ``from_instinct=True``. THIS module ships the persistence so the
 #   re-run code has data to work with.
-# * Outcome event emission per executed row (Wave 3c).
 # * UI for triggering bulk runs (paw-enterprise concern).
 # * Per-agent concurrency / rate-limiting (production hardening).
 # * Idempotency keys for retried bulk batches.
+#
+# Wave 3c addition (2026-05-28): outcome event emission per executed row
+# is wired here, NOT via the per-row ``run_action`` invocation. The bulk
+# path deliberately does NOT thread ``template`` into ``run_action`` (the
+# planner already ran the gate; re-threading would re-evaluate it and
+# risk a duplicate approval row). The outcome emitter therefore runs
+# from the bulk wrapper directly, once per row whose ``run_action``
+# returned ``ok:true``. Rows that fail (``ok:false``) skip emission, the
+# same invariant the executor's success-path emit enforces.
 #
 # Import-linter posture: this module is Beanie-PURE. It calls
 # ``instinct_approvals.service.create_approval`` (a permitted writer)
@@ -218,10 +226,16 @@ async def dispatch_bulk(
     # cause an idempotent re-eval at minimum and a race-created duplicate
     # approval at worst. Wave 3a wired the gate at the per-row entry; the
     # bulk path runs the gate ONCE per row via the planner instead.
+    #
+    # ``template`` IS still passed through to ``_fire_executions`` for
+    # the Wave 3c outcome emission — the bulk path emits outcomes per
+    # successful row directly (NOT through ``run_action``'s template-
+    # gated emit) because ``run_action`` here doesn't see the template.
     executions: list[ExecutionResult] = await _fire_executions(
         workspace_id=workspace_id,
         user_id=user_id,
         pocket_id=pocket_id,
+        template=template,
         plan=plan,
         pocket=pocket,
         action_executor=action_executor,
@@ -324,6 +338,7 @@ async def _fire_executions(
     workspace_id: str,
     user_id: str,
     pocket_id: str,
+    template: PocketTemplate,
     plan: Any,
     pocket: dict,
     action_executor: Any,
@@ -393,6 +408,9 @@ async def _fire_executions(
     raw_path = raw_action.get("path") or "/"
     raw_params = raw_action.get("params") if isinstance(raw_action.get("params"), dict) else {}
 
+    # Lazy import to keep this module's static import graph minimal.
+    from pocketpaw_ee.cloud.pockets import outcomes_emitter
+
     results: list[ExecutionResult] = []
     for row in plan.executions:
         result_dict = await action_executor.run_action(
@@ -412,6 +430,32 @@ async def _fire_executions(
             # the planner already produced the verdict. See the comment
             # block in ``dispatch_bulk`` for the reasoning.
         )
+        # ── Wave 3c: per-row outcome emission ──────────────────────
+        # Each row that returns ``ok:true`` fires its declared
+        # outcomes. Failure / ``ok:false`` rows skip emission (same
+        # invariant the executor's success-path emit enforces).
+        # Emission is wrapped so a hiccup in the bus / audit layer
+        # never breaks the bulk dispatch return value.
+        if result_dict.get("ok"):
+            try:
+                await outcomes_emitter.emit_outcomes(
+                    workspace_id=workspace_id,
+                    user_id=user_id,
+                    pocket_id=pocket_id,
+                    template=template,
+                    action_name=plan.action_name,
+                    row_id=row.row_id,
+                    row_context=dict(row.row),
+                )
+            except Exception:  # noqa: BLE001 — emission must not break dispatch
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "outcome emission failed for action=%s row=%s",
+                    plan.action_name,
+                    row.row_id,
+                    exc_info=True,
+                )
         results.append(
             ExecutionResult(
                 row_id=row.row_id,

--- a/ee/pocketpaw_ee/cloud/pockets/outcomes_emitter.py
+++ b/ee/pocketpaw_ee/cloud/pockets/outcomes_emitter.py
@@ -1,0 +1,248 @@
+# ee/pocketpaw_ee/cloud/pockets/outcomes_emitter.py
+# Created: 2026-05-28 (feat/wave-3c-outcomes) — emitter for RFC 03 v2
+# template-level outcome events. Per the RFC §"actions[] sub-schema"
+# (``outcomes_emitted: list[str]``) and §"Integration touchpoints"
+# (Outcomes meter): when an action successfully completes (HTTP 2xx
+# from ``action_executor.run_action``), emit each declared outcome
+# event so the Outcomes meter can count billable events. Bulk actions
+# emit one event per row.
+#
+# Wave 3c scope (library + wiring, locked by the architect brief):
+#
+# * Public function ``emit_outcomes(...)`` looks up the action on the
+#   template, builds one ``OutcomeEmitted`` event per name in the
+#   action's ``outcomes_emitted`` list, fires each via the realtime bus,
+#   and appends a single audit-log entry summarising the batch.
+# * Wired into ``action_executor.run_action`` on the HTTP 2xx success
+#   path (after the success audit, before the return). Failure,
+#   blocked, and approval-pending paths DO NOT emit — outcomes are
+#   billable; only confirmed success counts.
+# * Wired into ``bulk_dispatch._fire_executions`` per successful row,
+#   so a bulk run that executes 50 rows fires the row-finalized outcome
+#   50 times. The bulk path deliberately does NOT thread ``template``
+#   into ``run_action`` (Wave 3b: skipping re-gate-eval on the re-entry);
+#   the emitter is therefore invoked directly from the bulk wrapper
+#   instead of riding the executor's per-row emit.
+#
+# Out of scope (separate PRs):
+#
+# * Outcomes meter consumer / billing logic / persistence of outcome
+#   counts. PR 3c ships the emitter + the wire-up; downstream meter
+#   consumes the bus events.
+# * Outcome persistence (Beanie doc for outcomes ledger). The M2b.2
+#   ``PocketOutcomeEvent`` has a ledger writer at ``outcomes/service.py``;
+#   the RFC 03 v2 ``OutcomeEmitted`` event will get its own listener in
+#   the meter PR.
+# * Idempotency for retried action invocations — a retried action that
+#   succeeds twice will emit its outcomes twice. The meter PR can
+#   dedupe via ``(workspace_id, pocket_id, action_name, row_id,
+#   event_name, idempotency_key)`` if needed.
+#
+# Import-linter posture: this module is Beanie-PURE. It calls the
+# realtime bus (a permitted writer) and the security audit log (a
+# permitted writer) but never imports a Beanie document class.
+
+"""Outcome event emission for RFC 03 v2 template-level outcomes."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from pocketpaw.bundled_templates import PocketTemplate
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+
+logger = logging.getLogger(__name__)
+
+
+def _audit_outcomes_emitted(
+    *,
+    actor: str,
+    workspace_id: str,
+    pocket_id: str,
+    action_name: str,
+    row_id: str,
+    count: int,
+    event_names: list[str],
+) -> None:
+    """Write a single audit-log entry per ``emit_outcomes`` call.
+
+    One line per call, NOT per event — keeps the audit log readable
+    when an action emits many outcomes across many rows. The Outcomes
+    meter consumer reads the bus events; this audit entry is for
+    debug / forensic review of billable event emission.
+
+    Mirrors the shape of ``action_executor._audit_action_run``: category
+    ``pocket_backend_config``, severity INFO (outcomes are routine
+    success-path events; a WARNING would crowd the audit log on every
+    successful row). Audit failures must not break emission, so the
+    call is wrapped — emitting an outcome is the billable side-effect;
+    losing the audit line is a smaller failure than losing the event.
+    """
+    if count == 0:
+        # No emissions → no audit entry. Keeps the log clean for the
+        # common case of an action with empty ``outcomes_emitted``.
+        return
+    try:
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        fields: dict[str, Any] = {
+            "pocket_id": pocket_id,
+            "pocket_action": action_name,
+            "row_id": row_id,
+            "outcome_count": count,
+            "outcome_names": event_names,
+        }
+
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=AuditSeverity.INFO,
+                actor=actor,
+                action="pocket.outcomes.emit",
+                target=pocket_id,
+                status="emitted",
+                category="pocket_backend_config",
+                workspace_id=workspace_id,
+                **fields,
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break emission
+        logger.warning("pocket outcomes audit-log write failed", exc_info=True)
+
+
+def _find_action(template: PocketTemplate, action_name: str) -> Any:
+    """Return the ``ActionDef`` matching ``action_name`` on ``template``.
+
+    Raises ``NotFound("outcome_action", action_name)`` when no action
+    with that name is declared — defensive; the caller should have
+    validated. Matches the ``NotFound`` shape ``instinct_dispatch`` uses
+    for an unknown action.
+    """
+    for action in template.actions:
+        if action.name == action_name:
+            return action
+    raise NotFound("outcome_action", action_name)
+
+
+async def emit_outcomes(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    template: PocketTemplate,
+    action_name: str,
+    row_id: str,
+    row_context: dict[str, Any],
+    audit_metadata: dict[str, Any] | None = None,
+) -> list[OutcomeEmitted]:
+    """Emit one ``OutcomeEmitted`` event per name in
+    ``template.actions[action_name].outcomes_emitted``.
+
+    Steps (per the architect brief):
+
+    1. Look up the ``ActionDef`` for ``action_name`` on ``template``.
+       Unknown action → ``NotFound`` (defensive — the caller should
+       have validated).
+    2. For each name in ``action.outcomes_emitted``, build one
+       ``OutcomeEmitted`` event carrying the canonical payload (see
+       ``events.OutcomeEmitted`` docstring for the field shape).
+    3. ``await emit(event)`` for each via the realtime bus.
+    4. Append a single audit-log entry summarising the batch (one
+       line per ``emit_outcomes`` call, not per event).
+    5. Return the list of emitted events for caller introspection.
+
+    The function is pure with respect to its inputs — no template
+    mutation, no row_context mutation. The bus emit + audit entry are
+    the only side effects.
+
+    Args
+    ----
+    workspace_id:
+        Tenancy. Rides on every emitted event.
+    user_id:
+        The actor — the user whose successful action triggered the
+        emit. Logged on the audit entry; NOT carried on the event
+        payload (the Outcomes meter aggregates by workspace + pocket
+        + action; the actor is a debug / forensic detail).
+    pocket_id:
+        The pocket the action ran on.
+    template:
+        The validated ``PocketTemplate`` (already passed through
+        ``model_validate`` upstream — the schema's
+        ``_outcomes_emitted_subset`` validator already enforced that
+        every entry in ``outcomes_emitted`` exists in the top-level
+        ``outcomes[]`` catalog).
+    action_name:
+        Must match an entry in ``template.actions``. Unknown →
+        ``NotFound``.
+    row_id:
+        Stable identifier for the row the action ran on. Empty string
+        when the action does not bind to a row (e.g. a page-level
+        action).
+    row_context:
+        The row dict at emit time. Captured verbatim on each event so
+        the meter sees what payload triggered the emit.
+    audit_metadata:
+        Reserved for future use (e.g. an idempotency key or a
+        correlation id). Currently unused; pass ``None``.
+
+    Returns
+    -------
+    list[OutcomeEmitted]
+        The events that were placed on the bus, in declaration order.
+        Empty when ``outcomes_emitted`` is empty.
+
+    Raises
+    ------
+    NotFound
+        ``action_name`` is not declared on ``template``.
+    """
+    _ = audit_metadata  # reserved for a future idempotency-key path
+
+    action = _find_action(template, action_name)
+    names = list(action.outcomes_emitted)
+
+    if not names:
+        # No outcomes declared → nothing to emit, no audit entry. The
+        # caller doesn't need to wrap the call in a guard.
+        return []
+
+    now_iso = datetime.now(UTC).isoformat()
+    events: list[OutcomeEmitted] = []
+
+    for event_name in names:
+        payload: dict[str, Any] = {
+            "event_name": event_name,
+            "workspace_id": workspace_id,
+            "pocket_id": pocket_id,
+            "action_name": action_name,
+            "row_id": row_id,
+            "row_context_snapshot": dict(row_context),
+            "emitted_at": now_iso,
+            "template_name": template.name,
+            "template_version": template.version,
+        }
+        evt = OutcomeEmitted(data=payload)
+        # ``emit`` swallows bus failures; we still want the event in our
+        # return list because the caller is asserting that emission
+        # happened from this function's perspective (and the dropped
+        # event has already been logged by ``emit``).
+        await emit(evt)
+        events.append(evt)
+
+    _audit_outcomes_emitted(
+        actor=user_id,
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        action_name=action_name,
+        row_id=row_id,
+        count=len(events),
+        event_names=names,
+    )
+    return events
+
+
+__all__ = ["emit_outcomes"]

--- a/tests/cloud/test_outcomes_emitter.py
+++ b/tests/cloud/test_outcomes_emitter.py
@@ -1,0 +1,763 @@
+# tests/cloud/test_outcomes_emitter.py
+# Created: 2026-05-28 (feat/wave-3c-outcomes) — pins the RFC 03 v2
+# template-level outcome event emission wired into the EE action
+# pipeline.
+#
+# What this pins:
+#   * Direct emitter: an action with N declared `outcomes_emitted` fires
+#     N `OutcomeEmitted` events on the bus, plus ONE audit-log line.
+#   * Empty outcomes_emitted: no events, no audit entry.
+#   * Unknown action_name → `NotFound`.
+#   * action_executor success path: outcomes fire AFTER the HTTP 2xx
+#     audit, BEFORE the return. Failure / blocked / pending-approval
+#     paths emit ZERO outcomes.
+#   * Bulk dispatch fan-out: 3 successful rows × 1 outcome → 3 events.
+#   * Tenant isolation: workspace_id rides on every event.
+#   * Backward compat: no `template` threaded → no emission (every
+#     legacy caller is byte-identical).
+#
+# The outcome bus event is intentionally distinct from M2b.2's
+# `pocket.outcome` (binding-driven). RFC 03 v2 introduces a TEMPLATE-
+# driven outcomes catalog + per-action emit list; the two coexist on
+# the bus under different EVENT_TYPE strings.
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from pocketpaw.bundled_templates import PocketTemplate
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — minimal valid v2 PocketTemplate dicts.
+# ---------------------------------------------------------------------------
+
+
+def _template(
+    *,
+    action_name: str = "renew_lease",
+    outcomes_emitted: list[str] | None = None,
+    outcomes_catalog: list[str] | None = None,
+    instinct_policy: str = "auto",
+    rules: list[dict] | None = None,
+    kind: str = "single-row",
+) -> PocketTemplate:
+    """Build a v2 ``PocketTemplate`` with one action that carries the
+    declared ``outcomes_emitted`` list. The top-level ``outcomes``
+    catalog is auto-derived to cover the emitted names so the schema's
+    subset validator passes.
+    """
+    emitted = list(outcomes_emitted or [])
+    catalog = list(outcomes_catalog or emitted)
+    raw: dict[str, Any] = {
+        "schema_version": "2",
+        "name": "test-template",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "test fixture",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [{"field": "value", "widget": "number"}],
+            "id_field": "id",
+        },
+        "actions": [
+            {
+                "name": action_name,
+                "label": "Do Thing",
+                "kind": kind,
+                "instinct_policy": instinct_policy,
+                "outcomes_emitted": emitted,
+            }
+        ],
+        "outcomes": catalog,
+    }
+    if rules is not None:
+        raw["instinct_rules"] = {"rules": rules}
+    return PocketTemplate.model_validate(raw)
+
+
+def _raw_action() -> dict:
+    """A minimal ActionBinding-parseable raw action."""
+    return {"kind": "write_binding", "method": "POST", "path": "/items"}
+
+
+def _patch_http_ok(monkeypatch, *, body: dict | None = None, status: int = 200) -> None:
+    """Patch httpx.AsyncClient inside action_executor so the HTTP path
+    returns a synthetic 2xx without hitting the network. Returns ``body``
+    as the JSON response."""
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json=body or {"ok": True})
+
+    real_client = httpx.AsyncClient
+
+    def _factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = httpx.MockTransport(_handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(action_executor.httpx, "AsyncClient", _factory)
+
+
+def _patch_http_500(monkeypatch) -> None:
+    """Patch httpx so the executor sees a 500 — failure path."""
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    real_client = httpx.AsyncClient
+
+    def _factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = httpx.MockTransport(_handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(action_executor.httpx, "AsyncClient", _factory)
+
+
+def _patch_dns_external(monkeypatch) -> None:
+    """Stub the DNS pre-resolve so the SSRF guard passes for example.test."""
+    from pocketpaw_ee.cloud.pockets import _http_guard
+
+    async def _ok(host: str) -> None:  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(_http_guard, "_assert_host_external", _ok)
+    # The executor also imports the symbol directly into its module
+    # namespace; patch there too so the lookup path is consistent.
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    monkeypatch.setattr(action_executor, "_assert_host_external", _ok)
+
+
+@pytest.fixture(autouse=True)
+def _reset_action_rate_limit():
+    """Each test starts with an empty write-rate-limit dict so a test
+    that fires 3 rows in a row doesn't trip the 20-writes/min cap on a
+    flaky CI re-run."""
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    action_executor._action_log.clear()
+    yield
+    action_executor._action_log.clear()
+
+
+# ---------------------------------------------------------------------------
+# Direct emitter — no executor, just emit_outcomes
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_outcomes_fires_one_event_per_declared_name(recording_bus) -> None:
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.pockets import outcomes_emitter
+
+    template = _template(
+        action_name="renew_lease",
+        outcomes_emitted=["renewal_completed", "revenue_recognized"],
+    )
+    row_context = {"id": "row-1", "value": 100}
+
+    emitted = await outcomes_emitter.emit_outcomes(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="renew_lease",
+        row_id="row-1",
+        row_context=row_context,
+    )
+
+    # Return value: list of emitted events (caller can introspect).
+    assert len(emitted) == 2
+    names = {e.data["event_name"] for e in emitted}
+    assert names == {"renewal_completed", "revenue_recognized"}
+
+    # Bus saw exactly the two events.
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert len(bus_events) == 2
+
+    # Each event carries the canonical payload.
+    for evt in bus_events:
+        assert evt.data["workspace_id"] == "w1"
+        assert evt.data["pocket_id"] == "p1"
+        assert evt.data["action_name"] == "renew_lease"
+        assert evt.data["row_id"] == "row-1"
+        assert evt.data["row_context_snapshot"] == row_context
+        assert evt.data["template_name"] == "test-template"
+        assert evt.data["template_version"] == "1.0.0"
+        assert "emitted_at" in evt.data
+
+
+async def test_emit_outcomes_empty_list_is_a_no_op(recording_bus) -> None:
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.pockets import outcomes_emitter
+
+    template = _template(
+        action_name="quiet_action",
+        outcomes_emitted=[],
+    )
+
+    emitted = await outcomes_emitter.emit_outcomes(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="quiet_action",
+        row_id="r1",
+        row_context={"id": "r1"},
+    )
+    assert emitted == []
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert bus_events == []
+
+
+async def test_emit_outcomes_unknown_action_raises_not_found() -> None:
+    from pocketpaw_ee.cloud._core.errors import NotFound
+    from pocketpaw_ee.cloud.pockets import outcomes_emitter
+
+    template = _template(action_name="known_action", outcomes_emitted=["x"])
+
+    with pytest.raises(NotFound) as excinfo:
+        await outcomes_emitter.emit_outcomes(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id="p1",
+            template=template,
+            action_name="ghost_action",
+            row_id="r1",
+            row_context={},
+        )
+    assert "ghost_action" in str(excinfo.value)
+
+
+async def test_emit_outcomes_carries_workspace_isolation(recording_bus) -> None:
+    """Every event must carry the caller's workspace_id verbatim."""
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.pockets import outcomes_emitter
+
+    template = _template(
+        action_name="ship_it",
+        outcomes_emitted=["shipped"],
+    )
+
+    await outcomes_emitter.emit_outcomes(
+        workspace_id="wA",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="ship_it",
+        row_id="r1",
+        row_context={"id": "r1"},
+    )
+    await outcomes_emitter.emit_outcomes(
+        workspace_id="wB",
+        user_id="u2",
+        pocket_id="p2",
+        template=template,
+        action_name="ship_it",
+        row_id="r2",
+        row_context={"id": "r2"},
+    )
+
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert len(bus_events) == 2
+    workspaces = {e.data["workspace_id"] for e in bus_events}
+    assert workspaces == {"wA", "wB"}
+
+
+# ---------------------------------------------------------------------------
+# action_executor — outcomes fire only on the HTTP 2xx success path
+# ---------------------------------------------------------------------------
+
+
+async def test_executor_success_emits_outcomes(monkeypatch, recording_bus) -> None:
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    template = _template(
+        action_name="renew_lease",
+        outcomes_emitted=["renewal_completed"],
+    )
+    _patch_dns_external(monkeypatch)
+    _patch_http_ok(monkeypatch, body={"renewed": True})
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="renew_lease",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"id": "row-7", "value": 100},
+        row_id="row-7",
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == 200
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert len(bus_events) == 1
+    assert bus_events[0].data["event_name"] == "renewal_completed"
+    assert bus_events[0].data["row_id"] == "row-7"
+
+
+async def test_executor_failure_emits_zero_outcomes(monkeypatch, recording_bus) -> None:
+    """A 500 from the backend → outcomes MUST NOT fire."""
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    template = _template(
+        action_name="renew_lease",
+        outcomes_emitted=["renewal_completed"],
+    )
+    _patch_dns_external(monkeypatch)
+    _patch_http_500(monkeypatch)
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="renew_lease",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"id": "row-1", "value": 1},
+        row_id="row-1",
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "http_error"
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert bus_events == []
+
+
+async def test_executor_blocked_path_emits_zero_outcomes(monkeypatch, recording_bus) -> None:
+    """An Instinct BLOCK verdict → outcomes MUST NOT fire."""
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    template = _template(
+        action_name="renew_lease",
+        outcomes_emitted=["renewal_completed"],
+        rules=[{"when": "value > 100", "action": "block"}],
+    )
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="renew_lease",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"value": 999},
+        row_id="row-1",
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "instinct_blocked"
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert bus_events == []
+
+
+async def test_executor_pending_approval_emits_zero_outcomes(recording_bus) -> None:
+    """An Instinct ESCALATE_APPROVAL verdict → outcomes MUST NOT fire on
+    the parking call. The eventual re-entry post-approval (Wave 3c
+    follow-up flow) is where outcomes fire instead."""
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    template = _template(
+        action_name="renew_lease",
+        outcomes_emitted=["renewal_completed"],
+        rules=[{"when": "value > 100", "action": "require_approval"}],
+    )
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="renew_lease",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"value": 200},
+        row_id="row-1",
+    )
+
+    assert result["ok"] is True
+    assert result["code"] == "instinct_pending"
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert bus_events == []
+
+
+async def test_executor_without_template_emits_zero_outcomes(monkeypatch, recording_bus) -> None:
+    """Backward-compat: every existing caller that doesn't thread a
+    template through skips outcome emission entirely (the action's
+    outcomes_emitted list is not even reachable without a template)."""
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    _patch_dns_external(monkeypatch)
+    _patch_http_ok(monkeypatch)
+
+    result = await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="renew_lease",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+    )
+
+    assert result["ok"] is True
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert bus_events == []
+
+
+async def test_executor_emits_one_event_per_outcome(monkeypatch, recording_bus) -> None:
+    """An action declaring 3 outcomes_emitted fires 3 events on one
+    successful run."""
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    template = _template(
+        action_name="multi_emit",
+        outcomes_emitted=["a_done", "b_done", "c_done"],
+    )
+    _patch_dns_external(monkeypatch)
+    _patch_http_ok(monkeypatch)
+
+    await action_executor.run_action(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="multi_emit",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url="https://example.test",
+        auth_type="bearer",
+        auth_header=None,
+        token="t",
+        allowed_writes=[{"method": "POST", "path_pattern": "/items*"}],
+        template=template,
+        row_context={"id": "r1"},
+        row_id="r1",
+    )
+
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert len(bus_events) == 3
+    names = {e.data["event_name"] for e in bus_events}
+    assert names == {"a_done", "b_done", "c_done"}
+
+
+# ---------------------------------------------------------------------------
+# Bulk dispatch — per-row outcome emission
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_dispatch_emits_outcomes_per_row(recording_bus, monkeypatch) -> None:
+    """3 rows × 1 declared outcome → 3 OutcomeEmitted events."""
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+    from pocketpaw_ee.cloud.models.pocket_backend import (
+        AllowedWrite as _AllowedWriteDoc,
+    )
+    from pocketpaw_ee.cloud.models.pocket_backend import (
+        PocketBackendCredential as _BackendCredentialDoc,
+    )
+    from pocketpaw_ee.cloud.pockets import action_executor, bulk_dispatch
+
+    template = _template(
+        action_name="mark_done",
+        outcomes_emitted=["row_finalized"],
+        instinct_policy="auto",
+        kind="bulk",
+    )
+
+    # Insert pocket + backend creds so bulk_dispatch finds them.
+    pocket = _PocketDoc(
+        workspace="w1",
+        name="bulk-pocket",
+        owner="u1",
+        rippleSpec={
+            "actions": {
+                "mark_done": {
+                    "kind": "write_binding",
+                    "method": "POST",
+                    "path": "/items",
+                }
+            }
+        },
+        visibility="workspace",
+        widgets=[],
+    )
+    await pocket.insert()
+    pocket_id = str(pocket.id)
+    await _BackendCredentialDoc(
+        pocket_id=pocket_id,
+        workspace_id="w1",
+        base_url="https://example.test",
+        auth_type="none",
+        auth_header=None,
+        encrypted_token=None,
+        nonce=None,
+        salt=None,
+        allowed_writes=[
+            _AllowedWriteDoc.model_validate({"method": "POST", "path_pattern": "/items*"})
+        ],
+    ).insert()
+
+    # Stub run_action to return success without HTTP — the outcomes
+    # emitter should fire AFTER each successful row, regardless of
+    # whether the call was real or stubbed.
+    call_log: list[dict] = []
+
+    async def _stub(**kwargs: Any) -> dict:
+        call_log.append(kwargs)
+        return {
+            "ok": True,
+            "action": kwargs["action"],
+            "status": 200,
+            "response": {"ok": True},
+            "on_success": [],
+            "on_error": [],
+        }
+
+    monkeypatch.setattr(action_executor, "run_action", _stub)
+
+    rows = [
+        {"id": "r1", "value": 1},
+        {"id": "r2", "value": 2},
+        {"id": "r3", "value": 3},
+    ]
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+    )
+
+    assert len(result.executions) == 3
+    assert len(call_log) == 3
+
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert len(bus_events) == 3
+    row_ids = {e.data["row_id"] for e in bus_events}
+    assert row_ids == {"r1", "r2", "r3"}
+    for evt in bus_events:
+        assert evt.data["event_name"] == "row_finalized"
+        assert evt.data["workspace_id"] == "w1"
+        assert evt.data["pocket_id"] == pocket_id
+
+
+async def test_bulk_dispatch_zero_outcomes_when_action_declares_none(
+    recording_bus, monkeypatch
+) -> None:
+    """Bulk action with outcomes_emitted=[] → 0 OutcomeEmitted events."""
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+    from pocketpaw_ee.cloud.models.pocket_backend import (
+        AllowedWrite as _AllowedWriteDoc,
+    )
+    from pocketpaw_ee.cloud.models.pocket_backend import (
+        PocketBackendCredential as _BackendCredentialDoc,
+    )
+    from pocketpaw_ee.cloud.pockets import action_executor, bulk_dispatch
+
+    template = _template(
+        action_name="mark_done",
+        outcomes_emitted=[],
+        kind="bulk",
+    )
+
+    pocket = _PocketDoc(
+        workspace="w1",
+        name="bulk-pocket",
+        owner="u1",
+        rippleSpec={
+            "actions": {
+                "mark_done": {
+                    "kind": "write_binding",
+                    "method": "POST",
+                    "path": "/items",
+                }
+            }
+        },
+        visibility="workspace",
+        widgets=[],
+    )
+    await pocket.insert()
+    pocket_id = str(pocket.id)
+    await _BackendCredentialDoc(
+        pocket_id=pocket_id,
+        workspace_id="w1",
+        base_url="https://example.test",
+        auth_type="none",
+        auth_header=None,
+        encrypted_token=None,
+        nonce=None,
+        salt=None,
+        allowed_writes=[
+            _AllowedWriteDoc.model_validate({"method": "POST", "path_pattern": "/items*"})
+        ],
+    ).insert()
+
+    async def _stub(**kwargs: Any) -> dict:
+        return {
+            "ok": True,
+            "action": kwargs["action"],
+            "status": 200,
+            "response": {"ok": True},
+            "on_success": [],
+            "on_error": [],
+        }
+
+    monkeypatch.setattr(action_executor, "run_action", _stub)
+
+    rows = [{"id": "r1", "value": 1}, {"id": "r2", "value": 2}]
+    result = await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+    )
+
+    assert len(result.executions) == 2
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert bus_events == []
+
+
+async def test_bulk_dispatch_failed_rows_skip_outcomes(recording_bus, monkeypatch) -> None:
+    """If a row's run_action returns ok:false, NO outcome fires for it.
+    Rows that succeed still get their outcomes."""
+    from pocketpaw_ee.cloud._core.realtime.events import OutcomeEmitted
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+    from pocketpaw_ee.cloud.models.pocket_backend import (
+        AllowedWrite as _AllowedWriteDoc,
+    )
+    from pocketpaw_ee.cloud.models.pocket_backend import (
+        PocketBackendCredential as _BackendCredentialDoc,
+    )
+    from pocketpaw_ee.cloud.pockets import action_executor, bulk_dispatch
+
+    template = _template(
+        action_name="mark_done",
+        outcomes_emitted=["row_finalized"],
+        kind="bulk",
+    )
+
+    pocket = _PocketDoc(
+        workspace="w1",
+        name="bulk-pocket",
+        owner="u1",
+        rippleSpec={
+            "actions": {
+                "mark_done": {
+                    "kind": "write_binding",
+                    "method": "POST",
+                    "path": "/items",
+                }
+            }
+        },
+        visibility="workspace",
+        widgets=[],
+    )
+    await pocket.insert()
+    pocket_id = str(pocket.id)
+    await _BackendCredentialDoc(
+        pocket_id=pocket_id,
+        workspace_id="w1",
+        base_url="https://example.test",
+        auth_type="none",
+        auth_header=None,
+        encrypted_token=None,
+        nonce=None,
+        salt=None,
+        allowed_writes=[
+            _AllowedWriteDoc.model_validate({"method": "POST", "path_pattern": "/items*"})
+        ],
+    ).insert()
+
+    # First row succeeds, second fails.
+    seq: list[dict] = [
+        {
+            "ok": True,
+            "action": "mark_done",
+            "status": 200,
+            "response": {"ok": True},
+            "on_success": [],
+            "on_error": [],
+        },
+        {
+            "ok": False,
+            "action": "mark_done",
+            "error": "boom",
+            "code": "http_error",
+            "on_error": [],
+        },
+    ]
+    calls = {"i": 0}
+
+    async def _stub(**kwargs: Any) -> dict:  # noqa: ARG001
+        out = seq[calls["i"]]
+        calls["i"] += 1
+        return out
+
+    monkeypatch.setattr(action_executor, "run_action", _stub)
+
+    rows = [{"id": "r1", "value": 1}, {"id": "r2", "value": 2}]
+    await bulk_dispatch.dispatch_bulk(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        template=template,
+        action_name="mark_done",
+        selected_rows=rows,
+    )
+
+    bus_events = [e for e in recording_bus.events if isinstance(e, OutcomeEmitted)]
+    assert len(bus_events) == 1
+    assert bus_events[0].data["row_id"] == "r1"


### PR DESCRIPTION
# Wave 3c — Outcome event emission for RFC 03 v2

Stacked on Wave 3b (`feat/wave-3b-action-pipeline`, pocketpaw#1276).
Architect retargets to `dev` after 3a + 3b merge.

## Summary

- New `OutcomeEmitted` bus event (type `pocket.outcome_emitted`) plus an `emit_outcomes` helper that fires one event per name declared in an action's `outcomes_emitted[]` after a confirmed HTTP 2xx success.
- Wired into `action_executor.run_action` on the SUCCESS path (after the success audit, before the return). Failure / blocked / pending-approval paths emit nothing — outcomes are billable, so only confirmed success counts.
- Wired into `bulk_dispatch._fire_executions` per successful row, so a bulk run that executes 50 rows fires the declared outcomes 50 times.
- Backward compatible — callers that don't thread a `template` skip emission entirely.

## What's in / out

**In (library + wiring):**

- `ee/pocketpaw_ee/cloud/pockets/outcomes_emitter.py` — NEW (248 LOC). `emit_outcomes(...)` looks up the `ActionDef`, builds one `OutcomeEmitted` event per declared name, emits via the realtime bus, appends one audit-log line per call.
- `ee/pocketpaw_ee/cloud/_core/realtime/events.py` — `OutcomeEmitted` event registered (type `pocket.outcome_emitted`). Distinct from M2b.2's `PocketOutcomeEvent`: M2b.2 is binding-driven, Wave 3c is template-driven; both coexist on the bus.
- `ee/pocketpaw_ee/cloud/pockets/action_executor.py` — success path now calls `emit_outcomes` when `template` is threaded. Wrapped so an emit hiccup never breaks the action's success return.
- `ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py` — `_fire_executions` invokes `emit_outcomes` directly per successful row (the bulk path deliberately doesn't thread `template` through `run_action`, preserving Wave 3b's no-re-gate invariant — the emit is invoked at the bulk wrapper instead).
- `tests/cloud/test_outcomes_emitter.py` — 13 tests (~615 LOC).

**Out of scope (separate PRs):**

- Outcomes meter consumer / billing logic / aggregation. The bus is the seam — downstream meter subscribes to `pocket.outcome_emitted`.
- Outcomes ledger persistence for the new event (the existing M2b.2 ledger remains; the new event will get its own listener when the meter PR lands).
- Idempotency for retried action invocations — a retried action that succeeds twice will double-emit. Documented in the emitter module header; meter PR can dedupe via `(workspace_id, pocket_id, action_name, row_id, event_name, idempotency_key)`.
- OSS code under `src/pocketpaw/` — untouched.

## Architectural decisions

1. **Emit on confirmed HTTP 2xx success only.** Failure / approval-pending / blocked / from-instinct-bypass paths emit zero events. Outcomes are billable.
2. **One event per declared outcome name per row.** Multiple names on one action means multiple emits on one successful run. Bulk emits per row.
3. **Bus events, not Beanie writes.** Wave 3c is library + wiring; the Outcomes meter / ledger writer comes next.
4. **One audit log line per `emit_outcomes` call**, not per event. Keeps the log readable when an action emits many outcomes across many rows. Category `pocket_backend_config`, severity INFO, fields include `outcome_count` + `outcome_names`.
5. **Touched `action_executor.py` minimally.** The Wave 3a/3b additions established a clear gate/dispatch pattern; the emit call is the smallest possible extension — one wrapped block inside the existing success-path return.
6. **New event distinct from M2b.2 `PocketOutcomeEvent`.** Different semantics (template-driven vs binding-driven) → different `EVENT_TYPE`. Both coexist.

## Tests

`tests/cloud/test_outcomes_emitter.py` — 13 tests pinning:

- Direct emitter: 2 declared outcomes → 2 events; empty list → no event + no audit; unknown action → `NotFound`; tenant isolation on `workspace_id`.
- action_executor wiring: success path emits; failure (HTTP 500) emits zero; blocked path emits zero; pending-approval emits zero; no-template caller emits zero; multi-name action fires one event per name.
- bulk_dispatch wiring: 3 rows × 1 outcome → 3 events; empty `outcomes_emitted` → zero events; per-row failure → that row skipped, successful rows still emit.

Regression: 68 / 68 adjacent (outcomes + bulk + instinct + pocket-action-executor + ops + lift) pass. Import-linter 18 / 18 contracts kept.

## Risk

Low. Backward-compatible (every legacy caller without `template` is byte-identical), no OSS touch, no Beanie writes, no schema changes. The emit is wrapped so a bus / audit hiccup logs a warning but does not break the action's success return.
