### PR TITLE
Unify the inline-spec contract on ui-spec + {version, ui}

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,4 +1,14 @@
-"""Agent-run core — the loop the executor invokes for every chat run."""
+"""Agent-run core — the loop the executor invokes for every chat run.
+
+Changes: 2026-05-31 (RFC 13 M0 — inline-spec contract unification). The inline
+Ripple extractor now treats the ``ui-spec`` fence + ``{version, ui}`` envelope
+as the canonical path — the same contract the prompt (``pocketpaw.ripple._inline``)
+tells the agent to emit and the one paw-enterprise ``MarkdownRenderer`` tokenizes
+as a ``ui-spec`` segment. The legacy ``json`` fence + ``{widgets, lifecycle}``
+shape is still accepted via a transitional branch so in-flight conversations
+don't break; that branch is deprecated and slated for removal once no active
+conversation references the old shape (cutover window is RFC 13 open question #6).
+"""
 
 from __future__ import annotations
 
@@ -38,7 +48,55 @@ from pocketpaw_ee.cloud.chat.runs.transport import get_stream_transport
 logger = logging.getLogger(__name__)
 
 
+# Canonical inline-spec fence (RFC 13 M0). The prompt mandates a ``ui-spec``
+# fence carrying a ``{version, ui}`` envelope, and paw-enterprise's
+# ``MarkdownRenderer`` tokenizes exactly this fence as a ``ui-spec`` segment.
+# This is the path every new reply takes.
+RIPPLE_UISPEC_RE = re.compile(r"```ui-spec\s*(\{.*?\})\s*```", re.DOTALL)
+
+# DEPRECATED (RFC 13 M0): the legacy fence the cloud extractor used to be the
+# only path it knew. It pairs a ``json`` fence with a ``{widgets, lifecycle}``
+# shape — the contract before unification. Kept ONLY as a transitional accept
+# branch so conversations already holding a legacy block keep rendering. Remove
+# once no active conversation references the old shape; the cutover timeline is
+# RFC 13 open question #6 ("how long do we keep the legacy json accept-branch").
 RIPPLE_JSON_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+def _looks_like_ripple_spec(candidate: Any) -> bool:
+    """True when ``candidate`` is the canonical inline ``ui-spec`` envelope.
+
+    Recognizes the shapes ``normalize_ripple_spec`` accepts as a UISpec: the
+    canonical ``{version, ui}`` doc, a multi-pane ``{panes}`` doc, a spec whose
+    UI tree hides under a misnamed top-level key (``root`` / ``tree`` / ``view``
+    / ``body`` / ``content``), or a raw root node (``{type, props|children}``).
+    A plain ``json`` object that merely happens to sit in a ``ui-spec`` fence
+    (no ``ui``/``panes``/node shape) is rejected so we don't attach non-specs.
+    """
+    if not isinstance(candidate, dict):
+        return False
+    if isinstance(candidate.get("ui"), dict):
+        return True
+    if isinstance(candidate.get("panes"), dict):
+        return True
+    for alias in ("root", "tree", "view", "body", "content"):
+        node = candidate.get(alias)
+        if isinstance(node, dict) and isinstance(node.get("type"), str):
+            return True
+    # Raw root node: ``{type: "flex", props|children, ...}`` with no ``ui`` wrap.
+    if isinstance(candidate.get("type"), str) and ("props" in candidate or "children" in candidate):
+        return True
+    return False
+
+
+def _looks_like_legacy_ripple_spec(candidate: Any) -> bool:
+    """True for the DEPRECATED legacy ``{widgets, lifecycle}`` inline shape.
+
+    Transitional gate (RFC 13 M0). Mirrors the original ``_extract_ripple_attachment``
+    check. Slated for removal alongside ``RIPPLE_JSON_RE`` per RFC 13 open
+    question #6.
+    """
+    return isinstance(candidate, dict) and ("lifecycle" in candidate or "widgets" in candidate)
 
 
 def _stream_ttl() -> int:
@@ -312,17 +370,57 @@ def _new_run_id() -> str:
 
 
 def _extract_ripple_attachment(full_text: str) -> tuple[str, dict[str, Any] | None]:
-    """Strip the trailing ripple JSON fence and return ``(remaining_text, spec_or_None)``."""
-    match = RIPPLE_JSON_RE.search(full_text)
-    if not match:
+    """Strip the inline ripple fence and return ``(remaining_text, spec_or_None)``.
+
+    Contract (RFC 13 M0): the canonical fence is ``ui-spec`` carrying a
+    ``{version, ui}`` envelope (the prompt's contract and what ``MarkdownRenderer``
+    tokenizes). We try that first. If no canonical fence is present, we fall back
+    to the DEPRECATED legacy ``json`` fence + ``{widgets, lifecycle}`` shape so
+    in-flight conversations keep rendering — that branch ages out per RFC 13 open
+    question #6. On either path, the spec is normalized through
+    ``normalize_ripple_spec`` and the fence is stripped from the message body.
+    A truncated / unparseable fence leaves the text untouched and returns no
+    attachment (the frontend's ``ui-spec-error`` segment surfaces it).
+    """
+    # Canonical path: ``ui-spec`` fence + {version, ui}.
+    match = RIPPLE_UISPEC_RE.search(full_text)
+    if match is not None:
+        candidate = _parse_fence_json(match.group(1))
+        if _looks_like_ripple_spec(candidate):
+            return _normalize_and_strip(full_text, match, candidate)
+        # A ui-spec fence that doesn't parse / isn't a spec falls through; we do
+        # NOT then try the legacy json fence on the same text — a malformed
+        # canonical block stays inline rather than risk a wrong extraction.
         return full_text, None
+
+    # Transitional path (DEPRECATED): legacy ``json`` fence + {widgets, lifecycle}.
+    match = RIPPLE_JSON_RE.search(full_text)
+    if match is None:
+        return full_text, None
+    candidate = _parse_fence_json(match.group(1))
+    if not _looks_like_legacy_ripple_spec(candidate):
+        return full_text, None
+    return _normalize_and_strip(full_text, match, candidate)
+
+
+def _parse_fence_json(raw: str) -> Any:
+    """Parse a fence body to JSON, returning ``None`` on any failure.
+
+    A truncated or malformed block (the model cut off mid-spec) yields ``None``,
+    which both shape gates reject — so the fence is left inline for the
+    frontend's recovery / ``ui-spec-error`` path rather than half-extracted.
+    """
     try:
-        candidate = json.loads(match.group(1))
+        return json.loads(raw)
     except Exception:
         logger.debug("Ripple parse failed", exc_info=True)
-        return full_text, None
-    if not (isinstance(candidate, dict) and ("lifecycle" in candidate or "widgets" in candidate)):
-        return full_text, None
+        return None
+
+
+def _normalize_and_strip(
+    full_text: str, match: re.Match[str], candidate: dict[str, Any]
+) -> tuple[str, dict[str, Any]]:
+    """Normalize ``candidate`` and remove its fence from ``full_text``."""
     spec: dict[str, Any] = candidate
     try:
         from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec

--- a/tests/cloud/runs/test_run_core.py
+++ b/tests/cloud/runs/test_run_core.py
@@ -1,4 +1,10 @@
-"""Tests for ``execute_run``."""
+"""Tests for ``execute_run``.
+
+Includes the RFC 13 M0 inline-spec contract coverage: ``_extract_ripple_attachment``
+must pull a canonical ``ui-spec`` + ``{version, ui}`` block AND a transitional
+legacy ``json`` + ``{widgets, lifecycle}`` block, both into a ripple attachment and
+the ``ripple`` SSE event, while leaving a truncated / non-spec fence inline.
+"""
 
 from __future__ import annotations
 
@@ -433,3 +439,163 @@ async def test_execute_run_failure_marks_failed_with_error(monkeypatch):
             "error": "boom",
         }
     ]
