### PR TITLE
Deploy published Paw Sites to the Cloudflare edge

### DIFF
--- a/ee/pocketpaw_ee/sites/cloudflare_client.py
+++ b/ee/pocketpaw_ee/sites/cloudflare_client.py
@@ -1,11 +1,38 @@
 # ee/pocketpaw_ee/sites/cloudflare_client.py — async Cloudflare API client for
-# the Sites control plane. Two surfaces:
-#   * Workers for Platforms — PUT a user Worker into our dispatch namespace
-#     (one synchronous call per site; live on 200; no per-account script cap).
-#   * Cloudflare for SaaS — create a custom hostname, return the single CNAME
-#     the client pastes, poll validation + TLS status.
+# the Sites control plane. Surfaces:
+#   * Workers for Platforms — deploy a generated SvelteKit site (adapter-cloudflare
+#     output) into our dispatch namespace as one user Worker tagged by site id.
+#   * Cloudflare for SaaS — create a custom hostname, return the single CNAME the
+#     client pastes, poll validation + TLS status, verify it end to end.
 # httpx-based; account id + token come from settings (env), not per-tenant rows
-# in v1. Non-2xx raises a CloudError so the standard envelope applies.
+# in v1. Non-2xx raises a ValidationError so the standard envelope applies.
+#
+# Updated 2026-06-06 (feat/1346-cf-deploy — Cloudflare deploy pipeline):
+#   * NEW deploy_site(): the REAL edge-deploy entry point the publish path uses.
+#     A SvelteKit adapter-cloudflare build is NOT a single module — it emits a
+#     _worker.js entry, a _routes.json, and a static-assets tree (_app/…, the
+#     prerendered marketing HTML). A bare single-module PUT (the old put_worker)
+#     would deploy a worker with NO static assets and NO bindings, so the
+#     prerendered routes 404 and the form endpoint's D1/Queue bindings are
+#     missing — which is exactly why "the preview URL is dead" (issue #1346).
+#     deploy_site does the correct upload:
+#       1. Workers Assets two-step — open an upload session for the static tree,
+#          upload the files the API reports missing, receive a completion JWT.
+#       2. Multipart script PUT to the dispatch namespace with a `metadata` part
+#          (main_module, compatibility_date/flags, the bindings parsed from the
+#          generated wrangler.toml, and the assets {jwt, config}) + the worker
+#          module part. Live on 200.
+#     bindings + compatibility settings are read FROM the generated wrangler.toml
+#     (the generator stays the source of truth) via _read_wrangler_config().
+#   * NEW verify_domain(): re-poll a custom hostname and report whether it has
+#     reached LIVE (CNAME seen + TLS active) — the backend half of the
+#     DomainsPanel "Verify" action. Thin wrapper over get_hostname_status so the
+#     status mapping stays in one place.
+#   * NEW live_url_for(): the stable *.workers.dev-style URL a deployed script is
+#     reachable at, derived from the configured dispatch base. Returned by
+#     deploy_site so the caller can persist a real openable address.
+#   * put_worker() is kept verbatim for back-compat (callers/tests that upload a
+#     raw single module). deploy_site is the path publish() should take.
 #
 # Secret handling: the CF API token lives only in the in-memory Authorization
 # header — never logged, never written to disk. All errors fail closed (raise
@@ -14,12 +41,29 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import json
+import os
+import tomllib
+from pathlib import Path
+from typing import Any
+
 import httpx
 
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus
 
 _CF_API = "https://api.cloudflare.com/client/v4"
+
+# adapter-cloudflare emits the deployable artifact here (same dir the local
+# server serves and the bundle reader reads _worker.js from).
+_CLOUDFLARE_BUILD_REL = ".svelte-kit/cloudflare"
+_WORKER_ENTRY = "_worker.js"
+# Files the SvelteKit Cloudflare build emits that are NOT user-servable static
+# assets — they configure the deploy, not the site, so they are excluded from the
+# Workers Assets upload.
+_NON_ASSET_FILES = {_WORKER_ENTRY, "_routes.json", "_headers", "_redirects"}
 
 
 def _map_status(cf_status: str, ssl_status: str) -> HostnameStatus:
@@ -32,6 +76,57 @@ def _map_status(cf_status: str, ssl_status: str) -> HostnameStatus:
     return HostnameStatus.ERROR
 
 
