### PR TITLE
feat(foresight): joined /rehearsals listing endpoint

### DIFF
--- a/ee/pocketpaw_ee/cloud/foresight/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/foresight/agent_context.py
@@ -41,6 +41,11 @@
 # ground-truth anchors the chat surface can't reliably produce. The chat
 # agent can answer "did we backtest yet?" / "what was the gate
 # decision?" / "are we unlocked?" without a curl fallback.
+#
+# 2026-05-29 update: added ``list_rehearsals_for_agent`` — the joined
+# scenarios-with-runs view that backs the v2 ``/foresight`` landing.
+# The chat surface uses it to answer "which rehearsals have I actually
+# run?" without an N+1 follow-up tool call per scenario.
 
 from __future__ import annotations
 
@@ -129,6 +134,42 @@ async def list_scenarios_for_agent(
     ctx = _build_request_context(workspace_id, user_id)
     try:
         response = await foresight_scenarios.list_custom_scenarios(
+            ctx, sub_type=sub_type, limit=limit, offset=offset
+        )
+    except CloudError as exc:
+        return _cloud_error_payload(exc)
+
+    payload = response.model_dump()
+    payload["ok"] = True
+    return payload
+
+
+async def list_rehearsals_for_agent(
+    limit: int = 20, offset: int = 0, sub_type: str | None = None
+) -> dict[str, Any]:
+    """List the workspace's rehearsals (custom scenarios + joined run
+    metadata) for the active stream.
+
+    Returns the same items as ``list_scenarios_for_agent`` plus a
+    ``run_count`` integer and an inline ``last_run`` summary per item
+    (id / status / ran_at / verdict_summary) so the chat agent can
+    answer "which rehearsals have I actually run?" without an N+1
+    follow-up tool call per scenario.
+
+    Shape on success: ``{"ok": True, "items": [...], "total": N,
+    "limit": int, "offset": int, "has_more": bool}``. Errors collapse to
+    the standard ``{"ok": False, "error", "message"}`` envelope.
+    """
+    workspace_id, user_id = _resolve_identity()
+    if not workspace_id or not user_id:
+        return _no_workspace_error()
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.foresight import scenarios as foresight_scenarios
+
+    ctx = _build_request_context(workspace_id, user_id)
+    try:
+        response = await foresight_scenarios.list_rehearsals(
             ctx, sub_type=sub_type, limit=limit, offset=offset
         )
     except CloudError as exc:

--- a/ee/pocketpaw_ee/cloud/foresight/dto.py
+++ b/ee/pocketpaw_ee/cloud/foresight/dto.py
@@ -1,4 +1,17 @@
 # ee/pocketpaw_ee/cloud/foresight/dto.py
+# Modified: 2026-05-29 (feat/foresight-rehearsals-joined) — v2 landing
+# card hydration. Adds the joined rehearsals surface:
+#   - ``RehearsalLastRun`` — compact summary of the most recent run
+#     (id / status / ran_at / verdict_summary) embedded inline on each
+#     list item so the v2 landing card can render without an N+1.
+#   - ``RehearsalListItem`` — one card on the v2 ``/foresight`` landing.
+#     Mirrors the existing ``CustomScenarioListItem`` field set plus
+#     ``run_count`` + optional ``last_run`` for the "draft vs. ran"
+#     state badge.
+#   - ``RehearsalListResponse`` — paginated envelope; same shape as the
+#     ``CustomScenarioListResponse`` (items / total / limit / offset /
+#     has_more) so the picker UI can swap the source endpoint without
+#     reshaping the store.
 # Modified: 2026-05-26 (feat/foresight-v10-scenario-editor-backend) — RFC
 # 08 v1.0 wave 3 adds the workspace-scoped custom-scenario surface:
 #   - ``CustomScenarioParsedMetaDto`` — denormalized parse result on the
@@ -1152,6 +1165,86 @@ class CreateCustomScenarioRequest(BaseModel):
     )
 
 
