### PR TITLE
Thread surface_meta through RunSpec so the /sites gate survives the run executor

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -118,6 +118,11 @@ async def post_agent_chat(
         attachments=body.attachments or [],
         mentions=[],
         reply_to=body.reply_to,
+        # Carry the surface hint to the executor so it can re-resolve
+        # ``ctx.surface_context`` — the resolution at :77 lives on THIS
+        # request's ctx and is dropped when the run is submitted.
+        surface=body.surface,
+        surface_meta=body.surface_meta or {},
     )
     # create_run is idempotent on (workspace, client_message_id) — when a doc
     # already exists, re-use its run_id so the executor + SSE stream both

--- a/ee/pocketpaw_ee/cloud/chat/runs/domain.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/domain.py
@@ -1,11 +1,21 @@
 """Value objects for chat runs. ``RunSpec`` must survive an arq pickle
-round-trip — primitives only."""
+round-trip — primitives only.
+
+Changes: 2026-06-05 (fix/sites-surface-through-runspec) — ``RunSpec`` grows
+``surface`` + ``surface_meta``. The HTTP handler resolves the per-turn
+``SurfaceContext`` but submits a ``RunSpec`` to the run executor, which
+rebuilds its own ctx from this spec — so without these fields the surface
+hint was dropped at the boundary and the whole SurfaceProfile gate (tool-deny,
+ripple-block omission, preamble, create-svelte-site skill) silently no-oped on
+the real ``/agent`` path. Both default to the legacy shape (``None`` / ``{}``),
+which the resolver turns into a GENERIC context with an empty deny — so
+non-/sites and older clients are unchanged."""
 
 from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RunSpec(BaseModel):
@@ -27,3 +37,9 @@ class RunSpec(BaseModel):
     attachments: list[dict[str, Any]] = []
     mentions: list[str] = []
     reply_to: str | None = None
+    # Per-turn surface hint, mirrored from ``CloudAgentChatRequest`` so the
+    # executor can re-resolve ``ctx.surface_context`` (the HTTP handler's
+    # resolution doesn't survive the submit). ``None`` / ``{}`` keep the
+    # legacy path (GENERIC context, empty deny).
+    surface: str | None = None
+    surface_meta: dict[str, Any] = Field(default_factory=dict)

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -46,7 +46,7 @@ from pocketpaw_ee.cloud.chat.agent_service import (
 from pocketpaw_ee.cloud.chat.runs import service as run_service
 from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
 from pocketpaw_ee.cloud.chat.runs.transport import get_stream_transport
-from pocketpaw_ee.cloud.surface import resolve_profile
+from pocketpaw_ee.cloud.surface import resolve_profile, resolve_surface_context
 
 logger = logging.getLogger(__name__)
 
@@ -655,6 +655,21 @@ async def execute_run(spec: RunSpec) -> None:
     except Exception:
         logger.exception("ensure session failed for run %s", spec.run_id)
         ctx.session_id = None
+
+    # Mirror agent_router:77 — re-resolve the surface context from the spec.
+    # The HTTP handler resolves ``ctx.surface_context`` on ITS request ctx,
+    # but submits a RunSpec to the executor, which rebuilds its own ctx via
+    # resolve_scope_context (scope only — surface_context stays None). Without
+    # this the whole SurfaceProfile gate silently no-ops on the /agent path:
+    # the tool-deny (run_core:457), the ripple-block omission + create-svelte
+    # skill (build_behavior_instructions), and the surface preamble
+    # (build_dynamic_context) all see None and fall back to the legacy shape.
+    # The resolver never raises; a missing/legacy hint -> GENERIC + empty deny.
+    ctx.surface_context = await resolve_surface_context(
+        ctx.workspace_id,
+        ctx.user_id,
+        {"surface": spec.surface, "meta": spec.surface_meta},
+    )
 
     await _mark_running(spec.run_id)
     await _broadcast_agent_typing(ctx, active=True)

--- a/tests/cloud/runs/test_run_core.py
+++ b/tests/cloud/runs/test_run_core.py
@@ -7,9 +7,11 @@ from typing import Any
 
 import fakeredis.aioredis
 import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
 from pocketpaw_ee.cloud.chat.runs import run_core
 from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
 from pocketpaw_ee.cloud.chat.runs.redis_stream import RedisStreamTransport
+from pocketpaw_ee.cloud.surface import resolve_profile
 
 pytestmark = pytest.mark.asyncio
 
@@ -433,3 +435,138 @@ async def test_execute_run_failure_marks_failed_with_error(monkeypatch):
             "error": "boom",
         }
     ]
+
+
+# --- surface_context survives the RunSpec/executor boundary -----------------
+
+
+def _sites_svelte_spec() -> RunSpec:
+    """A /sites svelte-CREATE turn: ``surface="sites"`` + ``engine="svelte"``,
+    no ``pocket_id`` (so the resolver picks the svelte-create profile that
+    denies the two ripple-create tools)."""
+    return RunSpec(
+        run_id="r1",
+        workspace_id="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c1",
+        user_message_id="m1",
+        content="build a dentist landing site",
+        history=[],
+        intent=None,
+        surface="sites",
+        surface_meta={"engine": "svelte"},
+    )
+
+
+def _scope_only_ctx() -> ScopeContext:
+    """A real ``ScopeContext`` exactly as ``resolve_scope_context`` builds it:
+    scope/tenancy fields populated, ``surface_context`` left ``None``. This is
+    the executor's starting point — the bug is that nothing re-populates
+    ``surface_context`` from the spec before the agent loop reads it."""
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+
+
+async def test_execute_run_threads_surface_meta_into_ctx(monkeypatch):
+    """Regression: the /sites SurfaceProfile gate must survive the
+    RunSpec/executor boundary.
+
+    The HTTP handler resolves ``ctx.surface_context`` but submits a
+    ``RunSpec`` to the executor; the executor rebuilds its OWN ctx via
+    ``resolve_scope_context`` (scope only) and used to leave
+    ``surface_context`` as ``None``. That silently no-ops the entire
+    SurfaceProfile mechanism (tool-deny, ripple-block omission, preamble,
+    skill) on the real ``/agent`` path. Here we assert the executor
+    re-resolves ``surface_context`` from the spec, so the resolved deny set
+    reaching the agent loop is the non-empty ripple-create pair.
+    """
+    captured: dict[str, Any] = {}
+
+    async def _capture_ctx(spec, ctx):
+        # Intercept exactly where the executor hands its ctx to the agent
+        # loop. By this point ``execute_run`` must have re-resolved
+        # ``surface_context`` from the spec.
+        captured["surface_context"] = ctx.surface_context
+        return
+        yield  # pragma: no cover - make this an async generator
+
+    async def _fake_resolve_scope_context(**_):
+        return _scope_only_ctx()
+
+    async def _noop_ensure(**_):
+        return None
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", _capture_ctx)
+    monkeypatch.setattr(run_core, "resolve_scope_context", _fake_resolve_scope_context)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr("pocketpaw_ee.cloud.sessions.service.ensure_for_agent_scope", _noop_ensure)
+
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+
+    await run_core.execute_run(_sites_svelte_spec())
+
+    surface_context = captured.get("surface_context")
+    # BEFORE the fix this is ``None`` (surface info dropped at the boundary).
+    assert surface_context is not None, (
+        "executor dropped surface_context — RunSpec carried no surface/surface_meta"
+    )
+    deny = resolve_profile(surface_context.kind, surface_context.meta).deny_mcp_tool_ids
+    # The two ripple-create tools the /sites svelte-create profile forbids.
+    assert deny == frozenset(
+        {
+            "mcp__pocketpaw_sites_manager__create_landing_site",
+            "mcp__pocketpaw_pocket_specialist__create",
+        }
+    )
+
+
+async def test_execute_run_legacy_path_leaves_surface_context_none(monkeypatch):
+    """A spec with no surface hint (older clients) must keep the legacy path:
+    ``surface_context`` resolves to a GENERIC context with an empty deny set,
+    so non-/sites turns are unchanged."""
+    captured: dict[str, Any] = {}
+
+    async def _capture_ctx(spec, ctx):
+        captured["surface_context"] = ctx.surface_context
+        return
+        yield  # pragma: no cover - make this an async generator
+
+    async def _fake_resolve_scope_context(**_):
+        return _scope_only_ctx()
+
+    async def _noop_ensure(**_):
+        return None
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", _capture_ctx)
+    monkeypatch.setattr(run_core, "resolve_scope_context", _fake_resolve_scope_context)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr("pocketpaw_ee.cloud.sessions.service.ensure_for_agent_scope", _noop_ensure)
+
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+
+    await run_core.execute_run(_spec())  # _spec() has no surface fields
+
+    surface_context = captured.get("surface_context")
+    # resolve_surface_context never raises; a missing hint -> GENERIC, no deny.
+    assert surface_context is not None
+    deny = resolve_profile(surface_context.kind, surface_context.meta).deny_mcp_tool_ids
+    assert deny == frozenset()

--- a/tests/cloud/runs/test_run_domain.py
+++ b/tests/cloud/runs/test_run_domain.py
@@ -26,3 +26,52 @@ def test_run_spec_roundtrips_json():
 def test_run_spec_requires_tenancy():
     with pytest.raises(pydantic.ValidationError):
         RunSpec(run_id="r1")  # missing workspace_id etc.
+
+
+def test_run_spec_roundtrips_surface_fields():
+    """The surface hint must ride the spec across the arq pickle boundary so
+    the executor can re-resolve ``surface_context`` from it."""
+    spec = RunSpec(
+        run_id="r1",
+        workspace_id="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c1",
+        user_message_id="m1",
+        content="hello",
+        history=[],
+        intent=None,
+        surface="sites",
+        surface_meta={"engine": "svelte"},
+    )
+    restored = RunSpec.model_validate(spec.model_dump())
+    assert restored == spec
+    assert restored.surface == "sites"
+    assert restored.surface_meta == {"engine": "svelte"}
+
+
+def test_run_spec_surface_fields_default_to_legacy():
+    """Older callers that don't set surface fields get the legacy shape:
+    ``surface=None`` + empty ``surface_meta`` (the resolver then yields a
+    GENERIC context with no deny)."""
+    spec = RunSpec(
+        run_id="r1",
+        workspace_id="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c1",
+        user_message_id="m1",
+        content="hello",
+        history=[],
+        intent=None,
+    )
+    assert spec.surface is None
+    assert spec.surface_meta == {}


### PR DESCRIPTION
## What was broken

`/sites` chat is supposed to shape the agent's tools via a typed `SurfaceProfile` resolved from `surface_meta`. On `engine="svelte"` create turns (no `pocket_id`) the two ripple-create tools should be denied and the ripple system-prompt block dropped, so the agent hand-authors SvelteKit instead of falling back to a ripple landing page. PRs #1340 + #1341 shipped that resolver, and it's correct in-process.

It was completely dead on the real cloud `/agent` path. The reason is a dropped boundary, not a broken resolver:

- The HTTP handler resolves `ctx.surface_context` (agent_router.py:77).
- But `/agent` runs the turn through the resumable-run executor: it builds a `RunSpec` and submits it. `RunSpec` had no `surface` / `surface_meta` fields, so the surface hint never crossed into the run.
- The executor rebuilds its own `ctx` via `resolve_scope_context` (scope only). It already re-mirrors `session_id` by hand, but it never re-resolved `surface_context` — so it stayed `None`.
- With `surface_context` `None`, every consumer takes the legacy branch: the tool-deny resolves to an empty set, and the ripple-block omission, the surface preamble, and the create-svelte-site skill all silently no-op.

A live `engine:svelte` `/sites` turn produced zero `Surface tool-deny` log lines and kept `create_landing_site` + `pocket_specialist__create` in the agent's allowed tools. The existing unit tests didn't catch it because they fed a `ctx` that already had `surface_context` populated — they never exercised the RunSpec/executor boundary where the drop happens.

## The fix

Three edits, mirroring the `session_id` mirror that's already in `execute_run`:

1. `runs/domain.py` — `RunSpec` gains `surface: str | None = None` and `surface_meta: dict[str, Any] = {}`. Defaults keep the legacy path: a missing hint resolves to a GENERIC context with an empty deny, so non-/sites turns and older clients are unchanged.
2. `chat/agent_router.py` — pass `body.surface` / `body.surface_meta` into the `RunSpec`.
3. `runs/run_core.py` — `execute_run` re-resolves `ctx.surface_context` from the spec (same call shape as agent_router.py:77) before the agent loop reads it.

This restores the whole `SurfaceProfile` mechanism on the `/agent` path — the tool-deny, the ripple-block omission, the surface preamble, and the create-svelte-site skill — not just the deny set.

## Proof

- New executor-level repro test reproduces the drop: it builds a `/sites` svelte-create `RunSpec`, captures the `ctx` reaching the agent loop, and asserts the resolved deny set is the ripple-create pair. It failed before the fix (`surface_context` was `None`) and passes after.
- A legacy-path test asserts a spec with no surface hint still resolves to GENERIC with an empty deny.
- RunSpec round-trip coverage for the new fields (the spec survives the arq pickle round-trip).
- `tests/cloud/runs` + `tests/cloud/surface` + surface-profile + surface-injection suites: 142 passed.
- `-k "surface or run or deny or profile"` across `tests/cloud/runs` + `tests/ee`: 185 passed. Deny / tool-policy / agent_router suites: 53 passed.
- `ruff check` clean on every touched file.