### PR TITLE
feat(fabric): concrete FabricRegistry backed by SQLite for RFC 03 v2

### DIFF
--- a/ee/pocketpaw_ee/fabric/__init__.py
+++ b/ee/pocketpaw_ee/fabric/__init__.py
@@ -1,7 +1,28 @@
 # pocketpaw_ee/fabric/ — enterprise HTTP surface for the Fabric ontology.
 #
-# The Fabric logic (store, models, policy, projection, events) moved to
-# pocketpaw.fabric in the OSS-EE split (Phase 2). What remains here is the
-# FastAPI router, which gates access behind enterprise license / plan /
-# RBAC checks (pocketpaw_ee.cloud.*). Import the logic from pocketpaw.fabric;
-# import the router from pocketpaw_ee.fabric.router.
+# Created: 2026-03-28 — first introduced as the FastAPI router gating
+# Fabric API access behind enterprise license / plan / RBAC checks.
+# Updated: 2026-05-28 (feat/wave-4c-fabric-registry) — adds the
+# concrete ``WorkspaceFabricRegistry`` (RFC 03 v2 PR 2g promised seam)
+# and its workspace-scoped SQLite write-side
+# (``WorkspaceFabricStore``). The pair satisfies the
+# ``pocketpaw.bundled_templates.FabricRegistry`` Protocol so EE callers
+# can lint / resolve ``tier: registered`` templates against real
+# workspace data instead of the Wave 4b JSON mock.
+#
+# The Fabric *object* layer (live entity instances, links, projection,
+# events) still lives in ``pocketpaw.fabric`` from the Phase 2 OSS-EE
+# split. What lives here is intentionally smaller: the FastAPI router
+# (HTTP gating) and the workspace-scoped *registry* contract (entity
+# type / property / link declarations consumed by the lint + runtime
+# resolver paths). The two layers are independent on purpose — Wave 4b
+# lint must not require booting the full async object store.
+
+from pocketpaw_ee.fabric.registry import WorkspaceFabricRegistry
+from pocketpaw_ee.fabric.storage import DEFAULT_DB_PATH, WorkspaceFabricStore
+
+__all__ = [
+    "DEFAULT_DB_PATH",
+    "WorkspaceFabricRegistry",
+    "WorkspaceFabricStore",
+]

--- a/ee/pocketpaw_ee/fabric/registry.py
+++ b/ee/pocketpaw_ee/fabric/registry.py
@@ -1,0 +1,96 @@
+# ee/pocketpaw_ee/fabric/registry.py
+# Created: 2026-05-28 (feat/wave-4c-fabric-registry) — concrete EE
+# implementation of the ``pocketpaw.bundled_templates.FabricRegistry``
+# Protocol. The class is a thin read-side wrapper that delegates every
+# query to a ``WorkspaceFabricStore`` bound to a single workspace.
+# Mutations stay on the store; the registry stays read-only by design
+# so wiring code can keep one Protocol type in its signatures and the
+# call-site stays simple (``WorkspaceFabricRegistry(store, ws_id)``).
+"""Concrete ``FabricRegistry`` implementation backed by
+:class:`WorkspaceFabricStore`.
+
+The class is the final piece of RFC 03 v2's Fabric tier-registered
+seam. ``pocketpaw.bundled_templates.fabric_registry.FabricRegistry``
+declares the Protocol; Wave 4b shipped the OSS-side JSON mock; this
+module ships the EE-side concrete implementation that satisfies the
+same Protocol against real workspace data.
+
+Why this is a read-only wrapper
+-------------------------------
+
+Two reasons.
+
+1. The Protocol surface is intentionally read-only — three boolean /
+   set-returning methods, no mutators. Keeping the concrete class
+   read-only matches that contract exactly so callers that program
+   against the Protocol can swap registries without behavioural
+   surprises.
+2. Writes have a richer surface (per-entity, per-property, per-link,
+   cascade-delete) that doesn't fit a generic read seam. They live on
+   :class:`WorkspaceFabricStore`. The split mirrors how
+   ``pocketpaw_ee.cloud.<entity>`` separates service writes from
+   read-mapping in the 4-file shape.
+
+How to wire it
+--------------
+
+EE callers construct one per workspace and pass it to the Wave 4b
+validator / runtime resolver:
+
+.. code-block:: python
+
+    store = WorkspaceFabricStore()  # defaults to ~/.pocketpaw/fabric_registry.db
+    registry = WorkspaceFabricRegistry(store=store, workspace_id=ws_id)
+    errors = validate_template_with_registry(template, registry)
+
+The OSS lint CLI still defaults to ``NullFabricRegistry`` /
+``JSONFileFabricRegistry``; an EE auto-wire hook can land in a separate
+PR.
+"""
+
+from __future__ import annotations
+
+from pocketpaw_ee.fabric.storage import WorkspaceFabricStore
+
+
+class WorkspaceFabricRegistry:
+    """Concrete ``FabricRegistry`` for a single workspace.
+
+    Bound to a workspace at construction; every Protocol query
+    delegates to the store with the bound ``workspace_id``. Two
+    registries built against the same store but different workspace
+    ids return disjoint views — multi-tenancy is enforced by the store,
+    not the registry.
+    """
+
+    __slots__ = ("_store", "_workspace_id")
+
+    def __init__(self, store: WorkspaceFabricStore, workspace_id: str) -> None:
+        self._store = store
+        self._workspace_id = workspace_id
+
+    @property
+    def workspace_id(self) -> str:
+        """The workspace this registry is bound to. Exposed so wiring
+        code can sanity-check the binding without poking ``_slots__``
+        internals."""
+        return self._workspace_id
+
+    # -- FabricRegistry Protocol surface -------------------------------------
+
+    def entity_type_exists(self, name: str) -> bool:
+        return self._store.entity_exists(self._workspace_id, name)
+
+    def link_exists(self, from_type: str, to_type: str, link_name: str) -> bool:
+        return self._store.link_exists(self._workspace_id, link_name, from_type, to_type)
+
+    def get_entity_properties(self, name: str) -> set[str]:
+        # Store already returns a fresh set (set comprehension result),
+        # so callers can mutate the returned value without affecting
+        # the store. We return it directly to avoid a redundant copy.
+        return self._store.get_properties(self._workspace_id, name)
+
+
+__all__ = [
+    "WorkspaceFabricRegistry",
+]

