### PR TITLE
Chain Flow: Back navigation and deep branch validation

### DIFF
--- a/src/pocketpaw/ripple/_flows.py
+++ b/src/pocketpaw/ripple/_flows.py
@@ -14,6 +14,16 @@
 #     NodeRenderer(ui) when no field data is present). The terminal review/confirm
 #     step carries structured `review_rows` for the same designed-render benefit.
 #
+# Changes:
+#   - 2026-06-07 (polish/rfc13-flow-nav-validation): added a `_back_button`
+#     helper (emits `flow.back`, mirroring `_continue_button`'s emit shape) and
+#     a `_nav_row` container, then wired Back into the intermediate (non-first,
+#     non-terminal) steps of BOTH templates — the onboarding details step and
+#     the due-diligence financials + risk steps. The runtime already supported
+#     `flow.back` via the history stack, but no template rendered the control,
+#     so users could not step backward. Root/first steps (nothing to go back
+#     to) and terminal confirm/review steps (Submit) deliberately get no Back.
+#
 # What this is:
 #   The DETERMINISTIC half of the `start_flow` authoring tool. The LLM emits a
 #   tiny descriptor — `flow_type` (an enum of known templates), an optional
@@ -186,6 +196,28 @@ def _review_row(label: str, value: str) -> dict[str, Any]:
     return {"label": label, "value": value}
 
 
+def _back_button(label: str = "Back") -> dict[str, Any]:
+    """A step-back button — fires `flow.back`, which pops the FlowRunner's
+    history stack and re-renders the previous step.
+
+    Mirrors `_continue_button` / `_submit_button`: same `emit` action shape,
+    targeting the `flow.back` verb the inline chat adapter routes into the
+    ChainExecutor. Carries an empty `value` — stepping back needs no payload;
+    the previously-accumulated step data is what the runner restores.
+    """
+    return {
+        "type": "button",
+        "props": {"label": label},
+        "on_click": {"action": "emit", "target": "flow.back", "value": {}},
+    }
+
+
+def _nav_row(children: list[dict[str, Any]]) -> dict[str, Any]:
+    """A small inline container grouping a step's navigation buttons so Back
+    and Continue sit together in one row."""
+    return _container(children, cls="flow-nav")
+
+
 def _container(children: list[dict[str, Any]], cls: str | None = None) -> dict[str, Any]:
     node: dict[str, Any] = {"type": "container", "children": children}
     if cls:
@@ -280,7 +312,14 @@ def build_onboarding_wizard(config: dict[str, Any] | None = None) -> dict[str, A
                 [
                     _heading(heading),
                     _input("workspace", "Workspace name", placeholder),
-                    _continue_button("Continue", ["workspace"]),
+                    # Intermediate step: Back (flow.back) sits before Continue
+                    # (flow.next) so the user can return to the goal pick.
+                    _nav_row(
+                        [
+                            _back_button("Back"),
+                            _continue_button("Continue", ["workspace"]),
+                        ]
+                    ),
                 ]
             ),
         }
@@ -420,7 +459,14 @@ def build_due_diligence_intake(config: dict[str, Any] | None = None) -> dict[str
                 _heading("Note the top risk"),
                 _input("key_risk", "Biggest open risk", "Customer concentration"),
                 _input("mitigation", "Mitigation (optional)", "Diversifying pipeline"),
-                _continue_button("Continue to review", ["key_risk", "mitigation"]),
+                # Intermediate step: Back (flow.back) steps to the financials
+                # form; Continue (flow.next) advances to review.
+                _nav_row(
+                    [
+                        _back_button("Back"),
+                        _continue_button("Continue to review", ["key_risk", "mitigation"]),
+                    ]
+                ),
             ]
         ),
     }
