### PR TITLE
fix(composio): meta-tools mode on empty allow-list + keep SDK agent on PocketPaw persona

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -532,9 +532,13 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     """
     parts: list[str] = []
     parts.append(_RUNTIME_IDENTITY_RULE)
-    # Composio search-fallback guidance is conditional: only useful if
-    # Composio is actually wired up for this deployment. Gating avoids
-    # telling the agent about tools it doesn't have.
+    # Composio auth/search guidance is injected whenever Composio is
+    # enabled. An enabled deployment ALWAYS surfaces at least the
+    # discovery meta-tools — ``providers.py`` falls back to them when no
+    # toolkit is allow-listed — and the search-fallback rule matters MOST
+    # in that meta-tools-only mode. So gate on credentials (is_enabled),
+    # not on the toolkit allow-list: the prompt and the real tool list
+    # agree because enabled ⇒ tools present.
     from pocketpaw_ee.cloud.composio import service as _composio_service
 
     if _composio_service.is_enabled():

--- a/ee/pocketpaw_ee/cloud/composio/providers.py
+++ b/ee/pocketpaw_ee/cloud/composio/providers.py
@@ -225,40 +225,49 @@ def _build_session_and_tools(
     # surface all 200+ integrations and blow context budgets. Failing
     # loud here is friendlier than silently sending 0 tools.
     toolkits = list(settings.composio_toolkits)
-    if not toolkits:
-        logger.warning(
-            "Composio: no toolkits configured. Set POCKETPAW_COMPOSIO_TOOLKITS=gmail,"
-            "slack,... to expose concrete tools to the agent. Agent will run with no "
-            "Composio tools this turn."
-        )
-        return []
-
-    # ``composio.tools.get`` paginates alphabetically across the
-    # combined toolkit set, so a single call with ``toolkits=[a,b,c]``
-    # can return ~200 entries from the first letter alone. Fetch
-    # per-toolkit so every requested integration is represented.
-    # 50 tools/toolkit keeps multi-toolkit setups under the typical
-    # LLM tool-schema budget (Claude historically caps ~128). Users
-    # who need the full surface of a single toolkit should narrow
-    # ``composio_toolkits`` to that one toolkit.
-    per_toolkit_limit = 50
     combined: list[Any] = []
     seen_names: set[str] = set()
-    for toolkit in toolkits:
-        try:
-            tk_tools = composio_client.tools.get(
-                user_id=namespaced_user_id, toolkits=[toolkit], limit=per_toolkit_limit
-            )
-        except Exception:  # noqa: BLE001
-            logger.warning("Composio: failed to fetch toolkit %r — skipping", toolkit)
-            continue
-        for t in tk_tools or []:
-            name = getattr(t, "name", None) or (t.get("name") if isinstance(t, dict) else None)
-            if name and name in seen_names:
+
+    # An empty allow-list is NOT an error — we fall through to the
+    # discovery meta-tools (+ connection tools) below, so the agent can
+    # reach any of Composio's 200+ toolkits on demand via SEARCH ->
+    # GET_SCHEMAS -> EXECUTE. We deliberately do NOT pre-load every
+    # toolkit's concrete tools: ``tools.get`` with no filter paginates
+    # alphabetically (returning ~200 entries all from the first letter)
+    # and thousands of schemas would blow the LLM tool-schema budget.
+    # Concrete tools load ONLY for integrations explicitly allow-listed
+    # in ``composio_toolkits``.
+    if not toolkits:
+        logger.info(
+            "Composio: no toolkits allow-listed — exposing discovery meta-tools "
+            "only. Set POCKETPAW_COMPOSIO_TOOLKITS=gmail,slack,… to also load "
+            "concrete tools for specific integrations."
+        )
+    else:
+        # ``composio.tools.get`` paginates alphabetically across the
+        # combined toolkit set, so a single call with ``toolkits=[a,b,c]``
+        # can return ~200 entries from the first letter alone. Fetch
+        # per-toolkit so every requested integration is represented.
+        # 50 tools/toolkit keeps multi-toolkit setups under the typical
+        # LLM tool-schema budget (Claude historically caps ~128). Users
+        # who need the full surface of a single toolkit should narrow
+        # ``composio_toolkits`` to that one toolkit.
+        per_toolkit_limit = 50
+        for toolkit in toolkits:
+            try:
+                tk_tools = composio_client.tools.get(
+                    user_id=namespaced_user_id, toolkits=[toolkit], limit=per_toolkit_limit
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning("Composio: failed to fetch toolkit %r — skipping", toolkit)
                 continue
-            if name:
-                seen_names.add(name)
-            combined.append(t)
+            for t in tk_tools or []:
+                name = getattr(t, "name", None) or (t.get("name") if isinstance(t, dict) else None)
+                if name and name in seen_names:
+                    continue
+                if name:
+                    seen_names.add(name)
+                combined.append(t)
 
     # Append Composio's search-flow meta-tools as a discovery fallback.
     # The direct-tools surface above caps at ``per_toolkit_limit`` per

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1059,10 +1059,21 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     prompt_path,
                 )
 
+            # ``setting_sources=[]`` keeps the agent on its OWN persona.
+            # PocketPaw is not Claude Code: we pass a custom ``system_prompt``
+            # string (never the ``claude_code`` preset), and an empty
+            # setting-source list stops the SDK from injecting CLAUDE.md,
+            # output styles, or filesystem settings as context. The repo
+            # CLAUDE.md literally opens with "guidance to Claude Code
+            # (claude.ai/code)" — loading it bled that identity into the
+            # agent. Hooks, MCP servers, allowed_tools and permissions are
+            # all passed explicitly below, so none of them depend on
+            # setting sources. See
+            # https://code.claude.com/docs/en/agent-sdk/modifying-system-prompts
             options_kwargs = {
                 "system_prompt": system_prompt_arg,
                 "allowed_tools": allowed_tools,
-                "setting_sources": ["user", "project"],
+                "setting_sources": [],
                 "hooks": hooks,
                 "cwd": str(self._cwd),
                 "max_turns": self.settings.claude_sdk_max_turns or None,

--- a/tests/cloud/composio/test_providers.py
+++ b/tests/cloud/composio/test_providers.py
@@ -223,6 +223,63 @@ def test_returns_empty_when_session_build_raises(
     assert composio_providers.build_tools_for_backend("claude_agent_sdk") == []
 
 
+def test_empty_allow_list_exposes_meta_tools_only(
+    stub_provider_modules: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    force_settings,  # type: ignore[no-untyped-def]
+) -> None:
+    """No toolkit allow-list is NOT an error: the agent still gets the
+    discovery meta-tools so it can reach any toolkit on demand. No
+    concrete per-toolkit tools are pre-loaded."""
+    force_settings(_enabled_settings(composio_toolkits=[]))
+    monkeypatch.setattr(composio_providers, "_resolve_ctx", lambda: _fake_ctx())
+
+    tools = composio_providers.build_tools_for_backend("claude_agent_sdk")
+    names = {_tool_name(t) for t in tools}
+    assert "COMPOSIO_SEARCH_TOOLS" in names
+    assert "COMPOSIO_GET_TOOL_SCHEMAS" in names
+    assert "COMPOSIO_MULTI_EXECUTE_TOOL" in names
+    # The concrete per-toolkit path (stub emits ``tool(<slug>)`` names)
+    # never ran.
+    assert not any((n or "").startswith("tool(") for n in names)
+
+
+# ---------------------------------------------------------------------------
+# MCP-server registration (claude_agent_sdk path)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_provider_registers_server_when_tools_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CloudComposioMcpProvider.build_server`` must yield a
+    ``("composio", server)`` tuple whenever ``build_tools_for_backend``
+    returns tools — including the meta-tools-only (empty allow-list)
+    case — and ``None`` only when there are genuinely zero tools
+    (Composio disabled / no stream context). Guards against anyone
+    reintroducing an early ``return []`` that silently un-registers the
+    server."""
+    from pocketpaw_ee.extensions import CloudComposioMcpProvider
+
+    # Stub the SDK so the test doesn't depend on the real
+    # ``create_sdk_mcp_server`` validating tool objects.
+    sentinel = object()
+    fake_sdk = types.ModuleType("claude_agent_sdk")
+    fake_sdk.create_sdk_mcp_server = lambda **kw: sentinel  # type: ignore[attr-defined]
+    fake_sdk.tool = lambda *a, **k: lambda f: f  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_sdk)
+
+    provider = CloudComposioMcpProvider()
+
+    # Tools present (e.g. meta-tools from an empty allow-list) → registered.
+    monkeypatch.setattr(composio_providers, "build_tools_for_backend", lambda *a, **k: ["meta"])
+    assert provider.build_server() == ("composio", sentinel)
+
+    # No tools (disabled / no context) → not registered.
+    monkeypatch.setattr(composio_providers, "build_tools_for_backend", lambda *a, **k: [])
+    assert provider.build_server() is None
+
+
 # ---------------------------------------------------------------------------
 # Per-backend dispatch
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_agent_service_tools_context.py
+++ b/tests/cloud/test_agent_service_tools_context.py
@@ -447,6 +447,86 @@ def test_non_home_pocket_scope_keeps_specialist_delegation_rule():
     assert "<pocket-delegation>" in block
 
 