--- a/ee/pocketpaw_ee/fabric/storage.py
+++ b/ee/pocketpaw_ee/fabric/storage.py
@@ -1,0 +1,274 @@
+# ee/pocketpaw_ee/fabric/storage.py
+# Created: 2026-05-28 (feat/wave-4c-fabric-registry) — workspace-scoped
+# SQLite storage that backs the concrete ``FabricRegistry`` Protocol
+# implementation in ``ee/pocketpaw_ee/fabric/registry.py``. The store
+# holds the registered entity types, properties, and links that Wave
+# 4b's ``tier: registered`` lint contract consumes. Sync stdlib
+# ``sqlite3`` only — wrap in ``asyncio.to_thread`` at FastAPI call
+# sites if needed. Sibling to ``pocketpaw.fabric.store.FabricStore``
+# (OSS, async, holds the live ontology object data); the ``Workspace``
+# prefix flags the workspace-scoped, registry-only role.
+"""SQLite-backed workspace-scoped Fabric registry store.
+
+The store is the write-side of the concrete ``FabricRegistry``
+implementation that PR 2g promised. Wave 4b ships the OSS-side mock
+(:class:`pocketpaw.bundled_templates.JSONFileFabricRegistry`); Wave 4c
+adds the EE concrete impl so the same Protocol satisfies a real
+workspace's data.
+
+Schema
+------
+
+Three tables. Each row carries a ``workspace`` column and every read
+filters on it — multi-tenant isolation is enforced by the index, not by
+the file path. The single shared file simplifies v0 deployment (one
+SQLite to back up, one to migrate); a future PR can shard to
+per-workspace files without changing the public Python surface.
+
+* ``fabric_entity_types(name, workspace, created_at)`` — registered
+  ObjectType names.
+* ``fabric_entity_properties(entity_type, property_name, property_type,
+  workspace)`` — property declarations.
+* ``fabric_registry_links(name, from_type, to_type, workspace)`` —
+  directed link declarations.
+
+Why a separate store from ``pocketpaw.fabric.FabricStore``
+---------------------------------------------------------
+
+The OSS-side ``FabricStore`` holds the live ontology data (object
+instances + their relationships). This EE-side store holds the
+*registry* — which types and links are *declared* — so the
+``tier: registered`` lint contract has something to check against. The
+data layers are intentionally split: lint-time validation should not
+require booting the full Fabric object store. A future PR can
+rendezvous the two stores once the EE wiring for "auto-register an
+ObjectType definition when one is created via the Fabric API" lands.
+
+Concurrency
+-----------
+
+Each method opens, executes, and closes its own ``sqlite3`` connection.
+That keeps the store thread-safe under FastAPI's default thread-pool
+executor without an explicit lock. Hot-path callers that want
+connection pooling can build it on top; v0 favours correctness over
+throughput because the registry surface is read-mostly and writes are
+admin-driven, not user-driven.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS fabric_entity_types (
+    name TEXT NOT NULL,
+    workspace TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (workspace, name)
+);
+
+CREATE TABLE IF NOT EXISTS fabric_entity_properties (
+    entity_type TEXT NOT NULL,
+    property_name TEXT NOT NULL,
+    property_type TEXT NOT NULL DEFAULT 'string',
+    workspace TEXT NOT NULL,
+    PRIMARY KEY (workspace, entity_type, property_name)
+);
+
+CREATE TABLE IF NOT EXISTS fabric_registry_links (
+    name TEXT NOT NULL,
+    from_type TEXT NOT NULL,
+    to_type TEXT NOT NULL,
+    workspace TEXT NOT NULL,
+    PRIMARY KEY (workspace, name, from_type, to_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fabric_entity_types_workspace
+    ON fabric_entity_types(workspace, name);
+CREATE INDEX IF NOT EXISTS idx_fabric_entity_properties_workspace
+    ON fabric_entity_properties(workspace, entity_type);
+CREATE INDEX IF NOT EXISTS idx_fabric_registry_links_workspace
+    ON fabric_registry_links(workspace, from_type, to_type);
+"""
+
+
+DEFAULT_DB_PATH = Path.home() / ".pocketpaw" / "fabric_registry.db"
+
+
+class WorkspaceFabricStore:
+    """Workspace-scoped SQLite store for the Fabric registry contract.
+
+    The store is the write-side; :class:`WorkspaceFabricRegistry` is the
+    read-side Protocol implementation that callers hand to the Wave 4b
+    validator and the runtime resolver.
+    """
+
+    __slots__ = ("_db_path",)
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        """Create / open the registry SQLite database at ``db_path``.
+
+        When ``db_path`` is ``None`` the default
+        ``~/.pocketpaw/fabric_registry.db`` location is used. Parent
+        directories are created as needed so the first registration on a
+        fresh install does not fail with ``FileNotFoundError``.
+        """
+        path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._db_path = path
+        self._ensure_schema()
+
+    # -- Schema bootstrap ----------------------------------------------------
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA_SQL)
+            conn.commit()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        # Foreign keys are not strictly needed for this schema (we don't
+        # declare any), but enabling the pragma protects future
+        # extensions from silent constraint violations.
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    # -- Entity types --------------------------------------------------------
+
+    def register_entity_type(self, workspace_id: str, name: str) -> None:
+        """Register ``name`` as an ObjectType in ``workspace_id``.
+
+        Idempotent — re-registering the same type is a no-op
+        (``INSERT OR IGNORE``)."""
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO fabric_entity_types (name, workspace) VALUES (?, ?)",
+                (name, workspace_id),
+            )
+            conn.commit()
+
+    def list_entity_types(self, workspace_id: str) -> list[str]:
+        """Return every entity-type name registered in ``workspace_id``,
+        sorted alphabetically for stable callers."""
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT name FROM fabric_entity_types WHERE workspace = ? ORDER BY name",
+                (workspace_id,),
+            )
+            return [row[0] for row in cur.fetchall()]
+
+    def entity_exists(self, workspace_id: str, name: str) -> bool:
+        """Return True iff ``name`` is registered in ``workspace_id``."""
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT 1 FROM fabric_entity_types WHERE workspace = ? AND name = ? LIMIT 1",
+                (workspace_id, name),
+            )
+            return cur.fetchone() is not None
+
+    def delete_entity_type(self, workspace_id: str, name: str) -> None:
+        """Remove ``name`` from ``workspace_id``.
+
+        Cascades to ``fabric_entity_properties`` (all rows for the
+        entity) and ``fabric_registry_links`` (any link with ``name`` on
+        either end). Other workspaces are not affected because every
+        statement filters on ``workspace``.
+        """
+        with self._connect() as conn:
+            conn.execute(
+                "DELETE FROM fabric_entity_properties WHERE workspace = ? AND entity_type = ?",
+                (workspace_id, name),
+            )
+            conn.execute(
+                "DELETE FROM fabric_registry_links "
+                "WHERE workspace = ? AND (from_type = ? OR to_type = ?)",
+                (workspace_id, name, name),
+            )
+            conn.execute(
+                "DELETE FROM fabric_entity_types WHERE workspace = ? AND name = ?",
+                (workspace_id, name),
+            )
+            conn.commit()
+
+    # -- Properties ----------------------------------------------------------
+
+    def register_property(
+        self,
+        workspace_id: str,
+        entity_type: str,
+        property_name: str,
+        property_type: str = "string",
+    ) -> None:
+        """Declare ``property_name`` on ``entity_type`` in
+        ``workspace_id``.
+
+        ``INSERT OR REPLACE`` semantics — re-registering the same
+        property updates the stored ``property_type`` rather than
+        failing. v0 only stores a plain-string type; enums / foreign
+        keys are out of scope for Wave 4c.
+        """
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO fabric_entity_properties "
+                "(entity_type, property_name, property_type, workspace) "
+                "VALUES (?, ?, ?, ?)",
+                (entity_type, property_name, property_type, workspace_id),
+            )
+            conn.commit()
+
+    def get_properties(self, workspace_id: str, entity_type: str) -> set[str]:
+        """Return the set of declared property names for ``entity_type``
+        in ``workspace_id``. Unknown entity types return ``set()`` to
+        match the :class:`NullFabricRegistry` contract."""
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT property_name FROM fabric_entity_properties "
+                "WHERE workspace = ? AND entity_type = ?",
+                (workspace_id, entity_type),
+            )
+            return {row[0] for row in cur.fetchall()}
+
+    # -- Links ---------------------------------------------------------------
+
+    def register_link(
+        self,
+        workspace_id: str,
+        name: str,
+        from_type: str,
+        to_type: str,
+    ) -> None:
+        """Register a directed link called ``name`` connecting
+        ``from_type`` -> ``to_type`` in ``workspace_id``. Idempotent."""
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO fabric_registry_links "
+                "(name, from_type, to_type, workspace) VALUES (?, ?, ?, ?)",
+                (name, from_type, to_type, workspace_id),
+            )
+            conn.commit()
+
+    def link_exists(
+        self,
+        workspace_id: str,
+        name: str,
+        from_type: str,
+        to_type: str,
+    ) -> bool:
+        """Return True iff a link called ``name`` connects
+        ``from_type`` -> ``to_type`` in ``workspace_id``. Direction
+        matters — the reverse pair is not implied."""
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT 1 FROM fabric_registry_links "
+                "WHERE workspace = ? AND name = ? AND from_type = ? AND to_type = ? "
+                "LIMIT 1",
+                (workspace_id, name, from_type, to_type),
+            )
+            return cur.fetchone() is not None
+
+
+__all__ = [
+    "DEFAULT_DB_PATH",
+    "WorkspaceFabricStore",
+]