@@ -439,7 +485,16 @@ def build_due_diligence_intake(config: dict[str, Any] | None = None) -> dict[str
             children.append(_input(bind, label, placeholder))
             binds.append(bind)
             form_fields.append(_form_field(bind, label, placeholder))
-        children.append(_continue_button("Continue", binds))
+        # Intermediate step: Back (flow.back) returns to the stage pick;
+        # Continue (flow.next) advances to the risk step.
+        children.append(
+            _nav_row(
+                [
+                    _back_button("Back"),
+                    _continue_button("Continue", binds),
+                ]
+            )
+        )
         return {
             "version": "2.0",
             "id": step_id,

--- a/src/pocketpaw/ripple/manifest.py
+++ b/src/pocketpaw/ripple/manifest.py
@@ -11,6 +11,13 @@ returns None — the caller is expected to fall back to a different
 source (today: kb scope search).
 
 Changes:
+  - 2026-06-07 (polish/rfc13-flow-nav-validation): made the catalog and
+    action-verb walkers (``_walk_catalog`` / ``_walk_action_verbs``) descend a
+    Chain Flow step's ``ui`` tree, its linear ``chain`` next step, and each
+    ``chain_map`` branch step — not just ``children`` / ``else_children``.
+    Previously a bad widget type or unknown action verb buried in step 2/3 of a
+    materialized flow escaped author-time validation; now every step's UI node
+    tree in the flow is checked, not just the root step's.
   - 2026-06-04 (feat/sites-validator-site-aware): added ``relax_ssr_props``
     to ``validate_against_manifest`` + the ``SSR_NODE_LEVEL_PROPS`` allowlist.
     On the site-generation path the renderer-honored SSR node-level props
@@ -407,6 +414,22 @@ def _walk_catalog(
             for i, child in enumerate(kids):
                 _walk_catalog(child, f"{path}.{key}[{i}]", allowed, pool, issues)
 
+    # Chain Flow descent (RFC 13): a step node carries its widget tree under
+    # `ui`, a linear next step under `chain`, and selection-branch steps under
+    # `chain_map`. Without descending these, a bad widget buried in step 2/3 of
+    # a materialized flow escapes catalog validation.
+    ui = node.get("ui")
+    if isinstance(ui, dict):
+        _walk_catalog(ui, f"{path}.ui", allowed, pool, issues)
+    chain = node.get("chain")
+    if isinstance(chain, dict):
+        _walk_catalog(chain, f"{path}.chain", allowed, pool, issues)
+    chain_map = node.get("chain_map")
+    if isinstance(chain_map, dict):
+        for branch_id, branch in chain_map.items():
+            if isinstance(branch, dict):
+                _walk_catalog(branch, f"{path}.chain_map[{branch_id}]", allowed, pool, issues)
+
 
 # ---------------------------------------------------------------------------
 # Embed URL / host policy (Increment 5).
@@ -727,6 +750,21 @@ def _walk_action_verbs(node: Any, path: str, issues: list[dict[str, Any]]) -> No
             if isinstance(kids, list):
                 for i, child in enumerate(kids):
                     _walk_action_verbs(child, f"{path}.{key}[{i}]", issues)
+
+        # Chain Flow descent (RFC 13): descend a step node's `ui` tree, its
+        # linear `chain` next step, and each `chain_map` branch step, so a bad
+        # action verb buried in a later flow step is caught at author time.
+        ui = node.get("ui")
+        if isinstance(ui, dict):
+            _walk_action_verbs(ui, f"{path}.ui", issues)
+        chain = node.get("chain")
+        if isinstance(chain, dict):
+            _walk_action_verbs(chain, f"{path}.chain", issues)
+        chain_map = node.get("chain_map")
+        if isinstance(chain_map, dict):
+            for branch_id, branch in chain_map.items():
+                if isinstance(branch, dict):
+                    _walk_action_verbs(branch, f"{path}.chain_map[{branch_id}]", issues)
 
 
 def validate_action_verbs(spec: dict[str, Any] | None) -> list[dict[str, Any]]:

--- a/tests/test_flow_authoring.py
+++ b/tests/test_flow_authoring.py
@@ -1,6 +1,14 @@
 # tests/test_flow_authoring.py
 # Created: 2026-05-31 (RFC 13 M3, feat/m3-flow-authoring-tool).
 #
+# Changes:
+#   - 2026-06-07 (polish/rfc13-flow-nav-validation): added (a) Back-navigation
+#     tests asserting both templates' intermediate (non-first, non-terminal)
+#     steps render a `flow.back` button while root/terminal steps do not, and
+#     (b) deep-validation tests asserting validate_against_catalog /
+#     validate_action_verbs now descend chain / chain_map branches — rejecting a
+#     bad widget or verb buried in a later flow step, accepting a clean one.
+#
 # Tests for the `start_flow` Chain Flow authoring tool and its deterministic
 # builders (`pocketpaw.ripple._flows` + `pocketpaw.tools.builtin.flow_tool`).
 #
@@ -334,6 +342,185 @@ def test_every_step_passes_action_verb_validator(builder) -> None:
     for step in _iter_steps(builder()["ui"]):
         issues = validate_action_verbs({"ui": step["ui"]})
         assert issues == [], f"step {step.get('id')!r} has action-verb violations: {issues}"
+
+
+# ---------------------------------------------------------------------------
+# Back navigation (Task 1) — intermediate steps render a flow.back control.
+# ---------------------------------------------------------------------------
+
+
+def _back_targets(step: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every node in a step's UI whose on_click emits the `flow.back` verb."""
+    out: list[dict[str, Any]] = []
+    for node in _walk_nodes(step["ui"]):
+        handler = node.get("on_click")
+        if isinstance(handler, dict) and handler.get("target") == "flow.back":
+            out.append(node)
+    return out
+
+
+def _next_targets(step: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for node in _walk_nodes(step["ui"]):
+        handler = node.get("on_click")
+        if isinstance(handler, dict) and handler.get("target") == "flow.next":
+            out.append(node)
+    return out
+
+
+def _is_root(step: dict[str, Any], root: dict[str, Any]) -> bool:
+    return step is root
+
+
+@_BUILDERS
+def test_intermediate_steps_have_a_back_button(builder) -> None:
+    """Every non-first, non-terminal step renders a `flow.back` button — so the
+    runtime's history stack / flow.back verb is finally reachable from the UI.
+
+    A step is intermediate when it is neither the root (first) step nor the
+    terminal (no chain/chain_map) step. The root has nothing to go back to and
+    the terminal carries Submit, so neither gets a Back control.
+    """
+    root = builder()["ui"]
+    steps = _iter_steps(root)
+    intermediate = [s for s in steps if not _is_root(s, root) and not _is_terminal(s)]
+    assert intermediate, "template has no intermediate steps to validate"
+
+    for step in intermediate:
+        backs = _back_targets(step)
+        assert len(backs) == 1, (
+            f"intermediate step {step.get('id')!r} should render exactly one "
+            f"flow.back button (found {len(backs)})"
+        )
+        back = backs[0]
+        # Mirrors the _continue_button / _submit_button emit shape exactly.
+        assert back["type"] == "button"
+        assert back["on_click"]["action"] == "emit"
+        assert back["on_click"]["value"] == {}
+
+
+@_BUILDERS
+def test_root_and_terminal_steps_have_no_back_button(builder) -> None:
+    """The first step (nothing to go back to) and the terminal step (Submit, not
+    Back) must NOT render a flow.back control."""
+    root = builder()["ui"]
+    assert _back_targets(root) == [], "root step should not have a Back button"
+    terminal = next(s for s in _iter_steps(root) if _is_terminal(s))
+    assert _back_targets(terminal) == [], "terminal step should not have a Back button"
+
+
+@_BUILDERS
+def test_back_button_precedes_continue(builder) -> None:
+    """In an intermediate step's button row, Back sits before Continue."""
+    root = builder()["ui"]
+    intermediate = [s for s in _iter_steps(root) if not _is_root(s, root) and not _is_terminal(s)]
+    for step in intermediate:
+        ordered = _walk_nodes(step["ui"])
+        back_idx = next(
+            i
+            for i, n in enumerate(ordered)
+            if isinstance(n.get("on_click"), dict) and n["on_click"].get("target") == "flow.back"
+        )
+        next_idx = next(
+            i
+            for i, n in enumerate(ordered)
+            if isinstance(n.get("on_click"), dict) and n["on_click"].get("target") == "flow.next"
+        )
+        assert back_idx < next_idx, (
+            f"step {step.get('id')!r}: Back should precede Continue in the row"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deep validation (Task 2) — validators descend chain / chain_map branches.
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_validator_descends_chain_and_chain_map() -> None:
+    """A bad widget buried in a chain / chain_map branch step is caught.
+
+    Two violations are planted: one in a linear `chain` step's UI, one in a
+    `chain_map` branch step's UI. The shallow walker (children-only) would miss
+    both; the deep walker must report exactly these two.
+    """
+    flow = {
+        "version": "1.0",
+        "ui": {
+            "version": "2.0",
+            "id": "root",
+            "flowId": "root",
+            "chain_map": {
+                "a": {
+                    "version": "2.0",
+                    "id": "branch-a",
+                    "flowId": "a",
+                    "chain": {
+                        "version": "2.0",
+                        "id": "deep",
+                        "flowId": "deep",
+                        # buried in a linear chain step's UI
+                        "ui": {"type": "container", "children": [{"type": "bogus-widget"}]},
+                    },
+                    # buried in a chain_map branch step's UI
+                    "ui": {"type": "container", "children": [{"type": "another-bad-one"}]},
+                },
+            },
+            "ui": {"type": "container", "children": [{"type": "heading"}]},
+        },
+    }
+    issues = validate_against_catalog(flow, ALLOWED_TYPES)
+    bad_types = {i["type"] for i in issues}
+    assert bad_types == {"bogus-widget", "another-bad-one"}, (
+        f"deep walker must flag both buried bad widgets, got: {bad_types}"
+    )
+
+
+def test_action_verb_validator_descends_chain_and_chain_map() -> None:
+    """A bad action verb buried in a chain / chain_map branch is caught."""
+    flow = {
+        "version": "1.0",
+        "ui": {
+            "version": "2.0",
+            "id": "root",
+            "flowId": "root",
+            "chain_map": {
+                "a": {
+                    "version": "2.0",
+                    "id": "branch-a",
+                    "flowId": "a",
+                    "chain": {
+                        "version": "2.0",
+                        "id": "deep",
+                        "flowId": "deep",
+                        "ui": {
+                            "type": "button",
+                            "props": {
+                                "label": "Go",
+                                "on_click": {"action": "teleport", "target": "x"},
+                            },
+                        },
+                    },
+                    "ui": {"type": "container", "children": [{"type": "text"}]},
+                },
+            },
+            "ui": {"type": "container", "children": [{"type": "heading"}]},
+        },
+    }
+    issues = validate_action_verbs(flow)
+    bad_verbs = {i["action"] for i in issues}
+    assert "teleport" in bad_verbs, (
+        f"deep walker must flag the buried unknown verb, got: {bad_verbs}"
+    )
+
+
+@_BUILDERS
+def test_full_materialized_flow_passes_deep_validators(builder) -> None:
+    """A clean, fully-materialized flow tree (root + every nested step) passes
+    BOTH deep validators when validated end to end — not just per-step. This is
+    the accept case complementing the reject cases above."""
+    doc = builder()
+    assert validate_against_catalog(doc, ALLOWED_TYPES) == []
+    assert validate_action_verbs(doc) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two polish fixes in the Chain Flow subsystem (RFC 13). Both close gaps where the runtime already did the right thing but authoring never exposed it.

## Back navigation in the templates

The FlowRunner keeps a history stack and the inline chat adapter already routes a `flow.back` verb. The two authoring templates never rendered a Back control, though, so users could only move forward. End-to-end testing of back/forward was blocked purely because no template emitted the button.

- New `_back_button` helper emits `flow.back` with the same shape `_continue_button` uses for `flow.next` (empty value, since stepping back restores the previously accumulated data).
- New `_nav_row` container groups Back and Continue in one row.
- Back is wired into the intermediate (non-first, non-terminal) steps of both templates: the onboarding details step, and the due-diligence financials and risk steps. Back sits before Continue.
- The root step gets no Back (nothing to return to) and the terminal step keeps Submit instead. The existing `{state.x}` prefill wiring is untouched.

## Deep flow-tree validation

The catalog and action-verb walkers only recursed into `children` and `else_children`. A bad widget type or unknown action verb buried in step 2 or 3 of a materialized flow slipped past author-time validation.

Both walkers now also descend:
- a step's `ui` node tree,
- its linear `chain` next step,
- every `chain_map` branch step.

So the whole flow is validated, not just the root step.

## Tests

Extended `tests/test_flow_authoring.py`:
- Both templates' intermediate steps render exactly one `flow.back` button; root and terminal steps render none; Back precedes Continue.
- The deep validators reject a bad widget and a bad verb planted in a `chain`/`chain_map` branch, and a clean materialized flow passes both end to end.

`tests/test_flow_authoring.py` (40), `tests/test_ripple_manifest_action_wiring.py` + `tests/test_ripple_catalog.py` (combined 82), and the cloud validator suites `tests/cloud/test_ripple_validator.py` + `tests/cloud/test_pocket_widget_spec_gate.py` (36) all pass. `ruff format` and `ruff check` are clean on the changed files.