### PR TITLE
feat(ee): temporal trigger sweep scheduler for RFC 03 v2

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -238,6 +238,16 @@ def mount_cloud(app: FastAPI) -> None:
     # exposes the operator-facing read + decision surface.
     app.include_router(instinct_approvals_router, prefix="/api/v1")
 
+    # Temporal sweeps — RFC 03 v2 Wave 3d. Read-only inspect endpoint
+    # for the persisted (trigger, row) state matrix; the actual sweep
+    # is driven by the in-process scheduler at
+    # ``cloud._core.temporal_scheduler`` and the per-pocket dispatcher
+    # at ``cloud.pockets.temporal_dispatcher``. No "sweep now" route in
+    # v0 (deferred).
+    from pocketpaw_ee.cloud.temporal_sweeps.router import router as temporal_sweeps_router
+
+    app.include_router(temporal_sweeps_router, prefix="/api/v1")
+
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
     # inline (instead of via build_router's ctx_factory) so the routes can
     # use the canonical `Depends(current_active_user)` auth chain without

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -24,6 +24,13 @@
 #   per declared catalog event (multiple per action allowed), the M2b.2
 #   binding-level emit fires the single ``binding.outcome`` name. Both
 #   coexist on the bus under different EVENT_TYPE strings.
+# Updated: 2026-05-28 (feat/wave-3d-temporal-scheduler) — added
+#   ``TemporalSweepCompleted`` (type="pocket.temporal_sweep_completed"),
+#   emitted once per per-pocket sweep tick by
+#   ``temporal_sweeps.service.upsert_state``. Carries the sweep tally
+#   (edges_fired / blocked / escalated / errors / sweep_duration_ms) so
+#   audit + dashboards listen to one event per dispatch rather than N
+#   per-row events, the same shape ``BulkActionDispatched`` uses.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -579,3 +586,29 @@ class BulkActionDispatched(Event):
 @dataclass
 class OutcomeEmitted(Event):
     EVENT_TYPE: ClassVar[str] = "pocket.outcome_emitted"
+
+
+# Temporal sweep completion event (RFC 03 v2 Wave 3d).
+# Fired by ``temporal_sweeps.service.upsert_state`` once per (workspace,
+# pocket) sweep, with the sweep's tally: edges_fired (how many rising-
+# edge transitions dispatched), blocked (how many Instinct blocked),
+# escalated (how many escalated to approval), errors (per-row eval
+# failures), and the wall-clock duration. Downstream listeners (audit,
+# dashboards) key off this single event instead of N per-row events,
+# the same way ``BulkActionDispatched`` is one event per dispatch.
+#
+# Payload (carried under ``Event.data``):
+#   workspace_id        — tenancy.
+#   pocket_id           — pocket whose temporal triggers were swept.
+#   edges_fired         — count of rising edges that dispatched.
+#   blocked             — count of edges whose Instinct gate returned
+#                         BLOCK (action_executor never called).
+#   escalated           — count of edges whose Instinct gate returned
+#                         ESCALATE_APPROVAL (one InstinctApproval row
+#                         persisted per row).
+#   errors              — count of per-row CEL eval failures.
+#   sweep_duration_ms   — wall-clock ms the sweep ran for. Forensic /
+#                         dashboard signal; long sweeps deserve a look.
+@dataclass
+class TemporalSweepCompleted(Event):
+    EVENT_TYPE: ClassVar[str] = "pocket.temporal_sweep_completed"

--- a/ee/pocketpaw_ee/cloud/_core/temporal_scheduler.py
+++ b/ee/pocketpaw_ee/cloud/_core/temporal_scheduler.py
@@ -1,0 +1,282 @@
+# ee/pocketpaw_ee/cloud/_core/temporal_scheduler.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — in-process
+# cron driver for the RFC 03 v2 temporal trigger sweeper. Periodically
+# sweeps every pocket that carries at least one ``type: temporal``
+# trigger, detects rising edges (false → true per-row predicate), and
+# dispatches the trigger's action via the Wave 3a gate when an edge
+# fires.
+#
+# Design (mirrors ``cycles/scheduler.py`` and
+# ``pockets/refresh_scheduler.py``):
+#
+#   - One loop, one task. Every ``_INTERVAL_SECONDS`` it scans the
+#     workspace × pocket cross-product, picks pockets that declare at
+#     least one temporal trigger, and calls
+#     ``temporal_dispatcher.sweep_pocket`` for each.
+#   - Per-pocket failures are logged + swallowed so one bad pocket
+#     can't kill the loop for everyone else.
+#   - Cancel-safe: the loop re-raises ``CancelledError``;
+#     ``stop_scheduler`` cancels and awaits it so cloud teardown is
+#     clean.
+#   - Opt-in via ``POCKETPAW_TEMPORAL_SWEEP_ENABLED=true`` (default OFF
+#     so pytest runs and multi-replica deploys don't spawn a background
+#     loop). Mirrors the cycles snapshot-scheduler gate.
+#   - Cadence is env-configurable via
+#     ``POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS`` (default 3600 = 1h
+#     per RFC "typically hourly"). Floor at 60s to prevent runaway
+#     loops a misconfigured tiny value would cause.
+#
+# Out of scope (per the architect brief):
+#   * HA / leader election. Single-node only for v0. A multi-replica
+#     deploy must either gate this scheduler to one replica via the
+#     env flag or accept duplicate sweeps (state writes are
+#     idempotent; HTTP dispatches are not).
+#   * Per-tenant cadence overrides — env var only, one cadence for the
+#     whole deployment.
+#   * Cron syntax for non-1h intervals. Env var is a simple integer
+#     second count.
+#   * Manual "sweep now" route. Future PR.
+#   * Per-pocket template resolution. The pocket Beanie doc has no
+#     ``template_slug`` field yet (same gap the bulk dispatcher has);
+#     the scheduler skips pockets for which no template can be
+#     resolved. The architectural seam is here for the day the
+#     resolver lands.
+#
+# Hard constraint: this module imports the ``temporal_dispatcher`` +
+# ``pockets.service`` (for the workspace + pocket scan). It MUST NOT
+# import a Beanie document class directly — the scan helper is in
+# ``pockets.service`` which is the only Beanie writer for pockets.
+
+"""In-process temporal trigger sweep scheduler."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from datetime import UTC, datetime
+
+logger = logging.getLogger(__name__)
+
+# Default cadence: 1h per RFC 03 v2 "typically hourly". Configurable
+# via the env var.
+_DEFAULT_INTERVAL_SECONDS = 3600
+# Floor: 60s — anything tighter risks runaway loops on a
+# misconfigured deployment. Mirrors ``_refresh_budget.clamp_interval``.
+_MIN_INTERVAL_SECONDS = 60
+
+_ENV_FLAG = "POCKETPAW_TEMPORAL_SWEEP_ENABLED"
+_ENV_INTERVAL = "POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS"
+
+# Module-level handle on the running task. The cloud lifecycle hook
+# has no FastAPI ``app`` to stash it on (LifecycleHook takes no args),
+# so the task lives here. ``start_scheduler`` / ``stop_scheduler`` are
+# idempotent against this single slot — mirrors the refresh-scheduler
+# pattern.
+_task: asyncio.Task | None = None
+
+
+def is_enabled() -> bool:
+    """True when the temporal scheduler is switched on for this process."""
+    return os.environ.get(_ENV_FLAG, "").lower() == "true"
+
+
+def _interval_seconds() -> int:
+    """Resolve the per-tick cadence, honoring the env var.
+
+    Defaults to ``_DEFAULT_INTERVAL_SECONDS`` (1h). A configured value
+    below ``_MIN_INTERVAL_SECONDS`` is clamped UP — a hallucinated
+    ``1`` cannot wedge the loop. Non-integer values fall back to the
+    default.
+    """
+    raw = os.environ.get(_ENV_INTERVAL, "").strip()
+    if not raw:
+        return _DEFAULT_INTERVAL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "temporal-scheduler: %s=%r is not an integer, falling back to %ds",
+            _ENV_INTERVAL,
+            raw,
+            _DEFAULT_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_INTERVAL_SECONDS
+    if value < _MIN_INTERVAL_SECONDS:
+        logger.warning(
+            "temporal-scheduler: %s=%d below floor — clamping to %ds",
+            _ENV_INTERVAL,
+            value,
+            _MIN_INTERVAL_SECONDS,
+        )
+        return _MIN_INTERVAL_SECONDS
+    return value
+
+
+async def _resolve_pocket_template_and_rows(
+    workspace_id: str,
+    pocket_id: str,
+) -> tuple[object | None, list[dict]]:
+    """Return ``(template, rows)`` for one pocket, or ``(None, [])``.
+
+    v0: the Pocket Beanie doc has no ``template_slug`` field, so the
+    scheduler can't resolve a ``PocketTemplate`` for an arbitrary
+    pocket. The scan helper accepts this — a pocket whose template
+    can't be resolved is a no-op for the sweeper.
+
+    The architectural seam is here for the day a template resolver
+    lands (likely as a service-level helper on
+    ``pockets.service.get_pocket_template``). When that ships, this
+    function returns ``(template, [])`` (rows still empty in v0) and
+    the dispatcher does real work.
+
+    Returning ``(None, [])`` short-circuits the dispatcher's early-
+    return path: it does no row work, persists no state, and emits
+    no completion event.
+    """
+    # No template resolution available in v0. Tests that want to
+    # exercise the dispatch path patch this function directly.
+    _ = workspace_id, pocket_id
+    return None, []
+
+
+async def run_one_pass() -> int:
+    """Run a single scan-and-sweep pass across every pocket.
+
+    Returns the number of pockets visited. Extracted from the loop
+    so a test can exercise one pass without the interval sleep.
+    Per-pocket failures are caught here so one bad pocket cannot
+    abort the pass.
+
+    Scan strategy: iterate every Pocket that has a non-null
+    ``rippleSpec`` (the universe of pockets that might carry
+    triggers). Per pocket, resolve the template; when no template
+    resolves, skip cheaply. When a template does resolve and carries
+    a temporal trigger, call ``sweep_pocket``.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    started = datetime.now(UTC)
+    try:
+        # v0: re-use the existing ``list_interval_source_pockets`` scan
+        # as a stand-in. It returns every pocket with a non-null
+        # ``rippleSpec.sources``. A pocket with temporal triggers but
+        # no sources is missed by this scan in v0 — documented
+        # limitation. The follow-up resolver PR will replace this with
+        # a proper "list pockets with temporal triggers" scan helper.
+        pockets = await pockets_service.list_interval_source_pockets()
+    except Exception:
+        logger.exception("temporal-scheduler: failed to list pockets")
+        return 0
+
+    visited = 0
+    for pocket in pockets:
+        pocket_id = pocket.get("pocket_id")
+        workspace_id = pocket.get("workspace_id")
+        if not pocket_id or not workspace_id:
+            continue
+        try:
+            template, rows = await _resolve_pocket_template_and_rows(workspace_id, pocket_id)
+            if template is None:
+                # No template resolved — skip cheaply, do not write
+                # state. Logged at DEBUG so a 1000-pocket deployment
+                # doesn't flood logs every hour.
+                logger.debug(
+                    "temporal-scheduler: pocket=%s no template resolved — skipping",
+                    pocket_id,
+                )
+                continue
+            await temporal_dispatcher.sweep_pocket(
+                workspace_id,
+                pocket_id,
+                template=template,
+                rows=rows,
+            )
+            visited += 1
+        except Exception:
+            logger.exception(
+                "temporal-scheduler: sweep failed for pocket=%s",
+                pocket_id,
+            )
+
+    duration = (datetime.now(UTC) - started).total_seconds()
+    logger.info(
+        "temporal-scheduler: pass complete — pockets visited=%d duration=%.2fs",
+        visited,
+        duration,
+    )
+    return visited
+
+
+async def _loop() -> None:
+    """The scheduler loop body — forever, one pass per interval.
+
+    Sleeps interval-seconds between passes. The very first pass also
+    waits one interval (no immediate sweep at boot) so a deployment
+    that flips the flag mid-startup isn't surprised by an
+    instantaneous sweep before the rest of the cloud has finished
+    coming up.
+    """
+    interval = _interval_seconds()
+    logger.info("temporal-scheduler: loop started (interval=%ds)", interval)
+    while True:
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("temporal-scheduler: loop cancelled — exiting")
+            raise
+        # ``run_one_pass`` already swallows per-pocket errors; the
+        # outer guard defends against an unexpected failure in the
+        # scan helper itself so the loop never dies.
+        try:
+            await run_one_pass()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("temporal-scheduler: unexpected pass failure")
+
+
+async def start_scheduler() -> None:
+    """Start the temporal sweep loop. Idempotent and gated.
+
+    A no-op when ``POCKETPAW_TEMPORAL_SWEEP_ENABLED`` is not ``true``
+    or when a loop is already running. Called from the cloud
+    ``CloudLifecycleHook.on_startup`` hook in
+    ``ee/pocketpaw_ee/extensions.py``.
+    """
+    global _task
+    if not is_enabled():
+        logger.debug("temporal-scheduler: disabled (%s not 'true')", _ENV_FLAG)
+        return
+    if _task is not None and not _task.done():
+        return
+    _task = asyncio.create_task(_loop(), name="pocket-temporal-sweep")
+
+
+async def stop_scheduler() -> None:
+    """Cancel + await the temporal sweep loop. Safe to call repeatedly."""
+    global _task
+    task = _task
+    if task is None or task.done():
+        _task = None
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+    _task = None
+
+
+def _reset_for_tests() -> None:
+    """Clear the module-level task handle. Test-only."""
+    global _task
+    _task = None
+
+
+__all__ = [
+    "is_enabled",
+    "run_one_pass",
+    "start_scheduler",
+    "stop_scheduler",
+]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -30,6 +30,7 @@ from pocketpaw_ee.cloud.models.project import Project
 from pocketpaw_ee.cloud.models.read_state import ReadState
 from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.task import Task, TaskAssignee, TaskSource
