### PR TITLE
Sites backend: surface orientation + create→publish, /pockets exclusion, naming

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -1,5 +1,12 @@
 """Pockets domain — FastAPI router.
 
+Updated: 2026-06-03 (Sites fix A) — the desktop ``GET /pockets`` gallery
+route now hides pockets that have been published as Paw Sites (they show
+under ``/sites`` instead). It calls ``sites_service.site_pocket_ids`` (a
+cross-entity read via the sites SERVICE, never the Site Beanie model) and
+passes the result as ``exclude_pocket_ids`` to ``list_pockets``. Only this
+route excludes sites — every other ``list_pockets`` caller is unchanged.
+
 Updated: 2026-05-25 (PR #1222 R1 fixes) — the loopback bypass on the
 spec-merge + pocket-read endpoints now requires a process-local
 internal token in addition to the previous loopback + magic header +
@@ -320,7 +327,18 @@ async def list_pockets(
     user_id: str = Depends(current_user_id),
     project_id: str | None = Query(default=None, alias="project_id"),
 ) -> list[dict]:
-    return await pockets_service.list_pockets(workspace_id, user_id, project_id=project_id)
+    # Desktop /pockets gallery. Hide pockets already published as Paw Sites —
+    # they show under /sites instead. The site→pocket lookup goes through the
+    # sites SERVICE (cross-entity read via a service function, not the Site
+    # Beanie model) to respect entity isolation. Only this gallery route
+    # excludes sites; other list_pockets callers (mission control, planners,
+    # kb, surface) keep listing every pocket.
+    from pocketpaw_ee.sites import service as sites_service
+
+    exclude = await sites_service.site_pocket_ids(workspace_id)
+    return await pockets_service.list_pockets(
+        workspace_id, user_id, project_id=project_id, exclude_pocket_ids=exclude
+    )
 
 
 @router.get("/home", response_model=HomePocketResponse)

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -114,6 +114,13 @@ RETURNS ``(authored_keys, skipped_keys)``; both widget paths stash the
 result on the returned view under ``_source_merge`` so the agent_context
 wrappers can build an HONEST tool result — the agent can confirm only the
 sources that actually persisted and can't claim a binding that was dropped.
+Changes: 2026-06-03 (Sites fix A) — ``list_pockets`` gained an optional
+``exclude_pocket_ids: set[str] | None`` kwarg. When provided it adds
+``{"_id": {"$nin": [...]}}`` to the query (pocket ids are stored as
+strings, so no ObjectId cast). The /pockets gallery route passes the ids
+of pockets already published as Sites so they don't appear in both the
+pocket gallery and the sites list. ``None`` is a no-op, so mission
+control / kb / surface / planner callers are unchanged.
 """
 
 from __future__ import annotations
@@ -127,6 +134,7 @@ from pathlib import Path
 from typing import Any
 
 from beanie import PydanticObjectId
+from bson.errors import InvalidId
 from pydantic import ValidationError as PydanticValidationError
 
 from pocketpaw_ee.cloud._core.realtime.emit import emit
