### PR TITLE
feat(plugins): install a .claude-plugin's skills from GitHub

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -289,6 +289,64 @@ the 2 MB cap, the document is unparseable, or it carries no `paths`
 object. Every install is audit-logged with the workspace, the actor, and
 the resulting slug — never the spec contents.
 
+## Plugins — Install a `.claude-plugin`'s Skills
+
+PocketPaw adopts the `.claude-plugin` standard so a whole plugin's skills
+install in one step. This endpoint clones a GitHub repo, reads its
+`.claude-plugin/plugin.json`, copies each `skills/<name>/SKILL.md`
+directory into the skill loader path, reloads the loader, and records the
+install in a registry at `~/.pocketpaw/plugins.json`.
+
+> Scope note: this slice installs **skills only**. A plugin's MCP servers
+> and the list/remove surface ship in follow-up endpoints.
+
+### `POST /plugins/install`
+
+Install a plugin's skills from a GitHub source. Requires the **admin**
+scope — installing skills changes workspace-wide agent behaviour.
+
+Request body:
+
+```json
+{ "source": "owner/repo" }
+```
+
+`source` accepts `owner/repo`, `owner/repo/subdir` (when the plugin lives
+in a subdirectory), or a full GitHub URL (a `/tree/<ref>/<subdir>` path is
+honoured). The repo (or subdir) must contain a `.claude-plugin/plugin.json`
+manifest and at least one `skills/<name>/SKILL.md`.
+
+Response `200` — a step-by-step install report:
+
+```json
+{
+  "plugin": "my-plugin",
+  "installed_at": "2026-06-07T12:00:00",
+  "steps": [
+    { "name": "read_manifest", "status": "succeeded", "detail": "my-plugin v1.2.3" },
+    { "name": "skill:alpha", "status": "succeeded", "detail": "" },
+    { "name": "reload_loader", "status": "succeeded", "detail": "" },
+    { "name": "record_registry", "status": "succeeded", "detail": "" }
+  ],
+  "installed_skills": ["alpha"]
+}
+```
+
+Each unit of work is a step with status `succeeded` / `skipped` /
+`failed`, so a per-skill copy failure surfaces in the report rather than
+aborting the whole install. Up-front failures return clear status codes
+instead of `500`:
+
+| Status | When |
+|--------|------|
+| `400` | Missing or malformed `source`, or an invalid `plugin.json`. |
+| `404` | No `.claude-plugin/plugin.json`, or no skills found in the plugin. |
+| `502` | The git clone failed. |
+| `504` | The git clone timed out. |
+
+Every install is audit-logged with the source, plugin name, version, and
+the installed skill names.
+
 ## Pockets — Catalog-as-Allowlist Ingest Gate
 
 Increment 5. The Ripple renderer has a **closed widget registry**: a

--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -10,6 +10,9 @@
 # Updated: 2026-04-16 (feat/widget-journal-projection) — Added the
 #   Widgets router — journal-backed widget graduation + co-occurrence
 #   (supersedes held PRs #941 / #942).
+# Updated: 2026-06-07 (feat/plugin-installer-skills) — Added the Plugins
+#   router (POST /api/v1/plugins/install) for the .claude-plugin installer
+#   (skills slice). Non-critical: mounts best-effort like the rest.
 #
 # mount_v1_routers(app) registers all domain routers at /api/v1/ (canonical).
 # Existing dashboard.py endpoints at /api/ remain as backward-compat aliases.
