### PR TITLE
fix(sites): stop the validator downgrading Paw Site specs to generics

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/adapters.py
@@ -57,6 +57,14 @@
 # reach the persisted pocket. Previously these were dropped here (the
 # tool_args dict only carried name/description/icon/color/target_pocket_id),
 # so sites persisted as type="custom", pattern=None.
+# Modified: 2026-06-04 (feat/sites-validator-site-aware) — added the
+# marketing pack (navbar/feature-grid/testimonial/logo-cloud/cta/footer; hero
+# + pricing-table were already present) to ``_STARTER_WIDGET_KINDS`` and a
+# ``landing`` bucket to ``rich_widgets_by_pattern``. The manifest already
+# carries these widgets; the curated agent-mode hint list did not, so a direct
+# agent-mode landing draft couldn't reach for them. With this, direct agent
+# mode (no template short-circuit) can compose a real marketing page instead
+# of falling back to dashboard/showcase widgets.
 """Mode-specific adapters for the pocket specialist's create + edit endpoints.
 
 The MCP tool handlers (``mcp_tool._create_handler`` / ``_edit_handler``)
@@ -103,6 +111,18 @@ _STARTER_WIDGET_KINDS: tuple[str, ...] = (
     "section",
     "page-header",
     "hero",
+    # marketing pack (use when pattern=landing / a Paw Site) — these compose
+    # a real sales page by conversion role. Reach for the marketing widget,
+    # NOT a grid+card hand-roll: navbar (sticky nav + CTA), feature-grid
+    # (services/benefits), testimonial + logo-cloud (social proof),
+    # pricing-table (tiers), cta (conversion band), footer (sitemap). hero +
+    # pricing-table above double as the landing hero + pricing.
+    "navbar",
+    "feature-grid",
+    "testimonial",
+    "logo-cloud",
+    "cta",
+    "footer",
     # full-fledged app shell (use when the brief is "an app for X")
     "app-shell",
     "sidebar",
@@ -443,6 +463,20 @@ def _draft_kit_response(input: Any, *, started: float) -> Any:
                 "timeline",
                 "comment-thread",
                 "notification-center",
+            ],
+            # A Paw Site landing page is composed from the marketing pack by
+            # conversion role — not grid+card primitives. Top→bottom: navbar →
+            # hero → feature-grid (services) → testimonial + logo-cloud (proof)
+            # → pricing-table (tiers) → cta band → flat lead form → footer.
+            "landing": [
+                "navbar",
+                "hero",
+                "feature-grid",
+                "testimonial",
+                "logo-cloud",
+                "pricing-table",
+                "cta",
+                "footer",
             ],
         },
         "widget_quality_bar": (

--- a/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
+++ b/ee/pocketpaw_ee/agent/pocket_specialist/tools.py
@@ -34,6 +34,15 @@ marketing-site brain's type="site" + pattern="landing" land on the
 pocket. Only forwarded when set (the service keeps its type="custom",
 pattern=None defaults otherwise); the update path is untouched — editing
 an existing pocket doesn't restamp create intent.
+Changes: 2026-06-04 (feat/sites-validator-site-aware) —
+``make_persist_pocket_tool`` now derives ``is_site`` from the same
+``type``/``pattern`` args (type=="site" or pattern=="landing") and passes
+``relax_ssr_props=is_site`` to ``validate_against_manifest``. A spliced
+marketing skeleton's renderer-honored SSR props (section/card ``id``
+anchors, input/textarea ``name`` POST fields, button/cta ``href`` anchor
+CTAs) no longer surface as warnings on the site path, so the validation
+retry/redraft loop stops downgrading sites to generic widgets. Dashboard /
+pocket creates pass the flag False and validate unchanged.
 """
 
 from __future__ import annotations
@@ -231,9 +240,27 @@ def make_persist_pocket_tool(
             settings.ripple_manifest_url,
             ttl_seconds=settings.ripple_manifest_ttl_seconds,
         )
