### PR TITLE
Add zero-config weather, wiki, and currency tools

### DIFF
--- a/docs/docs-config.json
+++ b/docs/docs-config.json
@@ -460,6 +460,11 @@
             "icon": "lucide:search"
           },
           {
+            "label": "Zero-Config Tools",
+            "href": "/tools/zero-config",
+            "icon": "lucide:zap"
+          },
+          {
             "label": "Image Generation",
             "href": "/tools/image-generation",
             "icon": "lucide:image"

--- a/docs/tools/index.mdx
+++ b/docs/tools/index.mdx
@@ -19,6 +19,9 @@ PocketPaw ships with 50+ built-in tools organized into categories. Tools are gov
   <Card title="Web Search" icon="lucide:search" href="/tools/web-search">
     Search the web via Tavily or Brave Search APIs.
   </Card>
+  <Card title="Zero-Config Tools" icon="lucide:zap" href="/tools/zero-config">
+    Weather, Wikipedia, and currency — no API key required.
+  </Card>
   <Card title="Image Generation" icon="lucide:image" href="/tools/image-generation">
     Generate images with Google Gemini models.
   </Card>
@@ -67,6 +70,9 @@ PocketPaw ships with 50+ built-in tools organized into categories. Tools are gov
 | `edit_file` / `Edit` | `group:filesystem` | Edit existing files |
 | `list_dir` | `group:filesystem` | List directory contents |
 | `web_search` | `group:search` | Web search (Tavily/Brave) |
+| `weather` | `group:knowledge` | Weather forecast (Open-Meteo, no key) |
+| `wiki` | `group:knowledge` | Wikipedia summaries (no key) |
+| `currency` | `group:knowledge` | Currency conversion (Frankfurter, no key) |
 | `image_gen` | `group:media` | Image generation (Gemini) |
 | `voice` | `group:voice` | Text-to-speech |
 | `stt` | `group:voice` | Speech-to-text |

--- a/docs/tools/zero-config.mdx
+++ b/docs/tools/zero-config.mdx
@@ -1,0 +1,114 @@
+---
+title: "Zero-Config Tools: Weather, Wikipedia & Currency (No API Key)"
+description: "Three built-in PocketPaw tools that work the moment you start chatting — weather forecasts, Wikipedia summaries, and currency conversion. No API key, no setup, no provider to wire up."
+section: Tools
+ogType: article
+keywords: ["zero config", "no api key", "weather", "wikipedia", "currency conversion", "open-meteo", "frankfurter"]
+tags: ["tools", "zero-config"]
+---
+
+# Zero-Config Tools: Weather, Wikipedia & Currency
+
+Most tools need an API key before they do anything useful. These three don't. They call free, keyless public APIs, so they work the first time you open a chat — nothing to configure, no provider to register.
+
+| Tool | Source | API key |
+|------|--------|---------|
+| `weather` | [Open-Meteo](https://open-meteo.com) | None |
+| `wiki` | [Wikipedia REST API](https://en.wikipedia.org/api/rest_v1/) | None |
+| `currency` | [Frankfurter](https://frankfurter.dev) (ECB rates) | None |
+
+## Weather
+
+Returns current conditions plus a multi-day forecast for any place. The location is resolved through Open-Meteo's geocoder, so a plain city name is enough.
+
+```
+User: What's the weather in Tokyo this week?
+Agent: [uses weather tool] → Now: Mainly clear, 18°C... 5-day forecast: ...
+```
+
+```json
+{
+  "name": "weather",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "location": { "type": "string", "description": "City or place name" },
+      "days": { "type": "integer", "description": "Forecast days (1-14, default 5)" },
+      "units": { "type": "string", "description": "'celsius' (default) or 'fahrenheit'" }
+    },
+    "required": ["location"]
+  }
+}
+```
+
+## Wikipedia
+
+Pulls a concise summary for a topic from Wikipedia's REST API — good for "what is X", "who is X", or background facts.
+
+```
+User: Tell me about the Eiffel Tower.
+Agent: [uses wiki tool] → The Eiffel Tower is a wrought-iron lattice tower in Paris...
+```
+
+```json
+{
+  "name": "wiki",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "topic": { "type": "string", "description": "The topic to look up" }
+    },
+    "required": ["topic"]
+  }
+}
+```
+
+## Currency
+
+Converts an amount between two currencies using live European Central Bank reference rates from Frankfurter. Covers roughly 30 major currencies.
+
+```
+User: How much is 100 USD in Japanese yen?
+Agent: [uses currency tool] → $100.00 USD = ¥15,927 JPY (1 USD = 159.27 JPY)
+```
+
+```json
+{
+  "name": "currency",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "amount": { "type": "number", "description": "Amount to convert" },
+      "from_currency": { "type": "string", "description": "Source code, e.g. USD" },
+      "to_currency": { "type": "string", "description": "Target code, e.g. JPY" }
+    },
+    "required": ["amount", "from_currency", "to_currency"]
+  }
+}
+```
+
+## Policy Group
+
+All three belong to `group:knowledge`. To control access:
+
+```bash
+# Allow only the zero-config knowledge tools
+export POCKETPAW_TOOLS_ALLOW="group:knowledge"
+
+# Or deny one of them
+export POCKETPAW_TOOLS_DENY="currency"
+```
+
+## Related
+
+<CardGroup>
+  <Card title="Web Search" icon="lucide:search" href="/tools/web-search">
+    Search the live web via Tavily or Brave when a topic needs fresh results.
+  </Card>
+  <Card title="Tool Policy" icon="lucide:shield-check" href="/tools/tool-policy">
+    Control which tools the agent can reach with profiles and allow/deny lists.
+  </Card>
+  <Card title="Tools Overview" icon="lucide:wrench" href="/tools">
+    Browse all 50+ built-in tools available in PocketPaw.
+  </Card>
+</CardGroup>

--- a/src/pocketpaw/tools/builtin/__init__.py
+++ b/src/pocketpaw/tools/builtin/__init__.py
@@ -10,6 +10,7 @@
 #   - 2026-03-12: Added EditFileTool, RunPythonTool, InstallPackageTool (issue #581)
 #   - 2026-03-27: Added AddWidgetTool, RemoveWidgetTool for pocket mutations
 #   - 2026-03-28: Added Fabric + Instinct enterprise tools (guarded by ee/ availability)
+#   - 2026-05-31: Added zero-config WeatherTool, WikiTool, CurrencyTool (no API key)
 
 import importlib as _importlib
 
@@ -83,6 +84,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ConnectorConnectTool": (".connector_tools", "ConnectorConnectTool"),
     "ConnectorExecuteTool": (".connector_tools", "ConnectorExecuteTool"),
     "ConnectorActionsTool": (".connector_tools", "ConnectorActionsTool"),
+    # Zero-config capability tools — no API key required.
+    "WeatherTool": (".weather", "WeatherTool"),
+    "WikiTool": (".wiki", "WikiTool"),
+    "CurrencyTool": (".currency", "CurrencyTool"),
 }
 
 # Enterprise tools (require ee/ module) — guarded so community installs don't break.

--- a/src/pocketpaw/tools/builtin/currency.py
+++ b/src/pocketpaw/tools/builtin/currency.py
@@ -1,0 +1,157 @@
+# Currency conversion tool — keyless FX via Frankfurter (ECB reference rates).
+# Created: 2026-05-31 — zero-config builtin tool (no API key required).
+#
+# Frankfurter (https://frankfurter.dev) is a free, keyless FX API backed by
+# European Central Bank reference rates. We hit the canonical host
+# https://api.frankfurter.dev/v1/latest to avoid the legacy host's redirect.
+# Returns clean structured text the agent renders; no inline ui-spec plumbing
+# (the inline-primitive layer is owned by a separate RFC).
+
+import logging
+from typing import Any
+
+import httpx
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+_LATEST_URL = "https://api.frankfurter.dev/v1/latest"
+
+# Display symbols for common currencies (cosmetic only — Frankfurter covers ~30).
+_SYMBOLS: dict[str, str] = {
+    "USD": "$",
+    "EUR": "€",
+    "GBP": "£",
+    "JPY": "¥",
+    "CNY": "¥",
+    "INR": "₹",
+    "AUD": "A$",
+    "CAD": "C$",
+    "CHF": "CHF",
+    "KRW": "₩",
+    "SGD": "S$",
+    "HKD": "HK$",
+    "NZD": "NZ$",
+    "SEK": "kr",
+    "BRL": "R$",
+    "ZAR": "R",
+}
+
+# Currencies conventionally shown without decimal places.
+_NO_DECIMAL = frozenset({"JPY", "KRW", "HUF", "ISK"})
+
+
+def _fmt_amount(amount: float, code: str) -> str:
+    symbol = _SYMBOLS.get(code, "")
+    decimals = 0 if code in _NO_DECIMAL else 2
+    return f"{symbol}{amount:,.{decimals}f} {code}"
+
+
+class CurrencyTool(BaseTool):
+    """Convert an amount between two currencies using live ECB rates.
+
+    Uses Frankfurter (free, no API key). Returns the converted amount, the
+    exchange rate, and the rate date.
+    """
+
+    @property
+    def name(self) -> str:
+        return "currency"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Convert an amount between two currencies using live exchange rates. "
+            "No API key required. Supports ~30 major currencies (USD, EUR, GBP, JPY, "
+            "CNY, INR, AUD, CAD, CHF, and more). Use for currency conversion, travel "
+            "budgets, or international pricing."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "standard"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number",
+                    "description": "The amount to convert (must be positive).",
+                },
+                "from_currency": {
+                    "type": "string",
+                    "description": "Source 3-letter currency code, e.g. USD, EUR, GBP.",
+                },
+                "to_currency": {
+                    "type": "string",
+                    "description": "Target 3-letter currency code, e.g. JPY, INR, CNY.",
+                },
+            },
+            "required": ["amount", "from_currency", "to_currency"],
+        }
+
+    async def execute(
+        self,
+        amount: float,
+        from_currency: str,
+        to_currency: str,
+    ) -> str:
+        try:
+            amount = float(amount)
+        except (TypeError, ValueError):
+            return self._error("Amount must be a number.")
+        if amount <= 0:
+            return self._error("Amount must be a positive number.")
+
+        from_code = (from_currency or "").strip().upper()
+        to_code = (to_currency or "").strip().upper()
+        if len(from_code) != 3 or len(to_code) != 3:
+            return self._error("Currency codes must be 3 letters (e.g. USD, EUR, JPY).")
+
+        if from_code == to_code:
+            return self._success(
+                f"{_fmt_amount(amount, from_code)} = {_fmt_amount(amount, to_code)} "
+                "(same currency, rate 1.0000)."
+            )
+
+        try:
+            async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+                resp = await client.get(
+                    _LATEST_URL,
+                    params={"base": from_code, "symbols": to_code},
+                )
+        except httpx.TimeoutException:
+            return self._error("Currency request timed out. Please try again.")
+        except Exception as e:
+            return self._error(f"Currency lookup failed: {e}")
+
+        # Frankfurter returns 404 for an unknown base currency.
+        if resp.status_code == 404:
+            return self._error(f"Unknown or unsupported currency code: {from_code}.")
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            return self._error(f"Currency API error: {e.response.status_code}")
+
+        try:
+            data = resp.json()
+        except Exception:
+            return self._error("Currency API returned an unreadable response.")
+
+        rates = data.get("rates") or {}
+        rate = rates.get(to_code)
+        if rate is None:
+            return self._error(
+                f"No exchange rate available for {from_code} -> {to_code}. "
+                "Check the target currency code."
+            )
+
+        converted = amount * rate
+        date = data.get("date", "")
+        return (
+            f"{_fmt_amount(amount, from_code)} = {_fmt_amount(converted, to_code)}\n"
+            f"Rate: 1 {from_code} = {rate:.4f} {to_code}" + (f" (as of {date})" if date else "")
+        )

