### PR TITLE
Landing-aware refine on the per-site chat

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -10,6 +10,11 @@
 # ``SurfaceContext`` (resolved snapshot + rendered preamble). Per the
 # 11 entity rules, tenancy is enforced at construction — ``workspace_id``
 # and ``user_id`` are required on ``SurfaceContext``.
+#
+# Updated: 2026-06-04 (feat/sites-refine-surface) — ``SurfaceMeta`` grows a
+# ``site_id`` hint. The /sites/[siteId] refine chat stamps the published
+# site id (and the underlying pocket_id) so the sites handler can branch onto
+# a LANDING-AWARE REFINE preamble instead of the create-a-new-site one.
 
 from __future__ import annotations
 
@@ -72,6 +77,11 @@ class SurfaceMeta:
     run_id: str | None = None
     scenario_id: str | None = None
     panel: str | None = None
+    # Sites surface hint — set by the /sites/[siteId] refine chat. The id of
+    # the published Paw Site being refined; paired with ``pocket_id`` (the
+    # site's source pocket) so the handler routes to the refine/edit path
+    # instead of the create-a-new-site path. Absent on the /sites gallery.
+    site_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/surface/dto.py
+++ b/ee/pocketpaw_ee/cloud/surface/dto.py
@@ -11,6 +11,10 @@
 # response shape. There is no response DTO here because the surface
 # context is consumed in-process by ``chat/agent_service`` (no HTTP
 # round-trip).
+#
+# Updated: 2026-06-04 (feat/sites-refine-surface) — mirror ``SurfaceMeta``'s
+# new ``site_id`` hint so the /sites/[siteId] refine chat can stamp the
+# published site id on the wire and the sites handler can branch to refine.
 
 from __future__ import annotations
 
@@ -36,6 +40,9 @@ class SurfaceMetaRequest(BaseModel):
     run_id: str | None = None
     scenario_id: str | None = None
     panel: str | None = None
+    # Sites hint — mirror SurfaceMeta. Set by the /sites/[siteId] refine chat
+    # alongside pocket_id so the handler refines the existing site. Optional.
+    site_id: str | None = None
 
 
 class SurfaceRequest(BaseModel):

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -28,6 +28,16 @@
 # leads (the broken "Option A" render). The lead form must be FLAT native
 # `input`/`button{type:submit}` with real `name=`. create-site Path A (publish an
 # existing pocket) is unchanged; only a brand-new-site description routes here.
+# Updated: 2026-06-04 (feat/sites-refine-surface) — The /sites surface now has
+# TWO modes. The gallery (no pocket_id) keeps the create-a-new-site preamble
+# above. The per-site refine chat at /sites/[siteId] stamps `pocket_id` (the
+# site's source pocket) + `site_id` in the surface meta; when `pocket_id` is
+# present, `build_preamble` branches to a LANDING-AWARE REFINE preamble that
+# tells the agent to EDIT the existing published pocket via
+# `mcp__pocketpaw_pocket_specialist__edit` — never rebuild from scratch, never
+# treat it as a dashboard pocket — while preserving the landing structure and
+# the same 5 SSR rules the create brain enforces. Refine-mode rules mirror
+# `src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md`.
 
 from __future__ import annotations
 
@@ -35,7 +45,23 @@ from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
 
 
 async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
