### PR TITLE
fix(chat): accept {type, data} envelope on inbound WS

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/router.py
+++ b/ee/pocketpaw_ee/cloud/chat/router.py
@@ -493,6 +493,25 @@ router.include_router(agent_router)
 # ---------------------------------------------------------------------------
 
 
+def _normalize_ws_inbound(payload: Any) -> Any:
+    """Unwrap the ``{type, data: {...}}`` bus envelope into a flat shape.
+
+    The browser bus (``paw-enterprise/src/lib/core/shared/bus.svelte.ts``)
+    nests every send under ``data`` to mirror the outbound :class:`WsOutbound`
+    envelope, while :class:`WsInbound` is flat for historical native clients.
+    Lift the nested keys into the top level so both shapes parse cleanly.
+    Top-level keys win when both sides set the same field — this preserves
+    explicit overrides and is a no-op for legacy flat payloads.
+    """
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), dict):
+        return payload
+    out = dict(payload)
+    nested = out.pop("data")
+    for k, v in nested.items():
+        out.setdefault(k, v)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
@@ -571,7 +590,7 @@ async def websocket_endpoint(websocket: WebSocket, token: str | None = Query(Non
             raw = await websocket.receive_text()
             try:
                 data = json.loads(raw)
-                msg = WsInbound.model_validate(data)
+                msg = WsInbound.model_validate(_normalize_ws_inbound(data))
             except Exception:
                 await websocket.send_json(
                     WsOutbound(

--- a/tests/cloud/test_chat_schemas.py
+++ b/tests/cloud/test_chat_schemas.py
@@ -58,6 +58,47 @@ def test_ws_inbound_message_send():
     assert msg.type == "message.send"
 
 
+def test_ws_inbound_envelope_lift_flattens_bus_payload():
+    """``{type, data: {...}}`` (browser bus shape) parses the same as flat."""
+    from pocketpaw_ee.cloud.chat.router import _normalize_ws_inbound
+
+    payload = {
+        "type": "message.send",
+        "data": {
+            "group_id": "g1",
+            "content": "hello",
+            "attachments": [{"type": "file", "url": "/api/v1/uploads/u1", "name": "x.pdf"}],
+        },
+    }
+    flat = _normalize_ws_inbound(payload)
+    msg = WsInbound.model_validate(flat)
+    assert msg.type == "message.send"
+    assert msg.group_id == "g1"
+    assert msg.content == "hello"
+    assert msg.attachments == [{"type": "file", "url": "/api/v1/uploads/u1", "name": "x.pdf"}]
+
+
+def test_ws_inbound_envelope_lift_is_noop_for_flat():
+    from pocketpaw_ee.cloud.chat.router import _normalize_ws_inbound
+
+    payload = {"type": "typing.start", "group_id": "g1"}
+    assert _normalize_ws_inbound(payload) == payload
+
+
+def test_ws_inbound_envelope_lift_prefers_top_level_on_conflict():
+    """Explicit top-level ``group_id`` wins over a nested duplicate."""
+    from pocketpaw_ee.cloud.chat.router import _normalize_ws_inbound
+
+    payload = {
+        "type": "message.send",
+        "group_id": "explicit",
+        "data": {"group_id": "nested", "content": "hi"},
+    }
+    flat = _normalize_ws_inbound(payload)
+    assert flat["group_id"] == "explicit"
+    assert flat["content"] == "hi"
+
+
 def test_ws_inbound_typing():
     msg = WsInbound.model_validate({"type": "typing.start", "group_id": "g1"})
     assert msg.type == "typing.start"


### PR DESCRIPTION
## Summary

- The browser bus (`paw-enterprise/src/lib/core/shared/bus.svelte.ts`) wraps every send as `{type, data: {...}}` to mirror the outbound `WsOutbound` envelope, but `WsInbound` is flat. `model_validate({type:'message.send', data:{group_id, content, attachments}})` produced `group_id=None, content=None, attachments=[]`, so `_ws_message_send` silently early-returned. Every message sent over the bus dropped on the floor — the user saw the optimistic local row and lost the message + attachments on refresh.
- Lift the nested `data.*` keys to top level before `model_validate`. Top-level keys win on conflict so legacy flat clients keep working and explicit overrides are preserved.

## Changes

- `chat/router.py` — new `_normalize_ws_inbound()` helper called between `json.loads` and `WsInbound.model_validate`. Unwraps the bus envelope when present; no-op on flat payloads.
- `tests/cloud/test_chat_schemas.py` — three new unit tests: envelope lifts cleanly, no-op on flat, top-level wins on conflict.

## Test plan

- [x] `pytest tests/cloud/test_chat_schemas.py` — 34 pass (includes the 3 new tests)
- [x] `ruff check` clean on touched files
- [ ] Manual smoke: send a message in a group chat, refresh, verify both text and attachments survive