### PR TITLE
Fix workspace invites returning a 500 from the old token index

### DIFF
--- a/ee/pocketpaw_ee/cloud/shared/db.py
+++ b/ee/pocketpaw_ee/cloud/shared/db.py
@@ -1,4 +1,15 @@
-"""MongoDB connection and Beanie ODM initialization."""
+"""MongoDB connection and Beanie ODM initialization.
+
+2026-06-07: added ``_drop_legacy_invite_token_index`` and called it after
+``init_beanie``. The invite-token hashing rollout dropped ``unique=True``
+from ``Invite.token`` (uniqueness moved to ``token_hash``), but Beanie only
+*creates* indexes from the model — it never drops ones that disappear. The
+old non-sparse unique index ``token_1`` therefore survived in every existing
+deployment, and because new invites persist ``token=None``, the second new
+invite collided on ``{ token: null }`` with a ``DuplicateKeyError`` that
+escaped as an unhandled 500 on ``POST /workspaces/{id}/invites``. This
+reconciles the live schema with the current model on startup.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +21,55 @@ from pymongo import AsyncMongoClient
 logger = logging.getLogger(__name__)
 
 _client: AsyncMongoClient | None = None
+
+
+async def _drop_legacy_invite_token_index(db) -> None:  # type: ignore[no-untyped-def]
+    """Drop the stale ``token_1`` unique index on ``invites`` if present.
+
+    The current ``Invite`` model declares uniqueness on ``token_hash``, not
+    ``token`` — ``token`` is a nullable legacy column. A leftover unique
+    index on ``token`` makes ``token: null`` collide across new invites
+    (which all persist ``token=None``), so the insert raises
+    ``DuplicateKeyError``. Beanie never removes indexes the model no longer
+    declares, so we reconcile here.
+
+    Idempotent and best-effort: only drops an index that is exactly the
+    legacy single-field unique ``token`` index, logs what it did, and never
+    raises into startup (a failed drop must not take the app down — the
+    service-layer guard still converts the resulting collision into a
+    handled 409).
+    """
+    try:
+        coll = db["invites"]
+        info = await coll.index_information()
+    except Exception:  # pragma: no cover - startup must not fail on probe
+        logger.exception("Could not read invites index information; skipping legacy-index cleanup")
+        return
+
+    legacy = info.get("token_1")
+    if not legacy:
+        return
+
+    key = legacy.get("key")
+    # Only touch the exact legacy shape: single-field unique index on `token`,
+    # not a TTL index and not a compound index that happens to lead with token.
+    is_legacy_shape = (
+        list(key) == [("token", 1)]
+        and legacy.get("unique") is True
+        and "expireAfterSeconds" not in legacy
+    )
+    if not is_legacy_shape:
+        return
+
+    try:
+        await coll.drop_index("token_1")
+        logger.warning(
+            "Dropped stale unique index 'token_1' on invites — the model now "
+            "enforces uniqueness via token_hash; the legacy index made new "
+            "invites collide on token=null."
+        )
+    except Exception:  # pragma: no cover - startup must not fail on drop
+        logger.exception("Failed to drop legacy 'token_1' index on invites")
 
 
 async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterprise") -> None:
@@ -29,6 +89,11 @@ async def init_cloud_db(mongo_uri: str = "mongodb://localhost:27017/paw-enterpri
     documents = [*ALL_DOCUMENTS, MemoryFactDoc]
     await init_beanie(database=db, document_models=documents)
     logger.info("Cloud DB initialized: %s (%d models)", db_name, len(documents))
+
+    # Reconcile a schema drift Beanie can't: drop indexes the model no longer
+    # declares. The invite-token hashing rollout left a unique index on the
+    # now-nullable `token` column that 500s every second invite.
+    await _drop_legacy_invite_token_index(db)
 
     # Flip the memory backend AFTER Beanie is initialized so the
     # MongoMemoryStore's first .insert()/.find() call can never race a

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -21,6 +21,10 @@ Public API:
   dep fails open on plan rather than crashing with a 500.
 
 Changes: added get_workspace_plan helper for plan-feature gate dep.
+2026-06-07: _mint_invite_for_email now maps a DuplicateKeyError on insert to
+a ConflictError (409) instead of letting it escape as an unhandled 500 — the
+leftover unique index on the nullable legacy ``token`` column made every
+second invite collide on ``token=null``.
 """
 
 from __future__ import annotations
