### PR TITLE
fix(auth): bridge EE JWT into OSS full_access for workspace admins

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -112,16 +112,22 @@ def mount_cloud(app: FastAPI) -> None:
     """Mount all cloud domain routers, the error handler, and the
     request-timing middleware."""
     from pocketpaw_ee.cloud._core.csrf import CSRFMiddleware, csrf_router
+    from pocketpaw_ee.cloud._core.ee_auth_bridge import EEAuthBridgeMiddleware
     from pocketpaw_ee.cloud._core.http import add_error_handler
     from pocketpaw_ee.cloud._core.timing import TimingMiddleware
 
     # Starlette's add_middleware is a stack — LAST registered runs OUTERMOST
-    # on inbound. Effective order here: CSRF → Timing → route handler.
+    # on inbound. Effective order here:
+    #   CSRF → Timing → EEAuthBridge → AuthMiddleware (OSS) → route handler.
+    # The bridge marks admin/owner cloud users as ``full_access`` before
+    # the OSS AuthMiddleware reads it, so OSS routes (settings/channels/...)
+    # accept EE JWT auth without 403'ing on missing scopes.
     # A CSRF 403 short-circuits before Timing observes the request, so perf
     # data won't include rejected POSTs. That's a deliberate tradeoff: the
     # CSRF gate exists to be fast and predictable, not measured. Reorder
     # ONLY if you want Timing to wrap CSRF rejections (swap the two add_
     # middleware calls — TimingMiddleware would then run outermost).
+    app.add_middleware(EEAuthBridgeMiddleware)
     app.add_middleware(TimingMiddleware)
 
     # CSRF middleware — outermost on inbound, runs before any route.

