### PR TITLE
add_widget can author RFC-04 sources on the home pocket

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
@@ -37,6 +37,15 @@ agent's retry loop sees a tight, focused corrective hint that names the
 exact bad verb without needing a cloud round-trip. The service-layer gate
 in ``pockets/service.py`` is still the authoritative ground truth — this
 is a cheap belt-and-suspenders that runs first.
+Changes: 2026-05-31 (feat/home-pocket-sources-authoring) — the ``add_widget``
+tool now documents an optional ``widget.sources`` field: a dict keyed by
+source name of RFC-04 GET bindings ({method, path, bind, refresh}) that the
+home grid runs to hydrate the tile's state. ``add_widget_for_agent`` pulls
+``sources`` off the widget dict and the service layer merges it (logged /
+drift-allowed) onto the pocket's top-level ``rippleSpec.sources`` in the same
+write — so the agent can create a live tile AND the source feeding it in one
+call. The handler itself is unchanged (it forwards the whole ``widget``); only
+the tool schema/description grew.
 """
 
 from __future__ import annotations
@@ -340,7 +349,15 @@ def build_pocket_context_server() -> tuple[str, Any] | None:
             "real `data` series). Call `get_widget_spec` for the widget "
             "type FIRST so the spec uses valid props; a spec with invented "
             'props is rejected. Native widgets pass `type:"native"` and '
-            "no `spec`."
+            "no `spec`. To make the tile LIVE, also pass `widget.sources` — "
+            "a dict keyed by source name; each value is a read-only GET "
+            "binding `{method:'GET', path:'/...', bind:'state.<key>', "
+            "refresh:['pocket_open'|'manual']}`. The source hydrates the "
+            "state path the tile's `spec` binds to (e.g. tile "
+            "`value:'{state.revenue}'` + source `bind:'state.revenue'`). "
+            "Sources are authored onto the pocket's top-level "
+            "rippleSpec.sources and run by the source executor; an invalid "
+            "source is dropped without blocking the tile."
         ),
         {
             "type": "object",
@@ -352,8 +369,12 @@ def build_pocket_context_server() -> tuple[str, Any] | None:
                 "widget": {
                     "type": "object",
                     "description": (
-                        "Widget entry: name, type, optional icon/color, and a "
-                        "rippleSpec `spec` subtree (omit for native widgets)."
+                        "Widget entry: name, type, optional icon/color, a "
+                        "rippleSpec `spec` subtree (omit for native widgets), "
+                        "and optional `sources` — a dict keyed by source name "
+                        "of RFC-04 GET bindings ({method, path, bind, refresh}) "
+                        "that feed the tile's state. Omit `sources` for a "
+                        "static tile."
                     ),
                 },
             },

--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -34,6 +34,15 @@ closes the only remaining gap. ``kind`` is the simpler client-facing
 label; ``family`` is kept untouched on the granular-op frames for
 back-compat. See ``ee/docs/architecture/pocket-mutation-channel.md``
 for the full channel contract.
+Changes: 2026-05-31 (feat/home-pocket-sources-authoring) —
+``add_widget_for_agent`` now pulls an optional ``sources`` dict off the
+``widget`` argument and threads it to ``agent_add_widget`` as an explicit
+kwarg, so the home agent can author the RFC-04 source that feeds a live tile
+in the same call that adds the tile. The merge happens at the service layer
+in LOGGED (drift-allowed) mode; this wrapper only routes ``sources`` so it
+never lands as a widget field, and still emits the full-document ``replace``
+``pocket_mutation`` via ``_push_replace`` (the frontend already understands
+``replace`` — no paw-enterprise change needed).
 """
 
 from __future__ import annotations
