### PR TITLE
Draft/published state machine for Paw Sites

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,9 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-06-06 (feat/1345-draft-published) — added ``PocketVersion`` (the
+draft/published pocket-content version-history log, pocketpaw#1345 Phase 1) to
+the imports, ``__all__``, and ``get_all_documents()`` so the versions collection
+is wired into ``init_beanie``.
 Updated: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.2) — added the
 ``Lead`` and ``Site`` tenant-scoped Paw Sites documents (plus their
 ``LeadSource`` / ``SiteDomain`` subdocs) to the imports, ``__all__``, and the
@@ -69,6 +73,7 @@ from pocketpaw_ee.cloud.models.notification import Notification, NotificationSou
 from pocketpaw_ee.cloud.models.planner import PlanSession, PlanSessionAgentGap
 from pocketpaw_ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
 from pocketpaw_ee.cloud.models.pocket_backend import PocketBackendCredential
+from pocketpaw_ee.cloud.models.pocket_version import PocketVersion
 from pocketpaw_ee.cloud.models.project import Project
 from pocketpaw_ee.cloud.models.read_state import ReadState
 from pocketpaw_ee.cloud.models.session import Session
@@ -153,6 +158,7 @@ __all__ = [
     "PlanSession",
     "PlanSessionAgentGap",
     "Pocket",
+    "PocketVersion",
     "Project",
     "Reaction",
     "ReadState",
@@ -183,6 +189,7 @@ def get_all_documents():
         Agent,
         Pocket,
         PocketBackendCredential,
+        PocketVersion,
         Session,
         Comment,
         Notification,

--- a/ee/pocketpaw_ee/cloud/models/pocket.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket.py
@@ -32,6 +32,15 @@ SvelteKit source map a svelte-engine site materializes from (the svelte
 analog of ``rippleSpec``). ``engine`` defaults to ``"ripple"`` and
 ``source`` to ``None`` so every existing pocket reads back as a ripple
 pocket with no source map — additive, no Mongo migration.
+Updated: 2026-06-06 (feat/1345-draft-published) — added the version-history
+pointer cache (pocketpaw#1345 Phase 1, plan §5): ``draft_version_no`` /
+``published_version_no`` denormalize the pocket's current draft/published
+``PocketVersion.version_no`` (the authoritative log is the
+``pocket_versions`` collection — these are a read-optimization the versions
+service keeps in sync), and ``last_deploy_status`` (``none|pending|live|
+failed``) is the REAL-deploy axis kept separate from the version status
+(a version is published once promoted; the deploy can still be pending or
+failed). All optional / defaulted — additive, no Mongo migration.
 """
 
 from __future__ import annotations
@@ -139,6 +148,18 @@ class Pocket(TimestampedDocument):
     # performed inside this pocket. Each entry is free-form so built-in IDs,
     # workspace MCP refs, and inline declarative tools can coexist.
     tool_specs: list[dict[str, Any]] = Field(default_factory=list)
+    # Version-history pointers (pocketpaw#1345 Phase 1). The authoritative log is
+    # the ``pocket_versions`` collection; these denormalize the current draft and
+    # published ``version_no`` so a pocket read knows its draft/published state
+    # without scanning the log. The versions service keeps them in sync. ``None``
+    # until the pocket has its first version — legacy pockets read back as None.
+    draft_version_no: int | None = None
+    published_version_no: int | None = None
+    # The REAL-deploy outcome, a SEPARATE axis from version status: a version is
+    # "published" once promoted, but the deploy can still be pending/failed. For
+    # sites the Site doc carries the canonical deploy state; this mirrors it onto
+    # the pocket. none | pending | live | failed.
+    last_deploy_status: str = "none"
 
     model_config = {"populate_by_name": True}
 

--- a/ee/pocketpaw_ee/cloud/models/pocket_version.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket_version.py
@@ -22,12 +22,20 @@
 # (rippleSpec) + ``source`` (svelte map) + ``engine`` so the svelte track isn't
 # silently versioned empty; renamed parent → ``parent_version_no``; added
 # ``origin``; compound index ordered version_no DESC (newest-first reads).
+# Updated 2026-06-06 (code review BLOCK-1 + engine guard): made the
+# (workspace, pocket_id, version_no) index UNIQUE so a check-then-act race in
+# record_draft can no longer write two rows with the same version_no — the second
+# insert now fails loudly with a duplicate-key error (the service retries it
+# instead of silently corrupting the log). Constrained ``engine`` to
+# ^(ripple|svelte)$ so a bad engine value can't slip a snapshot into a track that
+# returns a None preview.
 from __future__ import annotations
 
 from typing import Any
 
 from beanie import Indexed
 from pydantic import Field
+from pymongo import IndexModel
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
@@ -47,8 +55,10 @@ class PocketVersion(TimestampedDocument):
     # entirely in ``source`` — is never versioned empty.
     source: dict[str, str] | None = None
     # Which generation track this snapshot belongs to ("ripple" | "svelte"), so a
-    # publish/rollback restores the right track.
-    engine: str = "ripple"
+    # publish/rollback restores the right track. Constrained to the two known
+    # tracks: a stray value would version into a track whose preview reader
+    # returns None (silent data loss on read-back).
+    engine: str = Field(default="ripple", pattern="^(ripple|svelte)$")
     # Optional human label for the version (e.g. "before redesign"). Phase 2 UI.
     label: str | None = None
     # Who created the version: a user id, or "agent" for an agent-authored edit.
@@ -67,6 +77,14 @@ class PocketVersion(TimestampedDocument):
         name = "pocket_versions"
         indexes = [
             # Every Phase-2 query is "this pocket's versions, newest first".
-            [("workspace", 1), ("pocket_id", 1), ("version_no", -1)],
-            [("workspace", 1), ("pocket_id", 1), ("status", 1)],
+            # UNIQUE: two concurrent record_draft calls for the same (workspace,
+            # pocket) would otherwise both read the same latest_version_no, +1, and
+            # insert duplicate version_no rows — corrupting the monotonic log.
+            # Uniqueness turns that race into a loud DuplicateKeyError the service
+            # retries (see versions/service.record_draft).
+            IndexModel(
+                [("workspace", 1), ("pocket_id", 1), ("version_no", -1)],
+                unique=True,
+            ),
+            IndexModel([("workspace", 1), ("pocket_id", 1), ("status", 1)]),
         ]

--- a/ee/pocketpaw_ee/cloud/models/pocket_version.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket_version.py
@@ -1,0 +1,72 @@
+# ee/pocketpaw_ee/cloud/models/pocket_version.py — a single version (snapshot) of
+# a pocket's content in the draft/published version-history log (pocketpaw#1345
+# Phase 1, plan §5). Each row is a FULL snapshot of the pocket content. The
+# snapshot is engine-aware: ``content`` holds the rippleSpec dict, ``source``
+# holds the svelte SvelteKit source map ({path: contents}), and ``engine`` records
+# which track the snapshot belongs to — both are captured together so a svelte
+# site (rippleSpec=None, all content in ``source``) versions and rolls back
+# correctly. version_no is a per-(workspace, pocket) monotonic 1-based counter;
+# status is draft|published|archived; parent_version_no links the chain so
+# history/rollback can walk it; origin records what triggered the snapshot.
+# workspace-scoped for tenant isolation.
+#
+# Why a snapshot, not a diff: the content is small (one spec / a few source
+# files), so full snapshots are cheap and language-agnostic — plan §4 option C.
+# Why a separate collection, not an embedded array: a refine-heavy site would
+# blow Mongo's 16MB doc limit if every snapshot were embedded on the Pocket;
+# Site/Lead are the sibling-collection precedent.
+#
+# Created 2026-06-06 (feat/1345-draft-published).
+# Updated 2026-06-06 (architect schema review): 3-state status enum
+# (draft|published|archived) from day one; split the snapshot into ``content``
+# (rippleSpec) + ``source`` (svelte map) + ``engine`` so the svelte track isn't
+# silently versioned empty; renamed parent → ``parent_version_no``; added
+# ``origin``; compound index ordered version_no DESC (newest-first reads).
+from __future__ import annotations
+
+from typing import Any
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class PocketVersion(TimestampedDocument):
+    """One snapshot of a pocket's content in the version-history log."""
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    pocket_id: str
+    # Per-(workspace, pocket) monotonic version number, 1-based. Don't rely on
+    # createdAt ordering — this is the authoritative order.
+    version_no: int
+    # The rippleSpec snapshot (ripple track). None for a pure svelte site.
+    content: dict[str, Any] | None = None
+    # The svelte source-map snapshot ({relative_path: file_contents}). None for a
+    # ripple site. Captured ALONGSIDE content so the svelte track — which lives
+    # entirely in ``source`` — is never versioned empty.
+    source: dict[str, str] | None = None
+    # Which generation track this snapshot belongs to ("ripple" | "svelte"), so a
+    # publish/rollback restores the right track.
+    engine: str = "ripple"
+    # Optional human label for the version (e.g. "before redesign"). Phase 2 UI.
+    label: str | None = None
+    # Who created the version: a user id, or "agent" for an agent-authored edit.
+    author: str | None = None
+    # draft = a working version; published = the promoted live candidate;
+    # archived = superseded / pruned (Phase 2 rollback + retention).
+    status: str = Field(default="draft", pattern="^(draft|published|archived)$")
+    # The version_no this one was derived from (None for the first version).
+    # Impossible to reconstruct after the fact — captured at write time.
+    parent_version_no: int | None = None
+    # What triggered the snapshot: create | refine | merge_spec | rest_update |
+    # rollback | publish. Free-form so new call sites can add their own tag.
+    origin: str | None = None
+
+    class Settings:
+        name = "pocket_versions"
+        indexes = [
+            # Every Phase-2 query is "this pocket's versions, newest first".
+            [("workspace", 1), ("pocket_id", 1), ("version_no", -1)],
+            [("workspace", 1), ("pocket_id", 1), ("status", 1)],
+        ]

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -16,6 +16,13 @@
 # openable address for the cmux smoke. In the real CF path it is left "" in v1
 # (the deployed Worker is reached via its custom domain, surfaced through the
 # domains list) until a canonical workers.dev URL is wired.
+#
+# Updated 2026-06-06 (feat/1345-draft-published): added ``status`` ("draft" |
+# "published"), the denormalized version state the sites service keeps in sync
+# with the pocket_versions log. Paired with ``deployed`` (the real-deploy axis),
+# it lets the SiteResponse tell the frontend draft vs published vs live without a
+# version-log scan on every read — the fix for "a site is stamped deployed the
+# moment it's created". A freshly created site is status="draft", deployed=False.
 
 from __future__ import annotations
 
@@ -45,7 +52,17 @@ class Site(TimestampedDocument):
     name: str = ""
     # Workers-for-Platforms script name (== site id) once deployed.
     script_name: str = ""
+    # The REAL-deploy axis: True ONLY after a successful publish/deploy. A site
+    # created as a draft is deployed=False until an explicit publish succeeds.
     deployed: bool = False
+    # Draft/published version state (pocketpaw#1345). "draft" = there are
+    # unpublished edits (the latest version is newer than the published one, or
+    # nothing is published yet); "published" = the published version IS the
+    # latest. Denormalized from the pocket_versions log by the sites service so
+    # ``_to_response`` is a sync read. Combined with ``deployed``, the frontend
+    # shows: draft (status=draft), published+live (published & deployed),
+    # published-with-pending-edits (status=draft & deployed — refined since live).
+    status: str = "draft"
     # Canonical deployed URL. LOCAL mode: the localhost URL the per-site static
     # server serves. CF mode: "" in v1 (reached via custom domain).
     url: str = ""

--- a/ee/pocketpaw_ee/cloud/versions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/versions/__init__.py
@@ -1,0 +1,10 @@
+# ee/pocketpaw_ee/cloud/versions/ — the pocket-content version-history module
+# (pocketpaw#1345 Phase 1, plan §5/§6). A draft/published state machine over a
+# versions collection (PocketVersion): edit/refine writes a new draft, publish
+# promotes the draft to published, rollback clones an old version into a new
+# draft. The draft/published pointers are DERIVED from the collection, so no
+# Pocket-model change is needed.
+#
+# This is the foundation Phase 2 (history UI, rollback, diff) builds on. Sites
+# layer publish/deploy/Live on top (see ee/pocketpaw_ee/sites/service.py).
+# Created 2026-06-06 (feat/1345-draft-published).

--- a/ee/pocketpaw_ee/cloud/versions/service.py
+++ b/ee/pocketpaw_ee/cloud/versions/service.py
@@ -1,0 +1,346 @@
+# ee/pocketpaw_ee/cloud/versions/service.py — the draft/published state machine
+# over the pocket-content version log (pocketpaw#1345 Phase 1, plan §5/§6).
+#
+# Operations (plan §6):
+#   * record_draft  — edit/refine: write a NEW draft version (the working one).
+#   * publish_draft — promote the current draft to published (tag it). The deploy
+#                     + "Live" flip is the CALLER's job (sites/service.publish);
+#                     this only moves the version state, keeping deploy a separate
+#                     axis (architect review #2).
+#   * rollback      — clone an old version's content into a NEW draft.
+#   * get_draft / get_published / get_draft_content — read the working/live snap.
+#   * status_for    — derive {status, draft_version, published_version} from the
+#                     log. A pocket is "draft" when draft != published (there are
+#                     unpublished edits), "published" when draft == published, and
+#                     "none" when it has no versions yet.
+#
+# Source of truth: the ``pocket_versions`` collection. The Pocket doc's
+# draft_version_no / published_version_no are a denormalized cache this module
+# keeps in sync (best-effort — a missing Pocket, e.g. a site keyed on a source
+# pocket id, is skipped, never fatal). status_for always reads the collection so
+# correctness never depends on the cache.
+#
+# Engine-aware: every snapshot carries content (rippleSpec) AND source (svelte
+# map) AND engine together, so a svelte site — which lives entirely in ``source``
+# — versions and rolls back correctly (architect review #5).
+#
+# OSS/EE seam: the persistence sits behind ``VersionStoreProtocol`` so an OSS
+# local store could implement the same async surface later; the EE default is
+# Beanie/Mongo. Phase 1 ships only the Beanie store.
+#
+# Created 2026-06-06 (feat/1345-draft-published).
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from pocketpaw_ee.cloud.models.pocket_version import PocketVersion
+
+
+@dataclass(frozen=True)
+class VersionStatus:
+    """The derived draft/published state of a pocket's content.
+
+    ``status`` is one of:
+      * "none"      — the pocket has no versions yet.
+      * "draft"     — the latest version is newer than the published one (there
+                      are unpublished edits), or nothing is published yet.
+      * "published" — the latest version IS the published one (no pending edits).
+    """
+
+    status: str
+    draft_version: int | None
+    published_version: int | None
+
+
+class VersionStoreProtocol(Protocol):
+    """Async persistence surface for pocket-content versions. The EE default is
+    Beanie/Mongo; an OSS local store could implement the same shape later."""
+
+    async def latest_version_no(self, workspace_id: str, pocket_id: str) -> int | None: ...
+    async def latest(self, workspace_id: str, pocket_id: str) -> PocketVersion | None: ...
+    async def latest_published(
+        self, workspace_id: str, pocket_id: str
+    ) -> PocketVersion | None: ...
+    async def get(
+        self, workspace_id: str, pocket_id: str, version_no: int
+    ) -> PocketVersion | None: ...
+    async def insert(self, version: PocketVersion) -> PocketVersion: ...
+    async def list_versions(
+        self, workspace_id: str, pocket_id: str
+    ) -> list[PocketVersion]: ...
+
+
+class _BeanieVersionStore:
+    """The EE Mongo-backed store (the only Phase-1 implementation)."""
+
+    async def latest_version_no(self, workspace_id: str, pocket_id: str) -> int | None:
+        doc = (
+            await PocketVersion.find(
+                PocketVersion.workspace == workspace_id,
+                PocketVersion.pocket_id == pocket_id,
+            )
+            .sort(-PocketVersion.version_no)  # type: ignore[operator]
+            .first_or_none()
+        )
+        return doc.version_no if doc else None
+
+    async def latest(self, workspace_id: str, pocket_id: str) -> PocketVersion | None:
+        return (
+            await PocketVersion.find(
+                PocketVersion.workspace == workspace_id,
+                PocketVersion.pocket_id == pocket_id,
+            )
+            .sort(-PocketVersion.version_no)  # type: ignore[operator]
+            .first_or_none()
+        )
+
+    async def latest_published(
+        self, workspace_id: str, pocket_id: str
+    ) -> PocketVersion | None:
+        return (
+            await PocketVersion.find(
+                PocketVersion.workspace == workspace_id,
+                PocketVersion.pocket_id == pocket_id,
+                PocketVersion.status == "published",
+            )
+            .sort(-PocketVersion.version_no)  # type: ignore[operator]
+            .first_or_none()
+        )
+
+    async def get(
+        self, workspace_id: str, pocket_id: str, version_no: int
+    ) -> PocketVersion | None:
+        return await PocketVersion.find_one(
+            PocketVersion.workspace == workspace_id,
+            PocketVersion.pocket_id == pocket_id,
+            PocketVersion.version_no == version_no,
+        )
+
+    async def insert(self, version: PocketVersion) -> PocketVersion:
+        await version.insert()
+        return version
+
+    async def list_versions(
+        self, workspace_id: str, pocket_id: str
+    ) -> list[PocketVersion]:
+        return (
+            await PocketVersion.find(
+                PocketVersion.workspace == workspace_id,
+                PocketVersion.pocket_id == pocket_id,
+            )
+            .sort(-PocketVersion.version_no)  # type: ignore[operator]
+            .to_list()
+        )
+
+
+# Module-level default store. Tests can pass their own via the ``_store`` kwarg,
+# but the Beanie store works against the in-memory mongomock db, so they don't
+# need to.
+_default_store: VersionStoreProtocol = _BeanieVersionStore()
+
+
+async def _sync_pocket_pointers(
+    workspace_id: str,
+    pocket_id: str,
+    *,
+    draft_no: int | None,
+    published_no: int | None,
+    deploy_status: str | None = None,
+) -> None:
+    """Best-effort denormalized-pointer update on the Pocket doc. A site is keyed
+    on its SOURCE pocket id, so the Pocket usually exists; if it doesn't (or the
+    id isn't an ObjectId), we skip silently — the collection stays the source of
+    truth."""
+    from bson import ObjectId
+    from bson.errors import InvalidId
+
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    try:
+        oid = ObjectId(pocket_id)
+    except (InvalidId, TypeError):
+        return
+    doc = await Pocket.find_one(Pocket.id == oid, Pocket.workspace == workspace_id)
+    if doc is None:
+        return
+    doc.draft_version_no = draft_no
+    doc.published_version_no = published_no
+    if deploy_status is not None:
+        doc.last_deploy_status = deploy_status
+    await doc.save()
+
+
+async def record_draft(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    content: dict[str, Any] | None = None,
+    source: dict[str, str] | None = None,
+    engine: str = "ripple",
+    author: str | None = None,
+    label: str | None = None,
+    origin: str | None = None,
+    _store: VersionStoreProtocol | None = None,
+) -> PocketVersion:
+    """Write a NEW draft version — the edit/refine operation. version_no is the
+    previous max + 1; parent_version_no links the chain. The published pointer is
+    untouched. Both content (rippleSpec) and source (svelte map) are snapshotted
+    so the engine round-trips on rollback."""
+    store = _store or _default_store
+    prev_no = await store.latest_version_no(workspace_id, pocket_id)
+    version_no = (prev_no or 0) + 1
+    version = PocketVersion(
+        workspace=workspace_id,
+        pocket_id=pocket_id,
+        version_no=version_no,
+        content=content,
+        source=source,
+        engine=engine,
+        author=author,
+        label=label,
+        status="draft",
+        parent_version_no=prev_no,
+        origin=origin or "refine",
+    )
+    await store.insert(version)
+    published = await store.latest_published(workspace_id, pocket_id)
+    await _sync_pocket_pointers(
+        workspace_id,
+        pocket_id,
+        draft_no=version_no,
+        published_no=published.version_no if published else None,
+    )
+    return version
+
+
+async def publish_draft(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    version_no: int | None = None,
+    _store: VersionStoreProtocol | None = None,
+) -> PocketVersion:
+    """Promote a version to published (tag it). Defaults to the current draft (the
+    latest version); pass ``version_no`` to publish a specific one. Returns the
+    promoted version. The caller triggers the deploy and flips "Live" — this only
+    moves the version state (deploy is a separate axis, architect review #2)."""
+    store = _store or _default_store
+    if version_no is None:
+        target = await store.latest(workspace_id, pocket_id)
+    else:
+        target = await store.get(workspace_id, pocket_id, version_no)
+    if target is None:
+        raise ValueError(f"no version to publish for pocket {pocket_id}")
+    target.status = "published"
+    await target.save()
+    await _sync_pocket_pointers(
+        workspace_id,
+        pocket_id,
+        draft_no=target.version_no,
+        published_no=target.version_no,
+    )
+    return target
+
+
+async def rollback(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    target_version: int,
+    author: str | None = None,
+    _store: VersionStoreProtocol | None = None,
+) -> PocketVersion:
+    """Make an old version the new draft: clone its content/source/engine into a
+    fresh draft version (leaving the original row intact). Publishing the result
+    goes live. Raises ValueError if the target version doesn't exist."""
+    store = _store or _default_store
+    src = await store.get(workspace_id, pocket_id, target_version)
+    if src is None:
+        raise ValueError(f"version {target_version} not found for pocket {pocket_id}")
+    return await record_draft(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        content=src.content,
+        source=src.source,
+        engine=src.engine,
+        author=author,
+        label=f"rollback to v{target_version}",
+        origin="rollback",
+        _store=store,
+    )
+
+
+async def get_draft(
+    *, workspace_id: str, pocket_id: str, _store: VersionStoreProtocol | None = None
+) -> PocketVersion | None:
+    """The current working version (the latest version, regardless of status)."""
+    store = _store or _default_store
+    return await store.latest(workspace_id, pocket_id)
+
+
+async def get_published(
+    *, workspace_id: str, pocket_id: str, _store: VersionStoreProtocol | None = None
+) -> PocketVersion | None:
+    """The current published (live-candidate) version, or None if never published."""
+    store = _store or _default_store
+    return await store.latest_published(workspace_id, pocket_id)
+
+
+async def get_draft_content(
+    *, workspace_id: str, pocket_id: str, _store: VersionStoreProtocol | None = None
+) -> dict[str, Any] | None:
+    """The working version's content for the preview. Returns the rippleSpec
+    (``content``) for a ripple pocket, or the svelte ``source`` map for a svelte
+    pocket — whichever the latest version carries. None if no versions exist."""
+    draft = await get_draft(workspace_id=workspace_id, pocket_id=pocket_id, _store=_store)
+    if draft is None:
+        return None
+    if draft.engine == "svelte":
+        return draft.source
+    return draft.content
+
+
+async def status_for(
+    *, workspace_id: str, pocket_id: str, _store: VersionStoreProtocol | None = None
+) -> VersionStatus:
+    """Derive the draft/published state from the version log (source of truth)."""
+    store = _store or _default_store
+    latest = await store.latest(workspace_id, pocket_id)
+    if latest is None:
+        return VersionStatus(status="none", draft_version=None, published_version=None)
+    published = await store.latest_published(workspace_id, pocket_id)
+    published_no = published.version_no if published else None
+    # "published" only when the latest version IS the published one (no pending
+    # edits). Otherwise there are unpublished edits → "draft".
+    if published_no is not None and published_no == latest.version_no:
+        status = "published"
+    else:
+        status = "draft"
+    return VersionStatus(
+        status=status,
+        draft_version=latest.version_no,
+        published_version=published_no,
+    )
+
+
+async def list_versions(
+    *, workspace_id: str, pocket_id: str, _store: VersionStoreProtocol | None = None
+) -> list[PocketVersion]:
+    """All versions for a pocket, newest first (Phase-2 history view)."""
+    store = _store or _default_store
+    return await store.list_versions(workspace_id, pocket_id)
+
+
+__all__ = [
+    "VersionStatus",
+    "VersionStoreProtocol",
+    "record_draft",
+    "publish_draft",
+    "rollback",
+    "get_draft",
+    "get_published",
+    "get_draft_content",
+    "status_for",
+    "list_versions",
+]

--- a/ee/pocketpaw_ee/cloud/versions/service.py
+++ b/ee/pocketpaw_ee/cloud/versions/service.py
@@ -29,12 +29,25 @@
 # Beanie/Mongo. Phase 1 ships only the Beanie store.
 #
 # Created 2026-06-06 (feat/1345-draft-published).
+# Updated 2026-06-06 (code review BLOCK-1): record_draft is now race-safe. The
+# (workspace, pocket_id, version_no) index is UNIQUE, so two concurrent
+# record_draft calls that compute the same version_no no longer both succeed —
+# the loser gets a DuplicateKeyError. record_draft catches it and retries (re-read
+# latest_version_no → re-increment → re-insert) up to a small bound, so two quick
+# "Refine" clicks both land as distinct versions instead of one surfacing a 500.
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from pymongo.errors import DuplicateKeyError
+
 from pocketpaw_ee.cloud.models.pocket_version import PocketVersion
+
+# How many times record_draft re-derives version_no after losing the unique-index
+# race before giving up. Contention is between a user's own near-simultaneous
+# edits (a double "Refine" click), so a handful of attempts is plenty.
+_RECORD_DRAFT_MAX_ATTEMPTS = 5
 
 
 @dataclass(frozen=True)
@@ -59,16 +72,12 @@ class VersionStoreProtocol(Protocol):
 
     async def latest_version_no(self, workspace_id: str, pocket_id: str) -> int | None: ...
     async def latest(self, workspace_id: str, pocket_id: str) -> PocketVersion | None: ...
-    async def latest_published(
-        self, workspace_id: str, pocket_id: str
-    ) -> PocketVersion | None: ...
+    async def latest_published(self, workspace_id: str, pocket_id: str) -> PocketVersion | None: ...
     async def get(
         self, workspace_id: str, pocket_id: str, version_no: int
     ) -> PocketVersion | None: ...
     async def insert(self, version: PocketVersion) -> PocketVersion: ...
-    async def list_versions(
-        self, workspace_id: str, pocket_id: str
-    ) -> list[PocketVersion]: ...
+    async def list_versions(self, workspace_id: str, pocket_id: str) -> list[PocketVersion]: ...
 
 
 class _BeanieVersionStore:
@@ -95,9 +104,7 @@ class _BeanieVersionStore:
             .first_or_none()
         )
 
-    async def latest_published(
-        self, workspace_id: str, pocket_id: str
-    ) -> PocketVersion | None:
+    async def latest_published(self, workspace_id: str, pocket_id: str) -> PocketVersion | None:
         return (
             await PocketVersion.find(
                 PocketVersion.workspace == workspace_id,
@@ -108,9 +115,7 @@ class _BeanieVersionStore:
             .first_or_none()
         )
 
-    async def get(
-        self, workspace_id: str, pocket_id: str, version_no: int
-    ) -> PocketVersion | None:
+    async def get(self, workspace_id: str, pocket_id: str, version_no: int) -> PocketVersion | None:
         return await PocketVersion.find_one(
             PocketVersion.workspace == workspace_id,
             PocketVersion.pocket_id == pocket_id,
@@ -121,9 +126,7 @@ class _BeanieVersionStore:
         await version.insert()
         return version
 
-    async def list_versions(
-        self, workspace_id: str, pocket_id: str
-    ) -> list[PocketVersion]:
+    async def list_versions(self, workspace_id: str, pocket_id: str) -> list[PocketVersion]:
         return (
             await PocketVersion.find(
                 PocketVersion.workspace == workspace_id,
@@ -186,24 +189,40 @@ async def record_draft(
     """Write a NEW draft version — the edit/refine operation. version_no is the
     previous max + 1; parent_version_no links the chain. The published pointer is
     untouched. Both content (rippleSpec) and source (svelte map) are snapshotted
-    so the engine round-trips on rollback."""
+    so the engine round-trips on rollback.
+
+    Race-safe: version_no is read-then-written, so two concurrent calls can derive
+    the same number. The (workspace, pocket_id, version_no) unique index makes the
+    loser's insert fail with DuplicateKeyError; we re-read the max and retry up to
+    ``_RECORD_DRAFT_MAX_ATTEMPTS`` times so both edits land as distinct versions."""
     store = _store or _default_store
-    prev_no = await store.latest_version_no(workspace_id, pocket_id)
-    version_no = (prev_no or 0) + 1
-    version = PocketVersion(
-        workspace=workspace_id,
-        pocket_id=pocket_id,
-        version_no=version_no,
-        content=content,
-        source=source,
-        engine=engine,
-        author=author,
-        label=label,
-        status="draft",
-        parent_version_no=prev_no,
-        origin=origin or "refine",
-    )
-    await store.insert(version)
+    version: PocketVersion | None = None
+    for attempt in range(_RECORD_DRAFT_MAX_ATTEMPTS):
+        prev_no = await store.latest_version_no(workspace_id, pocket_id)
+        version_no = (prev_no or 0) + 1
+        candidate = PocketVersion(
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            version_no=version_no,
+            content=content,
+            source=source,
+            engine=engine,
+            author=author,
+            label=label,
+            status="draft",
+            parent_version_no=prev_no,
+            origin=origin or "refine",
+        )
+        try:
+            await store.insert(candidate)
+        except DuplicateKeyError:
+            # Another writer claimed this version_no first. Re-read and retry.
+            if attempt == _RECORD_DRAFT_MAX_ATTEMPTS - 1:
+                raise
+            continue
+        version = candidate
+        break
+    assert version is not None  # the loop either sets this or re-raises
     published = await store.latest_published(workspace_id, pocket_id)
     await _sync_pocket_pointers(
         workspace_id,
@@ -219,12 +238,19 @@ async def publish_draft(
     workspace_id: str,
     pocket_id: str,
     version_no: int | None = None,
+    deploy_status: str | None = None,
     _store: VersionStoreProtocol | None = None,
 ) -> PocketVersion:
     """Promote a version to published (tag it). Defaults to the current draft (the
     latest version); pass ``version_no`` to publish a specific one. Returns the
     promoted version. The caller triggers the deploy and flips "Live" — this only
-    moves the version state (deploy is a separate axis, architect review #2)."""
+    moves the version state (deploy is a separate axis, architect review #2).
+
+    ``deploy_status`` is the optional deploy-axis value to mirror onto the Pocket
+    pointer cache in the SAME write that advances the version pointers (e.g.
+    sites/service.publish passes "live" once its deploy succeeds). Folding it in
+    here keeps callers to ONE public call instead of reaching for the private
+    pointer sync."""
     store = _store or _default_store
     if version_no is None:
         target = await store.latest(workspace_id, pocket_id)
@@ -239,6 +265,7 @@ async def publish_draft(
         pocket_id,
         draft_no=target.version_no,
         published_no=target.version_no,
+        deploy_status=deploy_status,
     )
     return target
 

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -7,8 +7,19 @@
 # per-site static server serves so the caller (and the cmux smoke) can open the
 # published site directly. Empty in the CF path in v1 (reached via custom
 # domain). The frontend Site type mirrors this in Phase 4.
+#
+# Updated 2026-06-06 (feat/1345-draft-published): SiteResponse now carries the
+# draft/published state the frontend reads to stop "Live" from lying —
+# ``status`` ("draft" | "published") is the version state (draft == there are
+# unpublished edits), and ``is_live`` is the REAL-deploy axis (True only after a
+# successful publish/deploy). Added SiteStatusResponse (the standalone status read
+# backing the badge, with the draft/published version pointers) and
+# PreviewResponse (the current DRAFT content the builder preview renders, which
+# fixes the dead-published-URL iframe).
 
 from __future__ import annotations
+
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -25,6 +36,35 @@ class SiteResponse(BaseModel):
     deployed: bool
     signed_key: str
     url: str = ""
+    # Draft/published state machine (pocketpaw#1345). ``status`` is the version
+    # state: "draft" (unpublished edits exist) | "published" (live candidate ==
+    # latest). ``is_live`` is the deploy-confirmed axis: True ONLY after a
+    # successful publish/deploy. A freshly created site is status="draft",
+    # is_live=False — it is NOT live until an explicit publish succeeds.
+    status: str = "draft"
+    is_live: bool = False
+
+
+class SiteStatusResponse(BaseModel):
+    """The draft/published status read backing the Draft/Live badge."""
+
+    pocket_id: str
+    site_id: str | None = None
+    status: str  # draft | published
+    is_live: bool
+    draft_version: int | None = None
+    published_version: int | None = None
+    url: str = ""
+
+
+class PreviewResponse(BaseModel):
+    """The current DRAFT content the builder preview renders (not the published
+    URL). ``content`` is the rippleSpec for a ripple site, or the svelte source
+    map for a svelte site. ``engine`` tells the renderer which it got."""
+
+    pocket_id: str
+    engine: str = "ripple"
+    content: dict[str, Any] | None = None
 
 
 class DomainRequest(BaseModel):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -21,6 +21,15 @@
 # require_plan_feature("fabric") router gate + require_action_any_workspace
 # scoping as the other authed sites reads) so the Domains tab can rehydrate on
 # reload. A site in another workspace surfaces as a 404 (via the service _load).
+#
+# Updated 2026-06-06 (feat/1345-draft-published): added two pocket-keyed reads for
+# the draft/published state machine (pocketpaw#1345), both gated fabric.read:
+#   * GET /sites/by-pocket/{pocket_id}/status  — the Draft/Live badge state
+#     (status + is_live + draft/published version pointers). Keyed by SOURCE
+#     pocket id because a draft has no site_id until first publish.
+#   * GET /sites/by-pocket/{pocket_id}/preview — the current DRAFT content the
+#     builder iframe renders (rippleSpec or svelte source map), fixing the
+#     dead-published-URL preview.
 
 from __future__ import annotations
 
@@ -32,8 +41,10 @@ from pocketpaw_ee.sites import service as sites_service
 from pocketpaw_ee.sites.dto import (
     DomainRequest,
     DomainStatusResponse,
+    PreviewResponse,
     PublishRequest,
     SiteResponse,
+    SiteStatusResponse,
 )
 
 router = APIRouter(
@@ -64,6 +75,36 @@ async def publish_site(
 @router.get("/sites", response_model=list[SiteResponse])
 async def list_sites(ctx: RequestContext = Depends(request_context)) -> list[SiteResponse]:
     return await sites_service.list_for_workspace(ctx.workspace_id)
+
+
+@router.get(
+    "/sites/by-pocket/{pocket_id}/status",
+    response_model=SiteStatusResponse,
+)
+async def site_status(
+    pocket_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> SiteStatusResponse:
+    """The draft/published + is_live badge state for a pocket's site. Works
+    before the first publish (no Site doc yet) — the version state comes from the
+    versions log and ``is_live`` is False until a deploy succeeds."""
+    return await sites_service.site_status(workspace_id=ctx.workspace_id, pocket_id=pocket_id)
+
+
+@router.get(
+    "/sites/by-pocket/{pocket_id}/preview",
+    response_model=PreviewResponse,
+)
+async def site_preview(
+    pocket_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> PreviewResponse:
+    """The current DRAFT content the builder preview renders (rippleSpec for a
+    ripple site, svelte source map for a svelte site) — NOT the published URL.
+    Fixes the builder preview iframing a dead local-serve address."""
+    return await sites_service.preview(workspace_id=ctx.workspace_id, pocket_id=pocket_id)
 
 
 @router.post("/sites/{site_id}/domains", response_model=DomainStatusResponse)

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -22,6 +22,13 @@
 # _to_response now carries status + is_live. The deploy seam is unchanged: publish
 # still calls generator.build(...) and cf.put_worker(...)/local deploy as-is.
 #
+# Updated 2026-06-06 (code review BLOCK-2): publish() no longer calls the versions
+# module's PRIVATE _sync_pocket_pointers. The post-deploy "mark live" pointer
+# write is now folded into the public versions_service.publish_draft(...,
+# deploy_status="live") call one line above — so sites/service makes exactly one
+# public versions call to promote + mark-live, and no private cross-module call
+# remains.
+#
 # Updated 2026-06-01 (Phase 4 — chat→create-site): added publish_pocket(), the
 # shared "publish a pocket by id" path. It reads the pocket's rippleSpec + theme
 # via pockets_service (logic lifted verbatim from the router) and delegates to
@@ -235,14 +242,10 @@ async def _find_site_for_pocket(workspace_id: str, pocket_id: str) -> _SiteDoc |
     """The Site row (if any) for a pocket in a workspace. A pocket has at most one
     site (the compound (workspace, pocket_id) index), so publish reuses it rather
     than stacking a second row when a draft was created first."""
-    return await _SiteDoc.find_one(
-        {"workspace": workspace_id, "pocket_id": pocket_id}
-    )
+    return await _SiteDoc.find_one({"workspace": workspace_id, "pocket_id": pocket_id})
 
 
-async def _resolve_site_name(
-    *, name: str, pocket_id: str, user_id: str
-) -> str:
+async def _resolve_site_name(*, name: str, pocket_id: str, user_id: str) -> str:
     """Default a blank name to the source pocket's own display name (the publish
     schema promises this), falling back to "Untitled site". Reads the pocket via
     the pockets service's PUBLIC ``get`` (a wire dict — no Beanie import)."""
@@ -416,9 +419,7 @@ async def publish(
     # (no prior draft) records one now from the passed content so the published
     # version reflects exactly what was deployed.
     if await versions_service.get_draft(workspace_id=workspace_id, pocket_id=pocket_id) is None:
-        content, src = _version_content(
-            engine=engine, ripple_spec=ripple_spec, source=source
-        )
+        content, src = _version_content(engine=engine, ripple_spec=ripple_spec, source=source)
         await versions_service.record_draft(
             workspace_id=workspace_id,
             pocket_id=pocket_id,
@@ -457,8 +458,12 @@ async def publish(
         await cf.put_worker(script_name=site_id, bundle=bundle)
 
     # Deploy succeeded — NOW promote the draft to published and mark the site
-    # live. The deploy status is mirrored onto the pocket pointer as "live".
-    await versions_service.publish_draft(workspace_id=workspace_id, pocket_id=pocket_id)
+    # live. publish_draft advances the version pointers AND mirrors the deploy
+    # status ("live") onto the Pocket pointer cache in one write, so this stays a
+    # single PUBLIC call (no reaching into the versions module's privates).
+    await versions_service.publish_draft(
+        workspace_id=workspace_id, pocket_id=pocket_id, deploy_status="live"
+    )
 
     if existing is not None:
         existing.name = site_name
@@ -488,18 +493,6 @@ async def publish(
         )
         await doc.insert()
 
-    # Mirror the real version pointers + the live deploy onto the pocket pointer
-    # cache in one write (best-effort — skipped if the pocket doc isn't present).
-    vstatus = await versions_service.status_for(
-        workspace_id=workspace_id, pocket_id=pocket_id
-    )
-    await versions_service._sync_pocket_pointers(
-        workspace_id,
-        pocket_id,
-        draft_no=vstatus.draft_version,
-        published_no=vstatus.published_version,
-        deploy_status="live",
-    )
     return doc
 
 
@@ -666,9 +659,7 @@ async def site_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespons
     ``is_live`` is False until a deploy succeeds. ``status`` "none" surfaces as
     "draft" to the badge (a pocket with no versions yet is, practically, a draft).
     """
-    vstatus = await versions_service.status_for(
-        workspace_id=workspace_id, pocket_id=pocket_id
-    )
+    vstatus = await versions_service.status_for(workspace_id=workspace_id, pocket_id=pocket_id)
     site = await _find_site_for_pocket(workspace_id, pocket_id)
     is_live = bool(site.deployed) if site is not None else False
     # Map the version "none" (no versions yet) to the badge's "draft".
@@ -684,25 +675,19 @@ async def site_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespons
     )
 
 
-async def preview_content(
-    *, workspace_id: str, pocket_id: str
-) -> dict[str, Any] | None:
+async def preview_content(*, workspace_id: str, pocket_id: str) -> dict[str, Any] | None:
     """The current DRAFT content the builder preview renders — the rippleSpec for
     a ripple site, or the svelte source map for a svelte site. Returns the WORKING
     version (the latest draft), NOT the published URL — this is the fix for the
     builder preview iframing a dead local-serve URL. ``None`` when the pocket has
     no versions yet."""
-    return await versions_service.get_draft_content(
-        workspace_id=workspace_id, pocket_id=pocket_id
-    )
+    return await versions_service.get_draft_content(workspace_id=workspace_id, pocket_id=pocket_id)
 
 
 async def preview(*, workspace_id: str, pocket_id: str) -> PreviewResponse:
     """``preview_content`` wrapped in the response DTO (with the engine), for the
     REST preview endpoint."""
-    draft = await versions_service.get_draft(
-        workspace_id=workspace_id, pocket_id=pocket_id
-    )
+    draft = await versions_service.get_draft(workspace_id=workspace_id, pocket_id=pocket_id)
     if draft is None:
         return PreviewResponse(pocket_id=pocket_id, engine="ripple", content=None)
     content = draft.source if draft.engine == "svelte" else draft.content

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,27 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-06 (feat/1345-draft-published — draft/published state machine,
+# pocketpaw#1345): stop "Live" from lying. New flow on top of the versions module
+# (ee/pocketpaw_ee/cloud/versions):
+#   * create_draft_site() records the content as the first DRAFT version and
+#     persists a Site doc that is NOT deployed and NOT live (status="draft",
+#     deployed=False) — creating a site no longer claims it's live.
+#   * record_site_draft() is the refine buffer: it writes a NEW draft version and
+#     flips the site to "draft", leaving the published version + live deploy
+#     untouched until the next publish.
+#   * publish() now builds + deploys FIRST, and only on a SUCCESSFUL deploy
+#     promotes the draft → published and marks the site deployed/live. A failed
+#     build (SmokeGateFailed) or failed Worker upload leaves a recoverable draft
+#     and never a phantom-live site. It reuses the draft site's row/identity per
+#     pocket instead of stacking a second Site, and records a draft from the
+#     passed content if none exists (the direct-publish path).
+#   * site_status() returns the draft/published + is_live badge state (works
+#     before the first publish); preview()/preview_content() return the current
+#     DRAFT content the builder renders (fixes the dead-published-URL iframe).
+# _to_response now carries status + is_live. The deploy seam is unchanged: publish
+# still calls generator.build(...) and cf.put_worker(...)/local deploy as-is.
+#
 # Updated 2026-06-01 (Phase 4 — chat→create-site): added publish_pocket(), the
 # shared "publish a pocket by id" path. It reads the pocket's rippleSpec + theme
 # via pockets_service (logic lifted verbatim from the router) and delegates to
@@ -95,8 +116,14 @@ from bson.errors import InvalidId
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
+from pocketpaw_ee.cloud.versions import service as versions_service
 from pocketpaw_ee.sites.domain import HostnameStatus
-from pocketpaw_ee.sites.dto import DomainStatusResponse, SiteResponse
+from pocketpaw_ee.sites.dto import (
+    DomainStatusResponse,
+    PreviewResponse,
+    SiteResponse,
+    SiteStatusResponse,
+)
 from pocketpaw_ee.sites.generator_client import GeneratorClient
 
 # The control plane reads the Worker bundle adapter-cloudflare emits here.
@@ -177,6 +204,9 @@ def _local_mode() -> bool:
 
 
 def _to_response(doc: _SiteDoc) -> SiteResponse:
+    # ``status`` is the denormalized version state on the doc ("draft" |
+    # "published"); ``is_live`` is the deploy-confirmed axis (the site was
+    # actually deployed). A draft site reads status="draft", is_live=False.
     return SiteResponse(
         id=str(doc.id),
         pocket_id=doc.pocket_id,
@@ -185,7 +215,138 @@ def _to_response(doc: _SiteDoc) -> SiteResponse:
         deployed=doc.deployed,
         signed_key=doc.signed_key,
         url=doc.url,
+        status=getattr(doc, "status", "draft"),
+        is_live=bool(doc.deployed),
     )
+
+
+def _version_content(
+    *, engine: str, ripple_spec: dict[str, Any] | None, source: dict[str, str] | None
+) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
+    """Split the publish payload into the (content, source) snapshot pair the
+    versions log stores. Svelte sites version their ``source`` map; ripple sites
+    version their ``rippleSpec``. The other field is None on each track."""
+    if engine == "svelte":
+        return None, source
+    return ripple_spec, None
+
+
+async def _find_site_for_pocket(workspace_id: str, pocket_id: str) -> _SiteDoc | None:
+    """The Site row (if any) for a pocket in a workspace. A pocket has at most one
+    site (the compound (workspace, pocket_id) index), so publish reuses it rather
+    than stacking a second row when a draft was created first."""
+    return await _SiteDoc.find_one(
+        {"workspace": workspace_id, "pocket_id": pocket_id}
+    )
+
+
+async def _resolve_site_name(
+    *, name: str, pocket_id: str, user_id: str
+) -> str:
+    """Default a blank name to the source pocket's own display name (the publish
+    schema promises this), falling back to "Untitled site". Reads the pocket via
+    the pockets service's PUBLIC ``get`` (a wire dict — no Beanie import)."""
+    site_name = name.strip() if name else ""
+    if not site_name:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        pocket = await pockets_service.get(pocket_id, user_id)
+        site_name = (pocket.get("name") or "").strip()
+    if not site_name:
+        site_name = "Untitled site"
+    return site_name
+
+
+async def create_draft_site(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    ripple_spec: dict[str, Any] | None = None,
+    theme: dict[str, Any],
+    name: str = "",
+    engine: str = "ripple",
+    source: dict[str, str] | None = None,
+) -> _SiteDoc:
+    """Create a site as a DRAFT — record its content as the first draft version
+    and persist a Site doc that is NOT deployed and NOT live (status="draft",
+    deployed=False). This is the fix for "a site is stamped deployed the moment
+    it's created": creating a site no longer claims it's live. An explicit
+    ``publish`` builds, deploys, and flips it live.
+
+    The site id + signed key + script name are minted here (they're identifiers,
+    not deploy state) so the draft has a stable identity the later publish reuses.
+    Idempotent per pocket: if a site already exists for this pocket, the new
+    content is recorded as a fresh draft and the existing doc is returned
+    (status reset to "draft" — there are now unpublished edits)."""
+    content, src = _version_content(engine=engine, ripple_spec=ripple_spec, source=source)
+    await versions_service.record_draft(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        content=content,
+        source=src,
+        engine=engine,
+        author=user_id,
+        origin="create",
+    )
+    site_name = await _resolve_site_name(name=name, pocket_id=pocket_id, user_id=user_id)
+
+    existing = await _find_site_for_pocket(workspace_id, pocket_id)
+    if existing is not None:
+        existing.name = site_name
+        existing.status = "draft"  # new unpublished edits
+        await existing.save()
+        return existing
+
+    site_id = str(ObjectId())
+    signed_key = f"site_key_{secrets.token_urlsafe(24)}"
+    doc = _SiteDoc(
+        id=ObjectId(site_id),
+        workspace=workspace_id,
+        pocket_id=pocket_id,
+        owner=user_id,
+        name=site_name,
+        script_name=site_id,
+        deployed=False,
+        status="draft",
+        signed_key=signed_key,
+        url="",
+        allowed_origins=_default_allowed_origins(),
+        event_mapping=_DEFAULT_EVENT_MAPPING,
+    )
+    await doc.insert()
+    return doc
+
+
+async def record_site_draft(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    content: dict[str, Any] | None = None,
+    source: dict[str, str] | None = None,
+    engine: str = "ripple",
+) -> _SiteDoc | None:
+    """Refine a site's content: write a NEW draft version and mark the site
+    "draft" (there are unpublished edits). The published version's content — and
+    the live deploy — are untouched until the next publish. This is the buffer the
+    bug report asked for ("every refine overwrites the live thing with no draft
+    buffer and no way back"). Returns the Site doc if one exists yet (a site can
+    be refined before it is first published), else None."""
+    await versions_service.record_draft(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        content=content,
+        source=source,
+        engine=engine,
+        author=user_id,
+        origin="refine",
+    )
+    doc = await _find_site_for_pocket(workspace_id, pocket_id)
+    if doc is not None:
+        doc.status = "draft"
+        await doc.save()
+    return doc
 
 
 async def publish(
@@ -203,9 +364,23 @@ async def publish(
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
     _local_deploy: Callable[[str, str], str] | None = None,
 ) -> _SiteDoc:
-    """Generate, smoke-gate, deploy, and persist a site. Raises SmokeGateFailed
-    (from generator_client) if the workerd smoke render fails — the site is not
-    deployed and not persisted as deployed.
+    """Promote the pocket's draft to published, build, smoke-gate, deploy, and
+    persist the site as live. Raises SmokeGateFailed (from generator_client) if
+    the workerd smoke render fails, or the deploy error if the Worker upload
+    fails — in BOTH cases the version stays a draft and the site is NOT marked
+    live (the "Live only after a successful deploy" guarantee).
+
+    Order matters: build + deploy run FIRST; only on success does the draft
+    version get promoted to published and the Site doc persisted as
+    deployed/published. So a failed publish leaves a recoverable draft and never
+    a phantom-live site.
+
+    Idempotent per pocket: reuses the Site row created by ``create_draft_site``
+    (and its minted id / signed key / script name) when one exists, instead of
+    stacking a second row; otherwise mints a fresh identity (the direct-publish
+    path, e.g. ``publish_pocket``). If no draft version exists yet (direct
+    publish), one is recorded from the passed content before promotion, so publish
+    always has a version to promote.
 
     Deploy has two branches:
       * REAL Cloudflare (default when creds are present, or when a CF client is
@@ -224,22 +399,38 @@ async def publish(
     so the common path does not re-fetch."""
     generator = _generator or GeneratorClient()
 
-    # Default a blank name to the source pocket's own display name so the schema's
-    # "defaults to the pocket's own name" promise is true at the source-of-truth
-    # layer. Cross-entity read goes through the pockets service's PUBLIC function
-    # (wire dict), never the Pocket Beanie model.
-    site_name = name.strip() if name else ""
-    if not site_name:
-        from pocketpaw_ee.cloud.pockets import service as pockets_service
+    site_name = await _resolve_site_name(name=name, pocket_id=pocket_id, user_id=user_id)
 
-        pocket = await pockets_service.get(pocket_id, user_id)
-        site_name = (pocket.get("name") or "").strip()
-    if not site_name:
-        site_name = "Untitled site"
+    # Reuse the draft site's identity if it exists, so publish updates that row
+    # rather than creating a second site for the same pocket.
+    existing = await _find_site_for_pocket(workspace_id, pocket_id)
+    if existing is not None:
+        site_id = str(existing.id)
+        signed_key = existing.signed_key
+    else:
+        site_id = str(ObjectId())
+        signed_key = f"site_key_{secrets.token_urlsafe(24)}"
 
-    site_id = str(ObjectId())
-    signed_key = f"site_key_{secrets.token_urlsafe(24)}"
+    # Ensure there is a draft version to promote. The create-then-publish path
+    # already recorded one (the user's working content); the direct-publish path
+    # (no prior draft) records one now from the passed content so the published
+    # version reflects exactly what was deployed.
+    if await versions_service.get_draft(workspace_id=workspace_id, pocket_id=pocket_id) is None:
+        content, src = _version_content(
+            engine=engine, ripple_spec=ripple_spec, source=source
+        )
+        await versions_service.record_draft(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            content=content,
+            source=src,
+            engine=engine,
+            author=user_id,
+            origin="publish",
+        )
 
+    # Build + deploy FIRST. A failure here propagates BEFORE any promotion or
+    # live-marking, so the version stays a draft and the site is not live.
     build = await generator.build(
         ripple_spec=ripple_spec,
         theme=theme,
@@ -265,24 +456,50 @@ async def publish(
         bundle = _bundle_reader(build.project_dir)
         await cf.put_worker(script_name=site_id, bundle=bundle)
 
-    doc = _SiteDoc(
-        id=ObjectId(site_id),
-        workspace=workspace_id,
-        pocket_id=pocket_id,
-        owner=user_id,
-        name=site_name,
-        script_name=site_id,
-        deployed=True,
-        signed_key=signed_key,
-        url=url,
-        # Seed capture config so a lead lands with no manual Mongo edit: a default
-        # mapping keyed on the form_type the generated endpoint sends, and the
-        # local dev origins so the local smoke works. add_domain() appends the
-        # production hostname when a custom domain is connected.
-        allowed_origins=_default_allowed_origins(),
-        event_mapping=_DEFAULT_EVENT_MAPPING,
+    # Deploy succeeded — NOW promote the draft to published and mark the site
+    # live. The deploy status is mirrored onto the pocket pointer as "live".
+    await versions_service.publish_draft(workspace_id=workspace_id, pocket_id=pocket_id)
+
+    if existing is not None:
+        existing.name = site_name
+        existing.deployed = True
+        existing.status = "published"
+        existing.url = url
+        await existing.save()
+        doc = existing
+    else:
+        doc = _SiteDoc(
+            id=ObjectId(site_id),
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            owner=user_id,
+            name=site_name,
+            script_name=site_id,
+            deployed=True,
+            status="published",
+            signed_key=signed_key,
+            url=url,
+            # Seed capture config so a lead lands with no manual Mongo edit: a
+            # default mapping keyed on the form_type the generated endpoint sends,
+            # and the local dev origins so the local smoke works. add_domain()
+            # appends the production hostname when a custom domain is connected.
+            allowed_origins=_default_allowed_origins(),
+            event_mapping=_DEFAULT_EVENT_MAPPING,
+        )
+        await doc.insert()
+
+    # Mirror the real version pointers + the live deploy onto the pocket pointer
+    # cache in one write (best-effort — skipped if the pocket doc isn't present).
+    vstatus = await versions_service.status_for(
+        workspace_id=workspace_id, pocket_id=pocket_id
     )
-    await doc.insert()
+    await versions_service._sync_pocket_pointers(
+        workspace_id,
+        pocket_id,
+        draft_no=vstatus.draft_version,
+        published_no=vstatus.published_version,
+        deploy_status="live",
+    )
     return doc
 
 
@@ -440,9 +657,66 @@ async def site_pocket_ids(workspace_id: str) -> set[str]:
     return {doc.pocket_id async for doc in cursor}
 
 
+async def site_status(*, workspace_id: str, pocket_id: str) -> SiteStatusResponse:
+    """The draft/published status for a site, by source pocket id — backs the
+    Draft/Live badge. ``status`` is the version state (draft = unpublished edits |
+    published = the live candidate is the latest version), and ``is_live`` is the
+    deploy-confirmed axis (the Site was actually deployed). Works before the first
+    publish (no Site doc yet): version state comes from the versions log,
+    ``is_live`` is False until a deploy succeeds. ``status`` "none" surfaces as
+    "draft" to the badge (a pocket with no versions yet is, practically, a draft).
+    """
+    vstatus = await versions_service.status_for(
+        workspace_id=workspace_id, pocket_id=pocket_id
+    )
+    site = await _find_site_for_pocket(workspace_id, pocket_id)
+    is_live = bool(site.deployed) if site is not None else False
+    # Map the version "none" (no versions yet) to the badge's "draft".
+    badge_status = "published" if vstatus.status == "published" else "draft"
+    return SiteStatusResponse(
+        pocket_id=pocket_id,
+        site_id=str(site.id) if site is not None else None,
+        status=badge_status,
+        is_live=is_live,
+        draft_version=vstatus.draft_version,
+        published_version=vstatus.published_version,
+        url=site.url if site is not None else "",
+    )
+
+
+async def preview_content(
+    *, workspace_id: str, pocket_id: str
+) -> dict[str, Any] | None:
+    """The current DRAFT content the builder preview renders — the rippleSpec for
+    a ripple site, or the svelte source map for a svelte site. Returns the WORKING
+    version (the latest draft), NOT the published URL — this is the fix for the
+    builder preview iframing a dead local-serve URL. ``None`` when the pocket has
+    no versions yet."""
+    return await versions_service.get_draft_content(
+        workspace_id=workspace_id, pocket_id=pocket_id
+    )
+
+
+async def preview(*, workspace_id: str, pocket_id: str) -> PreviewResponse:
+    """``preview_content`` wrapped in the response DTO (with the engine), for the
+    REST preview endpoint."""
+    draft = await versions_service.get_draft(
+        workspace_id=workspace_id, pocket_id=pocket_id
+    )
+    if draft is None:
+        return PreviewResponse(pocket_id=pocket_id, engine="ripple", content=None)
+    content = draft.source if draft.engine == "svelte" else draft.content
+    return PreviewResponse(pocket_id=pocket_id, engine=draft.engine, content=content)
+
+
 __all__ = [
     "publish",
     "publish_pocket",
+    "create_draft_site",
+    "record_site_draft",
+    "site_status",
+    "preview",
+    "preview_content",
     "add_domain",
     "domain_status",
     "list_domains",

--- a/tests/ee/sites/test_draft_published.py
+++ b/tests/ee/sites/test_draft_published.py
@@ -1,0 +1,296 @@
+# tests/ee/sites/test_draft_published.py — reproduces and locks the /sites
+# draft-vs-published bug (pocketpaw#1345, "stop 'Live' from lying").
+#
+# The three reported failures, each asserted as a behaviour:
+#   1. A freshly CREATED site is Draft, not Live (creating content must not stamp
+#      deployed/live). Before the fix, the only create path (publish) stamped
+#      deployed=True instantly.
+#   2. "Live" is true only after a successful (mocked) deploy — and a FAILED
+#      deploy leaves the site not-live (and the published pointer un-advanced).
+#   3. The preview returns the current DRAFT content, not the dead published URL.
+#   4. Refine writes a NEW draft version and leaves the published version's
+#      content untouched until the next explicit publish.
+#
+# The generator + Cloudflare seams are injected with fakes (the same pattern as
+# test_service.py), so no Bun/workerd/CF/network is touched.
+#
+# Created 2026-06-06 (feat/1345-draft-published).
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+
+class _FakeGenerator:
+    """Successful build: returns a project dir, never raises."""
+
+    def __init__(self) -> None:
+        self.built: dict | None = None
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FailingGenerator:
+    """Build/smoke gate fails — the deploy must NOT proceed and Live must stay
+    false (the 'Live only after a successful deploy' guarantee)."""
+
+    async def build(self, **kw):
+        raise SmokeGateFailed("workerd SSR failure: window is not defined")
+
+
+class _FakeCF:
+    def __init__(self) -> None:
+        self.put_calls: list[str] = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+class _FailingCF:
+    """Worker upload fails after a good build — Live must stay false."""
+
+    async def put_worker(self, *, script_name, bundle):
+        raise RuntimeError("cloudflare 500: dispatch namespace upload failed")
+
+
+# ---------------------------------------------------------------------------
+# 1. Fresh site → Draft, not Live
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_draft_site_is_draft_not_live(beanie_test_db):
+    """Creating a site records its content as a DRAFT — it is NOT deployed and
+    NOT live. This is the fix for 'a site is stamped deployed the moment it's
+    created'."""
+    site = await sites_service.create_draft_site(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Fresh Site",
+    )
+    resp = sites_service._to_response(site)
+    assert resp.status == "draft"
+    assert resp.is_live is False
+    assert site.deployed is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Live only after a successful deploy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_sets_live_after_successful_deploy(beanie_test_db):
+    """Publish promotes the draft to published, deploys, and flips Live true on a
+    SUCCESSFUL deploy."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.create_draft_site(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Site",
+    )
+    published = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Site",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+    )
+    resp = sites_service._to_response(published)
+    assert resp.status == "published"
+    assert resp.is_live is True
+    assert published.deployed is True
+    assert cf.put_calls == [published.script_name]
+    # Same Site doc (publish reuses the draft site for this pocket, not a 2nd row).
+    assert str(published.id) == str(site.id)
+
+
+@pytest.mark.asyncio
+async def test_publish_failed_build_leaves_site_not_live(beanie_test_db):
+    """A failed build (smoke gate) must NOT mark the site live, must NOT advance
+    the published pointer, and must leave a recoverable draft."""
+    await sites_service.create_draft_site(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Site",
+    )
+    with pytest.raises(SmokeGateFailed):
+        await sites_service.publish(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            ripple_spec={"type": "container"},
+            theme={},
+            name="Site",
+            _generator=_FailingGenerator(),
+            _cloudflare=_FakeCF(),
+            _bundle_reader=lambda d: b"x",
+        )
+    status = await sites_service.site_status(workspace_id="ws1", pocket_id="pk1")
+    assert status.is_live is False
+    assert status.status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_publish_failed_deploy_leaves_site_not_live(beanie_test_db):
+    """A good build but a failed Worker upload must NOT mark the site live."""
+    await sites_service.create_draft_site(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Site",
+    )
+    with pytest.raises(RuntimeError):
+        await sites_service.publish(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            ripple_spec={"type": "container"},
+            theme={},
+            name="Site",
+            _generator=_FakeGenerator(),
+            _cloudflare=_FailingCF(),
+            _bundle_reader=lambda d: b"x",
+        )
+    status = await sites_service.site_status(workspace_id="ws1", pocket_id="pk1")
+    assert status.is_live is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Preview returns the current draft content (no dead URL)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_returns_current_draft_content(beanie_test_db):
+    """The builder preview renders the DRAFT content, not the published URL. After
+    a publish + a refine, preview returns the NEW draft, while the published
+    version keeps the old content."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    await sites_service.create_draft_site(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container", "rev": 1},
+        theme={},
+        name="Site",
+    )
+    await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container", "rev": 1},
+        theme={},
+        name="Site",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    # Refine: a new draft.
+    await sites_service.record_site_draft(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        content={"type": "container", "rev": 2},
+        engine="ripple",
+    )
+    preview = await sites_service.preview_content(workspace_id="ws1", pocket_id="pk1")
+    assert preview == {"type": "container", "rev": 2}
+
+
+# ---------------------------------------------------------------------------
+# 4. Refine creates a new draft; published untouched until Publish
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refine_creates_new_draft_published_untouched(beanie_test_db):
+    gen, cf = _FakeGenerator(), _FakeCF()
+    await sites_service.create_draft_site(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container", "rev": 1},
+        theme={},
+        name="Site",
+    )
+    await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container", "rev": 1},
+        theme={},
+        name="Site",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    # Status right after publish: published, live.
+    s1 = await sites_service.site_status(workspace_id="ws1", pocket_id="pk1")
+    assert s1.status == "published"
+    assert s1.is_live is True
+
+    # Refine writes a new draft → status flips to draft (unpublished edits) but
+    # the deploy/live state of the published version is unchanged until re-publish.
+    await sites_service.record_site_draft(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        content={"type": "container", "rev": 2},
+        engine="ripple",
+    )
+    s2 = await sites_service.site_status(workspace_id="ws1", pocket_id="pk1")
+    assert s2.status == "draft"
+    assert s2.draft_version == 2
+    assert s2.published_version == 1
+
+
+# ---------------------------------------------------------------------------
+# Back-compat: the existing publish_pocket path still works and goes live.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_pocket_still_goes_live(beanie_test_db):
+    """publish_pocket (the REST + MCP shared path) reads the pocket and publishes;
+    a successful deploy still yields a live, published site."""
+    from unittest.mock import AsyncMock, patch
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    wire = {"name": "Dental", "rippleSpec": {"type": "container", "theme": {}}}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        site = await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"export default {}",
+        )
+    resp = sites_service._to_response(site)
+    assert resp.status == "published"
+    assert resp.is_live is True

--- a/tests/ee/sites/test_draft_published.py
+++ b/tests/ee/sites/test_draft_published.py
@@ -15,9 +15,16 @@
 # test_service.py), so no Bun/workerd/CF/network is touched.
 #
 # Created 2026-06-06 (feat/1345-draft-published).
+# Updated 2026-06-06 (code review TEST-1 + TEST-2): added a svelte-track create →
+# preview round-trip (create_draft_site(engine="svelte") → preview_content returns
+# the SOURCE map, not None — the engine branch had zero coverage) and a
+# failed-re-publish test on an ALREADY-LIVE site (refine v2 → publish v2 fails →
+# the site must stay live on v1, published pointer unmoved — the existing
+# failed-publish tests only covered the never-published case).
 from __future__ import annotations
 
 import pytest
+from pocketpaw_ee.cloud.versions import service as versions_service
 from pocketpaw_ee.sites import service as sites_service
 from pocketpaw_ee.sites.generator_client import SmokeGateFailed
 
@@ -294,3 +301,112 @@ async def test_publish_pocket_still_goes_live(beanie_test_db):
     resp = sites_service._to_response(site)
     assert resp.status == "published"
     assert resp.is_live is True
+
+
+# ---------------------------------------------------------------------------
+# TEST-1: svelte-track create → preview round-trip. create_draft_site on the
+# svelte engine stores the SOURCE map (content=None); preview_content must return
+# that map, not None. If the engine branch were flipped this returns None.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_draft_svelte_site_preview_returns_source(beanie_test_db):
+    source = {"src/routes/+page.svelte": "<h1>hi</h1>"}
+    await sites_service.create_draft_site(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        theme={},
+        name="Svelte Site",
+        engine="svelte",
+        source=source,
+        ripple_spec=None,
+    )
+    preview = await sites_service.preview_content(workspace_id="ws1", pocket_id="pk1")
+    assert preview == source  # the svelte source map, not None
+
+    # The preview DTO also carries the svelte engine + source.
+    dto = await sites_service.preview(workspace_id="ws1", pocket_id="pk1")
+    assert dto.engine == "svelte"
+    assert dto.content == source
+
+
+# ---------------------------------------------------------------------------
+# TEST-2: a FAILED re-publish on an already-live site must not take it down. The
+# existing failed-publish tests only cover the never-published case; this covers
+# the live-site case (publish v1 → refine v2 → publish v2 fails).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_republish_keeps_site_live_on_previous_version(beanie_test_db):
+    """A site is live on v1. A refine creates draft v2. Publishing v2 fails at the
+    build/deploy step. The site must STAY live on v1: deployed=True, the published
+    pointer stays at v1 (v2 is NOT promoted), and the live URL is unchanged. The
+    failed deploy must not promote v2 or take the site down."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    # Publish v1 → live.
+    await sites_service.create_draft_site(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container", "rev": 1},
+        theme={},
+        name="Site",
+    )
+    live_v1 = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container", "rev": 1},
+        theme={},
+        name="Site",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    v1_url = live_v1.url
+    s1 = await sites_service.site_status(workspace_id="ws1", pocket_id="pk1")
+    assert s1.is_live is True
+    assert s1.published_version == 1
+
+    # Refine → draft v2 (live deploy untouched).
+    await sites_service.record_site_draft(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        content={"type": "container", "rev": 2},
+        engine="ripple",
+    )
+
+    # Publish v2 fails at the build/smoke gate.
+    with pytest.raises(SmokeGateFailed):
+        await sites_service.publish(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            ripple_spec={"type": "container", "rev": 2},
+            theme={},
+            name="Site",
+            _generator=_FailingGenerator(),
+            _cloudflare=_FakeCF(),
+            _bundle_reader=lambda d: b"x",
+        )
+
+    # The site is STILL live, STILL on v1.
+    s2 = await sites_service.site_status(workspace_id="ws1", pocket_id="pk1")
+    assert s2.is_live is True  # not taken down
+    assert s2.published_version == 1  # v2 was NOT promoted
+    assert s2.draft_version == 2  # the failed draft is still the working version
+    assert s2.status == "draft"  # unpublished edits remain
+    assert s2.url == v1_url  # the live URL did not change
+
+    # v2 is still a draft in the log; the published version is still v1's content.
+    pub = await versions_service.get_published(workspace_id="ws1", pocket_id="pk1")
+    assert pub is not None
+    assert pub.version_no == 1
+    assert pub.content == {"type": "container", "rev": 1}
+
+    # A failed deploy must NOT have uploaded a v2 worker.
+    assert cf.put_calls == [live_v1.script_name]  # only the v1 publish uploaded

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -3,6 +3,12 @@
 # covers GET /sites/{site_id}/domains end-to-end through a FastAPI app — the new
 # tenant-scoped domains read backing the Domains tab's reload rehydration.
 #
+# Updated 2026-06-06 (feat/1345-draft-published): covers the two new pocket-keyed
+# reads end-to-end — GET /sites/by-pocket/{pocket_id}/status (the Draft/Live badge
+# state) and GET /sites/by-pocket/{pocket_id}/preview (the current draft content
+# the builder renders). Asserts a fresh draft reads status="draft"/is_live=False
+# and preview returns the working content.
+#
 # Auth wiring mirrors tests/cloud/test_ee_fabric_list_endpoints.py: the sites
 # router gates on require_plan_feature("fabric") (router level) +
 # require_action_any_workspace("fabric.read"), both of which resolve the caller
@@ -144,3 +150,47 @@ async def test_get_domains_cross_tenant_is_404(_seeded_site, monkeypatch):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         resp = await c.get(f"/api/v1/sites/{site.script_name}/domains")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_status_for_fresh_draft_is_draft_not_live(beanie_test_db, monkeypatch):
+    """GET /sites/by-pocket/{pocket_id}/status on a freshly created draft reports
+    status="draft", is_live=False — the badge no longer lies."""
+    await sites_service.create_draft_site(
+        workspace_id="ws_owner",
+        user_id="u1",
+        pocket_id="pk_status",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Draft Site",
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_status/status")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "draft"
+    assert body["is_live"] is False
+    assert body["draft_version"] == 1
+    assert body["published_version"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_preview_returns_draft_content(beanie_test_db, monkeypatch):
+    """GET /sites/by-pocket/{pocket_id}/preview returns the working draft content
+    the builder renders, not the published URL."""
+    await sites_service.create_draft_site(
+        workspace_id="ws_owner",
+        user_id="u1",
+        pocket_id="pk_prev",
+        ripple_spec={"type": "container", "rev": 7},
+        theme={},
+        name="Preview Site",
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_prev/preview")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["engine"] == "ripple"
+    assert body["content"] == {"type": "container", "rev": 7}

--- a/tests/ee/versions/__init__.py
+++ b/tests/ee/versions/__init__.py
@@ -1,0 +1,2 @@
+# tests/ee/versions/ — package marker for the pocket-content version-history
+# module tests (pocketpaw#1345 Phase 1). Created 2026-06-06.

--- a/tests/ee/versions/test_service.py
+++ b/tests/ee/versions/test_service.py
@@ -1,0 +1,200 @@
+# tests/ee/versions/test_service.py — state-machine tests for the pocket-content
+# version-history module (pocketpaw#1345 Phase 1, plan §5/§6). Exercises the
+# draft/published version log directly against the shared ``beanie_test_db``
+# fixture (mongomock-motor), so no real Mongo is touched.
+#
+# Behaviours locked here (plan §6 operations):
+#   * record_draft writes a NEW draft version, increments version_no, and links
+#     the parent chain; the published pointer is untouched.
+#   * a pocket with only a draft (never published) is status="draft", not_live.
+#   * publish_draft promotes the current draft to published; status flips to
+#     "published" and the draft/published pointers converge (draft_no == pub_no).
+#   * editing AFTER a publish writes a new draft and leaves the published version
+#     content untouched (the core "refine must not clobber live" guarantee).
+#   * rollback clones an old version's content into a NEW draft (then publish goes
+#     live), leaving history intact.
+#   * get_draft_content returns the working version's content (for the preview).
+#
+# Created 2026-06-06 (feat/1345-draft-published).
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.versions import service as versions_service
+
+
+@pytest.mark.asyncio
+async def test_record_draft_creates_first_version(beanie_test_db):
+    v = await versions_service.record_draft(
+        workspace_id="ws1",
+        pocket_id="pk1",
+        content={"type": "container", "rev": 1},
+        engine="ripple",
+        author="u1",
+    )
+    assert v.version_no == 1
+    assert v.status == "draft"
+    assert v.parent_version_no is None
+    assert v.content == {"type": "container", "rev": 1}
+    assert v.pocket_id == "pk1"
+    assert v.workspace == "ws1"
+
+
+@pytest.mark.asyncio
+async def test_record_draft_increments_and_links_parent(beanie_test_db):
+    v1 = await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 1}, engine="ripple"
+    )
+    v2 = await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 2}, engine="ripple"
+    )
+    assert v2.version_no == 2
+    assert v2.parent_version_no == v1.version_no
+
+
+@pytest.mark.asyncio
+async def test_fresh_pocket_is_draft_not_live(beanie_test_db):
+    """A pocket that has a draft but was NEVER published is Draft, not live. This
+    is the core of the 'Live lies' bug at the version layer: creating content
+    must not imply published/live."""
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 1}, engine="ripple"
+    )
+    status = await versions_service.status_for(workspace_id="ws1", pocket_id="pk1")
+    assert status.status == "draft"
+    assert status.published_version is None
+    assert status.draft_version == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_promotes_draft_to_published(beanie_test_db):
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 1}, engine="ripple"
+    )
+    published = await versions_service.publish_draft(workspace_id="ws1", pocket_id="pk1")
+    assert published.status == "published"
+    assert published.version_no == 1
+
+    status = await versions_service.status_for(workspace_id="ws1", pocket_id="pk1")
+    # draft == published → the pocket is "published" (no unpublished edits).
+    assert status.status == "published"
+    assert status.published_version == 1
+    assert status.draft_version == 1
+
+
+@pytest.mark.asyncio
+async def test_edit_after_publish_creates_new_draft_published_untouched(beanie_test_db):
+    """The headline guarantee: after publishing v1, an edit writes v2 as a draft
+    and the published version's CONTENT is untouched until the next publish."""
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 1}, engine="ripple"
+    )
+    await versions_service.publish_draft(workspace_id="ws1", pocket_id="pk1")
+
+    # Refine: a new draft on top of the published version.
+    v2 = await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 2}, engine="ripple"
+    )
+    assert v2.version_no == 2
+    assert v2.status == "draft"
+
+    status = await versions_service.status_for(workspace_id="ws1", pocket_id="pk1")
+    # draft (2) != published (1) → unpublished edits exist → status "draft".
+    assert status.status == "draft"
+    assert status.draft_version == 2
+    assert status.published_version == 1
+
+    # The published version's content is the ORIGINAL, not the new draft.
+    pub = await versions_service.get_published(workspace_id="ws1", pocket_id="pk1")
+    assert pub is not None
+    assert pub.content == {"rev": 1}
+
+    # The draft content (what preview renders) is the NEW content.
+    draft_content = await versions_service.get_draft_content(workspace_id="ws1", pocket_id="pk1")
+    assert draft_content == {"rev": 2}
+
+
+@pytest.mark.asyncio
+async def test_publish_second_draft_advances_published_pointer(beanie_test_db):
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 1}, engine="ripple"
+    )
+    await versions_service.publish_draft(workspace_id="ws1", pocket_id="pk1")
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 2}, engine="ripple"
+    )
+    pub2 = await versions_service.publish_draft(workspace_id="ws1", pocket_id="pk1")
+    assert pub2.version_no == 2
+
+    status = await versions_service.status_for(workspace_id="ws1", pocket_id="pk1")
+    assert status.status == "published"
+    assert status.published_version == 2
+    assert status.draft_version == 2
+    pub = await versions_service.get_published(workspace_id="ws1", pocket_id="pk1")
+    assert pub.content == {"rev": 2}
+
+
+@pytest.mark.asyncio
+async def test_rollback_clones_old_version_into_new_draft(beanie_test_db):
+    """Rollback makes an old version the new draft (a fresh version with the old
+    content), leaving the history intact. Publishing it then goes live."""
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 1}, engine="ripple"
+    )
+    await versions_service.publish_draft(workspace_id="ws1", pocket_id="pk1")
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 2}, engine="ripple"
+    )
+    await versions_service.publish_draft(workspace_id="ws1", pocket_id="pk1")
+
+    # Roll back to v1's content.
+    rolled = await versions_service.rollback(workspace_id="ws1", pocket_id="pk1", target_version=1)
+    assert rolled.version_no == 3  # a NEW version, not a mutation of v1
+    assert rolled.status == "draft"
+    assert rolled.content == {"rev": 1}
+
+    status = await versions_service.status_for(workspace_id="ws1", pocket_id="pk1")
+    # The rolled-back draft is unpublished until an explicit publish.
+    assert status.status == "draft"
+    assert status.draft_version == 3
+    assert status.published_version == 2
+
+
+@pytest.mark.asyncio
+async def test_get_draft_content_returns_latest_working_content(beanie_test_db):
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 1}, engine="ripple"
+    )
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", content={"rev": 2}, engine="ripple"
+    )
+    content = await versions_service.get_draft_content(workspace_id="ws1", pocket_id="pk1")
+    assert content == {"rev": 2}
+
+
+@pytest.mark.asyncio
+async def test_status_for_unknown_pocket_is_none(beanie_test_db):
+    """A pocket with no versions has no draft/published — status_for reports a
+    'none' status so callers can treat it as 'not versioned yet'."""
+    status = await versions_service.status_for(workspace_id="ws1", pocket_id="nope")
+    assert status.status == "none"
+    assert status.draft_version is None
+    assert status.published_version is None
+
+
+@pytest.mark.asyncio
+async def test_versions_are_workspace_scoped(beanie_test_db):
+    """Two workspaces with the same pocket_id never see each other's versions
+    (tenant isolation)."""
+    await versions_service.record_draft(
+        workspace_id="ws_a", pocket_id="pk1", content={"who": "a"}, engine="ripple"
+    )
+    await versions_service.record_draft(
+        workspace_id="ws_b", pocket_id="pk1", content={"who": "b"}, engine="ripple"
+    )
+    a = await versions_service.get_draft_content(workspace_id="ws_a", pocket_id="pk1")
+    b = await versions_service.get_draft_content(workspace_id="ws_b", pocket_id="pk1")
+    assert a == {"who": "a"}
+    assert b == {"who": "b"}
+    # Each workspace's first version is version_no 1 (counter is per (ws, pocket)).
+    status_a = await versions_service.status_for(workspace_id="ws_a", pocket_id="pk1")
+    assert status_a.draft_version == 1

