### PR TITLE
Home agent authors live-data sources on build and refine

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/pockets.py
@@ -46,6 +46,14 @@ drift-allowed) onto the pocket's top-level ``rippleSpec.sources`` in the same
 write — so the agent can create a live tile AND the source feeding it in one
 call. The handler itself is unchanged (it forwards the whole ``widget``); only
 the tool schema/description grew.
+Changes: 2026-05-31 (feat/home-agent-source-authoring) — the REFINE half.
+The ``update_widget`` tool now documents an optional ``fields.sources`` field
+(same RFC-04 GET-binding shape) so refining a static tile into a live one is
+one call. Both ``add_widget`` and ``update_widget`` descriptions now point the
+agent at the ``authored_sources`` / ``skipped_sources`` honesty fields the
+result carries — confirm only the authored keys. The handlers are unchanged
+(they forward the whole ``widget`` / ``fields``); ``update_widget_for_agent``
+pulls ``sources`` off ``fields`` so it never lands as a widget field.
 """
 
 from __future__ import annotations
@@ -395,7 +403,16 @@ def build_pocket_context_server() -> tuple[str, Any] | None:
             "`{spec: <new spec>}`. Validation runs on the new spec the same "
             "way `add_widget` does; an invalid spec is rejected. Use this "
             "when the user says 'refresh', 'reload', 'update', 'show latest' "
-            "on an existing tile."
+            "on an existing tile. To turn a STATIC tile LIVE, also pass "
+            "`fields.sources` — a dict keyed by source name; each value is a "
+            "read-only GET binding `{method:'GET', path:'/...', "
+            "bind:'state.<key>', refresh:['pocket_open'|'manual']}` — and bind "
+            "the tile's `spec` to the same `{state.<key>}` (mirrors "
+            "`add_widget`'s `widget.sources`). Sources are authored onto the "
+            "pocket's top-level rippleSpec.sources; an invalid source is "
+            "dropped without blocking the patch. The result carries "
+            "`authored_sources` / `skipped_sources` — confirm ONLY the "
+            "authored keys; never report a skipped one as written."
         ),
         {
             "type": "object",
@@ -412,7 +429,12 @@ def build_pocket_context_server() -> tuple[str, Any] | None:
                     "type": "object",
                     "description": (
                         "Widget fields to overwrite. Usually "
-                        "{spec: <new rippleSpec>} for a refresh."
+                        "{spec: <new rippleSpec>} for a refresh. Pass optional "
+                        "`sources` (a dict keyed by source name of RFC-04 GET "
+                        "bindings {method, path, bind, refresh}) to make the "
+                        "tile live — bind the spec to the same state path. "
+                        "`sources` is authored at the pocket's top-level "
+                        "sources, never as a widget field."
                     ),
                 },
             },

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -34,6 +34,17 @@ prepends its preamble before the legacy scope/participants/current-pocket
 tags so the chat agent sees the surface snapshot first. Clients that
 don't stamp a surface hint keep the old three-line shape unchanged —
 ``surface_context is None`` is the legacy path.
+Changes: 2026-05-31 (feat/home-agent-source-authoring) — ``ScopeContext``
+carries an optional ``backend_summary`` (the non-secret {base_url,
+auth_type, configured} dict from ``pockets.service.get_pocket_backend``,
+never the token). The resolvers populate it ONLY for a ``type="home"``
+pocket (via the new ``_home_backend_summary`` helper);
+``build_behavior_instructions`` fills it into ``HOME_POCKET_PROMPT``'s
+``__BACKEND_SUMMARY__`` token via ``fill_current_pocket`` so the home agent
+SEES whether a backend is configured (and its base_url) before authoring a
+``sources`` block — fixing the smoke-test finding where the agent claimed
+"no integration wired up" despite a configured backend. Non-home scopes
+keep ``backend_summary=None`` and pay no extra read.
 """
 
 from __future__ import annotations
@@ -214,6 +225,15 @@ class ScopeContext:
     # ``build_dynamic_context`` falls back to the legacy three-line
     # shape in that case.
     surface_context: SurfaceContext | None = None
+    # The anchored pocket's NON-SECRET backend summary ({base_url,
+    # auth_type, configured}) — the same shape ``get_pocket_backend``
+    # returns, never the token. Populated by the resolvers ONLY for a
+    # ``type="home"`` pocket (the home agent inlines it into the static
+    # HOME_POCKET_PROMPT so it can SEE a configured backend and author a
+    # ``sources`` block — mirroring how the pocket_specialist gets the
+    # summary via ``get_pocket_backend``). ``None`` for non-home scopes,
+    # which read the summary lazily through ``get_pocket`` when needed.
+    backend_summary: dict[str, Any] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -252,6 +272,30 @@ async def _get_session(session_id: str) -> Any:
         return await Session.get(PydanticObjectId(session_id))
     except Exception:
         return None
