### PR TITLE
feat(ripple): enforce manifest-required widget props at spec ingest

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -314,6 +314,31 @@ Each flagged node reports `{path, type, suggestion}`, where `suggestion`
 is the nearest catalog widget by edit distance. The gate is best-effort:
 when the widget manifest can't be fetched it is skipped.
 
+### Required-prop gate
+
+The widget manifest marks the props a widget cannot render without as
+`required: true` (a `chart` with no `data`, a `stat` with no `value`, a
+`table` with no `columns`/`rows`). That flag used to live only in the
+system prompt — a node like `{"type": "chart", "props": {}}` passed the
+catalog gate (its `type` is known) and rendered an empty box. The
+required-prop gate runs as a sibling to the catalog walk and closes that
+hole: it flags any node missing a manifest-required prop for its `type`.
+
+It is the rippleSpec expression of the constraint-zone model's 🔒 **HARD**
+`required_fields` zone — the agent is free to choose which widgets to use
+and how to fill the creative props, but the manifest-declared structural
+minimum is locked and checked, not merely asked for. Same **strict**
+(agent path, blocks + returns a corrective message naming the missing
+prop) / **logged** (human / import path, structured warning, never blocks)
+posture as the catalog gate, and the same best-effort skip when the
+manifest can't be fetched. A prop counts as present when its key exists
+with a non-null value — a literal, an empty list / `0` / `false`, or a
+bound `{...}` expression all satisfy it; only a missing key or explicit
+`null` is a violation. A node-level `bind` satisfies a single-required-prop
+input widget (the bound value populates the prop at render time).
+
+Each flagged node reports `{path, type, missing, required}`.
+
 ### Escape-hatch widgets
 
 Two catalog widgets cover content the rest of the catalog can't express:

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -156,13 +156,17 @@ from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
 from pocketpaw_ee.cloud.ripple_validator import (
     ActionWiringViolationError,
     CatalogViolationError,
+    MissingRequiredPropError,
     find_unreferenced_state_keys,
     format_action_violations_for_agent,
+    format_required_prop_violations_for_agent,
     format_violations_for_agent,
     validate_action_wiring_logged,
     validate_action_wiring_strict,
     validate_against_catalog_logged,
     validate_against_catalog_strict,
+    validate_required_props_logged,
+    validate_required_props_strict,
     validate_ripple_spec_logged,
 )
 from pocketpaw_ee.cloud.shared.errors import Forbidden, NotFound, ValidationError
@@ -418,6 +422,35 @@ async def _catalog_allowed_types() -> list[str] | None:
         return None
 
 
+async def _catalog_required_props() -> dict[str, list[str]] | None:
+    """Resolve the per-widget required-prop map from the Ripple manifest.
+
+    Returns ``{type: [required_prop, ...]}`` for the constraint-zone HARD
+    required-prop gate, or ``None`` when the manifest is unavailable or no
+    widget declares a required prop — the caller skips the gate in that case,
+    best-effort like :func:`_catalog_allowed_types`.
+
+    ``get_manifest`` is in-process TTL-cached, so this resolves from the same
+    cache entry the allow-list lookup populated — no extra network fetch.
+    """
+    try:
+        from pocketpaw.config import get_settings
+        from pocketpaw.ripple.manifest import get_manifest, required_props_from_manifest
+
+        settings = get_settings()
+        manifest = await get_manifest(
+            settings.ripple_manifest_url,
+            ttl_seconds=settings.ripple_manifest_ttl_seconds,
+        )
+        if manifest is None:
+            return None
+        required = required_props_from_manifest(manifest)
+        return required or None
+    except Exception:
+        logger.debug("ripple required-prop map lookup skipped (non-fatal)", exc_info=True)
+        return None
+
+
 def _embed_allowed_hosts() -> list[str]:
     """Return the configured ``embed`` host allow-list."""
     try:
@@ -521,6 +554,20 @@ async def _gate_catalog(
             pocket_id=pocket_id,
             workspace_id=workspace_id,
         )