--- a/tests/ee/versions/test_service.py
+++ b/tests/ee/versions/test_service.py
@@ -16,6 +16,11 @@
 #   * get_draft_content returns the working version's content (for the preview).
 #
 # Created 2026-06-06 (feat/1345-draft-published).
+# Updated 2026-06-06 (code review TEST-1 + BLOCK-1): added a svelte-track snapshot
+# round-trip (record_draft(engine="svelte") → get_draft_content returns the SOURCE
+# map, not None — the #1 data-loss risk, previously zero-covered), and a race
+# regression test proving the unique index + record_draft retry never produce two
+# rows with the same version_no.
 from __future__ import annotations
 
 import pytest
@@ -198,3 +203,126 @@ async def test_versions_are_workspace_scoped(beanie_test_db):
     # Each workspace's first version is version_no 1 (counter is per (ws, pocket)).
     status_a = await versions_service.status_for(workspace_id="ws_a", pocket_id="pk1")
     assert status_a.draft_version == 1
+
+
+# ---------------------------------------------------------------------------
+# TEST-1: svelte-track snapshot round-trip. The #1 data-loss risk — every other
+# test runs engine="ripple", so the svelte branch of get_draft_content (return
+# ``source``, not ``content``) had zero coverage. If the engine branch were
+# flipped, these fail.
+# ---------------------------------------------------------------------------
+
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": "<h1>hi</h1>",
+    "src/routes/+layout.svelte": "<slot />",
+}
+
+
+@pytest.mark.asyncio
+async def test_record_draft_svelte_source_round_trips(beanie_test_db):
+    """A svelte version stores its content in ``source`` (content=None).
+    get_draft_content must return that source map — NOT None, NOT the empty
+    ``content``. Flipping the engine branch (returning ``content``) makes this
+    return None and the test fails."""
+    v = await versions_service.record_draft(
+        workspace_id="ws1",
+        pocket_id="pk1",
+        engine="svelte",
+        source=_SVELTE_SOURCE,
+        content=None,
+    )
+    assert v.engine == "svelte"
+    assert v.source == _SVELTE_SOURCE
+    assert v.content is None
+
+    draft_content = await versions_service.get_draft_content(workspace_id="ws1", pocket_id="pk1")
+    assert draft_content == _SVELTE_SOURCE  # the source map, not None
+
+
+@pytest.mark.asyncio
+async def test_svelte_version_rolls_back_with_source(beanie_test_db):
+    """A svelte rollback clones ``source`` (not ``content``) into the new draft,
+    so the svelte track round-trips through publish → refine → rollback."""
+    await versions_service.record_draft(
+        workspace_id="ws1", pocket_id="pk1", engine="svelte", source=_SVELTE_SOURCE
+    )
+    await versions_service.publish_draft(workspace_id="ws1", pocket_id="pk1")
+    await versions_service.record_draft(
+        workspace_id="ws1",
+        pocket_id="pk1",
+        engine="svelte",
+        source={"src/routes/+page.svelte": "<h1>v2</h1>"},
+    )
+    rolled = await versions_service.rollback(workspace_id="ws1", pocket_id="pk1", target_version=1)
+    assert rolled.engine == "svelte"
+    assert rolled.source == _SVELTE_SOURCE
+    assert rolled.content is None
+    content = await versions_service.get_draft_content(workspace_id="ws1", pocket_id="pk1")
+    assert content == _SVELTE_SOURCE
+
+
+# ---------------------------------------------------------------------------
+# BLOCK-1: record_draft is race-safe. The unique index on
+# (workspace, pocket_id, version_no) turns a lost check-then-act race into a
+# DuplicateKeyError; record_draft retries (re-read max → re-increment → insert).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duplicate_version_no_is_rejected_by_unique_index(beanie_test_db):
+    """The unique index forbids two rows with the same (ws, pocket, version_no):
+    a raw second insert at v1 must raise DuplicateKeyError, not silently corrupt
+    the log. This is what makes the record_draft retry meaningful."""
+    from pocketpaw_ee.cloud.models.pocket_version import PocketVersion
+    from pymongo.errors import DuplicateKeyError
+
+    await PocketVersion(workspace="ws1", pocket_id="pk1", version_no=1, content={"rev": 1}).insert()
+    with pytest.raises(DuplicateKeyError):
+        await PocketVersion(
+            workspace="ws1", pocket_id="pk1", version_no=1, content={"rev": 1}
+        ).insert()
+
+
+@pytest.mark.asyncio
+async def test_record_draft_retries_when_version_no_is_stolen(beanie_test_db):
+    """Simulate the race deterministically: a concurrent writer has already taken
+    v2, but our ``latest_version_no`` reads a STALE max (1) on the first attempt,
+    so record_draft computes v2 and its insert hits the unique index. record_draft
+    must catch the DuplicateKeyError, re-read the now-current max (2), and insert
+    v3 — the edit lands as a distinct version instead of surfacing a 500."""
+    from pocketpaw_ee.cloud.models.pocket_version import PocketVersion
+    from pocketpaw_ee.cloud.versions.service import _BeanieVersionStore
+
+    # v1 already exists (an earlier edit), and a racing writer has claimed v2.
+    await versions_service.record_draft(workspace_id="ws1", pocket_id="pk1", content={"rev": 1})
+    await PocketVersion(
+        workspace="ws1", pocket_id="pk1", version_no=2, content={"rev": "racer"}
+    ).insert()
+
+    class _StaleOnceStore(_BeanieVersionStore):
+        """Reports a stale max (1) on the FIRST read so the caller computes the
+        already-taken v2 and collides; every later read returns the true max."""
+
+        def __init__(self) -> None:
+            self._served_stale = False
+
+        async def latest_version_no(self, workspace_id: str, pocket_id: str):
+            if not self._served_stale:
+                self._served_stale = True
+                return 1  # stale: hides the racer's v2 → caller computes v2, collides
+            return await super().latest_version_no(workspace_id, pocket_id)
+
+    v = await versions_service.record_draft(
+        workspace_id="ws1",
+        pocket_id="pk1",
+        content={"rev": 2},
+        _store=_StaleOnceStore(),
+    )
+    # Retry recovered: our edit landed AFTER the racer's v2, as v3 — never a
+    # duplicate, never a raised error.
+    assert v.version_no == 3
+    assert v.content == {"rev": 2}
+
+    versions = await versions_service.list_versions(workspace_id="ws1", pocket_id="pk1")
+    nums = sorted(x.version_no for x in versions)
+    assert nums == [1, 2, 3]  # no duplicates in the log