--- a/tests/ee/test_fabric_registry.py
+++ b/tests/ee/test_fabric_registry.py
@@ -1,0 +1,188 @@
+# tests/ee/test_fabric_registry.py
+# Created: 2026-05-28 (feat/wave-4c-fabric-registry) — RED-first tests
+# for ``WorkspaceFabricRegistry``, the concrete EE-side implementation
+# of the ``pocketpaw.bundled_templates.FabricRegistry`` Protocol that
+# PR 2g defined. The registry is a thin read-side wrapper over
+# ``WorkspaceFabricStore`` bound to a single workspace; mutations go
+# through the store directly. Coverage: per-method behaviour against a
+# populated store, empty-store defaults, workspace isolation, and
+# runtime Protocol conformance.
+"""Tests for ``pocketpaw_ee.fabric.registry.WorkspaceFabricRegistry``.
+
+The registry satisfies the :class:`FabricRegistry` Protocol declared in
+``pocketpaw.bundled_templates.fabric_registry`` and feeds the Wave 4b
+lint path (``validate_template_with_registry``) and the runtime
+``FabricResolver``. Each registry instance is bound to a single
+``workspace_id``; the underlying store handles the multi-tenant table
+filter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.fabric import WorkspaceFabricRegistry, WorkspaceFabricStore
+
+from pocketpaw.bundled_templates import FabricRegistry
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> WorkspaceFabricStore:
+    return WorkspaceFabricStore(tmp_path / "fabric_registry.db")
+
+
+@pytest.fixture()
+def populated_store(store: WorkspaceFabricStore) -> WorkspaceFabricStore:
+    """Pre-seed two workspaces. ``ws-a`` carries the lease ontology;
+    ``ws-b`` carries a distinct invoice ontology so isolation tests have
+    something concrete to assert against."""
+    store.register_entity_type("ws-a", "Lease")
+    store.register_entity_type("ws-a", "Tenant")
+    store.register_entity_type("ws-a", "Property")
+    store.register_property("ws-a", "Lease", "expiry_date", "date")
+    store.register_property("ws-a", "Lease", "rent_current", "number")
+    store.register_property("ws-a", "Tenant", "name", "string")
+    store.register_link("ws-a", "lease_tenant", "Lease", "Tenant")
+    store.register_link("ws-a", "lease_property", "Lease", "Property")
+
+    store.register_entity_type("ws-b", "Invoice")
+    store.register_entity_type("ws-b", "Customer")
+    store.register_property("ws-b", "Invoice", "due_date", "date")
+    store.register_link("ws-b", "invoice_customer", "Invoice", "Customer")
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Protocol surface — populated workspace
+# ---------------------------------------------------------------------------
+
+
+def test_entity_type_exists_returns_true_for_known(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    assert reg.entity_type_exists("Lease") is True
+    assert reg.entity_type_exists("Tenant") is True
+
+
+def test_entity_type_exists_returns_false_for_unknown(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    assert reg.entity_type_exists("Ghost") is False
+
+
+def test_link_exists_returns_true_for_registered(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    assert reg.link_exists("Lease", "Tenant", "lease_tenant") is True
+    assert reg.link_exists("Lease", "Property", "lease_property") is True
+
+
+def test_link_exists_returns_false_for_unregistered(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    # Wrong name.
+    assert reg.link_exists("Lease", "Tenant", "wrong_link") is False
+    # Wrong direction.
+    assert reg.link_exists("Tenant", "Lease", "lease_tenant") is False
+    # Unknown endpoint.
+    assert reg.link_exists("Ghost", "Tenant", "lease_tenant") is False
+
+
+def test_get_entity_properties_returns_declared_props(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    assert reg.get_entity_properties("Lease") == {"expiry_date", "rent_current"}
+    assert reg.get_entity_properties("Tenant") == {"name"}
+
+
+def test_get_entity_properties_for_unknown_returns_empty(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    assert reg.get_entity_properties("Ghost") == set()
+
+
+# ---------------------------------------------------------------------------
+# Empty store
+# ---------------------------------------------------------------------------
+
+
+def test_empty_store_reports_no_entities(store: WorkspaceFabricStore) -> None:
+    reg = WorkspaceFabricRegistry(store=store, workspace_id="ws-empty")
+    assert reg.entity_type_exists("Anything") is False
+    assert reg.link_exists("A", "B", "link") is False
+    assert reg.get_entity_properties("X") == set()
+
+
+# ---------------------------------------------------------------------------
+# Workspace isolation
+# ---------------------------------------------------------------------------
+
+
+def test_registry_bound_to_workspace_a_does_not_see_workspace_b(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg_a = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    # ws-a has Lease but not Invoice.
+    assert reg_a.entity_type_exists("Lease") is True
+    assert reg_a.entity_type_exists("Invoice") is False
+    assert reg_a.link_exists("Invoice", "Customer", "invoice_customer") is False
+    assert reg_a.get_entity_properties("Invoice") == set()
+
+
+def test_registry_bound_to_workspace_b_does_not_see_workspace_a(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg_b = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-b")
+    assert reg_b.entity_type_exists("Invoice") is True
+    assert reg_b.entity_type_exists("Lease") is False
+    assert reg_b.link_exists("Lease", "Tenant", "lease_tenant") is False
+    assert reg_b.get_entity_properties("Lease") == set()
+
+
+def test_registries_for_different_workspaces_share_store(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    """Two registries sharing the same store but bound to different
+    workspaces return disjoint views — the store does the filtering."""
+    reg_a = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    reg_b = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-b")
+    assert reg_a.entity_type_exists("Lease") is True
+    assert reg_b.entity_type_exists("Lease") is False
+    assert reg_a.entity_type_exists("Invoice") is False
+    assert reg_b.entity_type_exists("Invoice") is True
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_protocol_check(store: WorkspaceFabricStore) -> None:
+    """``isinstance(reg, FabricRegistry)`` must succeed at runtime so the
+    EE wiring can assert the binding without importing
+    ``WorkspaceFabricRegistry`` directly."""
+    reg = WorkspaceFabricRegistry(store=store, workspace_id="ws-a")
+    assert isinstance(reg, FabricRegistry)
+
+
+def test_get_entity_properties_returns_independent_copy(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    """Mutating the returned set must not affect the store's internal
+    state — matches the contract of
+    :class:`JSONFileFabricRegistry.get_entity_properties`."""
+    reg = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    props = reg.get_entity_properties("Lease")
+    props.add("ghost_property")
+    assert reg.get_entity_properties("Lease") == {"expiry_date", "rent_current"}

--- a/tests/ee/test_fabric_storage.py
+++ b/tests/ee/test_fabric_storage.py
@@ -1,0 +1,252 @@
+# tests/ee/test_fabric_storage.py
+# Created: 2026-05-28 (feat/wave-4c-fabric-registry) — RED-first tests
+# for ``WorkspaceFabricStore``, the EE-side workspace-scoped SQLite
+# store that backs the concrete ``FabricRegistry`` Protocol
+# implementation. The store registers entity types, properties, and
+# links for the Wave 4b ``tier: registered`` lint contract. Coverage:
+# round-trip, cascade delete, workspace isolation, and a smoke test
+# wiring the populated store through ``WorkspaceFabricRegistry`` into
+# the Wave 4b validator against ``lease-renewal-v2.yaml``.
+"""Tests for ``pocketpaw_ee.fabric.storage.WorkspaceFabricStore``.
+
+The store is the write-side; ``WorkspaceFabricRegistry`` (covered in
+``test_fabric_registry.py``) is the read-side Protocol implementation.
+Both live under ``ee/pocketpaw_ee/fabric/``. The split mirrors the
+Beanie domain/service pattern adapted to SQLite — service writes, view
+reads.
+
+Storage shape (locked in this PR):
+
+* Single shared SQLite file (default ``~/.pocketpaw/fabric_registry.db``).
+* Every row carries a ``workspace`` column; every read filters on it.
+* Three tables — ``fabric_entity_types``, ``fabric_entity_properties``,
+  ``fabric_registry_links``.
+
+The store is sync (stdlib ``sqlite3``); callers wrap in
+``asyncio.to_thread`` if they need an async surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pocketpaw_ee.fabric import WorkspaceFabricRegistry, WorkspaceFabricStore
+
+from pocketpaw.bundled_templates import (
+    PocketTemplate,
+    validate_template_with_registry,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> WorkspaceFabricStore:
+    """Fresh store backed by a tmp-path SQLite file. Each test gets its
+    own DB — implicit teardown when ``tmp_path`` unwinds."""
+    return WorkspaceFabricStore(tmp_path / "fabric_registry.db")
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_register_and_list_entity_types(store: WorkspaceFabricStore) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    store.register_entity_type("ws-a", "Tenant")
+    store.register_entity_type("ws-a", "Property")
+    assert sorted(store.list_entity_types("ws-a")) == ["Lease", "Property", "Tenant"]
+
+
+def test_entity_exists_true_after_register(store: WorkspaceFabricStore) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    assert store.entity_exists("ws-a", "Lease") is True
+    assert store.entity_exists("ws-a", "Ghost") is False
+
+
+def test_register_entity_type_is_idempotent(store: WorkspaceFabricStore) -> None:
+    """Re-registering an existing type is a no-op (INSERT OR IGNORE)."""
+    store.register_entity_type("ws-a", "Lease")
+    store.register_entity_type("ws-a", "Lease")
+    assert store.list_entity_types("ws-a") == ["Lease"]
+
+
+def test_register_and_get_properties(store: WorkspaceFabricStore) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    store.register_property("ws-a", "Lease", "expiry_date", "date")
+    store.register_property("ws-a", "Lease", "rent_current", "number")
+    store.register_property("ws-a", "Lease", "rent_proposed", "number")
+    assert store.get_properties("ws-a", "Lease") == {
+        "expiry_date",
+        "rent_current",
+        "rent_proposed",
+    }
+
+
+def test_register_property_replaces_on_conflict(store: WorkspaceFabricStore) -> None:
+    """Re-registering the same property updates its type (INSERT OR
+    REPLACE) rather than failing."""
+    store.register_entity_type("ws-a", "Lease")
+    store.register_property("ws-a", "Lease", "expiry_date", "date")
+    store.register_property("ws-a", "Lease", "expiry_date", "string")
+    assert store.get_properties("ws-a", "Lease") == {"expiry_date"}
+
+
+def test_get_properties_for_unknown_entity_returns_empty(
+    store: WorkspaceFabricStore,
+) -> None:
+    assert store.get_properties("ws-a", "Ghost") == set()
+
+
+def test_register_and_link_exists(store: WorkspaceFabricStore) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    store.register_entity_type("ws-a", "Tenant")
+    store.register_link("ws-a", "lease_tenant", "Lease", "Tenant")
+    assert store.link_exists("ws-a", "lease_tenant", "Lease", "Tenant") is True
+    # Direction matters — reverse is not implied.
+    assert store.link_exists("ws-a", "lease_tenant", "Tenant", "Lease") is False
+    # Different link name on the same pair → not registered.
+    assert store.link_exists("ws-a", "other_name", "Lease", "Tenant") is False
+
+
+def test_register_link_is_idempotent(store: WorkspaceFabricStore) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    store.register_entity_type("ws-a", "Tenant")
+    store.register_link("ws-a", "lease_tenant", "Lease", "Tenant")
+    store.register_link("ws-a", "lease_tenant", "Lease", "Tenant")
+    # Sanity — single row, still exists.
+    assert store.link_exists("ws-a", "lease_tenant", "Lease", "Tenant") is True
+
+
+# ---------------------------------------------------------------------------
+# Workspace isolation
+# ---------------------------------------------------------------------------
+
+
+def test_entity_types_isolated_by_workspace(store: WorkspaceFabricStore) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    store.register_entity_type("ws-b", "Invoice")
+
+    assert store.list_entity_types("ws-a") == ["Lease"]
+    assert store.list_entity_types("ws-b") == ["Invoice"]
+    assert store.entity_exists("ws-a", "Invoice") is False
+    assert store.entity_exists("ws-b", "Lease") is False
+
+
+def test_properties_isolated_by_workspace(store: WorkspaceFabricStore) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    store.register_entity_type("ws-b", "Lease")  # same name, different ws
+    store.register_property("ws-a", "Lease", "expiry_date", "date")
+    store.register_property("ws-b", "Lease", "renewal_id", "string")
+
+    assert store.get_properties("ws-a", "Lease") == {"expiry_date"}
+    assert store.get_properties("ws-b", "Lease") == {"renewal_id"}
+
+
+def test_links_isolated_by_workspace(store: WorkspaceFabricStore) -> None:
+    for ws in ("ws-a", "ws-b"):
+        store.register_entity_type(ws, "Lease")
+        store.register_entity_type(ws, "Tenant")
+    store.register_link("ws-a", "lease_tenant", "Lease", "Tenant")
+
+    assert store.link_exists("ws-a", "lease_tenant", "Lease", "Tenant") is True
+    assert store.link_exists("ws-b", "lease_tenant", "Lease", "Tenant") is False
+
+
+# ---------------------------------------------------------------------------
+# Cascade delete
+# ---------------------------------------------------------------------------
+
+
+def test_delete_entity_type_cascades_to_properties(store: WorkspaceFabricStore) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    store.register_property("ws-a", "Lease", "expiry_date", "date")
+    store.register_property("ws-a", "Lease", "rent_current", "number")
+
+    store.delete_entity_type("ws-a", "Lease")
+
+    assert store.entity_exists("ws-a", "Lease") is False
+    assert store.get_properties("ws-a", "Lease") == set()
+
+
+def test_delete_entity_type_cascades_to_links(store: WorkspaceFabricStore) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    store.register_entity_type("ws-a", "Tenant")
+    store.register_entity_type("ws-a", "Property")
+    store.register_link("ws-a", "lease_tenant", "Lease", "Tenant")
+    store.register_link("ws-a", "lease_property", "Lease", "Property")
+    # Link pointing INTO the deleted type also drops.
+    store.register_link("ws-a", "tenant_to_lease", "Tenant", "Lease")
+
+    store.delete_entity_type("ws-a", "Lease")
+
+    assert store.link_exists("ws-a", "lease_tenant", "Lease", "Tenant") is False
+    assert store.link_exists("ws-a", "lease_property", "Lease", "Property") is False
+    assert store.link_exists("ws-a", "tenant_to_lease", "Tenant", "Lease") is False
+
+
+def test_delete_entity_type_does_not_touch_other_workspace(
+    store: WorkspaceFabricStore,
+) -> None:
+    store.register_entity_type("ws-a", "Lease")
+    store.register_entity_type("ws-b", "Lease")
+    store.register_property("ws-a", "Lease", "x", "string")
+    store.register_property("ws-b", "Lease", "y", "string")
+
+    store.delete_entity_type("ws-a", "Lease")
+
+    assert store.entity_exists("ws-b", "Lease") is True
+    assert store.get_properties("ws-b", "Lease") == {"y"}
+
+
+# ---------------------------------------------------------------------------
+# Persistence — restart on the same file recovers state
+# ---------------------------------------------------------------------------
+
+
+def test_store_persists_across_instances(tmp_path: Path) -> None:
+    db_path = tmp_path / "fabric_registry.db"
+    s1 = WorkspaceFabricStore(db_path)
+    s1.register_entity_type("ws-a", "Lease")
+    s1.register_property("ws-a", "Lease", "expiry_date", "date")
+    s1.register_link("ws-a", "lease_tenant", "Lease", "Tenant")
+
+    s2 = WorkspaceFabricStore(db_path)
+    assert s2.entity_exists("ws-a", "Lease") is True
+    assert s2.get_properties("ws-a", "Lease") == {"expiry_date"}
+    assert s2.link_exists("ws-a", "lease_tenant", "Lease", "Tenant") is True
+
+
+# ---------------------------------------------------------------------------
+# Wave 4b integration smoke — wired through WorkspaceFabricRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_populated_store_lints_lease_fixture_clean(store: WorkspaceFabricStore) -> None:
+    """Populate the store with the entity types + links the lease
+    fixture references and run the Wave 4b validator. The expected
+    result is zero Fabric errors — proving the concrete EE registry
+    satisfies the same contract the JSON mock does."""
+    workspace = "ws-property-mgmt"
+    for name in ("Lease", "Tenant", "Property"):
+        store.register_entity_type(workspace, name)
+    for prop in ("expiry_date", "rent_current", "rent_proposed", "renewal_stage"):
+        store.register_property(workspace, "Lease", prop, "string")
+    for prop in ("name", "email", "late_payment_count_12mo"):
+        store.register_property(workspace, "Tenant", prop, "string")
+    store.register_link(workspace, "lease_tenant", "Lease", "Tenant")
+    store.register_link(workspace, "lease_property", "Lease", "Property")
+
+    registry = WorkspaceFabricRegistry(store=store, workspace_id=workspace)
+
+    lease_path = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "templates" / "lease-renewal-v2.yaml"
+    )
+    template = PocketTemplate.model_validate(yaml.safe_load(lease_path.read_text()))
+    errors = validate_template_with_registry(template, registry)
+    assert errors == []