--- a/src/pocketpaw/tools/builtin/weather.py
+++ b/src/pocketpaw/tools/builtin/weather.py
@@ -1,0 +1,215 @@
+# Weather tool — current conditions + multi-day forecast via Open-Meteo.
+# Created: 2026-05-31 — zero-config builtin tool (no API key required).
+#
+# Open-Meteo is a free, keyless weather API. Two hops:
+#   - Geocoding: https://geocoding-api.open-meteo.com/v1/search (city -> lat/lon)
+#   - Forecast:  https://api.open-meteo.com/v1/forecast
+# Returns clean structured text the agent renders; no inline ui-spec plumbing
+# (the inline-primitive layer is owned by a separate RFC).
+
+import logging
+from typing import Any
+
+import httpx
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+_GEOCODE_URL = "https://geocoding-api.open-meteo.com/v1/search"
+_FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
+
+# WMO weather interpretation codes -> short description.
+_WEATHER_CODES: dict[int, str] = {
+    0: "Clear sky",
+    1: "Mainly clear",
+    2: "Partly cloudy",
+    3: "Overcast",
+    45: "Foggy",
+    48: "Depositing rime fog",
+    51: "Light drizzle",
+    53: "Moderate drizzle",
+    55: "Dense drizzle",
+    56: "Light freezing drizzle",
+    57: "Dense freezing drizzle",
+    61: "Slight rain",
+    63: "Moderate rain",
+    65: "Heavy rain",
+    66: "Light freezing rain",
+    67: "Heavy freezing rain",
+    71: "Slight snow",
+    73: "Moderate snow",
+    75: "Heavy snow",
+    77: "Snow grains",
+    80: "Slight rain showers",
+    81: "Moderate rain showers",
+    82: "Violent rain showers",
+    85: "Slight snow showers",
+    86: "Heavy snow showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm with slight hail",
+    99: "Thunderstorm with heavy hail",
+}
+
+
+def _describe(code: int) -> str:
+    return _WEATHER_CODES.get(code, "Unknown")
+
+
+class WeatherTool(BaseTool):
+    """Get current conditions and a multi-day forecast for any location.
+
+    Uses Open-Meteo (free, no API key). Returns structured text with current
+    temperature, conditions, and a daily high/low/precip forecast.
+    """
+
+    @property
+    def name(self) -> str:
+        return "weather"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get the weather forecast for any location. No API key required. "
+            "Returns current conditions plus a multi-day forecast with daily highs, "
+            "lows, precipitation, and wind. Use for weather questions, trip planning, "
+            "or deciding what to wear."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "standard"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": 'City or place name, e.g. "Tokyo", "New York", "London".',
+                },
+                "days": {
+                    "type": "integer",
+                    "description": "Number of forecast days (1-14). Default: 5.",
+                    "default": 5,
+                },
+                "units": {
+                    "type": "string",
+                    "description": "Temperature units: 'celsius' (default) or 'fahrenheit'.",
+                    "default": "celsius",
+                },
+            },
+            "required": ["location"],
+        }
+
+    async def execute(
+        self,
+        location: str,
+        days: int = 5,
+        units: str = "celsius",
+    ) -> str:
+        if not location or not location.strip():
+            return self._error("No location provided.")
+
+        days = min(max(int(days), 1), 14)
+        units = units.lower()
+        if units not in ("celsius", "fahrenheit"):
+            units = "celsius"
+
+        try:
+            async with httpx.AsyncClient(timeout=15) as client:
+                geo = await self._geocode(client, location)
+                if geo is None:
+                    return self._error(
+                        f"Could not find a location named '{location}'. "
+                        "Try a different or more specific name."
+                    )
+
+                forecast = await self._forecast(
+                    client, geo["latitude"], geo["longitude"], days, units
+                )
+        except httpx.HTTPStatusError as e:
+            return self._error(f"Weather API error: {e.response.status_code}")
+        except httpx.TimeoutException:
+            return self._error("Weather request timed out. Please try again.")
+        except Exception as e:
+            return self._error(f"Weather lookup failed: {e}")
+
+        if not forecast or not forecast.get("daily"):
+            return self._error("Weather data unavailable for that location right now.")
+
+        return self._format(geo, forecast, days, units)
+
+    async def _geocode(self, client: httpx.AsyncClient, location: str) -> dict | None:
+        resp = await client.get(
+            _GEOCODE_URL,
+            params={"name": location, "count": 1, "language": "en", "format": "json"},
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results") or []
+        return results[0] if results else None
+
+    async def _forecast(
+        self,
+        client: httpx.AsyncClient,
+        lat: float,
+        lon: float,
+        days: int,
+        units: str,
+    ) -> dict:
+        params: dict[str, Any] = {
+            "latitude": lat,
+            "longitude": lon,
+            "current": "temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m",
+            "daily": (
+                "weather_code,temperature_2m_max,temperature_2m_min,"
+                "precipitation_sum,wind_speed_10m_max"
+            ),
+            "forecast_days": days,
+            "timezone": "auto",
+        }
+        if units == "fahrenheit":
+            params["temperature_unit"] = "fahrenheit"
+            params["wind_speed_unit"] = "mph"
+        resp = await client.get(_FORECAST_URL, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    @staticmethod
+    def _format(geo: dict, forecast: dict, days: int, units: str) -> str:
+        temp_unit = "°F" if units == "fahrenheit" else "°C"
+        wind_unit = "mph" if units == "fahrenheit" else "km/h"
+
+        admin1 = geo.get("admin1")
+        country = geo.get("country", "")
+        name = geo.get("name", "")
+        place = f"{name}, {admin1}, {country}" if admin1 else f"{name}, {country}"
+        place = place.strip().strip(",")
+
+        lines = [f"Weather for {place}:"]
+
+        current = forecast.get("current") or {}
+        if current:
+            lines.append(
+                f"\nNow: {_describe(current.get('weather_code', -1))}, "
+                f"{round(current.get('temperature_2m', 0))}{temp_unit}, "
+                f"humidity {current.get('relative_humidity_2m', 0)}%, "
+                f"wind {round(current.get('wind_speed_10m', 0))} {wind_unit}"
+            )
+
+        daily = forecast.get("daily", {})
+        times = daily.get("time", [])
+        if times:
+            lines.append(f"\n{days}-day forecast:")
+            for i, date in enumerate(times):
+                code = daily["weather_code"][i]
+                high = round(daily["temperature_2m_max"][i])
+                low = round(daily["temperature_2m_min"][i])
+                precip = daily["precipitation_sum"][i]
+                lines.append(
+                    f"  {date}: {_describe(code)}, high {high}{temp_unit} / "
+                    f"low {low}{temp_unit}, precip {precip}mm"
+                )
+
+        return "\n".join(lines)

--- a/src/pocketpaw/tools/builtin/wiki.py
+++ b/src/pocketpaw/tools/builtin/wiki.py
@@ -1,0 +1,124 @@
+# Wikipedia info tool — topic summaries via Wikipedia's free REST API.
+# Created: 2026-05-31 — zero-config builtin tool (no API key required).
+#
+# Calls https://en.wikipedia.org/api/rest_v1/page/summary/{title} which is
+# free and keyless. Returns a clean text summary the agent renders; no inline
+# ui-spec plumbing (the inline-primitive layer is owned by a separate RFC).
+
+import logging
+import re
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from pocketpaw.tools.protocol import BaseTool
+
+logger = logging.getLogger(__name__)
+
+_SUMMARY_URL = "https://en.wikipedia.org/api/rest_v1/page/summary/"
+# Wikipedia asks REST clients to send a descriptive User-Agent.
+_USER_AGENT = "PocketPaw/1.0 (https://github.com/pocketpaw/pocketpaw)"
+
+
+def _strip_html(text: str) -> str:
+    return re.sub(r"<[^>]*>", "", text).strip()
+
+
+class WikiTool(BaseTool):
+    """Look up a topic on Wikipedia and return a concise summary.
+
+    Uses Wikipedia's free REST summary API (no key). Good for "what is X",
+    "who is X", or background facts on a person, place, or concept.
+    """
+
+    @property
+    def name(self) -> str:
+        return "wiki"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Look up any topic on Wikipedia and get a concise summary. "
+            "No API key required. Use for 'what is X', 'who is X', 'tell me about X', "
+            "or background facts on a person, place, thing, or concept."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "standard"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "description": (
+                        'The topic to look up, e.g. "Eiffel Tower", "Alan Turing", '
+                        '"photosynthesis".'
+                    ),
+                },
+            },
+            "required": ["topic"],
+        }
+
+    async def execute(self, topic: str) -> str:
+        if not topic or not topic.strip():
+            return self._error("No topic provided.")
+
+        # Wikipedia title path uses underscores for spaces.
+        title = quote(topic.strip().replace(" ", "_"), safe="")
+        url = f"{_SUMMARY_URL}{title}"
+
+        try:
+            async with httpx.AsyncClient(timeout=15, follow_redirects=True) as client:
+                resp = await client.get(
+                    url,
+                    headers={"User-Agent": _USER_AGENT, "Accept": "application/json"},
+                )
+        except httpx.TimeoutException:
+            return self._error("Wikipedia request timed out. Please try again.")
+        except Exception as e:
+            return self._error(f"Wikipedia lookup failed: {e}")
+
+        if resp.status_code == 404:
+            return self._error(f"No Wikipedia article found for '{topic}'. Try a different term.")
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            return self._error(f"Wikipedia API error: {e.response.status_code}")
+
+        try:
+            data = resp.json()
+        except Exception:
+            return self._error("Wikipedia returned an unreadable response.")
+
+        extract = (data.get("extract") or "").strip()
+        if not extract:
+            return self._error(f"No summary available for '{topic}'. Try a different term.")
+
+        return self._format(data, extract)
+
+    @staticmethod
+    def _format(data: dict, extract: str) -> str:
+        title = _strip_html(data.get("displaytitle") or "") or data.get("title", "")
+        lines = [title] if title else []
+
+        description = data.get("description")
+        if description:
+            lines.append(f"({description})")
+
+        lines.append("")
+        lines.append(extract)
+
+        coords = data.get("coordinates")
+        if coords and "lat" in coords and "lon" in coords:
+            lines.append(f"\nLocation: {coords['lat']:.4f}, {coords['lon']:.4f}")
+
+        url = (data.get("content_urls") or {}).get("desktop", {}).get("page")
+        if url:
+            lines.append(f"Source: {url}")
+
+        return "\n".join(lines)

