### PR TITLE
feat(agents): add Google Antigravity agent backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ The processing pipeline lives in `agents/loop.py` and `agents/router.py`:
    - `opencode` — External server-based backend via REST API. Lives in `agents/opencode.py`.
    - `copilot_sdk` — GitHub Copilot SDK with multi-provider support. Lives in `agents/copilot_sdk.py`.
    - `deep_agents` — LangChain Deep Agents with LangGraph runtime, built-in planning/subagent tools, and multi-provider support. Lives in `agents/deep_agents.py`.
+   - `antigravity` — Google Antigravity SDK (`google-antigravity`), an async batteries-included Gemini agent with plain-callable tools and stdio MCP servers. Auths via `GEMINI_API_KEY` (resolved from `antigravity_api_key` → `gemini_api_key` → `google_api_key`). Lives in `agents/antigravity.py`.
 3. All backends implement the `AgentBackend` protocol (`agents/backend.py`) and yield standardized `AgentEvent` objects with `type`, `content`, and `metadata`
 4. Legacy backend names (`pocketpaw_native`, `open_interpreter`, `claude_code`, `gemini_cli`) are mapped to active backends via `_LEGACY_BACKENDS` in the registry
 

--- a/client/src/lib/api/types.ts
+++ b/client/src/lib/api/types.ts
@@ -65,6 +65,9 @@ export interface Settings {
   openai_agents_max_turns?: number;
   google_adk_model?: string;
   google_adk_max_turns?: number;
+  antigravity_model?: string;
+  antigravity_max_turns?: number;
+  antigravity_api_key?: string;
   codex_cli_model?: string;
   codex_cli_max_turns?: number;
   copilot_sdk_provider?: string;

--- a/client/src/lib/components/settings/TabAIModel.svelte
+++ b/client/src/lib/components/settings/TabAIModel.svelte
@@ -95,6 +95,10 @@
       modelField: "google_adk_model",
       maxTurnsField: "google_adk_max_turns",
     },