@@ -36,6 +39,7 @@ _V1_ROUTERS: list[tuple[str, str, str]] = [
     ("pocketpaw.api.v1.memory", "router", "Memory"),
     ("pocketpaw.api.v1.mcp", "router", "MCP"),
     ("pocketpaw.api.v1.skills", "router", "Skills"),
+    ("pocketpaw.api.v1.plugins", "router", "Plugins"),
     ("pocketpaw.api.v1.webhooks", "router", "Webhooks"),
     ("pocketpaw.api.v1.backends", "router", "Backends"),
     ("pocketpaw.api.v1.api_keys", "router", "API Keys"),

--- a/src/pocketpaw/api/v1/plugins.py
+++ b/src/pocketpaw/api/v1/plugins.py
@@ -1,0 +1,42 @@
+# src/pocketpaw/api/v1/plugins.py
+# Created: 2026-06-07 (feat/plugin-installer-skills) — Plugins router.
+# POST /api/v1/plugins/install clones a .claude-plugin repo, installs its
+# skills, and returns a step-by-step PluginInstallReport. Admin-scoped,
+# mirroring api/v1/mcp.py. Skills-only slice — MCP + list/remove ship
+# separately (#1357, #1358).
+"""REST surface for the Plugin Installer (skills slice)."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from pocketpaw.api.deps import require_scope
+from pocketpaw.plugins.installer import PluginInstaller, PluginInstallError
+from pocketpaw.plugins.models import PluginInstallReport
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Plugins"], dependencies=[Depends(require_scope("admin"))])
+
+
+@router.post("/plugins/install", response_model=PluginInstallReport)
+async def install_plugin(request: Request) -> PluginInstallReport:
+    """Install a .claude-plugin's skills from a GitHub source.
+
+    Body: ``{"source": "owner/repo"}`` (also ``owner/repo/subdir`` or a
+    GitHub URL). Returns a :class:`PluginInstallReport`.
+    """
+    data = await request.json()
+    source = (data.get("source") or "").strip()
+    if not source:
+        raise HTTPException(status_code=400, detail="Missing 'source' field")
+
+    try:
+        return await PluginInstaller().install(source)
+    except PluginInstallError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    except Exception:
+        logger.exception("Plugin install failed")
+        raise HTTPException(status_code=500, detail="Plugin install failed")

--- a/src/pocketpaw/plugins/__init__.py
+++ b/src/pocketpaw/plugins/__init__.py
@@ -1,0 +1,22 @@
+# src/pocketpaw/plugins/__init__.py
+# Created: 2026-06-07 (feat/plugin-installer-skills) — Plugin Installer
+# package. Adopts the .claude-plugin standard: clone a GitHub repo, read
+# .claude-plugin/plugin.json, install the repo's skills into the skill
+# loader path, and record the install. Skills-only slice (MCP + list/remove
+# ship separately).
+
+from __future__ import annotations
+
+from pocketpaw.plugins.installer import PluginInstaller
+from pocketpaw.plugins.models import (
+    PluginInstallReport,
+    PluginInstallStep,
+    PluginManifest,
+)
+
+__all__ = [
+    "PluginInstallReport",
+    "PluginInstallStep",
+    "PluginInstaller",
+    "PluginManifest",
+]

--- a/src/pocketpaw/plugins/installer.py
+++ b/src/pocketpaw/plugins/installer.py
@@ -1,0 +1,358 @@
+# src/pocketpaw/plugins/installer.py
+# Created: 2026-06-07 (feat/plugin-installer-skills) — PluginInstaller:
+# adopts the .claude-plugin standard. Parses an "owner/repo" source (also
+# "owner/repo/subdir" and GitHub URLs), clones via the shared
+# skills.installer.clone_github_repo helper, structurally validates
+# .claude-plugin/plugin.json, copies each skills/<name>/SKILL.md into the
+# skill loader path, reloads the loader, records a registry entry under
+# ~/.pocketpaw/plugins.json, and returns a step-by-step PluginInstallReport.
+# Skills-only slice — MCP + list/remove ship separately (#1357, #1358).
+"""Install a ``.claude-plugin``'s skills from a GitHub repo.
+
+Each unit of work is a :class:`PluginInstallStep` that never raises out of
+the installer — failures become ``failed``/``skipped`` steps so the caller
+gets a full report even on partial success. The two genuinely up-front
+errors (a malformed source string and a clone failure) raise
+:class:`PluginInstallError` so the API layer can map them to 400/404/502.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from pathlib import Path
+from typing import Any
+
+from pocketpaw.plugins.models import (
+    PluginInstallReport,
+    PluginInstallStep,
+    PluginManifest,
+)
+from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+from pocketpaw.skills.installer import (
+    INSTALL_DIR,
+    _ignore_symlinks,
+    clone_github_repo,
+)
+from pocketpaw.skills.loader import get_skill_loader
+
+logger = logging.getLogger(__name__)
+
+# Registry of installed plugins (read-modify-write JSON).
+REGISTRY_PATH = Path.home() / ".pocketpaw" / "plugins.json"
+
+# GitHub naming rules — reused from skills/installer.py validation regexes.
+_OWNER_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
+_REPO_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+# Skill/subdir path segments: same charset, no traversal.
+_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Type alias for the clone factory so tests can inject a local fixture dir.
+CloneFactory = Callable[..., AbstractAsyncContextManager[Path]]
+
+
+class PluginInstallError(Exception):
+    """Raised for up-front, non-recoverable install errors (bad source,
+    clone failure, missing manifest/skills). Carries an HTTP status code so
+    the API layer returns 400/404/502 instead of a 500.
+    """
+
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def parse_source(source: str) -> tuple[str, str, str | None]:
+    """Parse a plugin source string into ``(owner, repo, subdir)``.
+
+    Accepts:
+      * ``owner/repo``
+      * ``owner/repo/subdir`` (subdir may itself contain ``/``)
+      * a full GitHub URL (``https://github.com/owner/repo`` with an
+        optional trailing ``.git`` and/or ``/tree/<ref>/<subdir>``).
+
+    Returns ``(owner, repo, subdir_or_None)``.
+
+    Raises:
+        PluginInstallError: If the source is empty or malformed.
+    """
+    source = (source or "").strip()
+    if not source:
+        raise PluginInstallError("Missing 'source' field", 400)
+
+    subdir: str | None = None
+
+    # Normalise a GitHub URL down to its path component.
+    url_match = re.match(
+        r"^(?:https?://)?(?:www\.)?github\.com/(.+)$",
+        source,
+        flags=re.IGNORECASE,
+    )
+    if url_match:
+        path = url_match.group(1)
+        # Drop a /tree/<ref> or /blob/<ref> segment, keeping any subdir after it.
+        tree_match = re.match(r"^([^/]+)/([^/]+)/(?:tree|blob)/[^/]+/?(.*)$", path)
+        if tree_match:
+            owner, repo, subdir_part = tree_match.groups()
+            subdir = subdir_part or None
+        else:
+            parts = path.split("/", 2)
+            if len(parts) < 2:
+                raise PluginInstallError("Invalid GitHub URL", 400)
+            owner, repo = parts[0], parts[1]
+            subdir = parts[2] if len(parts) == 3 and parts[2] else None
+    else:
+        parts = source.split("/", 2)
+        if len(parts) < 2:
+            raise PluginInstallError("Source must be owner/repo or owner/repo/subdir", 400)
+        owner, repo = parts[0], parts[1]
+        subdir = parts[2] if len(parts) == 3 and parts[2] else None
+
+    repo = repo[:-4] if repo.endswith(".git") else repo
+    if subdir:
+        subdir = subdir.strip("/") or None
+
+    if not _OWNER_RE.match(owner):
+        raise PluginInstallError("Invalid owner format", 400)
+    if not _REPO_RE.match(repo):
+        raise PluginInstallError("Invalid repo format", 400)
+    if subdir:
+        for segment in subdir.split("/"):
+            if segment in (".", "..") or not _NAME_RE.match(segment):
+                raise PluginInstallError("Invalid subdir format", 400)
+
+    return owner, repo, subdir
+
+
+class PluginInstaller:
+    """Install a ``.claude-plugin``'s skills from a GitHub source."""
+
+    def __init__(
+        self,
+        *,
+        clone_factory: CloneFactory = clone_github_repo,
+        install_dir: Path = INSTALL_DIR,
+        registry_path: Path = REGISTRY_PATH,
+        actor: str = "dashboard_user",
+    ):
+        self._clone = clone_factory
+        self._install_dir = install_dir
+        self._registry_path = registry_path
+        self._actor = actor
+
+    async def install(self, source: str, *, timeout: float = 60) -> PluginInstallReport:
+        """Clone, validate, install skills, reload, and record the plugin.
+
+        Args:
+            source: ``owner/repo`` / ``owner/repo/subdir`` / GitHub URL.
+            timeout: Clone timeout in seconds.
+
+        Returns:
+            A :class:`PluginInstallReport` describing every step.
+
+        Raises:
+            PluginInstallError: bad source / clone failure / missing
+                manifest / no skills. (Per-skill problems are non-fatal and
+                surface as steps, not exceptions.)
+        """
+        owner, repo, subdir = parse_source(source)
+
+        try:
+            clone_cm = self._clone(owner, repo, timeout=timeout)
+        except TypeError:
+            # Test fixtures may inject a clone factory with no timeout kwarg.
+            clone_cm = self._clone(owner, repo)
+
+        try:
+            async with clone_cm as repo_root:
+                return self._install_from_tree(
+                    repo_root=repo_root,
+                    subdir=subdir,
+                    source=f"{owner}/{repo}",
+                )
+        except TimeoutError as exc:
+            raise PluginInstallError(f"Clone timed out ({timeout:g}s)", 504) from exc
+        except RuntimeError as exc:
+            logger.warning("Plugin clone failed: %s", exc)
+            raise PluginInstallError("Plugin clone failed", 502) from exc
+
+    def _install_from_tree(
+        self,
+        *,
+        repo_root: Path,
+        subdir: str | None,
+        source: str,
+    ) -> PluginInstallReport:
+        """Run the install pipeline against an already-cloned working tree."""
+        plugin_root = (repo_root / subdir) if subdir else repo_root
+
+        manifest = self._read_manifest(plugin_root)  # raises PluginInstallError on failure
+        report = PluginInstallReport(plugin=manifest.name)
+        report.steps.append(
+            PluginInstallStep(
+                name="read_manifest",
+                status="succeeded",
+                detail=f"{manifest.name} v{manifest.version}",
+            )
+        )
+
+        skill_sources = self._discover_skills(plugin_root, manifest)
+        if not skill_sources:
+            raise PluginInstallError("No skills found in plugin", 404)
+
+        installed = self._install_skills(skill_sources, report)
+
+        report.steps.append(self._reload_loader())
+        report.steps.append(self._record_registry(manifest, source, installed))
+        report.installed_skills = installed
+
+        self._audit(source, manifest, installed, report.succeeded())
+        return report
+
+    def _read_manifest(self, plugin_root: Path) -> PluginManifest:
+        """Read + structurally validate ``.claude-plugin/plugin.json``.
+
+        Precedent: bundled_skills/installer.py treats the manifest + skills
+        dir as the markers of a valid local plugin.
+        """
+        manifest_path = plugin_root / ".claude-plugin" / "plugin.json"
+        if not manifest_path.is_file():
+            raise PluginInstallError("No .claude-plugin/plugin.json found", 404)
+        try:
+            raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise PluginInstallError("Invalid plugin.json", 400) from exc
+        if not isinstance(raw, dict):
+            raise PluginInstallError("plugin.json must be a JSON object", 400)
+        try:
+            manifest = PluginManifest.model_validate(raw)
+        except Exception as exc:  # pydantic ValidationError
+            raise PluginInstallError("plugin.json failed validation", 400) from exc
+        if not _NAME_RE.match(manifest.name):
+            raise PluginInstallError("Invalid plugin name in manifest", 400)
+        return manifest
+
+    def _discover_skills(
+        self, plugin_root: Path, manifest: PluginManifest
+    ) -> list[tuple[str, Path]]:
+        """Find ``<skills>/<name>/SKILL.md`` directories.
+
+        Looks under the manifest's ``skills`` path override when set,
+        otherwise the conventional ``skills/`` dir, and finally bare
+        ``<name>/SKILL.md`` at the plugin root.
+        """
+        scan_dirs: list[Path] = []
+        if manifest.skills:
+            scan_dirs.append(plugin_root / manifest.skills)
+        else:
+            scan_dirs.append(plugin_root / "skills")
+            scan_dirs.append(plugin_root)
+
+        found: dict[str, Path] = {}
+        for scan_dir in scan_dirs:
+            if not scan_dir.is_dir():
+                continue
+            for item in sorted(scan_dir.iterdir()):
+                if not item.is_dir() or not (item / "SKILL.md").is_file():
+                    continue
+                found.setdefault(item.name, item)
+        return list(found.items())
+
+    def _install_skills(
+        self, skill_sources: list[tuple[str, Path]], report: PluginInstallReport
+    ) -> list[str]:
+        """Copy each skill dir into the loader path. One step per skill."""
+        self._install_dir.mkdir(parents=True, exist_ok=True)
+        installed: list[str] = []
+        for name, src_dir in skill_sources:
+            step_name = f"skill:{name}"
+            if name in (".", "..") or not _NAME_RE.match(name):
+                report.steps.append(
+                    PluginInstallStep(name=step_name, status="skipped", detail="invalid skill name")
+                )
+                continue
+            try:
+                dest = self._install_dir / name
+                if dest.exists():
+                    shutil.rmtree(dest)
+                shutil.copytree(src_dir, dest, ignore=_ignore_symlinks)
+            except OSError as exc:
+                report.steps.append(
+                    PluginInstallStep(name=step_name, status="failed", detail=str(exc))
+                )
+                continue
+            installed.append(name)
+            report.steps.append(PluginInstallStep(name=step_name, status="succeeded"))
+        return installed
+
+    def _reload_loader(self) -> PluginInstallStep:
+        """Reload the skill loader so new skills become invocable."""
+        try:
+            get_skill_loader().reload()
+            return PluginInstallStep(name="reload_loader", status="succeeded")
+        except Exception as exc:  # never block the install on a reload hiccup
+            logger.warning("Skill loader reload failed: %s", exc)
+            return PluginInstallStep(name="reload_loader", status="failed", detail=str(exc))
+
+    def _record_registry(
+        self, manifest: PluginManifest, source: str, installed: list[str]
+    ) -> PluginInstallStep:
+        """Write the plugin entry to the registry (read-modify-write)."""
+        from datetime import datetime
+
+        try:
+            registry = self._load_registry()
+            registry[manifest.name] = {
+                "version": manifest.version,
+                "source": source,
+                "skills": installed,
+                "installed_at": datetime.now().isoformat(),
+            }
+            self._registry_path.parent.mkdir(parents=True, exist_ok=True)
+            self._registry_path.write_text(
+                json.dumps(registry, indent=2, sort_keys=True), encoding="utf-8"
+            )
+            return PluginInstallStep(name="record_registry", status="succeeded")
+        except OSError as exc:
+            logger.warning("Plugin registry write failed: %s", exc)
+            return PluginInstallStep(name="record_registry", status="failed", detail=str(exc))
+
+    def _load_registry(self) -> dict[str, Any]:
+        """Load the registry JSON, returning an empty dict if absent/corrupt."""
+        if not self._registry_path.is_file():
+            return {}
+        try:
+            data = json.loads(self._registry_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            logger.warning("Plugin registry unreadable; starting fresh")
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _audit(self, source: str, manifest: PluginManifest, installed: list[str], ok: bool) -> None:
+        """Audit-log the install (best-effort; precedent: skills installer)."""
+        try:
+            get_audit_logger().log(
+                AuditEvent.create(
+                    severity=AuditSeverity.INFO if ok else AuditSeverity.WARNING,
+                    actor=self._actor,
+                    action="plugin_install",
+                    target=source,
+                    status="success" if ok else "partial",
+                    plugin=manifest.name,
+                    version=manifest.version,
+                    installed=installed,
+                )
+            )
+        except Exception:  # audit must never break the install
+            logger.warning("Plugin install audit log failed", exc_info=True)
+
+
+__all__ = [
+    "PluginInstallError",
+    "PluginInstaller",
+    "parse_source",
+]

--- a/src/pocketpaw/plugins/models.py
+++ b/src/pocketpaw/plugins/models.py
@@ -1,0 +1,62 @@
+# src/pocketpaw/plugins/models.py
+# Created: 2026-06-07 (feat/plugin-installer-skills) — Pydantic models for
+# the Plugin Installer. Mirrors the SHAPE of ee/pocketpaw_ee/fleet/models.py
+# (FleetInstallStep / FleetInstallReport) but copied into OSS so the core
+# never imports pocketpaw_ee (import-linter forbids it).
+"""Models for the .claude-plugin installer.
+
+``PluginManifest`` is the structurally-validated view of a repo's
+``.claude-plugin/plugin.json``. ``PluginInstallStep`` /
+``PluginInstallReport`` describe an install run so the UI can show partial
+progress (succeeded / skipped / failed) without re-running everything.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class PluginManifest(BaseModel):
+    """Parsed ``.claude-plugin/plugin.json``.
+
+    Only ``name`` is required; the rest mirror the optional fields the
+    Claude Code plugin standard allows. ``skills`` is an optional path
+    override for where the plugin's ``SKILL.md`` directories live (defaults
+    to the conventional ``skills/`` directory when unset).
+    """
+
+    name: str
+    version: str = "0.0.0"
+    description: str = ""
+    skills: str | None = None
+
+
+class PluginInstallStep(BaseModel):
+    """One step in the install pipeline.
+
+    Reports ``succeeded`` / ``skipped`` / ``failed`` so the UI can show
+    partial progress. Steps never raise out of the installer — failures are
+    captured here.
+    """
+
+    name: str
+    status: Literal["succeeded", "skipped", "failed"]
+    detail: str = ""
+
+
+class PluginInstallReport(BaseModel):
+    """Full report of a plugin install run."""
+
+    plugin: str
+    installed_at: datetime = Field(default_factory=datetime.now)
+    steps: list[PluginInstallStep] = Field(default_factory=list)
+    installed_skills: list[str] = Field(default_factory=list)
+
+    def succeeded(self) -> bool:
+        return all(step.status != "failed" for step in self.steps)
+
+    def failed_steps(self) -> list[PluginInstallStep]:
+        return [s for s in self.steps if s.status == "failed"]

--- a/src/pocketpaw/skills/installer.py
+++ b/src/pocketpaw/skills/installer.py
@@ -1,6 +1,11 @@
 """Shared skill installer -- clone GitHub repos and install SKILL.md directories.
 
 Created: 2026-03-22
+Updated: 2026-06-07 (feat/plugin-installer-skills) — extracted the
+``git clone --depth=1`` + tempdir block into a reusable
+``clone_github_repo`` async context manager so the plugin installer can
+share the same clone path. ``install_skills_from_github`` now calls it;
+its behavior is unchanged.
 """
 
 from __future__ import annotations
@@ -11,6 +16,8 @@ import os
 import re
 import shutil
 import tempfile
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
@@ -32,6 +39,48 @@ class SkillInstallError(Exception):
     def __init__(self, message: str, status_code: int = 400):
         super().__init__(message)
         self.status_code = status_code
+
+
+@asynccontextmanager
+async def clone_github_repo(
+    owner: str,
+    repo: str,
+    timeout: float = 60,
+) -> AsyncIterator[Path]:
+    """Shallow-clone a GitHub repo into a temp dir and yield its path.
+
+    Shared clone primitive for skill and plugin installers. The temp
+    directory is removed when the context exits, so callers must finish
+    reading/copying files before leaving the ``async with`` block.
+
+    Args:
+        owner: GitHub owner (e.g. "googleworkspace").
+        repo: GitHub repo name (e.g. "cli").
+        timeout: Git clone timeout in seconds.
+
+    Yields:
+        Path to the cloned working tree (the temp dir root).
+
+    Raises:
+        RuntimeError: If the clone fails.
+        TimeoutError: If the clone exceeds *timeout* seconds.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "clone",
+            "--depth=1",
+            f"https://github.com/{owner}/{repo}.git",
+            tmpdir,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        if proc.returncode != 0:
+            err = stderr.decode(errors="replace").strip()
+            raise RuntimeError(f"Clone failed: {err}")
+        yield Path(tmpdir)
 
 
 async def install_skills_from_github(
@@ -59,23 +108,7 @@ async def install_skills_from_github(
     """
     INSTALL_DIR.mkdir(parents=True, exist_ok=True)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            "clone",
-            "--depth=1",
-            f"https://github.com/{owner}/{repo}.git",
-            tmpdir,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        if proc.returncode != 0:
-            err = stderr.decode(errors="replace").strip()
-            raise RuntimeError(f"Clone failed: {err}")
-
-        tmp = Path(tmpdir)
+    async with clone_github_repo(owner, repo, timeout=timeout) as tmp:
         skill_dirs: list[tuple[str, Path]] = []
 
         if skill_name:

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -1,0 +1,296 @@
+# tests/test_plugin_installer.py
+# Created: 2026-06-07 (feat/plugin-installer-skills) — covers the
+# .claude-plugin skills installer: manifest parse + structural validation,
+# source parsing, skills discovery/copy/reload, registry write, and error
+# paths (bad source, missing manifest, no skills). The clone is mocked by
+# injecting a clone factory that yields a local fixture .claude-plugin dir.
+"""Unit tests for pocketpaw.plugins (skills slice)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.plugins.installer import (
+    PluginInstaller,
+    PluginInstallError,
+    parse_source,
+)
+from pocketpaw.plugins.models import PluginManifest
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures                                                                     #
+# --------------------------------------------------------------------------- #
+def _write_plugin(
+    root: Path,
+    *,
+    name: str = "my-plugin",
+    version: str = "1.2.3",
+    skills: list[str] | None = None,
+    skills_subdir: str = "skills",
+    write_manifest: bool = True,
+) -> Path:
+    """Build a fake .claude-plugin tree under *root* and return it."""
+    if write_manifest:
+        manifest_dir = root / ".claude-plugin"
+        manifest_dir.mkdir(parents=True, exist_ok=True)
+        (manifest_dir / "plugin.json").write_text(
+            json.dumps({"name": name, "version": version, "description": "test"}),
+            encoding="utf-8",
+        )
+    for skill_name in skills or []:
+        sk = root / skills_subdir / skill_name
+        sk.mkdir(parents=True, exist_ok=True)
+        (sk / "SKILL.md").write_text(
+            f"---\nname: {skill_name}\ndescription: d\n---\nbody\n", encoding="utf-8"
+        )
+    return root
+
+
+@pytest.fixture
+def fixture_repo(tmp_path) -> Path:
+    """A valid plugin repo with two skills."""
+    return _write_plugin(tmp_path / "repo", skills=["alpha", "beta"])
+
+
+def _clone_factory(repo_root: Path):
+    """Return a clone factory that yields *repo_root* (no real git)."""
+
+    @asynccontextmanager
+    async def _clone(owner, repo, timeout=60):
+        yield repo_root
+
+    return _clone
+
+
+def _installer(repo_root: Path, tmp_path: Path) -> PluginInstaller:
+    return PluginInstaller(
+        clone_factory=_clone_factory(repo_root),
+        install_dir=tmp_path / "skills_install",
+        registry_path=tmp_path / "registry" / "plugins.json",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Source parsing                                                              #
+# --------------------------------------------------------------------------- #
+class TestParseSource:
+    def test_owner_repo(self):
+        assert parse_source("acme/widgets") == ("acme", "widgets", None)
+
+    def test_owner_repo_subdir(self):
+        assert parse_source("acme/widgets/plugins/foo") == ("acme", "widgets", "plugins/foo")
+
+    def test_https_url(self):
+        assert parse_source("https://github.com/acme/widgets") == ("acme", "widgets", None)
+
+    def test_url_with_git_suffix(self):
+        assert parse_source("https://github.com/acme/widgets.git") == ("acme", "widgets", None)
+
+    def test_url_with_tree_subdir(self):
+        owner, repo, subdir = parse_source("https://github.com/acme/widgets/tree/main/plugins/x")
+        assert (owner, repo, subdir) == ("acme", "widgets", "plugins/x")
+
+    def test_empty_source_raises(self):
+        with pytest.raises(PluginInstallError) as exc:
+            parse_source("   ")
+        assert exc.value.status_code == 400
+
+    def test_single_segment_raises(self):
+        with pytest.raises(PluginInstallError):
+            parse_source("justowner")
+
+    def test_invalid_owner_raises(self):
+        with pytest.raises(PluginInstallError):
+            parse_source("bad owner/repo")
+
+    def test_traversal_subdir_raises(self):
+        with pytest.raises(PluginInstallError):
+            parse_source("acme/widgets/../etc")
+
+
+# --------------------------------------------------------------------------- #
+# Manifest model                                                              #
+# --------------------------------------------------------------------------- #
+class TestPluginManifest:
+    def test_minimal_manifest(self):
+        m = PluginManifest.model_validate({"name": "x"})
+        assert m.name == "x"
+        assert m.version == "0.0.0"
+        assert m.skills is None
+
+    def test_full_manifest(self):
+        m = PluginManifest.model_validate(
+            {"name": "x", "version": "2.0", "description": "d", "skills": "custom"}
+        )
+        assert (m.version, m.description, m.skills) == ("2.0", "d", "custom")
+
+    def test_missing_name_invalid(self):
+        with pytest.raises(Exception):
+            PluginManifest.model_validate({"version": "1.0"})
+
+
+# --------------------------------------------------------------------------- #
+# Install happy path                                                          #
+# --------------------------------------------------------------------------- #
+class TestInstall:
+    async def test_installs_skills_and_returns_report(self, fixture_repo, tmp_path, monkeypatch):
+        reloaded = {"count": 0}
+        monkeypatch.setattr(
+            "pocketpaw.plugins.installer.get_skill_loader",
+            lambda: type("L", (), {"reload": lambda self: reloaded.__setitem__("count", 1)})(),
+        )
+
+        inst = _installer(fixture_repo, tmp_path)
+        report = await inst.install("acme/widgets")
+
+        assert report.plugin == "my-plugin"
+        assert sorted(report.installed_skills) == ["alpha", "beta"]
+        assert report.succeeded()
+        assert reloaded["count"] == 1
+
+        # Files copied into the loader path.
+        install_dir = tmp_path / "skills_install"
+        assert (install_dir / "alpha" / "SKILL.md").is_file()
+        assert (install_dir / "beta" / "SKILL.md").is_file()
+
+        # Step report has the expected stages.
+        names = [s.name for s in report.steps]
+        assert "read_manifest" in names
+        assert "skill:alpha" in names
+        assert "reload_loader" in names
+        assert "record_registry" in names
+
+    async def test_writes_registry_entry(self, fixture_repo, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "pocketpaw.plugins.installer.get_skill_loader",
+            lambda: type("L", (), {"reload": lambda self: None})(),
+        )
+        inst = _installer(fixture_repo, tmp_path)
+        await inst.install("acme/widgets")
+
+        registry_path = tmp_path / "registry" / "plugins.json"
+        assert registry_path.is_file()
+        registry = json.loads(registry_path.read_text())
+        assert "my-plugin" in registry
+        entry = registry["my-plugin"]
+        assert entry["version"] == "1.2.3"
+        assert entry["source"] == "acme/widgets"
+        assert sorted(entry["skills"]) == ["alpha", "beta"]
+        assert "installed_at" in entry
+
+    async def test_registry_merges_existing(self, fixture_repo, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "pocketpaw.plugins.installer.get_skill_loader",
+            lambda: type("L", (), {"reload": lambda self: None})(),
+        )
+        registry_path = tmp_path / "registry" / "plugins.json"
+        registry_path.parent.mkdir(parents=True)
+        registry_path.write_text(json.dumps({"other": {"version": "9"}}))
+
+        inst = _installer(fixture_repo, tmp_path)
+        await inst.install("acme/widgets")
+
+        registry = json.loads(registry_path.read_text())
+        assert "other" in registry  # untouched
+        assert "my-plugin" in registry
+
+    async def test_subdir_plugin(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "pocketpaw.plugins.installer.get_skill_loader",
+            lambda: type("L", (), {"reload": lambda self: None})(),
+        )
+        repo = tmp_path / "repo"
+        _write_plugin(repo / "plugins" / "foo", name="foo", skills=["one"])
+
+        inst = PluginInstaller(
+            clone_factory=_clone_factory(repo),
+            install_dir=tmp_path / "skills_install",
+            registry_path=tmp_path / "registry" / "plugins.json",
+        )
+        report = await inst.install("acme/widgets/plugins/foo")
+        assert report.plugin == "foo"
+        assert report.installed_skills == ["one"]
+
+    async def test_manifest_skills_path_override(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "pocketpaw.plugins.installer.get_skill_loader",
+            lambda: type("L", (), {"reload": lambda self: None})(),
+        )
+        repo = tmp_path / "repo"
+        _write_plugin(repo, name="ov", skills=["s1"], skills_subdir="custom-skills")
+        # Patch the manifest to point skills at the custom dir.
+        manifest = repo / ".claude-plugin" / "plugin.json"
+        manifest.write_text(json.dumps({"name": "ov", "skills": "custom-skills"}))
+
+        inst = _installer(repo, tmp_path)
+        report = await inst.install("acme/widgets")
+        assert report.installed_skills == ["s1"]
+
+
+# --------------------------------------------------------------------------- #
+# Error paths                                                                 #
+# --------------------------------------------------------------------------- #
+class TestInstallErrors:
+    async def test_bad_source(self, tmp_path):
+        inst = _installer(tmp_path, tmp_path)
+        with pytest.raises(PluginInstallError) as exc:
+            await inst.install("nope")
+        assert exc.value.status_code == 400
+
+    async def test_missing_manifest(self, tmp_path):
+        repo = _write_plugin(tmp_path / "repo", skills=["a"], write_manifest=False)
+        inst = _installer(repo, tmp_path)
+        with pytest.raises(PluginInstallError) as exc:
+            await inst.install("acme/widgets")
+        assert exc.value.status_code == 404
+
+    async def test_no_skills(self, tmp_path):
+        repo = _write_plugin(tmp_path / "repo", skills=[])  # manifest only
+        inst = _installer(repo, tmp_path)
+        with pytest.raises(PluginInstallError) as exc:
+            await inst.install("acme/widgets")
+        assert exc.value.status_code == 404
+
+    async def test_invalid_manifest_json(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / ".claude-plugin").mkdir(parents=True)
+        (repo / ".claude-plugin" / "plugin.json").write_text("{not json")
+        inst = _installer(repo, tmp_path)
+        with pytest.raises(PluginInstallError) as exc:
+            await inst.install("acme/widgets")
+        assert exc.value.status_code == 400
+
+    async def test_clone_failure_maps_to_502(self, tmp_path, monkeypatch):
+        @asynccontextmanager
+        async def boom(owner, repo, timeout=60):
+            raise RuntimeError("Clone failed: not found")
+            yield  # pragma: no cover
+
+        inst = PluginInstaller(
+            clone_factory=boom,
+            install_dir=tmp_path / "i",
+            registry_path=tmp_path / "r.json",
+        )
+        with pytest.raises(PluginInstallError) as exc:
+            await inst.install("acme/widgets")
+        assert exc.value.status_code == 502
+
+    async def test_clone_timeout_maps_to_504(self, tmp_path):
+        @asynccontextmanager
+        async def slow(owner, repo, timeout=60):
+            raise TimeoutError
+            yield  # pragma: no cover
+
+        inst = PluginInstaller(
+            clone_factory=slow,
+            install_dir=tmp_path / "i",
+            registry_path=tmp_path / "r.json",
+        )
+        with pytest.raises(PluginInstallError) as exc:
+            await inst.install("acme/widgets")
+        assert exc.value.status_code == 504

--- a/tests/v1/test_api_v1_plugins.py
+++ b/tests/v1/test_api_v1_plugins.py
@@ -1,0 +1,58 @@
+# tests/v1/test_api_v1_plugins.py
+# Created: 2026-06-07 (feat/plugin-installer-skills) — API tests for the
+# Plugins router: missing source -> 400, PluginInstallError status passthrough,
+# and a successful install returning the report. require_scope is bypassed via
+# tests/v1/conftest.py's _TESTING_FULL_ACCESS escape hatch.
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from pocketpaw.api.v1.plugins import router
+from pocketpaw.plugins.installer import PluginInstallError
+from pocketpaw.plugins.models import PluginInstallReport, PluginInstallStep
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    return TestClient(app)
+
+
+class TestInstallPlugin:
+    def test_missing_source(self, client):
+        resp = client.post("/api/v1/plugins/install", json={"source": ""})
+        assert resp.status_code == 400
+
+    def test_bad_source_maps_to_400(self, client):
+        resp = client.post("/api/v1/plugins/install", json={"source": "single"})
+        assert resp.status_code == 400
+
+    def test_install_error_status_passthrough(self, client):
+        with patch(
+            "pocketpaw.api.v1.plugins.PluginInstaller.install",
+            new=AsyncMock(side_effect=PluginInstallError("nope", 404)),
+        ):
+            resp = client.post("/api/v1/plugins/install", json={"source": "acme/widgets"})
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "nope"
+
+    def test_successful_install_returns_report(self, client):
+        report = PluginInstallReport(
+            plugin="my-plugin",
+            steps=[PluginInstallStep(name="read_manifest", status="succeeded")],
+            installed_skills=["alpha"],
+        )
+        with patch(
+            "pocketpaw.api.v1.plugins.PluginInstaller.install",
+            new=AsyncMock(return_value=report),
+        ):
+            resp = client.post("/api/v1/plugins/install", json={"source": "acme/widgets"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["plugin"] == "my-plugin"
+        assert data["installed_skills"] == ["alpha"]
+        assert data["steps"][0]["name"] == "read_manifest"


### PR DESCRIPTION
Closes #1356. First slice of the Plugin Installer — adopting the cross-agent `.claude-plugin` standard (RFC 14, M3). Skills only here; MCP servers (#1357) and list/remove (#1358) stack on this.

## What this ships

`POST /api/v1/plugins/install {"source": "owner/repo"}` (admin-gated) clones the repo, validates `.claude-plugin/plugin.json`, copies each `skills/<name>/SKILL.md` into the skill loader path, reloads the loader, records the install in `~/.pocketpaw/plugins.json`, audit-logs, and returns a per-step report.

## How it's built

- Extracted a shared `clone_github_repo()` async context manager from `install_skills_from_github` so skills and plugins share one clone path — existing behavior unchanged.
- New `src/pocketpaw/plugins/` package: `models.py` (`PluginManifest`, `PluginInstallReport`, `PluginInstallStep` — shape mirrors the ee fleet report, copied into OSS, no `pocketpaw_ee` import) and `installer.py` (`PluginInstaller` — clone, validate, route skills, registry, audit, step report).
- New admin-scoped `api/v1/plugins.py`, registered in `_V1_ROUTERS`.
- Reuses the existing name validation, symlink-skip copy, and skill loader — nothing in the hot path, no change to `surface/`, `pool.py`, `run_core.py`, or the SDK `plugins=` block.

## Tests

58 passing (`tests/test_plugin_installer.py`, `tests/v1/test_api_v1_plugins.py`, plus the existing skills-install tests stay green). Covers manifest parse/validate, source parsing (owner/repo, subdir, URL), discovery + copy + reload, registry write/merge, path-traversal rejection, and the error paths (bad source → 400, missing manifest / no skills → 404, clone fail → 502, timeout → 504). Clone is mocked against a local fixture bundle.

## Notes

- Trust model for v1 is admin-gate + audit; `hooks.json` is never auto-run. Signing / allow-prompt are later slices.
- Known minor, deferred to #1358: the registry read-modify-write isn't concurrency-locked yet (fine for a single-operator admin endpoint).
- Reviewed in two stages (spec + quality) — both clean; security surfaces (no shell in clone, name validation before filesystem writes, home-confined paths) verified.

PRD / design: `docs/design/drafts/2026-06-07-plugin-installer{,-prd}.md` in paw-workspace.