-    """Render the /sites surface preamble (static orientation + build procedure)."""
+    """Render the /sites surface preamble.
+
+    Two modes, keyed on whether the meta carries a ``pocket_id``:
+
+    * **Create** (no ``pocket_id``) — the /sites gallery / describe-to-create
+      rail. Build AND publish a brand-new marketing site.
+    * **Refine** (``pocket_id`` present) — the per-site chat at
+      ``/sites/[siteId]``. Refine the EXISTING published site by editing its
+      source pocket in place; never rebuild from scratch.
+    """
+    if meta.pocket_id:
+        return _refine_preamble(meta)
+    return _create_preamble(meta)
+
+
+def _create_preamble(meta: SurfaceMeta) -> str:
+    """The /sites gallery preamble — build AND publish a brand-new site."""
     route = meta.route_path or "/sites"
     return (
         f'<surface kind="sites" route="{route}" />\n'
@@ -73,6 +99,65 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         "Either way: relay any publish error — never claim a phantom publish — and "
         "after it succeeds, SHOW the live `url` plus a link to /sites where the "
         "user manages their sites. Keep talking 'site' / 'page', never 'pocket'.\n"
+        "</sites-procedure>"
+    )
+
+
+def _refine_preamble(meta: SurfaceMeta) -> str:
+    """The /sites/[siteId] refine preamble — edit an EXISTING published site.
+
+    Landing-aware: mirrors the create-paw-site brain's structure + 5 SSR rules
+    so an edit can't reintroduce a static-site trap. Carries the source
+    ``pocket_id`` so the agent edits the right pocket in place.
+    """
+    route = meta.route_path or "/sites"
+    pocket_id = meta.pocket_id or ""
+    return (
+        f'<surface kind="sites" route="{route}" pocket="{pocket_id}" mode="refine" />\n'
+        "<sites-orientation>\n"
+        f"The user is REFINING an EXISTING published Paw Site (source pocket "
+        f"`{pocket_id}`) — a live standalone marketing website already deployed "
+        "as a static page on the edge. They are on its per-site chat, asking for "
+        "a CHANGE to that page. Do NOT rebuild the site from scratch, do NOT "
+        "create a new site or a new pocket, and do NOT treat it as an in-app "
+        "dashboard pocket. It is a real marketing landing page that reads top to "
+        "bottom as a conversion funnel: nav, hero, services, social proof, "
+        "pricing, a call-to-action, a flat lead-capture form, footer. Talk about "
+        "it as a 'site' or 'page' — never a 'pocket'. The page renders STATICALLY "
+        "(no JavaScript runs for the visitor), so every change must still work as "
+        "plain HTML.\n"
+        "</sites-orientation>\n"
+        "<sites-procedure>\n"
+        "Treat the user's message as an edit to APPLY to the existing site, then "
+        f"re-publish. Apply the change to pocket `{pocket_id}` via "
+        "`mcp__pocketpaw_pocket_specialist__edit` (the merge/edit path — it "
+        "mutates the existing spec in place). NEVER use the create path and NEVER "
+        "rebuild the page from scratch; a refine is a targeted edit on top of the "
+        "current landing spec. After the edit lands it can be re-published (the "
+        "site auto-publishes from its source pocket); relay any publish error — "
+        "never claim a phantom publish — and show the live `url`.\n"
+        "PRESERVE the landing structure (nav → hero → services → proof → pricing "
+        "→ flat lead form → footer) and keep the 5 static-site (SSR) rules intact "
+        "while you edit:\n"
+        "1. Lead capture stays FLAT native `input`/`textarea`/"
+        "`button{type:\"submit\"}` with real field names (name, email, phone, "
+        "message) — NEVER the `form` or `newsletter` widget, which nests an "
+        "invalid `<form>` inside the site template's outer POST form and captures "
+        "zero leads.\n"
+        "2. `pricing-table` uses `tiers` (never `plans`/`columns`).\n"
+        "3. An FAQ is `heading` + `text` pairs — NEVER the `accordion` widget "
+        "(its panels only open with JS, so on a static site the answers never "
+        "expand).\n"
+        "4. Every CTA is an anchor `href` (or `tel:` / `mailto:`) — never an "
+        "`on_click` handler, which is a dead button with no client JS.\n"
+        "5. `hero` is the marketing Hero widget — never the dashboard "
+        "`hero+grid` (a page-header plus a KPI `stat` grid); no metric grid, no "
+        "charts. This is marketing, not analytics.\n"
+        "Any animation stays Tier-0 (CSS-only, static-safe) — `aurora`, "
+        "`marquee`, `border-beam`, `shimmer`, `text-effect`; never `reveal`, "
+        "`parallax`, or `spotlight` (they need client JS and hide content on a "
+        "static page). Keep `type=\"site\"` + `pattern=\"landing\"` on the pocket. "
+        "Keep talking 'site' / 'page', never 'pocket'.\n"
         "</sites-procedure>"
     )
 

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -117,6 +117,7 @@ def _meta_from_request(req: SurfaceMetaRequest) -> SurfaceMeta:
         run_id=req.run_id,
         scenario_id=req.scenario_id,
         panel=req.panel,