+def _read_wrangler_config(project_dir: str) -> dict[str, Any]:
+    """Parse the generated wrangler.toml into the deploy metadata's
+    compatibility settings + bindings. The generator is the source of truth for
+    what the worker binds (D1, Queues), so we read its config rather than
+    hardcode it here. Missing file → empty config (a static-only worker with no
+    bindings still deploys)."""
+    path = Path(project_dir, "wrangler.toml")
+    if not path.is_file():
+        return {"compatibility_date": None, "compatibility_flags": [], "bindings": []}
+    raw = tomllib.loads(path.read_text())
+    bindings: list[dict[str, Any]] = []
+    for d1 in raw.get("d1_databases", []) or []:
+        # A site with an unprovisioned D1 (database_id still the __TOKEN__ or
+        # empty) is static-only — skip the binding so the deploy doesn't fail on
+        # a non-existent database. Dynamic sites carry a real id (RFC 12 A2).
+        db_id = (d1.get("database_id") or "").strip()
+        if not db_id or db_id.startswith("__"):
+            continue
+        bindings.append({"type": "d1", "name": d1["binding"], "id": db_id})
+    for prod in raw.get("queues", {}).get("producers", []) or []:
+        bindings.append({"type": "queue", "name": prod["binding"], "queue_name": prod["queue"]})
+    return {
+        "compatibility_date": raw.get("compatibility_date"),
+        "compatibility_flags": raw.get("compatibility_flags", []) or [],
+        "bindings": bindings,
+    }
+
+
+def _collect_assets(project_dir: str) -> dict[str, Path]:
+    """Map each static asset's server path ("/_app/…", "/index.html", …) to its
+    file on disk, walking the adapter-cloudflare output and excluding the worker
+    entry + the deploy-config files. These are what the Workers Assets session
+    uploads so the prerendered marketing routes are actually served."""
+    root = Path(project_dir, _CLOUDFLARE_BUILD_REL)
+    assets: dict[str, Path] = {}
+    for f in root.rglob("*"):
+        if not f.is_file():
+            continue
+        rel = f.relative_to(root).as_posix()
+        if rel in _NON_ASSET_FILES:
+            continue
+        assets["/" + rel] = f
+    return assets
+
+
+def _hash_asset(data: bytes) -> str:
+    """The content hash the Workers Assets API keys files by (sha256 hex,
+    truncated to 32 chars — Cloudflare's manifest hash length)."""
+    return hashlib.sha256(data).hexdigest()[:32]
+
+
 class CloudflareClient:
     def __init__(
         self,
@@ -40,16 +135,25 @@ class CloudflareClient:
         api_token: str,
         zone_id: str,
         dispatch_namespace: str,
+        dispatch_base: str | None = None,
         _transport: httpx.BaseTransport | None = None,
     ) -> None:
         self._account_id = account_id
         self._zone_id = zone_id
         self._namespace = dispatch_namespace