+
+
+async def _home_backend_summary(
+    pocket_type: str | None, workspace_id: str, pocket_id: str
+) -> dict[str, Any] | None:
+    """Fetch the NON-SECRET backend summary for a HOME pocket, or ``None``.
+
+    Only the home agent inlines the summary into its static prompt (so it can
+    SEE a configured backend before authoring a ``sources`` block — the same
+    summary the pocket_specialist gets via ``get_pocket_backend``). Non-home
+    scopes return ``None`` and never pay the read — they fetch the summary
+    lazily via ``get_pocket`` when the specialist needs it. The token is
+    NEVER returned; a fetch failure degrades to ``None`` so a transient
+    backend-collection hiccup never blocks scope resolution."""
+    if pocket_type != "home" or not workspace_id or not pocket_id:
+        return None
+    try:
+        from pocketpaw_ee.cloud.pockets import service as _pockets_service
+
+        summary = await _pockets_service.get_pocket_backend(workspace_id, pocket_id)
+    except Exception:  # noqa: BLE001 — a backend-read failure must not block resolution
+        logger.debug("home backend summary fetch failed for pocket %s", pocket_id, exc_info=True)
+        return None
+    return summary
 
 
 async def _get_default_workspace_agent_id(workspace_id: str) -> str | None:
@@ -317,12 +361,20 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
     # those chats would silently lose pocket tools.
     pocket_tool_specs: list[dict[str, Any]] = []
     pocket_type: str | None = None
+    backend_summary: dict[str, Any] | None = None
     pocket_id = getattr(session, "pocket", None)
     if pocket_id:
         pocket = await _get_pocket(str(pocket_id))
         if pocket is not None:
             pocket_tool_specs = list(getattr(pocket, "tool_specs", []) or [])
             pocket_type = getattr(pocket, "type", None)
+            # The home page commonly chats through session scope (so the
+            # active session id is honored). Surface the home pocket's
+            # backend summary here too so the home agent inlines it whether
+            # the chat routed through pocket or session scope.
+            backend_summary = await _home_backend_summary(
+                pocket_type, str(getattr(session, "workspace", "")), str(pocket_id)
+            )
 
     target = agent_id_hint or getattr(session, "agent", None)
     if not target:
@@ -347,6 +399,7 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
         pocket_tool_specs=pocket_tool_specs,
         pocket_id=str(pocket_id) if pocket_id else None,
         pocket_type=pocket_type,
+        backend_summary=backend_summary,
     )
 
 
