### PR TITLE
fix(agent): make start_flow reachable from the cloud chat agent (RFC 13)

### DIFF
--- a/src/pocketpaw/agents/sdk_mcp_widgets.py
+++ b/src/pocketpaw/agents/sdk_mcp_widgets.py
@@ -2,14 +2,27 @@
 
 The ``get_widget_spec`` / ``get_inline_widget_help`` tools let an agent fetch
 the canonical prop schema for a ripple widget before composing a ui-spec, so it
-never guesses prop names. Pure core: they read the ripple manifest and the
-inline-widget catalog (``pocketpaw.ripple``), which carry no cloud dependency.
+never guesses prop names. ``start_flow`` scaffolds a complete multi-step Chain
+Flow from a tiny descriptor so the agent never hand-authors a nested
+chain / chain_map tree. Pure core: they read the ripple manifest, the
+inline-widget catalog, and the flow-template builder (``pocketpaw.ripple``),
+which carry no cloud dependency.
 
 Split out of the old ``sdk_mcp_pocket.py`` in the OSS-EE split (Phase 3b). That
 file also carried cloud ``get_pocket`` / ``list_pockets`` tools, which moved to
 ``pocketpaw_ee.agent.mcp_servers.pockets``. The two surfaces are now separate
 in-process MCP servers — ``pocketpaw_widgets`` (this one, core) and
 ``pocketpaw_pocket`` (EE).