+        # The hostname deployed scripts are reachable at, e.g.
+        # "paw-sites.example.workers.dev" or a Cloudflare-for-SaaS fallback
+        # origin. Per-site URL is "https://<base>/<script_name>/". Configured via
+        # PAW_CF_DISPATCH_BASE; falls back to the namespace name so a URL is
+        # always returned (the custom domain is the real public address).
+        self._dispatch_base = dispatch_base or os.environ.get(
+            "PAW_CF_DISPATCH_BASE", f"{dispatch_namespace}.workers.dev"
+        )
         self._headers = {"Authorization": f"Bearer {api_token}"}
         self._transport = _transport  # tests inject a MockTransport
 
     def _client(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(headers=self._headers, transport=self._transport, timeout=30.0)
+        return httpx.AsyncClient(headers=self._headers, transport=self._transport, timeout=60.0)
 
     @staticmethod
     def _unwrap(resp: httpx.Response) -> dict:
@@ -61,8 +165,130 @@ class CloudflareClient:
             raise ValidationError("sites.cloudflare_error", str(errs[0].get("message")))
         return body.get("result", {})
 
+    def live_url_for(self, script_name: str) -> str:
+        """The stable URL a deployed dispatch-namespace script is served at. The
+        custom domain (Cloudflare for SaaS) is the real public address; this is
+        the always-available fallback so the Site carries an openable URL."""
+        return f"https://{self._dispatch_base}/{script_name}/"
+
+    # ---- Workers for Platforms: deploy a generated SvelteKit site -----------
+
+    async def deploy_site(self, *, script_name: str, project_dir: str) -> str:
+        """Deploy the generated adapter-cloudflare build into the dispatch
+        namespace as one Worker (script + static assets + bindings) and return
+        its stable live URL. Live on 200.
+
+        This is the publish path's real deploy step. Unlike put_worker (a raw
+        single-module PUT), it ships the whole SvelteKit artifact: the static
+        assets the prerendered marketing routes need AND the D1/Queue bindings
+        the form endpoint reads, taken from the generated wrangler.toml. Fails
+        closed (raises ValidationError) on any non-2xx — a failed deploy never
+        reports success."""
+        root = Path(project_dir, _CLOUDFLARE_BUILD_REL)
+        worker_path = root / _WORKER_ENTRY
+        if not worker_path.is_file():
+            raise ValidationError("sites.cloudflare_error", f"no worker entry at {worker_path}")
+        config = _read_wrangler_config(project_dir)
+        assets = _collect_assets(project_dir)
+        assets_jwt = await self._upload_assets(script_name, assets) if assets else None
+        await self._put_script(
+            script_name=script_name,
+            worker_module=worker_path.read_bytes(),
+            config=config,
+            assets_jwt=assets_jwt,
+        )
+        return self.live_url_for(script_name)
+
+    async def _upload_assets(self, script_name: str, assets: dict[str, Path]) -> str:
+        """Run the Workers Assets two-step for a dispatch-namespace script and
+        return the completion JWT the script PUT references.
+
+        Step 1 — POST the manifest (path → {hash, size}); the API replies with an
+        upload JWT and the buckets of hashes it still needs.
+        Step 2 — for each non-empty bucket, upload the file bodies (base64) keyed
+        by hash; the final 2xx carries the completion JWT.
+        If the API already has every file (no buckets), step 1's JWT is the
+        completion JWT and no upload round-trip is needed."""
+        # ``assets`` is already {server_path -> file}, so read each body and key
+        # the manifest by that server path. by_hash lets an upload bucket (a list
+        # of content hashes) map back to the file bytes.
+        contents: dict[str, bytes] = {sp: path.read_bytes() for sp, path in assets.items()}
+        manifest = {
+            server_path: {"hash": _hash_asset(data), "size": len(data)}
+            for server_path, data in contents.items()
+        }
+        by_hash = {_hash_asset(data): data for data in contents.values()}
+
+        session_url = (
+            f"{_CF_API}/accounts/{self._account_id}"
+            f"/workers/dispatch/namespaces/{self._namespace}"
+            f"/scripts/{script_name}/assets-upload-session"
+        )
+        async with self._client() as client:
+            resp = await client.post(session_url, json={"manifest": manifest})
+            result = self._unwrap(resp)
+            jwt = result.get("jwt", "")
+            buckets = result.get("buckets") or []
+            if not buckets:
+                # Nothing to upload — the session JWT is the completion token.
+                return jwt
+            upload_url = f"{_CF_API}/accounts/{self._account_id}/workers/assets/upload?base64=true"
+            completion_jwt = jwt
+            for bucket in buckets:
+                files = {h: base64.b64encode(by_hash[h]).decode() for h in bucket if h in by_hash}
+                up = await client.post(
+                    upload_url,
+                    headers={"Authorization": f"Bearer {jwt}"},
+                    json={"files": files},
+                )
+                done = self._unwrap(up)
+                completion_jwt = done.get("jwt") or completion_jwt
+            return completion_jwt
+
+    async def _put_script(
+        self,
+        *,
+        script_name: str,
+        worker_module: bytes,
+        config: dict[str, Any],
+        assets_jwt: str | None,
+    ) -> None:
+        """Multipart script PUT into the dispatch namespace: a `metadata` JSON
+        part (main_module, compatibility settings, bindings, assets) plus the
+        worker ESM module part."""
+        metadata: dict[str, Any] = {
+            "main_module": _WORKER_ENTRY,
+            "compatibility_date": config.get("compatibility_date") or "2024-09-23",
+            "compatibility_flags": config.get("compatibility_flags") or [],
+            "bindings": config.get("bindings") or [],
+        }
+        if assets_jwt:
+            # html_handling/not_found_handling make the static prerendered routes
+            # serve cleanly (pretty URLs, SPA-less 404 → the worker).
+            metadata["assets"] = {
+                "jwt": assets_jwt,
+                "config": {"html_handling": "auto-trailing-slash"},
+            }
+        url = (
+            f"{_CF_API}/accounts/{self._account_id}"
+            f"/workers/dispatch/namespaces/{self._namespace}/scripts/{script_name}"
+        )
+        files = {
+            "metadata": (None, json.dumps(metadata), "application/json"),
+            _WORKER_ENTRY: (
+                _WORKER_ENTRY,
+                worker_module,
+                "application/javascript+module",
+            ),
+        }
+        async with self._client() as client:
+            resp = await client.put(url, files=files)
+        self._unwrap(resp)
+
     async def put_worker(self, *, script_name: str, bundle: bytes) -> bool:
-        """Upload a user Worker into the dispatch namespace. Live on 200."""
+        """Upload a raw single-module user Worker into the dispatch namespace.
+        Live on 200. Kept for back-compat; the full publish path uses
+        deploy_site (which also ships static assets + bindings)."""
         url = (
             f"{_CF_API}/accounts/{self._account_id}"
             f"/workers/dispatch/namespaces/{self._namespace}/scripts/{script_name}"
@@ -75,6 +301,8 @@ class CloudflareClient:
             )
         self._unwrap(resp)
         return True
+
+    # ---- Cloudflare for SaaS: custom hostnames -----------------------------
 
     async def create_custom_hostname(self, hostname: str) -> CustomHostname:
         url = f"{_CF_API}/zones/{self._zone_id}/custom_hostnames"
@@ -99,3 +327,11 @@ class CloudflareClient:
             resp = await client.get(url)
         result = self._unwrap(resp)
         return _map_status(result.get("status", ""), (result.get("ssl") or {}).get("status", ""))
+
+    async def verify_domain(self, hostname_id: str) -> bool:
+        """Re-poll a custom hostname and report whether it is fully verified
+        (CNAME seen + TLS active → LIVE). The backend half of the DomainsPanel
+        "Verify" action: the client pastes the CNAME, then this confirms
+        Cloudflare has validated it end to end. Status mapping stays in
+        get_hostname_status so there is one source of truth."""
+        return await self.get_hostname_status(hostname_id) is HostnameStatus.LIVE

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -6,6 +6,21 @@
 # without Bun/workerd present.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-06-06 (feat/1346-cf-deploy — Cloudflare deploy pipeline):
+#   * NEW build_and_deploy(): the single seam the publish path (#1345) calls. It
+#     runs build() (generate → install → workerd smoke gate) and, ONLY if the
+#     gate passes, deploys the artifact, returning a DeployResult
+#     {success: bool, url: str|None, error: str|None}. It NEVER raises for an
+#     expected failure (smoke-gate fail OR deploy fail) — both come back as
+#     success=False with the reason in `error`, so the caller flips "Live" off
+#     cleanly instead of catching exceptions. Deploy target is chosen by the
+#     caller: pass a `cloudflare` client (real edge: cf.deploy_site uploads the
+#     worker + static assets + bindings) OR a `local_deploy` callable (the
+#     no-CF/PAW_SITES_LOCAL dev path: serve the build from localhost). This keeps
+#     the CF-vs-local POLICY in the service layer (which reads the env) and the
+#     build→gate→deploy MECHANICS here. build() is unchanged, so existing callers
+#     and the dentist/local integration tests keep working.
+#
 # Updated 2026-06-04 (feat/sites-svelte-engine — Paw Sites "Svelte track"):
 #   * FIX: BuildResult.ripple_version is now optional and build() reads it with
 #     gen.get("rippleVersion") (was gen["rippleVersion"]). The svelte
@@ -49,6 +64,7 @@ import json
 import os
 import shlex
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -67,6 +83,29 @@ class BuildResult:
     # this is ``None`` on the svelte path. Optional so reading the svelte result
     # does not KeyError.
     ripple_version: str | None = None
+
+
+@dataclass(frozen=True)
+class DeployResult:
+    """The result of build_and_deploy — the seam the publish path (#1345) reads
+    to set "Live". Shape: ``{success: bool, url: str | None, error: str | None}``.
+
+    ``success`` is True only when the build passed the workerd smoke gate AND the
+    deploy reported 200. On any expected failure (smoke gate failed, or the
+    deploy call failed) ``success`` is False, ``url`` is None, and ``error`` holds
+    the human-readable reason — build_and_deploy does NOT raise for these, so the
+    caller flips "Live" off without a try/except."""
+
+    success: bool
+    url: str | None = None
+    error: str | None = None
+
+
+class _CloudflareDeployer(Protocol):
+    """The deploy surface build_and_deploy needs from a Cloudflare client. The
+    real ``CloudflareClient`` satisfies it; tests pass a fake."""
+
+    async def deploy_site(self, *, script_name: str, project_dir: str) -> str: ...
 
 
 def _gen_cmd_argv() -> list[str]:
@@ -247,3 +286,75 @@ class GeneratorClient:
         # path omits it (paw-sites types.ts §4.2), so read it defensively — a svelte
         # build must not KeyError here.
         return BuildResult(project_dir=gen["projectDir"], ripple_version=gen.get("rippleVersion"))
+
+    async def build_and_deploy(
+        self,
+        *,
+        ripple_spec: dict[str, Any] | None = None,
+        theme: dict[str, Any],
+        site_id: str,
+        title: str,
+        capture_api_base: str,
+        capture_signed_key: str,
+        engine: str = "ripple",
+        source: dict[str, str] | None = None,
+        cloudflare: _CloudflareDeployer | None = None,
+        local_deploy: Callable[[str, str], str] | None = None,
+    ) -> DeployResult:
+        """Build, smoke-gate, and deploy a Paw Site — the ONE call the publish
+        path (#1345) makes. Returns a ``DeployResult``
+        ``{success: bool, url: str | None, error: str | None}``.
+
+        Flow: ``build()`` (generate → install → workerd smoke gate). If the gate
+        fails, return ``DeployResult(success=False, error=<reason>)`` WITHOUT
+        deploying — the gate fails closed (Contract clause 4). If it passes,
+        deploy and return the live URL.
+
+        Deploy target (caller picks; the service layer reads the env to decide):
+          * ``cloudflare`` set → real edge deploy: ``cf.deploy_site`` uploads the
+            worker + static assets + bindings into the dispatch namespace and
+            returns the stable URL.
+          * else ``local_deploy`` set → the no-CF dev path: a ``(site_id,
+            project_dir) -> url`` callable (local_server.deploy_local) serves the
+            build from localhost.
+          * neither set → ``DeployResult(success=False, error=...)`` (a deploy
+            with no target is a misconfiguration, surfaced not raised).
+
+        Never raises for an expected failure: a smoke-gate failure OR a deploy
+        error both come back as ``success=False`` with the reason in ``error``, so
+        the caller sets "Live" off without a try/except. (An unexpected
+        programming error still propagates.)"""
+        try:
+            build = await self.build(
+                ripple_spec=ripple_spec,
+                theme=theme,
+                site_id=site_id,
+                title=title,
+                capture_api_base=capture_api_base,
+                capture_signed_key=capture_signed_key,
+                engine=engine,
+                source=source,
+            )
+        except SmokeGateFailed as exc:
+            # The workerd smoke gate (or the pre-build install) failed — the site
+            # is broken and must NOT go live. Surface, don't raise.
+            return DeployResult(success=False, error=str(exc))
+
+        try:
+            if cloudflare is not None:
+                url = await cloudflare.deploy_site(
+                    script_name=site_id, project_dir=build.project_dir
+                )
+            elif local_deploy is not None:
+                url = local_deploy(site_id, build.project_dir)
+            else:
+                return DeployResult(
+                    success=False,
+                    error="no deploy target: pass a cloudflare client or a local_deploy callable",
+                )
+        except Exception as exc:  # noqa: BLE001 - any deploy failure → success=False
+            # A failed deploy (CF non-2xx → ValidationError, a missing artifact,
+            # a network error) must report failure, never a false "Live".
+            return DeployResult(success=False, error=f"deploy failed: {exc}")
+
+        return DeployResult(success=True, url=url)

--- a/tests/ee/sites/test_cloudflare_client.py
+++ b/tests/ee/sites/test_cloudflare_client.py
@@ -8,10 +8,30 @@
 #     the single CNAME target the client pastes.
 #   * get_hostname_status — maps CF's status/ssl pair onto HostnameStatus.
 #   * non-2xx responses fail closed (raise).
+#
+# Updated 2026-06-06 (feat/1346-cf-deploy — Cloudflare deploy pipeline):
+# new tests for the REAL site deploy, all against httpx.MockTransport (no
+# network) over a fake adapter-cloudflare output tree on disk:
+#   * deploy_site — the full Workers-for-Platforms upload: the Workers Assets
+#     two-step (manifest session → upload the missing files) then the multipart
+#     script PUT. Asserts every CF endpoint is hit in order, the static asset is
+#     uploaded, the worker module + a metadata part ride the PUT, the D1/Queue
+#     bindings parsed from the generated wrangler.toml land in the metadata, and a
+#     stable live URL comes back.
+#   * deploy_site with no missing assets — the session reports empty buckets, so
+#     the upload round-trip is skipped and the session JWT is reused.
+#   * deploy_site fails closed — a non-2xx on the script PUT raises (no false
+#     "Live").
+#   * deploy_site with a missing worker entry raises before any network call.
+#   * verify_domain — maps an active hostname to True, a pending one to False.
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 import httpx
 import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.sites.cloudflare_client import CloudflareClient
 from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus
 
@@ -96,3 +116,225 @@ async def test_non_2xx_raises():
     client = _client(handler)
     with pytest.raises(Exception):
         await client.put_worker(script_name="x", bundle=b"")
+
+
+# --- deploy_site: the REAL site deploy (worker + static assets + bindings) ----
+
+
+def _fake_build(tmp_path: Path, *, with_d1: bool = True) -> str:
+    """Write a fake adapter-cloudflare output tree under
+    <tmp>/.svelte-kit/cloudflare/ : the worker entry, one prerendered asset, the
+    deploy-config files that must NOT be uploaded as assets, and the generated
+    wrangler.toml the deploy reads bindings + compat settings from. Returns the
+    project dir (the parent of .svelte-kit), which is what deploy_site takes."""
+    project = tmp_path / "proj"
+    cf = project / ".svelte-kit" / "cloudflare"
+    (cf / "_app" / "immutable" / "assets").mkdir(parents=True)
+    (cf / "_worker.js").write_text("export default { fetch() {} }")
+    (cf / "index.html").write_text("<h1>Bright Smile Dental</h1>")
+    (cf / "_app" / "immutable" / "assets" / "app.css").write_text("body{}")
+    # Deploy-config files — excluded from the asset upload.
+    (cf / "_routes.json").write_text('{"version":1}')
+    (cf / "_headers").write_text("/*\n  X-Frame-Options: DENY")
+    # The generated wrangler.toml: a real (provisioned) D1 id + a Queue producer.
+    db_id = "d1-abc123" if with_d1 else "__D1_DATABASE_ID__"
+    (project / "wrangler.toml").write_text(
+        'name = "paw-site-x"\n'
+        'compatibility_date = "2024-09-23"\n'
+        'compatibility_flags = ["nodejs_compat"]\n'
+        "[[queues.producers]]\n"
+        'binding = "LEADS_QUEUE"\n'
+        'queue = "paw-leads-x"\n'
+        "[[d1_databases]]\n"
+        'binding = "DB"\n'
+        'database_name = "paw-site-x"\n'
+        f'database_id = "{db_id}"\n'
+    )
+    return str(project)
+
+
+@pytest.mark.asyncio
+async def test_deploy_site_uploads_assets_then_puts_script(tmp_path: Path):
+    """The happy path: deploy_site opens an asset upload session, uploads the
+    file the API says it's missing, then PUTs the worker script with a metadata
+    part — and returns a stable live URL. Asserts the endpoints are hit in order
+    and the bindings from wrangler.toml ride the script metadata."""
+    project = _fake_build(tmp_path)
+    seen: list[str] = []
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.endswith("/assets-upload-session"):
+            seen.append("session")
+            body = json.loads(request.content)
+            captured["manifest"] = body["manifest"]
+            # Report ONE bucket: the API is missing every file's hash.
+            hashes = [v["hash"] for v in body["manifest"].values()]
+            return httpx.Response(
+                200, json={"success": True, "result": {"jwt": "session_jwt", "buckets": [hashes]}}
+            )
+        if "/workers/assets/upload" in url:
+            seen.append("upload")
+            captured["upload_auth"] = request.headers.get("Authorization")
+            captured["uploaded"] = json.loads(request.content)["files"]
+            return httpx.Response(200, json={"success": True, "result": {"jwt": "completion_jwt"}})
+        # The multipart script PUT.
+        seen.append("put")
+        captured["put_method"] = request.method
+        captured["put_url"] = url
+        captured["put_body"] = request.content  # multipart bytes
+        return httpx.Response(200, json={"success": True, "result": {"id": "site_x"}})
+
+    client = _client(handler)
+    url = await client.deploy_site(script_name="site_x", project_dir=project)
+
+    # Endpoints hit in the right order: session → upload → script PUT.
+    assert seen == ["session", "upload", "put"]
+    # The manifest covered the servable assets and EXCLUDED the deploy-config
+    # files (_worker.js / _routes.json / _headers).
+    paths = set(captured["manifest"].keys())
+    assert "/index.html" in paths
+    assert "/_app/immutable/assets/app.css" in paths
+    assert "/_worker.js" not in paths
+    assert "/_routes.json" not in paths
+    assert "/_headers" not in paths
+    # The upload reused the session JWT and sent the (base64) file bodies.
+    assert captured["upload_auth"] == "Bearer session_jwt"
+    assert len(captured["uploaded"]) == len(paths)
+    # The script PUT is a multipart PUT to the dispatch namespace.
+    assert captured["put_method"] == "PUT"
+    assert "dispatch/namespaces/paw-sites/scripts/site_x" in captured["put_url"]
+    body = captured["put_body"].decode("utf-8", "replace")
+    assert "_worker.js" in body  # the worker module part
+    assert '"main_module": "_worker.js"' in body  # metadata part
+    assert "completion_jwt" in body  # the assets completion JWT
+    # Bindings parsed from wrangler.toml landed in the metadata.
+    assert '"type": "d1"' in body
+    assert "d1-abc123" in body
+    assert '"type": "queue"' in body
+    assert "LEADS_QUEUE" in body
+    # A stable live URL comes back.
+    assert url == "https://paw-sites.workers.dev/site_x/"
+
+
+@pytest.mark.asyncio
+async def test_deploy_site_skips_upload_when_no_missing_assets(tmp_path: Path):
+    """If the asset session reports no buckets (CF already has every file), the
+    upload round-trip is skipped and the session JWT is reused as the completion
+    token."""
+    project = _fake_build(tmp_path)
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.endswith("/assets-upload-session"):
+            seen.append("session")
+            return httpx.Response(
+                200, json={"success": True, "result": {"jwt": "reused_jwt", "buckets": []}}
+            )
+        if "/workers/assets/upload" in url:
+            seen.append("upload")  # must NOT happen
+            return httpx.Response(200, json={"success": True, "result": {"jwt": "x"}})
+        seen.append("put")
+        assert b"reused_jwt" in request.content
+        return httpx.Response(200, json={"success": True, "result": {}})
+
+    client = _client(handler)
+    url = await client.deploy_site(script_name="site_y", project_dir=project)
+    assert seen == ["session", "put"]  # no upload step
+    assert url == "https://paw-sites.workers.dev/site_y/"
+
+
+@pytest.mark.asyncio
+async def test_deploy_site_fails_closed_on_put_error(tmp_path: Path):
+    """A non-2xx on the script PUT raises ValidationError — the deploy fails
+    closed so "Live" never flips true on a broken upload."""
+    project = _fake_build(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.endswith("/assets-upload-session"):
+            body = json.loads(request.content)
+            hashes = [v["hash"] for v in body["manifest"].values()]
+            return httpx.Response(
+                200, json={"success": True, "result": {"jwt": "j", "buckets": [hashes]}}
+            )
+        if "/workers/assets/upload" in url:
+            return httpx.Response(200, json={"success": True, "result": {"jwt": "j2"}})
+        return httpx.Response(
+            500, json={"success": False, "errors": [{"message": "script too large"}]}
+        )
+
+    client = _client(handler)
+    with pytest.raises(ValidationError):
+        await client.deploy_site(script_name="site_z", project_dir=project)
+
+
+@pytest.mark.asyncio
+async def test_deploy_site_missing_worker_raises_before_network(tmp_path: Path):
+    """No _worker.js in the build → deploy_site raises before any HTTP call."""
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+        raise AssertionError("no network call should happen")
+
+    # An empty project dir: no .svelte-kit/cloudflare/_worker.js.
+    (tmp_path / "empty").mkdir()
+    client = _client(handler)
+    with pytest.raises(ValidationError):
+        await client.deploy_site(script_name="x", project_dir=str(tmp_path / "empty"))
+
+
+@pytest.mark.asyncio
+async def test_deploy_site_skips_unprovisioned_d1_binding(tmp_path: Path):
+    """A static-only site whose wrangler.toml still carries the __D1_DATABASE_ID__
+    token (no real D1 provisioned) must NOT send a d1 binding — an unresolved id
+    would fail the deploy."""
+    project = _fake_build(tmp_path, with_d1=False)
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.endswith("/assets-upload-session"):
+            body = json.loads(request.content)
+            hashes = [v["hash"] for v in body["manifest"].values()]
+            return httpx.Response(
+                200, json={"success": True, "result": {"jwt": "j", "buckets": [hashes]}}
+            )
+        if "/workers/assets/upload" in url:
+            return httpx.Response(200, json={"success": True, "result": {"jwt": "j2"}})
+        captured["body"] = request.content.decode("utf-8", "replace")
+        return httpx.Response(200, json={"success": True, "result": {}})
+
+    client = _client(handler)
+    await client.deploy_site(script_name="static_site", project_dir=project)
+    assert '"type": "d1"' not in captured["body"]
+    # The Queue binding still rides (it has no unresolved id).
+    assert "LEADS_QUEUE" in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_verify_domain_true_only_when_live():
+    """verify_domain returns True when the hostname is active+TLS-active (LIVE),
+    False otherwise — the backend half of the DomainsPanel "Verify" action."""
+
+    def live_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "success": True,
+                "result": {"status": "active", "ssl": {"status": "active"}},
+            },
+        )
+
+    def pending_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "success": True,
+                "result": {"status": "pending", "ssl": {"status": "pending_validation"}},
+            },
+        )
+
+    assert await _client(live_handler).verify_domain("ch_1") is True
+    assert await _client(pending_handler).verify_domain("ch_1") is False

