### PR TITLE
fix(chat): broadcast typing.start/.stop over WS so the typing indicator renders

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/router.py
+++ b/ee/pocketpaw_ee/cloud/chat/router.py
@@ -770,14 +770,17 @@ async def _ws_typing(user_id: str, msg: WsInbound, *, active: bool) -> None:
     else:
         manager.stop_typing(msg.group_id, user_id)
 
+    # Broadcast the registered typing.start / typing.stop event (matches
+    # EVENT_REGISTRY + the browser bus topics). A prior ad-hoc type="typing"
+    # with an `active` flag never matched the client's typing.start/.stop
+    # subscriptions, so the indicator never rendered.
     await manager.send_to_room(
         msg.group_id,
         WsOutbound(
-            type="typing",
+            type="typing.start" if active else "typing.stop",
             data={
                 "group_id": msg.group_id,
                 "user_id": user_id,
-                "active": active,
             },
         ),
         exclude_user=user_id,


### PR DESCRIPTION
## Summary
The cloud WebSocket typing broadcast emitted an ad-hoc `type: "typing"` (with an `active` flag) that never matched the browser bus subscriptions (`typing.start` / `typing.stop`) or the generated topic registry (`topics.gen.ts` mirrors `EVENT_REGISTRY`, which has no bare `typing`). So a peer typing was received by the client and dropped — the indicator never rendered.

## Fix
`_ws_typing` now broadcasts the registered `typing.start` / `typing.stop` event types (data `{group_id, user_id}`), matching the client subscriptions and the cross-process `emit(TypingStart/TypingStop)` which already used those types.

## Pairs with
The paw-enterprise client wiring (composer emits typing + dots-in-feed render) in qbtrix/paw-enterprise#330. Needs a backend deploy for the indicator to work end to end.

## Tests
No test pinned the old broadcast type (the typing emit tests assert the cross-process `emit()`, which is unchanged). ruff + ruff-format pass.