+# ---------------------------------------------------------------------------
+# Rehearsals (v2 landing) — joined view of custom scenarios + their latest
+# run, used by the paw-enterprise ``/foresight`` landing's RehearsalCard so
+# each card can render ``run_count`` + a "last run was X" badge without an
+# N+1 client-side fetch per card.
+#
+# The shape is intentionally close to ``CustomScenarioListItem`` so the
+# editor picker UI can keep its sorts / filters wired; the additions
+# (``run_count`` / ``last_run``) are additive.
+# ---------------------------------------------------------------------------
+
+
+class RehearsalLastRun(BaseModel):
+    """Compact summary of a rehearsal's most recent run.
+
+    Embedded on each :class:`RehearsalListItem` so the v2 landing card can
+    render the "last run was X" badge without a separate fetch per
+    scenario. ``verdict_summary`` is a best-effort one-line string derived
+    from ``ForesightRun.result`` (modal outcome when present, else a
+    generic "Run complete"); it is intentionally short (≤120 chars) so
+    the card layout stays predictable. ``None`` when the run is still
+    in flight (status ``running``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    status: Literal["queued", "running", "complete", "failed"]
+    ran_at: str  # ISO-8601 UTC; sourced from the run doc's ``createdAt``.
+    verdict_summary: str | None = Field(default=None, max_length=120)
+
+
+class RehearsalListItem(BaseModel):
+    """One row on the v2 ``/foresight`` landing.
+
+    Mirrors :class:`CustomScenarioListItem` field set + two joined fields
+    the landing card needs to render its state badge:
+
+      - ``run_count`` — total number of runs ever spawned from this
+        scenario in the workspace. ``0`` means the scenario is a draft.
+      - ``last_run`` — compact summary of the most recent run (or
+        ``None`` when ``run_count == 0``).
+
+    Field-name fidelity with the sibling ``CustomScenarioListItem`` is
+    deliberate: paw-enterprise's editor picker can swap source endpoints
+    (``/scenarios/custom`` ↔ ``/rehearsals``) without reshaping the store
+    — only the two new fields layer on.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    sub_type: CustomScenarioSubType
+    description: str = ""
+    num_personas: int = Field(..., ge=0)
+    num_ticks: int = Field(..., ge=0)
+    updated_at: str  # ISO-8601
+    run_count: int = Field(default=0, ge=0)
+    last_run: RehearsalLastRun | None = None
+
+
+class RehearsalListResponse(BaseModel):
+    """``GET /api/v1/foresight/rehearsals`` paginated envelope.
+
+    Same pagination shape as :class:`CustomScenarioListResponse` (items /
+    total / limit / offset / has_more) so the v2 landing's data hook can
+    reuse the cursor logic. ``limit`` is capped at 100 at the router
+    layer; the default 50 matches the v2 landing's first-paint quota.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[RehearsalListItem]
+    total: int = Field(..., ge=0)
+    limit: int = Field(..., ge=1, le=100)
+    offset: int = Field(..., ge=0)
+    has_more: bool
+
+
 __all__ = [
     "AggregateRollupResponse",
     "Anomaly",
@@ -1181,6 +1274,9 @@ __all__ = [
     "PersonaSpecRequest",
     "ProjectedDecisionListResponse",
     "ProjectedDecisionResponse",
+    "RehearsalLastRun",
+    "RehearsalListItem",
+    "RehearsalListResponse",
     "RollingAccuracyPointDto",
     "RollingAccuracySeriesDto",
     "SampledTrace",

--- a/ee/pocketpaw_ee/cloud/foresight/router.py
+++ b/ee/pocketpaw_ee/cloud/foresight/router.py
@@ -1,4 +1,13 @@
 # ee/pocketpaw_ee/cloud/foresight/router.py
+# Modified: 2026-05-29 (feat/foresight-rehearsals-joined) — v2 landing
+# card hydration. Adds the joined ``/rehearsals`` listing endpoint:
+#     GET /api/v1/foresight/rehearsals?limit=50&offset=0&sub_type=...
+#       → RehearsalListResponse (paginated; each item carries
+#         ``run_count`` + optional ``last_run`` summary so the v2
+#         landing card can render without N+1 fetches).
+#   Delegates to ``ee.cloud.foresight.scenarios.list_rehearsals`` per
+#   cloud rule #2 (the joined read lives next to the workspace-scenarios
+#   reads it builds on).
 # Modified: 2026-05-26 (feat/foresight-v12-skill-and-loopback-auth) — RFC 08
 # v1.0 wave 4. All foresight endpoints now resolve their RequestContext
 # via ``loopback_or_request_context`` (the JWT-or-loopback dep). The
@@ -154,6 +163,7 @@ from pocketpaw_ee.cloud.foresight.dto import (
     LiveSnapshotResponse,
     OnboardingGateResponse,
     ProjectedDecisionListResponse,
+    RehearsalListResponse,
     ScenarioCatalogResponse,
     ScenarioRunListItemResponse,
     ScenarioRunResponse,
@@ -767,6 +777,48 @@ async def delete_custom_scenario(
     """
     await foresight_scenarios.delete_custom_scenario(ctx, scenario_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# Rehearsals listing (v2 landing card hydration)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/rehearsals",
+    response_model=RehearsalListResponse,
+)
+async def list_rehearsals(
+    sub_type: str | None = Query(default=None, max_length=64),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    ctx: RequestContext = Depends(loopback_or_request_context),
+) -> RehearsalListResponse:
+    """List the workspace's custom scenarios with joined run metadata.
+
+    Backs the v2 ``/foresight`` landing's RehearsalCard hydration —
+    every card needs ``run_count`` + a "last run was X" badge, and the
+    landing renders ~10-50 cards on first paint. Doing this client-side
+    would require an N+1 (list scenarios, then for each, list its runs);
+    this endpoint folds the join into one round trip.
+
+    Response shape mirrors :class:`CustomScenarioListResponse` (items /
+    total / limit / offset / has_more) so the v2 landing's data hook
+    can reuse the cursor logic. ``limit`` defaults to 50 (the v2
+    landing's first-paint quota) and is hard-capped at 100.
+
+    Optional ``sub_type`` filter narrows to ``decision_forecast`` /
+    ``market_sim`` / ``org_change_rehearsal`` — same vocabulary the
+    sibling ``/scenarios/custom`` endpoint accepts. Tenancy: 403 when
+    no active workspace; runs from other workspaces never leak via the
+    joined ``$in`` query (workspace filter is the leading clause).
+    """
+    return await foresight_scenarios.list_rehearsals(
+        ctx,
+        limit=limit,
+        offset=offset,
+        sub_type=sub_type,
+    )
 
 
 __all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/foresight/scenarios.py