--- a/tests/ee/sites/test_generator_client_deploy.py
+++ b/tests/ee/sites/test_generator_client_deploy.py
@@ -1,0 +1,161 @@
+# tests/ee/sites/test_generator_client_deploy.py — the deploy seam.
+# Created 2026-06-06 (feat/1346-cf-deploy — Cloudflare deploy pipeline).
+#
+# Exercises GeneratorClient.build_and_deploy, the ONE call the publish path
+# (#1345) makes: build → workerd smoke gate → deploy, returning a DeployResult
+# {success, url, error}. The build subprocess calls are faked (the same _FakeRunner
+# pattern as test_generator_client.py) and the deploy target is a fake — NOTHING
+# spawns bun/workerd and NOTHING hits the network. Covers the captain's gaps:
+#   * smoke-gate FAIL → deploy is NOT called; result is {success: False}.
+#   * smoke-gate PASS → deploy invoked once → result carries the stable URL.
+#   * deploy FAILURE → result is {success: False} ("Live" must not flip true).
+#   * the LOCAL (no-CF) path: a local_deploy callable is used and returns a URL.
+#   * no deploy target → {success: False} (a misconfig is surfaced, not raised).
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites.generator_client import DeployResult, GeneratorClient
+
+
+class _FakeRunner:
+    """Stands in for the generate + bun install + workerd smoke subprocesses."""
+
+    def __init__(self, *, smoke_ok: bool = True, smoke_reason: str = "") -> None:
+        self.smoke_ok = smoke_ok
+        self.smoke_reason = smoke_reason
+        self.calls: list[str] = []
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.calls.append("generate")
+        return {"projectDir": "/tmp/site_build", "rippleVersion": "0.2.0"}
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("install")
+        return True, "ok"
+
+    async def smoke(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("smoke")
+        return self.smoke_ok, self.smoke_reason
+
+
+class _FakeCF:
+    """A fake CloudflareClient deploy surface — records the deploy and returns a
+    stable URL, or raises to simulate a failed edge deploy."""
+
+    def __init__(self, *, raise_with: Exception | None = None) -> None:
+        self.raise_with = raise_with
+        self.deployed: list[tuple[str, str]] = []
+
+    async def deploy_site(self, *, script_name: str, project_dir: str) -> str:
+        self.deployed.append((script_name, project_dir))
+        if self.raise_with is not None:
+            raise self.raise_with
+        return f"https://paw-sites.workers.dev/{script_name}/"
+
+
+_BUILD_KW = dict(
+    ripple_spec={"type": "container"},
+    theme={"primary": "#0A84FF"},
+    site_id="site_1",
+    title="Bright Smile",
+    capture_api_base="https://api.paw.example",
+    capture_signed_key="pp_tok_x",
+)
+
+
+@pytest.mark.asyncio
+async def test_smoke_gate_fail_blocks_deploy():
+    """The gate fails closed: the smoke render fails → the CF client's deploy is
+    NEVER called, and the result is {success: False} with the reason."""
+    runner = _FakeRunner(smoke_ok=False, smoke_reason="workerd SSR failure: window is not defined")
+    cf = _FakeCF()
+    result = await GeneratorClient(_runner=runner).build_and_deploy(cloudflare=cf, **_BUILD_KW)
+
+    assert isinstance(result, DeployResult)
+    assert result.success is False
+    assert result.url is None
+    assert "window is not defined" in (result.error or "")
+    # Deploy was NOT invoked — the broken site never reached Cloudflare.
+    assert cf.deployed == []
+    # generate + install + smoke ran; nothing past the gate.
+    assert runner.calls == ["generate", "install", "smoke"]
+
+
+@pytest.mark.asyncio
+async def test_smoke_gate_pass_deploys_and_returns_url():
+    """Gate passes → deploy is invoked exactly once with the built project dir →
+    the result is {success: True, url: <stable url>}."""
+    runner = _FakeRunner(smoke_ok=True)
+    cf = _FakeCF()
+    result = await GeneratorClient(_runner=runner).build_and_deploy(cloudflare=cf, **_BUILD_KW)
+
+    assert result.success is True
+    assert result.url == "https://paw-sites.workers.dev/site_1/"
+    assert result.error is None
+    # Deploy invoked once, with the script name == site id and the build dir.
+    assert cf.deployed == [("site_1", "/tmp/site_build")]
+
+
+@pytest.mark.asyncio
+async def test_deploy_failure_surfaces_as_unsuccessful():
+    """A failed edge deploy (e.g. CF non-2xx → an exception from deploy_site) is
+    reported as {success: False} — "Live" must not flip true."""
+    runner = _FakeRunner(smoke_ok=True)
+    cf = _FakeCF(raise_with=RuntimeError("Cloudflare API 500"))
+    result = await GeneratorClient(_runner=runner).build_and_deploy(cloudflare=cf, **_BUILD_KW)
+
+    assert result.success is False
+    assert result.url is None
+    assert "deploy failed" in (result.error or "")
+    assert "Cloudflare API 500" in (result.error or "")
+    # The deploy WAS attempted (gate passed) — it just failed.
+    assert cf.deployed == [("site_1", "/tmp/site_build")]
+
+
+@pytest.mark.asyncio
+async def test_local_path_uses_local_deploy_callable():
+    """The PAW_SITES_LOCAL (no-CF) path: with no cloudflare client but a
+    local_deploy callable, build_and_deploy calls it and returns its URL. Proves
+    local dev keeps working with zero CF creds."""
+    runner = _FakeRunner(smoke_ok=True)
+    seen: list[tuple[str, str]] = []
+
+    def local_deploy(site_id: str, project_dir: str) -> str:
+        seen.append((site_id, project_dir))
+        return f"http://127.0.0.1:54321/{site_id}/"
+
+    result = await GeneratorClient(_runner=runner).build_and_deploy(
+        local_deploy=local_deploy, **_BUILD_KW
+    )
+
+    assert result.success is True
+    assert result.url == "http://127.0.0.1:54321/site_1/"
+    assert seen == [("site_1", "/tmp/site_build")]
+
+
+@pytest.mark.asyncio
+async def test_local_path_still_gated_by_smoke():
+    """Even on the local path, a failed smoke gate blocks the (local) deploy."""
+    runner = _FakeRunner(smoke_ok=False, smoke_reason="build failed (exit 1)")
+    called = False
+
+    def local_deploy(site_id: str, project_dir: str) -> str:
+        nonlocal called
+        called = True
+        return "x"
+
+    result = await GeneratorClient(_runner=runner).build_and_deploy(
+        local_deploy=local_deploy, **_BUILD_KW
+    )
+    assert result.success is False
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_no_deploy_target_is_surfaced_not_raised():
+    """No cloudflare client and no local_deploy → a misconfiguration, returned as
+    {success: False} rather than an exception."""
+    runner = _FakeRunner(smoke_ok=True)
+    result = await GeneratorClient(_runner=runner).build_and_deploy(**_BUILD_KW)
+    assert result.success is False
+    assert "no deploy target" in (result.error or "")


### PR DESCRIPTION
Closes #1346 (the deploy half).

## What this does

Publishing a Paw Site built the static output and ran the workerd smoke gate, but nothing deployed it to Cloudflare. So "Live" was never true in any real sense and the preview URL pointed at nothing. This wires the deploy step that runs after the smoke gate passes.

Two files change, both already scaffolded behind `PAW_CF_*` / `PAW_SITES_LOCAL`:

**`cloudflare_client.py` — `deploy_site()`**, the real Workers-for-Platforms upload. A SvelteKit `adapter-cloudflare` build is a worker module *plus* a static-assets tree *plus* bindings, not a single file. The existing `put_worker` did a bare single-module PUT, which would have deployed a worker with no static assets and no D1/Queue bindings, so the prerendered marketing routes 404 and the form endpoint's bindings go missing. That is the dead-URL symptom. `deploy_site` does it properly:

1. The Workers Assets two-step: open an upload session with the asset manifest, upload the files Cloudflare reports it's missing, take the completion JWT.
2. A multipart script PUT into the dispatch namespace with a `metadata` part (main module, compatibility settings, the bindings parsed from the generated `wrangler.toml`, and the assets config) plus the worker module.

It returns a stable live URL and fails closed on any non-2xx. The bindings and compatibility settings are read from the generated `wrangler.toml` so the generator stays the single source of truth. `verify_domain()` re-polls a custom hostname for the DomainsPanel verify action. `put_worker` is untouched for back-compat.

**`generator_client.py` — `build_and_deploy()`**, the single call the publish path makes (see the seam below).

## The seam for #1345 (publish orchestration)

The publish path calls one method and reads the result to set "Live":

```python
async def build_and_deploy(
    self,
    *,
    ripple_spec: dict[str, Any] | None = None,
    theme: dict[str, Any],
    site_id: str,
    title: str,
    capture_api_base: str,
    capture_signed_key: str,
    engine: str = "ripple",
    source: dict[str, str] | None = None,
    cloudflare: _CloudflareDeployer | None = None,   # the real edge target
    local_deploy: Callable[[str, str], str] | None = None,  # the no-CF dev target
) -> DeployResult
```

`DeployResult` is a frozen dataclass — `{success: bool, url: str | None, error: str | None}`:

- `success=True` only when the build passed the smoke gate **and** the deploy returned 200; `url` carries the live URL.
- A smoke-gate failure or a deploy failure both come back `success=False` with the reason in `error` — `build_and_deploy` does **not** raise for those, so the caller flips "Live" off without a try/except.

Deploy target is the caller's choice (the service layer reads the env to decide): pass a `cloudflare` client for the edge, or a `local_deploy` callable (`local_server.deploy_local`) for the `PAW_SITES_LOCAL` path. Pass neither and you get `success=False` with a clear message rather than an exception.

The build params mirror the existing `build()` exactly, so wiring this in is a drop-in. `build()` is unchanged, so the current `publish()` and the dentist/local integration tests keep working while #1345 migrates the call.

## Tests

Everything is mocked — no network, no bun/workerd. The Cloudflare HTTP layer is an `httpx.MockTransport` over a fake `adapter-cloudflare` output tree on disk; the build subprocesses use the same fake-runner pattern the existing generator tests use.

The deploy seam covers the three cases that matter:
- smoke-gate fail → deploy is never called, result is `success=False`;
- smoke-gate pass → deploy invoked once → result carries the stable URL;
- deploy failure → `success=False` (Live stays off).

Plus the `deploy_site` mechanics (asset two-step, the skip-upload-when-nothing-missing path, fail-closed on a PUT error, an unprovisioned-D1 binding getting skipped, missing worker raising before any call) and `verify_domain`. The local (no-CF) path is covered too.

```
uv run pytest tests/ee/sites/test_cloudflare_client.py tests/ee/sites/test_generator_client_deploy.py
# 16 passed

uv run pytest tests/ee/sites/    # full sites suite, no regressions
# 69 passed, 1 skipped
```

(The 1 skip is the opt-in local-deploy integration test that needs `PAW_SITES_INTEGRATION=1` plus a local bun/node toolchain.)

## What is NOT verified here, and what the captain needs to provide

The wiring is complete and unit-tested, but a true end-to-end run (a real published site reachable at a Cloudflare URL, a custom domain verified for real) needs a Cloudflare account and credentials this environment doesn't have. To finish the live verification:

- **`PAW_CF_ACCOUNT_ID`** — the Cloudflare account id.
- **`PAW_CF_API_TOKEN`** — a scoped API token with: Workers Scripts (edit), Workers for Platforms dispatch namespace (edit), Workers Assets (write), and SSL/custom hostnames (edit) for the zone.
- **`PAW_CF_ZONE_ID`** — the zone for Cloudflare for SaaS custom hostnames.
- **`PAW_CF_DISPATCH_NAMESPACE`** — the dispatch namespace (defaults to `paw-sites`); the namespace must exist in the account.
- **`PAW_CF_DISPATCH_BASE`** — the hostname deployed scripts are served at (e.g. `paw-sites.<account>.workers.dev`, or the SaaS fallback origin). Used for the returned live URL.

Account setup: a **Workers for Platforms** subscription (dispatch namespaces are a paid WfP feature), the dispatch namespace created, and — for custom domains — Cloudflare for SaaS enabled on the zone with a fallback origin. For dynamic sites (RFC 12 A2) the per-tenant D1 also has to be provisioned before deploy; static sites skip the D1 binding automatically.

## Follow-up (not done here — needs publish creds)

The default `paw-sites-gen` bin still isn't svelte-aware, which is why publishing leans on the `PAW_SITES_GEN_CMD` override pointing at the built dist. Dropping that override needs the generator republished: bump and publish `@paw/sites-generator` with the svelte track included, install the bin on PATH in the deploy image, then remove the `PAW_SITES_GEN_CMD` default. That's a release task that needs publish credentials, so I've left it as a follow-up rather than attempting it.
