### PR TITLE
feat(livekit): DeepSeek-powered meeting summary with rich markdown notes

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/tasks.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/tasks.py
@@ -42,11 +42,13 @@ SERVER_NAME = "pocketpaw_tasks"
 LIST_MY_TASKS_TOOL_ID = f"mcp__{SERVER_NAME}__list_my_tasks"
 CLAIM_TASK_TOOL_ID = f"mcp__{SERVER_NAME}__claim_task"
 COMPLETE_TASK_TOOL_ID = f"mcp__{SERVER_NAME}__complete_task"
+CREATE_TASK_TOOL_ID = f"mcp__{SERVER_NAME}__create_task"
 
 TASK_TOOL_IDS = (
     LIST_MY_TASKS_TOOL_ID,
     CLAIM_TASK_TOOL_ID,
     COMPLETE_TASK_TOOL_ID,
+    CREATE_TASK_TOOL_ID,
 )
 
 
@@ -211,6 +213,71 @@ async def _complete_task_handler(args: dict) -> dict:
     return _success_response({"ok": True, "task": response.model_dump()})
 
 
+async def _create_task_handler(args: dict) -> dict:
+    """Create a new Mission Control Task.
+
+    Accepts:
+      - title (required) — task title, 1-200 chars
+      - summary (optional) — description / details
+      - assignee_kind (default "human") — "human" or "agent"
+      - assignee_id (default "__unassigned__") — user or agent id
+      - assignee_name (default "Unassigned") — display name
+      - priority (default "normal") — low, normal, high, urgent
+      - project_id (optional) — Mission Control project id
+    """
+    workspace_id, agent_id = _identity()
+    if not workspace_id or not agent_id:
+        return _error_response(
+            "no active workspace/agent — create_task can only be called "
+            "from inside a cloud SSE chat stream"
+        )
+
+    title = args.get("title")
+    if not isinstance(title, str) or not title:
+        return _error_response("title is required (string, 1-200 chars)")
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.tasks import service as tasks_service
+    from pocketpaw_ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest, SourceDTO
+
+    assignee_kind = args.get("assignee_kind") or "human"
+    assignee_id = args.get("assignee_id") or "__unassigned__"
+    assignee_name = args.get("assignee_name") or "Unassigned"
+    priority = args.get("priority") or "normal"
+    if priority not in ("low", "normal", "high", "urgent"):
+        priority = "normal"
+    summary = args.get("summary") or ""
+    project_id = args.get("project_id")
+
+    ctx = _build_ctx(workspace_id, agent_id)
+    try:
+        response = await tasks_service.agent_create_task(
+            ctx,
+            CreateTaskRequest(
+                title=title,
+                summary=str(summary),
+                assignee=AssigneeDTO(
+                    kind=assignee_kind,  # type: ignore[arg-type]
+                    id=assignee_id,
+                    name=assignee_name,
+                ),
+                priority=priority,  # type: ignore[arg-type]
+                project_id=project_id or None,
+                source=SourceDTO(
+                    type="mcp",
+                    ref_id=agent_id,
+                ),
+            ),
+        )
+    except CloudError as exc:
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("create_task failed", exc_info=True)
+        return _error_response(f"create_task failed: {exc}")
+
+    return _success_response({"ok": True, "task": response.model_dump()})
+
+
 # ---------------------------------------------------------------------------
 # Server factory
 # ---------------------------------------------------------------------------
@@ -280,10 +347,34 @@ def build_tasks_context_server() -> tuple[str, Any] | None:
     async def complete_task(args):  # type: ignore[no-untyped-def]
         return await _complete_task_handler(args)
 
+    @tool(
+        "create_task",
+        (
+            "Create a new Mission Control Task. Required: ``title``. "
+            "Optional: ``summary``, ``assignee_kind`` (human|agent, default human), "
+            "``assignee_id`` (default __unassigned__), ``assignee_name`` (default Unassigned), "
+            "``priority`` (low|normal|high|urgent, default normal), "
+            "``project_id`` (Mission Control project id). "
+            "Use this to convert an action item or decision from a conversation "
+            "into a tracked Task in Mission Control."
+        ),
+        {
+            "title": str,
+            "summary": str,
+            "assignee_kind": str,
+            "assignee_id": str,
+            "assignee_name": str,
+            "priority": str,
+            "project_id": str,
+        },
+    )
+    async def create_task(args):  # type: ignore[no-untyped-def]
+        return await _create_task_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[list_my_tasks, claim_task, complete_task],
+        tools=[list_my_tasks, claim_task, complete_task, create_task],
     )
     return SERVER_NAME, server
 
@@ -291,6 +382,7 @@ def build_tasks_context_server() -> tuple[str, Any] | None:
 __all__ = [
     "CLAIM_TASK_TOOL_ID",
     "COMPLETE_TASK_TOOL_ID",
+    "CREATE_TASK_TOOL_ID",
     "LIST_MY_TASKS_TOOL_ID",
     "SERVER_NAME",
     "TASK_TOOL_IDS",

--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -629,8 +629,17 @@ class CallMeetingAgent:
                 action_items = ["Transcript captured but summarization failed."]
         else:
             transcript_text = ""
-            summary = "Call ended with no speech detected."
-            action_items = []
+
+            # Still attempt AI summarization so DeepSeek can process
+            # whatever context is available (room info, participant IDs).
+            try:
+                summary, action_items = await self._generate_summary(
+                    transcript_text or "(no speech captured)",
+                )
+            except Exception:
+                logger.exception("Agent: AI summarization failed — posting notes without summary")
+                summary = "Call ended with no speech detected."
+                action_items = []
 
         # Merge participant identities from room tracking + transcript
         all_participants = list(self._participant_identities | speakers_seen)
@@ -667,13 +676,22 @@ class CallMeetingAgent:
     ) -> tuple[str, list[str]]:
         """Generate a meeting summary and action items from transcript.
 
-        Uses Anthropic Claude by default, falls back to OpenAI.
-        Falls back to heuristic extraction if no LLM is configured.
+        Uses DeepSeek by default (OpenAI-compatible API), falls back to
+        Anthropic Claude, then OpenAI. Falls back to heuristic extraction
+        if no LLM is configured.
         """
         if not transcript:
             return "No speech detected during the call.", []
 
-        # Try Anthropic first
+        # Try DeepSeek first (OpenAI-compatible API)
+        deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "")
+        if deepseek_key:
+            try:
+                return await self._summarize_with_deepseek(transcript, deepseek_key)
+            except Exception as exc:
+                logger.warning("DeepSeek summarization failed: %s", exc)
+
+        # Fall back to Anthropic
         api_key = os.environ.get("ANTHROPIC_API_KEY", "")
         if api_key:
             try:
@@ -728,6 +746,62 @@ class CallMeetingAgent:
             data = resp.json()
 
         content = data.get("content", [{}])[0].get("text", "")