+
+Changes:
+  - 2026-05-31 (fix/bridge-start-flow-to-chat, RFC 13): added the
+    ``start_flow`` tool. The RFC 13 M3 authoring tool shipped only in the
+    runtime builtin registry (``tools/builtin/flow_tool.py``); it was never
+    bridged into the cloud chat agent's MCP surface, so the home/cloud agent
+    could not call it and hand-authored a flat ``set``-stepped spec instead
+    (the anti-pattern start_flow exists to prevent). Hosting it on this
+    already-ambient core server is the minimal reachable bridge — it rides
+    the same registration + allowlist path as ``get_inline_widget_help``.
 """
 
 from __future__ import annotations
@@ -24,10 +37,12 @@ SERVER_NAME = "pocketpaw_widgets"
 # Allowlist entries must use this exact form.
 GET_WIDGET_SPEC_TOOL_ID = f"mcp__{SERVER_NAME}__get_widget_spec"
 GET_INLINE_WIDGET_HELP_TOOL_ID = f"mcp__{SERVER_NAME}__get_inline_widget_help"
+START_FLOW_TOOL_ID = f"mcp__{SERVER_NAME}__start_flow"
 
 WIDGET_TOOL_IDS = (
     GET_WIDGET_SPEC_TOOL_ID,
     GET_INLINE_WIDGET_HELP_TOOL_ID,
+    START_FLOW_TOOL_ID,
 )
 
 
@@ -103,6 +118,65 @@ async def _get_inline_widget_help_handler(args: dict) -> dict:
     return {"content": [{"type": "text", "text": widget_help([str(t) for t in types])}]}
 
 
+def _text_result(text: str, *, is_error: bool = False) -> dict:
+    """Shape an SDK MCP tool result from a single text block."""
+    out: dict = {"content": [{"type": "text", "text": text}]}
+    if is_error:
+        out["is_error"] = True
+    return out
+
+
+async def _start_flow_handler(args: dict) -> dict:
+    """Expand a flow descriptor into a ``{version, ui}`` Chain Flow doc.
+
+    Backs the ``start_flow`` MCP tool. Shares the deterministic
+    ``pocketpaw.ripple._flows.build_flow`` builder with the runtime
+    ``StartFlowTool`` so the cloud agent and the runtime registry scaffold
+    identical trees. The model emits only ``flow_type`` (+ optional ``domain``
+    / ``config``); Python owns the recursively-nested chain / chain_map tree.
+
+    Args:
+      flow_type: required template name (one of ``FLOW_TYPES``).
+      domain:    optional forward-compatible hint; does not change the tree.
+      config:    optional per-template copy overrides (shape-stable). May
+                 arrive as a JSON string from some callers — coerced here.
+    """
+    import json
+
+    from pocketpaw.ripple._flows import FLOW_TYPES, build_flow
+
+    flow_type = args.get("flow_type") or ""
+    if not isinstance(flow_type, str) or not flow_type:
+        valid = ", ".join(sorted(FLOW_TYPES))
+        return _text_result(
+            f"Error: start_flow needs a `flow_type`. Known templates: {valid}.",
+            is_error=True,
+        )
+
+    domain = args.get("domain")
+    if domain is not None and not isinstance(domain, str):
+        domain = None
+
+    config = args.get("config")
+    # `config` may arrive as a JSON string from callers that can't pass a
+    # nested object through a flat signature. Coerce it, matching StartFlowTool.
+    if isinstance(config, str):
+        try:
+            config = json.loads(config) if config.strip() else None
+        except json.JSONDecodeError:
+            return _text_result("Error: `config` was a string but not valid JSON.", is_error=True)
+    if config is not None and not isinstance(config, dict):
+        return _text_result("Error: `config` must be an object (key/value map).", is_error=True)
+
+    try:
+        doc = build_flow(flow_type, domain=domain, config=config)
+    except ValueError as exc:
+        # Unknown flow_type — surface the valid set so the model can retry.
+        return _text_result(f"Error: {exc}", is_error=True)
+
+    return _text_result(json.dumps(doc, ensure_ascii=False))
+
+
 def build_widgets_context_server() -> tuple[str, Any] | None:
     """Build the in-process SDK MCP server, or None if the SDK is unavailable."""
     try:
@@ -155,18 +229,92 @@ def build_widgets_context_server() -> tuple[str, Any] | None:
     async def get_inline_widget_help(args):  # type: ignore[no-untyped-def]
         return await _get_inline_widget_help_handler(args)
 
+    @tool(
+        "start_flow",
+        (
+            "Scaffold a complete multi-step flow (wizard / intake / survey / "
+            "any step-by-step or collect-then-act sequence) from a tiny "
+            "descriptor. DO NOT hand-author nested chain / chain_map step "
+            "trees and DO NOT fake a multi-step flow with a single `set`-"
+            "stepped spec — both are fragile and render only the first step. "
+            "Pick a `flow_type` template and this tool returns the ENTIRE "
+            "nested flow tree as a {version, ui} doc, ready to drop verbatim "
+            "into a ```ui-spec fenced block. The flow then advances entirely "
+            "client-side with no further model calls between steps.\n\n"
+            "Templates (`flow_type`):\n"
+            "- `onboarding_wizard` — pick a goal -> enter workspace details "
+            "(branches on the goal) -> confirm. A new-user setup wizard.\n"
+            "- `due_diligence_intake` — pick a deal stage -> stage-specific "
+            "financials (branches on the stage) -> risk flags -> review. A "
+            "multi-step vertical intake; the same shape works for a survey.\n\n"
+            "Optional `config` tweaks copy without changing the tree's shape "
+            "(onboarding_wizard accepts {product_name, goals}; "
+            "due_diligence_intake accepts {company_name, submit_event}). When "
+            "in doubt, pass just `flow_type`. Returns the JSON doc to emit — "
+            "wrap it verbatim in a ```ui-spec fence; do not edit the chain / "
+            "chain_map structure."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "flow_type": {
+                    "type": "string",
+                    "enum": list(_flow_types_for_schema()),
+                    "description": (
+                        "Which flow template to scaffold. The builder owns "
+                        "the full nested step tree for this template."
+                    ),
+                },
+                "domain": {
+                    "type": "string",
+                    "description": (
+                        "Optional domain hint (e.g. 'fintech', 'saas'). "
+                        "Reserved for a future data-fresh path; does not "
+                        "change the tree today."
+                    ),
+                },
+                "config": {
+                    "type": "object",
+                    "description": (
+                        "Optional per-template copy overrides. Shape-stable: "
+                        "tweaks labels/text, never the chain structure."
+                    ),
+                },
+            },
+            "required": ["flow_type"],
+        },
+    )
+    async def start_flow(args):  # type: ignore[no-untyped-def]
+        return await _start_flow_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[get_widget_spec, get_inline_widget_help],
+        tools=[get_widget_spec, get_inline_widget_help, start_flow],
     )
     return SERVER_NAME, server
+
+
+def _flow_types_for_schema() -> tuple[str, ...]:
+    """The known flow templates, for the ``start_flow`` enum.
+
+    Imported lazily so the module stays importable without the ripple flow
+    builder loaded at definition time; falls back to an empty tuple (the SDK
+    accepts any string then) if the import is unavailable.
+    """
+    try:
+        from pocketpaw.ripple._flows import FLOW_TYPES
+
+        return tuple(FLOW_TYPES)
+    except Exception:  # pragma: no cover - defensive
+        return ()
 
 
 __all__ = [
     "GET_INLINE_WIDGET_HELP_TOOL_ID",
     "GET_WIDGET_SPEC_TOOL_ID",
     "SERVER_NAME",
+    "START_FLOW_TOOL_ID",
     "WIDGET_TOOL_IDS",
     "build_widgets_context_server",
 ]

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -15,6 +15,13 @@
 #
 # Modified: 2026-05-21 — prepended a ground-truth / do-not-mock rule to
 # the inline system prompt. Reworked from PR #1106.
+# Modified: 2026-05-31 (fix/bridge-start-flow-to-chat, RFC 13) — added
+#   `_MULTI_STEP_FLOW_RULE`: for any multi-step / wizard / step-by-step /
+#   collect-then-act flow, call the `start_flow` tool (descriptor only) and
+#   emit its returned doc verbatim. Do NOT hand-author nested chain /
+#   chain_map trees and do NOT fake a flow with a single `set`-stepped spec
+#   — that anti-pattern renders step 1 and never advances. Wired into the
+#   assembled prompt + the final self-check.
 
 from pocketpaw.ripple._design import USE_THE_WIDGET_RULE, WIDGET_CATALOG
 
@@ -305,6 +312,41 @@ true), `nextLabel`, `layout` ("inline" | "stacked", default inline).
 """
 
 
