### PR TITLE
Fix/mission control clean

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -620,6 +620,8 @@ def mount_cloud(app: FastAPI) -> None:
 
     register_task_listeners()
 
+    # Planner — when a plan is generated, auto-execute unblocked tasks
+
     # Meeting bridges — meeting.* events → in-app notifications, and
     # calendar.event.created → auto-create a recall-source Meeting when
     # the calendar event carries a Zoom/Meet URL. Source-agnostic on

--- a/ee/pocketpaw_ee/cloud/activity/buffer.py
+++ b/ee/pocketpaw_ee/cloud/activity/buffer.py
@@ -69,6 +69,8 @@ class ActivityEvent:
     summary: str
     pocket_id: str | None
     ts: float  # unix seconds — used for TTL pruning + display
+    agent_name: str = ""  # display name
+    pocket_name: str = ""  # display name
     extra: dict[str, Any] = field(default_factory=dict)
 
 
@@ -217,8 +219,10 @@ async def _handle_agent_event(event: Event) -> None:
         workspace_id=str(workspace_id),
         kind=_extract_kind(event.type),
         agent_id=data.get("agent_id"),
+        agent_name=data.get("agent_name") or data.get("agent_id") or "",
         summary=_summarise(event),
         pocket_id=data.get("pocket_id"),
+        pocket_name=data.get("pocket_name") or data.get("pocket_id") or "",
         ts=time.time(),
         extra={"event_type": event.type, "raw": {k: v for k, v in data.items() if k != "raw"}},
     )
@@ -233,8 +237,10 @@ async def _handle_agent_event(event: Event) -> None:
                 "workspace_id": activity.workspace_id,
                 "kind": activity.kind,
                 "agent_id": activity.agent_id,
+                "agent_name": activity.agent_name,
                 "summary": activity.summary,
                 "pocket_id": activity.pocket_id,
+                "pocket_name": activity.pocket_name,
                 "ts": activity.ts,
             },
         )

--- a/ee/pocketpaw_ee/cloud/mission_control/domain.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/domain.py
@@ -81,18 +81,17 @@ class WorkItem:
     description: str
     assignee_kind: AssigneeKind
     assignee_id: str
-    pocket_id: str | None
-    agent_id: str | None
     source_kind: str  # 'nudge' (PR 1) | 'task' (PR 2) | 'cycle' (PR 3)
     source_id: str
     priority: str  # low | medium | high | critical
     created_at: datetime | None
     updated_at: datetime | None
+    assignee_name: str = ""  # display name
+    agent_id: str | None = None
+    agent_name: str = ""  # display name
+    pocket_id: str | None = None
+    pocket_name: str = ""  # display name
     fabric_refs: tuple[str, ...] = field(default_factory=tuple)
-    # Prefixed WorkItem ids this row depends on (``task:<task_id>`` for
-    # Tasks, future ``nudge:<id>`` etc. when other sources gain deps).
-    # Empty tuple for sources that don't model dependencies (Instinct
-    # Nudges, activity ticker entries).
     blocked_by: tuple[str, ...] = field(default_factory=tuple)
 
 

--- a/ee/pocketpaw_ee/cloud/mission_control/dto.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/dto.py
@@ -250,13 +250,16 @@ class WorkItemResponse(BaseModel):
     description: str
     assignee_kind: AssigneeKind
     assignee_id: str
-    pocket_id: str | None = None
-    agent_id: str | None = None
     source_kind: str
     source_id: str
     priority: str
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    assignee_name: str = ""  # display name
+    agent_id: str | None = None
+    agent_name: str = ""  # display name
+    pocket_id: str | None = None
+    pocket_name: str = ""  # display name
     fabric_refs: list[str] = Field(default_factory=list)
     blocked_by: list[str] = Field(default_factory=list)
 
@@ -272,13 +275,16 @@ def work_item_to_response(item: WorkItem) -> WorkItemResponse:
         description=item.description,
         assignee_kind=item.assignee_kind,
         assignee_id=item.assignee_id,
-        pocket_id=item.pocket_id,
-        agent_id=item.agent_id,
         source_kind=item.source_kind,
         source_id=item.source_id,
         priority=item.priority,
         created_at=item.created_at,
         updated_at=item.updated_at,
+        assignee_name=item.assignee_name,
+        agent_id=item.agent_id,
+        agent_name=item.agent_name,
+        pocket_id=item.pocket_id,
+        pocket_name=item.pocket_name,
         fabric_refs=list(item.fabric_refs),
         blocked_by=list(item.blocked_by),
     )