+        # Site-generation path: when the create intent is a Paw Site
+        # (type="site" or pattern="landing"), the spliced marketing skeleton
+        # is renderer-valid and authoritative — its SSR-essential node-level
+        # props (section/card ``id`` anchors, input/textarea ``name`` POST
+        # fields, button/cta ``href`` anchor CTAs) render fine on a static
+        # page but the manifest omits them from per-widget props. Relax those
+        # specific combos so they don't surface as warnings and trip the
+        # redraft loop into stripping the marketing widgets. Dashboard /
+        # pocket creates (the common case) pass relax_ssr_props=False and
+        # validate exactly as before.
+        is_site = (isinstance(type, str) and type == "site") or (
+            isinstance(pattern, str) and pattern == "landing"
+        )
         warnings: list[str] = []
         if manifest is not None:
-            issues = validate_against_manifest(ripple_spec, manifest, apply_aliases=True)
+            issues = validate_against_manifest(
+                ripple_spec,
+                manifest,
+                apply_aliases=True,
+                relax_ssr_props=is_site,
+            )
             warnings = [_format_issue(issue) for issue in issues]
         if capture is not None:
             capture["warnings"] = warnings

--- a/src/pocketpaw/bundled_templates/_bundled/index.json
+++ b/src/pocketpaw/bundled_templates/_bundled/index.json
@@ -62,7 +62,7 @@
       "title": "Landing Page",
       "shape": "custom",
       "pattern": "landing",
-      "keywords": ["landing page", "landing site", "marketing page", "marketing site", "sales page", "website for", "site for"],
+      "keywords": ["landing page", "landing site", "marketing page", "marketing site", "sales page", "website for", "site for", "website", "homepage", "home page", "portfolio site", "personal site", "personal website", "about page"],
       "connectors_hint": []
     }
   ]

--- a/src/pocketpaw/ripple/manifest.py
+++ b/src/pocketpaw/ripple/manifest.py
@@ -11,6 +11,15 @@ returns None — the caller is expected to fall back to a different
 source (today: kb scope search).
 
 Changes:
+  - 2026-06-04 (feat/sites-validator-site-aware): added ``relax_ssr_props``
+    to ``validate_against_manifest`` + the ``SSR_NODE_LEVEL_PROPS`` allowlist.
+    On the site-generation path the renderer-honored SSR node-level props
+    (``section``/``card`` ``id`` anchors, ``input``/``textarea`` ``name`` POST
+    fields, ``button``/``cta`` ``href`` anchor CTAs) are no longer flagged as
+    ``unknown_props`` — they render on a static Paw Site but the manifest omits
+    them from per-widget props, so the default walk was driving the agent's
+    redraft loop into stripping the marketing widgets. Closed combo list, gated
+    on the flag; dashboard validation (flag defaults False) is unchanged.
   - 2026-05-31 (constraint-zone enforcer): added ``validate_required_props``
     + ``required_props_from_manifest`` — a mechanical walker that flags any
     node missing a prop the manifest marks ``required: true`` for its
@@ -142,11 +151,46 @@ _KNOWN_ITEM_ALIASES: dict[str, dict[str, dict[str, str]]] = {
 }
 
 