--- a/src/pocketpaw/tools/policy.py
+++ b/src/pocketpaw/tools/policy.py
@@ -55,6 +55,8 @@ TOOL_GROUPS: dict[str, list[str]] = {
     "group:media": ["image_generate", "ocr", "deliver_artifact"],
     "group:translate": ["translate"],
     "group:reddit": ["reddit_search", "reddit_read", "reddit_trending"],
+    # Zero-config capability tools — no API key required.
+    "group:knowledge": ["weather", "wiki", "currency"],
     "group:sessions": [
         "new_session",
         "list_sessions",

--- a/tests/test_zero_config_tools.py
+++ b/tests/test_zero_config_tools.py
@@ -1,0 +1,261 @@
+# Tests for the zero-config capability tools: weather, wiki, currency.
+# Created: 2026-05-31
+#
+# These tools call free, keyless public APIs. All external HTTP is mocked —
+# no live network. Each tool gets a happy-path test plus an error/timeout path.
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from pocketpaw.tools.builtin.currency import CurrencyTool
+from pocketpaw.tools.builtin.weather import WeatherTool
+from pocketpaw.tools.builtin.wiki import WikiTool
+
+
+def _mock_client(get_side_effect):
+    """Build a mock httpx.AsyncClient whose .get() is driven by *get_side_effect*.
+
+    *get_side_effect* may be a list (one response per sequential .get call) or a
+    single response / exception. Returns the patch target's mock client.
+    """
+    client = AsyncMock()
+    if isinstance(get_side_effect, list):
+        client.get.side_effect = get_side_effect
+    elif isinstance(get_side_effect, BaseException) or (
+        isinstance(get_side_effect, type) and issubclass(get_side_effect, BaseException)
+    ):
+        client.get.side_effect = get_side_effect
+    else:
+        client.get.return_value = get_side_effect
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+def _resp(json_data, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = json_data
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# WeatherTool
+# ---------------------------------------------------------------------------
+class TestWeatherTool:
+    @pytest.fixture
+    def tool(self):
+        return WeatherTool()
+
+    def test_name_and_trust(self, tool):
+        assert tool.name == "weather"
+        assert tool.trust_level == "standard"
+
+    def test_parameters_schema(self, tool):
+        params = tool.parameters
+        assert "location" in params["properties"]
+        assert params["required"] == ["location"]
+
+    async def test_forecast_success(self, tool):
+        geo_resp = _resp(
+            {
+                "results": [
+                    {
+                        "name": "Tokyo",
+                        "latitude": 35.69,
+                        "longitude": 139.69,
+                        "country": "Japan",
+                        "admin1": "Tokyo",
+                        "timezone": "Asia/Tokyo",
+                    }
+                ]
+            }
+        )
+        forecast_resp = _resp(
+            {
+                "current": {
+                    "temperature_2m": 18.4,
+                    "weather_code": 1,
+                    "wind_speed_10m": 12.0,
+                    "relative_humidity_2m": 55,
+                },
+                "daily": {
+                    "time": ["2026-05-31", "2026-06-01"],
+                    "weather_code": [1, 61],
+                    "temperature_2m_max": [22.1, 19.8],
+                    "temperature_2m_min": [14.0, 13.2],
+                    "precipitation_sum": [0.0, 5.4],
+                    "wind_speed_10m_max": [15.0, 20.0],
+                },
+            }
+        )
+        client = _mock_client([geo_resp, forecast_resp])
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(location="Tokyo", days=2)
+
+        assert "Tokyo" in result
+        assert "Japan" in result
+        assert "Mainly clear" in result  # weather_code 1
+        assert "Slight rain" in result  # weather_code 61
+        assert "18" in result  # current temp rounded
+
+    async def test_location_not_found(self, tool):
+        geo_resp = _resp({"results": []})
+        client = _mock_client([geo_resp])
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(location="Nowheresville XYZ")
+        assert "Error" in result
+        assert "Could not find" in result
+
+    async def test_empty_location(self, tool):
+        result = await tool.execute(location="   ")
+        assert "Error" in result
+        assert "No location" in result
+
+    async def test_timeout(self, tool):
+        client = _mock_client(httpx.TimeoutException("slow"))
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(location="Tokyo")
+        assert "Error" in result
+        assert "timed out" in result
+
+
+# ---------------------------------------------------------------------------
+# WikiTool
+# ---------------------------------------------------------------------------
+class TestWikiTool:
+    @pytest.fixture
+    def tool(self):
+        return WikiTool()
+
+    def test_name_and_trust(self, tool):
+        assert tool.name == "wiki"
+        assert tool.trust_level == "standard"
+
+    def test_parameters_schema(self, tool):
+        params = tool.parameters
+        assert "topic" in params["properties"]
+        assert params["required"] == ["topic"]
+
+    async def test_summary_success(self, tool):
+        resp = _resp(
+            {
+                "title": "Eiffel Tower",
+                "displaytitle": '<span class="mw-page-title-main">Eiffel Tower</span>',
+                "description": "Tower in Paris, France",
+                "extract": "The Eiffel Tower is a wrought-iron lattice tower in Paris.",
+                "content_urls": {"desktop": {"page": "https://en.wikipedia.org/wiki/Eiffel_Tower"}},
+                "coordinates": {"lat": 48.8584, "lon": 2.2945},
+            }
+        )
+        client = _mock_client(resp)
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(topic="Eiffel Tower")
+
+        assert "Eiffel Tower" in result
+        assert "wrought-iron lattice tower" in result
+        assert "Tower in Paris, France" in result
+        assert "en.wikipedia.org/wiki/Eiffel_Tower" in result
+        # HTML must be stripped from the title.
+        assert "<span" not in result
+
+    async def test_not_found_404(self, tool):
+        resp = _resp({}, status_code=404)
+        client = _mock_client(resp)
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(topic="asdkjfhqwoeiruzzz")
+        assert "Error" in result
+        assert "No Wikipedia article" in result
+
+    async def test_empty_topic(self, tool):
+        result = await tool.execute(topic="")
+        assert "Error" in result
+        assert "No topic" in result
+
+    async def test_timeout(self, tool):
+        client = _mock_client(httpx.TimeoutException("slow"))
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(topic="Paris")
+        assert "Error" in result
+        assert "timed out" in result
+
+
+# ---------------------------------------------------------------------------
+# CurrencyTool
+# ---------------------------------------------------------------------------
+class TestCurrencyTool:
+    @pytest.fixture
+    def tool(self):
+        return CurrencyTool()
+
+    def test_name_and_trust(self, tool):
+        assert tool.name == "currency"
+        assert tool.trust_level == "standard"
+
+    def test_parameters_schema(self, tool):
+        params = tool.parameters
+        assert set(params["required"]) == {"amount", "from_currency", "to_currency"}
+
+    async def test_conversion_success(self, tool):
+        resp = _resp(
+            {
+                "amount": 1.0,
+                "base": "USD",
+                "date": "2026-05-29",
+                "rates": {"JPY": 159.27},
+            }
+        )
+        client = _mock_client(resp)
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(amount=100, from_currency="usd", to_currency="jpy")
+
+        assert "USD" in result
+        assert "JPY" in result
+        assert "159.27" in result
+        assert "2026-05-29" in result
+        # 100 * 159.27 = 15927, JPY shown without decimals.
+        assert "15,927" in result
+
+    async def test_same_currency_short_circuits(self, tool):
+        # No HTTP call needed for same-currency conversion.
+        client = _mock_client(httpx.TimeoutException("should not be called"))
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(amount=50, from_currency="EUR", to_currency="EUR")
+        assert "same currency" in result
+        client.get.assert_not_called()
+
+    async def test_invalid_amount(self, tool):
+        result = await tool.execute(amount=-5, from_currency="USD", to_currency="EUR")
+        assert "Error" in result
+        assert "positive" in result
+
+    async def test_bad_currency_code(self, tool):
+        result = await tool.execute(amount=10, from_currency="DOLLARS", to_currency="EUR")
+        assert "Error" in result
+        assert "3 letters" in result
+
+    async def test_unknown_base_404(self, tool):
+        resp = _resp({}, status_code=404)
+        client = _mock_client(resp)
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(amount=10, from_currency="XYZ", to_currency="EUR")
+        assert "Error" in result
+        assert "Unknown or unsupported" in result
+
+    async def test_missing_target_rate(self, tool):
+        resp = _resp({"amount": 1.0, "base": "USD", "date": "2026-05-29", "rates": {}})
+        client = _mock_client(resp)
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(amount=10, from_currency="USD", to_currency="ZZZ")
+        assert "Error" in result
+        assert "No exchange rate" in result
+
+    async def test_timeout(self, tool):
+        client = _mock_client(httpx.TimeoutException("slow"))
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await tool.execute(amount=10, from_currency="USD", to_currency="EUR")
+        assert "Error" in result
+        assert "timed out" in result


### PR DESCRIPTION
## What

Three new builtin tools that need no API key, so a brand-new chat can return real data the moment someone asks, without first wiring up a connector or pasting a key:

- **`weather`** — current conditions plus a multi-day forecast via [Open-Meteo](https://open-meteo.com). It geocodes the place name, then fetches the forecast. Supports celsius/fahrenheit and 1-14 days.
- **`wiki`** — a concise topic summary from the [Wikipedia REST API](https://en.wikipedia.org/api/rest_v1/). Good for "what is X" / "who is X" questions.
- **`currency`** — converts an amount between ~30 major currencies using European Central Bank reference rates from [Frankfurter](https://frankfurter.dev).

All three call free, keyless public APIs. They work on an OSS install with nothing configured.

## How it fits the existing pattern

Each tool is a `BaseTool` subclass like the other builtins:

- async `execute`, typed JSON-schema params, `standard` trust level
- HTTP through `httpx.AsyncClient` with a 15s timeout
- errors and timeouts return a clean message via `_error` instead of raising, so a bad city name or a slow API surfaces as readable text
- results go back as structured text the agent renders, matching how the current data tools behave (no inline rendering plumbing — that layer is tracked separately)

Registration is the usual lazy-import entry in `builtin/__init__.py`, and the three land in a new `group:knowledge` policy group so they can be allowed or denied as a set.

## Tests

`tests/test_zero_config_tools.py` mocks all outbound HTTP — no live network. Per tool it covers the happy path plus a not-found and a timeout case, plus schema and input-validation checks. 21 tests, all green.

```
uv run pytest tests/test_zero_config_tools.py -q
21 passed
```

The tool policy, registration, and bridge tests still pass (`test_tool_policy.py`, `test_tools.py`, `test_tool_bridge.py`, `test_tool_filter.py`).

## Docs

- New page: `docs/tools/zero-config.mdx` (schemas, examples, policy group)
- Added the three rows to the tool list and a card in `docs/tools/index.mdx`
- Wired the new page into the sidebar in `docs-config.json`

## Deferred (need API keys)

The other genesis capability tools aren't keyless, so they're out of scope here: `news` (needs a news provider key / ships mock data today), `stocks` (Alpha Vantage key), `search` and `research` (need a configured search provider), and `image_search` (SerpAPI key). The genesis currency tool used a keyed ExchangeRate-API; this one swaps to keyless Frankfurter to keep it zero-config.