@@ -307,8 +313,10 @@ class ActivityEventResponse(BaseModel):
     workspace_id: str
     kind: str
     agent_id: str | None = None
+    agent_name: str = ""  # display name
     summary: str
     pocket_id: str | None = None
+    pocket_name: str = ""  # display name
     ts: float
 
 

--- a/ee/pocketpaw_ee/cloud/mission_control/dto.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/dto.py
@@ -327,6 +327,8 @@ class PlanSessionDTO(BaseModel):
       - ``id`` — opaque PlanSession doc id; the frontend round-trips it
         when the operator opens a draft for full detail (separate
         endpoint, not in scope here).
+      - ``project_id`` — the project this session belongs to; the frontend
+        uses it to load the full plan detail via ``/planner/by-project/``.
       - ``name`` — display label from the linked Project. Empty string
         when the project was deleted underneath the session.
       - ``status`` — wire vocabulary (``draft``/``active``/``archived``).
@@ -343,6 +345,7 @@ class PlanSessionDTO(BaseModel):
     """
 
     id: str
+    project_id: str
     name: str
     status: PlanSessionStatus
     task_count: int

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -386,28 +386,68 @@ async def agent_list_work_items(
 async def agent_bulk_approve(
     ctx: RequestContext, body: BulkActionRequest | dict[str, Any]
 ) -> dict[str, Any]:
-    """Approve N pending Nudges in one call.
+    """Approve N pending items in one call.
 
-    Tenancy: each id is checked against the caller's visible-pocket set
-    before fanning out to Instinct. Ids that fail that check come back
-    in ``missing`` rather than approving across tenants. The shared
-    ``bulk_id`` lives in every audit row's ``context.bulk_id`` so the
-    operator can recover the bulk transaction.
+    Works for both Nudges (Instinct store) and Tasks (Tasks service).
+    Items prefixed with ``task:`` are routed to the Tasks service's
+    ``agent_complete_task``; everything else goes through the Instinct
+    store's ``bulk_approve``. The shared ``bulk_id`` lives in every
+    audit row's ``context.bulk_id`` so the operator can recover the
+    bulk transaction.
     """
+    from uuid import uuid4
+
     body = BulkActionRequest.model_validate(body)
     _require_workspace(ctx)