+# SSR-essential node-level props that the renderer honors on specific widgets
+# but the manifest's per-widget ``props`` map omits (they are universal
+# node-level attributes the renderer wraps on, not per-widget props). A
+# statically-rendered Paw Site (csr=false, no client JS) REQUIRES these:
+#
+#   * ``id`` on ``section`` / ``card`` — emitted as the HTML element ``id``
+#     so in-page anchor links (#services, #book) resolve. Confirmed in the
+#     ripple source: ``<section {id} …>`` / ``<div {id} … (Card)>``.
+#   * ``name`` on ``input`` / ``textarea`` — emitted on the native control so
+#     the page's outer <form> POSTs the field. Confirmed: ``<input {name} …>``
+#     / ``<textarea {name} …>``.
+#   * ``href`` on ``button`` — renders the button as an anchor CTA on a static
+#     page; ``href`` on ``cta`` is already a declared manifest prop but is
+#     included here so the relaxation is symmetric for anchor CTAs.
+#
+# These are flagged as ``unknown_props`` by the default manifest walk, which
+# drives the agent's redraft loop into stripping the marketing widgets. The
+# walk relaxes them ONLY when ``relax_ssr_props=True`` (the site-generation
+# path), keyed to this closed combo list — it is NOT a blanket "allow ``id``
+# everywhere". Dashboard / pocket validation passes the flag False and is
+# unaffected. When a new SSR-honored prop/widget combo is confirmed in the
+# renderer, add it here.
+#
+# Format: ``{ widget_type: frozenset({prop, …}) }``
+SSR_NODE_LEVEL_PROPS: dict[str, frozenset[str]] = {
+    "section": frozenset({"id"}),
+    "card": frozenset({"id"}),
+    "input": frozenset({"name"}),
+    "textarea": frozenset({"name"}),
+    "button": frozenset({"href", "name"}),
+    "cta": frozenset({"href"}),
+}
+
+
 def validate_against_manifest(
     spec: dict[str, Any] | None,
     manifest: dict[str, Any],
     *,
     apply_aliases: bool = False,
+    relax_ssr_props: bool = False,
 ) -> list[dict[str, Any]]:
     """Walk a rippleSpec tree and flag nodes whose ``props`` keys are not
     declared in the manifest for that ``type``.
@@ -155,6 +199,19 @@ def validate_against_manifest(
     drifted in production (see ``_KNOWN_ITEM_ALIASES``). When
     ``apply_aliases=True``, the spec is mutated in place to rewrite the
     known wrong keys to their canonical form.
+
+    ``relax_ssr_props`` (site-generation path only): when True, the
+    SSR-essential renderer-honored node-level props in
+    :data:`SSR_NODE_LEVEL_PROPS` (``section.id`` / ``card.id`` anchor
+    targets, ``input.name`` / ``textarea.name`` native POST fields,
+    ``button.href`` / ``cta.href`` anchor CTAs) are NOT reported as
+    ``unknown_props``. They render correctly on a static Paw Site
+    (csr=false) but the manifest omits them from per-widget props, so the
+    default walk would flag them and trigger the agent's redraft loop into
+    stripping the marketing widgets. The relaxation is a closed combo list,
+    keyed to the specific widget — it does NOT blanket-allow ``id``/``name``/
+    ``href`` everywhere. Dashboard / pocket validation passes False (the
+    default) and is unaffected.
 
     Returns one issue dict per offending node; ``[]`` when ``spec`` is not
     a dict or no issues are found. Issue shape::
@@ -185,7 +242,7 @@ def validate_against_manifest(
 
     root = spec.get("ui") if isinstance(spec.get("ui"), dict) else spec
     issues: list[dict[str, Any]] = []
-    _walk_validate(root, "ui", by_type, apply_aliases, issues)
+    _walk_validate(root, "ui", by_type, apply_aliases, issues, relax_ssr_props)
     return issues
 
 
@@ -195,6 +252,7 @@ def _walk_validate(
     by_type: dict[str, set[str]],
     apply_aliases: bool,
     issues: list[dict[str, Any]],
+    relax_ssr_props: bool = False,
 ) -> None:
     if not isinstance(node, dict):
         return
@@ -203,7 +261,14 @@ def _walk_validate(
     props = node.get("props")
     if isinstance(wtype, str) and wtype in by_type and isinstance(props, dict):
         allowed = by_type[wtype]
-        unknown = sorted(k for k in props.keys() if k not in allowed)
+        # On the site-generation path, the SSR-essential renderer-honored
+        # node-level props (anchor ``id``, native-POST ``name``, anchor
+        # ``href``) are treated as allowed for the specific widget that
+        # carries them — they render fine on a static page but the manifest
+        # omits them from per-widget props. Closed combo list, NOT a blanket
+        # allow; dashboard validation (relax_ssr_props=False) is untouched.
+        ssr_ok = SSR_NODE_LEVEL_PROPS.get(wtype, frozenset()) if relax_ssr_props else frozenset()
+        unknown = sorted(k for k in props.keys() if k not in allowed and k not in ssr_ok)
         item_issues: list[dict[str, Any]] = []
 
         for items_key, alias_map in _KNOWN_ITEM_ALIASES.get(wtype, {}).items():
@@ -241,7 +306,14 @@ def _walk_validate(
     children = node.get("children")
     if isinstance(children, list):
         for i, child in enumerate(children):
-            _walk_validate(child, f"{path}.children[{i}]", by_type, apply_aliases, issues)
+            _walk_validate(
+                child,
+                f"{path}.children[{i}]",
+                by_type,
+                apply_aliases,
+                issues,
+                relax_ssr_props,
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ee/agent/test_pocket_specialist/test_tools.py
+++ b/tests/ee/agent/test_pocket_specialist/test_tools.py
@@ -114,3 +114,120 @@ class TestPersistPocketTool:
             call = mocked.await_args
             assert call.kwargs.get("pocket_id") == "p1"
             assert result["id"] == "p1"
+
+
+# A manifest mirroring the marketing/scaffold widgets a Paw Site uses. None
+# declare id/name/href in per-widget props (matches the live manifest) — those
+# are universal node-level props the renderer wraps on.
+_SITE_MANIFEST = {
+    "schema": "ripple.manifest/v1",
+    "widgets": [
+        {"type": "section", "props": {"title": {}}},
+        {"type": "card", "props": {"title": {}}},
+        {"type": "input", "props": {"label": {}, "type": {}}},
+        {"type": "textarea", "props": {"label": {}}},
+        {"type": "button", "props": {"label": {}, "type": {}}},
+        {"type": "navbar", "props": {"brand": {}, "links": {}, "cta": {}, "ctaHref": {}}},
+        {"type": "feature-grid", "props": {"columns": {}, "features": {}}},
+        {"type": "testimonial", "props": {"quote": {}, "author": {}, "role": {}}},
+        {"type": "cta", "props": {"headline": {}, "button": {}, "href": {}}},
+        {"type": "footer", "props": {"columns": {}, "copyright": {}}},
+    ],
+}
+
+# A spliced landing skeleton (trimmed) carrying the SSR-essential props that
+# the default manifest validator flags: section.id (anchors), input/textarea
+# .name (native POST), card.id (anchor). This is the exact shape that was
+# being downgraded to generics.
+_SITE_SPEC = {
+    "version": "1.0",
+    "ui": {
+        "type": "flex",
+        "children": [
+            {"type": "navbar", "props": {"brand": "X", "cta": "Book", "ctaHref": "#book"}},
+            {
+                "type": "section",
+                "props": {"id": "services"},
+                "children": [{"type": "feature-grid", "props": {"columns": 3, "features": []}}],
+            },
+            {"type": "testimonial", "props": {"quote": "q", "author": "a", "role": "r"}},
+            {"type": "cta", "props": {"headline": "Go", "button": "Book", "href": "#book"}},
+            {
+                "type": "card",
+                "props": {"id": "book", "title": "Book"},
+                "children": [
+                    {"type": "input", "props": {"name": "email", "type": "email"}},
+                    {"type": "textarea", "props": {"name": "message"}},
+                    {"type": "button", "props": {"label": "Send", "type": "submit"}},
+                ],
+            },
+            {"type": "footer", "props": {"columns": [], "copyright": "c"}},
+        ],
+    },
+}
+
+
+class TestPersistPocketSiteAware:
+    """The site-aware trust path: a spliced marketing skeleton (type='site' /
+    pattern='landing') with renderer-honored SSR props must NOT trip the
+    redraft loop. In dashboard mode the same props DO trip it — proving the
+    relaxation is gated on site mode and doesn't weaken non-site validation."""
+
+    @pytest.mark.asyncio
+    async def test_site_skeleton_persists_without_redraft(self):
+        """type='site' + the SSR props → persists (no redraft short-circuit).
+        This is the regression fix: the marketing widgets survive."""
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.tools._get_manifest",
+                new=AsyncMock(return_value=_SITE_MANIFEST),
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.tools._agent_create",
+                new=AsyncMock(return_value=({"id": "site-1", "name": "Landing"}, "site-1", None)),
+            ) as created,
+        ):
+            capture: dict = {}
+            tool = make_persist_pocket_tool(workspace_id="ws-1", user_id="user-A", capture=capture)
+            result = await tool.ainvoke(
+                {
+                    "name": "Landing",
+                    "type": "site",
+                    "pattern": "landing",
+                    "ripple_spec": _SITE_SPEC,
+                }
+            )
+            # Persisted — not a redraft short-circuit.
+            created.assert_awaited_once()
+            assert result.get("redraft_required") is not True
+            assert result["id"] == "site-1"
+            # The SSR props produced no blocking warnings.
+            assert capture.get("warnings") == []
+
+    @pytest.mark.asyncio
+    async def test_dashboard_spec_with_ssr_props_still_redrafts(self):
+        """Same SSR props, but WITHOUT site mode → the validator flags them and
+        the tool short-circuits to redraft on attempt 1 (unchanged behavior).
+        This proves the relaxation is gated and dashboards are unaffected."""
+        with (
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.tools._get_manifest",
+                new=AsyncMock(return_value=_SITE_MANIFEST),
+            ),
+            patch(
+                "pocketpaw_ee.agent.pocket_specialist.tools._agent_create",
+                new=AsyncMock(return_value=({"id": "x", "name": "x"}, "x", None)),
+            ) as created,
+        ):
+            capture: dict = {}
+            tool = make_persist_pocket_tool(workspace_id="ws-1", user_id="user-A", capture=capture)
+            result = await tool.ainvoke(
+                {
+                    "name": "Dash",
+                    "ripple_spec": _SITE_SPEC,  # no type/pattern → dashboard path
+                }
+            )
+            # Short-circuited to redraft — NOT persisted.
+            created.assert_not_awaited()
+            assert result.get("redraft_required") is True
+            assert result["warnings"], "dashboard mode must still surface the prop warnings"