@@ -942,6 +950,7 @@ async def list_pockets(
     user_id: str,
     *,
     project_id: str | None = None,
+    exclude_pocket_ids: set[str] | None = None,
 ) -> list[dict]:
     """List pockets visible to the user (owned, shared_with, or workspace-visible).
 
@@ -955,6 +964,17 @@ async def list_pockets(
     whose ``project_id`` matches. Pass an empty string to filter for
     "no project assigned" — that's the Mission Control "Unassigned"
     bucket. Kept as a kwarg so existing callers don't change.
+
+    ``exclude_pocket_ids`` filter: when provided, drops pockets whose id is
+    in the set via ``{"_id": {"$nin": [...]}}``. The /pockets gallery passes
+    the ids of pockets already published as Sites (they show under /sites,
+    not in the pocket gallery). The ids arrive as STRINGS (the wire form), but
+    Beanie persists ``_id`` as an ``ObjectId`` (the ``Pocket.id: str`` annotation
+    is overridden by the Document base), so each id is cast to ``PydanticObjectId``
+    before the ``$nin`` — a string ``$nin`` would silently match nothing and
+    leak every site back into the gallery. Malformed ids are skipped (they can't
+    match any stored ``_id`` anyway). A ``None`` / empty set is a no-op so every
+    other caller (mission control, planners, kb, surface) is unchanged.
     """
     query: dict = {
         "workspace": workspace_id,
@@ -967,6 +987,17 @@ async def list_pockets(
     if project_id is not None:
         # Empty string is intentional → "no project assigned".
         query["project_id"] = project_id or None
+    if exclude_pocket_ids:
+        # _id is stored as an ObjectId — cast the wire-string ids. Skip any
+        # malformed id rather than raise: it can't match a stored _id anyway.
+        oids: list[PydanticObjectId] = []
+        for pid in exclude_pocket_ids:
+            try:
+                oids.append(PydanticObjectId(pid))
+            except (InvalidId, TypeError, ValueError):
+                continue
+        if oids:
+            query["_id"] = {"$nin": oids}
     docs = await _PocketDoc.find(query).to_list()
     return [await _resolved_wire_dict(d, user_id) for d in docs]
 

--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -43,6 +43,7 @@ class SurfaceKind(StrEnum):
     SETTINGS = "settings"
     SIDEPANEL = "sidepanel"
     FORESIGHT = "foresight"  # /foresight + /foresight/scenarios/* routes
+    SITES = "sites"  # /sites — describe-to-create + manage published Paw Sites
     GENERIC = "generic"  # any unknown surface — agent still gets a usable preamble
 
 

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -1,0 +1,32 @@
+# sites.py — /sites surface preamble.
+#
+# Created: 2026-06-02 — Orients the chat agent when the user is on the /sites
+# surface (the Paw Sites gallery + describe-to-create rail). Without it the
+# surface fell back to GENERIC and the agent built + talked "pocket" instead of
+# a publishable website (the operator-reported "agent builds pockets not sites"
+# drift). Static orientation — no live data to fake.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the /sites surface preamble (static orientation, no live data)."""
+    route = meta.route_path or "/sites"
+    return (
+        f'<surface kind="sites" route="{route}" />\n'
+        "<sites-orientation>\n"
+        "The user is on the SITES surface, building a publishable WEBSITE that "
+        "deploys as a standalone static page on the edge — not an in-app pocket "
+        "dashboard. Design a real marketing landing page: a hero, a few content "
+        "sections, and a lead-capture form whose inputs have clear field names. "
+        "Talk about it as a 'site' or 'page' — never a 'pocket'. The pocket you "
+        "create is only the source spec; it will be auto-published to a live URL, "
+        "so favor clean marketing copy, real sections, and a working contact / "
+        "sign-up form over generic dashboard widgets.\n"
+        "</sites-orientation>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -5,6 +5,17 @@
 # surface fell back to GENERIC and the agent built + talked "pocket" instead of
 # a publishable website (the operator-reported "agent builds pockets not sites"
 # drift). Static orientation — no live data to fake.
+#
+# Updated: 2026-06-03 — Folded the create→publish PROCEDURE into the preamble.
+# The /sites create flow used to fire a `/pocketpaw-create-site` slash command
+# to invoke the create-site skill, but the chat agent runs the Claude Agent SDK
+# with `setting_sources=[]` (persona isolation) which disables skill discovery,
+# so the slash command was a silent no-op. The frontend now sends the user's
+# description as PLAIN TEXT, so the two-step the skill used to carry (create the
+# source pocket via the pocket-specialist MCP tool, then publish it via the
+# sites-manager MCP tool, then show the live URL) has to live in this always-on
+# preamble instead. We instruct the agent to call the MCP tools DIRECTLY — not
+# to invoke a Skill, since skills can't load under setting_sources=[].
 
 from __future__ import annotations
 
@@ -12,7 +23,7 @@ from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
 
 
 async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
-    """Render the /sites surface preamble (static orientation, no live data)."""
+    """Render the /sites surface preamble (static orientation + build procedure)."""
     route = meta.route_path or "/sites"
     return (
         f'<surface kind="sites" route="{route}" />\n'
@@ -21,11 +32,28 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         "deploys as a standalone static page on the edge — not an in-app pocket "
         "dashboard. Design a real marketing landing page: a hero, a few content "
         "sections, and a lead-capture form whose inputs have clear field names. "
-        "Talk about it as a 'site' or 'page' — never a 'pocket'. The pocket you "
-        "create is only the source spec; it will be auto-published to a live URL, "
-        "so favor clean marketing copy, real sections, and a working contact / "
-        "sign-up form over generic dashboard widgets.\n"
-        "</sites-orientation>"
+        "Talk about it as a 'site' or 'page' — never a 'pocket'. The pocket is "
+        "only the source spec; it auto-publishes to a live URL, so favor clean "
+        "marketing copy, real sections, and a working contact / sign-up form over "
+        "generic dashboard widgets.\n"
+        "</sites-orientation>\n"
+        "<sites-procedure>\n"
+        "Treat the user's message on this surface as a request to BUILD AND "
+        "PUBLISH a site. Do it directly via the MCP tools below — do NOT invoke a "
+        "skill or slash command (they don't load here):\n"
+        "1. CREATE the source spec by calling the "
+        "`mcp__pocketpaw_pocket_specialist__create` tool with a marketing/landing "
+        "layout: a hero (page-header), a few value/content sections, and a "
+        "contact / lead-capture form (form-layout) whose inputs have CLEAR field "
+        "names — e.g. full_name, email, phone, message — so the published site "
+        "captures leads out of the box.\n"
+        "2. PUBLISH it as a live site by calling the "
+        "`mcp__pocketpaw_sites_manager__publish` tool with the new pocket_id "
+        "returned in step 1. If it returns an error, relay it — never claim a "
+        "phantom publish.\n"
+        "3. SHOW the user the live `url` from the publish response plus a link to "
+        "/sites where they manage their sites. Keep talking 'site' / 'page'.\n"
+        "</sites-procedure>"
     )
 
 

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -51,6 +51,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
         quickask,
         settings,
         sidepanel,
+        sites,
     )
     from pocketpaw_ee.cloud.surface.handlers import (
         agent as agent_handler,
@@ -83,6 +84,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
         SurfaceKind.SETTINGS: settings.build_preamble,
         SurfaceKind.SIDEPANEL: sidepanel.build_preamble,
         SurfaceKind.FORESIGHT: foresight_handler.build_preamble,
+        SurfaceKind.SITES: sites.build_preamble,
         SurfaceKind.GENERIC: generic.build_preamble,
     }
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -61,6 +61,18 @@
 # cmux smoke. The REAL Cloudflare path is unchanged and stays the default when
 # creds ARE present (or a CF client is injected, e.g. by tests). PROD TODO: local
 # mode is a dev shim — production always takes the CF path.
+#
+# Updated 2026-06-03 (Sites backend fixes A+B): (A) added site_pocket_ids() — the
+# set of pocket_ids that have a Site in a workspace, so the /pockets gallery can
+# exclude already-published pockets WITHOUT the pockets service importing the Site
+# model (entity isolation: the Site read stays here, the sole owner of Site
+# reads). (B) publish() now resolves a blank ``name`` to the source pocket's own
+# display name (via the pockets service's PUBLIC ``get`` — no Beanie import),
+# falling back to "Untitled site" only when the pocket has no name. This makes the
+# publish schema's "defaults to the pocket's own name" promise true at the
+# source-of-truth layer, so sites no longer land unnamed when the caller omits a
+# name. The resolved name flows into BOTH the generated site ``title`` and the
+# stored ``Site.name``.
 
 from __future__ import annotations
 
@@ -191,8 +203,29 @@ async def publish(
       * LOCAL fake-deploy (no CF creds / PAW_SITES_LOCAL=1, and no injected CF
         client): persist the built static site and serve it from localhost,
         storing that URL on the Site so the response is openable. Cloudflare is
-        not contacted at all."""
+        not contacted at all.
+
+    ``name`` defaults to the source pocket's own display name when the caller
+    omits it (the publish schema promises this). The fallback reads the pocket
+    through the pockets service's PUBLIC ``get`` (a wire dict — no Beanie import,
+    respecting entity isolation) and uses its ``name`` field; only when the pocket
+    has no name does it fall back to "Untitled site". Callers that pre-resolve the
+    name (e.g. ``publish_pocket``, which already holds the wire dict) pass it in,
+    so the common path does not re-fetch."""
     generator = _generator or GeneratorClient()
+
+    # Default a blank name to the source pocket's own display name so the schema's
+    # "defaults to the pocket's own name" promise is true at the source-of-truth
+    # layer. Cross-entity read goes through the pockets service's PUBLIC function
+    # (wire dict), never the Pocket Beanie model.
+    site_name = name.strip() if name else ""
+    if not site_name:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        pocket = await pockets_service.get(pocket_id, user_id)
+        site_name = (pocket.get("name") or "").strip()
+    if not site_name:
+        site_name = "Untitled site"
 
     site_id = str(ObjectId())
     signed_key = f"site_key_{secrets.token_urlsafe(24)}"
@@ -201,7 +234,7 @@ async def publish(
         ripple_spec=ripple_spec,
         theme=theme,
         site_id=site_id,
-        title=name or "Untitled site",
+        title=site_name,
         capture_api_base=_capture_base(),
         capture_signed_key=signed_key,
     )
@@ -225,7 +258,7 @@ async def publish(
         workspace=workspace_id,
         pocket_id=pocket_id,
         owner=user_id,
-        name=name,
+        name=site_name,
         script_name=site_id,
         deployed=True,
         signed_key=signed_key,
@@ -338,7 +371,10 @@ async def publish_pocket(
     ``POST /sites/publish`` endpoint and the ``sites_manager__publish`` MCP tool
     call this so the two surfaces share one code path: a single place reads the
     pocket, derives the theme, and names the site. ``name`` falls back to the
-    pocket's own name when the caller does not override it.
+    pocket's own name when the caller does not override it — resolved HERE from the
+    wire dict this function already holds, so ``publish`` does not re-fetch the
+    pocket on this path. (``publish`` carries the same fallback as a safety net for
+    direct callers who pass a blank name.)
 
     The generator / Cloudflare / bundle-reader / local-deploy seams are forwarded
     straight through to ``publish`` so the shared path is unit-testable without
@@ -369,6 +405,19 @@ async def list_for_workspace(workspace_id: str) -> list[SiteResponse]:
     return [_to_response(doc) async for doc in cursor]
 
 
+async def site_pocket_ids(workspace_id: str) -> set[str]:
+    """Return the set of ``pocket_id``s that have a published Site in this
+    workspace.
+
+    Lets the /pockets gallery hide pockets that have been published as a Site
+    (they show under /sites instead) WITHOUT the pockets service importing the
+    Site Beanie model — the Site read stays in this service, which is the sole
+    owner of Site reads (entity isolation). Tenant-scoped on ``workspace``.
+    """
+    cursor = _SiteDoc.find({"workspace": workspace_id})
+    return {doc.pocket_id async for doc in cursor}
+
+
 __all__ = [
     "publish",
     "publish_pocket",
@@ -376,4 +425,5 @@ __all__ = [
     "domain_status",
     "list_domains",
     "list_for_workspace",
+    "site_pocket_ids",
 ]

--- a/tests/cloud/pockets/test_gallery_site_exclusion.py
+++ b/tests/cloud/pockets/test_gallery_site_exclusion.py
@@ -1,0 +1,134 @@
+# tests/cloud/pockets/test_gallery_site_exclusion.py
+# Created: 2026-06-03 (Sites fix A) — pins that the desktop /pockets gallery
+# hides pockets already published as Paw Sites, while keeping every other
+# list_pockets caller (mission control, kb, surface, planners) unchanged.
+#
+# Covers:
+#   * sites_service.site_pocket_ids — returns the set of pocket_ids that have a
+#     Site in the workspace (tenant-scoped).
+#   * the GALLERY route handler (pockets.router.list_pockets) — returns only the
+#     non-site pocket once one of two pockets is published as a Site.
+#   * list_pockets WITHOUT the exclude kwarg — still returns BOTH pockets, so the
+#     exclusion is opt-in and the existing callers don't regress.
+#
+# Uses the shared ``mongo_db`` fixture (tests/cloud/conftest.py) which inits
+# Beanie against an in-memory Mongo with ALL_DOCUMENTS (Pocket + Site both
+# registered) and auto-installs a RecordingBus so the create() emit() succeeds.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+# The gallery route HANDLER (not the APIRouter — pockets/__init__ re-exports the
+# APIRouter as ``router``, so import the handler from the submodule by path).
+from pocketpaw_ee.cloud.pockets.router import list_pockets as gallery_list_route
+from pocketpaw_ee.sites import service as sites_service
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_gallery"
+_USER = "user_gallery"
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakeCF:
+    async def put_worker(self, *, script_name, bundle):
+        return True
+
+
+async def _make_pocket(name: str) -> str:
+    """Create a pocket via the service and return its id."""
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name=name))
+    return wire["_id"]
+
+
+async def _publish_as_site(pocket_id: str) -> None:
+    """Publish a pocket as a Site through the real service boundary (fakes for
+    the generator + Cloudflare), so a Site doc with the right pocket_id lands."""
+    await sites_service.publish(
+        workspace_id=_WS,
+        user_id=_USER,
+        pocket_id=pocket_id,
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Published Site",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"export default {}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_site_pocket_ids_returns_published_pocket_ids() -> None:
+    plain_id = await _make_pocket("Plain Pocket")
+    site_pocket_id = await _make_pocket("Site Pocket")
+    await _publish_as_site(site_pocket_id)
+
+    ids = await sites_service.site_pocket_ids(_WS)
+
+    assert ids == {site_pocket_id}
+    assert plain_id not in ids
+
+
+@pytest.mark.asyncio
+async def test_site_pocket_ids_empty_when_no_sites() -> None:
+    await _make_pocket("Lonely Pocket")
+    assert await sites_service.site_pocket_ids(_WS) == set()
+
+
+@pytest.mark.asyncio
+async def test_site_pocket_ids_is_tenant_scoped() -> None:
+    site_pocket_id = await _make_pocket("Site Pocket")
+    await _publish_as_site(site_pocket_id)
+
+    # A different workspace sees none of this workspace's site pockets.
+    assert await sites_service.site_pocket_ids("ws_other") == set()
+
+
+@pytest.mark.asyncio
+async def test_gallery_route_excludes_published_site_pocket() -> None:
+    plain_id = await _make_pocket("Plain Pocket")
+    site_pocket_id = await _make_pocket("Site Pocket")
+    await _publish_as_site(site_pocket_id)
+
+    # Call the gallery route handler directly with explicit args (overriding the
+    # FastAPI Depends defaults) so we exercise the handler's exclusion wiring.
+    result = await gallery_list_route(workspace_id=_WS, user_id=_USER, project_id=None)
+
+    returned_ids = {p["_id"] for p in result}
+    assert plain_id in returned_ids
+    assert site_pocket_id not in returned_ids
+    assert returned_ids == {plain_id}
+
+
+@pytest.mark.asyncio
+async def test_plain_list_pockets_still_returns_both_no_regression() -> None:
+    plain_id = await _make_pocket("Plain Pocket")
+    site_pocket_id = await _make_pocket("Site Pocket")
+    await _publish_as_site(site_pocket_id)
+
+    # The service-level list_pockets (no exclude kwarg) is what mission control,
+    # kb, surface, and planners call — it must keep returning EVERY pocket.
+    result = await pockets_service.list_pockets(_WS, _USER)
+
+    returned_ids = {p["_id"] for p in result}
+    assert returned_ids == {plain_id, site_pocket_id}
+
+
+@pytest.mark.asyncio
+async def test_list_pockets_exclude_kwarg_drops_only_named_ids() -> None:
+    keep_id = await _make_pocket("Keep")
+    drop_id = await _make_pocket("Drop")
+
+    result = await pockets_service.list_pockets(_WS, _USER, exclude_pocket_ids={drop_id})
+
+    returned_ids = {p["_id"] for p in result}
+    assert returned_ids == {keep_id}

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -1,0 +1,57 @@
+# tests/cloud/surface/test_sites_handler.py — Sites surface handler.
+#
+# Created: 2026-06-03 — Guards the /sites surface preamble. The create-site
+# skill can't load under the chat agent's `setting_sources=[]` SDK config
+# (skill discovery disabled for persona isolation), so the create→publish
+# PROCEDURE has to live in the always-on /sites preamble instead. These
+# tests assert the preamble carries:
+#   1. The orientation it already had — surface kind="sites", talk "site"
+#      not "pocket" as the deliverable.
+#   2. The folded-in procedure — the create MCP tool, the publish MCP tool,
+#      and a lead-capture form with named fields so the published site
+#      captures leads out of the box.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import sites as sites_handler
+
+pytestmark = pytest.mark.asyncio
+
+WORKSPACE = "ws-surface-sites"
+USER = "u-sites"
+
+
+async def test_sites_handler_carries_orientation() -> None:
+    """The preamble still orients: surface=sites, build a site (not a pocket)."""
+    preamble = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+
+    assert '<surface kind="sites"' in preamble
+    # Talks about the deliverable as a site/page.
+    assert "site" in preamble.lower()
+    # Must NOT frame the deliverable as a pocket — the agent kept building
+    # in-app pockets instead of publishable sites (the reported drift).
+    assert "build a pocket" not in preamble.lower()
+    assert "build a 'pocket'" not in preamble.lower()
+
+
+async def test_sites_handler_carries_create_publish_procedure() -> None:
+    """The preamble folds the create→publish two-step in via the MCP tools."""
+    preamble = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+
+    # Step 1 — create the source pocket via the pocket specialist MCP tool.
+    assert "mcp__pocketpaw_pocket_specialist__create" in preamble
+    # Step 2 — publish it as a live site via the sites manager MCP tool.
+    assert "mcp__pocketpaw_sites_manager__publish" in preamble
+
+
+async def test_sites_handler_specifies_lead_capture_form() -> None:
+    """The procedure asks for a lead-capture form with clear field names."""
+    preamble = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+
+    lower = preamble.lower()
+    # A form is part of the marketing/landing build.
+    assert "form" in lower
+    # At least one concrete, named field so leads are actually captured.
+    assert "email" in lower or "full_name" in lower

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -23,6 +23,13 @@
 # tool both call — mocks pockets_service.get to prove it derives the theme from
 # rippleSpec, falls back to the pocket's name, applies a name override, and
 # propagates NotFound rather than swallowing it.
+# Updated 2026-06-03 (Sites fix B — published site name defaults to the pocket
+# name): coverage that publish() resolves a BLANK name to the source pocket's own
+# display name (read via the pockets service's public get, no Beanie import) for
+# both the stored Site.name and the generated site title, falling back to
+# "Untitled site" only when the pocket has no name. Also pins the end-to-end
+# publish_pocket path: a pocket named "Flower Shop Landing Page" published with no
+# name lands a Site named "Flower Shop Landing Page".
 from __future__ import annotations
 
 import pytest
@@ -457,3 +464,121 @@ async def test_publish_pocket_propagates_not_found(beanie_test_db):
                 user_id="u1",
                 pocket_id="pk_missing",
             )
+
+
+# ---------------------------------------------------------------------------
+# Fix B — a published site's name defaults to the source pocket's own name when
+# the caller omits it (the publish schema promises this). Resolved in publish()
+# itself (the source of truth) so a blank name never lands an unnamed site.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_blank_name_defaults_to_pocket_name(beanie_test_db):
+    """publish() with a blank name looks up the source pocket (via the pockets
+    service's public get) and uses its display name for BOTH the stored Site.name
+    and the generated site title."""
+    from unittest.mock import AsyncMock, patch
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    wire = {"name": "Flower Shop Landing Page", "rippleSpec": {"type": "container"}}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ) as mock_get:
+        site = await sites_service.publish(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            ripple_spec={"type": "container"},
+            theme={},
+            # name deliberately omitted (defaults to "")
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"export default {}",
+        )
+
+    mock_get.assert_awaited_once_with("pk1", "u1")
+    assert site.name == "Flower Shop Landing Page"
+    # The generated site title used the same resolved name (not "Untitled site").
+    assert gen.built["title"] == "Flower Shop Landing Page"
+
+
+@pytest.mark.asyncio
+async def test_publish_explicit_name_skips_pocket_lookup(beanie_test_db):
+    """A non-blank name wins and publish() does NOT read the pocket for a name."""
+    from unittest.mock import AsyncMock, patch
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value={"name": "Pocket Name"}),
+    ) as mock_get:
+        site = await sites_service.publish(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            ripple_spec={"type": "container"},
+            theme={},
+            name="Explicit Name",
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"export default {}",
+        )
+
+    mock_get.assert_not_awaited()
+    assert site.name == "Explicit Name"
+    assert gen.built["title"] == "Explicit Name"
+
+
+@pytest.mark.asyncio
+async def test_publish_blank_name_and_nameless_pocket_falls_back_to_untitled(
+    beanie_test_db,
+):
+    """When the name is blank AND the pocket has no name, publish() falls back to
+    'Untitled site' rather than persisting an empty name."""
+    from unittest.mock import AsyncMock, patch
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value={"name": ""}),
+    ):
+        site = await sites_service.publish(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            ripple_spec={"type": "container"},
+            theme={},
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"export default {}",
+        )
+
+    assert site.name == "Untitled site"
+
+
+@pytest.mark.asyncio
+async def test_publish_pocket_no_name_lands_site_with_pocket_name(beanie_test_db):
+    """End-to-end: publishing a pocket named 'Flower Shop Landing Page' WITHOUT a
+    name (the shared publish_pocket path the REST + MCP surfaces use) results in a
+    Site named 'Flower Shop Landing Page'."""
+    from unittest.mock import AsyncMock, patch
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    wire = {"name": "Flower Shop Landing Page", "rippleSpec": {"type": "container"}}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        site = await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            # no name passed — the agent / UI omitted it
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"export default {}",
+        )
+
+    assert site.name == "Flower Shop Landing Page"


### PR DESCRIPTION
The backend half of the /sites create flow.

## What's here
- **Surface orientation + the procedure.** A `SurfaceKind.SITES` handler injects a /sites preamble so the chat agent builds a publishable website, not an in-app pocket. The agent SDK runs with `setting_sources=[]` (persona isolation), so the create-site skill can't load — the preamble carries the procedure itself: create the source pocket via pocket_specialist (hero + sections + a named-field lead form), publish via the sites manager, show the live URL. A plain-text description drives it; no slash command.
- **Sites stay out of /pockets.** A site is generated from a pocket, so that source pocket was doubling up in the /pockets gallery. The gallery list now excludes any pocket that has a Site (resolved through the sites service to keep entity isolation intact).
- **Sites name themselves after their pocket.** `publish()` defaults a site's name to its pocket's name when none is passed — the tool always promised this but stored a blank, so sites were landing unnamed or duplicate-named.

## Tests
- surface preamble carries the procedure + named form fields
- /pockets gallery excludes site source-pockets (and the plain list still returns them, no regression)
- publish names the site after its pocket
Green locally; broader pockets/sites/surface sweep clean.

Builds on the Paw Sites backend control plane (#1298, merged).