+_MULTI_STEP_FLOW_RULE = """\
+# MULTI-STEP FLOWS — CALL start_flow, DO NOT HAND-AUTHOR
+
+For ANY multi-step flow — a wizard, an intake form, a survey, an
+onboarding sequence, a step-by-step or collect-then-act flow where the
+user moves through more than one screen before you act — call the
+`start_flow` tool. Pass ONLY a tiny descriptor: a `flow_type` template
+(plus optional `domain` / `config`). The tool returns the ENTIRE nested
+flow as a `{version, ui}` doc; drop that doc VERBATIM into your `ui-spec`
+fence. The flow then advances entirely client-side — no further model
+calls between steps.
+
+DO NOT hand-author the flow yourself. Specifically, NEVER:
+- write a nested `chain` / `chain_map` step tree by hand — these are
+  recursively nested and fragile to author; a single misplaced key and
+  the flow renders step 1 and silently never advances.
+- fake a multi-step flow with ONE `set`-stepped single spec (a spec that
+  tries to swap its own content via `set` actions). That is the exact
+  anti-pattern `start_flow` exists to prevent: it renders the first step
+  and dead-ends.
+
+`ask-user-questions` (above) is for a SHORT stepped Q&A that gathers a
+few answers in one bubble. `start_flow` is for a real branching,
+multi-screen flow with its own step tree. When in doubt for anything
+wizard-shaped, reach for `start_flow` — the descriptor is ~3 fields and
+Python owns the tree, so it renders correctly on the first try.
+
+If no `flow_type` template fits the request, say so plainly and gather
+the requirements with `ask-user-questions` instead — do NOT fall back to
+hand-authoring a chain tree.
+
+---
+"""
+
+
 _INLINE_RULES = """\
 # RULES
 
@@ -327,6 +369,7 @@ Final self-check before sending:
 ✔ One focal widget — clean, minimal layout, no clutter
 ✔ flex/grid `gap` is tight for inline — numeric 2 or 4, not 10/12+
 ✔ Used a core widget, or called `get_inline_widget_help` BEFORE emitting the type
+✔ Multi-step / wizard / intake flow → called `start_flow`, not a hand-authored or `set`-stepped spec
 ✔ Leads to a clear next step
 ✔ No static lists for open-ended queries
 ✔ Valid JSON, concrete values, one fence
@@ -341,6 +384,8 @@ INLINE_RIPPLE_SYSTEM_PROMPT = (
     + USE_THE_WIDGET_RULE
     + "\n"
     + _INLINE_CORE_CATALOG
+    + "\n"
+    + _MULTI_STEP_FLOW_RULE
     + "\n"
     + _INLINE_RULES
 )

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -15,6 +15,14 @@ Updated: 2026-05-22 (#1174) — added ``TestMcpToolAllowlist``: the resolved
   in-process MCP tool-id allowlist (``_collect_mcp_tool_ids``) includes the
   cloud ``pocketpaw_pocket`` server's writable ``add_widget`` tool, so the
   home-pocket agent on this backend can pin real widgets.
+Updated: 2026-05-31 (fix/bridge-start-flow-to-chat, RFC 13) — added
+  ``TestStartFlowReachable``: the RFC 13 M3 ``start_flow`` authoring tool must
+  be present in the cloud chat agent's ASSEMBLED tool set (the widgets server
+  is registered AND its ``start_flow`` id is on the in-process allowlist). M3
+  shipped ``start_flow`` only in the runtime builtin registry and its tests
+  imported the tool directly, so the gap — the tool being unreachable from the
+  cloud chat agent — went uncaught. This is the guard that catches it:
+  reachability, not just importability.
 
 All SDK imports are mocked.
 """
