### PR TITLE
fix(tests): skip ee-dependent claude_sdk cache-key test in OSS-only CI

### DIFF
--- a/tests/test_claude_sdk_client_cache_key.py
+++ b/tests/test_claude_sdk_client_cache_key.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
 
 
@@ -107,6 +109,8 @@ def test_real_home_behavior_instructions_flip_changes_key():
     until a cold restart. If someone moves the backend summary VALUE into the
     per-turn volatile tail this guard still passes only because the behavioral
     instructions themselves carry it — keep it in the static prefix."""
+    pytest.importorskip("pocketpaw_ee")
+
     from pocketpaw_ee.cloud.chat.agent_service import (
         ScopeContext,
         ScopeKind,


### PR DESCRIPTION
tests/test_claude_sdk_client_cache_key.py::test_real_home_behavior_instructions_flip_changes_key imports pocketpaw_ee, which the OSS-only CI job doesn't install. It fails there with ModuleNotFoundError (1 failed / 4968 passed) on dev itself and on every open PR — including the RFC 13 and Saga gate PRs, whose red CI is entirely this one test, not their own code.

Guard it with pytest.importorskip("pocketpaw_ee") so it skips cleanly in OSS-only and still runs on the full --group ee install. Verified: ruff clean, 7/7 pass with ee.