### PR TITLE
Per-mode session endpoints with keyset pagination

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/session.py
+++ b/ee/pocketpaw_ee/cloud/models/session.py
@@ -2,12 +2,14 @@
 
 Recent change: added the optional ``surface`` field so the frontend can tell
 where a session-scope row originated (``chat`` vs ``files`` vs
-``pocket_creation``). Without it the three /chat / /files / /pockets
-chat surfaces all produced ``Session`` rows indistinguishable on
-``pocket=None`` + ``context_type="session"``, which the /chat sidebar then
-listed together (the "session bleed" bug). Legacy rows keep ``surface=None``
-and are still returned from unfiltered listings so the migration is non-
-disruptive.
+``pocket_creation`` vs ``foresight``). Without it the /chat / /files /
+/pockets / foresight chat surfaces all produced ``Session`` rows
+indistinguishable on ``pocket=None`` + ``context_type="session"``, which the
+/chat sidebar then listed together (the "session bleed" bug). ``foresight``
+was added so Foresight chats isolate server-side instead of relying on a
+client-side manifest. Legacy rows keep ``surface=None``; they are treated as
+``chat`` (returned only by the chat-surface listing, never files/pocket/
+foresight) so the migration is non-disruptive and no backfill is needed.
 """
 
 from __future__ import annotations
@@ -22,9 +24,9 @@ from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
 ContextType = Literal["pocket", "group", "session"]
 # Surface tags the chat UI that minted this session — used by the /chat
-# sidebar to filter out pocket-creation / files-panel sessions that would
-# otherwise appear alongside DM threads (see "session bleed" fix).
-SurfaceType = Literal["chat", "files", "pocket_creation"]
+# sidebar to filter out pocket-creation / files-panel / foresight sessions
+# that would otherwise appear alongside DM threads (see "session bleed" fix).
+SurfaceType = Literal["chat", "files", "pocket_creation", "foresight"]
 
 
 class Session(TimestampedDocument):

--- a/ee/pocketpaw_ee/cloud/sessions/dto.py
+++ b/ee/pocketpaw_ee/cloud/sessions/dto.py
@@ -1,9 +1,12 @@
 """Sessions domain — Pydantic request/response schemas + domain → wire mapper.
 
-Recent change: added the ``surface`` field on ``CreateSessionRequest`` and
-``SessionResponse`` (and the wire dict) so the frontend can stamp / read the
-originating chat surface (``chat`` / ``files`` / ``pocket_creation``). Field
-is optional everywhere so legacy callers and pre-fix rows still validate.
+Recent change: added ``foresight`` to the ``surface`` literal so Foresight
+chats are isolated server-side instead of piggybacking on ``chat`` + a
+client-side manifest. The ``surface`` field on ``CreateSessionRequest`` and
+``SessionResponse`` (and the wire dict) lets the frontend stamp / read the
+originating chat surface (``chat`` / ``files`` / ``pocket_creation`` /
+``foresight``). Field is optional everywhere so legacy callers and pre-fix
+rows (``surface=None``) still validate.
 """
 
 from __future__ import annotations
@@ -17,7 +20,7 @@ from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.sessions.domain import Session
 
 # Surface tag values — kept in lockstep with ``models.session.SurfaceType``.
-Surface = Literal["chat", "files", "pocket_creation"]
+Surface = Literal["chat", "files", "pocket_creation", "foresight"]
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +66,19 @@ class SessionResponse(BaseModel):
     surface: Surface | None = None
 
 
+class SessionPage(BaseModel):
+    """One keyset-paginated page of sessions for a single mode/surface.
+
+    ``sessions`` are legacy wire dicts (``session_to_wire_dict`` shape) for
+    drop-in compatibility with the existing list endpoints. ``nextCursor`` is
+    the opaque cursor for the following page, or ``None`` on the last page.
+    Backs ``GET /sessions/{chat,files,foresight,pocket-creation}``.
+    """
+
+    sessions: list[dict[str, Any]]
+    nextCursor: str | None = None
+
+
 def session_to_wire_dict(s: Session) -> dict[str, Any]:
     """Map a domain ``Session`` to the legacy wire-format dict.
 