@@ -439,6 +492,9 @@ async def _resolve_pocket(scope_id: str, user_id: str, agent_id_hint: str | None
         seen.add(m)
         members.append(m)
 
+    pocket_type = getattr(pocket, "type", None)
+    backend_summary = await _home_backend_summary(pocket_type, workspace_id, scope_id)
+
     return ScopeContext(
         kind=ScopeKind.POCKET,
         scope_id=scope_id,
@@ -449,7 +505,8 @@ async def _resolve_pocket(scope_id: str, user_id: str, agent_id_hint: str | None
         agent_ids_in_scope=agent_ids,
         pocket_tool_specs=list(getattr(pocket, "tool_specs", []) or []),
         pocket_id=scope_id,
-        pocket_type=getattr(pocket, "type", None),
+        pocket_type=pocket_type,
+        backend_summary=backend_summary,
     )
 
 
@@ -575,8 +632,17 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     # Home surface: append the home-surface prompt so the agent calls
     # add_widget for an explicit widget request and answers directly
     # otherwise. Backend-agnostic — the discriminator is the pocket type.
+    # HOME_POCKET_PROMPT carries the __BACKEND_SUMMARY__ token: fill it with
+    # the resolved non-secret summary so the home agent can SEE whether a
+    # backend is configured (and its base_url) before it authors a sources
+    # block — fixing the smoke-test finding where the agent claimed "no
+    # integration wired up" despite a configured backend. ``None`` renders as
+    # "configured state unknown — call get_pocket to check". The literal
+    # token never leaks because ``fill_current_pocket`` always replaces it.
     if is_home:
-        parts.append(HOME_POCKET_PROMPT)
+        parts.append(
+            fill_current_pocket(HOME_POCKET_PROMPT, ctx.pocket_id or "", ctx.backend_summary)
+        )
     return "\n".join(parts)
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -43,6 +43,17 @@ in LOGGED (drift-allowed) mode; this wrapper only routes ``sources`` so it
 never lands as a widget field, and still emits the full-document ``replace``
 ``pocket_mutation`` via ``_push_replace`` (the frontend already understands
 ``replace`` — no paw-enterprise change needed).
+Changes: 2026-05-31 (feat/home-agent-source-authoring) — the REFINE half.
+``update_widget_for_agent`` now pulls an optional ``sources`` dict off the
+``fields`` argument (stripping it from the widget patch) and threads it to
+``agent_update_widget``, mirroring ``add_widget_for_agent`` — so refining a
+static tile into a live one is one call. Both widget wrappers now route
+their ``{ok, pocket}`` return through ``_widget_result_with_source_honesty``,
+which surfaces the service layer's authored / skipped source keys (stashed
+on the view under ``_source_merge``) as ``authored_sources`` /
+``skipped_sources`` so the agent can't report a source that was silently
+dropped. No honesty keys appear when no ``sources`` were supplied — the
+legacy result shape is unchanged.
 """
 
 from __future__ import annotations
@@ -406,18 +417,56 @@ async def add_widget_for_agent(pocket_id: str, widget: dict[str, Any]) -> dict[s
     if err is not None:
         return {"ok": False, "error": err}
     await _push_replace(view)
-    return {"ok": True, "pocket": view}
+    return _widget_result_with_source_honesty(view)
 
 
 async def update_widget_for_agent(
     pocket_id: str, widget_id: str, fields: dict[str, Any]
 ) -> dict[str, Any]:
-    """Patch fields on a single embedded widget."""
-    view, err = await pockets_service.agent_update_widget(pocket_id, widget_id, fields)
+    """Patch fields on a single embedded widget.
+
+    When the ``fields`` dict carries an optional ``sources`` key (a dict
+    keyed by source name, each value an RFC-04 ``SourceBinding``), those
+    entries are authored onto the pocket's top-level ``rippleSpec.sources``
+    in the same write — mirroring ``add_widget_for_agent``. This is the
+    REFINE path: the home agent can turn a static tile live by patching its
+    bind AND authoring the source in one call. ``sources`` rides ON the
+    ``fields`` dict (not the widget doc) — it is pulled off here and threaded
+    as an explicit kwarg so it never lands as a widget field."""
+    raw_sources = fields.get("sources") if isinstance(fields, dict) else None
+    sources = raw_sources if isinstance(raw_sources, dict) else None
+    # Strip ``sources`` from the widget-field patch so it is never persisted
+    # as a widget attribute (it belongs at the pocket's top-level sources).
+    patch_fields = (
+        {k: v for k, v in fields.items() if k != "sources"}
+        if isinstance(fields, dict) and "sources" in fields
+        else fields
+    )
+    view, err = await pockets_service.agent_update_widget(
+        pocket_id, widget_id, patch_fields, sources=sources
+    )
     if err is not None:
         return {"ok": False, "error": err}
     await _push_replace(view)
-    return {"ok": True, "pocket": view}
+    return _widget_result_with_source_honesty(view)
+
+
+def _widget_result_with_source_honesty(view: dict[str, Any]) -> dict[str, Any]:
+    """Build the ``{ok, pocket}`` result and, when sources were in play, add
+    an HONEST readout of which authored sources actually persisted.
+
+    The service layer stashes ``{"authored": [...], "skipped": [...]}`` on
+    the view under the private ``_source_merge`` key whenever a ``sources``
+    block was supplied. We surface those keys (and drop the private marker
+    from the pocket the agent sees) so the agent confirms only what landed
+    and can't report a source it never wrote. When no sources were supplied,
+    no honesty keys appear — the legacy result shape is unchanged."""
+    merge = view.pop("_source_merge", None) if isinstance(view, dict) else None
+    result: dict[str, Any] = {"ok": True, "pocket": view}
+    if isinstance(merge, dict):
+        result["authored_sources"] = list(merge.get("authored", []))
+        result["skipped_sources"] = list(merge.get("skipped", []))
+    return result
 
 
 async def remove_widget_for_agent(pocket_id: str, widget_id: str) -> dict[str, Any]:

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -105,6 +105,15 @@ hand-rolled ``isinstance`` + presence checks the original MVP carried
 are gone. Behaviour is unchanged for the happy path; bad bodies now
 raise the same ``spec_merge.invalid_body`` ValidationError but via
 Pydantic instead of an ad-hoc branch.
+Changes: 2026-05-31 (feat/home-agent-source-authoring) — the REFINE half
+of the home-pocket live-data fix. ``agent_update_widget`` gains an optional
+``sources`` kwarg and authors it onto ``rippleSpec.sources`` via the same
+``_merge_authored_sources_logged`` helper ``agent_add_widget`` (PR-4) uses,
+so refining a static tile into a live one is one call. That helper now
+RETURNS ``(authored_keys, skipped_keys)``; both widget paths stash the
+result on the returned view under ``_source_merge`` so the agent_context
+wrappers can build an HONEST tool result — the agent can confirm only the
+sources that actually persisted and can't claim a binding that was dropped.
 """
 
 from __future__ import annotations
@@ -1853,7 +1862,9 @@ async def agent_update(
     return _agent_view_dict(doc), None
 
 
-def _merge_authored_sources_logged(doc: _PocketDoc, sources: dict[str, Any]) -> None:
+def _merge_authored_sources_logged(
+    doc: _PocketDoc, sources: dict[str, Any]
+) -> tuple[list[str], list[str]]:
     """Merge agent-authored RFC-04 sources into ``doc.rippleSpec.sources``.
 
     This is the LOGGED (drift-allowed) sibling of ``agent_set_source``'s
@@ -1869,11 +1880,19 @@ def _merge_authored_sources_logged(doc: _PocketDoc, sources: dict[str, Any]) -> 
     Mutates ``doc.rippleSpec`` in place via the pure ``sources_ops`` helper.
     A non-dict ``sources`` arg, or one with no valid entry, is a no-op — the
     ``sources`` key is only materialised when at least one binding validates.
+
+    Returns ``(authored_keys, skipped_keys)`` so the caller can build an
+    HONEST tool result: the agent can confirm only the sources that actually
+    persisted and learn which it must NOT report as written. This closes the
+    smoke-test gap where the agent claimed "source authored" for a binding
+    that was silently dropped.
     """
     from pocketpaw_ee.cloud.pockets.source_executor import SourceBinding
 
+    authored: list[str] = []
+    skipped: list[str] = []
     if not isinstance(sources, dict) or not sources:
-        return
+        return authored, skipped
     spec = _sources_root(doc)
     for key, entry in sources.items():
         if not key or not isinstance(entry, dict):
@@ -1883,6 +1902,7 @@ def _merge_authored_sources_logged(doc: _PocketDoc, sources: dict[str, Any]) -> 
                 key,
                 str(doc.id),
             )
+            skipped.append(key)
             continue
         try:
             normalized = SourceBinding.model_validate(entry).model_dump(mode="json")
@@ -1893,9 +1913,11 @@ def _merge_authored_sources_logged(doc: _PocketDoc, sources: dict[str, Any]) -> 
                 str(doc.id),
                 exc.errors()[0].get("msg", exc) if exc.errors() else exc,
             )
