### PR TITLE
feat(surface): gate the ripple block per-surface so /sites writes Svelte

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -65,7 +65,7 @@ from pocketpaw.ripple import (
 )
 from pocketpaw.ripple._pockets import _MCP_POCKET_BACKENDS
 from pocketpaw_ee.cloud.shared.errors import CloudError, NotFound
-from pocketpaw_ee.cloud.surface import SurfaceContext
+from pocketpaw_ee.cloud.surface import SurfaceContext, resolve_profile
 
 logger = logging.getLogger(__name__)
 
@@ -586,7 +586,27 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     HOME_POCKET_PROMPT`` and NOT the delegation rule, because the home
     agent mutates widgets directly via the ``add_widget`` MCP tool rather
     than delegating to the pocket specialist.
+
+    Surface gating ("ripple-default bias" fix): the resolved per-request
+    ``SurfaceProfile`` decides whether the ripple LAW applies at all. On the
+    /sites surface the agent hand-authors a Svelte Paw Site, so its profile
+    has ``ripple_mode="off"`` and we OMIT INLINE_RIPPLE_SYSTEM_PROMPT,
+    POCKET_DELEGATION_RULE, and the inline ripple-creation prompt — otherwise
+    the "default to ui-spec" LAW biases the agent toward emitting a ripple
+    ui-spec instead of Svelte. Every other surface (and the legacy
+    ``surface_context is None`` path) keeps ``ripple_mode="on"`` — unchanged.
+    The profile is the single source of truth; we never branch on a bare
+    ``kind == SITES`` check here.
     """
+    # Resolve the surface policy once. ``surface_context is None`` is the
+    # legacy path — default to ripple ON (do NOT omit) so surface-less clients
+    # keep today's behavior exactly. Only an explicit ``ripple_mode="off"``
+    # profile (the /sites row) suppresses the ripple block.
+    ripple_off = (
+        ctx.surface_context is not None
+        and resolve_profile(ctx.surface_context.kind, ctx.surface_context.meta).ripple_mode == "off"
+    )
+
     parts: list[str] = []
     parts.append(_RUNTIME_IDENTITY_RULE)
     # Composio auth/search guidance is injected whenever Composio is
@@ -615,15 +635,23 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
         # specialist-delegation rule (MCP backends) or the heavy
         # interaction prompt (CLI backends) — both carry the contradicting
         # "delegate, don't call add_widget" framing. Just the base ripple
-        # conventions, then HOME_POCKET_PROMPT.
+        # conventions, then HOME_POCKET_PROMPT. (No /sites home pocket exists,
+        # so the surface gate doesn't apply here.)
         parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
     elif backend_name in _MCP_POCKET_BACKENDS:
-        parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
-        parts.append(POCKET_DELEGATION_RULE)
+        # Surface gate: omit the ripple LAW + delegation rule on a
+        # ripple-off surface (/sites). The agent there hand-authors Svelte —
+        # the "default to ui-spec" LAW would bias it away from that.
+        if not ripple_off:
+            parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
+            parts.append(POCKET_DELEGATION_RULE)
     else:
         creation_prompt, interaction_prompt = get_pocket_prompts(backend_name=backend_name)
         if ctx.intent == "pocket_create":
-            parts.append(creation_prompt)
+            # The creation prompt is the ripple-authoring LAW for CLI
+            # backends — omit it on a ripple-off surface for the same reason.
+            if not ripple_off:
+                parts.append(creation_prompt)
         elif ctx.pocket_id:
             # build_behavior_instructions is sync — it cannot await the
             # backend-summary read. The main chat agent delegates edits
@@ -631,7 +659,7 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
             # "configured state unknown — call get_pocket to check",
             # and get_pocket now carries the real backend summary.
             parts.append(fill_current_pocket(interaction_prompt, ctx.pocket_id, None))
-        else:
+        elif not ripple_off:
             parts.append(INLINE_RIPPLE_SYSTEM_PROMPT)
     # Home surface: append the home-surface prompt so the agent calls
     # add_widget for an explicit widget request and answers directly

--- a/ee/pocketpaw_ee/cloud/surface/__init__.py
+++ b/ee/pocketpaw_ee/cloud/surface/__init__.py
@@ -3,15 +3,27 @@
 # Created: 2026-05-24 — Re-exports the resolver and the two domain
 # value objects every consumer needs. Handlers stay private to the
 # sub-package; callers don't import them directly.
+#
+# Changes: 2026-06-05 (feat/surface-profile-bias-kill) — also re-export the
+# new ``SurfaceProfile`` descriptor and its ``resolve_profile`` resolver so
+# the chat agent_service can gate the ripple block on the per-surface policy
+# (the "ripple-default bias" fix) via the package's public surface.
 
 from __future__ import annotations
 
-from pocketpaw_ee.cloud.surface.domain import SurfaceContext, SurfaceKind, SurfaceMeta
-from pocketpaw_ee.cloud.surface.service import resolve_surface_context
+from pocketpaw_ee.cloud.surface.domain import (
+    SurfaceContext,
+    SurfaceKind,
+    SurfaceMeta,
+    SurfaceProfile,
+)
+from pocketpaw_ee.cloud.surface.service import resolve_profile, resolve_surface_context
 
 __all__ = [
     "SurfaceContext",
     "SurfaceKind",
     "SurfaceMeta",
+    "SurfaceProfile",
     "resolve_surface_context",
+    "resolve_profile",
 ]

--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -10,11 +10,24 @@
 # ``SurfaceContext`` (resolved snapshot + rendered preamble). Per the
 # 11 entity rules, tenancy is enforced at construction — ``workspace_id``
 # and ``user_id`` are required on ``SurfaceContext``.
+#
+# Changes: 2026-06-05 (feat/surface-profile-bias-kill) — added the typed
+# ``SurfaceProfile`` descriptor, the per-surface POLICY object (the data
+# backbone of the "ripple-default bias" fix). Its ``ripple_mode`` drives
+# whether ``build_behavior_instructions`` includes the ~20k-char
+# INLINE_RIPPLE_SYSTEM_PROMPT ("default to ui-spec" LAW); ``off`` omits it
+# so the /sites surface stops defaulting to a ripple ui-spec instead of
+# hand-authored Svelte. ``deny_mcp_tool_ids`` / ``skill_names`` /
+# ``allowed_sdk_tools`` / ``system_message_override`` are DECLARED here but
+# only ``ripple_mode`` is consumed in PR 1 — the tool/skill fields are the
+# tested DATA that PR 2 will wire (tool-deny + skill-surfacing). The
+# resolver lives in ``service.py`` (a pure SurfaceKind table).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Literal
 
 
 class SurfaceKind(StrEnum):
@@ -95,4 +108,40 @@ class SurfaceContext:
     preamble: str
 
 
-__all__ = ["SurfaceKind", "SurfaceMeta", "SurfaceContext"]
+@dataclass(frozen=True)
+class SurfaceProfile:
+    """The behavioral policy a surface imposes on the chat agent.
+
+    Resolved once per request from ``SurfaceKind`` via ``resolve_profile``.
+    The single source of truth for surface-specific agent shaping, so
+    consumers branch on a typed field rather than re-deriving rules from a
+    bare ``kind ==`` check scattered across the codebase.
+
+    Fields:
+      * ``ripple_mode`` — whether the ripple LAW applies. ``"on"`` (default,
+        every surface except /sites) keeps INLINE_RIPPLE_SYSTEM_PROMPT;
+        ``"off"`` omits it (the /sites row — the agent hand-authors Svelte,
+        so the "default to ui-spec" LAW is actively wrong); ``"trim"`` is
+        reserved for a future slimmed variant (declared, not yet used).
+      * ``allowed_sdk_tools`` — optional SDK-tool allowlist (``None`` = no
+        surface restriction). Declared for PR 2; not consumed in PR 1.
+      * ``deny_mcp_tool_ids`` — MCP tool ids this surface forbids. Declared
+        + tested DATA for PR 2's tool-deny pass; not enforced in PR 1.
+      * ``skill_names`` — skills this surface surfaces to the agent. Declared
+        + tested DATA for PR 2's skill-surfacing pass; not enforced in PR 1.
+      * ``system_message_override`` — optional full system-message swap for a
+        surface. Declared for a future PR; not consumed in PR 1.
+
+    PR 1 CONSUMES ``ripple_mode`` only. The other fields are intentionally
+    populated-but-inert so the descriptor's shape is locked now and later
+    PRs add enforcement without re-designing the primitive.
+    """
+
+    ripple_mode: Literal["on", "off", "trim"]
+    allowed_sdk_tools: frozenset[str] | None = None
+    deny_mcp_tool_ids: frozenset[str] = field(default_factory=frozenset)
+    skill_names: frozenset[str] = field(default_factory=frozenset)
+    system_message_override: str | None = None
+
+
+__all__ = ["SurfaceKind", "SurfaceMeta", "SurfaceContext", "SurfaceProfile"]

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -10,16 +10,87 @@
 # Failure stays inert: any handler error logs and returns a
 # ``GENERIC`` context with empty preamble. The chat path is the consumer
 # — never let a surface failure break a chat send.
+#
+# Changes: 2026-06-05 (feat/surface-profile-bias-kill) — added
+# ``resolve_profile(surface_kind, meta) -> SurfaceProfile``, the resolver
+# for the new per-surface policy descriptor (the data backbone of the
+# "ripple-default bias" fix). It is a PURE table lookup keyed on
+# ``SurfaceKind`` (sync — no I/O), so unlike ``resolve_surface_context`` it
+# never touches Mongo or a handler. ONLY the ``sites`` row changes behavior
+# (``ripple_mode="off"`` so the ripple LAW is omitted on /sites); every
+# other kind AND any unmapped kind falls through to the default
+# (``ripple_mode="on"``) — today's behavior, zero regression. PR 1 consumes
+# ``ripple_mode`` only; the deny/skill fields on the sites row are tested
+# DATA that PR 2 will enforce.
 
 from __future__ import annotations
 
 import logging
 from typing import Any
 
-from pocketpaw_ee.cloud.surface.domain import SurfaceContext, SurfaceKind, SurfaceMeta
+from pocketpaw_ee.cloud.surface.domain import (
+    SurfaceContext,
+    SurfaceKind,
+    SurfaceMeta,
+    SurfaceProfile,
+)
 from pocketpaw_ee.cloud.surface.dto import SurfaceMetaRequest, SurfaceRequest
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Surface profile resolution (the "ripple-default bias" policy table)
+#
+# A SurfaceProfile is the per-surface behavioral policy the chat agent
+# applies. ``resolve_profile`` resolves it from the surface kind via a
+# single static table. Keep this a PURE function (no I/O): it runs once per
+# request on the hot chat path and must not block on Mongo or a handler.
+#
+# Only surfaces whose policy DIFFERS from the default appear in the table.
+# Everything else — and any unmapped/future kind — gets ``_DEFAULT_PROFILE``
+# (ripple on, no denies, no skills), which is exactly today's behavior. That
+# is the zero-regression guarantee: the only surface that changes is /sites.
+# ---------------------------------------------------------------------------
+
+# Ripple on, no surface-specific policy. The behavior every surface had
+# before this primitive existed.
+_DEFAULT_PROFILE = SurfaceProfile(ripple_mode="on")
+
+# Per-kind overrides. Add a row only when a surface needs to deviate from
+# ``_DEFAULT_PROFILE``. Today only /sites does: it hand-authors a Svelte Paw
+# Site, so the ripple LAW ("default to ui-spec") is wrong there.
+#
+# The ``deny_mcp_tool_ids`` / ``skill_names`` on the sites row are DECLARED +
+# tested DATA for PR 2 (tool-deny + skill-surfacing); PR 1 consumes only
+# ``ripple_mode``.
+_PROFILES: dict[SurfaceKind, SurfaceProfile] = {
+    SurfaceKind.SITES: SurfaceProfile(
+        ripple_mode="off",
+        deny_mcp_tool_ids=frozenset(
+            {
+                "mcp__pocketpaw_sites_manager__create_landing_site",
+                "mcp__pocketpaw_pocket_specialist__create",
+            }
+        ),
+        skill_names=frozenset({"create-svelte-site"}),
+    ),
+}
+
+
+def resolve_profile(surface_kind: SurfaceKind, meta: SurfaceMeta) -> SurfaceProfile:
+    """Resolve a ``SurfaceKind`` to its behavioral ``SurfaceProfile``.
+
+    Pure table lookup — no I/O, safe to call once per request on the hot
+    chat path. Unknown / unmapped kinds (and every kind whose policy matches
+    the default) return ``_DEFAULT_PROFILE`` (``ripple_mode="on"``), so the
+    only surface that deviates from today's behavior is /sites.
+
+    ``meta`` is accepted for forward compatibility — a future surface may
+    branch its profile on a meta hint (e.g. a /pocket surface in
+    widget-focus mode) — but no current profile reads it.
+    """
+    return _PROFILES.get(surface_kind, _DEFAULT_PROFILE)
 
 
 # Handler registry: SurfaceKind -> async callable returning the preamble.
@@ -197,4 +268,4 @@ async def resolve_surface_context(
     )
 
 
-__all__ = ["resolve_surface_context"]
+__all__ = ["resolve_surface_context", "resolve_profile"]

--- a/tests/cloud/test_agent_service_tools_context.py
+++ b/tests/cloud/test_agent_service_tools_context.py
@@ -1,3 +1,15 @@
+# test_agent_service_tools_context.py — Toolset assembly + context block helpers.
+#
+# Modified: 2026-06-05 (feat/surface-profile-bias-kill) — Added two surface-gate
+# tests for the "ripple-default bias" RED phase:
+#   * test_sites_surface_omits_ripple_block (RED driver) — proves that a /sites
+#     surface ScopeContext must NOT carry INLINE_RIPPLE_SYSTEM_PROMPT. Fails
+#     today because build_behavior_instructions never gates the ripple block on
+#     surface, so the agent on /sites still gets the full "default to ui-spec"
+#     LAW and writes ripple instead of hand-authored Svelte.
+#   * test_non_sites_surface_keeps_ripple_block (no-regression guard) — locks in
+#     current behavior for non-sites / surface-less scopes so the fix doesn't
+#     over-omit. Passes today.
 """Toolset assembly + context block helpers."""
 
 from __future__ import annotations
@@ -12,7 +24,9 @@ from pocketpaw_ee.cloud.chat.agent_service import (
     build_context_block,
     build_knowledge_context,
 )
+from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceKind, SurfaceMeta
 
+from pocketpaw.ripple import INLINE_RIPPLE_SYSTEM_PROMPT
 from pocketpaw.ripple._design import RIPPLE_DESIGN_RULES
 
 
@@ -445,6 +459,120 @@ def test_non_home_pocket_scope_keeps_specialist_delegation_rule():
     )
     block = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
     assert "<pocket-delegation>" in block
+
+
+# ---------------------------------------------------------------------------
+# Surface gate — the "ripple-default bias" (feat/surface-profile-bias-kill).
+#
+# build_behavior_instructions injects the full ~20k-char
+# INLINE_RIPPLE_SYSTEM_PROMPT ("default to ui-spec / use the widget" LAW) on
+# every turn, gated only on backend + pocket_type, NEVER on surface. On the
+# /sites surface the user is describe-to-creating a hand-authored Svelte Paw
+# Site, so the ripple LAW is actively wrong — it biases the agent toward
+# emitting a ui-spec instead of writing Svelte. The fix adds a
+# SurfaceProfile-driven branch that OMITS the ripple block when the surface is
+# SITES. These two tests encode that desired behavior.
+# ---------------------------------------------------------------------------
+
+
+def _sites_surface_ctx() -> ScopeContext:
+    """A SESSION scope whose resolved surface is /sites.
+
+    Surface arrives ONLY via the optional ``surface_context`` field — there is
+    no ``surface_kind`` shortcut on ScopeContext. Tenancy (workspace_id,
+    user_id) is required on SurfaceContext at construction per the entity
+    rules, and ``meta`` / ``preamble`` are required positional-ish fields, so
+    populate them explicitly.
+    """
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        session_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        surface_context=SurfaceContext(
+            workspace_id="w1",
+            user_id="u1",
+            kind=SurfaceKind.SITES,
+            meta=SurfaceMeta(),
+            preamble="",
+        ),
+    )
+
+
+def test_sites_surface_omits_ripple_block():
+    """RED driver: on the /sites surface the agent is hand-authoring a Svelte
+    Paw Site, so it must NOT receive INLINE_RIPPLE_SYSTEM_PROMPT (the "default
+    to ui-spec / use the widget" LAW). Today this FAILS — the ripple block is
+    gated on backend + pocket_type only and is always injected for an MCP
+    backend, so the sites agent gets the full ripple LAW and defaults to a
+    ui-spec instead of Svelte."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    block = build_behavior_instructions(_sites_surface_ctx(), backend_name="claude_agent_sdk")
+    # The whole inline ripple prompt must be gone.
+    assert INLINE_RIPPLE_SYSTEM_PROMPT not in block, (
+        "INLINE_RIPPLE_SYSTEM_PROMPT must be omitted on the /sites surface — "
+        "its 'default to ui-spec' LAW biases the agent away from hand-authored "
+        "Svelte"
+    )
+    # A couple of distinctive ripple phrases must also be absent, so a future
+    # refactor that splits the block can't silently leak the LAW back in.
+    assert "<ripple>" not in block, "the <ripple> framing tag leaked onto /sites"
+    assert "Default to ui-spec whenever the answer has structure" not in block, (
+        "the ripple 'default to ui-spec' decision rule leaked onto /sites"
+    )
+
+
+def test_non_sites_surface_keeps_ripple_block():
+    """No-regression guard (NOT a RED driver): a non-sites surface — and a
+    surface-less scope — must KEEP INLINE_RIPPLE_SYSTEM_PROMPT. This locks in
+    today's behavior so the SITES omission fix doesn't over-omit and strip
+    ripple from ordinary chat surfaces. Passes today."""
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    # A non-sites resolved surface (the /pockets index) keeps ripple.
+    pockets_ctx = ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        session_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        surface_context=SurfaceContext(
+            workspace_id="w1",
+            user_id="u1",
+            kind=SurfaceKind.POCKETS_LIST,
+            meta=SurfaceMeta(),
+            preamble="",
+        ),
+    )
+    block = build_behavior_instructions(pockets_ctx, backend_name="claude_agent_sdk")
+    assert INLINE_RIPPLE_SYSTEM_PROMPT in block, (
+        "a non-sites surface must keep INLINE_RIPPLE_SYSTEM_PROMPT — the SITES "
+        "omission must not regress ordinary chat surfaces"
+    )
+
+    # And the legacy surface-less path (surface_context is None) also keeps it.
+    legacy_ctx = ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        session_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+    )
+    legacy_block = build_behavior_instructions(legacy_ctx, backend_name="claude_agent_sdk")
+    assert INLINE_RIPPLE_SYSTEM_PROMPT in legacy_block, (
+        "the surface-less legacy path must keep INLINE_RIPPLE_SYSTEM_PROMPT"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_surface_profile.py
+++ b/tests/cloud/test_surface_profile.py
@@ -1,0 +1,72 @@
+# test_surface_profile.py — SurfaceProfile descriptor + resolve_profile resolver.
+#
+# Created: 2026-06-05 (feat/surface-profile-bias-kill) — RED-first tests for the
+# new typed SurfaceProfile primitive and its per-kind resolver, the data
+# backbone of the "ripple-default bias" fix.
+#
+# A SurfaceProfile is the policy a surface carries: whether the ripple LAW
+# (INLINE_RIPPLE_SYSTEM_PROMPT) applies (``ripple_mode``), which SDK tools are
+# allowed, which MCP tool ids are denied, which skills are surfaced, and an
+# optional system-message override. ``resolve_profile(kind, meta)`` is a pure
+# table lookup keyed on SurfaceKind.
+#
+# Scope note (PR 1): only ``ripple_mode`` is CONSUMED in PR 1 — the
+# build_behavior_instructions gate reads it to omit the ripple block on /sites.
+# The ``deny_mcp_tool_ids`` / ``skill_names`` fields on the SITES row are
+# DECLARED + tested DATA that PR 2 will wire (tool-deny + skill-surfacing); they
+# are asserted here so the descriptor's shape is locked now and PR 2 only has to
+# enforce, not re-design. Only the ``sites`` row changes behavior; every other
+# kind AND any unmapped kind falls through to ``ripple_mode="on"`` (today's
+# behavior) — zero regression by construction.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface import SurfaceKind, SurfaceMeta, SurfaceProfile, resolve_profile
+
+
+def test_sites_profile_turns_ripple_off():
+    """The /sites surface hand-authors a Svelte Paw Site — the ripple LAW is
+    wrong there, so its profile turns ripple off."""
+    profile = resolve_profile(SurfaceKind.SITES, SurfaceMeta())
+    assert isinstance(profile, SurfaceProfile)
+    assert profile.ripple_mode == "off"
+
+
+def test_sites_profile_declares_deny_set_and_skill():
+    """PR-2 DATA, declared now: the SITES profile denies the ripple-authoring
+    MCP tools and surfaces the svelte-site skill. PR 1 does not yet enforce
+    these — it only locks the shape so PR 2 wires enforcement, not design."""
+    profile = resolve_profile(SurfaceKind.SITES, SurfaceMeta())
+    assert profile.deny_mcp_tool_ids == frozenset(
+        {
+            "mcp__pocketpaw_sites_manager__create_landing_site",
+            "mcp__pocketpaw_pocket_specialist__create",
+        }
+    )
+    assert "create-svelte-site" in profile.skill_names
+
+
+def test_generic_profile_keeps_ripple_on():
+    """The catch-all GENERIC surface keeps ripple on — it's an ordinary chat
+    surface where the widget LAW is correct."""
+    profile = resolve_profile(SurfaceKind.GENERIC, SurfaceMeta())
+    assert profile.ripple_mode == "on"
+
+
+def test_unmapped_kind_defaults_to_ripple_on():
+    """Any kind NOT in the table (e.g. CALENDAR) falls through to the safe
+    default — ripple on. This is the zero-regression guarantee: every surface
+    except /sites behaves exactly as it does today."""
+    profile = resolve_profile(SurfaceKind.CALENDAR, SurfaceMeta())
+    assert profile.ripple_mode == "on"
+
+
+def test_default_profile_has_no_denies_or_skills():
+    """The default (ripple-on) profile carries empty deny / skill sets and no
+    SDK-tool allowlist — it imposes no surface-specific policy."""
+    profile = resolve_profile(SurfaceKind.POCKETS_LIST, SurfaceMeta())
+    assert profile.ripple_mode == "on"
+    assert profile.deny_mcp_tool_ids == frozenset()
+    assert profile.skill_names == frozenset()
+    assert profile.allowed_sdk_tools is None
+    assert profile.system_message_override is None

--- a/tests/test_claude_sdk_client_cache_key.py
+++ b/tests/test_claude_sdk_client_cache_key.py
@@ -8,6 +8,14 @@
 # client on the very next turn. Per-turn KB/memory/history (appended after the
 # behavioral prefix) are excluded so the warm-client optimization still holds
 # for normal turns.
+#
+# Modified: 2026-06-05 (feat/surface-profile-bias-kill) — Added
+# test_sites_surface_behavior_prefix_changes_key (RED driver). Mirrors the home
+# flip guard for the surface dimension: a /sites-surface ctx and a non-sites
+# ctx must produce DIFFERENT behavior instructions (sites omits the ripple
+# block), so the persistent-client cache keys must differ. Fails today because
+# build_behavior_instructions ignores surface entirely — both ctxs get the same
+# ripple-laden instructions, the same prefix digest, and the same key.
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -150,4 +158,73 @@ def test_real_home_behavior_instructions_flip_changes_key():
     assert key_before != key_after, (
         "a mid-session backend config change must rebuild the warm client so "
         "the agent reads the CURRENT backend state on the next message"
+    )
+
+
+def test_sites_surface_behavior_prefix_changes_key():
+    """RED driver (feat/surface-profile-bias-kill): build the ACTUAL behavior
+    instructions for a /sites-surface ctx vs a non-sites ctx and assert the
+    persistent-client cache keys differ.
+
+    On /sites the agent hand-authors a Svelte Paw Site, so its behavior
+    instructions must OMIT the ~20k-char INLINE_RIPPLE_SYSTEM_PROMPT ("default
+    to ui-spec" LAW); a non-sites surface keeps it. Different instructions →
+    different behavioral prefix → different prefix digest → different key, so
+    switching surfaces mid-session rebuilds the warm client with the right
+    instructions on the next message.
+
+    Fails today: build_behavior_instructions never gates the ripple block on
+    surface, so both ctxs produce identical ripple-laden instructions, an
+    identical prefix digest, and an identical key."""
+    # build_behavior_instructions / the surface value objects live in the
+    # enterprise layer; skip when the OSS-only test job runs without it.
+    import pytest
+
+    pytest.importorskip("pocketpaw_ee")
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        ScopeContext,
+        ScopeKind,
+        build_behavior_instructions,
+    )
+    from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceKind, SurfaceMeta
+
+    def _ctx(surface_kind):
+        return ScopeContext(
+            kind=ScopeKind.SESSION,
+            scope_id="s1",
+            session_id="s1",
+            workspace_id="w1",
+            user_id="u1",
+            members=["u1"],
+            target_agent_id="a1",
+            agent_ids_in_scope=["a1"],
+            surface_context=SurfaceContext(
+                workspace_id="w1",
+                user_id="u1",
+                kind=surface_kind,
+                meta=SurfaceMeta(),
+                preamble="",
+            ),
+        )
+
+    sites = build_behavior_instructions(_ctx(SurfaceKind.SITES), backend_name="claude_agent_sdk")
+    non_sites = build_behavior_instructions(
+        _ctx(SurfaceKind.POCKETS_LIST), backend_name="claude_agent_sdk"
+    )
+    assert sites != non_sites, (
+        "behavior instructions must differ by surface — /sites omits the ripple "
+        "block that non-sites surfaces keep"
+    )
+
+    # Wrap each as ``AgentPool.run`` does: persona + behavior prefix, then a
+    # volatile per-turn KB tail that differs between the two (it must NOT mask
+    # the surface flip).
+    sp_sites = f"persona\n\n{sites}\n\n## Your Knowledge Base\nsites turn snippet"
+    sp_non_sites = f"persona\n\n{non_sites}\n\n## Your Knowledge Base\npockets turn snippet"
+    key_sites = ClaudeSDKBackend._client_cache_key(_opts(sp_sites), session_key="s1")
+    key_non_sites = ClaudeSDKBackend._client_cache_key(_opts(sp_non_sites), session_key="s1")
+    assert key_sites != key_non_sites, (
+        "the /sites and non-sites behavioral prefixes must produce different "
+        "cache keys so switching surfaces mid-session rebuilds the warm client "
+        "with surface-correct instructions"
     )