@@ -89,6 +105,7 @@ def session_to_wire_dict(s: Session) -> dict[str, Any]:
 
 __all__ = [
     "CreateSessionRequest",
+    "SessionPage",
     "SessionResponse",
     "UpdateSessionRequest",
     "session_to_wire_dict",

--- a/ee/pocketpaw_ee/cloud/sessions/router.py
+++ b/ee/pocketpaw_ee/cloud/sessions/router.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from starlette.responses import Response
 
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.sessions import service as sessions_service
 from pocketpaw_ee.cloud.sessions.dto import (
     CreateSessionRequest,
+    SessionPage,
     Surface,
     UpdateSessionRequest,
     session_to_wire_dict,
@@ -59,6 +60,79 @@ async def list_sessions(
     else:
         items = await sessions_service.list_for_owner(ctx, workspace_id, surface=surface)
     return [session_to_wire_dict(s) for s in items]
+
+
+# ---------------------------------------------------------------------------
+# Per-mode listing — one keyset-paginated endpoint per chat surface. Each
+# mode's rail paginates independently so a workspace with 95 chat threads and
+# 100+ pocket chats never merges them into one list. Surface scoping follows
+# the legacy-null-as-chat rule (handled in the service). These literal routes
+# MUST stay above ``GET /{session_id}`` so they aren't captured as an id.
+# ---------------------------------------------------------------------------
+
+
+async def _mode_page(
+    surface: str,
+    cursor: str | None,
+    limit: int,
+    workspace_id: str,
+    user_id: str,
+) -> SessionPage:
+    ctx = sessions_service.legacy_ctx(user_id, workspace_id)
+    rows, next_cursor = await sessions_service.list_for_owner_page(
+        ctx, workspace_id, surface=surface, cursor=cursor, limit=limit
+    )
+    return SessionPage(
+        sessions=[session_to_wire_dict(s) for s in rows],
+        nextCursor=next_cursor,
+    )
+
+
+@router.get("/chat", dependencies=[Depends(require_action_any_workspace("session.read_own"))])
+async def list_chat_sessions(
+    cursor: str | None = None,
+    limit: int = Query(default=50, ge=1, le=200),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> SessionPage:
+    """Chat-surface sessions (includes legacy ``surface=None`` rows)."""
+    return await _mode_page("chat", cursor, limit, workspace_id, user_id)
+
+
+@router.get("/files", dependencies=[Depends(require_action_any_workspace("session.read_own"))])
+async def list_files_sessions(
+    cursor: str | None = None,
+    limit: int = Query(default=50, ge=1, le=200),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> SessionPage:
+    """Files-surface sessions only."""
+    return await _mode_page("files", cursor, limit, workspace_id, user_id)
+
+
+@router.get("/foresight", dependencies=[Depends(require_action_any_workspace("session.read_own"))])
+async def list_foresight_sessions(
+    cursor: str | None = None,
+    limit: int = Query(default=50, ge=1, le=200),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> SessionPage:
+    """Foresight-surface sessions only."""
+    return await _mode_page("foresight", cursor, limit, workspace_id, user_id)
+
+
+@router.get(
+    "/pocket-creation",
+    dependencies=[Depends(require_action_any_workspace("session.read_own"))],
+)
+async def list_pocket_creation_sessions(
+    cursor: str | None = None,
+    limit: int = Query(default=50, ge=1, le=200),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> SessionPage:
+    """Pocket-creation-surface sessions only."""
+    return await _mode_page("pocket_creation", cursor, limit, workspace_id, user_id)
 
 
 @router.get("/runtime")

--- a/ee/pocketpaw_ee/cloud/sessions/service.py
+++ b/ee/pocketpaw_ee/cloud/sessions/service.py
@@ -30,6 +30,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from beanie import PydanticObjectId
+from beanie.operators import In
 
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
 from pocketpaw_ee.cloud._core.realtime.emit import emit
@@ -184,6 +185,24 @@ async def create(
     return session
 
 
+def _surface_filters(surface: str | None) -> list[Any]:
+    """Build the surface predicate for a session listing.
+
+    Legacy-null-as-chat rule: rows stamped ``surface=None`` predate the
+    surface split and belong to the main /chat sidebar *only*. So a
+    ``"chat"`` request matches ``surface IN ("chat", None)`` — Mongo's
+    ``$in: [..., null]`` matches both explicit nulls and missing fields.
+    Every other surface (``"files"`` / ``"pocket_creation"`` / ``"foresight"``)
+    matches its tag *exactly*, so legacy nulls never bleed into those rails.
+    ``surface=None`` (the unfiltered default) keeps returning every row.
+    """
+    if surface == "chat":
+        return [In(_SessionDoc.surface, ["chat", None])]
+    if surface is not None:
+        return [_SessionDoc.surface == surface]
+    return []
+
+
 async def list_for_owner(
     ctx: RequestContext,
     workspace_id: str,
@@ -192,24 +211,108 @@ async def list_for_owner(
 ) -> list[DomainSession]:
     """List the caller's sessions in ``workspace_id``.
 
-    ``surface`` (when provided) restricts the listing to rows stamped with
-    that originating surface (``"chat"`` / ``"files"`` / ``"pocket_creation"``).
-    Passing ``None`` (the default) preserves legacy behavior — every row
-    returns, including pre-fix rows that have ``surface=None``.
+    ``surface`` (when provided) restricts the listing per
+    :func:`_surface_filters` — a ``"chat"`` request also includes legacy
+    ``surface=None`` rows; other surfaces match exactly. Passing ``None``
+    (the default) preserves legacy behavior — every row returns.
     """
     filters: list[Any] = [
         _SessionDoc.workspace == workspace_id,
         _SessionDoc.owner == ctx.user_id,
         _SessionDoc.deleted_at == None,  # noqa: E711
+        *_surface_filters(surface),
     ]
-    if surface is not None:
-        filters.append(_SessionDoc.surface == surface)
     docs = (
         await _SessionDoc.find(*filters)
         .sort(-_SessionDoc.lastActivity)  # type: ignore[arg-type, operator]
         .to_list()
     )
     return [_to_domain(d) for d in docs]
+
+
+def _encode_session_cursor(last_activity: datetime, oid: str) -> str:
+    """Opaque keyset cursor — composite ``{lastActivity_iso}|{oid}``.
+
+    Mirrors the audit-event cursor (``audit/service.py``). Keyed on
+    ``(lastActivity, _id)`` so pages stay stable even as sessions reorder by
+    activity between fetches.
+    """
+    return f"{last_activity.isoformat()}|{oid}"
+
+
+def _decode_session_cursor(cursor: str) -> tuple[datetime, PydanticObjectId]:
+    try:
+        at_iso, oid_str = cursor.split("|", 1)
+        return datetime.fromisoformat(at_iso), PydanticObjectId(oid_str)
+    except (ValueError, TypeError) as exc:
+        raise NotFound("session.bad_cursor", "Invalid pagination cursor") from exc
+
+
+def _surface_mongo_clause(surface: str | None) -> dict[str, Any] | None:
+    """Raw-mongo equivalent of :func:`_surface_filters` for the keyset query.
+
+    ``chat`` → ``surface IN ("chat", null)`` (``$in: [null]`` also matches
+    missing fields, i.e. legacy rows). Other surfaces match exactly. ``None``
+    → no surface clause.
+    """
+    if surface == "chat":
+        return {"surface": {"$in": ["chat", None]}}
+    if surface is not None:
+        return {"surface": surface}
+    return None
+
+
+async def list_for_owner_page(
+    ctx: RequestContext,
+    workspace_id: str,
+    *,
+    surface: str | None = None,
+    cursor: str | None = None,
+    limit: int = 50,
+) -> tuple[list[DomainSession], str | None]:
+    """Keyset-paginated session listing for one surface, newest first.
+
+    Returns ``(rows, next_cursor)`` where ``next_cursor`` is ``None`` on the
+    last page. Surface scoping follows the legacy-null-as-chat rule
+    (:func:`_surface_mongo_clause`). Backs the per-mode endpoints
+    (``GET /sessions/{chat,files,foresight,pocket-creation}``) so each mode's
+    rail paginates independently of the others.
+    """
+    clauses: list[dict[str, Any]] = [
+        {"workspace": workspace_id},
+        {"owner": ctx.user_id},
+        {"deleted_at": None},
+    ]
+    surface_clause = _surface_mongo_clause(surface)
+    if surface_clause is not None:
+        clauses.append(surface_clause)
+    if cursor:
+        c_at, c_oid = _decode_session_cursor(cursor)
+        clauses.append(
+            {
+                "$or": [
+                    {"lastActivity": {"$lt": c_at}},
+                    {"lastActivity": c_at, "_id": {"$lt": c_oid}},
+                ],
+            }
+        )
+
+    mongo_filter: dict[str, Any] = clauses[0] if len(clauses) == 1 else {"$and": clauses}
+    docs = (
+        await _SessionDoc.find(mongo_filter)
+        .sort([("lastActivity", -1), ("_id", -1)])  # type: ignore[arg-type, list-item]
+        .limit(limit + 1)
+        .to_list()
+    )
+
+    has_more = len(docs) > limit
+    rows = [_to_domain(d) for d in docs[:limit]]
+    next_cursor = (
+        _encode_session_cursor(rows[-1].last_activity, rows[-1].id)
+        if has_more and rows
+        else None
+    )
+    return rows, next_cursor
 
 
 async def list_by_agent(
@@ -245,21 +348,26 @@ async def list_for_user(
     workspace_id: str,
     user_id: str,
     limit: int | None = None,
+    *,
+    surface: str | None = None,
 ) -> list[dict]:
     """Sessions in ``workspace_id`` owned by ``user_id``, newest first.
 
     Wire-dict shape so callers outside the cloud entity (e.g. surface
     preamble handlers) don't need to import the domain object. Field
     names mirror :class:`DomainSession`. ``limit`` (when provided) caps
-    the returned slice; ``None`` returns the full set. Both the
-    workspace and owner filters are applied per the cloud entity
-    tenancy rule — no global reads.
+    the returned slice; ``None`` returns the full set. ``surface`` (when
+    provided) scopes the listing per :func:`_surface_filters` — a
+    ``"chat"`` request also includes legacy ``surface=None`` rows; other
+    surfaces match exactly. Both the workspace and owner filters are
+    applied per the cloud entity tenancy rule — no global reads.
     """
     query = (
         _SessionDoc.find(
             _SessionDoc.workspace == workspace_id,
             _SessionDoc.owner == user_id,
             _SessionDoc.deleted_at == None,  # noqa: E711
+            *_surface_filters(surface),
         ).sort(-_SessionDoc.lastActivity)  # type: ignore[arg-type, operator]
     )
     if limit is not None:

--- a/ee/pocketpaw_ee/cloud/surface/handlers/chat.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/chat.py
@@ -1,5 +1,10 @@
 # chat.py — /chat surface preamble.
 #
+# Updated: 2026-06-06 — ``_session_count`` now passes ``surface="chat"`` so
+# the preamble reports only chat-surface (+ legacy null) threads, not the
+# files / pocket-creation / foresight sessions that live in their own rails
+# (session-isolation fix).
+#
 # Updated: 2026-05-24 — The sessions service now exposes a real
 # ``list_for_user`` helper, so the forward-compat getattr probe in
 # ``_session_count`` can go. Direct call, graceful try/except remains
@@ -37,7 +42,12 @@ async def _session_count(workspace_id: str, user_id: str) -> int | None:
     try:
         from pocketpaw_ee.cloud.sessions import service as sessions_service
 
-        sessions = await sessions_service.list_for_user(workspace_id=workspace_id, user_id=user_id)
+        # Scope to the chat surface (chat + legacy null rows) so the count
+        # reflects the /chat sidebar, not files / pocket-creation / foresight
+        # threads that live in their own rails.
+        sessions = await sessions_service.list_for_user(
+            workspace_id=workspace_id, user_id=user_id, surface="chat"
+        )
         return len(sessions or [])
     except Exception:
         logger.debug("chat_handler: session count failed", exc_info=True)

--- a/tests/cloud/sessions/test_session_surface_filter.py
+++ b/tests/cloud/sessions/test_session_surface_filter.py
@@ -55,10 +55,7 @@ async def test_create_without_surface_defaults_to_none() -> None:
     assert s.surface is None
 
 
-async def test_list_for_owner_filters_by_surface() -> None:
-    """``surface="chat"`` returns only chat-originated rows; legacy ``surface=None``
-    rows are excluded from the filtered listing (they originated elsewhere /
-    pre-migration and shouldn't pollute the /chat sidebar)."""
+async def _seed_one_per_surface() -> None:
     await sessions_service.create(
         _ctx(), "w1", CreateSessionRequest(title="from chat", surface="chat")
     )
@@ -66,9 +63,10 @@ async def test_list_for_owner_filters_by_surface() -> None:
         _ctx(), "w1", CreateSessionRequest(title="from files", surface="files")
     )
     await sessions_service.create(
-        _ctx(),
-        "w1",
-        CreateSessionRequest(title="from pockets", surface="pocket_creation"),
+        _ctx(), "w1", CreateSessionRequest(title="from pockets", surface="pocket_creation")
+    )
+    await sessions_service.create(
+        _ctx(), "w1", CreateSessionRequest(title="from foresight", surface="foresight")
     )
     await sessions_service.create(
         _ctx(),
@@ -76,11 +74,34 @@ async def test_list_for_owner_filters_by_surface() -> None:
         CreateSessionRequest(title="legacy"),  # surface=None
     )
 
+
+async def test_list_for_owner_chat_includes_legacy_null() -> None:
+    """Legacy-null-as-chat: ``surface="chat"`` returns chat-stamped rows AND
+    legacy ``surface=None`` rows (they predate the split and belong to the
+    /chat sidebar), but nothing from files / pockets / foresight."""
+    await _seed_one_per_surface()
+
     chat_only = await sessions_service.list_for_owner(_ctx(), "w1", surface="chat")
     titles = {s.title for s in chat_only}
-    assert titles == {"from chat"}, (
-        "surface=chat filter must return only sessions stamped with surface=chat"
+    assert titles == {"from chat", "legacy"}, (
+        "surface=chat must include legacy null rows but exclude other surfaces"
     )
+
+
+async def test_list_for_owner_files_excludes_legacy_null() -> None:
+    """Non-chat surfaces match their tag exactly — legacy nulls never bleed in."""
+    await _seed_one_per_surface()
+
+    files_only = await sessions_service.list_for_owner(_ctx(), "w1", surface="files")
+    assert {s.title for s in files_only} == {"from files"}
+
+
+async def test_list_for_owner_foresight_excludes_chat_and_null() -> None:
+    """Foresight is a first-class surface — isolated from chat + legacy rows."""
+    await _seed_one_per_surface()
+
+    foresight_only = await sessions_service.list_for_owner(_ctx(), "w1", surface="foresight")
+    assert {s.title for s in foresight_only} == {"from foresight"}
 
 
 async def test_list_for_owner_without_filter_returns_all() -> None:
@@ -108,3 +129,43 @@ async def test_list_for_owner_without_filter_returns_all() -> None:
     assert len(all_sessions) == 4
     titles = {s.title for s in all_sessions}
     assert titles == {"from chat", "from files", "from pockets", "legacy"}
+
+
+async def test_list_for_owner_page_walks_all_rows_without_dupes() -> None:
+    """Keyset pagination returns every chat row exactly once across pages."""
+    for i in range(5):
+        await sessions_service.create(
+            _ctx(), "w1", CreateSessionRequest(title=f"chat-{i}", surface="chat")
+        )
+
+    seen: list[str] = []
+    cursor: str | None = None
+    pages = 0
+    while True:
+        rows, cursor = await sessions_service.list_for_owner_page(
+            _ctx(), "w1", surface="chat", cursor=cursor, limit=2
+        )
+        seen.extend(s.title for s in rows)
+        pages += 1
+        if cursor is None:
+            break
+        assert pages < 10, "pagination did not terminate"
+
+    assert sorted(seen) == ["chat-0", "chat-1", "chat-2", "chat-3", "chat-4"]
+    assert len(seen) == len(set(seen)), "no row should appear on two pages"
+
+
+async def test_list_for_owner_page_is_surface_scoped() -> None:
+    """The paginated lister honours the same surface scoping as list_for_owner."""
+    await _seed_one_per_surface()
+
+    rows, cursor = await sessions_service.list_for_owner_page(
+        _ctx(), "w1", surface="foresight", limit=50
+    )
+    assert {s.title for s in rows} == {"from foresight"}
+    assert cursor is None
+
+    chat_rows, _ = await sessions_service.list_for_owner_page(
+        _ctx(), "w1", surface="chat", limit=50
+    )
+    assert {s.title for s in chat_rows} == {"from chat", "legacy"}


### PR DESCRIPTION
## What this does

Chat sessions used to share one workspace-wide list. The /chat sidebar then showed everything: pocket-creation threads, /files chats, and foresight conversations all mixed in with your DMs. This splits the listing per mode so each surface only sees its own sessions.

## Changes

- **`foresight` is now a real persisted surface.** It was riding on `surface="chat"` and being separated client-side by a manifest. The backend can isolate it directly now.
- **Legacy untagged rows count as chat.** Rows stamped `surface=None` predate the split, so they show only in the /chat list, never in files/pocket/foresight. No migration, nothing disappears.
- **One paginated endpoint per mode:** `GET /sessions/{chat,files,foresight,pocket-creation}` returning `{sessions, nextCursor}`. Each mode walks its own keyset cursor, so a workspace with 95 chat threads and 100+ pocket chats never has to merge and page through them together. The cursor follows the same `(at, _id)` shape as the audit log.
- The chat-surface preamble count is scoped to chat (+legacy) rows instead of counting every surface.

The old `GET /sessions?surface=` and `GET /pockets/{id}/sessions` endpoints stay for the agent_id DM lookup and back-compat.

## Tests

`tests/cloud/sessions/test_session_surface_filter.py` updated for legacy-null-as-chat and extended with foresight isolation + pagination coverage (cursor walk returns every row once, surface scoping holds). 33 tests pass. Ruff clean; no new mypy errors.

This is the backend half. The paw-enterprise client rewiring is a paired PR. Pillars for Mongo-only persistence and per-mode tool scoping follow on this branch.