### PR TITLE
feat(ee): wire template_slug + compile-on-install for RFC 03 v2

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/temporal_scheduler.py
+++ b/ee/pocketpaw_ee/cloud/_core/temporal_scheduler.py
@@ -36,11 +36,11 @@
 #   * Cron syntax for non-1h intervals. Env var is a simple integer
 #     second count.
 #   * Manual "sweep now" route. Future PR.
-#   * Per-pocket template resolution. The pocket Beanie doc has no
-#     ``template_slug`` field yet (same gap the bulk dispatcher has);
-#     the scheduler skips pockets for which no template can be
-#     resolved. The architectural seam is here for the day the
-#     resolver lands.
+#   * (Closed 2026-05-28, Wave 3e) Per-pocket template resolution now
+#     goes through ``pockets.service.resolve_pocket_template`` — the
+#     scheduler still skips pockets without a resolvable template, but
+#     pockets that DO carry a ``template_slug`` get a real
+#     ``PocketTemplate`` here.
 #
 # Hard constraint: this module imports the ``temporal_dispatcher`` +
 # ``pockets.service`` (for the workspace + pocket scan). It MUST NOT
@@ -120,25 +120,25 @@ async def _resolve_pocket_template_and_rows(
 ) -> tuple[object | None, list[dict]]:
     """Return ``(template, rows)`` for one pocket, or ``(None, [])``.
 
-    v0: the Pocket Beanie doc has no ``template_slug`` field, so the
-    scheduler can't resolve a ``PocketTemplate`` for an arbitrary
-    pocket. The scan helper accepts this — a pocket whose template
-    can't be resolved is a no-op for the sweeper.
-
-    The architectural seam is here for the day a template resolver
-    lands (likely as a service-level helper on
-    ``pockets.service.get_pocket_template``). When that ships, this
-    function returns ``(template, [])`` (rows still empty in v0) and
-    the dispatcher does real work.
+    Wave 3e — wired through ``pockets.service.resolve_pocket_template``.
+    A pocket with no ``template_slug``, an unknown slug, or a stale
+    on-disk template still returns ``(None, [])`` so the scheduler's
+    skip-cheaply behaviour for unresolvable pockets is unchanged. A
+    pocket that DOES carry a resolvable slug returns
+    ``(template, [])`` — ``rows`` stays empty in v0 (the OSS sweeper
+    is row-driven; a future PR will wire a materialized row source
+    like the data-sources cache or Fabric).
 
     Returning ``(None, [])`` short-circuits the dispatcher's early-
     return path: it does no row work, persists no state, and emits
     no completion event.
     """
-    # No template resolution available in v0. Tests that want to
-    # exercise the dispatch path patch this function directly.
-    _ = workspace_id, pocket_id
-    return None, []
+    # Lazy import — keep the scheduler's static import graph minimal
+    # for the import-linter contract (this module is Beanie-pure).
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    template = await pockets_service.resolve_pocket_template(workspace_id, pocket_id)
+    return template, []
 
 
 async def run_one_pass() -> int:

--- a/ee/pocketpaw_ee/cloud/models/pocket.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket.py
@@ -10,6 +10,13 @@ rippleSpec subtree for a single tile (e.g. a ``chart`` node with a real
 ``data`` series). The home grid renders a ``widgets[]`` entry from its
 ``spec``; the home agent's ``add_widget`` MCP tool populates it. Native
 widgets leave it ``None``.
+Updated: 2026-05-28 (feat/wave-3e-template-slug) — added the optional
+``Pocket.template_slug`` field: the kebab-case slug of the RFC 03 v2
+:class:`PocketTemplate` this pocket was instantiated from. Optional so
+legacy pockets (no template) read back as ``None`` without a Mongo
+migration. ``pockets.service.resolve_pocket_template`` reads this field
+and feeds the resolved template to the bulk dispatcher + temporal
+scheduler.
 """
 
 from __future__ import annotations
@@ -74,6 +81,13 @@ class Pocket(TimestampedDocument):
     # No pattern restriction — frontend sends data, deep-work, etc.
     # ``type="home"`` marks the per-user pocket that backs the home page.
     type: str = "custom"
+    # Optional RFC 03 v2 template slug — the bundled-template this pocket
+    # was instantiated from (e.g. ``"todo-task-tracker"``). When set,
+    # ``pockets.service.resolve_pocket_template`` loads + validates the
+    # template so the bulk dispatcher / temporal scheduler can fan out
+    # actions against it. Legacy pockets (no template) read as ``None``
+    # — no Mongo migration needed for adding an optional field.
+    template_slug: str | None = None
     icon: str = ""
     color: str = ""
     owner: str

--- a/ee/pocketpaw_ee/cloud/pockets/domain.py
+++ b/ee/pocketpaw_ee/cloud/pockets/domain.py
@@ -4,6 +4,11 @@ Pure-Python frozen dataclasses. ``pockets/service.py`` owns the
 conversion between these and the Beanie ``Pocket`` / ``Widget``
 documents — domain objects are what every consumer outside the service
 sees on read paths.
+
+Updated: 2026-05-28 (feat/wave-3e-template-slug) — added optional
+``Pocket.template_slug`` so the wire layer + bulk dispatcher can read
+the RFC 03 v2 template the pocket was instantiated from. ``None`` for
+legacy pockets.
 """
 
 from __future__ import annotations
@@ -86,6 +91,10 @@ class Pocket:
     shared_with: tuple[str, ...]
     tool_specs: tuple[dict[str, Any], ...] = field(default_factory=tuple)
     project_id: str | None = None