### PR DESCRIPTION
## Summary

This is the **final pocketpaw PR for RFC 03 v2 Waves 3 + 4** — the
concrete `FabricRegistry` that PR 2g (the Protocol seam) and Wave 4b
(the OSS-side JSON mock) both pointed at. With this PR, the
`tier: registered` lint contract can now run against real
workspace-scoped data instead of a hand-authored JSON manifest.

- **`WorkspaceFabricStore`** (`ee/pocketpaw_ee/fabric/storage.py`) —
  workspace-scoped SQLite store using stdlib `sqlite3`. Three tables
  (`fabric_entity_types`, `fabric_entity_properties`,
  `fabric_registry_links`), every row carries a `workspace` column,
  every read filters on it. Single shared file at
  `~/.pocketpaw/fabric_registry.db`; multi-tenancy enforced by the
  index, not the file path. Idempotent registers (`INSERT OR IGNORE` /
  `OR REPLACE`), cascade `delete_entity_type` (drops properties + any
  link referencing the type).
- **`WorkspaceFabricRegistry`** (`ee/pocketpaw_ee/fabric/registry.py`)
  — concrete implementation of the
  `pocketpaw.bundled_templates.FabricRegistry` Protocol. Thin
  read-side wrapper bound to a single workspace; every method
  delegates to the store with the bound `workspace_id`. Passes
  `isinstance(reg, FabricRegistry)` at runtime.