+++ b/ee/pocketpaw_ee/cloud/foresight/scenarios.py
@@ -1,4 +1,22 @@
 # ee/pocketpaw_ee/cloud/foresight/scenarios.py
+# Modified: 2026-05-29 (feat/foresight-rehearsals-joined) — v2 landing
+# card hydration. Adds ``list_rehearsals(ctx, *, limit, offset, sub_type)``
+# — joins ``ForesightWorkspaceScenario`` (custom scenarios) with
+# ``ForesightRun`` (runs) so the v2 ``/foresight`` landing can render
+# ``run_count`` + a "last run was X" badge per scenario without N+1
+# fetches from the frontend.
+#
+# Strategy: two-read group (Option B) — list the scenarios page, then
+# fetch matching runs via ``request.custom_scenario_id`` ``$in`` query
+# scoped to the same workspace. Grouped client-side. Avoids Mongo
+# ``$lookup`` aggregation gymnastics; re-evaluate when page-size growth
+# pushes us past ~500 docs per page.
+#
+# Verdict summary derivation is best-effort: the engine's wire dict
+# carries ``result["modal_outcome"]`` (a dict when the sub-type is
+# Decision Forecast) at the top level or under ``result["aggregate"]``.
+# We stringify compactly when present; fall back to "Run complete" on
+# success and the persisted error message on failure.
 # Created: 2026-05-26 (feat/foresight-v10-scenario-editor-backend) — RFC 08
 # v1.0 wave 3. Workspace-scoped custom scenario CRUD service.
 #
