### PR TITLE
feat(pockets): saga compensation for multi-step write sequences

### DIFF
--- a/docs/concepts/pocket-write-actions.mdx
+++ b/docs/concepts/pocket-write-actions.mdx
@@ -18,9 +18,9 @@ A pocket write action is a **declared, agent-callable verb** that mutates extern
 
 **Workspace RFC:** [docs/rfc/05-pocket-write-actions-rfc.md](https://github.com/qbtrix/paw-workspace/blob/main/docs/rfc/05-pocket-write-actions-rfc.md)
 
-**What's live:** write actions wired via the `call_binding` ripple verb; Instinct routing for approval-gated bindings; outcome emission; execution router splits structure edits from data writes.
+**What's live:** write actions wired via the `call_binding` ripple verb; Instinct routing for approval-gated bindings; outcome emission; execution router splits structure edits from data writes; **Saga compensation** — a per-action `compensate` spec plus a server-side rollback runtime for multi-step write sequences (first pass).
 
-**What's planned:** multi-step action chains; richer outcome schemas tied to RFC 07 Decisions.
+**What's planned:** the call sites that drive a write SEQUENCE (Chain Flow / RFC 13); saga over Instinct-gated forward writes; richer outcome schemas tied to RFC 07 Decisions.
 </Callout>
 
 ## What It Is
@@ -78,6 +78,7 @@ A write binding lives inside `rippleSpec.actions` on the pocket. The minimum sha
 | `requires_instinct` | When `true`, runs validation gates but parks the write for human approval via the Instinct surface. |
 | `instinct_policy` | Optional reference to a named Instinct policy. Rejected by the model validator if set without `requires_instinct`. |
 | `outcome` | Optional outcome name emitted on success. Feeds RFC 07's DecisionProjection. |
+| `compensate` | Optional inverse-write spec (`{method, path, params, outcome?}`) — the action that undoes this one if a later step in a write sequence fails. Fired by the Saga runtime on rollback; ignored on a single `run_action` call. See [Saga Compensation](#saga-compensation-multi-step-rollback). |
 
 The matching write rule on `allowed_writes` lives on the backend credential, set via:
 
@@ -118,6 +119,70 @@ The outcomes service persists the row and emits a bus event. Downstream:
 - The pocket's UI reconciles via the `on_success` handler the agent wired into the widget event.
 - The Decision Graph (RFC 07) consumes the outcome as evidence on the relevant `DecisionProjection`.
 - The audit log keeps a tenant-filterable record (`workspace_id` is on every entry).
+
+## Saga Compensation (Multi-Step Rollback)
+
+A single write action either fires or it doesn't. But an agent-authored flow often performs **several writes in a row** — reserve inventory, charge the card, confirm the order. If the third write fails, the first two are already committed on the backend: inventory is held, the card is charged. Left alone, the backend is in an inconsistent state.
+
+Saga compensation closes that gap. Each forward action declares a `compensate` spec — the **inverse write** that undoes it (`charge` → `refund`, `reserve` → `release`). When a write **sequence** fails partway, the runtime fires the completed steps' compensations in **reverse order**, leaving the backend consistent.
+
+### The `compensate` spec
+
+```json
+{
+  "actions": {
+    "charge_card": {
+      "method": "POST",
+      "path": "/payments/charge",
+      "outcome": "payment_captured",
+      "compensate": {
+        "method": "POST",
+        "path": "/payments/refund",
+        "outcome": "payment_refunded"
+      }
+    }
+  }
+}
+```
+
+A compensation **is** a write binding — it shares the executor and is subject to the **same gates** (allowlist, SSRF, rate limit). The owner must allow-list the inverse write's `method` + `path` too, or the rollback is rejected at the allowlist gate. Two fields are deliberately absent from a `compensate` spec versus a full action:
+
+- **No `requires_instinct`.** A compensation fires **automatically**. Pausing a rollback for human approval would leave the backend in the inconsistent state the rollback exists to repair. The forward write's gate is the human checkpoint; the compensation is the automatic cleanup once a committed write must be undone.
+- **No nested `compensate`.** A compensation that itself fails is logged and surfaced for manual reconciliation — it is not auto-compensated recursively.
+
+### The rollback algorithm
+
+`pockets/saga.py:run_action_sequence` runs a list of steps through the existing single-write executor:
+
+1. Run each step in order via `action_executor.run_action`. Push every step that **fires** (`ok:true`, not parked) onto a completed stack, and emit its forward outcome.
+2. On the **first** failure — an `ok:false` result, **or** a step that parks for Instinct (`instinct_pending`) — stop advancing.
+3. Fire the completed steps' compensations in **reverse** order (newest-committed first), each as its own `run_action` call against the inverse binding.
+4. A successful compensation that declares an `outcome` emits a `pocket.outcome` event with `compensated: true`, so the audit trail closes and the meter can net the rollback against the forward outcome.
+
+```text
+reserve  ✓   charge  ✓   confirm  ✗   ← step 3 fails
+                              │
+                              ▼  roll back, newest-first
+                  refund (charge⁻¹)  →  release (reserve⁻¹)
+```
+
+The executor is **not** modified — it stays a pure single-write primitive, so the three existing single-write callers (the direct route, bulk fan-out, the Instinct re-entry) are byte-stable. The saga is a wrapper that orchestrates it.
+
+### Failure handling
+
+- **A compensation that itself fails** does *not* abort the rollback — the remaining compensations still fire (a half-rolled-back saga is worse than a fully-attempted one). Failed legs land in `SagaResult.compensation_failures` with `status: "failed"` for an operator to reconcile by hand.
+- **A completed step with no `compensate` spec** is recorded as a `no_compensator` gap rather than silently dropped — the operator sees exactly what was left committed. `rolled_back` is then `false`.
+- **`SagaResult.rolled_back`** is `true` only when every completed step was cleanly compensated. `false` means the backend may be partially inconsistent and needs attention.
+
+### Idempotency
+
+A compensation carries an `Idempotency-Key` derived from the forward step's key (suffixed `:compensate`) so a retried rollback dedupes on the backend without colliding with the forward write's key. A compensation is **required to be idempotent on the backend side** — re-firing `refund` for an already-refunded charge must be a no-op.
+
+### Open questions (first pass)
+
+- **Saga over Instinct-gated forward writes.** A `requires_instinct` forward write parks instead of firing, so it can't be part of an *automatic* saga. Today the saga treats a parked step as a sequence failure and rolls back the steps before it. A real "approve the whole sequence, then fire" (or per-step approval mid-saga) flow is a larger design, deferred.
+- **Who drives the sequence?** This pass ships the field + the runtime. The call sites that *assemble* a multi-step write sequence — Chain Flow (RFC 13), an agent-authored flow tool — are wired separately.
+- **Compensation retry policy.** A failed compensation is surfaced, not retried. A bounded-retry / dead-letter policy for stuck compensations is future work.
 
 ## Execution Router and the Structure/Data Split (PR #1181)
 

--- a/ee/pocketpaw_ee/cloud/outcomes/domain.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/domain.py
@@ -19,6 +19,13 @@
 #   the ledger row so `meter_outcomes` can sum value by unit per workspace.
 #   The fields and their defaults are unchanged; only the meaning is — a
 #   pre-gap-3 ledger row (both `None`) reads back as a count-only outcome.
+# Updated: 2026-06-01 (RFC 05 Saga Compensate) — added the optional
+#   `compensated` flag. A compensating write (a rollback fired when a
+#   multi-step write sequence failed partway) lands an outcome too — a
+#   rollback is a real business event, not a silent side effect — but the
+#   ledger must distinguish it from a forward outcome so a "renewal_sent"
+#   that was later refunded does not over-count. Defaults False so every
+#   pre-saga ledger row is byte-stable.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -50,6 +57,10 @@ class OutcomeRecord:
     outcome_value: float | None = None
     outcome_unit: str | None = None
     decision_id: str | None = None  # RFC 07 Slice 2 back-reference
+    # RFC 05 Saga Compensate — True when this outcome is a rollback (a
+    # compensating write fired because a later step in a sequence failed),
+    # False for an ordinary forward outcome. The meter can net these out.
+    compensated: bool = False
 
 
 __all__ = ["OutcomeRecord"]

--- a/ee/pocketpaw_ee/cloud/outcomes/service.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/service.py
@@ -157,12 +157,15 @@ async def emit_pocket_outcome(
     decision_id: str | None = None,
     outcome_value: float | None = None,
     outcome_unit: str | None = None,
+    compensated: bool = False,
 ) -> None:
     """Emit a ``pocket.outcome`` event for a successful write action.
 
-    Called by the pockets router (a direct, non-gated write) and by
+    Called by the pockets router (a direct, non-gated write), by
     ``instinct_bridge.execute_approved_write`` (a write fired after
-    Instinct approval) AFTER ``run_action`` returns ``ok:true``.
+    Instinct approval), and by ``saga.run_action_sequence`` (a
+    compensating write fired on rollback) AFTER ``run_action`` returns
+    ``ok:true``.
 
     A binding that declared no ``outcome`` passes ``outcome=None`` — this
     is a NO-OP, no event is emitted. Only a named outcome produces an
@@ -183,6 +186,12 @@ async def emit_pocket_outcome(
     when the caller has one in hand. ``None`` is fine for writers that
     don't yet know their Decision (legacy producers); the listener
     only fires the back-reference path when the id is present.
+
+    ``compensated`` (RFC 05 Saga Compensate) is ``True`` when this outcome
+    is a rollback — a compensating write fired because a later step in a
+    multi-step write sequence failed. The ledger records it so the meter
+    can net a refunded "renewal_completed" against the forward one instead
+    of over-counting. Defaults ``False`` (an ordinary forward outcome).
     """
     if not outcome:
         # No declared outcome — nothing to meter. The write still
@@ -206,6 +215,8 @@ async def emit_pocket_outcome(
                 "outcome_unit": outcome_unit,
                 # RFC 07 Slice 2 — back-reference to the decision graph.
                 "decision_id": decision_id,
+                # RFC 05 Saga Compensate — True for a rollback outcome.
+                "compensated": compensated,
             }
         )
     )
