### PR TITLE
feat(sites): drive /sites create→publish via the create-site skill

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -6,16 +6,19 @@
 # a publishable website (the operator-reported "agent builds pockets not sites"
 # drift). Static orientation — no live data to fake.
 #
-# Updated: 2026-06-03 — Folded the create→publish PROCEDURE into the preamble.
-# The /sites create flow used to fire a `/pocketpaw-create-site` slash command
-# to invoke the create-site skill, but the chat agent runs the Claude Agent SDK
-# with `setting_sources=[]` (persona isolation) which disables skill discovery,
-# so the slash command was a silent no-op. The frontend now sends the user's
-# description as PLAIN TEXT, so the two-step the skill used to carry (create the
-# source pocket via the pocket-specialist MCP tool, then publish it via the
-# sites-manager MCP tool, then show the live URL) has to live in this always-on
-# preamble instead. We instruct the agent to call the MCP tools DIRECTLY — not
-# to invoke a Skill, since skills can't load under setting_sources=[].
+# Updated: 2026-06-03 (pm) — Point the procedure back at the `pocketpaw-create-site`
+# skill now that bundled skills actually load on the SDK backend. The earlier
+# note here ("skills can't load under setting_sources=[]") is obsolete: the
+# claude_agent_sdk backend now loads the bundled skills as a Claude Code local
+# plugin via the SDK `plugins=` option (see `bundled_skills_plugin_dir` +
+# `settings.sdk_load_bundled_skills`), so the agent can invoke the skill by
+# natural-language intent — no slash command, no setting_sources change. The
+# skill carries the full create→publish flow (build the source pocket via
+# create-pocket, publish via the sites-manager tool, surface the live URL, relay
+# errors), so the preamble PREFERS it and keeps the raw MCP tools only as a
+# fallback for when the skill is unavailable (e.g. sdk_load_bundled_skills off).
+# The rail still sends the user's description as PLAIN TEXT; intent invocation
+# does not need a slash.
 
 from __future__ import annotations
 
@@ -39,20 +42,20 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         "</sites-orientation>\n"
         "<sites-procedure>\n"
         "Treat the user's message on this surface as a request to BUILD AND "
-        "PUBLISH a site. Do it directly via the MCP tools below — do NOT invoke a "
-        "skill or slash command (they don't load here):\n"
-        "1. CREATE the source spec by calling the "
-        "`mcp__pocketpaw_pocket_specialist__create` tool with a marketing/landing "
-        "layout: a hero (page-header), a few value/content sections, and a "
-        "contact / lead-capture form (form-layout) whose inputs have CLEAR field "
-        "names — e.g. full_name, email, phone, message — so the published site "
-        "captures leads out of the box.\n"
-        "2. PUBLISH it as a live site by calling the "
-        "`mcp__pocketpaw_sites_manager__publish` tool with the new pocket_id "
-        "returned in step 1. If it returns an error, relay it — never claim a "
-        "phantom publish.\n"
-        "3. SHOW the user the live `url` from the publish response plus a link to "
-        "/sites where they manage their sites. Keep talking 'site' / 'page'.\n"
+        "PUBLISH a site. PREFER the `pocketpaw-create-site` skill — invoke it by "
+        "intent (no slash command needed). It carries the whole flow: build the "
+        "source pocket as a marketing/landing page — a hero (page-header), a few "
+        "value/content sections, and a contact / lead-capture form (form-layout) "
+        "whose inputs have CLEAR field names like full_name, email, phone, "
+        "message so the published site captures leads out of the box — then "
+        "publish it and show the live URL.\n"
+        "If the skill is unavailable, fall back to the same two steps directly "
+        "with the MCP tools: call `mcp__pocketpaw_pocket_specialist__create` to "
+        "build the landing-page spec, then `mcp__pocketpaw_sites_manager__publish` "
+        "with the returned pocket_id.\n"
+        "Either way: relay any publish error — never claim a phantom publish — and "
+        "after it succeeds, SHOW the live `url` plus a link to /sites where the "
+        "user manages their sites. Keep talking 'site' / 'page', never 'pocket'.\n"
         "</sites-procedure>"
     )
 

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -1,15 +1,16 @@
 # tests/cloud/surface/test_sites_handler.py — Sites surface handler.
 #