@@ -66,6 +84,12 @@ from pocketpaw_ee.cloud.foresight.dto import (
     CustomScenarioListResponse,
     CustomScenarioParsedMetaDto,
     CustomScenarioResponse,
+    RehearsalLastRun,
+    RehearsalListItem,
+    RehearsalListResponse,
+)
+from pocketpaw_ee.cloud.models.foresight_run import (
+    ForesightRun as _ForesightRunDoc,
 )
 from pocketpaw_ee.cloud.models.foresight_workspace_scenario import (
     ForesightWorkspaceScenario as _ForesightWorkspaceScenarioDoc,
@@ -591,6 +615,273 @@ async def load_workspace_scenario(workspace_id: str, scenario_id: str) -> Custom
     return _to_domain(doc)
 
 
+# ---------------------------------------------------------------------------
+# Rehearsals listing — joined view of custom scenarios + their runs.
+#
+# Why here (and not in ``service.py``): the rehearsal landing endpoint
+# is conceptually "list scenarios with run metadata", so the read drives
+# off the scenario collection (workspace-scenarios) and joins runs in.
+# ``scenarios.py`` already owns the workspace-scenarios reads; adding
+# the runs read here keeps the joined query in one module rather than
+# splitting it across ``service.py`` and ``scenarios.py``.
+#
+# Strategy notes:
+#   - Two-read group (Option B), not Mongo ``$lookup`` aggregation.
+#     v2 landing caps at 50 items per page; client-side group across
+#     50 scenario ids stays well under one millisecond.
+#   - Filter runs by ``request.custom_scenario_id`` (the scenario id is
+#     persisted INSIDE the run doc's ``request`` blob — see
+#     ``service.create_scenario_run`` where ``request=body.model_dump()``).
+#     The ``$in`` query is workspace-scoped so cross-tenant leakage
+#     can't happen even when scenario ids collide across tenants.
+#   - Verdict summary is best-effort. The engine wire dict shape varies
+#     across sub-types; we look at ``result["modal_outcome"]`` first
+#     (top-level, set by ``RunResult.as_wire_dict`` for Decision Forecast),
+#     then ``result["aggregate"]["modal_outcome"]`` (other sub-types).
+#     Fallbacks: "Run complete" on a successful run with no surfaced
+#     verdict, and the persisted error message on failure.
+# ---------------------------------------------------------------------------
+
+
+# Verdict summary cap — the wire field is capped at 120 chars; keep the
+# helper one ceiling lower so callers don't trip the DTO max_length.
+_VERDICT_SUMMARY_MAX: int = 120
+
+
+def _wire_run_status(raw_status: str) -> str:
+    """Normalize the persisted run status onto the v2 rehearsals
+    vocabulary (``queued`` | ``running`` | ``complete`` | ``failed``).
+
+    Defensive identity map — the ForesightRun doc's pattern already
+    constrains the persisted value to that set, but explicit handling
+    keeps the DTO Literal validator from crashing on a corrupt row.
+    """
+    if raw_status in ("queued", "running", "complete", "failed"):
+        return raw_status
+    # Collapse anything unexpected into ``running``; the UI's "in flight"
+    # state is the safest fallback for an unknown status (a misclassified
+    # ``complete`` would mislabel the verdict badge).
+    return "running"
+
+
+def _extract_modal_outcome_from_result(result: dict[str, Any] | None) -> Any:
+    """Return the raw ``modal_outcome`` value from a run's result blob, or
+    ``None`` when neither the top-level field nor the ``aggregate`` block
+    carries one.
+
+    Decision Forecast surfaces ``modal_outcome`` at the top level via
+    :meth:`pocketpaw_ee.foresight.scenarios.runner.RunResult.as_wire_dict`;
+    other sub-types nest it under ``aggregate``. The two read paths are
+    additive — try top-level first.
+    """
+    if not isinstance(result, dict):
+        return None
+    top = result.get("modal_outcome")
+    if top:
+        return top
+    aggregate = result.get("aggregate")
+    if isinstance(aggregate, dict):
+        return aggregate.get("modal_outcome")
+    return None
+
+
+def _format_verdict_summary(doc: _ForesightRunDoc) -> str | None:
+    """Build a short one-line verdict for a run, best-effort.
+
+    Rules:
+      - ``failed`` → the persisted ``error`` (truncated). Operator wants
+        to see WHY it failed, not "Run complete".
+      - ``running`` / ``queued`` → ``None``; the UI renders an in-flight
+        spinner from ``status`` instead.
+      - ``complete`` with a non-empty modal outcome → stringify it
+        compactly (``"approve"`` / ``"action=approve"`` / ``"approved 78%"``).
+      - ``complete`` with no surfaced verdict → ``"Run complete"``.
+
+    Truncation: caps at ``_VERDICT_SUMMARY_MAX - 1`` chars to leave room
+    for the ellipsis suffix.
+    """
+    status = _wire_run_status(doc.status)
+    if status == "failed":
+        # Take the first line of the error so the badge stays one row.
+        error_message = (doc.error or "Run failed").splitlines()[0]
+        if len(error_message) > _VERDICT_SUMMARY_MAX:
+            return error_message[: _VERDICT_SUMMARY_MAX - 1] + "…"
+        return error_message
+    if status in ("queued", "running"):
+        return None
+
+    modal = _extract_modal_outcome_from_result(doc.result)
+    if isinstance(modal, dict) and modal:
+        # Compact representation — keep keys deterministic so the UI
+        # doesn't get badge-text churn across re-fetches.
+        parts = [f"{k}={v}" for k, v in sorted(modal.items())]
+        text = ", ".join(parts)
+    elif isinstance(modal, str) and modal.strip():
+        text = modal.strip()
+    elif modal is not None and not isinstance(modal, dict | str):
+        text = str(modal)
+    else:
+        text = "Run complete"
+
+    if len(text) > _VERDICT_SUMMARY_MAX:
+        return text[: _VERDICT_SUMMARY_MAX - 1] + "…"
+    return text
+
+
+def _to_rehearsal_last_run(doc: _ForesightRunDoc) -> RehearsalLastRun:
+    """Map a :class:`ForesightRun` doc onto the inline
+    :class:`RehearsalLastRun` summary shape. ``ran_at`` is the run's
+    ``createdAt`` (when the operator kicked it off) — matches the
+    semantics of the cloud surface's other run lists.
+    """
+    return RehearsalLastRun(
+        id=str(doc.id),
+        status=_wire_run_status(doc.status),  # type: ignore[arg-type]
+        ran_at=iso_utc(doc.createdAt) or "",
+        verdict_summary=_format_verdict_summary(doc),
+    )
+
+
+def _to_rehearsal_list_item(
+    scenario: CustomScenario,
+    runs_for_scenario: list[_ForesightRunDoc],
+) -> RehearsalListItem:
+    """Build one ``RehearsalListItem`` from a scenario + the list of runs
+    that targeted it. ``runs_for_scenario`` is the runs grouped by
+    ``request.custom_scenario_id`` for this scenario; an empty list is
+    the "draft" state (``run_count=0``, ``last_run=None``).
+    """
+    last_run: RehearsalLastRun | None = None
+    if runs_for_scenario:
+        # Sort newest-first so the head is the most recent run; the
+        # caller already passes a workspace-scoped page so cross-tenant
+        # leakage can't happen via this list.
+        latest_doc = max(
+            runs_for_scenario,
+            key=lambda d: (d.createdAt, str(d.id)),
+        )
+        last_run = _to_rehearsal_last_run(latest_doc)
+
+    return RehearsalListItem(
+        id=scenario.id,
+        name=scenario.name,
+        sub_type=scenario.sub_type,  # type: ignore[arg-type]
+        description=scenario.description,
+        num_personas=scenario.parsed_meta.num_personas,
+        num_ticks=scenario.parsed_meta.num_ticks,
+        updated_at=iso_utc(scenario.updated_at) or "",
+        run_count=len(runs_for_scenario),
+        last_run=last_run,
+    )
+
+
+async def list_rehearsals(
+    ctx: RequestContext,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+    sub_type: str | None = None,
+) -> RehearsalListResponse:
+    """List the workspace's custom scenarios with joined run metadata.
+
+    Backs ``GET /api/v1/foresight/rehearsals`` — the v2 ``/foresight``
+    landing card hydration endpoint. Returns the same scenarios as
+    ``list_custom_scenarios`` plus ``run_count`` and an inline
+    ``last_run`` summary so the landing card can render its "draft vs.
+    ran" state badge without an N+1 client-side fetch.
+
+    Implementation strategy (Option B — two-read group):
+      1. Fetch the scenarios page (same query + sort as
+         ``list_custom_scenarios``: workspace + optional sub_type filter,
+         most-recently-edited first, capped at ``limit``).
+      2. Pull ALL runs in this workspace whose
+         ``request.custom_scenario_id`` matches one of the scenario ids
+         on the page. Single ``$in`` query; the workspace filter keeps
+         the scan tenant-scoped (cloud rule #7).
+      3. Group runs by scenario id client-side, count + pick the most
+         recent per group.
+
+    Why Option B over a Mongo ``$lookup`` aggregation: at v2 page sizes
+    (≤100), client-side grouping over a single query batch is faster to
+    reason about and easier to debug than a multi-stage pipeline. The
+    bottleneck would be the unindexed ``request.custom_scenario_id``
+    filter; for the in-process Mongo mock + the workspace cardinality
+    we ship at v1.0, the cost is acceptable. Re-evaluate once a
+    workspace accumulates more than ~500 active scenarios.
+
+    Pagination / tenancy / validation rules match
+    :func:`list_custom_scenarios` so the v2 landing's data hook can
+    reuse the cursor logic without divergence.
+    """
+    workspace_id = _require_workspace(ctx)
+    if limit < 1:
+        raise ValidationError("foresight.invalid_limit", "limit must be >= 1")
+    if limit > 100:
+        limit = 100
+    if offset < 0:
+        raise ValidationError("foresight.invalid_offset", "offset must be >= 0")
+
+    # Step 1: scenarios page. Same query shape as ``list_custom_scenarios``
+    # so the rehearsals list stays in lock-step with the editor picker.
+    scenario_query: dict[str, Any] = {"workspace_id": workspace_id}
+    if sub_type:
+        scenario_query["sub_type"] = sub_type
+
+    total = await _ForesightWorkspaceScenarioDoc.find(scenario_query).count()
+    scenario_docs = (
+        await _ForesightWorkspaceScenarioDoc.find(scenario_query)
+        .sort([("updatedAt", -1), ("_id", -1)])  # type: ignore[list-item]
+        .skip(offset)
+        .limit(limit)
+        .to_list()
+    )
+
+    if not scenario_docs:
+        return RehearsalListResponse(
+            items=[],
+            total=total,
+            limit=limit,
+            offset=offset,
+            has_more=False,
+        )
+
+    scenarios: list[CustomScenario] = [_to_domain(doc) for doc in scenario_docs]
+    scenario_ids: list[str] = [scenario.id for scenario in scenarios]
+
+    # Step 2: pull runs that target any scenario on the page. Tenant
+    # filter is the leading clause (cloud rule #7) so the ``$in`` scan
+    # never crosses a workspace boundary even when scenario ids collide.
+    run_docs: list[_ForesightRunDoc] = await _ForesightRunDoc.find(
+        {
+            "workspace": workspace_id,
+            "request.custom_scenario_id": {"$in": scenario_ids},
+        }
+    ).to_list()
+
+    # Step 3: group runs by scenario id client-side. Each value list is
+    # the unsorted set of runs for that scenario; the per-item mapper
+    # picks the most recent.
+    runs_by_scenario: dict[str, list[_ForesightRunDoc]] = {sid: [] for sid in scenario_ids}
+    for run_doc in run_docs:
+        request_blob = run_doc.request or {}
+        raw_sid = request_blob.get("custom_scenario_id")
+        if isinstance(raw_sid, str) and raw_sid in runs_by_scenario:
+            runs_by_scenario[raw_sid].append(run_doc)
+
+    items = [
+        _to_rehearsal_list_item(scenario, runs_by_scenario.get(scenario.id, []))
+        for scenario in scenarios
+    ]
+
+    return RehearsalListResponse(
+        items=items,
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=offset + len(items) < total,
+    )
+
+
 __all__ = [
     "DEFAULT_TIER_MIX",
     "MAX_PERSONAS",
@@ -600,6 +891,7 @@ __all__ = [
     "delete_custom_scenario",
     "get_custom_scenario",
     "list_custom_scenarios",
+    "list_rehearsals",
     "load_workspace_scenario",
     "update_custom_scenario",
 ]

--- a/tests/cloud/test_foresight_rehearsals_listing.py
+++ b/tests/cloud/test_foresight_rehearsals_listing.py
@@ -1,0 +1,346 @@
+# tests/cloud/test_foresight_rehearsals_listing.py
+# Created: 2026-05-29 (feat/foresight-rehearsals-joined) — service-level
+# tests for ``ee.cloud.foresight.scenarios.list_rehearsals``. Covers the
+# v2 ``/foresight`` landing card hydration paths: empty workspace, draft
+# scenario (no runs), scenario with multiple completed runs (last_run
+# picks the latest), in-flight latest run (status=running surfaces),
+# tenancy isolation, pagination, and sub_type filter.
+"""Tests for ``ee.cloud.foresight.scenarios.list_rehearsals``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.foresight import scenarios as foresight_scenarios
+from pocketpaw_ee.cloud.foresight import service as foresight_service
+from pocketpaw_ee.cloud.foresight.dto import (
+    CreateCustomScenarioRequest,
+    CreateScenarioRequest,
+)
+from pocketpaw_ee.cloud.models.foresight_run import (
+    ForesightRun as _ForesightRunDoc,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(workspace: str | None = "w1", user: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _decision_forecast_yaml(name: str = "saved-df", n_ticks: int = 1) -> str:
+    return f"""name: {name}
+sub_type: decision_forecast
+n_ticks: {n_ticks}
+personas:
+  - name: tenant-anne
+    role: tenant
+    ocean:
+      conscientiousness: 0.4
+  - name: approver-bob
+    role: approver
+    ocean:
+      conscientiousness: 0.8
+"""
+
+
+def _market_sim_yaml(name: str = "saved-ms") -> str:
+    return f"""name: {name}
+sub_type: market_sim
+n_ticks: 1
+personas:
+  - name: enterprise-buyer
+    role: customer
+    ocean: {{}}
+  - name: competitor-acme
+    role: competitor
+    ocean: {{}}
+"""
+
+
+async def _save_scenario(
+    ctx: RequestContext,
+    *,
+    name: str,
+    sub_type: str = "decision_forecast",
+) -> str:
+    yaml_body = (
+        _market_sim_yaml(name=name)
+        if sub_type == "market_sim"
+        else _decision_forecast_yaml(name=name)
+    )
+    saved = await foresight_scenarios.create_custom_scenario(
+        ctx,
+        CreateCustomScenarioRequest(
+            name=name,
+            sub_type=sub_type,  # type: ignore[arg-type]
+            description=f"desc for {name}",
+            yaml_body=yaml_body,
+        ),
+    )
+    return saved.id
+
+
+async def _run_saved(ctx: RequestContext, scenario_id: str) -> str:
+    """Drive a run through the cloud service so the persisted shape
+    (request.custom_scenario_id + workspace + status=complete) matches
+    what production writes — keeps the test honest about the join key."""
+    body = CreateScenarioRequest(
+        name="rehearsal-run",
+        sub_type="decision_forecast",
+        n_ticks=1,
+        personas=[],
+        custom_scenario_id=scenario_id,
+    )
+    out = await foresight_service.create_scenario_run(ctx, body)
+    return out.id
+
+
+async def _force_status(
+    run_id: str,
+    *,
+    status: str,
+    error: str | None = None,
+    result: dict[str, Any] | None = None,
+) -> None:
+    """Flip a persisted run doc's status (and optionally error/result)
+    after the engine pass already ran. Used to exercise the
+    in-flight / failed / verdict-summary branches without rewiring the
+    engine fake."""
+    from beanie import PydanticObjectId
+
+    oid = PydanticObjectId(run_id)
+    doc = await _ForesightRunDoc.find_one({"_id": oid})
+    assert doc is not None
+    doc.status = status
+    if error is not None:
+        doc.error = error
+    if result is not None:
+        doc.result = result
+    await doc.save()
+
+
+# ---------------------------------------------------------------------------
+# Empty + draft state
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_workspace_returns_zero_items() -> None:
+    ctx = _ctx(workspace="w-empty")
+    response = await foresight_scenarios.list_rehearsals(ctx)
+    assert response.items == []
+    assert response.total == 0
+    assert response.limit == 50
+    assert response.offset == 0
+    assert response.has_more is False
+
+
+async def test_scenario_with_no_runs_reports_zero_count_and_none_last_run() -> None:
+    """A saved scenario with no runs is the v2 landing's "draft" state:
+    ``run_count=0`` and ``last_run=None`` so the card renders the
+    "never run" badge instead of a verdict."""
+    ctx = _ctx()
+    await _save_scenario(ctx, name="draft-renewal")
+
+    response = await foresight_scenarios.list_rehearsals(ctx)
+    assert len(response.items) == 1
+    item = response.items[0]
+    assert item.name == "draft-renewal"
+    assert item.run_count == 0
+    assert item.last_run is None
+
+
+# ---------------------------------------------------------------------------
+# Multi-run grouping + last_run picks the latest
+# ---------------------------------------------------------------------------
+
+
+async def test_scenario_with_multiple_runs_counts_and_picks_latest() -> None:
+    """Two runs against the same scenario: ``run_count == 2`` and
+    ``last_run.id`` is the most recently created run."""
+    ctx = _ctx()
+    saved_id = await _save_scenario(ctx, name="renewal-q3")
+    _first_run_id = await _run_saved(ctx, saved_id)
+    second_run_id = await _run_saved(ctx, saved_id)
+
+    response = await foresight_scenarios.list_rehearsals(ctx)
+    assert len(response.items) == 1
+    item = response.items[0]
+    assert item.run_count == 2
+    assert item.last_run is not None
+    # The second run is the most recent — it should win.
+    assert item.last_run.id == second_run_id
+    # The deterministic engine completes the run synchronously so the
+    # persisted status flips to ``complete`` before the rehearsals read
+    # sees it.
+    assert item.last_run.status == "complete"
+    # Verdict summary is best-effort. The deterministic Decision Forecast
+    # backend surfaces a non-empty modal_outcome (``last_action=observe``);
+    # the helper stringifies it as ``key=value`` pairs sorted by key. We
+    # don't pin the exact verdict string here (engine output may evolve);
+    # we just assert the summary is non-empty and isn't the failure label.
+    assert item.last_run.verdict_summary is not None
+    assert item.last_run.verdict_summary != ""
+    assert not item.last_run.verdict_summary.startswith("Run failed")
+
+
+async def test_last_run_status_running_when_latest_run_is_in_flight() -> None:
+    """If the most-recent run is still in flight, the landing card needs
+    to see ``status=running`` (not the previous run's ``complete``) so
+    the badge can render the spinner."""
+    ctx = _ctx()
+    saved_id = await _save_scenario(ctx, name="long-sim")
+    _first_run_id = await _run_saved(ctx, saved_id)
+    second_run_id = await _run_saved(ctx, saved_id)
+    # Flip the latest run to ``running`` to simulate the v1.0 worker case.
+    await _force_status(second_run_id, status="running", result=None)
+
+    response = await foresight_scenarios.list_rehearsals(ctx)
+    item = response.items[0]
+    assert item.run_count == 2
+    assert item.last_run is not None
+    assert item.last_run.id == second_run_id
+    assert item.last_run.status == "running"
+    # In-flight runs surface ``verdict_summary=None`` so the UI renders
+    # the spinner instead of an outcome string.
+    assert item.last_run.verdict_summary is None
+
+
+async def test_failed_run_surfaces_error_in_verdict_summary() -> None:
+    """A failed run reports its persisted error in ``verdict_summary``
+    so the landing card can show "why it failed" without click-through."""
+    ctx = _ctx()
+    saved_id = await _save_scenario(ctx, name="will-fail")
+    run_id = await _run_saved(ctx, saved_id)
+    await _force_status(
+        run_id,
+        status="failed",
+        error="EngineError: persona pool exhausted",
+    )
+
+    response = await foresight_scenarios.list_rehearsals(ctx)
+    item = response.items[0]
+    assert item.last_run is not None
+    assert item.last_run.status == "failed"
+    assert item.last_run.verdict_summary == "EngineError: persona pool exhausted"
+
+
+async def test_verdict_summary_surfaces_modal_outcome_when_present() -> None:
+    """When the run's result blob carries a non-empty ``modal_outcome``,
+    the verdict_summary stringifies the dict instead of the
+    "Run complete" fallback."""
+    ctx = _ctx()
+    saved_id = await _save_scenario(ctx, name="verdict-test")
+    run_id = await _run_saved(ctx, saved_id)
+    await _force_status(
+        run_id,
+        status="complete",
+        result={
+            "scenario_name": "verdict-test",
+            "modal_outcome": {"action": "approve"},
+            "aggregate": {},
+        },
+    )
+
+    response = await foresight_scenarios.list_rehearsals(ctx)
+    item = response.items[0]
+    assert item.last_run is not None
+    assert item.last_run.verdict_summary == "action=approve"
+
+
+# ---------------------------------------------------------------------------
+# Tenancy isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_runs_from_other_workspace_dont_leak_into_count() -> None:
+    """Workspace A's runs don't count against workspace B's scenarios —
+    even when scenario ids would collide on a cross-tenant ``$in``
+    query, the workspace filter is the leading clause."""
+    ctx_a = _ctx(workspace="ws-a", user="ua")
+    ctx_b = _ctx(workspace="ws-b", user="ub")
+
+    scenario_a_id = await _save_scenario(ctx_a, name="a-only")
+    scenario_b_id = await _save_scenario(ctx_b, name="b-only")
+    await _run_saved(ctx_a, scenario_a_id)
+    await _run_saved(ctx_a, scenario_a_id)
+    await _run_saved(ctx_b, scenario_b_id)
+
+    response_a = await foresight_scenarios.list_rehearsals(ctx_a)
+    response_b = await foresight_scenarios.list_rehearsals(ctx_b)
+
+    # Workspace A sees its own scenario + 2 runs; never sees B's.
+    assert [item.name for item in response_a.items] == ["a-only"]
+    assert response_a.items[0].run_count == 2
+    # Workspace B sees its own scenario + 1 run; never sees A's.
+    assert [item.name for item in response_b.items] == ["b-only"]
+    assert response_b.items[0].run_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+async def test_pagination_slices_by_limit_and_offset() -> None:
+    """``limit=2 offset=2`` returns the third and fourth scenarios sorted
+    by ``updatedAt desc`` — the same ordering the editor picker uses."""
+    ctx = _ctx()
+    names = ["s1", "s2", "s3", "s4", "s5"]
+    for name in names:
+        await _save_scenario(ctx, name=name)
+
+    response = await foresight_scenarios.list_rehearsals(ctx, limit=2, offset=2)
+    assert response.limit == 2
+    assert response.offset == 2
+    assert response.total == 5
+    assert response.has_more is True
+    assert len(response.items) == 2
+    # Most-recent-edit-first: s5, s4, s3, s2, s1 → offset 2 → s3, s2.
+    assert [item.name for item in response.items] == ["s3", "s2"]
+
+
+async def test_pagination_has_more_false_on_last_page() -> None:
+    ctx = _ctx()
+    for name in ["a", "b", "c"]:
+        await _save_scenario(ctx, name=name)
+
+    response = await foresight_scenarios.list_rehearsals(ctx, limit=2, offset=2)
+    assert response.total == 3
+    assert response.has_more is False
+    assert len(response.items) == 1
+
+
+# ---------------------------------------------------------------------------
+# sub_type filter
+# ---------------------------------------------------------------------------
+
+
+async def test_sub_type_filter_narrows_to_matching_scenarios_only() -> None:
+    """``sub_type=market_sim`` returns only the Market Sim scenarios —
+    Decision Forecasts and Org Change rehearsals are excluded even when
+    they live in the same workspace."""
+    ctx = _ctx()
+    await _save_scenario(ctx, name="forecast-1", sub_type="decision_forecast")
+    await _save_scenario(ctx, name="market-1", sub_type="market_sim")
+    await _save_scenario(ctx, name="market-2", sub_type="market_sim")
+
+    response = await foresight_scenarios.list_rehearsals(ctx, sub_type="market_sim")
+    assert response.total == 2
+    assert {item.name for item in response.items} == {"market-1", "market-2"}
+    for item in response.items:
+        assert item.sub_type == "market_sim"


### PR DESCRIPTION
## Context

Unblocks the v2 ``/foresight`` landing card hydration. Without this
endpoint every card on the landing shows as a draft because the
frontend has no efficient way to compute ``last_run`` + ``run_count``
per scenario without an N+1 fetch per card.

Frontend pair: ``feat/foresight-v2-rehearsals`` on paw-enterprise
(Slice A's ``RehearsalsPanel.svelte``).

## What ships

``GET /api/v1/foresight/rehearsals?limit=50&offset=0&sub_type=...`` —
returns a paginated envelope of saved scenarios with two joined fields:

- ``run_count`` — total runs targeting this scenario in the workspace.
  ``0`` is the draft state.
- ``last_run`` — compact summary (id / status / ran_at /
  verdict_summary) of the most recent run, or ``None`` when
  ``run_count == 0``.

Response shape mirrors ``CustomScenarioListResponse`` (items / total /
limit / offset / has_more) so the v2 landing's data hook can reuse the
cursor logic with one source swap.

## Wire shape

```ts
type RehearsalListItem = {
  id: string;
  name: string;
  sub_type: 'decision_forecast' | 'market_sim' | 'org_change_rehearsal';
  description: string;
  num_personas: number;
  num_ticks: number;
  updated_at: string;
  run_count: number;
  last_run?: {
    id: string;
    status: 'queued' | 'running' | 'complete' | 'failed';
    ran_at: string;
    verdict_summary?: string;
  };
};
```

## Implementation — Option B (two reads + client-side group)

The task brief offered two implementations: Mongo ``$lookup``
aggregation (Option A) or two reads + client-side group (Option B).
Picked Option B because:

- v2 landing caps at 50 items per page; client-side group over 50
  scenario ids is sub-millisecond.
- Aggregation pipelines are harder to reason about + debug under
  mongomock-motor than two ``find()`` calls.
- The join key (``request.custom_scenario_id``) lives inside the run
  doc's nested ``request`` blob — straightforward as an ``$in`` filter,
  more brittle inside a ``$lookup`` ``let`` expression.

Re-evaluate Option A when a workspace passes ~500 active scenarios.

## Verdict summary derivation

Best-effort, per the task brief. The helper reads
``result.modal_outcome`` (top-level) then ``result.aggregate.modal_outcome``
and stringifies compactly when present. Failure runs surface the
persisted error; in-flight runs surface ``None``; completed runs with
no surfaced verdict fall back to ``"Run complete"``. Capped at 120
chars so the badge layout stays predictable.

## Tenancy

- Workspace filter is the leading clause on both reads.
- Runs from other workspaces never leak via the ``$in`` query, even
  when scenario ids would collide (covered by
  ``test_runs_from_other_workspace_dont_leak_into_count``).
- 403 ``foresight.no_workspace`` when the caller has no active
  workspace (matches the sibling endpoints' behaviour).

## What's NOT in this PR

- Frontend wiring. The follow-up paw-enterprise PR on
  ``feat/foresight-v2-rehearsals`` calls the new endpoint and threads
  ``last_run`` / ``run_count`` through to ``RehearsalCard``.

## Files

- ``ee/pocketpaw_ee/cloud/foresight/dto.py`` — ``RehearsalLastRun`` /
  ``RehearsalListItem`` / ``RehearsalListResponse`` DTOs.
- ``ee/pocketpaw_ee/cloud/foresight/scenarios.py`` — ``list_rehearsals``
  service function + the ``_format_verdict_summary`` helper.
- ``ee/pocketpaw_ee/cloud/foresight/router.py`` — ``GET /rehearsals``
  route wiring.
- ``ee/pocketpaw_ee/cloud/foresight/agent_context.py`` —
  ``list_rehearsals_for_agent`` MCP wrapper.
- ``tests/cloud/test_foresight_rehearsals_listing.py`` — 10 new tests.

## Test plan

- [x] ``uv run pytest tests/cloud/test_foresight_rehearsals_listing.py``
  (10 passed)
- [x] ``uv run pytest tests/cloud/ -k foresight --ignore=tests/cloud/extraction``
  (355 passed)
- [x] ``uv run ruff check`` clean on all touched files.
- [x] ``uv run mypy`` clean on all touched files.
- [x] ``uv run lint-imports`` — 18 contracts kept, 0 broken.

## Next step

- paw-enterprise PR on ``feat/foresight-v2-rehearsals`` to call this
  endpoint and hydrate ``RehearsalCard`` with the joined fields.