+        site_id=req.site_id,
     )
 
 

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -10,7 +10,15 @@
 # `form`/`newsletter` widgets nest an invalid `<form>` inside the static
 # template's outer POST form (the broken-dashboard render). The lead-form test
 # now pins the FLAT-native-input guidance instead of a form widget.
-# These tests assert the preamble carries:
+# Updated: 2026-06-04 (feat/sites-refine-surface) — the /sites surface now has
+# TWO modes. The gallery (no pocket_id) still gets the create-a-new-site
+# preamble; the per-site refine chat (meta carries a pocket_id) gets a
+# LANDING-AWARE REFINE preamble that edits the existing published pocket via
+# the merge/edit path instead of rebuilding from scratch. The create-mode tests
+# below pin the no-pocket_id branch; the new refine-mode tests pin the
+# pocket_id branch (existing-site orientation, edit tool, the same 5 SSR rules,
+# and that it does NOT say "build a new site").
+# These tests assert the create-mode preamble carries:
 #   1. The orientation — surface kind="sites", talk "site" not "pocket".
 #   2. The preferred path — the `pocketpaw-create-paw-site` marketing brain.
 #   3. The fallback path — the create MCP tool + the publish MCP tool — still
@@ -41,6 +49,19 @@ async def test_sites_handler_carries_orientation() -> None:
     # in-app pockets instead of publishable sites (the reported drift).
     assert "build a pocket" not in preamble.lower()
     assert "build a 'pocket'" not in preamble.lower()
+
+
+async def test_sites_handler_create_mode_when_no_pocket_id() -> None:
+    """The gallery / no-pocket_id case still routes to BUILD AND PUBLISH a NEW
+    site — the create branch must not regress now that a refine branch exists."""
+    preamble = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+
+    lower = preamble.lower()
+    # The create orientation: build a brand-new marketing site.
+    assert "build and publish" in lower
+    # It must NOT slip into refine framing when there's no pocket to refine.
+    assert "refine" not in lower
+    assert "existing" not in lower
 
 
 async def test_sites_handler_prefers_create_paw_site_brain() -> None:
@@ -85,3 +106,77 @@ async def test_sites_handler_specifies_flat_lead_capture_form() -> None:
     # form/newsletter widget as the thing to avoid.
     assert "flat" in lower
     assert "newsletter" in lower
