### PR TITLE
Livekit meeting bugs fixes

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -546,6 +546,16 @@ class CallEnded(Event):
     EVENT_TYPE: ClassVar[str] = "call.ended"
 
 
+@dataclass
+class CallParticipantJoined(Event):
+    EVENT_TYPE: ClassVar[str] = "call.participant_joined"
+
+
+@dataclass
+class CallParticipantLeft(Event):
+    EVENT_TYPE: ClassVar[str] = "call.participant_left"
+
+
 # Meetings — scheduled group meeting lifecycle
 @dataclass
 class MeetingScheduled(Event):

--- a/ee/pocketpaw_ee/cloud/livekit/router.py
+++ b/ee/pocketpaw_ee/cloud/livekit/router.py
@@ -175,7 +175,7 @@ async def create_room(
     group = await _get_group_domain_or_404(body.group_id)
     _require_domain_group_member(group, str(user.id))
 
-    result = await livekit_service.create_room(body.group_id)
+    result = await livekit_service.create_room(body.group_id, workspace_id, str(user.id))
 
     # Only emit call.started when the room was actually created (not when
     # someone joins an existing room). The is_new flag is set atomically
@@ -284,7 +284,7 @@ async def end_call(
     group = await _get_group_domain_or_404(group_id)
     _require_domain_group_member(group, str(user.id))
 
-    result = await livekit_service.end_room(group_id)
+    result = await livekit_service.end_room(group_id, workspace_id)
 
     # Emit realtime event so group members know the call ended
     try:

--- a/ee/pocketpaw_ee/cloud/livekit/router.py
+++ b/ee/pocketpaw_ee/cloud/livekit/router.py
@@ -28,7 +28,12 @@ from pocketpaw_ee.cloud.chat.group_service import (
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.livekit import service as livekit_service
 from pocketpaw_ee.cloud.realtime.emit import emit
-from pocketpaw_ee.cloud.realtime.events import CallEnded, CallStarted
+from pocketpaw_ee.cloud.realtime.events import (
+    CallEnded,
+    CallParticipantJoined,
+    CallParticipantLeft,
+    CallStarted,
+)
 from pocketpaw_ee.cloud.shared.deps import current_user, current_workspace_id
 
 logger = logging.getLogger(__name__)
@@ -231,6 +236,23 @@ async def generate_token(
         can_subscribe=body.can_subscribe,
         ttl_seconds=body.ttl_seconds,
     )
+
+    # Notify group members that someone joined the call.
+    if gid:
+        try:
+            await emit(
+                CallParticipantJoined(
+                    data={
+                        "group_id": gid,
+                        "room_name": body.room_name,
+                        "identity": body.identity,
+                        "name": display_name,
+                    }
+                )
+            )
+        except Exception:
+            pass
+
     return TokenResponse(
         token=token,
         url=livekit_service.LIVEKIT_URL,
@@ -265,6 +287,29 @@ async def get_room_info(
             participants=[],
         )
     return RoomInfoResponse(**info)
+
+
+@router.post("/rooms/{group_id}/leave")
+async def leave_call(
+    group_id: str,
+    user=Depends(current_user),
+):
+    """Notify that a participant left a call without ending it."""
+    gid = group_id
+    try:
+        await emit(
+            CallParticipantLeft(
+                data={
+                    "group_id": gid,
+                    "room_name": livekit_service.room_name_for_group(gid),
+                    "identity": str(user.id),
+                    "name": user.full_name or str(user.id),
+                }
+            )
+        )
+    except Exception:
+        pass
+    return {"ok": True}
 
 
 @router.delete("/rooms/{group_id}")

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -23,7 +23,12 @@ from livekit.protocol.room import (
 )
 
 from pocketpaw_ee.cloud._core.realtime.emit import emit
-from pocketpaw_ee.cloud._core.realtime.events import CallEnded, CallNotesPosted, CallStarted
+from pocketpaw_ee.cloud._core.realtime.events import (
+    CallEnded,
+    CallNotesPosted,
+    CallStarted,
+    MessageNew,
+)
 from pocketpaw_ee.cloud.models.meeting import Meeting as MeetingDoc
 from pocketpaw_ee.cloud.models.meeting import MeetingTranscript
 
@@ -899,6 +904,22 @@ async def post_meeting_notes_to_group(
                 }
             )
         )
+        await emit(
+            MessageNew(
+                data={
+                    "group": group_id,
+                    "group_id": group_id,
+                    "sender": CALL_BOT_USER_ID,
+                    "senderName": "Meeting Notes",
+                    "senderType": "user",
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "message_id": domain_msg.id,
+                    "_id": domain_msg.id,
+                    "content": content,
+                    "mentions": [],
+                }
+            )
+        )
         logger.info("Posted meeting notes to group %s (message %s)", group_id, domain_msg.id)
     except Exception as exc:
         logger.error("Failed to post meeting notes to group %s: %s", group_id, exc)
@@ -907,8 +928,6 @@ async def post_meeting_notes_to_group(
     # Store transcript as a file and create MeetingTranscript doc.
     if workspace_id and transcript:
         try:
-            from datetime import UTC
-
             from pocketpaw_ee.cloud.meetings.events import MeetingTranscriptReady
             from pocketpaw_ee.cloud.uploads.service import write_text_file
 

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -25,6 +25,7 @@ from livekit.protocol.room import (
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import CallEnded, CallNotesPosted, CallStarted
 from pocketpaw_ee.cloud.models.meeting import Meeting as MeetingDoc
+from pocketpaw_ee.cloud.models.meeting import MeetingTranscript
 
 logger = logging.getLogger(__name__)
 
@@ -235,6 +236,7 @@ async def _collect_agent_notes(
 async def _reap_agent_process(
     group_id: str,
     proc: asyncio.subprocess.Process,
+    workspace_id: str = "",
 ) -> None:
     """Wait for an agent subprocess to finish, then clean up the registry.
 
@@ -280,6 +282,7 @@ async def _reap_agent_process(
                 action_items=payload.get("action_items", []),
                 participants=payload.get("participants", []),
                 duration_seconds=payload.get("duration_seconds", 0),
+                workspace_id=workspace_id,
             )
             logger.info("Posted meeting notes for group %s from agent payload", group_id)
         except Exception:
@@ -634,7 +637,7 @@ async def create_room(
 
         # Background task: wait for the subprocess to finish, then clean
         # up the registry so we don't leak agent references.
-        asyncio.create_task(_reap_agent_process(group_id, proc))
+        asyncio.create_task(_reap_agent_process(group_id, proc, workspace_id))
 
         logger.info("Started meeting agent subprocess for group %s (room %s)", group_id, room_name)
 
@@ -722,6 +725,7 @@ async def end_room(group_id: str, workspace_id: str = "") -> dict[str, Any]:
                 action_items=payload.get("action_items", []),
                 participants=payload.get("participants", []),
                 duration_seconds=payload.get("duration_seconds", 0),
+                workspace_id=workspace_id,
             )
             logger.info("Posted meeting notes for group %s (end_room)", group_id)
         except Exception as exc:
@@ -822,12 +826,15 @@ async def post_meeting_notes_to_group(
     action_items: list[str],
     participants: list[str],
     duration_seconds: int,
+    workspace_id: str = "",
 ) -> None:
     """Post meeting notes to a group after a call ends.
 
     Creates a system message directly (bypassing membership check since the
     call-bot is not a group member) and emits a real-time event so all
-    group members see it.
+    group members see it. Also stores the transcript as a file and creates
+    a MeetingTranscript record so the meeting detail in /meetings can
+    display the transcript.
     """
     lines = [
         "📋 **Meeting Notes**",
@@ -896,6 +903,71 @@ async def post_meeting_notes_to_group(
     except Exception as exc:
         logger.error("Failed to post meeting notes to group %s: %s", group_id, exc)
         raise
+
+    # Store transcript as a file and create MeetingTranscript doc.
+    if workspace_id and transcript:
+        try:
+            from datetime import UTC
+
+            from pocketpaw_ee.cloud.meetings.events import MeetingTranscriptReady
+            from pocketpaw_ee.cloud.uploads.service import write_text_file
+
+            room_name = room_name_for_group(group_id)
+            meeting = await MeetingDoc.find_one(
+                MeetingDoc.workspace == workspace_id,
+                MeetingDoc.provider_meeting_id == room_name,
+                MeetingDoc.source == "livekit",
+            )
+            if meeting is None:
+                return
+
+            safe_title = (meeting.title or "call").replace("/", "-")[:80]
+            file_rec = await write_text_file(
+                workspace_id=workspace_id,
+                owner_id=meeting.created_by_user_id or "system",
+                folder_path="/transcripts",
+                filename=f"{safe_title}-transcript.vtt",
+                content=transcript,
+                mime="text/vtt",
+            )
+
+            import re as _re
+
+            cue_count = transcript.count("\n--> ") + transcript.count(" --> ")
+            # For plain-text transcripts (no VTT cues), fall back to line count
+            entry_count = max(cue_count, 1) if transcript.strip() else 0
+            speaker_count = len({m.group(1) for m in _re.finditer(r"<v\s+([^>]+)>", transcript)})
+
+            transcript_doc = MeetingTranscript(
+                workspace=workspace_id,
+                meeting_id=str(meeting.id),
+                provider_transcript_id=room_name,
+                file_id=file_rec.id,
+                entry_count=entry_count,
+                speaker_count=speaker_count,
+                language=None,
+                fetched_at=datetime.now(UTC),
+                indexed_in_kb=False,
+                kb_indexed_version=1,
+            )
+            await transcript_doc.insert()
+
+            await emit(
+                MeetingTranscriptReady(
+                    data={
+                        "workspace_id": workspace_id,
+                        "meeting_id": str(meeting.id),
+                        "source": "livekit",
+                        "file_id": file_rec.id,
+                        "entry_count": entry_count,
+                        "speaker_count": speaker_count,
+                        "language": None,
+                    }
+                )
+            )
+            logger.info("Stored transcript for meeting %s (%d cues)", meeting.id, cue_count)
+        except Exception as exc:
+            logger.warning("Failed to store transcript: %s", exc)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -24,6 +24,7 @@ from livekit.protocol.room import (
 
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import CallEnded, CallNotesPosted, CallStarted
+from pocketpaw_ee.cloud.models.meeting import Meeting as MeetingDoc
 
 logger = logging.getLogger(__name__)
 
@@ -522,7 +523,11 @@ async def get_recording_info(group_id: str) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
-async def create_room(group_id: str) -> dict[str, Any]:
+async def create_room(
+    group_id: str,
+    workspace_id: str = "",
+    user_id: str = "",
+) -> dict[str, Any]:
     """Create a LiveKit room for a group call.
 
     Returns room metadata including the room name and the admin token.
@@ -530,7 +535,9 @@ async def create_room(group_id: str) -> dict[str, Any]:
     Automatically starts the meeting notes agent for this room.
 
     The returned dict includes an ``is_new`` boolean indicating whether
-    the room was just created or already existed.
+    the room was just created or already existed. When a new room is
+    created, a ``Meeting`` document is also persisted so the call
+    appears in the scheduled meetings sidebar as "Live".
     """
     _ensure_configured()
 
@@ -556,6 +563,47 @@ async def create_room(group_id: str) -> dict[str, Any]:
             is_new = True
         else:
             logger.info("LiveKit room %s already exists for group %s", room_name, group_id)
+
+    # Persist a Meeting document when a new room is created so the
+    # call shows up in the scheduled meetings sidebar as "Live".
+    if is_new and workspace_id:
+        try:
+            now = datetime.now(UTC)
+            meeting = MeetingDoc(
+                workspace=workspace_id,
+                source="livekit",
+                provider=None,
+                provider_meeting_id=room_name,
+                title="Instant call",
+                join_url="",
+                scheduled_start=now,
+                scheduled_end=None,
+                actual_start=now,
+                status="in_progress",
+                participants=[],
+                recording_file_ids=[],
+                raw_provider_payload={"group_id": group_id},
+                created_by_user_id=user_id or None,
+            )
+            await meeting.insert()
+            logger.info("Created Meeting doc for instant call in group %s", group_id)
+
+            # Emit meeting.started so other clients pick it up
+            from pocketpaw_ee.cloud.meetings.events import MeetingStarted
+
+            await emit(
+                MeetingStarted(
+                    data={
+                        "workspace_id": workspace_id,
+                        "meeting_id": str(meeting.id),
+                        "source": "livekit",
+                        "group_id": group_id,
+                    }
+                )
+            )
+            logger.info("Emitted meeting.started for instant call in group %s", group_id)
+        except Exception as exc:
+            logger.warning("Failed to create Meeting doc for instant call: %s", exc)
 
     # Generate a subscriber-only token for the call bot (no agent flag
     # so it auto-subscribes to remote tracks for transcription).
@@ -635,11 +683,13 @@ async def generate_participant_token(
     )
 
 
-async def end_room(group_id: str) -> dict[str, Any]:
+async def end_room(group_id: str, workspace_id: str = "") -> dict[str, Any]:
     """End an active call by deleting the LiveKit room.
 
     When the room is deleted, all participants are disconnected and the
     call bot's cleanup logic (posting meeting notes) is triggered.
+    Also transitions the associated Meeting document to ``ended`` so
+    the call shows as "Over" in the scheduled meetings sidebar.
     """
     _ensure_configured()
 
@@ -691,6 +741,24 @@ async def end_room(group_id: str) -> dict[str, Any]:
                 raise
 
     await emit(CallEnded(data={"group_id": group_id, "room_name": room_name}))
+
+    # Transition the Meeting doc to ended so the call shows as "Over".
+    if workspace_id:
+        try:
+            now = datetime.now(UTC)
+            meeting = await MeetingDoc.find_one(
+                MeetingDoc.workspace == workspace_id,
+                MeetingDoc.provider_meeting_id == room_name,
+                MeetingDoc.source == "livekit",
+                MeetingDoc.status == "in_progress",
+            )
+            if meeting is not None:
+                meeting.status = "ended"
+                meeting.actual_end = now
+                await meeting.save()
+                logger.info("Marked Meeting %s as ended for group %s", meeting.id, group_id)
+        except Exception as exc:
+            logger.warning("Failed to end Meeting for group %s: %s", group_id, exc)
 
     return {
         "room_name": room_name,

--- a/ee/pocketpaw_ee/cloud/meetings/dto.py
+++ b/ee/pocketpaw_ee/cloud/meetings/dto.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 MeetingSourceName = Literal["recall", "livekit"]
 MeetingProviderName = Literal["google_meet", "zoom"]
@@ -85,6 +85,24 @@ class MeetingResponse(BaseModel):
     # don't originate from a calendar event.
     calendar_event_id: str | None = None
 
+    # ── Force UTC serialization ───────────────────────────────────────
+    # Backend stores all datetimes as naive (timezone-unaware) UTC values.
+    # Pydantic's default JSON serialisation omits the timezone suffix,
+    # making JS `new Date()` interpret them as LOCAL time instead of UTC.
+    # Appending 'Z' ensures every consumer correctly treats them as UTC.
+    @field_serializer(
+        "scheduled_start",
+        "scheduled_end",
+        "actual_start",
+        "actual_end",
+        "created_at",
+        "bot_status_at",
+    )
+    def _serialize_dt(v: datetime | None) -> str | None:
+        if v is None:
+            return None
+        return v.isoformat() + "Z"
+
 
 class MeetingDetailResponse(MeetingResponse):
     """GET /meetings/{id} — includes the full participants snapshot."""
@@ -107,6 +125,12 @@ class TranscriptResponse(BaseModel):
     language: str | None
     fetched_at: datetime | None
     indexed_in_kb: bool
+
+    @field_serializer("fetched_at")
+    def _serialize_fetched_at(v: datetime | None) -> str | None:
+        if v is None:
+            return None
+        return v.isoformat() + "Z"
 
 
 # ---------------------------------------------------------------------------
@@ -148,6 +172,12 @@ class CredentialsResponse(BaseModel):
     has_credentials: bool
     last_validated_at: datetime | None = None
     last_error: str = ""
+
+    @field_serializer("last_validated_at")
+    def _serialize_validated_at(v: datetime | None) -> str | None:
+        if v is None:
+            return None
+        return v.isoformat() + "Z"
 
 
 class GoogleMeetAuthUrlResponse(BaseModel):

--- a/ee/pocketpaw_ee/cloud/meetings/router.py
+++ b/ee/pocketpaw_ee/cloud/meetings/router.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.meetings import service as meetings_service
@@ -278,6 +278,12 @@ class BotStatusResponseDTO(BaseModel):
     status_detail: str | None = None
     status_at: datetime | None = None
     summary: str
+
+    @field_serializer("status_at")
+    def _serialize_status_at(v: datetime | None) -> str | None:
+        if v is None:
+            return None
+        return v.isoformat() + "Z"
 
 
 @router.get("/{meeting_id}/bot", response_model=BotStatusResponseDTO)

--- a/ee/pocketpaw_ee/cloud/meetings/scheduling/reminders.py
+++ b/ee/pocketpaw_ee/cloud/meetings/scheduling/reminders.py
@@ -56,6 +56,10 @@ def _autostart_job_id(meeting_id: str) -> str:
     return f"autostart:{meeting_id}"
 
 
+def _autoend_job_id(meeting_id: str) -> str:
+    return f"autoend:{meeting_id}"
+
+
 # ---------------------------------------------------------------------------
 # Job callbacks
 # ---------------------------------------------------------------------------
@@ -111,6 +115,23 @@ async def _send_reminder(doc: _MeetingDoc) -> None:
             )
 
 
+async def _auto_end_meeting(doc: _MeetingDoc) -> None:
+    """Auto-end a meeting at its scheduled end time.
+
+    Transitions ``in_progress`` → ``ended`` so the frontend correctly
+    shows the meeting as over rather than stuck at "Live" forever.
+    Idempotent — safe to call from both the APScheduler job and the
+    query-time hydration in ``list_meetings``.
+    """
+    current = await _MeetingDoc.get(doc.id)
+    if current is None or current.status != "in_progress":
+        return
+
+    from pocketpaw_ee.cloud.meetings.scheduling import service as scheduling_service
+
+    await scheduling_service.end_meeting(doc.workspace, str(doc.id))
+
+
 async def _auto_start_meeting(doc: _MeetingDoc) -> None:
     """Auto-start a meeting at its scheduled time.
 
@@ -156,7 +177,7 @@ async def _auto_start_meeting(doc: _MeetingDoc) -> None:
 
 
 def schedule_meeting_jobs(doc: _MeetingDoc) -> None:
-    """Schedule the reminder + auto-start APScheduler jobs for a meeting.
+    """Schedule the reminder + auto-start + auto-end APScheduler jobs for a meeting.
 
     Call after ``doc.insert()`` or after changing ``scheduled_start``.
     Idempotent — replaces existing jobs with the same ID.
@@ -196,11 +217,34 @@ def schedule_meeting_jobs(doc: _MeetingDoc) -> None:
         replace_existing=True,
     )
 
+    # Auto-end: at scheduled_end (with UTC tzinfo)
+    duration_min = (doc.raw_provider_payload or {}).get("duration_minutes", 30)
+    end_time = (
+        doc.scheduled_end or (doc.scheduled_start + timedelta(minutes=duration_min))
+        if doc.scheduled_start
+        else None
+    )
+    if end_time:
+        autoend_at = end_time.replace(tzinfo=UTC)
+        if autoend_at > datetime.now(UTC):
+            sched.add_job(
+                _auto_end_meeting,
+                trigger=_DateTrigger(run_date=autoend_at),
+                args=[doc],
+                id=_autoend_job_id(mid),
+                replace_existing=True,
+            )
+        logger.debug("Scheduled auto-end for meeting %s at %s", mid, autoend_at)
+
 
 def unschedule_meeting_jobs(meeting_id: str) -> None:
     """Remove a meeting's APScheduler jobs (on cancel / status change)."""
     sched = _get_scheduler()
-    for job_id in (_reminder_job_id(meeting_id), _autostart_job_id(meeting_id)):
+    for job_id in (
+        _reminder_job_id(meeting_id),
+        _autostart_job_id(meeting_id),
+        _autoend_job_id(meeting_id),
+    ):
         try:
             sched.remove_job(job_id)
         except Exception:
@@ -213,23 +257,70 @@ async def _recover_jobs_on_startup() -> None:
     Called on startup to recover jobs that were lost during a server restart.
     Queries MongoDB for all meetings with status ``scheduled`` whose
     ``scheduled_start`` is still in the future and schedules reminder +
-    auto-start jobs.
+    auto-start jobs. Also recovers auto-end jobs for ``in_progress``
+    meetings whose ``scheduled_end`` is still in the future.
     """
-    now = datetime.now(UTC).replace(tzinfo=None)
-    docs = await _MeetingDoc.find(
-        {"status": "scheduled", "scheduled_start": {"$gte": now}}
+    now_naive = datetime.now(UTC).replace(tzinfo=None)
+
+    # Recover scheduled meetings (reminder + auto-start + auto-end)
+    scheduled_docs = await _MeetingDoc.find(
+        {"status": "scheduled", "scheduled_start": {"$gte": now_naive}}
     ).to_list()
 
     count = 0
-    for doc in docs:
+    for doc in scheduled_docs:
         try:
             schedule_meeting_jobs(doc)
             count += 1
         except Exception as exc:
             logger.warning("Failed to re-schedule meeting %s on startup: %s", doc.id, exc)
 
+    # Recover in-progress meetings (auto-end only)
+    in_progress_docs = await _MeetingDoc.find(
+        {"status": "in_progress", "scheduled_end": {"$gte": now_naive}}
+    ).to_list()
+
+    for doc in in_progress_docs:
+        try:
+            _schedule_autoend_only(doc)
+            count += 1
+        except Exception as exc:
+            logger.warning(
+                "Failed to schedule auto-end for in_progress meeting %s on startup: %s",
+                doc.id,
+                exc,
+            )
+
     if count:
         logger.info("Re-scheduled %d meeting job(s) from DB on startup", count)
+
+
+def _schedule_autoend_only(doc: _MeetingDoc) -> None:
+    """Schedule only the auto-end job for an in-progress meeting.
+
+    Used during recovery — the reminder and auto-start jobs already fired
+    (or should not fire), so we only add the auto-end job.
+    """
+    sched = _get_scheduler()
+    mid = str(doc.id)
+
+    duration_min = (doc.raw_provider_payload or {}).get("duration_minutes", 30)
+    end_time = (
+        doc.scheduled_end or (doc.scheduled_start + timedelta(minutes=duration_min))
+        if doc.scheduled_start
+        else None
+    )
+    if end_time:
+        autoend_at = end_time.replace(tzinfo=UTC)
+        if autoend_at > datetime.now(UTC):
+            sched.add_job(
+                _auto_end_meeting,
+                trigger=_DateTrigger(run_date=autoend_at),
+                args=[doc],
+                id=_autoend_job_id(mid),
+                replace_existing=True,
+            )
+            logger.debug("Recovered auto-end job for in_progress meeting %s at %s", mid, autoend_at)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/meetings/service.py
+++ b/ee/pocketpaw_ee/cloud/meetings/service.py
@@ -130,8 +130,52 @@ async def list_meetings(workspace_id: str, body: ListMeetingsRequest) -> list[Me
     Read-only. Tenant filter on the Beanie query (rule §7). Returns a
     plain list — pagination via cursor lands in Phase 1.5 once we have
     real data volumes to size against.
+
+    Before returning, hydrates stale meeting statuses:
+      - ``scheduled`` → ``ended`` when ``scheduled_end + 5 min`` grace has passed
+      - ``in_progress`` → ``ended`` when ``scheduled_end + 5 min`` grace has passed
+    This self-heals any statuses that the APScheduler auto-end job missed
+    (server restart, job scheduling bug, etc.).
     """
     body = ListMeetingsRequest.model_validate(body)
+
+    # ── Hydration: auto-transition stale statuses ──────────────────────
+    now_utc = datetime.now(UTC)
+    grace = timedelta(minutes=5)
+
+    # scheduled → ended (meeting never started)
+    stale_scheduled = await _MeetingDoc.find(
+        {
+            "workspace": workspace_id,
+            "status": "scheduled",
+            "scheduled_end": {"$ne": None},
+        }
+    ).to_list()
+    for doc in stale_scheduled:
+        end = _aware(doc.scheduled_end)
+        if end and end + grace < now_utc:
+            doc.status = "ended"
+            doc.actual_end = now_utc
+            await doc.save()
+            logger.info("Hydrated meeting %s: scheduled → ended (past scheduled_end)", doc.id)
+
+    # in_progress → ended (meeting ran past scheduled_end + grace)
+    stale_running = await _MeetingDoc.find(
+        {
+            "workspace": workspace_id,
+            "status": "in_progress",
+            "scheduled_end": {"$ne": None},
+        }
+    ).to_list()
+    for doc in stale_running:
+        end = _aware(doc.scheduled_end)
+        if end and end + grace < now_utc:
+            doc.status = "ended"
+            doc.actual_end = now_utc
+            await doc.save()
+            logger.info("Hydrated meeting %s: in_progress → ended (past scheduled_end)", doc.id)
+
+    # ── Main query ────────────────────────────────────────────────────
     query: dict = {"workspace": workspace_id}
     if body.provider:
         query["provider"] = body.provider


### PR DESCRIPTION
## Summary

Backend support for instant call Meeting docs, livekit transcripts in `/meetings`, auto-end mechanism, realtime WS events for message.new and meeting lifecycle.

## Changes (pocketpaw)

### 1. Instant calls create Meeting docs
- `livekit/service.py:create_room()` — creates `Meeting(source=livekit, status=in_progress)` when a LiveKit room is created
- `livekit/service.py:end_room()` — transitions Meeting to `ended` when room is deleted
- Emits `meeting.started` on the WS bus so sidebar is realtime

### 2. LiveKit transcripts in /meetings
- `post_meeting_notes_to_group()` now stores transcript as VTT file via `write_text_file`
- Creates `MeetingTranscript` doc and emits `meeting.transcript_ready`
- `entry_count` fallback for plain-text transcripts (no VTT timestamps)
- `workspace_id` plumbing through `_reap_agent_process`

### 3. Realtime message.new for meeting notes
- `post_meeting_notes_to_group()` emits `MessageNew` on WS bus with `group` + `group_id` keys
- Meeting notes appear in group chat without page refresh
- Audience resolver correctly routes via `group_id`, frontend matches on `group`

### 4. Auto-end mechanism
- `reminders.py` — `_auto_end_meeting()` APScheduler job fires at `scheduled_end`
- Startup recovery for auto-end jobs on `in_progress` meetings
- `service.py:list_meetings()` — query-time hydration transitions stale `scheduled → ended` / `in_progress → ended` (5min grace)

### 5. UTC datetime serialization
- `dto.py` — `MeetingResponse`, `TranscriptResponse`, `CredentialsResponse` append `Z` suffix via `@field_serializer`
- `router.py` — `BotStatusResponseDTO` same fix

### 6. Participant join/leave events
- `events.py` — `CallParticipantJoined` / `CallParticipantLeft` event classes
- `POST /livekit/token` — emits `call.participant_joined` when token is generated
- `POST /livekit/rooms/{group_id}/leave` — new endpoint emits `call.participant_left`

### Modified files
- `ee/pocketpaw_ee/cloud/livekit/service.py` — Meeting doc creation, transcript storage, message.new emit
- `ee/pocketpaw_ee/cloud/livekit/router.py` — participant events, workspace_id plumbing, leave endpoint
- `ee/pocketpaw_ee/cloud/meetings/service.py` — stale meeting hydration
- `ee/pocketpaw_ee/cloud/meetings/scheduling/reminders.py` — auto-end job
- `ee/pocketpaw_ee/cloud/meetings/dto.py` — Z suffix on datetimes
- `ee/pocketpaw_ee/cloud/_core/realtime/events.py` — CallParticipantJoined/Left events

### Commits
```
ecdbe4ae fix(livekit): emit message.new with group+group_id for audience resolver + frontend
159ce54d fix(livekit): store transcript as MeetingTranscript for /meetings detail panel
714b8542 fix(instant-calls): create Meeting doc for instant calls so they appear in sidebar
57934c5b fix(meetings): auto-end mechanism + UTC datetime serialization + stale hydration
```