--- a/tests/ee/test_ripple_manifest.py
+++ b/tests/ee/test_ripple_manifest.py
@@ -476,6 +476,143 @@ def test_validate_unknown_widget_type_is_ignored():
 
 
 # ---------------------------------------------------------------------------
+# relax_ssr_props — site-aware relaxation of renderer-honored node-level props
+# (feat/sites-validator-site-aware, 2026-06-04).
+#
+# A statically-rendered Paw Site (csr=false) depends on three node-level props
+# the renderer honors on EVERY widget but the manifest's per-widget `props`
+# map omits: `id` (anchor targets like #services/#book), `name` (native form
+# POST field), and `href` (anchor CTA, no client JS). The default validator
+# flags these as `unknown_props`, which drives the agent's redraft loop into
+# dropping the marketing widgets. `relax_ssr_props=True` stops the WARNING on
+# exactly those prop/widget combos; everything else (and every other widget)
+# is validated unchanged. Dashboard specs pass relax_ssr_props=False and see
+# the old behavior, so this can't weaken non-site validation.
+# ---------------------------------------------------------------------------
+
+
+# A manifest mirroring the real marketing/scaffold widgets that the
+# landing-page skeleton uses. Mirrors the live ripple manifest shape (props
+# is a map of name -> spec). NONE of these declare `id` / `name` / `href`
+# in their per-widget props — exactly like the published manifest — because
+# those are universal node-level props the renderer wraps on.
+SITE_MANIFEST = {
+    "schema": "ripple.manifest/v1",
+    "version": "0.2.0",
+    "widgets": [
+        {"type": "section", "props": {"title": {}, "description": {}}},
+        {
+            "type": "card",
+            "props": {"title": {}, "description": {}, "variant": {}, "density": {}},
+        },
+        {"type": "input", "props": {"label": {}, "placeholder": {}, "type": {}, "required": {}}},
+        {"type": "textarea", "props": {"label": {}, "placeholder": {}, "rows": {}}},
+        {"type": "button", "props": {"label": {}, "type": {}, "variant": {}}},
+        {"type": "feature-grid", "props": {"columns": {}, "features": {}}},
+        {"type": "testimonial", "props": {"quote": {}, "author": {}, "role": {}}},
+        {"type": "cta", "props": {"headline": {}, "subtext": {}, "button": {}, "href": {}}},
+        {"type": "footer", "props": {"columns": {}, "copyright": {}}},
+    ],
+}
+
+
+def test_ssr_props_flagged_by_default_no_regression():
+    """Default behavior (relax_ssr_props=False) STILL flags `id`/`name` on the
+    site widgets — proving the relaxation is opt-in and dashboard validation is
+    untouched. This is the no-regression guard."""
+    from pocketpaw.ripple import manifest as m
+
+    spec = {
+        "ui": {
+            "type": "section",
+            "props": {"id": "services"},
+            "children": [
+                {"type": "input", "props": {"name": "email", "label": "Email"}},
+                {"type": "textarea", "props": {"name": "msg"}},
+            ],
+        }
+    }
+    issues = m.validate_against_manifest(spec, SITE_MANIFEST)
+    flagged = {(i["type"], tuple(i["unknown_props"])) for i in issues}
+    assert ("section", ("id",)) in flagged
+    assert ("input", ("name",)) in flagged
+    assert ("textarea", ("name",)) in flagged
+
+
+def test_ssr_props_relaxed_when_site_mode():
+    """relax_ssr_props=True drops the WARNING on the SSR-essential
+    renderer-honored props: `id` on section/card, `name` on input/textarea,
+    `href` on button/cta. The spliced marketing skeleton then validates
+    clean — no redraft loop, marketing widgets survive to persistence."""
+    from pocketpaw.ripple import manifest as m
+
+    spec = {
+        "ui": {
+            "type": "flex",
+            "children": [
+                {"type": "section", "props": {"id": "services"}},
+                {"type": "section", "props": {"id": "pricing"}},
+                {
+                    "type": "card",
+                    "props": {"id": "book", "title": "Book"},
+                    "children": [
+                        {"type": "input", "props": {"name": "name", "label": "Name"}},
+                        {"type": "input", "props": {"name": "email", "type": "email"}},
+                        {"type": "textarea", "props": {"name": "message"}},
+                        {"type": "button", "props": {"label": "Send", "type": "submit"}},
+                    ],
+                },
+                {"type": "cta", "props": {"headline": "Go", "button": "Book", "href": "#book"}},
+            ],
+        }
+    }
+    issues = m.validate_against_manifest(spec, SITE_MANIFEST, relax_ssr_props=True)
+    assert issues == [], f"site skeleton should validate clean, got: {issues}"
+
+
+def test_ssr_props_relaxed_honors_button_href_combo():
+    """`href` on `button` is renderer-honored (anchor CTA on a static page) —
+    relaxed so an anchor button doesn't trip the redraft loop."""
+    from pocketpaw.ripple import manifest as m
+
+    spec = {"ui": {"type": "button", "props": {"label": "Book", "href": "#book"}}}
+    assert m.validate_against_manifest(spec, SITE_MANIFEST, relax_ssr_props=True) == []
+    # …but still flagged in default mode (dashboard buttons don't use href).
+    issues = m.validate_against_manifest(spec, SITE_MANIFEST)
+    assert issues and issues[0]["unknown_props"] == ["href"]
+
+
+def test_relax_ssr_props_still_flags_genuinely_unknown_props():
+    """Relaxation is surgical — it whitelists ONLY id/name/href on the SSR
+    widgets. A genuinely hallucinated prop (e.g. a typo) is STILL flagged even
+    in site mode, so the validator keeps catching real drift on a site."""
+    from pocketpaw.ripple import manifest as m
+
+    spec = {
+        "ui": {
+            "type": "section",
+            "props": {"id": "services", "titel": "Servces"},  # `titel` is a typo
+        }
+    }
+    issues = m.validate_against_manifest(spec, SITE_MANIFEST, relax_ssr_props=True)
+    assert len(issues) == 1
+    # `id` is relaxed away; the typo survives as the only unknown prop.
+    assert issues[0]["unknown_props"] == ["titel"]
+
+
+def test_relax_ssr_props_does_not_relax_id_on_arbitrary_widget():
+    """The relaxation is keyed to the SSR widget set. `id` on a widget that is
+    NOT an anchor host (e.g. `feature-grid`) is still flagged — relaxation is
+    a closed combo list, not a blanket `id` allow."""
+    from pocketpaw.ripple import manifest as m
+
+    spec = {"ui": {"type": "feature-grid", "props": {"columns": 3, "id": "x"}}}
+    issues = m.validate_against_manifest(spec, SITE_MANIFEST, relax_ssr_props=True)
+    assert len(issues) == 1
+    assert issues[0]["unknown_props"] == ["id"]
+
+
+# ---------------------------------------------------------------------------
 # agent_context._validate_ripple_spec — the wiring on the write path.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The problem