+
+
+# --- Refine mode (meta carries a pocket_id — the per-site /sites/[siteId] chat) ---
+
+REFINE_POCKET = "pkt-existing-site-123"
+
+
+async def test_sites_handler_refine_mode_orients_to_existing_site() -> None:
+    """When the meta carries a pocket_id, the surface is the per-site refine
+    chat: the agent must REFINE the EXISTING published site, not create a new
+    one and not treat it as a dashboard pocket."""
+    preamble = await sites_handler.build_preamble(
+        WORKSPACE,
+        USER,
+        SurfaceMeta(route_path="/sites/site-abc", pocket_id=REFINE_POCKET, site_id="site-abc"),
+    )
+
+    lower = preamble.lower()
+    # Still the sites surface.
+    assert '<surface kind="sites"' in preamble
+    # Framed as refining an existing site.
+    assert "refine" in lower
+    assert "existing" in lower
+    # The concrete pocket id is named so the agent edits the right one.
+    assert REFINE_POCKET in preamble
+    # It must NOT tell the agent to build a new site — that's the regression
+    # the per-site chat reported (refine turned into a fresh create).
+    assert "build and publish a new" not in lower
+    assert "build a new site" not in lower
+    # And it must not collapse the site back into a dashboard pocket.
+    assert "dashboard pocket" in lower  # names the thing to avoid
+
+
+async def test_sites_handler_refine_mode_uses_edit_path() -> None:
+    """Refine applies the change via the merge/edit path on the existing pocket,
+    not the create path — so the published site is updated in place."""
+    preamble = await sites_handler.build_preamble(
+        WORKSPACE,
+        USER,
+        SurfaceMeta(route_path="/sites/site-abc", pocket_id=REFINE_POCKET, site_id="site-abc"),
+    )
+
+    # The edit/merge tool, not a fresh create.
+    assert "mcp__pocketpaw_pocket_specialist__edit" in preamble
+    # It should not steer the agent to spin up a brand-new pocket from scratch.
+    assert "from scratch" in preamble.lower()  # named as the thing to avoid
+
+
+async def test_sites_handler_refine_mode_is_landing_aware() -> None:
+    """The refine preamble carries the same landing structure + 5 SSR rules as
+    the create brain, so an edit can't introduce a static-site trap."""
+    preamble = await sites_handler.build_preamble(
+        WORKSPACE,
+        USER,
+        SurfaceMeta(route_path="/sites/site-abc", pocket_id=REFINE_POCKET, site_id="site-abc"),
+    )
+
+    lower = preamble.lower()
+    # Preserve the landing/conversion structure.
+    assert "hero" in lower
+    assert "pricing" in lower
+    assert "footer" in lower
+    # The 5 SSR rules survive an edit:
+    # Rule 1 — flat native lead form, never form/newsletter.
+    assert "flat" in lower
+    assert "newsletter" in lower
+    # Rule 2 — pricing-table uses tiers.
+    assert "tiers" in lower
+    # Rule 3 — FAQ never accordion.
+    assert "accordion" in lower
+    # Rule 4 — CTAs are anchor href.
+    assert "href" in lower
+    # Animation Tier-0 only.
+    assert "tier-0" in lower or "tier 0" in lower


### PR DESCRIPTION
## What

The `/sites/[siteId]` refine chat was landing on a "build a new site" path. Ask it to "make the hero copy punchier" and it would rebuild the whole page from scratch, or treat the site as a generic dashboard pocket. This makes the refine chat actually refine.

The `/sites` surface now has two modes, keyed on whether the surface meta carries a `pocket_id`:

- **Gallery** (no `pocket_id`) — unchanged. Build and publish a brand-new marketing site.
- **Refine** (`pocket_id` present) — the per-site chat. Edit the existing published pocket in place.

The frontend (built in parallel) stamps `site_id` + `pocket_id` in the surface meta on the per-site route. This is the backend half: carry those fields and branch the preamble on them.

## Changes

- `SurfaceMeta` / `SurfaceMetaRequest` / `_meta_from_request` — thread a new `site_id` hint through domain, DTO, and the request mapping.
- `handlers/sites.py` — `build_preamble` branches on `meta.pocket_id`. No id keeps the existing create preamble untouched. A pocket id gets a new refine preamble that tells the agent to apply the change via `mcp__pocketpaw_pocket_specialist__edit` instead of rebuilding, and not to treat the site as a dashboard pocket.

The refine preamble is landing-aware. It preserves the landing structure (nav, hero, services, proof, pricing, flat lead form, footer) and repeats the same 5 SSR rules the create-paw-site brain enforces, so an edit can't reintroduce a static-site trap:

1. Flat native lead form, never the `form`/`newsletter` widget.
2. `pricing-table` uses `tiers`.
3. FAQ is heading + text, never `accordion`.
4. CTAs are anchor `href`, never `on_click`.
5. `hero` is the marketing Hero, never `hero+grid`. Animation stays Tier-0 only.

## Tests

Extended `tests/cloud/surface/test_sites_handler.py`. The create-mode tests now also assert the no-`pocket_id` branch stays a create (no refine framing leaks in). Three new refine-mode tests assert that a `pocket_id` produces the existing-site orientation, names the edit tool, carries the landing rules, and never says "build a new site". All 45 surface tests pass.

Stacks on #1334 (`feat/sites-landing-brain`).