### PR TITLE
fix(meetings): transcript-read tool + utf-8 charset on stored text

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/meetings.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/meetings.py
@@ -29,6 +29,7 @@ LIST_TOOL_ID = f"mcp__{SERVER_NAME}__list_meetings"
 CANCEL_TOOL_ID = f"mcp__{SERVER_NAME}__cancel_meeting"
 SEARCH_TOOL_ID = f"mcp__{SERVER_NAME}__search_meetings"
 TRANSCRIPT_TOOL_ID = f"mcp__{SERVER_NAME}__find_meeting_transcript"
+READ_TRANSCRIPT_TOOL_ID = f"mcp__{SERVER_NAME}__read_meeting_transcript"
 SEND_BOT_TOOL_ID = f"mcp__{SERVER_NAME}__send_bot_to_meeting"
 CHECK_BOT_TOOL_ID = f"mcp__{SERVER_NAME}__check_meeting_bot"
 
@@ -38,9 +39,16 @@ MEETING_TOOL_IDS = (
     CANCEL_TOOL_ID,
     SEARCH_TOOL_ID,
     TRANSCRIPT_TOOL_ID,
+    READ_TRANSCRIPT_TOOL_ID,
     SEND_BOT_TOOL_ID,
     CHECK_BOT_TOOL_ID,
 )
+
+# Cap on transcript text returned to the model. A long meeting can run to
+# tens of KB of speech; past this we truncate and flag it so the agent can
+# tell the user it summarized a partial transcript rather than silently
+# dropping the tail.
+_TRANSCRIPT_TEXT_MAX_CHARS = 24_000
 
 
 def _error_response(message: str) -> dict[str, Any]:
@@ -289,6 +297,81 @@ async def _find_transcript_handler(args: dict) -> dict:
     return _success_response(body)
 
 