A "landing site" brief now correctly matches the bundled `landing-page` template and splices the pre-baked marketing skeleton (navbar / hero / feature-grid / testimonial / logo-cloud / pricing-table / cta / footer, plus a flat lead form). But the pocket that landed in Mongo came out generic: a hero, a pricing-table, and a pile of grid/card/quote/icon. The marketing widgets and their props were getting stripped before persistence.

## Why it happened

The pre-persist manifest validator (`validate_against_manifest`) flags any prop it can't find in a widget's manifest entry. The skeleton leans on three node-level props the renderer honors on every widget but the manifest leaves out of per-widget props:

- `id` on `section` / `card`, the in-page anchor targets (`#services`, `#pricing`, `#book`)
- `name` on `input` / `textarea`, the native form POST fields
- `href` on `button` / `cta`, anchor CTAs (a static page with `csr=false` has no JS to run an `on_click`)

Run against the real skeleton and the live manifest, that's 8 unknown-prop warnings. The persist tool's redraft loop reads warnings as "your spec is wrong," hands them back to the agent, and the agent strips the marketing widgets to make them go away. The pocket falls back to a generic dashboard shape.

The props aren't actually wrong. The ripple source emits them straight through: `<section {id}>`, `<input {name}>`, `<textarea {name}>`, `<button {name}>`. They're universal node-level attributes rather than per-widget props, which is exactly why the manifest doesn't list them.

