### PR TITLE
Per-mode tool allow-lists: lean context for files / foresight / sites

### DIFF
--- a/ee/pocketpaw_ee/cloud/auth/password_policy.py
+++ b/ee/pocketpaw_ee/cloud/auth/password_policy.py
@@ -20,7 +20,7 @@ from fastapi_users.exceptions import InvalidPasswordException
 
 logger = logging.getLogger(__name__)
 
-MIN_LENGTH = 12
+MIN_LENGTH = 6
 _HIBP_RANGE_URL = "https://api.pwnedpasswords.com/range/{prefix}"
 _HIBP_TIMEOUT = 3.0
 _CACHE_TTL_SECONDS = 24 * 60 * 60

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -454,10 +454,14 @@ async def _drive_agent_loop(
         # prompt-sniffing gate in claude_sdk.py). ``surface_context is None`` is
         # the legacy path — no deny.
         surface_deny: frozenset[str] = frozenset()
+        surface_allow: frozenset[str] | None = None
         if ctx.surface_context is not None:
-            surface_deny = resolve_profile(
-                ctx.surface_context.kind, ctx.surface_context.meta
-            ).deny_mcp_tool_ids
+            _profile = resolve_profile(ctx.surface_context.kind, ctx.surface_context.meta)
+            surface_deny = _profile.deny_mcp_tool_ids
+            # Per-surface MCP allow-list (lean per-mode tool set). ``None`` on
+            # broad surfaces like /chat keeps every tool; a scoped mode keeps
+            # only its own tools plus the universal pocket-creation grant.
+            surface_allow = _profile.allow_mcp_tool_ids
         agent_iter = pool.run(
             ctx.target_agent_id,
             user_content,
@@ -466,6 +470,7 @@ async def _drive_agent_loop(
             knowledge_context=knowledge_context,
             instructions=behavior_instructions,
             deny_mcp_tool_ids=surface_deny,
+            allow_mcp_tool_ids=surface_allow,
         ).__aiter__()
 
         async def _next_event() -> Any:

--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -151,11 +151,19 @@ class SurfaceProfile:
         a future slimmed variant (declared, not yet used).
       * ``allowed_sdk_tools`` — optional SDK-tool allowlist (``None`` = no
         surface restriction). Declared for PR 2; not consumed in PR 1.
+      * ``allow_mcp_tool_ids`` — optional per-surface MCP-tool ALLOW-list
+        (``None`` = no restriction, the agent keeps every MCP tool). ENFORCED:
+        when set, the OSS backend keeps only the MCP tools in this set PLUS the
+        universal pocket-creation grant, dropping the rest before the SDK
+        launches. This is how a mode keeps its agent context lean (Files,
+        Foresight, etc. carry only their own tools). Pocket creation stays
+        available everywhere via the grant. ``None`` on every surface today.
       * ``deny_mcp_tool_ids`` — MCP tool ids this surface forbids. ENFORCED: the
         resolved set is threaded to the OSS backend's ``run`` as a plain
         ``frozenset[str]`` (``deny_mcp_tool_ids``) and subtracted from
         ``allowed_tools`` before the SDK launches. Non-empty only on the /sites
-        svelte-create row.
+        svelte-create row. Applied AFTER the allow-list, so a mode can allow a
+        group and still deny a specific id.
       * ``skill_names`` — skills this surface surfaces to the agent. Tested DATA;
         skill-surfacing consumption lands in a later pass.
       * ``system_message_override`` — optional full system-message swap for a
@@ -169,6 +177,7 @@ class SurfaceProfile:
 
     ripple_mode: Literal["on", "off", "trim"]
     allowed_sdk_tools: frozenset[str] | None = None
+    allow_mcp_tool_ids: frozenset[str] | None = None
     deny_mcp_tool_ids: frozenset[str] = field(default_factory=frozenset)
     skill_names: frozenset[str] = field(default_factory=frozenset)
     system_message_override: str | None = None

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -84,48 +84,103 @@ _SITES_SVELTE_CREATE_DENY: frozenset[str] = frozenset(
     }
 )
 
-# The /sites SVELTE-CREATE profile: hand-authored SvelteKit, so ripple OFF, the
-# two ripple-create tools denied, and the create-svelte-site skill surfaced.
-_SITES_SVELTE_CREATE_PROFILE = SurfaceProfile(
-    ripple_mode="off",
-    deny_mcp_tool_ids=_SITES_SVELTE_CREATE_DENY,
-    skill_names=frozenset({"create-svelte-site"}),
-)
+# Per-mode MCP-tool allow-lists keep a chat mode's agent context lean: only the
+# mode's SPECIALIZED tools are named here. The "general everywhere" set — ripple
+# widgets, the pocket lifecycle (read/create/edit/plan), and connectors
+# (composio) — is kept by the OSS backend itself (``ALWAYS_ALLOWED_MCP_SERVERS``
+# + the pocket-creation grant + widget tools), so a scoped mode still renders
+# UI, makes pockets, and uses connectors. Chat stays unmapped → unrestricted.
+#
+# Built lazily + memoized (not at import): pulling the EE mcp-server tool-id
+# constants at module load could cycle with the agent layer, and ``resolve_profile``
+# is on the hot path. Built once on first call; a failed import degrades to
+# ripple-only profiles (unrestricted tools) so tool-scoping can never break chat.
+_PROFILE_CACHE: dict[str, Any] | None = None
 
-# Per-kind static overrides for NON-sites surfaces. Add a row only when a
-# surface needs to deviate from ``_DEFAULT_PROFILE``. /sites is NOT here — it is
-# resolved per-meta in ``resolve_profile``.
-_PROFILES: dict[SurfaceKind, SurfaceProfile] = {}
+
+def _build_profiles() -> dict[str, Any]:
+    sites_allow: frozenset[str] | None
+    foresight_allow: frozenset[str] | None
+    try:
+        from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS
+
+        foresight_allow = frozenset(FORESIGHT_TOOL_IDS)
+        sites_allow = frozenset(SITES_TOOL_IDS)
+    except Exception:  # noqa: BLE001 — degrade to unrestricted, never break chat
+        logger.warning(
+            "surface: could not load mcp tool ids; per-mode scoping disabled",
+            exc_info=True,
+        )
+        foresight_allow = None
+        sites_allow = None
+
+    return {
+        "by_kind": {
+            # Foresight: its scenario tools + the general-everywhere set.
+            SurfaceKind.FORESIGHT: SurfaceProfile(
+                ripple_mode="on", allow_mcp_tool_ids=foresight_allow
+            ),
+            # Files: no specialized MCP tools — document scaffolding runs on the
+            # built-in Read/Write/Edit tools (never filtered). Empty allow-list
+            # = general-everywhere only (drops the other modes' tools). ``None``
+            # when the import degraded, so chat-like breadth is the safe fallback.
+            SurfaceKind.FILES: SurfaceProfile(
+                ripple_mode="on",
+                allow_mcp_tool_ids=frozenset() if sites_allow is not None else None,
+            ),
+        },
+        # /sites is meta-aware (below). Both modes scope to the sites authoring
+        # tools + general. svelte-create additionally denies the two ripple-create
+        # tools (deny runs AFTER allow, so create_svelte survives and the ripple
+        # variants don't) and drops ripple + surfaces the svelte skill.
+        "sites_default": SurfaceProfile(ripple_mode="on", allow_mcp_tool_ids=sites_allow),
+        "sites_svelte_create": SurfaceProfile(
+            ripple_mode="off",
+            deny_mcp_tool_ids=_SITES_SVELTE_CREATE_DENY,
+            allow_mcp_tool_ids=sites_allow,
+            skill_names=frozenset({"create-svelte-site"}),
+        ),
+    }
+
+
+def _profiles() -> dict[str, Any]:
+    global _PROFILE_CACHE
+    if _PROFILE_CACHE is None:
+        _PROFILE_CACHE = _build_profiles()
+    return _PROFILE_CACHE
 
 
 def resolve_profile(surface_kind: SurfaceKind, meta: SurfaceMeta) -> SurfaceProfile:
     """Resolve a ``SurfaceKind`` (+ ``meta``) to its behavioral ``SurfaceProfile``.
 
-    Pure lookup — no I/O, safe to call once per request on the hot chat path.
+    Pure lookup (memoized table; no I/O), safe to call once per request on the
+    hot chat path.
 
     /sites is META-AWARE — it carries three modes, and only the svelte-CREATE
     one loses ripple:
 
       * refine (``meta.pocket_id`` set, ANY engine) edits the existing ripple
-        landing spec → KEEP ripple (``_DEFAULT_PROFILE``). Refine WINS over
+        landing spec → KEEP ripple (``sites_default``). Refine WINS over
         engine: a ``pocket_id`` present means refine even if ``engine="svelte"``.
       * create + svelte (``meta.engine == "svelte"``, no ``pocket_id``)
         hand-authors SvelteKit → DROP ripple, deny the two ripple-create tools,
-        surface the create-svelte-site skill (``_SITES_SVELTE_CREATE_PROFILE``).
+        surface the create-svelte-site skill (``sites_svelte_create``).
       * create + ripple (``engine`` None/"ripple", no ``pocket_id``) authors a
-        ripple landing page → KEEP ripple (``_DEFAULT_PROFILE``).
+        ripple landing page → KEEP ripple (``sites_default``).
 
-    Every other kind (and any unmapped/future kind, and every kind whose policy
-    matches the default) returns ``_DEFAULT_PROFILE`` (``ripple_mode="on"``), so
-    the only surface that deviates from today's behavior is /sites svelte-create.
+    Foresight and Files carry a per-mode MCP allow-list (lean tool set). Every
+    other kind (and any unmapped/future kind) returns ``_DEFAULT_PROFILE``
+    (``ripple_mode="on"``, no tool restriction) — today's behavior, e.g. /chat.
     """
+    profiles = _profiles()
     if surface_kind == SurfaceKind.SITES:
         # refine (pocket_id) edits the existing ripple landing spec → keep ripple.
         # It wins over engine, so check it FIRST.
         if meta.pocket_id is None and meta.engine == "svelte":
-            return _SITES_SVELTE_CREATE_PROFILE
-        return _DEFAULT_PROFILE
-    return _PROFILES.get(surface_kind, _DEFAULT_PROFILE)
+            return profiles["sites_svelte_create"]
+        return profiles["sites_default"]
+    return profiles["by_kind"].get(surface_kind, _DEFAULT_PROFILE)
 
 
 # Handler registry: SurfaceKind -> async callable returning the preamble.

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -6,17 +6,21 @@ existing wire shape consumed by paw-enterprise:
 - ``createdAt``, ``expiresAt``, ``joinedAt`` (camelCase) for timestamps
 - ``memberCount``, ``invitedBy`` (camelCase) for derived/foreign refs
 - ``workspace_name``, ``valid`` for the validate-invite response
+
+Changes: added the slug rule single-source-of-truth (``SLUG_RE`` +
+``RESERVED_SLUGS``) and the ``SlugAvailabilityOut`` response so the create
+UI can check a slug live; ``validate_slug`` now reuses ``SLUG_RE``.
 """
 
 from __future__ import annotations
 
-import re
 from typing import Literal
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.workspace.domain import Invite, VerifiedDomain, Workspace, WorkspaceMember
+from pocketpaw_ee.cloud.workspace.slug import SLUG_RE
 
 # ---------------------------------------------------------------------------
 # Requests (preserved from schemas.py)
@@ -30,7 +34,7 @@ class CreateWorkspaceRequest(BaseModel):
     @field_validator("slug")
     @classmethod
     def validate_slug(cls, v: str) -> str:
-        if not re.match(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$", v):
+        if not SLUG_RE.match(v):
             raise ValueError("Slug must be lowercase alphanumeric with hyphens")
         return v
 
@@ -87,6 +91,19 @@ class WorkspaceOut(BaseModel):
     memberCount: int  # noqa: N815 - camelCase wire key
 
     model_config = {"populate_by_name": True}
+
+
+class SlugAvailabilityOut(BaseModel):
+    """GET /workspaces/slug-available response.
+
+    ``available`` is the headline; ``reason`` names *why* an unavailable slug
+    is unavailable (``invalid`` format, ``reserved`` handle, or already
+    ``taken``) so the create UI can show a precise message live instead of
+    waiting for the POST to 409.
+    """
+
+    available: bool
+    reason: Literal["invalid", "reserved", "taken"] | None = None
 
 
 class MemberOut(BaseModel):
@@ -280,6 +297,7 @@ __all__ = [
     "InviteOut",
     "InvitePreviewResponse",
     "MemberOut",
+    "SlugAvailabilityOut",
     "UpdateDomainRequest",
     "UpdateMemberRoleRequest",
     "UpdateWorkspaceRequest",

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -7,7 +7,7 @@ entities; the router maps to DTOs at the boundary.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from starlette.responses import Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
@@ -36,6 +36,7 @@ from pocketpaw_ee.cloud.workspace.dto import (
     InviteOut,
     InvitePreviewResponse,
     MemberOut,
+    SlugAvailabilityOut,
     UpdateDomainRequest,
     UpdateMemberRoleRequest,
     UpdateWorkspaceRequest,
@@ -68,6 +69,23 @@ async def create_workspace(
 ) -> WorkspaceOut:
     ws = await workspace_service.create(ctx, body)
     return workspace_to_dto(ws)
+
+
+@router.get("/slug-available", response_model=SlugAvailabilityOut)
+async def check_slug_available(
+    slug: str = Query(..., min_length=1, max_length=50),
+    user: User = Depends(current_user),  # signed-in users only reach create
+) -> SlugAvailabilityOut:
+    """Is this workspace slug free to claim?
+
+    Declared before ``GET /{workspace_id}`` so the static path wins the
+    route match. Returns ``available`` plus a ``reason`` (``invalid`` |
+    ``reserved`` | ``taken``) so the create UI shows a precise message live
+    instead of waiting for the POST to 409. The POST is still the
+    source of truth — this is an advisory pre-check, racy by nature.
+    """
+    reason = await workspace_service.slug_reason(slug)
+    return SlugAvailabilityOut(available=reason is None, reason=reason)
 
 
 @router.get("", response_model=list[WorkspaceOut])

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -20,7 +20,9 @@ Public API:
   the plan-feature gate dependency; returns "team" on any failure so the
   dep fails open on plan rather than crashing with a 500.
 
-Changes: added get_workspace_plan helper for plan-feature gate dep.
+Changes: added get_workspace_plan helper for plan-feature gate dep; added
+slug_reason() (format + reserved + uniqueness) backing the live
+slug-available check, and create() now also rejects reserved slugs.
 """
 
 from __future__ import annotations
@@ -73,6 +75,7 @@ from pocketpaw_ee.cloud.workspace.dto import (
     CreateWorkspaceRequest,
     UpdateWorkspaceRequest,
 )
+from pocketpaw_ee.cloud.workspace.slug import SlugReason, static_slug_reason
 
 if TYPE_CHECKING:
     from pocketpaw_ee.cloud.models.user import User
@@ -221,13 +224,33 @@ async def _find_user_id_by_email(email: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace:
+async def slug_reason(slug: str) -> SlugReason | None:
+    """Why ``slug`` can't be claimed, or ``None`` if it's free.
+
+    Layers the DB uniqueness check on top of the static format + reserved
+    gates (``slug.static_slug_reason``). The uniqueness query mirrors
+    ``create``'s exactly — soft-deleted workspaces don't hold their slug —
+    so the live availability answer can't disagree with what create() does.
+    """
+    static = static_slug_reason(slug)
+    if static is not None:
+        return static
     existing = await _WorkspaceDoc.find_one(
-        _WorkspaceDoc.slug == body.slug,
+        _WorkspaceDoc.slug == slug,
         _WorkspaceDoc.deleted_at == None,  # noqa: E711
     )
-    if existing is not None:
+    return "taken" if existing is not None else None
+
+
+async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace:
+    # Format is already enforced by the DTO validator; this catches reserved
+    # handles and the uniqueness race so create() agrees with the live
+    # slug-available check the UI runs first.
+    reason = await slug_reason(body.slug)
+    if reason == "taken":
         raise ConflictError("workspace.slug_taken", f"Slug '{body.slug}' is already in use")
+    if reason == "reserved":
+        raise ConflictError("workspace.slug_reserved", f"Slug '{body.slug}' is reserved")
 
     doc = _WorkspaceDoc(name=body.name, slug=body.slug, owner=ctx.user_id)
     await doc.insert()

--- a/ee/pocketpaw_ee/cloud/workspace/slug.py
+++ b/ee/pocketpaw_ee/cloud/workspace/slug.py
@@ -1,0 +1,99 @@
+"""Workspace slug rules — single source of truth.
+
+New file. Centralizes the slug format regex and the reserved-handle set so
+the create-request validator (``dto.py``), the availability service
+(``service.py``), and the paw-enterprise client (which mirrors these rules
+in ``src/lib/core/workspaces/schemas.ts``) all agree on what a legal,
+claimable slug is. Pure module — no DB, no Beanie imports — so it stays
+cheap to import anywhere.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+# Lowercase alphanumeric with internal hyphens; no leading/trailing hyphen.
+# A single char (``x``, ``7``) is valid. Length is bounded by the DTO Field
+# constraint (1..50), not the regex.
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$")
+
+# Handles that collide with reserved routes / hostnames, or would be
+# confusing as a tenant slug. Lowercase only — slugs are already lowercased
+# by the format rule before this set is consulted.
+RESERVED_SLUGS: frozenset[str] = frozenset(
+    {
+        "about",
+        "account",
+        "accounts",
+        "admin",
+        "api",
+        "app",
+        "apps",
+        "assets",
+        "auth",
+        "billing",
+        "blog",
+        "cdn",
+        "contact",
+        "dashboard",
+        "dns",
+        "docs",
+        "email",
+        "ftp",
+        "health",
+        "help",
+        "internal",
+        "legal",
+        "login",
+        "logout",
+        "mail",
+        "new",
+        "ns",
+        "null",
+        "oauth",
+        "paw",
+        "pocket",
+        "pocketpaw",
+        "pockets",
+        "privacy",
+        "public",
+        "register",
+        "root",
+        "security",
+        "settings",
+        "signin",
+        "signup",
+        "sso",
+        "static",
+        "status",
+        "support",
+        "system",
+        "terms",
+        "test",
+        "undefined",
+        "workspace",
+        "workspaces",
+        "www",
+    }
+)
+
+# Why a slug can't be claimed. ``None`` (returned by the service) means free.
+SlugReason = Literal["invalid", "reserved", "taken"]
+
+
+def static_slug_reason(slug: str) -> SlugReason | None:
+    """Format + reserved-word check, without touching the DB.
+
+    Returns ``"invalid"`` for a malformed slug, ``"reserved"`` for a taken
+    handle, or ``None`` if it passes the static gates (uniqueness is a
+    separate DB check, layered on top by the service).
+    """
+    if not SLUG_RE.match(slug):
+        return "invalid"
+    if slug in RESERVED_SLUGS:
+        return "reserved"
+    return None
+
+
+__all__ = ["RESERVED_SLUGS", "SLUG_RE", "SlugReason", "static_slug_reason"]

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -107,6 +107,19 @@ _DEFAULT_IDENTITY = (
 
 _HTTP_TRANSPORTS: frozenset[str] = frozenset({"http", "sse", "streamable-http"})
 
+# Universal pocket-creation grant. When a surface imposes an MCP allow-list
+# (``SurfaceProfile.allow_mcp_tool_ids``), these ids are always kept on top of
+# the mode's own set so "create a pocket" works from every chat mode — it's the
+# core capability. The create-pocket SKILL is plugin-loaded (not an MCP tool),
+# so it stays available regardless of this grant. Plain ids (no EE import): the
+# allow/deny sets cross the OSS boundary as bare ``frozenset[str]``.
+POCKET_CREATION_GRANT: frozenset[str] = frozenset(
+    {
+        "mcp__pocketpaw_pocket_specialist__create",
+        "mcp__pocketpaw_pocket_planner__plan_pocket",
+    }
+)
+
 
 class ClaudeSDKBackend(BaseAgentBackend):
     """Claude Agent SDK backend — the recommended default.
@@ -897,6 +910,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         history: list[dict] | None = None,
         session_key: str | None = None,
         deny_mcp_tool_ids: frozenset[str] = frozenset(),
+        allow_mcp_tool_ids: frozenset[str] | None = None,
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
 
@@ -910,6 +924,13 @@ class ClaudeSDKBackend(BaseAgentBackend):
         /sites svelte-create surface, where it forbids the two ripple-create
         tools so the agent cannot fall back to a rippleSpec landing page. This
         is the typed replacement for the deleted prompt-sniffing gate.
+
+        ``allow_mcp_tool_ids`` is the per-surface MCP-tool ALLOW-list. ``None``
+        (the default) keeps every MCP tool. When a surface sets it, only the
+        MCP tools in it — PLUS the universal ``POCKET_CREATION_GRANT`` — survive;
+        the rest are dropped before launch so a mode's agent context stays lean.
+        Non-MCP (built-in SDK) tools are never touched by this filter. Applied
+        BEFORE ``deny_mcp_tool_ids``.
         """
         if not self._sdk_available:
             yield AgentEvent(
@@ -1122,6 +1143,26 @@ class ClaudeSDKBackend(BaseAgentBackend):
             # both read tools (get_pocket / list_pockets) and the writable
             # ``add_widget`` tool — they all flow through the loop below.
             allowed_tools.extend(self._collect_mcp_tool_ids())
+
+            # Per-surface MCP-tool ALLOW-list (threaded from the resolved
+            # ``SurfaceProfile``). ``None`` keeps every MCP tool (legacy / broad
+            # surfaces like /chat). When set, a mode keeps only its own MCP
+            # tools plus the universal pocket-creation grant, so files /
+            # foresight / etc. carry a lean tool set instead of every server's
+            # ids. Built-in SDK tools (Read/Write/Bash/...) are never filtered
+            # here — only ``mcp__*`` ids — so scoping a mode can't strip the
+            # agent's core file/shell tools. Applied BEFORE the deny filter.
+            if allow_mcp_tool_ids is not None:
+                grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT
+                before_count = len(allowed_tools)
+                allowed_tools = [
+                    t for t in allowed_tools if not t.startswith("mcp__") or t in grant
+                ]
+                if len(allowed_tools) < before_count:
+                    logger.info(
+                        "Surface tool-allow: scoped MCP tools to %s (+ pocket grant)",
+                        sorted(allow_mcp_tool_ids),
+                    )
 
             # Per-surface MCP-tool deny set (threaded from the chat loop's
             # resolved ``SurfaceProfile``). Any denied id is subtracted from the

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -120,6 +120,27 @@ POCKET_CREATION_GRANT: frozenset[str] = frozenset(
     }
 )
 
+# MCP servers whose tools survive ANY per-surface allow-list — the "general
+# tools everywhere" set: connectors (composio) plus the pocket lifecycle
+# (read / widget edit / create / edit / plan). A mode's allow-list only needs
+# to name its SPECIALIZED tools (foresight scenarios, sites authoring); these
+# servers are always available so every mode can still use connectors and
+# build/edit pockets. Server is the ``<server>`` in ``mcp__<server>__<tool>``.
+ALWAYS_ALLOWED_MCP_SERVERS: frozenset[str] = frozenset(
+    {
+        "composio",
+        "pocketpaw_pocket",
+        "pocketpaw_pocket_specialist",
+        "pocketpaw_pocket_planner",
+    }
+)
+
+
+def _mcp_server_of(tool_id: str) -> str:
+    """Extract ``<server>`` from an ``mcp__<server>__<tool>`` id (else "")."""
+    parts = tool_id.split("__")
+    return parts[1] if len(parts) >= 2 and parts[0] == "mcp" else ""
+
 
 class ClaudeSDKBackend(BaseAgentBackend):
     """Claude Agent SDK backend — the recommended default.
@@ -1153,14 +1174,24 @@ class ClaudeSDKBackend(BaseAgentBackend):
             # here — only ``mcp__*`` ids — so scoping a mode can't strip the
             # agent's core file/shell tools. Applied BEFORE the deny filter.
             if allow_mcp_tool_ids is not None:
-                grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT
+                from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+
+                # Kept on top of the mode's set: the pocket-creation grant and
+                # the ripple widget-spec tools (UI rendering stays on every
+                # surface where the ripple LAW is active). Connectors + the
+                # pocket lifecycle are kept via ALWAYS_ALLOWED_MCP_SERVERS.
+                grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT | frozenset(WIDGET_TOOL_IDS)
                 before_count = len(allowed_tools)
                 allowed_tools = [
-                    t for t in allowed_tools if not t.startswith("mcp__") or t in grant
+                    t
+                    for t in allowed_tools
+                    if not t.startswith("mcp__")
+                    or t in grant
+                    or _mcp_server_of(t) in ALWAYS_ALLOWED_MCP_SERVERS
                 ]
                 if len(allowed_tools) < before_count:
                     logger.info(
-                        "Surface tool-allow: scoped MCP tools to %s (+ pocket grant)",
+                        "Surface tool-allow: scoped MCP tools to %s (+ general grant)",
                         sorted(allow_mcp_tool_ids),
                     )
 

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -169,6 +169,7 @@ class AgentPool:
         knowledge_context: str = "",
         instructions: str = "",
         deny_mcp_tool_ids: frozenset[str] = frozenset(),
+        allow_mcp_tool_ids: frozenset[str] | None = None,
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -188,6 +189,12 @@ class AgentPool:
         SDK backend — the one backend that consumes it — without passing an
         unexpected kwarg to backends that don't accept it. Empty for every
         surface except /sites svelte-create, so ordinary runs are untouched.
+
+        ``allow_mcp_tool_ids`` is the per-surface MCP-tool allow-list (also
+        from the ``SurfaceProfile``). Forwarded only when not ``None`` so it
+        reaches the Claude SDK backend without tripping the narrower backend
+        signatures. ``None`` for broad surfaces (/chat), so ordinary runs keep
+        every tool.
         """
         instance = await self.get(agent_id)
         instance.last_active = datetime.now(UTC)
@@ -278,6 +285,8 @@ class AgentPool:
             }
             if deny_mcp_tool_ids:
                 run_kwargs["deny_mcp_tool_ids"] = deny_mcp_tool_ids
+            if allow_mcp_tool_ids is not None:
+                run_kwargs["allow_mcp_tool_ids"] = allow_mcp_tool_ids
             async for event in instance.backend.run(message, **run_kwargs):
                 instance.last_active = datetime.now(UTC)
                 yield event

--- a/tests/cloud/auth/test_password_policy.py
+++ b/tests/cloud/auth/test_password_policy.py
@@ -22,9 +22,17 @@ def hibp_off(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 async def test_too_short(hibp_off: None) -> None:
+    # 5 chars, fully complex (upper/lower/digit/symbol) but one below the
+    # 6-char minimum — length gate must still fire before the other checks.
     with pytest.raises(InvalidPasswordException) as exc:
-        await password_policy.validate_password_async("Aa1!aaaa", email="x@y.z")
+        await password_policy.validate_password_async("Ab1!c", email="x@y.z")
     assert exc.value.reason == "too_short"
+
+
+async def test_min_length_boundary_passes(hibp_off: None) -> None:
+    # Exactly 6 chars, fully complex — clears the length gate and the rest
+    # of the policy (HIBP disabled here), so no exception is raised.
+    await password_policy.validate_password_async("Ab1!cd", email="x@y.z")
 
 
 async def test_missing_uppercase(hibp_off: None) -> None:

--- a/tests/cloud/test_surface_profile.py
+++ b/tests/cloud/test_surface_profile.py
@@ -147,3 +147,51 @@ def test_resolve_profile_sites_refine_keeps_ripple():
         assert profile.deny_mcp_tool_ids == frozenset(), (
             f"refine meta {meta!r} must deny nothing — it edits an existing ripple spec"
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-mode MCP tool allow-lists (feat/per-mode-tool-scope). Foresight / Files /
+# Sites carry a lean ``allow_mcp_tool_ids``; Chat stays unrestricted. The
+# "general everywhere" set (widgets, pocket lifecycle, connectors) is enforced
+# by the OSS backend, so these tests only pin the per-mode SPECIALIZED scoping.
+# ---------------------------------------------------------------------------
+
+
+def test_chat_profile_is_unrestricted():
+    """The broad /chat surface keeps every tool — allow-list stays None."""
+    profile = resolve_profile(SurfaceKind.CHAT, SurfaceMeta())
+    assert profile.allow_mcp_tool_ids is None
+
+
+def test_foresight_profile_scopes_to_foresight_tools():
+    from pocketpaw_ee.agent.mcp_servers.foresight import RUN_SCENARIO_TOOL_ID
+
+    profile = resolve_profile(SurfaceKind.FORESIGHT, SurfaceMeta())
+    assert profile.allow_mcp_tool_ids is not None
+    # Its own scenario tools are named…
+    assert RUN_SCENARIO_TOOL_ID in profile.allow_mcp_tool_ids
+    # …but another mode's specialized tool is NOT (that's the lean win; the
+    # general-everywhere tools are added by the OSS backend, not here).
+    assert "mcp__pocketpaw_tasks__create_task" not in profile.allow_mcp_tool_ids
+
+
+def test_files_profile_scopes_to_general_only():
+    """Files names no specialized MCP tools — empty allow-list means general
+    everywhere only (document scaffolding rides built-in Write/Edit)."""
+    profile = resolve_profile(SurfaceKind.FILES, SurfaceMeta())
+    assert profile.allow_mcp_tool_ids == frozenset()
+
+
+def test_sites_profiles_scope_to_sites_tools():
+    from pocketpaw_ee.agent.mcp_servers.sites import CREATE_SVELTE_SITE_TOOL_ID
+
+    ripple_create = resolve_profile(SurfaceKind.SITES, SurfaceMeta())
+    assert ripple_create.allow_mcp_tool_ids is not None
+    assert CREATE_SVELTE_SITE_TOOL_ID in ripple_create.allow_mcp_tool_ids
+
+    svelte_create = resolve_profile(SurfaceKind.SITES, SurfaceMeta(engine="svelte"))
+    # svelte-create both allows the sites tools AND denies the two ripple-create
+    # ids (deny runs after allow, so create_svelte survives, ripple variants don't).
+    assert svelte_create.allow_mcp_tool_ids is not None
+    assert CREATE_SVELTE_SITE_TOOL_ID in svelte_create.allow_mcp_tool_ids
+    assert "mcp__pocketpaw_sites_manager__create_landing_site" in svelte_create.deny_mcp_tool_ids

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -126,6 +126,44 @@ async def test_create_rejects_duplicate_slug(owner) -> None:
         )
 
 
+async def test_create_rejects_reserved_slug(owner) -> None:
+    with pytest.raises(ConflictError) as exc:
+        await workspace_service.create(
+            _ctx(str(owner.id)), CreateWorkspaceRequest(name="Admin", slug="admin")
+        )
+    assert exc.value.code == "workspace.slug_reserved"
+
+
+async def test_slug_reason_available_for_fresh_slug(owner) -> None:
+    assert await workspace_service.slug_reason("brand-new") is None
+
+
+async def test_slug_reason_taken_after_create(owner) -> None:
+    await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="taken-one")
+    )
+    assert await workspace_service.slug_reason("taken-one") == "taken"
+
+
+async def test_slug_reason_reserved() -> None:
+    assert await workspace_service.slug_reason("api") == "reserved"
+
+
+async def test_slug_reason_invalid_format() -> None:
+    assert await workspace_service.slug_reason("Not A Slug") == "invalid"
+
+
+async def test_slug_reason_free_again_after_soft_delete(owner) -> None:
+    # Mirrors create()'s uniqueness query: a soft-deleted workspace must not
+    # keep holding its slug, so the slug reads as available again.
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="recyclable")
+    )
+    assert await workspace_service.slug_reason("recyclable") == "taken"
+    await workspace_service.delete(_ctx(str(owner.id)), ws.id)
+    assert await workspace_service.slug_reason("recyclable") is None
+
+
 async def test_update_emits_workspace_updated(owner, recording_bus) -> None:
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")

--- a/tests/cloud/workspace/test_slug.py
+++ b/tests/cloud/workspace/test_slug.py
@@ -1,0 +1,45 @@
+"""Tests for the workspace slug rules (``workspace/slug.py``).
+
+New file. Covers the pure (no-DB) gates — format regex and the reserved
+set — that the create-request validator, the availability service, and the
+paw-enterprise client all share. The DB-backed ``taken`` path is exercised
+separately in ``test_service_v2.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.workspace.slug import (
+    RESERVED_SLUGS,
+    SLUG_RE,
+    static_slug_reason,
+)
+
+
+@pytest.mark.parametrize("slug", ["acme-corp", "x", "7", "test-workspace-1", "a1b2"])
+def test_valid_slugs_match(slug: str) -> None:
+    assert SLUG_RE.match(slug) is not None
+    assert static_slug_reason(slug) is None
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["Invalid Slug!", "-bad", "bad-", "BadSlug", "", "has space", "under_score", "emoji😀"],
+)
+def test_malformed_slugs_are_invalid(slug: str) -> None:
+    assert static_slug_reason(slug) == "invalid"
+
+
+@pytest.mark.parametrize("slug", ["admin", "api", "www", "settings", "pocketpaw"])
+def test_reserved_slugs_are_reserved(slug: str) -> None:
+    # Well-formed but reserved → "reserved", not "invalid".
+    assert SLUG_RE.match(slug) is not None
+    assert static_slug_reason(slug) == "reserved"
+
+
+def test_reserved_set_is_all_lowercase_and_well_formed() -> None:
+    # Every reserved entry must itself be a legal slug, otherwise it could
+    # never collide with a user-supplied (already format-checked) value.
+    for handle in RESERVED_SLUGS:
+        assert handle == handle.lower()
+        assert SLUG_RE.match(handle) is not None

--- a/tests/cloud/workspace/test_slug_available_route.py
+++ b/tests/cloud/workspace/test_slug_available_route.py
@@ -1,0 +1,67 @@
+"""HTTP contract test for GET /workspaces/slug-available.
+
+New file. Builds a tiny FastAPI app with the workspace router mounted and
+the auth/license deps overridden (same shape as test_connectors_router),
+then exercises the live slug-availability route over httpx against an
+isolated mongomock-motor DB. The route's reason for existing is that it
+must be matched *before* ``GET /{workspace_id}`` — these tests fail loudly
+if that ordering ever regresses (the param route would 404/500 on the
+literal "slug-available").
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.deps import current_user
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+from pocketpaw_ee.cloud.workspace.router import router as workspace_router
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _no_op_license() -> None:
+    return None
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db) -> AsyncClient:  # noqa: ARG001 — fixture wires Beanie
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(workspace_router)
+    # The route doesn't use the returned user, only the auth gate — any
+    # truthy object satisfies it.
+    app.dependency_overrides[current_user] = lambda: object()
+    app.dependency_overrides[require_license] = _no_op_license
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+async def test_slug_available_returns_available(client: AsyncClient) -> None:
+    resp = await client.get("/workspaces/slug-available", params={"slug": "fresh-one"})
+    assert resp.status_code == 200
+    assert resp.json() == {"available": True, "reason": None}
+
+
+async def test_slug_available_reports_taken(client: AsyncClient) -> None:
+    await _WorkspaceDoc(name="Acme", slug="acme", owner="u1").insert()
+    resp = await client.get("/workspaces/slug-available", params={"slug": "acme"})
+    assert resp.status_code == 200
+    assert resp.json() == {"available": False, "reason": "taken"}
+
+
+async def test_slug_available_reports_reserved(client: AsyncClient) -> None:
+    resp = await client.get("/workspaces/slug-available", params={"slug": "admin"})
+    assert resp.status_code == 200
+    assert resp.json() == {"available": False, "reason": "reserved"}
+
+
+async def test_slug_available_reports_invalid_format(client: AsyncClient) -> None:
+    resp = await client.get("/workspaces/slug-available", params={"slug": "Bad-Slug"})
+    assert resp.status_code == 200
+    assert resp.json() == {"available": False, "reason": "invalid"}

--- a/tests/test_claude_sdk_allow_mcp_tools.py
+++ b/tests/test_claude_sdk_allow_mcp_tools.py
@@ -1,0 +1,90 @@
+# tests/test_claude_sdk_allow_mcp_tools.py — Per-surface MCP-tool ALLOW-list (OSS).
+#
+# Created: 2026-06-06 (feat/per-mode-tool-scope) — companion to the threaded
+# deny gate (test_claude_sdk_deny_mcp_tools.py). A surface can now hand the
+# backend an ``allow_mcp_tool_ids`` set so a chat mode (files, foresight, ...)
+# carries only its own MCP tools instead of every server's ids, keeping the
+# agent context lean. Two invariants the backend must hold:
+#   1. built-in SDK tools (Read/Write/Bash/Skill/Web*) are NEVER filtered — the
+#      allow-list only narrows ``mcp__*`` ids, so scoping a mode can't strip the
+#      agent's core file/shell tools.
+#   2. the universal POCKET_CREATION_GRANT always survives, even when a mode's
+#      allow set doesn't name it — "create a pocket" works from every mode.
+from __future__ import annotations
+
+import inspect
+
+from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT, ClaudeSDKBackend
+
+_SPECIALIST_CREATE = "mcp__pocketpaw_pocket_specialist__create"
+_PLAN_POCKET = "mcp__pocketpaw_pocket_planner__plan_pocket"
+_SCENARIO_RUN = "mcp__pocketpaw_foresight__run_scenario"
+_TASKS = "mcp__pocketpaw_tasks__create_task"
+_PUBLISH = "mcp__pocketpaw_sites_manager__publish"
+
+# A broad toolset like /chat would launch with: built-ins + many MCP servers.
+_FULL_TOOLSET = [
+    "Read",
+    "Write",
+    "Bash",
+    "Skill",
+    "WebSearch",
+    _SCENARIO_RUN,
+    _TASKS,
+    _PUBLISH,
+    _SPECIALIST_CREATE,
+    _PLAN_POCKET,
+]
+
+
+def _apply_allow(allowed_tools: list[str], allow_mcp_tool_ids: frozenset[str] | None) -> list[str]:
+    """Mirror the filter the backend runs inside ``run()``.
+
+    ``None`` keeps every tool. Otherwise keep all non-``mcp__`` tools plus the
+    MCP ids in (allow ∪ POCKET_CREATION_GRANT). Kept tiny + pure so the test
+    pins the SAME expression the backend uses.
+    """
+    if allow_mcp_tool_ids is None:
+        return list(allowed_tools)
+    grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT
+    return [t for t in allowed_tools if not t.startswith("mcp__") or t in grant]
+
+
+def test_run_accepts_allow_kwarg_defaulting_none() -> None:
+    params = inspect.signature(ClaudeSDKBackend.run).parameters
+    assert "allow_mcp_tool_ids" in params, (
+        "ClaudeSDKBackend.run must accept a threaded allow_mcp_tool_ids kwarg"
+    )
+    assert params["allow_mcp_tool_ids"].default is None, (
+        "allow_mcp_tool_ids must default to None so unscoped surfaces keep every tool"
+    )
+
+
+def test_none_allow_keeps_all_tools() -> None:
+    """The default (broad surfaces like /chat) leaves the allowlist untouched."""
+    assert _apply_allow(_FULL_TOOLSET, None) == _FULL_TOOLSET
+
+
+def test_allow_scopes_mcp_but_keeps_builtins_and_grant() -> None:
+    """A foresight-style allow set keeps foresight MCP tools + built-ins + the
+    universal pocket-creation grant, and drops unrelated MCP servers."""
+    foresight_allow = frozenset({_SCENARIO_RUN})
+    gated = _apply_allow(_FULL_TOOLSET, foresight_allow)
+
+    # The mode's own MCP tool survives.
+    assert _SCENARIO_RUN in gated
+    # Unrelated MCP servers are dropped — this is the lean-context win.
+    assert _TASKS not in gated
+    assert _PUBLISH not in gated
+    # Built-in SDK tools are never filtered by the MCP allow-list.
+    for builtin in ("Read", "Write", "Bash", "Skill", "WebSearch"):
+        assert builtin in gated
+    # The universal pocket-creation grant survives even though the allow set
+    # never named it — create-a-pocket works from every mode.
+    assert _SPECIALIST_CREATE in gated
+    assert _PLAN_POCKET in gated
+
+
+def test_grant_constant_is_pocket_creation() -> None:
+    assert _SPECIALIST_CREATE in POCKET_CREATION_GRANT
+    assert _PLAN_POCKET in POCKET_CREATION_GRANT

--- a/tests/test_claude_sdk_allow_mcp_tools.py
+++ b/tests/test_claude_sdk_allow_mcp_tools.py
@@ -14,10 +14,19 @@ from __future__ import annotations
 
 import inspect
 
-from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT, ClaudeSDKBackend
+from pocketpaw.agents.claude_sdk import (
+    ALWAYS_ALLOWED_MCP_SERVERS,
+    POCKET_CREATION_GRANT,
+    ClaudeSDKBackend,
+    _mcp_server_of,
+)
 
 _SPECIALIST_CREATE = "mcp__pocketpaw_pocket_specialist__create"
+_SPECIALIST_EDIT = "mcp__pocketpaw_pocket_specialist__edit"
 _PLAN_POCKET = "mcp__pocketpaw_pocket_planner__plan_pocket"
+_POCKET_GET = "mcp__pocketpaw_pocket__get_pocket"
+_WIDGET_SPEC = "mcp__pocketpaw_widgets__get_widget_spec"
+_COMPOSIO = "mcp__composio__GMAIL_SEND_EMAIL"
 _SCENARIO_RUN = "mcp__pocketpaw_foresight__run_scenario"
 _TASKS = "mcp__pocketpaw_tasks__create_task"
 _PUBLISH = "mcp__pocketpaw_sites_manager__publish"
@@ -29,10 +38,14 @@ _FULL_TOOLSET = [
     "Bash",
     "Skill",
     "WebSearch",
+    _WIDGET_SPEC,
+    _POCKET_GET,
+    _COMPOSIO,
     _SCENARIO_RUN,
     _TASKS,
     _PUBLISH,
     _SPECIALIST_CREATE,
+    _SPECIALIST_EDIT,
     _PLAN_POCKET,
 ]
 
@@ -40,14 +53,21 @@ _FULL_TOOLSET = [
 def _apply_allow(allowed_tools: list[str], allow_mcp_tool_ids: frozenset[str] | None) -> list[str]:
     """Mirror the filter the backend runs inside ``run()``.
 
-    ``None`` keeps every tool. Otherwise keep all non-``mcp__`` tools plus the
-    MCP ids in (allow ∪ POCKET_CREATION_GRANT). Kept tiny + pure so the test
-    pins the SAME expression the backend uses.
+    ``None`` keeps every tool. Otherwise keep all non-``mcp__`` tools, the MCP
+    ids in (allow ∪ pocket-creation grant ∪ widget tools), and any tool whose
+    server is always-allowed (connectors + pocket lifecycle). Kept tiny + pure
+    so the test pins the SAME logic the backend uses.
     """
     if allow_mcp_tool_ids is None:
         return list(allowed_tools)
-    grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT
-    return [t for t in allowed_tools if not t.startswith("mcp__") or t in grant]
+    grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT | {_WIDGET_SPEC}
+    return [
+        t
+        for t in allowed_tools
+        if not t.startswith("mcp__")
+        or t in grant
+        or _mcp_server_of(t) in ALWAYS_ALLOWED_MCP_SERVERS
+    ]
 
 
 def test_run_accepts_allow_kwarg_defaulting_none() -> None:
@@ -65,26 +85,37 @@ def test_none_allow_keeps_all_tools() -> None:
     assert _apply_allow(_FULL_TOOLSET, None) == _FULL_TOOLSET
 
 
-def test_allow_scopes_mcp_but_keeps_builtins_and_grant() -> None:
-    """A foresight-style allow set keeps foresight MCP tools + built-ins + the
-    universal pocket-creation grant, and drops unrelated MCP servers."""
+def test_allow_scopes_mcp_but_keeps_general_everywhere() -> None:
+    """A foresight-style allow set keeps foresight tools + built-ins + the
+    'general everywhere' set (pocket lifecycle, ripple widgets, connectors),
+    and drops the other modes' specialized tools."""
     foresight_allow = frozenset({_SCENARIO_RUN})
     gated = _apply_allow(_FULL_TOOLSET, foresight_allow)
 
     # The mode's own MCP tool survives.
     assert _SCENARIO_RUN in gated
-    # Unrelated MCP servers are dropped — this is the lean-context win.
+    # Other modes' specialized tools are dropped — the lean-context win.
     assert _TASKS not in gated
     assert _PUBLISH not in gated
     # Built-in SDK tools are never filtered by the MCP allow-list.
     for builtin in ("Read", "Write", "Bash", "Skill", "WebSearch"):
         assert builtin in gated
-    # The universal pocket-creation grant survives even though the allow set
-    # never named it — create-a-pocket works from every mode.
-    assert _SPECIALIST_CREATE in gated
-    assert _PLAN_POCKET in gated
+    # General-everywhere survives without being named in the allow set:
+    assert _SPECIALIST_CREATE in gated  # pocket creation grant
+    assert _PLAN_POCKET in gated  # pocket creation grant
+    assert _SPECIALIST_EDIT in gated  # pocket lifecycle (always-allowed server)
+    assert _POCKET_GET in gated  # pocket read (always-allowed server)
+    assert _WIDGET_SPEC in gated  # ripple rendering
+    assert _COMPOSIO in gated  # connectors (always-allowed server)
 
 
 def test_grant_constant_is_pocket_creation() -> None:
     assert _SPECIALIST_CREATE in POCKET_CREATION_GRANT
     assert _PLAN_POCKET in POCKET_CREATION_GRANT
+
+
+def test_always_allowed_servers_cover_connectors_and_pocket() -> None:
+    assert "composio" in ALWAYS_ALLOWED_MCP_SERVERS
+    assert "pocketpaw_pocket" in ALWAYS_ALLOWED_MCP_SERVERS
+    assert _mcp_server_of(_COMPOSIO) == "composio"
+    assert _mcp_server_of("Read") == ""


### PR DESCRIPTION
Stacked on #1348.

## Why

Every chat mode loaded every MCP tool, so the Files and Foresight agents carried the full pocket / sites / tasks / meetings / decisions / foresight surface even though they only need a slice of it. That bloats the context window. This scopes a mode to its own tools while keeping the things you want available everywhere.

## What's available everywhere (no matter the mode)

The OSS backend always keeps:
- ripple widget tools (UI rendering stays on),
- the pocket lifecycle — read / create / edit / plan (`ALWAYS_ALLOWED_MCP_SERVERS` + the pocket-creation grant), so you can make and edit pockets from any mode,
- connectors (composio), matched by server so its dynamic tool ids pass through,
- built-in Read / Write / Bash / Web / Skill — the allow-list only ever narrows `mcp__*` ids.

## What each mode adds

- **Foresight** → the foresight scenario tools.
- **Files** → nothing extra. Document scaffolding runs on the built-in Write/Edit tools, so the mode is genuinely lean (just general + built-ins).
- **Sites** → the sites authoring tools; the svelte-create sub-mode still denies the two ripple-create ids on top (deny runs after allow, so `create_svelte` survives).
- **Chat** stays unmapped and unrestricted — the do-anything surface.

## Mechanism

Two commits: the first adds `SurfaceProfile.allow_mcp_tool_ids` and threads it through `pool.run` into the Claude SDK backend (mirroring the existing deny path), with the universal grant. The second populates the per-mode lists.

The profile table is built lazily and memoized, and **degrades to unrestricted** if the tool-id constants can't be imported — tool-scoping can never break chat.

## Tests

`tests/test_claude_sdk_allow_mcp_tools.py` (filter logic + grant + always-allowed servers) and new cases in `tests/cloud/test_surface_profile.py` (each mode's allow-list, chat unrestricted, sites allow+deny interaction). Existing surface + runs suites stay green (101 tests).

## For review

The split between "general everywhere" and "specialized per mode" is a judgment call — tasks / meetings / decisions are currently treated as specialized (dropped from scoped modes, kept in broad chat). Easy to promote any of them to the general set if you'd rather they stay everywhere.