### PR TITLE
fix(home): rebuild the agent client when the backend summary changes mid-session

### DIFF
--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,16 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-05-31 (fix/home-backend-summary-per-turn) — the persistent-client
+  cache key now folds in a digest of the system prompt's STABLE behavioral
+  prefix (``_client_cache_key`` / ``_behavior_prefix``), not just
+  session+model+tools. The home agent bakes its non-secret backend summary
+  ({base_url, auth_type, configured}) into the static system prompt; that
+  prompt is applied to the subprocess only at connect() time and ignored on
+  warm reuse, so configuring a pocket's backend mid-session stayed frozen
+  until a cold restart. Keying on the behavioral prefix makes a config flip
+  change the key, which rebuilds the client on the very next turn. The volatile
+  per-turn tail (KB block, soul memories, conversation history) is stripped
+  before hashing so ordinary turns still reuse the warm subprocess.
 Updated: 2026-05-28 (#FU-F) — promote silent MCP provider build failures from
   DEBUG to WARNING. A stale editable install (CloudForesightMcpProvider with a
   missing SDK dependency) failed silently; the diagnostic took 30+ minutes.
@@ -56,6 +67,7 @@ Uses the official Claude Agent SDK (pip install claude-agent-sdk) which provides
 """
 
 import asyncio
+import hashlib
 import logging
 import re
 from collections.abc import AsyncIterator
@@ -703,19 +715,75 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 ids.append(tool_id)
         return ids
 
+    # Section markers that ``AgentPool.run`` appends to the system prompt
+    # AFTER the authoritative behavioral instructions. Everything from the
+    # first marker onward is per-turn and volatile (query-specific KB hits,
+    # soul-memory recall, injected conversation history on a cold subprocess),
+    # so it MUST NOT participate in the persistent-client cache key — otherwise
+    # every turn would needlessly tear down and rebuild the subprocess. The
+    # behavioral prefix BEFORE these markers carries the home-pocket backend
+    # summary, which is exactly the mutable state we want the key to track.
+    _VOLATILE_PROMPT_MARKERS = (
+        "\n\n## Your Knowledge Base",
+        "\n\n## Relevant Past Memories",
+        "\n\n# Recent Conversation",
+    )
+
+    @classmethod
+    def _behavior_prefix(cls, system_prompt: Any) -> str:
+        """Return the stable behavioral prefix of ``system_prompt``.
+
+        Strips the volatile per-turn tail (KB block, soul memories, injected
+        history) so two turns that differ only in retrieved context hash to the
+        same value. On Windows the SDK may pass ``system_prompt`` as a
+        ``{type: "file", path: ...}`` dict — there is no inline text to key on,
+        so fall back to the path (stable per connect) repr.
+        """
+        if isinstance(system_prompt, dict):
+            return f"file:{system_prompt.get('path', '')}"
+        if not isinstance(system_prompt, str):
+            return ""
+        cut = len(system_prompt)
+        for marker in cls._VOLATILE_PROMPT_MARKERS:
+            idx = system_prompt.find(marker)
+            if idx != -1:
+                cut = min(cut, idx)
+        return system_prompt[:cut]
+
+    @classmethod
+    def _client_cache_key(cls, options: Any, *, session_key: str | None = None) -> str:
+        """Persistent-client cache key: session + model + tools + a digest of
+        the system prompt's stable behavioral prefix.
+
+        The prefix digest is what makes a mid-session backend config change
+        (configured:false -> configured:true, baked into the static home
+        prompt) evict and rebuild the warm subprocess on the next turn, instead
+        of staying frozen until a cold restart. Hashing keeps the key bounded
+        regardless of prompt length.
+        """
+        prefix = cls._behavior_prefix(getattr(options, "system_prompt", None))
+        prefix_digest = hashlib.sha256(prefix.encode("utf-8", "replace")).hexdigest()[:16]
+        return (
+            f"{session_key or ''}:"
+            f"{getattr(options, 'model', '')}:"
+            f"{sorted(getattr(options, 'allowed_tools', []) or [])}:"
+            f"{prefix_digest}"
+        )
+
     async def _get_or_create_client(self, options: Any, *, session_key: str | None = None) -> Any:
         """Get or create a persistent ClaudeSDKClient.
 
-        Reuses the existing subprocess if model, tools, **and session** haven't
-        changed.  Different sessions get a fresh subprocess so the CLI's
-        internal conversation context doesn't leak between chats.
+        Reuses the existing subprocess if model, tools, session, **and the
+        system prompt's behavioral prefix** haven't changed. Different sessions
+        get a fresh subprocess so the CLI's internal conversation context
+        doesn't leak between chats; a changed behavioral prefix (e.g. the home
+        pocket's backend summary flipping to "configured" mid-session) also
+        forces a fresh subprocess so the new prompt actually takes effect — the
+        SDK applies the system prompt only at connect() time.
         """
         import time
 
-        key = (
-            f"{session_key or ''}:"
-            f"{getattr(options, 'model', '')}:{sorted(getattr(options, 'allowed_tools', []) or [])}"
-        )
+        key = self._client_cache_key(options, session_key=session_key)
 
         if self._client is not None and self._client_options_key == key:
             logger.debug("Reusing persistent client (key=%s)", key)

--- a/tests/test_claude_sdk_client_cache_key.py
+++ b/tests/test_claude_sdk_client_cache_key.py
@@ -1,0 +1,148 @@
+# Added 2026-05-31 (fix/home-backend-summary-per-turn): regression tests for
+# the persistent-client cache key. The home agent baked the backend summary
+# ({base_url, auth_type, configured}) into its STATIC system prompt; that
+# prompt is applied to the SDK subprocess only at connect() time and ignored
+# on warm reuse, so configuring a pocket's backend mid-session was frozen
+# until a cold restart. The cache key now folds in a digest of the system
+# prompt's stable behavioral prefix, so a config flip rebuilds the persistent
+# client on the very next turn. Per-turn KB/memory/history (appended after the
+# behavioral prefix) are excluded so the warm-client optimization still holds
+# for normal turns.
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+
+def _opts(system_prompt, *, model="claude-x", tools=("Agent", "WebSearch")):
+    return SimpleNamespace(
+        model=model,
+        allowed_tools=list(tools),
+        system_prompt=system_prompt,
+    )
+
+
+# The two volatile section markers ``pool.run`` appends AFTER the behavioral
+# instructions. Anything from the first marker onward must NOT influence the
+# key, or every per-turn KB/memory change would needlessly rebuild the client.
+_KB_HEADER = "## Your Knowledge Base\nUse the following information..."
+_MEM_HEADER = "## Relevant Past Memories\nBelow are memories..."
+
+
+def test_config_flip_changes_key():
+    """A home backend flipping configured:false -> configured:true changes the
+    behavioral prefix, so the cache key must differ and force a client rebuild."""
+    before = "<home-pocket>\nBackend: not configured\n...rest of static prompt..."
+    after = (
+        "<home-pocket>\nBackend: configured — https://api.acme.test (auth: bearer)\n"
+        "...rest of static prompt..."
+    )
+    key_before = ClaudeSDKBackend._client_cache_key(_opts(before), session_key="s1")
+    key_after = ClaudeSDKBackend._client_cache_key(_opts(after), session_key="s1")
+    assert key_before != key_after, (
+        "config flip must change the cache key so the warm client rebuilds with "
+        "the fresh backend summary — otherwise mid-session config stays frozen"
+    )
+
+
+def test_per_turn_kb_change_keeps_key_stable():
+    """Only the per-turn knowledge-base block changed between two turns; the
+    behavioral prefix is identical, so the key MUST stay the same (warm reuse)."""
+    behavior = "<home-pocket>\nBackend: configured — https://api.acme.test (auth: bearer)\n"
+    turn1 = behavior + "\n\n" + _KB_HEADER + "\nsnippet about revenue"
+    turn2 = behavior + "\n\n" + _KB_HEADER + "\na totally different KB snippet"
+    k1 = ClaudeSDKBackend._client_cache_key(_opts(turn1), session_key="s1")
+    k2 = ClaudeSDKBackend._client_cache_key(_opts(turn2), session_key="s1")
+    assert k1 == k2, "a per-turn KB change must not rebuild the warm client"
+
+
+def test_per_turn_memory_change_keeps_key_stable():
+    behavior = "<home-pocket>\nBackend: configured — https://api.acme.test (auth: bearer)\n"
+    turn1 = behavior + "\n\n" + _MEM_HEADER + "\nremembered fact A"
+    turn2 = behavior + "\n\n" + _MEM_HEADER + "\nremembered fact B"
+    k1 = ClaudeSDKBackend._client_cache_key(_opts(turn1), session_key="s1")
+    k2 = ClaudeSDKBackend._client_cache_key(_opts(turn2), session_key="s1")
+    assert k1 == k2
+
+
+def test_history_change_keeps_key_stable():
+    """Cold-start runs inject "# Recent Conversation" history into the prompt.
+    That is per-turn and must not influence the key."""
+    behavior = "<home-pocket>\nBackend: configured — https://api.acme.test (auth: bearer)\n"
+    turn1 = behavior + "\n\n# Recent Conversation\n**User**: hi"
+    turn2 = behavior + "\n\n# Recent Conversation\n**User**: hi\n**Assistant**: hello"
+    k1 = ClaudeSDKBackend._client_cache_key(_opts(turn1), session_key="s1")
+    k2 = ClaudeSDKBackend._client_cache_key(_opts(turn2), session_key="s1")
+    assert k1 == k2
+
+
+def test_model_and_tools_still_keyed():
+    """The original key inputs (session, model, allowed_tools) still
+    participate — a model or tool change must rebuild the client."""
+    sp = "<home-pocket>\nBackend: not configured\n"
+    base = ClaudeSDKBackend._client_cache_key(_opts(sp), session_key="s1")
+    other_model = ClaudeSDKBackend._client_cache_key(_opts(sp, model="claude-y"), session_key="s1")
+    other_tools = ClaudeSDKBackend._client_cache_key(_opts(sp, tools=("Agent",)), session_key="s1")
+    other_session = ClaudeSDKBackend._client_cache_key(_opts(sp), session_key="s2")
+    assert base != other_model
+    assert base != other_tools
+    assert base != other_session
+
+
+def test_file_system_prompt_does_not_crash():
+    """On Windows the SDK passes ``system_prompt`` as a ``{type, path}`` dict
+    instead of a string. The key computation must tolerate that shape."""
+    file_prompt = {"type": "file", "path": "/tmp/system_prompt.md"}
+    key = ClaudeSDKBackend._client_cache_key(_opts(file_prompt), session_key="s1")
+    assert isinstance(key, str) and key
+
+
+def test_real_home_behavior_instructions_flip_changes_key():
+    """End-to-end guard: build the ACTUAL home behavior instructions with a
+    configured:false then configured:true backend summary (a mid-session
+    config), wrap each as a system prompt the way ``AgentPool.run`` would, and
+    assert the persistent-client cache key differs. This is the regression the
+    smoke test surfaced: same session, config flipped, agent read stale state
+    until a cold restart. If someone moves the backend summary VALUE into the
+    per-turn volatile tail this guard still passes only because the behavioral
+    instructions themselves carry it — keep it in the static prefix."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        ScopeContext,
+        ScopeKind,
+        build_behavior_instructions,
+    )
+
+    def _ctx(summary):
+        return ScopeContext(
+            kind=ScopeKind.POCKET,
+            scope_id="home-pocket-1",
+            workspace_id="w1",
+            user_id="u1",
+            members=["u1"],
+            target_agent_id="a1",
+            agent_ids_in_scope=["a1"],
+            pocket_id="home-pocket-1",
+            pocket_type="home",
+            backend_summary=summary,
+        )
+
+    before = build_behavior_instructions(
+        _ctx({"configured": False}), backend_name="claude_agent_sdk"
+    )
+    after = build_behavior_instructions(
+        _ctx({"configured": True, "base_url": "https://api.acme.test", "auth_type": "bearer"}),
+        backend_name="claude_agent_sdk",
+    )
+    assert before != after, "behavior instructions must reflect the config flip"
+
+    # Wrap as ``AgentPool.run`` does: behavior prefix, then a volatile per-turn
+    # KB tail that differs between the two turns (it must NOT mask the flip).
+    sp_before = f"persona\n\n{before}\n\n## Your Knowledge Base\nstale turn-1 snippet"
+    sp_after = f"persona\n\n{after}\n\n## Your Knowledge Base\ndifferent turn-2 snippet"
+    key_before = ClaudeSDKBackend._client_cache_key(_opts(sp_before), session_key="s1")
+    key_after = ClaudeSDKBackend._client_cache_key(_opts(sp_after), session_key="s1")
+    assert key_before != key_after, (
+        "a mid-session backend config change must rebuild the warm client so "
+        "the agent reads the CURRENT backend state on the next message"
+    )