## The fix (site-aware, dashboards untouched)

1. `manifest.py`: `validate_against_manifest` takes a new `relax_ssr_props` flag. When set, the SSR-essential combos in `SSR_NODE_LEVEL_PROPS` stop being reported as unknown. It's a closed widget/prop allowlist, not a blanket "allow `id` anywhere", so `id` on a `feature-grid` is still flagged. Defaults to `False`, so dashboard and pocket validation see no change.
2. `tools.py`: `make_persist_pocket_tool` derives `is_site` from `type == "site"` / `pattern == "landing"` (already threaded through from the marketing brain) and passes it down. A spliced site skeleton validates clean and the marketing widgets reach persistence.
3. `adapters.py`: the marketing pack (navbar / feature-grid / testimonial / logo-cloud / cta / footer) joins the agent-mode starter list, plus a `landing` bucket in the pattern hints. The manifest already had these widgets; the curated hint list didn't, so direct agent mode couldn't reach for them. Now it can.
4. `index.json`: "website", "homepage", "portfolio site", and "about page" route to the landing skeleton. A portfolio isn't a marketing page, but the skeleton beats cold-drafting generics. A dedicated portfolio skeleton is a follow-up.

## Trusting a spliced skeleton

When a site template is spliced, the skeleton is authoritative and already renderer-valid. The relaxation in (1) and (2) keeps its warnings out of the redraft loop, so the marketing widgets and SSR props make it through to the saved pocket.

## Tests

`relax_ssr_props` behavior in `test_ripple_manifest.py`:

- the SSR props are still flagged by default (the dashboard no-regression guard)
- they're relaxed in site mode, so the skeleton validates clean
- a genuine typo (`titel`) is still caught in site mode, so the relaxation stays surgical
- `id` on a non-anchor widget (`feature-grid`) is still flagged

Site-aware persist path in `test_tools.py`:

- a site skeleton carrying the SSR props persists without a redraft short-circuit
- the same spec without site mode still redrafts, which proves dashboards are unaffected

Run with `uv run --group ee --extra mongodb pytest <test> -q`. RED before the fix (the flag didn't exist), GREEN after.

End-to-end check against the real skeleton and the live manifest: 8 unknown-prop issues in dashboard mode, 0 in site mode.

No regression: the full `pocket_specialist` suite, the manifest tests, the ripple_validator tests, and the sites e2e tests pass (268 passed, 1 skipped when the manifest is offline).

## Notes

- `ee/uv.lock` is intentionally left out of this branch.
- The pre-existing "dashboard" to kanban routing quirk (`dashboard` contains the substring `board`) predates this change and is out of scope.
