### PR TITLE
Wire publish() to the Cloudflare build_and_deploy seam

### DIFF
--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,34 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-06 (feat/sites-publish-deploy-wire — wire publish() to the CF
+# deploy seam, pocketpaw#1346): publish() now calls the generator client's
+# build_and_deploy() seam INSTEAD of the old manual build() + put_worker() /
+# deploy_local() sequence. build_and_deploy runs build → workerd smoke gate →
+# real Workers-for-Platforms deploy (cf.deploy_site, which ships the worker +
+# static assets + bindings, not just a raw module) and returns one total
+# DeployResult{success, url, error}; it never raises for an expected failure.
+#   * CF-vs-local selection is unchanged POLICY (this layer reads the env): the
+#     same use_local = (no injected CF client) AND _local_mode() decides which
+#     deploy target build_and_deploy gets — cloudflare=<client> for the real edge
+#     path, local_deploy=<callable> for the PAW_SITES_LOCAL / no-creds dev path.
+#     BOTH paths are preserved.
+#   * State machine is unchanged: on result.success the draft is promoted to
+#     published and the Site is marked deployed/live (url=result.url); on
+#     failure publish() raises SmokeGateFailed(result.error) BEFORE any promotion
+#     or live-marking, so #1345's guarantees hold verbatim — a failed publish
+#     leaves a recoverable draft, and a failed RE-publish on an already-live site
+#     keeps it live on the OLD published version (publish_draft is the only write
+#     that advances the published pointer + mirrors deploy_status="live", and it
+#     is never reached on failure). Raising (vs. returning the not-live doc) keeps
+#     the existing caller contract: the MCP tool's is_error / the REST 5xx path
+#     still surface a failed deploy instead of reporting a phantom publish.
+#   * The raw build() + put_worker()/deploy_local() sequence is removed from
+#     publish(); those client methods stay defined (back-compat, other callers).
+#     The legacy ``_bundle_reader`` param is now UNUSED by publish() (deploy_site
+#     reads its own bundle) — kept on the signature so existing callers/tests that
+#     pass it don't break.
+#
 # Updated 2026-06-06 (feat/1345-draft-published — draft/published state machine,
 # pocketpaw#1345): stop "Live" from lying. New flow on top of the versions module
 # (ee/pocketpaw_ee/cloud/versions):
@@ -131,7 +159,7 @@ from pocketpaw_ee.sites.dto import (
     SiteResponse,
     SiteStatusResponse,
 )
-from pocketpaw_ee.sites.generator_client import GeneratorClient
+from pocketpaw_ee.sites.generator_client import GeneratorClient, SmokeGateFailed
 
 # The control plane reads the Worker bundle adapter-cloudflare emits here.
 _WORKER_BUNDLE_REL = ".svelte-kit/cloudflare/_worker.js"
@@ -368,15 +396,21 @@ async def publish(
     _local_deploy: Callable[[str, str], str] | None = None,
 ) -> _SiteDoc:
     """Promote the pocket's draft to published, build, smoke-gate, deploy, and
-    persist the site as live. Raises SmokeGateFailed (from generator_client) if
-    the workerd smoke render fails, or the deploy error if the Worker upload
-    fails — in BOTH cases the version stays a draft and the site is NOT marked
-    live (the "Live only after a successful deploy" guarantee).
+    persist the site as live. Raises SmokeGateFailed if the build/smoke gate OR
+    the deploy fails (the failure reason is the exception message) — in BOTH
+    cases the version stays a draft and the site is NOT marked live (the "Live
+    only after a successful deploy" guarantee).
 
-    Order matters: build + deploy run FIRST; only on success does the draft
-    version get promoted to published and the Site doc persisted as
-    deployed/published. So a failed publish leaves a recoverable draft and never
-    a phantom-live site.
+    Build + deploy run through the generator client's ONE ``build_and_deploy``
+    seam (generate → workerd smoke gate → real Workers-for-Platforms deploy),
+    which returns a total ``DeployResult{success, url, error}`` and never raises
+    for an expected failure. Order matters: that seam runs FIRST; only on
+    ``result.success`` does the draft version get promoted to published and the
+    Site doc persisted as deployed/published with ``url=result.url``. On failure
+    publish() raises BEFORE any promotion or live-marking, so a failed publish
+    leaves a recoverable draft and never a phantom-live site — and a failed
+    RE-publish on an already-live site keeps it live on the OLD published version
+    (the publish-pointer advance only happens on success).
 
     Idempotent per pocket: reuses the Site row created by ``create_draft_site``
     (and its minted id / signed key / script name) when one exists, instead of
@@ -385,13 +419,16 @@ async def publish(
     publish), one is recorded from the passed content before promotion, so publish
     always has a version to promote.
 
-    Deploy has two branches:
+    Deploy target is chosen HERE (the policy layer reads the env) and handed to
+    ``build_and_deploy`` as one of two params:
       * REAL Cloudflare (default when creds are present, or when a CF client is
-        injected): PUT the Worker bundle into the dispatch namespace.
+        injected): ``cloudflare=<client>`` → ``cf.deploy_site`` ships the worker
+        + static assets + bindings into the dispatch namespace and returns the
+        live URL.
       * LOCAL fake-deploy (no CF creds / PAW_SITES_LOCAL=1, and no injected CF
-        client): persist the built static site and serve it from localhost,
-        storing that URL on the Site so the response is openable. Cloudflare is
-        not contacted at all.
+        client): ``local_deploy=<callable>`` → the built static site is served
+        from localhost and that URL is stored on the Site so the response is
+        openable. Cloudflare is not contacted at all.
 
     ``name`` defaults to the source pocket's own display name when the caller
     omits it (the publish schema promises this). The fallback reads the pocket
@@ -430,9 +467,23 @@ async def publish(
             origin="publish",
         )
 
-    # Build + deploy FIRST. A failure here propagates BEFORE any promotion or
-    # live-marking, so the version stays a draft and the site is not live.
-    build = await generator.build(
+    # Pick the deploy target (POLICY lives here; MECHANICS live in the seam).
+    # Local mode only when the caller did NOT inject a CF client (tests inject a
+    # fake CF and expect the real branch) AND the environment selects it.
+    use_local = _cloudflare is None and _local_mode()
+    if use_local:
+        from pocketpaw_ee.sites import local_server
+
+        cloudflare = None
+        local_deploy: Callable[[str, str], str] | None = _local_deploy or local_server.deploy_local
+    else:
+        cloudflare = _cloudflare or _cf_client()
+        local_deploy = None
+
+    # Build + deploy through the ONE seam (generate → smoke gate → deploy). It
+    # returns a total DeployResult and never raises for an expected failure, so a
+    # broken site / failed deploy comes back as success=False.
+    result = await generator.build_and_deploy(
         ripple_spec=ripple_spec,
         theme=theme,
         site_id=site_id,
@@ -441,21 +492,22 @@ async def publish(
         capture_signed_key=signed_key,
         engine=engine,
         source=source,
+        cloudflare=cloudflare,
+        local_deploy=local_deploy,
     )
 
-    # Local mode only when the caller did NOT inject a CF client (tests inject a
-    # fake CF and expect the real branch) AND the environment selects it.
-    use_local = _cloudflare is None and _local_mode()
-    url = ""
-    if use_local:
-        from pocketpaw_ee.sites import local_server
+    if not result.success:
+        # The build/smoke gate or the deploy failed. Raise BEFORE any promotion
+        # or live-marking so the version stays a draft and the site is NOT
+        # marked live — and an already-live site keeps its OLD published version
+        # live (publish_draft below, the only write that advances the published
+        # pointer + flips deploy_status="live", is never reached). Raising (not
+        # returning the not-live doc) keeps the caller contract: the MCP tool's
+        # is_error / the REST error path surface the failure instead of a phantom
+        # publish.
+        raise SmokeGateFailed(result.error or "publish failed: deploy unsuccessful")
 
-        deploy = _local_deploy or local_server.deploy_local
-        url = deploy(site_id, build.project_dir)
-    else:
-        cf = _cloudflare or _cf_client()
-        bundle = _bundle_reader(build.project_dir)
-        await cf.put_worker(script_name=site_id, bundle=bundle)
+    url = result.url or ""
 
     # Deploy succeeded — NOW promote the draft to published and mark the site
     # live. publish_draft advances the version pointers AND mirrors the deploy

--- a/tests/cloud/pockets/test_gallery_site_exclusion.py
+++ b/tests/cloud/pockets/test_gallery_site_exclusion.py
@@ -14,6 +14,11 @@
 # Uses the shared ``mongo_db`` fixture (tests/cloud/conftest.py) which inits
 # Beanie against an in-memory Mongo with ALL_DOCUMENTS (Pocket + Site both
 # registered) and auto-installs a RecordingBus so the create() emit() succeeds.
+#
+# Updated 2026-06-06 (feat/sites-publish-deploy-wire — CF deploy seam): publish()
+# now goes through the generator's build_and_deploy() seam, so the publish fakes
+# expose build_and_deploy (dispatching to the CF target) + deploy_site instead of
+# the old build() + put_worker pair.
 
 from __future__ import annotations
 
@@ -33,15 +38,21 @@ _USER = "user_gallery"
 
 
 class _FakeGenerator:
-    async def build(self, **kw):
-        from pocketpaw_ee.sites.generator_client import BuildResult
+    async def build_and_deploy(self, *, cloudflare=None, local_deploy=None, **kw):
+        from pocketpaw_ee.sites.generator_client import DeployResult
 
-        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+        if cloudflare is not None:
+            url = await cloudflare.deploy_site(script_name=kw["site_id"], project_dir="/tmp/site")
+        elif local_deploy is not None:
+            url = local_deploy(kw["site_id"], "/tmp/site")
+        else:
+            return DeployResult(success=False, error="no deploy target")
+        return DeployResult(success=True, url=url)
 
 
 class _FakeCF:
-    async def put_worker(self, *, script_name, bundle):
-        return True
+    async def deploy_site(self, *, script_name, project_dir):
+        return f"https://paw-sites.workers.dev/{script_name}/"
 
 
 async def _make_pocket(name: str) -> str:

--- a/tests/ee/sites/test_dentist_e2e.py
+++ b/tests/ee/sites/test_dentist_e2e.py
@@ -31,6 +31,9 @@
 #      ("Sam Rivera" / "775-555-0100") scans NONE on the InjectionScanner, the
 #      empty honeypot field is untripped, and the body is well under the 8 KB
 #      payload cap, so every security gate is satisfied by valid input.
+# Updated 2026-06-06 (feat/sites-publish-deploy-wire — CF deploy seam): publish()
+# now goes through build_and_deploy(); the fakes expose build_and_deploy
+# (dispatching to the CF target) + deploy_site instead of build() + put_worker.
 from __future__ import annotations
 
 import pytest
@@ -40,15 +43,23 @@ from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus
 
 
 class _FakeGenerator:
-    async def build(self, **kw):
-        from pocketpaw_ee.sites.generator_client import BuildResult
+    async def build_and_deploy(self, *, cloudflare=None, local_deploy=None, **kw):
+        from pocketpaw_ee.sites.generator_client import DeployResult
 
-        return BuildResult(project_dir="/tmp/dentist", ripple_version="0.2.0")
+        if cloudflare is not None:
+            url = await cloudflare.deploy_site(
+                script_name=kw["site_id"], project_dir="/tmp/dentist"
+            )
+        elif local_deploy is not None:
+            url = local_deploy(kw["site_id"], "/tmp/dentist")
+        else:
+            return DeployResult(success=False, error="no deploy target")
+        return DeployResult(success=True, url=url)
 
 
 class _FakeCF:
-    async def put_worker(self, *, script_name, bundle):
-        return True
+    async def deploy_site(self, *, script_name, project_dir):
+        return f"https://paw-sites.workers.dev/{script_name}/"
 
     async def create_custom_hostname(self, hostname):
         return CustomHostname(

--- a/tests/ee/sites/test_draft_published.py
+++ b/tests/ee/sites/test_draft_published.py
@@ -21,48 +21,75 @@
 # failed-re-publish test on an ALREADY-LIVE site (refine v2 → publish v2 fails →
 # the site must stay live on v1, published pointer unmoved — the existing
 # failed-publish tests only covered the never-published case).
+# Updated 2026-06-06 (feat/sites-publish-deploy-wire — CF deploy seam): publish()
+# now goes through the generator's build_and_deploy() seam (build → smoke gate →
+# deploy → DeployResult), so the fakes follow: _FakeGenerator.build_and_deploy
+# DISPATCHES to the cloudflare / local_deploy target publish() hands it and
+# returns a DeployResult; _FakeCF exposes deploy_site (records the deploy URL);
+# _FailingGenerator returns DeployResult(success=False) (the seam never raises for
+# an expected failure); _FailingCF.deploy_site raises (the seam catches it →
+# success=False). publish() still RAISES on a failed DeployResult so the caller
+# contract (MCP is_error / REST error) is preserved — but now it is always a
+# SmokeGateFailed carrying the DeployResult.error, so the failed-deploy test
+# asserts SmokeGateFailed (was RuntimeError). All the #1345 state-machine
+# guarantees (not-live on failure, failed-re-publish keeps old version live) are
+# unchanged.
 from __future__ import annotations
 
 import pytest
 from pocketpaw_ee.cloud.versions import service as versions_service
 from pocketpaw_ee.sites import service as sites_service
-from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+from pocketpaw_ee.sites.generator_client import DeployResult, SmokeGateFailed
 
 
 class _FakeGenerator:
-    """Successful build: returns a project dir, never raises."""
+    """Successful build: dispatches to the deploy target publish() selected
+    (cloudflare or local_deploy), mirroring the real build_and_deploy seam, and
+    returns a successful DeployResult carrying that target's URL."""
 
     def __init__(self) -> None:
         self.built: dict | None = None
 
-    async def build(self, **kw):
-        from pocketpaw_ee.sites.generator_client import BuildResult
-
+    async def build_and_deploy(self, *, cloudflare=None, local_deploy=None, **kw):
         self.built = kw
-        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+        project_dir = "/tmp/site"
+        try:
+            if cloudflare is not None:
+                url = await cloudflare.deploy_site(
+                    script_name=kw["site_id"], project_dir=project_dir
+                )
+            elif local_deploy is not None:
+                url = local_deploy(kw["site_id"], project_dir)
+            else:
+                return DeployResult(success=False, error="no deploy target")
+        except Exception as exc:  # noqa: BLE001 - mirror the seam: deploy failure → success=False
+            return DeployResult(success=False, error=f"deploy failed: {exc}")
+        return DeployResult(success=True, url=url)
 
 
 class _FailingGenerator:
-    """Build/smoke gate fails — the deploy must NOT proceed and Live must stay
-    false (the 'Live only after a successful deploy' guarantee)."""
+    """Build/smoke gate fails — the seam returns success=False WITHOUT deploying
+    (it never raises for an expected failure). publish() then raises so Live
+    stays false (the 'Live only after a successful deploy' guarantee)."""
 
-    async def build(self, **kw):
-        raise SmokeGateFailed("workerd SSR failure: window is not defined")
+    async def build_and_deploy(self, **kw):
+        return DeployResult(success=False, error="workerd SSR failure: window is not defined")
 
 
 class _FakeCF:
     def __init__(self) -> None:
-        self.put_calls: list[str] = []
+        self.deploy_calls: list[str] = []
 
-    async def put_worker(self, *, script_name, bundle):
-        self.put_calls.append(script_name)
-        return True
+    async def deploy_site(self, *, script_name, project_dir):
+        self.deploy_calls.append(script_name)
+        return f"https://paw-sites.workers.dev/{script_name}/"
 
 
 class _FailingCF:
-    """Worker upload fails after a good build — Live must stay false."""
+    """Edge deploy fails after a good build — the seam catches the raise and
+    returns success=False, so publish() raises and Live stays false."""
 
-    async def put_worker(self, *, script_name, bundle):
+    async def deploy_site(self, *, script_name, project_dir):
         raise RuntimeError("cloudflare 500: dispatch namespace upload failed")
 
 
@@ -123,7 +150,10 @@ async def test_publish_sets_live_after_successful_deploy(beanie_test_db):
     assert resp.status == "published"
     assert resp.is_live is True
     assert published.deployed is True
-    assert cf.put_calls == [published.script_name]
+    # The seam deployed via cf.deploy_site (the real edge step) and the live URL
+    # it returned landed on the Site.
+    assert cf.deploy_calls == [published.script_name]
+    assert published.url == f"https://paw-sites.workers.dev/{published.script_name}/"
     # Same Site doc (publish reuses the draft site for this pocket, not a 2nd row).
     assert str(published.id) == str(site.id)
 
@@ -159,7 +189,9 @@ async def test_publish_failed_build_leaves_site_not_live(beanie_test_db):
 
 @pytest.mark.asyncio
 async def test_publish_failed_deploy_leaves_site_not_live(beanie_test_db):
-    """A good build but a failed Worker upload must NOT mark the site live."""
+    """A good build but a failed edge deploy must NOT mark the site live. The seam
+    turns the deploy raise into DeployResult(success=False), and publish() raises
+    SmokeGateFailed (carrying the reason) so the caller still sees a failure."""
     await sites_service.create_draft_site(
         workspace_id="ws1",
         user_id="u1",
@@ -168,7 +200,7 @@ async def test_publish_failed_deploy_leaves_site_not_live(beanie_test_db):
         theme={},
         name="Site",
     )
-    with pytest.raises(RuntimeError):
+    with pytest.raises(SmokeGateFailed):
         await sites_service.publish(
             workspace_id="ws1",
             user_id="u1",
@@ -408,5 +440,6 @@ async def test_failed_republish_keeps_site_live_on_previous_version(beanie_test_
     assert pub.version_no == 1
     assert pub.content == {"type": "container", "rev": 1}
 
-    # A failed deploy must NOT have uploaded a v2 worker.
-    assert cf.put_calls == [live_v1.script_name]  # only the v1 publish uploaded
+    # A failed (build-gated) v2 publish must NOT have deployed a v2 worker; only
+    # the v1 publish reached the edge.
+    assert cf.deploy_calls == [live_v1.script_name]

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -17,6 +17,10 @@
 # require_license, and stubs get_workspace_plan -> "business" so the plan gate
 # passes (fabric is a business+ feature). add_error_handler maps the service's
 # NotFound (cross-tenant) to a 404.
+#
+# Updated 2026-06-06 (feat/sites-publish-deploy-wire — CF deploy seam): publish()
+# now goes through build_and_deploy(); the seed fakes expose build_and_deploy
+# (dispatching to the CF target) + deploy_site instead of build() + put_worker.
 
 from __future__ import annotations
 
@@ -32,15 +36,21 @@ from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus
 
 
 class _FakeGenerator:
-    async def build(self, **kw):
-        from pocketpaw_ee.sites.generator_client import BuildResult
+    async def build_and_deploy(self, *, cloudflare=None, local_deploy=None, **kw):
+        from pocketpaw_ee.sites.generator_client import DeployResult
 
-        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+        if cloudflare is not None:
+            url = await cloudflare.deploy_site(script_name=kw["site_id"], project_dir="/tmp/site")
+        elif local_deploy is not None:
+            url = local_deploy(kw["site_id"], "/tmp/site")
+        else:
+            return DeployResult(success=False, error="no deploy target")
+        return DeployResult(success=True, url=url)
 
 
 class _FakeCF:
-    async def put_worker(self, *, script_name, bundle):
-        return True
+    async def deploy_site(self, *, script_name, project_dir):
+        return f"https://paw-sites.workers.dev/{script_name}/"
 
     async def create_custom_hostname(self, hostname):
         return CustomHostname(

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -17,7 +17,8 @@
 # branch — with no CF creds and no injected CF client, publish() does NOT contact
 # Cloudflare, persists the site via the local deployer, and stores+returns a local
 # URL on the Site (and SiteResponse). Also asserts an injected CF client always
-# wins (the real branch), so the existing CF tests keep exercising put_worker.
+# wins (the real branch), so the existing CF tests keep exercising the edge
+# deploy (cf.deploy_site after the seam rewire).
 # Updated 2026-06-01 (Phase 4 — chat→create-site): coverage for publish_pocket(),
 # the shared pocket-read + publish path the REST router and the in-process MCP
 # tool both call — mocks pockets_service.get to prove it derives the theme from
@@ -30,6 +31,14 @@
 # "Untitled site" only when the pocket has no name. Also pins the end-to-end
 # publish_pocket path: a pocket named "Flower Shop Landing Page" published with no
 # name lands a Site named "Flower Shop Landing Page".
+# Updated 2026-06-06 (feat/sites-publish-deploy-wire — CF deploy seam): publish()
+# now calls the generator's build_and_deploy() seam instead of build() +
+# put_worker()/deploy_local(). The fakes follow suit: _FakeGenerator exposes
+# build_and_deploy(...) which DISPATCHES to the cloudflare / local_deploy target
+# publish() hands it (mirroring the real seam) and returns a DeployResult, and
+# _FakeCF exposes deploy_site (the real CF deploy step) instead of put_worker. The
+# CF-path test now asserts the deploy URL lands on the Site (the seam's
+# cf.deploy_site returns a real URL — the old put_worker left url empty).
 from __future__ import annotations
 
 import pytest
@@ -39,20 +48,40 @@ from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus
 
 
 class _FakeGenerator:
-    async def build(self, **kw):
-        from pocketpaw_ee.sites.generator_client import BuildResult
+    """Stands in for GeneratorClient. ``build_and_deploy`` mirrors the real seam:
+    a successful build, then it dispatches to whichever deploy target publish()
+    selected (``cloudflare`` for the edge path, ``local_deploy`` for the local
+    path), and returns a DeployResult carrying that target's URL. This keeps the
+    service tests focused on publish()'s wiring (target selection + reading the
+    DeployResult) without re-testing the seam's build→gate→deploy internals
+    (that's tests/ee/sites/test_generator_client_deploy.py)."""
+
+    async def build_and_deploy(self, *, cloudflare=None, local_deploy=None, **kw):
+        from pocketpaw_ee.sites.generator_client import DeployResult
 
         self.built = kw
-        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+        project_dir = "/tmp/site"
+        try:
+            if cloudflare is not None:
+                url = await cloudflare.deploy_site(
+                    script_name=kw["site_id"], project_dir=project_dir
+                )
+            elif local_deploy is not None:
+                url = local_deploy(kw["site_id"], project_dir)
+            else:
+                return DeployResult(success=False, error="no deploy target")
+        except Exception as exc:  # noqa: BLE001 - mirror the seam: deploy failure → success=False
+            return DeployResult(success=False, error=f"deploy failed: {exc}")
+        return DeployResult(success=True, url=url)
 
 
 class _FakeCF:
     def __init__(self):
-        self.put_calls = []
+        self.deploy_calls = []
 
-    async def put_worker(self, *, script_name, bundle):
-        self.put_calls.append(script_name)
-        return True
+    async def deploy_site(self, *, script_name, project_dir):
+        self.deploy_calls.append(script_name)
+        return f"https://paw-sites.workers.dev/{script_name}/"
 
     async def create_custom_hostname(self, hostname):
         return CustomHostname(
@@ -85,7 +114,10 @@ async def test_publish_generates_deploys_and_persists_site(beanie_test_db):
     # is typed str + used as the CF URL path segment); ``site.id`` is an
     # ObjectId, so compare against its str form.
     assert site.script_name == str(site.id)
-    assert cf.put_calls == [site.script_name]
+    # The seam deployed via cf.deploy_site (the real edge step) with the script
+    # name, and the returned live URL landed on the Site.
+    assert cf.deploy_calls == [site.script_name]
+    assert site.url == f"https://paw-sites.workers.dev/{site.script_name}/"
     assert site.signed_key  # a per-site signed key was minted
 
 
@@ -137,7 +169,7 @@ async def test_publish_injected_cf_takes_real_branch_even_without_creds(
 ):
     """Phase 3 Gap 2 (additive, not a replacement): injecting a CF client forces
     the REAL Cloudflare branch even with no env creds, so the existing CF tests
-    keep exercising put_worker and the local branch never hijacks them."""
+    keep exercising the edge deploy and the local branch never hijacks them."""
     monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
     cf = _FakeCF()
 
@@ -156,8 +188,11 @@ async def test_publish_injected_cf_takes_real_branch_even_without_creds(
         _bundle_reader=lambda d: b"export default {}",
         _local_deploy=boom,
     )
-    assert cf.put_calls == [site.script_name]
-    assert site.url == ""  # CF path leaves url empty in v1
+    # The CF path ran (deploy_site), not the local one (boom would have raised).
+    # The seam's cf.deploy_site returns a real URL now, so the Site carries it
+    # (the old put_worker path left url empty).
+    assert cf.deploy_calls == [site.script_name]
+    assert site.url == f"https://paw-sites.workers.dev/{site.script_name}/"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What this does

`#1350` added `build_and_deploy()` to the generator client — build, workerd smoke gate, then a real Workers-for-Platforms deploy (`cf.deploy_site` ships the worker + static assets + bindings, not just a raw module) — returning one `DeployResult{success, url, error}` that never raises for an expected failure. `#1351` added the draft/published state machine to `publish()`. But `publish()` was still running the OLD `build()` + `put_worker()`/`deploy_local()` sequence and marking the site live whenever those didn't raise. This is the wire both PRs flagged as the one piece left.

`publish()` now:

- Picks the deploy target (policy stays in the service layer, which reads the env): the Cloudflare client when `PAW_CF_*` is configured, the local deploy callable on the `PAW_SITES_LOCAL` / no-creds dev path. Both paths are preserved.
- Hands that target to `build_and_deploy` and reads the `DeployResult`.
- On `success`: promotes the draft to published, marks the site deployed/live, and stores `result.url`.
- On failure: raises before any promotion or live-marking, so the draft stays recoverable and an already-live site keeps its previous published version live (the publish-pointer advance only runs on a real success).

## Before / after

| | Before | After |
|---|---|---|
| Build + deploy | `build()` then `put_worker()` / `deploy_local()` | one `build_and_deploy(cloudflare=…, local_deploy=…)` call |
| Live decision | "the calls didn't raise" | `DeployResult.success is True` |
| CF-path URL | blank (`put_worker` returns nothing) | the real live URL `deploy_site` returns |
| Failed publish | relied on an exception | reads `success=False`, then re-raises `SmokeGateFailed(error)` |

Raising on failure (instead of returning a not-live doc) keeps the existing caller contract: the publish MCP tool's `is_error` path and the REST error envelope still surface a failed deploy instead of reporting a phantom publish.

## CF-vs-local selection

Unchanged policy. `use_local = (no injected CF client) and _local_mode()`. Local mode → `local_deploy` is passed and `cloudflare=None`; otherwise the CF client is passed and `local_deploy=None`. An injected CF client still forces the real branch even with no env creds, so the integration coverage keeps exercising both.

## The raw sequence

Removed from `publish()`. `put_worker` / `deploy_local` definitions stay (back-compat; `put_worker` is already documented as such on the client). The legacy `_bundle_reader` param is now unused by `publish()` — `deploy_site` reads its own bundle — but kept on the signature so existing callers and tests don't break.

## Tests

Publish fakes moved to the seam: `_FakeGenerator` exposes `build_and_deploy` that dispatches to whichever target `publish()` selected (so the tests still assert CF-vs-local), and the CF fake exposes `deploy_site`. Coverage:

- publish success → `deployed=True`, live URL set, draft promoted to published, `is_live` true.
- smoke-gate fail and deploy fail → `DeployResult.success=False` → site not live, published version unchanged.
- a failed **re**-publish on an already-live site stays live on the old version, published pointer unmoved, live URL unchanged, no v2 worker deployed.
- the `PAW_SITES_LOCAL` path still publishes via the local deploy callable.

The failed-deploy test now asserts `SmokeGateFailed` (the seam folds a deploy raise into `success=False`, which `publish()` re-raises) rather than the old `RuntimeError`.

`uv run pytest tests/ee/sites/ tests/ee/versions/` → 94 passed, 1 skipped (the opt-in local-deploy integration test, which needs the bun/node toolchain). The out-of-scope `tests/cloud/pockets/test_gallery_site_exclusion.py` also calls `publish()`; its fakes were updated too and it stays green.