### PR DESCRIPTION
## The problem

The chat agent reaches for ripple ui-specs on every surface, including `/sites`, where it should be hand-authoring Svelte. One injection site is behind it: `build_behavior_instructions` appends the full ~20K-char `INLINE_RIPPLE_SYSTEM_PROMPT` (the "default to ui-spec" rules) to the authoritative system message on every turn. It's gated on backend and pocket type, never on the surface the agent is running on. So `/sites` gets 20K chars of "build a ripple ui-spec," and that's where the model leans.

## The change

A typed `SurfaceProfile` (the per-surface policy, resolved once per request from `SurfaceKind`) now decides whether the ripple block applies. The `/sites` row is `ripple_mode="off"`, which omits the block. Every other surface stays `"on"`.

`build_behavior_instructions` reads the resolved profile's `ripple_mode`. It never branches on a bare `kind == SITES` check, so the profile stays the single source of truth.

Smoke check: `/sites` behavior instructions drop from 30,050 to 1,696 chars. The ripple law is gone, the rest is untouched.

## Why omit instead of out-shout

Adding a louder "don't use ripple here" message inside the same authoritative channel just recreates the 20K-vs-1.5K size gap, and the bigger block still wins. The fix that holds is removing the block on the surfaces where it's wrong.

## Zero regression