### PR DESCRIPTION
## What this does

Phase 1 of the version-history module — the draft/published state machine for Paw Sites (pocketpaw#1345). Backend only; the paw-enterprise badge + Publish action are a separate fast-follow.

### The bug it fixes

A `/sites` site was stamped `deployed` the instant it was created, so:
- the Live badge showed before the site served anything,
- the builder preview iframed an ephemeral local serve that was already gone,
- every refine overwrote the live version with no draft buffer and no way back.

### The approach

A versions collection plus a draft/published state machine (the plan's Option C), wired into the sites publish path:

- **`PocketVersion`** — a per-pocket version log. Each row is a full, engine-aware snapshot: `content` holds the rippleSpec, `source` holds the svelte source map, `engine` records which. Carries `version_no`, `parent_version_no`, and a `draft|published|archived` status. Separate Mongo collection (a refine-heavy site would blow the 16MB doc limit if snapshots were embedded), workspace-scoped, indexed newest-first.
- **versions service** — the state machine. `record_draft` writes a new working version; `publish_draft` promotes the current draft to published; `rollback` clones an old version into a new draft. The draft/published pointers derive from the log (source of truth); the Pocket doc carries a denormalized cache the service keeps in sync.
- **sites service** — `create_draft_site` records content as a draft and persists a Site that is **not deployed, not live**. `record_site_draft` is the refine buffer (new draft, published version untouched). `publish` now builds and deploys **first** and only promotes the draft + marks the site live **on a successful deploy** — a failed build or upload leaves a recoverable draft, never a phantom-live site. It reuses the draft site's row per pocket instead of stacking a second Site.

### API contract (for the frontend fast-follow)

`SiteResponse` gains two fields:
- `status`: `"draft" | "published"` — the version state. `draft` means there are unpublished edits (or nothing published yet); `published` means the live candidate is the latest version.
- `is_live`: `bool` — the deploy-confirmed axis. True **only** after a successful publish/deploy.

A fresh draft reads `status="draft"`, `is_live=False`. After a refine on a live site: `status="draft"`, `is_live=True` (edits pending, old version still serving).

Two pocket-keyed reads (gated `fabric.read`, keyed on the **source pocket id** because a draft has no site id until first publish):
- `GET /api/v1/sites/by-pocket/{pocket_id}/status` → `SiteStatusResponse { pocket_id, site_id?, status, is_live, draft_version?, published_version?, url }` — the Draft/Live badge state.
- `GET /api/v1/sites/by-pocket/{pocket_id}/preview` → `PreviewResponse { pocket_id, engine, content? }` — the current draft content the builder iframe renders (rippleSpec, or svelte source map). Fixes the dead-URL preview.

### Deploy seam (for the #1346 Cloudflare-deploy agent)

`publish()` calls the existing generator/Cloudflare seams **as-is** — nothing in `generator_client.py` or `cloudflare_client.py` changed:
- `await generator.build(*, ripple_spec, theme, site_id, title, capture_api_base, capture_signed_key, engine, source) -> BuildResult(project_dir: str, ripple_version: str | None)`. Raises `SmokeGateFailed` if the smoke render fails.
- deploy: `await cf.put_worker(script_name=..., bundle=...)` (real CF) or `local_server.deploy_local(site_id, project_dir) -> url` (local mode).

"Live" is set from deploy **success** = `build()` did not raise **and** the deploy call did not raise. Both run before any version promotion or live-marking, so a raise leaves a draft. If #1346 changes `build()` to return an explicit `{success, url}`, this path can read it directly — flagging the assumption so we line up.

## Scope notes

- Phase 1 wires versioning into the **sites** path only. The general pocket mutation paths (`merge_spec`, `create_from_ripple_spec`, REST update) can adopt `versions_service.record_draft` at touch-time in Phase 2 (history UI, rollback, diff) — kept out here to avoid touching the shared pockets service.
- Additive, optional fields only on `Pocket` (`draft_version_no`, `published_version_no`, `last_deploy_status`) and `Site` (`status`) — no Mongo migration; legacy docs read back with safe defaults.

## Tests

TDD — failing tests written first, then implemented to green:

```
uv run pytest tests/ee/sites/ tests/ee/versions/
76 passed, 1 skipped
```

Covers: a fresh site is Draft not Live; Live only after a successful (mocked) deploy; a failed build/upload leaves it not-live; refine creates a new draft with the published version untouched; rollback clones into a new draft; preview returns the working content; the two new endpoints end-to-end. The 19 existing sites-service tests still pass (publish is backward-compatible). The deploy/generator is mocked throughout — no Bun/workerd/Cloudflare/network.

Refs pocketpaw#1345