+        # Required-prop "HARD constraint" gate — same strict posture. Runs
+        # after the catalog walk so an unknown ``type`` surfaces as the
+        # fundamental "no such widget" error first; this catches the
+        # known-widget-but-missing-required-prop case (a ``chart`` with no
+        # ``data``) the catalog can't see. Best-effort: skipped when the
+        # required-prop map can't be resolved.
+        required_props = await _catalog_required_props()
+        if required_props:
+            validate_required_props_strict(
+                spec,
+                required_props,
+                pocket_id=pocket_id,
+                workspace_id=workspace_id,
+            )
     else:
         validate_against_catalog_logged(
             spec,
@@ -534,6 +581,14 @@ async def _gate_catalog(
             pocket_id=pocket_id,
             workspace_id=workspace_id,
         )
+        required_props = await _catalog_required_props()
+        if required_props:
+            validate_required_props_logged(
+                spec,
+                required_props,
+                pocket_id=pocket_id,
+                workspace_id=workspace_id,
+            )
 
 
 # Widget ``type`` whose tiles carry no rippleSpec — the frontend renders them
@@ -584,6 +639,8 @@ async def _gate_widget_spec_for_agent(
         return format_violations_for_agent(exc.violations)
     except ActionWiringViolationError as exc:
         return format_action_violations_for_agent(exc.violations)
+    except MissingRequiredPropError as exc:
+        return format_required_prop_violations_for_agent(exc.violations)
     return None
 
 
@@ -1126,6 +1183,13 @@ async def merge_spec(
                 "rippleSpec": doc.rippleSpec,
                 "warnings": warnings + [format_action_violations_for_agent(exc.violations)],
             }
+        except MissingRequiredPropError as exc:
+            return {
+                "ok": False,
+                "pocket_id": str(doc.id),
+                "rippleSpec": doc.rippleSpec,
+                "warnings": warnings + [format_required_prop_violations_for_agent(exc.violations)],
+            }
 
     # Persist + emit.
     doc.rippleSpec = normalized
@@ -1268,6 +1332,14 @@ async def create_from_ripple_spec(
         # Strict action-wiring gate blocked the auto-create (PR #1196).
         logger.warning(
             "Auto-create blocked by action-wiring gate: %d violation(s); paths=%s",
+            len(exc.violations),
+            [v.get("path") for v in exc.violations],
+        )
+        return None
+    except MissingRequiredPropError as exc:
+        # Strict required-prop gate blocked the auto-create (constraint-zone).
+        logger.warning(
+            "Auto-create blocked by required-prop gate: %d violation(s); paths=%s",
             len(exc.violations),
             [v.get("path") for v in exc.violations],
         )
@@ -1845,6 +1917,8 @@ async def agent_update(
                 return None, format_violations_for_agent(exc.violations)
             except ActionWiringViolationError as exc:
                 return None, format_action_violations_for_agent(exc.violations)
+            except MissingRequiredPropError as exc:
+                return None, format_required_prop_violations_for_agent(exc.violations)
     try:
         await doc.save()
     except Exception as exc:  # noqa: BLE001
@@ -2896,6 +2970,8 @@ async def agent_create(
             return None, None, format_violations_for_agent(exc.violations)
         except ActionWiringViolationError as exc:
             return None, None, format_action_violations_for_agent(exc.violations)
+        except MissingRequiredPropError as exc:
+            return None, None, format_required_prop_violations_for_agent(exc.violations)
     try:
         doc = _PocketDoc(
             workspace=workspace_id,

--- a/ee/pocketpaw_ee/cloud/ripple_validator.py
+++ b/ee/pocketpaw_ee/cloud/ripple_validator.py
@@ -23,6 +23,15 @@ new token / method added to the resolver should be added here too — the
 two files together are the contract.
 
 Changes:
+  - 2026-05-31 (constraint-zone enforcer): added the required-prop gate —
+    ``MissingRequiredPropError`` plus ``validate_required_props_strict``
+    (agent-generation path, RAISES) and ``..._logged`` (human/import path,
+    structured warn, does not block). Mirrors the catalog / action-wiring
+    strict/logged split. The pure walk + the manifest required-prop reader
+    live in OSS ``pocketpaw.ripple.manifest``; this module supplies the
+    EE-side strict/logged wiring + the agent-readable error formatting. It
+    is the rippleSpec analogue of the genesis "Constraint Zones" 🔒 HARD
+    ``required_fields`` zone.
   - 2026-05-30 (issue #1301): added ``find_unreferenced_state_keys`` —
     a pure ui-walk collector (mirrors ``find_unwired_live_buttons``) that
     returns top-level ``state`` keys no ui node references. Closes the
@@ -52,6 +61,7 @@ from pocketpaw.ripple.manifest import (
     find_unwired_live_buttons,
     validate_action_verbs,
     validate_against_catalog,
+    validate_required_props,
 )
 
 log = logging.getLogger(__name__)
@@ -668,6 +678,128 @@ def validate_action_wiring_strict(
 
 
 # ---------------------------------------------------------------------------
+# Required-prop gate (constraint-zone enforcer, 2026-05-31).
+#
+# The widget manifest marks the props a widget cannot render without as
+# ``required: true``. That flag was previously surfaced only in the system
+# prompt — a node like ``{"type": "chart", "props": {}}`` passed the catalog
+# gate (its ``type`` is known) and the action-wiring gate (no handlers) and
+# rendered an empty box. This gate closes that hole: the genesis "Constraint
+# Zones" model's 🔒 HARD ``required_fields`` zone, re-expressed for rippleSpec
+# at the widget-prop level. The pure walk lives in OSS
+# ``pocketpaw.ripple.manifest``; this layer adds the strict / logged wiring +
+# the agent-readable error formatting, symmetric with the catalog gate above.
+# ---------------------------------------------------------------------------
+
+
+class MissingRequiredPropError(Exception):
+    """Raised by :func:`validate_required_props_strict` when a spec carries a
+    node missing a prop the widget manifest marks ``required: true``.
+
+    Same shape as :class:`CatalogViolationError` / :class:`ActionWiringViolationError`:
+    ``.violations`` plus a class-level formatter so the chat agent's retry
+    loop can surface a focused corrective hint naming the missing prop.
+    """
+
+    def __init__(self, violations: list[dict[str, Any]]) -> None:
+        self.violations = violations
+        super().__init__(self._format(violations))
+
+    @staticmethod
+    def _format(violations: list[dict[str, Any]]) -> str:
+        lines = [f"{len(violations)} required-prop violation(s) in rippleSpec:"]
+        for v in violations[:20]:
+            missing = ", ".join(v.get("missing", []))
+            lines.append(
+                f"  - [missing_required_prop] {v['path']}: '{v['type']}' is missing "
+                f"required prop(s): {missing}"
+            )
+        if len(violations) > 20:
+            lines.append(f"  - …and {len(violations) - 20} more")
+        return "\n".join(lines)
+
+
+def format_required_prop_violations_for_agent(violations: list[dict[str, Any]]) -> str:
+    """Build a compact, agent-readable summary of required-prop violations.
+
+    Suitable as the ``error`` field on an MCP tool result so the specialist
+    sees specifically which node is missing which required prop and can target
+    its fix.
+    """
+    if not violations:
+        return ""
+    lines = ["The rippleSpec was rejected — some widgets are missing required props:"]
+    for v in violations[:10]:
+        missing = ", ".join(v.get("missing", []))
+        lines.append(
+            f"  • {v['path']}: '{v['type']}' must set {missing} "
+            f"(required props for this widget: {', '.join(v.get('required', []))})."
+        )
+    if len(violations) > 10:
+        lines.append(f"  • …and {len(violations) - 10} more")
+    lines.append(
+        "Every prop the widget catalog marks `required` must be present on the node "
+        "(a literal value or a bound `{...}` expression). A missing required prop "
+        "renders the widget empty / broken even though every other gate passes."
+    )
+    return "\n".join(lines)
+
+
+def validate_required_props_logged(
+    spec: dict[str, Any] | None,
+    manifest_or_required: dict[str, Any],
+    *,
+    pocket_id: str | None = None,
+    workspace_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Validate manifest-required props, emit one ``log.warning`` per
+    violation, and return the violations list.
+
+    Use this on the human / import path — a violation is recorded for triage
+    but does NOT block the write (an older imported spec may predate a prop
+    becoming required).
+    """
+    violations = validate_required_props(spec, manifest_or_required)
+    for v in violations:
+        log.warning(
+            "ripple_spec.missing_required_prop",
+            extra={
+                "pocket_id": pocket_id,
+                "workspace_id": workspace_id,
+                "field_path": v["path"],
+                "widget_type": v["type"],
+                "missing_props": v.get("missing"),
+            },
+        )
+    return violations
+
+
+def validate_required_props_strict(
+    spec: dict[str, Any] | None,
+    manifest_or_required: dict[str, Any],
+    *,
+    pocket_id: str | None = None,
+    workspace_id: str | None = None,
+) -> None:
+    """Validate manifest-required props; raise :class:`MissingRequiredPropError`
+    if any node omits a prop its widget marks ``required: true``.
+
+    Use this only on the agent-generation path where the caller can handle a
+    retry. Human / import callers should use
+    :func:`validate_required_props_logged` — strict mode would block a
+    legitimate import of an older spec.
+    """
+    violations = validate_required_props_logged(
+        spec,
+        manifest_or_required,
+        pocket_id=pocket_id,
+        workspace_id=workspace_id,
+    )
+    if violations:
+        raise MissingRequiredPropError(violations)
+
+
+# ---------------------------------------------------------------------------
 # Orphan-state gate (issue #1301, 2026-05-30).
 #
 # An add-widget intent that lands as a STATE-ONLY merge patch is
@@ -816,15 +948,19 @@ __all__ = [
     "ActionWiringViolationError",
     "CatalogViolationError",
     "ExpressionWarning",
+    "MissingRequiredPropError",
     "RippleSpecGrammarError",
     "find_unreferenced_state_keys",
     "format_action_violations_for_agent",
+    "format_required_prop_violations_for_agent",
     "format_violations_for_agent",
     "format_warnings_for_agent",
     "validate_action_wiring_logged",
     "validate_action_wiring_strict",
     "validate_against_catalog_logged",
     "validate_against_catalog_strict",
+    "validate_required_props_logged",
+    "validate_required_props_strict",
     "validate_ripple_spec",
     "validate_ripple_spec_logged",
     "validate_ripple_spec_strict",

--- a/src/pocketpaw/ripple/manifest.py
+++ b/src/pocketpaw/ripple/manifest.py
@@ -11,6 +11,13 @@ returns None — the caller is expected to fall back to a different
 source (today: kb scope search).
 
 Changes:
+  - 2026-05-31 (constraint-zone enforcer): added ``validate_required_props``
+    + ``required_props_from_manifest`` — a mechanical walker that flags any
+    node missing a prop the manifest marks ``required: true`` for its
+    ``type``. The rippleSpec analogue of the genesis "Constraint Zones" 🔒
+    HARD ``required_fields`` zone; sibling to ``validate_against_catalog`` /
+    ``validate_action_verbs``. Previously the ``required`` flag was surfaced
+    only in the system prompt and never enforced at gate time.
   - 2026-05-22 (Increment 5): added ``validate_against_catalog`` — a
     catalog-as-allowlist ingest gate that flags any node whose ``type``
     is not in the widget manifest (sibling to ``validate_against_manifest``,
@@ -809,6 +816,169 @@ def find_unwired_live_buttons(spec: dict[str, Any] | None) -> list[dict[str, Any
     root = spec.get("ui") if isinstance(spec.get("ui"), dict) else spec
     issues: list[dict[str, Any]] = []
     _walk_live_buttons(root, "ui", raw_sources, issues)
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Required-prop "HARD constraint" gate (2026-05-31).
+#
+# The widget manifest declares ``required: true`` on the props a widget
+# cannot render without (a ``chart`` with no ``data``, a ``stat`` with no
+# ``value``, an ``each``-driven ``table`` with no ``columns``). Today that
+# flag is surfaced only in the system prompt — nothing mechanically enforces
+# it, so a node like ``{"type": "chart", "props": {}}`` sails through every
+# gate and renders an empty box.
+#
+# This is the rippleSpec analogue of the genesis "Constraint Zones" model's
+# 🔒 HARD ``required_fields`` zone: the agent is free to choose WHICH widgets
+# to use and HOW to fill the creative props, but the structural minimum — the
+# manifest-declared required props — is locked and checked, not merely asked
+# for. A prompt-side "include required props" rule rots at agent-write-rate;
+# this walker catches every omission for free, exactly like the catalog and
+# action-verb gates it sits beside.
+#
+# Runs as a sibling to ``validate_against_catalog`` — strict on the
+# agent-generation path (raises so the chat agent can retry with the missing
+# prop named), logged on the human / import path.
+# ---------------------------------------------------------------------------
+
+
+def required_props_from_manifest(manifest: dict[str, Any]) -> dict[str, list[str]]:
+    """Extract the per-widget required-prop map from a parsed manifest.
+
+    Returns ``{ widget_type: [required_prop, ...] }`` for every widget that
+    declares at least one ``required: true`` prop; widgets with no required
+    props are omitted entirely (so a membership test doubles as "does this
+    type have anything to enforce"). Prop order follows the manifest's
+    declaration order so corrective hints read naturally.
+
+    Mirrors :func:`allowed_types_from_manifest` — a pure manifest reader with
+    no spec involvement.
+    """
+    out: dict[str, list[str]] = {}
+    for w in manifest.get("widgets") or []:
+        if not isinstance(w, dict):
+            continue
+        wtype = w.get("type")
+        props = w.get("props")
+        if not isinstance(wtype, str) or not wtype or not isinstance(props, dict):
+            continue
+        required = [
+            name
+            for name, spec in props.items()
+            if isinstance(spec, dict) and spec.get("required") and isinstance(name, str)
+        ]
+        if required:
+            out[wtype] = required
+    return out
+
+
+def _prop_is_present(value: Any) -> bool:
+    """True when a prop value counts as "provided" for required-prop checks.
+
+    Present means the key exists with a non-``None`` value. An empty string,
+    empty list, empty dict, ``0``, or ``False`` all count as present — the
+    agent made a deliberate choice and the renderer can handle them; only a
+    missing key or an explicit ``null`` is a structural omission. A bound
+    expression string (``"{item.data}"``) is a non-empty string, so it counts
+    — key-presence, not value-resolution, is what this gate enforces.
+    """
+    return value is not None
+
+
+def _walk_required_props(
+    node: Any,
+    path: str,
+    required_by_type: dict[str, list[str]],
+    issues: list[dict[str, Any]],
+) -> None:
+    """Recursive walk that flags nodes missing a manifest-required prop.
+
+    Only nodes whose ``type`` is a key in ``required_by_type`` are checked —
+    an unknown ``type`` is the catalog gate's concern, not this one, so it is
+    never double-flagged here. A node that carries ``bind`` for a required
+    prop is treated as supplying it: the bound value populates the prop at
+    render time even though the literal key is absent from ``props``.
+    """
+    if not isinstance(node, dict):
+        return
+
+    wtype = node.get("type")
+    if isinstance(wtype, str) and wtype in required_by_type:
+        props = node.get("props")
+        props = props if isinstance(props, dict) else {}
+        # A node-level ``bind`` feeds exactly one prop (the widget's bind
+        # contract target). We can't know that prop's name here without the
+        # bind-contract map, so a present ``bind`` rescues the single most
+        # common bindable required prop families. Conservative: only suppress
+        # when bind is set AND there's exactly one required prop, the typical
+        # input-widget case (``value`` on input, ``checked`` on checkbox).
+        bound = isinstance(node.get("bind"), str) and bool(node.get("bind"))
+        required = required_by_type[wtype]
+        missing = [p for p in required if not _prop_is_present(props.get(p))]
+        if missing and bound and len(required) == 1:
+            missing = []
+        if missing:
+            issues.append(
+                {
+                    "path": path,
+                    "type": wtype,
+                    "missing": missing,
+                    "required": list(required),
+                }
+            )
+
+    for key in ("children", "else_children"):
+        kids = node.get(key)
+        if isinstance(kids, list):
+            for i, child in enumerate(kids):
+                _walk_required_props(child, f"{path}.{key}[{i}]", required_by_type, issues)
+
+
+def validate_required_props(
+    spec: dict[str, Any] | None,
+    manifest_or_required: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Walk a rippleSpec tree and flag every node missing a prop the widget
+    manifest marks ``required: true`` for that ``type``.
+
+    ``manifest_or_required`` accepts either a full parsed manifest (a dict
+    with a ``widgets`` array) or an already-extracted required-prop map
+    (``{type: [prop, ...]}`` from :func:`required_props_from_manifest`); the
+    latter lets a hot path extract the map once and reuse it across specs.
+
+    Returns one issue dict per offending node; ``[]`` when ``spec`` is not a
+    dict or every node supplies its required props. Issue shape::
+
+        {
+          "path": "ui.children[2]",
+          "type": "chart",
+          "missing": ["data"],            # required props this node omitted
+          "required": ["data"],           # all required props for the type
+        }
+
+    The renderer draws a node with a missing required prop as an empty / broken
+    widget rather than erroring, so the failure is invisible until a human
+    looks at the canvas. Catching it at spec ingest forces the agent to fill
+    the structural minimum — the rippleSpec analogue of the genesis HARD
+    ``required_fields`` constraint zone.
+    """
+    if not isinstance(spec, dict):
+        return []
+    if "widgets" in manifest_or_required:
+        required_by_type = required_props_from_manifest(manifest_or_required)
+    else:
+        required_by_type = {
+            t: list(p)
+            for t, p in manifest_or_required.items()
+            if isinstance(t, str) and isinstance(p, (list, tuple))
+        }
+    if not required_by_type:
+        return []
+
+    root = spec.get("ui") if isinstance(spec.get("ui"), dict) else spec
+    issues: list[dict[str, Any]] = []
+    _walk_required_props(root, "ui", required_by_type, issues)
     return issues
 
 

--- a/tests/cloud/test_ripple_required_props_gate.py
+++ b/tests/cloud/test_ripple_required_props_gate.py
@@ -1,0 +1,144 @@
+# tests/cloud/test_ripple_required_props_gate.py
+# Created: 2026-05-31 (constraint-zone enforcer) — EE-side wiring tests for
+# the required-prop "HARD constraint" gate. The pure walker is covered in
+# tests/test_ripple_required_props.py; this file covers the strict/logged
+# variants, the agent-readable formatter, and the MissingRequiredPropError
+# shape so the chat agent's retry loop can read it. Mirrors
+# tests/cloud/test_ripple_validator_action_wiring.py.
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pocketpaw_ee.cloud.ripple_validator import (
+    MissingRequiredPropError,
+    format_required_prop_violations_for_agent,
+    validate_required_props_logged,
+    validate_required_props_strict,
+)
+
+# `chart` requires `data`; `table` requires `columns` + `rows`; `text` requires
+# nothing. Passed in the already-extracted map form (the shape `_gate_catalog`
+# hands the validator from `_catalog_required_props`).
+REQUIRED = {"chart": ["data"], "table": ["columns", "rows"]}
+
+
+def _spec_missing_required() -> dict:
+    """A chart node with no `data` — passes catalog + action-wiring, renders empty."""
+    return {"ui": {"type": "chart", "props": {"title": "Sales"}}}
+
+
+def _clean_spec() -> dict:
+    return {"ui": {"type": "chart", "props": {"data": "{state.series}"}}}
+
+
+# ---------------------------------------------------------------------------
+# Strict mode raises MissingRequiredPropError
+# ---------------------------------------------------------------------------
+
+
+class TestStrict:
+    def test_raises_on_missing_required_prop(self):
+        with pytest.raises(MissingRequiredPropError) as ei:
+            validate_required_props_strict(_spec_missing_required(), REQUIRED)
+        # The exception carries the structured violations list AND formats a
+        # human-readable message naming the missing prop.
+        assert len(ei.value.violations) >= 1
+        assert "data" in str(ei.value)
+        assert ei.value.violations[0]["type"] == "chart"
+        assert ei.value.violations[0]["missing"] == ["data"]
+
+    def test_clean_spec_does_not_raise(self):
+        # No assertion needed beyond "doesn't raise".
+        validate_required_props_strict(_clean_spec(), REQUIRED)
+
+    def test_no_required_map_does_not_raise(self):
+        validate_required_props_strict(_spec_missing_required(), {})
+
+    def test_multi_required_partial_raises_with_missing_only(self):
+        spec = {"ui": {"type": "table", "props": {"columns": ["a"]}}}
+        with pytest.raises(MissingRequiredPropError) as ei:
+            validate_required_props_strict(spec, REQUIRED)
+        assert ei.value.violations[0]["missing"] == ["rows"]
+
+
+# ---------------------------------------------------------------------------
+# Logged mode returns violations, never raises, emits structured warnings
+# ---------------------------------------------------------------------------
+
+
+class TestLogged:
+    def test_returns_violations_without_raising(self):
+        violations = validate_required_props_logged(_spec_missing_required(), REQUIRED)
+        assert len(violations) == 1
+        assert violations[0]["type"] == "chart"
+
+    def test_clean_spec_returns_empty(self):
+        assert validate_required_props_logged(_clean_spec(), REQUIRED) == []
+
+    def test_emits_structured_warning_per_violation(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            validate_required_props_logged(
+                _spec_missing_required(),
+                REQUIRED,
+                pocket_id="pkt_1",
+                workspace_id="ws_1",
+            )
+        records = [r for r in caplog.records if r.message == "ripple_spec.missing_required_prop"]
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.pocket_id == "pkt_1"
+        assert rec.workspace_id == "ws_1"
+        assert rec.widget_type == "chart"
+        assert rec.missing_props == ["data"]
+
+    def test_logged_does_not_block_on_violation(self):
+        # The whole point of logged mode — an older imported spec with a
+        # now-required prop missing is recorded for triage, not blocked.
+        violations = validate_required_props_logged(_spec_missing_required(), REQUIRED)
+        assert violations  # recorded
+        # No exception escaped — reaching here is the assertion.
+
+
+# ---------------------------------------------------------------------------
+# Agent-readable formatter
+# ---------------------------------------------------------------------------
+
+
+class TestFormatter:
+    def test_empty_violations_format_to_empty_string(self):
+        assert format_required_prop_violations_for_agent([]) == ""
+
+    def test_formatter_names_node_and_missing_prop(self):
+        violations = [
+            {"path": "ui.children[2]", "type": "chart", "missing": ["data"], "required": ["data"]}
+        ]
+        out = format_required_prop_violations_for_agent(violations)
+        assert "ui.children[2]" in out
+        assert "chart" in out
+        assert "data" in out
+
+    def test_formatter_caps_long_lists(self):
+        violations = [
+            {
+                "path": f"ui.children[{i}]",
+                "type": "chart",
+                "missing": ["data"],
+                "required": ["data"],
+            }
+            for i in range(15)
+        ]
+        out = format_required_prop_violations_for_agent(violations)
+        assert "…and 5 more" in out
+
+    def test_error_class_message_mirrors_siblings(self):
+        # MissingRequiredPropError._format produces the same compact shape as
+        # CatalogViolationError / ActionWiringViolationError.
+        exc = MissingRequiredPropError(
+            [{"path": "ui", "type": "stat", "missing": ["value"], "required": ["value"]}]
+        )
+        msg = str(exc)
+        assert "required-prop violation" in msg
+        assert "stat" in msg
+        assert "value" in msg

--- a/tests/test_ripple_required_props.py
+++ b/tests/test_ripple_required_props.py
@@ -1,0 +1,290 @@
+# tests/test_ripple_required_props.py
+# Created: 2026-05-31 (constraint-zone enforcer) — OSS-core tests for the
+# required-prop "HARD constraint" walker in `pocketpaw.ripple.manifest`:
+# `required_props_from_manifest` (the manifest reader) and
+# `validate_required_props` (the spec walker). The rippleSpec analogue of
+# the genesis "Constraint Zones" 🔒 HARD `required_fields` zone — a node
+# that omits a prop the manifest marks `required: true` renders empty even
+# though every existing gate (catalog, action-verb) passes.
+#
+# No EE imports, so this file runs in the `Test (OSS-only)` CI scope. The
+# EE strict/logged wiring is covered in
+# `tests/cloud/test_ripple_required_props_gate.py`.
+"""Tests for the Ripple required-prop gate (constraint-zone HARD enforcement)."""
+
+from __future__ import annotations
+
+from pocketpaw.ripple.manifest import (
+    required_props_from_manifest,
+    validate_required_props,
+)
+
+# A representative manifest fragment: `chart` requires `data`, `stat` requires
+# `value`, `table` requires both `columns` and `rows`, `input` requires `value`
+# (the bindable case), and `text` requires nothing (creative-zone widget).
+MANIFEST = {
+    "schema": "ripple.manifest/v1",
+    "widgets": [
+        {
+            "type": "chart",
+            "props": {
+                "data": {"type": "array", "required": True},
+                "title": {"type": "string"},
+            },
+        },
+        {
+            "type": "stat",
+            "props": {
+                "value": {"type": "number", "required": True},
+                "label": {"type": "string"},
+            },
+        },
+        {
+            "type": "table",
+            "props": {
+                "columns": {"type": "array", "required": True},
+                "rows": {"type": "array", "required": True},
+            },
+        },
+        {
+            "type": "input",
+            "props": {"value": {"type": "string", "required": True}},
+        },
+        {
+            "type": "text",
+            "props": {"content": {"type": "string"}},
+        },
+        {"type": "flex", "props": {}},
+    ],
+}
+
+# The extracted required-prop map, for tests that pass the map form directly.
+REQUIRED = required_props_from_manifest(MANIFEST)
+
+
+# ---------------------------------------------------------------------------
+# required_props_from_manifest
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredPropsFromManifest:
+    def test_extracts_required_props_per_type(self) -> None:
+        out = required_props_from_manifest(MANIFEST)
+        assert out["chart"] == ["data"]
+        assert out["stat"] == ["value"]
+        assert out["input"] == ["value"]
+
+    def test_multiple_required_props_preserve_declaration_order(self) -> None:
+        assert required_props_from_manifest(MANIFEST)["table"] == ["columns", "rows"]
+
+    def test_widgets_without_required_props_are_omitted(self) -> None:
+        out = required_props_from_manifest(MANIFEST)
+        # `text` and `flex` have no required props → not keys at all, so a
+        # membership test doubles as "does this type have anything to enforce".
+        assert "text" not in out
+        assert "flex" not in out
+
+    def test_empty_manifest_returns_empty_map(self) -> None:
+        assert required_props_from_manifest({}) == {}
+        assert required_props_from_manifest({"widgets": []}) == {}
+
+    def test_malformed_widget_entries_skipped(self) -> None:
+        manifest = {
+            "widgets": [
+                {"type": "ok", "props": {"x": {"required": True}}},
+                {"props": {"y": {"required": True}}},  # no type
+                {"type": "noprops"},  # no props
+                {"type": "bad-props", "props": "not-a-dict"},
+                "not-a-dict",
+            ]
+        }
+        out = required_props_from_manifest(manifest)
+        assert out == {"ok": ["x"]}
+
+
+# ---------------------------------------------------------------------------
+# validate_required_props — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRequiredPropsClean:
+    def test_non_dict_spec_returns_empty(self) -> None:
+        assert validate_required_props(None, MANIFEST) == []
+        assert validate_required_props("nope", MANIFEST) == []  # type: ignore[arg-type]
+        assert validate_required_props([], MANIFEST) == []  # type: ignore[arg-type]
+
+    def test_all_required_props_present_passes(self) -> None:
+        spec = {
+            "ui": {
+                "type": "flex",
+                "children": [
+                    {"type": "stat", "props": {"label": "Revenue", "value": 42}},
+                    {"type": "chart", "props": {"data": [1, 2, 3]}},
+                ],
+            }
+        }
+        assert validate_required_props(spec, MANIFEST) == []
+
+    def test_bound_expression_counts_as_present(self) -> None:
+        # A required prop fed by a `{...}` expression is present — the gate
+        # checks key-presence, not value-resolution.
+        spec = {"ui": {"type": "chart", "props": {"data": "{state.series}"}}}
+        assert validate_required_props(spec, MANIFEST) == []
+
+    def test_falsy_but_present_values_pass(self) -> None:
+        # Empty list / 0 / "" / False are deliberate choices, not omissions.
+        spec = {
+            "ui": {
+                "type": "flex",
+                "children": [
+                    {"type": "chart", "props": {"data": []}},
+                    {"type": "stat", "props": {"value": 0}},
+                ],
+            }
+        }
+        assert validate_required_props(spec, MANIFEST) == []
+
+    def test_unknown_widget_type_not_flagged_here(self) -> None:
+        # An unknown `type` is the catalog gate's concern — the required-prop
+        # walker only checks types that declare required props, so it never
+        # double-flags an unknown widget.
+        spec = {"ui": {"type": "revenue-card", "props": {}}}
+        assert validate_required_props(spec, MANIFEST) == []
+
+    def test_widget_with_no_required_props_never_flagged(self) -> None:
+        spec = {"ui": {"type": "text", "props": {}}}
+        assert validate_required_props(spec, MANIFEST) == []
+
+    def test_empty_required_map_short_circuits(self) -> None:
+        spec = {"ui": {"type": "chart", "props": {}}}
+        assert validate_required_props(spec, {}) == []
+        assert validate_required_props(spec, {"widgets": []}) == []
+
+
+# ---------------------------------------------------------------------------
+# validate_required_props — violation paths
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRequiredPropsViolations:
+    def test_missing_required_prop_flagged(self) -> None:
+        spec = {"ui": {"type": "chart", "props": {"title": "Sales"}}}
+        issues = validate_required_props(spec, MANIFEST)
+        assert len(issues) == 1
+        assert issues[0]["type"] == "chart"
+        assert issues[0]["missing"] == ["data"]
+        assert issues[0]["required"] == ["data"]
+        assert issues[0]["path"] == "ui"
+
+    def test_missing_props_entirely_flagged(self) -> None:
+        # No `props` key at all → the single required prop is missing.
+        spec = {"ui": {"type": "stat"}}
+        issues = validate_required_props(spec, MANIFEST)
+        assert len(issues) == 1
+        assert issues[0]["missing"] == ["value"]
+
+    def test_explicit_null_is_missing(self) -> None:
+        spec = {"ui": {"type": "chart", "props": {"data": None}}}
+        issues = validate_required_props(spec, MANIFEST)
+        assert len(issues) == 1
+        assert issues[0]["missing"] == ["data"]
+
+    def test_partial_multi_required_reports_only_missing(self) -> None:
+        # `table` requires columns + rows; supply only columns.
+        spec = {"ui": {"type": "table", "props": {"columns": ["a", "b"]}}}
+        issues = validate_required_props(spec, MANIFEST)
+        assert len(issues) == 1
+        assert issues[0]["missing"] == ["rows"]
+        assert issues[0]["required"] == ["columns", "rows"]
+
+    def test_nested_path_is_reported(self) -> None:
+        spec = {
+            "ui": {
+                "type": "flex",
+                "children": [
+                    {"type": "text", "props": {"content": "ok"}},
+                    {"type": "chart", "props": {}},
+                ],
+            }
+        }
+        issues = validate_required_props(spec, MANIFEST)
+        assert len(issues) == 1
+        assert issues[0]["path"] == "ui.children[1]"
+        assert issues[0]["type"] == "chart"
+
+    def test_multiple_violations_collected(self) -> None:
+        spec = {
+            "ui": {
+                "type": "flex",
+                "children": [
+                    {"type": "chart", "props": {}},
+                    {"type": "stat", "props": {}},
+                    {"type": "table", "props": {}},
+                ],
+            }
+        }
+        issues = validate_required_props(spec, MANIFEST)
+        assert len(issues) == 3
+        by_type = {i["type"]: i["missing"] for i in issues}
+        assert by_type["chart"] == ["data"]
+        assert by_type["stat"] == ["value"]
+        assert by_type["table"] == ["columns", "rows"]
+
+    def test_walks_else_children_branch(self) -> None:
+        # `if` nodes carry an `else_children` collection — the walker must
+        # descend it too (mirrors the catalog walk).
+        spec = {
+            "ui": {
+                "type": "if",
+                "condition": "{state.ok}",
+                "children": [{"type": "stat", "props": {"value": 1}}],
+                "else_children": [{"type": "chart", "props": {}}],
+            }
+        }
+        issues = validate_required_props(spec, MANIFEST)
+        assert len(issues) == 1
+        assert issues[0]["path"] == "ui.else_children[0]"
+        assert issues[0]["type"] == "chart"
+
+    def test_accepts_unwrapped_subtree(self) -> None:
+        # The walker tolerates a bare node (no `ui` wrapper) the same way the
+        # catalog walk does — used by the per-widget `spec` gate.
+        spec = {"type": "chart", "props": {}}
+        issues = validate_required_props(spec, MANIFEST)
+        assert len(issues) == 1
+        assert issues[0]["type"] == "chart"
+
+
+# ---------------------------------------------------------------------------
+# Bind-rescue: a single-required-prop input fed by node-level `bind`
+# ---------------------------------------------------------------------------
+
+
+class TestBindRescue:
+    def test_node_level_bind_satisfies_single_required_prop(self) -> None:
+        # `input` requires `value`; a node-level `bind` populates it at render
+        # time (the widget's bind contract target), so it must not be flagged.
+        spec = {"ui": {"type": "input", "bind": "state.email"}}
+        assert validate_required_props(spec, MANIFEST) == []
+
+    def test_bind_does_not_rescue_multi_required_widget(self) -> None:
+        # `table` has two required props — a single `bind` can't supply both,
+        # so the rescue does NOT apply and the omission is still flagged.
+        spec = {"ui": {"type": "table", "bind": "state.sel", "props": {"columns": ["a"]}}}
+        issues = validate_required_props(spec, MANIFEST)
+        assert len(issues) == 1
+        assert issues[0]["missing"] == ["rows"]
+
+
+# ---------------------------------------------------------------------------
+# Map form vs manifest form — both inputs produce identical results
+# ---------------------------------------------------------------------------
+
+
+class TestInputForms:
+    def test_map_form_matches_manifest_form(self) -> None:
+        spec = {"ui": {"type": "chart", "props": {}}}
+        from_manifest = validate_required_props(spec, MANIFEST)
+        from_map = validate_required_props(spec, REQUIRED)
+        assert from_manifest == from_map
+        assert from_map[0]["missing"] == ["data"]


### PR DESCRIPTION
## What

Adds a mechanical walker that flags any rippleSpec node missing a prop the widget manifest marks `required: true`, wired into the same ingest gate as the catalog and action-verb checks.

## Why

The manifest already declares which props a widget can't render without (`chart` → `data`, `stat` → `value`, `table` → `columns`/`rows`). Until now that flag was surfaced only in the system prompt and never enforced. A node like `{"type": "chart", "props": {}}` sailed through the catalog gate (its `type` is known) and the action-wiring gate (no handlers) and rendered an empty box — invisible until someone looked at the canvas.

A prompt-side "include the required props" rule rots at agent-write-rate. A mechanical walker enforcing the same rule catches every omission for free, exactly like the catalog and action-verb gates it sits beside. **88 of the 152 catalog widgets** declare at least one required prop.

This is the rippleSpec expression of the constraint-zone model's HARD required-fields rail: the agent stays free to choose which widgets to use and how to fill the creative props, but the manifest-declared structural minimum is locked and checked rather than asked for. The other two zones of that model (SOFT defaults, CREATIVE freedom) and its layout/selection-mode constraints describe a high-level intent envelope that rippleSpec doesn't carry — only the required-fields rail maps onto the widget tree, and it's the one piece nothing already enforced.

## How

- `validate_required_props` + `required_props_from_manifest` land in OSS `pocketpaw.ripple.manifest`, alongside `validate_against_catalog` / `validate_action_verbs` / `find_unwired_live_buttons`. Same return shape (`{path, type, missing, required}`), same tolerance for an unwrapped subtree, same recursion into `children` / `else_children`. No EE import — the import-linter contract stays green.
- The strict/logged wiring (`validate_required_props_strict` / `_logged`), the `MissingRequiredPropError`, and the agent-readable formatter live in EE `ripple_validator`, mirroring `CatalogViolationError` and `ActionWiringViolationError`.
- `_gate_catalog` runs the new check after the catalog and action-wiring walks: strict on the agent path (blocks, returns a corrective message naming the missing prop), logged on the human / import path (structured warning, never blocks an older spec). It pulls the required-prop map from the same in-process-cached manifest the allow-list lookup already fetched — no extra network call. All five strict `_gate_catalog` call sites and the per-widget gate now surface the new error as a retry hint instead of a 500.

### Present vs missing

A prop counts as present when its key exists with a non-null value. A literal, an empty list / `0` / `false`, or a bound `{...}` expression all satisfy it — those are deliberate authoring choices the renderer handles. Only a missing key or an explicit `null` is a violation. A node-level `bind` satisfies a single-required-prop input widget, since the bound value populates the prop at render time.

## Tests

- `tests/test_ripple_required_props.py` — OSS-core walker + manifest-reader coverage (happy paths, every violation shape, the bind-rescue, nested/`else_children` paths, malformed-manifest robustness). Runs in the OSS-only CI scope.
- `tests/cloud/test_ripple_required_props_gate.py` — EE strict/logged variants, the structured-warning fields, the formatter, and the error-class message shape.

Verification on the branch (targeted, plus the adjacent gate/merge suites as a regression check):

```
tests/test_ripple_required_props.py ................ 23 passed
tests/cloud/test_ripple_required_props_gate.py ..... 12 passed
+ existing catalog / action-wiring / merge-spec suites ... all green (136 + 17)
```

`ruff check`, `ruff format --check`, `mypy` on the OSS module, and the import-linter contract all pass.

## Docs

Adds a "Required-prop gate" section to `docs/api-reference.md`, alongside the catalog-gate docs it parallels.

## Not in scope

The Chain Flow primitive (RFC 13) and RFC 06's flat model are orthogonal — this is about structural constraints on authored specs, independent of the flow mechanism.