@@ -31,6 +35,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from beanie import PydanticObjectId
+from pymongo.errors import DuplicateKeyError
 
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
 from pocketpaw_ee.cloud._core.errors import (
@@ -688,7 +693,25 @@ async def _mint_invite_for_email(
         token_hash=hash_token(plaintext),
         group=group_id,
     )
-    await invite_doc.insert()
+    try:
+        await invite_doc.insert()
+    except DuplicateKeyError as exc:
+        # An insert collision here is an EXPECTED failure, not a server fault,
+        # so surface it as a CloudError (409) rather than letting it escape as
+        # an unhandled 500 (which also drops the CORS header above the
+        # middleware and shows up in the browser as a misleading CORS error).
+        #
+        # Two ways this fires:
+        #   - A leftover unique index on the nullable legacy `token` column
+        #     (token=null for every new invite). The startup reconciler in
+        #     shared/db.py drops it; this guards the window before that runs
+        #     (e.g. a multi-instance deploy mid-rollout).
+        #   - A genuine token_hash collision (astronomically unlikely with a
+        #     256-bit token, but still expected-failure semantics).
+        raise ConflictError(
+            "invite.create_conflict",
+            "Could not create the invite due to a conflicting record. Please retry.",
+        ) from exc
     return _invite_to_domain(invite_doc, plaintext_token=plaintext)
 
 

--- a/tests/cloud/workspace/test_invite_send_500_regression.py
+++ b/tests/cloud/workspace/test_invite_send_500_regression.py
@@ -1,0 +1,209 @@
+# tests/cloud/workspace/test_invite_send_500_regression.py
+#
+# Created 2026-06-07 — regression coverage for the unhandled 500 on
+# POST /api/v1/workspaces/{id}/invites (admin sends a workspace invite).
+#
+# Root cause: the invite-token hashing rollout moved uniqueness from the
+# `token` column to `token_hash`, but Beanie never drops indexes that
+# disappear from the model. The leftover non-sparse unique index `token_1`
+# survived in live deployments. New invites persist `token=None`, so the
+# SECOND new invite collided on `{ token: null }` with a pymongo
+# DuplicateKeyError that escaped `_mint_invite_for_email` as an unhandled
+# 500 (which also drops the CORS header above the middleware, so the
+# browser reports a misleading CORS error).
+#
+# mongomock does NOT enforce unique indexes the way real Mongo does, which
+# is why the existing service/route tests never caught this. These tests
+# reproduce both halves deterministically without a live Mongo:
+#   - the service guard: a DuplicateKeyError on insert must become a
+#     ConflictError (409), never propagate as a 500;
+#   - the startup reconciler: the stale `token_1` index must be dropped so
+#     the feature actually works again, and nothing else gets touched.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import ConflictError
+from pocketpaw_ee.cloud.models.invite import Invite as _InviteDoc
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.shared.db import _drop_legacy_invite_token_index
+from pocketpaw_ee.cloud.workspace import service as workspace_service
+from pocketpaw_ee.cloud.workspace.dto import CreateInviteRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+async def _seed_user(*, email: str) -> _UserDoc:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="U",
+        workspaces=[],
+    )
+    await doc.insert()
+    return doc
+
+
+def _ctx(user_id: str) -> RequestContext:
+    from datetime import UTC, datetime
+
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=None,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_workspace(owner: _UserDoc, *, slug: str) -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+
+    ws_doc = _WorkspaceDoc(name="W", slug=slug, owner=str(owner.id))
+    await ws_doc.insert()
+    ws_id = str(ws_doc.id)
+    await workspace_service._add_member(ws_id, str(owner.id), role="owner", set_active=True)
+    return ws_id
+
+
+# ---------------------------------------------------------------------------
+# Service guard: DuplicateKeyError on insert -> ConflictError (409), not 500
+# ---------------------------------------------------------------------------
+
+
+async def test_create_invite_maps_duplicate_key_to_conflict(
+    owner, monkeypatch, resolver_mock
+) -> None:
+    """A pymongo DuplicateKeyError raised by the insert must surface as a
+    ConflictError (CloudError -> 409), not escape as an unhandled 500.
+
+    Before the fix the raw DuplicateKeyError propagated out of
+    create_invite. mongomock won't trigger the unique-index collision on
+    its own, so we simulate the exact insert failure real Mongo produces
+    against the stale `token_1` index.
+    """
+    from pymongo.errors import DuplicateKeyError
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create",
+        _async_noop,
+    )
+
+    ws_id = await _seed_workspace(owner, slug="dup")
+
+    async def _boom(self, *args, **kwargs):  # noqa: ANN001, ARG001
+        raise DuplicateKeyError(
+            "E11000 duplicate key error collection: paw-enterprise.invites "
+            "index: token_1 dup key: { token: null }",
+            11000,
+        )
+
+    monkeypatch.setattr(_InviteDoc, "insert", _boom, raising=True)
+
+    with pytest.raises(ConflictError) as exc:
+        await workspace_service.create_invite(
+            _ctx(str(owner.id)), ws_id, CreateInviteRequest(email="fresh@x.c", role="member")
+        )
+    assert exc.value.code == "invite.create_conflict"
+
+
+# ---------------------------------------------------------------------------
+# Startup reconciler: drop the stale `token_1` unique index
+# ---------------------------------------------------------------------------
+
+
+async def test_drop_legacy_token_index_removes_stale_unique(mongo_db) -> None:
+    """When a leftover unique `token_1` index exists, the reconciler drops
+    it so new invites stop colliding on token=null."""
+    coll = mongo_db["invites"]
+    await coll.create_index([("token", 1)], unique=True, name="token_1")
+    assert "token_1" in await coll.index_information()
+
+    await _drop_legacy_invite_token_index(mongo_db)
+
+    assert "token_1" not in await coll.index_information()
+
+
+async def test_drop_legacy_token_index_is_noop_when_absent(mongo_db) -> None:
+    """No `token_1` index → reconciler leaves the collection untouched."""
+    coll = mongo_db["invites"]
+    before = set(await coll.index_information())
+    assert "token_1" not in before
+
+    await _drop_legacy_invite_token_index(mongo_db)
+
+    assert set(await coll.index_information()) == before
+
+
+async def test_drop_legacy_token_index_preserves_token_hash_index(mongo_db) -> None:
+    """The reconciler must only touch the legacy `token` index, never the
+    current `token_hash` uniqueness the model relies on."""
+    coll = mongo_db["invites"]
+    await coll.create_index([("token", 1)], unique=True, name="token_1")
+    await coll.create_index([("token_hash", 1)], unique=True, name="token_hash_1")
+
+    await _drop_legacy_invite_token_index(mongo_db)
+
+    info = await coll.index_information()
+    assert "token_1" not in info
+    assert "token_hash_1" in info
+
+
+# ---------------------------------------------------------------------------
+# End-to-end happy path through the real route (deps + real insert +
+# response_model serialization). Guards against re-introducing a 500 in the
+# normal admin-sends-invite flow.
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_create_invite_fresh_email_route_returns_200() -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.auth.core import current_optional_user
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.workspace.router import router as workspace_router
+
+    admin = await _seed_user(email="admin@acme.test")
+    ws_id = await _seed_workspace(admin, slug="acme")
+    admin = await _UserDoc.get(admin.id)
+    assert admin is not None
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(workspace_router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: admin
+    app.dependency_overrides[current_optional_user] = lambda: admin
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.post(
+        f"/api/v1/workspaces/{ws_id}/invites",
+        json={"email": "fresh-invitee@acme.test", "role": "member"},
+    )
+    assert resp.status_code == 200, f"got {resp.status_code}: {resp.text}"
+    assert resp.json()["email"] == "fresh-invitee@acme.test"
+
+
+async def _async_noop(*_args, **_kwargs):
+    return None
+
+
+@pytest.fixture(autouse=True)
+def resolver_mock(monkeypatch):
+    """Stub the realtime resolver so emit-time get_resolver() doesn't explode
+    (the real one needs init_realtime, which unit tests don't run)."""
+    from unittest.mock import MagicMock
+
+    mock = MagicMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.get_resolver", lambda: mock)
+    return mock
+
+
+@pytest.fixture
+async def owner() -> _UserDoc:
+    return await _seed_user(email="owner@x.c")


### PR DESCRIPTION
## What was breaking

Sending a workspace invite — `POST /api/v1/workspaces/{id}/invites` — returned an unhandled 500. In the browser it surfaced as a CORS error (`net::ERR_FAILED`, "No Access-Control-Allow-Origin"), but that was a symptom, not the cause: the 500 escaped above the CORS middleware, so the error response lost its `Access-Control-Allow-Origin` header. CORS config itself is fine.

## The actual root cause

A stale unique index left over from the token-hashing migration.

When invite tokens moved to being hashed at rest, the `Invite` model dropped `unique=True` from the plaintext `token` column — uniqueness moved to `token_hash`. But Beanie only *creates* indexes declared on the model; it never drops ones that disappear. So the old `token_1` unique index survived in every existing database.

New invites persist `token=None`. A non-sparse unique index treats `null` as a real value, so only one document can have `token: null`. The moment a single hashed invite exists, the **next** insert collides and pymongo raises `DuplicateKeyError` straight out of `_mint_invite_for_email`, where nothing catches it.

I reproduced it against the live local Mongo with the exact insert the service performs:

```
pymongo.errors.DuplicateKeyError: E11000 duplicate key error collection:
paw-enterprise.invites index: token_1 dup key: { token: null }, full error:
{'index': 0, 'code': 11000, 'errmsg': 'E11000 duplicate key error collection:
paw-enterprise.invites index: token_1 dup key: { token: null }',
'keyPattern': {'token': 1}, 'keyValue': {'token': None}}
```

The DB already had one `token: null` row, so every subsequent invite was guaranteed to fail.

This is also why the existing service and route tests stayed green: mongomock doesn't enforce that index, and the one RBAC route test that hits this endpoint mocks the service entirely.

## The fix

Two parts:

1. **Reconcile the schema on startup.** `init_cloud_db` now drops the leftover `token_1` index when present. It only touches that exact legacy shape (single-field unique on `token`, no TTL), logs a WARN when it does, and never fails startup if the drop errors. This is what actually restores the feature on existing data — without it, invites stay broken regardless of error handling.

2. **Defense in depth in the service.** A `DuplicateKeyError` on insert now maps to a `ConflictError` (409, code `invite.create_conflict`) instead of escaping as a 500. This covers the window before a redeploy runs the cleanup (e.g. a multi-instance deploy mid-rollout) and any genuine token-hash collision, and keeps the CORS header on the response.

## Tests

`tests/cloud/workspace/test_invite_send_500_regression.py` reproduces both halves against mongomock — it supports the index API (`create_index` / `index_information` / `drop_index`) even though it doesn't enforce uniqueness, so the reconciler is testable, and the service guard is exercised by simulating the exact `DuplicateKeyError` real Mongo raises.

I verified these fail without the fix: with the service guard reverted, the duplicate-key test fails with the raw `DuplicateKeyError` propagating; with the reconciler neutered, the drop tests fail because `token_1` is still there.

```
tests/cloud/workspace/test_invite_send_500_regression.py .....  [5 passed]
```

All 40 invite-related tests (the 5 new ones plus the existing 35 in `test_service_v2.py`) pass.

## Notes

- Internal bug fix — no new public API, CLI command, or memory tier, so no reference docs change. The new `invite.create_conflict` 409 code isn't catalogued anywhere that would drift.
- There are pre-existing failures on `dev` in `test_service_v2.py::test_delete_preview_*` (they assert `agent_count == 0` but workspace creation now seeds a default agent) and in some `test_rbac_routes.py` cases. They reproduce with this branch's changes stashed, so they're unrelated to this fix — flagging for separate cleanup.
- `mypy` flags one error in `shared/db.py` at `close_cloud_db` (`_client.close()` is now a coroutine under the async pymongo client). It's pre-existing on `dev` (verbatim) and outside this fix's scope, so I left it untouched.