+            skipped.append(key)
             continue
         try:
             sources_ops.set_source(spec, key, normalized)
+            authored.append(key)
         except ValueError as exc:
             logger.warning(
                 "add_widget: could not merge authored source %r on pocket %s: %s",
@@ -1903,6 +1925,8 @@ def _merge_authored_sources_logged(doc: _PocketDoc, sources: dict[str, Any]) -> 
                 str(doc.id),
                 exc,
             )
+            skipped.append(key)
+    return authored, skipped
 
 
 async def agent_add_widget(
@@ -1950,20 +1974,39 @@ async def agent_add_widget(
     doc.widgets.append(new_widget)
     # Author the tile's data sources onto the pocket's top-level
     # rippleSpec.sources in the SAME save (RFC-04). Logged/drift-allowed so
-    # a hallucinated binding never blocks the tile.
+    # a hallucinated binding never blocks the tile. The authored/skipped keys
+    # ride back on the view dict (under ``_source_merge``) so the agent_context
+    # wrapper can build an HONEST tool result without us widening the 2-tuple
+    # signature that the widget-gate callers depend on.
+    authored: list[str] = []
+    skipped: list[str] = []
     if sources is not None:
-        _merge_authored_sources_logged(doc, sources)
+        authored, skipped = _merge_authored_sources_logged(doc, sources)
     try:
         await doc.save()
     except Exception as exc:  # noqa: BLE001
         return None, f"save failed: {exc}"
     await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
-    return _agent_view_dict(doc), None
+    view = _agent_view_dict(doc)
+    if sources is not None:
+        view["_source_merge"] = {"authored": authored, "skipped": skipped}
+    return view, None
 
 
 async def agent_update_widget(
-    pocket_id: str, widget_id: str, fields: dict
+    pocket_id: str,
+    widget_id: str,
+    fields: dict,
+    *,
+    sources: dict[str, Any] | None = None,
 ) -> tuple[dict | None, str | None]:
+    """Patch fields on one embedded widget, and — when ``sources`` is supplied
+    — author the RFC-04 data sources that feed it onto the pocket's top-level
+    ``rippleSpec.sources`` in the same write. Mirrors ``agent_add_widget``:
+    refining a static tile into a live one is one call (patch the bind + author
+    the source). The sources merge is LOGGED (drift-allowed); the authored /
+    skipped keys ride back on the view under ``_source_merge`` for an honest
+    tool result."""
     if not isinstance(fields, dict):
         return None, "fields must be a JSON object"
     doc, err = await _agent_load_doc(pocket_id)
@@ -2002,12 +2045,20 @@ async def agent_update_widget(
         widget.props = fields["props"]
     if "dataSourceType" in fields:
         widget.dataSourceType = fields["dataSourceType"]
+    # Author/refine the tile's data sources in the SAME save (RFC-04), logged.
+    authored: list[str] = []
+    skipped: list[str] = []
+    if sources is not None:
+        authored, skipped = _merge_authored_sources_logged(doc, sources)
     try:
         await doc.save()
     except Exception as exc:  # noqa: BLE001
         return None, f"save failed: {exc}"
     await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
-    return _agent_view_dict(doc), None
+    view = _agent_view_dict(doc)
+    if sources is not None:
+        view["_source_merge"] = {"authored": authored, "skipped": skipped}
+    return view, None
 
 
 async def agent_remove_widget(pocket_id: str, widget_id: str) -> tuple[dict | None, str | None]:

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1,5 +1,18 @@
 # pocketpaw/ripple/_pockets.py — System prompts for the Ripple Pockets surface.
 #
+# Changes: 2026-05-31 (feat/home-agent-source-authoring) — `HOME_POCKET_PROMPT`
+# now (1) carries the `__BACKEND_SUMMARY__` token in its intro (filled via
+# `fill_current_pocket` from the resolved scope) so the home agent SEES
+# whether a backend is configured and stops claiming "no integration wired
+# up", and (2) gains a `## Live data` section porting the pocket_specialist's
+# source-authoring guidance: when a backend is configured and the user wants
+# live data, author a read-only GET `widget.sources` binding
+# ({method:"GET", path, bind:"state.<key>", refresh:["pocket_open"]}) on
+# `add_widget`/`update_widget` and bind the tile spec to it. Adds the
+# data-shape rule the smoke test surfaced (bind a FIELD PATH / scalar, never a
+# whole object) and the honest-result rule (only confirm `authored_sources`,
+# never claim a `skipped_sources` key).
+#
 # Changes: 2026-05-24 (surface-context PR) — extended `HOME_POCKET_PROMPT`
 # with a `## Surface-context blocks` section that teaches the agent to
 # read the new `<pinned-widgets>` / `<live-snapshot>` /
@@ -2437,6 +2450,15 @@ the user keeps an eye on (a revenue stat, a task list, a sales chart). It
 is the user's own dashboard, assembled one widget at a time. The pocket
 id is in the `<current-pocket>` block — pass it as `pocket_id`.
 
+Backend: __BACKEND_SUMMARY__
+
+That line is the home pocket's data backend. "configured" = a real HTTP
+backend is wired at that base URL and you CAN bind tiles to live data
+(see "Live data" below) — never say "no integration is wired up" then.
+"not configured" = none; use believable static data and say so.
+"configured state unknown" = call `get_pocket` (its `backend` summary
+carries the same truth) before deciding.
+
 ## Surface-context blocks (you may already have these)
 
 The system context above may include three surface-aware tags built
@@ -2492,31 +2514,13 @@ points. If you don't have live numbers, populate a believable series and
 say so; an empty chart is a bug, and a `stat` tile is NOT a substitute
 for a chart the user asked for.
 
-Worked example — "add a 7-day sales chart":
+Worked example — "add a 7-day sales chart" (seven points; abbreviated):
 
-  add_widget({
-    "pocket_id": "<from current-pocket>",
-    "widget": {
-      "name": "7-day sales",
-      "type": "chart",
-      "icon": "trending-up",
-      "spec": {
-        "type": "chart",
-        "props": {
-          "variant": "bar",
-          "data": [
-            {"label": "Mon", "value": 1200},
-            {"label": "Tue", "value": 1850},
-            {"label": "Wed", "value": 1400},
-            {"label": "Thu", "value": 2100},
-            {"label": "Fri", "value": 2600},
-            {"label": "Sat", "value": 900},
-            {"label": "Sun", "value": 700}
-          ]
-        }
-      }
-    }
-  })
+  add_widget({"pocket_id": "<from current-pocket>", "widget": {
+    "name": "7-day sales", "type": "chart", "icon": "trending-up",
+    "spec": {"type": "chart", "props": {"variant": "bar", "data": [
+      {"label": "Mon", "value": 1200}, {"label": "Tue", "value": 1850},
+      ... {"label": "Sun", "value": 700}]}}}})
 
 A native widget (a built-in component the user picks by name) passes
 `type:"native"` and no `spec`.
@@ -2528,6 +2532,39 @@ To see what is already on the home grid, call `get_pocket` once with the
 pocket id and read the returned widgets. Add one widget per explicit
 request — don't pre-populate the grid.
 
+## Live data — bind a tile to the backend
+
+When the user wants a tile to show LIVE data AND `Backend:` reads
+"configured", make the tile live by authoring a data SOURCE in the SAME
+`add_widget` call. A source is a read-only GET binding the home grid runs
+on open to hydrate a state path the tile reads. Bind the tile's spec to a
+state key (a `stat` reads `props.value: "{state.revenue}"`, NOT a
+hardcoded number), then pass `widget.sources`:
+
+  "sources": {"revenue": {"method": "GET", "path": "/revenue/today",
+              "bind": "state.revenue", "refresh": ["pocket_open"]}}
+
+  - `method` is always `"GET"` (sources are read-only).
+  - `path` is RELATIVE (e.g. `/revenue/today`), never an absolute URL —
+    the runtime joins it to the backend base URL.
+  - `bind` is the `state.<key>` the source writes; it MUST match the
+    `{state.<key>}` the tile's spec reads.
+  - `refresh`: `["pocket_open"]` (on load) and/or `["manual"]`.
+
+DATA-SHAPE RULE: a GET often returns an OBJECT
+(e.g. `{"total": 4200, "currency": "USD"}`), not a bare number. A scalar
+tile (`stat`) shows ONE value — bind to a FIELD PATH, not the whole
+object: `bind: "state.revenue.total"`, tile reads
+`"{state.revenue.total}"`. Binding a whole object into a scalar renders
+`[object Object]` — never do that. Unsure of the shape? Pick the most
+likely scalar field and say which one you bound.
+
+After the call, read `authored_sources` / `skipped_sources` on the
+result. Confirm "live data wired up" ONLY for `authored_sources` keys; a
+`skipped_sources` key was dropped (invalid) — fix and retry, never claim
+it landed. If `Backend:` is "not configured", do NOT author a source —
+use static data and say no backend is wired up yet.
+
 ## How to refresh a widget
 
 When the user asks to "refresh", "reload", "update", or "show the latest"
@@ -2538,16 +2575,20 @@ again — that would create a duplicate tile. Instead:
   the entry whose `name` matches the widget the user means (or the most
   recent one if ambiguous). Grab its `_id`.
 
-  STEP 2. Fetch fresh data. You have `WebSearch`, `WebFetch`, and the
-  in-process MCP tools (Composio's gmail / calendar / drive when
-  configured) available. Use whichever fits the widget — a sales chart
-  may need a Composio CRM call, a competitor-news tile a WebSearch.
+  STEP 2. Fetch fresh data with whichever tool fits — `WebSearch`,
+  `WebFetch`, or the configured MCP data tools (Composio CRM/gmail/etc.).
 
   STEP 3. Call `update_widget` with the same `pocket_id`, the widget's
   `_id` as `widget_id`, and `fields: {spec: <new rippleSpec>}` carrying
-  the fresh data. The spec shape stays the same as the original; only
-  the `data` series (or rows, or text) changes. The renderer re-renders
-  the tile in place.
+  the fresh data. The spec shape stays the same; only the `data` (rows /
+  text) changes. The renderer re-renders the tile in place.
+
+To turn a STATIC tile LIVE ("wire this to live data"), `update_widget`
+also accepts a `sources` block on `fields` — same shape as `add_widget`'s
+`widget.sources`. Patch the spec to read the `{state.<key>}` bind AND
+author the source in one call. The same `authored_sources` /
+`skipped_sources` honesty fields come back — confirm only what landed.
+Configured backend only; the data-shape rule above applies.
 
 A native widget (Mission · Tray etc.) refreshes itself from its own
 endpoint — you do not need to touch it.

--- a/tests/cloud/pockets/test_home_widget_sources.py
+++ b/tests/cloud/pockets/test_home_widget_sources.py
@@ -27,6 +27,7 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -293,3 +294,139 @@ async def test_invalid_source_is_skipped_logged_not_blocking(home_doc):
     assert "revenue" in home_doc.rippleSpec["sources"]
     assert "broken" not in home_doc.rippleSpec["sources"]
     assert home_doc.saves == 1
+
+
+# ---------------------------------------------------------------------------
+# REFINE path — update_widget can author sources (feat/home-agent-source-
+# authoring). Mirrors the add_widget tests above on the in-place refresh path.
+# ---------------------------------------------------------------------------
+
+
+def _seed_widget(doc: _FakeDoc, widget_id: str, name: str) -> None:
+    """Append a minimal widget the update path can target by id."""
+    doc.widgets.append(
+        SimpleNamespace(
+            id=widget_id,
+            name=name,
+            type="stat",
+            icon="",
+            color="",
+            span=None,
+            data=None,
+            spec={"type": "stat", "props": {"label": "Revenue", "value": "0"}},
+            assignedAgent=None,
+            config={},
+            props={},
+            dataSourceType=None,
+        )
+    )
+
+
+async def test_update_widget_for_agent_authors_source(home_doc):
+    """The refine fix: ``update_widget_for_agent`` with a ``sources`` block on
+    its fields merges the binding into the pocket's top-level
+    ``rippleSpec.sources`` AND patches the tile — so refining a static tile can
+    make it live."""
+    _seed_widget(home_doc, "w_rev", "Live revenue")
+    fields = {
+        "spec": {"type": "stat", "props": {"label": "Revenue", "value": "{state.revenue}"}},
+        "sources": {"revenue": dict(_REVENUE_SOURCE)},
+    }
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.update_widget_for_agent(home_doc.id, "w_rev", fields)
+
+    assert result["ok"] is True
+    assert home_doc.rippleSpec["sources"]["revenue"]["path"] == "/revenue/today"
+    assert home_doc.rippleSpec["sources"]["revenue"]["bind"] == "state.revenue"
+    # The tile spec was patched too.
+    assert home_doc.widgets[0].spec["props"]["value"] == "{state.revenue}"
+    assert home_doc.saves == 1
+
+
+async def test_agent_update_widget_service_authors_source(home_doc):
+    """Same merge on the service-layer entry point ``agent_update_widget`` with
+    an explicit ``sources`` kwarg."""
+    _seed_widget(home_doc, "w_rev", "Live revenue")
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        view, err = await pocket_service.agent_update_widget(
+            home_doc.id,
+            "w_rev",
+            {"name": "Live revenue"},
+            sources={"revenue": dict(_REVENUE_SOURCE)},
+        )
+    assert err is None
+    assert view is not None
+    assert home_doc.rippleSpec["sources"]["revenue"]["bind"] == "state.revenue"
+
+
+async def test_update_widget_without_sources_is_noop_on_sources(home_doc):
+    """Omitting ``sources`` on update_widget never materialises a sources key —
+    no regression for legacy refresh calls."""
+    _seed_widget(home_doc, "w_rev", "Live revenue")
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.update_widget_for_agent(
+            home_doc.id, "w_rev", {"name": "Renamed"}
+        )
+    assert result["ok"] is True
+    assert "sources" not in home_doc.rippleSpec
+    assert home_doc.widgets[0].name == "Renamed"
+
+
+# ---------------------------------------------------------------------------
+# Honest tool result — the result reflects what actually persisted re: sources
+# so the agent can't report "source authored" when nothing was written.
+# ---------------------------------------------------------------------------
+
+
+async def test_add_widget_result_reports_authored_source_keys(home_doc):
+    """``add_widget_for_agent`` returns the authored source keys so the agent
+    can honestly confirm the source landed."""
+    widget = {**_REVENUE_TILE, "sources": {"revenue": dict(_REVENUE_SOURCE)}}
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.add_widget_for_agent(home_doc.id, widget)
+    assert result["ok"] is True
+    assert result.get("authored_sources") == ["revenue"]
+    assert result.get("skipped_sources") == []
+
+
+async def test_add_widget_result_reports_skipped_invalid_source(home_doc):
+    """An invalid binding shows up in ``skipped_sources`` (and NOT in
+    ``authored_sources``) so the agent can't claim a source it didn't write."""
+    widget = {
+        **_REVENUE_TILE,
+        "sources": {
+            "revenue": dict(_REVENUE_SOURCE),
+            "broken": {"method": "GET"},  # no path / bind — invalid
+        },
+    }
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.add_widget_for_agent(home_doc.id, widget)
+    assert result["ok"] is True
+    assert result.get("authored_sources") == ["revenue"]
+    assert result.get("skipped_sources") == ["broken"]
+
+
+async def test_update_widget_result_reports_authored_source_keys(home_doc):
+    """The honest-result fields are present on the refine path too."""
+    _seed_widget(home_doc, "w_rev", "Live revenue")
+    fields = {"sources": {"revenue": dict(_REVENUE_SOURCE)}}
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.update_widget_for_agent(home_doc.id, "w_rev", fields)
+    assert result["ok"] is True
+    assert result.get("authored_sources") == ["revenue"]
+
+
+async def test_add_widget_without_sources_omits_honest_result_keys(home_doc):
+    """When no ``sources`` are supplied, the honest-result keys are absent (or
+    empty) — they only appear when sources were actually in play."""
+    ctx, _ = _patches(home_doc, allowed_types=None)
+    with ctx:
+        result = await agent_context.add_widget_for_agent(home_doc.id, dict(_REVENUE_TILE))
+    assert result["ok"] is True
+    assert "authored_sources" not in result

--- a/tests/cloud/test_agent_service_scope.py
+++ b/tests/cloud/test_agent_service_scope.py
@@ -115,6 +115,66 @@ async def test_resolve_pocket_uses_first_agent_when_no_hint():
 
 
 @pytest.mark.asyncio
+async def test_resolve_home_pocket_populates_backend_summary():
+    """A type='home' pocket scope must carry the non-secret backend summary
+    on the resolved ScopeContext so the (sync) prompt builder can render the
+    configured base_url into HOME_POCKET_PROMPT. Mirrors how the
+    pocket_specialist fetches `get_pocket_backend`."""
+    pocket = SimpleNamespace(
+        id="home-1",
+        type="home",
+        workspace="w1",
+        owner="u_caller",
+        team=["u_caller"],
+        agents=["agent_primary"],
+        tool_specs=[],
+        visibility="workspace",
+        shared_with=[],
+    )
+    summary = {"configured": True, "base_url": "https://api.acme.test", "auth_type": "bearer"}
+    with (
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_pocket", AsyncMock(return_value=pocket)),
+        patch(
+            "pocketpaw_ee.cloud.pockets.service.get_pocket_backend",
+            AsyncMock(return_value=summary),
+        ),
+    ):
+        ctx = await resolve_scope_context(
+            scope="pocket", scope_id="home-1", user_id="u_caller", agent_id_hint=None
+        )
+    assert ctx.pocket_type == "home"
+    assert ctx.backend_summary == summary
+
+
+@pytest.mark.asyncio
+async def test_resolve_non_home_pocket_skips_backend_summary():
+    """A normal (non-home) pocket scope does NOT pay the backend-summary read —
+    only the home agent inlines it into a static prompt; ordinary pockets get
+    the summary lazily via get_pocket when the specialist needs it."""
+    pocket = SimpleNamespace(
+        id="p1",
+        type="custom",
+        workspace="w1",
+        owner="u_caller",
+        team=["u_caller"],
+        agents=["agent_primary"],
+        tool_specs=[],
+        visibility="workspace",
+        shared_with=[],
+    )
+    backend_mock = AsyncMock(return_value={"configured": True})
+    with (
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_pocket", AsyncMock(return_value=pocket)),
+        patch("pocketpaw_ee.cloud.pockets.service.get_pocket_backend", backend_mock),
+    ):
+        ctx = await resolve_scope_context(
+            scope="pocket", scope_id="p1", user_id="u_caller", agent_id_hint=None
+        )
+    assert ctx.backend_summary is None
+    backend_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_resolve_unknown_scope_raises():
     with pytest.raises(InvalidScope):
         await resolve_scope_context(scope="nope", scope_id="x", user_id="u", agent_id_hint=None)

--- a/tests/cloud/test_agent_service_tools_context.py
+++ b/tests/cloud/test_agent_service_tools_context.py
@@ -447,6 +447,86 @@ def test_non_home_pocket_scope_keeps_specialist_delegation_rule():
     assert "<pocket-delegation>" in block
 
 
+# ---------------------------------------------------------------------------
+# Home agent backend-summary surfacing (feat/home-agent-source-authoring).
+#
+# Mirrors how the pocket_specialist surfaces a non-secret backend summary so
+# it knows whether a backend is configured before authoring a `sources`
+# block. The home agent must SEE the configured backend + its base_url so it
+# stops claiming "no integration wired up" and authors a source on add_widget.
+# ---------------------------------------------------------------------------
+
+
+def _home_ctx(backend_summary):
+    return ScopeContext(
+        kind=ScopeKind.POCKET,
+        scope_id="home-pocket-1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        pocket_id="home-pocket-1",
+        pocket_type="home",
+        backend_summary=backend_summary,
+    )
+
+
+def test_home_prompt_surfaces_configured_backend_summary():
+    """When the resolved home scope carries a configured backend summary, the
+    behavior instructions must render the base_url so the agent can SEE the
+    backend exists (and stop saying "no integration wired up")."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    ctx = _home_ctx(
+        {"configured": True, "base_url": "https://api.acme.test", "auth_type": "bearer"}
+    )
+    block = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+    assert "<home-pocket>" in block
+    # The configured base_url is rendered into the prompt verbatim.
+    assert "https://api.acme.test" in block
+    # The literal token never leaks.
+    assert "__BACKEND_SUMMARY__" not in block
+
+
+def test_home_prompt_renders_not_configured_when_no_backend():
+    """A home scope with an explicit `configured: False` summary renders the
+    "not configured" state — the agent must NOT author a source then."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    ctx = _home_ctx({"configured": False})
+    block = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+    assert "<home-pocket>" in block
+    assert "not configured" in block
+    assert "__BACKEND_SUMMARY__" not in block
+
+
+def test_home_prompt_renders_unknown_when_summary_absent():
+    """No backend summary on the scope renders the "unknown — call get_pocket"
+    fallback rather than asserting there is no backend."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    ctx = _home_ctx(None)
+    block = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+    assert "<home-pocket>" in block
+    assert "configured state unknown" in block
+    assert "__BACKEND_SUMMARY__" not in block
+
+
+def test_home_prompt_carries_source_authoring_guidance():
+    """The home prompt must teach the agent to author a `widget.sources` GET
+    binding when a backend is configured — borrowed from the specialist's
+    live-data guidance — and the data-shape rule (bind a field path / scalar,
+    never a whole object)."""
+    from pocketpaw.ripple import HOME_POCKET_PROMPT
+
+    assert "sources" in HOME_POCKET_PROMPT
+    # The read-only GET binding shape.
+    assert "refresh" in HOME_POCKET_PROMPT and "pocket_open" in HOME_POCKET_PROMPT
+    # The data-shape rule the smoke test surfaced.
+    assert "field path" in HOME_POCKET_PROMPT.lower() or "field-path" in HOME_POCKET_PROMPT.lower()
+
+
 @pytest.mark.asyncio
 async def test_build_knowledge_context_includes_workspace_kb_hits_and_file_refs():
     ctx = ScopeContext(


### PR DESCRIPTION
## What this fixes

The home page smoke test proved every layer of live data works except one: the home agent never emits `widget.sources` at build time, and it can't author a source on refine. Two root causes:

- **Build path:** the home agent wasn't backend-aware (it told the user "I don't have an integration wired up" even though a backend was configured), and its prompt never told it to author sources.
- **Refine path:** `update_widget` had no `sources` parameter, so refining a tile couldn't author a source — yet the agent falsely claimed success.

The fix ports the pattern the `pocket_specialist` already uses for composed pockets to the home agent. No new mechanism.

## Build path

- `ScopeContext` now carries the home pocket's non-secret `backend_summary` (`{base_url, auth_type, configured}` — never the token). The scope resolvers populate it only for `type="home"` pockets via `get_pocket_backend`, the same call the specialist uses. `build_behavior_instructions` fills it into `HOME_POCKET_PROMPT`'s `__BACKEND_SUMMARY__` token, so the agent can see the backend is configured and stops claiming none is wired up.
- `HOME_POCKET_PROMPT` gains a **Live data** section: when a backend is configured and the user asks for live data, author a read-only GET `widget.sources` binding (`{method:"GET", path, bind:"state.<key>", refresh:["pocket_open"]}`) and bind the tile spec to it. It also carries the data-shape rule the smoke test surfaced — bind to a field path or a scalar, never a whole object into a stat tile.

## Refine path

- `update_widget_for_agent` and `agent_update_widget` accept a `sources` block and merge it through the same `_merge_authored_sources_logged` helper `add_widget` uses (PR-4). Documented on the `update_widget` MCP tool schema.
- **Honest result:** the merge helper now returns the authored and skipped source keys. Both widget paths surface them as `authored_sources` / `skipped_sources`, so the agent confirms only what actually persisted and can't report a source that was dropped.

## Tests

TDD, red then green. Coverage:
- `backend_summary` is surfaced into the home agent's assembled prompt when a backend is configured, renders "not configured" / "unknown" otherwise, and never leaks the literal token. Resolver populates it for home scopes only.
- `update_widget_for_agent` with a `sources` block merges into `rippleSpec.sources`; omitting it is a no-op.
- the tool result carries the authored source keys (and skipped ones for an invalid binding).

`uv run pytest tests/cloud/pockets/ tests/cloud/test_agent_service_tools_context.py tests/cloud/test_agent_service_scope.py -k "source or backend or update_widget"` — 21 passed. Full relevant suite (widget gate, home pocket, prompts single-source) 128 passed.

## For the captain at re-smoke

The actual "agent emits sources" behavior is LLM-driven, verified live, not by unit tests. Worth checking at re-smoke:
- the agent now SEES the configured backend (no more "no integration wired up") and authors a GET source on build,
- refining a static tile to live works through `update_widget` + `sources`,
- the agent only confirms `authored_sources` keys and surfaces `skipped_sources` honestly.

Targets `integration/home-live-data` (not dev). Stacked on PR-4 (#1307).