+    # RFC 03 v2 (Wave 3e) — the bundled-template slug the pocket was
+    # instantiated from (e.g. ``"todo-task-tracker"``). ``None`` for
+    # cold-generated or legacy pockets.
+    template_slug: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -49,6 +49,13 @@ BulkBlockedRowDTO for the new
 request carries ``rows`` (per-row dicts); the response surfaces the
 RFC 03 v2 bucketing — ``executions`` / ``blocked`` /
 ``batch_approval_id`` — plus the consolidated ``approval_row_ids``.
+Updated: 2026-05-28 (feat/wave-3e-template-slug) — added the optional
+``template_slug`` (aliased ``templateSlug``) field on
+``CreatePocketRequest`` / ``UpdatePocketRequest`` / ``PocketResponse``.
+When supplied on create, the service loads the named bundled template,
+compiles it, and merges the runtime-shaped dict into the pocket's
+``rippleSpec`` (compile-on-install). Legacy callers that omit it see
+the same shape they always have.
 """
 
 from __future__ import annotations
@@ -71,6 +78,11 @@ class CreatePocketRequest(BaseModel):
     ripple_spec: dict | None = Field(default=None, alias="rippleSpec")
     widgets: list[dict] = Field(default_factory=list)  # Initial widget definitions
     project_id: str | None = Field(default=None, alias="projectId")
+    # RFC 03 v2 (Wave 3e) — the bundled-template slug this pocket is
+    # instantiated from. When set, the service loads + compiles the
+    # template at create time and merges the result into ``rippleSpec``.
+    # Omitting it preserves the pre-Wave-3e behaviour.
+    template_slug: str | None = Field(default=None, alias="templateSlug")
 
     model_config = {"populate_by_name": True}
 
@@ -84,6 +96,11 @@ class UpdatePocketRequest(BaseModel):
     visibility: str | None = None
     ripple_spec: dict | None = Field(default=None, alias="rippleSpec")
     project_id: str | None = Field(default=None, alias="projectId")
+    # When provided, the service treats this as "switch / set the template
+    # for this pocket" — re-loads + recompiles + merges into rippleSpec.
+    # Pass the same slug to force a recompile (template content edited
+    # out-of-band). ``None`` (the default) means "leave it alone."
+    template_slug: str | None = Field(default=None, alias="templateSlug")
 
     model_config = {"populate_by_name": True}
 
@@ -158,6 +175,9 @@ class PocketResponse(BaseModel):
     share_link_access: str = "view"
     shared_with: list[str]
     project_id: str | None = None
+    # RFC 03 v2 (Wave 3e) — the bundled-template slug, or ``None`` for
+    # legacy pockets / cold-generated rippleSpecs.
+    template_slug: str | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -471,6 +491,9 @@ def pocket_to_wire_dict(p) -> dict:
         "shareLinkAccess": p.share_link_access,
         "sharedWith": list(p.shared_with),
         "projectId": p.project_id,
+        # RFC 03 v2 (Wave 3e) — the bundled-template slug the pocket was
+        # instantiated from. ``None`` for legacy / cold-generated pockets.
+        "templateSlug": getattr(p, "template_slug", None),
         "createdAt": iso_utc(p.created_at),
         "updatedAt": iso_utc(p.updated_at),
     }

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -775,12 +775,12 @@ async def dispatch_bulk_action_route(
       exactly ONE InstinctApproval row covers every approval-needing
       row in the batch (RFC mandate — never N approvals).
 
-    Out of scope for this PR: the per-pocket template resolver. The
-    paw-enterprise UI / a follow-up PR will resolve the
-    :class:`PocketTemplate` from the pocket's persisted template
-    reference; this route surfaces ``400`` until that lookup lands so
-    the contract is observable but the endpoint is not yet
-    silently-broken.
+    Wave 3e — template resolution is now wired through
+    ``pockets.service.resolve_pocket_template`` which reads the pocket's
+    ``template_slug`` and loads the OSS bundled template. A pocket with
+    no slug, an unknown slug, or a stale on-disk template surfaces as
+    ``404 pocket_template.not_found`` so the operator can fix the
+    template binding rather than receive a generic 500.
     """
     body = body or DispatchBulkRequest(
         pocket_id=pocket_id,
@@ -793,21 +793,29 @@ async def dispatch_bulk_action_route(
     body_dict["pocket_id"] = pocket_id
     body_dict["action_name"] = action_name
 
-    # Template resolution is a follow-up: the pocket needs a stable
-    # ``template_slug`` field plus a service-level loader that maps
-    # slug → :class:`PocketTemplate`. Returning 400 here keeps the
-    # endpoint observable in OpenAPI without leaking a half-wired
-    # behaviour onto the wire.
-    raise CloudError(
-        400,
-        "bulk_action.template_resolver_pending",
-        (
-            "Bulk dispatch HTTP route requires the per-pocket template "
-            "resolver (Wave 3b follow-up); call "
-            "pockets.service.dispatch_bulk_action(..., template=...) "
-            "directly from library / job callers."
-        ),
+    # Wave 3e — resolve the pocket's RFC 03 v2 template. ``None`` means
+    # the pocket has no slug, the slug is unknown, or the on-disk
+    # template is stale; treat as 404 so the operator is signalled to
+    # fix the binding (vs. a 500 / generic error).
+    template = await pockets_service.resolve_pocket_template(workspace_id, pocket_id)
+    if template is None:
+        raise CloudError(
+            404,
+            "pocket_template.not_found",
+            (
+                "No RFC 03 v2 template is bound to this pocket — set "
+                "``template_slug`` on the pocket before dispatching a "
+                "bulk action."
+            ),
+        )
+
+    result_wire = await pockets_service.dispatch_bulk_action(
+        workspace_id,
+        user_id,
+        body_dict,
+        template=template,
     )
+    return BulkDispatchResponse(**result_wire)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -74,6 +74,16 @@ Changes: 2026-05-22 (#1174) — widgets carry an optional ``spec`` field (a
 per-tile rippleSpec subtree the home grid renders). ``_build_widget_doc``,
 ``_widget_to_domain``, the REST ``add_widget``, and ``agent_update_widget``
 thread it through; the home agent's ``add_widget`` MCP tool populates it.
+Changes: 2026-05-28 (feat/wave-3e-template-slug) — wired the RFC 03 v2
+``template_slug`` field end-to-end: ``create`` / ``update`` load + compile
+the bundled template (via OSS ``load_template`` + ``compile_template``)
+and **merge** the compile output into ``rippleSpec`` (option B —
+user-customized fields survive a re-apply). Added the
+``resolve_pocket_template(workspace_id, pocket_id)`` helper the bulk
+dispatcher + temporal scheduler call to obtain a typed ``PocketTemplate``
+from a pocket. A stale / missing slug never breaks pocket creation: the
+loader's ``strict=False`` mode returns ``None`` and the rippleSpec is
+left unmodified so a later resolver run can retry.
 """
 
 from __future__ import annotations
@@ -83,6 +93,7 @@ import copy
 import logging
 import secrets
 from collections import OrderedDict
+from pathlib import Path
 from typing import Any
 
 from beanie import PydanticObjectId
@@ -190,6 +201,8 @@ def _pocket_to_domain(doc: _PocketDoc) -> Pocket:
         shared_with=tuple(doc.shared_with),
         tool_specs=tuple(doc.tool_specs),
         project_id=getattr(doc, "project_id", None),
+        # Wave 3e — optional. ``getattr`` for legacy docs that pre-date the field.
+        template_slug=getattr(doc, "template_slug", None),
         created_at=getattr(doc, "createdAt", None),
         updated_at=getattr(doc, "updatedAt", None),
     )
@@ -500,6 +513,149 @@ async def _gate_catalog(
 
 
 # ---------------------------------------------------------------------------
+# Template compile-on-install + resolver (RFC 03 v2 / Wave 3e)
+# ---------------------------------------------------------------------------
+#
+# A pocket created or updated with a ``template_slug`` is "instantiated"
+# from one of the bundled RFC 03 v2 templates: the OSS loader reads the
+# template off disk, the OSS compile pass translates it into a runtime-
+# shaped dict, and the EE service MERGES that dict into the pocket's
+# ``rippleSpec`` (option B — keep user-customized fields, replace the
+# compile-output keys). The merge strategy is intentional: a user can
+# tweak ``rippleSpec.ui`` after instantiation and a subsequent
+# template-recompile (template upgraded out-of-band) won't blow those
+# tweaks away — only the fields the compile pass produced get replaced.
+#
+# Tolerance posture: ``load_template(slug, strict=False)`` never raises;
+# a stale / missing / malformed template returns ``None``. The pocket
+# keeps its slug (so a later resolver attempt can retry) and its
+# rippleSpec is left unmodified — the create/update never fails just
+# because the template went away. A WARNING is logged so an operator can
+# see the drift.
+
+
+def _compile_template_to_runtime_dict(loaded: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Translate an OSS ``load_template`` result into the runtime rippleSpec dict.
+
+    Returns the compile output dict on success, or ``None`` if the
+    loader returned ``None`` (unknown / stale slug — see the section
+    docstring for the tolerance posture). Validation failures inside
+    the loader already became ``None`` under ``strict=False``; this
+    function only re-runs ``PocketTemplate.model_validate`` to obtain
+    the typed model the OSS ``compile_template`` consumes.
+    """
+    if loaded is None:
+        return None
+    meta = loaded.get("meta")
+    if not isinstance(meta, dict):
+        return None
+
+    # Lazy imports — OSS bundled_templates is the only place that owns the
+    # ``PocketTemplate`` schema + ``compile_template`` pure function.
+    from pocketpaw.bundled_templates import PocketTemplate, compile_template
+
+    try:
+        template = PocketTemplate.model_validate(meta)
+    except Exception as exc:  # noqa: BLE001 — the loader already deferred validation
+        logger.warning("template compile: schema validation failed: %s", exc)
+        return None
+    try:
+        return compile_template(template)
+    except Exception as exc:  # noqa: BLE001 — compile is pure; bug in OSS if it raises
+        logger.warning("template compile: compile_template raised: %s", exc)
+        return None
+
+
+def _merge_compile_into_ripple_spec(
+    existing: dict[str, Any] | None,
+    compiled: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge a ``compile_template`` result into an existing rippleSpec.
+
+    Merge strategy (option B in the Wave 3e brief): keys produced by
+    the compile pass (``sources``, ``state``, ``actions``, ``agents``,
+    ``triggers``, ``outcomes``, etc.) REPLACE matching keys in the
+    existing spec. Keys the compile pass does NOT produce
+    (e.g. ``ui`` — a user-authored render tree) survive unchanged.
+    The result is a NEW dict; neither input is mutated.
+
+    Rationale: a pocket created from a template carries the template's
+    sources / state / actions verbatim, but the user may have edited
+    ``rippleSpec.ui`` to rearrange the canvas. A subsequent template
+    re-apply (template upgraded out-of-band) should refresh the
+    machinery without nuking the user's layout.
+    """
+    out: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    for key, value in compiled.items():
+        out[key] = value
+    return out
+
+
+async def resolve_pocket_template(
+    workspace_id: str,
+    pocket_id: str,
+    *,
+    templates_dir: Path | None = None,
+) -> Any | None:
+    """Return the resolved :class:`PocketTemplate` for a pocket, or ``None``.
+
+    Tenant-filtered: a pocket in a different workspace, a missing
+    pocket, an unset ``template_slug``, or a template the loader can't
+    read all return ``None``. Callers (``bulk_dispatch``,
+    ``temporal_scheduler``) treat ``None`` as "no-op for this pocket"
+    — never an error.
+
+    Args:
+        workspace_id: Tenancy. Required.
+        pocket_id: The pocket to resolve. Required.
+        templates_dir: Optional override of the OSS loader's templates
+            root — used by tests to point at a tmp install. Defaults to
+            ``~/.pocketpaw/templates/`` via the OSS default.
+
+    Returns:
+        A validated ``PocketTemplate`` instance, or ``None`` for any
+        of the failure modes above.
+    """
+    if not workspace_id or not pocket_id:
+        return None
+    try:
+        doc = await _PocketDoc.get(PydanticObjectId(pocket_id))
+    except Exception:  # noqa: BLE001 — malformed id surfaces as "not found"
+        return None
+    # Rule 7 — tenant filter on every read.
+    if doc is None or doc.workspace != workspace_id:
+        return None
+    slug = getattr(doc, "template_slug", None)
+    if not slug:
+        return None
+
+    # Lazy import — keep the OSS schema off the eager import path.
+    from pocketpaw.bundled_templates import PocketTemplate, load_template
+
+    loaded = load_template(slug, templates_dir=templates_dir, strict=False)
+    if loaded is None:
+        logger.warning(
+            "resolve_pocket_template: pocket=%s slug=%r could not be loaded — returning None",
+            pocket_id,
+            slug,
+        )
+        return None
+    meta = loaded.get("meta")
+    if not isinstance(meta, dict):
+        return None
+    try:
+        return PocketTemplate.model_validate(meta)
+    except Exception as exc:  # noqa: BLE001 — strict=False already swallowed validation
+        logger.warning(
+            "resolve_pocket_template: pocket=%s slug=%r post-load validation failed: %s",
+            pocket_id,
+            slug,
+            exc,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
 # CRUD
 # ---------------------------------------------------------------------------
 
@@ -516,6 +672,20 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     from pocketpaw_ee.cloud.sessions import service as sessions_service
 
     normalized_spec = normalize_ripple_spec(body.ripple_spec) if body.ripple_spec else None
+    # Wave 3e — compile-on-install. When ``template_slug`` is set, load
+    # the bundled template, compile it, and merge the runtime dict into
+    # the caller-supplied rippleSpec (option B merge — see the section
+    # docstring above ``_merge_compile_into_ripple_spec``). A stale /
+    # missing slug logs a warning and leaves the rippleSpec unchanged —
+    # the pocket still gets created and keeps the slug for retry.
+    if body.template_slug:
+        from pocketpaw.bundled_templates import load_template
+
+        loaded = load_template(body.template_slug, strict=False)
+        compiled = _compile_template_to_runtime_dict(loaded)
+        if compiled is not None:
+            normalized_spec = _merge_compile_into_ripple_spec(normalized_spec, compiled)
+
     if normalized_spec:
         validate_ripple_spec_logged(normalized_spec, workspace_id=workspace_id)
         # Human/import path — catalog drift is logged for triage, not blocked.
@@ -538,6 +708,7 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
         agents=list(body.agents or []),
         widgets=widget_docs,
         rippleSpec=normalized_spec,
+        template_slug=body.template_slug,
     )
     await doc.insert()
     pocket = _pocket_to_domain(doc)
@@ -686,6 +857,21 @@ async def update(pocket_id: str, user_id: str, body: UpdatePocketRequest) -> dic
         _check_domain_owner(pocket, user_id)
 
     normalized_spec = normalize_ripple_spec(body.ripple_spec) if body.ripple_spec else None
+    # Wave 3e — recompile-on-update when ``template_slug`` is supplied in
+    # the body (different OR same slug — same body slug forces a
+    # refresh against the on-disk template). The compile output merges
+    # into either the caller-supplied rippleSpec or the existing one.
+    # Same tolerance posture as ``create``: a stale slug leaves the
+    # rippleSpec untouched and logs a warning.
+    if body.template_slug is not None:
+        from pocketpaw.bundled_templates import load_template
+
+        loaded = load_template(body.template_slug, strict=False)
+        compiled = _compile_template_to_runtime_dict(loaded)
+        if compiled is not None:
+            merge_base = normalized_spec if normalized_spec is not None else doc.rippleSpec
+            normalized_spec = _merge_compile_into_ripple_spec(merge_base, compiled)
+
     if normalized_spec:
         validate_ripple_spec_logged(
             normalized_spec, pocket_id=str(doc.id), workspace_id=doc.workspace
@@ -713,6 +899,8 @@ async def update(pocket_id: str, user_id: str, body: UpdatePocketRequest) -> dic
         doc.visibility = body.visibility
     if normalized_spec is not None:
         doc.rippleSpec = normalized_spec
+    if body.template_slug is not None:
+        doc.template_slug = body.template_slug
     if body.project_id is not None:
         # Empty string is the "unassign" signal; non-empty must point at a
         # real project in the same workspace.
@@ -3226,6 +3414,7 @@ __all__ = [
     "remove_team_member",
     "remove_widget",
     "reorder_widgets",
+    "resolve_pocket_template",
     "resolve_webhook_pocket",
     "revoke_share_link",
     "rotate_webhook_secret",

--- a/tests/cloud/test_template_resolution.py
+++ b/tests/cloud/test_template_resolution.py
@@ -1,0 +1,458 @@
+# tests/cloud/test_template_resolution.py
+# Created: 2026-05-28 (feat/wave-3e-template-slug) — pins RFC 03 v2
+# template-slug wiring + compile-on-install + the new
+# ``resolve_pocket_template`` service helper.
+#
+# What this pins:
+#
+#   * ``Pocket.template_slug`` is an optional Beanie field — legacy
+#     pockets (no slug) read back as ``None``.
+#   * ``service.create`` with a ``template_slug`` loads + compiles the
+#     bundled template and MERGES the compile output into rippleSpec
+#     (option B — user-customized keys survive). Without a slug, the
+#     behaviour is unchanged from before Wave 3e.
+#   * ``service.update`` with a ``template_slug`` triggers a
+#     recompile + merge against the current rippleSpec.
+#   * ``resolve_pocket_template`` returns a typed ``PocketTemplate``
+#     for a pocket with a known slug, ``None`` for an unknown slug,
+#     ``None`` for a slug-less pocket, and ``None`` for a pocket in a
+#     different workspace (tenant isolation).
+#   * ``dispatch_bulk_action`` (library entry point) succeeds
+#     end-to-end when given a resolved template — closing the Wave 3b
+#     gap.
+#   * ``temporal_scheduler.run_one_pass`` no longer skips every pocket
+#     — pockets that DO carry a resolvable template feed
+#     ``temporal_dispatcher.sweep_pocket`` — closing the Wave 3d gap.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+from pocketpaw_ee.cloud.models.pocket_backend import (
+    AllowedWrite as _AllowedWriteDoc,
+)
+from pocketpaw_ee.cloud.models.pocket_backend import (
+    PocketBackendCredential as _BackendCredentialDoc,
+)
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import (
+    CreatePocketRequest,
+    UpdatePocketRequest,
+)
+
+from pocketpaw.bundled_templates import (
+    PocketTemplate,
+    install_bundled_templates,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def templates_dir(tmp_path: Path) -> Path:
+    """Install the bundled templates into a tmp dir so the loader can read
+    them without depending on the host's ``~/.pocketpaw/templates``.
+
+    Returns the install root the resolver / loader call points at."""
+    install_bundled_templates(destination_root=tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def patched_loader(monkeypatch, templates_dir: Path):
+    """Patch ``load_template`` everywhere the service uses it to point at
+    the tmp templates dir. The service imports ``load_template`` lazily
+    inside ``create`` / ``update``; the lazy ``from pocketpaw.bundled_templates
+    import load_template`` resolves against the package's module-level
+    attribute, so patching the package symbol catches every lazy import."""
+    from pocketpaw.bundled_templates import loader as loader_mod
+
+    real = loader_mod.load_template
+    install_root = templates_dir
+
+    def _patched(slug: str, *, templates_dir: Path | None = None, strict: bool = False):
+        return real(slug, templates_dir=templates_dir or install_root, strict=strict)
+
+    monkeypatch.setattr(loader_mod, "load_template", _patched)
+    import pocketpaw.bundled_templates as bt_pkg
+
+    monkeypatch.setattr(bt_pkg, "load_template", _patched)
+    return install_root
+
+
+# ---------------------------------------------------------------------------
+# Beanie field — pocket reads back template_slug
+# ---------------------------------------------------------------------------
+
+
+async def test_pocket_template_slug_field_persists() -> None:
+    """A new Pocket Beanie doc accepts ``template_slug`` and reads it back."""
+    doc = _PocketDoc(
+        workspace="w1",
+        name="t",
+        owner="u1",
+        template_slug="todo-task-tracker",
+    )
+    await doc.insert()
+
+    fetched = await _PocketDoc.get(doc.id)
+    assert fetched is not None
+    assert fetched.template_slug == "todo-task-tracker"
+
+
+async def test_pocket_template_slug_defaults_to_none() -> None:
+    """A pocket created without a slug reads back ``None`` — Mongo
+    doesn't need a migration for adding an optional field."""
+    doc = _PocketDoc(workspace="w1", name="t", owner="u1")
+    await doc.insert()
+
+    fetched = await _PocketDoc.get(doc.id)
+    assert fetched is not None
+    assert fetched.template_slug is None
+
+
+# ---------------------------------------------------------------------------
+# service.create — compile-on-install + merge
+# ---------------------------------------------------------------------------
+
+
+async def test_create_with_template_slug_compiles_and_merges(patched_loader) -> None:
+    """``create`` with a ``template_slug`` populates ``rippleSpec`` from
+    the OSS compile pass and persists the slug on the pocket."""
+    body = CreatePocketRequest(name="My Todo", template_slug="todo-task-tracker")
+    pocket = await pockets_service.create("w1", "u1", body)
+
+    assert pocket["templateSlug"] == "todo-task-tracker"
+    spec = pocket["rippleSpec"]
+    assert isinstance(spec, dict)
+    # The compile pass surfaces template fields (``state``, ``name`` of
+    # the template, etc.) onto the spec.
+    assert spec.get("name") == "todo-task-tracker"
+
+
+async def test_create_without_template_slug_skips_compile() -> None:
+    """A pocket created without a slug behaves identically to pre-Wave-3e:
+    no compile, no rippleSpec injected by the service."""
+    body = CreatePocketRequest(name="cold pocket")
+    pocket = await pockets_service.create("w1", "u1", body)
+    assert pocket["templateSlug"] is None
+    assert pocket["rippleSpec"] is None
+
+
+async def test_create_with_unknown_slug_keeps_slug_and_leaves_spec_unchanged(monkeypatch) -> None:
+    """An unknown slug doesn't break create. The pocket is persisted
+    with the slug intact so a later resolver can retry; the rippleSpec
+    is left at whatever the caller passed (None in this test)."""
+    # No patched_loader fixture here — ``load_template`` runs against the
+    # real default dir which doesn't carry ``does-not-exist``.
+    body = CreatePocketRequest(name="bad slug", template_slug="does-not-exist")
+    pocket = await pockets_service.create("w1", "u1", body)
+    assert pocket["templateSlug"] == "does-not-exist"
+    assert pocket["rippleSpec"] is None
+
+
+async def test_create_with_template_preserves_user_supplied_ui(patched_loader) -> None:
+    """Option B merge: a caller-supplied rippleSpec key (e.g. a ``ui``
+    tree) that the compile pass doesn't produce survives the merge."""
+    user_ui = {"id": "n_root", "type": "stack", "children": []}
+    body = CreatePocketRequest(
+        name="custom canvas",
+        template_slug="todo-task-tracker",
+        ripple_spec={"ui": user_ui},
+    )
+    pocket = await pockets_service.create("w1", "u1", body)
+    spec = pocket["rippleSpec"]
+    assert spec.get("ui", {}).get("type") == "stack"
+    # The compile pass still landed its keys onto the spec.
+    assert "state" in spec
+
+
+# ---------------------------------------------------------------------------
+# service.update — recompile-on-set
+# ---------------------------------------------------------------------------
+
+
+async def test_update_with_template_slug_recompiles(patched_loader) -> None:
+    """``update`` with a new slug triggers a recompile + merge."""
+    create_body = CreatePocketRequest(name="initial")
+    pocket = await pockets_service.create("w1", "u1", create_body)
+    pocket_id = pocket["_id"]
+
+    update_body = UpdatePocketRequest(template_slug="kanban-board")
+    updated = await pockets_service.update(pocket_id, "u1", update_body)
+    assert updated["templateSlug"] == "kanban-board"
+    spec = updated["rippleSpec"]
+    assert isinstance(spec, dict)
+    assert spec.get("name") == "kanban-board"
+
+
+async def test_update_without_template_slug_leaves_slug_alone(patched_loader) -> None:
+    """An update that doesn't touch ``template_slug`` keeps the slug
+    and the rippleSpec from the prior create."""
+    create_body = CreatePocketRequest(name="hold", template_slug="todo-task-tracker")
+    pocket = await pockets_service.create("w1", "u1", create_body)
+    pocket_id = pocket["_id"]
+
+    update_body = UpdatePocketRequest(description="new description")
+    updated = await pockets_service.update(pocket_id, "u1", update_body)
+    assert updated["templateSlug"] == "todo-task-tracker"
+    assert updated["description"] == "new description"
+
+
+# ---------------------------------------------------------------------------
+# resolve_pocket_template
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_returns_template_for_known_slug(templates_dir: Path) -> None:
+    """A pocket with a known slug resolves to a typed ``PocketTemplate``."""
+    doc = _PocketDoc(workspace="w1", name="t", owner="u1", template_slug="todo-task-tracker")
+    await doc.insert()
+
+    template = await pockets_service.resolve_pocket_template(
+        "w1", str(doc.id), templates_dir=templates_dir
+    )
+    assert isinstance(template, PocketTemplate)
+    assert template.name == "todo-task-tracker"
+
+
+async def test_resolve_returns_none_for_pocket_without_slug(templates_dir: Path) -> None:
+    """A pocket with no ``template_slug`` returns ``None`` — not an error."""
+    doc = _PocketDoc(workspace="w1", name="t", owner="u1")
+    await doc.insert()
+    template = await pockets_service.resolve_pocket_template(
+        "w1", str(doc.id), templates_dir=templates_dir
+    )
+    assert template is None
+
+
+async def test_resolve_returns_none_for_unknown_slug(templates_dir: Path) -> None:
+    """A slug the on-disk install doesn't carry returns ``None`` — the
+    loader's strict=False mode handles it gracefully."""
+    doc = _PocketDoc(workspace="w1", name="t", owner="u1", template_slug="does-not-exist")
+    await doc.insert()
+    template = await pockets_service.resolve_pocket_template(
+        "w1", str(doc.id), templates_dir=templates_dir
+    )
+    assert template is None
+
+
+async def test_resolve_returns_none_for_unknown_pocket(templates_dir: Path) -> None:
+    """A pocket_id that doesn't exist returns ``None`` (not an error)."""
+    from beanie import PydanticObjectId
+
+    fake_id = str(PydanticObjectId())
+    template = await pockets_service.resolve_pocket_template(
+        "w1", fake_id, templates_dir=templates_dir
+    )
+    assert template is None
+
+
+async def test_resolve_tenant_isolation(templates_dir: Path) -> None:
+    """A pocket in workspace A is invisible to a resolver call from
+    workspace B — Rule 7 (tenant filter on every read)."""
+    doc = _PocketDoc(workspace="w1", name="t", owner="u1", template_slug="todo-task-tracker")
+    await doc.insert()
+    template = await pockets_service.resolve_pocket_template(
+        "w-other", str(doc.id), templates_dir=templates_dir
+    )
+    assert template is None
+
+
+# ---------------------------------------------------------------------------
+# Wave 3b closure — dispatch_bulk_action via the resolver works end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _bulk_template() -> PocketTemplate:
+    """Minimal v2 template carrying ONE bulk action."""
+    return PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "wave-3e-test",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "test",
+            "description": "Wave 3e end-to-end fixture",
+            "shape": "data-grid",
+            "state": {
+                "entity_type": "Thing",
+                "columns": [{"field": "value", "widget": "number"}],
+                "id_field": "id",
+            },
+            "actions": [
+                {
+                    "name": "mark_done",
+                    "label": "Done",
+                    "kind": "bulk",
+                    "instinct_policy": "auto",
+                }
+            ],
+        }
+    )
+
+
+async def _make_pocket_for_dispatch(
+    *,
+    workspace: str = "w1",
+    owner: str = "u1",
+) -> str:
+    """Insert a pocket with a rippleSpec carrying the ``mark_done`` write
+    binding plus an allowlisted backend so ``dispatch_bulk_action``
+    can fan out without 500ing on missing creds."""
+    doc = _PocketDoc(
+        workspace=workspace,
+        name="bulk-pocket",
+        owner=owner,
+        rippleSpec={
+            "actions": {
+                "mark_done": {
+                    "kind": "write_binding",
+                    "method": "POST",
+                    "path": "/items",
+                }
+            }
+        },
+        visibility="workspace",
+    )
+    await doc.insert()
+    await _BackendCredentialDoc(
+        pocket_id=str(doc.id),
+        workspace_id=workspace,
+        base_url="https://example.test",
+        auth_type="none",
+        auth_header=None,
+        encrypted_token=None,
+        nonce=None,
+        salt=None,
+        allowed_writes=[
+            _AllowedWriteDoc.model_validate({"method": "POST", "path_pattern": "/items*"})
+        ],
+    ).insert()
+    return str(doc.id)
+
+
+async def test_dispatch_bulk_action_runs_with_resolved_template(monkeypatch) -> None:
+    """The Wave 3b gap closure: ``dispatch_bulk_action`` succeeds for a
+    pocket+template pair. The route's resolver-fed call no longer
+    returns ``bulk_action.template_resolver_pending``."""
+    pocket_id = await _make_pocket_for_dispatch()
+
+    calls: list[dict] = []
+
+    async def _stub_run_action(**kwargs: Any) -> dict:
+        calls.append(kwargs)
+        return {
+            "ok": True,
+            "action": kwargs["action"],
+            "status": 200,
+            "response": {"ok": True},
+            "on_success": [],
+            "on_error": [],
+        }
+
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    monkeypatch.setattr(action_executor, "run_action", _stub_run_action)
+
+    body = {
+        "pocket_id": pocket_id,
+        "action_name": "mark_done",
+        "rows": [{"id": "r1", "value": 1}, {"id": "r2", "value": 2}],
+    }
+    result = await pockets_service.dispatch_bulk_action(
+        "w1",
+        "u1",
+        body,
+        template=_bulk_template(),
+        now=datetime(2026, 5, 28, 12, 0, 0, tzinfo=UTC),
+    )
+    assert result["total_rows"] == 2
+    assert len(result["executions"]) == 2
+    assert result["batch_approval_id"] is None
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Wave 3d closure — temporal scheduler no longer skips every pocket
+# ---------------------------------------------------------------------------
+
+
+async def test_temporal_scheduler_uses_resolver(monkeypatch, templates_dir: Path) -> None:
+    """The scheduler's ``_resolve_pocket_template_and_rows`` now hits
+    ``resolve_pocket_template`` instead of returning ``(None, [])``
+    unconditionally. A pocket with a known slug receives a non-None
+    template at the scheduler seam."""
+    pocket_id = await _make_pocket_for_dispatch()
+    # Stamp the slug onto the pocket so the resolver finds it.
+    doc = await _PocketDoc.get(pocket_id)
+    assert doc is not None
+    doc.template_slug = "todo-task-tracker"
+    # Ensure ``rippleSpec.sources`` exists so the scheduler's scan picks
+    # the pocket up (the scan filters on a non-empty sources dict in v0).
+    spec = dict(doc.rippleSpec or {})
+    spec["sources"] = {
+        "items": {
+            "method": "GET",
+            "path": "/items",
+            "bind": "state.items",
+            "refresh": ["interval"],
+            "refresh_interval_seconds": 3600,
+        }
+    }
+    doc.rippleSpec = spec
+    await doc.save()
+
+    # The scheduler calls ``pockets_service.resolve_pocket_template``
+    # which itself calls ``load_template`` — no ``templates_dir`` kwarg
+    # threads through that path, so we patch the loader to default to
+    # the tmp install root.
+    from pocketpaw.bundled_templates import loader as loader_mod
+
+    real_load = loader_mod.load_template
+    install_root = templates_dir
+
+    def _redirect(slug: str, *, templates_dir: Path | None = None, strict: bool = False):
+        return real_load(slug, templates_dir=templates_dir or install_root, strict=strict)
+
+    monkeypatch.setattr(loader_mod, "load_template", _redirect)
+    import pocketpaw.bundled_templates as bt_pkg
+
+    monkeypatch.setattr(bt_pkg, "load_template", _redirect)
+
+    from pocketpaw_ee.cloud._core import temporal_scheduler
+
+    resolved_calls: list[tuple[str, str, object]] = []
+
+    async def _spy_sweep(workspace_id: str, pocket_id: str, *, template, rows):
+        from pocketpaw_ee.cloud.temporal_sweeps.domain import SweepDispatchResult
+
+        resolved_calls.append((workspace_id, pocket_id, template))
+        return SweepDispatchResult(
+            pocket_id=pocket_id,
+            edges_fired=0,
+            blocked=0,
+            escalated=0,
+            errors=0,
+            sweep_duration_ms=0,
+        )
+
+    from pocketpaw_ee.cloud.pockets import temporal_dispatcher
+
+    monkeypatch.setattr(temporal_dispatcher, "sweep_pocket", _spy_sweep)
+
+    visited = await temporal_scheduler.run_one_pass()
+    assert visited == 1
+    assert len(resolved_calls) == 1
+    _ws, _pid, template = resolved_calls[0]
+    assert isinstance(template, PocketTemplate)
+    assert template.name == "todo-task-tracker"


### PR DESCRIPTION
## Summary

Wave 3e closes the load-bearing gap that Waves 3b and 3d both flagged: pockets had no `template_slug` field, so the runtime could not resolve a Pocket to a `PocketTemplate` and call `compile_template`. As a result Wave 3b's `dispatch-bulk` route returned `400 bulk_action.template_resolver_pending` and Wave 3d's temporal scheduler skipped every pocket. This PR closes both.

- **`Pocket.template_slug`** — optional Beanie field; legacy pockets read back as `None` (no migration needed).
- **Compile-on-install** — `service.create` and `service.update` load the bundled RFC 03 v2 template via `load_template(slug, strict=False)`, run `compile_template`, and **merge** the runtime dict into `rippleSpec`. Merge strategy is **option B**: keys produced by the compile pass replace matching keys; keys it does not produce (e.g. a user-edited `ui` tree) survive a re-apply. Stale or unknown slugs log a WARNING and leave `rippleSpec` untouched — the pocket still gets created and keeps the slug for a later resolver retry.
- **`resolve_pocket_template(workspace_id, pocket_id)`** — the single seam every downstream caller goes through. Tenant-filtered (Rule 7). Cross-workspace, missing pocket, slug-less pocket, and stale-template all return `None` rather than raise.
- **Wave 3b closure** — `router.dispatch_bulk_action_route` now resolves the template and calls `dispatch_bulk_action`. Missing template surfaces as `404 pocket_template.not_found`. The 400 `template_resolver_pending` stub is gone.
- **Wave 3d closure** — `_core.temporal_scheduler._resolve_pocket_template_and_rows` calls the resolver instead of unconditionally returning `(None, [])`. Pockets with a resolvable slug now feed `temporal_dispatcher.sweep_pocket` with a real `PocketTemplate`.

## Files changed

- `ee/pocketpaw_ee/cloud/models/pocket.py` — added `template_slug: str | None = None`.
- `ee/pocketpaw_ee/cloud/pockets/domain.py` — added `template_slug` on the frozen `Pocket` dataclass.
- `ee/pocketpaw_ee/cloud/pockets/dto.py` — `CreatePocketRequest` / `UpdatePocketRequest` / `PocketResponse` carry the field; `pocket_to_wire_dict` adds `templateSlug` on the wire.
- `ee/pocketpaw_ee/cloud/pockets/service.py` — compile-on-install in `create` / `update`, new `resolve_pocket_template`, helper `_compile_template_to_runtime_dict` + `_merge_compile_into_ripple_spec`.
- `ee/pocketpaw_ee/cloud/pockets/router.py` — replaces the `template_resolver_pending` stub with a real resolve + dispatch path.
- `ee/pocketpaw_ee/cloud/_core/temporal_scheduler.py` — `_resolve_pocket_template_and_rows` now calls the resolver.
- `tests/cloud/test_template_resolution.py` — 15 new tests pinning the contract.

## Test plan

- [x] `uv run pytest tests/cloud/test_template_resolution.py -xvs` — 15 passed.
- [x] `uv run pytest tests/cloud/test_bulk_dispatch.py tests/cloud/test_temporal_dispatcher.py tests/cloud/test_temporal_scheduler.py tests/cloud/test_pocket_model.py tests/cloud/test_pocket_action_executor.py tests/cloud/test_pocket_schemas.py tests/cloud/test_pocket_service_resolver.py tests/cloud/test_pocket_granular_ops.py tests/cloud/test_pocket_mutation_family.py` — 159 passed, zero regressions.
- [x] `uv run ruff check` + `uv run ruff format` clean across the touched files.
- [x] `uv run lint-imports --config ee/pyproject.toml` — 19 contracts kept, 0 broken. Beanie-pure invariants on `bulk_dispatch`, `temporal_dispatcher`, and `_core.temporal_scheduler` are preserved.
- [x] `uv run mypy` — no new typed errors introduced. The lone new line is the same `bundled_templates` "missing py.typed marker" warning the existing `bulk_dispatch.py` already accepts.

## Architectural decisions

1. **Optional field, no migration.** Existing pockets read as `template_slug=None`. The legacy create/update path (no slug in body) is byte-identical to pre-Wave-3e behaviour.
2. **Merge over replace.** A template re-apply refreshes the machinery (sources, state, actions) but leaves user-customized canvas keys (`ui`) intact.
3. **`load_template(strict=False)` everywhere.** Pocket creation never fails because of a stale template; the pocket retains the slug for retry, and a WARNING surfaces the drift to operators.
4. **Single seam.** `resolve_pocket_template` is the only path the bulk dispatcher and temporal scheduler use. A future row-source / template-version pinning PR has one well-defined seam to extend.

## Out of scope (deliberately deferred)

- Template version pinning (`template_version` on the pocket).
- Schema-diff / upgrade prompts when a bound template changes.
- Persistence of compiled rippleSpec separate from the live one (the `pocket.lock.json` idea from the RFC).
- A migration script for legacy pockets — the optional field means none is needed.
- paw-enterprise UI for selecting a template at pocket creation.

## Closes / unblocks

- Closes Wave 3b's `bulk_action.template_resolver_pending` stub.
- Closes Wave 3d's `_resolve_pocket_template_and_rows -> (None, [])` stub.
- Unblocks the paw-enterprise side that needs `templateSlug` on the wire to surface a "based on template" badge.