@@ -320,6 +328,58 @@ class TestMcpToolAllowlist:
         sdk = self._make_sdk()
         ids = sdk._collect_mcp_tool_ids()
         assert not any(f"__{_PLANNER_MCP_SERVER_NAME}__" in t for t in ids)
+
+
+class TestStartFlowReachable:
+    """GUARD (RFC 13 M3): the ``start_flow`` authoring tool must be reachable
+    from the cloud chat agent's ASSEMBLED tool set — not merely importable.
+
+    M3 (#1318) shipped ``start_flow`` only in the runtime builtin registry and
+    its tests imported ``StartFlowTool`` directly, so nothing caught that the
+    cloud chat agent (claude_agent_sdk backend) had no way to *call* it. The
+    agent then hand-authored a flat ``set``-stepped spec — the anti-pattern
+    start_flow exists to prevent. This test asserts the bridge: the
+    ``pocketpaw_widgets`` server is registered AND ``start_flow``'s tool id is
+    on the in-process allowlist, with no policy opt-in. If the bridge is ever
+    removed, this fails."""
+
+    def _make_sdk(self) -> ClaudeAgentSDK:
+        settings = Settings(anthropic_api_key="test-key", tool_profile="full")
+        with patch.object(ClaudeAgentSDK, "_initialize"):
+            sdk = ClaudeAgentSDK(settings)
+            sdk._sdk_available = False
+        return sdk
+
+    def test_start_flow_on_allowlist_by_default(self):
+        """The assembled in-process tool allowlist carries ``start_flow`` with
+        no opt-in — the cloud chat agent calls it via
+        ``mcp__pocketpaw_widgets__start_flow`` and that id must be reachable."""
+        from pocketpaw.agents.sdk_mcp_widgets import START_FLOW_TOOL_ID
+
+        sdk = self._make_sdk()
+        ids = sdk._collect_mcp_tool_ids()
+        assert START_FLOW_TOOL_ID in ids, (
+            "start_flow must be on the assembled allowlist or the cloud chat "
+            "agent cannot call it (the exact RFC 13 M3 reachability gap)"
+        )
+
+    def test_widgets_server_with_start_flow_is_registered(self):
+        """The host server for ``start_flow`` (``pocketpaw_widgets``) must
+        appear in the assembled ``_get_mcp_servers`` set — registration is the
+        other half of reachability."""
+        sdk = self._make_sdk()
+        with patch("pocketpaw.mcp.config.load_mcp_config", return_value=[]):
+            servers = sdk._get_mcp_servers()
+        assert _WIDGETS_MCP_SERVER_NAME in servers, (
+            "the pocketpaw_widgets server (host of start_flow) must be registered"
+        )
+
+    def test_start_flow_id_matches_widgets_server_namespace(self):
+        """The tool id is namespaced under the registered server, so the SDK
+        routes ``mcp__pocketpaw_widgets__start_flow`` to this server."""
+        from pocketpaw.agents.sdk_mcp_widgets import START_FLOW_TOOL_ID
+
+        assert START_FLOW_TOOL_ID == f"mcp__{_WIDGETS_MCP_SERVER_NAME}__start_flow"
 
 
 class TestMcpProviderLoadFailures:

--- a/tests/ee/test_pocket_specialist.py
+++ b/tests/ee/test_pocket_specialist.py
@@ -22,18 +22,26 @@ def test_delegation_rule_points_at_mcp_tool():
     assert "subagent_type='pocket_specialist'" not in POCKET_DELEGATION_RULE
 
 
-def test_widget_spec_mcp_server_is_read_only():
-    """The core ``pocketpaw_widgets`` server exposes ONLY read tools — it
-    serves the catalog/manifest, nothing mutable.
+def test_widget_spec_mcp_server_persists_nothing():
+    """The core ``pocketpaw_widgets`` server holds only tools that persist
+    NOTHING — they serve the catalog/manifest or scaffold an inline doc, but
+    none mutate cloud / pocket state (contrast the EE ``pocketpaw_pocket``
+    server's ``add_widget`` / ``update_widget``, which write a pocket's
+    ``widgets[]`` array in Mongo).
 
     The OSS-EE split (Phase 3b) split the old ``pocketpaw_pocket`` server in
     two: ripple widget-spec tools (core ``pocketpaw_widgets``, this one) and