@@ -377,8 +386,23 @@ async def update_pocket_for_agent(
 
 
 async def add_widget_for_agent(pocket_id: str, widget: dict[str, Any]) -> dict[str, Any]:
-    """Append a widget to the pocket's embedded widget list."""
-    view, err = await pockets_service.agent_add_widget(pocket_id, widget)
+    """Append a widget to the pocket's embedded widget list.
+
+    When the ``widget`` dict carries an optional ``sources`` key (a dict
+    keyed by source name, each value an RFC-04 ``SourceBinding`` —
+    ``method`` / ``path`` / ``bind`` / ``refresh`` / …), those entries are
+    authored onto the pocket's top-level ``rippleSpec.sources`` in the same
+    write so the home agent can create a live tile AND the source that feeds
+    it in one call. The sources merge is LOGGED (drift-allowed) at the
+    service layer: a single invalid binding is skipped, never blocking the
+    tile. ``sources`` rides ON the widget dict (not the widget doc) — it is
+    pulled off here and threaded as an explicit kwarg so it never lands as a
+    widget field."""
+    # Pull ``sources`` off the widget dict (a non-dict widget falls through
+    # to the service layer's "must be a JSON object" guard unchanged).
+    raw_sources = widget.get("sources") if isinstance(widget, dict) else None
+    sources = raw_sources if isinstance(raw_sources, dict) else None
+    view, err = await pockets_service.agent_add_widget(pocket_id, widget, sources=sources)
     if err is not None:
         return {"ok": False, "error": err}
     await _push_replace(view)

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -1853,7 +1853,76 @@ async def agent_update(
     return _agent_view_dict(doc), None
 
 
-async def agent_add_widget(pocket_id: str, widget: dict) -> tuple[dict | None, str | None]:
+def _merge_authored_sources_logged(doc: _PocketDoc, sources: dict[str, Any]) -> None:
+    """Merge agent-authored RFC-04 sources into ``doc.rippleSpec.sources``.
+
+    This is the LOGGED (drift-allowed) sibling of ``agent_set_source``'s
+    strict per-source validation — it mirrors how the create / human-import
+    paths treat catalog drift (``validate_against_catalog_logged``) and how
+    the source executor's own ``_parse_bindings`` treats a malformed entry:
+    a bad binding is logged and SKIPPED, never raised, so one hallucinated
+    source can't block the whole ``add_widget``. Each surviving entry is
+    normalized through the ``SourceBinding`` model (the same schema the
+    executor parses), so the binding the executor later runs is identical to
+    a binding authored via ``set_source``.
+
+    Mutates ``doc.rippleSpec`` in place via the pure ``sources_ops`` helper.
+    A non-dict ``sources`` arg, or one with no valid entry, is a no-op — the
+    ``sources`` key is only materialised when at least one binding validates.
+    """
+    from pocketpaw_ee.cloud.pockets.source_executor import SourceBinding
+
+    if not isinstance(sources, dict) or not sources:
+        return
+    spec = _sources_root(doc)
+    for key, entry in sources.items():
+        if not key or not isinstance(entry, dict):
+            logger.warning(
+                "add_widget: skipping authored source %r — entry must be a non-empty "
+                "keyed object (pocket %s)",
+                key,
+                str(doc.id),
+            )
+            continue
+        try:
+            normalized = SourceBinding.model_validate(entry).model_dump(mode="json")
+        except PydanticValidationError as exc:
+            logger.warning(
+                "add_widget: skipping invalid authored source %r on pocket %s: %s",
+                key,
+                str(doc.id),
+                exc.errors()[0].get("msg", exc) if exc.errors() else exc,
+            )
+            continue
+        try:
+            sources_ops.set_source(spec, key, normalized)
+        except ValueError as exc:
+            logger.warning(
+                "add_widget: could not merge authored source %r on pocket %s: %s",
+                key,
+                str(doc.id),
+                exc,
+            )
+
+
+async def agent_add_widget(
+    pocket_id: str,
+    widget: dict,
+    *,
+    sources: dict[str, Any] | None = None,
+) -> tuple[dict | None, str | None]:
+    """Append one widget tile to the pocket's embedded widget list, and —
+    when ``sources`` is supplied — author the RFC-04 data sources that feed
+    it onto the pocket's top-level ``rippleSpec.sources`` in the same write.
+
+    ``sources`` is a dict keyed by source name; each value is an RFC-04
+    ``SourceBinding`` (``method`` / ``path`` / ``bind`` / ``refresh`` / …).
+    It is merged in LOGGED (drift-allowed) mode — see
+    :func:`_merge_authored_sources_logged` — so a single bad binding is
+    skipped rather than blocking the tile. The tile's own spec carries the
+    ``{state.<path>}`` bind that references the source's ``bind`` target; no
+    special handling beyond persisting it.
+    """
     if not isinstance(widget, dict):
         return None, "widget must be a JSON object"
     doc, err = await _agent_load_doc(pocket_id)
@@ -1879,6 +1948,11 @@ async def agent_add_widget(pocket_id: str, widget: dict) -> tuple[dict | None, s
     except Exception as exc:  # noqa: BLE001
         return None, f"invalid widget spec: {exc}"
     doc.widgets.append(new_widget)
+    # Author the tile's data sources onto the pocket's top-level
+    # rippleSpec.sources in the SAME save (RFC-04). Logged/drift-allowed so
+    # a hallucinated binding never blocks the tile.
+    if sources is not None:
+        _merge_authored_sources_logged(doc, sources)
     try:
         await doc.save()
     except Exception as exc:  # noqa: BLE001

--- a/tests/cloud/pockets/test_home_widget_sources.py
+++ b/tests/cloud/pockets/test_home_widget_sources.py
@@ -1,0 +1,295 @@
+# tests/cloud/pockets/test_home_widget_sources.py
+# Created: 2026-05-31 (feat/home-pocket-sources-authoring) — coverage for the
+# add_widget path authoring a pocket-level RFC-04 source alongside a tile.
+#
+# Feature: "live data on the home page." The home page is a per-user pocket
+# whose grid renders ``pocket.widgets[]`` tiles; RFC-04 live data sources live
+# at the pocket's top-level ``rippleSpec.sources`` (a dict keyed by source
+# name) and the ``source_executor`` runs them via ``POST /pockets/{id}/
+# sources/run``. Before this change the home agent's ``add_widget`` could add a
+# tile but not the source that feeds it, so the tile stayed static.
+#
+# What's covered:
+#   - ``add_widget_for_agent`` with a ``sources`` block merges the binding
+#     into the pocket's top-level ``rippleSpec.sources`` AND adds the tile.
+#   - ``agent_add_widget`` (service layer) is the same on the explicit path.
+#   - A ``sources`` block merges ALONGSIDE an existing ``rippleSpec.sources``
+#     dict (additive, doesn't clobber a sibling source).
+#   - Omitting ``sources`` still adds the tile with no ``sources`` key
+#     materialised (no regression for legacy ``add_widget`` calls).
+#   - An invalid source binding is handled per the LOGGED (drift-allowed)
+#     gate: the tile still lands, the bad source is skipped, a valid sibling
+#     in the same batch is persisted.
+#   - The authored binding matches the RFC-04 ``SourceBinding`` schema
+#     (``method`` / ``path`` / ``bind`` / ``refresh``) so the executor runs
+#     it unchanged; ``refresh`` defaults to ``["pocket_open"]``.
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.pockets import agent_context  # noqa: E402
+from pocketpaw_ee.cloud.pockets import service as pocket_service  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fake doc + patch helper (mirrors test_pocket_sources_ops.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDoc:
+    """Minimum surface to stand in for a ``_PocketDoc`` in these tests.
+
+    Mutations operate on ``self.rippleSpec`` / ``self.widgets`` in place,
+    like a real Beanie doc. ``save()`` is an async no-op; calls are counted
+    via ``saves``.
+    """
+
+    def __init__(self, pocket_id: str, ripple_spec: dict[str, Any] | None):
+        self.id = pocket_id
+        self.workspace = "w1"
+        self.name = "Home"
+        self.description = ""
+        self.type = "home"
+        self.icon = ""
+        self.color = ""
+        self.owner = "u1"
+        self.visibility = "workspace"
+        self.team: list[str] = []
+        self.agents: list[str] = []
+        self.widgets: list[Any] = []
+        self.rippleSpec = ripple_spec
+        self.share_link_token = None
+        self.share_link_access = "view"
+        self.shared_with: list[str] = []
+        self.tool_specs: list[Any] = []
+        self.saves = 0
+
+    async def save(self) -> None:
+        self.saves += 1
+
+    def model_dump(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "_id": self.id,
+            "workspace": self.workspace,
+            "rippleSpec": self.rippleSpec,
+            "owner": self.owner,
+            "widgets": [
+                w.model_dump(by_alias=True) if hasattr(w, "model_dump") else w for w in self.widgets
+            ],
+        }
+
+
+@pytest.fixture
+def home_doc() -> _FakeDoc:
+    """A persisted home pocket with a UI tree but NO sources and NO tiles."""
+    return _FakeDoc(
+        "507f1f77bcf86cd799439011",
+        {
+            "version": "1.0",
+            "state": {"revenue": 0},
+            "ui": {"id": "n_root0000", "type": "flex", "children": []},
+        },
+    )
+
+
+def _patches(doc: _FakeDoc, *, allowed_types: list[str] | None = None):
+    """Patch the doc fetch + emit/push seams + identity ContextVars + the
+    catalog allow-list. ``allowed_types=None`` simulates a manifest outage so
+    the widget-spec gate is a no-op (keeps these tests focused on the sources
+    merge, not on the catalog walk). Returns ``(ExitStack, push_calls)``.
+    """
+    push_calls: list[dict[str, Any]] = []
+
+    def _capture(payload: dict[str, Any]) -> None:
+        push_calls.append(payload)
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._PocketDoc.get",
+            new=AsyncMock(return_value=doc),
+        )
+    )
+    stack.enter_context(patch("pocketpaw_ee.cloud.pockets.service.emit", new=AsyncMock()))
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service._pocket_event_payload",
+            new=AsyncMock(return_value={"pocket_id": doc.id}),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.push_pocket_mutation",
+            new=MagicMock(side_effect=_capture),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.normalize_ripple_spec",
+            new=lambda s: s,
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            new=MagicMock(return_value=doc.workspace),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            new=MagicMock(return_value=doc.owner),
+        )
+    )
+
+    async def _allowed() -> list[str] | None:
+        return allowed_types
+
+    stack.enter_context(patch.object(pocket_service, "_catalog_allowed_types", _allowed))
+    return stack, push_calls
+
+
+# A tile bound to ``state.revenue`` — the source below hydrates that path.
+_REVENUE_TILE = {
+    "name": "Live revenue",
+    "type": "stat",
+    "spec": {"type": "stat", "props": {"label": "Revenue", "value": "{state.revenue}"}},
+}
+
+# The RFC-04 source that feeds the tile. method/path/bind/refresh — the exact
+# SourceBinding field names so the executor runs it unchanged.
+_REVENUE_SOURCE = {
+    "method": "GET",
+    "path": "/revenue/today",
+    "bind": "state.revenue",
+    "refresh": ["pocket_open", "manual"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — the red test: add_widget authors a top-level source.
+# ---------------------------------------------------------------------------
+
+
+async def test_add_widget_for_agent_authors_source_on_home_pocket(home_doc):
+    """The core feature: calling ``add_widget_for_agent`` with a ``sources``
+    block persists the binding at the pocket's top-level
+    ``rippleSpec.sources`` AND adds the tile. Without this the agent could
+    add a tile but it stayed static."""
+    widget = {**_REVENUE_TILE, "sources": {"revenue": dict(_REVENUE_SOURCE)}}
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.add_widget_for_agent(home_doc.id, widget)
+
+    assert result["ok"] is True
+    # The source landed at the pocket's top-level rippleSpec.sources.
+    assert home_doc.rippleSpec["sources"]["revenue"]["path"] == "/revenue/today"
+    assert home_doc.rippleSpec["sources"]["revenue"]["bind"] == "state.revenue"
+    assert home_doc.rippleSpec["sources"]["revenue"]["method"] == "GET"
+    # The tile landed too.
+    assert len(home_doc.widgets) == 1
+    assert home_doc.widgets[0].name == "Live revenue"
+    assert home_doc.saves == 1
+
+
+async def test_agent_add_widget_service_authors_source(home_doc):
+    """Same merge on the service-layer entry point ``agent_add_widget`` with
+    an explicit ``sources`` kwarg."""
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        view, err = await pocket_service.agent_add_widget(
+            home_doc.id, dict(_REVENUE_TILE), sources={"revenue": dict(_REVENUE_SOURCE)}
+        )
+    assert err is None
+    assert view is not None
+    assert home_doc.rippleSpec["sources"]["revenue"]["bind"] == "state.revenue"
+    assert len(home_doc.widgets) == 1
+
+
+async def test_authored_source_defaults_refresh(home_doc):
+    """A source that omits ``refresh`` gets ``["pocket_open"]`` via the
+    SourceBinding model — proves the binding is normalized through the same
+    RFC-04 schema the executor parses."""
+    source = {"method": "GET", "path": "/revenue/today", "bind": "state.revenue"}
+    widget = {**_REVENUE_TILE, "sources": {"revenue": source}}
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        await agent_context.add_widget_for_agent(home_doc.id, widget)
+    assert home_doc.rippleSpec["sources"]["revenue"]["refresh"] == ["pocket_open"]
+
+
+async def test_authored_source_merges_alongside_existing_sources():
+    """A new source merges INTO an existing ``rippleSpec.sources`` dict
+    without clobbering a sibling — additive merge."""
+    doc = _FakeDoc(
+        "507f1f77bcf86cd799439022",
+        {
+            "version": "1.0",
+            "state": {"revenue": 0, "prs": []},
+            "ui": {"id": "n_root0000", "type": "flex"},
+            "sources": {
+                "prs": {"method": "GET", "path": "/pulls", "bind": "state.prs"},
+            },
+        },
+    )
+    widget = {**_REVENUE_TILE, "sources": {"revenue": dict(_REVENUE_SOURCE)}}
+    ctx, _ = _patches(doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.add_widget_for_agent(doc.id, widget)
+    assert result["ok"] is True
+    assert set(doc.rippleSpec["sources"]) == {"prs", "revenue"}
+    assert doc.rippleSpec["sources"]["prs"]["path"] == "/pulls"
+    assert doc.rippleSpec["sources"]["revenue"]["path"] == "/revenue/today"
+
+
+# ---------------------------------------------------------------------------
+# No regression — omitting sources still adds the tile.
+# ---------------------------------------------------------------------------
+
+
+async def test_add_widget_without_sources_still_works(home_doc):
+    """A legacy ``add_widget`` call that omits ``sources`` adds the tile and
+    never materialises a ``sources`` key."""
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.add_widget_for_agent(home_doc.id, dict(_REVENUE_TILE))
+    assert result["ok"] is True
+    assert len(home_doc.widgets) == 1
+    assert "sources" not in home_doc.rippleSpec
+    assert home_doc.saves == 1
+
+
+# ---------------------------------------------------------------------------
+# Invalid source handled per the LOGGED (drift-allowed) gate.
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_source_is_skipped_logged_not_blocking(home_doc):
+    """An invalid source binding (missing required ``path``/``bind``) is
+    handled per the logged gate: it is skipped, the tile still lands, and a
+    valid sibling source in the same batch is persisted. The widget-add is
+    NOT blocked the way the strict agent-create gate would block it."""
+    widget = {
+        **_REVENUE_TILE,
+        "sources": {
+            "revenue": dict(_REVENUE_SOURCE),
+            "broken": {"method": "GET"},  # no path / bind — invalid
+        },
+    }
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.add_widget_for_agent(home_doc.id, widget)
+
+    assert result["ok"] is True
+    # The tile landed.
+    assert len(home_doc.widgets) == 1
+    # The valid source persisted; the invalid one was dropped (logged).
+    assert "revenue" in home_doc.rippleSpec["sources"]
+    assert "broken" not in home_doc.rippleSpec["sources"]
+    assert home_doc.saves == 1


### PR DESCRIPTION
## What

Lets the home agent's `add_widget` tool author a pocket-level RFC-04 source in the same call that adds a tile. The agent passes an optional `sources` dict on the `widget` argument, and each entry gets merged onto the pocket's top-level `rippleSpec.sources` in the same save that appends the tile.

Before this, the agent could add a "live revenue" tile but had no way to create the source feeding it. The tile just sat there static until something else authored the source.

## Why

The home page is a per-user pocket whose grid renders `pocket.widgets[]` tiles. RFC-04 live data sources live at the pocket's top-level `rippleSpec.sources`, and `source_executor` already runs them via `POST /pockets/{id}/sources/run`. The home grid (separate PR) is wiring the grid to run those sources. This PR is the missing agent-side piece, so "add a live tile" produces the tile and its source together instead of just the tile.

## How

- `agent_add_widget` takes an optional `sources` kwarg. When it's set, `_merge_authored_sources_logged` runs each entry through the existing `SourceBinding` model and writes it with the same pure `sources_ops.set_source` helper `set_source` uses. The persisted binding is byte-identical to one authored through the edit specialist.
- The merge runs in logged / drift-allowed mode, not the strict agent-create gate. An invalid binding gets logged and skipped rather than blocking the tile. That matches how `source_executor`'s `_parse_bindings` and the human-import catalog gate already handle drift.
- `add_widget_for_agent` pulls `sources` off the widget dict and passes it as an explicit kwarg, so it never lands as a widget field. A non-dict widget still falls through to the existing "must be a JSON object" guard.
- The MCP `add_widget` tool schema and description now document `sources` so the agent knows the field exists.

The REST human path (`AddWidgetRequest` / `POST /pockets/{id}/widgets`) is a separate service function and I left it alone. This PR only touches the agent path.

## Source schema (for the frontend PR to confirm)

Each `sources` entry is an RFC-04 `SourceBinding`:

| Field | Type | Notes |
|-------|------|-------|
| `method` | `"GET"` | defaults to `"GET"`; only GET is accepted |
| `path` | string | required, the backend path |
| `bind` | string | required, the state target, e.g. `state.revenue` |
| `refresh` | list | defaults to `["pocket_open"]`; values are `pocket_open` / `manual` / `interval` / `webhook` |
| `refresh_interval_seconds` | int or null | optional, used with `interval` |

A tile binds to its source by pointing at the source's `bind` target in the tile spec. So tile `value: "{state.revenue}"` pairs with source `bind: "state.revenue"`.

## Tests

New file: `tests/cloud/pockets/test_home_widget_sources.py`, written test-first (red before the implementation). It covers the merge through both `add_widget_for_agent` and `agent_add_widget`, merging next to an existing source, `refresh` defaulting, the no-`sources` path still working, and an invalid source getting skipped without taking the tile down with it.

`uv run pytest tests/cloud/pockets/test_home_widget_sources.py` passes (6). The sibling suites that touch this code (`test_pocket_widget_spec_gate`, `test_pocket_sources_ops`, `test_pocket_agent_context`, `test_mcp_pocket_add_widget`, `test_home_pocket`) pass too (105 total), no regressions.