--- a/ee/pocketpaw_ee/cloud/_core/ee_auth_bridge.py
+++ b/ee/pocketpaw_ee/cloud/_core/ee_auth_bridge.py
@@ -1,0 +1,143 @@
+"""Bridge EE JWT auth → OSS ``request.state.full_access`` for admin/owner.
+
+OSS routes under ``src/pocketpaw/api/v1/`` (settings, channels, budget, soul,
+...) gate access with ``require_scope(...)`` from ``pocketpaw.api.deps``. That
+dependency accepts:
+
+  * ``request.state.full_access`` truthy — the cookie/session/master-token
+    paths in ``dashboard_auth.py`` set this for fully-trusted callers.
+  * ``request.state.api_key`` with matching scopes.
+  * ``request.state.oauth_token`` with matching scopes.
+
+The EE cloud uses fastapi-users JWT (cookie ``paw_auth`` or Bearer) at the
+route level. The OSS ``AuthMiddleware`` doesn't know about EE auth, so a
+fully-authenticated cloud admin hitting ``/api/v1/settings`` would 403 with
+``Missing required scope: settings:read or settings:write`` because nothing
+sets ``full_access``.
+
+This middleware closes that gap. On every request:
+
+  1. Decode the JWT from ``paw_auth`` cookie or ``Authorization: Bearer``.
+  2. Resolve the User and their active workspace role.
+  3. If owner or admin, set ``request.state.full_access = True``.
+
+Members + viewers stay locked out — settings + channels are platform-grade
+config that shouldn't be writable by every workspace member.
+
+Performance: the JWT decode is local (HMAC); the User lookup is one Beanie
+``get()`` per request. We skip entirely for paths that already exempt from
+auth (static assets, oauth callbacks) and for requests with no cookie or
+bearer at all.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import jwt
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+# Paths the OSS AuthMiddleware skips entirely. Don't waste a JWT decode
+# on these.
+_EXEMPT_PREFIXES = (
+    "/static/",
+    "/uploads/",
+    "/api/v1/auth/login",
+    "/api/v1/auth/register",
+    "/api/v1/auth/bearer/login",
+    "/api/v1/auth/refresh",
+    "/api/v1/auth/forgot-password",
+    "/api/v1/auth/reset-password",
+    "/api/v1/auth/request-verify-token",
+    "/api/v1/auth/verify",
+)
+
+
+class EEAuthBridgeMiddleware(BaseHTTPMiddleware):
+    """Mark EE-authenticated admin/owner requests as ``full_access`` for OSS."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[no-untyped-def]
+        path = request.url.path
+        if path == "/" or any(path.startswith(p) for p in _EXEMPT_PREFIXES):
+            return await call_next(request)
+
+        # Pull the JWT from cookie first, then Authorization header. We don't
+        # care which transport authenticated the caller — both are valid EE
+        # auth surfaces.
+        token = request.cookies.get("paw_auth")
+        if not token:
+            auth_header = request.headers.get("Authorization", "")
+            if auth_header.startswith("Bearer "):
+                bearer = auth_header.removeprefix("Bearer ").strip()
+                # Skip OSS-issued API keys (pp_*) and OAuth tokens (ppat_*).
+                # Those are handled by the OSS AuthMiddleware cascade with
+                # their own scope semantics.
+                if bearer and not bearer.startswith(("pp_", "ppat_")):
+                    token = bearer
+
+        if not token:
+            return await call_next(request)
+
+        user = await _resolve_user(token)
+        if user is None:
+            return await call_next(request)
+
+        role = _active_workspace_role(user)
+        if role in ("owner", "admin"):
+            request.state.full_access = True
+
+        return await call_next(request)
+
+
+async def _resolve_user(token: str):  # noqa: ANN202 — Beanie Document, avoid circular import
+    """Decode the JWT and load the User document. Returns None on any failure."""
+    try:
+        # Lazy imports — keeps middleware module light and avoids triggering
+        # the EE auth chain on processes that don't mount the cloud.
+        from pocketpaw_ee.cloud.auth import sessions as sessions_service
+        from pocketpaw_ee.cloud.auth.core import SECRET, RevocableJWTStrategy
+        from pocketpaw_ee.cloud.models.user import User
+
+        strategy = RevocableJWTStrategy(secret=SECRET, lifetime_seconds=1)
+        try:
+            payload = jwt.decode(
+                token,
+                strategy.decode_key
+                if isinstance(strategy.decode_key, str)
+                else strategy.decode_key.get_secret_value(),
+                audience=strategy.token_audience,
+                algorithms=[strategy.algorithm],
+            )
+        except jwt.PyJWTError:
+            return None
+
+        jti = payload.get("jti")
+        user_id = payload.get("sub")
+        if not user_id:
+            return None
+        if jti and await sessions_service.is_revoked(user_id, jti):
+            return None
+        return await User.get(user_id)
+    except Exception:
+        # Swallow — bridge auth is best-effort. A failure here just means the
+        # caller doesn't get full_access; the route's own auth still runs.
+        logger.debug("EE auth bridge failed to resolve user", exc_info=True)
+        return None
+
+
+def _active_workspace_role(user) -> str | None:  # noqa: ANN001 — User Document
+    """Return the user's role string on their currently-active workspace, or None."""
+    active = getattr(user, "active_workspace", None)
+    if not active:
+        return None
+    for membership in getattr(user, "workspaces", []) or []:
+        if getattr(membership, "workspace", None) == active:
+            return getattr(membership, "role", None)
+    return None

--- a/src/pocketpaw/dashboard_auth.py
+++ b/src/pocketpaw/dashboard_auth.py
@@ -498,7 +498,13 @@ async def _auth_dispatch(request: Request) -> Response | None:
     is_valid = False
     # full_access means "bypass scope checks" (issue #888). Set by the
     # master/session/cookie/localhost paths — NOT by API key or OAuth auth.
-    request.state.full_access = False
+    # Defensive default: preserve any upstream-set value so the EE auth
+    # bridge middleware (mounted by ``mount_cloud()``) can mark admin/owner
+    # cloud users as full-access before we get here.
+    if getattr(request.state, "full_access", False):
+        is_valid = True
+    else:
+        request.state.full_access = False
 
     # 1. Check Query Param (master token or session token)
     if token:

