### PR TITLE
fix(chat): inline uploaded-file text into agent context (S3-safe)

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -814,10 +814,11 @@ async def build_knowledge_context(
     mentions: list[dict[str, Any]] | None = None,
 ) -> str:
     """Build the per-turn knowledge context — dynamic scope/participants
-    tags + KB hits. Static behavioral rules are NOT included here; the
-    caller must inject them via ``pool.run(instructions=...)`` so they
-    land outside the "Your Knowledge Base" framing that makes the model
-    treat them as reference data instead of rules."""
+    tags + KB hits + inlined attachment text. Static behavioral rules are
+    NOT included here; the caller must inject them via
+    ``pool.run(instructions=...)`` so they land outside the "Your Knowledge
+    Base" framing that makes the model treat them as reference data
+    instead of rules."""
     scope_block = build_dynamic_context(ctx)
     query = (user_message or "").strip()
     refs = _file_reference_terms(attachments=attachments, mentions=mentions)
@@ -829,18 +830,34 @@ async def build_knowledge_context(
             )
         ref_line = ", ".join(refs[:12])
         query = f"{query}\nReferenced uploads: {ref_line}" if query else ref_line
-    if not query:
-        return scope_block
 
+    sections: list[str] = []
+
+    attachments_block = await _build_attachments_block(ctx, attachments)
+    if attachments_block:
+        sections.append(attachments_block)
+
+    if query:
+        kb_block = await _build_kb_snippets_block(ctx, query)
+        if kb_block:
+            sections.append(kb_block)
+
+    if not sections:
+        return scope_block
+    return f"{scope_block}\n\n" + "\n\n".join(sections)
+
+
+async def _build_kb_snippets_block(ctx: ScopeContext, query: str) -> str:
+    """Search KB scopes for ``query`` and return a ``<knowledge-base>`` block."""
     scopes = _kb_scopes_for_context(ctx)
     if not scopes:
-        return scope_block
+        return ""
 
     try:
         from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
     except Exception:
-        logger.debug("KnowledgeService unavailable; using scope block only", exc_info=True)
-        return scope_block
+        logger.debug("KnowledgeService unavailable; skipping KB block", exc_info=True)
+        return ""
 
     snippets: list[tuple[str, str]] = []
     for scope in scopes:
@@ -854,7 +871,7 @@ async def build_knowledge_context(
             snippets.append((scope, cleaned))
 
     if not snippets:
-        return scope_block
+        return ""
 
     kb_lines = [
         "<knowledge-base>",
@@ -863,7 +880,117 @@ async def build_knowledge_context(
     for scope, text in snippets:
         kb_lines.append(f"### {scope}\n{text}")
     kb_lines.append("</knowledge-base>")
-    return f"{scope_block}\n\n" + "\n\n".join(kb_lines)
+    return "\n".join(kb_lines)
+
+
+# Bounds for inlined attachment text. Per-file cap keeps a single huge PDF
+# from eating the budget; total cap keeps a batch of files from blowing the
+# context window. Image/binary attachments typically yield empty text and
+# get a stub entry so the agent at least knows they exist.
+_ATTACHMENT_MAX_FILES = 5
+_ATTACHMENT_PER_FILE_CHARS = 8000
+_ATTACHMENT_TOTAL_CHARS = 30000
+
+
+async def _build_attachments_block(
+    ctx: ScopeContext,
+    attachments: list[dict[str, Any]] | None,
+) -> str:
+    """Inline extracted text from each upload URL in ``attachments``.
+
+    Resolves each attachment via :class:`EEUploadResolver`, runs the
+    configured extraction chain on the resulting local path (streaming
+    from S3 into a temp file when needed), and emits an
+    ``<uploaded-files>`` block the model can read directly. Failures are
+    isolated per-file: a single broken extraction or unresolvable URL
+    drops only that entry.
+    """
+    if not attachments or not ctx.workspace_id:
+        return ""
+
+    try:
+        from pocketpaw.config import get_settings
+        from pocketpaw_ee.cloud.extraction import build_chain
+        from pocketpaw_ee.cloud.uploads.resolver import default_resolver
+    except Exception:
+        logger.debug("attachment extraction deps unavailable", exc_info=True)
+        return ""
+
+    try:
+        resolver = default_resolver()
+    except Exception:
+        logger.debug("default_resolver unavailable; skipping attachments", exc_info=True)
+        return ""
+
+    chain = None
+    entries: list[str] = []
+    used_chars = 0
+    processed = 0
+
+    for att in attachments:
+        if processed >= _ATTACHMENT_MAX_FILES:
+            break
+        if used_chars >= _ATTACHMENT_TOTAL_CHARS:
+            break
+        if not isinstance(att, dict):
+            continue
+        url = att.get("url")
+        if not isinstance(url, str) or not url:
+            continue
+
+        try:
+            cm = resolver.open_local_for_url(url, workspace=ctx.workspace_id)
+            async with cm as resolved:
+                if resolved is None:
+                    continue
+                rec, path = resolved
+                if chain is None:
+                    try:
+                        chain = build_chain(get_settings())
+                    except Exception:
+                        logger.exception("build_chain failed; skipping attachments")
+                        return ""
+                try:
+                    result = await chain.run(path, rec.mime)
+                except Exception:
+                    logger.warning(
+                        "extraction failed for attachment %s (file_id=%s)",
+                        rec.filename,
+                        rec.id,
+                        exc_info=True,
+                    )
+                    continue
+
+                text = (result.text or "").strip()
+                header = f"### {rec.filename} ({rec.mime}, {rec.size} bytes)"
+                if not text:
+                    entries.append(f"{header}\n(no text extracted)")
+                    processed += 1
+                    continue
+
+                remaining = _ATTACHMENT_TOTAL_CHARS - used_chars
+                per_file_cap = min(_ATTACHMENT_PER_FILE_CHARS, remaining)
+                if len(text) > per_file_cap:
+                    text = text[:per_file_cap].rstrip() + "\n…[truncated]"
+                entries.append(f"{header}\n{text}")
+                used_chars += len(text)
+                processed += 1
+        except Exception:
+            logger.warning("attachment resolve failed for url=%s", url, exc_info=True)
+            continue
+
+    if not entries:
+        return ""
+
+    lines = [
+        "<uploaded-files>",
+        "The user attached the following file(s) to this turn. "
+        "Their extracted contents are inlined below — treat them as part "
+        "of the user's message, not as external reference.",
+    ]
+    lines.extend(entries)
+    lines.append("</uploaded-files>")
+    return "\n\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/uploads/listeners.py
+++ b/ee/pocketpaw_ee/cloud/uploads/listeners.py
@@ -42,15 +42,12 @@ Pocket-scope routing arrives in Stage 3.E: the listener will check
 
 from __future__ import annotations
 
-import contextlib
 import logging
-import mimetypes
-import tempfile
-from collections.abc import AsyncIterator
 from pathlib import Path
 
 from pocketpaw_ee.cloud._core.realtime.bus import get_bus
 from pocketpaw_ee.cloud._core.realtime.events import Event, FileReady
+from pocketpaw_ee.cloud.uploads.resolver import materialize_to_local_path
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +78,17 @@ async def index_uploaded_file(event: Event) -> None:
         )
         return
 
-    async with _path_for_extraction(storage_key, mime, filename) as path:
+    adapter = _resolve_adapter()
+    if adapter is None or not storage_key:
+        logger.info(
+            "skipping KB index: no adapter or storage_key for file_id=%s",
+            file_id,
+        )
+        return
+
+    async with materialize_to_local_path(
+        adapter, storage_key, mime=mime, filename=filename
+    ) as path:
         if path is None:
             logger.info(
                 "skipping KB index: no path for file_id=%s storage_key=%r",
@@ -315,75 +322,6 @@ async def _write_vector_to_kb(
             logger.debug("temp vec cleanup failed for %s", tmp.name)
 
 
-@contextlib.asynccontextmanager
-async def _path_for_extraction(
-    storage_key: str | None,
-    mime: str,
-    filename: str,
-) -> AsyncIterator[Path | None]:
-    """Yield a Path the extraction chain can read.
-
-    Local-disk adapter: yields the on-disk path unchanged (zero extra I/O).
-    Remote adapter (S3, GCS): streams the blob into a NamedTemporaryFile,
-    yields its Path, then deletes the file on exit. The temp suffix
-    matches the original filename so suffix-routed extractors (pypdf for
-    .pdf, python-docx for .docx, etc.) keep working.
-
-    Yields ``None`` when neither path works — the listener treats that as
-    "skip this upload, log, and move on".
-    """
-    if not storage_key:
-        yield None
-        return
-
-    direct = _resolve_local_path(storage_key)
-    if direct is not None:
-        yield direct
-        return
-
-    adapter = _resolve_adapter()
-    if adapter is None:
-        yield None
-        return
-
-    suffix = _extension_for(filename, mime)
-    tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115 — manual lifecycle
-        prefix="paw-extract-",
-        suffix=suffix,
-        delete=False,
-    )
-    tmp_path = Path(tmp.name)
-    try:
-        try:
-            async for chunk in adapter.open(storage_key):
-                tmp.write(chunk)
-        except Exception:
-            logger.exception("stream-to-temp failed for storage_key=%r", storage_key)
-            yield None
-            return
-        finally:
-            tmp.close()
-
-        yield tmp_path
-    finally:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            logger.warning("temp cleanup failed for %s", tmp_path)
-
-
-def _resolve_local_path(storage_key: str) -> Path | None:
-    """Return the adapter's on-disk path for ``storage_key`` if available."""
-    adapter = _resolve_adapter()
-    if adapter is None:
-        return None
-    try:
-        return adapter.local_path(storage_key)
-    except Exception:
-        logger.exception("local_path lookup failed for storage_key=%r", storage_key)
-        return None
-
-
 def _resolve_adapter():
     """Look up the EE upload singleton's storage adapter.
 
@@ -399,23 +337,6 @@ def _resolve_adapter():
     except Exception:
         logger.exception("upload adapter import failed")
         return None
-
-
-def _extension_for(filename: str, mime: str) -> str:
-    """Pick a temp-file suffix the extractors will route correctly.
-
-    Prefers the original filename's extension (matches what the user
-    uploaded). Falls back to ``mimetypes.guess_extension`` and finally to
-    an empty string when the MIME isn't registered. Suffix matters because
-    ``LocalExtractor`` routes by ``path.suffix`` (pypdf for .pdf, docx for
-    .docx, pytesseract for .png/.jpg) and ``GeminiFlashExtractor`` checks
-    MIME directly so extension is forgiven there.
-    """
-    suffix = Path(filename).suffix
-    if suffix:
-        return suffix
-    guessed = mimetypes.guess_extension(mime, strict=False) or ""
-    return guessed
 
 
 def register_upload_listeners() -> None:

--- a/ee/pocketpaw_ee/cloud/uploads/resolver.py
+++ b/ee/pocketpaw_ee/cloud/uploads/resolver.py
@@ -7,14 +7,84 @@ up metadata in Mongo with workspace isolation. Cross-tenant lookups return
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import mimetypes
+import tempfile
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 from pocketpaw.uploads.adapter import StorageAdapter
+from pocketpaw.uploads.file_store import FileRecord
 from pocketpaw.uploads.resolver import parse_upload_url
 from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
 
 logger = logging.getLogger(__name__)
+
+
+def _extension_for(filename: str, mime: str) -> str:
+    """Pick a temp-file suffix so suffix-routed extractors still match."""
+    suffix = Path(filename).suffix
+    if suffix:
+        return suffix
+    return mimetypes.guess_extension(mime, strict=False) or ""
+
+
+@contextlib.asynccontextmanager
+async def materialize_to_local_path(
+    adapter: StorageAdapter,
+    storage_key: str,
+    *,
+    mime: str = "application/octet-stream",
+    filename: str = "upload",
+) -> AsyncIterator[Path | None]:
+    """Yield a local :class:`Path` for ``storage_key`` regardless of adapter.
+
+    Local-disk adapter: yields ``adapter.local_path(...)`` unchanged
+    (zero extra I/O). Remote adapter (S3, GCS): streams the blob into a
+    ``NamedTemporaryFile`` whose suffix matches the original filename,
+    yields its Path, then deletes the file on exit.
+
+    Yields ``None`` when neither path works — callers should treat that as
+    "skip this entry, log, and move on".
+    """
+    if not storage_key:
+        yield None
+        return
+
+    try:
+        direct = adapter.local_path(storage_key)
+    except Exception:
+        logger.exception("local_path lookup failed for storage_key=%r", storage_key)
+        direct = None
+    if direct is not None:
+        yield direct
+        return
+
+    suffix = _extension_for(filename, mime)
+    tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115 — manual lifecycle
+        prefix="paw-upload-",
+        suffix=suffix,
+        delete=False,
+    )
+    tmp_path = Path(tmp.name)
+    try:
+        try:
+            async for chunk in adapter.open(storage_key):
+                tmp.write(chunk)
+        except Exception:
+            logger.exception("stream-to-temp failed for storage_key=%r", storage_key)
+            yield None
+            return
+        finally:
+            tmp.close()
+
+        yield tmp_path
+    finally:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("temp cleanup failed for %s", tmp_path)
 
 
 class EEUploadResolver:
@@ -25,15 +95,19 @@ class EEUploadResolver:
         self._meta = meta
 
     async def resolve(self, url: str, workspace: str) -> Path | None:
+        """Return a local :class:`Path` for ``url`` if the adapter exposes one.
+
+        Returns ``None`` for remote adapters (S3, GCS) — callers that need
+        to read the bytes regardless should use :meth:`open_local_for_url`
+        instead, which streams the blob into a temp file for the duration
+        of the ``async with`` block.
+        """
         file_id = parse_upload_url(url)
         if file_id is None:
             return None
         rec = await self._meta.get_scoped(file_id, workspace=workspace)
         if rec is None:
             return None
-        # Contain unexpected adapter failures (permission errors on the
-        # storage root, remount races, future remote adapters) so chat
-        # never crashes over a bad attachment — just drops the entry.
         try:
             return self._adapter.local_path(rec.storage_key)
         except Exception:
@@ -45,6 +119,35 @@ class EEUploadResolver:
             )
             return None
 
+    @contextlib.asynccontextmanager
+    async def open_local_for_url(
+        self, url: str, workspace: str
+    ) -> AsyncIterator[tuple[FileRecord, Path] | None]:
+        """Yield ``(record, local_path)`` for ``url`` regardless of adapter.
+
+        S3-safe counterpart to :meth:`resolve` — when the adapter has no
+        on-disk path, the blob is streamed into a temp file for the body
+        of the ``async with`` block and cleaned up afterwards.
+        """
+        file_id = parse_upload_url(url)
+        if file_id is None:
+            yield None
+            return
+        rec = await self._meta.get_scoped(file_id, workspace=workspace)
+        if rec is None:
+            yield None
+            return
+        async with materialize_to_local_path(
+            self._adapter,
+            rec.storage_key,
+            mime=rec.mime,
+            filename=rec.filename,
+        ) as path:
+            if path is None:
+                yield None
+            else:
+                yield rec, path
+
 
 async def resolve_media_paths_scoped(
     media: list[str],
@@ -55,7 +158,10 @@ async def resolve_media_paths_scoped(
     """Async counterpart to :func:`pocketpaw.uploads.resolver.resolve_media_paths`.
 
     Same semantics: upload URLs → local paths, unresolvable URLs dropped,