Every surface except `/sites` resolves to the default profile (ripple on), which is today's behavior exactly. The surface-less legacy path (`surface_context=None`) also stays on. A guard test locks both in.

## Tests

- `test_sites_surface_omits_ripple_block`: `/sites` instructions no longer carry the ripple block
- `test_non_sites_surface_keeps_ripple_block`: the guard (non-sites surfaces and the legacy `None` path keep it)
- `test_sites_surface_behavior_prefix_changes_key`: the surface dimension flips the persistent-client cache key
- `tests/cloud/test_surface_profile.py`: five unit tests on the descriptor and the resolver table

42 passed on the touched files, 129 in the broader cloud sweep. ruff and mypy clean. No changes under `src/pocketpaw` (EE only).

## Scope and stacking

Based on `integration/sites-backend` (#1333) for its surface infrastructure, and targets that branch so the diff is just this change. If this is still open when #1333 lands, merge #1333 with `--rebase` so the stack doesn't collide.

The `deny_mcp_tool_ids` and `skill_names` fields on the sites row are declared and tested here, but nothing enforces them yet. PR 2 wires them into tool-binding on the `feat/sites-svelte-engine` branch, where the create tools live. Flipping chat and files to ripple-off, and backfilling the rest of the surfaces, is Phase 2.
