### PR TITLE
Lower password minimum length to 6

### DIFF
--- a/ee/pocketpaw_ee/cloud/auth/password_policy.py
+++ b/ee/pocketpaw_ee/cloud/auth/password_policy.py
@@ -20,7 +20,7 @@ from fastapi_users.exceptions import InvalidPasswordException
 
 logger = logging.getLogger(__name__)
 
-MIN_LENGTH = 12
+MIN_LENGTH = 6
 _HIBP_RANGE_URL = "https://api.pwnedpasswords.com/range/{prefix}"
 _HIBP_TIMEOUT = 3.0
 _CACHE_TTL_SECONDS = 24 * 60 * 60

--- a/tests/cloud/auth/test_password_policy.py
+++ b/tests/cloud/auth/test_password_policy.py
@@ -22,9 +22,17 @@ def hibp_off(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 async def test_too_short(hibp_off: None) -> None:
+    # 5 chars, fully complex (upper/lower/digit/symbol) but one below the
+    # 6-char minimum — length gate must still fire before the other checks.
     with pytest.raises(InvalidPasswordException) as exc:
-        await password_policy.validate_password_async("Aa1!aaaa", email="x@y.z")
+        await password_policy.validate_password_async("Ab1!c", email="x@y.z")
     assert exc.value.reason == "too_short"
+
+
+async def test_min_length_boundary_passes(hibp_off: None) -> None:
+    # Exactly 6 chars, fully complex — clears the length gate and the rest
+    # of the policy (HIBP disabled here), so no exception is raised.
+    await password_policy.validate_password_async("Ab1!cd", email="x@y.z")
 
 
 async def test_missing_uppercase(hibp_off: None) -> None:


### PR DESCRIPTION
This drops the cloud auth password floor from 12 characters to 6. It's a deliberate policy relaxation that the captain signed off on, not a security regression: every other rule stays exactly as it was.

What still applies:
- complexity (one uppercase, one lowercase, one digit, one symbol)
- the email-local-part check (a password can't embed the email's local part)
- the HaveIBeenPwned k-anonymity breach check, which still rejects any password that shows up in a known breach

So the only thing that moved is the length boundary.

### Tests
Updated `tests/cloud/auth/test_password_policy.py` to track the new boundary. The "too short" case now uses a 5-char password that's otherwise fully complex and still has to raise `too_short`, and I added a case proving a 6-char complex password (`Ab1!cd`) clears the length gate. The complexity, email, and breach tests are untouched.

```
13 passed in 0.72s
```

### Frontend
The paw-enterprise frontend copy (the "at least 12 characters" hint and client-side validation) is being updated separately so the two sides agree.