@@ -265,6 +276,8 @@ async def record_outcome(event) -> None:  # type: ignore[no-untyped-def]
         outcome_unit=outcome_unit,
         # RFC 07 Slice 2 — back-reference into the decision graph.
         decision_id=decision_id,
+        # RFC 05 Saga Compensate — True for a rollback outcome.
+        compensated=bool(data.get("compensated")),
     )
     path = _ledger_path(record.workspace_id)
     try:

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -116,6 +116,20 @@
 #   correlation_id is THREADED through to ``_park`` so the bridge can stash
 #   it on the parked Instinct Action (schema-2 bump in ``instinct_bridge``).
 #
+# Updated: 2026-06-01 (RFC 05 Saga Compensate — first pass) — ``ActionBinding``
+#   gains an optional ``compensate`` field: a nested ``CompensateSpec``
+#   (method / path / params / outcome) declaring the inverse write that
+#   undoes this action ("charge→refund", "reserve→release"). The field is
+#   declaration-only HERE — ``run_action`` does NOT read or fire it, and a
+#   single write is unchanged byte-for-byte. The rollback runtime lives in
+#   the new ``saga.py`` module, which orchestrates a SEQUENCE of
+#   ``run_action`` calls, tracks the completed (fired) writes, and on a
+#   mid-sequence failure fires each completed write's ``compensate`` via
+#   ``run_action`` in REVERSE order. Keeping ``run_action`` a pure
+#   single-write executor preserves its contract for the three existing
+#   callers (direct route, bulk fan-out, Instinct re-entry); the saga is a
+#   wrapper, not a fork.
+#
 # A write has blast radius a read does not, so this executor adds three
 # concerns on TOP of the shared SSRF guards:
 #   1. The per-pocket WRITE ALLOWLIST (`allowed_writes`) — set by a human in
@@ -217,6 +231,46 @@ class _BackendHTTPError(Exception):
         self.status_code = status_code
 
 
