### PR TITLE
Inference gateway integration seam (RFC 11)

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -45,6 +45,27 @@ def _stream_ttl() -> int:
     return int(os.environ.get("POCKETPAW_CLOUD_RUN_STREAM_TTL", "3600"))
 
 
+def usage_from_token_event(event: Any) -> dict[str, Any]:
+    """Map a ``token_usage`` AgentEvent's metadata into the wire ``usage`` dict.
+
+    ``claude_sdk.py`` emits a ``token_usage`` event carrying input/output token
+    counts and cost in ``event.metadata`` (RFC 11). This was previously dropped,
+    leaving the ``stream_end`` frame's ``usage`` field empty. Returns ``{}`` when
+    there's no metadata, and coerces missing numeric fields to zero so a partial
+    event still produces a usable record.
+    """
+    meta = getattr(event, "metadata", None)
+    if not isinstance(meta, dict) or not meta:
+        return {}
+    return {
+        "input_tokens": int(meta.get("input_tokens") or 0),
+        "output_tokens": int(meta.get("output_tokens") or 0),
+        "cached_input_tokens": int(meta.get("cached_input_tokens") or 0),
+        "cost_usd": float(meta.get("total_cost_usd") or 0.0),
+        "model": meta.get("model") or "",
+    }
+
+
 async def _persist_assistant_message(
     ctx: ScopeContext, content: str, attachments: list[dict[str, Any]]
 ) -> Any:
@@ -432,6 +453,24 @@ async def _drive_agent_loop(
     handled_pocket_ids: set[str] = set()
     next_event_task: asyncio.Task[Any] | None = None
     next_queue_task: asyncio.Task[tuple[str, dict[str, Any]]] | None = None
+    # Inference-gateway hook (RFC 11). When a closed pocketpaw_igw package is
+    # installed it registers a provider under ``pocketpaw.inference_gateway``;
+    # we ask it for per-run Settings overrides (model tier, provider, env) and
+    # keep the handle for token metering on the ``token_usage`` event. When no
+    # provider is registered ``first(...)`` returns None and the path is
+    # byte-for-byte today's behaviour — zero overhead, fully opt-in.
+    from pocketpaw import _registry  # type: ignore[import-untyped]
+
+    _igw = _registry.first("pocketpaw.inference_gateway")
+    settings_override: dict[str, Any] | None = None
+    if _igw is not None:
+        try:
+            override = _igw.settings_override(ctx)
+            settings_override = override or None
+        except Exception:
+            logger.exception("inference gateway settings_override failed; using defaults")
+            settings_override = None
+
     try:
         session_key = session_key_for(ctx)
         agent_iter = pool.run(
@@ -441,6 +480,7 @@ async def _drive_agent_loop(
             history=history,
             knowledge_context=knowledge_context,
             instructions=behavior_instructions,
+            settings_override=settings_override,
         ).__aiter__()
 
         async def _next_event() -> Any:
@@ -514,6 +554,26 @@ async def _drive_agent_loop(
                     handled_pocket_ids=handled_pocket_ids,
                 )
                 yield ("tool_result", {"tool": name, "output": output})
+            elif etype == "token_usage":
+                # RFC 11: the backend emits this once per run with token counts
+                # and cost. Previously unhandled, which is why the stream_end
+                # frame always carried ``usage: {}``. Capture it, forward to the
+                # inference gateway for per-actor budgeting (best-effort), and
+                # surface it to ``execute_run`` via a ``usage`` tuple so the
+                # stream_end frame can report real numbers.
+                _last_usage = usage_from_token_event(event)
+                if _igw is not None and _last_usage:
+                    try:
+                        _igw.record_usage(
+                            ctx,
+                            model=_last_usage.get("model", ""),
+                            input_tokens=_last_usage.get("input_tokens", 0),
+                            output_tokens=_last_usage.get("output_tokens", 0),
+                            cost_usd=_last_usage.get("cost_usd", 0.0),
+                        )
+                    except Exception:
+                        logger.exception("inference gateway record_usage failed")
+                yield ("usage", _last_usage)
             elif etype == "error":
                 # Surface backend-yielded errors instead of silently dropping
                 # them — a misconfigured backend (codex_cli without
@@ -638,11 +698,20 @@ async def execute_run(spec: RunSpec) -> None:
     cancelled = False
     error: Exception | None = None
     backend_error_message: str | None = None
+    # RFC 11: token usage captured from the ``token_usage`` event (relayed as a
+    # ``usage`` tuple by ``_drive_agent_loop``). Stays ``{}`` when the backend
+    # emits no usage, preserving the prior stream_end shape.
+    last_usage: dict[str, Any] = {}
     try:
         async for event_name, event_data in _iter_agent_events(spec, ctx):
             if await transport.is_cancelled(spec.run_id):
                 cancelled = True
                 break
+            if event_name == "usage":
+                # Internal relay only — capture and don't write it to the
+                # client stream (the wire protocol exposes usage on stream_end).
+                last_usage = event_data if isinstance(event_data, dict) else {}
+                continue
             if event_name == "chunk":
                 content = event_data.get("content", "")
                 if isinstance(content, str):
@@ -732,7 +801,7 @@ async def execute_run(spec: RunSpec) -> None:
         await transport.append_event(
             spec.run_id,
             "stream_end",
-            {"assistant_message_id": None, "usage": {}, "cancelled": cancelled},
+            {"assistant_message_id": None, "usage": last_usage, "cancelled": cancelled},
         )
         await transport.set_ttl(spec.run_id, _stream_ttl())
         return
@@ -748,6 +817,6 @@ async def execute_run(spec: RunSpec) -> None:
     await transport.append_event(
         spec.run_id,
         "stream_end",
-        {"assistant_message_id": assistant_id, "usage": {}, "cancelled": False},
+        {"assistant_message_id": assistant_id, "usage": last_usage, "cancelled": False},
     )
     await transport.set_ttl(spec.run_id, _stream_ttl())

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -767,11 +767,29 @@ class ClaudeSDKBackend(BaseAgentBackend):
         system_prompt: str | None = None,
         history: list[dict] | None = None,
         session_key: str | None = None,
+        settings_override: dict[str, Any] | None = None,
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
 
         Yields AgentEvent objects as the agent responds.
+
+        ``settings_override`` (RFC 11): a per-call dict of ``Settings`` field
+        overrides from an inference-gateway provider — model tier, provider,
+        ``smart_routing_enabled=False``, DeepSeek env, etc. It is applied as a
+        ``model_copy`` for this call only; ``self.settings`` (the warm pool
+        instance) is never mutated. When ``None`` the run reads ``self.settings``
+        directly and behaves exactly as before.
         """
+        # Per-call effective settings — model_copy so a gateway override never
+        # mutates the warm-pool instance. Everything in run() that previously
+        # read ``self.settings`` reads ``effective`` instead, so the override
+        # shapes provider resolution, the subprocess env (ANTHROPIC_BASE_URL),
+        # and the smart-routing suppression in one place.
+        effective = (
+            self.settings.model_copy(update=settings_override)
+            if settings_override
+            else self.settings
+        )
         if not self._sdk_available:
             yield AgentEvent(
                 type="error",
@@ -833,8 +851,8 @@ class ClaudeSDKBackend(BaseAgentBackend):
             # See: https://code.claude.com/docs/en/legal-and-compliance
             from pocketpaw.llm.client import resolve_llm_client
 
-            provider = self.settings.claude_sdk_provider or "anthropic"
-            llm = resolve_llm_client(self.settings, force_provider=provider)
+            provider = effective.claude_sdk_provider or "anthropic"
+            llm = resolve_llm_client(effective, force_provider=provider)
 
             # ── API key check for Anthropic provider ──────────────
             # Skip if using a non-Anthropic provider, or if the active
@@ -870,10 +888,10 @@ class ClaudeSDKBackend(BaseAgentBackend):
             # All messages go through the Claude Code CLI subprocess, which
             # handles conversation compaction automatically (PreCompact hook).
             selection = None
-            if self.settings.smart_routing_enabled and not is_non_anthropic:
+            if effective.smart_routing_enabled and not is_non_anthropic:
                 from pocketpaw.agents.model_router import ModelRouter
 
-                model_router = ModelRouter(self.settings)
+                model_router = ModelRouter(effective)
                 selection = model_router.classify(message)
                 logger.info(
                     "Smart routing: %s -> %s (%s)",
@@ -1022,7 +1040,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 "setting_sources": ["user", "project"],
                 "hooks": hooks,
                 "cwd": str(self._cwd),
-                "max_turns": self.settings.claude_sdk_max_turns or None,
+                "max_turns": effective.claude_sdk_max_turns or None,
             }
 
             # Configure LLM provider for the Claude CLI subprocess.
@@ -1091,14 +1109,14 @@ class ClaudeSDKBackend(BaseAgentBackend):
             # 2. Explicit claude_sdk_model — user-chosen fixed model
             # 3. Neither set — let Claude Code CLI auto-select (recommended)
             if not is_non_anthropic:
-                if self.settings.smart_routing_enabled:
+                if effective.smart_routing_enabled:
                     from pocketpaw.agents.model_router import ModelRouter
 
-                    model_router = ModelRouter(self.settings)
+                    model_router = ModelRouter(effective)
                     selection = model_router.classify(message)
                     options_kwargs["model"] = selection.model
-                elif self.settings.claude_sdk_model:
-                    options_kwargs["model"] = self.settings.claude_sdk_model
+                elif effective.claude_sdk_model:
+                    options_kwargs["model"] = effective.claude_sdk_model
 
             # Capture stderr for better error diagnostics
             def _on_stderr(line: str) -> None:

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -161,6 +161,7 @@ class AgentPool:
         history: list[dict] | None = None,
         knowledge_context: str = "",
         instructions: str = "",
+        settings_override: dict[str, Any] | None = None,
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -173,6 +174,14 @@ class AgentPool:
 
         ``knowledge_context`` remains reference material (KB snippets +
         per-turn scope/participants tags). Kept under the wrapper.
+
+        ``settings_override`` is a per-call dict of ``Settings`` field
+        overrides supplied by an inference-gateway provider (RFC 11). It is
+        applied inside the backend's ``run()`` as a ``model_copy`` for this
+        call only — the warm pool instance and its ``self.settings`` are
+        never mutated. It is passed to the backend only when non-empty, so
+        backends that don't accept the kwarg (every backend except the
+        Claude SDK lane) keep working when no gateway is registered.
         """
         instance = await self.get(agent_id)
         instance.last_active = datetime.now(UTC)
@@ -249,12 +258,18 @@ class AgentPool:
         # LRU evictor honor.
         instance.active_runs += 1
         try:
-            async for event in instance.backend.run(
-                message,
-                system_prompt=system_prompt,
-                history=history,
-                session_key=session_key,
-            ):
+            # Only thread ``settings_override`` to the backend when a gateway
+            # actually supplied one. Backends other than the Claude SDK lane
+            # don't accept the kwarg; passing it unconditionally would raise
+            # TypeError on the OSS-default direct path (no gateway registered).
+            run_kwargs: dict[str, Any] = {
+                "system_prompt": system_prompt,
+                "history": history,
+                "session_key": session_key,
+            }
+            if settings_override:
+                run_kwargs["settings_override"] = settings_override
+            async for event in instance.backend.run(message, **run_kwargs):
                 instance.last_active = datetime.now(UTC)
                 yield event
         finally:

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -202,6 +202,39 @@ class PocketWriter(Protocol):
 
 
 @runtime_checkable
+class InferenceGatewayProvider(Protocol):
+    """Entry-point group: ``pocketpaw.inference_gateway``
+
+    Sits between the cloud run path and the model backend. For each run it
+    returns a set of ``Settings`` field overrides (model tier, provider,
+    routing, env) applied per-call, and records the run's token usage for
+    per-actor budgeting. A closed ``pocketpaw_igw`` package registers the
+    real implementation; an OSS install registers none, so the cloud path
+    runs unchanged with no override and no metering (see RFC 11).
+    """
+
+    def settings_override(self, ctx: Any) -> dict[str, Any]:
+        """Per-run ``Settings`` field overrides for this request — e.g.
+        ``{"claude_sdk_model": ..., "claude_sdk_provider": ...,
+        "smart_routing_enabled": False}``. An empty dict means no override
+        (the run uses the agent's own settings)."""
+        ...
+
+    def record_usage(
+        self,
+        ctx: Any,
+        *,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+    ) -> None:
+        """Record the token usage and cost of a completed run against the
+        actor/workspace in ``ctx`` (per-actor budget + ledger)."""
+        ...
+
+
+@runtime_checkable
 class ComposioToolProvider(Protocol):
     """Entry-point group: ``pocketpaw.composio_tools``
 

--- a/tests/cloud/runs/test_run_core_usage_capture.py
+++ b/tests/cloud/runs/test_run_core_usage_capture.py
@@ -1,0 +1,66 @@
+# Tests for the RFC 11 token-usage capture helper in run_core.
+# Created: 2026-05-29 — TDD coverage for the EE-side metering seam. The cloud
+#   run path emits a `token_usage` AgentEvent from claude_sdk.py that was
+#   previously dropped on the floor, which is why the stream_end frame always
+#   carried `"usage": {}`. RFC 11 wires it: capture the usage off the event and
+#   (when an inference-gateway provider is registered) forward it to
+#   provider.record_usage(...).
+#
+# The full _drive_agent_loop / execute_run path needs Mongo + Redis cloud
+# fixtures, so the capture logic is extracted into a pure helper and unit-tested
+# here. The end-to-end wiring (loop -> stream_end usage field) is covered by an
+# integration gap noted in the PR body.
+
+from __future__ import annotations
+
+from typing import Any
+
+from pocketpaw_ee.cloud.chat.runs.run_core import usage_from_token_event
+
+
+class _FakeEvent:
+    def __init__(self, metadata: dict[str, Any] | None) -> None:
+        self.type = "token_usage"
+        self.content = ""
+        self.metadata = metadata
+
+
+def test_usage_from_token_event_maps_metadata():
+    ev = _FakeEvent(
+        {
+            "input_tokens": 1200,
+            "output_tokens": 340,
+            "cached_input_tokens": 800,
+            "total_cost_usd": 0.0123,
+            "model": "claude-haiku",
+            "backend": "claude_agent_sdk",
+        }
+    )
+    usage = usage_from_token_event(ev)
+    assert usage["input_tokens"] == 1200
+    assert usage["output_tokens"] == 340
+    assert usage["cached_input_tokens"] == 800
+    assert usage["cost_usd"] == 0.0123
+    assert usage["model"] == "claude-haiku"
+
+
+def test_usage_from_token_event_handles_missing_metadata():
+    assert usage_from_token_event(_FakeEvent(None)) == {}
+    assert usage_from_token_event(_FakeEvent({})) == {}
+
+
+def test_usage_from_token_event_defaults_missing_numbers_to_zero():
+    usage = usage_from_token_event(_FakeEvent({"model": "claude"}))
+    assert usage["input_tokens"] == 0
+    assert usage["output_tokens"] == 0
+    assert usage["cost_usd"] == 0.0
+    assert usage["model"] == "claude"
+
+
+def test_usage_from_token_event_handles_null_cost():
+    # claude_sdk emits total_cost_usd=None when the SDK omits it.
+    usage = usage_from_token_event(
+        _FakeEvent({"input_tokens": 5, "output_tokens": 3, "total_cost_usd": None})
+    )
+    assert usage["cost_usd"] == 0.0
+    assert usage["input_tokens"] == 5

--- a/tests/test_inference_gateway_seam.py
+++ b/tests/test_inference_gateway_seam.py
@@ -1,0 +1,313 @@
+# Tests for the RFC 11 inference-gateway integration seam.
+# Created: 2026-05-29 — TDD coverage for the OSS-core additive seam that lets a
+#   closed pocketpaw_igw package override Settings per run and meter token usage:
+#     - InferenceGatewayProvider Protocol + registry discovery (pocketpaw.inference_gateway)
+#     - AgentPool.run(settings_override=...) threading down to the backend
+#     - ClaudeSDKBackend.run(settings_override=...) building a per-call effective
+#       Settings via model_copy while leaving self.settings untouched.
+#
+# These tests use fakes/stubs; no `claude` subprocess is spawned.
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Protocol + registry
+# ---------------------------------------------------------------------------
+
+
+class _FakeIGWProvider:
+    """Minimal object satisfying the InferenceGatewayProvider Protocol."""
+
+    def settings_override(self, ctx: Any) -> dict[str, Any]:
+        return {
+            "claude_sdk_model": "claude-haiku-test",
+            "claude_sdk_provider": "openai_compatible",
+            "smart_routing_enabled": False,
+        }
+
+    def record_usage(
+        self,
+        ctx: Any,
+        *,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+    ) -> None:
+        return None
+
+
+def test_inference_gateway_protocol_is_runtime_checkable():
+    from pocketpaw.extensions import InferenceGatewayProvider
+
+    fake = _FakeIGWProvider()
+    assert isinstance(fake, InferenceGatewayProvider)
+
+
+def test_inference_gateway_protocol_rejects_non_conforming_object():
+    from pocketpaw.extensions import InferenceGatewayProvider
+
+    class _Missing:
+        # has settings_override but not record_usage
+        def settings_override(self, ctx: Any) -> dict[str, Any]:
+            return {}
+
+    assert not isinstance(_Missing(), InferenceGatewayProvider)
+
+
+def test_registry_returns_none_when_no_gateway_registered():
+    from pocketpaw import _registry
+
+    _registry.clear_cache()
+    assert _registry.first("pocketpaw.inference_gateway") is None
+
+
+def test_registry_discovers_registered_gateway(monkeypatch):
+    """When an entry point is registered under pocketpaw.inference_gateway,
+    `first` returns the instantiated provider."""
+    from importlib.metadata import EntryPoint
+
+    from pocketpaw import _registry
+
+    # Stash the fake provider class somewhere importable by EntryPoint.load().
+    mod = types.ModuleType("_igw_fake_mod")
+    mod._FakeIGWProvider = _FakeIGWProvider  # type: ignore[attr-defined]
+    sys.modules["_igw_fake_mod"] = mod
+
+    ep = EntryPoint(
+        name="inference_gateway",
+        value="_igw_fake_mod:_FakeIGWProvider",
+        group="pocketpaw.inference_gateway",
+    )
+
+    def _fake_entry_points(*, group: str):
+        return [ep] if group == "pocketpaw.inference_gateway" else []
+
+    monkeypatch.setattr("pocketpaw._registry.entry_points", _fake_entry_points)
+    _registry.clear_cache()
+    try:
+        provider = _registry.first("pocketpaw.inference_gateway")
+        assert provider is not None
+        assert isinstance(provider, _FakeIGWProvider)
+    finally:
+        _registry.clear_cache()
+        sys.modules.pop("_igw_fake_mod", None)
+
+
+# ---------------------------------------------------------------------------
+# AgentPool.run(settings_override=...)
+# ---------------------------------------------------------------------------
+
+
+class _StubBackend:
+    """Captures the settings the pool hands it via a per-call effective clone.
+
+    The pool does NOT pass settings_override into the backend constructor; it
+    passes it as a kwarg to backend.run(). This stub records what it received.
+    """
+
+    def __init__(self, settings: Any) -> None:
+        self.settings = settings
+        self.received_override: dict[str, Any] | None = None
+
+    async def run(
+        self, message, *, system_prompt=None, history=None, session_key=None, settings_override=None
+    ):
+        self.received_override = settings_override
+        # Compute the same effective the real backend would, so the test can
+        # assert the override actually shapes the run.
+        effective = (
+            self.settings.model_copy(update=settings_override)
+            if settings_override
+            else self.settings
+        )
+        from pocketpaw.agents.backend import AgentEvent
+
+        yield AgentEvent(
+            type="effective_probe",
+            content="",
+            metadata={
+                "claude_sdk_model": effective.claude_sdk_model,
+                "claude_sdk_provider": effective.claude_sdk_provider,
+                "smart_routing_enabled": effective.smart_routing_enabled,
+            },
+        )
+        yield AgentEvent(type="done", content="")
+
+
+@pytest.fixture
+def _pool_with_stub(monkeypatch):
+    """Build an AgentPool whose `get` returns an instance backed by _StubBackend."""
+    from pocketpaw.agents.pool import AgentInstance, AgentPool
+    from pocketpaw.config import Settings
+
+    pool = AgentPool()
+    settings = Settings()
+    settings.claude_sdk_model = "claude-default"
+    settings.claude_sdk_provider = "anthropic"
+    settings.smart_routing_enabled = True
+
+    backend = _StubBackend(settings)
+    instance = AgentInstance(
+        agent_id="agent-1",
+        agent_name="Agent One",
+        config={},
+        backend=backend,
+        soul_manager=None,
+        memory_namespace="agent-1",
+    )
+
+    async def _fake_get(agent_id: str):
+        return instance
+
+    monkeypatch.setattr(pool, "get", _fake_get)
+    return pool, backend
+
+
+async def test_pool_run_threads_settings_override_to_backend(_pool_with_stub):
+    pool, backend = _pool_with_stub
+    override = {
+        "claude_sdk_model": "claude-haiku-test",
+        "claude_sdk_provider": "openai_compatible",
+        "smart_routing_enabled": False,
+    }
+
+    events = [
+        ev async for ev in pool.run("agent-1", "hello", "session-1", settings_override=override)
+    ]
+
+    assert backend.received_override == override
+    probe = next(e for e in events if e.type == "effective_probe")
+    assert probe.metadata["claude_sdk_model"] == "claude-haiku-test"
+    assert probe.metadata["claude_sdk_provider"] == "openai_compatible"
+    assert probe.metadata["smart_routing_enabled"] is False
+    # The instance's own settings must be untouched (per-call only).
+    assert backend.settings.claude_sdk_model == "claude-default"
+    assert backend.settings.smart_routing_enabled is True
+
+
+async def test_pool_run_without_override_passes_none(_pool_with_stub):
+    pool, backend = _pool_with_stub
+    _events = [ev async for ev in pool.run("agent-1", "hi", "session-1")]
+    assert backend.received_override is None
+
+
+# ---------------------------------------------------------------------------
+# ClaudeSDKBackend.run(settings_override=...)
+# ---------------------------------------------------------------------------
+
+
+def _make_backend_settings() -> Any:
+    from pocketpaw.config import Settings
+
+    s = Settings()
+    s.claude_sdk_model = "claude-sonnet-default"
+    s.claude_sdk_provider = "anthropic"
+    s.smart_routing_enabled = True
+    return s
+
+
+def _spy_llm():
+    """A MagicMock standing in for the resolved LLM client.
+
+    All provider-kind flags are False so `is_non_anthropic` stays False and
+    `run()` follows the Anthropic path. `to_sdk_env` returns an empty dict so
+    no real env is built. The run still fails downstream when the (absent) SDK
+    options class is constructed — that failure is caught inside run() and
+    surfaced as an `error` event, which is fine: by then `effective` has
+    already been captured by the resolve spy.
+    """
+    llm = MagicMock()
+    llm.is_ollama = False
+    llm.is_openai_compatible = False
+    llm.is_gemini = False
+    llm.is_litellm = False
+    llm.is_openrouter = False
+    llm.api_key = ""
+    llm.to_sdk_env.return_value = {}
+    llm.format_api_error.return_value = "stubbed error"
+    return llm
+
+
+async def test_claude_sdk_run_builds_effective_clone_and_leaves_self_unchanged(monkeypatch):
+    """run(settings_override=...) must build a model_copy and read provider
+    resolution off the clone, never mutating self.settings."""
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+    backend = ClaudeSDKBackend(_make_backend_settings())
+    # Get past the early availability guards without spawning anything.
+    backend._sdk_available = True
+    backend._cli_available = True
+
+    captured: dict[str, Any] = {}
+
+    def _spy_resolve(settings, *, force_provider=None):
+        captured["settings"] = settings
+        captured["force_provider"] = force_provider
+        return _spy_llm()
+
+    monkeypatch.setattr("pocketpaw.llm.client.resolve_llm_client", _spy_resolve)
+
+    override = {
+        "claude_sdk_model": "claude-haiku-test",
+        "claude_sdk_provider": "openai_compatible",
+        "smart_routing_enabled": False,
+    }
+
+    # Drain the stream — run() ultimately fails building the (unloaded) SDK
+    # options, which is caught and surfaced as an error event, so iteration
+    # completes without raising.
+    _events = [
+        ev
+        async for ev in backend.run(
+            "hello",
+            system_prompt=None,
+            history=None,
+            session_key="s1",
+            settings_override=override,
+        )
+    ]
+
+    eff = captured["settings"]
+    assert eff.claude_sdk_model == "claude-haiku-test"
+    assert eff.claude_sdk_provider == "openai_compatible"
+    assert eff.smart_routing_enabled is False
+    # force_provider must come off the effective clone, not self.settings.
+    assert captured["force_provider"] == "openai_compatible"
+    # effective is a distinct object from self.settings (a model_copy).
+    assert eff is not backend.settings
+
+    # self.settings is unchanged: per-call override only.
+    assert backend.settings.claude_sdk_model == "claude-sonnet-default"
+    assert backend.settings.claude_sdk_provider == "anthropic"
+    assert backend.settings.smart_routing_enabled is True
+
+
+async def test_claude_sdk_run_without_override_uses_self_settings(monkeypatch):
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+    backend = ClaudeSDKBackend(_make_backend_settings())
+    backend._sdk_available = True
+    backend._cli_available = True
+
+    captured: dict[str, Any] = {}
+
+    def _spy_resolve(settings, *, force_provider=None):
+        captured["settings"] = settings
+        return _spy_llm()
+
+    monkeypatch.setattr("pocketpaw.llm.client.resolve_llm_client", _spy_resolve)
+
+    _events = [
+        ev async for ev in backend.run("hi", system_prompt=None, history=None, session_key="s1")
+    ]
+
+    # With no override, effective IS self.settings (same object).
+    assert captured["settings"] is backend.settings


### PR DESCRIPTION
## What this does

Builds the OSS-side integration seam for RFC 11 (Inference Gateway). It lets a closed `pocketpaw_igw` package override model settings per run and meter token usage, without the OSS core ever depending on it. With no gateway installed, the run path is unchanged.

This is the seam only. The gateway package itself (routing, budget governor, DeepSeek lanes) is out of scope and ships separately.

## Changes

**OSS core (`pocketpaw`)**
- `src/pocketpaw/extensions.py`: new `InferenceGatewayProvider` Protocol under the `pocketpaw.inference_gateway` entry-point group, with `settings_override(ctx) -> dict` and `record_usage(...)`. Declaration only, modeled on the existing runtime-checkable Protocols in the file.
- `src/pocketpaw/agents/pool.py`: `AgentPool.run()` takes a `settings_override` param and passes it to the backend only when non-empty, so backends that don't accept the kwarg keep working on the default path.
- `src/pocketpaw/agents/claude_sdk.py`: `ClaudeSDKBackend.run()` takes `settings_override` and builds a per-call `effective = self.settings.model_copy(update=...)` at the top of the method. Provider resolution, the subprocess env (`ANTHROPIC_BASE_URL` flows through `resolve_llm_client(effective)`), `max_turns`, and both smart-routing branches now read `effective`. `self.settings` is never mutated, so an override applies to one call only and the warm pool is undisturbed. Setting `smart_routing_enabled=False` on the override suppresses re-routing.

**Cloud (`pocketpaw_ee`)**
- `ee/pocketpaw_ee/cloud/chat/runs/run_core.py`:
  - Look up the gateway provider before `pool.run()`, build the override from the `ScopeContext`, and pass it down. Keep the handle for metering.
  - Handle the `token_usage` event the backend already emits but was being dropped. A new `usage_from_token_event()` helper maps the event metadata into the wire usage dict; the loop forwards it to `record_usage()` and relays it to `execute_run`.
  - Replace the two hardcoded `"usage": {}` values on the `stream_end` frame with the captured usage.

All gateway calls are best-effort and wrapped so a provider error can't abort a run.

## Tests

Written first, confirmed red, then green.

- `tests/test_inference_gateway_seam.py`
  - `InferenceGatewayProvider` is runtime-checkable: a conforming fake passes `isinstance`, a non-conforming object fails it.
  - `_registry.first("pocketpaw.inference_gateway")` returns `None` when nothing is registered, and returns the instantiated provider when an entry point is present.
  - `AgentPool.run(settings_override=...)` reaches the backend, and the resulting effective settings carry the overridden model/provider with `smart_routing_enabled=False`. Without an override the backend gets `None`. Uses a stub backend, no `claude` subprocess.
  - `ClaudeSDKBackend.run(settings_override=...)` resolves the provider off a `model_copy` clone and leaves `self.settings` untouched. The SDK transport is mocked so nothing spawns.
- `tests/cloud/runs/test_run_core_usage_capture.py` covers `usage_from_token_event()`: metadata mapping, missing/empty metadata, zero defaults, and null cost.

```
12 passed
```

## Test gap

The full `_drive_agent_loop` to `execute_run` path needs Mongo and Redis cloud fixtures, so I did not write an end-to-end test that proves a `token_usage` event lands in the `stream_end` usage field or that `record_usage` fires during a real run. Instead I pulled the usage mapping out into the pure `usage_from_token_event()` helper and unit-tested that, and I ran the existing `tests/cloud/runs/` suite to confirm the relay change doesn't break it. To close the gap, drive a fake backend that emits a `token_usage` event through `execute_run` with the runs fixtures.

## Pre-existing failure (not from this PR)

`tests/test_agents.py::TestClaudeSDKCliAuth::test_auto_resolve_no_key_gives_ollama` fails on this branch with my source changes stashed, so it predates this work. It's an environment-dependent provider-default assertion, unrelated to the seam.
