### PR TITLE
fix(pockets): warn on spec/merge orphan state with no ui referent (#1301)

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -156,6 +156,7 @@ from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
 from pocketpaw_ee.cloud.ripple_validator import (
     ActionWiringViolationError,
     CatalogViolationError,
+    find_unreferenced_state_keys,
     format_action_violations_for_agent,
     format_violations_for_agent,
     validate_action_wiring_logged,
@@ -1046,11 +1047,17 @@ async def merge_spec(
 
     # Compute the new spec.
     orphans: list[str] = []
+    base_spec = doc.rippleSpec or {}
+    # Top-level state keys present BEFORE this edit — so the orphan-state
+    # warning below names only keys this edit ADDED, not pre-existing
+    # orphans the agent didn't touch (avoids re-warning noise on replace).
+    base_state_keys: set[str] = set(
+        base_spec.get("state", {}) if isinstance(base_spec.get("state"), dict) else {}
+    )
     if parsed.replace is not None:
         new_spec_raw = parsed.replace
     else:
         assert parsed.merge is not None  # narrowing for type checkers
-        base_spec = doc.rippleSpec or {}
         new_spec_raw, orphans = merge_ripple_spec(base_spec, parsed.merge)
 
     # Normalize + validate (mirror the create_from_ripple_spec gate
@@ -1064,6 +1071,29 @@ async def merge_spec(
             f"dropped: {', '.join(orphans)}. To add a new node, re-state "
             "its parent with the new child appended to children."
         )
+
+    # Orphan-state warning (issue #1301) — NON-BLOCKING. A state-only
+    # merge patch (an add-widget intent that never carried a ui node)
+    # adds a state key no widget reads, so it renders nothing. Mirror the
+    # orphan-node warning above: name the newly-added unreferenced keys so
+    # the specialist self-correction loop can wire a widget. Limit to keys
+    # this edit ADDED — a pre-existing orphan or a legitimate ``sources``
+    # bind target must not re-warn (the collector already excludes the
+    # latter).
+    if normalized:
+        added_orphan_state = [
+            k
+            for k in find_unreferenced_state_keys(normalized)
+            if k not in base_state_keys
+        ]
+        if added_orphan_state:
+            warnings.append(
+                "Added state key(s) with no ui widget reading them — "
+                f"{', '.join(added_orphan_state)}. A new state key with no "
+                "binding widget renders nothing. Add the ui node that reads "
+                "it (a `{state.<key>}` expression or a `bind`), or declare a "
+                "`sources` entry that binds it."
+            )
 
     if normalized:
         # Expression-grammar — never blocks; collect for the caller.

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -1082,9 +1082,7 @@ async def merge_spec(
     # latter).
     if normalized:
         added_orphan_state = [
-            k
-            for k in find_unreferenced_state_keys(normalized)
-            if k not in base_state_keys
+            k for k in find_unreferenced_state_keys(normalized) if k not in base_state_keys
         ]
         if added_orphan_state:
             warnings.append(

--- a/ee/pocketpaw_ee/cloud/ripple_validator.py
+++ b/ee/pocketpaw_ee/cloud/ripple_validator.py
@@ -23,6 +23,12 @@ new token / method added to the resolver should be added here too — the
 two files together are the contract.
 
 Changes:
+  - 2026-05-30 (issue #1301): added ``find_unreferenced_state_keys`` —
+    a pure ui-walk collector (mirrors ``find_unwired_live_buttons``) that
+    returns top-level ``state`` keys no ui node references. Closes the
+    silent-orphan-state gap where an add-widget intent landing as a
+    state-only merge patch persisted with nothing rendering it. Used by
+    ``pockets/service.merge_spec`` to emit a NON-BLOCKING warning.
   - 2026-05-22 (Increment 5): added the catalog-as-allowlist gate —
     ``CatalogViolationError`` plus ``validate_against_catalog_strict``
     (agent-generation path, RAISES) and ``..._logged`` (human/import
@@ -661,11 +667,157 @@ def validate_action_wiring_strict(
         raise ActionWiringViolationError(violations)
 
 
+# ---------------------------------------------------------------------------
+# Orphan-state gate (issue #1301, 2026-05-30).
+#
+# An add-widget intent that lands as a STATE-ONLY merge patch is
+# structurally valid at every layer, and nothing cross-references state
+# against ui — so a new state key with no ui referent persists silently
+# and renders nothing. This pure collector closes that gap: it walks the
+# ui tree, gathers EVERY state reference (template expressions + node-level
+# ``bind`` values, dotted and bare), unions in the legitimate ``sources``
+# bind targets (write-targets no widget may read yet), and returns the
+# state keys with no referent.
+#
+# Mirrors the structure of ``find_unwired_live_buttons`` in OSS
+# ``pocketpaw.ripple.manifest`` (a pure ui-walk collector). The caller
+# (``pockets/service.merge_spec``) surfaces the result as a NON-BLOCKING
+# warning — a state-only seed of a ``sources`` bind target is legitimate.
+# ---------------------------------------------------------------------------
+
+
+# Top-level state key inside a ``{state.<key>...}`` expression body. The
+# resolver addresses state by dotted path; only the FIRST segment is the
+# top-level key the merge shallow-merges against.
+_STATE_REF_RE = re.compile(r"\bstate\.([A-Za-z_$][\w$]*)")
+
+# Built-in loop / event context vars the renderer injects inside ``each``
+# bodies. A bare ``bind`` to one of these is loop-scoped, NOT a top-level
+# state key, so it must not count as a state reference.
+_LOOP_CONTEXT_VARS: frozenset[str] = frozenset({"item", "card", "index", "event", "i"})
+
+
+def _state_keys_in_expression(value: str) -> Iterator[str]:
+    """Yield every top-level state key referenced inside any ``{…}``
+    template in ``value`` (e.g. ``{state.tickets}`` → ``tickets``,
+    ``{state.x + state.y}`` → ``x``, ``y``)."""
+    for body in _expressions_in(value):
+        for m in _STATE_REF_RE.finditer(body):
+            yield m.group(1)
+
+
+def _normalize_bind_target(bind: str) -> str:
+    """Strip a leading ``state.`` from a dotted bind path and return the
+    top-level key. ``"state.prs"`` → ``"prs"``; ``"draft_lane"`` →
+    ``"draft_lane"``; ``"state.form.x"`` → ``"form"`` (only the top-level
+    key the merge shallow-merges against matters)."""
+    stripped = bind[len("state.") :] if bind.startswith("state.") else bind
+    # Only the first dotted segment is the top-level state key.
+    return stripped.split(".", 1)[0].split("[", 1)[0]
+
+
+def _collect_referenced_state(
+    node: Any,
+    referenced: set[str],
+    loop_vars: frozenset[str],
+) -> None:
+    """Recursive ui walk that records every state key a node reads.
+
+    Two reference forms are collected:
+
+    * ``{state.<key>…}`` template expressions in ANY string value, and
+    * node-level ``bind`` values — dotted (``state.x``) or bare (``x``).
+      A bare ``bind`` that names a loop / event context var in scope is
+      loop-scoped, not a top-level state key, and is skipped.
+
+    Generous on purpose: over-collecting a reference only suppresses a
+    warning (safe); under-collecting would emit a false positive. The
+    ``state`` seed block is never walked here — initial values are plain
+    data, not references.
+    """
+    if isinstance(node, dict):
+        # Extend loop-var scope for ``each`` bodies — the conventional
+        # loop-context names plus any ``item_as`` / ``index_as`` aliases.
+        # Reserved ONLY inside ``each``; a top-level bare bind is real state.
+        child_loop_vars = loop_vars
+        if node.get("type") == "each":
+            extra = set(loop_vars)
+            for alias_key in ("item_as", "index_as"):
+                alias = node.get(alias_key)
+                if isinstance(alias, str) and alias:
+                    extra.add(alias)
+            child_loop_vars = frozenset(extra | _LOOP_CONTEXT_VARS)
+
+        for key, value in node.items():
+            if key == "bind" and isinstance(value, str) and value:
+                if value.startswith("state."):
+                    referenced.add(_normalize_bind_target(value))
+                else:
+                    head = _normalize_bind_target(value)
+                    if head not in child_loop_vars:
+                        referenced.add(head)
+                continue
+            if isinstance(value, str):
+                referenced.update(_state_keys_in_expression(value))
+            else:
+                _collect_referenced_state(value, referenced, child_loop_vars)
+    elif isinstance(node, list):
+        for child in node:
+            _collect_referenced_state(child, referenced, loop_vars)
+    elif isinstance(node, str):
+        referenced.update(_state_keys_in_expression(node))
+
+
+def find_unreferenced_state_keys(spec: dict[str, Any] | None) -> list[str]:
+    """Return top-level ``state`` keys that no ui node references.
+
+    Walks ``spec["ui"]`` collecting every state reference (template
+    expressions in all forms, node-level ``bind`` values dotted and bare,
+    excluding loop-scoped item vars), unions in every ``sources`` bind
+    target (legitimate write-targets a widget may not read yet), then
+    returns the ``state`` keys minus that referenced set, sorted.
+
+    Pure / side-effect-free — mirrors ``find_unwired_live_buttons``. The
+    caller decides what to do with the result; this never blocks.
+
+    Returns ``[]`` when ``spec`` is not a dict or has no ``state`` dict.
+    """
+    if not isinstance(spec, dict):
+        return []
+    state = spec.get("state")
+    if not isinstance(state, dict) or not state:
+        return []
+
+    referenced: set[str] = set()
+
+    # 1. References from the ui tree (templates + node-level binds).
+    ui = spec.get("ui")
+    if isinstance(ui, (dict, list)):
+        # Top-level scope reserves NO loop vars — a state key literally named
+        # ``item``/``index``/etc. read by a top-level bare bind must be rescued
+        # (loop-context names are reserved only inside ``each`` bodies).
+        _collect_referenced_state(ui, referenced, frozenset())
+
+    # 2. Legitimate ``sources`` write-targets — a source binding seeds a
+    #    state key that no widget may read yet (the unconditional seed
+    #    rule). Union them in so they're never flagged as orphans.
+    sources = spec.get("sources")
+    if isinstance(sources, dict):
+        for binding in sources.values():
+            if isinstance(binding, dict):
+                bind = binding.get("bind")
+                if isinstance(bind, str) and bind:
+                    referenced.add(_normalize_bind_target(bind))
+
+    return sorted(k for k in state if k not in referenced)
+
+
 __all__ = [
     "ActionWiringViolationError",
     "CatalogViolationError",
     "ExpressionWarning",
     "RippleSpecGrammarError",
+    "find_unreferenced_state_keys",
     "format_action_violations_for_agent",
     "format_violations_for_agent",
     "format_warnings_for_agent",

--- a/src/pocketpaw/bundled_skills/_bundled/pocketpaw-pocket-specialist/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/pocketpaw-pocket-specialist/SKILL.md
@@ -167,6 +167,13 @@ get shallow-merged; keys you don't mention stay.
 { "merge": { "state": { "filter": "overdue", "count": 7 } } }
 ```
 
+Reverse coherence: a state-only patch is correct only when a widget
+already reads the key (e.g. ``filter`` drives a list a ``{state.filter}``
+binding shows). When you're ADDING a widget, add the ui node AND its
+state together in one merge — a new state key with no binding widget
+renders nothing. The merge endpoint now returns a non-blocking warning
+naming any state key it added that no ui node reads; wire that key.
+
 ### Replace — only for >50% rewrites
 
 If the user said "redesign this completely" or you're inserting an
@@ -270,6 +277,9 @@ the spot the user asked are fine; silently dropping existing widgets,
   (selects + kanban column matching).
 - Don't invent new state keys without a reason — every new key is
   context the agent has to remember next session.
+- Don't add a state key without the ui that reads it. When adding a
+  widget, add the ui node AND its state together; a new state key with
+  no binding widget renders nothing.
 - Don't read source files, grep the repo, or run ``web_search`` to
   figure out a pocket operation. The merge endpoint + the rules above
   are the whole interface.

--- a/tests/cloud/pockets/test_merge_spec.py
+++ b/tests/cloud/pockets/test_merge_spec.py
@@ -9,14 +9,30 @@
 # guard added to ``_collect_patch_nodes`` / ``_collect_all_ids``. The
 # patch tree is untrusted agent output; a self-referential children
 # graph used to loop forever before the guard.
+# Updated: 2026-05-30 (issue #1301 RED) — added
+# ``test_add_widget_intent_lands_orphan_state_warns`` to reproduce the
+# silent-orphan-state bug: a state-only merge patch that adds a brand-new
+# state key with NO ui referent persists silently and renders nothing.
+# The test drives the service-level ``merge_spec`` (the layer that owns
+# the ``ok`` / ``warnings`` envelope the specialist self-correction loop
+# reads) and asserts a non-blocking warning names the orphan key.
+# Updated: 2026-05-30 (issue #1301 GREEN) — the fix lands a NON-BLOCKING
+# orphan-state warning via ``find_unreferenced_state_keys``. Reworked the
+# helper-level bug-pin ``test_state_only_patch_shallow_merges`` so its
+# patched keys are referenced by ui (it no longer pins the bug), and added
+# the negative test ``test_state_patch_for_referenced_key_no_warning``
+# (updating an already-bound key AND seeding a ``sources`` bind target both
+# emit NO orphan-state warning) to guard against false positives.
 """Unit tests for ``pocketpaw_ee.cloud.pockets._merge.merge_ripple_spec``."""
 
 from __future__ import annotations
 
+import asyncio
 import copy
 from typing import Any
 
 import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
 from pocketpaw_ee.cloud.pockets._merge import merge_ripple_spec
 
 # ---------------------------------------------------------------------------
@@ -136,16 +152,32 @@ def test_add_child_via_parent_restatement():
 def test_state_only_patch_shallow_merges():
     """Patch with only a ``state`` key shallow-merges into existing
     state. Keys not present in the patch are kept; the ui tree is
-    untouched byte-identical."""
+    untouched byte-identical.
+
+    The patch only touches keys the base ui already reads (``draft`` via
+    the input binding, ``count`` via the badge text). Updating an
+    already-bound key is the legitimate state-only edit — it must NOT
+    surface an orphan-state warning (issue #1301). A patch that ADDED an
+    unreferenced key would, but that's covered by the service-level repro
+    ``test_add_widget_intent_lands_orphan_state_warns``; here we keep the
+    shallow-merge contract honest with a coherent (referenced) patch."""
     base = _base_spec()
-    patch = {"state": {"count": 7, "newKey": "hello"}}
+    # Wire the base ui so both keys the patch touches are already read by
+    # a widget — this is the well-formed state-only edit shape.
+    base["ui"]["children"][0]["props"]["value"] = "{state.draft}"
+    base["ui"]["children"][1]["props"]["label"] = "{state.count}"
+    patch = {"state": {"draft": "typed", "count": 7}}
 
     merged, orphans = merge_ripple_spec(base, patch)
 
     assert orphans == []
-    assert merged["state"] == {"draft": "", "count": 7, "newKey": "hello"}
+    assert merged["state"] == {"draft": "typed", "count": 7}
     # ui untouched
     assert merged["ui"] == base["ui"]
+    # And no orphan-state: every key the patch touched is read by the ui.
+    from pocketpaw_ee.cloud.ripple_validator import find_unreferenced_state_keys
+
+    assert find_unreferenced_state_keys(merged) == []
 
 
 # ---------------------------------------------------------------------------
@@ -247,7 +279,6 @@ def test_merge_cycle_in_patch_does_not_hang():
     references node_a must terminate. ``asyncio.wait_for`` is the
     timeout primitive available without an extra plugin.
     """
-    import asyncio
 
     # Construct a cycle via shared dict references — the merge walk
     # follows ``children`` lists, so two id-bearing dicts that point at
@@ -279,3 +310,227 @@ def test_merge_cycle_in_patch_does_not_hang():
     # patch but not in base) — exactly once each, no infinite duplicates.
     assert orphans.count("n_a00001") == 1
     assert orphans.count("n_b00001") == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #1301 — an add-widget intent that lands as a state-only merge patch.
+#
+# Root cause: ``merge_spec`` merges ``state`` and ``ui`` as INDEPENDENT
+# branches and seeds warnings ONLY from ``orphans`` (ui ids in the patch
+# not reachable from base.ui). A state-only patch produces zero orphans,
+# so a brand-new state key with NO ui node that reads it persists silently
+# and renders nothing — ``ok:true`` with empty ``warnings``.
+#
+# The fix is a deterministic NON-BLOCKING orphan-state warning: a new state
+# key that no ui node references (and isn't a legitimate ``sources`` bind
+# target) must surface a warning naming it, flowing back through the
+# existing warnings channel into the specialist self-correction loop. The
+# merge still persists (``ok:true``) because a state-only seed can be
+# legitimate.
+#
+# This test drives the service-level ``merge_spec`` because that is the
+# layer that owns the ``ok`` / ``warnings`` envelope the specialist reads.
+# Its DB-bound collaborators are stubbed in-memory (the same mock-the-
+# collaborators posture ``test_merge_spec_endpoint.py`` uses) so the test
+# isolates the warning behaviour, not the Beanie / catalog plumbing.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDoc:
+    """In-memory stand-in for ``_PocketDoc`` — only the attributes the
+    ``merge_spec`` path reads/writes (``rippleSpec``, ``id``, ``workspace``,
+    ``save``)."""
+
+    def __init__(self, spec: dict, *, pocket_id: str, workspace: str) -> None:
+        self.rippleSpec = spec
+        self.id = pocket_id
+        self.workspace = workspace
+        self.save_calls = 0
+
+    async def save(self) -> None:
+        self.save_calls += 1
+
+
+def _wire_merge_spec_stubs(monkeypatch: pytest.MonkeyPatch, fake_doc: _FakeDoc) -> None:
+    """Monkeypatch every DB-bound collaborator ``merge_spec`` touches so it
+    runs in-memory against ``fake_doc`` — same mock-the-collaborators posture
+    ``test_merge_spec_endpoint.py`` uses. Isolates the orphan-state warning
+    behaviour from Beanie / catalog plumbing."""
+
+    async def _fake_fetch(pocket_id: str):  # type: ignore[no-untyped-def]
+        return fake_doc
+
+    async def _fake_resolved_wire_dict(doc, viewer_user_id):  # type: ignore[no-untyped-def]
+        return {"id": doc.id, "rippleSpec": doc.rippleSpec}
+
+    async def _fake_event_payload(doc):  # type: ignore[no-untyped-def]
+        return {"recipient_ids": [], "pocket": {"id": doc.id}}
+
+    async def _fake_emit(event):  # type: ignore[no-untyped-def]
+        return None
+
+    async def _noop_gate_catalog(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(pockets_service, "_fetch_pocket", _fake_fetch)
+    monkeypatch.setattr(pockets_service, "_pocket_to_domain", lambda doc: object())
+    monkeypatch.setattr(pockets_service, "_check_domain_edit_access", lambda *a, **k: None)
+    monkeypatch.setattr(pockets_service, "_gate_catalog", _noop_gate_catalog)
+    monkeypatch.setattr(pockets_service, "_resolved_wire_dict", _fake_resolved_wire_dict)
+    monkeypatch.setattr(pockets_service, "_pocket_event_payload", _fake_event_payload)
+    monkeypatch.setattr(pockets_service, "emit", _fake_emit)
+
+
+def test_add_widget_intent_lands_orphan_state_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An add-widget intent that lands as a STATE-ONLY merge patch — a
+    brand-new state key with NO ui referent — must persist (``ok:true``,
+    non-blocking) AND surface a warning naming the new key as orphan /
+    unreferenced state.
+
+    Reproduces issue #1301: today the merge succeeds with empty warnings
+    because nothing cross-references state against ui. RED — this asserts
+    the warning that the fix will add.
+    """
+    # Base spec whose ui references an existing state key (state.draft via
+    # the textarea-style binding the renderer reads). ``smokeNotes`` below
+    # is the brand-new key with no ui node that reads it.
+    base_spec = {
+        "version": "1.0",
+        "state": {"draft": ""},
+        "ui": {
+            "id": "n_root0001",
+            "type": "flex",
+            "props": {"direction": "column", "gap": 12},
+            "children": [
+                {
+                    "id": "n_input001",
+                    "type": "input",
+                    "props": {"value": "{{state.draft}}", "label": "Draft"},
+                },
+            ],
+        },
+    }
+
+    fake_doc = _FakeDoc(
+        copy.deepcopy(base_spec),
+        pocket_id="pocket-1301",
+        workspace="ws-1301",
+    )
+
+    # --- Stub the DB-bound collaborators so ``merge_spec`` runs in-memory.
+    _wire_merge_spec_stubs(monkeypatch, fake_doc)
+
+    # State-only merge patch: adds a brand-new key with NO ui node reading it.
+    body = {"merge": {"state": {"smokeNotes": "remember to wire a widget"}}}
+
+    result = asyncio.run(
+        pockets_service.merge_spec(
+            workspace_id="ws-1301",
+            user_id="user-1301",
+            pocket_id="pocket-1301",
+            body=body,
+        )
+    )
+
+    # Non-blocking: the seed persists.
+    assert result["ok"] is True, result
+    assert fake_doc.save_calls == 1
+    # The new key is in the persisted state (shallow-merged in).
+    assert fake_doc.rippleSpec["state"]["smokeNotes"] == "remember to wire a widget"
+
+    # The bug fix: a warning must name the orphan / unreferenced state key.
+    warnings = result.get("warnings") or []
+    assert any("smokeNotes" in w for w in warnings), (
+        "expected a non-blocking warning naming 'smokeNotes' as orphan / "
+        f"unreferenced state, got warnings={warnings!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1301 negative — guard against false positives. Two legitimate
+# state-only edits must produce NO orphan-state warning:
+#   (a) updating an already-ui-bound key, and
+#   (b) seeding a ``sources`` bind target (a write-target no widget reads
+#       yet — the unconditional-seed rule makes this legitimate).
+# ---------------------------------------------------------------------------
+
+
+def test_state_patch_for_referenced_key_no_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An UPDATE to an already-bound state key and a seed of a ``sources``
+    bind target must both persist (``ok:true``) with NO orphan-state
+    warning. Guards the #1301 fix against false positives."""
+    # --- Case (a): patch updates ``draft``, which the input already reads.
+    base_a = {
+        "version": "1.0",
+        "state": {"draft": ""},
+        "ui": {
+            "id": "n_root0001",
+            "type": "flex",
+            "props": {"direction": "column"},
+            "children": [
+                {
+                    "id": "n_input001",
+                    "type": "input",
+                    "props": {"value": "{state.draft}", "label": "Draft"},
+                },
+            ],
+        },
+    }
+    doc_a = _FakeDoc(copy.deepcopy(base_a), pocket_id="p-a", workspace="ws-a")
+    _wire_merge_spec_stubs(monkeypatch, doc_a)
+
+    result_a = asyncio.run(
+        pockets_service.merge_spec(
+            workspace_id="ws-a",
+            user_id="u-a",
+            pocket_id="p-a",
+            body={"merge": {"state": {"draft": "now typed"}}},
+        )
+    )
+
+    assert result_a["ok"] is True, result_a
+    assert doc_a.save_calls == 1
+    warnings_a = result_a.get("warnings") or []
+    assert not any("draft" in w and "no ui widget" in w for w in warnings_a), (
+        f"updating an already-bound key must not warn, got {warnings_a!r}"
+    )
+
+    # --- Case (b): patch seeds ``prs`` — a declared ``sources`` bind
+    #     target that no widget reads yet. Legitimate per the seed rule.
+    base_b = {
+        "version": "1.0",
+        "state": {},
+        "sources": {
+            "prs": {"path": "/pulls", "bind": "state.prs", "method": "GET"},
+        },
+        "ui": {
+            "id": "n_root0001",
+            "type": "flex",
+            "props": {"direction": "column"},
+            "children": [
+                {"id": "n_text0001", "type": "text", "props": {"value": "Loading…"}},
+            ],
+        },
+    }
+    doc_b = _FakeDoc(copy.deepcopy(base_b), pocket_id="p-b", workspace="ws-b")
+    _wire_merge_spec_stubs(monkeypatch, doc_b)
+
+    result_b = asyncio.run(
+        pockets_service.merge_spec(
+            workspace_id="ws-b",
+            user_id="u-b",
+            pocket_id="p-b",
+            body={"merge": {"state": {"prs": []}}},
+        )
+    )
+
+    assert result_b["ok"] is True, result_b
+    assert doc_b.save_calls == 1
+    warnings_b = result_b.get("warnings") or []
+    assert not any("prs" in w and "no ui widget" in w for w in warnings_b), (
+        f"seeding a declared sources bind target must not warn, got {warnings_b!r}"
+    )

--- a/tests/cloud/test_ripple_validator.py
+++ b/tests/cloud/test_ripple_validator.py
@@ -2,6 +2,10 @@
 # Updated: 2026-05-22 (Increment 5) — added the catalog-as-allowlist gate
 # tests: CatalogViolationError, validate_against_catalog_strict/_logged,
 # the embed URL/host policy via the validator, and format_violations_for_agent.
+# Updated: 2026-05-30 (issue #1301) — added unit coverage for the new pure
+# collector ``find_unreferenced_state_keys`` (orphan-state detection across
+# template / bare-bind / dotted-bind forms, loop-var exclusion, and the
+# ``sources`` bind-target union).
 """Tests for ripple_validator — grammar warnings on AI-generated specs."""
 
 from __future__ import annotations
@@ -18,6 +22,7 @@ from pocketpaw_ee.cloud.ripple_validator import (  # noqa: E402
     CatalogViolationError,
     ExpressionWarning,
     RippleSpecGrammarError,
+    find_unreferenced_state_keys,
     format_violations_for_agent,
     format_warnings_for_agent,
     validate_against_catalog_logged,
@@ -281,3 +286,94 @@ def test_catalog_violation_error_message_caps_at_20() -> None:
     err = CatalogViolationError(violations)
     assert err.violations == violations
     assert "and 5 more" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1301 — find_unreferenced_state_keys. A pure ui-walk collector that
+# returns the top-level state keys no widget references. Mirrors
+# find_unwired_live_buttons. The orphan-state warning the merge endpoint
+# emits is driven by this; these tests pin the collector itself.
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_state_key_with_no_ui_referent_is_flagged() -> None:
+    spec = {
+        "state": {"draft": "", "smokeNotes": "x"},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {"type": "input", "props": {"value": "{state.draft}"}},
+            ],
+        },
+    }
+    # ``draft`` is read by the input; ``smokeNotes`` is read by nothing.
+    assert find_unreferenced_state_keys(spec) == ["smokeNotes"]
+
+
+def test_template_dotted_and_bare_bind_all_count_as_references() -> None:
+    spec = {
+        "state": {"tickets": [], "selected": 0, "draftLane": "lead", "src": []},
+        "sources": {"feed": {"bind": "state.src", "path": "/x"}},
+        "ui": {
+            "type": "flex",
+            "children": [
+                # template expression
+                {"type": "master-detail", "props": {"items": "{state.tickets}"}},
+                # bare bind
+                {"type": "input", "bind": "selected"},
+                # dotted bind
+                {"type": "select", "bind": "state.draftLane"},
+            ],
+        },
+    }
+    # tickets (template), selected (bare bind), draftLane (dotted bind),
+    # src (sources bind target) — all referenced, nothing orphaned.
+    assert find_unreferenced_state_keys(spec) == []
+
+
+def test_loop_item_var_is_not_mistaken_for_state_key() -> None:
+    spec = {
+        "state": {"tickets": [], "ghost": 1},
+        "ui": {
+            "type": "each",
+            "items": "{state.tickets}",
+            "item_as": "ticket",
+            "children": [
+                # ``{ticket.title}`` is loop-scoped, NOT a state ref. ``ghost``
+                # below has no referent and must surface as the only orphan.
+                {"type": "text", "props": {"value": "{ticket.title}"}},
+                {"type": "badge", "bind": "ticket"},
+            ],
+        },
+    }
+    assert find_unreferenced_state_keys(spec) == ["ghost"]
+
+
+def test_non_dict_or_empty_state_returns_empty() -> None:
+    assert find_unreferenced_state_keys(None) == []
+    assert find_unreferenced_state_keys([]) == []  # type: ignore[arg-type]
+    assert find_unreferenced_state_keys({"state": {}, "ui": {}}) == []
+    assert find_unreferenced_state_keys({"ui": {}}) == []
+
+
+def test_reserved_loop_name_as_top_level_state_key_is_rescued() -> None:
+    # A state key literally named after a loop-context var (``item``) that a
+    # TOP-LEVEL bare bind reads must NOT be flagged — loop names are reserved
+    # only inside ``each`` bodies (#1301 hardening).
+    top_level = {
+        "state": {"item": "x"},
+        "ui": {"type": "input", "bind": "item"},
+    }
+    assert find_unreferenced_state_keys(top_level) == []
+
+    # Inside an ``each`` the same name IS the loop var, so a state key ``item``
+    # has no real referent and surfaces as an orphan.
+    inside_loop = {
+        "state": {"item": "x", "rows": []},
+        "ui": {
+            "type": "each",
+            "items": "{state.rows}",
+            "children": [{"type": "text", "bind": "item"}],
+        },
+    }
+    assert find_unreferenced_state_keys(inside_loop) == ["item"]


### PR DESCRIPTION
Fixes #1301.

## The bug

An "add a widget" intent that the pocket_specialist lands as a **state-only** merge patch was structurally valid at every layer, and nothing cross-referenced `state` against `ui`. So a new state key with no binding widget persisted silently and rendered nothing — the merge returned `ok=true` with zero warnings, and the user saw an unchanged canvas. (The title-rename in the smoke test worked because it re-states an existing ui node; only the add-widget-as-state-only path hits this.)

## The fix — a deterministic, non-blocking orphan-state warning

- **`find_unreferenced_state_keys(spec)`** (new, in `ripple_validator.py`) — a pure ui-walk collector mirroring `find_unwired_live_buttons`. It gathers every state reference from the ui tree (template `{state.x}` expressions, `bind` values dotted and bare), unions in every `sources` bind target (legitimate write-targets a widget may not read yet), and returns the state keys nothing references.
- **`merge_spec`** now diffs that against the pre-merge state and emits a **non-blocking** warning naming only the keys *this* edit added with no ui referent. The spec still persists (`ok=true`) — a state-only seed of a `sources` target is legitimate, so this never blocks a valid edit. The warning flows back through the existing channel into the pocket_specialist's self-correction loop, nudging it to add the missing ui node.

Why warning, not reject: the false-positive surface is real (state is referenced in several syntactic forms), so a hard gate would risk rejecting valid edits. Warning-only caps the blast radius to an ignorable nudge.

Loop-context names (`item`/`index`/…) are reserved **only inside `each` bodies**, so a top-level state key literally named `item` read by a bare bind is not a false positive (regression-tested).

## Also

- Fixes `test_state_only_patch_shallow_merges`, which **pinned the bug** by asserting zero warnings for an unreferenced new key.
- Adds the reverse-coherence rule to the specialist `SKILL.md` (add the ui node *and* its state together) as a complementary nudge — the deterministic server guard is the durable fix.

## Tests (TDD)

Failing repro first (`test_add_widget_intent_lands_orphan_state_warns`), then a false-positive negative test (a referenced key + a `sources` target both stay warning-free), plus collector unit tests and the loop-name regression test. **51 passing** across `tests/cloud/pockets/` + `tests/cloud/test_ripple_validator.py`; ruff clean.

Closes #1301
