### PR TITLE
Deterministic landing-site fast-path (copy-only, bypasses pocket_specialist)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites.py
@@ -45,8 +45,12 @@ SERVER_NAME = "pocketpaw_sites_manager"
 # Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
 # Allowlist entries must use this exact form.
 PUBLISH_TOOL_ID = f"mcp__{SERVER_NAME}__publish"
+# The deterministic landing-site create tool registers on the SAME server (see
+# sites_create.py — two create_sdk_mcp_server calls under one name would clobber
+# each other, so create + publish share one server object).
+CREATE_LANDING_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_landing_site"
 
-SITES_TOOL_IDS = (PUBLISH_TOOL_ID,)
+SITES_TOOL_IDS = (PUBLISH_TOOL_ID, CREATE_LANDING_SITE_TOOL_ID)
 
 
 def _error_response(message: str) -> dict[str, Any]:
@@ -196,15 +200,25 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     async def publish(args):  # type: ignore[no-untyped-def]
         return await _publish_handler(args)
 
+    # Register the deterministic landing-site create tool on this SAME server.
+    # The SKILL flow is: produce the `content` copy → create_landing_site →
+    # publish, so the two hops sit on one allowlisted server. Built here (not as a
+    # separate create_sdk_mcp_server) because the claude_sdk registration loop
+    # keys servers by name and a second server under this name would clobber it.
+    from pocketpaw_ee.agent.mcp_servers.sites_create import make_create_landing_site_tool
+
+    create_landing_site = make_create_landing_site_tool(tool)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[publish],
+        tools=[publish, create_landing_site],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
+    "CREATE_LANDING_SITE_TOOL_ID",
     "PUBLISH_TOOL_ID",
     "SERVER_NAME",
     "SITES_TOOL_IDS",

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,0 +1,291 @@
+# sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
+# create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
+#
+# This is the decisive bypass of the dashboard-built ``pocket_specialist``
+# create machinery. The agent-mode pocket_specialist path (draft kit / plan kit /
+# subagent delegation + the validate-redraft loop) kept downgrading landing
+# sites to generic hero+grid+card widgets no matter what the prompt whitelisted,
+# because the LLM owned the page STRUCTURE. Here, the LLM provides COPY ONLY and
+# this tool assembles the marketing-widget structure in code (``landing_assembler
+# .assemble_landing_spec``), then persists it DIRECTLY through the pockets
+# service's ``agent_create`` — NO pocket_specialist, NO validate/redraft loop, NO
+# subagent. The structure cannot be downgraded.
+#
+# Mirrors the sibling ``sites.py`` (publish) server: ``create_sdk_mcp_server``
+# with an SDK import-guard, ``SERVER_NAME`` / ``*_TOOL_ID`` allowlist constants,
+# and ContextVar-sourced identity (the same ``current_workspace_id`` /
+# ``current_user_id`` accessors in ``ee.cloud.chat.agent_service`` the publish +
+# pocket-specialist servers read). Tool id namespaces under the SAME
+# ``pocketpaw_sites_manager`` server (``mcp__pocketpaw_sites_manager__
+# create_landing_site``) so the create + publish hops sit side by side for the
+# chat agent — the SKILL produces copy → create_landing_site → publish.
+"""Agent-side MCP surface for DETERMINISTIC Paw Site landing-page creation.
+
+A landing site is built from an LLM ``content`` copy object. This tool:
+
+  1. assembles the FIXED marketing-widget rippleSpec from ``content`` in code
+     (``assemble_landing_spec``) — the LLM never decides the structure;
+  2. persists the pocket DIRECTLY via ``pockets.service.agent_create`` stamped
+     ``type="site"`` + ``pattern="landing"`` — bypassing the pocket_specialist
+     adapter, its draft/redraft loop, and any subagent delegation;
+  3. binds the active chat session + pushes the ``pocket_created`` SSE event (the
+     same post-create side effects the specialist's persist tool runs) so the
+     canvas auto-opens.
+
+Returns ``{ok, pocket_id, pocket}`` so the agent hands ``pocket_id`` straight to
+``mcp__pocketpaw_sites_manager__publish``. ``is_error`` is set when identity is
+missing or the persist fails (e.g. the strict catalog gate rejects the spec) so
+the agent surfaces the reason instead of fabricating a created pocket.
+
+Workspace / user identity comes from the per-stream ``ContextVar``s in
+``ee.cloud.chat.agent_service``. When run outside an SSE chat stream the tool
+returns a clear error rather than silently mis-tenanting the pocket.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Same server as the publish tool — the create + publish hops live together so
+# the chat agent reaches both under one allowlisted server name.
+SERVER_NAME = "pocketpaw_sites_manager"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+CREATE_LANDING_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_landing_site"
+
+SITES_CREATE_TOOL_IDS = (CREATE_LANDING_SITE_TOOL_ID,)
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None]:
+    """Resolve the active workspace + user id from the per-stream ContextVars set
+    by the cloud chat agent runtime. Returns ``(workspace_id, user_id)``."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id, current_workspace_id
+
+        return current_workspace_id(), current_user_id()
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+async def _bind_session_and_emit(pocket_id: str, view: dict[str, Any], user_id: str) -> None:
+    """Bind the active chat session to the new pocket and push the
+    ``pocket_created`` SSE event so the canvas auto-opens — the same atomic
+    post-create side effects ``make_persist_pocket_tool`` runs. Best-effort: a
+    bind / SSE failure must never undo a successful create (the pocket already
+    exists in Mongo, which is the primary contract)."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_session_mongo_id,
+            push_sse_event,
+        )
+        from pocketpaw_ee.cloud.sessions import service as sessions_service
+
+        session_mongo_id = current_session_mongo_id()
+        if session_mongo_id:
+            await sessions_service.attach_pocket_to_session_doc(
+                session_mongo_id, user_id, pocket_id
+            )
+        push_sse_event(
+            "pocket_created",
+            {"pocket_id": pocket_id, "pocket": view, "session_id": session_mongo_id},
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "create_landing_site: post-create side effects failed (non-fatal)",
+            exc_info=True,
+        )
+
+
+async def _create_landing_site_handler(args: dict) -> dict:
+    """MCP handler for ``sites_manager__create_landing_site``.
+
+    Reads workspace/user identity from the per-stream ContextVars, validates the
+    ``content`` input, assembles the deterministic landing rippleSpec, and
+    persists it DIRECTLY via ``agent_create`` (type="site", pattern="landing").
+    Returns ``{ok, pocket_id, pocket}`` on success; sets ``is_error`` when
+    identity is missing, ``content`` is absent/malformed, or the persist fails.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "create_landing_site requires workspace and user context (call from a "
+            "cloud chat session)."
+        )
+
+    content = args.get("content")
+    if not isinstance(content, dict) or not content:
+        return _error_response(
+            "create_landing_site requires a `content` object — the COPY for the "
+            "landing page (brand, hero, services, testimonials, tiers, cta_band, "
+            "contact, footer). You provide copy only; the tool builds the page."
+        )
+
+    name_raw = args.get("name")
+    # Default the pocket name to the brand from the copy when not given.
+    name = name_raw if isinstance(name_raw, str) and name_raw.strip() else ""
+    if not name:
+        brand = content.get("brand")
+        name = brand.strip() if isinstance(brand, str) and brand.strip() else "Landing site"
+
+    description_raw = args.get("description")
+    description = description_raw if isinstance(description_raw, str) else ""
+    icon_raw = args.get("icon")
+    icon = icon_raw if isinstance(icon_raw, str) else ""
+    color_raw = args.get("color")
+    color = color_raw if isinstance(color_raw, str) else ""
+
+    # CODE owns the structure — assemble the fixed marketing tree from the copy.
+    from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+    try:
+        ripple_spec = assemble_landing_spec(content)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("create_landing_site: assemble failed", exc_info=True)
+        return _error_response(f"could not assemble the landing page: {exc}")
+
+    # Persist DIRECTLY through the pockets service — NOT the pocket_specialist
+    # create path, so there is no draft/redraft loop and no subagent to downgrade
+    # the spec. ``type_="site"`` + ``pattern="landing"`` stamp the site identity
+    # so the generator + any later edit treat the pocket as a marketing page.
+    # ``trusted=True`` skips the STRICT catalog gate: the spec is code-assembled
+    # from the renderer-valid skeleton, but the PUBLISHED manifest is stale and
+    # omits the marketing widgets (navbar/feature-grid/testimonial/logo-cloud/
+    # cta/footer), so the strict gate would false-reject the page and its
+    # "suggestion" would push toward generic widgets — the exact downgrade this
+    # path exists to prevent. The logged catalog walk + embed audit still run.
+    from pocketpaw_ee.cloud.pockets.service import agent_create
+
+    try:
+        view, new_pocket_id, err = await agent_create(
+            workspace_id=workspace_id,
+            owner_id=user_id,
+            name=name,
+            description=description,
+            type_="site",
+            pattern="landing",
+            icon=icon,
+            color=color,
+            ripple_spec=ripple_spec,
+            trusted=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("create_landing_site: persist raised", exc_info=True)
+        return _error_response(f"create failed: {exc}")
+
+    if err is not None or view is None or new_pocket_id is None:
+        return _error_response(f"create failed: {err or 'create returned no view'}")
+
+    await _bind_session_and_emit(new_pocket_id, view, user_id)
+
+    return _success_response(
+        {
+            "ok": True,
+            "pocket_id": new_pocket_id,
+            "pocket": {
+                "id": new_pocket_id,
+                "name": view.get("name"),
+                "type": view.get("type"),
+                "pattern": view.get("pattern"),
+            },
+        }
+    )
+
+
+def make_create_landing_site_tool(tool: Any) -> Any:
+    """Build the ``create_landing_site`` SDK tool object using the SDK's ``tool``
+    decorator (passed in by the caller that already imported it).
+
+    Returned so the publish server (``sites.py``) can register BOTH tools on the
+    ONE ``pocketpaw_sites_manager`` server. The registration loop in
+    ``claude_sdk.py`` keys ``servers[name] = cfg`` by server name, so two
+    ``create_sdk_mcp_server`` calls under the same name would clobber each other —
+    the create + publish tools must therefore live on a single server object.
+    """
+
+    @tool(
+        "create_landing_site",
+        (
+            "Create a Paw Site landing page DETERMINISTICALLY. You provide COPY "
+            "ONLY — the tool assembles the marketing page structure (navbar, "
+            "hero, services, social proof, pricing, CTA, lead form, footer) in "
+            "code and persists it as a pocket stamped type='site' + "
+            "pattern='landing'. You do NOT compose a rippleSpec and you do NOT "
+            "call pocket_specialist — pass the `content` copy object and the tool "
+            "builds the page. Use this for a BRAND-NEW marketing/landing site "
+            "('build a dentist landing site', 'a landing page for my bakery'). "
+            "`content` keys (all optional, plausible copy fills gaps — never "
+            "'TBD'/'Lorem ipsum'): brand (str); hero {eyebrow, title, subtitle, "
+            "cta_label}; services [{title, desc, icon}]; testimonials [{quote, "
+            "author, role}]; tiers [{name, price, period, features:[str], "
+            "popular, cta_label}]; cta_band {headline, subtext, button_label}; "
+            "contact {address, phone, email}; footer {copyright}. Variable-length "
+            "services/testimonials/tiers are handled. Returns {ok, pocket_id, "
+            "pocket}; hand `pocket_id` to "
+            "`mcp__pocketpaw_sites_manager__publish` to publish. ok=false with an "
+            "error means relay the reason, do NOT report a created pocket."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "object",
+                    "description": (
+                        "The COPY for the landing page — words only, no structure. "
+                        "brand, hero, services, testimonials, tiers, cta_band, "
+                        "contact, footer (see the tool description for the shape)."
+                    ),
+                    "additionalProperties": True,
+                },
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Optional pocket/site name. Defaults to the brand from "
+                        "`content` when omitted."
+                    ),
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional one-line pocket description.",
+                },
+                "icon": {"type": "string", "description": "Optional lucide icon name."},
+                "color": {"type": "string", "description": "Optional accent color hex."},
+            },
+            "required": ["content"],
+            "additionalProperties": False,
+        },
+    )
+    async def create_landing_site(args):  # type: ignore[no-untyped-def]
+        return await _create_landing_site_handler(args)
+
+    return create_landing_site
+
+
+__all__ = [
+    "CREATE_LANDING_SITE_TOOL_ID",
+    "SERVER_NAME",
+    "SITES_CREATE_TOOL_IDS",
+    "make_create_landing_site_tool",
+]

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -3122,6 +3122,7 @@ async def agent_create(
     icon: str = "",
     color: str = "",
     ripple_spec: dict | None = None,
+    trusted: bool = False,
 ) -> tuple[dict | None, str | None, str | None]:
     """Insert a brand-new pocket owned by ``owner_id`` in ``workspace_id``.
 
@@ -3136,6 +3137,20 @@ async def agent_create(
     page renders as a landing page rather than a dashboard. Both keep
     today's defaults (``type_="custom"``, ``pattern=None``) for callers
     that pass neither, so the change is additive — no Mongo migration.
+
+    ``trusted=True`` skips the STRICT catalog gate — use it ONLY for a
+    code-assembled spec the caller fully controls (the deterministic Paw Site
+    fast-path's ``assemble_landing_spec``), never for raw LLM output. The strict
+    gate's allow-list is the PUBLISHED widget manifest, which lags the renderer:
+    the real marketing widgets (navbar/feature-grid/testimonial/logo-cloud/cta/
+    footer) ship in the renderer but are absent from the current published
+    manifest, so the gate false-rejects a perfectly valid landing page and its
+    "suggestion" pushes the caller toward generic widgets (avatar/data-grid/…) —
+    the exact downgrade the deterministic fast-path exists to prevent. The spec
+    is still normalized + structurally validated (``validate_ripple_spec_logged``)
+    and the embed audit still runs; only the manifest-type allow-list (which is
+    the stale part) is bypassed. The normal agent path keeps ``trusted=False``
+    and the strict gate unchanged.
     """
     if not name:
         return None, None, "name is required"