+from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc
 from pocketpaw_ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
 
@@ -102,6 +103,7 @@ __all__ = [
     "Task",
     "TaskAssignee",
     "TaskSource",
+    "TemporalSweepStateDoc",
     "User",
     "Widget",
     "WidgetPosition",
@@ -136,6 +138,7 @@ def get_all_documents():
         Message,
         ReadState,
         Task,
+        TemporalSweepStateDoc,
         Cycle,
         Project,
         PlanSession,

--- a/ee/pocketpaw_ee/cloud/models/temporal_sweep_state.py
+++ b/ee/pocketpaw_ee/cloud/models/temporal_sweep_state.py
@@ -1,0 +1,96 @@
+# ee/pocketpaw_ee/cloud/models/temporal_sweep_state.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — Beanie document
+# backing the per-(workspace, pocket, trigger_key, row_id) state row the
+# RFC 03 v2 temporal sweeper persists between sweeps. The pure OSS
+# ``sweep_temporal_triggers`` library is stateless across calls; the
+# caller hands in the prior sweep's truth map and gets back an updated
+# map. Wave 3d persists that map per pocket+trigger+row so a rising-edge
+# transition (false → true) fires exactly once.
+#
+# Tenancy: ``workspace`` is required + indexed. Every read in
+# ``temporal_sweeps/service.py`` filters by it, so a sweep-state row in
+# workspace A is invisible to workspace B. The composite unique index on
+# (workspace, pocket_id, trigger_key, row_id) makes the upsert pattern
+# safe under concurrent sweep ticks (HA is out of scope for v0, but the
+# index pins the invariant for the day it lands).
+#
+# Storage shape (one row per (workspace, pocket, trigger_key, row_id)):
+#   * predicate_value — last evaluated boolean truth value of the
+#     trigger's ``when`` CEL on this row.
+#   * last_swept_at — wall-clock UTC of the sweep that produced the
+#     value. Used for forensic / dashboard debug, not for cadence (the
+#     scheduler owns cadence).
+#
+# Why a separate collection rather than embedding on Pocket: the matrix
+# is (triggers × rows), which can be large for a pocket with many rows.
+# Keeping it side-table-ish avoids bloating the Pocket doc and lets
+# Mongo's index on the composite key serve point lookups efficiently.
+
+"""Beanie document for the RFC 03 v2 temporal-sweep state matrix."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class TemporalSweepStateDoc(TimestampedDocument):
+    """One persisted (trigger × row) truth value from a temporal sweep.
+
+    A row is written/upserted by ``temporal_sweeps.service.upsert_state``
+    on every sweep that produced a state entry for the (trigger, row)
+    pair. ``predicate_value`` carries the last evaluated boolean — a
+    sweep's rising-edge detection diffs the prior persisted value
+    against the new CEL eval to decide whether to dispatch.
+
+    Fields:
+        workspace: tenant id. Indexed; every read filters by it.
+        pocket_id: pocket the trigger lives on.
+        trigger_key: stable key the OSS sweeper synthesizes for the
+            trigger — the action name when unique, otherwise
+            ``temporal_{action}_{idx}`` / ``temporal_{idx}``.
+        row_id: identifier of the row the predicate evaluated against.
+        predicate_value: the boolean the CEL ``when`` evaluated to on
+            the last sweep. ``True`` means the row currently satisfies
+            the trigger; rising-edge dispatches fire when a stored
+            ``False`` flips to a current ``True``.
+        last_swept_at: wall-clock UTC of the sweep that produced this
+            value. Distinct from ``updatedAt`` (which Beanie sets on
+            every save) — operators want the sweep timestamp, not the
+            Mongo write timestamp.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    pocket_id: str
+    trigger_key: str
+    row_id: str
+    predicate_value: bool
+    last_swept_at: datetime
+
+    class Settings:
+        name = "temporal_sweep_state"
+        indexes = [
+            # Composite unique key: one row per
+            # (workspace, pocket, trigger, row). Upserts target this
+            # tuple; HA-safe under future leader election.
+            IndexModel(
+                [
+                    ("workspace", 1),
+                    ("pocket_id", 1),
+                    ("trigger_key", 1),
+                    ("row_id", 1),
+                ],
+                unique=True,
+                name="ws_pocket_trigger_row_uniq",
+            ),
+            # Per-pocket scan: the dispatcher loads every (trigger, row)
+            # state for one pocket at the start of a sweep.
+            [("workspace", 1), ("pocket_id", 1)],
+        ]
+
+
+__all__ = ["TemporalSweepStateDoc"]

--- a/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
+++ b/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
@@ -1,0 +1,469 @@
+# ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — per-pocket
+# entry point for the RFC 03 v2 temporal trigger sweeper. Calls the
+# pure OSS ``sweep_temporal_triggers`` planner, then dispatches each
+# rising-edge transition through Wave 3a's Instinct gate +
+# ``action_executor.run_action``. State persistence is the
+# ``temporal_sweeps`` entity's job; per-row Instinct branching is
+# Wave 3a's; this module is the orchestration glue.
+#
+# Wave 3d scope (locked by the architect brief):
+#
+#   1. Load the prior sweep state via ``temporal_sweeps.service.load_last_seen``.
+#   2. Fetch the pocket's current rows (see "Rows source" below).
+#   3. Call OSS ``sweep_temporal_triggers(template, rows,
+#      last_seen_state=..., now=...)`` once per pocket — pure decision.
+#   4. For each ``TemporalRisingEdge``: invoke ``gate_action`` to apply
+#      Instinct (per RFC: a temporal trigger is just like any other
+#      action firing; the gate applies).
+#      * BLOCK → log + skip (count under ``blocked``).
+#      * ESCALATE_APPROVAL → persist approval row (the gate wrapper
+#        does this), log + skip the HTTP call (count under
+#        ``escalated``).
+#      * EXECUTE / NOTIFY_AND_EXECUTE → call
+#        ``action_executor.run_action`` with the threaded ``template``.
+#        Outcomes fire automatically per Wave 3c's success-path emit.
+#   5. Call ``temporal_sweeps.service.upsert_state(...)`` with the
+#      OSS-produced ``new_state`` map AND the dispatch tally (so the
+#      service emits one ``TemporalSweepCompleted`` per call).
+#   6. Call ``temporal_sweeps.service.record_errors(...)`` for any per-
+#      row CEL eval failures (audit-log only — the sweep continues
+#      past them per the OSS contract).
+#   7. Return ``SweepDispatchResult``.
+#
+# **Sweep failure does not abort the loop** — a pocket whose sweep
+# crashes is logged and the scheduler keeps going to the next pocket on
+# the next tick. The dispatcher catches per-row executor failures so
+# the OSS ``new_state`` map still persists.
+#
+# Rows source (v0 — locked by the architect brief):
+#   The RFC is ambiguous on where temporal-sweep rows come from. The
+#   cleanest seam for Wave 3d is to accept a ``rows`` parameter the
+#   caller supplies. The scheduler tick passes an empty list (no
+#   materialized row source yet); library callers (tests, ad-hoc
+#   tooling, future "sweep now" route) pass rows directly. A follow-up
+#   PR can wire ``data_sources`` executor cache, Fabric, or whatever
+#   row source ships first.
+#
+# Template lookup (v0 — locked by the architect brief):
+#   Same ambiguity as the bulk dispatcher's `template_resolver_pending`:
+#   the Pocket Beanie doc has no `template_slug` field. The dispatcher
+#   accepts ``template`` as a parameter; the scheduler skips pockets
+#   for which no template can be resolved (no-op, debug-logged). When
+#   a template loader lands, the scheduler can wire it in without
+#   changing this contract.
+#
+# Hard constraint: this module imports OSS PURE functions
+# (``sweep_temporal_triggers``, ``PocketTemplate``) and the EE-side
+# services that own Beanie writes (``temporal_sweeps.service``,
+# ``instinct_dispatch``). It MUST NOT import a Beanie document class
+# directly — the import-linter contract treats this module as
+# Beanie-pure (same posture as ``bulk_dispatch.py``).
+
+"""Per-pocket dispatcher for RFC 03 v2 temporal triggers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from pocketpaw.bundled_templates import PocketTemplate
+from pocketpaw.bundled_templates.identifier_resolver import IdentifierResolver
+from pocketpaw.bundled_templates.temporal_sweeper import (
+    SweepResult,
+    TemporalRisingEdge,
+    sweep_temporal_triggers,
+)
+from pocketpaw_ee.cloud.temporal_sweeps.domain import SweepDispatchResult
+
+logger = logging.getLogger(__name__)
+
+
+def _has_temporal_trigger(template: PocketTemplate) -> bool:
+    """True when ``template`` declares at least one ``type: temporal`` trigger.
+
+    The sweep is a no-op for a template with no temporal triggers; the
+    OSS sweeper would just return an empty result, but checking up
+    front lets the dispatcher skip the (potentially expensive) row
+    fetch entirely.
+    """
+    return any(t.type == "temporal" for t in template.triggers)
+
+
+async def _dispatch_one_edge(
+    *,
+    edge: TemporalRisingEdge,
+    workspace_id: str,
+    pocket_id: str,
+    template: PocketTemplate,
+) -> str:
+    """Dispatch ONE rising-edge transition through the Wave 3a gate +
+    Wave 3b/3c executor.
+
+    Returns one of ``"fired"`` / ``"blocked"`` / ``"escalated"`` /
+    ``"error"`` so the caller can tally the counts on the
+    ``SweepDispatchResult``. A returned ``"error"`` is a defensive
+    safety-net for an exception the gate or executor raised that
+    should not have escaped — the sweep continues to other edges.
+
+    The dispatch path:
+      * If the trigger declares no ``action`` (a pure "fact" trigger),
+        skip the executor — there is nothing to invoke. The state-
+        machine still records the rising edge (the caller will count
+        it as ``"fired"`` so the row is observable).
+      * Otherwise, call ``instinct_dispatch.gate_action`` with the row
+        as ``row_context`` and ``user_id`` set to the synthetic
+        sweeper actor. The gate returns one of three branches.
+      * On ``"proceed"``, call ``action_executor.run_action`` with the
+        threaded template so Wave 3c outcome emission fires.
+
+    The Instinct gate uses a synthetic actor ``system:temporal-sweeper``
+    so a rising-edge dispatch never eats a real user's per-(pocket, user)
+    write budget in the executor and is clearly attributable in the
+    audit log.
+    """
+    action_name = edge.action
+    if not action_name:
+        # A temporal trigger without an action declared is a no-op
+        # dispatch — the OSS sweeper still reports it (so the caller
+        # can observe the transition), but there's nothing for the
+        # executor to invoke. Count it as fired (the state moved) and
+        # move on.
+        logger.debug(
+            "temporal sweep: pocket=%s edge row=%s has no action — skipping dispatch",
+            pocket_id,
+            edge.row_id,
+        )
+        return "fired"
+
+    # Lazy import — keep this module's static import graph free of EE
+    # entity references so the import-linter contract treats it as
+    # Beanie-pure. The dispatch + executor modules are already in the
+    # ``pockets`` package, so the lazy import is a structural choice,
+    # not a cycle-break.
+    try:
+        from pocketpaw_ee.cloud.pockets import action_executor, instinct_dispatch
+    except Exception:  # noqa: BLE001 — defensive
+        logger.warning(
+            "temporal sweep: pocket=%s could not import dispatch modules", pocket_id, exc_info=True
+        )
+        return "error"
+
+    actor = "system:temporal-sweeper"
+    row_context = dict(edge.row)
+
+    try:
+        gate = await instinct_dispatch.gate_action(
+            workspace_id=workspace_id,
+            user_id=actor,
+            pocket_id=pocket_id,
+            template=template,
+            action_name=action_name,
+            row_context=row_context,
+            row_id=edge.row_id,
+        )
+    except Exception:  # noqa: BLE001 — gate raising into the loop is a bug; isolate
+        logger.warning(
+            "temporal sweep: pocket=%s gate failed for action=%s row=%s",
+            pocket_id,
+            action_name,
+            edge.row_id,
+            exc_info=True,
+        )
+        return "error"
+
+    if gate.next_step == "blocked":
+        logger.info(
+            "temporal sweep: pocket=%s action=%s row=%s BLOCKED — %s",
+            pocket_id,
+            action_name,
+            edge.row_id,
+            gate.decision.reason,
+        )
+        return "blocked"
+
+    if gate.next_step == "pending_approval":
+        # The gate already persisted an ``InstinctApproval`` row. We
+        # don't fire the HTTP call; a human will decide via the
+        # approvals surface. The sweeper has done its job — state was
+        # written, the rising edge was honored.
+        logger.info(
+            "temporal sweep: pocket=%s action=%s row=%s ESCALATED — approval_id=%s",
+            pocket_id,
+            action_name,
+            edge.row_id,
+            gate.approval_id,
+        )
+        return "escalated"
+
+    # gate.next_step == "proceed" — fire the executor. We do NOT
+    # re-thread the template into the gate path of ``run_action`` (the
+    # gate already ran here, threading it again would create a second
+    # approval row on a flapping rule, the same invariant the bulk
+    # dispatcher honors). We DO thread it so Wave 3c outcome emission
+    # fires on success.
+    try:
+        result = await _invoke_executor(
+            executor=action_executor,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=actor,
+            template=template,
+            action_name=action_name,
+            row_context=row_context,
+            row_id=edge.row_id,
+        )
+    except Exception:  # noqa: BLE001 — executor raising into the loop is a bug; isolate
+        logger.warning(
+            "temporal sweep: pocket=%s executor failed for action=%s row=%s",
+            pocket_id,
+            action_name,
+            edge.row_id,
+            exc_info=True,
+        )
+        return "error"
+
+    if not result.get("ok"):
+        logger.info(
+            "temporal sweep: pocket=%s action=%s row=%s execution failed (code=%s)",
+            pocket_id,
+            action_name,
+            edge.row_id,
+            result.get("code"),
+        )
+        # An ok:false from the executor (rate limited, allowlist miss,
+        # backend error) still represents a fired dispatch attempt;
+        # the rising edge transitioned in state and the caller saw
+        # the call. Count it under ``fired`` so the tally is symmetric
+        # with the bulk dispatcher's success-or-failure-counted-once
+        # pattern.
+    return "fired"
+
+
+async def _invoke_executor(
+    *,
+    executor: Any,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    template: PocketTemplate,
+    action_name: str,
+    row_context: dict[str, Any],
+    row_id: str,
+) -> dict:
+    """Call ``action_executor.run_action`` for one rising-edge row.
+
+    The pocket's write binding (``rippleSpec.actions[action_name]``)
+    and backend creds come from the pocket — we fetch them lazily so
+    a pocket without a configured backend or without the named
+    binding fails cleanly with ``ok:false`` rather than crashing the
+    sweep.
+
+    Wave 3d uses the threaded ``template`` so Wave 3c outcome emission
+    fires on success. The gate is intentionally NOT re-evaluated by
+    ``run_action`` for this row — we pass ``from_instinct=False`` so
+    the executor's per-call gate runs ONCE and we set
+    ``from_instinct=True`` is NOT applicable here (this is a direct
+    EXECUTE dispatch, not a post-approval replay). The gate just
+    completed in ``_dispatch_one_edge`` above, so threading
+    ``template`` does mean the executor's internal gate re-evaluates;
+    in v0 we accept that double-evaluation cost (it's pure CEL, no
+    I/O) because not threading the template would also drop Wave 3c
+    outcome emission. A future PR can split the executor's "emit" and
+    "gate" code paths to avoid the duplicate eval.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, pocket_id)
+    if creds is None:
+        return {
+            "ok": False,
+            "action": action_name,
+            "error": "This pocket has no backend configured",
+            "code": "pocket_backend.not_configured",
+            "on_error": [],
+        }
+    base_url, auth_type, auth_header, token, allowed_writes, _approval_route = creds
+
+    ripple_spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
+    actions = (ripple_spec or {}).get("actions")
+    raw_action = actions.get(action_name) if isinstance(actions, dict) else None
+    if not isinstance(raw_action, dict):
+        return {
+            "ok": False,
+            "action": action_name,
+            "error": f"no rippleSpec.actions[{action_name!r}] binding on pocket",
+            "code": "action_not_found",
+            "on_error": [],
+        }
+
+    raw_path = raw_action.get("path") or "/"
+    raw_params = raw_action.get("params") if isinstance(raw_action.get("params"), dict) else {}
+
+    return await executor.run_action(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        user_id=user_id,
+        action=action_name,
+        raw_action=raw_action,
+        path=raw_path,
+        params=dict(raw_params),
+        base_url=base_url,
+        auth_type=auth_type,
+        auth_header=auth_header,
+        token=token,
+        allowed_writes=allowed_writes,
+        # The gate already ran in ``_dispatch_one_edge``; the executor
+        # will re-run it because we pass ``template`` so Wave 3c
+        # outcome emission fires. Documented above — v0 trade-off.
+        from_instinct=False,
+        template=template,
+        row_context=row_context,
+        row_id=row_id,
+    )
+
+
+async def sweep_pocket(
+    workspace_id: str,
+    pocket_id: str,
+    *,
+    template: PocketTemplate | None,
+    rows: list[dict[str, Any]] | None = None,
+    resolver: IdentifierResolver | None = None,
+    now: datetime | None = None,
+) -> SweepDispatchResult:
+    """Sweep ONE pocket's temporal triggers and dispatch any rising edges.
+
+    Steps (per the architect brief):
+
+      1. Early-return when no template was resolved or it carries no
+         ``type: temporal`` triggers. The result is a zero-tally
+         ``SweepDispatchResult`` and NO state is written — the next
+         sweep will start from the same (empty) prior state, which is
+         correct.
+      2. Load prior state via ``temporal_sweeps.service.load_last_seen``.
+      3. Call OSS ``sweep_temporal_triggers`` for the rising-edge plan.
+      4. Dispatch each ``TemporalRisingEdge`` through the gate +
+         executor.
+      5. Persist the OSS-produced ``new_state`` and emit
+         ``TemporalSweepCompleted``.
+      6. Audit any per-row CEL eval errors.
+
+    Parameters
+    ----------
+    workspace_id:
+        Tenancy. Required.
+    pocket_id:
+        The pocket whose temporal triggers will be swept. Required.
+    template:
+        Resolved ``PocketTemplate``. Pass ``None`` for an unresolved
+        template — the sweep is a no-op (the scheduler treats this as
+        "skip pocket until template resolver lands"). Tests and
+        library callers pass the template directly.
+    rows:
+        The current row set for the pocket. v0 callers (the scheduler)
+        pass ``[]``; library callers can pass real rows. The OSS
+        sweeper evaluates the ``when`` predicate per row.
+    resolver:
+        Optional ``IdentifierResolver`` override. Defaults to the
+        template's built-in resolver.
+    now:
+        Wall-clock injection for the CEL ``within(field, duration)``
+        function. Defaults to ``datetime.now(UTC)``. Tests pass a
+        fixed value for determinism.
+
+    Returns
+    -------
+    :class:`SweepDispatchResult`
+        Tally of dispatched edges + blocked / escalated / errors +
+        wall-clock duration.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+    if rows is None:
+        rows = []
+
+    started_at = time.monotonic()
+
+    if template is None or not _has_temporal_trigger(template):
+        # No template OR no temporal triggers → no work. Don't touch
+        # state (the matrix stays as-is) and don't emit a completion
+        # event — the sweep didn't actually run.
+        return SweepDispatchResult(
+            pocket_id=pocket_id,
+            edges_fired=0,
+            blocked=0,
+            escalated=0,
+            errors=0,
+            sweep_duration_ms=int((time.monotonic() - started_at) * 1000),
+        )
+
+    # Lazy import — keep this module's static import graph free of EE
+    # entity references for the import-linter contract.
+    from pocketpaw_ee.cloud.temporal_sweeps import service as sweeps_service
+
+    last_seen = await sweeps_service.load_last_seen(workspace_id, pocket_id)
+
+    sweep_result: SweepResult = sweep_temporal_triggers(
+        template,
+        rows,
+        last_seen_state=last_seen,
+        resolver=resolver,
+        now=now,
+    )
+
+    edges_fired = 0
+    blocked = 0
+    escalated = 0
+    for edge in sweep_result.rising_edges:
+        verdict = await _dispatch_one_edge(
+            edge=edge,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            template=template,
+        )
+        if verdict == "fired":
+            edges_fired += 1
+        elif verdict == "blocked":
+            blocked += 1
+        elif verdict == "escalated":
+            escalated += 1
+        else:
+            # "error" — count under errors so the tally surfaces it.
+            # The sweep continues to other edges.
+            pass
+
+    errors_count = len(sweep_result.errors)
+
+    duration_ms = int((time.monotonic() - started_at) * 1000)
+
+    dispatch_result = SweepDispatchResult(
+        pocket_id=pocket_id,
+        edges_fired=edges_fired,
+        blocked=blocked,
+        escalated=escalated,
+        errors=errors_count,
+        sweep_duration_ms=duration_ms,
+    )
+
+    # Persist + emit. ``upsert_state`` fires ``TemporalSweepCompleted``
+    # with the dispatch tally so audit/dashboards see one event per
+    # pocket sweep (rule 9).
+    await sweeps_service.upsert_state(
+        workspace_id,
+        pocket_id,
+        sweep_result.new_state,
+        dispatch_result=dispatch_result,
+    )
+
+    # Audit per-row eval failures separately so an operator can see
+    # which rows failed. Doesn't block / mutate the dispatch result.
+    if sweep_result.errors:
+        await sweeps_service.record_errors(workspace_id, pocket_id, list(sweep_result.errors))
+
+    return dispatch_result
+
+
+__all__ = ["sweep_pocket"]

--- a/ee/pocketpaw_ee/cloud/temporal_sweeps/__init__.py
+++ b/ee/pocketpaw_ee/cloud/temporal_sweeps/__init__.py
@@ -1,0 +1,9 @@
+# ee/pocketpaw_ee/cloud/temporal_sweeps/__init__.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — entity package
+# for the RFC 03 v2 temporal sweep state-persistence layer. The 4-file
+# shape lives here (``domain.py``, ``dto.py``, ``service.py``,
+# ``router.py``); the per-pocket dispatcher + cron driver live in
+# ``ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py`` and
+# ``ee/pocketpaw_ee/cloud/_core/temporal_scheduler.py`` respectively.
+
+"""Temporal sweep state-persistence entity (RFC 03 v2 Wave 3d)."""

--- a/ee/pocketpaw_ee/cloud/temporal_sweeps/domain.py
+++ b/ee/pocketpaw_ee/cloud/temporal_sweeps/domain.py
@@ -1,0 +1,64 @@
+# ee/pocketpaw_ee/cloud/temporal_sweeps/domain.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — domain value
+# objects for the RFC 03 v2 temporal-sweep state matrix. Frozen
+# dataclasses with REQUIRED tenancy fields (workspace_id has no default)
+# — constructing one without tenancy is a type error. EE rule 3.
+
+"""Domain value objects for ``temporal_sweeps``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class TemporalSweepState:
+    """One persisted (workspace, pocket, trigger, row) truth value.
+
+    The OSS ``sweep_temporal_triggers`` library hands the EE caller a
+    ``new_state`` mapping keyed by ``(trigger_key, row_id)``; the EE
+    service persists each entry as one of these. ``predicate_value`` is
+    the last CEL ``when`` evaluation result; a rising edge fires when
+    the stored ``False`` flips to a current ``True``.
+
+    Frozen so downstream readers (dashboard / audit) cannot mutate the
+    object after the service hands it back. Tenancy fields
+    (``workspace_id``) are required positional so the type system
+    catches a missing tenancy at construction time — the EE cloud rule
+    3 invariant.
+    """
+
+    workspace_id: str
+    pocket_id: str
+    trigger_key: str
+    row_id: str
+    predicate_value: bool
+    last_swept_at: datetime
+
+
+@dataclass(frozen=True)
+class SweepDispatchResult:
+    """Aggregate outcome of one ``sweep_pocket`` invocation.
+
+    Returned by ``temporal_dispatcher.sweep_pocket`` so callers (the
+    scheduler tick, library callers, ad-hoc tooling) can record the
+    tally. The same shape rides on the ``TemporalSweepCompleted`` bus
+    event the service emits after persisting new state.
+
+    ``edges_fired`` counts dispatches that reached the executor's HTTP
+    call (``EXECUTE`` / ``NOTIFY_AND_EXECUTE``). ``blocked`` and
+    ``escalated`` are honored gates that short-circuited the dispatch;
+    they still represent a rising-edge transition that the runtime
+    decided not to fire. ``errors`` is per-row CEL eval failures.
+    """
+
+    pocket_id: str
+    edges_fired: int
+    blocked: int
+    escalated: int
+    errors: int
+    sweep_duration_ms: int
+
+
+__all__ = ["SweepDispatchResult", "TemporalSweepState"]