### PR DESCRIPTION
## The bug

Configure a pocket's backend mid-session, confirm `configured:true` over REST, then ask the home agent about it. It still reads `configured:false` and pins a placeholder ("the configure doesn't appear to have landed"). Reloading the page does nothing. Only a cold backend restart fixes it.

## Why

The home agent bakes its non-secret backend summary (`base_url`, `auth_type`, `configured`) into the static system prompt via the `__BACKEND_SUMMARY__` token. That prompt is handed to the Claude SDK subprocess, and the SDK applies a system prompt only at `connect()` time. On warm reuse the subprocess keeps the prompt it connected with and ignores later changes.

The persistent-client cache key was `session_key : model : allowed_tools`. None of those change when you configure a backend, so the warm client is never evicted and the agent keeps reading the stale summary until something else tears the client down (cold start, session switch, idle eviction).

I confirmed both the static prompt AND the per-turn `knowledge_context` get folded into the same `system_prompt` in `AgentPool.run`, so moving the value into the per-turn dynamic context would not have helped. The dynamic context is frozen on a warm client too. The only thing that reaches a warm subprocess each turn is the user `message`. So the fix has to live at the cache key.

## The fix

Fold a digest of the system prompt's stable behavioral prefix into the cache key. When the backend summary flips, the prefix changes, the key changes, and the next turn rebuilds the client with the fresh prompt. No restart, no waiting for eviction.

The volatile per-turn tail (the KB block, soul memories, injected conversation history) is stripped before hashing, so an ordinary turn whose only difference is retrieved context still reuses the warm subprocess. The original key inputs (session, model, tools) still participate.

## Tests

New `tests/test_claude_sdk_client_cache_key.py`:
- a config flip changes the key (the regression)
- a per-turn KB / memory / history change does NOT change the key (warm reuse holds)
- session, model, and tools still key the client
- a Windows file-style `system_prompt` dict does not crash the key computation
- an end-to-end guard that builds the real home behavior instructions with `configured:false` then `configured:true` and asserts the resulting keys differ even with a differing KB tail

```
uv run pytest tests/test_claude_sdk_client_cache_key.py \
  tests/cloud/test_agent_service_tools_context.py \
  tests/cloud/test_pocket_prompts_single_source.py -q
49 passed
```

Backend protocol and stream-cleanup suites still pass (57 passed).

## Scope

`src/pocketpaw/agents/claude_sdk.py` plus the new test. No protocol changes, no other backend touched. Internal behavior only, no docs surface affected.