+def _session_ctx() -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+    )
+
+
+def _force_settings(monkeypatch, **overrides):
+    """Make ``Settings.load()`` return a controlled instance for the
+    Composio gating checks inside ``build_behavior_instructions``.
+
+    Clears the Composio env vars first so the result depends only on the
+    explicit overrides, not on whatever the host machine has exported.
+    """
+    from pocketpaw.config import Settings
+
+    for var in (
+        "POCKETPAW_COMPOSIO_API_KEY",
+        "POCKETPAW_COMPOSIO_ENTERPRISE_ID",
+        "POCKETPAW_COMPOSIO_TOOLKITS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    s = Settings(_env_file=None, **overrides)
+    monkeypatch.setattr(Settings, "load", classmethod(lambda cls: s))
+    return s
+
+
+def test_composio_rules_injected_when_enabled_without_toolkits(monkeypatch):
+    """Credentials set but no toolkit allow-list. ``providers`` falls back
+    to the discovery meta-tools (COMPOSIO_SEARCH_TOOLS et al.), so the
+    agent DOES have Composio tools — the auth/search rules must be
+    injected (the search-fallback rule matters most in this mode)."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    _force_settings(
+        monkeypatch,
+        composio_api_key="ck_test",
+        composio_enterprise_id="ent_acme",
+        composio_toolkits=[],
+    )
+    block = build_behavior_instructions(_session_ctx(), backend_name="claude_agent_sdk")
+    assert "<composio-auth-flow>" in block
+    assert "<composio-search-fallback>" in block
+    assert "<runtime-identity>" in block
+
+
+def test_composio_rules_injected_when_toolkits_configured(monkeypatch):
+    """Credentials AND a non-empty toolkit allow-list → concrete tools +
+    meta-tools, so the auth/search guidance is injected."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    _force_settings(
+        monkeypatch,
+        composio_api_key="ck_test",
+        composio_enterprise_id="ent_acme",
+        composio_toolkits=["gmail", "slack"],
+    )
+    block = build_behavior_instructions(_session_ctx(), backend_name="claude_agent_sdk")
+    assert "<composio-auth-flow>" in block
+    assert "<composio-search-fallback>" in block
+
+
+def test_composio_rules_omitted_when_disabled(monkeypatch):
+    """No credentials → Composio is off, no tools at all. The auth/search
+    rules must NOT be injected, but the always-on identity rule (which
+    tells the agent to say so plainly) still is."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    _force_settings(monkeypatch)  # bare Settings: no api_key / enterprise_id
+    block = build_behavior_instructions(_session_ctx(), backend_name="claude_agent_sdk")
+    assert "<composio-auth-flow>" not in block
+    assert "<composio-search-fallback>" not in block
+    assert "<runtime-identity>" in block
+
+
 @pytest.mark.asyncio
 async def test_build_knowledge_context_includes_workspace_kb_hits_and_file_refs():
     ctx = ScopeContext(


### PR DESCRIPTION
## Summary

Two related agent-tooling fixes.

### Composio: empty allow-list → discovery meta-tools (not zero tools)
An unconfigured `POCKETPAW_COMPOSIO_TOOLKITS` previously logged a warning and returned `[]`, leaving the agent with **no** Composio tools. Now an empty allow-list is treated as zero-config **meta-tools mode**: it falls through to the discovery meta-tools (`SEARCH` → `GET_SCHEMAS` → `EXECUTE`) so an enabled deployment can reach any of the 200+ toolkits on demand. Concrete per-toolkit tools still load **only** for explicitly allow-listed toolkits, keeping the tool-schema budget bounded.

The prompt's Composio auth/search guidance now gates on `is_enabled()` rather than on the toolkit allow-list, so the prompt and the real tool list agree (`enabled ⇒ tools present`) — and the search-fallback rule matters most in meta-tools-only mode.

### claude_sdk: `setting_sources=[]` keeps the agent on its own persona
`setting_sources=["user", "project"]` let the SDK inject the repo `CLAUDE.md` (which opens with *"guidance to Claude Code"*), output styles, and filesystem settings — bleeding Claude Code identity into the agent. PocketPaw passes its own custom `system_prompt`, and hooks, MCP servers, `allowed_tools` and permissions are all supplied explicitly, so none depend on setting sources. Set `setting_sources=[]`.

## Tests
- New: empty-allow-list exposes meta-tools only; MCP provider registers the server whenever tools are present; Composio prompt rules injected when enabled (with/without toolkits) and omitted when disabled.
- `pytest tests/cloud/composio/test_providers.py tests/cloud/test_agent_service_tools_context.py` → **43 passed**.