--- a/tests/cloud/auth/test_ee_auth_bridge.py
+++ b/tests/cloud/auth/test_ee_auth_bridge.py
@@ -1,0 +1,220 @@
+"""EE auth bridge middleware tests.
+
+Verifies the middleware that bridges fastapi-users JWT auth into the OSS
+``require_scope`` system. Concretely:
+
+* admin/owner of the active workspace → ``request.state.full_access``
+  becomes True → OSS scope-gated routes return 200.
+* member / viewer → ``full_access`` stays False → 403.
+* unauthenticated / bad JWT → ``full_access`` stays False → 403.
+* OSS API keys (pp_*) and OAuth tokens (ppat_*) → the bridge ignores them
+  so the existing OSS AuthMiddleware cascade owns those paths.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+os.environ.setdefault("AUTH_SECRET", "test-bridge-secret-do-not-use-in-prod")
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+
+import pytest
+import pytest_asyncio
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.ee_auth_bridge import EEAuthBridgeMiddleware
+from pocketpaw_ee.cloud.auth.core import SECRET, RevocableJWTStrategy
+from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+
+from pocketpaw.api.deps import require_scope
+
+# Every test in this module needs the real fail-closed behaviour — opt out
+# of the _TESTING_FULL_ACCESS bypass that the root conftest sets up. Without
+# this, the global bypass returns 200 for every caller and the role-based
+# acceptance / rejection assertions are meaningless.
+pytestmark = pytest.mark.enforce_scope
+
+
+# ---------------------------------------------------------------------------
+# Test app — a single route gated by require_scope("settings:read")
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(EEAuthBridgeMiddleware)
+
+    @app.get(
+        "/api/v1/settings",
+        dependencies=[Depends(require_scope("settings:read", "settings:write"))],
+    )
+    async def _settings() -> dict[str, Any]:
+        return {"ok": True}
+
+    @app.get(
+        "/api/v1/channels",
+        dependencies=[Depends(require_scope("channels"))],
+    )
+    async def _channels() -> dict[str, Any]:
+        return {"channels": []}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Test users — one per role on the same active workspace
+# ---------------------------------------------------------------------------
+
+_WS_ID = "w-bridge-test"
+
+
+async def _seed_user(email: str, role: str) -> User:
+    user = User(
+        email=email,
+        hashed_password="x",  # not used; we mint JWTs directly
+        is_active=True,
+        is_verified=True,
+        active_workspace=_WS_ID,
+        workspaces=[WorkspaceMembership(workspace=_WS_ID, role=role)],
+    )
+    await user.insert()
+    return user
+
+
+async def _mint_jwt(user: User) -> str:
+    """Mint a real JWT the same way the cloud auth backend does."""
+    strategy = RevocableJWTStrategy(secret=SECRET, lifetime_seconds=60)
+    return await strategy.write_token(user)
+
+
+@pytest_asyncio.fixture
+async def env(mongo_db):  # noqa: ARG001 — fixture forces Beanie init
+    owner = await _seed_user("owner@bridge.test", "owner")
+    admin = await _seed_user("admin@bridge.test", "admin")
+    member = await _seed_user("member@bridge.test", "member")
+    no_ws = User(
+        email="lonely@bridge.test",
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        active_workspace=None,
+        workspaces=[],
+    )
+    await no_ws.insert()
+
+    tokens = {
+        "owner": await _mint_jwt(owner),
+        "admin": await _mint_jwt(admin),
+        "member": await _mint_jwt(member),
+        "no_ws": await _mint_jwt(no_ws),
+    }
+
+    app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client, tokens
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_owner_via_cookie_passes_settings_scope(env) -> None:
+    client, tokens = env
+    res = await client.get("/api/v1/settings", cookies={"paw_auth": tokens["owner"]})
+    assert res.status_code == 200, res.text
+    assert res.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_admin_via_cookie_passes_settings_scope(env) -> None:
+    client, tokens = env
+    res = await client.get("/api/v1/settings", cookies={"paw_auth": tokens["admin"]})
+    assert res.status_code == 200, res.text
+
+
+@pytest.mark.asyncio
+async def test_admin_via_bearer_passes_channels_scope(env) -> None:
+    client, tokens = env
+    res = await client.get(
+        "/api/v1/channels",
+        headers={"Authorization": f"Bearer {tokens['admin']}"},
+    )
+    assert res.status_code == 200, res.text
+
+
+@pytest.mark.asyncio
+async def test_owner_via_bearer_passes_settings_scope(env) -> None:
+    client, tokens = env
+    res = await client.get(
+        "/api/v1/settings",
+        headers={"Authorization": f"Bearer {tokens['owner']}"},
+    )
+    assert res.status_code == 200, res.text
+
+
+@pytest.mark.asyncio
+async def test_member_is_rejected_with_403(env) -> None:
+    client, tokens = env
+    res = await client.get("/api/v1/settings", cookies={"paw_auth": tokens["member"]})
+    assert res.status_code == 403
+    assert "Missing required scope" in res.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_member_is_rejected_from_channels_too(env) -> None:
+    client, tokens = env
+    res = await client.get("/api/v1/channels", cookies={"paw_auth": tokens["member"]})
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_user_with_no_active_workspace_is_rejected(env) -> None:
+    client, tokens = env
+    res = await client.get("/api/v1/settings", cookies={"paw_auth": tokens["no_ws"]})
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_no_token_at_all_is_rejected(env) -> None:
+    client, _ = env
+    res = await client.get("/api/v1/settings")
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_garbage_jwt_is_rejected_silently(env) -> None:
+    """A malformed JWT must not crash the bridge — request just continues
+    unauthenticated and the scope check rejects it."""
+    client, _ = env
+    res = await client.get("/api/v1/settings", cookies={"paw_auth": "not.a.real.jwt"})
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_oss_api_key_bearer_is_passed_through(env) -> None:
+    """pp_* bearers must not be decoded by the bridge — they belong to the
+    OSS AuthMiddleware cascade. In this isolated app there's no AuthMiddleware,
+    so the request falls through to require_scope and 403s, but the assertion
+    we care about is that the bridge didn't *accept* it (didn't set
+    full_access). 403 is the expected outcome here."""
+    client, _ = env
+    res = await client.get(
+        "/api/v1/settings",
+        headers={"Authorization": "Bearer pp_fake_key_value"},
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_oauth_token_bearer_is_passed_through(env) -> None:
+    """Same as above for ppat_* OAuth tokens."""
+    client, _ = env
+    res = await client.get(
+        "/api/v1/settings",
+        headers={"Authorization": "Bearer ppat_fake_token_value"},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- Admins/owners on the cloud were 403'ing on OSS routes (`/api/v1/settings`, `/api/v1/channels`, ...) with `Missing required scope: settings:read or settings:write` because EE auth (fastapi-users JWT) never populates `request.state.full_access` — only OSS dashboard auth (master/session/cookie) does. The scope strings `settings:read` / `channels` aren't in the EE scope registry either, so neither the API-key nor the OAuth branch could ever satisfy them.
- New `EEAuthBridgeMiddleware` decodes the EE JWT (`paw_auth` cookie or Bearer), looks up the user's role on their active workspace, and marks `full_access = True` for `owner` / `admin`. Members + viewers stay locked out — settings + channels are admin-grade platform config.
- `AuthMiddleware` now preserves an upstream-set `full_access` instead of clobbering it back to `False`.

## How it composes
Inbound middleware order after the fix:
```
CSRF → Timing → EEAuthBridge → OSS AuthMiddleware → route
```
The bridge sets `full_access` before `AuthMiddleware` reads it. OSS API keys (`pp_*`) and OAuth tokens (`ppat_*`) are skipped — the existing AuthMiddleware cascade owns those.

## Test plan
- [x] Existing `tests/test_require_scope_enforcement.py` still passes (10/10).
- [ ] Manual: log in to the desktop client as a workspace owner, open Settings → page renders.
- [ ] Manual: same as above for Channels.
- [ ] Manual: log in as a workspace `member`, confirm Settings + Channels still 403 (they're admin-grade — members shouldn't have write access to the agent's API keys / channel adapters).
- [ ] Manual: log out → both routes 401/403 as before.