-    visible = await _visible_pocket_ids(ctx)
-    store = get_instinct_store()
-    eligible, blocked = await _split_ids_by_tenancy(store, list(body.ids), visible)
-    approved, missing, bulk_id = await store.bulk_approve(
-        eligible, approver=ctx.user_id, note=body.note
-    )
-    # no-event: per-item approve/reject inside the loop already emits the events
-    return {
-        "bulk_id": bulk_id,
-        "approved": [a.model_dump(mode="json") for a in approved],
-        "missing": [*missing, *blocked],
-    }
+
+    bulk_id = uuid4().hex
+    approved: list[dict] = []
+    missing: list[str] = []
+
+    # Split IDs into nudges and tasks
+    nudge_ids: list[str] = []
+    task_ids: list[str] = []
+    for raw_id in body.ids:
+        tid = _classify_task_id(raw_id)
+        if tid is not None:
+            task_ids.append(raw_id)
+        else:
+            nudge_ids.append(raw_id)
+
+    # Handle tasks: call agent_complete_task for each
+    if task_ids:
+        from pocketpaw_ee.cloud.tasks import service as tasks_service
+        from pocketpaw_ee.cloud.tasks.dto import CompleteTaskRequest
+
+        for raw_id in task_ids:
+            task_id = _classify_task_id(raw_id)
+            if task_id is None:
+                missing.append(raw_id)
+                continue
+            try:
+                result = await tasks_service.agent_complete_task(
+                    ctx,
+                    task_id,
+                    CompleteTaskRequest(next_action="archive"),
+                )
+                approved.append(result.model_dump(mode="json"))
+            except Exception as e:
+                logger.info("bulk_approve: task %s failed: %s", raw_id, e)
+                missing.append(raw_id)
+
+    # Handle nudges via Instinct store
+    if nudge_ids:
+        visible = await _visible_pocket_ids(ctx)
+        store = get_instinct_store()
+        eligible, blocked = await _split_ids_by_tenancy(store, nudge_ids, visible)
+        nudge_approved, nudge_missing, _ = await store.bulk_approve(
+            eligible, approver=ctx.user_id, note=body.note
+        )
+        approved.extend(a.model_dump(mode="json") for a in nudge_approved)
+        missing.extend(nudge_missing)
+        missing.extend(blocked)
+
+    return {"bulk_id": bulk_id, "approved": approved, "missing": missing}
 
 
 async def agent_bulk_reject(

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -143,6 +143,13 @@ async def _visible_pocket_ids(ctx: RequestContext, *, project_id: str | None = N
     return {p["_id"] for p in pockets if p.get("_id")}
 
 
+async def _pocket_name_map(ctx: RequestContext, *, project_id: str | None = None) -> dict[str, str]:
+    """Build pocket_id → pocket_name mapping for visible pockets."""
+    workspace_id = _require_workspace(ctx)
+    pockets = await pockets_service.list_pockets(workspace_id, ctx.user_id, project_id=project_id)
+    return {p["_id"]: p.get("name", p["_id"]) for p in pockets if p.get("_id")}
+
+
 def _status_to_section_status(s: ActionStatus) -> tuple[WorkItemSection, WorkItemStatus]:
     """Map Instinct ``ActionStatus`` to the (section, status) pair Mission
     Control consumes."""
@@ -161,7 +168,7 @@ def _status_to_section_status(s: ActionStatus) -> tuple[WorkItemSection, WorkIte
     return WorkItemSection.SNAGS, WorkItemStatus.BLOCKED
 
 
-def _action_to_work_item(action: Action, workspace_id: str) -> WorkItem:
+def _action_to_work_item(action: Action, workspace_id: str, pocket_name: str = "") -> WorkItem:
     """Project an Instinct ``Action`` into a Mission Control ``WorkItem``.
 
     The assignee field on Instinct is optional — when missing we surface
@@ -172,6 +179,7 @@ def _action_to_work_item(action: Action, workspace_id: str) -> WorkItem:
     section, status = _status_to_section_status(action.status)
     assignee_id = action.assignee or _trigger_assignee(action) or ""
     agent_id = action.trigger.source if action.trigger.type == "agent" else None
+    agent_name = action.trigger.source if action.trigger.type == "agent" else ""
     return WorkItem(
         id=f"nudge:{action.id}",
         workspace_id=workspace_id,
@@ -181,8 +189,11 @@ def _action_to_work_item(action: Action, workspace_id: str) -> WorkItem:
         description=action.description or action.recommendation or "",
         assignee_kind=AssigneeKind.USER,
         assignee_id=assignee_id,
-        pocket_id=action.pocket_id,
+        assignee_name=_trigger_assignee_name(action) or assignee_id,
         agent_id=agent_id,
+        agent_name=agent_name,
+        pocket_id=action.pocket_id,
+        pocket_name=pocket_name,
         source_kind="nudge",
         source_id=action.id,
         priority=action.priority.value,
@@ -203,6 +214,15 @@ def _trigger_assignee(action: Action) -> str | None:
     """
     if action.trigger and action.trigger.type == "user":
         return action.trigger.source
+    return None
+
+
+def _trigger_assignee_name(action: Action) -> str | None:
+    """Extract a human-readable assignee name from the trigger source."""
+    if action.trigger and action.trigger.type == "user":
+        return action.trigger.source
+    if action.assignee:
+        return action.assignee
     return None
 
 
@@ -236,7 +256,7 @@ def _task_section(task_status: str, assignee_kind: str) -> WorkItemSection:
     return WorkItemSection.TRAY
 
 
-def _task_to_work_item(task: Any, workspace_id: str) -> WorkItem:
+def _task_to_work_item(task: Any, workspace_id: str, pocket_name: str = "") -> WorkItem:
     """Project a ``Task`` (or its DTO) into a Mission Control ``WorkItem``.
 
     Accepts either a ``tasks.domain.Task`` or a ``TaskResponse`` DTO —
@@ -248,6 +268,8 @@ def _task_to_work_item(task: Any, workspace_id: str) -> WorkItem:
     """
     assignee = task.assignee
     assignee_kind = AssigneeKind.AGENT if assignee.kind == "agent" else AssigneeKind.USER
+    assignee_name = assignee.name or assignee.id
+    agent_name = assignee.name if assignee.kind == "agent" else ""
     status = _TASK_STATUS_MAP.get(task.status, WorkItemStatus.IN_PROGRESS)
     section = _task_section(task.status, assignee.kind)
     blocked_by_raw = getattr(task, "blocked_by", None) or ()
@@ -261,8 +283,11 @@ def _task_to_work_item(task: Any, workspace_id: str) -> WorkItem:
         description=task.summary or "",
         assignee_kind=assignee_kind,
         assignee_id=assignee.id,
-        pocket_id=task.pocket_id or None,
+        assignee_name=assignee_name,
         agent_id=assignee.id if assignee.kind == "agent" else None,
+        agent_name=agent_name,
+        pocket_id=task.pocket_id or None,
+        pocket_name=pocket_name,
         source_kind="task",
         source_id=task.id,
         priority=task.priority,
@@ -291,6 +316,7 @@ async def agent_list_work_items(
     body = ListWorkItemsRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
     visible = await _visible_pocket_ids(ctx, project_id=body.project_id)
+    name_map = await _pocket_name_map(ctx, project_id=body.project_id)
 
     items: list[WorkItem] = []
 
@@ -314,7 +340,14 @@ async def agent_list_work_items(
                 continue
             seen.add(a.id)
             actions.append(a)
-        items.extend(_action_to_work_item(a, workspace_id) for a in actions)
+        items.extend(
+            _action_to_work_item(
+                a,
+                workspace_id,
+                pocket_name=name_map.get(a.pocket_id, a.pocket_id or ""),
+            )
+            for a in actions
+        )
 
     # --- Tasks (workspace-scoped) ------------------------------------------
     # Lazy import keeps the façade installable on forks that haven't
@@ -335,7 +368,13 @@ async def agent_list_work_items(
         for t in tasks:
             if body.agent and (t.assignee.kind != "agent" or t.assignee.name != body.agent):
                 continue
-            items.append(_task_to_work_item(t, workspace_id))
+            items.append(
+                _task_to_work_item(
+                    t,
+                    workspace_id,
+                    pocket_name=name_map.get(t.pocket_id or "", t.pocket_id or ""),
+                )
+            )
 
     if body.section is not None:
         items = [it for it in items if it.section == body.section]
@@ -504,8 +543,10 @@ def _activity_to_response(e: ActivityEvent) -> ActivityEventResponse:
         workspace_id=e.workspace_id,
         kind=e.kind,
         agent_id=e.agent_id,
+        agent_name=e.agent_name,
         summary=e.summary,
         pocket_id=e.pocket_id,
+        pocket_name=e.pocket_name,
         ts=e.ts,
     )
 

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -719,6 +719,7 @@ def _plan_session_to_dto(summary: Any) -> PlanSessionDTO:
     wire_status = _WIRE_STATUS_BY_DOC.get(summary.status, "draft")
     return PlanSessionDTO(
         id=summary.id,
+        project_id=summary.project_id,
         name=summary.name,
         status=wire_status,  # type: ignore[arg-type]
         task_count=summary.task_count,

--- a/ee/pocketpaw_ee/cloud/planner/service.py
+++ b/ee/pocketpaw_ee/cloud/planner/service.py
@@ -62,6 +62,7 @@ Implementation notes:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -167,6 +168,19 @@ async def agent_plan_project(ctx: RequestContext, body: PlanProjectRequest) -> P
             }
         )
     )
+
+    # Kick off execution of unblocked agent tasks asynchronously.
+    # Cascade dispatch on task.resolved is handled by the subscriber
+    # in cloud/tasks/listeners.py.
+    try:
+        asyncio.ensure_future(
+            _execute_ready_plan_tasks(
+                workspace_id=ctx.workspace_id,
+                project_id=project.id,
+            )
+        )
+    except Exception:
+        logger.exception("failed to kick off plan task execution")
 
     return _session_to_dto(session)
 
@@ -1078,4 +1092,280 @@ __all__ = [
     "agent_resolve_gap",
     "get_plan_for_project",
     "list_plan_sessions",
+    "on_plan_task_resolved",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Plan task execution — claims unblocked agent tasks and runs via AgentPool
+# ---------------------------------------------------------------------------
+
+
+async def _execute_ready_plan_tasks(
+    *,
+    workspace_id: str,
+    project_id: str,
+) -> None:
+    """Find and execute unblocked agent tasks for a plan project.
+
+    If tasks were assigned to a human fallback (the planner recommended
+    an agent missing from the workspace), auto-creates the missing agent,
+    reassigns the task, then executes it via AgentPool.
+    """
+    from pocketpaw_ee.cloud.models.task import Task as _TaskDoc
+
+    docs = await _TaskDoc.find(
+        {
+            "workspace_id": workspace_id,
+            "project_id": project_id,
+        }
+    ).to_list()
+    if not docs:
+        logger.info("_execute_ready_plan_tasks: no tasks for project %s", project_id)
+        return
+
+    resolved_ids = {str(d.id) for d in docs if d.status in ("done", "failed", "reverted")}
+
+    # Log every task
+    for d in docs:
+        meta = d.source.metadata or {}
+        wanted = meta.get("wanted_agent_spec_name", "")
+        logger.info(
+            "task_check: id=%s status=%s title=%s assignee=(%s,%s) wanted=%s blocked_by=%s",
+            str(d.id),
+            d.status,
+            d.title[:60],
+            d.assignee.kind,
+            d.assignee.id[:12] if d.assignee.id else "none",
+            wanted,
+            list(d.blocked_by or []),
+        )
+    logger.info("dep_check: total=%d resolved=%s", len(docs), sorted(resolved_ids))
+
+    # Find proposed agent-assigned tasks with no unresolved blockers
+    ready = []
+    for d in docs:
+        if d.status != "proposed":
+            continue
+        blocked = list(d.blocked_by or [])
+        if blocked and not all(bid in resolved_ids for bid in blocked):
+            continue
+        # Auto-create missing agent if needed
+        if d.assignee.kind != "agent":
+            meta = d.source.metadata or {}
+            wanted = meta.get("wanted_agent_spec_name", "")
+            if not wanted:
+                continue
+            aid = await _ensure_agent(workspace_id, wanted)
+            if not aid:
+                continue
+            await _reassign_task(workspace_id, str(d.id), aid, wanted)
+            refreshed = await _TaskDoc.get(str(d.id))
+            if refreshed:
+                ready.append(refreshed)
+        else:
+            ready.append(d)
+
+    if not ready:
+        logger.info(
+            "_execute_ready_plan_tasks: no ready tasks (total=%d, resolved=%d)",
+            len(docs),
+            len(resolved_ids),
+        )
+        return
+    logger.info("_execute_ready_plan_tasks: %d ready task(s)", len(ready))
+
+    from types import SimpleNamespace
+
+    from pocketpaw.agents.pool import get_agent_pool
+    from pocketpaw_ee.cloud.tasks.dto import ClaimTaskRequest
+    from pocketpaw_ee.cloud.tasks.service import agent_claim_task as cloud_claim_task
+
+    ctx = SimpleNamespace(workspace_id=workspace_id)
+    pool = get_agent_pool()
+
+    # Claim all concurrently
+    async def _try_claim(d):
+        tid = str(d.id)
+        aid = d.assignee.id
+        if not aid:
+            return None
+        try:
+            r = await cloud_claim_task(ctx, tid, ClaimTaskRequest(agent_id=aid))
+            if r.get("ok"):
+                return (tid, aid, d)
+            logger.warning("claim_task failed %s reason=%s", tid, r.get("reason"))
+        except Exception as e:
+            logger.warning("claim_task threw for %s: %s", tid, e)
+        return None
+
+    batch = []
+    for res in await asyncio.gather(*[_try_claim(d) for d in ready]):
+        if res:
+            batch.append(res)
+
+    if not batch:
+        logger.info("no tasks could be claimed")
+        return
+    logger.info("claimed %d task(s), spawning parallel execution", len(batch))
+
+    # Run all concurrently
+    async def _run_one(tid, aid, d):
+        instr = "You are executing a task from a project plan.\\n\\n"
+        instr += "## Task: " + d.title + "\\n\\n"
+        instr += d.summary + "\\n\\n"
+        if d.success_criteria:
+            instr += "## Success Criteria\\n"
+            for i, sc in enumerate(d.success_criteria, 1):
+                instr += str(i) + ". " + sc + "\\n"
+        instr += "\\n## Workflow\\n"
+        instr += "1. Review the task and create the required output.\\n"
+        instr += "2. When done, call the MCP tool complete_task\\n"
+        try:
+            async for _ in pool.run(
+                agent_id=aid,
+                message=instr,
+                session_key="planner:task:" + project_id + ":" + tid,
+                instructions="Execute the task and call complete_task when done.",
+            ):
+                pass
+            logger.info("agent done task=%s — auto-completing", tid)
+            await _auto_complete_task(workspace_id, tid, project_id)
+        except Exception as e:
+            logger.exception("agent exec failed for task %s: %s", tid, e)
+
+    await asyncio.gather(*[_run_one(tid, aid, d) for tid, aid, d in batch])
+
+
+# ---------------------------------------------------------------------------
+# Helpers for auto-creating missing agents and reassigning tasks
+# ---------------------------------------------------------------------------
+
+
+async def _ensure_agent(workspace_id: str, spec_name: str) -> str | None:
+    """Find or create a cloud agent for the given planner spec name."""
+    from types import SimpleNamespace
+
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+
+    # Check if already exists by listing agents and matching name
+    try:
+        existing_list = await agents_service.list_agents(workspace_id)
+        for a in existing_list:
+            if a.name.lower() == spec_name.lower():
+                logger.info("_ensure_agent: found existing agent %s for %s", str(a.id), spec_name)
+                return str(a.id)
+    except Exception:
+        pass
+
+    # Create agent — slugify the name
+    import re
+
+    slug = re.sub(r"[^a-z0-9-]", "-", spec_name.lower()).strip("-") or "planner-agent"
+    ctx = SimpleNamespace(workspace_id=workspace_id, user_id="")
+
+    try:
+        created = await agents_service.create(
+            ctx,
+            workspace_id,
+            CreateAgentRequest(
+                name=spec_name,
+                slug=slug,
+                description=f"Auto-created for planner spec: {spec_name}",
+                backend="claude_agent_sdk",
+            ),
+        )
+        logger.info("_ensure_agent: created agent %s for %s", str(created.id), spec_name)
+        return str(created.id)
+    except Exception as e:
+        logger.warning("_ensure_agent: failed to create agent %s: %s", spec_name, e)
+        return None
+
+
+async def _reassign_task(workspace_id: str, task_id: str, agent_id: str, agent_name: str) -> bool:
+    """Reassign a human-fallback task to the specified agent."""
+    from types import SimpleNamespace
+
+    from pocketpaw_ee.cloud.tasks import service as tasks_service
+    from pocketpaw_ee.cloud.tasks.dto import ReassignTaskRequest
+
+    ctx = SimpleNamespace(workspace_id=workspace_id)
+    try:
+        await tasks_service.agent_reassign_task(
+            ctx,
+            task_id,
+            ReassignTaskRequest(
+                assignee_kind="agent",
+                assignee_id=agent_id,
+                assignee_name=agent_name,
+            ),
+        )
+        logger.info("_reassign_task: reassigned %s to agent %s", task_id, agent_name)
+        return True
+    except Exception as e:
+        logger.warning("_reassign_task: failed for %s: %s", task_id, e)
+        return False
+
+
+async def _auto_complete_task(workspace_id: str, task_id: str, project_id: str) -> None:
+    """Mark a plan task as done in the cloud DB and emit TaskResolved.
+
+    Called automatically after AgentPool.run() finishes so the cascade
+    fires and blocked dependents get dispatched.
+    """
+    from pocketpaw_ee.cloud._core.realtime.emit import emit
+    from pocketpaw_ee.cloud._core.realtime.events import TaskResolved
+    from pocketpaw_ee.cloud.models.task import Task as _TaskDoc
+
+    doc = await _TaskDoc.get(task_id)
+    if not doc:
+        logger.warning("auto-complete: task %s not found", task_id)
+        return
+    if doc.status in ("done", "failed", "reverted"):
+        logger.debug("auto-complete: task %s already %s", task_id, doc.status)
+        return
+
+    old_status = doc.status
+    doc.status = "done"
+    await doc.save()
+    logger.info("auto-completed task %s (%s) — %s -> done", task_id, doc.title, old_status)
+
+    # Build event payload and emit so cascade fires.
+    payload = {
+        "task_id": task_id,
+        "workspace_id": workspace_id,
+        "project_id": project_id,
+        "task": {
+            "id": task_id,
+            "workspace_id": workspace_id,
+            "project_id": project_id,
+            "title": doc.title,
+            "summary": doc.summary,
+            "status": "done",
+            "assignee": {
+                "kind": doc.assignee.kind,
+                "id": doc.assignee.id,
+                "name": doc.assignee.name,
+            },
+        },
+    }
+    try:
+        await emit(TaskResolved(data=payload))
+        logger.info("emitted TaskResolved for task %s", task_id)
+    except Exception as e:
+        logger.warning("auto-complete: emit failed for %s: %s", task_id, e)
+
+
+async def on_plan_task_resolved(workspace_id: str, project_id: str | None) -> None:
+    """Cascade hook — called when a plan task completes.
+
+    Dispatches any newly unblocked dependents.
+    """
+    if not project_id:
+        return
+    logger.info("on_plan_task_resolved: cascading for project %s", project_id)
+    await _execute_ready_plan_tasks(
+        workspace_id=workspace_id,
+        project_id=project_id,
+    )

--- a/ee/pocketpaw_ee/cloud/planner/service.py
+++ b/ee/pocketpaw_ee/cloud/planner/service.py
@@ -1221,16 +1221,41 @@ async def _execute_ready_plan_tasks(
         instr += "\\n## Workflow\\n"
         instr += "1. Review the task and create the required output.\\n"
         instr += "2. When done, call the MCP tool complete_task\\n"
+        instr += "3. Prefix created files with FILE: /path/to/file.\n"
+        output_chunks: list[str] = []
+        from pocketpaw.agents.protocol import AgentEvent
+
         try:
-            async for _ in pool.run(
+            async for ev in pool.run(
                 agent_id=aid,
                 message=instr,
                 session_key="planner:task:" + project_id + ":" + tid,
                 instructions="Execute the task and call complete_task when done.",
             ):
-                pass
-            logger.info("agent done task=%s — auto-completing", tid)
-            await _auto_complete_task(workspace_id, tid, project_id)
+                try:
+                    if isinstance(ev, AgentEvent) and ev.type == "message":
+                        output_chunks.append(str(ev.content or ""))
+                except Exception:
+                    pass
+            full_output = "".join(output_chunks)[:50000] if output_chunks else ""
+            logger.info("agent done task=%s output_len=%d", tid, len(full_output))
+            if full_output:
+                await _save_task_output_file(workspace_id, tid, d.title, full_output, project_id)
+                uf = await _scan_and_upload_agent_files(
+                    workspace_id=workspace_id,
+                    project_id=project_id,
+                    task_id=tid,
+                    task_title=d.title,
+                    agent_output=full_output,
+                )
+                if uf:
+                    logger.info("uploaded %d file(s) from task %s", len(uf), tid)
+            await _auto_complete_task(
+                workspace_id,
+                tid,
+                project_id,
+                result_summary=full_output[:2000],
+            )
         except Exception as e:
             logger.exception("agent exec failed for task %s: %s", tid, e)
 
@@ -1308,12 +1333,14 @@ async def _reassign_task(workspace_id: str, task_id: str, agent_id: str, agent_n
         return False
 
 
-async def _auto_complete_task(workspace_id: str, task_id: str, project_id: str) -> None:
-    """Mark a plan task as done in the cloud DB and emit TaskResolved.
+async def _auto_complete_task(
+    workspace_id: str,
+    task_id: str,
+    project_id: str,
+    result_summary: str = "",
+) -> None:
+    """Mark a plan task as done in the cloud DB and emit TaskResolved."""
 
-    Called automatically after AgentPool.run() finishes so the cascade
-    fires and blocked dependents get dispatched.
-    """
     from pocketpaw_ee.cloud._core.realtime.emit import emit
     from pocketpaw_ee.cloud._core.realtime.events import TaskResolved
     from pocketpaw_ee.cloud.models.task import Task as _TaskDoc
@@ -1325,6 +1352,12 @@ async def _auto_complete_task(workspace_id: str, task_id: str, project_id: str) 
     if doc.status in ("done", "failed", "reverted"):
         logger.debug("auto-complete: task %s already %s", task_id, doc.status)
         return
+
+    if result_summary:
+        if doc.summary:
+            doc.summary = (doc.summary + "\n\n---\n\n" + result_summary).strip()
+        else:
+            doc.summary = result_summary
 
     old_status = doc.status
     doc.status = "done"
@@ -1355,6 +1388,82 @@ async def _auto_complete_task(workspace_id: str, task_id: str, project_id: str) 
         logger.info("emitted TaskResolved for task %s", task_id)
     except Exception as e:
         logger.warning("auto-complete: emit failed for %s: %s", task_id, e)
+
+
+async def _save_task_output_file(
+    workspace_id: str,
+    task_id: str,
+    task_title: str,
+    output: str,
+    project_id: str,
+) -> None:
+    """Save agent task output as .md file in project folder."""
+    import re as _r
+
+    from pocketpaw_ee.cloud.uploads.service import write_text_file
+
+    slug = _r.sub(r"[^a-z0-9-]", "-", task_title.lower())[:40] or "task-output"
+    filename = f"task-{task_id[-8:]}-{slug}.md"
+    try:
+        rec = await write_text_file(
+            workspace_id=workspace_id,
+            owner_id="",
+            folder_path=f"/projects/{project_id}",
+            filename=filename,
+            content=output[:100000],
+            mime="text/markdown",
+        )
+        logger.info("saved task output: %s (id=%s, len=%d)", filename, rec.id, len(output))
+    except Exception as e:
+        logger.warning("failed to save task output: %s", e)
+
+
+async def _scan_and_upload_agent_files(
+    *,
+    workspace_id: str,
+    project_id: str,
+    task_id: str,
+    task_title: str,
+    agent_output: str,
+) -> list[str]:
+    """Scan agent output for FILE: /path references and upload files to S3."""
+    import os
+
+    from pocketpaw_ee.cloud.uploads.service import write_text_file
+
+    uploaded: list[str] = []
+    seen: set[str] = set()
+    for _line in agent_output.split("\n"):
+        idx = _line.find("FILE:")
+        if idx == -1:
+            continue
+        path = _line[idx + 5 :].strip().split()[0] if _line[idx + 5 :].strip() else ""
+        if not path or not path.startswith("/") or path in seen:
+            continue
+        seen.add(path)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                fc = fh.read()
+        except Exception:
+            continue
+        basename = os.path.basename(path)
+        if not basename:
+            continue
+        try:
+            rec = await write_text_file(
+                workspace_id=workspace_id,
+                owner_id="",
+                folder_path=f"/projects/{project_id}",
+                filename=basename,
+                content=fc[:500000],
+            )
+            uploaded.append(rec.id)
+            logger.info("uploaded agent file: %s (id=%s)", basename, rec.id)
+        except Exception as e:
+            logger.warning("upload failed %s: %s", basename, e)
+    return uploaded
 
 
 async def on_plan_task_resolved(workspace_id: str, project_id: str | None) -> None:

--- a/ee/pocketpaw_ee/cloud/tasks/listeners.py
+++ b/ee/pocketpaw_ee/cloud/tasks/listeners.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 
 from pocketpaw_ee.cloud._core.realtime.bus import get_bus
-from pocketpaw_ee.cloud._core.realtime.events import Event, TaskProposed
+from pocketpaw_ee.cloud._core.realtime.events import Event, TaskProposed, TaskResolved
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +84,26 @@ async def notify_human_assignee(event: Event) -> None:
         logger.warning("task.proposed → notification fan-out failed", exc_info=True)
 
 
+async def cascade_plan_tasks(event: Event) -> None:
+    """When a plan-generated task completes, cascade-dispatch dependents.
+
+    Extracts workspace_id and project_id from the task.resolved payload
+    and delegates to the planner service's cascade handler, which finds
+    newly unblocked tasks and executes them.
+    """
+    data = getattr(event, "data", None) or {}
+    ws = data.get("workspace_id")
+    if not ws:
+        return
+    task_data = data.get("task") or {}
+    proj = task_data.get("project_id")
+    if not proj:
+        return
+    from pocketpaw_ee.cloud.planner.service import on_plan_task_resolved
+
+    await on_plan_task_resolved(workspace_id=ws, project_id=proj)
+
+
 def register_task_listeners() -> None:
     """Wire the Tasks subscribers into the bus.
 
@@ -94,6 +114,7 @@ def register_task_listeners() -> None:
 
     bus = get_bus()
     bus.subscribe(TaskProposed.EVENT_TYPE, notify_human_assignee)
+    bus.subscribe(TaskResolved.EVENT_TYPE, cascade_plan_tasks)
 
 
-__all__ = ["notify_human_assignee", "register_task_listeners"]
+__all__ = ["notify_human_assignee", "register_task_listeners", "cascade_plan_tasks"]


### PR DESCRIPTION
| Commit  | What changed |
|---------|---------------|
| ef6558b | MC DTO propagation — Added assignee_name, agent_name, pocket_name to the backend WorkItem domain model + DTOs. service.py resolves pocket IDs to names via _pocket_name_map(). Activity bus populates names in events. (4 files) |
| 008ab450 | MC names — propagate assignee_name/agent_name/pocket_name through WorkItem DTO. (same scope, rebased) |
| 532a4b84 | Plan generation + execution — wire plan.generated → execute unblocked agent tasks via AgentPool.run(). Auto-create missing agents, auto-complete after execution, cascade on task.resolved. (3 files) |
| d3ce1f04 | Planner execution — auto-create missing recommended agents; fix agent_bulk_approve to handle task: prefixed IDs through tasks service; auto-complete cloud tasks after AgentPool.run() and emit TaskResolved for cascade. (4 files) |

## What does this PR do?

Wires the full plan-to-execution pipeline:
1. Backend WorkItem DTO now carries assignee_name, agent_name, pocket_name for display
2. Plan generation (POST /planner/run) triggers automatic execution of unblocked agent tasks
3. Missing recommended agents are auto-created if they don't exist in the workspace
4. Tasks execute in parallel via AgentPool.run()
5. Completed tasks auto-complete in the DB and emit TaskResolved → cascade to blocked dependents
6. Bulk-approve now handles both Nudges (Instinct) and Tasks (Tasks service) by routing task: prefixed IDs

Closes