-    the cloud pocket-context tools (EE ``pocketpaw_pocket``)."""
+    the cloud pocket-context tools (EE ``pocketpaw_pocket``). ``start_flow``
+    (RFC 13 M3, bridged 2026-05-31) joined this server because it is the same
+    category: a pure deterministic template expander that returns a
+    ``{version, ui}`` doc for the agent to emit inline — it imports no cloud
+    code and writes no document."""
     from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
 
     assert set(WIDGET_TOOL_IDS) == {
         "mcp__pocketpaw_widgets__get_widget_spec",
         "mcp__pocketpaw_widgets__get_inline_widget_help",
+        "mcp__pocketpaw_widgets__start_flow",
     }, f"drift in widget MCP tool surface: {set(WIDGET_TOOL_IDS)}"
 
 

--- a/tests/test_sdk_mcp_inline_help.py
+++ b/tests/test_sdk_mcp_inline_help.py
@@ -1,4 +1,13 @@
-"""Tests for the get_inline_widget_help MCP tool handler."""
+# tests/test_sdk_mcp_inline_help.py
+# Tests for the pocketpaw_widgets in-process MCP tool handlers.
+#
+# Changes:
+#   - 2026-05-31 (fix/bridge-start-flow-to-chat, RFC 13): added
+#     TestStartFlowHandler. The start_flow authoring tool was bridged onto
+#     this core server so the cloud chat agent can reach it; these tests
+#     prove the MCP handler scaffolds a real {version, ui} flow tree (reusing
+#     the same builder as the runtime StartFlowTool) and returns an
+#     agent-readable error for a bad descriptor.
 
 import pytest
 
@@ -38,3 +47,83 @@ async def test_inline_widget_help_handler_no_types_returns_full_catalog():
     assert text_block["text"] == RIPPLE_DESIGN_RULES, (
         "no-types call must return the full RIPPLE_DESIGN_RULES verbatim"
     )