--- a/ee/pocketpaw_ee/cloud/temporal_sweeps/dto.py
+++ b/ee/pocketpaw_ee/cloud/temporal_sweeps/dto.py
@@ -1,0 +1,93 @@
+# ee/pocketpaw_ee/cloud/temporal_sweeps/dto.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — wire-format
+# DTOs for the RFC 03 v2 temporal-sweep state surface. Distinct request
+# and response classes per EE cloud rule 4 — never reuse one model for
+# input and output.
+
+"""Wire-format DTOs for the ``temporal_sweeps`` entity."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from pocketpaw_ee.cloud._core.time import iso_utc
+from pocketpaw_ee.cloud.temporal_sweeps.domain import (
+    SweepDispatchResult,
+    TemporalSweepState,
+)
+
+
+class ListSweepStateRequest(BaseModel):
+    """Filter parameters for the per-pocket state-inspect endpoint.
+
+    No filter today beyond the pocket id (URL param) — kept as a typed
+    model so future fields (e.g. trigger_key filter, paging) do not
+    break the wire shape.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    limit: int = Field(default=500, ge=1, le=5000)
+
+
+class TemporalSweepStateResponse(BaseModel):
+    """Wire response for one persisted (trigger, row) state row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: str
+    pocket_id: str
+    trigger_key: str
+    row_id: str
+    predicate_value: bool
+    last_swept_at: str
+
+
+class SweepDispatchResultResponse(BaseModel):
+    """Wire response for one ``sweep_pocket`` invocation tally."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    pocket_id: str
+    edges_fired: int
+    blocked: int
+    escalated: int
+    errors: int
+    sweep_duration_ms: int
+
+
+def state_to_dto(s: TemporalSweepState) -> TemporalSweepStateResponse:
+    """Map a domain ``TemporalSweepState`` to its wire DTO."""
+    return TemporalSweepStateResponse(
+        workspace_id=s.workspace_id,
+        pocket_id=s.pocket_id,
+        trigger_key=s.trigger_key,
+        row_id=s.row_id,
+        predicate_value=s.predicate_value,
+        last_swept_at=iso_utc(s.last_swept_at),
+    )
+
+
+def state_to_wire_dict(s: TemporalSweepState) -> dict:
+    return state_to_dto(s).model_dump()
+
+
+def dispatch_to_wire_dict(r: SweepDispatchResult) -> dict:
+    return SweepDispatchResultResponse(
+        pocket_id=r.pocket_id,
+        edges_fired=r.edges_fired,
+        blocked=r.blocked,
+        escalated=r.escalated,
+        errors=r.errors,
+        sweep_duration_ms=r.sweep_duration_ms,
+    ).model_dump()
+
+
+__all__ = [
+    "ListSweepStateRequest",
+    "SweepDispatchResultResponse",
+    "TemporalSweepStateResponse",
+    "dispatch_to_wire_dict",
+    "state_to_dto",
+    "state_to_wire_dict",
+]

