### PR TITLE
Re-home the retrieval router and credential broker into pocketpaw.retrieval

### DIFF
--- a/src/pocketpaw/retrieval/__init__.py
+++ b/src/pocketpaw/retrieval/__init__.py
@@ -1,4 +1,15 @@
-# ee/retrieval/__init__.py — Retrieval log + graduation as a journal projection.
+# retrieval/__init__.py — Retrieval orchestration + the journal projection.
+# Updated: 2026-06-02 (feat/retrieval-rehome, #1327) — re-homed the retrieval
+# *orchestration* classes that soul-protocol 0.4.0 (#179) deleted from
+# ``soul_protocol.engine.retrieval``: ``RetrievalRouter`` (the dispatcher),
+# ``InMemoryCredentialBroker`` (the reference broker), and ``ProjectionAdapter``
+# (the callable-wrapping adapter). soul-protocol now ships only the retrieval
+# *vocabulary* (models + protocols + exceptions) under spec.retrieval; the
+# concrete orchestration is application-layer and belongs here in the consuming
+# runtime. They live alongside the existing journal-projection layer below — two
+# concerns, one package. Note: ``RetrievalRouter`` here is the dispatcher, NOT
+# the FastAPI ``APIRouter`` exported as the ``router`` object from router.py.
+#
 # Created: 2026-04-16 (feat/retrieval-journal-projection) — Wave 3 / Org
 # Architecture RFC, Phase 3. Supersedes the side-channel design in held PRs
 # #936 (JSONL retrieval sink) and #937 (graduation policy over that JSONL).
@@ -8,10 +19,13 @@
 # JSONL sink is retired and the domain logic re-lands here as a projection
 # over the journal's ``retrieval.query`` + ``graduation.applied`` events.
 #
-# What we re-export: the store (write path), the projection (read path),
-# the policy (graduation decisions), plus the canonical action names and
-# payload builders for callers that want to emit events out of band.
+# What we re-export: the orchestration (router + broker + projection adapter),
+# the store (write path), the projection (read path), the policy (graduation
+# decisions), plus the canonical action names and payload builders for callers
+# that want to emit events out of band.
 