+        return self._parse_summary_json(content)
+
+    async def _summarize_with_deepseek(
+        self,
+        transcript: str,
+        api_key: str,
+    ) -> tuple[str, list[str]]:
+        """Use DeepSeek (OpenAI-compatible API) to summarize the transcript."""
+        import httpx
+
+        prompt = (
+            "You are a professional meeting notes assistant. Given the following transcript of a "
+            "group call, produce a comprehensive, well-structured Markdown meeting summary.\n\n"
+            "Include the following sections where applicable:\n\n"
+            "## 📋 Overview\n"
+            "A concise 1-2 paragraph summary of what was discussed — the context, "
+            "the main agenda, and the overall outcome of the call.\n\n"
+            "## 📌 Topics Covered\n"
+            "A bullet-point or numbered list of the main topics / subjects discussed "
+            "during the call. Describe each topic in a sentence or two.\n\n"
+            "## ⚙️ Technical Decisions\n"
+            "Any architectural decisions, tool choices, code changes, or implementation "
+            "plans that were agreed upon.\n\n"
+            "## ✅ Action Items\n"
+            "A bullet list of clear action items with who is responsible (e.g. "
+            "'@Admin: merge the notification PR', '@Amritesh: test the deployment'). "
+            "Be specific — mention the person and what they need to do.\n\n"
+            "## ❓ Key Questions\n"
+            "Any open questions, unresolved issues, or things that need further "
+            "discussion.\n\n"
+            "## 🔜 Next Steps\n"
+            "What happens next — any follow-ups, pending reviews, or scheduled items.\n\n"
+            "Format your ENTIRE response as raw Markdown (no wrapping JSON, no code fences). "
+            "Use bold, headings, lists as appropriate. Make it look like a polished "
+            "meeting notes document.\n\n"
+            f"Transcript:\n{transcript}"
+        )
+        logger.info("DeepSeek prompt length: %d chars", len(prompt))
+
+        async with httpx.AsyncClient(timeout=120) as client:
+            resp = await client.post(
+                "https://api.deepseek.com/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": "deepseek-chat",
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": 4096,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
         return self._parse_summary_json(content)
 
     async def _summarize_with_openai(

--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -37,6 +37,12 @@ import os
 import time
 from typing import Any
 
+from pocketpaw_ee.cloud.livekit.prompts import (
+    ANTHROPIC_SUMMARY_PROMPT,
+    DEEPSEEK_SUMMARY_PROMPT,
+    OPENAI_SUMMARY_PROMPT,
+)
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -730,15 +736,7 @@ class CallMeetingAgent:
         """Use Anthropic Claude to summarize the transcript."""
         import httpx
 
-        prompt = (
-            "You are a meeting notes assistant. Given the following transcript of a group call, "
-            "provide:\n"
-            "1. A concise summary (2-3 paragraphs) of what was discussed\n"
-            "2. A list of action items / decisions made\n\n"
-            "Format your response as JSON with keys 'summary' (string) and "
-            "'action_items' (list of strings).\n\n"
-            f"Transcript:\n{transcript}"
-        )
+        prompt = ANTHROPIC_SUMMARY_PROMPT.format(transcript=transcript)
 
         async with httpx.AsyncClient(timeout=60) as client:
             resp = await client.post(
@@ -768,33 +766,7 @@ class CallMeetingAgent:
         """Use DeepSeek (OpenAI-compatible API) to summarize the transcript."""
         import httpx
 
-        prompt = (
-            "You are a professional meeting notes assistant. Given the following transcript of a "
-            "group call, produce a comprehensive, well-structured Markdown meeting summary.\n\n"
-            "Include the following sections where applicable:\n\n"
-            "## 📋 Overview\n"
-            "A concise 1-2 paragraph summary of what was discussed — the context, "
-            "the main agenda, and the overall outcome of the call.\n\n"
-            "## 📌 Topics Covered\n"
-            "A bullet-point or numbered list of the main topics / subjects discussed "
-            "during the call. Describe each topic in a sentence or two.\n\n"
-            "## ⚙️ Technical Decisions\n"
-            "Any architectural decisions, tool choices, code changes, or implementation "
-            "plans that were agreed upon.\n\n"
-            "## ✅ Action Items\n"
-            "A bullet list of clear action items with who is responsible (e.g. "
-            "'@Admin: merge the notification PR', '@Amritesh: test the deployment'). "
-            "Be specific — mention the person and what they need to do.\n\n"
-            "## ❓ Key Questions\n"
-            "Any open questions, unresolved issues, or things that need further "
-            "discussion.\n\n"
-            "## 🔜 Next Steps\n"
-            "What happens next — any follow-ups, pending reviews, or scheduled items.\n\n"
-            "Format your ENTIRE response as raw Markdown (no wrapping JSON, no code fences). "
-            "Use bold, headings, lists as appropriate. Make it look like a polished "
-            "meeting notes document.\n\n"
-            f"Transcript:\n{transcript}"
-        )
+        prompt = DEEPSEEK_SUMMARY_PROMPT.format(transcript=transcript)
         logger.info("DeepSeek prompt length: %d chars", len(prompt))
 
         async with httpx.AsyncClient(timeout=120) as client:
@@ -824,15 +796,7 @@ class CallMeetingAgent:
         """Use OpenAI GPT to summarize the transcript."""
         import httpx
 
-        prompt = (
-            "You are a meeting notes assistant. Given the following transcript of a group call, "
-            "provide:\n"
-            "1. A concise summary (2-3 paragraphs) of what was discussed\n"
-            "2. A list of action items / decisions made\n\n"
-            "Format your response as JSON with keys 'summary' (string) and "
-            "'action_items' (list of strings).\n\n"
-            f"Transcript:\n{transcript}"
-        )
+        prompt = OPENAI_SUMMARY_PROMPT.format(transcript=transcript)
 
         async with httpx.AsyncClient(timeout=60) as client:
             resp = await client.post(

--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -650,8 +650,15 @@ class CallMeetingAgent:
                 summary = "Call ended with no speech detected."
                 action_items = []
 
-        # Merge participant identities from room tracking + transcript
-        all_participants = list(self._participant_identities | speakers_seen)
+        # Merge participant identities from room tracking + transcript.
+        # Resolve identity strings to display names for the meeting notes.
+        all_participants_set: set[str] = set()
+        for pid in sorted(self._participant_identities):
+            display_name = self._participant_info.get(pid, pid)
+            all_participants_set.add(display_name)
+        for s in speakers_seen:
+            all_participants_set.add(s)
+        all_participants = sorted(all_participants_set)
 
         # Build structured participant info (identity → display_name) so the
         # service can resolve @mentions in action items to real user IDs

--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -78,6 +78,7 @@ class CallMeetingAgent:
         # Accumulated transcript segments
         self.transcript_segments: list[dict[str, Any]] = []
         self._participant_identities: set[str] = set()
+        self._participant_info: dict[str, str] = {}  # identity → display_name
         self._has_ever_had_humans: bool = False
         self._call_start_time: float = 0.0
 
@@ -227,6 +228,7 @@ class CallMeetingAgent:
 
                 pname = participant.name or pid
                 self._participant_identities.add(pid)
+                self._participant_info[pid] = pname
                 logger.info("Agent: setting up audio pipe for %s (from_participant)", pname)
 
                 try:
@@ -512,6 +514,7 @@ class CallMeetingAgent:
                         if pid and pid != "call-bot":
                             human_count += 1
                             self._participant_identities.add(pid)
+                            self._participant_info[pid] = p.get("name", "") or pid
                             self._has_ever_had_humans = True
 
                 if human_count == 0:
@@ -644,6 +647,14 @@ class CallMeetingAgent:
         # Merge participant identities from room tracking + transcript
         all_participants = list(self._participant_identities | speakers_seen)
 
+        # Build structured participant info (identity → display_name) so the
+        # service can resolve @mentions in action items to real user IDs
+        # without querying the User collection.
+        participant_map = [
+            {"identity": pid, "name": self._participant_info.get(pid, pid)}
+            for pid in sorted(self._participant_identities)
+        ]
+
         # ── Emit notes payload to stdout ──
         # Instead of calling post_meeting_notes_to_group directly (which
         # requires Beanie/MongoDB initialized in this subprocess), we write
@@ -657,6 +668,7 @@ class CallMeetingAgent:
                 "summary": summary,
                 "action_items": action_items,
                 "participants": all_participants,
+                "participant_map": participant_map,
                 "duration_seconds": duration,
             }
         )

--- a/ee/pocketpaw_ee/cloud/livekit/prompts.py
+++ b/ee/pocketpaw_ee/cloud/livekit/prompts.py
@@ -1,0 +1,135 @@
+"""Prompt templates for LiveKit meeting notes agent.
+
+All prompts are module-level constants with ``{placeholder}`` fields
+for ``.format()`` / ``.replace()`` at call time.  Keeps the agent logic
+free of inline prompt text and makes it easy to iterate on prompt
+content without touching the agent code.
+
+Prompt templates:
+    ANTHROPIC_SUMMARY_PROMPT — JSON-format summary + action items
+    DEEPSEEK_SUMMARY_PROMPT — structured Markdown meeting notes
+    OPENAI_SUMMARY_PROMPT   — JSON-format summary + action items
+"""
+
+ANTHROPIC_SUMMARY_PROMPT = """\
+You are a meeting notes assistant. Given the following transcript of a group call, \
+provide:
+1. A concise summary (2-3 paragraphs) of what was discussed
+2. A list of action items / decisions made
+
+Format your response as JSON with keys 'summary' (string) and \
+'action_items' (list of strings).
+
+Transcript:
+{transcript}"""
+
+
+DEEPSEEK_SUMMARY_PROMPT = """\
+You are a professional meeting notes assistant.
+
+Given a transcript of a group call, generate a comprehensive, accurate, \
+and well-structured Markdown meeting summary.
+
+## General Rules
+
+* Base the summary **only on information explicitly present in the \
+transcript**.
+* Do **not infer, invent, assume, or hallucinate** decisions, action \
+items, owners, next steps, or unresolved questions.
+* If a section has no relevant information in the transcript, **omit \
+that section entirely**.
+* Do not create placeholder content such as "No action items discussed" \
+unless explicitly requested.
+* Only assign action items when a person clearly commits to, is assigned, \
+or agrees to perform a task.
+* Only include technical decisions when an actual decision or agreement \
+was made.
+* Only include questions if they remain unresolved by the end of the \
+discussion.
+* If the conversation is informal brainstorming, status updates, \
+knowledge sharing, or general discussion, summarize it accordingly \
+without forcing project-management style outputs.
+* Use participant names exactly as they appear in the transcript whenever possible.
+
+## Required Section
+
+### 📋 Overview
+
+Provide a concise 1–2 paragraph summary covering:
+
+* The purpose or context of the discussion.
+* Key points that were discussed.
+* Major conclusions or outcomes (if any).
+
+## Optional Sections
+
+Include the following sections **only if supported by the transcript**.
+
+### 📌 Topics Covered
+
+List the major topics discussed and briefly explain each one.
+
+### ⚙️ Technical Decisions
+
+Include only decisions, agreements, architectural choices, tool \
+selections, implementation approaches, approvals, or finalized plans \
+that were explicitly agreed upon.
+
+### ✅ Action Items
+
+Include only tasks that have:
+
+* A clear owner, OR
+* A clearly implied owner from the conversation.
+
+Format:
+
+* **@Name:** Specific task description.
+
+Do not create action items from:
+
+* Suggestions
+* Ideas
+* Questions
+* Possibilities
+* General discussion
+
+### ❓ Key Questions
+
+Include unresolved questions, blockers, uncertainties, or topics requiring further discussion.
+
+Exclude questions that were answered during the meeting.
+
+### 🔜 Next Steps
+
+Include follow-up activities, planned meetings, pending reviews, \
+upcoming milestones, or future work that participants explicitly \
+mentioned.
+
+## Output Requirements
+
+* Output valid Markdown only.
+* Use clear headings and bullet points.
+* Keep the summary concise but comprehensive.
+* Omit empty sections.
+* If the transcript contains only casual discussion, generate only \
+the sections that are supported by the conversation.
+* If the transcript contains no decisions, no action items, and no \
+next steps, do not create those sections.
+
+
+Transcript:
+{transcript}"""
+
+
+OPENAI_SUMMARY_PROMPT = """\
+You are a meeting notes assistant. Given the following transcript of a group call, \
+provide:
+1. A concise summary (2-3 paragraphs) of what was discussed
+2. A list of action items / decisions made
+
+Format your response as JSON with keys 'summary' (string) and \
+'action_items' (list of strings).
+
+Transcript:
+{transcript}"""

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -847,9 +847,15 @@ async def post_meeting_notes_to_group(
         f"**Duration:** {_format_duration(duration_seconds)}",
         f"**Participants:** {', '.join(participants) if participants else 'N/A'}",
         "",
-        "**Summary:**",
-        summary,
     ]
+
+    # If the summary is rich markdown (has its own headings), use it directly.
+    # Otherwise, wrap it in a "**Summary:**" label.
+    if summary.strip().startswith("## "):
+        lines.append(summary)
+    else:
+        lines.append("**Summary:**")
+        lines.append(summary)
 
     if action_items:
         lines.append("")

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -844,11 +844,22 @@ async def post_meeting_notes_to_group(
     a MeetingTranscript record so the meeting detail in /meetings can
     display the transcript.
     """
+    # Resolve participant identities to display names using participant_map
+    # (which maps identity → name as sent by the agent).
+    name_map: dict[str, str] = {}
+    if participant_map:
+        for p in participant_map:
+            pid = p.get("identity", "")
+            pname = p.get("name", "") or pid
+            if pid:
+                name_map[pid] = pname
+    participant_names = [name_map.get(p, p) for p in participants]
+
     lines = [
         "📋 **Meeting Notes**",
         "",
         f"**Duration:** {_format_duration(duration_seconds)}",
-        f"**Participants:** {', '.join(participants) if participants else 'N/A'}",
+        f"**Participants:** {', '.join(participant_names) if participant_names else 'N/A'}",
         "",
     ]
 
@@ -998,13 +1009,14 @@ async def post_meeting_notes_to_group(
             logger.warning("Failed to store transcript: %s", exc)
 
     # ── Create Mission Control tasks from action items ──
-    # Parse the ## ✅ Action Items section from the markdown summary
-    # and create Tasks assigned to the matched participant.
-    if workspace_id and summary:
+    # Prefer the structured action_items list (already extracted by the LLM)
+    # over re-parsing the markdown summary.
+    if workspace_id and (action_items or summary):
         try:
             await _create_tasks_from_meeting_notes(
                 workspace_id=workspace_id,
                 group_id=group_id,
+                action_items=action_items,
                 summary=summary,
                 participant_map=participant_map,
             )
@@ -1088,12 +1100,23 @@ def _format_joined_at(joined_at: Any) -> str | None:
 async def _create_tasks_from_meeting_notes(
     workspace_id: str,
     group_id: str,
-    summary: str,
+    action_items: list[str] | None = None,
+    summary: str = "",
     participant_map: list[dict[str, str]] | None = None,
 ) -> None:
-    """Parse action items from the meeting notes summary and create Tasks."""
-    action_items = _extract_action_items_from_markdown(summary)
-    if not action_items:
+    """Create Mission Control tasks from meeting notes action items.
+
+    Prefers the structured ``action_items`` list (already extracted by the
+    LLM), falling back to parsing ``## ✅ Action Items`` from the markdown
+    ``summary`` for backwards compatibility.
+    """
+    items: list[str] = []
+    if action_items:
+        items = action_items
+    elif summary:
+        items = _extract_action_items_from_markdown(summary)
+
+    if not items:
         logger.info("No action items found in meeting notes for group %s", group_id)
         return
 
@@ -1124,11 +1147,23 @@ async def _create_tasks_from_meeting_notes(
     )
 
     created = 0
-    for item in action_items:
+    for item in items:
         try:
             # Parse @Name prefix from the action item, e.g. "@Admin: do X"
             assignee_name, description = _parse_action_item_assignee(item)
-            assignee_id = name_to_id.get(assignee_name.lower(), "__unassigned__")
+
+            # Resolve the @mention name to a user ID using participant_map.
+            q = assignee_name.strip().lower()
+            assignee_id = name_to_id.get(q)
+            if not assignee_id and participant_map:
+                # Check if mention is a substring of a participant name
+                # or if a participant name is a substring of the mention
+                for p in participant_map:
+                    pname = (p.get("name", "") or "").lower()
+                    if q in pname or pname in q:
+                        assignee_id = p.get("identity")
+                        break
+            assignee_id = assignee_id or "__unassigned__"
 
             await tasks_service.agent_create_task(
                 ctx,

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -286,6 +286,7 @@ async def _reap_agent_process(
                 summary=payload.get("summary", "Call ended."),
                 action_items=payload.get("action_items", []),
                 participants=payload.get("participants", []),
+                participant_map=payload.get("participant_map", None),
                 duration_seconds=payload.get("duration_seconds", 0),
                 workspace_id=workspace_id,
             )
@@ -729,6 +730,7 @@ async def end_room(group_id: str, workspace_id: str = "") -> dict[str, Any]:
                 summary=payload.get("summary", "Call ended."),
                 action_items=payload.get("action_items", []),
                 participants=payload.get("participants", []),
+                participant_map=payload.get("participant_map", None),
                 duration_seconds=payload.get("duration_seconds", 0),
                 workspace_id=workspace_id,
             )
@@ -832,6 +834,7 @@ async def post_meeting_notes_to_group(
     participants: list[str],
     duration_seconds: int,
     workspace_id: str = "",
+    participant_map: list[dict[str, str]] | None = None,
 ) -> None:
     """Post meeting notes to a group after a call ends.
 
@@ -996,13 +999,14 @@ async def post_meeting_notes_to_group(
 
     # ── Create Mission Control tasks from action items ──
     # Parse the ## ✅ Action Items section from the markdown summary
-    # and create unassigned Tasks so they appear in Mission Control.
+    # and create Tasks assigned to the matched participant.
     if workspace_id and summary:
         try:
             await _create_tasks_from_meeting_notes(
                 workspace_id=workspace_id,
                 group_id=group_id,
                 summary=summary,
+                participant_map=participant_map,
             )
         except Exception as exc:
             logger.warning("Failed to create tasks from meeting notes: %s", exc)
@@ -1085,12 +1089,25 @@ async def _create_tasks_from_meeting_notes(
     workspace_id: str,
     group_id: str,
     summary: str,
+    participant_map: list[dict[str, str]] | None = None,
 ) -> None:
     """Parse action items from the meeting notes summary and create Tasks."""
     action_items = _extract_action_items_from_markdown(summary)
     if not action_items:
         logger.info("No action items found in meeting notes for group %s", group_id)
         return
+
+    # Build name→id lookup from participant_map (sent by agent, no DB needed)
+    name_to_id: dict[str, str] = {}
+    if participant_map:
+        for p in participant_map:
+            pid = p.get("identity", "")
+            pname = p.get("name", "")
+            if pid and pname:
+                name_to_id[pname.lower()] = pid
+                first_word = pname.split(" ", 1)[0].lower()
+                if first_word not in name_to_id:
+                    name_to_id[first_word] = pid
 
     from datetime import UTC, datetime
 
@@ -1109,15 +1126,19 @@ async def _create_tasks_from_meeting_notes(
     created = 0
     for item in action_items:
         try:
+            # Parse @Name prefix from the action item, e.g. "@Admin: do X"
+            assignee_name, description = _parse_action_item_assignee(item)
+            assignee_id = name_to_id.get(assignee_name.lower(), "__unassigned__")
+
             await tasks_service.agent_create_task(
                 ctx,
                 CreateTaskRequest(
-                    title=item[:200],  # title is max 200 chars
+                    title=(description or item)[:200],
                     summary=f"(from meeting notes, group {group_id})",
                     assignee=AssigneeDTO(
                         kind="human",
-                        id="__unassigned__",
-                        name="Unassigned",
+                        id=assignee_id,
+                        name=assignee_name,
                     ),
                     source=SourceDTO(
                         type="meeting_notes",
@@ -1131,6 +1152,16 @@ async def _create_tasks_from_meeting_notes(
             logger.warning("Failed to create task for action item %r: %s", item, exc)
 
     logger.info("Created %d tasks from meeting notes for group %s", created, group_id)
+
+
+def _parse_action_item_assignee(item: str) -> tuple[str, str]:
+    """Extract ``@Name`` prefix from an action item, returning (assignee, rest)."""
+    import re
+
+    m = re.match(r"@(\S[\w\s]*?)\s*[:—\-]\s*(.*)", item.strip())
+    if m:
+        return m.group(1).strip(), m.group(2).strip()
+    return "__unassigned__", item
 
 
 def _extract_action_items_from_markdown(markdown: str) -> list[str]:

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -994,6 +994,19 @@ async def post_meeting_notes_to_group(
         except Exception as exc:
             logger.warning("Failed to store transcript: %s", exc)
 
+    # ── Create Mission Control tasks from action items ──
+    # Parse the ## ✅ Action Items section from the markdown summary
+    # and create unassigned Tasks so they appear in Mission Control.
+    if workspace_id and summary:
+        try:
+            await _create_tasks_from_meeting_notes(
+                workspace_id=workspace_id,
+                group_id=group_id,
+                summary=summary,
+            )
+        except Exception as exc:
+            logger.warning("Failed to create tasks from meeting notes: %s", exc)
+
 
 # ---------------------------------------------------------------------------
 # Private helpers
@@ -1061,3 +1074,101 @@ def _format_joined_at(joined_at: Any) -> str | None:
     if isinstance(joined_at, int | float):
         return datetime.fromtimestamp(joined_at, tz=UTC).isoformat()
     return str(joined_at)
+
+
+# ---------------------------------------------------------------------------
+# Meeting notes → Mission Control tasks
+# ---------------------------------------------------------------------------
+
+
+async def _create_tasks_from_meeting_notes(
+    workspace_id: str,
+    group_id: str,
+    summary: str,
+) -> None:
+    """Parse action items from the meeting notes summary and create Tasks."""
+    action_items = _extract_action_items_from_markdown(summary)
+    if not action_items:
+        logger.info("No action items found in meeting notes for group %s", group_id)
+        return
+
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+    from pocketpaw_ee.cloud.tasks import service as tasks_service
+    from pocketpaw_ee.cloud.tasks.dto import AssigneeDTO, CreateTaskRequest, SourceDTO
+
+    ctx = RequestContext(
+        user_id=CALL_BOT_USER_ID,
+        workspace_id=workspace_id,
+        request_id=f"meeting-notes-{group_id}",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+    created = 0
+    for item in action_items:
+        try:
+            await tasks_service.agent_create_task(
+                ctx,
+                CreateTaskRequest(
+                    title=item[:200],  # title is max 200 chars
+                    summary=f"(from meeting notes, group {group_id})",
+                    assignee=AssigneeDTO(
+                        kind="human",
+                        id="__unassigned__",
+                        name="Unassigned",
+                    ),
+                    source=SourceDTO(
+                        type="meeting_notes",
+                        ref_id=group_id,
+                        metadata={"group_id": group_id},
+                    ),
+                ),
+            )
+            created += 1
+        except Exception as exc:
+            logger.warning("Failed to create task for action item %r: %s", item, exc)
+
+    logger.info("Created %d tasks from meeting notes for group %s", created, group_id)
+
+
+def _extract_action_items_from_markdown(markdown: str) -> list[str]:
+    """Extract bullet-point action items from the ## ✅ Action Items section.
+
+    Looks for a heading matching "Action Items" (with optional emoji prefix)
+    and collects all following list items until the next heading or end of text.
+    """
+    import re
+
+    lines = markdown.split("\n")
+    in_section = False
+    items: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Detect the start of the Action Items section
+        if (
+            re.match(r"^##\s*[✅📋📌⚠️🔜❓⚙️]*\s*Action\s*Items", stripped, re.IGNORECASE)
+            or re.match(r"^##\s*✅\s*Action\s*Items", stripped, re.IGNORECASE)
+            or re.match(r"^##\s*Action\s*Items", stripped, re.IGNORECASE)
+        ):
+            in_section = True
+            continue
+
+        # If we hit another heading, stop
+        if in_section and stripped.startswith("## "):
+            break
+
+        if in_section:
+            # Match bullet points: -, *, or numbered 1.
+            m = re.match(r"\s*[-*]\s+(.*)", stripped)
+            if not m:
+                m = re.match(r"\s*\d+[.)]\s+(.*)", stripped)
+            if m:
+                text = m.group(1).strip()
+                if text and text != "None" and not text.startswith("```"):
+                    items.append(text)
+
+    return items

--- a/ee/pocketpaw_ee/cloud/mission_control/dto.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/dto.py
@@ -366,8 +366,45 @@ class PlanSessionListResponse(BaseModel):
     total: int
 
 
+class AnalyticsDayDTO(BaseModel):
+    """Shipped count for one day."""
+
+    day: str  # e.g. "Mon"
+    shipped: int
+
+
+class AnalyticsAgentDTO(BaseModel):
+    """Per-agent shipped/reverted counts."""
+
+    agent: str
+    shipped: int
+    reverted: int
+
+
+class AnalyticsPocketDTO(BaseModel):
+    """Per-pocket shipped + share %."""
+
+    pocket: str
+    shipped: int
+    share: float
+
+
+class AnalyticsResponse(BaseModel):
+    """Full analytics snapshot for the operator dashboard."""
+
+    shipped: int
+    approval_rate: float  # 0-100
+    revert_rate: float  # 0-100
+    latency_p50_seconds: float
+    latency_p90_seconds: float
+    per_day: list[AnalyticsDayDTO]
+    by_agent: list[AnalyticsAgentDTO]
+    by_pocket: list[AnalyticsPocketDTO]
+
+
 __all__ = [
     "ActivityEventResponse",
+    "AnalyticsResponse",
     "BulkActionRequest",
     "BulkReassignRequest",
     "BulkSnoozeRequest",

--- a/ee/pocketpaw_ee/cloud/mission_control/router.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/router.py
@@ -48,6 +48,7 @@ from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.mission_control import service as mc_service
 from pocketpaw_ee.cloud.mission_control.dto import (
     ActivityEventResponse,
+    AnalyticsResponse,
     AttachCycleItemsRequest,
     AttachCycleItemsResponse,
     BulkActionRequest,
@@ -230,6 +231,20 @@ async def attach_cycle_items(
     so a half-stale selection still partially succeeds.
     """
     return await mc_service.agent_attach_cycle_items(ctx, cycle_id, body)
+
+
+@router.get("/analytics", response_model=AnalyticsResponse)
+async def analytics(
+    window: str = Query("7d", pattern=r"^(1h|24h|7d)$"),
+    ctx: RequestContext = Depends(request_context),
+) -> AnalyticsResponse:
+    """Compute analytics snapshot for the operator dashboard.
+
+    Returns shipped counts, approval/revert rates, latency percentiles,
+    daily breakdown, by-agent, and by-pocket aggregations over the
+    requested window (1h | 24h | 7d).
+    """
+    return await mc_service.agent_analytics(ctx, window=window)
 
 
 @router.get("/plan-sessions", response_model=PlanSessionListResponse)

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -66,8 +66,6 @@ import logging
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
-from beanie import PydanticObjectId
-
 from pocketpaw.instinct.models import Action, ActionStatus
 from pocketpaw_ee.api import get_instinct_store
 from pocketpaw_ee.cloud._core.context import RequestContext
@@ -997,7 +995,6 @@ async def agent_attach_cycle_items(
 async def agent_analytics(ctx: RequestContext, window: str = "7d") -> AnalyticsResponse:
     """Compute the operator analytics dashboard for the given window."""
     _require_workspace(ctx)
-    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
     from pocketpaw_ee.cloud.models.task import Task as _TaskDoc
 
     cutoff = datetime.now(tz=UTC) - _window_to_delta(window)
@@ -1061,12 +1058,11 @@ async def agent_analytics(ctx: RequestContext, window: str = "7d") -> AnalyticsR
         for name, v in sorted(agent_map.items(), key=lambda x: -x[1]["shipped"])
     ]
 
-    # By pocket — resolve pocket names
-    pocket_ids = {d.pocket_id for d in shipped if d.pocket_id}
-    pocket_docs = await _PocketDoc.find(
-        {"_id": {"$in": [PydanticObjectId(pid) for pid in pocket_ids]}}
-    ).to_list()
-    pocket_name_map: dict[str, str] = {str(p.id): p.name for p in pocket_docs}
+    # By pocket — resolve pocket names via the pockets service
+    pockets = await pockets_service.list_pockets(ctx.workspace_id, ctx.user_id)
+    pocket_name_map: dict[str, str] = {
+        p["_id"]: p.get("name", p["_id"]) for p in pockets if p.get("_id")
+    }
 
     pocket_map: dict[str, int] = {}
     for d in shipped:

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -66,6 +66,8 @@ import logging
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
+from beanie import PydanticObjectId
+
 from pocketpaw.instinct.models import Action, ActionStatus
 from pocketpaw_ee.api import get_instinct_store
 from pocketpaw_ee.cloud._core.context import RequestContext
@@ -79,6 +81,10 @@ from pocketpaw_ee.cloud.mission_control.domain import (
 )
 from pocketpaw_ee.cloud.mission_control.dto import (
     ActivityEventResponse,
+    AnalyticsAgentDTO,
+    AnalyticsDayDTO,
+    AnalyticsPocketDTO,
+    AnalyticsResponse,
     AttachCycleItemsRequest,
     AttachCycleItemsResponse,
     BulkActionRequest,
@@ -983,7 +989,113 @@ async def agent_attach_cycle_items(
     )
 
 
+# ---------------------------------------------------------------------------
+# Analytics
+# ---------------------------------------------------------------------------
+
+
+async def agent_analytics(ctx: RequestContext, window: str = "7d") -> AnalyticsResponse:
+    """Compute the operator analytics dashboard for the given window."""
+    _require_workspace(ctx)
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+    from pocketpaw_ee.cloud.models.task import Task as _TaskDoc
+
+    cutoff = datetime.now(tz=UTC) - _window_to_delta(window)
+
+    # Fetch all tasks that were updated within the window
+    docs = (
+        await _TaskDoc.find(
+            {
+                "workspace_id": ctx.workspace_id,
+                "updatedAt": {"$gte": cutoff},
+            }
+        )
+        .sort(-_TaskDoc.updatedAt)
+        .to_list()
+    )
+
+    shipped: list[_TaskDoc] = [d for d in docs if d.status == "done"]
+    reverted: list[_TaskDoc] = [d for d in docs if d.status == "reverted"]
+
+    total_shipped = len(shipped)
+    total_reverted = len(reverted)
+    total_decided = total_shipped + total_reverted
+    approval_rate = round((total_shipped / total_decided * 100) if total_decided > 0 else 100, 1)
+    revert_rate = round((total_reverted / total_decided * 100) if total_decided > 0 else 0, 1)
+
+    # Latency: time from creation to completion for shipped tasks
+    latencies = [
+        (d.updatedAt - d.createdAt).total_seconds()
+        for d in shipped
+        if d.updatedAt and d.createdAt and d.updatedAt > d.createdAt
+    ]
+    latencies.sort()
+    n = len(latencies)
+    latency_p50 = latencies[max(0, min(n - 1, int(n * 0.5)))] if n > 0 else 0.0
+    latency_p90 = latencies[max(0, min(n - 1, int(n * 0.9)))] if n > 0 else 0.0
+
+    # Per-day breakdown
+    day_names = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    day_map: dict[str, int] = {}
+    for d in shipped:
+        if d.updatedAt:
+            day_name = day_names[d.updatedAt.weekday()]
+            day_map[day_name] = day_map.get(day_name, 0) + 1
+    per_day = [
+        AnalyticsDayDTO(day=name, shipped=day_map.get(name, 0))
+        for name in ["Wed", "Thu", "Fri", "Sat", "Sun", "Mon", "Tue"]
+    ]
+
+    # By agent
+    agent_map: dict[str, dict[str, int]] = {}
+    for d in shipped:
+        name = d.assignee.name or d.assignee.id
+        agent_map.setdefault(name, {"shipped": 0, "reverted": 0})
+        agent_map[name]["shipped"] += 1
+    for d in reverted:
+        name = d.assignee.name or d.assignee.id
+        agent_map.setdefault(name, {"shipped": 0, "reverted": 0})
+        agent_map[name]["reverted"] += 1
+    by_agent = [
+        AnalyticsAgentDTO(agent=name, shipped=v["shipped"], reverted=v["reverted"])
+        for name, v in sorted(agent_map.items(), key=lambda x: -x[1]["shipped"])
+    ]
+
+    # By pocket — resolve pocket names
+    pocket_ids = {d.pocket_id for d in shipped if d.pocket_id}
+    pocket_docs = await _PocketDoc.find(
+        {"_id": {"$in": [PydanticObjectId(pid) for pid in pocket_ids]}}
+    ).to_list()
+    pocket_name_map: dict[str, str] = {str(p.id): p.name for p in pocket_docs}
+
+    pocket_map: dict[str, int] = {}
+    for d in shipped:
+        pid = d.pocket_id or "__unknown__"
+        pocket_map[pid] = pocket_map.get(pid, 0) + 1
+    total_pocket = sum(pocket_map.values())
+    by_pocket = [
+        AnalyticsPocketDTO(
+            pocket=pocket_name_map.get(pid, pid),
+            shipped=count,
+            share=round(count / total_pocket * 100, 1) if total_pocket > 0 else 0,
+        )
+        for pid, count in sorted(pocket_map.items(), key=lambda x: -x[1])
+    ]
+
+    return AnalyticsResponse(
+        shipped=total_shipped,
+        approval_rate=approval_rate,
+        revert_rate=revert_rate,
+        latency_p50_seconds=latency_p50,
+        latency_p90_seconds=latency_p90,
+        per_day=per_day,
+        by_agent=by_agent,
+        by_pocket=by_pocket,
+    )
+
+
 __all__ = [
+    "agent_analytics",
     "agent_attach_cycle_items",
     "agent_bulk_approve",
     "agent_bulk_reassign",

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -75,6 +75,7 @@ from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
 from pocketpaw_ee.cloud.models.task import Task, TaskAssignee, TaskSource
+from pocketpaw_ee.cloud.models.task_event import TaskEvent
 from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc
 from pocketpaw_ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
@@ -163,6 +164,7 @@ __all__ = [
     "Task",
     "TaskAssignee",
     "TaskSource",
+    "TaskEvent",
     "TemporalSweepStateDoc",
     "User",
     "Widget",
@@ -223,6 +225,7 @@ def get_all_documents():
         AuditWebhook,
         AuthSession,
         APIKey,
+        TaskEvent,
         cal_doc,
         evt_doc,
     ]

--- a/ee/pocketpaw_ee/cloud/models/task_event.py
+++ b/ee/pocketpaw_ee/cloud/models/task_event.py
@@ -1,0 +1,26 @@
+"""TaskEvent document — comments and activity on a Task."""
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class TaskEvent(TimestampedDocument):
+    """A comment or activity entry on a task (persistent, realtime)."""
+
+    workspace_id: Indexed(str)  # type: ignore[valid-type]
+    task_id: Indexed(str)  # type: ignore[valid-type]
+    author_id: str
+    author_name: str
+    body: str
+
+    class Settings:
+        name = "task_events"
+        indexes = [
+            [("task_id", 1), ("created_at", -1)],
+        ]
+
+
+__all__ = ["TaskEvent"]

--- a/ee/pocketpaw_ee/cloud/tasks/dto.py
+++ b/ee/pocketpaw_ee/cloud/tasks/dto.py
@@ -245,17 +245,48 @@ def task_to_dto(task: Task) -> TaskResponse:
     )
 
 
+class CreateTaskEventRequest(BaseModel):
+    """Body for ``POST /tasks/{id}/events``."""
+
+    body: str = Field(min_length=1, max_length=2000)
+
+
+class TaskEventResponse(BaseModel):
+    """Wire shape for one task event."""
+
+    id: str
+    task_id: str
+    author_id: str
+    author_name: str
+    body: str
+    created_at: str | None = None
+
+
+def task_event_to_dto(event: Any) -> TaskEventResponse:
+    return TaskEventResponse(
+        id=str(event.id),
+        task_id=event.task_id,
+        author_id=event.author_id,
+        author_name=event.author_name,
+        body=event.body,
+        created_at=iso_utc(event.createdAt) if event.createdAt else None,
+    )
+
+
 __all__ = [
     "AssigneeDTO",
     "BlockTaskRequest",
     "BulkReassignRequest",
     "ClaimTaskRequest",
     "CompleteTaskRequest",
+    "CreateTaskEventRequest",
     "CreateTaskRequest",
     "ListTasksRequest",
     "ReassignTaskRequest",
     "SourceDTO",
+    "TaskEventResponse",
     "TaskResponse",
     "UpdateTaskRequest",
+    "task_event_to_dto",
     "task_to_dto",
 ]

--- a/ee/pocketpaw_ee/cloud/tasks/router.py
+++ b/ee/pocketpaw_ee/cloud/tasks/router.py
@@ -29,9 +29,11 @@ from pocketpaw_ee.cloud.tasks.dto import (
     BlockTaskRequest,
     ClaimTaskRequest,
     CompleteTaskRequest,
+    CreateTaskEventRequest,
     CreateTaskRequest,
     ListTasksRequest,
     ReassignTaskRequest,
+    TaskEventResponse,
     TaskResponse,
     UpdateTaskRequest,
 )
@@ -129,3 +131,23 @@ async def reassign_task(
     ctx: RequestContext = Depends(request_context),
 ) -> TaskResponse:
     return await tasks_service.agent_reassign_task(ctx, task_id, body)
+
+
+@router.post("/{task_id}/events", response_model=TaskEventResponse, status_code=201)
+async def create_task_event(
+    task_id: str,
+    body: CreateTaskEventRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> TaskEventResponse:
+    """Post a comment/activity entry on a task."""
+    return await tasks_service.agent_create_task_event(ctx, task_id, body)
+
+
+@router.get("/{task_id}/events", response_model=list[TaskEventResponse])
+async def list_task_events(
+    task_id: str,
+    limit: int = Query(default=50, ge=1, le=200),
+    ctx: RequestContext = Depends(request_context),
+) -> list[TaskEventResponse]:
+    """List comments/activity for a task, newest first."""
+    return await tasks_service.agent_list_task_events(ctx, task_id, limit)

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -171,6 +171,16 @@ def _event_payload(doc: _TaskDoc, task: Task | None = None) -> dict:
     }
 
 
+async def _is_workspace_owner(user_id: str, workspace_id: str) -> bool:
+    """Check if the user has the ``owner`` role in the given workspace."""
+    from pocketpaw_ee.cloud.models.user import User
+
+    user = await User.get(user_id)
+    if not user:
+        return False
+    return any(m.workspace == workspace_id and m.role == "owner" for m in user.workspaces)
+
+
 # ---------------------------------------------------------------------------
 # CRUD
 # ---------------------------------------------------------------------------
@@ -448,11 +458,12 @@ async def agent_complete_task(
     doc = await _fetch_task(ctx, task_id)
 
     if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
-        # Only the creator or the assignee can mark a task complete.
-        # Other workspace members must reassign or escalate.
-        raise Forbidden(
-            "task.complete_denied", "Only the creator or assignee can complete this task"
-        )
+        # Workspace owners can also complete tasks (bulk approve from MC).
+        if not await _is_workspace_owner(ctx.user_id, doc.workspace_id):
+            raise Forbidden(
+                "task.complete_denied",
+                "Only the creator, assignee, or workspace owner can complete this task",
+            )
 
     if doc.status in {"done", "reverted", "failed"}:
         raise ValidationError("task.terminal", f"task is already {doc.status!r}")

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -71,16 +71,20 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 from pocketpaw_ee.cloud.models.task import Task as _TaskDoc
 from pocketpaw_ee.cloud.models.task import TaskAssignee as _AssigneeDoc
 from pocketpaw_ee.cloud.models.task import TaskSource as _SourceDoc
+from pocketpaw_ee.cloud.models.task_event import TaskEvent as _TaskEventDoc
 from pocketpaw_ee.cloud.tasks.domain import Task, TaskAssignee, TaskSource
 from pocketpaw_ee.cloud.tasks.dto import (
     BlockTaskRequest,
     ClaimTaskRequest,
     CompleteTaskRequest,
+    CreateTaskEventRequest,
     CreateTaskRequest,
     ListTasksRequest,
     ReassignTaskRequest,
+    TaskEventResponse,
     TaskResponse,
     UpdateTaskRequest,
+    task_event_to_dto,
     task_to_dto,
 )
 
@@ -624,12 +628,66 @@ async def unassign_project_on_tasks(workspace_id: str, project_id: str) -> int:
     return getattr(result, "modified_count", 0) or 0
 
 
+# ---------------------------------------------------------------------------
+# Task Event (comments/activity on a task)
+# ---------------------------------------------------------------------------
+
+
+async def agent_create_task_event(
+    ctx: RequestContext, task_id: str, body: CreateTaskEventRequest
+) -> TaskEventResponse:
+    """Post a comment/activity entry on a task."""
+    body = CreateTaskEventRequest.model_validate(body)
+    task_doc = await _fetch_task(ctx, task_id)
+    from pocketpaw_ee.cloud.models.user import User
+
+    user = await User.get(ctx.user_id)
+    author_name = user.full_name if user else ctx.user_id
+    doc = _TaskEventDoc(
+        workspace_id=task_doc.workspace_id,
+        task_id=task_id,
+        author_id=ctx.user_id,
+        author_name=author_name,
+        body=body.body,
+    )
+    await doc.insert()
+    # Emit a bus event so the frontend gets a realtime update
+    event_dto = task_event_to_dto(doc)
+    await emit(TaskUpdated(data={
+        "task_id": task_id,
+        "task": None,
+        "event": event_dto.model_dump(mode="json"),
+        "workspace_id": task_doc.workspace_id,
+        "recipient_ids": [task_doc.creator_id],
+    }))
+    return event_dto
+
+
+async def agent_list_task_events(
+    ctx: RequestContext, task_id: str, limit: int = 50
+) -> list[TaskEventResponse]:
+    """List events for a task, newest first."""
+    _ = await _fetch_task(ctx, task_id)  # tenant guard
+    docs = (
+        await _TaskEventDoc.find(
+            _TaskEventDoc.task_id == task_id,
+            _TaskEventDoc.workspace_id == ctx.workspace_id,
+        )
+        .sort(-_TaskEventDoc.createdAt)  # type: ignore[operator]
+        .limit(max(1, min(limit, 200)))
+        .to_list()
+    )
+    return [task_event_to_dto(d) for d in docs]
+
+
 __all__ = [
     "agent_block_task",
     "agent_claim_task",
     "agent_complete_task",
     "agent_create_task",
+    "agent_create_task_event",
     "agent_get_task",
+    "agent_list_task_events",
     "agent_list_tasks",
     "agent_reassign_task",
     "agent_reassign_task_cycle",

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -283,10 +283,10 @@ async def agent_update_task(
 
     body = UpdateTaskRequest.model_validate(body)
     doc = await _fetch_task(ctx, task_id)
-    if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
-        # Only creator or assignee can edit. Other workspace members
-        # should escalate through reassignment / approval flows.
-        raise Forbidden("task.edit_denied", "Only the creator or assignee can edit this task")
+    # No creator/assignee guard here — metadata fields (title, summary,
+    # priority, etc.) are safe for any workspace member to edit. Status
+    # transitions are protected by their own dedicated endpoints
+    # (claim/complete/block/reassign) with tighter guards.
 
     if body.title is not None:
         doc.title = body.title

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -664,13 +664,17 @@ async def agent_create_task_event(
     await doc.insert()
     # Emit a bus event so the frontend gets a realtime update
     event_dto = task_event_to_dto(doc)
-    await emit(TaskUpdated(data={
-        "task_id": task_id,
-        "task": None,
-        "event": event_dto.model_dump(mode="json"),
-        "workspace_id": task_doc.workspace_id,
-        "recipient_ids": [task_doc.creator_id],
-    }))
+    await emit(
+        TaskUpdated(
+            data={
+                "task_id": task_id,
+                "task": None,
+                "event": event_dto.model_dump(mode="json"),
+                "workspace_id": task_doc.workspace_id,
+                "recipient_ids": [task_doc.creator_id],
+            }
+        )
+    )
     return event_dto
 
 


### PR DESCRIPTION
## feat(livekit): DeepSeek-powered meeting summary with rich markdown notes

### Overview

Adds AI-powered meeting summarization using DeepSeek as the primary LLM, with automatic task creation from action items and a live analytics dashboard for Mission Control.

---

### Changes

#### 🤖 Meeting Summarization (`agent.py`, `service.py`)

- Added `_summarize_with_deepseek()` as the primary LLM for post-call summarization
- Prompt produces structured Markdown notes: **Overview, Topics, Decisions, Action Items, Key Questions, Next Steps**
- Summarization is always attempted even when no speech is captured
- `service.py` detects rich Markdown summaries and renders them directly in-chat
- Transcript is truncated to 4,000 chars for in-chat display; full transcript is still sent to DeepSeek
- Extracted LLM prompts (Anthropic, DeepSeek, OpenAI) into a dedicated `prompts.py` module as named constants with `{transcript}` placeholders — decouples prompt iteration from agent logic
- Participant identities (raw ObjectIds) are now resolved to display names before notes are posted

#### ✅ Auto Task Creation (`service.py`)

- Added `_create_tasks_from_meeting_notes()` to parse `## ✅ Action Items` from the DeepSeek summary and create unassigned Tasks automatically
- Added `_extract_action_items_from_markdown()` helper
- Uses the structured `action_items` list from the LLM as the primary source; falls back to Markdown parsing if unavailable
- Resolves `@mention` names against `participant_map` using substring matching to handle LLM name variations
- Hooked into `post_meeting_notes_to_group()` after notes are posted

#### 🛠️ Task Management (`tasks.py`)

- Added `create_task` MCP tool for the agent runtime to create Tasks from conversation action items
- Supports `title`, `summary`, `assignee_kind/id/name`, `priority`, `project_id`
- Defaults to unassigned if no assignee is specified
- Workspace members can now edit task metadata (title, summary, priority) — removed the creator/assignee-only guard from `agent_update_task`
- Status transitions (claim/complete/block/reassign) remain protected by dedicated endpoints
- Workspace owners can now complete/approve tasks, fixing bulk-approve from Mission Control

#### 💬 Task Events (`tasks.py`)

- Added `TaskEvent` Beanie model for persistent task comments and activity
- New endpoints: `POST /tasks/{id}/events`, `GET /tasks/{id}/events`
- Bus event includes `workspace_id` so the audience resolver fans out to all workspace members
- Full event payload is carried in the bus event so the frontend can append locally without a REST re-fetch

#### 📊 Analytics Dashboard (`service.py`, `Analytics.svelte`)

- Added `GET /mission-control/analytics` endpoint
- Implements `agent_analytics()`: shipped tasks, approval rate, latency, per-day breakdown, by-agent and by-pocket aggregations from Task documents
- Added `AnalyticsDayDTO`, `AnalyticsAgentDTO`, `AnalyticsPocketDTO`, `AnalyticsResponse` DTOs
- Frontend: wired `Analytics.svelte` to fetch live data with a loading state via `getAnalytics()` in `MissionControlApi`
- Fixed import-linter violation: replaced direct `_PocketDoc.find()` call with `pockets_service.list_pockets()`

---

### Security Note

`asyncio.create_subprocess_exec` on line 151 of `service.py` was flagged by the automated scanner. This call is intentional — reviewer should confirm inputs are sanitized and no user-controlled data reaches the subprocess args.

---

### Testing Checklist

- [X] End-to-end meeting call generates a structured Markdown summary
- [X] Action items are auto-created as Tasks after the call ends
- [x] `@mention` names in action items are resolved correctly to workspace members
- [x] Workspace owner can approve/complete tasks from Mission Control
- [x] Task comments/events are persisted and pushed via WebSocket
- [x] Analytics dashboard renders live data correctly