@@ -3146,14 +3161,25 @@ async def agent_create(
         # returned as the error string so the specialist sees the
         # corrective detail and can retry, instead of persisting a spec
         # the renderer would draw as a red "Unknown widget type" box.
-        try:
-            await _gate_catalog(normalized, strict=True, actor=owner_id, workspace_id=workspace_id)
-        except CatalogViolationError as exc:
-            return None, None, format_violations_for_agent(exc.violations)
-        except ActionWiringViolationError as exc:
-            return None, None, format_action_violations_for_agent(exc.violations)
-        except MissingRequiredPropError as exc:
-            return None, None, format_required_prop_violations_for_agent(exc.violations)
+        # Trusted code-assembled specs skip the STRICT gate (the published
+        # manifest is stale for marketing widgets — see the docstring) but
+        # still get the LOGGED catalog walk so the embed audit runs and any
+        # genuine drift is recorded, just not blocked.
+        if trusted:
+            await _gate_catalog(
+                normalized, strict=False, actor=owner_id, workspace_id=workspace_id
+            )
+        else:
+            try:
+                await _gate_catalog(
+                    normalized, strict=True, actor=owner_id, workspace_id=workspace_id
+                )
+            except CatalogViolationError as exc:
+                return None, None, format_violations_for_agent(exc.violations)
+            except ActionWiringViolationError as exc:
+                return None, None, format_action_violations_for_agent(exc.violations)
+            except MissingRequiredPropError as exc:
+                return None, None, format_required_prop_violations_for_agent(exc.violations)
     try:
         doc = _PocketDoc(
             workspace=workspace_id,

--- a/ee/pocketpaw_ee/sites/landing_assembler.py
+++ b/ee/pocketpaw_ee/sites/landing_assembler.py
@@ -1,0 +1,373 @@
+# ee/pocketpaw_ee/sites/landing_assembler.py — the DETERMINISTIC Paw Site
+# landing-page assembler. A pure function that turns an LLM-provided COPY object
+# into the fixed marketing-widget rippleSpec. The LLM provides words; CODE owns
+# the structure, so the page can NEVER be downgraded to generic
+# hero+grid+card+quote widgets the way the agent-mode pocket_specialist path was.
+#
+# Created: 2026-06-04 (feat/sites-deterministic-fastpath). This is the keystone
+# of the deterministic fast-path: the create-paw-site SKILL no longer hand-
+# composes a rippleSpec or routes through ``pocket_specialist__create`` (whose
+# agent-mode draft/redraft/subagent-delegation loop kept dropping the marketing
+# widgets). Instead the skill produces ONLY the ``content`` copy object and calls
+# ``mcp__pocketpaw_sites_manager__create_landing_site``, which runs this
+# assembler and persists the result directly.
+#
+# The emitted structure mirrors the renderer-VALID bundled landing skeleton
+# (``src/pocketpaw/bundled_templates/_bundled/landing-page/ripple_spec.json``)
+# section-for-section — same widget kinds, same SSR-safe props — but every copy
+# value comes from ``content`` and the variable-length collections (services /
+# testimonials / tiers) drive real loops. The fixed conversion order is:
+#
+#   navbar → hero → section#services[feature-grid] → section#reviews[testimonial*
+#   (+ optional logo-cloud)] → section#pricing[pricing-table.tiers] → cta band →
+#   card#book[flat input/textarea/button lead form] → footer
+#
+# Hard-coded SSR contract (all by construction, never the LLM's choice):
+#   * section/card ``id`` anchors (#services/#reviews/#pricing/#book) — marketing
+#     widgets carry no id of their own, so anchor targets live on the wrappers.
+#   * input/textarea ``name`` POST fields so the native outer-form submit maps a
+#     lead (rule 1: FLAT inputs, never a nested ``form``/``newsletter`` widget).
+#   * anchor ``href`` CTAs everywhere (navbar.ctaHref, cta.href, footer/nav link
+#     hrefs) — never ``on_click`` (rule 4: a click handler is dead on a static
+#     page).
+#   * pricing-table uses ``tiers`` (rule 2), currency is the ``$`` symbol, tier
+#     ``cta`` is a string label.
+
+from __future__ import annotations
+
+from typing import Any
+
+# Anchor ids the navbar / CTAs / footer link to. The wrapping section/card
+# carries the id because marketing widgets have none of their own.
+_ANCHOR_SERVICES = "services"
+_ANCHOR_REVIEWS = "reviews"
+_ANCHOR_PRICING = "pricing"
+_ANCHOR_BOOK = "book"
+
+# A small default icon rotation for services that omit an ``icon``, so a
+# feature-grid never renders an empty glyph slot. Lucide icon names.
+_DEFAULT_SERVICE_ICONS = ("sparkles", "shield", "smile", "star", "zap", "heart")
+
+
+def _s(value: Any, default: str = "") -> str:
+    """Coerce a copy field to a stripped string, falling back to ``default``.
+
+    The assembler is defensive: the LLM provides copy and may omit or mistype a
+    field. A missing headline becomes an empty string rather than ``None`` (which
+    the renderer would print literally), so the page always renders.
+    """
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip() or default
+    return str(value)
+
+
+def _navbar(content: dict[str, Any]) -> dict[str, Any]:
+    brand = _s(content.get("brand"), "Your Business")
+    cta_label = _s((content.get("hero") or {}).get("cta_label"), "Get in touch")
+    return {
+        "type": "navbar",
+        "props": {
+            "brand": brand,
+            "links": [
+                {"label": "Services", "href": f"#{_ANCHOR_SERVICES}"},
+                {"label": "Reviews", "href": f"#{_ANCHOR_REVIEWS}"},
+                {"label": "Pricing", "href": f"#{_ANCHOR_PRICING}"},
+                {"label": "Book", "href": f"#{_ANCHOR_BOOK}"},
+            ],
+            # ``cta`` is a STRING label; the destination is the SEPARATE
+            # ``ctaHref`` prop (never nested in ``cta``).
+            "cta": cta_label,
+            "ctaHref": f"#{_ANCHOR_BOOK}",
+            "sticky": True,
+        },
+    }
+
+
+def _hero(content: dict[str, Any]) -> dict[str, Any]:
+    hero = content.get("hero") or {}
+    # ``hero`` has no CTA prop — the call-to-action lives in the navbar + the cta
+    # band, so we don't emit one here (it would silently drop).
+    return {
+        "type": "hero",
+        "props": {
+            "eyebrow": _s(hero.get("eyebrow")),
+            "title": _s(hero.get("title"), "A headline that sells"),
+            "subtitle": _s(hero.get("subtitle")),
+            "align": "center",
+        },
+    }
+
+
+def _services_section(content: dict[str, Any]) -> dict[str, Any]:
+    services = content.get("services") or []
+    features: list[dict[str, Any]] = []
+    for i, svc in enumerate(services):
+        if not isinstance(svc, dict):
+            continue
+        icon = _s(svc.get("icon")) or _DEFAULT_SERVICE_ICONS[i % len(_DEFAULT_SERVICE_ICONS)]
+        features.append(
+            {
+                "icon": icon,
+                "title": _s(svc.get("title"), f"Service {i + 1}"),
+                "description": _s(svc.get("desc") or svc.get("description")),
+            }
+        )
+    # Column count tracks the item count (capped at 4) so a short list doesn't
+    # leave gaping empty columns and a long one wraps cleanly.
+    columns = max(2, min(4, len(features))) if features else 3
+    return {
+        "type": "section",
+        "props": {"id": _ANCHOR_SERVICES},
+        "children": [
+            {
+                "type": "feature-grid",
+                "props": {"columns": columns, "features": features},
+            }
+        ],
+    }
+
+
+def _reviews_section(content: dict[str, Any]) -> dict[str, Any]:
+    testimonials = content.get("testimonials") or []
+    children: list[dict[str, Any]] = []
+    # ONE testimonial widget per quote — there is no ``items`` array.
+    for t in testimonials:
+        if not isinstance(t, dict):
+            continue
+        children.append(
+            {
+                "type": "testimonial",
+                "props": {
+                    "quote": _s(t.get("quote")),
+                    "author": _s(t.get("author")),
+                    "role": _s(t.get("role")),
+                },
+            }
+        )
+    # Optional text-mode logo-cloud (rule 6): only when the copy gives a trust
+    # heading, and ALWAYS with an empty ``logos`` list — never invented
+    # ``src`` paths (they render as broken images on the live site).
+    proof = content.get("proof") or {}
+    trust_heading = _s(proof.get("logos_heading") or content.get("logos_heading"))
+    if trust_heading:
+        children.append(
+            {
+                "type": "logo-cloud",
+                "props": {"heading": trust_heading, "logos": []},
+            }
+        )
+    return {
+        "type": "section",
+        "props": {"id": _ANCHOR_REVIEWS},
+        "children": children,
+    }
+
+
+def _pricing_section(content: dict[str, Any]) -> dict[str, Any]:
+    tiers_in = content.get("tiers") or []
+    tiers: list[dict[str, Any]] = []
+    for i, tier in enumerate(tiers_in):
+        if not isinstance(tier, dict):
+            continue
+        # ``features`` accepts Array<string>; pass strings straight through.
+        raw_features = tier.get("features") or []
+        features = [_s(f) for f in raw_features if _s(f)]
+        out: dict[str, Any] = {
+            "id": _s(tier.get("id")) or f"tier-{i + 1}",
+            "name": _s(tier.get("name"), f"Plan {i + 1}"),
+            # price is a string or number; keep the LLM's value, stringified.
+            "price": _s(tier.get("price")),
+            "period": _s(tier.get("period")),
+            "features": features,
+            # tier ``cta`` is a STRING button label (not an object).
+            "cta": _s(tier.get("cta_label") or tier.get("cta"), "Get started"),
+        }
+        if tier.get("popular"):
+            out["popular"] = True
+        tiers.append(out)
+    return {
+        "type": "section",
+        "props": {"id": _ANCHOR_PRICING},
+        "children": [
+            {
+                "type": "pricing-table",
+                # ``currency`` is the SYMBOL, not a code; the required array prop
+                # is ``tiers`` (never ``plans``/``columns``).
+                "props": {"currency": "$", "tiers": tiers},
+            }
+        ],
+    }
+
+
+def _cta_band(content: dict[str, Any]) -> dict[str, Any]:
+    band = content.get("cta_band") or {}
+    return {
+        "type": "cta",
+        "props": {
+            # ``cta`` uses ``headline`` (not title) / ``subtext`` (not subtitle) /
+            # ``button`` string label / ``href`` destination (sibling, not nested).
+            "headline": _s(band.get("headline"), "Ready to get started?"),
+            "subtext": _s(band.get("subtext")),
+            "button": _s(band.get("button_label") or band.get("button"), "Get in touch"),
+            "href": f"#{_ANCHOR_BOOK}",
+            "align": "center",
+        },
+    }
+
+
+def _lead_form_card(content: dict[str, Any]) -> dict[str, Any]:
+    """The FLAT lead-capture form (SSR rule 1).
+
+    Flat ``input`` / ``textarea`` / ``button{type:submit}`` placed directly in a
+    ``card`` — NEVER a ``form`` or ``newsletter`` widget (those emit a nested
+    ``<form>`` that the browser drops inside the site template's outer form, so
+    the visitor's submit silently captures nothing). Each input carries a real
+    ``name`` so the native POST maps the lead. The default
+    ``name``/``email``/``phone``/``message`` field set matches the Site service's
+    seeded ``event_mapping``, so a lead lands with no manual config.
+    """
+    contact = content.get("contact") or {}
+    title = _s(content.get("form_title"), "Get in touch")
+    return {
+        "type": "card",
+        "props": {"id": _ANCHOR_BOOK, "title": title},
+        "children": [
+            {
+                "type": "input",
+                "props": {
+                    "name": "name",
+                    "label": "Your name",
+                    "placeholder": _s(contact.get("name_placeholder"), "Jane Doe"),
+                    "required": True,
+                },
+            },
+            {
+                "type": "input",
+                "props": {
+                    "name": "email",
+                    "label": "Email",
+                    "type": "email",
+                    "placeholder": _s(contact.get("email"), "you@email.com"),
+                    "required": True,
+                },
+            },
+            {
+                "type": "input",
+                "props": {
+                    "name": "phone",
+                    "label": "Phone",
+                    "type": "tel",
+                    "placeholder": _s(contact.get("phone"), "(555) 010-1234"),
+                },
+            },
+            {
+                "type": "textarea",
+                "props": {
+                    "name": "message",
+                    "label": "How can we help?",
+                    "placeholder": _s(
+                        content.get("message_placeholder"), "Tell us what you need..."
+                    ),
+                },
+            },
+            {
+                "type": "button",
+                "props": {
+                    "label": _s((content.get("cta_band") or {}).get("button_label"), "Send"),
+                    # type=submit so the native outer-form POST fires.
+                    "type": "submit",
+                    "variant": "primary",
+                },
+            },
+        ],
+    }
+
+
+def _footer(content: dict[str, Any]) -> dict[str, Any]:
+    footer = content.get("footer") or {}
+    contact = content.get("contact") or {}
+    brand = _s(content.get("brand"), "Your Business")
+
+    visit_links: list[dict[str, str]] = []
+    address = _s(contact.get("address"))
+    if address:
+        visit_links.append({"label": address, "href": f"#{_ANCHOR_BOOK}"})
+    phone = _s(contact.get("phone"))
+    if phone:
+        tel = "tel:" + "".join(ch for ch in phone if ch.isdigit())
+        visit_links.append({"label": phone, "href": tel})
+    if not visit_links:
+        visit_links.append({"label": "Book", "href": f"#{_ANCHOR_BOOK}"})
+
+    return {
+        "type": "footer",
+        # ``footer`` groups links into titled ``columns`` + a ``copyright`` line;
+        # it has no ``brand``/flat ``links`` props (those silently drop).
+        "props": {
+            "columns": [
+                {"title": "Visit", "links": visit_links},
+                {
+                    "title": "Explore",
+                    "links": [
+                        {"label": "Services", "href": f"#{_ANCHOR_SERVICES}"},
+                        {"label": "Pricing", "href": f"#{_ANCHOR_PRICING}"},
+                        {"label": "Book", "href": f"#{_ANCHOR_BOOK}"},
+                    ],
+                },
+            ],
+            "copyright": _s(footer.get("copyright"), f"© {brand}"),
+        },
+    }
+
+
+def assemble_landing_spec(content: dict[str, Any]) -> dict[str, Any]:
+    """Assemble a renderer-valid landing-page rippleSpec from an LLM copy object.
+
+    ``content`` carries COPY ONLY — the assembler decides every widget kind and
+    the whole node tree, so the structure is a pure function of the input and can
+    never be downgraded. Expected (all optional, defaults fill gaps)::
+
+        {
+          "brand": str,
+          "hero": {"eyebrow", "title", "subtitle", "cta_label"},
+          "services": [{"title", "desc", "icon"}],          # variable length
+          "testimonials": [{"quote", "author", "role"}],     # variable length
+          "tiers": [{"name", "price", "period", "features": [str],
+                     "popular": bool, "cta_label": str}],     # variable length
+          "cta_band": {"headline", "subtext", "button_label"},
+          "contact": {"address", "phone", "email"},
+          "footer": {"copyright"},
+        }
+
+    Returns a ``{version, state, ui}`` rippleSpec whose ``ui`` is the fixed
+    conversion-ordered marketing tree. The caller persists it straight (no
+    validate/redraft loop, no subagent) via the pockets service.
+    """
+    if not isinstance(content, dict):
+        raise TypeError("assemble_landing_spec expects a content dict (copy only)")
+
+    children: list[dict[str, Any]] = [
+        _navbar(content),
+        _hero(content),
+        _services_section(content),
+        _reviews_section(content),
+        _pricing_section(content),
+        _cta_band(content),
+        _lead_form_card(content),
+        _footer(content),
+    ]
+
+    return {
+        "version": "1.0",
+        "state": {},
+        "ui": {
+            "type": "flex",
+            "props": {"direction": "column", "gap": "0"},
+            "children": children,
+        },
+    }
+
+
+__all__ = ["assemble_landing_spec"]

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
@@ -8,10 +8,11 @@ description: |
   site: "build a dentist landing site", "make a marketing page for my
   bakery", "a landing page for my SaaS", or when the create-site flow
   routes a new-site request here. This is the marketing-first authoring
-  brain — it composes a sales page, NOT a dashboard. It stamps the pocket
-  with type="site" + pattern="landing" so the published page renders as a
-  landing page. For publishing an EXISTING pocket as a site, use
-  pocketpaw-create-site (Path A). Loading this skill keeps the chat
+  brain — it composes a sales page, NOT a dashboard. You provide the COPY
+  only; a deterministic tool assembles the page structure and stamps the
+  pocket with type="site" + pattern="landing" so the published page
+  renders as a landing page. For publishing an EXISTING pocket as a site,
+  use pocketpaw-create-site (Path A). Loading this skill keeps the chat
   agent's always-on system prompt small while still delivering the full
   marketing brain when a landing site is actually requested.
 ---
@@ -20,540 +21,185 @@ description: |
 
 You're building a **Paw Site**: a real, standalone marketing website that
 gets rendered **statically** (server-side, `csr=false`) and deployed to
-the edge from a PocketPaw pocket's ``rippleSpec``. The pocket is the
-source of truth; the generator turns its spec into a SvelteKit site.
+the edge.
+
+**The one rule that changes everything: you do NOT compose a rippleSpec.**
+You write the **copy** — the business name, the headline, the services,
+the testimonials, the prices — and hand it to a deterministic tool
+(`mcp__pocketpaw_sites_manager__create_landing_site`). **CODE** assembles
+the page structure (every marketing widget, the conversion order, the SSR
+rules) from your copy. The structure is fixed and cannot be downgraded —
+so your whole job is to write a sales page worth of words and let the tool
+build the page.
 
 This is **not** a dashboard. A landing page sells. It reads top to bottom
 as a conversion funnel: grab attention, explain the offer, prove it,
-price it, and capture the lead. Your job is to compose that page **by
-conversion role** out of Ripple's marketing widgets, persist it as a
-pocket stamped ``type="site"`` + ``pattern="landing"``, and hand the
-pocket id to the publish step.
+price it, and capture the lead. The tool emits exactly that funnel from
+your copy.
 
-## STEP 0 — Match the brief to the landing-page skeleton (the fast-path)
+## Why copy-only (and why this is the reliable path)
 
-**Do this FIRST, before drafting anything.** PocketPaw ships a pre-baked
-``landing-page`` template — a complete, conversion-ordered rippleSpec
-skeleton built from the real marketing widgets, with ``[bracketed]``
-placeholder copy. When the brief is a landing/marketing/sales site, you
-**instantiate that skeleton** instead of cold-drafting the whole tree.
-This is the difference between a ~4-minute cold draft and a near-instant
-fill.
+Earlier versions of this skill asked the agent to draft the rippleSpec
+itself (or route it through the pocket specialist's create/redraft loop).
+That path kept silently downgrading the page to generic
+`hero + grid + card + quote` widgets — the marketing widgets got dropped
+between drafting and persistence. The deterministic tool removes the whole
+failure mode: **the LLM provides copy, code owns structure.** There is
+nothing left to downgrade.
 
-The match is a simple, case-insensitive substring check — the same one
-the bundled template registry uses:
+So: **do not call `get_widget_spec`. Do not draft a `rippleSpec`. Do not
+call `pocket_specialist__create`. Do not delegate to a subagent.** Build
+the `content` object and call `create_landing_site`.
 
-1. Lower-case the user's brief.
-2. Read the keyword rows in
-   ``src/pocketpaw/bundled_templates/_bundled/index.json``. The
-   ``landing-page`` row registers:
-   ``landing page``, ``landing site``, ``marketing page``,
-   ``marketing site``, ``sales page``, ``website for``, ``site for``.
-3. If **any** of those keywords is a substring of the lowered brief, it's
-   a landing match.
+## STEP 1 — Write the `content` copy object
 
-On a landing match: **set ``hints.template_id = "landing-page"`` on the
-create call (STEP 4) and STOP cold-drafting.** The specialist's shared
-template splice then loads the skeleton and injects it into the build
-prompt under an "INSTANTIATE AND CUSTOMIZE, DO NOT REDESIGN" banner — the
-skeleton already encodes the conversion order, every marketing widget, and
-the five SSR rules below **by construction.** Your job collapses to STEP 1:
-replace the ``[bracketed]`` copy. You do **not** re-pick widgets, re-derive
-the section order, or hand-compose the tree.
-
-(If the brief is genuinely not a landing site — no keyword matches — fall
-back to the full compose path: confirm widget props with
-``get_widget_spec`` and build by conversion role using the section grammar
-and the worked example further down as your reference.)
-
-## The static-render fact (drives every SSR rule below)
-
-The single most important fact: **the site is prerendered static HTML.**
-Client-side JS does not run for the visitor on first paint (and for many
-visitors, never). Everything that must work — the lead form submit, every
-call-to-action link, the pricing cards, the FAQ answers — must work as
-plain HTML. This drives every hard rule below. A widget that needs client
-JS to function is **dead on a Paw Site.**
-
-The site template wraps the whole page in one outer
-``<form method="POST">`` so a native form submit posts the lead back to
-the platform. That single fact creates the nested-form trap in rule 1.
-
-## STEP 1 — Fill the spliced skeleton (replace the [bracketed] copy)
-
-On a landing match (STEP 0) you are handed the ``landing-page`` skeleton
-already spliced into your build prompt. **Do NOT call ``get_widget_spec``
-per widget and do NOT hand-compose the tree — the skeleton already did
-both correctly.** Instantiate it:
-
-- Replace every ``[bracketed]`` placeholder with concrete, on-domain copy:
-  the business name, the real services, real testimonial quotes with
-  names, real tier names + prices, the address/phone in the footer. A
-  dentist brief gets New Patient Exam / Whitening / Invisalign — never
-  "TBD" or "Service one".
-- **Preserve the structure.** The node tree, the conversion order, the
-  marketing widget at each section, the anchor ``id``s on the wrapping
-  ``section`` / ``card``, the flat lead form, the ``tiers`` shape — all
-  correct already. Do not swap a marketing widget for ``grid`` + ``card``,
-  do not reorder the funnel, do not add a ``form`` / ``accordion`` widget.
-- Keep the lead form flat and named (rule 1), keep ``pricing-table`` on
-  ``tiers`` (rule 2), keep every CTA an anchor ``href`` (rule 4).
-- Drop the ``_placeholder_note`` and any ``_``-prefixed key before persist.
-
-Then go straight to STEP 4 (persist) and STEP 5 (publish). The SSR rules
-in STEP 3 are your **review checklist** over the filled skeleton — verify
-them, don't re-derive the page from them.
-
-<details>
-<summary><b>Fallback only — the full compose path (no landing keyword matched)</b></summary>
-
-When STEP 0 found no landing match you build the page by hand. First
-confirm the widget props, then compose by conversion role.
-
-**Confirm the widget props.** Call ``mcp__pocketpaw_pocket__get_widget_spec``
-for **every** marketing widget you'll use:
-
-> ``navbar``, ``hero``, ``feature-grid``, ``testimonial``,
-> ``logo-cloud``, ``pricing-table``, ``cta``, ``newsletter``, ``footer``
-
-Copy prop names **verbatim** from the spec. The renderer has a **closed
-registry**: an invented widget ``type`` renders as a red "Unknown widget
-type" box, and an invented or mis-shaped prop **silently drops** — the
-widget renders empty. That empty-render is the trap that makes a brain
-abandon the widget and hand-roll the section from ``grid`` + ``card``
-instead. Don't. Confirm the prop shape, fill it correctly, and the widget
-renders polished.
-
-**Compose by conversion role.** Build every section with its purpose-built
-marketing widget. Do NOT hand-roll services / proof / nav / footer / CTA /
-logos / email as generic ``grid`` + ``card`` + ``text`` + ``flex``. Each
-conversion job below has ONE mandated widget. Use it. The only section
-built from flat primitives is the lead form (rule 1). Lay the page out in
-this order. Top to bottom, this is the funnel.
-
-| # | Conversion job | MANDATED widget | NEVER hand-roll as |
-|---|---|---|---|
-| 1 | **Navigation** — brand + anchor links | ``navbar`` | ~~``flex`` + ``text`` + ``button``~~ |
-| 2 | **Hook** — above-the-fold promise | ``hero`` | ~~``page-header`` + ``stat`` grid~~ |
-| 3 | **Offer** — services / value props | ``feature-grid`` | ~~``grid`` + ``card``~~ |
-| 4 | **Proof** — testimonials | ``testimonial`` (one per quote) | ~~``grid`` + ``card``~~ |
-| 5 | **Trust** — client / partner logos | ``logo-cloud`` | ~~``flex`` + broken ``img``~~ |
-| 6 | **Price** — plans | ``pricing-table`` (``tiers``) | ~~``grid`` + ``card``~~ |
-| 7 | **Mid-page nudge** — 2nd conversion band | ``cta`` | ~~``flex`` + ``text`` + ``button``~~ |
-| 8 | **Email** (optional) — list signup | ``newsletter`` | ~~``flex`` + ``input`` + ``button``~~ |
-| 9 | **Capture** — the lead form | **flat** ``input`` / ``textarea`` / ``button{type:"submit"}`` in a ``card`` (rule 1 — UNCHANGED) | — |
-| 10 | **Close** — footer | ``footer`` | ~~``flex`` + ``text``~~ |
-
-Wrap the whole thing in a ``flex`` (``direction: column``) root. The
-marketing widgets carry **no ``id`` prop of their own**, so where the
-navbar / CTA anchors need a landing target (``#services``, ``#pricing``,
-``#reviews``, ``#book``), wrap that widget — or place the lead form — in a
-``section`` / ``card`` that carries the ``id``. Anchors point at the
-wrapper's ``id``; the widget renders inside it.
-
-### The mandated widgets — real prop shapes (paste-ready)
-
-Confirm each with ``get_widget_spec`` (live source of truth), but these
-are the shapes you'll fill. **Watch the shapes marked ⚠ — they are the
-ones a brain most often gets wrong, which is why the widget renders empty
-and tempts a fall back to ``grid`` + ``card``.**
-
-- **``navbar``** — ``brand`` (string), ``links`` (``Array<{label, href}>``),
-  ``cta`` (string label ⚠ — a **string**, not an object),
-  ``ctaHref`` (string ⚠ — the CTA destination is a **separate** prop, not
-  nested in ``cta``), ``sticky`` (boolean).
-- **``hero``** — ``title`` *(required)*, ``subtitle``, ``eyebrow``,
-  ``align`` (``"left"|"center"``). ⚠ **``hero`` has no CTA prop.** Put the
-  primary call-to-action in the ``navbar``'s ``cta`` or in a following
-  ``cta`` band — do not invent a ``hero`` button.
-- **``feature-grid``** — ``features`` *(required)*,
-  ``Array<{title, description?, icon?}>`` — each item's optional ``icon``
-  is a **lucide icon name** (e.g. ``"tooth"``, ``"sparkles"``,
-  ``"shield"``); ``columns`` (``2|3|4``, default 3).
-- **``testimonial``** — ``quote`` *(required)*, ``author``, ``role``,
-  ``avatar`` (image URL). ⚠ **One testimonial per widget** — no ``items``
-  array; for three quotes, emit three ``testimonial`` nodes. There is **no
-  ``rating`` prop and no ``id`` prop** — don't add them (they silently
-  drop).
-- **``logo-cloud``** — ``heading`` (e.g. "Trusted by"),
-  ``logos`` (``Array<{src, alt, href?}>``).
-- **``pricing-table``** — ``tiers`` *(required)*,
-  ``Array<{id, name, price, period?, description?, features?, cta?, popular?}>``;
-  ``currency`` (a **symbol** like ``"$"`` ⚠ — not ``"USD"``). ⚠ Inside a
-  tier, ``cta`` is a **string** button label (not an object), ``price`` is
-  a string **or** number, and ``features`` is ``Array<string>`` **or**
-  ``Array<{label, included?}>`` (use the object form to show
-  ✓/✗ rows). Mark one tier ``popular: true``.
-- **``cta``** — ``headline`` *(required)* ⚠ (**not** ``title``),
-  ``subtext`` ⚠ (**not** ``subtitle``), ``button`` (string label ⚠ — not
-  an object), ``href`` (the destination ⚠ — a sibling prop, not nested in
-  ``button``), ``align``.
-- **``newsletter``** — ``heading``, ``subtext``, ``placeholder``
-  (default ``"you@example.com"``), ``button`` (default ``"Subscribe"``).
-  Emits the email via ``on_submit``. (For the **lead-capture** form, use
-  flat inputs per rule 1 — ``newsletter`` is only for an optional
-  list-signup band, and even then it emits its own ``<form>``; if SSR
-  capture matters, prefer flat inputs.)
-- **``footer``** — ``columns``
-  (``Array<{title, links: Array<{label, href}>}>``), ``copyright`` (the
-  legal line). ⚠ **No ``brand`` / ``tagline`` / flat ``links`` props** —
-  group links into titled ``columns`` and put the business name in
-  ``copyright``.
-
-### WORKED EXAMPLE — a full landing spec with the real widgets
-
-A dentist landing page. Every section is its purpose-built widget; only
-the lead form is flat (rule 1). Copy this shape and adapt the copy.
+`content` is COPY ONLY — words, never structure. Every field is optional;
+the tool fills any gap with plausible copy, but a good page comes from you
+giving it real, on-domain words. The shape:
 
 ```json
 {
-  "version": "1.0",
-  "ui": {
-    "type": "flex",
-    "props": { "direction": "column", "gap": "0" },
-    "children": [
-      { "type": "navbar", "props": {
-          "brand": "Bright Smile Dental",
-          "links": [
-            { "label": "Services", "href": "#services" },
-            { "label": "Reviews",  "href": "#reviews" },
-            { "label": "Pricing",  "href": "#pricing" },
-            { "label": "Book",     "href": "#book" }
-          ],
-          "cta": "Book a visit",
-          "ctaHref": "#book",
-          "sticky": true
-      }},
-
-      { "type": "hero", "props": {
-          "eyebrow": "Family & cosmetic dentistry",
-          "title": "Care that fits your whole family",
-          "subtitle": "Gentle, modern dentistry in downtown Austin. Same-week appointments, transparent pricing, no surprises.",
-          "align": "center"
-      }},
-
-      { "type": "section", "props": { "id": "services" }, "children": [
-        { "type": "feature-grid", "props": {
-            "columns": 4,
-            "features": [
-              { "icon": "tooth",    "title": "New Patient Exams", "description": "Full exam, digital X-rays, and a cleaning in one visit." },
-              { "icon": "sparkles", "title": "Teeth Whitening",   "description": "In-office whitening up to 8 shades brighter in an hour." },
-              { "icon": "smile",    "title": "Invisalign",        "description": "Clear aligners with a custom plan and a free consult." },
-              { "icon": "shield",   "title": "Emergency Care",    "description": "Same-day relief for pain, chips, and lost fillings." }
-            ]
-        }}
-      ]},
-
-      { "type": "section", "props": { "id": "reviews" }, "children": [
-        { "type": "testimonial", "props": {
-            "quote": "Best dental experience I've had. They explained every option and the cleaning was painless.",
-            "author": "Maria G.", "role": "Patient since 2023"
-        }},
-        { "type": "testimonial", "props": {
-            "quote": "Booking went from a phone-tag headache to one tap. The team is wonderful.",
-            "author": "James T.", "role": "Patient since 2021"
-        }},
-        { "type": "logo-cloud", "props": {
-            "heading": "Trusted by families across Austin",
-            "logos": [
-              { "src": "/logos/delta-dental.svg", "alt": "Delta Dental" },
-              { "src": "/logos/cigna.svg",        "alt": "Cigna" },
-              { "src": "/logos/metlife.svg",      "alt": "MetLife" }
-            ]
-        }}
-      ]},
-
-      { "type": "section", "props": { "id": "pricing" }, "children": [
-        { "type": "pricing-table", "props": {
-            "currency": "$",
-            "tiers": [
-              { "id": "exam",  "name": "New Patient Exam", "price": "89",  "period": "one-time",
-                "features": ["Full exam", "Digital X-rays", "Cleaning"], "cta": "Book" },
-              { "id": "white", "name": "Whitening",        "price": "299", "period": "one-time", "popular": true,
-                "features": ["In-office session", "Up to 8 shades", "Take-home trays"], "cta": "Book" },
-              { "id": "invis", "name": "Invisalign",       "price": "3,900", "period": "full plan",
-                "features": ["Custom aligners", "All visits", "Retainers included"], "cta": "Free consult" }
-            ]
-        }}
-      ]},
-
-      { "type": "cta", "props": {
-          "headline": "Ready for a healthier smile?",
-          "subtext": "Same-week appointments are filling up.",
-          "button": "Request an appointment",
-          "href": "#book",
-          "align": "center"
-      }},
-
-      { "type": "card", "props": { "id": "book", "title": "Book your visit" },
-        "children": [
-          { "type": "input",    "props": { "name": "name",  "label": "Your name", "placeholder": "Jane Doe", "required": true } },
-          { "type": "input",    "props": { "name": "email", "label": "Email", "type": "email", "placeholder": "jane@email.com", "required": true } },
-          { "type": "input",    "props": { "name": "phone", "label": "Phone", "type": "tel", "placeholder": "(555) 010-1234" } },
-          { "type": "textarea", "props": { "name": "message", "label": "What do you need?", "placeholder": "I'd like a checkup and cleaning..." } },
-          { "type": "button",   "props": { "label": "Request appointment", "type": "submit", "variant": "primary" } }
-        ]
-      },
-
-      { "type": "footer", "props": {
-          "columns": [
-            { "title": "Visit",   "links": [ { "label": "421 Congress Ave, Austin TX", "href": "#book" }, { "label": "(555) 010-1234", "href": "tel:5550101234" } ] },
-            { "title": "Explore", "links": [ { "label": "Services", "href": "#services" }, { "label": "Pricing", "href": "#pricing" }, { "label": "Book", "href": "#book" } ] }
-          ],
-          "copyright": "© 2026 Bright Smile Dental"
-      }}
-    ]
-  }
+  "brand": "Bright Smile Dental",
+  "hero": {
+    "eyebrow": "Family & cosmetic dentistry",
+    "title": "Care that fits your whole family",
+    "subtitle": "Gentle, modern dentistry in downtown Austin. Same-week appointments, transparent pricing, no surprises.",
+    "cta_label": "Book a visit"
+  },
+  "services": [
+    { "title": "New Patient Exams", "desc": "Full exam, digital X-rays, and a cleaning in one visit.", "icon": "tooth" },
+    { "title": "Teeth Whitening",   "desc": "In-office whitening up to 8 shades brighter in an hour.",   "icon": "sparkles" },
+    { "title": "Invisalign",        "desc": "Clear aligners with a custom plan and a free consult.",      "icon": "smile" },
+    { "title": "Emergency Care",    "desc": "Same-day relief for pain, chips, and lost fillings.",        "icon": "shield" }
+  ],
+  "testimonials": [
+    { "quote": "Best dental experience I've had. They explained every option and the cleaning was painless.", "author": "Maria G.", "role": "Patient since 2023" },
+    { "quote": "Booking went from a phone-tag headache to one tap. The team is wonderful.",                   "author": "James T.", "role": "Patient since 2021" }
+  ],
+  "tiers": [
+    { "name": "New Patient Exam", "price": "89",    "period": "one-time", "features": ["Full exam", "Digital X-rays", "Cleaning"],              "cta_label": "Book" },
+    { "name": "Whitening",        "price": "299",   "period": "one-time", "features": ["In-office session", "Up to 8 shades", "Take-home trays"], "popular": true, "cta_label": "Book" },
+    { "name": "Invisalign",       "price": "3,900", "period": "full plan", "features": ["Custom aligners", "All visits", "Retainers included"],   "cta_label": "Free consult" }
+  ],
+  "cta_band": {
+    "headline": "Ready for a healthier smile?",
+    "subtext": "Same-week appointments are filling up.",
+    "button_label": "Request an appointment"
+  },
+  "contact": {
+    "address": "421 Congress Ave, Austin TX",
+    "phone": "(555) 010-1234",
+    "email": "hello@brightsmile.com"
+  },
+  "footer": { "copyright": "© 2026 Bright Smile Dental" }
 }
 ```
 
-Note in the example: ``navbar`` carries the only ``cta`` (the ``hero`` has
-none); ``cta`` uses ``headline`` / ``subtext`` / ``button`` / ``href``;
-each tier ``cta`` is a **string**; ``currency`` is ``"$"``; the footer is
-titled ``columns`` + ``copyright`` (no ``brand`` / flat ``links``); two
-quotes = two ``testimonial`` nodes; anchor ids live on wrapping
-``section`` / ``card`` because the marketing widgets carry none. This is
-the polished, Ripple-native page — not a ``grid`` + ``card`` wireframe.
-(The ``landing-page`` skeleton you splice in STEP 0 is this exact shape
-with ``[bracketed]`` copy — the fast-path is just "fill this in".)
+### Field reference
 
-</details>
+- **`brand`** — the business name. Shows in the navbar and footer.
+- **`hero`** — `eyebrow` (short category line), `title` (the headline
+  promise), `subtitle` (one sentence on the offer/location/why-easy),
+  `cta_label` (the primary button label — the tool wires it to the lead
+  form anchor).
+- **`services`** — a list of `{title, desc, icon}`. `icon` is a **lucide
+  icon name** (e.g. `tooth`, `sparkles`, `shield`, `smile`); omit it and
+  the tool picks one. Variable length — give as many as the business has.
+- **`testimonials`** — a list of `{quote, author, role}`. Real-sounding
+  quotes with names. Variable length.
+- **`tiers`** — pricing plans: `{name, price, period, features[],
+  popular?, cta_label}`. `price` is a string or number **without** a
+  currency symbol (the tool renders `$`); `features` is a list of strings;
+  mark the recommended tier `"popular": true`. Variable length.
+- **`cta_band`** — the mid-page conversion nudge: `{headline, subtext,
+  button_label}`.
+- **`contact`** — `{address, phone, email}`. Feeds the footer and the lead
+  form placeholders.
+- **`footer`** — `{copyright}` (the legal line).
 
-## STEP 3 — The HARD SSR rules (your checklist over the filled skeleton)
+### Write real copy — never placeholders
 
-Rules 1–5 are the **SSR contract** — the difference between a shippable
-landing page and a broken one; each was a real failure on a real render.
-Rule 6 is the matching **widget-integrity** rule for ``logo-cloud``. The
-``landing-page`` skeleton already satisfies all six **by construction**, so
-on the fast-path these are your **review checklist** — verify the filled
-spec still honors them (and that your copy edits didn't reintroduce a
-``form`` widget, an ``accordion``, a ``plans`` key, or an ``on_click``).
-On the fallback compose path they are the rules you build to. Do not
-soften any of them.
-
-### Rule 1 — Lead form = FLAT native inputs. NEVER a `form` or `newsletter` widget.
-
-The lead-capture section is built from **flat** primitives placed
-directly in a ``card`` or ``section``:
-
-- ``input`` widgets, each with a real ``name`` (``name="name"``,
-  ``name="email"``, ``name="phone"``) and a ``label`` / ``placeholder``.
-- an optional ``textarea`` with ``name="message"``.
-- a ``button`` with ``type: "submit"`` to post the form.
-
-**NEVER use the ``form`` widget or the ``newsletter`` widget here.** They
-emit their **own** nested ``<form>`` element. The site template already
-wraps the page in an outer ``<form method="POST">`` — a nested ``<form>``
-is invalid HTML, the browser drops it, and the visitor's submit silently
-does nothing. Flat ``input``s with real ``name``s ride the template's
-outer form and POST natively. This is the trap that broke the first
-render: the ``form`` widget produced ``<form novalidate>`` inside the
-outer form and the page captured zero leads.
-
-```json
-{
-  "type": "card",
-  "props": {"id": "book", "title": "Book your visit"},
-  "children": [
-    {"type": "input", "props": {"name": "name", "label": "Your name", "placeholder": "Jane Doe", "required": true}},
-    {"type": "input", "props": {"name": "email", "label": "Email", "type": "email", "placeholder": "jane@email.com", "required": true}},
-    {"type": "input", "props": {"name": "phone", "label": "Phone", "type": "tel", "placeholder": "(555) 010-1234"}},
-    {"type": "textarea", "props": {"name": "message", "label": "What do you need?", "placeholder": "I'd like a checkup..."}},
-    {"type": "button", "props": {"label": "Request appointment", "type": "submit", "variant": "primary"}}
-  ]
-}
-```
-
-### Rule 2 — `pricing-table` uses `tiers`, never `plans`/`columns`.
-
-``pricing-table``'s required array prop is **``tiers``** (confirmed in the
-catalog). ``plans`` and ``columns`` are **wrong** — they render an empty
-table. Each tier:
-
-```json
-{"id": "checkup", "name": "New Patient Exam", "price": "89", "period": "one-time",
- "features": ["Full exam", "X-rays", "Cleaning"], "popular": true,
- "cta": "Book"}
-```
-
-The tier ``cta`` is a **string** button label, not an object — the
-pricing-table renders the tier card and routes the click itself. Set
-``currency`` to a **symbol** (``"$"``, ``"€"``), not a code like
-``"USD"``. ``price`` is a string or number; ``features`` is
-``Array<string>`` or ``Array<{label, included?}>`` (object form shows
-✓/✗ rows). Mark one tier ``popular: true``. **Call
-``get_widget_spec`` for ``pricing-table`` before drafting** to confirm the
-exact tier-object keys.
-
-### Rule 3 — FAQ = flat `heading` + `text` pairs. NEVER `accordion`.
-
-If you add an FAQ, build it as a stack of ``heading`` (the question) +
-``text`` (the answer) pairs. **Never use the ``accordion`` widget** — it
-is a bits-ui client primitive whose panels only open with JavaScript. On
-a static site the answers never expand and the FAQ is unreadable.
-
-### Rule 4 — Every CTA is an anchor `href`. NEVER `on_click`.
-
-CTAs link by **anchor destination**, never a click handler. An
-``on_click`` handler needs client JS, which doesn't run — an ``on_click``
-CTA is a **dead button** on a static site. The native action is the lead
-form's submit (rule 1); everything else navigates by anchor:
-
-- ``navbar`` CTA → set ``ctaHref`` (e.g. ``"#book"``).
-- standalone ``cta`` band → set ``href`` (e.g. ``"#book"``, or
-  ``tel:`` / ``mailto:`` for "call us").
-- ``navbar`` / ``footer`` link items → each carries its own ``href``.
-- ``pricing-table`` tiers → the tier ``cta`` is a string **label**; the
-  pricing-table wires the click to the page's lead anchor itself. Don't
-  bolt an ``on_click`` onto a tier.
-
-### Rule 5 — `hero` is the marketing Hero widget. NEVER the dashboard `hero+grid`.
-
-Use the ``hero`` widget — ``eyebrow`` + ``title`` + ``subtitle`` +
-``align``. It carries **no CTA prop** (don't invent one); the primary
-call-to-action lives in the ``navbar`` (``cta`` + ``ctaHref``) and in the
-mid-page ``cta`` band. Do **not** build the dashboard "``hero+grid``"
-layout (a ``page-header`` followed by a grid of KPI ``stat`` tiles). That
-is a dashboard pattern; a KPI grid at the top of a sales page screams
-"internal tool", not "landing page". No ``stat`` tiles, no metric grid, no
-charts. This is marketing, not analytics.
-
-### Rule 6 — `logo-cloud` with no real logos: text-mode or omit. NEVER broken `<img>`s.
-
-``logo-cloud`` renders ``logos: Array<{src, alt, href?}>`` as ``<img>``
-tags. If you don't have **real, resolvable** logo URLs, a made-up ``src``
-(``/logos/acme.svg``) renders as a **broken-image icon** on the live site
-— worse than no logo wall at all. So when the brief gives you no real
-logos:
-
-- **Prefer omit** — drop the ``logo-cloud`` entirely and lean on
-  ``testimonial`` for social proof.
-- **Or go text-mode** — keep the ``heading`` (e.g. "Trusted by 400+
-  Austin families") and skip ``logos`` (empty array), so the trust line
-  renders without any broken images.
-
-Never ship invented ``src`` paths. A broken-image row reads as
-"unfinished site".
-
-## Animated polish — Tier-0 widgets ONLY
-
-You may add tasteful motion, but **only Tier-0 (CSS-only, static-safe)
-animation widgets**, because they animate with pure CSS and need no
-client JS:
-
-> ``aurora``, ``marquee``, ``border-beam``, ``shimmer``,
-> ``animated-beam``, ``text-effect``, ``bento-grid``
-
-An ``aurora`` backdrop behind the hero, a ``marquee`` of client logos, or
-a ``border-beam`` on the popular pricing tier all work statically.
-
-**NEVER** use ``reveal``, ``parallax``, or ``spotlight`` — they are
-scroll/pointer-driven and need client JS, so on a static site they either
-hide content (reveal-on-scroll never fires → the section stays invisible)
-or simply don't move. When in doubt, leave it static; a clean static page
-beats a broken animated one.
-
-## STEP 4 — Persist the pocket (stamp type=site + pattern=landing)
-
-Create the pocket via the specialist create path, stamping the site
-identity:
-
-- ``type="site"`` — this pocket IS a site, not a dashboard pocket.
-- ``pattern="landing"`` — records the landing/conversion intent as
-  first-class metadata, so the generator and any later edit flow treat it
-  as a marketing page.
-- ``template_id="landing-page"`` — **set this on the fast-path** (STEP 0
-  matched a landing keyword). It tells the specialist to splice the
-  pre-baked landing skeleton into the build prompt, so the model
-  instantiates rather than cold-drafts. Omit it only on the fallback
-  compose path (no keyword matched), where you supply a fully hand-built
-  ``spec`` instead.
-
-Call ``mcp__pocketpaw_pocket_specialist__create`` with the brief, the
-hints (set ``type: "site"``, ``pattern: "landing"``, and on the fast-path
-``template_id: "landing-page"``), and — on the fallback path — the drafted
-``spec``. If your deployment routes custom multi-section builds through the
-merge endpoint, use ``POST /api/v1/pockets/<id>/spec/merge`` to assemble
-the sections — but the create call must carry ``type="site"`` +
-``pattern="landing"`` so the identity lands on the pocket.
-
-```json
-{
-  "brief": "<the user's original brief>",
-  "hints": {
-    "name": "Bright Smile Dental",
-    "description": "Family dentist landing page",
-    "type": "site",
-    "pattern": "landing",
-    "template_id": "landing-page",
-    "color": "#0ea5e9",
-    "icon": "tooth",
-    "purpose": "Capture new-patient appointment requests"
-  }
-}
-```
-
-On the fast-path the spliced skeleton IS the starting spec; you fill its
-``[bracketed]`` copy in the build prompt, so you don't pass a hand-drafted
-``spec`` here. On the fallback path, add your conversion-ordered
-``"spec": { ... }`` to the call.
-
-## STEP 5 — Publish
-
-Once the pocket exists, publish it as a site. Hand the pocket id to
-``mcp__pocketpaw_sites_manager__publish`` (the same publish hop the
-``pocketpaw-create-site`` skill uses) and show the user the returned
-``url`` plus a pointer to **/sites**. Relay any ``ok: false`` error —
-never claim a phantom publish.
-
-If you arrived here from the ``pocketpaw-create-site`` skill's Path B,
-that skill owns the publish call — return the created pocket id to it.
-
-## Mock content is required
-
-Vague briefs get **plausible, concrete copy** — never "TBD" or "Lorem
+Vague briefs get **plausible, concrete copy**, never "TBD" or "Lorem
 ipsum". A dentist gets real service names (New Patient Exam, Whitening,
-Invisalign), real testimonial quotes with names (Maria G., James T.),
-real tier prices. The page must read like a finished business site, not a
-wireframe.
+Invisalign), real testimonial quotes with names (Maria G., James T.), real
+tier prices. The page must read like a finished business site. The tool
+will fill any field you omit, but it can't invent the business's real
+offer — that's your job.
 
-## Quality bar
+## STEP 2 — Call `create_landing_site`
 
-The site is built right when:
+Hand the copy to the tool. It assembles the fixed marketing structure and
+persists the pocket stamped `type="site"` + `pattern="landing"`.
 
-1. **Every section is its purpose-built marketing widget.** ``navbar`` /
-   ``hero`` / ``feature-grid`` / ``testimonial`` / ``logo-cloud`` /
-   ``pricing-table`` / ``cta`` / ``footer`` — **not** hand-rolled from
-   ``grid`` + ``card`` + ``text`` + ``flex``. (The lead form is the lone
-   flat exception, per rule 1.) If services or proof or the nav/footer are
-   built from generic primitives, the page reads as a wireframe and the
-   build is wrong.
-2. **It reads as a funnel.** Top to bottom: nav → hero → services →
-   proof → pricing → CTA → lead form → footer. A visitor can scan it and
-   know what's sold and how to buy.
-3. **The lead form is flat + named.** Real ``<input name>``s and a submit
-   button — no ``form`` / ``newsletter`` widget — so the published page
-   POSTs natively and captures leads on the first paint with zero JS.
-4. **Pricing is populated.** ``pricing-table`` with real ``tiers`` — not
-   ``plans``/``columns``, not an empty table; tier ``cta`` a string,
-   ``currency`` a symbol.
-5. **Every CTA navigates.** Anchor destinations (``navbar.ctaHref`` /
-   ``cta.href`` / link ``href``s, or ``tel:`` / ``mailto:``) — no dead
-   ``on_click`` buttons, no ``accordion`` FAQ.
-6. **No dashboard widgets.** No KPI ``stat`` grid, no ``hero+grid``, no
-   charts. It's a marketing page, stamped ``pattern="landing"``.
+```
+mcp__pocketpaw_sites_manager__create_landing_site(
+  content = <the copy object from STEP 1>,
+  name    = "Bright Smile Dental"      // optional; defaults to content.brand
+)
+```
+
+It returns `{ ok, pocket_id, pocket }`. Keep `pocket_id` for STEP 3. If
+`ok` is false, relay the error — do **not** claim a phantom create and do
+**not** fall back to drafting a spec yourself.
+
+## STEP 3 — Publish
+
+Publish the new pocket as a site:
+
+```
+mcp__pocketpaw_sites_manager__publish(pocket_id = <the id from STEP 2>)
+```
+
+Show the user the returned `url` plus a pointer to **/sites**. Relay any
+`ok: false` error — never claim a phantom publish.
+
+If you arrived here from the `pocketpaw-create-site` skill's Path B, that
+skill owns the publish call — return the created `pocket_id` to it.
+
+## What the tool builds (so you know what your copy becomes)
+
+You don't assemble any of this — it's here so you understand how your copy
+maps to the page. The tool emits, top to bottom (the conversion funnel):
+
+| # | Section | Built from your copy |
+|---|---------|----------------------|
+| 1 | **navbar** (sticky, brand + anchor links + CTA) | `brand`, `hero.cta_label` |
+| 2 | **hero** (eyebrow + title + subtitle) | `hero` |
+| 3 | **feature-grid** under `#services` | `services[]` |
+| 4 | **testimonial** per quote under `#reviews` | `testimonials[]` |
+| 5 | **pricing-table** (`tiers`) under `#pricing` | `tiers[]` |
+| 6 | **cta** band | `cta_band` |
+| 7 | **flat lead form** in a `#book` card (input/textarea/submit) | `contact`, `cta_band.button_label` |
+| 8 | **footer** (titled columns + copyright) | `contact`, `footer`, `brand` |
+
+The page is **prerendered static HTML** (`csr=false`) — no client JS runs
+for the visitor on first paint. The tool bakes in every SSR rule by
+construction, so you never have to think about them:
+
+- The lead form is **flat** `input` / `textarea` / `button{type:submit}`
+  with real `name`s — never a `form`/`newsletter` widget (which would emit
+  a nested `<form>` and capture nothing). It rides the page's outer form
+  and POSTs natively.
+- Every CTA is an **anchor `href`** (`#book`, `tel:`, `mailto:`), never an
+  `on_click` (a dead button on a static page).
+- `pricing-table` uses `tiers` with a `$` currency symbol; the popular
+  tier is highlighted.
+- Anchor targets (`#services` / `#reviews` / `#pricing` / `#book`) live on
+  wrapping `section` / `card` nodes, because the marketing widgets carry
+  no `id` of their own.
+- No dashboard widgets — no KPI `stat` grid, no charts, no `accordion`. A
+  marketing page, not an internal tool.
+
+Because all of that is fixed in code, the page can't be downgraded, and
+your copy is the only variable. Write it well.
 
 ## Related tools (via MCP)
 
-- ``mcp__pocketpaw_pocket__get_widget_spec`` — **call this first** for
-  every marketing widget by name: ``navbar`` / ``hero`` / ``feature-grid``
-  / ``testimonial`` / ``logo-cloud`` / ``pricing-table`` / ``cta`` /
-  ``newsletter`` / ``footer``. Confirm ``pricing-table``'s string-``cta``
-  tier shape, ``cta``'s ``headline`` / ``button`` / ``href``, and
-  ``footer``'s ``columns`` before drafting.
-- ``mcp__pocketpaw_pocket_specialist__create`` — persist the pocket
-  (stamp ``type="site"`` + ``pattern="landing"``).
-- ``mcp__pocketpaw_sites_manager__publish`` — publish the pocket as a
-  live site; show the user the ``url``.
-- ``mcp__pocketpaw_pocket__list_pockets`` — find an existing pocket if the
+- `mcp__pocketpaw_sites_manager__create_landing_site` — **the create
+  step.** Pass the `content` copy object; the tool assembles the marketing
+  page and persists it stamped `type="site"` + `pattern="landing"`.
+  Returns `{ok, pocket_id, pocket}`.
+- `mcp__pocketpaw_sites_manager__publish` — publish the pocket as a live
+  site; show the user the `url`.
+- `mcp__pocketpaw_pocket__list_pockets` — find an existing pocket if the
   user named one rather than describing a new site.

--- a/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
@@ -25,6 +25,7 @@ pytest.importorskip("pocketpaw_ee")
 class TestSitesMcpServerRegistration:
     def test_server_name_and_tool_id(self) -> None:
         from pocketpaw_ee.agent.mcp_servers.sites import (
+            CREATE_LANDING_SITE_TOOL_ID,
             PUBLISH_TOOL_ID,
             SERVER_NAME,
             SITES_TOOL_IDS,
@@ -33,8 +34,13 @@ class TestSitesMcpServerRegistration:
         assert SERVER_NAME == "pocketpaw_sites_manager"
         # Allowlist entries must use the exact ``mcp__<server>__<tool>`` form.
         assert PUBLISH_TOOL_ID == "mcp__pocketpaw_sites_manager__publish"
+        # The deterministic create tool registers on the SAME server (two
+        # create_sdk_mcp_server calls under one name would clobber each other),
+        # so both ids ride the one ``pocketpaw_sites_manager`` server.
+        assert CREATE_LANDING_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_landing_site"
         assert PUBLISH_TOOL_ID in SITES_TOOL_IDS
-        assert len(SITES_TOOL_IDS) == 1
+        assert CREATE_LANDING_SITE_TOOL_ID in SITES_TOOL_IDS
+        assert len(SITES_TOOL_IDS) == 2
 
     def test_extension_provider_advertises_tool_id(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk

--- a/tests/ee/sites/test_landing_assembler.py
+++ b/tests/ee/sites/test_landing_assembler.py
@@ -1,0 +1,431 @@
+# tests/ee/sites/test_landing_assembler.py
+# Created: 2026-06-04 (feat/sites-deterministic-fastpath) — KEYSTONE coverage for
+# the deterministic Paw Sites fast-path. Proves the marketing widgets survive
+# persistence end-to-end, the failure the three prior agent-mode fixes never
+# closed.
+#
+# Two layers:
+#   1. Pure assembler (``assemble_landing_spec``) — given an LLM ``content`` copy
+#      object, CODE emits the fixed marketing-widget structure. Asserts the
+#      widget-type set CONTAINS navbar / hero / feature-grid / testimonial /
+#      pricing-table / cta / footer, a FLAT lead form (input/textarea/button, NO
+#      ``form`` widget), section ``id`` anchors + input ``name`` POST fields, the
+#      ``tiers`` (not ``plans``) pricing shape, and determinism (same content →
+#      identical structure; impossible to downgrade).
+#   2. End-to-end create tool (``_create_landing_site_handler``) — against a real
+#      (mongomock) Beanie DB it persists the assembled spec via the pockets
+#      service ``agent_create`` path and reads the PERSISTED ``_PocketDoc`` back
+#      to confirm ``type=="site"`` / ``pattern=="landing"`` and that the
+#      marketing widgets actually landed in Mongo (NOT agent narration).
+"""Keystone tests for the deterministic landing-site fast-path."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+# ---------------------------------------------------------------------------
+# A representative LLM-provided ``content`` copy object. COPY ONLY — no
+# structure. The assembler decides every widget kind and the node tree.
+# Variable-length services / tiers / testimonials exercise the loops.
+# ---------------------------------------------------------------------------
+
+
+def _sample_content() -> dict[str, Any]:
+    return {
+        "brand": "Bright Smile Dental",
+        "hero": {
+            "eyebrow": "Family & cosmetic dentistry",
+            "title": "Care that fits your whole family",
+            "subtitle": "Gentle, modern dentistry in downtown Austin.",
+            "cta_label": "Book a visit",
+        },
+        "services": [
+            {
+                "title": "New Patient Exams",
+                "desc": "Exam, X-rays, cleaning in one visit.",
+                "icon": "tooth",
+            },
+            {
+                "title": "Teeth Whitening",
+                "desc": "Up to 8 shades brighter in an hour.",
+                "icon": "sparkles",
+            },
+            {"title": "Invisalign", "desc": "Clear aligners with a free consult.", "icon": "smile"},
+        ],
+        "testimonials": [
+            {
+                "quote": "Best dental experience I've had.",
+                "author": "Maria G.",
+                "role": "Patient since 2023",
+            },
+            {
+                "quote": "Booking went from a headache to one tap.",
+                "author": "James T.",
+                "role": "Patient since 2021",
+            },
+        ],
+        "tiers": [
+            {
+                "name": "New Patient Exam",
+                "price": "89",
+                "period": "one-time",
+                "features": ["Full exam", "Digital X-rays", "Cleaning"],
+                "cta_label": "Book",
+            },
+            {
+                "name": "Whitening",
+                "price": "299",
+                "period": "one-time",
+                "features": ["In-office session", "Up to 8 shades", "Take-home trays"],
+                "popular": True,
+                "cta_label": "Book",
+            },
+        ],
+        "cta_band": {
+            "headline": "Ready for a healthier smile?",
+            "button_label": "Request an appointment",
+        },
+        "contact": {
+            "address": "421 Congress Ave, Austin TX",
+            "phone": "(555) 010-1234",
+            "email": "hi@brightsmile.com",
+        },
+        "footer": {"copyright": "© 2026 Bright Smile Dental"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tree-walk helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_nodes(node: dict[str, Any]):
+    """Depth-first walk over a rippleSpec UI node tree."""
+    if not isinstance(node, dict):
+        return
+    yield node
+    for child in node.get("children") or []:
+        yield from _iter_nodes(child)
+
+
+def _widget_types(spec: dict[str, Any]) -> set[str]:
+    ui = spec.get("ui") or spec
+    return {n.get("type") for n in _iter_nodes(ui) if isinstance(n.get("type"), str)}
+
+
+def _nodes_of_type(spec: dict[str, Any], type_: str) -> list[dict[str, Any]]:
+    ui = spec.get("ui") or spec
+    return [n for n in _iter_nodes(ui) if n.get("type") == type_]
+
+
+def _section_ids(spec: dict[str, Any]) -> set[str]:
+    ui = spec.get("ui") or spec
+    ids: set[str] = set()
+    for n in _iter_nodes(ui):
+        if n.get("type") in ("section", "card"):
+            sid = (n.get("props") or {}).get("id")
+            if isinstance(sid, str):
+                ids.add(sid)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# 1. The pure assembler — structure is decided by CODE, not the LLM.
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleLandingSpec:
+    def test_contains_every_marketing_widget(self) -> None:
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        spec = assemble_landing_spec(_sample_content())
+        types = _widget_types(spec)
+        for kind in (
+            "navbar",
+            "hero",
+            "feature-grid",
+            "testimonial",
+            "pricing-table",
+            "cta",
+            "footer",
+        ):
+            assert kind in types, (
+                f"marketing widget {kind!r} missing from assembled spec; got {sorted(types)}"
+            )
+
+    def test_lead_form_is_flat_never_a_form_widget(self) -> None:
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        spec = assemble_landing_spec(_sample_content())
+        types = _widget_types(spec)
+        # Flat native inputs ride the site template's outer <form>.
+        assert "input" in types
+        assert "textarea" in types
+        assert "button" in types
+        # A nested ``form`` / ``newsletter`` widget would emit its own <form>
+        # and silently drop the lead on a static page (SSR rule 1).
+        assert "form" not in types, "lead form must be FLAT — no nested `form` widget"
+        assert "newsletter" not in types
+
+        # The submit button carries type=submit so the native POST fires.
+        buttons = _nodes_of_type(spec, "button")
+        assert any((b.get("props") or {}).get("type") == "submit" for b in buttons), (
+            "lead form needs a button with type='submit'"
+        )
+
+    def test_section_anchors_and_input_names_present(self) -> None:
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        spec = assemble_landing_spec(_sample_content())
+
+        # Anchor targets live on wrapping section/card (marketing widgets carry
+        # no id of their own). The navbar links to these.
+        anchors = _section_ids(spec)
+        for anchor in ("services", "reviews", "pricing", "book"):
+            assert anchor in anchors, (
+                f"missing section/card anchor id #{anchor}; got {sorted(anchors)}"
+            )
+
+        # Inputs must carry real ``name``s so the native form POST maps fields.
+        input_names = {(n.get("props") or {}).get("name") for n in _nodes_of_type(spec, "input")}
+        assert {"name", "email"} <= input_names, f"lead inputs need name+email; got {input_names}"
+        textarea_names = {
+            (n.get("props") or {}).get("name") for n in _nodes_of_type(spec, "textarea")
+        }
+        assert "message" in textarea_names
+
+    def test_pricing_uses_tiers_not_plans(self) -> None:
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        spec = assemble_landing_spec(_sample_content())
+        tables = _nodes_of_type(spec, "pricing-table")
+        assert len(tables) == 1
+        props = tables[0].get("props") or {}
+        assert "tiers" in props, "pricing-table must use `tiers`"
+        assert "plans" not in props and "columns" not in props
+        assert isinstance(props["tiers"], list) and len(props["tiers"]) == 2
+        # currency is a symbol, not a code.
+        assert props.get("currency") == "$"
+        # one tier marked popular; tier cta is a string label.
+        assert any(t.get("popular") for t in props["tiers"])
+        for t in props["tiers"]:
+            assert isinstance(t.get("cta"), str)
+
+    def test_navbar_cta_uses_href_no_on_click(self) -> None:
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        spec = assemble_landing_spec(_sample_content())
+        navbars = _nodes_of_type(spec, "navbar")
+        assert len(navbars) == 1
+        props = navbars[0].get("props") or {}
+        assert props.get("ctaHref") == "#book"
+        assert isinstance(props.get("cta"), str)
+        # No on_click handlers anywhere — every CTA navigates by anchor.
+        ui = spec.get("ui") or spec
+        for n in _iter_nodes(ui):
+            assert "on_click" not in (n.get("props") or {}), "static site: no on_click CTAs"
+
+    def test_handles_variable_length_collections(self) -> None:
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        content = _sample_content()
+        content["services"] = [{"title": "Only one", "desc": "Single service."}]
+        content["testimonials"] = [
+            {"quote": "Q1", "author": "A"},
+            {"quote": "Q2", "author": "B"},
+            {"quote": "Q3", "author": "C"},
+            {"quote": "Q4", "author": "D"},
+        ]
+        content["tiers"] = [
+            {"name": "Solo", "price": "10", "features": ["x"], "cta_label": "Go"},
+        ]
+        spec = assemble_landing_spec(content)
+
+        feature_grids = _nodes_of_type(spec, "feature-grid")
+        assert len(feature_grids) == 1
+        assert len((feature_grids[0]["props"]).get("features", [])) == 1
+        # one testimonial node per quote
+        assert len(_nodes_of_type(spec, "testimonial")) == 4
+        assert len((_nodes_of_type(spec, "pricing-table")[0]["props"])["tiers"]) == 1
+
+    def test_is_deterministic_same_content_identical_structure(self) -> None:
+        """The whole point: structure is a pure function of content. Same input
+        → byte-identical spec, so the LLM can never downgrade it."""
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        c = _sample_content()
+        a = assemble_landing_spec(c)
+        b = assemble_landing_spec(c)
+        assert a == b, "assembler must be deterministic"
+
+        # And the widget-type SET is invariant regardless of copy values.
+        c2 = _sample_content()
+        c2["brand"] = "Totally Different Co"
+        c2["hero"]["title"] = "Another headline"
+        assert _widget_types(a) == _widget_types(assemble_landing_spec(c2))
+
+    def test_copy_lands_in_the_right_widgets(self) -> None:
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        spec = assemble_landing_spec(_sample_content())
+        # brand on navbar
+        assert (_nodes_of_type(spec, "navbar")[0]["props"]).get("brand") == "Bright Smile Dental"
+        # hero title
+        assert (
+            (_nodes_of_type(spec, "hero")[0]["props"]).get("title")
+            == "Care that fits your whole family"
+        )
+        # service titles flow into feature-grid features
+        feat_titles = {
+            f.get("title") for f in (_nodes_of_type(spec, "feature-grid")[0]["props"])["features"]
+        }
+        assert "Teeth Whitening" in feat_titles
+        # No leftover ``[bracketed]`` placeholders (the skeleton's authoring
+        # copy, e.g. "[Business Name]"). Match a '[' immediately followed by a
+        # letter — JSON array syntax ('[{', '["') never has that shape.
+        import json as _json
+        import re as _re
+
+        blob = _json.dumps(spec)
+        assert not _re.search(r"\[[A-Za-z]", blob), "no [bracketed] placeholders should remain"
+
+
+# ---------------------------------------------------------------------------
+# 2. End-to-end — the create tool PERSISTS the marketing widgets (ground truth
+#    is the Mongo doc, not the agent's narration).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def recording_bus():
+    """Install a recording EventBus so ``agent_create``'s ``emit(PocketCreated)``
+    doesn't raise (the real bus is only wired by ``init_realtime()`` at boot).
+    Mirrors the ``tests/cloud/conftest.py`` fixture, which isn't visible from
+    this package."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+class TestCreateLandingSiteEndToEnd:
+    @pytest.mark.asyncio
+    async def test_persists_site_with_marketing_widgets(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """Drive the tool handler against a real (mongomock) Beanie DB and read
+        the persisted ``_PocketDoc`` back. Proves: a pocket lands with
+        type=="site" / pattern=="landing", and its rippleSpec CONTAINS the
+        marketing widgets — the downgrade the prior fixes never stopped."""
+        from bson import ObjectId
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+
+        # Identity flows from the per-stream ContextVars, like the publish tool.
+        from unittest.mock import patch
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=workspace_id,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=user_id,
+            ),
+        ):
+            out = await sites_create_mcp._create_landing_site_handler(
+                {"content": _sample_content(), "name": "Bright Smile Dental"}
+            )
+
+        assert not out.get("is_error"), out
+        import json as _json
+
+        body = _json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        pocket_id = body["pocket_id"]
+        assert pocket_id
+
+        # Ground truth: read the persisted doc straight from Mongo.
+        doc = await _PocketDoc.get(ObjectId(pocket_id))
+        assert doc is not None
+        assert doc.type == "site"
+        assert doc.pattern == "landing"
+
+        persisted_types = _widget_types(doc.rippleSpec)
+        for kind in (
+            "navbar",
+            "hero",
+            "feature-grid",
+            "testimonial",
+            "pricing-table",
+            "cta",
+            "footer",
+        ):
+            assert kind in persisted_types, (
+                f"PERSISTED spec dropped marketing widget {kind!r}; got {sorted(persisted_types)}"
+            )
+        # generic-downgrade guard: the page is NOT a hero+grid+card wireframe.
+        assert "input" in persisted_types and "form" not in persisted_types
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_is_error(self) -> None:
+        from unittest.mock import patch
+
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=None,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=None,
+            ),
+        ):
+            out = await sites_create_mcp._create_landing_site_handler(
+                {"content": _sample_content(), "name": "X"}
+            )
+        assert out.get("is_error") is True
+
+    @pytest.mark.asyncio
+    async def test_missing_content_is_error(self) -> None:
+        from unittest.mock import patch
+
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value="ws_1",
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value="u_1",
+            ),
+        ):
+            out = await sites_create_mcp._create_landing_site_handler({"name": "X"})
+        assert out.get("is_error") is True