-# Created: 2026-06-03 — Guards the /sites surface preamble. The create-site
-# skill can't load under the chat agent's `setting_sources=[]` SDK config
-# (skill discovery disabled for persona isolation), so the create→publish
-# PROCEDURE has to live in the always-on /sites preamble instead. These
-# tests assert the preamble carries:
-#   1. The orientation it already had — surface kind="sites", talk "site"
-#      not "pocket" as the deliverable.
-#   2. The folded-in procedure — the create MCP tool, the publish MCP tool,
-#      and a lead-capture form with named fields so the published site
-#      captures leads out of the box.
+# Created: 2026-06-03 — Guards the /sites surface preamble.
+# Updated: 2026-06-03 (pm) — Bundled skills now load on the SDK backend (local
+# plugin via the SDK `plugins=` option), so the preamble PREFERS the
+# `pocketpaw-create-site` skill and keeps the raw MCP tools only as a fallback.
+# These tests assert the preamble carries:
+#   1. The orientation — surface kind="sites", talk "site" not "pocket".
+#   2. The preferred path — the `pocketpaw-create-site` skill.
+#   3. The fallback path — the create MCP tool + the publish MCP tool — still
+#      present so the flow never breaks when the skill is unavailable.
+#   4. A lead-capture form with named fields so the published site captures
+#      leads out of the box.
 
 from __future__ import annotations
 
@@ -36,14 +37,28 @@ async def test_sites_handler_carries_orientation() -> None:
     assert "build a 'pocket'" not in preamble.lower()
 
 
-async def test_sites_handler_carries_create_publish_procedure() -> None:
-    """The preamble folds the create→publish two-step in via the MCP tools."""
+async def test_sites_handler_prefers_create_site_skill() -> None:
+    """The preamble points the agent at the create-site skill as the primary
+    path now that bundled skills load on the SDK backend."""
+    preamble = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+
+    assert "pocketpaw-create-site" in preamble
+    # It must be framed as the preferred route, not an afterthought.
+    assert "prefer" in preamble.lower()
+
+
+async def test_sites_handler_keeps_mcp_fallback() -> None:
+    """The raw MCP tools remain as a fallback so the create→publish flow never
+    breaks when the skill is unavailable (e.g. sdk_load_bundled_skills off, or a
+    backend without the bundled plugin)."""
     preamble = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
 
     # Step 1 — create the source pocket via the pocket specialist MCP tool.
     assert "mcp__pocketpaw_pocket_specialist__create" in preamble
     # Step 2 — publish it as a live site via the sites manager MCP tool.
     assert "mcp__pocketpaw_sites_manager__publish" in preamble
+    # Framed as a fallback, not the primary instruction.
+    assert "fall back" in preamble.lower() or "fallback" in preamble.lower()
 
 
 async def test_sites_handler_specifies_lead_capture_form() -> None:


### PR DESCRIPTION
Stacked on #1330 (where the `/sites` handler lives). Needs the bundled-skills plugin fix (#1331) at runtime — that's what makes the skill loadable on the SDK backend.

## What changed

When `/sites` shipped, the create→publish procedure was inlined into the surface preamble because bundled skills couldn't load on the `claude_agent_sdk` backend (`setting_sources=[]`). #1331 fixes that — the bundled skills now load as a local plugin. So the `/sites` preamble can point back at the `pocketpaw-create-site` skill, which already carries the richer flow (both paths, error relay, a quality bar) as a single source of truth.

The preamble now **prefers** the skill (invoked by natural-language intent, no slash) and keeps the raw MCP tools (`pocket_specialist__create` + `sites_manager__publish`) as an explicit **fallback**, so the flow never breaks if the skill is unavailable (`sdk_load_bundled_skills` off, or a backend without the bundled plugin). The rail still sends plain text — no frontend change.

## Verified

- Unit: the preamble prefers the skill, retains the MCP fallback, and keeps the lead-capture orientation (4 tests).
- Live cloud run on `surface=sites` (paw-enterprise → `pocketpaw serve`): the plugin loads and the agent identifies `pocketpaw-bundled:pocketpaw-create-site` as the skill to invoke. That namespaced form comes from the loaded plugin registry, not the preamble (which uses the bare name) — proof the agent is engaging the real skill, not echoing text.

## Merge order

#1331 (plugin fix) and #1330 (sites backend) can merge in either order; this lands after both. If you'd rather, I can fold it into #1330 instead of keeping it stacked.