### PR TITLE
feat(cli): wire Fabric tier:registered validation into template lint for RFC 03 v2

### DIFF
--- a/src/pocketpaw/__main__.py
+++ b/src/pocketpaw/__main__.py
@@ -1,6 +1,14 @@
 """PocketPaw entry point.
 
 Changes:
+  - 2026-05-28: Wave 4b — `template lint` now also enforces Fabric
+                `tier: registered` policy via
+                `validate_template_with_registry`. Defaults to
+                `NullFabricRegistry` (synthetic-tier templates lint
+                clean; registered-tier surfaces errors). New top-level
+                `--registry <path>` flag loads a JSONFileFabricRegistry
+                mock so developers can lint against a synthetic Fabric
+                without standing up the EE backend.
   - 2026-05-28: Added `template publish / install / upgrade` subactions
                 for RFC 03 v2 Wave 4a — content-addressed, optionally
                 signed (Ed25519) template bundles. Local-file only —
@@ -211,6 +219,7 @@ def _handle_early_command(args) -> int | None:
             destination=getattr(args, "dest", None),
             verify_key_path=getattr(args, "verify_key", None),
             no_prompt=getattr(args, "no_prompt", False),
+            registry_path=getattr(args, "registry", None),
         )
 
     return None
@@ -415,6 +424,18 @@ Examples:
         help=(
             "Refuse to apply a destructive template upgrade rather than "
             "prompting interactively (exit code 2)"
+        ),
+    )
+    # ── Wave 4b lint flag ──
+    parser.add_argument(
+        "--registry",
+        type=str,
+        default=None,
+        dest="registry",
+        help=(
+            "JSON Fabric-registry file for `template lint`. Defaults to "
+            "NullFabricRegistry (synthetic-tier templates lint clean; "
+            "registered-tier surfaces errors)."
         ),
     )
 

--- a/src/pocketpaw/bundled_templates/__init__.py
+++ b/src/pocketpaw/bundled_templates/__init__.py
@@ -37,6 +37,12 @@
 # ``BulkExecutionError``). PR 2e is the LAST library-layer piece —
 # composes the per-row composer (PR 2d) into the batch-approval
 # contract from RFC §"Bulk action execution model".
+# Modified 2026-05-28 (feat/wave-4b-lint-fabric): re-exports
+# ``JSONFileFabricRegistry`` — the OSS-side JSON-backed
+# :class:`FabricRegistry` implementation that powers ``pocketpaw
+# template lint --registry <path>``. Wave 4c will replace it with the
+# live EE FabricRegistry; until then, this is the developer-facing mock
+# for ``tier: registered`` lint workflows.
 """Built-in pocket templates bundled and auto-installed by PocketPaw.
 
 Third sibling to ``pocketpaw.bundled_skills`` and ``pocketpaw.bundled_kb``.
@@ -117,6 +123,10 @@ from pocketpaw.bundled_templates.instinct_composer import (
     InstinctVerdict,
     resolve_instinct,
 )