+
+
+# ---------------------------------------------------------------------------
+# RFC 13 M0 — inline-spec contract unification.
+#
+# The cloud extractor now treats ``ui-spec`` + ``{version, ui}`` as canonical
+# (the prompt's contract, the shape ``MarkdownRenderer`` tokenizes) and keeps a
+# transitional branch for the deprecated ``json`` + ``{widgets, lifecycle}``
+# shape. These tests pin both paths plus the truncated-fence recovery contract.
+# ---------------------------------------------------------------------------
+
+_CANONICAL_UI_SPEC_BLOCK = (
+    "Here are your numbers:\n\n"
+    "```ui-spec\n"
+    '{"version": "1.0", "ui": {"type": "stat", '
+    '"props": {"label": "Revenue", "value": "$42k"}}}\n'
+    "```\n\nLet me know if you want a breakdown."
+)
+
+_LEGACY_JSON_BLOCK = (
+    "Dashboard:\n\n"
+    "```json\n"
+    '{"widgets": [{"type": "metric", "name": "Sales"}], '
+    '"lifecycle": {"type": "persistent", "id": "p1"}}\n'
+    "```"
+)
+
+
+async def test_extract_canonical_ui_spec_block():
+    """Canonical ``ui-spec`` + ``{version, ui}`` extracts, normalizes, strips."""
+    remaining, spec = run_core._extract_ripple_attachment(_CANONICAL_UI_SPEC_BLOCK)
+
+    assert spec is not None
+    # Envelope + tree survive normalization.
+    assert spec["version"] == "1.0"
+    assert spec["ui"]["type"] == "stat"
+    assert spec["ui"]["props"]["label"] == "Revenue"
+    # The fence is stripped out of the message body; the prose stays.
+    assert "```ui-spec" not in remaining
+    assert "Here are your numbers:" in remaining
+    assert "Let me know if you want a breakdown." in remaining
+
+
+async def test_extract_legacy_json_widgets_block_still_works():
+    """Transitional path: deprecated ``json`` + ``{widgets, lifecycle}`` extracts."""
+    remaining, spec = run_core._extract_ripple_attachment(_LEGACY_JSON_BLOCK)
+
+    assert spec is not None
+    # The legacy widgets shape passes through the normalizer's widgets branch.
+    assert "widgets" in spec
+    assert spec["widgets"][0]["name"] == "Sales"
+    assert "```json" not in remaining
+    assert remaining == "Dashboard:"
+
+
+async def test_extract_truncated_ui_spec_leaves_text_inline():
+    """A truncated / unparseable ``ui-spec`` fence returns no attachment and
+    leaves the text untouched, so the frontend's ``ui-spec-error`` path owns it."""
+    truncated = (
+        'Oops:\n\n```ui-spec\n{"version": "1.0", "ui": {"type": "stat", "props": {"label":\n```'
+    )
+    remaining, spec = run_core._extract_ripple_attachment(truncated)
+
+    assert spec is None
+    assert remaining == truncated
+
+
+async def test_extract_non_spec_json_fence_is_not_attached():
+    """A plain ``json`` object that is not a ripple spec must not be extracted."""
+    plain = 'Config:\n\n```json\n{"foo": 1, "bar": 2}\n```'
+    remaining, spec = run_core._extract_ripple_attachment(plain)
+
+    assert spec is None
+    assert remaining == plain
+
+
+async def test_extract_non_spec_ui_spec_fence_does_not_fall_back():
+    """A ``ui-spec`` fence whose body is not a spec is left inline and does NOT
+    silently fall through to the legacy ``json`` path."""
+    nonspec = 'X:\n\n```ui-spec\n{"foo": 1}\n```'
+    remaining, spec = run_core._extract_ripple_attachment(nonspec)
+
+    assert spec is None
+    assert remaining == nonspec
+
+
+async def test_extract_prefers_canonical_over_legacy_when_both_present():
+    """If a reply carries both fences, the canonical ``ui-spec`` wins."""
+    both = _CANONICAL_UI_SPEC_BLOCK + "\n\n" + _LEGACY_JSON_BLOCK
+    remaining, spec = run_core._extract_ripple_attachment(both)
+
+    assert spec is not None
+    # Canonical extracted: it has a ``ui`` tree, not the legacy widgets list.
+    assert spec["ui"]["type"] == "stat"
+    assert "widgets" not in spec
+    # Only the canonical fence is stripped; the legacy block stays in the body.
+    assert "```ui-spec" not in remaining
+    assert "```json" in remaining
+
+
+def _fenced_reply_events(block: str):
+    async def _gen(spec, ctx):
+        yield ("chunk", {"content": block, "type": "text"})
+
+    return _gen
+
+
+async def _run_and_collect_ripple_event(monkeypatch, block: str):
+    """Drive ``execute_run`` with a single chunk carrying ``block`` and return
+    the appended ``ripple`` SSE event payload (or ``None``)."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", _fenced_reply_events(block))
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+
+    await run_core.execute_run(_spec())
+
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    ripple = next((e for e in events if e.event == "ripple"), None)
+    return ripple, events
+
+
+async def test_execute_run_emits_ripple_event_for_canonical_block(monkeypatch):
+    """End-to-end: a canonical ``ui-spec`` reply produces a ``ripple`` SSE event
+    carrying the normalized spec, and the fence is gone from the persisted text."""
+    ripple, events = await _run_and_collect_ripple_event(monkeypatch, _CANONICAL_UI_SPEC_BLOCK)
+
+    assert ripple is not None
+    assert ripple.data["spec"]["ui"]["type"] == "stat"
+    assert ripple.data["spec"]["version"] == "1.0"
+    # ``ripple`` fires before the terminal ``stream_end``.
+    assert [e.event for e in events][-1] == "stream_end"
+
+
+async def test_execute_run_emits_ripple_event_for_legacy_block(monkeypatch):
+    """End-to-end (transitional): a legacy ``json`` + ``{widgets}`` reply still
+    produces a ``ripple`` SSE event so in-flight conversations keep rendering."""
+    ripple, events = await _run_and_collect_ripple_event(monkeypatch, _LEGACY_JSON_BLOCK)
+
+    assert ripple is not None
+    assert "widgets" in ripple.data["spec"]
+    assert ripple.data["spec"]["widgets"][0]["name"] == "Sales"
+    assert [e.event for e in events][-1] == "stream_end"
+
+
+async def test_execute_run_no_ripple_event_for_truncated_block(monkeypatch):
+    """A truncated ``ui-spec`` reply emits no ``ripple`` event; the text streams
+    through and the run still completes via ``stream_end``."""
+    truncated = (
+        'Oops:\n\n```ui-spec\n{"version": "1.0", "ui": {"type": "stat", "props": {"label":\n```'
+    )
+    ripple, events = await _run_and_collect_ripple_event(monkeypatch, truncated)
+
+    assert ripple is None
+    assert [e.event for e in events][-1] == "stream_end"


### PR DESCRIPTION
RFC 13 milestone M0. This is the foundational fix the rest of the chain-flow work sits on, so it lands before any flow code.

## The problem

Inline Ripple in `/chat` works today, but the two sides of it disagree on the envelope:

- The agent prompt (`src/pocketpaw/ripple/_inline.py`) tells the model to emit a `ui-spec` fence wrapping `{version, ui}`, and says in as many words that a `json` or `ripple` tag won't render.
- The cloud extractor (`ee/.../chat/runs/run_core.py`, `RIPPLE_JSON_RE` + `_extract_ripple_attachment`) only matched a `json` fence holding the older `{widgets, lifecycle}` shape.

So a reply authored to the prompt's contract slipped straight past the extractor: the fence stayed embedded in the message body and the `ripple` SSE event never fired. paw-enterprise's `MarkdownRenderer` already tokenizes the `ui-spec` fence and expects the backend to have stripped and re-emitted the spec, which made the mismatch worse. Two paths, one of them legacy.

## What changed

- `ui-spec` + `{version, ui}` is now the path the extractor tries first. A new `RIPPLE_UISPEC_RE` plus a `_looks_like_ripple_spec` gate recognize the same shapes the normalizer already accepts (`{version, ui}`, multi-pane, a misnamed UI key, or a raw root node), so the canonical contract is the one that wins.
- The legacy `json` + `{widgets, lifecycle}` shape still extracts, through a transitional branch behind a deprecation comment. Conversations already holding an old block keep rendering. The branch is tied to the cutover window in RFC 13's open questions (#6) rather than hard-cut here.
- A truncated or non-spec fence is left inline untouched, so the frontend's existing `ui-spec-error` recovery owns it instead of the backend half-extracting a broken spec. A `ui-spec` fence whose body isn't a spec does not silently fall back to the `json` path.

The `ripple` SSE emit and the attachment shape downstream are unchanged; both envelopes now flow through that same path.

## Scope

M0 only. No flow runtime, no schema, no adapter verbs. Just the envelope both sides read.

## Tests

`tests/cloud/runs/test_run_core.py` (run with `uv run --group ee pytest tests/cloud/runs/ -q`, 87 passed):

- A canonical `ui-spec`/`{version, ui}` block and a legacy `json`/`{widgets, lifecycle}` block both extract into the ripple attachment and the `ripple` SSE event.
- A truncated block, a plain non-spec `json` block, and a non-spec `ui-spec` block all stay inline with no attachment.
- When a reply carries both fences, the canonical one is the one extracted.

## Notes

Targets `integration/chain-flow`, not `dev` — every RFC 13 PR collects on the integration branch for an end-to-end smoke pass once the milestones land.