+
+
+def _text_of(result: dict) -> str:
+    block = next((c for c in result.get("content", []) if c.get("type") == "text"), None)
+    assert block is not None, "handler must return a text content block"
+    return block["text"]
+
+
+class TestStartFlowHandler:
+    """The bridged ``start_flow`` MCP handler — the reachability fix for
+    RFC 13 M3. It must scaffold a real {version, ui} flow tree from a tiny
+    descriptor, using the same builder as the runtime ``StartFlowTool``."""
+
+    @pytest.mark.asyncio
+    async def test_scaffolds_full_flow_doc(self):
+        import json
+
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+
+        out = await _start_flow_handler({"flow_type": "onboarding_wizard"})
+        assert not out.get("is_error"), "a valid flow_type must not error"
+        doc = json.loads(_text_of(out))
+        # The descriptor expanded into a full {version, ui} flow doc — NOT a
+        # flat single spec. A nested chain/chain_map step tree is the whole
+        # point of start_flow (the anti-pattern it prevents is a flat spec).
+        assert set(doc) >= {"version", "ui"}
+        assert isinstance(doc["ui"], dict)
+        assert "chain" in doc["ui"] or "chain_map" in doc["ui"], (
+            "start_flow must return a multi-step chain/chain_map tree, not a flat spec"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handler_matches_runtime_tool_builder(self):
+        """The MCP handler and the runtime StartFlowTool share the builder,
+        so identical descriptors must yield identical trees — the cloud
+        agent and the runtime registry scaffold the same flow."""
+        import json
+
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+        from pocketpaw.tools.builtin.flow_tool import StartFlowTool
+
+        mcp_doc = json.loads(
+            _text_of(await _start_flow_handler({"flow_type": "onboarding_wizard"}))
+        )
+        runtime_raw = await StartFlowTool().execute(flow_type="onboarding_wizard")
+        runtime_doc = json.loads(runtime_raw)
+        assert mcp_doc == runtime_doc
+
+    @pytest.mark.asyncio
+    async def test_unknown_flow_type_returns_agent_readable_error(self):
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+
+        out = await _start_flow_handler({"flow_type": "definitely_not_a_template"})
+        assert out.get("is_error") is True
+        # The error names the valid templates so the model can retry.
+        assert "onboarding_wizard" in _text_of(out)
+
+    @pytest.mark.asyncio
+    async def test_missing_flow_type_returns_error(self):
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+
+        out = await _start_flow_handler({})
+        assert out.get("is_error") is True
+        assert "flow_type" in _text_of(out)
+
+    @pytest.mark.asyncio
+    async def test_config_as_json_string_is_coerced(self):
+        """Some callers pass ``config`` as a JSON string; the handler must
+        coerce it rather than reject it (parity with StartFlowTool)."""
+        import json
+
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+
+        out = await _start_flow_handler(
+            {"flow_type": "onboarding_wizard", "config": '{"product_name": "Acme"}'}
+        )
+        assert not out.get("is_error")
+        # Valid {version, ui} doc still produced with the override applied.
+        doc = json.loads(_text_of(out))
+        assert set(doc) >= {"version", "ui"}


### PR DESCRIPTION
## What broke

The RFC 13 smoke test caught a cross-repo seam gap. The `start_flow` authoring tool (RFC 13 M3, #1318) lives only in the runtime builtin registry (`src/pocketpaw/tools/builtin/flow_tool.py`). It was never bridged into the EE cloud chat agent's tool surface, so the home/cloud chat agent had no way to call it.

The agent's tool surface is `mcp__pocketpaw_{pocket,widgets,tasks,foresight,decisions,meetings,pocket_specialist,pocket_planner}__*` plus the SDK builtins — and none of those is `start_flow`. Asked for a wizard, the agent hand-authored a flat `set`-stepped spec, which is the exact anti-pattern `start_flow` exists to prevent: it renders step 1, never advances, and floods the M0 inline-spec parser with `parse-fenced-no-spec`.

M3's tests imported `StartFlowTool` directly, so they proved it was importable but never that it was reachable from the agent that needs it.

## The fix

**1. Bridge.** `start_flow` now rides the `pocketpaw_widgets` in-process MCP server (`src/pocketpaw/agents/sdk_mcp_widgets.py`). That server is the right home: it is already ambient (no opt-in gate), always seeded onto the in-process allowlist, and pure-core ripple domain with no cloud dependency — the same path `get_inline_widget_help` already uses to reach the cloud agent. The MCP handler reuses the same deterministic `build_flow` builder as the runtime tool, so the cloud agent and the runtime registry scaffold identical trees.

The bridge point is the claude_agent_sdk backend's tool assembly:
- `ClaudeAgentSDK._get_mcp_servers()` registers `pocketpaw_widgets`.
- `ClaudeAgentSDK._collect_mcp_tool_ids()` seeds `WIDGET_TOOL_IDS` (now including `mcp__pocketpaw_widgets__start_flow`) onto the allowlist.

**2. Prompt.** The inline system prompt (`src/pocketpaw/ripple/_inline.py`) now has a MULTI-STEP FLOWS rule: for any multi-step / wizard / intake / collect-then-act flow, call `start_flow` with a descriptor only. Do not hand-author a nested `chain`/`chain_map` tree, and do not fake a flow with a single `set`-stepped spec. The final self-check carries the same line.

**3. Guard test.** `tests/ee/test_mcp_claude_sdk.py::TestStartFlowReachable` asserts `start_flow` is present in the agent's assembled tool set — both on the allowlist and as a registered server — not merely importable. This is the test that would have caught the original gap.

The widgets-server contract test (`test_pocket_specialist.py`) moves from "is read only" to "persists nothing": `start_flow` mutates no pocket and writes no document, so it belongs on the same server as the catalog tools.

## Proof

Assembled cloud-agent tool list now carries the tool:

```
start_flow id on assembled allowlist : True -> mcp__pocketpaw_widgets__start_flow
pocketpaw_widgets server registered  : True

widgets tool ids the cloud agent can call:
   mcp__pocketpaw_widgets__get_inline_widget_help
   mcp__pocketpaw_widgets__get_widget_spec
   mcp__pocketpaw_widgets__start_flow
```

## Tests

`uv run --group ee pytest tests/ee/test_pocket_specialist.py tests/test_sdk_mcp_inline_help.py tests/ee/test_mcp_claude_sdk.py tests/test_flow_authoring.py -q` → 74 passed. Broader ripple/flow/mcp/pocket-specialist sweep → 446 passed, 1 skipped. Ruff check and format clean.

## Scope

Bridge plus prompt plus tests. No new Container or external dependency, so no C4 update needed — `start_flow` is an additive tool on an existing MCP server. No runtime-API or CLI surface change.