+async def _read_transcript_handler(args: dict) -> dict:
+    """Return the actual transcript SPEECH as plain text, not just metadata.
+
+    ``find_meeting_transcript`` hands back the ``file_id`` + counts; this
+    tool resolves that blob and returns the readable text so the agent can
+    actually summarize / answer questions about what was said. The VTT is
+    stripped to ``Speaker: text`` lines (timestamps + cue markup dropped),
+    the same cleaning the KB indexer applies. Falls through to the shared
+    'not ready' explanation when there's no stored transcript yet.
+    """
+    workspace_id, _ = _identity()
+    if not workspace_id:
+        return _error_response("no active workspace")
+
+    meeting_id = args.get("meeting_id")
+    if not isinstance(meeting_id, str) or not meeting_id:
+        return _error_response("meeting_id is required (string)")
+
+    from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+    from pocketpaw_ee.cloud.meetings import service as ms
+
+    try:
+        meta = await ms.get_transcript(workspace_id, meeting_id)
+    except NotFound:
+        return await _transcript_not_ready_response(workspace_id, meeting_id)
+    except CloudError as exc:
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("read_meeting_transcript metadata lookup failed", exc_info=True)
+        return _error_response(f"read_meeting_transcript failed: {exc}")
+
+    if not meta.file_id:
+        return await _transcript_not_ready_response(workspace_id, meeting_id)
+
+    # Resolve the stored blob → bytes → UTF-8 → plain speech. Workspace-scoped
+    # read, matching find_meeting_transcript's trust model (no per-user gate;
+    # the transcript is a workspace resource).
+    try:
+        from pathlib import Path
+
+        from pocketpaw.uploads.factory import build_adapter
+        from pocketpaw_ee.cloud.extraction.local import _vtt_to_plain
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        rec = await MongoFileStore().get_scoped(meta.file_id, workspace=workspace_id)
+        if rec is None:
+            return _error_response("transcript file is missing from storage")
+
+        adapter = build_adapter(Path.home() / ".pocketpaw" / "uploads")
+        chunks: list[bytes] = [chunk async for chunk in adapter.open(rec.storage_key)]
+        raw = b"".join(chunks).decode("utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("read_meeting_transcript blob read failed", exc_info=True)
+        return _error_response(f"could not read transcript content: {exc}")
+
+    text = _vtt_to_plain(raw)
+    if not text.strip():
+        return _error_response("transcript file held no readable speech")
+
+    truncated = len(text) > _TRANSCRIPT_TEXT_MAX_CHARS
+    if truncated:
+        text = text[:_TRANSCRIPT_TEXT_MAX_CHARS]
+
+    return _success_response(
+        {
+            "meeting_id": meeting_id,
+            "language": meta.language,
+            "speaker_count": meta.speaker_count,
+            "entry_count": meta.entry_count,
+            "truncated": truncated,
+            "text": text,
+        }
+    )
+
+
 # Map a Recall bot status to a coarse transcript state + ETA hint.
 # Used when the transcript isn't on disk yet so the agent can choose
 # the right thing to say instead of guessing.
@@ -501,6 +584,25 @@ def build_meetings_context_server() -> tuple[str, Any] | None:
         return await _find_transcript_handler(args)
 
     @tool(
+        "read_meeting_transcript",
+        (
+            "Read the actual SPOKEN CONTENT of a meeting's transcript as plain "
+            "text — use this whenever the user asks you to summarize a meeting, "
+            "pull action items / decisions, or answer questions about what was "
+            "said. ``find_meeting_transcript`` only returns metadata (file_id, "
+            "counts); THIS tool returns the words. The text is cleaned to "
+            "``Speaker: utterance`` lines (timestamps and markup stripped). If "
+            "the transcript isn't ready, you'll get the same ``ready``/``state`` "
+            "explanation as find_meeting_transcript — relay it instead of "
+            "inventing a summary. ``truncated: true`` means the meeting was long "
+            "and you only received the opening portion — say so to the user."
+        ),
+        {"meeting_id": str},
+    )
+    async def read_meeting_transcript(args):  # type: ignore[no-untyped-def]
+        return await _read_transcript_handler(args)
+
+    @tool(
         "send_bot_to_meeting",
         (
             "Send a Recall.ai bot to a meeting to capture audio and "
@@ -542,6 +644,7 @@ def build_meetings_context_server() -> tuple[str, Any] | None:
             cancel_meeting,
             search_meetings,
             find_meeting_transcript,
+            read_meeting_transcript,
             send_bot_to_meeting,
             check_meeting_bot,
         ],
@@ -554,6 +657,7 @@ __all__ = [
     "CHECK_BOT_TOOL_ID",
     "LIST_TOOL_ID",
     "MEETING_TOOL_IDS",
+    "READ_TRANSCRIPT_TOOL_ID",
     "SCHEDULE_TOOL_ID",
     "SEARCH_TOOL_ID",
     "SEND_BOT_TOOL_ID",

--- a/ee/pocketpaw_ee/cloud/uploads/service.py
+++ b/ee/pocketpaw_ee/cloud/uploads/service.py
@@ -308,16 +308,25 @@ async def write_text_file(
     payload = content.encode("utf-8") if isinstance(content, str) else content
     storage_key = new_storage_key("planner", _PLANNER_EXTENSION_BY_MIME.get(mime, "bin"))
 
+    # We always write UTF-8 here, so tell storage as much. Without an explicit
+    # charset the object is served as bare ``text/vtt`` and a browser opening
+    # the signed URL guesses an 8-bit codepage (Windows-1252) — non-ASCII text
+    # (Hindi, etc.) renders as mojibake. The base mime is still what we persist
+    # to Mongo so the FE's exact-match mime checks stay intact.
+    content_type = mime
+    if mime.startswith("text/") or mime == "application/json":
+        content_type = f"{mime}; charset=utf-8"
+
     async def _body() -> AsyncIterator[bytes]:
         yield payload
 
-    obj = await adapter.put(storage_key, _body(), mime)
+    obj = await adapter.put(storage_key, _body(), content_type)
 
     rec = FileRecord(
         id=uuid4().hex,
         storage_key=obj.key,
         filename=filename,
-        mime=obj.mime,
+        mime=mime,
         size=obj.size,
         owner_id=owner_id,
         chat_id=None,

--- a/tests/cloud/meetings/test_mcp_tools.py
+++ b/tests/cloud/meetings/test_mcp_tools.py
@@ -16,6 +16,7 @@ from pocketpaw_ee.agent.mcp_servers.meetings import (
     _check_bot_handler,
     _find_transcript_handler,
     _list_meetings_handler,
+    _read_transcript_handler,
     _schedule_meeting_handler,
     _search_meetings_handler,
     _send_bot_handler,
@@ -327,6 +328,97 @@ async def test_find_transcript_returns_not_ready_when_provider_empty(chat_identi
     assert payload["state"] == "no_bot"
     assert "no recording bot" in payload["message"].lower()
     assert payload["bot"]["has_bot"] is False
+
+
+async def test_read_transcript_returns_plain_speech(chat_identity):
+    """read_meeting_transcript returns cleaned speech, and non-ASCII (Hindi)
+    survives the store→read→decode round-trip intact (no mojibake)."""
+    import json
+
+    from pocketpaw_ee.cloud.meetings import service as ms
+    from pocketpaw_ee.cloud.models.meeting import Meeting as _MD
+
+    from pocketpaw.connectors.protocol import ActionResult
+
+    meeting = _MD(
+        workspace="ws-alpha",
+        provider="zoom",
+        provider_meeting_id="zoom-mtg-read",
+        title="Hindi sync",
+        join_url="https://zoom.us/j/9",
+    )
+    await meeting.insert()
+
+    vtt = (
+        "WEBVTT\n\n"
+        "00:00:00.000 --> 00:00:02.000\n<v Rohit>इसमें आवाज़ नहीं जा रहा</v>\n\n"
+        "00:00:02.000 --> 00:00:04.000\n<v Amritesh>हाँ बहुत slow है</v>"
+    )
+
+    class _FakeAdapter:
+        async def execute(self, action, params):
+            assert action == "transcript_get"
+            return ActionResult(success=True, data=vtt, records_affected=1)
+
+    async def _factory(workspace_id, provider):
+        return _FakeAdapter()
+
+    prev = ms._set_adapter_factory(_factory)
+    try:
+        # Prime the stored transcript blob (writes via write_text_file).
+        await ms.get_transcript("ws-alpha", str(meeting.id))
+        result = await _read_transcript_handler({"meeting_id": str(meeting.id)})
+    finally:
+        ms._set_adapter_factory(prev)
+
+    assert result.get("is_error") is not True, result
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["truncated"] is False
+    assert "Rohit: इसमें आवाज़ नहीं जा रहा" in payload["text"]
+    assert "Amritesh: हाँ बहुत slow है" in payload["text"]
+    # The mojibake signature must NOT appear — proves clean UTF-8 round-trip.
+    assert "à¤" not in payload["text"]
+
+
+async def test_read_transcript_not_ready_when_no_transcript(chat_identity):
+    """No transcript yet → structured not-ready payload, not an error."""
+    import json
+
+    from pocketpaw_ee.cloud.meetings import service as ms
+    from pocketpaw_ee.cloud.models.meeting import Meeting as _MD
+
+    from pocketpaw.connectors.protocol import ActionResult
+
+    meeting = _MD(
+        workspace="ws-alpha",
+        provider="zoom",
+        provider_meeting_id="zoom-mtg-empty-read",
+        title="Nothing yet",
+        join_url="https://zoom.us/j/10",
+    )
+    await meeting.insert()
+
+    class _EmptyAdapter:
+        async def execute(self, action, params):
+            return ActionResult(success=True, data="", records_affected=0)
+
+    async def _factory(workspace_id, provider):
+        return _EmptyAdapter()
+
+    prev = ms._set_adapter_factory(_factory)
+    try:
+        result = await _read_transcript_handler({"meeting_id": str(meeting.id)})
+    finally:
+        ms._set_adapter_factory(prev)
+
+    assert result.get("is_error") is not True, result
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ready"] is False
+
+
+async def test_read_transcript_requires_id(chat_identity):
+    result = await _read_transcript_handler({})
+    assert result["is_error"] is True
 
 
 async def test_cancel_meeting_requires_id(chat_identity):


### PR DESCRIPTION
The `feat/meetings-platform` work merged into `dev` before these two follow-up fixes landed, so they need to come in directly. Both came out of debugging live meeting-transcript issues.

## 1. `read_meeting_transcript` MCP tool
`find_meeting_transcript` only returns metadata (file_id + counts), so the cloud chat agent had no way to read the actual speech — it would (correctly) refuse to summarize a meeting it couldn''t read. New tool reads the stored blob by `file_id`, strips the VTT down to `Speaker: text` (same cleaning the KB indexer uses), and returns it with a 24k-char cap + `truncated` flag.

## 2. UTF-8 charset on stored text blobs
`write_text_file` now stamps `; charset=utf-8` on the stored object''s `Content-Type` for text mimes. The bytes were always clean UTF-8; without the charset, a browser opening the raw object-store URL guessed Windows-1252 and rendered Hindi / non-ASCII transcripts as mojibake (`à¤‡à¤¸à¤®à¥‡à¤‚`). The base mime is still persisted to Mongo so the frontend''s exact-mime checks are untouched.

## Tests
`tests/cloud/meetings/test_mcp_tools.py` — added a Hindi VTT round-trip (store → read → decode, asserts no mojibake), a not-ready path, and an id-required guard. 25 passed locally.

Note: the charset fix applies to newly-written transcripts; already-stored objects render correctly in-app (UTF-8 decode) but keep their old header on the raw URL until re-fetched.