+from pocketpaw.bundled_templates.json_registry import (
+    JSONFileFabricRegistry,
+    JSONFileFabricRegistryError,
+)
 from pocketpaw.bundled_templates.loader import load_template
 from pocketpaw.bundled_templates.schema import (
     ActionDef,
@@ -161,6 +171,8 @@ __all__ = [
     "InstinctRule",
     "InstinctRulesDef",
     "InstinctVerdict",
+    "JSONFileFabricRegistry",
+    "JSONFileFabricRegistryError",
     "JoinedEntity",
     "NullFabricRegistry",
     "PermissionsDef",

--- a/src/pocketpaw/bundled_templates/json_registry.py
+++ b/src/pocketpaw/bundled_templates/json_registry.py
@@ -1,0 +1,170 @@
+# src/pocketpaw/bundled_templates/json_registry.py
+# Created: 2026-05-28 (feat/wave-4b-lint-fabric) — OSS-side
+# :class:`FabricRegistry` implementation backed by a JSON manifest on
+# disk. Wave 4b ships it as the ``--registry <path>`` override for
+# ``pocketpaw template lint``. Wave 4c will replace it with the live EE
+# FabricRegistry inside the enterprise path; until then, this is what
+# lets a developer lint a ``tier: registered`` template without
+# standing up the EE backend.
+"""JSON-file backed :class:`FabricRegistry` for OSS lint workflows.
+
+The class is a thin, immutable view over a hand-authored JSON manifest:
+
+.. code-block:: json
+
+    {
+      "entity_types": ["Lease", "Tenant", "Property"],
+      "links": [
+        {"from": "Lease", "to": "Tenant", "name": "lease_tenant"},
+        {"from": "Lease", "to": "Property", "name": "lease_property"}
+      ],
+      "entity_properties": {
+        "Lease": ["expiry_date", "rent_current", "rent_proposed"],
+        "Tenant": ["name", "email", "late_payment_count_12mo"]
+      }
+    }
+
+Every top-level key defaults to empty when absent, so ``{}`` is a
+valid, no-op manifest equivalent to :class:`NullFabricRegistry`. A
+malformed file (missing the JSON top-level, malformed link entry,
+unreadable I/O) raises :class:`JSONFileFabricRegistryError` — a
+:class:`ValueError` subclass so the lint CLI can catch it alongside
+its own template-parse errors.
+
+The class is not registered as the default in any wiring. The CLI
+constructs one only when the operator passes ``--registry <path>``;
+otherwise lint runs against :class:`NullFabricRegistry`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+class JSONFileFabricRegistryError(ValueError):
+    """Raised by :class:`JSONFileFabricRegistry` on a malformed manifest.
+
+    Subclasses :class:`ValueError` so the lint CLI's existing
+    ``ValueError`` catch (used for template-parse errors) also covers
+    registry-load failures without a separate ``except`` clause.
+    """
+
+
+class JSONFileFabricRegistry:
+    """A :class:`FabricRegistry` implementation backed by a JSON file.
+
+    Loads the manifest once at construction time and answers every
+    Protocol method from in-memory data structures — no I/O on the hot
+    path. Instances are conceptually immutable; do not mutate the
+    backing collections from outside.
+    """
+
+    __slots__ = ("_entities", "_links", "_properties", "_path")
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._entities: set[str] = set()
+        self._links: set[tuple[str, str, str]] = set()
+        self._properties: dict[str, set[str]] = {}
+        self._load(path)
+
+    # -- Protocol surface ----------------------------------------------------
+
+    def entity_type_exists(self, name: str) -> bool:
+        return name in self._entities
+
+    def link_exists(self, from_type: str, to_type: str, link_name: str) -> bool:
+        return (from_type, to_type, link_name) in self._links
+
+    def get_entity_properties(self, name: str) -> set[str]:
+        # Return a copy so external callers can't mutate the backing set.
+        return set(self._properties.get(name, set()))
+
+    # -- Internals -----------------------------------------------------------
+
+    def _load(self, path: Path) -> None:
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise JSONFileFabricRegistryError(
+                f"failed to read Fabric registry file {path}: {exc}"
+            ) from exc
+        try:
+            data: Any = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise JSONFileFabricRegistryError(
+                f"failed to parse Fabric registry file {path}: {exc}"
+            ) from exc
+
+        if not isinstance(data, dict):
+            raise JSONFileFabricRegistryError(
+                f"{path}: expected a JSON object at top level, got {type(data).__name__}"
+            )
+
+        entity_types = data.get("entity_types", [])
+        if not isinstance(entity_types, list):
+            raise JSONFileFabricRegistryError(f"{path}: 'entity_types' must be a list of strings")
+        for name in entity_types:
+            if not isinstance(name, str):
+                raise JSONFileFabricRegistryError(
+                    f"{path}: 'entity_types' entries must be strings (got {name!r})"
+                )
+            self._entities.add(name)
+
+        links = data.get("links", [])
+        if not isinstance(links, list):
+            raise JSONFileFabricRegistryError(f"{path}: 'links' must be a list of objects")
+        for entry in links:
+            if not isinstance(entry, dict):
+                raise JSONFileFabricRegistryError(
+                    f"{path}: each 'links' entry must be an object (got {type(entry).__name__})"
+                )
+            missing = [k for k in ("from", "to", "name") if k not in entry]
+            if missing:
+                raise JSONFileFabricRegistryError(
+                    f"{path}: link entry {entry!r} is missing key(s): {', '.join(missing)}"
+                )
+            from_type = entry["from"]
+            to_type = entry["to"]
+            link_name = entry["name"]
+            if not (
+                isinstance(from_type, str)
+                and isinstance(to_type, str)
+                and isinstance(link_name, str)
+            ):
+                raise JSONFileFabricRegistryError(
+                    f"{path}: link entry {entry!r} must have string 'from', 'to', 'name'"
+                )
+            self._links.add((from_type, to_type, link_name))
+
+        props = data.get("entity_properties", {})
+        if not isinstance(props, dict):
+            raise JSONFileFabricRegistryError(
+                f"{path}: 'entity_properties' must be an object mapping "
+                "entity name -> list of strings"
+            )
+        for entity_name, prop_list in props.items():
+            if not isinstance(entity_name, str):
+                raise JSONFileFabricRegistryError(
+                    f"{path}: 'entity_properties' keys must be strings"
+                )
+            if not isinstance(prop_list, list):
+                raise JSONFileFabricRegistryError(
+                    f"{path}: 'entity_properties[{entity_name}]' must be a list of strings"
+                )
+            prop_set: set[str] = set()
+            for prop in prop_list:
+                if not isinstance(prop, str):
+                    raise JSONFileFabricRegistryError(
+                        f"{path}: 'entity_properties[{entity_name}]' entries must be strings"
+                    )
+                prop_set.add(prop)
+            self._properties[entity_name] = prop_set
+
+
+__all__ = [
+    "JSONFileFabricRegistry",
+    "JSONFileFabricRegistryError",
+]

--- a/src/pocketpaw/cli/template.py
+++ b/src/pocketpaw/cli/template.py
@@ -22,8 +22,16 @@
 #   * ``upgrade``  — diff an installed template against a new bundle
 #                    (or installed-slug pair), prompt for destructive
 #                    changes, apply non-destructive updates silently.
-# Fabric tier:registered + via_link enforcement in lint is deferred to
-# the Fabric integration PR (PR 2g).
+# Modified 2026-05-28 (feat/wave-4b-lint-fabric): ``lint`` now also
+# calls ``validate_template_with_registry`` after Pydantic validation
+# passes. Default registry is :class:`NullFabricRegistry` (synthetic-
+# tier templates lint clean; registered-tier templates surface errors —
+# the correct loud signal that Fabric isn't wired). New
+# ``registry_path`` parameter (CLI ``--registry <path>``) loads a JSON-
+# backed mock via :class:`JSONFileFabricRegistry` so developers can
+# lint registered-tier templates without standing up the EE
+# FabricRegistry. ``--json`` output gains a ``fabric_validations``
+# array; warnings keep exit 0, any severity=error fails with exit 1.
 """``pocketpaw template`` — author-side template tooling.
 
 Seven sub-subcommands: ``lint``, ``migrate``, ``diff``, ``compile``,
@@ -142,6 +150,7 @@ def run_template_cmd(
     destination: str | None = None,
     verify_key_path: str | None = None,
     no_prompt: bool = False,
+    registry_path: str | None = None,
 ) -> int:
     """Dispatch ``pocketpaw template <subaction>`` to the right handler.
 
@@ -160,9 +169,13 @@ def run_template_cmd(
 
     if subaction == "lint":
         if not file1:
-            _usage_error("pocketpaw template lint <file>", as_json)
+            _usage_error("pocketpaw template lint <file> [--registry FILE]", as_json)
             return 2
-        return _run_lint(Path(file1), as_json=as_json)
+        return _run_lint(
+            Path(file1),
+            as_json=as_json,
+            registry_path=Path(registry_path) if registry_path else None,
+        )
 
     if subaction == "migrate":
         if not file1:
@@ -243,7 +256,12 @@ def _usage_error(usage: str, as_json: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _run_lint(path: Path, *, as_json: bool) -> int:
+def _run_lint(
+    path: Path,
+    *,
+    as_json: bool,
+    registry_path: Path | None = None,
+) -> int:
     """Validate one template file.
 
     Steps:
@@ -251,16 +269,20 @@ def _run_lint(path: Path, *, as_json: bool) -> int:
       2. If v1, run the loader's private ``_promote_v1_to_v2`` and remember
          that a rewrite would apply.
       3. Try ``PocketTemplate.model_validate(merged)``.
-      4. Compute heuristic warnings (pattern × shape only — Fabric
-         ``via_link`` registry enforcement is out of scope).
-      5. Print human-readable or JSON output.
+      4. Load the Fabric registry — :class:`NullFabricRegistry` by
+         default, :class:`JSONFileFabricRegistry` when ``registry_path``
+         is supplied — and call ``validate_template_with_registry``.
+      5. Compute heuristic warnings (pattern × shape pairings).
+      6. Print human-readable or JSON output. Exit code: 0 when every
+         Fabric finding has severity=warning (and Pydantic passed); 1
+         on any severity=error finding.
     """
 
     # Phase 1 — read + parse
     try:
         meta = _parse_file(path)
     except ValueError as exc:
-        return _lint_fail(path, [str(exc)], [], False, as_json)
+        return _lint_fail(path, [str(exc)], [], [], False, as_json)
 
     promoted_from_v1 = _is_v1(meta)
 
@@ -275,17 +297,64 @@ def _run_lint(path: Path, *, as_json: bool) -> int:
 
         from pocketpaw.bundled_templates.schema import PocketTemplate  # noqa: PLC0415
 
-        PocketTemplate.model_validate(merged)
+        template = PocketTemplate.model_validate(merged)
     except ValidationError as exc:
         errors = _format_pydantic_errors(exc)
-        return _lint_fail(path, errors, [], promoted_from_v1, as_json)
+        return _lint_fail(path, errors, [], [], promoted_from_v1, as_json)
     except Exception as exc:  # noqa: BLE001 — defensive
-        return _lint_fail(path, [f"unexpected error: {exc}"], [], promoted_from_v1, as_json)
+        return _lint_fail(path, [f"unexpected error: {exc}"], [], [], promoted_from_v1, as_json)
 
-    # Phase 4 — heuristic warnings (Pydantic already passed)
+    # Phase 4 — Fabric tier:registered validation
+    from pocketpaw.bundled_templates.fabric_registry import (  # noqa: PLC0415
+        NullFabricRegistry,
+    )
+
+    registry: Any
+    if registry_path is None:
+        registry = NullFabricRegistry()
+    else:
+        from pocketpaw.bundled_templates.json_registry import (  # noqa: PLC0415
+            JSONFileFabricRegistry,
+            JSONFileFabricRegistryError,
+        )
+
+        try:
+            registry = JSONFileFabricRegistry(registry_path)
+        except JSONFileFabricRegistryError as exc:
+            return _lint_fail(path, [str(exc)], [], [], promoted_from_v1, as_json)
+
+    from pocketpaw.bundled_templates.fabric_validator import (  # noqa: PLC0415
+        validate_template_with_registry,
+    )
+
+    fabric_findings = validate_template_with_registry(template, registry)
+    fabric_payload = [
+        {
+            "severity": f.severity,
+            "message": f.message,
+            "path": f.path,
+            "data": dict(f.data),
+        }
+        for f in fabric_findings
+    ]
+    fabric_errors = [f for f in fabric_findings if f.severity == "error"]
+    fabric_warnings = [f for f in fabric_findings if f.severity == "warning"]
+
+    # Phase 5 — heuristic warnings (Pydantic already passed)
     warnings = _compute_warnings(merged)
 
-    # Phase 5 — output
+    # Phase 6 — output. Exit 1 only when Fabric surfaces a severity=error
+    # finding; warnings stay informational.
+    if fabric_errors:
+        return _lint_fail(
+            path,
+            [_format_fabric_error(f) for f in fabric_errors],
+            warnings,
+            fabric_payload,
+            promoted_from_v1,
+            as_json,
+        )
+
     name = merged.get("name", "<unknown>")
     if as_json:
         output_json(
@@ -296,6 +365,7 @@ def _run_lint(path: Path, *, as_json: bool) -> int:
                 "warnings": warnings,
                 "schema_version": "v2",
                 "promoted_from_v1": promoted_from_v1,
+                "fabric_validations": fabric_payload,
             }
         )
     else:
@@ -308,6 +378,8 @@ def _run_lint(path: Path, *, as_json: bool) -> int:
             )
         for w in warnings:
             print_warn(w)
+        for f in fabric_warnings:
+            print_warn(f"fabric: {_format_fabric_error(f)}")
     return 0
 
 
@@ -315,6 +387,7 @@ def _lint_fail(
     path: Path,
     errors: list[str],
     warnings: list[str],
+    fabric_payload: list[dict[str, Any]],
     promoted_from_v1: bool,
     as_json: bool,
 ) -> int:
@@ -327,6 +400,7 @@ def _lint_fail(
                 "warnings": warnings,
                 "schema_version": "v2",
                 "promoted_from_v1": promoted_from_v1,
+                "fabric_validations": fabric_payload,
             }
         )
         return 1
@@ -336,6 +410,12 @@ def _lint_fail(
     for w in warnings:
         print_warn(w)
     return 1
+
+
+def _format_fabric_error(finding: Any) -> str:
+    """Render a :class:`FabricValidationError` as a one-line lint string
+    matching the Pydantic-error format (``"at <path>: <message>"``)."""
+    return f"at {finding.path!r}: {finding.message}"
 
 
 def _format_pydantic_errors(exc: Any) -> list[str]:

--- a/tests/unit/test_cli_template.py
+++ b/tests/unit/test_cli_template.py
@@ -4,6 +4,15 @@
 # Modified 2026-05-25 (feat/rfc-03-v2-compile): added tests for the
 # new ``compile`` subaction — JSON (default) + YAML (--yaml) output,
 # end-to-end through the dispatch path, plus argparse wiring sanity.
+# Modified 2026-05-28 (feat/wave-4b-lint-fabric): added Wave 4b
+# ``lint`` Fabric-tier coverage. ``_run_lint`` now calls
+# ``validate_template_with_registry`` after the Pydantic chokepoint
+# passes, defaulting to ``NullFabricRegistry`` and accepting a
+# ``--registry <path>`` JSON override. The new tests cover:
+#   * synthetic-tier templates (no joins) lint clean against Null;
+#   * registered-tier templates fail against Null (correct loud signal);
+#   * a JSON registry mock unblocks the same template;
+#   * ``--json`` output gains a ``fabric_validations`` array.
 # These cover the six contract pillars from RFC 03 v2 "Style and tooling
 # notes":
 #   1. lint on a clean v2 fixture exits 0 and reports schema_version.
@@ -116,8 +125,30 @@ def _write_json(path: Path, data: dict) -> Path:
 # ===========================================================================
 
 
-def test_lint_clean_v2_fixture_exits_zero_and_reports_schema_version() -> None:
-    rc, out = _capture(run_template_cmd, subaction="lint", file1=str(_LEASE_V2))
+def test_lint_clean_v2_fixture_exits_zero_and_reports_schema_version(tmp_path: Path) -> None:
+    # Wave 4b: lease-renewal-v2 declares joined_entities (registered
+    # tier), so the default NullFabricRegistry would fail it. Pass an
+    # explicit JSON registry mock that satisfies the joins so the test
+    # exercises the "clean v2 fixture" path it originally targeted.
+    reg = tmp_path / "fabric.json"
+    reg.write_text(
+        json.dumps(
+            {
+                "entity_types": ["Lease", "Tenant", "Property"],
+                "links": [
+                    {"from": "Lease", "to": "Tenant", "name": "lease_tenant"},
+                    {"from": "Lease", "to": "Property", "name": "lease_property"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(_LEASE_V2),
+        registry_path=str(reg),
+    )
     assert rc == 0
     assert "valid" in out.lower()
     # surfaces both the schema version and the slug name
@@ -962,3 +993,165 @@ def test_argparse_template_no_prompt_flag(tmp_path: Path) -> None:
     _resolve_subargs(args)
     assert args.subaction == "upgrade"
     assert getattr(args, "no_prompt", False) is True
+
+
+# ===========================================================================
+# Wave 4b — pocketpaw template lint Fabric ``tier: registered`` enforcement
+# ===========================================================================
+#
+# After Pydantic validation succeeds, ``_run_lint`` now calls
+# ``validate_template_with_registry``. The default registry is
+# ``NullFabricRegistry`` — synthetic-tier templates (no dot-paths, no
+# joined entities) lint clean; registered-tier templates surface errors,
+# which is the correct loud signal that Fabric isn't wired. A
+# ``--registry <path>`` flag accepts a JSON file describing entity
+# types + links so a developer can lint against a mock Fabric before
+# the EE registry ships.
+# ===========================================================================
+
+
+_BUNDLED_DECISION_GRAPH = _BUNDLED_DIR / "decision-graph" / "template.pocket.yaml"
+
+
+def _lease_registry_json() -> dict:
+    """A JSON manifest that satisfies the lease-renewal fixture."""
+    return {
+        "entity_types": ["Lease", "Tenant", "Property"],
+        "links": [
+            {"from": "Lease", "to": "Tenant", "name": "lease_tenant"},
+            {"from": "Lease", "to": "Property", "name": "lease_property"},
+        ],
+    }
+
+
+def test_lint_synthetic_v2_passes_with_null_registry() -> None:
+    """``todo-task-tracker`` declares no joins / dot-paths — clean
+    against the default NullFabricRegistry."""
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(_TODO_V2),
+        as_json=True,
+    )
+    assert rc == 0, out
+    data = json.loads(out)
+    assert data["valid"] is True
+    assert data["fabric_validations"] == []
+
+
+def test_lint_decision_graph_template_passes_with_null_registry() -> None:
+    """``decision-graph`` ships ``shape: custom`` with no joins — must
+    stay clean against the Null default."""
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(_BUNDLED_DECISION_GRAPH),
+        as_json=True,
+    )
+    assert rc == 0, out
+    data = json.loads(out)
+    assert data["valid"] is True
+    assert data["fabric_validations"] == []
+
+
+def test_lint_registered_tier_template_fails_with_null_registry() -> None:
+    """The lease-renewal fixture declares ``joined_entities`` — Null
+    can't satisfy that, so lint must exit 1 with Fabric errors."""
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(_LEASE_V2),
+        as_json=True,
+    )
+    assert rc == 1, out
+    data = json.loads(out)
+    assert data["valid"] is False
+    fab = data["fabric_validations"]
+    assert isinstance(fab, list)
+    assert len(fab) > 0
+    # Each entry exposes the documented contract surface.
+    for entry in fab:
+        assert set(entry) >= {"severity", "message", "path", "data"}
+        assert entry["severity"] == "error"
+
+
+def test_lint_registered_tier_template_passes_with_json_registry(tmp_path: Path) -> None:
+    """The same lease fixture, against a JSON-registry mock that knows
+    the entity types + via_links, lints clean."""
+    reg_path = tmp_path / "fabric.json"
+    reg_path.write_text(json.dumps(_lease_registry_json()), encoding="utf-8")
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(_LEASE_V2),
+        registry_path=str(reg_path),
+        as_json=True,
+    )
+    assert rc == 0, out
+    data = json.loads(out)
+    assert data["valid"] is True
+    assert data["fabric_validations"] == []
+
+
+def test_lint_human_output_surfaces_fabric_errors() -> None:
+    """Human-readable lint must render Fabric errors when they fire —
+    the JSON path is for scripting; the default path needs operator-
+    legible failure lines."""
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(_LEASE_V2),
+    )
+    assert rc == 1, out
+    lower = out.lower()
+    assert "fabric" in lower or "via_link" in lower or "registered" in lower
+
+
+def test_lint_missing_registry_file_exits_one(tmp_path: Path) -> None:
+    """``--registry <path>`` where the path doesn't exist surfaces a
+    clean lint failure (exit 1) rather than crashing."""
+    rc, _out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(_TODO_V2),
+        registry_path=str(tmp_path / "missing.json"),
+    )
+    assert rc == 1
+
+
+def test_lint_malformed_registry_file_exits_one(tmp_path: Path) -> None:
+    """A registry file with malformed JSON also surfaces as a lint
+    failure rather than a crash."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ this is :: not json", encoding="utf-8")
+    rc, out = _capture(
+        run_template_cmd,
+        subaction="lint",
+        file1=str(_TODO_V2),
+        registry_path=str(bad),
+        as_json=True,
+    )
+    assert rc == 1
+    data = json.loads(out)
+    # The error surfaces in the top-level errors list — registry-load
+    # failures are not Fabric-validation failures (different lifecycle).
+    assert data["valid"] is False
+    assert any("registry" in e.lower() or "json" in e.lower() for e in data["errors"])
+
+
+def test_argparse_template_lint_registry_flag(tmp_path: Path) -> None:
+    """``--registry <path>`` parses through argparse alongside the
+    template subcommand."""
+    from pocketpaw.__main__ import _build_parser, _resolve_subargs
+
+    parser = _build_parser()
+    reg = tmp_path / "fabric.json"
+    args, unknown = parser.parse_known_args(
+        ["template", "lint", str(_LEASE_V2), "--registry", str(reg)]
+    )
+    if unknown:
+        args.subargs = list(args.subargs or []) + [a for a in unknown if not a.startswith("-")]
+    _resolve_subargs(args)
+    assert args.subaction == "lint"
+    assert args.file1 == str(_LEASE_V2)
+    assert getattr(args, "registry", None) == str(reg)

--- a/tests/unit/test_json_registry.py
+++ b/tests/unit/test_json_registry.py
@@ -1,0 +1,237 @@
+# tests/unit/test_json_registry.py
+# Created: 2026-05-28 (feat/wave-4b-lint-fabric) — RED-first tests for
+# ``JSONFileFabricRegistry``, the OSS-side mock that lets developers
+# lint ``tier: registered`` templates against a synthetic entity-type +
+# link manifest without standing up the EE Fabric backend.
+"""Tests for ``pocketpaw.bundled_templates.json_registry``.
+
+The registry implements the :class:`FabricRegistry` Protocol from a
+JSON manifest on disk. Wave 4b ships it as the ``--registry <path>``
+override for ``pocketpaw template lint``. Wave 4c will replace it with
+the live EE FabricRegistry inside the enterprise path.
+
+Coverage:
+
+1. Round-trip — a manifest with entities, links, and properties loads
+   and answers every Protocol method correctly.
+2. Defaults — missing top-level keys default to empty (so ``{}`` is a
+   valid, no-op registry).
+3. Malformed JSON / missing file — raises a typed error subclassing
+   :class:`ValueError` so the lint CLI can catch alongside its own
+   parse errors.
+4. Protocol conformance — the class satisfies
+   ``isinstance(reg, FabricRegistry)`` at runtime.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.bundled_templates import FabricRegistry, JSONFileFabricRegistry
+from pocketpaw.bundled_templates.json_registry import JSONFileFabricRegistryError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, data: dict) -> Path:
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _full_manifest() -> dict:
+    return {
+        "entity_types": ["Lease", "Tenant", "Property"],
+        "links": [
+            {"from": "Lease", "to": "Tenant", "name": "lease_tenant"},
+            {"from": "Lease", "to": "Property", "name": "lease_property"},
+        ],
+        "entity_properties": {
+            "Lease": ["expiry_date", "rent_current", "rent_proposed", "renewal_stage"],
+            "Tenant": ["name", "email", "late_payment_count_12mo"],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_load_full_manifest_round_trips(tmp_path: Path) -> None:
+    path = _write(tmp_path / "fabric.json", _full_manifest())
+    reg = JSONFileFabricRegistry(path)
+
+    assert reg.entity_type_exists("Lease") is True
+    assert reg.entity_type_exists("Tenant") is True
+    assert reg.entity_type_exists("Property") is True
+    assert reg.entity_type_exists("Ghost") is False
+
+    assert reg.link_exists("Lease", "Tenant", "lease_tenant") is True
+    assert reg.link_exists("Lease", "Property", "lease_property") is True
+    assert reg.link_exists("Lease", "Tenant", "wrong_name") is False
+    assert reg.link_exists("Tenant", "Lease", "lease_tenant") is False  # direction matters
+    assert reg.link_exists("Ghost", "Tenant", "lease_tenant") is False
+
+    assert reg.get_entity_properties("Lease") == {
+        "expiry_date",
+        "rent_current",
+        "rent_proposed",
+        "renewal_stage",
+    }
+    assert reg.get_entity_properties("Tenant") == {
+        "name",
+        "email",
+        "late_payment_count_12mo",
+    }
+    # Unknown entity → empty set, matching NullFabricRegistry.
+    assert reg.get_entity_properties("Ghost") == set()
+
+
+def test_runtime_protocol_check(tmp_path: Path) -> None:
+    """``isinstance(reg, FabricRegistry)`` must succeed at runtime."""
+    path = _write(tmp_path / "fabric.json", _full_manifest())
+    reg = JSONFileFabricRegistry(path)
+    assert isinstance(reg, FabricRegistry)
+
+
+# ---------------------------------------------------------------------------
+# Defaults — partial manifests
+# ---------------------------------------------------------------------------
+
+
+def test_missing_entity_types_key_defaults_to_empty(tmp_path: Path) -> None:
+    path = _write(tmp_path / "fabric.json", {"links": [], "entity_properties": {}})
+    reg = JSONFileFabricRegistry(path)
+    assert reg.entity_type_exists("Lease") is False
+    # Other methods still work — properties returns empty, link returns False.
+    assert reg.get_entity_properties("Lease") == set()
+    assert reg.link_exists("Lease", "Tenant", "x") is False
+
+
+def test_missing_links_key_defaults_to_empty(tmp_path: Path) -> None:
+    path = _write(tmp_path / "fabric.json", {"entity_types": ["Lease"]})
+    reg = JSONFileFabricRegistry(path)
+    assert reg.entity_type_exists("Lease") is True
+    assert reg.link_exists("Lease", "Tenant", "lease_tenant") is False
+
+
+def test_missing_entity_properties_key_defaults_to_empty(tmp_path: Path) -> None:
+    path = _write(tmp_path / "fabric.json", {"entity_types": ["Lease"]})
+    reg = JSONFileFabricRegistry(path)
+    assert reg.get_entity_properties("Lease") == set()
+
+
+def test_empty_object_manifest_loads_cleanly(tmp_path: Path) -> None:
+    """``{}`` is a valid manifest — yields a no-op registry equivalent
+    to :class:`NullFabricRegistry`."""
+    path = _write(tmp_path / "fabric.json", {})
+    reg = JSONFileFabricRegistry(path)
+    assert reg.entity_type_exists("Anything") is False
+    assert reg.link_exists("A", "B", "x") is False
+    assert reg.get_entity_properties("X") == set()
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file_raises_typed_error(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.json"
+    with pytest.raises(JSONFileFabricRegistryError) as excinfo:
+        JSONFileFabricRegistry(missing)
+    # ValueError-compatible so the lint CLI can catch it alongside its
+    # own parse errors.
+    assert isinstance(excinfo.value, ValueError)
+    assert "nope.json" in str(excinfo.value)
+
+
+def test_malformed_json_raises_typed_error(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{ not: valid, json", encoding="utf-8")
+    with pytest.raises(JSONFileFabricRegistryError) as excinfo:
+        JSONFileFabricRegistry(path)
+    assert isinstance(excinfo.value, ValueError)
+
+
+def test_non_object_top_level_raises(tmp_path: Path) -> None:
+    """Top-level array / scalar is not a valid manifest shape."""
+    path = tmp_path / "bad.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(JSONFileFabricRegistryError):
+        JSONFileFabricRegistry(path)
+
+
+def test_malformed_link_entry_raises(tmp_path: Path) -> None:
+    """A link entry missing ``from``/``to``/``name`` is a hard error so
+    typos surface at lint time rather than silently flipping a check
+    to ``False``."""
+    path = _write(
+        tmp_path / "fabric.json",
+        {"entity_types": ["Lease"], "links": [{"from": "Lease", "to": "Tenant"}]},
+    )
+    with pytest.raises(JSONFileFabricRegistryError):
+        JSONFileFabricRegistry(path)
+
+
+# ---------------------------------------------------------------------------
+# Plays nicely with the validator
+# ---------------------------------------------------------------------------
+
+
+def test_full_manifest_lints_lease_fixture_clean(tmp_path: Path) -> None:
+    """Loaded against the lease fixture, the full manifest produces no
+    Fabric errors — proving the OSS-side mock can stand in for an EE
+    Fabric registry."""
+    import yaml
+
+    from pocketpaw.bundled_templates import (
+        PocketTemplate,
+        validate_template_with_registry,
+    )
+
+    path = _write(tmp_path / "fabric.json", _full_manifest())
+    reg = JSONFileFabricRegistry(path)
+
+    lease_path = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "templates" / "lease-renewal-v2.yaml"
+    )
+    template = PocketTemplate.model_validate(yaml.safe_load(lease_path.read_text()))
+    errors = validate_template_with_registry(template, reg)
+    assert errors == []
+
+
+def test_partial_manifest_surfaces_only_unknown_link(tmp_path: Path) -> None:
+    """Manifest knows the entity types but not the via_link → the
+    validator emits the expected unregistered-link errors and nothing
+    else."""
+    import yaml
+
+    from pocketpaw.bundled_templates import (
+        PocketTemplate,
+        validate_template_with_registry,
+    )
+
+    path = _write(
+        tmp_path / "fabric.json",
+        {"entity_types": ["Lease", "Tenant", "Property"], "links": []},
+    )
+    reg = JSONFileFabricRegistry(path)
+
+    lease_path = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "templates" / "lease-renewal-v2.yaml"
+    )
+    template = PocketTemplate.model_validate(yaml.safe_load(lease_path.read_text()))
+    errors = validate_template_with_registry(template, reg)
+
+    # Two joined entities both fail via_link — but entity_type checks
+    # pass (we declared them above).
+    via_link_errors = [e for e in errors if "via_link" in e.path]
+    assert len(via_link_errors) == 2
+    entity_type_errors = [e for e in errors if e.path.endswith(".entity_type")]
+    assert entity_type_errors == []


### PR DESCRIPTION
## Summary

Wave 4b of RFC 03 v2: wires `validate_template_with_registry` (PR 2g, OSS library) into the existing `pocketpaw template lint <file>` subcommand and adds a `--registry <path>` developer-side mock so registered-tier templates can be linted before the EE FabricRegistry ships.

- After Pydantic chokepoint passes, `_run_lint` calls `validate_template_with_registry` against a registry. Default is `NullFabricRegistry`: synthetic-tier templates (no joined_entities, no dot-paths) lint clean; registered-tier templates surface every miss as a `[FAIL]` line — the correct loud signal that Fabric isn't wired.
- New `JSONFileFabricRegistry` reads a JSON manifest (`entity_types`, `links`, `entity_properties`) once at construction and answers the `FabricRegistry` Protocol from in-memory data. Malformed JSON / missing keys raise `JSONFileFabricRegistryError` (a `ValueError` subclass) so the lint CLI's existing parse-error path catches it.
- `--json` lint output gains a `fabric_validations` array with `{severity, message, path, data}` per finding. Exit code: `0` when every finding is `severity=warning`; `1` on any `severity=error`. Pre-existing JSON keys (`file`, `valid`, `errors`, `warnings`, `schema_version`, `promoted_from_v1`) are unchanged.

## Locked decisions

- **Default registry is `NullFabricRegistry`.** Synthetic templates lint clean. Registered-tier templates need a registry — failing loudly is the contract.
- **`--registry` is the OSS-side mock**, not the EE call. Wave 4c will auto-wire the EE FabricRegistry inside the enterprise dispatch path.
- **Warning vs error severity matters.** Warning-only findings keep exit `0`; any `severity=error` flips to `1`. Matches mypy / ruff behaviour.
- **`fabric_validations` is additive** in `--json` output. No breaking change for existing consumers.

## Scope

In:

- Modified `src/pocketpaw/cli/template.py` — `_run_lint` calls Fabric validator after Pydantic; `_lint_fail` carries the `fabric_payload`; new `_format_fabric_error` helper.
- Modified `src/pocketpaw/__main__.py` — new `--registry` top-level flag, threaded through `_handle_early_command` into `run_template_cmd`.
- New `src/pocketpaw/bundled_templates/json_registry.py` (~170 LOC) — `JSONFileFabricRegistry` + typed `JSONFileFabricRegistryError`.
- Re-exports from `bundled_templates/__init__.py`.
- Extended `tests/unit/test_cli_template.py` with 8 new Fabric tests + retargeted the existing `lease-renewal-v2` clean-fixture test through the new `--registry` mock.
- New `tests/unit/test_json_registry.py` (~200 LOC, 12 tests) covering round-trip, defaults, malformed inputs, Protocol conformance, validator integration.

Out (separate PRs):

- Wave 4c: concrete EE FabricRegistry backed by SQLite.
- Wiring the Fabric check into other subcommands (`compile`, `migrate`, `diff`).
- Auto-discovery of `~/.pocketpaw/fabric_registry.json` or similar — explicit `--registry` only.

## Smoke tests

```
$ uv run pocketpaw template lint src/pocketpaw/bundled_templates/_bundled/todo-task-tracker/template.pocket.yaml
[OK]   ... is valid (schema_version=v2, name=todo-task-tracker)

$ uv run pocketpaw template lint tests/fixtures/templates/lease-renewal-v2.yaml; echo exit=$?
[FAIL] tests/fixtures/templates/lease-renewal-v2.yaml failed validation:
    - at 'state.entity_type': unknown entity_type: 'Lease' is not registered in the Fabric registry
    - at 'state.joined_entities[0].entity_type': unknown joined entity_type: 'Tenant' on joined_entities[0] (name='tenant')
    - at 'state.joined_entities[0].via_link': via_link not registered: 'lease_tenant' on Lease->Tenant (joined_entities[0].name='tenant')
    - at 'state.joined_entities[1].entity_type': unknown joined entity_type: 'Property' on joined_entities[1] (name='property')
    - at 'state.joined_entities[1].via_link': via_link not registered: 'lease_property' on Lease->Property (joined_entities[1].name='property')
exit=1

$ uv run pocketpaw template lint tests/fixtures/templates/lease-renewal-v2.yaml --registry /tmp/lease-fabric.json; echo exit=$?
[OK]   ... is valid (schema_version=v2, name=lease-renewal-v1)
exit=0
```

## Test plan

- [x] `uv run pytest tests/unit/test_cli_template.py tests/unit/test_json_registry.py tests/unit/test_template_schema.py tests/unit/test_fabric_validator.py` — 120 passed
- [x] Wider unit sweep `uv run pytest tests/unit/` — 316 passed, 13 skipped, 0 failures
- [x] `uv run ruff check` + `uv run ruff format` — clean
- [x] Smoke: synthetic template lints clean against NullFabricRegistry
- [x] Smoke: lease-renewal-v2 against NullFabricRegistry → exit 1 with 5 Fabric errors
- [x] Smoke: lease-renewal-v2 against JSON-mock → exit 0, `fabric_validations: []`
- [x] Smoke: `--json` shape includes `fabric_validations` additively