--- a/tests/test_bundled_skills_installer.py
+++ b/tests/test_bundled_skills_installer.py
@@ -181,34 +181,46 @@ def test_install_includes_create_paw_site(tmp_path: Path) -> None:
     assert "name: pocketpaw-create-paw-site" in skill_file.read_text()
 
 
-def test_create_paw_site_carries_ssr_guardrails(tmp_path: Path) -> None:
-    """The brain's body must keep its five load-bearing SSR guardrails.
-    Each maps to a real static-render failure; a silent edit that drops
-    one would let the broken-dashboard output come back. We pin the
+def test_create_paw_site_is_copy_only_deterministic_brain(tmp_path: Path) -> None:
+    """The brain's body must keep its load-bearing DETERMINISTIC contract: the
+    agent writes COPY ONLY and calls the deterministic ``create_landing_site``
+    tool — it does NOT draft a rippleSpec and does NOT route through the
+    pocket specialist's create/redraft loop (the path that silently downgraded
+    landing pages to generic dashboard widgets). A silent edit that reintroduced
+    spec-drafting or the specialist route would bring the downgrade back. We pin
     discriminating tokens, not prose, so wording can evolve."""
     install_bundled_skills(destination_root=tmp_path)
     body = (tmp_path / "pocketpaw-create-paw-site" / "SKILL.md").read_text()
 
-    # Conversion-role grammar + the site identity it stamps.
+    # The site identity it stamps (the published page renders as a landing page).
     assert 'pattern="landing"' in body
     assert 'type="site"' in body
 
-    # Rule 1 — flat native lead form, never the form/newsletter widget.
-    assert 'type="submit"' in body or 'type": "submit"' in body
-    assert "newsletter" in body  # named so the brain knows to avoid it
+    # The deterministic create tool is the path — the agent calls it, the tool
+    # owns the structure.
+    assert "create_landing_site" in body
 
-    # Rule 2 — pricing-table uses tiers, not plans/columns.
+    # Copy-only contract: the agent does NOT compose a rippleSpec. Pin the
+    # explicit "copy only" steer AND the "do NOT compose" instruction.
+    assert "COPY ONLY" in body
+    assert "do NOT compose" in body
+
+    # The old downgrade route must NOT be the active instruction. It may only
+    # appear under a negative ("do not call pocket_specialist__create"), so we
+    # assert the negative phrasing is present rather than banning the token.
+    lowered = body.lower()
+    assert "do not call" in lowered and "pocket_specialist__create" in body
+
+    # The marketing widgets the page is built from are still named, so a silent
+    # edit that drops the marketing steer (back toward a dashboard) is caught.
+    for widget in ("navbar", "feature-grid", "testimonial", "pricing-table", "cta", "footer"):
+        assert widget in body, f"marketing widget {widget!r} no longer named in the brain"
+
+    # The dashboard anti-pattern is still warned against (no hero+grid KPI page).
+    assert "hero + grid" in body or "hero+grid" in body
+    # Pricing uses tiers; CTAs navigate by anchor not on_click.
     assert "tiers" in body
-
-    # Rule 3 — FAQ via heading+text, never accordion.
-    assert "accordion" in body  # named as the thing to avoid
-
-    # Rule 5 — the marketing hero, never the dashboard hero+grid.
-    assert "hero+grid" in body
-
-    # Tier-0 animation gate — static-safe widgets allowed, JS ones forbidden.
-    assert "aurora" in body
-    assert "parallax" in body  # named as a forbidden (JS-driven) widget
+    assert "on_click" in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this does

Builds a deterministic path for creating a Paw Site landing page. The LLM writes the copy; code assembles the page structure. The page can't be downgraded, because the structure is a pure function of the copy.

## Why

Landing sites kept persisting as generic `hero + grid + card + quote` pages even after three earlier fixes. Two things were happening.

1. The create flow ran through the pocket specialist. The chat agent drafted the rippleSpec itself (or got a draft/plan kit, or delegated to a subagent), and the marketing widgets got dropped somewhere between drafting and persistence. Agent narration claimed marketing widgets while the persisted spec was generic.

2. `agent_create`'s strict catalog gate rejected the real marketing widgets outright. The published widget manifest (`cdn.jsdelivr.net/gh/qbtrix/ripple-iui@latest`) is stale: 153 widgets, but missing `navbar`, `feature-grid`, `testimonial`, `logo-cloud`, `cta`, and `footer`. The gate's "suggestion" field even pointed the spec at `avatar` / `data-grid` / `terminal` / `popover`, which is the downgrade-to-generics mechanism itself. So even a correct draft failed at persistence.

The fix has two halves: take structure out of the LLM's hands, and stop the strict gate from false-rejecting trusted site specs.

## What changed

- `assemble_landing_spec(content)` is a pure function that emits the fixed marketing-widget tree from an LLM copy object. Conversion order top to bottom: navbar, hero, services (feature-grid), reviews (testimonials), pricing (pricing-table with tiers), CTA band, flat lead form, footer. Section id anchors, input names, anchor-href CTAs, and the tiers shape are hard-coded. Variable-length services / tiers / testimonials are handled. It mirrors the renderer-valid bundled landing skeleton section for section.

- `create_landing_site` is a new MCP tool, registered on the existing `pocketpaw_sites_manager` server next to `publish`. Two `create_sdk_mcp_server` calls under one server name would clobber each other, so both tools share the one server. It assembles the spec and persists it directly through the pockets service stamped `type="site"` + `pattern="landing"`, with no validate/redraft loop and no subagent. It returns the `pocket_id` for the publish step.

- `agent_create` gains a `trusted` flag. When set, it skips the strict catalog gate for a code-assembled spec the caller controls. The spec is still normalized and logged-validated, and the embed audit still runs; only the stale manifest-type allow-list is bypassed. The normal agent path keeps `trusted=False` and the gate unchanged.

- The `create-paw-site` skill is rewritten to the copy-only contract: build the `content` object, call `create_landing_site`, publish. It drops `get_widget_spec`, spec-drafting, and the `pocket_specialist__create` route. The body now says plainly that you provide copy and the tool builds the page.

## Tests

New keystone test (`tests/ee/sites/test_landing_assembler.py`):

- The pure assembler. The widget-type set contains navbar / hero / feature-grid / testimonial / pricing-table / cta / footer; the lead form is flat (input/textarea/button, no `form` widget); section ids and input names are present; pricing uses `tiers`; CTAs use anchor hrefs; variable-length collections work; the output is deterministic (same content gives an identical structure).

- End to end against a real (mongomock) Beanie DB. The tool persists, and the test reads the persisted Pocket doc back from Mongo to confirm `type=="site"` / `pattern=="landing"` and that the marketing widgets actually landed in the rippleSpec. The ground truth is the doc, not the agent's narration.

No regressions. The sites, sites-MCP, pocket-specialist, bundled-skills, catalog-gate, and template suites stay green (343 passed, 1 pre-existing skip).

## Scope notes

- The stale published manifest is what broke all three prior attempts. `trusted=True` works around it for the deterministic site path. Republishing the manifest with the marketing widgets is a separate follow-up.
- Docs: the create-paw-site skill body is the user-facing contract and is updated here. No CLI or runtime-API surface changed.

Does not merge, captain reviews.