+    antigravity: {
+      modelField: "antigravity_model",
+      maxTurnsField: "antigravity_max_turns",
+    },
     codex_cli: {
       modelField: "codex_cli_model",
       maxTurnsField: "codex_cli_max_turns",

--- a/client/src/lib/stores/settings.svelte.ts
+++ b/client/src/lib/stores/settings.svelte.ts
@@ -14,6 +14,7 @@ class SettingsStore {
       case "claude_agent_sdk": return s.claude_sdk_model ?? s.anthropic_model ?? "";
       case "openai_agents": return s.openai_agents_model ?? s.openai_model ?? "";
       case "google_adk": return s.google_adk_model ?? s.gemini_model ?? "";
+      case "antigravity": return s.antigravity_model ?? s.gemini_model ?? "";
       case "codex_cli": return s.codex_cli_model ?? "";
       case "copilot_sdk": return s.copilot_sdk_model ?? "";
       case "opencode": return s.opencode_model ?? "";

--- a/docs/backends/antigravity.mdx
+++ b/docs/backends/antigravity.mdx
@@ -1,0 +1,85 @@
+---
+title: "Google Antigravity: Async Gemini Agent SDK"
+description: "The Antigravity backend wraps Google's google-antigravity SDK — an async, batteries-included Gemini agent with plain-callable tools and stdio MCP servers. Streams text token-by-token and reuses your Gemini API key."
+section: Agent Backends
+ogType: article
+keywords: ["google antigravity", "gemini", "agent sdk", "mcp", "google ai"]
+tags: ["backends", "google"]
+---
+
+# Google Antigravity: Async Gemini Agent SDK
+
+The Antigravity backend wraps Google's **Antigravity SDK** (`google-antigravity` package). It runs a batteries-included async agent on Gemini models — the SDK handles binary discovery, tool wiring, hook registration, and policy defaults for you.
+
+## Overview
+
+- **Status**: Beta
+- **Provider support**: Google (Gemini models)
+- **Built-in tools**: view_file, edit_file, run_command
+- **MCP support**: Yes (stdio servers via `McpStdioServer`)
+- **Streaming**: Token-by-token text streaming
+
+## Configuration
+
+```bash
+export POCKETPAW_AGENT_BACKEND="antigravity"
+export POCKETPAW_ANTIGRAVITY_API_KEY="..."
+```
+
+The SDK authenticates via `GEMINI_API_KEY`. PocketPaw resolves the key from `antigravity_api_key` first, then falls back to `gemini_api_key`, then `google_api_key` — so a key already set up for Google ADK is reused automatically with no extra setup.
+
+### Backend-Specific Settings
+
+| Setting | Env Variable | Default | Description |
+|---------|-------------|---------|-------------|
+| `antigravity_model` | `POCKETPAW_ANTIGRAVITY_MODEL` | `gemini-3-pro-preview` | Gemini model to use |
+| `antigravity_max_turns` | `POCKETPAW_ANTIGRAVITY_MAX_TURNS` | `100` | Max tool-use turns per query (0 = unlimited) |
+| `antigravity_api_key` | `POCKETPAW_ANTIGRAVITY_API_KEY` | (falls back) | Gemini API key; falls back to `gemini_api_key`, then `google_api_key` |
+
+## Built-in Tools
+
+| Tool | Policy Mapping |
+|------|---------------|
+| `view_file` | `filesystem` |
+| `edit_file` | `filesystem` |
+| `run_command` | `shell` |
+
+PocketPaw's own tools are passed to the SDK as plain Python callables via the `build_antigravity_function_tools()` bridge in `tool_bridge.py`. The SDK introspects each function's name, docstring, and type annotations to build the tool schema.
+
+## MCP Integration
+
+Configured MCP servers are passed to the agent as `McpStdioServer` instances. Only **stdio** servers are wired today; SSE/HTTP servers are skipped. MCP tools obey the same tool policy as every other tool, and a server blocked by policy is dropped before launch.
+
+## How It Works
+
+1. PocketPaw builds a `LocalAgentConfig` with the system prompt, tools, and MCP servers, and creates an async `Agent`
+2. The message is sent via `await agent.chat(...)`, which returns a `ChatResponse`
+3. Text streams back token-by-token (`async for token in response`) as `AgentEvent` objects
+4. Conversation history is threaded into the system instructions for multi-turn context
+5. Token usage is reported from the response's `usage_metadata`
+
+## Installation
+
+```bash
+pip install pocketpaw[antigravity]
+```
+
+This installs `google-antigravity` as an optional dependency.
+
+<Callout type="info">
+  **Shares a key with Google ADK:** Both backends run on Gemini and read the same Google/Gemini key. If you already configured Google ADK, Antigravity works without re-entering anything.
+</Callout>
+
+## Related
+
+<CardGroup>
+  <Card title="Google ADK" icon="lucide:hexagon" href="/backends/google-adk">
+    Google's Agent Development Kit — another Gemini backend, with native search and code execution tools.
+  </Card>
+  <Card title="Claude Agent SDK" icon="lucide:sparkles" href="/backends/claude-sdk">
+    The recommended backend with native tools and MCP integration.
+  </Card>
+  <Card title="All Agent Backends" icon="lucide:layers" href="/backends">
+    Compare every backend side by side with capability badges.
+  </Card>
+</CardGroup>

--- a/docs/docs-config.json
+++ b/docs/docs-config.json
@@ -420,6 +420,11 @@
             "icon": "lucide:hexagon"
           },
           {
+            "label": "Google Antigravity",
+            "href": "/backends/antigravity",
+            "icon": "lucide:orbit"
+          },
+          {
             "label": "Codex CLI",
             "href": "/backends/codex-cli",
             "icon": "lucide:code"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ codex-sdk = [
 google-adk = [
     "google-adk>=1.0.0",
 ]
+antigravity = [
+    "google-antigravity>=0.1.0",
+]
 copilot-sdk = [
     "github-copilot-sdk>=0.1.0",
 ]
@@ -261,7 +264,7 @@ all-tools = [
     "soul-protocol[engine]>=0.3.0",
 ]
 all-backends = [
-    "pocketpaw[openai-agents,google-adk,copilot-sdk,deep-agents,litellm]",
+    "pocketpaw[openai-agents,google-adk,antigravity,copilot-sdk,deep-agents,litellm]",
 ]
 # NOTE: the `enterprise` extra was removed in the OSS-EE split (Phase 4).
 # Enterprise features now ship as the separate `pocketpaw-ee` package
@@ -298,6 +301,7 @@ all = [
     # backends
     "openai-agents>=0.2.0",
     "google-adk>=1.0.0",
+    "google-antigravity>=0.1.0",
     "github-copilot-sdk>=0.1.0",
     "deepagents>=0.5.8,<0.6.0",
     "langchain-mcp-adapters>=0.2.2,<0.3.0",
@@ -331,6 +335,7 @@ dev = [
     "mcp>=1.0.0",
     "openai-agents>=0.2.0",
     "google-adk>=1.0.0",
+    "google-antigravity>=0.1.0",
     "github-copilot-sdk>=0.1.0",
     "deepagents>=0.5.8,<0.6.0",
     "langchain-mcp-adapters>=0.2.2,<0.3.0",
@@ -441,6 +446,7 @@ dev = [
     "mcp>=1.0.0",
     "openai-agents>=0.2.0",
     "google-adk>=1.0.0",
+    "google-antigravity>=0.1.0",
     "github-copilot-sdk>=0.1.0",
     "deepagents>=0.5.8,<0.6.0",
     "langchain-mcp-adapters>=0.2.2,<0.3.0",

--- a/src/pocketpaw/agents/antigravity.py
+++ b/src/pocketpaw/agents/antigravity.py
@@ -1,0 +1,316 @@
+"""Google Antigravity backend for PocketPaw.
+
+Created: 2026-06-06 (feat/antigravity-backend) — adds the ``antigravity``
+agent backend wrapping the official Google Antigravity Python SDK
+(``pip install google-antigravity``), which provides:
+- ``Agent`` + ``LocalAgentConfig`` — a batteries-included async agent that
+  handles binary discovery, tool wiring, hook registration, and policy defaults
+- Gemini-model reasoning with streamed text tokens (``async for token in resp``)
+- Custom Python-callable tools (plain functions with docstrings)
+- MCP stdio servers via ``McpStdioServer``
+
+Requires: ``pip install 'pocketpaw[antigravity]'`` and a ``GEMINI_API_KEY``
+(PocketPaw resolves it from ``antigravity_api_key`` → ``gemini_api_key`` →
+``google_api_key``).
+
+The SDK exposes thoughts/tool-calls as *separate* async iterators on the
+response object, which makes true interleaved streaming awkward; v1 streams the
+assistant text and emits a terminal ``done`` event. Tool-call surfacing in the
+Activity panel is a tracked follow-up.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+
+from pocketpaw.agents.backend import (
+    _DEFAULT_IDENTITY,
+    BackendInfo,
+    BaseAgentBackend,
+    Capability,
+)
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.config import Settings
+from pocketpaw.tools.policy import ToolPolicy
+
+logger = logging.getLogger(__name__)
+
+
+class AntigravityBackend(BaseAgentBackend):
+    """Google Antigravity backend — async SDK for Gemini-powered agents."""
+
+    @staticmethod
+    def info() -> BackendInfo:
+        return BackendInfo(
+            name="antigravity",
+            display_name="Google Antigravity",
+            capabilities=(
+                Capability.STREAMING
+                | Capability.TOOLS
+                | Capability.MCP
+                | Capability.MULTI_TURN
+                | Capability.CUSTOM_SYSTEM_PROMPT
+            ),
+            builtin_tools=["view_file", "edit_file", "run_command"],
+            tool_policy_map={
+                "view_file": "filesystem",
+                "edit_file": "filesystem",
+                "run_command": "shell",
+            },
+            required_keys=["gemini_api_key"],
+            supported_providers=["google"],
+            install_hint={
+                "pip_package": "google-antigravity",
+                "pip_spec": "pocketpaw[antigravity]",
+                "verify_import": "google.antigravity",
+            },
+            beta=True,
+        )
+
+    def __init__(self, settings: Settings) -> None:
+        self.settings = settings
+        self._stop_flag = False
+        self._sdk_available = False
+        self._custom_tools: list | None = None
+        # session_key -> accumulated history text (the SDK ``Agent`` is created
+        # per-run, so multi-turn context is threaded via system instructions).
+        self._policy = ToolPolicy(
+            profile=settings.tool_profile,
+            allow=settings.tools_allow,
+            deny=settings.tools_deny,
+        )
+        self._initialize()
+
+    def get_tool_policy(self) -> ToolPolicy:
+        return self._policy
+
+    def set_tool_policy(self, policy: ToolPolicy) -> None:
+        self._policy = policy
+        self._custom_tools = None
+
+    # ------------------------------------------------------------------ init
+
+    def _resolve_api_key(self) -> str | None:
+        """Antigravity auths via ``GEMINI_API_KEY``.
+
+        Resolve from the dedicated ``antigravity_api_key`` first, then fall back
+        to the shared Gemini / Google keys so users who already configured
+        Google ADK don't have to re-enter a key.
+        """
+        return (
+            self.settings.antigravity_api_key
+            or self.settings.gemini_api_key
+            or self.settings.google_api_key
+        )
+
+    def _initialize(self) -> None:
+        try:
+            import google.antigravity  # noqa: F401
+
+            self._sdk_available = True
+            logger.info("Google Antigravity SDK ready")
+        except ImportError:
+            logger.warning(
+                "Google Antigravity not installed -- pip install 'pocketpaw[antigravity]'"
+            )
+            return
+
+        api_key = self._resolve_api_key()
+        if api_key:
+            # The SDK reads GEMINI_API_KEY from the environment; set it so the
+            # plain ``LocalAgentConfig()`` path authenticates without an explicit
+            # ``api_key=`` kwarg on SDK versions that don't accept one.
+            os.environ.setdefault("GEMINI_API_KEY", api_key)
+
+    # ------------------------------------------------------------------ tools
+
+    def _build_custom_tools(self) -> list:
+        """Lazily build PocketPaw custom tools as plain Antigravity callables.
+
+        Antigravity accepts plain Python functions with docstrings as tools, so
+        we reuse the tool_bridge wrapper builder. Cached for the instance — the
+        tool set is fixed for a given policy.
+        """
+        if self._custom_tools is not None:
+            return self._custom_tools
+        try:
+            from pocketpaw.agents.tool_bridge import build_antigravity_function_tools
+
+            self._custom_tools = build_antigravity_function_tools(
+                self.settings, backend="antigravity", policy=self._policy
+            )
+        except Exception as exc:
+            logger.debug("Could not build Antigravity custom tools: %s", exc)
+            self._custom_tools = []
+        return self._custom_tools
+
+    def _build_mcp_servers(self) -> list:
+        """Build Antigravity ``McpStdioServer`` instances from PocketPaw MCP config."""
+        try:
+            from google.antigravity.types import McpStdioServer
+        except ImportError:
+            logger.debug("Antigravity MCP types not available")
+            return []
+
+        try:
+            from pocketpaw.mcp.config import load_mcp_config
+        except ImportError:
+            return []
+
+        configs = load_mcp_config()
+        if not configs:
+            return []
+
+        servers: list = []
+        for cfg in configs:
+            if cfg.transport != "stdio":
+                # Antigravity's local agent wires stdio MCP servers; SSE/HTTP
+                # servers are skipped (parity with the conservative ADK path).
+                continue
+            if not self._policy.is_mcp_server_allowed(cfg.name):
+                logger.info("MCP server '%s' blocked by tool policy", cfg.name)
+                continue
+            try:
+                # NOTE: McpStdioServer takes no ``env`` kwarg — environment for
+                # the spawned server is inherited from the PocketPaw process.
+                servers.append(
+                    McpStdioServer(
+                        name=cfg.name,
+                        command=cfg.command,
+                        args=cfg.args or [],
+                    )
+                )
+            except Exception as exc:
+                logger.debug("Skipping MCP server %s: %s", cfg.name, exc)
+
+        logger.info("Built %d Antigravity MCP servers", len(servers))
+        return servers
+
+    def _build_config(self, instruction: str) -> Any:
+        """Construct ``LocalAgentConfig`` defensively.
+
+        The SDK's config signature varies across versions, so only forward
+        kwargs the installed ``LocalAgentConfig`` actually accepts. Keeps the
+        backend resilient to minor SDK drift instead of hard-failing on an
+        unexpected keyword.
+        """
+        from google.antigravity import LocalAgentConfig
+
+        candidate: dict[str, Any] = {
+            "system_instructions": instruction,
+            "tools": self._build_custom_tools(),
+            "mcp_servers": self._build_mcp_servers(),
+        }
+        api_key = self._resolve_api_key()
+        if api_key:
+            candidate["api_key"] = api_key
+
+        model = self.settings.antigravity_model
+        if model:
+            candidate["model"] = model
+
+        try:
+            accepted = set(inspect.signature(LocalAgentConfig).parameters)
+        except (TypeError, ValueError):
+            accepted = set(candidate)
+        kwargs = {k: v for k, v in candidate.items() if k in accepted}
+        return LocalAgentConfig(**kwargs)
+
+    @staticmethod
+    def _inject_history(instruction: str, history: list[dict]) -> str:
+        """Append recent conversation to the system instruction as text."""
+        lines = ["# Recent Conversation"]
+        for msg in history:
+            role = msg.get("role", "user").capitalize()
+            content = msg.get("content", "")
+            if len(content) > 500:
+                content = content[:500] + "..."
+            lines.append(f"**{role}**: {content}")
+        return instruction + "\n\n" + "\n".join(lines)
+
+    # ------------------------------------------------------------------- run
+
+    async def run(
+        self,
+        message: str,
+        *,
+        system_prompt: str | None = None,
+        history: list[dict] | None = None,
+        session_key: str | None = None,
+    ) -> AsyncIterator[AgentEvent]:
+        if not self._sdk_available:
+            yield AgentEvent(
+                type="error",
+                content=(
+                    "Google Antigravity not installed.\n\n"
+                    "Install with: pip install 'pocketpaw[antigravity]'"
+                ),
+            )
+            return
+
+        if not self._resolve_api_key():
+            yield AgentEvent(
+                type="error",
+                content=(
+                    "No Gemini API key configured for the Antigravity backend.\n\n"
+                    "Add one in **Settings > API Keys > Gemini API Key** "
+                    "(get a key at https://aistudio.google.com/apikey)."
+                ),
+            )
+            return
+
+        self._stop_flag = False
+
+        try:
+            from google.antigravity import Agent
+
+            instruction = system_prompt or _DEFAULT_IDENTITY
+            if history:
+                instruction = self._inject_history(instruction, history)
+
+            config = self._build_config(instruction)
+
+            async with Agent(config) as agent:
+                response = await agent.chat(message)
+
+                async for token in response:
+                    if self._stop_flag:
+                        break
+                    text = token if isinstance(token, str) else getattr(token, "text", "")
+                    if text:
+                        yield AgentEvent(type="message", content=text)
+
+            # Token usage — the SDK exposes Gemini-style counts on the response.
+            usage = getattr(response, "usage_metadata", None)
+            if usage is not None:
+                yield AgentEvent(
+                    type="token_usage",
+                    content="",
+                    metadata={
+                        "input_tokens": getattr(usage, "prompt_token_count", 0) or 0,
+                        "output_tokens": getattr(usage, "candidates_token_count", 0) or 0,
+                        "model": self.settings.antigravity_model,
+                        "backend": "antigravity",
+                    },
+                )
+
+            yield AgentEvent(type="done", content="")
+
+        except Exception as e:
+            logger.error("Google Antigravity error: %s", e)
+            yield AgentEvent(type="error", content=f"Google Antigravity error: {e}")
+
+    async def stop(self) -> None:
+        self._stop_flag = True
+
+    async def get_status(self) -> dict[str, Any]:
+        return {
+            "backend": "antigravity",
+            "available": self._sdk_available,
+            "running": not self._stop_flag,
+            "model": self.settings.antigravity_model,
+        }

--- a/src/pocketpaw/agents/antigravity.py
+++ b/src/pocketpaw/agents/antigravity.py
@@ -17,6 +17,12 @@ The SDK exposes thoughts/tool-calls as *separate* async iterators on the
 response object, which makes true interleaved streaming awkward; v1 streams the
 assistant text and emits a terminal ``done`` event. Tool-call surfacing in the
 Activity panel is a tracked follow-up.
+
+Updated 2026-06-08: wired ``antigravity_max_turns``. The SDK has no native turn
+cap (the agentic loop runs inside ``Agent.chat()``), so ``_build_hooks`` adds a
+``pre_tool_call_decide`` hook that counts tool calls and denies once the budget
+is spent; ``run`` resets the counter per query and surfaces a notice when the
+cap halts the loop.
 """
 
 from __future__ import annotations
@@ -76,6 +82,8 @@ class AntigravityBackend(BaseAgentBackend):
         self._stop_flag = False
         self._sdk_available = False
         self._custom_tools: list | None = None
+        # Per-run turn-limit bookkeeping, reset at the top of every run().
+        self._turn_state: dict[str, Any] = {"count": 0, "limit_hit": False}
         # session_key -> accumulated history text (the SDK ``Agent`` is created
         # per-run, so multi-turn context is threaded via system instructions).
         self._policy = ToolPolicy(
@@ -190,6 +198,47 @@ class AntigravityBackend(BaseAgentBackend):
         logger.info("Built %d Antigravity MCP servers", len(servers))
         return servers
 
+    def _build_hooks(self) -> list:
+        """Build SDK hooks — currently just the per-query turn cap.
+
+        ``antigravity_max_turns`` bounds how far the agentic loop may run
+        (0 = unlimited). The SDK has no native turn knob: the loop lives inside
+        ``Agent.chat()`` and its only in-loop interception point is the
+        ``pre_tool_call_decide`` hook. So we count tool calls — each one drives
+        another model step — and deny once the budget is spent. A denied call
+        returns a message to the model, which then wraps up with a final answer
+        instead of looping further. The decide hook is ANDed with the config's
+        default policy (``confirm_run_command``): allowing a call here defers to
+        the policy; denying short-circuits it.
+
+        The counter lives on ``self._turn_state`` (reset per run) so ``run()``
+        can surface a notice when the cap is hit.
+        """
+        max_turns = self.settings.antigravity_max_turns
+        if not max_turns or max_turns <= 0:
+            return []
+        try:
+            from google.antigravity.hooks import pre_tool_call_decide
+            from google.antigravity.types import HookResult
+        except ImportError:
+            logger.debug("Antigravity hooks unavailable; turn limit not enforced")
+            return []
+
+        state = self._turn_state
+
+        @pre_tool_call_decide
+        async def _enforce_turn_limit(_tool_call: Any) -> Any:
+            state["count"] += 1
+            if state["count"] > max_turns:
+                state["limit_hit"] = True
+                return HookResult(
+                    allow=False,
+                    message=f"Max turns ({max_turns}) reached — stopping.",
+                )
+            return HookResult(allow=True)
+
+        return [_enforce_turn_limit]
+
     def _build_config(self, instruction: str) -> Any:
         """Construct ``LocalAgentConfig`` defensively.
 
@@ -205,6 +254,9 @@ class AntigravityBackend(BaseAgentBackend):
             "tools": self._build_custom_tools(),
             "mcp_servers": self._build_mcp_servers(),
         }
+        hooks = self._build_hooks()
+        if hooks:
+            candidate["hooks"] = hooks
         api_key = self._resolve_api_key()
         if api_key:
             candidate["api_key"] = api_key
@@ -264,6 +316,7 @@ class AntigravityBackend(BaseAgentBackend):
             return
 
         self._stop_flag = False
+        self._turn_state = {"count": 0, "limit_hit": False}
 
         try:
             from google.antigravity import Agent
@@ -296,6 +349,17 @@ class AntigravityBackend(BaseAgentBackend):
                         "model": self.settings.antigravity_model,
                         "backend": "antigravity",
                     },
+                )
+
+            # Surface a notice if the per-query turn cap halted the agentic loop
+            # (parity with the Google ADK backend's max-turns handling).
+            if self._turn_state.get("limit_hit"):
+                yield AgentEvent(
+                    type="error",
+                    content=(
+                        f"Max turns ({self.settings.antigravity_max_turns}) reached — "
+                        "the response may be incomplete."
+                    ),
                 )
 
             yield AgentEvent(type="done", content="")

--- a/src/pocketpaw/agents/antigravity.py
+++ b/src/pocketpaw/agents/antigravity.py
@@ -67,7 +67,11 @@ class AntigravityBackend(BaseAgentBackend):
                 "edit_file": "filesystem",
                 "run_command": "shell",
             },
-            required_keys=["gemini_api_key"],
+            # google_api_key is the field the desktop client's "google" provider
+            # writes to (and the one google_adk advertises), so the same Gemini
+            # key is reused across both backends. _resolve_api_key still prefers a
+            # dedicated antigravity_api_key, then gemini_api_key, then this.
+            required_keys=["google_api_key"],
             supported_providers=["google"],
             install_hint={
                 "pip_package": "google-antigravity",

--- a/src/pocketpaw/agents/registry.py
+++ b/src/pocketpaw/agents/registry.py
@@ -25,6 +25,7 @@ _BACKEND_REGISTRY: dict[str, tuple[str, str]] = {
     "copilot_sdk": ("pocketpaw.agents.copilot_sdk", "CopilotSDKBackend"),
     "deep_agents": ("pocketpaw.agents.deep_agents", "DeepAgentsBackend"),
     "langchain_react": ("pocketpaw.agents.langchain_react", "LangchainReactBackend"),
+    "antigravity": ("pocketpaw.agents.antigravity", "AntigravityBackend"),
 }
 
 # Backends that were removed — map to fallback for graceful migration

--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -418,6 +418,41 @@ def _make_adk_wrapper(tool: Any):
     return _adk_tool_wrapper
 
 
+def build_antigravity_function_tools(
+    settings: Any, backend: str = "antigravity", policy: ToolPolicy | None = None
+) -> list:
+    """Build PocketPaw tools as plain callables for the Antigravity SDK.
+
+    The Google Antigravity SDK accepts plain Python functions with docstrings
+    and type annotations as tools (``LocalAgentConfig(tools=[...])``) — the exact
+    shape ``_make_adk_wrapper`` already produces, so we reuse it without the
+    ADK ``FunctionTool`` envelope.
+
+    Only tools permitted by the active ToolPolicy are included. Returns an empty
+    list if the tool registry can't be built.
+    """
+    if policy is None:
+        policy = ToolPolicy(
+            profile=settings.tool_profile,
+            allow=settings.tools_allow,
+            deny=settings.tools_deny,
+        )
+
+    registry = ToolRegistry(policy=policy)
+    for tool in _instantiate_all_tools(backend=backend):
+        registry.register(tool)
+
+    callables: list = []
+    for tool_name in registry.allowed_tool_names:
+        tool = registry.get(tool_name)
+        if tool is None:
+            continue
+        callables.append(_make_adk_wrapper(tool))
+
+    logger.info("Built %d Antigravity function tools from PocketPaw tools", len(callables))
+    return callables
+
+
 def build_deep_agents_tools(
     settings: Any, backend: str = "deep_agents", policy: ToolPolicy | None = None
 ) -> list:

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -204,9 +204,9 @@ class Settings(BaseSettings):
         default="claude_agent_sdk",
         description=(
             "Agent backend: 'claude_agent_sdk', 'openai_agents', 'google_adk', "
-            "'codex_cli', 'opencode', 'copilot_sdk', 'deep_agents', or "
-            "'langchain_react'. All backends support 'litellm' as a provider "
-            "for open-source model access."
+            "'codex_cli', 'opencode', 'copilot_sdk', 'deep_agents', "
+            "'langchain_react', or 'antigravity'. All backends support 'litellm' "
+            "as a provider for open-source model access."
         ),
     )
     # backend fallback chain
@@ -263,6 +263,24 @@ class Settings(BaseSettings):
     )
     google_adk_max_turns: int = Field(
         default=100, description="Max turns per query in Google ADK backend (0 = unlimited)"
+    )
+
+    # Google Antigravity Settings
+    antigravity_model: str = Field(
+        default="gemini-3-pro-preview",
+        description="Model for the Google Antigravity backend (Gemini family)",
+    )
+    antigravity_max_turns: int = Field(
+        default=100,
+        description="Max turns per query in the Antigravity backend (0 = unlimited)",
+    )
+    antigravity_api_key: str | None = Field(
+        default=None,
+        description=(
+            "API key for the Google Antigravity backend (read as GEMINI_API_KEY "
+            "by the SDK). Falls back to gemini_api_key, then google_api_key when "
+            "unset, so a key configured for Google ADK is reused automatically."
+        ),
     )
 
     # Codex CLI Settings

--- a/tests/test_antigravity_backend.py
+++ b/tests/test_antigravity_backend.py
@@ -1,0 +1,123 @@
+"""Tests for the Google Antigravity backend.
+
+Created: 2026-06-06 (feat/antigravity-backend). The ``google-antigravity`` SDK
+is an optional dependency; these tests cover metadata, registry wiring, API-key
+resolution, and the run-time guards that fire WITHOUT a live API call, so they
+pass whether or not the SDK wheel is installed in the test env.
+"""
+
+from pocketpaw.agents.antigravity import AntigravityBackend
+from pocketpaw.agents.backend import Capability
+from pocketpaw.config import Settings
+
+
+class TestAntigravityInfo:
+    def test_info_metadata(self):
+        info = AntigravityBackend.info()
+        assert info.name == "antigravity"
+        assert info.display_name == "Google Antigravity"
+        assert Capability.STREAMING in info.capabilities
+        assert Capability.TOOLS in info.capabilities
+        assert Capability.MCP in info.capabilities
+        assert Capability.MULTI_TURN in info.capabilities
+        assert Capability.CUSTOM_SYSTEM_PROMPT in info.capabilities
+
+    def test_install_hint(self):
+        info = AntigravityBackend.info()
+        assert info.install_hint["pip_package"] == "google-antigravity"
+        assert info.install_hint["pip_spec"] == "pocketpaw[antigravity]"
+        assert info.install_hint["verify_import"] == "google.antigravity"
+
+    def test_required_keys_and_providers(self):
+        info = AntigravityBackend.info()
+        assert "gemini_api_key" in info.required_keys
+        assert "google" in info.supported_providers
+        assert info.beta is True
+
+    def test_tool_policy_map(self):
+        info = AntigravityBackend.info()
+        assert info.tool_policy_map["run_command"] == "shell"
+        assert info.tool_policy_map["edit_file"] == "filesystem"
+
+
+class TestRegistryWiring:
+    def test_listed_in_registry(self):
+        from pocketpaw.agents.registry import list_backends
+
+        assert "antigravity" in list_backends()
+
+    def test_get_backend_class(self):
+        from pocketpaw.agents.registry import get_backend_class
+
+        cls = get_backend_class("antigravity")
+        assert cls is not None
+        assert cls.__name__ == "AntigravityBackend"
+
+    def test_get_backend_info(self):
+        from pocketpaw.agents.registry import get_backend_info
+
+        info = get_backend_info("antigravity")
+        assert info is not None
+        assert info.name == "antigravity"
+
+
+class TestApiKeyResolution:
+    def _backend(self, **kwargs):
+        backend = AntigravityBackend.__new__(AntigravityBackend)
+        backend.settings = Settings(**kwargs)
+        return backend
+
+    def test_prefers_dedicated_key(self):
+        backend = self._backend(
+            antigravity_api_key="antg", gemini_api_key="gem", google_api_key="goog"
+        )
+        assert backend._resolve_api_key() == "antg"
+
+    def test_falls_back_to_gemini(self):
+        backend = self._backend(gemini_api_key="gem", google_api_key="goog")
+        assert backend._resolve_api_key() == "gem"
+
+    def test_falls_back_to_google(self):
+        backend = self._backend(google_api_key="goog")
+        assert backend._resolve_api_key() == "goog"
+
+    def test_none_when_unset(self):
+        backend = self._backend()
+        assert backend._resolve_api_key() is None
+
+
+class TestRunGuards:
+    async def test_run_without_sdk_yields_install_error(self):
+        backend = AntigravityBackend.__new__(AntigravityBackend)
+        backend.settings = Settings(antigravity_api_key="k")
+        backend._sdk_available = False
+        backend._stop_flag = False
+
+        events = [ev async for ev in backend.run("hi")]
+        assert len(events) == 1
+        assert events[0].type == "error"
+        assert "not installed" in events[0].content
+
+    async def test_run_without_key_yields_key_error(self):
+        backend = AntigravityBackend.__new__(AntigravityBackend)
+        backend.settings = Settings()  # no keys
+        backend._sdk_available = True
+        backend._stop_flag = False
+
+        events = [ev async for ev in backend.run("hi")]
+        assert len(events) == 1
+        assert events[0].type == "error"
+        assert "API key" in events[0].content
+
+
+class TestStatus:
+    async def test_get_status_shape(self):
+        backend = AntigravityBackend.__new__(AntigravityBackend)
+        backend.settings = Settings()
+        backend._sdk_available = False
+        backend._stop_flag = False
+
+        status = await backend.get_status()
+        assert status["backend"] == "antigravity"
+        assert status["available"] is False
+        assert "model" in status

--- a/tests/test_antigravity_backend.py
+++ b/tests/test_antigravity_backend.py
@@ -4,11 +4,21 @@ Created: 2026-06-06 (feat/antigravity-backend). The ``google-antigravity`` SDK
 is an optional dependency; these tests cover metadata, registry wiring, API-key
 resolution, and the run-time guards that fire WITHOUT a live API call, so they
 pass whether or not the SDK wheel is installed in the test env.
+
+Updated: 2026-06-08 — added TestTurnLimit covering the antigravity_max_turns
+wiring. The SDK exposes no native turn cap, so the backend bounds the agentic
+loop with a pre_tool_call_decide hook that denies tool calls past the budget;
+those tests need the SDK and importorskip when it is absent.
 """
+
+import pytest
 
 from pocketpaw.agents.antigravity import AntigravityBackend
 from pocketpaw.agents.backend import Capability
 from pocketpaw.config import Settings
+
+# pytest is used by TestTurnLimit (importorskip); keep the import alive.
+_ = pytest
 
 
 class TestAntigravityInfo:
@@ -121,3 +131,89 @@ class TestStatus:
         assert status["backend"] == "antigravity"
         assert status["available"] is False
         assert "model" in status
+
+
+class TestTurnLimit:
+    """antigravity_max_turns is enforced via a pre_tool_call_decide hook.
+
+    The SDK runs the agentic loop inside Agent.chat() with no native turn cap,
+    so the backend counts tool calls (each drives another model step) and denies
+    once the budget is spent.
+    """
+
+    def _backend(self, max_turns):
+        backend = AntigravityBackend.__new__(AntigravityBackend)
+        backend.settings = Settings(antigravity_api_key="k", antigravity_max_turns=max_turns)
+        backend._turn_state = {"count": 0, "limit_hit": False}
+        return backend
+
+    def test_no_hook_when_unlimited(self):
+        # 0 == unlimited: no turn-limit hook is registered.
+        assert self._backend(0)._build_hooks() == []
+
+    async def test_hook_allows_within_budget_then_denies(self):
+        pytest.importorskip("google.antigravity")
+        backend = self._backend(2)
+        hooks = backend._build_hooks()
+        assert len(hooks) == 1
+        hook = hooks[0]
+
+        # First two tool calls allowed; the third is denied once the cap is hit.
+        r1 = await hook.run(context=None, data=object())
+        r2 = await hook.run(context=None, data=object())
+        r3 = await hook.run(context=None, data=object())
+        assert r1.allow is True
+        assert r2.allow is True
+        assert r3.allow is False
+        assert "2" in r3.message
+        assert backend._turn_state["limit_hit"] is True
+
+    def test_build_config_includes_turn_limit_hook(self):
+        pytest.importorskip("google.antigravity")
+        backend = self._backend(5)
+        backend._sdk_available = True
+        backend._custom_tools = []
+        backend._policy = None  # _build_mcp_servers short-circuits without config
+        config = backend._build_config("sys")
+        assert len(config.hooks) >= 1
+
+    async def test_run_surfaces_limit_notice(self):
+        pytest.importorskip("google.antigravity")
+        from unittest.mock import patch
+
+        backend = self._backend(1)
+        backend._sdk_available = True
+        backend._stop_flag = False
+        backend._custom_tools = []
+        backend._policy = None
+
+        class _Resp:
+            usage_metadata = None
+
+            def __aiter__(self):
+                async def gen():
+                    yield "done"
+
+                return gen()
+
+        class _FakeAgent:
+            def __init__(self, config):
+                pass
+
+            async def __aenter__(self):
+                # Simulate the hook having fired mid-run.
+                backend._turn_state["limit_hit"] = True
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def chat(self, message):
+                return _Resp()
+
+        with patch("google.antigravity.Agent", _FakeAgent):
+            events = [ev async for ev in backend.run("hi")]
+
+        types = [e.type for e in events]
+        assert "error" in types  # limit notice surfaced
+        assert types[-1] == "done"

--- a/tests/test_antigravity_backend.py
+++ b/tests/test_antigravity_backend.py
@@ -40,7 +40,11 @@ class TestAntigravityInfo:
 
     def test_required_keys_and_providers(self):
         info = AntigravityBackend.info()
-        assert "gemini_api_key" in info.required_keys
+        # The advertised key matches the client's "google" provider save field
+        # (google_api_key) and the google_adk sibling, so the key entered for
+        # either Gemini backend is reused. The backend still resolves a dedicated
+        # antigravity_api_key or gemini_api_key first (see TestApiKeyResolution).
+        assert "google_api_key" in info.required_keys
         assert "google" in info.supported_providers
         assert info.beta is True
 

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -18,6 +18,7 @@ class TestListBackends:
         assert "openai_agents" in backends
         assert "google_adk" in backends
         assert "opencode" in backends
+        assert "antigravity" in backends
 
     def test_does_not_include_legacy(self):
         backends = list_backends()

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1630,6 +1639,27 @@ wheels = [
 ]
 
 [[package]]
+name = "google-antigravity"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "google-genai" },
+    { name = "mcp" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/d5/c6dc9b06d8248059c4ebba3489f620be1e53b03528f822c0fcf9b2dcc1bf/google_antigravity-0.1.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:129f370b44320aefc00999ccf7c97418cd40252c5d3c07c3569843224500ffc5", size = 30044136, upload-time = "2026-06-04T21:19:14.18Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b0/a2cd625471f365601f45315b21ec02c4f9499180c00a88544bb88be567ec/google_antigravity-0.1.2-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e888b2aa0b39d4526eb4add020c6bd5c1a2bfc8e4a3e5c228fc1698af2de4011", size = 32525913, upload-time = "2026-06-04T21:19:17.176Z" },
+    { url = "https://files.pythonhosted.org/packages/73/af/36b933c23f9114c58185ea18c7c12ab40e862f06a3074bdcc6ab6208fcc6/google_antigravity-0.1.2-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:5e7a7d88f3f6401b8efbf45477184874c60e387990e9ddb52686aad0da0be5f2", size = 35584793, upload-time = "2026-06-04T21:19:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e4/d51b1003c03a2acb35919bf1e681974ec584f4354d3529bcaa79856d3c1c/google_antigravity-0.1.2-py3-none-win_amd64.whl", hash = "sha256:000fc0d3c0ef35551c7fc683a090ff2a61a20c5fedaad4d5e482239499d63207", size = 34671491, upload-time = "2026-06-04T21:19:23.747Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c4/0acbd66d9150f25ab693c3bfa14d440c48fa1e6dd32cdfe243f901cc1b61/google_antigravity-0.1.2-py3-none-win_arm64.whl", hash = "sha256:40cc33c30469008ee3f78e6cc8130cff9ad4e1d66c0a82b59740965a901d8b62", size = 31367318, upload-time = "2026-06-04T21:19:26.763Z" },
+]
+
+[[package]]
 name = "google-api-core"
 version = "2.30.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2279,38 +2309,45 @@ wheels = [
 
 [[package]]
 name = "httptools"
-version = "0.7.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954, upload-time = "2025-10-10T03:54:34.226Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175, upload-time = "2025-10-10T03:54:35.942Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310, upload-time = "2025-10-10T03:54:37.1Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875, upload-time = "2025-10-10T03:54:38.421Z" },
-    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
-    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
-    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
-    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
-    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
-    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
-    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
-    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/c3eedaef57de65c3cc5f8dc244cf12d09c84ad258a479055aad6db23206c/httptools-0.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ed377e64805bdba4943c82717333f8f8603a13b09aff9cead2717c6c817fb168", size = 208428, upload-time = "2026-05-25T22:16:59.717Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/94/dfe435d90d0ef61ec0f2cc3d480eef78c59727c6c2ce039f433882f6131a/httptools-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9518c406d7b310f05adb1a37f80acabac40504a575d7c0da6d3e365c695ac20d", size = 113366, upload-time = "2026-05-25T22:17:00.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d4/13025f1a56e615dcb331e0bbe2d9a1143212b58c263385fc5d2e558f5bac/httptools-0.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:57278e6fa0424c42a8a3e454828ab4f0aff27b40cddf9679579b98c6dce6a376", size = 464676, upload-time = "2026-05-25T22:17:02.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/95/4c1c26c0b985f8a3331682d802598f14e32dc41bf7509266eb2c04ad4801/httptools-0.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbb8caadb2b742d293169d2b458b5c001ef70e3158704aa3d3ef9597624c5d1d", size = 464235, upload-time = "2026-05-25T22:17:03.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/6735be2b0ca527718c431cdb8e5f70c3862c0844a687df0f572c51e11497/httptools-0.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:52dd695b865fe96d9d2b16b64a895f3f57bf3cb064e8383cd3b5713a069e8085", size = 449809, upload-time = "2026-05-25T22:17:04.443Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f9/5811c74f37a758c8a4aa3dc430375119d335947e883efc4664d8f3559a41/httptools-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20b4aac66ff65f7db06a375808b78f42a94970aa22e826b3cb2b43eb09174124", size = 452174, upload-time = "2026-05-25T22:17:05.476Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/94/97b75870dea07b71e3ec535cebe525b08d723152e4c7d13fa887e51f4de2/httptools-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:a1b4c8e7a489a0d750d91894e9a8cdc295838f1924c0ca903ae993456fddec07", size = 90991, upload-time = "2026-05-25T22:17:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5", size = 113064, upload-time = "2026-05-25T22:17:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150", size = 90918, upload-time = "2026-05-25T22:17:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
 ]
 
 [[package]]
@@ -4540,6 +4577,7 @@ all = [
     { name = "elevenlabs" },
     { name = "github-copilot-sdk" },
     { name = "google-adk" },
+    { name = "google-antigravity" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
@@ -4567,6 +4605,7 @@ all-backends = [
     { name = "deepagents" },
     { name = "github-copilot-sdk" },
     { name = "google-adk" },
+    { name = "google-antigravity" },
     { name = "langchain-litellm" },
     { name = "langchain-mcp-adapters" },
     { name = "langchain-openai" },
@@ -4599,6 +4638,9 @@ all-tools = [
     { name = "pytesseract" },
     { name = "sarvamai" },
     { name = "soul-protocol" },
+]
+antigravity = [
+    { name = "google-antigravity" },
 ]
 browser = [
     { name = "playwright" },
@@ -4638,6 +4680,7 @@ dev = [
     { name = "elevenlabs" },
     { name = "github-copilot-sdk" },
     { name = "google-adk" },
+    { name = "google-antigravity" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-genai" },
@@ -4772,6 +4815,7 @@ dev = [
     { name = "fakeredis" },
     { name = "github-copilot-sdk" },
     { name = "google-adk" },
+    { name = "google-antigravity" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-genai" },
@@ -4852,6 +4896,9 @@ requires-dist = [
     { name = "google-adk", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "google-adk", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=1.0.0" },
+    { name = "google-antigravity", marker = "extra == 'all'", specifier = ">=0.1.0" },
+    { name = "google-antigravity", marker = "extra == 'antigravity'", specifier = ">=0.1.0" },
+    { name = "google-antigravity", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "google-api-python-client", marker = "extra == 'all'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'all-channels'", specifier = ">=2.100.0" },
     { name = "google-api-python-client", marker = "extra == 'dev'", specifier = ">=2.100.0" },
@@ -4923,7 +4970,7 @@ requires-dist = [
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.50.0" },
     { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.50.0" },
     { name = "playwright", marker = "extra == 'recommended'", specifier = ">=1.50.0" },
-    { name = "pocketpaw", extras = ["openai-agents", "google-adk", "copilot-sdk", "deep-agents", "litellm"], marker = "extra == 'all-backends'" },
+    { name = "pocketpaw", extras = ["openai-agents", "google-adk", "antigravity", "copilot-sdk", "deep-agents", "litellm"], marker = "extra == 'all-backends'" },
     { name = "psutil", marker = "extra == 'all'", specifier = ">=5.9.0" },
     { name = "psutil", marker = "extra == 'all-tools'", specifier = ">=5.9.0" },
     { name = "psutil", marker = "extra == 'desktop'", specifier = ">=5.9.0" },
@@ -4973,7 +5020,7 @@ requires-dist = [
     { name = "trafilatura", marker = "extra == 'knowledge'" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.31.1" },
 ]
-provides-extras = ["vector", "knowledge", "databases", "postgresql", "mysql", "mongodb", "s3", "graph", "dashboard", "telegram", "browser", "desktop", "openai-agents", "codex-sdk", "google-adk", "copilot-sdk", "deep-agents", "litellm", "memory", "soul", "discord", "slack", "whatsapp-personal", "matrix", "teams", "gchat", "drive", "image", "extract", "voice", "ocr", "sarvam", "mcp", "recommended", "channels", "all-channels", "all-tools", "all-backends", "all", "dev"]
+provides-extras = ["vector", "knowledge", "databases", "postgresql", "mysql", "mongodb", "s3", "graph", "dashboard", "telegram", "browser", "desktop", "openai-agents", "codex-sdk", "google-adk", "antigravity", "copilot-sdk", "deep-agents", "litellm", "memory", "soul", "discord", "slack", "whatsapp-personal", "matrix", "teams", "gchat", "drive", "image", "extract", "voice", "ocr", "sarvam", "mcp", "recommended", "channels", "all-channels", "all-tools", "all-backends", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4985,6 +5032,7 @@ dev = [
     { name = "fakeredis", specifier = ">=2.21.0" },
     { name = "github-copilot-sdk", specifier = ">=0.1.0" },
     { name = "google-adk", specifier = ">=1.0.0" },
+    { name = "google-antigravity", specifier = ">=0.1.0" },
     { name = "google-api-python-client", specifier = ">=2.100.0" },
     { name = "google-auth", specifier = ">=2.25.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
@@ -7115,15 +7163,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.44.0"
+version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What

Adds **Google Antigravity** as a new agent backend (registry key `antigravity`), wrapping the `google-antigravity` SDK. It runs an async Gemini agent that streams text token-by-token, hands PocketPaw tools to the SDK as plain callables, and forwards configured stdio MCP servers.

Pick it from `settings.agent_backend` or per-agent config, same as every other backend.

## Changes

**Core**
- `agents/antigravity.py` — `AntigravityBackend` implementing the `AgentBackend` protocol
- `agents/registry.py` — registered under `antigravity`
- `config.py` — `antigravity_model`, `antigravity_max_turns`, `antigravity_api_key`. The key resolves `antigravity_api_key` → `gemini_api_key` → `google_api_key`, so a key already set up for Google ADK is reused with no extra step
- `agents/tool_bridge.py` — `build_antigravity_function_tools()` (the SDK takes plain functions, so it reuses the ADK wrapper without the `FunctionTool` envelope)
- `pyproject.toml` — `pocketpaw[antigravity]` extra + the all-backends aggregates

**Desktop client (`client/`)**
- The Settings → AI Model screen already loads backends from `GET /api/v1/backends`, so the backend, its capability badges, and the Install button show up on their own. Added the per-backend settings field map, the `Settings` type fields, and the model-display case so the selection persists and renders.

**Docs**
- `docs/backends/antigravity.mdx` + sidebar entry

## Verification

- The real `google-antigravity` wheel installs and imports; the implementation was checked against the actual SDK signatures (`LocalAgentConfig`, `McpStdioServer`, `UsageMetadata`, `ChatResponse`) rather than the README, which was wrong about `McpStdioServer(env=...)` and `CapabilitiesConfig(read/write)`.
- `ruff check` clean; 124 backend/registry/protocol/tool-bridge tests pass, including new coverage in `tests/test_antigravity_backend.py`.
- Client typecheck was not run here (`node_modules` not installed in the worktree); the TS edits mirror existing typed entries one-for-one.

## Notes

- Onboarding API-key setup is left as-is: Antigravity runs on Gemini and shares the Google key, so the existing Google path covers it without a confusing second Google option.
- Companion dashboard wiring (the enterprise agent picker) ships as a separate PR in `qbtrix/paw-enterprise`.