+class CompensateSpec(BaseModel):
+    """The inverse write that undoes a forward action (RFC 05 Saga Compensate).
+
+    A forward write declares ``compensate`` to name the action that rolls
+    it back: ``charge`` → ``refund``, ``reserve`` → ``release``,
+    ``send_invite`` → ``revoke_invite``. When a multi-step write SEQUENCE
+    fails partway, the saga runtime (``saga.py``) fires the completed
+    writes' compensations in REVERSE order so the backend is left
+    consistent.
+
+    A compensation IS a write binding — it shares the executor with the
+    forward action and is subject to the SAME guards (allowlist, SSRF,
+    rate limit). The owner must allow-list the compensation's method+path
+    just like any other write, or the rollback is rejected at the gate.
+
+    Two fields are DELIBERATELY absent versus ``ActionBinding``:
+
+    * ``requires_instinct`` — a compensation fires AUTO. Pausing a rollback
+      for human approval would leave the backend in the inconsistent state
+      the rollback exists to repair (money charged, inventory reserved).
+      The forward write's gate is the human checkpoint; the compensation
+      is the automatic cleanup once a committed write must be undone. The
+      gated-compensation case is an explicit open question in the RFC.
+    * ``compensate`` — no nested compensation-of-a-compensation. A
+      compensation that itself fails is logged and surfaced for manual
+      reconciliation (saga policy), not auto-compensated recursively.
+
+    ``outcome`` is carried so a successful compensation emits its own named
+    outcome (e.g. ``renewal_refunded``) and the audit trail closes — a
+    rollback is a real business event, not a silent side effect.
+    """
+
+    model_config = {"extra": "ignore"}
+
+    method: Literal["POST", "PUT", "PATCH", "DELETE"]
+    path: str
+    params: dict = Field(default_factory=dict)
+    outcome: str | None = None
+
+
 class ActionBinding(BaseModel):
     """One write binding parsed from `rippleSpec.actions`.
 
@@ -250,6 +304,15 @@ class ActionBinding(BaseModel):
     binding never sets ``requires_instinct``, so under the old ``False``
     default it bypassed the gate. Flipping the default closes that bypass at
     the single chokepoint every author and the executor validate through.
+
+    Saga Compensate adds one optional field:
+
+    * ``compensate`` — a :class:`CompensateSpec`, the inverse write that
+      undoes this action if a later step in a write SEQUENCE fails. The
+      executor does NOT read it on a single ``run_action`` call; the saga
+      runtime (``saga.py``) fires it on rollback. ``None`` (the default)
+      means this action has no declared undo — a saga that has to roll
+      back past it records the gap instead of silently dropping it.
 
     A ``model_validator`` rejects an ``instinct_policy`` set WITHOUT
     ``requires_instinct`` — a policy with no gate to apply to is a
@@ -295,6 +358,11 @@ class ActionBinding(BaseModel):
     # W2a: explicit, auditable exemption. A binding the author deliberately
     # allows to fire WITHOUT the gate sets this True in the persisted spec.
     instinct_exempt: bool = False
+    # --- Saga Compensate (RFC 05) ---------------------------------------
+    # The inverse write that undoes this action on a mid-sequence rollback.
+    # Declaration-only here; ``saga.py`` reads + fires it. ``None`` means
+    # no declared undo for this action.
+    compensate: CompensateSpec | None = None
 
     @model_validator(mode="after")
     def _policy_needs_gate(self) -> ActionBinding:
@@ -1327,4 +1395,4 @@ async def _do_request(
     return {"status": resp.status_code, "response": response}
 
 
-__all__ = ["ActionBinding", "run_action"]
+__all__ = ["ActionBinding", "CompensateSpec", "run_action"]

--- a/ee/pocketpaw_ee/cloud/pockets/saga.py
+++ b/ee/pocketpaw_ee/cloud/pockets/saga.py
@@ -1,0 +1,523 @@
+# saga.py — Saga-pattern rollback for multi-step pocket write SEQUENCES.
+# Created: 2026-06-01 (RFC 05 Saga Compensate — first pass).
+#
+# WHY THIS EXISTS
+# ---------------
+# `action_executor.run_action` runs exactly ONE write. Three callers use
+# it today — the direct `/actions/run` route, `bulk_dispatch` (the SAME
+# action fanned across N rows, each independent), and the Instinct
+# post-approval re-entry. None of them run a SEQUENCE of DIFFERENT writes
+# where a later failure must undo the earlier successes.
+#
+# A Chain Flow (RFC 13) — or any agent-authored multi-step write flow —
+# does exactly that: step 1 reserves inventory, step 2 charges the card,
+# step 3 confirms the order. If step 3 fails, steps 1+2 are already
+# committed on the backend (inventory held, card charged) and must roll
+# back (release the hold, refund the charge), or the backend is left in an
+# inconsistent state. RFC 05 open question #2 punted CLIENT-side optimistic
+# *UI* rollback as "a flow pattern, not a primitive" — but that is UI state
+# (a checkbox flipping back), NOT backend compensation. This module is the
+# missing server-side concern.
+#
+# THE SAGA PATTERN
+# ----------------
+# Each forward write declares a `compensate:` spec (the inverse write —
+# see `action_executor.CompensateSpec`). `run_action_sequence` runs the
+# steps in order through `run_action`, tracking each completed (FIRED,
+# `ok:true`) write on a stack. On the FIRST failure at step K it stops
+# advancing and fires the compensations for the completed steps
+# 1..K-1 in REVERSE order (K-1, K-2, ..., 1), each as its own
+# `run_action` call against the compensating binding. The backend is left
+# consistent: every committed write is undone, newest-first.
+#
+# DELIBERATE SCOPE (first pass)
+# -----------------------------
+# * `run_action` is NOT modified — it stays a pure single-write executor so
+#   the three existing callers are byte-stable. The saga ORCHESTRATES it.
+# * Compensations fire AUTO (never Instinct-gated): pausing a rollback for
+#   human approval would leave the backend in the inconsistent state the
+#   rollback exists to repair. The forward write's gate is the human
+#   checkpoint; the compensation is automatic cleanup.
+# * A forward step that PARKS (`requires_instinct` → `instinct_pending`)
+#   cannot be part of an AUTO saga — it never fired, so there is nothing to
+#   commit and nothing for a later step to depend on. The saga treats a
+#   parked step as a sequence failure and rolls back the already-committed
+#   steps before it. The "saga over gated forward writes" case (collect all
+#   approvals, THEN fire; or per-step approval mid-saga) is a larger design
+#   recorded as an open question in the RFC.
+# * A compensation that ITSELF fails does NOT abort the rollback — the
+#   remaining compensations still fire (a half-rolled-back saga is worse
+#   than a fully-attempted one). Failed compensations are collected and
+#   surfaced under `compensation_failures` for an operator to reconcile
+#   manually; they are NOT auto-compensated recursively.
+# * A completed step with NO `compensate` spec is recorded as a
+#   `no_compensator` gap (the rollback cannot undo it) rather than silently
+#   dropped — the operator sees exactly what was left committed.
+#
+# OUTCOMES
+# --------
+# A successful compensation whose `CompensateSpec` declares an `outcome`
+# emits a `pocket.outcome` event with `compensated=True` so the audit trail
+# closes and the meter can net the rollback against the forward outcome.
+# Forward-step outcomes are emitted by the saga too (mirroring what the
+# `/actions/run` route does for a single action) so a sequence meters the
+# same as N single calls would.
+#
+# IMPORT-LINTER POSTURE
+# ---------------------
+# This module is impure in the same way `instinct_bridge` is: it calls
+# `outcomes_service.emit_pocket_outcome` (a permitted emitter) but never
+# imports a Beanie document class. Backend creds + the per-step bindings
+# arrive by parameter — `pockets/service.py` owns all Beanie access. The
+# module is added to the `pockets` source_modules list in the import-linter
+# contract so the Beanie-pure invariant is locked.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from pocketpaw_ee.cloud.pockets.action_executor import ActionBinding, run_action
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+
+
+class SagaStep(BaseModel):
+    """One step in a write sequence — a named action plus its resolved call.
+
+    Mirrors the shape the `/actions/run` route resolves for a single
+    action: the action NAME, the raw binding dict from the persisted
+    ``rippleSpec.actions`` block (the executor reads ``method`` /
+    ``compensate`` / governance off it — the client never picks the verb),
+    and the client-resolved ``path`` / ``params`` (Ripple's ``{...}``
+    resolver ran client-side).
+
+    ``idempotency_key`` is optional — a retried saga step carries the same
+    key so the backend can dedupe. The compensation gets its OWN key
+    derived from the step's, so a retried rollback is also dedupable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    action: str = Field(min_length=1)
+    raw_action: dict[str, Any]
+    path: str = Field(min_length=1)
+    params: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+
+class CompensationResult(BaseModel):
+    """The outcome of one compensation attempt (or a recorded gap).
+
+    ``status`` is one of:
+
+    * ``compensated`` — the inverse write fired and returned ``ok:true``.
+    * ``failed`` — the inverse write was attempted but the executor /
+      backend rejected it. The rollback continued with the remaining
+      compensations; this one needs manual reconciliation.
+    * ``no_compensator`` — the completed forward step declared no
+      ``compensate`` spec, so its effect could NOT be undone. The
+      operator sees exactly what was left committed.
+
+    ``response`` carries the executor's full result dict for a fired
+    compensation (``ok`` / ``status`` / ``error`` / ``code``); it is
+    ``None`` for a ``no_compensator`` gap.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    action: str
+    status: str
+    response: dict[str, Any] | None = None
+
+
+class SagaResult(BaseModel):
+    """The frozen outcome of a `run_action_sequence` call.
+
+    ``ok`` is ``True`` only when EVERY step fired successfully — no
+    rollback ran. When ``ok`` is ``False``:
+
+    * ``failed_index`` / ``failed_action`` identify the step that failed.
+    * ``failure`` is that step's executor result dict (why it failed).
+    * ``completed`` lists the action names of the steps that fired before
+      the failure, in execution order (the ones that got compensated).
+    * ``compensations`` lists one ``CompensationResult`` per completed
+      step, in the REVERSE order they fired (rollback order).
+    * ``rolled_back`` is ``True`` when every completed step was
+      successfully compensated; ``False`` when at least one compensation
+      failed or had no compensator (the backend may be partially
+      inconsistent and needs manual attention).
+
+    ``results`` carries every fired forward step's executor result in
+    execution order, for the caller / UI to reconcile.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    ok: bool
+    results: list[dict[str, Any]] = Field(default_factory=list)
+    completed: list[str] = Field(default_factory=list)
+    failed_index: int | None = None
+    failed_action: str | None = None
+    failure: dict[str, Any] | None = None
+    compensations: list[CompensationResult] = Field(default_factory=list)
+    rolled_back: bool = False
+
+    @property
+    def compensation_failures(self) -> list[CompensationResult]:
+        """The compensations that did NOT cleanly undo their step.
+
+        A non-empty list means the backend may be partially inconsistent —
+        an operator should reconcile the listed actions by hand.
+        """
+        return [c for c in self.compensations if c.status != "compensated"]
+
+
+# ---------------------------------------------------------------------------
+# Runtime
+# ---------------------------------------------------------------------------
+
+
+def _is_parked(result: dict[str, Any]) -> bool:
+    """A forward step that routed to Instinct instead of firing."""
+    return result.get("code") == "instinct_pending"
+
+
+def _compensation_idempotency_key(step_key: str | None) -> str | None:
+    """Derive the compensation's idempotency key from the forward step's.
+
+    A retried rollback must carry a STABLE key so the backend dedupes it,
+    but it must DIFFER from the forward write's key (else a backend that
+    deduped the forward POST would drop the compensating POST as a replay).
+    Suffix the forward key with ``:compensate``. ``None`` forward key →
+    ``None`` (the executor mints a fresh server key on each call; a retried
+    rollback then can't be deduped, which is acceptable for a first pass —
+    a compensation is required to be idempotent on the backend side anyway,
+    per the RFC's idempotency contract).
+    """
+    if not step_key:
+        return None
+    return f"{step_key}:compensate"
+
+
+async def run_action_sequence(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    steps: list[SagaStep],
+    base_url: str,
+    auth_type: str,
+    auth_header: str | None,
+    token: str,
+    allowed_writes: list[dict[str, Any]],
+    correlation_id: UUID | None = None,
+    emit_outcomes: bool = True,
+) -> SagaResult:
+    """Run a sequence of write actions with Saga compensation on failure.
+
+    Runs ``steps`` in order through ``action_executor.run_action``. Each
+    step that FIRES (``ok:true``, not parked) is pushed onto a completed
+    stack. On the FIRST failure — an ``ok:false`` result OR a parked
+    (``instinct_pending``) step — advancing stops and the completed steps'
+    compensations fire in REVERSE order.
+
+    Returns a :class:`SagaResult`. ``ok`` is ``True`` iff every step fired;
+    otherwise the result carries the failed step, the completed steps, and
+    one :class:`CompensationResult` per completed step in rollback order.
+
+    The same backend credentials + ``allowed_writes`` apply to every step
+    AND every compensation — a saga is bound to one pocket's one backend.
+    A compensation whose method+path the owner has not allow-listed is
+    rejected at the executor's allowlist gate, surfaced as a ``failed``
+    compensation (the owner must allow-list the inverse write too).
+
+    ``emit_outcomes`` (default ``True``) controls whether forward-step and
+    compensation outcomes are emitted onto the bus. The route sets it
+    ``True`` so a sequence meters like N single calls; a caller that emits
+    outcomes itself (e.g. a future bulk-saga path mirroring
+    ``bulk_dispatch``'s direct emit) passes ``False``.
+    """
+    completed: list[tuple[SagaStep, ActionBinding, dict[str, Any]]] = []
+    results: list[dict[str, Any]] = []
+
+    failed_index: int | None = None
+    failed_action: str | None = None
+    failure: dict[str, Any] | None = None
+
+    for index, step in enumerate(steps):
+        # Parse the binding up front so we have the `compensate` spec and
+        # the `outcome` name in hand for a step that succeeds. A malformed
+        # binding is a step failure (no call fires) — `run_action` would
+        # reject it too, but parsing here lets us record the failed action
+        # cleanly and skip the network round-trip.
+        try:
+            binding = ActionBinding.model_validate(step.raw_action)
+        except ValidationError as exc:
+            failed_index = index
+            failed_action = step.action
+            failure = {
+                "ok": False,
+                "action": step.action,
+                "error": f"action binding is malformed: {exc.errors()!r}",
+                "code": "bad_binding",
+                "on_error": [],
+            }
+            break
+
+        result = await run_action(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            action=step.action,
+            raw_action=step.raw_action,
+            path=step.path,
+            params=step.params,
+            base_url=base_url,
+            auth_type=auth_type,
+            auth_header=auth_header,
+            token=token,
+            allowed_writes=allowed_writes,
+            idempotency_key=step.idempotency_key,
+            correlation_id=correlation_id,
+        )
+        results.append(result)
+
+        if _is_parked(result):
+            # A gated forward write parked instead of firing. It is NOT
+            # committed, so the sequence cannot continue past it — but the
+            # steps BEFORE it ARE committed and must roll back. Treat the
+            # park as a sequence failure (see the open question on gated
+            # forward writes in the RFC).
+            failed_index = index
+            failed_action = step.action
+            failure = result
+            logger.info(
+                "saga on pocket %s: step %d (%s) parked for Instinct — "
+                "rolling back %d completed step(s)",
+                pocket_id,
+                index,
+                step.action,
+                len(completed),
+            )
+            break
+
+        if not result.get("ok"):
+            failed_index = index
+            failed_action = step.action
+            failure = result
+            logger.info(
+                "saga on pocket %s: step %d (%s) failed (code=%s) — "
+                "rolling back %d completed step(s)",
+                pocket_id,
+                index,
+                step.action,
+                result.get("code"),
+                len(completed),
+            )
+            break
+
+        # Fired successfully — record it for possible rollback and emit
+        # its forward outcome (mirrors the single-action route).
+        completed.append((step, binding, result))
+        if emit_outcomes and binding.outcome:
+            await _emit_outcome(
+                outcome=binding.outcome,
+                pocket_id=pocket_id,
+                workspace_id=workspace_id,
+                action=step.action,
+                actor=user_id,
+                compensated=False,
+            )
+    else:
+        # Every step fired — no rollback. Happy path.
+        return SagaResult(ok=True, results=results, completed=[s.action for s, _, _ in completed])
+
+    # ── failure path: compensate the completed steps in REVERSE ─────────
+    compensations = await _compensate(
+        completed=completed,
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        user_id=user_id,
+        base_url=base_url,
+        auth_type=auth_type,
+        auth_header=auth_header,
+        token=token,
+        allowed_writes=allowed_writes,
+        correlation_id=correlation_id,
+        emit_outcomes=emit_outcomes,
+    )
+    rolled_back = all(c.status == "compensated" for c in compensations)
+
+    return SagaResult(
+        ok=False,
+        results=results,
+        completed=[s.action for s, _, _ in completed],
+        failed_index=failed_index,
+        failed_action=failed_action,
+        failure=failure,
+        compensations=compensations,
+        rolled_back=rolled_back,
+    )
+
+
+async def _compensate(
+    *,
+    completed: list[tuple[SagaStep, ActionBinding, dict[str, Any]]],
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    base_url: str,
+    auth_type: str,
+    auth_header: str | None,
+    token: str,
+    allowed_writes: list[dict[str, Any]],
+    correlation_id: UUID | None,
+    emit_outcomes: bool,
+) -> list[CompensationResult]:
+    """Fire the completed steps' compensations in REVERSE order.
+
+    Best-effort: a compensation that fails does NOT stop the rollback —
+    the remaining ones still fire. A completed step with no ``compensate``
+    spec is recorded as a ``no_compensator`` gap. Returns one
+    :class:`CompensationResult` per completed step, in rollback (reverse)
+    order.
+    """
+    compensations: list[CompensationResult] = []
+
+    for step, binding, _fwd_result in reversed(completed):
+        spec = binding.compensate
+        if spec is None:
+            # No declared undo — record the gap so the operator can see
+            # exactly what stayed committed. The backend is NOT consistent.
+            logger.warning(
+                "saga on pocket %s: step '%s' has no compensate spec — "
+                "its effect was NOT rolled back",
+                pocket_id,
+                step.action,
+            )
+            compensations.append(
+                CompensationResult(action=step.action, status="no_compensator", response=None)
+            )
+            continue
+
+        # A compensation IS a write binding. Build its raw_action with NO
+        # `requires_instinct` (it fires AUTO — never parks) and run it
+        # through the same executor + the same allowlist as any write.
+        comp_raw = {
+            "kind": "write_binding",
+            "method": spec.method,
+            "path": spec.path,
+            "params": dict(spec.params),
+        }
+        comp_result = await run_action(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            action=f"{step.action}.compensate",
+            raw_action=comp_raw,
+            path=spec.path,
+            params=dict(spec.params),
+            base_url=base_url,
+            auth_type=auth_type,
+            auth_header=auth_header,
+            token=token,
+            allowed_writes=allowed_writes,
+            idempotency_key=_compensation_idempotency_key(step.idempotency_key),
+            correlation_id=correlation_id,
+        )
+
+        if comp_result.get("ok") and not _is_parked(comp_result):
+            if emit_outcomes and spec.outcome:
+                await _emit_outcome(
+                    outcome=spec.outcome,
+                    pocket_id=pocket_id,
+                    workspace_id=workspace_id,
+                    action=f"{step.action}.compensate",
+                    actor=user_id,
+                    compensated=True,
+                )
+            compensations.append(
+                CompensationResult(
+                    action=step.action, status="compensated", response=dict(comp_result)
+                )
+            )
+        else:
+            # The inverse write was rejected — the rollback continues, but
+            # this leg needs manual reconciliation. Surface it; do NOT
+            # raise (a half-attempted rollback is worse than a fully-
+            # attempted one).
+            logger.warning(
+                "saga on pocket %s: compensation for step '%s' FAILED "
+                "(code=%s) — manual reconciliation needed",
+                pocket_id,
+                step.action,
+                comp_result.get("code"),
+            )
+            compensations.append(
+                CompensationResult(action=step.action, status="failed", response=dict(comp_result))
+            )
+
+    return compensations
+
+
+async def _emit_outcome(
+    *,
+    outcome: str,
+    pocket_id: str,
+    workspace_id: str,
+    action: str,
+    actor: str,
+    compensated: bool,
+) -> None:
+    """Emit a forward or compensating outcome, best-effort.
+
+    Lazy import keeps the saga module's static import surface minimal and
+    avoids a load-time cycle with the outcomes service. ``emit_pocket_outcome``
+    already swallows bus failures, but a wrapper here guards against an
+    import-time failure in an environment where the outcomes module isn't
+    wired (unit tests that mock the cloud bootstrap) so a metering hiccup
+    never breaks the saga's return value.
+    """
+    try:
+        from pocketpaw_ee.cloud.outcomes import service as outcomes_service
+
+        await outcomes_service.emit_pocket_outcome(
+            outcome=outcome,
+            pocket_id=pocket_id,
+            workspace_id=workspace_id,
+            action=action,
+            actor=actor,
+            via_instinct=False,
+            instinct_action_id=None,
+            compensated=compensated,
+        )
+    except Exception:  # noqa: BLE001 — outcome emit must never break the saga
+        logger.warning(
+            "saga outcome emit failed for action=%s pocket=%s (compensated=%s)",
+            action,
+            pocket_id,
+            compensated,
+            exc_info=True,
+        )
+
+
+__all__ = [
+    "CompensationResult",
+    "SagaResult",
+    "SagaStep",
+    "run_action_sequence",
+]