+from pocketpaw.retrieval.adapters import ProjectionAdapter
+from pocketpaw.retrieval.broker import Credential, InMemoryCredentialBroker
 from pocketpaw.retrieval.events import (
     ACTION_GRADUATION_APPLIED,
     ACTION_RETRIEVAL_QUERY,
@@ -19,6 +33,7 @@ from pocketpaw.retrieval.events import (
     graduation_applied_payload,
     retrieval_query_payload,
 )
+from pocketpaw.retrieval.orchestrator import RetrievalRouter
 from pocketpaw.retrieval.policy import (
     DEFAULT_EPISODIC_THRESHOLD,
     DEFAULT_SEMANTIC_THRESHOLD,
@@ -37,6 +52,11 @@ from pocketpaw.retrieval.projection import (
 from pocketpaw.retrieval.store import RetrievalJournalStore
 
 __all__ = [
+    # Retrieval orchestration (re-homed from soul-protocol 0.4.0, #1327).
+    "RetrievalRouter",
+    "InMemoryCredentialBroker",
+    "ProjectionAdapter",
+    "Credential",
     # Actions + payload builders.
     "ACTION_RETRIEVAL_QUERY",
     "ACTION_GRADUATION_APPLIED",

--- a/src/pocketpaw/retrieval/adapters.py
+++ b/src/pocketpaw/retrieval/adapters.py
@@ -1,0 +1,49 @@
+# adapters.py — Application-layer SourceAdapter implementations.
+# Created: 2026-06-02 (feat/retrieval-rehome, #1327) — re-homed from
+# soul-protocol's deleted ``engine/retrieval/adapters.py``. soul-protocol 0.4.0
+# (#179) kept the ``SourceAdapter`` / ``AsyncSourceAdapter`` *protocols* in
+# ``soul_protocol.spec.retrieval`` but deleted the concrete adapters — they are
+# application-layer, not spec.
+#
+# What ports here: ``ProjectionAdapter`` — the "local rebuilt view" shape.
+# Soul memory, kb, and fabric all live inside the same Paw OS instance the
+# router runs in; they don't need federation or credentials, so a plain
+# callable that takes the request and returns candidates is enough. The old
+# module also carried a ``MockAdapter`` test helper; that intentionally does
+# NOT port (test fixtures belong in the test tree, and the Drive connector +
+# its own ``FakeDriveClient`` already cover the dataref path).
+#
+# Adapted to the 0.4.0 surface: ``Credential`` / ``RetrievalCandidate`` /
+# ``RetrievalRequest`` import from ``soul_protocol.spec.retrieval`` (the old
+# code imported ``Credential`` from the sibling ``.broker`` and the rest from
+# spec). No behavioral change — the callable contract is identical.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from soul_protocol.spec.retrieval import Credential, RetrievalCandidate, RetrievalRequest
+
+
+class ProjectionAdapter:
+    """Adapter over a plain callable — the "local rebuilt view" shape.
+
+    Soul memory, kb, and fabric all live inside the same Paw OS instance the
+    router runs in. They don't need federation or credentials. A callable that
+    takes the request and returns candidates is enough.
+    """
+
+    supports_dataref: bool = False
+
+    def __init__(
+        self,
+        fn: Callable[[RetrievalRequest], list[RetrievalCandidate]],
+    ) -> None:
+        self._fn = fn
+
+    def query(
+        self,
+        request: RetrievalRequest,
+        credential: Credential | None,  # noqa: ARG002 — projection ignores creds
+    ) -> list[RetrievalCandidate]:
+        return list(self._fn(request))

--- a/src/pocketpaw/retrieval/broker.py
+++ b/src/pocketpaw/retrieval/broker.py
@@ -1,0 +1,141 @@
+# broker.py — InMemoryCredentialBroker: the reference CredentialBroker impl.
+# Created: 2026-06-02 (feat/retrieval-rehome, #1327) — re-homed from
+# soul-protocol's deleted ``engine/retrieval/broker.py``. soul-protocol 0.4.0
+# (#179) moved the ``Credential`` model + the ``CredentialBroker`` protocol +
+# the credential exception classes into ``soul_protocol.spec.retrieval`` and
+# deleted the concrete in-memory implementation. That implementation is
+# application-layer infrastructure, so it lives here in the consuming runtime.
+#
+# Adapted to the 0.4.0 surface:
+#   * ``Credential``, ``CredentialBroker``, ``CredentialExpiredError`` and
+#     ``CredentialScopeError`` now import from ``soul_protocol.spec.retrieval``
+#     (they used to live alongside this code under engine/retrieval/). The
+#     ``Credential`` field set is byte-for-byte the same as the old engine
+#     version, so the broker's construction call is unchanged.
+#   * ``scopes_overlap`` still lives at ``soul_protocol.engine.journal`` — the
+#     0.4.0 prune left the journal scope helpers in place.
+#   * ``Credential`` is re-exported from this module for callers that used to
+#     import it from the engine package; the canonical home is now the spec.
+#
+# The broker mints short-lived credentials for external sources (Drive,
+# Salesforce, Snowflake, ...). Scoped per DSP scope so a credential acquired
+# for ``org:sales:*`` cannot be reused by a requester operating in
+# ``org:support:*``. Every acquire/use/expire emits a journal event when a
+# journal is attached — that's the audit trail Zero-Copy federation depends on.
+#
+# ``InMemoryCredentialBroker`` is the reference impl: not persistent, not
+# distributed. Production deployments swap in a broker backed by the
+# platform's real secret store. ``Credential.token`` is deliberately an opaque
+# string — real brokers produce bearer tokens / OAuth access tokens / signed
+# JWTs; callers that need a structured token wrap this class.
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+from soul_protocol.engine.journal import Journal, scopes_overlap
+from soul_protocol.spec.journal import Actor, EventEntry
+from soul_protocol.spec.retrieval import (
+    Credential,
+    CredentialExpiredError,
+    CredentialScopeError,
+)
+
+# Re-export so callers that historically did ``from pocketpaw.retrieval import
+# Credential`` keep working. The canonical definition lives in the 0.4.0 spec.
+__all__ = ["Credential", "InMemoryCredentialBroker", "DEFAULT_TTL_S"]
+
+DEFAULT_TTL_S: float = 300.0
+
+
+class InMemoryCredentialBroker:
+    """Reference broker. Not persistent, not distributed — fine for
+    single-process Paw OS instances and tests."""
+
+    def __init__(
+        self,
+        *,
+        ttl_s: float = DEFAULT_TTL_S,
+        journal: Journal | None = None,
+        broker_actor: Actor | None = None,
+    ) -> None:
+        self._ttl_s = ttl_s
+        self._journal = journal
+        self._actor = broker_actor or Actor(kind="system", id="system:credential-broker")
+        self._active: dict[UUID, Credential] = {}
+
+    # -- lifecycle --------------------------------------------------------
+
+    def acquire(self, source: str, scopes: list[str]) -> Credential:
+        now = datetime.now(UTC)
+        cred = Credential(
+            source=source,
+            scopes=list(scopes),
+            token=secrets.token_urlsafe(16),
+            acquired_at=now,
+            expires_at=now + timedelta(seconds=self._ttl_s),
+        )
+        # Emit FIRST. If the audit append fails under the fail-closed policy,
+        # the credential never enters ``_active`` and the caller gets the
+        # exception — no orphan credentials hanging around post-failure.
+        self._emit("credential.acquired", cred)
+        self._active[cred.id] = cred
+        return cred
+
+    def ensure_usable(self, credential: Credential, requester_scopes: list[str]) -> None:
+        if credential.is_expired():
+            # Surface through the journal once, then forget the credential.
+            if credential.id in self._active:
+                self._emit("credential.expired", credential)
+                self._active.pop(credential.id, None)
+            raise CredentialExpiredError(
+                f"credential {credential.id} for {credential.source} expired at "
+                f"{credential.expires_at.isoformat()}"
+            )
+        if not scopes_overlap(credential.scopes, requester_scopes):
+            raise CredentialScopeError(
+                f"credential {credential.id} scoped to {credential.scopes} "
+                f"cannot be used by requester with scopes {requester_scopes}"
+            )
+
+    def mark_used(self, credential: Credential) -> None:
+        credential.last_used_at = datetime.now(UTC)
+        self._emit("credential.used", credential)
+
+    def revoke(self, credential_id: UUID) -> None:
+        cred = self._active.pop(credential_id, None)
+        if cred is not None:
+            self._emit("credential.expired", cred)
+
+    # -- journal glue -----------------------------------------------------
+
+    def _emit(self, action: str, cred: Credential) -> None:
+        """Append a credential-lifecycle event. Fail-closed by design.
+
+        If no journal is configured the caller has explicitly opted into
+        fire-and-forget operation (tests, ephemeral scripts). With a journal
+        attached, a failed append propagates: audit integrity outranks broker
+        availability on the credential path, and silently issuing / revoking a
+        credential whose lifecycle never made it into the log is worse than
+        surfacing the error to the caller.
+
+        Contrast with the router's ``retrieval.query`` emit, which stays
+        fire-and-forget — that's a query log, not an auth trail.
+        """
+        if self._journal is None:
+            return
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=self._actor,
+            action=action,
+            scope=list(cred.scopes),
+            payload={
+                "credential_id": str(cred.id),
+                "source": cred.source,
+                "expires_at": cred.expires_at.isoformat(),
+            },
+        )
+        self._journal.append(entry)

--- a/src/pocketpaw/retrieval/orchestrator.py
+++ b/src/pocketpaw/retrieval/orchestrator.py
@@ -1,0 +1,399 @@
+# orchestrator.py — RetrievalRouter: scope-filtered, strategy-aware dispatch.
+# Created: 2026-06-02 (feat/retrieval-rehome, #1327) — re-homed from
+# soul-protocol's deleted ``engine/retrieval/router.py``. soul-protocol 0.4.0
+# (#179) pruned the concrete retrieval orchestration out of the spec: the
+# package now ships only the *vocabulary* (request/response models, the
+# SourceAdapter + CredentialBroker protocols, the exception hierarchy) under
+# ``soul_protocol.spec.retrieval``. The dispatcher itself is application-layer
+# infrastructure, so it lives here in the consuming runtime.
+#
+# Adapted to the 0.4.0 surface:
+#   * Imports of CandidateSource / RetrievalCandidate / RetrievalRequest /
+#     RetrievalResult / SourceAdapter / the exceptions all come from
+#     ``soul_protocol.spec.retrieval`` now (they used to be split across
+#     engine/retrieval/{adapters,broker,exceptions}.py + spec/retrieval.py).
+#   * ``scope_matches`` still lives at ``soul_protocol.engine.journal`` — the
+#     0.4.0 prune only touched engine/retrieval, not the journal scope helpers.
+#   * ``Credential`` is imported from spec.retrieval for type hints; the typed
+#     ``DataRef`` content is opaque to the router (it never inspects
+#     candidate.content), so the candidate-payload type change is transparent
+#     here — the router merges by ``score`` and truncates, nothing else.
+#
+# This file is named ``orchestrator.py`` (not ``router.py``) on purpose: the
+# package already has a ``router.py`` that is a FastAPI ``APIRouter`` for the
+# retrieval-journal projection. Two different "routers" — keep them apart.
+#
+# Strategies:
+#   * ``first``      — try sources in registration order, return the first
+#                      that yields a non-empty list.
+#   * ``parallel``   — fan out on a ThreadPoolExecutor, gather all, merge by
+#                      score (None scores sink).
+#   * ``sequential`` — try in order, accumulate until ``limit`` is reached.
+#
+# Scope enforcement: a source is a candidate iff its registered scopes overlap
+# the request's scopes (bidirectional, via the journal's ``scope_matches``).
+#
+# Journal integration: if a Journal is attached, every dispatch writes a
+# ``retrieval.query`` event tagged with the request's scope + actor, payload
+# carrying the query text + the sources actually queried. Fire-and-forget —
+# the query log is observability, not the auth trail (the broker's credential
+# events are the fail-closed auth trail; see broker.py for the asymmetry).
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeout
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from soul_protocol.engine.journal import Journal, scope_matches
+from soul_protocol.spec.journal import EventEntry
+from soul_protocol.spec.retrieval import (
+    CandidateSource,
+    CredentialBroker,
+    NoSourcesError,
+    RetrievalCandidate,
+    RetrievalRequest,
+    RetrievalResult,
+    SourceAdapter,
+    SourceTimeoutError,
+)
+
+
+class RetrievalRouter:
+    """Scope-filtered, strategy-aware dispatcher over registered sources.
+
+    Usage::
+
+        router = RetrievalRouter(journal=journal, broker=broker)
+        router.register_source(CandidateSource(...), MyAdapter())
+        result = router.dispatch(RetrievalRequest(...))
+    """
+
+    def __init__(
+        self,
+        *,
+        journal: Journal | None = None,
+        broker: CredentialBroker | None = None,
+    ) -> None:
+        self._journal = journal
+        self._broker = broker
+        self._sources: dict[str, tuple[CandidateSource, SourceAdapter]] = {}
+
+    # -- registration -----------------------------------------------------
+
+    def register_source(self, source: CandidateSource, adapter: SourceAdapter) -> None:
+        self._sources[source.name] = (source, adapter)
+
+    # -- dispatch ---------------------------------------------------------
+
+    def dispatch(self, request: RetrievalRequest) -> RetrievalResult:
+        request_id = uuid4()
+        started = time.perf_counter()
+
+        selected = self._select_sources(request)
+        if not selected:
+            raise NoSourcesError(
+                f"no registered source matches scopes {request.scopes} "
+                f"(sources filter: {request.sources})"
+            )
+
+        if request.strategy == "first":
+            candidates, queried, failed = self._run_first(request, selected)
+        elif request.strategy == "sequential":
+            candidates, queried, failed = self._run_sequential(request, selected)
+        else:
+            candidates, queried, failed = self._run_parallel(request, selected)
+
+        merged = _merge_and_truncate(candidates, request.limit)
+        total_ms = (time.perf_counter() - started) * 1000.0
+
+        result = RetrievalResult(
+            request_id=request_id,
+            candidates=merged,
+            sources_queried=queried,
+            sources_failed=failed,
+            total_latency_ms=total_ms,
+            trace=None,  # RetrievalTrace receipt is a future slice.
+        )
+        self._emit_query_event(request, result)
+        return result
+
+    async def adispatch(self, request: RetrievalRequest) -> RetrievalResult:
+        """Async dispatch — prefers ``aquery`` per adapter, falls back to
+        threading the sync ``query``.
+
+        Adapters backed by async SDKs can participate in cooperative
+        multitasking without bridging through ``asyncio.run``. Sync-only
+        adapters keep working — the router wraps their ``query`` in
+        ``asyncio.to_thread``.
+
+        Strategy is parallel with per-source timeout (matching the default
+        sync dispatch). ``first`` and ``sequential`` strategies fall back to
+        the sync path — they serialize by design, so there's no async win.
+
+        Cancellation note: on timeout, the async path (``aquery``) is
+        cancelled via ``asyncio.wait_for`` and stops cooperatively. The sync
+        fallback via ``to_thread`` does *not* stop the running thread — the
+        wait just unblocks the caller while the adapter's sync ``query``
+        keeps running to completion. Standard asyncio behavior; adapters that
+        need hard cancellation should implement ``aquery`` natively.
+        """
+        if request.strategy in ("first", "sequential"):
+            return await asyncio.to_thread(self.dispatch, request)
+
+        request_id = uuid4()
+        started = time.perf_counter()
+
+        selected = self._select_sources(request)
+        if not selected:
+            raise NoSourcesError(
+                f"no registered source matches scopes {request.scopes} "
+                f"(sources filter: {request.sources})"
+            )
+
+        queried = [s.name for s, _ in selected]
+        failed: list[tuple[str, str]] = []
+        collected: list[RetrievalCandidate] = []
+
+        async def _run_one(
+            source: CandidateSource, adapter: SourceAdapter
+        ) -> tuple[str, list[RetrievalCandidate] | None, str | None]:
+            try:
+                out = await asyncio.wait_for(
+                    self._acall_adapter(request, source, adapter),
+                    timeout=request.timeout_s,
+                )
+                return source.name, out, None
+            except TimeoutError:
+                return (
+                    source.name,
+                    None,
+                    f"source {source.name} timed out after {request.timeout_s}s",
+                )
+            except Exception as e:
+                return source.name, None, f"{type(e).__name__}: {e}"
+
+        outcomes = await asyncio.gather(*(_run_one(s, a) for s, a in selected))
+        for name, out, err in outcomes:
+            if err is not None:
+                failed.append((name, err))
+            elif out is not None:
+                collected.extend(out)
+
+        merged = _merge_and_truncate(collected, request.limit)
+        total_ms = (time.perf_counter() - started) * 1000.0
+
+        result = RetrievalResult(
+            request_id=request_id,
+            candidates=merged,
+            sources_queried=queried,
+            sources_failed=failed,
+            total_latency_ms=total_ms,
+            trace=None,
+        )
+        self._emit_query_event(request, result)
+        return result
+
+    async def _acall_adapter(
+        self,
+        request: RetrievalRequest,
+        source: CandidateSource,
+        adapter: SourceAdapter,
+    ) -> list[RetrievalCandidate]:
+        """Async version of _call_adapter — prefer aquery, fall back to thread."""
+        credential = None
+        if source.kind == "dataref" and self._broker is not None:
+            credential = self._broker.acquire(source.name, request.scopes)
+            self._broker.ensure_usable(credential, request.scopes)
+            self._broker.mark_used(credential)
+
+        aquery = getattr(adapter, "aquery", None)
+        if aquery is not None and inspect.iscoroutinefunction(aquery):
+            return await aquery(request, credential)
+        return await asyncio.to_thread(adapter.query, request, credential)
+
+    # -- internals --------------------------------------------------------
+
+    def _select_sources(
+        self, request: RetrievalRequest
+    ) -> list[tuple[CandidateSource, SourceAdapter]]:
+        selected: list[tuple[CandidateSource, SourceAdapter]] = []
+        for name, (source, adapter) in self._sources.items():
+            if request.sources is not None and name not in request.sources:
+                continue
+            # Bidirectional overlap — a source registered for ``org:sales:*``
+            # should match a request scoped to ``org:sales:leads`` AND vice
+            # versa. ``scope_matches`` treats arg 2 as the pattern set, so we
+            # run it both ways.
+            if not (
+                scope_matches(request.scopes, source.scopes)
+                or scope_matches(source.scopes, request.scopes)
+            ):
+                continue
+            selected.append((source, adapter))
+        return selected
+
+    def _call_adapter(
+        self,
+        request: RetrievalRequest,
+        source: CandidateSource,
+        adapter: SourceAdapter,
+    ) -> list[RetrievalCandidate]:
+        credential = None
+        if source.kind == "dataref" and self._broker is not None:
+            credential = self._broker.acquire(source.name, request.scopes)
+            self._broker.ensure_usable(credential, request.scopes)
+            self._broker.mark_used(credential)
+        return adapter.query(request, credential)
+
+    def _run_first(
+        self,
+        request: RetrievalRequest,
+        selected: list[tuple[CandidateSource, SourceAdapter]],
+    ) -> tuple[list[RetrievalCandidate], list[str], list[tuple[str, str]]]:
+        queried: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for source, adapter in selected:
+            queried.append(source.name)
+            try:
+                out = _with_timeout(
+                    lambda s=source, a=adapter: self._call_adapter(request, s, a),
+                    request.timeout_s,
+                    source.name,
+                )
+            except SourceTimeoutError as e:
+                failed.append((source.name, str(e)))
+                continue
+            except Exception as e:  # pragma: no cover - defensive
+                failed.append((source.name, f"{type(e).__name__}: {e}"))
+                continue
+            if out:
+                return out, queried, failed
+        return [], queried, failed
+
+    def _run_sequential(
+        self,
+        request: RetrievalRequest,
+        selected: list[tuple[CandidateSource, SourceAdapter]],
+    ) -> tuple[list[RetrievalCandidate], list[str], list[tuple[str, str]]]:
+        collected: list[RetrievalCandidate] = []
+        queried: list[str] = []
+        failed: list[tuple[str, str]] = []
+        for source, adapter in selected:
+            queried.append(source.name)
+            try:
+                out = _with_timeout(
+                    lambda s=source, a=adapter: self._call_adapter(request, s, a),
+                    request.timeout_s,
+                    source.name,
+                )
+            except SourceTimeoutError as e:
+                failed.append((source.name, str(e)))
+                continue
+            except Exception as e:
+                failed.append((source.name, f"{type(e).__name__}: {e}"))
+                continue
+            collected.extend(out)
+            if len(collected) >= request.limit:
+                break
+        return collected, queried, failed
+
+    def _run_parallel(
+        self,
+        request: RetrievalRequest,
+        selected: list[tuple[CandidateSource, SourceAdapter]],
+    ) -> tuple[list[RetrievalCandidate], list[str], list[tuple[str, str]]]:
+        queried = [s.name for s, _ in selected]
+        failed: list[tuple[str, str]] = []
+        collected: list[RetrievalCandidate] = []
+        max_workers = max(1, len(selected))
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            future_to_name = {
+                pool.submit(self._call_adapter, request, source, adapter): source.name
+                for source, adapter in selected
+            }
+            for future, name in future_to_name.items():
+                try:
+                    out = future.result(timeout=request.timeout_s)
+                except FuturesTimeout:
+                    failed.append((name, f"source {name} timed out after {request.timeout_s}s"))
+                    future.cancel()
+                except Exception as e:
+                    failed.append((name, f"{type(e).__name__}: {e}"))
+                else:
+                    collected.extend(out)
+        return collected, queried, failed
+
+    def _emit_query_event(self, request: RetrievalRequest, result: RetrievalResult) -> None:
+        if self._journal is None:
+            return
+        entry = EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=request.actor,
+            action="retrieval.query",
+            scope=list(request.scopes),
+            correlation_id=request.correlation_id,
+            payload={
+                "request_id": str(result.request_id),
+                "query": request.query,
+                "strategy": request.strategy,
+                "sources_queried": result.sources_queried,
+                "sources_failed": [{"source": s, "reason": r} for s, r in result.sources_failed],
+                "candidate_count": len(result.candidates),
+                # point_in_time: record as ISO so downstream consumers can
+                # replay the time-travel intent. Only present when the caller
+                # asked for a historical snapshot.
+                **(
+                    {"point_in_time": request.point_in_time.isoformat()}
+                    if request.point_in_time is not None
+                    else {}
+                ),
+            },
+        )
+        try:
+            self._journal.append(entry)
+        except Exception:
+            # Fire-and-forget. The retrieval.query event is a query log, not
+            # an auth trail: losing it is an observability regression, not a
+            # security one. Credential lifecycle events on the broker are
+            # fail-closed precisely because they ARE the auth trail. The
+            # asymmetry is deliberate — don't unify these two policies.
+            pass
+
+
+# -- helpers --------------------------------------------------------------
+
+
+def _with_timeout(fn, timeout_s: float, source_name: str) -> list[RetrievalCandidate]:
+    """Run ``fn`` on a helper thread with a wall-clock deadline.
+
+    Used by the ``first`` and ``sequential`` strategies — ``parallel`` uses
+    its own thread pool + futures timeout. One helper thread per call, in a
+    ``with`` block so a wedged adapter never blocks interpreter shutdown.
+    """
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(fn)
+        try:
+            return future.result(timeout=timeout_s)
+        except FuturesTimeout as e:
+            future.cancel()
+            raise SourceTimeoutError(f"source {source_name} timed out after {timeout_s}s") from e
+
+
+def _merge_and_truncate(
+    candidates: list[RetrievalCandidate], limit: int
+) -> list[RetrievalCandidate]:
+    """Sort by score descending (None sinks), then truncate to ``limit``."""
+
+    def key(c: RetrievalCandidate) -> tuple[int, float]:
+        if c.score is None:
+            return (1, 0.0)
+        return (0, -c.score)
+
+    ordered = sorted(candidates, key=key)
+    return ordered[:limit]

--- a/tests/connectors/test_drive.py
+++ b/tests/connectors/test_drive.py
@@ -1,5 +1,11 @@
 # Tests for the Google Drive SourceAdapter (Workstream C2).
 # Created: 2026-04-16.
+# Updated: 2026-06-02 (feat/retrieval-rehome, #1327) — dropped the ImportError
+# guard + skip marker that fenced off the RetrievalRouter/InMemoryCredentialBroker
+# integration tests. Those classes are now re-homed in pocketpaw.retrieval, so
+# the end-to-end router/broker tests run for real. Also fixed the integration
+# assertion to read candidate.content.kind as an attribute: 0.4.0 promotes the
+# adapter's dataref dict to a typed DataRef, which isn't subscriptable.
 #
 # Covers:
 #   * DriveClient request plumbing (auth header, params, rate-limit retry,
@@ -39,29 +45,10 @@ from pocketpaw.connectors.drive.auth import resolve_bearer_token
 
 # Retrieval orchestration (RetrievalRouter, InMemoryCredentialBroker) was removed
 # from soul-protocol in 0.4.0 (#179) — the spec now ships only the vocabulary in
-# soul_protocol.spec.retrieval; the concrete orchestration is meant to live in
-# the consuming runtime at pocketpaw.retrieval (per the 0.4.0 CHANGELOG, "as of
-# pocketpaw v0.4.17"). That re-home has NOT landed in pocketpaw yet, so these
-# classes have no home. Guard the import so the rest of this module still
-# collects + runs; the router/broker integration tests below skip until the
-# re-home ships. Tracked in the gap issue referenced on the skip marker.
-try:  # pragma: no cover - exercised once the re-home lands
-    from pocketpaw.retrieval import InMemoryCredentialBroker, RetrievalRouter
-
-    _RETRIEVAL_ORCHESTRATION = True
-except ImportError:  # pragma: no cover
-    InMemoryCredentialBroker = RetrievalRouter = None  # type: ignore[assignment,misc]
-    _RETRIEVAL_ORCHESTRATION = False
-
-_needs_orchestration = pytest.mark.skipif(
-    not _RETRIEVAL_ORCHESTRATION,
-    reason=(
-        "RetrievalRouter/InMemoryCredentialBroker not yet re-homed in "
-        "pocketpaw.retrieval (soul-protocol #179 removed them from "
-        "soul_protocol.engine.retrieval in 0.4.0)"
-    ),
-)
-
+# soul_protocol.spec.retrieval. The concrete orchestration was re-homed into the
+# consuming runtime at pocketpaw.retrieval in #1327, so these classes import
+# directly now and the router/broker end-to-end tests below run for real.
+from pocketpaw.retrieval import InMemoryCredentialBroker, RetrievalRouter
 
 # ---------------------------------------------------------------------------
 # HTTP scripting helpers — a tiny replacement for httpx_mock so we don't pull
@@ -449,7 +436,6 @@ class TestDriveSourceAdapter:
         assert candidates[0].as_of == _ts(2026, 4, 1, 0)
         assert fake.revision_calls == [("file_1", _ts(2026, 4, 1, 0))]
 
-    @_needs_orchestration
     def test_query_uses_credential_token_when_provided(self) -> None:
         broker = InMemoryCredentialBroker()
         credential = broker.acquire("drive", ["org:sales:*"])
@@ -492,7 +478,6 @@ class TestDriveSourceAdapter:
 
 
 class TestResolveBearerToken:
-    @_needs_orchestration
     def test_credential_wins_over_env(self) -> None:
         broker = InMemoryCredentialBroker()
         cred = broker.acquire("drive", ["org:sales:*"])
@@ -522,7 +507,6 @@ class TestResolveBearerToken:
 # ---------------------------------------------------------------------------
 
 
-@_needs_orchestration
 class TestRouterIntegration:
     @pytest.fixture
     def journal(self, tmp_path: Path):
@@ -551,9 +535,12 @@ class TestRouterIntegration:
 
         result = router.dispatch(_make_request("Q3 forecast"))
 
-        # Router produced candidates with the DataRef shape.
+        # Router produced candidates with the DataRef shape. As of soul-protocol
+        # 0.4.0 the adapter's dataref dict is auto-promoted to a typed DataRef on
+        # RetrievalCandidate validation, so read the discriminator as an attribute
+        # (subscript would raise — pydantic models aren't subscriptable).
         assert len(result.candidates) == 2
-        assert result.candidates[0].content["kind"] == "dataref"
+        assert result.candidates[0].content.kind == "dataref"
         assert result.sources_queried == ["drive"]
         assert result.sources_failed == []
 


### PR DESCRIPTION
## What

soul-protocol 0.4.0 (#179) moved the retrieval *vocabulary* into `soul_protocol.spec.retrieval` and deleted the concrete orchestration that used to live under `soul_protocol.engine.retrieval`. That left `RetrievalRouter` and `InMemoryCredentialBroker` with no home, and the Drive end-to-end tests had been guarding the import and skipping when it failed.

This brings the orchestration back where it belongs, in the runtime that actually uses it. Three files land under `src/pocketpaw/retrieval/`:

- `orchestrator.py` — `RetrievalRouter`, the scope-filtered dispatcher (first / parallel / sequential strategies, sync and async). It's called `orchestrator` so it doesn't clash with the existing `router.py`, which is the FastAPI `APIRouter` for the retrieval-journal projection. Two different routers, same package, so the names need to stay apart.
- `broker.py` — `InMemoryCredentialBroker`, the reference broker. Credential lifecycle events stay fail-closed (a failed audit append surfaces to the caller); the router's `retrieval.query` emit stays fire-and-forget. That asymmetry is intentional: one is an auth trail, the other is a query log.
- `adapters.py` — `ProjectionAdapter`, the callable wrapper for local sources like soul memory, kb, and fabric. The old module's `MockAdapter` did not come along; it was a test fixture.

All three are exported from `pocketpaw.retrieval`.

## How it was adapted to 0.4.0

The port is mostly a relocation, but a few things shifted with the new API:

- Every model, protocol, and exception now imports from `soul_protocol.spec.retrieval` instead of the deleted `engine.retrieval.{adapters,broker,exceptions}` submodules.
- The journal scope helpers (`scope_matches`, `scopes_overlap`) never moved, so those imports from `soul_protocol.engine.journal` are unchanged.
- `DataRef` is a typed pydantic model now, but the router never looks inside `candidate.content`, so that change is transparent to the dispatcher. It still merges by score and truncates, nothing more.

## Tests

The `ImportError` guard and skip marker in `tests/connectors/test_drive.py` are gone, so the router + broker integration tests run for real instead of skipping. One assertion was stale against the old API: it read `candidate.content["kind"]` by subscript, but 0.4.0 promotes the adapter's dataref dict to a typed `DataRef`, which isn't subscriptable. It reads `.kind` as an attribute now, matching the sibling unit test that already did.

Results from the worktree (env synced from the committed lockfile, supply-chain gate untouched):

- `tests/connectors/test_drive.py`: 26 passed (was 22 passed + 4 skipped).
- `pytest tests/ -k "retriev or drive"`: 93 passed, 1 skipped (the skip is `test_vectordb.py`, which needs `chromadb`, unrelated).
- `tests/connectors/` + the retrieval-journal projection test: 116 passed.
- `ruff check` / `ruff format --check`: clean.
- `lint-imports`: the "OSS core may not import from EE" contract holds (the new modules only pull from `soul_protocol` and OSS core).

## Docs

No doc surface drifts here. This is internal infrastructure that consumers import programmatically, not a CLI command or runtime API endpoint, so there's nothing in `docs/` to update. Each new and changed file carries a file-top comment explaining the move per the repo convention.

Closes #1327