-    non-upload strings passed through.
+    non-upload strings passed through. Note this uses the local-path-only
+    :meth:`EEUploadResolver.resolve`; on S3 the path is ``None`` and the
+    entry is dropped. Callers that need the bytes should iterate with
+    :meth:`EEUploadResolver.open_local_for_url`.
     """
     out: list[str] = []
     for entry in media:
@@ -83,5 +189,6 @@ def default_resolver() -> EEUploadResolver:
 __all__ = [
     "EEUploadResolver",
     "default_resolver",
+    "materialize_to_local_path",
     "resolve_media_paths_scoped",
 ]

--- a/tests/cloud/uploads/test_listener.py
+++ b/tests/cloud/uploads/test_listener.py
@@ -212,7 +212,7 @@ async def test_remote_adapter_streams_into_temp_then_extracts(monkeypatch):
     temp_path, mime = chain.calls[0]
     assert mime == "image/png"
     assert temp_path.suffix == ".png", temp_path
-    assert temp_path.name.startswith("paw-extract-"), temp_path
+    assert temp_path.name.startswith("paw-upload-"), temp_path
     # File was wiped after the context manager exited.
     assert not temp_path.exists()
     # The temp file held both chunks before extraction ran. We can't peek


### PR DESCRIPTION
## Summary

- Chat attachments reached the agent as URL strings the model couldn't dereference, so users saw "I don't see the file" even though the upload succeeded. EEUploadResolver was only consulted from KB ingestion — never from the chat run path.
- Even if it had been wired in, the resolver returned `None` on S3 deployments because it called `adapter.local_path()`, which the S3 adapter doesn't implement.
- This PR hoists the listener's local-or-stream pattern into a shared `materialize_to_local_path()` context manager and threads extracted attachment text into the per-turn knowledge context, capped to keep batches from blowing the context window.

## Changes

- `uploads/resolver.py` — new `materialize_to_local_path()` async context manager (yields a local Path: direct on local-disk, streamed temp file on S3/GCS); new `EEUploadResolver.open_local_for_url()` that wraps it with a workspace-scoped Mongo lookup. Existing `resolve()` / `resolve_media_paths_scoped()` left intact.
- `uploads/listeners.py` — KB indexer now uses the shared helper instead of its private `_path_for_extraction`. ~80 lines deleted, no behavior change.
- `chat/agent_service.py` — `build_knowledge_context` now emits an `<uploaded-files>` block alongside the existing `<knowledge-base>` block. Per-file extraction via the configured chain; bounds: 5 files, 8K chars per file, 30K chars total. Non-extractable mimes (images, binary) get a stub entry so the agent still knows the file exists.
- `tests/cloud/uploads/test_listener.py` — one assertion updated (`paw-extract-` → `paw-upload-` prefix from the shared helper).

## Test plan

- [x] `ruff check` + `ruff format` clean on touched files
- [x] `mypy` unchanged from baseline (same pre-existing untyped-import notes for `pocketpaw.*`)
- [x] `tests/cloud/uploads/{test_resolver,test_listener,test_listener_pocket_route,test_listener_vector}.py` — 48 pass
- [x] `tests/uploads/test_resolver.py` — OSS resolver tests still pass
- [x] `tests/cloud/test_agent_service_tools_context.py` — 20 pass
- [x] `tests/cloud/test_agent_router*.py` — 17 pass
- [ ] Manual smoke on S3-backed deployment: upload a PDF in chat, confirm agent acknowledges the contents
- [ ] Manual smoke on local-disk deployment: confirm the local-path fast path still skips the temp-file dance

## Notes

- Image / audio / video attachments still don't have content surfaced — the extraction chain returns empty text for them. A future change could pass these through an image-supporting tool or via `presigned_get()`; for this fix they get a stub entry so at least the model knows they exist.
- kb-go availability is unrelated to this bug — uploads succeed without it, the agent just won't get KB-search hits for filename hints. Worth a separate check on prod deploys.