- **Wave 4b integration smoke** wires a populated store + registry
  through `validate_template_with_registry(lease-renewal-v2.yaml, ...)`
  and asserts zero errors — the EE concrete implementation satisfies
  the same contract the OSS JSON mock does.

## Naming note

The OSS side already has a `pocketpaw.fabric.store.FabricStore` (async,
no workspace column) that holds the live ontology *object* data
(instances + links produced by the Fabric API). This PR adds a sibling
EE store for the *registry contract* — which types / links are
declared, so the lint path has something to check against. Names are
deliberately distinct (`WorkspaceFabricStore`) to avoid symbol
collision and to signal the workspace-scoped, registry-only role. The
two stores stay independent on purpose — lint must not require booting
the full async object store. A future PR can rendezvous them once
"auto-register an ObjectType definition when one is created via the
Fabric API" wiring lands.

## Out of scope (deliberately deferred)

- Provenance tracking (who registered what, when).
- HTTP endpoints for registry CRUD — the existing `fabric/router.py`
  stays unchanged.
- Property typing beyond plain strings (enums, foreign keys, etc).
- Migration / schema versioning — v0 schema is locked.
- Auto-wire of `WorkspaceFabricRegistry` into the OSS `template lint`
  CLI. Lint defaults stay `NullFabricRegistry` /
  `JSONFileFabricRegistry`; EE callers pass `WorkspaceFabricRegistry`
  explicitly.

## Test plan

- [x] `uv run pytest tests/ee/test_fabric_storage.py tests/ee/test_fabric_registry.py -xvs` — 28 GREEN
- [x] `uv run pytest tests/ee/test_fabric_storage.py tests/ee/test_fabric_registry.py tests/unit/test_fabric_validator.py tests/unit/test_json_registry.py` — 57 GREEN (Wave 4b siblings stay clean)
- [x] `uv run ruff check ee/pocketpaw_ee/fabric/ tests/ee/test_fabric_storage.py tests/ee/test_fabric_registry.py` — clean
- [x] `uv run ruff format` — clean
- [x] `uv run lint-imports --config ee/pyproject.toml` — 19 contracts kept, 0 broken
- [x] `uv run lint-imports --config pyproject.toml` — OSS↔EE boundary kept, 0 broken