--- a/ee/pocketpaw_ee/cloud/temporal_sweeps/router.py
+++ b/ee/pocketpaw_ee/cloud/temporal_sweeps/router.py
@@ -1,0 +1,59 @@
+# ee/pocketpaw_ee/cloud/temporal_sweeps/router.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — REST surface
+# for inspecting the RFC 03 v2 temporal-sweep state matrix. The single
+# route is a debug / dashboard read-only endpoint:
+# ``GET /pockets/{id}/temporal-sweeps/state`` returns every persisted
+# (trigger, row) truth value for that pocket scoped to the caller's
+# workspace. Wave 3d does not surface a manual "sweep now" route — that
+# is explicitly out of scope (deferred to a follow-up PR).
+#
+# Routes are thin: parse, delegate to the service, return what the
+# service produced. Errors propagate via ``CloudError``; the central
+# ``cloud_error_handler`` maps to JSON. Never raises ``HTTPException``
+# (rule 10).
+
+"""FastAPI router for ``temporal_sweeps``."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.temporal_sweeps import service as sweeps_service
+
+router = APIRouter(prefix="/pockets", tags=["TemporalSweeps"])
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    if not ctx.workspace_id:
+        raise ValidationError(
+            "temporal_sweep.workspace_required",
+            "no active workspace on this request",
+        )
+    return ctx.workspace_id
+
+
+@router.get("/{pocket_id}/temporal-sweeps/state")
+async def list_state(
+    pocket_id: str,
+    limit: int = 500,
+    ctx: RequestContext = Depends(request_context),
+) -> list[dict]:
+    """Return the persisted (trigger, row) state rows for one pocket.
+
+    Tenant-filtered. Useful for dashboards + debugging — operators can
+    see why a temporal trigger did or did not fire on the last sweep
+    (the persisted ``predicate_value`` is the value the next sweep will
+    diff against).
+    """
+    workspace_id = _require_workspace(ctx)
+    return await sweeps_service.list_state_for_pocket(
+        workspace_id,
+        ctx.user_id,
+        pocket_id,
+        limit=limit,
+    )
+
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/temporal_sweeps/service.py
+++ b/ee/pocketpaw_ee/cloud/temporal_sweeps/service.py
@@ -1,0 +1,235 @@
+# ee/pocketpaw_ee/cloud/temporal_sweeps/service.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — sole Beanie
+# writer for the ``TemporalSweepStateDoc`` collection (RFC 03 v2). Module-
+# level ``async def`` API per EE cloud rule 5. Every state-mutating
+# function:
+#   * validates at entry via ``<Request>.model_validate(body)`` (rule 6)
+#     where the function accepts a body (state-write APIs here take
+#     typed primitive arguments and need no re-parse).
+#   * filters reads by ``workspace=workspace_id`` (rule 7)
+#   * raises ``CloudError`` subclasses, never ``HTTPException`` (rule 10)
+#   * emits an event on the way out (rule 9) — ``upsert_state`` fires
+#     one ``TemporalSweepCompleted`` per per-pocket call.
+#
+# The sweep state-table is a side-table whose row count is bounded by
+# (triggers × rows × pockets × workspaces); upserts target the
+# composite ``(workspace, pocket, trigger_key, row_id)`` unique key.
+# ``load_last_seen`` is the per-pocket scan the dispatcher calls at the
+# top of each sweep; ``upsert_state`` is the per-pocket write at the
+# bottom. ``record_errors`` audits per-row CEL eval failures so an
+# operator can see which rows failed (the sweeper continues past them
+# per the OSS contract).
+
+"""Service for the temporal-sweep state matrix."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import TemporalSweepCompleted
+from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc as _StateDoc
+from pocketpaw_ee.cloud.temporal_sweeps.domain import (
+    SweepDispatchResult,
+    TemporalSweepState,
+)
+from pocketpaw_ee.cloud.temporal_sweeps.dto import state_to_wire_dict
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Private mapping helper — Beanie doc → domain
+# ---------------------------------------------------------------------------
+
+
+def _to_domain(doc: _StateDoc) -> TemporalSweepState:
+    return TemporalSweepState(
+        workspace_id=doc.workspace,
+        pocket_id=doc.pocket_id,
+        trigger_key=doc.trigger_key,
+        row_id=doc.row_id,
+        predicate_value=doc.predicate_value,
+        last_swept_at=doc.last_swept_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def load_last_seen(
+    workspace_id: str,
+    pocket_id: str,
+) -> dict[tuple[str, str], bool]:
+    """Return the persisted ``(trigger_key, row_id) → bool`` map for one pocket.
+
+    Tenant-filtered: a ``(workspace, pocket_id)`` pair only sees its own
+    rows. A pocket with no prior sweep returns an empty dict — the OSS
+    sweeper treats that as "every currently-true row is a rising edge",
+    which is the documented first-sweep semantic.
+    """
+    query = {"workspace": workspace_id, "pocket_id": pocket_id}
+    out: dict[tuple[str, str], bool] = {}
+    async for doc in _StateDoc.find(query):
+        out[(doc.trigger_key, doc.row_id)] = bool(doc.predicate_value)
+    return out
+
+
+async def upsert_state(
+    workspace_id: str,
+    pocket_id: str,
+    new_state: dict[tuple[str, str], bool],
+    *,
+    dispatch_result: SweepDispatchResult | None = None,
+) -> None:
+    """Persist a sweep's ``new_state`` map for one pocket.
+
+    Iterates the ``new_state`` mapping and upserts each entry. The
+    composite unique index on ``(workspace, pocket, trigger_key,
+    row_id)`` makes the upsert pattern safe under future leader
+    election (HA is out of scope for v0 but the index pins the
+    invariant).
+
+    Emits one ``TemporalSweepCompleted`` event per call with the
+    dispatch tally — listeners (audit, dashboards) key off this single
+    event rather than N per-row events, the same shape
+    ``BulkActionDispatched`` uses (rule 9). Passing
+    ``dispatch_result=None`` is permitted for callers that want to
+    persist state without firing the completion event (rare; the
+    dispatcher always supplies one).
+    """
+    if not workspace_id:
+        raise ValueError("workspace_id is required to upsert temporal sweep state")
+    if not pocket_id:
+        raise ValueError("pocket_id is required to upsert temporal sweep state")
+
+    now = datetime.now(UTC)
+    for (trigger_key, row_id), value in new_state.items():
+        await _StateDoc.find_one(
+            {
+                "workspace": workspace_id,
+                "pocket_id": pocket_id,
+                "trigger_key": trigger_key,
+                "row_id": row_id,
+            },
+        ).upsert(
+            {
+                "$set": {
+                    "predicate_value": bool(value),
+                    "last_swept_at": now,
+                },
+            },
+            on_insert=_StateDoc(
+                workspace=workspace_id,
+                pocket_id=pocket_id,
+                trigger_key=trigger_key,
+                row_id=row_id,
+                predicate_value=bool(value),
+                last_swept_at=now,
+            ),
+        )
+
+    # rule 9 — emit on every write. The dispatcher always supplies a
+    # SweepDispatchResult; only the rare library-direct caller (e.g. a
+    # backfill) omits it.
+    if dispatch_result is not None:
+        await emit(
+            TemporalSweepCompleted(
+                data={
+                    "workspace_id": workspace_id,
+                    "pocket_id": pocket_id,
+                    "edges_fired": dispatch_result.edges_fired,
+                    "blocked": dispatch_result.blocked,
+                    "escalated": dispatch_result.escalated,
+                    "errors": dispatch_result.errors,
+                    "sweep_duration_ms": dispatch_result.sweep_duration_ms,
+                }
+            )
+        )
+
+
+async def record_errors(
+    workspace_id: str,
+    pocket_id: str,
+    errors: list[Any],
+) -> None:
+    """Audit-log per-row CEL eval failures from a sweep.
+
+    Wave 3d-scope: write one audit-log line per error so the operator
+    can see which rows failed. The audit-log writer is the same
+    facility the action_executor uses; we tag the entry with category
+    ``pocket_backend_config`` and severity WARNING so existing audit
+    dashboards pick it up without a new category.
+
+    A failure to audit must NEVER break the sweep — the call is wrapped
+    so a bus / audit hiccup doesn't propagate back into the dispatcher.
+    """
+    if not errors:
+        return
+    try:
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        logger_inst = get_audit_logger()
+        for err in errors:
+            # ``err`` is a ``TemporalSweepError`` (Pydantic) — extract
+            # via attribute access; tolerate dict shape for callers
+            # that pass a wire dict.
+            row_id = getattr(err, "row_id", None) or (
+                err.get("row_id") if isinstance(err, dict) else None
+            )
+            message = (
+                getattr(err, "message", None)
+                or (err.get("message") if isinstance(err, dict) else "")
+                or ""
+            )
+            action = getattr(err, "action", None) or (
+                err.get("action") if isinstance(err, dict) else None
+            )
+            logger_inst.log(
+                AuditEvent.create(
+                    severity=AuditSeverity.WARNING,
+                    actor="system:temporal-sweeper",
+                    action="pocket.temporal_sweep.row_error",
+                    target=pocket_id,
+                    status="error",
+                    category="pocket_backend_config",
+                    workspace_id=workspace_id,
+                    pocket_id=pocket_id,
+                    pocket_action=action,
+                    row_id=row_id or "",
+                    message=message,
+                )
+            )
+    except Exception:  # noqa: BLE001 — audit must never break the sweep
+        logger.warning("temporal sweep error audit-log write failed", exc_info=True)
+
+
+async def list_state_for_pocket(
+    workspace_id: str,
+    user_id: str,  # noqa: ARG001 — viewer context for future per-user filtering
+    pocket_id: str,
+    *,
+    limit: int = 500,
+) -> list[dict]:
+    """List the persisted (trigger, row) state rows for one pocket.
+
+    Tenant-filtered: returns only rows whose ``workspace`` matches the
+    caller's ``workspace_id``. Used by the GET inspect endpoint so
+    operators / dashboards can debug a sweep without re-reading Mongo
+    directly.
+    """
+    query = {"workspace": workspace_id, "pocket_id": pocket_id}
+    cursor = _StateDoc.find(query).limit(limit)
+    return [state_to_wire_dict(_to_domain(doc)) async for doc in cursor]
+
+
+__all__ = [
+    "list_state_for_pocket",
+    "load_last_seen",
+    "record_errors",
+    "upsert_state",
+]

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -16,6 +16,14 @@ pocket interval-refresh scheduler in ``on_startup`` and cancels it in
 scope inside ``cloud.pockets.refresh_scheduler``; it is self-gated on
 ``POCKETPAW_POCKET_REFRESH_SCHEDULER_ENABLED`` so the start call is a
 no-op unless a deployment opts in.
+
+Updated: 2026-05-28 (feat/wave-3d-temporal-scheduler) — ``CloudLifecycleHook``
+also starts the RFC 03 v2 temporal trigger sweep scheduler in
+``on_startup`` and cancels it in ``on_shutdown``. The scheduler lives at
+``cloud._core.temporal_scheduler`` and is self-gated on
+``POCKETPAW_TEMPORAL_SWEEP_ENABLED`` (default OFF) so pytest runs and
+multi-replica deployments don't double-fire. Cadence is configurable via
+``POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS`` (default 3600, floor 60).
 """
 
 from __future__ import annotations
@@ -194,6 +202,24 @@ class CloudLifecycleHook:
         except Exception as exc:  # noqa: BLE001
             logger.warning("Pocket interval-refresh scheduler start failed: %s", exc)
 
+        # RFC 03 v2 temporal trigger sweep scheduler (Wave 3d). A single
+        # asyncio task that periodically sweeps every pocket with a
+        # ``type: temporal`` trigger, detects rising edges, and
+        # dispatches the trigger's action through the Wave 3a gate.
+        # Self-gated on ``POCKETPAW_TEMPORAL_SWEEP_ENABLED`` (default
+        # OFF — a pytest run never spawns it; a multi-replica deploy
+        # runs it on exactly one replica). The task lives at module
+        # scope inside the scheduler so this no-``app`` lifecycle hook
+        # can still own it.
+        try:
+            from pocketpaw_ee.cloud._core.temporal_scheduler import (
+                start_scheduler as start_temporal_scheduler,
+            )
+
+            await start_temporal_scheduler()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Temporal sweep scheduler start failed: %s", exc)
+
         # Stale-run sweeper. Marks queued/running ChatRunDocs whose backend
         # process died as ``interrupted`` so clients render a retry instead
         # of subscribing to a stream nobody is writing to. One pass at boot
@@ -227,6 +253,15 @@ class CloudLifecycleHook:
             await stop_scheduler()
         except Exception as exc:  # noqa: BLE001
             logger.warning("Pocket interval-refresh scheduler stop failed: %s", exc)
+
+        try:
+            from pocketpaw_ee.cloud._core.temporal_scheduler import (
+                stop_scheduler as stop_temporal_scheduler,
+            )
+
+            await stop_temporal_scheduler()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Temporal sweep scheduler stop failed: %s", exc)
 
         try:
             await stop_run_sweeper()

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -204,12 +204,33 @@ source_modules = [
     # ``action_executor.run_action`` calls. Never imports a Beanie
     # document class directly.
     "pocketpaw_ee.cloud.pockets.bulk_dispatch",
+    # RFC 03 v2 Wave 3d — the per-pocket temporal trigger dispatcher.
+    # Calls the pure OSS ``sweep_temporal_triggers`` planner, the
+    # ``temporal_sweeps.service`` writer, ``instinct_dispatch``, and
+    # ``action_executor.run_action``. Never imports a Beanie document
+    # class directly.
+    "pocketpaw_ee.cloud.pockets.temporal_dispatcher",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",
     "pocketpaw_ee.cloud.models.pocket_backend",
     "pocketpaw_ee.cloud.models.session",
 ]
+
+[[tool.importlinter.contracts]]
+name = "TemporalSweeps — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.temporal_sweeps.router",
+    "pocketpaw_ee.cloud.temporal_sweeps.dto",
+    "pocketpaw_ee.cloud.temporal_sweeps.domain",
+    # The cron driver scans pockets through ``pockets.service`` and
+    # dispatches through ``temporal_dispatcher``; it never touches a
+    # Beanie document directly.
+    "pocketpaw_ee.cloud._core.temporal_scheduler",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.temporal_sweep_state"]
 
 [[tool.importlinter.contracts]]
 name = "InstinctApprovals — Beanie writes only from service.py"

--- a/tests/cloud/test_temporal_dispatcher.py
+++ b/tests/cloud/test_temporal_dispatcher.py
@@ -1,0 +1,541 @@
+# tests/cloud/test_temporal_dispatcher.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — pins the
+# RFC 03 v2 temporal trigger sweep dispatcher.
+#
+# What this pins:
+#   * No temporal triggers on the template → early return, zero state
+#     mutation, no completion event emitted.
+#   * First sweep with 1 row currently true → 1 rising edge, state
+#     persisted as ``True`` (subsequent sweeps will diff against it).
+#   * Second sweep, same row still true → 0 edges (continuing-true is
+#     idempotent — no re-fire).
+#   * Third sweep, row's value flipped to false → 0 edges, state
+#     updated to ``False``.
+#   * Fourth sweep, row's value back to true → 1 rising edge again.
+#   * Edge fires action through the gate: verify ``gate_action`` was
+#     called AND ``run_action`` was called.
+#   * Block path: a row that trips an Instinct block rule → edge
+#     does NOT fire HTTP; state still moves; count under ``blocked``.
+#   * Approval path: a row that needs approval → approval row
+#     persisted (via the gate wrapper); count under ``escalated``;
+#     state still moves.
+#   * Multi-tenant: workspace A's state is invisible to workspace B.
+#   * Eval failure: a bad CEL doesn't break the sweep — the failure
+#     is captured under ``errors`` and the sweep continues for the
+#     other rows.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from pocketpaw.bundled_templates import PocketTemplate
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Template fixtures — minimal valid v2 PocketTemplate dicts.
+# ---------------------------------------------------------------------------
+
+
+def _template_with_temporal(
+    *,
+    action_name: str = "alert_overdue",
+    when: str = "value > 0",
+    instinct_policy: str = "auto",
+    rules: list[dict] | None = None,
+) -> PocketTemplate:
+    raw: dict[str, Any] = {
+        "schema_version": "2",
+        "name": "temporal-fixture",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "test fixture",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [
+                {"field": "id", "widget": "text"},
+                {"field": "value", "widget": "number"},
+            ],
+            "id_field": "id",
+        },
+        "actions": [
+            {
+                "name": action_name,
+                "label": "Alert",
+                "kind": "single-row",
+                "instinct_policy": instinct_policy,
+                "outcomes_emitted": [],
+            }
+        ],
+        "triggers": [
+            {"type": "temporal", "when": when, "action": action_name},
+        ],
+        "outcomes": [],
+    }
+    if rules is not None:
+        raw["instinct_rules"] = {"rules": rules}
+    return PocketTemplate.model_validate(raw)
+
+
+def _template_no_temporal() -> PocketTemplate:
+    raw: dict[str, Any] = {
+        "schema_version": "2",
+        "name": "non-temporal-fixture",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "no temporal trigger",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [{"field": "id", "widget": "text"}],
+            "id_field": "id",
+        },
+        "actions": [],
+        "triggers": [
+            {"type": "manual"},
+        ],
+        "outcomes": [],
+    }
+    return PocketTemplate.model_validate(raw)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — capture gate + executor calls without HTTP / Instinct.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingGate:
+    """Captures every ``gate_action`` call + returns a configurable verdict."""
+
+    def __init__(self, next_step: str = "proceed", approval_id: str | None = None) -> None:
+        self.next_step = next_step
+        self.approval_id = approval_id
+        self.calls: list[dict] = []
+
+    async def gate_action(self, **kwargs: Any):  # noqa: ANN401
+        self.calls.append(kwargs)
+
+        # Minimal stand-in for ``InstinctGateResult`` — only the
+        # ``next_step`` / ``approval_id`` / ``decision.reason`` fields
+        # the dispatcher reads.
+        class _Decision:
+            reason = "test-reason"
+
+        class _Gate:
+            next_step = self.next_step
+            approval_id = self.approval_id
+            decision = _Decision()
+
+        return _Gate()
+
+
+class _RecordingExecutor:
+    """Captures every ``run_action`` call + returns a configurable result."""
+
+    def __init__(self, result: dict | None = None) -> None:
+        self.result = result or {"ok": True, "action": "alert_overdue", "status": 200}
+        self.calls: list[dict] = []
+
+    async def run_action(self, **kwargs: Any):  # noqa: ANN401
+        self.calls.append(kwargs)
+        return self.result
+
+
+def _patch_dispatch(monkeypatch, gate: _RecordingGate, executor: _RecordingExecutor) -> None:
+    """Patch the dispatcher's lazy imports so the test never reaches the
+    real gate or the real action executor."""
+    from pocketpaw_ee.cloud.pockets import action_executor as real_executor
+    from pocketpaw_ee.cloud.pockets import instinct_dispatch as real_gate
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    monkeypatch.setattr(real_gate, "gate_action", gate.gate_action)
+    monkeypatch.setattr(real_executor, "run_action", executor.run_action)
+
+    async def _creds(_ws: str, _pid: str):
+        # ``(base_url, auth_type, auth_header, token, allowed_writes, approval_route)``
+        return (
+            "https://api.example.test",
+            "none",
+            None,
+            "",
+            [{"method": "POST", "path_pattern": "*"}],
+            None,
+        )
+
+    async def _spec(_ws: str, _pid: str):
+        return {
+            "actions": {
+                "alert_overdue": {
+                    "kind": "write_binding",
+                    "method": "POST",
+                    "path": "/alerts",
+                    "params": {},
+                }
+            }
+        }
+
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _creds)
+    monkeypatch.setattr(pockets_service, "get_pocket_ripple_spec", _spec)
+
+
+# ---------------------------------------------------------------------------
+# Cases — rising-edge mechanics, gate branching, multi-tenancy, errors.
+# ---------------------------------------------------------------------------
+
+
+async def test_no_temporal_triggers_is_a_no_op(monkeypatch) -> None:
+    """A template with no ``type: temporal`` triggers → no state writes,
+    no completion event, zero tally."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+    from pocketpaw_ee.cloud.temporal_sweeps import service as sweeps_service
+
+    gate = _RecordingGate()
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    template = _template_no_temporal()
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1",
+        "p1",
+        template=template,
+        rows=[{"id": "r1", "value": 100}],
+    )
+
+    assert result.edges_fired == 0
+    assert result.blocked == 0
+    assert result.escalated == 0
+    assert result.errors == 0
+    assert gate.calls == []
+    assert executor.calls == []
+
+    # No state persisted.
+    persisted = await sweeps_service.load_last_seen("w1", "p1")
+    assert persisted == {}
+
+
+async def test_first_sweep_currently_true_fires_rising_edge(monkeypatch, recording_bus) -> None:
+    """A row currently true → 1 rising edge, state persisted as True,
+    gate + executor called once."""
+    from pocketpaw_ee.cloud._core.realtime.events import TemporalSweepCompleted
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+    from pocketpaw_ee.cloud.temporal_sweeps import service as sweeps_service
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    template = _template_with_temporal()
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1",
+        "p1",
+        template=template,
+        rows=[{"id": "r1", "value": 42}],
+    )
+
+    assert result.edges_fired == 1
+    assert result.blocked == 0
+    assert result.escalated == 0
+    assert result.errors == 0
+    assert len(gate.calls) == 1
+    assert len(executor.calls) == 1
+    assert gate.calls[0]["action_name"] == "alert_overdue"
+    assert gate.calls[0]["row_id"] == "r1"
+    assert executor.calls[0]["action"] == "alert_overdue"
+    # Synthetic actor for the sweeper — not a real user.
+    assert gate.calls[0]["user_id"] == "system:temporal-sweeper"
+
+    # State persisted.
+    persisted = await sweeps_service.load_last_seen("w1", "p1")
+    assert persisted == {("alert_overdue", "r1"): True}
+
+    # Completion event emitted with the tally.
+    completion = [e for e in recording_bus.events if isinstance(e, TemporalSweepCompleted)]
+    assert len(completion) == 1
+    assert completion[0].data["pocket_id"] == "p1"
+    assert completion[0].data["workspace_id"] == "w1"
+    assert completion[0].data["edges_fired"] == 1
+
+
+async def test_second_sweep_same_true_does_not_re_fire(monkeypatch) -> None:
+    """Continuing-true is idempotent — second sweep produces 0 edges."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    template = _template_with_temporal()
+
+    # First sweep — fires.
+    await temporal_dispatcher.sweep_pocket(
+        "w1",
+        "p1",
+        template=template,
+        rows=[{"id": "r1", "value": 42}],
+    )
+    assert len(executor.calls) == 1
+
+    # Second sweep, same row still true — must NOT re-fire.
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1",
+        "p1",
+        template=template,
+        rows=[{"id": "r1", "value": 42}],
+    )
+    assert result.edges_fired == 0
+    assert len(executor.calls) == 1  # unchanged
+    assert len(gate.calls) == 1  # gate never re-evaluated for a non-edge
+
+
+async def test_falling_edge_updates_state_to_false(monkeypatch) -> None:
+    """True → False on a row updates state but does NOT fire."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+    from pocketpaw_ee.cloud.temporal_sweeps import service as sweeps_service
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    template = _template_with_temporal()
+
+    # First — fires.
+    await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+    # Second — row falls to value=0 (predicate false).
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 0}]
+    )
+    assert result.edges_fired == 0
+
+    persisted = await sweeps_service.load_last_seen("w1", "p1")
+    assert persisted == {("alert_overdue", "r1"): False}
+
+
+async def test_re_rising_edge_after_falling_fires_again(monkeypatch) -> None:
+    """false → true after a falling edge fires a fresh rising edge."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    template = _template_with_temporal()
+
+    await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+    # Fall to false.
+    await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 0}]
+    )
+    # Re-rise.
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 99}]
+    )
+    assert result.edges_fired == 1
+    # Two total dispatches across the test.
+    assert len(executor.calls) == 2
+
+
+async def test_blocked_gate_short_circuits_dispatch(monkeypatch) -> None:
+    """Gate returns BLOCK → action_executor never called; tally goes to ``blocked``."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    gate = _RecordingGate(next_step="blocked")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    template = _template_with_temporal()
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+
+    assert result.edges_fired == 0
+    assert result.blocked == 1
+    assert result.escalated == 0
+    assert len(gate.calls) == 1
+    assert executor.calls == []  # no HTTP call
+
+
+async def test_escalated_gate_records_count_no_executor(monkeypatch) -> None:
+    """Gate returns ESCALATE_APPROVAL → action_executor never called; tally goes
+    to ``escalated``."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    gate = _RecordingGate(next_step="pending_approval", approval_id="approval-1")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    template = _template_with_temporal()
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+
+    assert result.edges_fired == 0
+    assert result.blocked == 0
+    assert result.escalated == 1
+    assert len(gate.calls) == 1
+    assert executor.calls == []
+
+
+async def test_multi_tenant_state_is_isolated(monkeypatch) -> None:
+    """Workspace A's state is invisible to workspace B — the same pocket
+    id in two workspaces sweeps independently."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+    from pocketpaw_ee.cloud.temporal_sweeps import service as sweeps_service
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    template = _template_with_temporal()
+
+    # Workspace A swept first.
+    await temporal_dispatcher.sweep_pocket(
+        "wA", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+    # Workspace B sweeps SAME pocket id, SAME row id — must see empty
+    # prior state (rising edge fires fresh).
+    result = await temporal_dispatcher.sweep_pocket(
+        "wB", "p1", template=template, rows=[{"id": "r1", "value": 42}]
+    )
+    assert result.edges_fired == 1
+
+    # Verify isolation: load each workspace's state separately.
+    state_a = await sweeps_service.load_last_seen("wA", "p1")
+    state_b = await sweeps_service.load_last_seen("wB", "p1")
+    assert state_a == {("alert_overdue", "r1"): True}
+    assert state_b == {("alert_overdue", "r1"): True}
+    # Two separate rows in the matrix — each workspace owns its own.
+
+
+async def test_bad_cel_isolates_to_error_tally(monkeypatch) -> None:
+    """A row whose CEL eval crashes is captured in ``errors`` and does
+    NOT crash the sweep — other rows still process."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    # ``when`` references a column the row doesn't carry — CEL eval
+    # fails on the bad row, succeeds on the good one.
+    template = _template_with_temporal(when="ghost_field > 0")
+
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1",
+        "p1",
+        template=template,
+        rows=[{"id": "r1", "value": 1}, {"id": "r2", "value": 2}],
+    )
+
+    # Both rows failed (the predicate references a missing field), so
+    # ``errors`` is 2 and ``edges_fired`` is 0. The important assertion
+    # is the sweep COMPLETED without raising.
+    assert result.errors == 2
+    assert result.edges_fired == 0
+
+
+async def test_no_action_trigger_counts_as_fired_no_executor(monkeypatch) -> None:
+    """A temporal trigger without an ``action`` is a pure fact-trigger —
+    the state still moves but no executor call happens. Counts under
+    ``fired`` so the rising edge is observable."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    raw = {
+        "schema_version": "2",
+        "name": "fact-trigger",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "no action",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [
+                {"field": "id", "widget": "text"},
+                {"field": "value", "widget": "number"},
+            ],
+            "id_field": "id",
+        },
+        "actions": [],
+        "triggers": [{"type": "temporal", "when": "value > 0"}],
+        "outcomes": [],
+    }
+    template = PocketTemplate.model_validate(raw)
+
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 1}]
+    )
+    assert result.edges_fired == 1
+    assert gate.calls == []  # no gate eval — no action declared
+    assert executor.calls == []
+
+
+async def test_sweep_duration_ms_is_recorded(monkeypatch) -> None:
+    """The ``sweep_duration_ms`` field is non-negative and rides on the
+    completion event."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    template = _template_with_temporal()
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 1}]
+    )
+    assert result.sweep_duration_ms >= 0
+
+
+async def test_explicit_now_is_honored(monkeypatch) -> None:
+    """Passing a fixed ``now`` keeps the OSS sweeper deterministic — the
+    test doesn't need to be tied to wall-clock."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    gate = _RecordingGate(next_step="proceed")
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    fixed = datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC)
+    template = _template_with_temporal()
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1", "p1", template=template, rows=[{"id": "r1", "value": 1}], now=fixed
+    )
+    assert result.edges_fired == 1
+
+
+async def test_template_none_is_no_op(monkeypatch) -> None:
+    """Scheduler path: when no template resolves, the dispatcher does
+    nothing — no state writes, no event, no gate / executor calls."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+    from pocketpaw_ee.cloud.temporal_sweeps import service as sweeps_service
+
+    gate = _RecordingGate()
+    executor = _RecordingExecutor()
+    _patch_dispatch(monkeypatch, gate, executor)
+
+    result = await temporal_dispatcher.sweep_pocket(
+        "w1",
+        "p1",
+        template=None,
+        rows=[{"id": "r1", "value": 1}],
+    )
+
+    assert result.edges_fired == 0
+    assert gate.calls == []
+    assert executor.calls == []
+    persisted = await sweeps_service.load_last_seen("w1", "p1")
+    assert persisted == {}

--- a/tests/cloud/test_temporal_scheduler.py
+++ b/tests/cloud/test_temporal_scheduler.py
@@ -1,0 +1,298 @@
+# tests/cloud/test_temporal_scheduler.py
+# Created: 2026-05-28 (feat/wave-3d-temporal-scheduler) — pins the
+# RFC 03 v2 temporal trigger sweep scheduler (the cron driver).
+#
+# What this pins:
+#   * ``is_enabled`` honors ``POCKETPAW_TEMPORAL_SWEEP_ENABLED``
+#     (default OFF for tests + multi-replica deploys).
+#   * Interval resolution honors ``POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS``
+#     with a default of 3600 and a floor of 60.
+#   * ``run_one_pass`` walks every pocket the scan helper yields and
+#     calls the per-pocket dispatcher (no real sweep work — the
+#     dispatcher is patched out).
+#   * Per-pocket exceptions are swallowed so one bad pocket can't
+#     abort the pass.
+#   * ``start_scheduler`` is idempotent; ``stop_scheduler`` cancels and
+#     awaits the loop cleanly (no leaked task at teardown).
+#   * Disabled scheduler is a no-op on ``start_scheduler``.
+#
+# The loop itself is NOT exercised with a real sleep — that would
+# require waiting an hour. The test patches the interval down + verifies
+# the loop body runs ``run_one_pass`` at least once, then cancels.
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+@pytest.fixture(autouse=True)
+def _reset_temporal_scheduler():
+    """Ensure the scheduler module-level task slot is clean before/after
+    each test so test order doesn't matter."""
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    temporal_scheduler._reset_for_tests()
+    yield
+    # Best-effort cancel on the way out.
+    try:
+        asyncio.get_event_loop().run_until_complete(temporal_scheduler.stop_scheduler())
+    except Exception:
+        pass
+    temporal_scheduler._reset_for_tests()
+
+
+@pytest.fixture
+def _enable_temporal(monkeypatch):
+    """Flip the opt-in env flag for tests that need the scheduler ON."""
+    monkeypatch.setenv("POCKETPAW_TEMPORAL_SWEEP_ENABLED", "true")
+
+
+def _patch_pockets_scan(monkeypatch, pockets: list[dict]) -> None:
+    """Patch the service scan helper so ``run_one_pass`` sees a fixed list."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    async def _list():
+        return list(pockets)
+
+    monkeypatch.setattr(pockets_service, "list_interval_source_pockets", _list)
+
+
+def _patch_dispatcher(monkeypatch, calls: list[tuple[str, str]], *, raises_for: str | None = None):
+    """Patch ``temporal_dispatcher.sweep_pocket`` to record calls and
+    optionally raise for a target pocket id."""
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+    from pocketpaw_ee.cloud.temporal_sweeps.domain import SweepDispatchResult
+
+    async def _sweep_pocket(workspace_id: str, pocket_id: str, **_kw: Any) -> SweepDispatchResult:
+        if raises_for is not None and pocket_id == raises_for:
+            raise RuntimeError(f"boom for {pocket_id}")
+        calls.append((workspace_id, pocket_id))
+        return SweepDispatchResult(
+            pocket_id=pocket_id,
+            edges_fired=0,
+            blocked=0,
+            escalated=0,
+            errors=0,
+            sweep_duration_ms=0,
+        )
+
+    monkeypatch.setattr(temporal_dispatcher, "sweep_pocket", _sweep_pocket)
+
+
+# ---------------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_default_off(monkeypatch) -> None:
+    monkeypatch.delenv("POCKETPAW_TEMPORAL_SWEEP_ENABLED", raising=False)
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    assert temporal_scheduler.is_enabled() is False
+
+
+def test_is_enabled_on_when_flag_is_true(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_TEMPORAL_SWEEP_ENABLED", "true")
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    assert temporal_scheduler.is_enabled() is True
+
+
+def test_is_enabled_off_for_any_other_value(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_TEMPORAL_SWEEP_ENABLED", "false")
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    assert temporal_scheduler.is_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Interval resolution
+# ---------------------------------------------------------------------------
+
+
+def test_default_interval_is_one_hour(monkeypatch) -> None:
+    monkeypatch.delenv("POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS", raising=False)
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    assert temporal_scheduler._interval_seconds() == 3600
+
+
+def test_env_interval_is_honored(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS", "300")
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    assert temporal_scheduler._interval_seconds() == 300
+
+
+def test_sub_floor_interval_is_clamped(monkeypatch) -> None:
+    """A misconfigured ``1`` second cadence must not wedge the loop —
+    clamp up to the 60s floor."""
+    monkeypatch.setenv("POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS", "1")
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    assert temporal_scheduler._interval_seconds() == 60
+
+
+def test_garbage_interval_falls_back_to_default(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS", "notanumber")
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    assert temporal_scheduler._interval_seconds() == 3600
+
+
+# ---------------------------------------------------------------------------
+# One-pass scan behavior
+# ---------------------------------------------------------------------------
+
+
+async def test_run_one_pass_iterates_every_pocket(monkeypatch) -> None:
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    pockets = [
+        {"pocket_id": "p1", "workspace_id": "w1", "sources": {}},
+        {"pocket_id": "p2", "workspace_id": "w1", "sources": {}},
+        {"pocket_id": "p3", "workspace_id": "w2", "sources": {}},
+    ]
+    _patch_pockets_scan(monkeypatch, pockets)
+
+    # Force the resolver to return a real (template, []) so the
+    # dispatcher fires for every pocket in the scan.
+    class _StubTpl:
+        triggers: list = []
+
+    async def _resolve(_ws: str, _pid: str):
+        return _StubTpl(), []
+
+    monkeypatch.setattr(temporal_scheduler, "_resolve_pocket_template_and_rows", _resolve)
+
+    calls: list[tuple[str, str]] = []
+    _patch_dispatcher(monkeypatch, calls)
+
+    visited = await temporal_scheduler.run_one_pass()
+    assert visited == 3
+    assert sorted(calls) == [("w1", "p1"), ("w1", "p2"), ("w2", "p3")]
+
+
+async def test_unresolved_template_skips_pocket(monkeypatch) -> None:
+    """A pocket whose template can't be resolved is skipped without
+    calling the dispatcher — v0 behaviour."""
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    _patch_pockets_scan(
+        monkeypatch,
+        [{"pocket_id": "p1", "workspace_id": "w1", "sources": {}}],
+    )
+
+    # The default resolver returns ``(None, [])``; no override.
+
+    calls: list[tuple[str, str]] = []
+    _patch_dispatcher(monkeypatch, calls)
+
+    visited = await temporal_scheduler.run_one_pass()
+    assert visited == 0
+    assert calls == []
+
+
+async def test_run_one_pass_swallows_per_pocket_failures(monkeypatch) -> None:
+    """One bad pocket cannot abort the pass — the remaining pockets are
+    still visited."""
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    pockets = [
+        {"pocket_id": "p1", "workspace_id": "w1", "sources": {}},
+        {"pocket_id": "BAD", "workspace_id": "w1", "sources": {}},
+        {"pocket_id": "p3", "workspace_id": "w1", "sources": {}},
+    ]
+    _patch_pockets_scan(monkeypatch, pockets)
+
+    class _StubTpl:
+        triggers: list = []
+
+    async def _resolve(_ws: str, _pid: str):
+        return _StubTpl(), []
+
+    monkeypatch.setattr(temporal_scheduler, "_resolve_pocket_template_and_rows", _resolve)
+
+    calls: list[tuple[str, str]] = []
+    _patch_dispatcher(monkeypatch, calls, raises_for="BAD")
+
+    visited = await temporal_scheduler.run_one_pass()
+    # p1 + p3 visited; BAD raised (caught and counted out).
+    assert visited == 2
+    assert ("w1", "p1") in calls
+    assert ("w1", "p3") in calls
+    assert ("w1", "BAD") not in calls
+
+
+async def test_scan_failure_returns_zero(monkeypatch) -> None:
+    """If the scan helper itself raises, the pass returns 0 — the loop
+    survives."""
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    async def _boom():
+        raise RuntimeError("scan exploded")
+
+    monkeypatch.setattr(pockets_service, "list_interval_source_pockets", _boom)
+
+    visited = await temporal_scheduler.run_one_pass()
+    assert visited == 0
+
+
+# ---------------------------------------------------------------------------
+# Start / stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_start_scheduler_disabled_is_a_no_op(monkeypatch) -> None:
+    monkeypatch.delenv("POCKETPAW_TEMPORAL_SWEEP_ENABLED", raising=False)
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    await temporal_scheduler.start_scheduler()
+    # Task slot stays unset.
+    assert temporal_scheduler._task is None
+
+
+async def test_start_then_stop_is_clean(_enable_temporal, monkeypatch) -> None:
+    """Start a real loop, then stop it — no leaked task."""
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    # Patch interval down so the loop's first sleep doesn't matter for
+    # the start/stop assertion.
+    monkeypatch.setenv("POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS", "60")
+
+    await temporal_scheduler.start_scheduler()
+    assert temporal_scheduler._task is not None
+    assert not temporal_scheduler._task.done()
+
+    await temporal_scheduler.stop_scheduler()
+    assert temporal_scheduler._task is None
+
+
+async def test_start_scheduler_is_idempotent(_enable_temporal) -> None:
+    """Calling ``start_scheduler`` twice does not create two tasks."""
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    await temporal_scheduler.start_scheduler()
+    first = temporal_scheduler._task
+    await temporal_scheduler.start_scheduler()
+    second = temporal_scheduler._task
+    assert first is second
+
+    await temporal_scheduler.stop_scheduler()
+
+
+async def test_stop_scheduler_on_unstarted_is_safe() -> None:
+    """``stop_scheduler`` is safe when the scheduler was never started."""
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    # Task slot was reset by the fixture.
+    assert temporal_scheduler._task is None
+    await temporal_scheduler.stop_scheduler()
+    # Still None — no crash.
+    assert temporal_scheduler._task is None


### PR DESCRIPTION
## Summary

Wires the OSS `sweep_temporal_triggers` planner (RFC 03 v2 — already on `dev`) into a cron-driven EE scheduler. Every tick sweeps each pocket that carries a `type: temporal` trigger, detects rising-edge transitions (false → true per-row CEL predicate) against persisted state, and dispatches the trigger's action through the Wave 3a Instinct gate + Wave 3b/3c action executor.

**Stacked on:** `feat/wave-3c-outcomes` (PR #1277 awaiting captain merge — architect retargets this to `dev` after the stack ahead lands).

## What ships

- **`ee/cloud/models/temporal_sweep_state.py`** — `TemporalSweepStateDoc` Beanie doc with a composite unique index on `(workspace, pocket_id, trigger_key, row_id)`. The matrix that lets the next sweep diff against the prior sweep.
- **`ee/cloud/temporal_sweeps/{__init__,domain,dto,service,router}.py`** — full 4-file shape:
  - `service.load_last_seen` reads the persisted map for one pocket (tenant-filtered).
  - `service.upsert_state` writes the new map and emits one `TemporalSweepCompleted` event per pocket sweep.
  - `service.record_errors` audits per-row CEL eval failures.
  - `router.py` exposes `GET /api/v1/pockets/{id}/temporal-sweeps/state` for dashboard / debug.
- **`ee/cloud/pockets/temporal_dispatcher.py`** — `sweep_pocket(workspace_id, pocket_id, *, template, rows, now=None)`. Calls OSS planner → per-edge: gate → executor (with template threaded so Wave 3c outcome emission fires) → persist state → emit completion → audit errors.
- **`ee/cloud/_core/temporal_scheduler.py`** — single asyncio loop, env-gated via `POCKETPAW_TEMPORAL_SWEEP_ENABLED` (default OFF so pytest + multi-replica deploys don't double-fire). Cadence via `POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS` (default 3600 = 1h per RFC, floor 60s). Wired into `CloudLifecycleHook.on_startup` / `on_shutdown`.
- **`TemporalSweepCompleted`** event added to the realtime event registry. Carries `edges_fired / blocked / escalated / errors / sweep_duration_ms` — one event per pocket sweep, mirroring `BulkActionDispatched`'s shape.

## Invariants pinned by tests

- **Rising-edge mechanics**: first sweep on a true row fires; continuing-true is idempotent (no re-fire); falling edge updates state to false without firing; re-rise after a fall fires fresh.
- **Gate branching**: BLOCK and ESCALATE_APPROVAL short-circuit the executor; state still moves; counts roll into `blocked` / `escalated` so the dispatch result is symmetric with bulk dispatch.
- **Multi-tenant isolation**: workspace A's state is invisible to workspace B (same pocket_id sweeps independently).
- **Error isolation**: a bad CEL eval is captured under `errors` and the sweep continues to other rows. A failing per-pocket sweep does NOT kill the cron loop (next pocket / next tick proceed).
- **Scheduler safety**: default OFF, idempotent start, clean stop, sub-floor cadence clamped, garbage env var falls back to default.

## Out of scope (separate PRs)

- HA / leader election. Single-node only for v0 — documented in the scheduler header.
- Per-tenant cadence overrides — env var only.
- Manual "sweep now" route.
- Cron syntax for non-1h intervals.
- **Template resolver from pocket_id**: same gap the bulk dispatcher's `bulk_action.template_resolver_pending` documents — the Pocket Beanie doc has no `template_slug` field. The scheduler's `_resolve_pocket_template_and_rows` returns `(None, [])` in v0, so the scheduler is a no-op for arbitrary pockets until the resolver lands. Library callers (tests, ad-hoc tooling, future "sweep now" route) pass `template` + `rows` directly and exercise the full dispatch path today.
- **Materialized rows source**: the OSS sweeper has no opinion on where rows come from. v0 callers from the scheduler pass `[]`; the architectural seam is here for the day a row source (data_sources executor cache, Fabric, etc.) wires in.

## Tests

```
$ uv run pytest tests/cloud/test_temporal_dispatcher.py tests/cloud/test_temporal_scheduler.py -v
28 passed
```

Adjacent regression — Wave 3a/3b/3c + refresh-scheduler suites — all 60 pass:

```
$ uv run pytest tests/cloud/test_instinct_dispatch.py tests/cloud/test_instinct_approvals_service.py tests/cloud/test_bulk_dispatch.py tests/cloud/test_outcomes_emitter.py tests/cloud/test_pocket_refresh_scheduler.py
60 passed
```

Import-linter — new `TemporalSweeps` contract kept, all 19 contracts pass:

```
$ uv run lint-imports --config ee/pyproject.toml
Contracts: 19 kept, 0 broken.
```

## Test plan

- [ ] Set `POCKETPAW_TEMPORAL_SWEEP_ENABLED=true` in a single-replica deploy; verify the loop logs `temporal-scheduler: loop started`.
- [ ] Confirm the `GET /api/v1/pockets/{id}/temporal-sweeps/state` endpoint returns an empty list for a never-swept pocket and the persisted matrix after a library-driven sweep.
- [ ] Confirm `TemporalSweepCompleted` events flow to any audit / dashboard subscribers (the same path `BulkActionDispatched` uses).
- [ ] When a template resolver ships, wire `_resolve_pocket_template_and_rows` to it and confirm the scheduler tick walks real templates end-to-end.