--- a/ee/pocketpaw_ee/cloud/pockets/saga.py
+++ b/ee/pocketpaw_ee/cloud/pockets/saga.py
@@ -1,4 +1,11 @@
 # saga.py — Saga-pattern rollback for multi-step pocket write SEQUENCES.
+# Updated: 2026-06-12 (W2a rebase) — compensations now declare
+#   `instinct_exempt: True` on their built raw_action. W2a flipped
+#   `ActionBinding.requires_instinct` to default True (deny-by-default), so
+#   an undeclared compensation binding would PARK at the gate — a rollback
+#   awaiting human approval is exactly the inconsistent-state hazard this
+#   module exists to prevent. The exemption is the declarative, auditable
+#   W2a mechanism; the forward write's gate remains the human checkpoint.
 # Created: 2026-06-01 (RFC 05 Saga Compensate — first pass).
 #
 # WHY THIS EXISTS
@@ -414,14 +421,19 @@ async def _compensate(
             )
             continue
 
-        # A compensation IS a write binding. Build its raw_action with NO
-        # `requires_instinct` (it fires AUTO — never parks) and run it
-        # through the same executor + the same allowlist as any write.
+        # A compensation IS a write binding. It fires AUTO — never parks:
+        # under W2a deny-by-default it must carry the declarative
+        # `instinct_exempt` flag, because a rollback parked for human
+        # approval would leave the backend in the inconsistent state the
+        # rollback exists to repair. The forward write's gate is the human
+        # checkpoint; the compensation is automatic cleanup. Same executor +
+        # same allowlist as any write.
         comp_raw = {
             "kind": "write_binding",
             "method": spec.method,
             "path": spec.path,
             "params": dict(spec.params),
+            "instinct_exempt": True,
         }
         comp_result = await run_action(
             workspace_id=workspace_id,

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -291,6 +291,12 @@ source_modules = [
     # pure. Both go through ``pockets.service`` only.
     "pocketpaw_ee.cloud.connectors.service",
     "pocketpaw_ee.cloud.connectors.derivation",
+    # RFC 05 Saga Compensate — the multi-step write-sequence rollback
+    # runtime. Orchestrates ``action_executor.run_action`` per step and
+    # fires compensations in reverse on failure; emits outcomes through
+    # ``outcomes.service``. Receives backend creds + bindings by
+    # parameter — never imports a Beanie document class directly.
+    "pocketpaw_ee.cloud.pockets.saga",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",

--- a/tests/cloud/test_pocket_saga.py
+++ b/tests/cloud/test_pocket_saga.py
@@ -119,8 +119,20 @@ def _step(
     outcome: str | None = None,
     idempotency_key: str | None = None,
 ) -> SagaStep:
-    """Build a SagaStep whose raw_action carries an optional compensate spec."""
-    raw: dict = {"kind": "write_binding", "method": method, "path": path, "params": {}}
+    """Build a SagaStep whose raw_action carries an optional compensate spec.
+
+    Steps are built `instinct_exempt` because these tests exercise the saga
+    MECHANICS (ordering, rollback, idempotency) — W2a's deny-by-default
+    would otherwise park every step at the gate. The gated-step test flips
+    the exemption off explicitly to cover the park-then-rollback path.
+    """
+    raw: dict = {
+        "kind": "write_binding",
+        "method": method,
+        "path": path,
+        "params": {},
+        "instinct_exempt": True,
+    }
     if compensate is not None:
         raw["compensate"] = compensate
     if outcome is not None:
@@ -404,9 +416,11 @@ async def test_parked_forward_step_rolls_back_prior_steps(monkeypatch, _capture_
     never fires, so the sequence cannot continue — the prior committed step
     rolls back and the park is the recorded failure."""
     rec = _Recorder({("POST", "/refund"): 200})
-    # step 2 requires instinct → parks before any call.
+    # step 2 requires instinct → parks before any call. Drop the test
+    # default exemption so W2a's gate actually engages.
     gated = _step("charge", "POST", "/charge")
     gated.raw_action["requires_instinct"] = True
+    gated.raw_action["instinct_exempt"] = False
 
     steps = [
         _step("reserve", "POST", "/reserve", compensate={"method": "POST", "path": "/refund"}),

--- a/tests/cloud/test_pocket_saga.py
+++ b/tests/cloud/test_pocket_saga.py
@@ -1,0 +1,489 @@
+# tests/cloud/test_pocket_saga.py — RFC 05 Saga Compensate (first pass).
+# Created: 2026-06-01 — coverage for the multi-step write-SEQUENCE rollback
+# runtime (`ee/pocketpaw_ee/cloud/pockets/saga.py`). No real network: the
+# outbound HTTP that `action_executor.run_action` makes is faked via
+# httpx.MockTransport, and socket.getaddrinfo is monkeypatched so fake
+# hostnames resolve to a public IP (mirrors test_pocket_action_executor.py).
+#
+# CRITICAL TEST-DESIGN NOTE (cross-slice integration, soul lesson
+# 2026-05-26): the saga ORCHESTRATES the real `run_action`. These tests
+# drive the PRODUCTION executor end-to-end — they do NOT stub `run_action`
+# at the saga↔executor seam. A 3-step saga where step 3 fails exercises
+# the real allowlist / SSRF / HTTP path on every forward step AND every
+# compensation, so a doubling / missing-emit bug between the saga and the
+# executor would surface here, not hide behind a mock.
+#
+# What this pins:
+#   - CompensateSpec parses; ActionBinding.compensate parses + defaults None.
+#   - Happy path: every step fires → ok:true, no compensations, forward
+#     outcomes emitted.
+#   - The headline: a 3-step write where step 3 fails fires step 1+2
+#     compensations in REVERSE order, with compensating outcomes emitted.
+#   - A completed step with no `compensate` is a `no_compensator` gap.
+#   - A compensation that itself fails does NOT abort the rollback; it is
+#     surfaced as `failed` and `rolled_back` is False.
+#   - A parked (instinct_pending) forward step is treated as a sequence
+#     failure and the prior committed steps roll back.
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud.pockets import action_executor, source_executor
+from pocketpaw_ee.cloud.pockets.action_executor import ActionBinding, CompensateSpec
+from pocketpaw_ee.cloud.pockets.saga import SagaStep, run_action_sequence
+
+BASE = "https://api.example.com"
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limits():
+    """Clear the executor rate-limit logs between tests."""
+    action_executor._action_log.clear()
+    source_executor._run_log.clear()
+    yield
+    action_executor._action_log.clear()
+    source_executor._run_log.clear()
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    """Make every hostname resolve to a public IP so the DNS guard passes."""
+
+    def _fake_getaddrinfo(host, *_args, **_kwargs):
+        return [(2, 1, 6, "", ("8.8.8.8", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", _fake_getaddrinfo)
+
+
+@pytest.fixture(autouse=True)
+def _capture_outcomes(monkeypatch):
+    """Capture every ``emit_pocket_outcome`` call the saga makes.
+
+    The saga emits forward + compensating outcomes through
+    ``outcomes.service.emit_pocket_outcome``. We patch it on the saga's
+    lazy-import target so the assertions can inspect ``compensated`` per
+    emit without a running bus / ledger. Returns the capture list.
+    """
+    captured: list[dict] = []
+
+    async def _fake_emit(**kwargs):
+        captured.append(kwargs)
+
+    import pocketpaw_ee.cloud.outcomes.service as outcomes_service
+
+    monkeypatch.setattr(outcomes_service, "emit_pocket_outcome", _fake_emit)
+    return captured
+
+
+class _Recorder:
+    """Records each request the executor makes and replies per a route map.
+
+    ``routes`` maps ``(METHOD, path)`` → either an int status or a
+    ``(status, json_body)`` tuple. An unmapped route replies 200 ``{}``.
+    ``calls`` is the ordered list of ``(method, path)`` actually hit — the
+    rollback-order assertions read it.
+    """
+
+    def __init__(self, routes: dict[tuple[str, str], object]):
+        self.routes = routes
+        self.calls: list[tuple[str, str]] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        key = (request.method, request.url.path)
+        self.calls.append(key)
+        spec = self.routes.get(key, 200)
+        if isinstance(spec, tuple):
+            status, body = spec
+            return httpx.Response(status, json=body)
+        return httpx.Response(int(spec), json={})
+
+
+def _patch_transport(monkeypatch, recorder: _Recorder) -> None:
+    """Route the executor's AsyncClient through the recorder's MockTransport."""
+    real_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(recorder.handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(action_executor.httpx, "AsyncClient", _factory)
+
+
+def _step(
+    action: str,
+    method: str,
+    path: str,
+    *,
+    compensate: dict | None = None,
+    outcome: str | None = None,
+    idempotency_key: str | None = None,
+) -> SagaStep:
+    """Build a SagaStep whose raw_action carries an optional compensate spec."""
+    raw: dict = {"kind": "write_binding", "method": method, "path": path, "params": {}}
+    if compensate is not None:
+        raw["compensate"] = compensate
+    if outcome is not None:
+        raw["outcome"] = outcome
+    return SagaStep(
+        action=action,
+        raw_action=raw,
+        path=path,
+        params={},
+        idempotency_key=idempotency_key,
+    )
+
+
+# A three-rule allowlist covering the forward writes AND their inverses.
+_ALLOW = [
+    {"method": "POST", "path_pattern": "/reserve"},
+    {"method": "DELETE", "path_pattern": "/reserve/*"},
+    {"method": "POST", "path_pattern": "/charge"},
+    {"method": "POST", "path_pattern": "/refund"},
+    {"method": "POST", "path_pattern": "/confirm"},
+]
+
+
+async def _run(steps, monkeypatch, recorder, **overrides):
+    """Drive `run_action_sequence` against the recorder's backend."""
+    _patch_transport(monkeypatch, recorder)
+    kwargs = dict(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        steps=steps,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_ALLOW,
+    )
+    kwargs.update(overrides)
+    return await run_action_sequence(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_compensate_spec_parses():
+    spec = CompensateSpec.model_validate(
+        {"method": "POST", "path": "/refund", "params": {"id": 7}, "outcome": "refunded"}
+    )
+    assert spec.method == "POST"
+    assert spec.path == "/refund"
+    assert spec.params == {"id": 7}
+    assert spec.outcome == "refunded"
+
+
+def test_compensate_spec_rejects_non_write_verb():
+    with pytest.raises(Exception):
+        CompensateSpec.model_validate({"method": "GET", "path": "/x"})
+
+
+def test_action_binding_parses_compensate():
+    binding = ActionBinding.model_validate(
+        {
+            "kind": "write_binding",
+            "method": "POST",
+            "path": "/charge",
+            "compensate": {"method": "POST", "path": "/refund", "outcome": "refunded"},
+        }
+    )
+    assert binding.compensate is not None
+    assert binding.compensate.method == "POST"
+    assert binding.compensate.path == "/refund"
+    assert binding.compensate.outcome == "refunded"
+
+
+def test_action_binding_compensate_defaults_none():
+    binding = ActionBinding.model_validate(
+        {"kind": "write_binding", "method": "POST", "path": "/charge"}
+    )
+    assert binding.compensate is None
+
+
+# ---------------------------------------------------------------------------
+# Happy path — every step fires, no rollback
+# ---------------------------------------------------------------------------
+
+
+async def test_all_steps_succeed_no_compensation(monkeypatch, _capture_outcomes):
+    rec = _Recorder({})  # everything 200
+    steps = [
+        _step("reserve", "POST", "/reserve", compensate={"method": "DELETE", "path": "/reserve/1"}),
+        _step("charge", "POST", "/charge", compensate={"method": "POST", "path": "/refund"}),
+        _step("confirm", "POST", "/confirm"),
+    ]
+    result = await _run(steps, monkeypatch, rec)
+
+    assert result.ok is True
+    assert result.completed == ["reserve", "charge", "confirm"]
+    assert result.compensations == []
+    assert result.rolled_back is False  # nothing to roll back
+    # Only the three forward writes fired — no compensations.
+    assert rec.calls == [("POST", "/reserve"), ("POST", "/charge"), ("POST", "/confirm")]
+
+
+async def test_forward_outcomes_emitted_on_success(monkeypatch, _capture_outcomes):
+    rec = _Recorder({})
+    steps = [
+        _step("reserve", "POST", "/reserve", outcome="reserved"),
+        _step("charge", "POST", "/charge", outcome="charged"),
+    ]
+    result = await _run(steps, monkeypatch, rec)
+
+    assert result.ok is True
+    emitted = [(c["outcome"], c["compensated"]) for c in _capture_outcomes]
+    assert emitted == [("reserved", False), ("charged", False)]
+
+
+# ---------------------------------------------------------------------------
+# THE HEADLINE — step 3 fails → step 1+2 compensations fire in REVERSE
+# ---------------------------------------------------------------------------
+
+
+async def test_step3_failure_fires_step1_and_2_compensations_in_reverse(
+    monkeypatch, _capture_outcomes
+):
+    """A 3-step write where step 3 fails (backend 500) rolls back steps 1+2
+    by firing their compensations newest-first (step 2's, then step 1's),
+    with compensating outcomes emitted."""
+    rec = _Recorder(
+        {
+            # forward writes 1+2 succeed; step 3 fails with a backend 500.
+            ("POST", "/confirm"): 500,
+            # compensations succeed.
+            ("POST", "/refund"): 200,
+            ("DELETE", "/reserve/1"): 200,
+        }
+    )
+    steps = [
+        _step(
+            "reserve",
+            "POST",
+            "/reserve",
+            compensate={
+                "method": "DELETE",
+                "path": "/reserve/1",
+                "outcome": "reservation_released",
+            },
+            outcome="reserved",
+        ),
+        _step(
+            "charge",
+            "POST",
+            "/charge",
+            compensate={"method": "POST", "path": "/refund", "outcome": "charge_refunded"},
+            outcome="charged",
+        ),
+        _step("confirm", "POST", "/confirm"),
+    ]
+    result = await _run(steps, monkeypatch, rec)
+
+    # Sequence failed at step 3.
+    assert result.ok is False
+    assert result.failed_index == 2
+    assert result.failed_action == "confirm"
+    assert result.failure["code"] == "http_error"
+    assert result.completed == ["reserve", "charge"]
+
+    # Compensations fired for the two completed steps, in REVERSE order:
+    # charge first (newest), then reserve.
+    assert [c.action for c in result.compensations] == ["charge", "reserve"]
+    assert all(c.status == "compensated" for c in result.compensations)
+    assert result.rolled_back is True
+    assert result.compensation_failures == []
+
+    # The ACTUAL backend call order proves reverse compensation: the two
+    # forward writes, the failed confirm, then refund (charge's inverse),
+    # then DELETE /reserve/1 (reserve's inverse) — newest-committed first.
+    assert rec.calls == [
+        ("POST", "/reserve"),
+        ("POST", "/charge"),
+        ("POST", "/confirm"),
+        ("POST", "/refund"),
+        ("DELETE", "/reserve/1"),
+    ]
+
+    # Outcomes: forward `reserved` + `charged` (compensated=False), then the
+    # compensating `charge_refunded` + `reservation_released` (compensated=True),
+    # in rollback order.
+    emitted = [(c["outcome"], c["compensated"]) for c in _capture_outcomes]
+    assert emitted == [
+        ("reserved", False),
+        ("charged", False),
+        ("charge_refunded", True),
+        ("reservation_released", True),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Edge: a completed step with no compensate spec → no_compensator gap
+# ---------------------------------------------------------------------------
+
+
+async def test_step_without_compensator_records_gap(monkeypatch, _capture_outcomes):
+    """When a completed step has no `compensate`, the rollback records a
+    `no_compensator` gap (the backend is left partially inconsistent) and
+    `rolled_back` is False."""
+    rec = _Recorder({("POST", "/confirm"): 500, ("POST", "/refund"): 200})
+    steps = [
+        # step 1 has NO compensate spec.
+        _step("reserve", "POST", "/reserve"),
+        _step("charge", "POST", "/charge", compensate={"method": "POST", "path": "/refund"}),
+        _step("confirm", "POST", "/confirm"),
+    ]
+    result = await _run(steps, monkeypatch, rec)
+
+    assert result.ok is False
+    assert result.completed == ["reserve", "charge"]
+    # charge compensated; reserve has no compensator.
+    by_action = {c.action: c.status for c in result.compensations}
+    assert by_action == {"charge": "compensated", "reserve": "no_compensator"}
+    assert result.rolled_back is False  # the gap means not fully rolled back
+    failures = result.compensation_failures
+    assert [c.action for c in failures] == ["reserve"]
+
+    # Only charge's inverse (refund) actually hit the backend — there is no
+    # inverse for reserve to fire.
+    assert ("POST", "/refund") in rec.calls
+    assert ("DELETE", "/reserve/1") not in rec.calls
+
+
+# ---------------------------------------------------------------------------
+# Edge: a compensation that itself fails → rollback continues, surfaced
+# ---------------------------------------------------------------------------
+
+
+async def test_failed_compensation_does_not_abort_rollback(monkeypatch, _capture_outcomes):
+    """If step 2's compensation itself fails, the rollback STILL fires step
+    1's compensation — a half-rolled-back saga is worse than a fully-
+    attempted one. The failed leg is surfaced; `rolled_back` is False."""
+    rec = _Recorder(
+        {
+            ("POST", "/confirm"): 500,  # step 3 fails
+            ("POST", "/refund"): 500,  # charge's compensation ALSO fails
+            ("DELETE", "/reserve/1"): 200,  # reserve's compensation succeeds
+        }
+    )
+    steps = [
+        _step(
+            "reserve",
+            "POST",
+            "/reserve",
+            compensate={"method": "DELETE", "path": "/reserve/1"},
+        ),
+        _step("charge", "POST", "/charge", compensate={"method": "POST", "path": "/refund"}),
+        _step("confirm", "POST", "/confirm"),
+    ]
+    result = await _run(steps, monkeypatch, rec)
+
+    assert result.ok is False
+    by_action = {c.action: c.status for c in result.compensations}
+    assert by_action == {"charge": "failed", "reserve": "compensated"}
+    assert result.rolled_back is False
+    assert [c.action for c in result.compensation_failures] == ["charge"]
+
+    # Both compensations were ATTEMPTED despite charge's failing — reserve's
+    # DELETE still fired after refund failed.
+    assert ("POST", "/refund") in rec.calls
+    assert ("DELETE", "/reserve/1") in rec.calls
+    # Order: refund (attempted, failed) came before the reserve DELETE.
+    assert rec.calls.index(("POST", "/refund")) < rec.calls.index(("DELETE", "/reserve/1"))
+
+
+# ---------------------------------------------------------------------------
+# Edge: a parked (instinct) forward step → treated as failure, prior rolls back
+# ---------------------------------------------------------------------------
+
+
+async def test_parked_forward_step_rolls_back_prior_steps(monkeypatch, _capture_outcomes):
+    """A forward step that PARKS (`requires_instinct` → instinct_pending)
+    never fires, so the sequence cannot continue — the prior committed step
+    rolls back and the park is the recorded failure."""
+    rec = _Recorder({("POST", "/refund"): 200})
+    # step 2 requires instinct → parks before any call.
+    gated = _step("charge", "POST", "/charge")
+    gated.raw_action["requires_instinct"] = True
+
+    steps = [
+        _step("reserve", "POST", "/reserve", compensate={"method": "POST", "path": "/refund"}),
+        gated,
+    ]
+    result = await _run(steps, monkeypatch, rec)
+
+    assert result.ok is False
+    assert result.failed_action == "charge"
+    assert result.failure["code"] == "instinct_pending"
+    assert result.completed == ["reserve"]
+    # reserve rolled back via its compensation.
+    assert [c.action for c in result.compensations] == ["reserve"]
+    assert result.compensations[0].status == "compensated"
+    assert result.rolled_back is True
+
+    # /charge never hit the backend (it parked); reserve + its refund did.
+    assert ("POST", "/charge") not in rec.calls
+    assert ("POST", "/reserve") in rec.calls
+    assert ("POST", "/refund") in rec.calls
+
+
+# ---------------------------------------------------------------------------
+# Edge: first step fails → nothing committed, nothing to compensate
+# ---------------------------------------------------------------------------
+
+
+async def test_first_step_failure_compensates_nothing(monkeypatch, _capture_outcomes):
+    rec = _Recorder({("POST", "/reserve"): 500})
+    steps = [
+        _step("reserve", "POST", "/reserve", compensate={"method": "POST", "path": "/refund"}),
+        _step("charge", "POST", "/charge", compensate={"method": "POST", "path": "/refund"}),
+    ]
+    result = await _run(steps, monkeypatch, rec)
+
+    assert result.ok is False
+    assert result.failed_index == 0
+    assert result.completed == []
+    assert result.compensations == []
+    # Only the failed first write fired; charge never ran, no compensation.
+    assert rec.calls == [("POST", "/reserve")]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: a compensation carries a derived, distinct idempotency key
+# ---------------------------------------------------------------------------
+
+
+async def test_compensation_idempotency_key_is_derived_and_distinct(monkeypatch, _capture_outcomes):
+    """A forward step's idempotency key suffixes ``:compensate`` on its
+    compensation so a retried rollback dedupes without colliding with the
+    forward write's key on the backend."""
+    seen: list[tuple[str, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.url.path, request.headers.get("Idempotency-Key")))
+        # Step 2 fails so step 1 compensates.
+        if request.url.path == "/charge":
+            return httpx.Response(500, json={})
+        return httpx.Response(200, json={})
+
+    rec = _Recorder({})
+    rec.handler = handler  # type: ignore[method-assign]
+
+    steps = [
+        _step(
+            "reserve",
+            "POST",
+            "/reserve",
+            compensate={"method": "POST", "path": "/refund"},
+            idempotency_key="key-reserve",
+        ),
+        _step("charge", "POST", "/charge"),
+    ]
+    await _run(steps, monkeypatch, rec)
+
+    keys = dict(seen)
+    assert keys["/reserve"] == "key-reserve"
+    # The compensation's key is the forward key + ":compensate".
+    assert keys["/refund"] == "key-reserve:compensate"


### PR DESCRIPTION
## What this does

A single pocket write fires or it doesn't. But an agent-authored flow often performs several writes in a row — reserve inventory, charge the card, confirm the order. If a later step fails, the earlier writes are already committed on the backend (inventory held, card charged). No client-side state rollback can undo a real charge.

This adds the Saga pattern: each action can declare the inverse write that undoes it, and a server-side runtime rolls the completed writes back in reverse order when a sequence fails partway.

This is the orthogonal complement to RFC 05 open question #2, which resolved *client-side optimistic UI* rollback as "a flow pattern, not a primitive." That stands — it's about a checkbox flipping back in the browser. This is the backend concern: committed writes undone with real inverse writes, orchestrated server-side.

## The design

**The `compensate` field.** A forward action gains an optional `compensate` spec — `{method, path, params, outcome?}`, the inverse write:

```yaml
actions:
  charge_card:
    method: POST
    path: /payments/charge
    outcome: payment_captured
    compensate:
      method: POST
      path: /payments/refund
      outcome: payment_refunded
```

A compensation is a write binding — same executor, same gates (allowlist, SSRF, rate limit). The owner must allow-list the inverse write's method+path too, or the rollback is rejected at the gate. Two fields are deliberately absent from a `compensate` spec: no `requires_instinct` (compensations fire automatically) and no nested `compensate` (a failed compensation is surfaced, not auto-compensated recursively).

**The rollback runtime.** `pockets/saga.py:run_action_sequence` orchestrates the existing single-write executor:

1. Run each step in order via `action_executor.run_action`; push every step that fires onto a completed stack and emit its forward outcome.
2. On the first failure — an `ok:false` result or a step that parks for Instinct — stop advancing.
3. Fire the completed steps' compensations in reverse order (newest-committed first).
4. A successful compensation that declares an outcome emits `pocket.outcome` with `compensated: true` so the meter can net the rollback against the forward outcome.

```
reserve OK   charge OK   confirm FAIL    <- step 3 fails
                             |
                             v  roll back, newest-first
                 refund (charge inverse) -> release (reserve inverse)
```

**The executor is not modified.** It stays a pure single-write primitive, so the three existing callers (the direct `/actions/run` route, bulk fan-out, the Instinct post-approval re-entry) are byte-stable. The saga is a wrapper.

## Decisions worth a look

- **Compensations fire automatically, never Instinct-gated.** Pausing a rollback for human approval would leave the backend in the inconsistent state the rollback exists to repair. The human checkpoint belongs on the forward write.
- **A parked forward write is treated as a sequence failure.** A `requires_instinct` forward step parks instead of firing, so it never commits. The saga rolls back the steps committed before it.
- **A compensation that itself fails doesn't abort the rollback.** The remaining compensations still fire; the failed leg lands in `SagaResult.compensation_failures` for manual reconciliation. `rolled_back` is true only when every completed step was cleanly compensated.
- **A step with no compensator is a recorded gap,** not a silent drop — so an operator sees exactly what stayed committed.
- **Idempotency:** a compensation's key is the forward step's key suffixed `:compensate`, so a retried rollback dedupes without colliding with the forward write.

## Open questions for review

1. **Saga over Instinct-gated forward writes.** A gated forward write can't be part of an automatic saga (it parks). A real "approve the whole sequence, then fire atomically" flow needs the Instinct surface to model a multi-action approval. Deferred.
2. **Who assembles the sequence?** This ships the field + the runtime, not the call site that builds a multi-step write sequence. Chain Flow (RFC 13) is the natural driver, but the handoff isn't wired yet.
3. **Compensation retry / dead-letter.** A failed compensation is surfaced, not retried. A bounded-retry + dead-letter policy is future work.

## Tests

`tests/cloud/test_pocket_saga.py` (12 tests) drives the real executor end to end — no stub at the saga/executor seam — so a doubling or missing-emit bug would surface here. Covers the headline 3-step-with-reverse-rollback case, the no-compensator gap, a failed compensation, a parked forward step, idempotency-key derivation, and the happy path.

```
tests/cloud/test_pocket_saga.py ............ 12 passed
```

Full sweep across the touched modules (executor, outcomes, instinct bridge, bulk dispatch, decision-event paths): 107 passed. The only failures in the outcomes route suite (`test_get_outcomes_counts`, `test_get_outcomes_rejects_workspace_id_query`) are a pre-existing 401 auth-fixture issue on `dev`, confirmed unrelated. `ruff check` + `ruff format` clean; `mypy` clean on the new module; all 22 import-linter contracts kept (the new `saga.py` stays Beanie-pure).

## Docs

`docs/concepts/pocket-write-actions.mdx` gains a Saga Compensation section. The canonical RFC 05 amendment (a new M3 section + open questions) lands in the `paw-workspace` repo at `docs/rfc/05-pocket-write-actions.md` — a sibling change, since the RFC lives in a different repo.

## Scope

Tight by design: the `compensate` field, the rollback runtime, the `compensated` outcome flag, and the tests. No call site that assembles a sequence yet — that's a follow-up.