### PR TITLE
feat(connectors): auto-author a pocket's surface_profile when a connector is bound

### DIFF
--- a/connectors/gmail.yaml
+++ b/connectors/gmail.yaml
@@ -1,5 +1,11 @@
 # Gmail connector — REST API over OAuth bearer token.
 # Created: 2026-05-03 — Phase 1 PR-3.
+# Updated: 2026-06-07 (M3 connector→skill auto-authoring) — added the optional
+#   ``surface_profile:`` block. When this connector is bound to a pocket
+#   (scope=pocket), the cloud derivation helper folds this block into the
+#   pocket's PocketSurfaceProfile so the entity room auto-loads the bundled
+#   ``gmail`` skill (no hand-setting). See ``allow_tools`` note below re: the
+#   tool-id pattern.
 # This YAML carries the catalog metadata + the action manifest. The
 # runtime wiring lives in src/pocketpaw/connectors/adapters/gmail.py
 # (GmailConnector) which wraps the existing GmailClient from
@@ -16,6 +22,24 @@ name: gmail
 display_name: Gmail
 type: communication
 icon: mail
+
+# M3 — connector→skill/tool auto-authoring. When Gmail is bound to a pocket,
+# the entity room auto-loads the bundled "gmail" skill (which teaches the
+# search→read→act workflow over the actions below).
+#
+# allow_tools NOTE on the tool-id pattern: gmail's agent tools are the
+# hand-written BaseTool classes in src/pocketpaw/tools/builtin/gmail.py
+# (gmail_search / gmail_read / gmail_send / ...). They are NOT yet wrapped as
+# ``mcp__<server>__<tool>`` SDK tool ids — a future connector-tools PR
+# generates those. So today the SKILL is the load-bearing contribution and
+# allow_tools is left EMPTY: the resolver treats an empty allow as "no SDK-tool
+# restriction" (the union only ADDS to the allowlist, never narrows it), so an
+# empty list is the safe, correct default until the gmail tools have stable MCP
+# ids to glob against. When they do, set e.g. allow_tools: ["mcp__*gmail*"].
+surface_profile:
+  skill: gmail
+  allow_tools: []
+  deny_tools: []
 
 auth:
   method: oauth2

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,3 +1,12 @@
+<!--
+  Connectors documentation.
+  Updated: 2026-06-07 (M3 connector→skill auto-authoring) — documented the
+  optional ``surface_profile`` YAML block and the connector→skill/tool
+  auto-authoring path (derivation at bind/unbind from the full enabled set, the
+  Gmail reference, and the coexistence rule with hand-set ripple_mode /
+  system_message_override).
+-->
+
 # Connectors — Data Source Integration
 
 Connectors bring external data into PocketPaw Pockets. Each service is defined in a YAML file — the engine reads the definition and handles auth, execution, and sync.
@@ -74,7 +83,15 @@ sync:
     name: name
     price: price
     created: created_at
+
+surface_profile:                  # OPTIONAL — connector→skill/tool auto-authoring
+  skill: my_service               # a skill to load in rooms with this connector
+  allow_tools: []                 # tool-id patterns to add to the SDK allowlist
+  deny_tools: []                  # tool-id patterns to deny
 ```
+
+The `surface_profile` block is optional. Connectors without it parse and behave
+exactly as before. See [Connector → Skill / Tool auto-authoring](#connector--skill--tool-auto-authoring) below.
 
 ## Auth Methods
 
@@ -95,6 +112,76 @@ Each action has a trust level that controls how much human oversight the agent n
 | `auto` | Agent executes without asking | Read-only operations (list, search) |
 | `confirm` | Agent asks user before executing | Write operations (create, update, delete) |
 | `restricted` | Requires admin approval | Destructive or financial operations |
+
+## Connector → Skill / Tool auto-authoring
+
+When a connector is **bound to a pocket** (`scope=pocket`), PocketPaw can
+auto-derive that pocket's behavioral profile — the skill the agent loads and the
+tool allow/deny lists — straight from the connector. No hand-setting. Bind Gmail
+to a room and the room's agent gets the Gmail skill automatically; unbind it and
+the skill drops back off.
+
+### The `surface_profile` YAML block
+
+The mapping source is a per-connector field, not a hard-coded table. Add an
+optional `surface_profile` block to the connector YAML:
+
+```yaml
+surface_profile:
+  skill: gmail                    # skill name loaded for rooms with this connector
+  allow_tools: ["mcp__*gmail*"]   # tool-id glob patterns to ALLOW (optional)
+  deny_tools: []                  # tool-id glob patterns to DENY (optional)
+```
+
+All three keys are optional; a block with none of them is treated as no block.
+Connectors with no block contribute nothing.
+
+### How it derives at bind / unbind
+
+A pocket's profile is **derived from ALL of its enabled pocket-scoped
+connectors**, not just the one being toggled:
+
+- **`skill_names`** — the union of every bound connector's `skill`.
+- **`allowed_sdk_tools`** — the union of every connector's `allow_tools`
+  (stays unrestricted/`None` when no connector contributes one).
+- **`deny_mcp_tool_ids`** — the union of every connector's `deny_tools`.
+
+Because it re-derives from the full enabled set every time, **enable and disable
+both converge correctly**: enabling adds a connector's contribution to the union;
+disabling removes the connector from the set, so its contribution drops on the
+next re-derive. The derivation is deterministic and idempotent — re-deriving from
+the same set yields the same profile.
+
+The derived profile flows end-to-end immediately: the entity-aware resolver
+unions it over the surface base, and the run forwards `skill_names` /
+`allowed_sdk_tools` / `deny_mcp_tool_ids` to the agent.
+
+### Coexistence with hand-set profiles
+
+The derivation **owns the connector-contributed dimensions** (`skill_names`,
+`allowed_sdk_tools`, `deny_mcp_tool_ids`) — it sets them to the connector union,
+overwriting any prior values on those dimensions. It **preserves the user-owned
+dimensions** (`ripple_mode`, `system_message_override`) already on the pocket.
+
+Practical consequence: a skill you hand-set on a pocket via the surface_profile
+override may be overwritten the next time a connector is bound or unbound. That's
+intentional — auto-authoring is the point. Keep durable, hand-set behavior in
+`ripple_mode` / `system_message_override`, which the derivation never touches.
+
+### Gmail — the reference
+
+`connectors/gmail.yaml` ships the block (`skill: gmail`). The bundled
+[`gmail` skill](../src/pocketpaw/bundled_skills/_bundled/skills/gmail/SKILL.md)
+teaches the agent the Gmail action surface (search → read → act) and the
+safe-by-default workflow (read before you act; confirm before you send or
+destroy). Bind Gmail to a pocket and the room gets that skill with zero
+configuration.
+
+`allow_tools` is left empty on Gmail today: its agent tools are hand-written
+classes (`gmail_search`, `gmail_send`, …) that are not yet wrapped as stable
+`mcp__<server>__<tool>` SDK tool ids. An empty allow means "no SDK-tool
+restriction" (the union only adds to the allowlist, never narrows it), so the
+skill is the load-bearing contribution until those ids exist.
 
 ## Using with Existing Integrations
 

--- a/ee/pocketpaw_ee/cloud/connectors/derivation.py
+++ b/ee/pocketpaw_ee/cloud/connectors/derivation.py
@@ -1,0 +1,69 @@
+# Connectors — pure surface-profile derivation (M3 connector→skill authoring).
+# Created: 2026-06-07 — Given the set of ENABLED pocket-scoped connectors for a
+#   pocket (as cloud-domain ``AvailableConnector`` rows), fold each connector's
+#   ``surface_profile`` contribution into ONE ``PocketSurfaceProfile``: skill_names
+#   = union of each connector's ``skill``; allowed_sdk_tools = union of each
+#   ``allow_tools``; deny_mcp_tool_ids = union of each ``deny_tools``. Connectors
+#   with no ``surface_profile`` block contribute nothing.
+#
+#   PURE — no I/O, no Beanie. The caller (``connectors.service.enable_connector`` /
+#   ``disable_connector``) loads the enabled set, calls this, then hands the result
+#   to ``pockets.service.apply_derived_surface_profile`` for the Beanie write
+#   (cloud Beanie-write boundary — connectors never touch the Pocket doc).
+#
+#   DETERMINISTIC + IDEMPOTENT: re-deriving from the full enabled set yields the
+#   same profile (sorted lists, set-deduped). Owns ONLY the connector-contributed
+#   dims; ``ripple_mode`` and ``system_message_override`` are left ``None`` here so
+#   the caller can preserve any user-owned values already on the pocket.
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from pocketpaw_ee.cloud.connectors.domain import AvailableConnector
+from pocketpaw_ee.cloud.surface.domain import PocketSurfaceProfile
+
+
+def derive_surface_profile(
+    connectors: Iterable[AvailableConnector],
+) -> PocketSurfaceProfile | None:
+    """Union the surface-profile contributions of a pocket's enabled connectors.
+
+    ``connectors`` is the set of connectors enabled at scope=pocket for ONE
+    pocket (already tenant-filtered + merged with their registry defs, so each
+    carries its ``surface_profile`` contribution). Order-independent.
+
+    Returns ``None`` when NO connector contributes anything (empty set, or only
+    connectors with no ``surface_profile`` block) — the "clear the connector-
+    derived dims" signal. Otherwise returns a ``PocketSurfaceProfile`` carrying
+    only the connector-owned dims (``skill_names`` / ``allowed_sdk_tools`` /
+    ``deny_mcp_tool_ids``); ``ripple_mode`` and ``system_message_override`` stay
+    ``None`` so the persistence layer can keep the user's values.
+    """
+    skills: set[str] = set()
+    allow: set[str] = set()
+    deny: set[str] = set()
+
+    for c in connectors:
+        sp = c.surface_profile
+        if sp is None:
+            continue
+        if sp.skill:
+            skills.add(sp.skill)
+        allow.update(sp.allow_tools)
+        deny.update(sp.deny_tools)
+
+    if not skills and not allow and not deny:
+        return None
+
+    return PocketSurfaceProfile(
+        skill_names=sorted(skills),
+        # ``allowed_sdk_tools=None`` means "no SDK-tool restriction"; only emit a
+        # concrete list when a connector actually contributed allow patterns, so
+        # an empty list never accidentally narrows the allowlist.
+        allowed_sdk_tools=sorted(allow) if allow else None,
+        deny_mcp_tool_ids=sorted(deny),
+    )
+
+
+__all__ = ["derive_surface_profile"]

--- a/ee/pocketpaw_ee/cloud/connectors/domain.py
+++ b/ee/pocketpaw_ee/cloud/connectors/domain.py
@@ -3,12 +3,32 @@
 # dataclasses constructed from Beanie docs in service.py. Tenancy is
 # required at construction (workspace_id has no default) per the
 # ee/cloud rule §3.
+# Updated: 2026-06-07 (M3 connector→skill auto-authoring) — ``AvailableConnector``
+#   grows an optional ``surface_profile`` field carrying the connector's
+#   skill/tool contribution (mirrors the OSS ``ConnectorSurfaceProfile``). The
+#   pure derivation helper in ``derivation.py`` folds these across a pocket's
+#   enabled connectors into a ``PocketSurfaceProfile``.
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
+
+
+@dataclass(frozen=True)
+class ConnectorSurfaceContribution:
+    """A connector's surface-profile contribution, in the cloud domain.
+
+    JSON-friendly mirror of the OSS ``yaml_engine.ConnectorSurfaceProfile``
+    (tuples instead of the raw YAML lists). Built in ``service.py`` from the
+    registry definition and carried on ``AvailableConnector`` so the derivation
+    helper never reaches across into the OSS registry types.
+    """
+
+    skill: str | None = None
+    allow_tools: tuple[str, ...] = field(default_factory=tuple)
+    deny_tools: tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -52,3 +72,7 @@ class AvailableConnector:
     icon: str
     auth_method: str
     actions: tuple[str, ...] = field(default_factory=tuple)
+    # M3 — the connector's surface-profile contribution (skill + tool patterns),
+    # or ``None`` when the YAML has no ``surface_profile:`` block. Consumed by
+    # the derivation helper when the connector is bound to a pocket.
+    surface_profile: ConnectorSurfaceContribution | None = None

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -1,5 +1,11 @@
 # Connectors — workspace-scoped business logic.
 # Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation.
+# Updated: 2026-06-07 (M3 connector→skill auto-authoring) — enable/disable of a
+#   POCKET-scoped connector now RE-DERIVES the pocket's surface_profile from ALL
+#   its enabled pocket-scoped connectors (``_rederive_pocket_surface_profile``)
+#   and persists it via ``pockets.service.apply_derived_surface_profile`` (the
+#   Beanie-write boundary — this service never imports the Pocket doc). Derivation
+#   itself is the pure ``derivation.derive_surface_profile``.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -27,7 +33,11 @@ from pocketpaw_ee.cloud._core.realtime.events import (
     ConnectorEnabled,
     ConnectorSyncRecorded,
 )
-from pocketpaw_ee.cloud.connectors.domain import AvailableConnector, WorkspaceConnector
+from pocketpaw_ee.cloud.connectors.domain import (
+    AvailableConnector,
+    ConnectorSurfaceContribution,
+    WorkspaceConnector,
+)
 from pocketpaw_ee.cloud.connectors.dto import (
     ConnectorDetailResponse,
     ConnectorResponse,
@@ -74,6 +84,20 @@ def _available_from_registry() -> list[AvailableConnector]:
             a.get("name", "") for a in (d.actions or []) if isinstance(a, dict) and a.get("name")
         )
         auth_method = (d.auth or {}).get("method", "none") if isinstance(d.auth, dict) else "none"
+        # M3 — carry the connector's surface-profile contribution (skill + tool
+        # patterns) into the cloud domain, translating the OSS
+        # ``ConnectorSurfaceProfile`` to the cloud-side mirror. ``None`` when the
+        # YAML has no block.
+        sp = getattr(d, "surface_profile", None)
+        contribution = (
+            ConnectorSurfaceContribution(
+                skill=sp.skill,
+                allow_tools=tuple(sp.allow_tools),
+                deny_tools=tuple(sp.deny_tools),
+            )
+            if sp is not None
+            else None
+        )
         out.append(
             AvailableConnector(
                 name=d.name,
@@ -82,9 +106,49 @@ def _available_from_registry() -> list[AvailableConnector]:
                 icon=d.icon,
                 auth_method=auth_method,
                 actions=actions,
+                surface_profile=contribution,
             ),
         )
     return out
+
+
+# ---------------------------------------------------------------------------
+# M3 — connector→skill/tool surface-profile auto-authoring
+# ---------------------------------------------------------------------------
+
+
+async def _rederive_pocket_surface_profile(workspace_id: str, pocket_id: str) -> None:
+    """Re-derive + persist a pocket's surface_profile from its enabled connectors.
+
+    Triggered on enable/disable of a POCKET-scoped connector. Loads ALL connectors
+    enabled at ``scope=pocket`` for this ``pocket_id`` (tenant-filtered, cloud rule
+    §7), merges each with its registry def to recover its ``surface_profile``
+    contribution, runs the pure ``derive_surface_profile`` over the full set, then
+    hands the result to ``pockets.service.apply_derived_surface_profile`` for the
+    Beanie write.
+
+    Deriving from the FULL enabled set (not just the toggled connector) is what
+    makes enable AND disable correct: a disabled connector simply isn't in the set,
+    so its contribution drops on the next re-derive.
+
+    The Pocket-doc write lives in ``pockets.service`` (Beanie-write boundary —
+    this connectors service must not import the Pocket model). Imported lazily to
+    keep import-linter's static graph clean and avoid an import cycle.
+    """
+    from pocketpaw_ee.cloud.connectors.derivation import derive_surface_profile
+    from pocketpaw_ee.cloud.pockets.service import apply_derived_surface_profile
+
+    enabled_docs = await _WCDoc.find(
+        _WCDoc.workspace == workspace_id,
+        _WCDoc.pocket_id == pocket_id,
+        _WCDoc.scope == "pocket",
+        _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+    ).to_list()
+
+    available = {a.name: a for a in _available_from_registry()}
+    contributing = [available[d.name] for d in enabled_docs if d.name in available]
+    profile = derive_surface_profile(contributing)
+    await apply_derived_surface_profile(workspace_id, pocket_id, profile)
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +292,12 @@ async def enable_connector(
             }
         )
     )
+
+    # M3 — auto-author the pocket's surface_profile from its enabled connectors.
+    # Re-derive from the FULL enabled set so this is idempotent and order-free.
+    if body.scope == "pocket" and body.pocket_id:
+        await _rederive_pocket_surface_profile(workspace_id, body.pocket_id)
+
     return _row_response(a, doc)
 
 
@@ -245,6 +315,11 @@ async def disable_connector(workspace_id: str, name: str) -> ConnectorResponse:
     if doc is None:
         # Already not enabled — return the disconnected row.
         return _row_response(available[name], None)
+    # Capture the binding BEFORE flipping the flag — a pocket-scoped connector
+    # being disabled must re-derive that pocket's surface_profile so its
+    # contribution drops out of the union.
+    was_pocket_scoped = doc.scope == "pocket" and bool(doc.pocket_id)
+    pocket_id_for_rederive = doc.pocket_id
     doc.enabled = False
     await doc.save()
     await event_bus.emit(
@@ -259,6 +334,12 @@ async def disable_connector(workspace_id: str, name: str) -> ConnectorResponse:
             }
         )
     )
+
+    # M3 — re-derive after the flag flip so the disabled connector (now
+    # ``enabled=False``) is excluded from the enabled set used by derivation.
+    if was_pocket_scoped and pocket_id_for_rederive:
+        await _rederive_pocket_surface_profile(workspace_id, pocket_id_for_rederive)
+
     return _row_response(available[name], doc)
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -121,6 +121,14 @@ strings, so no ObjectId cast). The /pockets gallery route passes the ids
 of pockets already published as Sites so they don't appear in both the
 pocket gallery and the sites list. ``None`` is a no-op, so mission
 control / kb / surface / planner callers are unchanged.
+Changes: 2026-06-07 (M3 connector→skill auto-authoring) — added
+``apply_derived_surface_profile``: the SOLE Beanie-write entry point for a
+connector-derived ``PocketSurfaceProfile``. The connectors service derives the
+profile (pure) and calls this; this owns the Pocket-doc write (tenant-filtered,
+mirroring the :1134 assignment) so the connectors package never imports the
+Pocket Beanie model. It OWNS the connector-contributed dims (``skill_names`` /
+``allowed_sdk_tools`` / ``deny_mcp_tool_ids``) and PRESERVES the user-owned
+``ripple_mode`` / ``system_message_override`` already on the pocket.
 Changes: 2026-06-04 (feat/sites-landing-brain) — ``agent_create`` now
 accepts an optional ``pattern`` (alongside the existing ``type_``) and
 stamps both onto the persisted ``Pocket``. The marketing-site brain
@@ -196,6 +204,7 @@ from pocketpaw_ee.cloud.ripple_validator import (
 )
 from pocketpaw_ee.cloud.shared.errors import Forbidden, NotFound, ValidationError
 from pocketpaw_ee.cloud.shared.events import event_bus
+from pocketpaw_ee.cloud.surface.domain import PocketSurfaceProfile
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +258,76 @@ def _surface_profile_to_dict(sp: Any) -> dict[str, Any] | None:
     if isinstance(sp, dict):
         return dict(sp)
     return None
+
+
+async def apply_derived_surface_profile(
+    workspace_id: str,
+    pocket_id: str,
+    profile: PocketSurfaceProfile | None,
+) -> None:
+    """Persist a CONNECTOR-DERIVED surface profile onto a pocket.
+
+    M3 connector→skill auto-authoring. This is the SOLE Beanie-write path for a
+    connector-derived ``PocketSurfaceProfile`` — the connectors service derives
+    the profile (pure) and calls this so the connectors package never imports the
+    ``Pocket`` Beanie document (cloud Beanie-write boundary, enforced by
+    import-linter).
+
+    Tenancy (cloud rule §7): the doc is loaded by id then verified to belong to
+    ``workspace_id``; a mismatch raises ``NotFound`` rather than writing across
+    tenants.
+
+    Coexistence rule: the derivation OWNS the connector-contributed dims
+    (``skill_names`` / ``allowed_sdk_tools`` / ``deny_mcp_tool_ids``) — it sets
+    them to the union from the pocket's enabled connectors, OVERWRITING any prior
+    connector-derived (or hand-set) values for those dims. It PRESERVES the
+    user-owned ``ripple_mode`` and ``system_message_override`` already on the
+    pocket. ``profile=None`` (no connector contributes anything) clears the
+    connector dims back to empty while still preserving the user-owned dims.
+
+    No event is emitted: this is an internal re-derive triggered by a
+    connector enable/disable that already emitted ``connector.enabled`` /
+    ``connector.disabled``. # no-event — covered by the connector lifecycle event.
+    """
+    doc = await _fetch_pocket(pocket_id)
+    if doc.workspace != workspace_id:
+        raise NotFound("pocket", pocket_id)
+
+    existing = getattr(doc, "surface_profile", None)
+    # Preserve the user-owned dims regardless of whether a connector contributes.
+    ripple_mode = getattr(existing, "ripple_mode", None)
+    sys_override = getattr(existing, "system_message_override", None)
+
+    if profile is None:
+        skill_names: list[str] = []
+        allowed_sdk_tools: list[str] | None = None
+        deny_mcp_tool_ids: list[str] = []
+    else:
+        skill_names = list(profile.skill_names)
+        allowed_sdk_tools = (
+            list(profile.allowed_sdk_tools) if profile.allowed_sdk_tools is not None else None
+        )
+        deny_mcp_tool_ids = list(profile.deny_mcp_tool_ids)
+
+    # If nothing remains set on any dim, drop the override entirely (legacy
+    # ``None`` shape) so a pocket that never had connector skills stays clean.
+    if (
+        ripple_mode is None
+        and sys_override is None
+        and not skill_names
+        and allowed_sdk_tools is None
+        and not deny_mcp_tool_ids
+    ):
+        doc.surface_profile = None
+    else:
+        doc.surface_profile = PocketSurfaceProfile(
+            ripple_mode=ripple_mode,
+            allowed_sdk_tools=allowed_sdk_tools,
+            deny_mcp_tool_ids=deny_mcp_tool_ids,
+            skill_names=skill_names,
+            system_message_override=sys_override,
+        )
+    await doc.save()
 
 
 def _pocket_to_domain(doc: _PocketDoc) -> Pocket:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -257,6 +257,13 @@ source_modules = [
     # ``action_executor.run_action``. Never imports a Beanie document
     # class directly.
     "pocketpaw_ee.cloud.pockets.temporal_dispatcher",
+    # M3 connector→skill auto-authoring — the connectors service re-derives a
+    # pocket's surface_profile on bind/unbind and persists it through
+    # ``pockets.service.apply_derived_surface_profile`` (the Beanie writer). It
+    # must NOT import the Pocket Beanie model directly; the derivation module is
+    # pure. Both go through ``pockets.service`` only.
+    "pocketpaw_ee.cloud.connectors.service",
+    "pocketpaw_ee.cloud.connectors.derivation",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",

--- a/src/pocketpaw/bundled_skills/_bundled/skills/gmail/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/gmail/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: gmail
+description: |
+  Work with the user's Gmail inside a pocket/room that has the Gmail
+  connector bound. Invoke when the user wants to find, read, triage, or
+  send email from the chat — "search my inbox for the invoice from Acme",
+  "what did Sarah email me yesterday", "reply to the last message from
+  legal", "draft and send a follow-up to the candidate", "label these as
+  Done". This skill teaches the Gmail action surface (search, read, send,
+  labels, trash) and the safe-by-default workflow: read before you act,
+  confirm before you send or destroy. It is auto-surfaced into a room when
+  the Gmail connector is bound to that pocket, so you only see it when
+  Gmail is actually available.
+---
+
+# Gmail in a Room
+
+This room has the **Gmail connector** bound to it. You can search, read,
+triage, and send email on the user's behalf through the connector's
+actions. The connector handles OAuth, MIME, and the Gmail API — you call
+named actions with simple parameters and get structured results back.
+
+Treat the mailbox as the user's real inbox. Reading is cheap and safe;
+**sending and destroying are not**. Default to caution.
+
+## The action surface
+
+| Action | What it does | Trust |
+|--------|--------------|-------|
+| `gmail_search` | Find messages by Gmail query syntax | auto |
+| `gmail_read` | Read one message's full body by id | auto |
+| `gmail_send` | Send a new email | confirm |
+| `gmail_list_labels` | List all mailbox labels | auto |
+| `gmail_create_label` | Create a new label | confirm |
+| `gmail_modify` | Add/remove labels on one message | confirm |
+| `gmail_trash` | Move one message to Trash | confirm |
+| `gmail_batch_modify` | Apply label changes to many messages | confirm |
+| `gmail_summary` | Inbox stats (unread / today) | auto |
+
+"Trust = confirm" means **show the user what you're about to do and get a
+yes before you do it.** Never send, trash, or relabel silently.
+
+## Core workflow: read before you act
+
+Almost every request starts with a search, then a read.
+
+1. **Search** to find the candidate messages. `gmail_search` takes a
+   `query` (Gmail's own search syntax) and an optional `max_results`
+   (default 5, capped at 20). It returns a list of message stubs, each
+   with an `id`, `from`, `subject`, and snippet.
+2. **Read** the specific message with `gmail_read` (pass the `message_id`
+   from the search result) when you need the full body — to summarize,
+   quote, or draft a reply.
+3. **Act** (send / label / trash) only after you've shown the user what
+   you found and they've confirmed the action.
+
+Don't dump raw search JSON at the user. Summarize: who, when, subject,
+and the one-line gist. Offer the obvious next step ("want me to open the
+Acme one?" / "want me to reply?").
+
+## Gmail search syntax — the queries you'll actually use
+
+`gmail_search` uses the same syntax as the Gmail search bar. The high-value
+operators:
+
+- `from:sarah@acme.com` — sender
+- `to:me` — addressed to the user
+- `subject:invoice` — subject contains
+- `is:unread` / `is:read` / `is:important` / `is:starred`
+- `newer_than:2d` / `older_than:1w` — relative time (d/w/m/y)
+- `has:attachment`
+- `label:Receipts`
+- combine freely: `from:legal is:unread newer_than:3d`
+
+Examples:
+
+```
+"unread email from my boss this week"
+  → gmail_search query="from:boss@company.com is:unread newer_than:7d"
+
+"the latest invoice from Acme"
+  → gmail_search query="from:acme.com subject:invoice" max_results=5
+  → then gmail_read on the most recent id
+```
+
+## Sending mail
+
+`gmail_send` takes `to`, `subject`, and `body` (plain text). Before you
+call it:
+
+1. **Draft the full message in chat** — recipient, subject, and body.
+2. **Show it to the user verbatim** and ask for explicit confirmation.
+3. Only on a clear yes, call `gmail_send`.
+
+For a reply, first `gmail_read` the original so your draft has the right
+context (quote sparingly, match the thread's subject). If the user edits
+your draft, re-show the final version before sending.
+
+Never invent recipients. If the address is ambiguous, search for the
+person's recent mail to confirm the right one, or ask.
+
+## Triage: labels and trash
+
+- `gmail_list_labels` first if you need a label's id — labels are
+  referenced by id, not name, in `gmail_modify` / `gmail_batch_modify`.
+- `gmail_modify` changes labels on one message; `gmail_batch_modify`
+  takes a `message_ids` list for bulk relabeling (e.g. "archive all the
+  newsletters" → search, then batch-modify removing `INBOX`).
+- `gmail_trash` is reversible (Trash, not permanent delete) but still a
+  destructive action — confirm the specific message first.
+- `gmail_create_label` when the user asks for a label that doesn't exist
+  yet; confirm the name.
+
+## A quick read on the inbox
+
+`gmail_summary` returns unread count and today's count cheaply — use it
+when the user asks "how's my inbox" or "anything new" before doing a
+heavier search.
+
+## Guardrails
+
+- **Confirm every `confirm`-trust action** (send, trash, label changes,
+  create label). Read-only actions (search, read, list labels, summary)
+  need no confirmation.
+- **Read the message before quoting or replying** — never paraphrase from
+  a search snippet alone for anything that matters.
+- **Cap result volume** — `max_results` is capped at 20; for broad
+  triage, search tightly rather than pulling everything.
+- **Stay in this mailbox** — the connector is bound to one account; don't
+  assume access to other inboxes.

--- a/src/pocketpaw/connectors/yaml_engine.py
+++ b/src/pocketpaw/connectors/yaml_engine.py
@@ -1,6 +1,11 @@
 # DirectREST YAML engine — reads connector YAML definitions and executes REST actions.
 # Created: 2026-03-27 — Primary adapter. One YAML per service.
 # Updated: 2026-03-28 — Real HTTP execution via httpx (was placeholder).
+# Updated: 2026-06-07 (M3 connector→skill auto-authoring) — ConnectorDef grows an
+#   optional ``surface_profile`` block (skill / allow_tools / deny_tools) parsed
+#   from the YAML. It is the per-connector mapping source for deriving a pocket's
+#   PocketSurfaceProfile when the connector is bound to a pocket. Backward-compat:
+#   connectors with no block parse with ``surface_profile=None``.
 
 from __future__ import annotations
 
@@ -20,6 +25,28 @@ from pocketpaw.connectors.protocol import (
 )
 
 
+@dataclass(frozen=True)
+class ConnectorSurfaceProfile:
+    """The surface-profile contribution a connector makes to a pocket.
+
+    Parsed from the OPTIONAL ``surface_profile:`` block on a connector YAML.
+    When a connector is bound to a pocket (scope=pocket), the cloud derivation
+    helper folds every enabled connector's ``ConnectorSurfaceProfile`` into the
+    pocket's ``PocketSurfaceProfile`` (skill_names + tool allow/deny). A
+    connector with no block contributes nothing (``ConnectorDef.surface_profile``
+    is ``None``).
+
+    Fields (all optional):
+      * ``skill`` — a single skill name to load for rooms with this connector.
+      * ``allow_tools`` — tool-id glob/patterns to add to the SDK allowlist.
+      * ``deny_tools`` — tool-id glob/patterns to deny.
+    """
+
+    skill: str | None = None
+    allow_tools: tuple[str, ...] = field(default_factory=tuple)
+    deny_tools: tuple[str, ...] = field(default_factory=tuple)
+
+
 @dataclass
 class ConnectorDef:
     """Parsed connector YAML definition."""
@@ -31,6 +58,30 @@ class ConnectorDef:
     auth: dict[str, Any] = field(default_factory=dict)
     actions: list[dict[str, Any]] = field(default_factory=list)
     sync: dict[str, Any] = field(default_factory=dict)
+    # M3 — optional connector→skill/tool mapping. ``None`` when the YAML has
+    # no ``surface_profile:`` block (the common case / backward-compat).
+    surface_profile: ConnectorSurfaceProfile | None = None
+
+
+def _parse_surface_profile(raw: Any) -> ConnectorSurfaceProfile | None:
+    """Parse the optional ``surface_profile:`` YAML block.
+
+    Returns ``None`` when the block is absent or not a mapping, so connectors
+    without the block stay byte-identical to pre-M3 behavior. Tolerates a bare
+    string or a list for ``skill`` only by ignoring non-string values; the
+    canonical shape is a mapping with ``skill`` / ``allow_tools`` / ``deny_tools``.
+    """
+    if not isinstance(raw, dict):
+        return None
+    skill = raw.get("skill")
+    skill = skill if isinstance(skill, str) and skill else None
+    allow = raw.get("allow_tools") or []
+    deny = raw.get("deny_tools") or []
+    allow_tuple = tuple(str(t) for t in allow if t) if isinstance(allow, list) else ()
+    deny_tuple = tuple(str(t) for t in deny if t) if isinstance(deny, list) else ()
+    if skill is None and not allow_tuple and not deny_tuple:
+        return None
+    return ConnectorSurfaceProfile(skill=skill, allow_tools=allow_tuple, deny_tools=deny_tuple)
 
 
 def parse_connector_yaml(path: Path) -> ConnectorDef:
@@ -46,6 +97,7 @@ def parse_connector_yaml(path: Path) -> ConnectorDef:
         auth=raw.get("auth", {}),
         actions=raw.get("actions", []),
         sync=raw.get("sync", {}),
+        surface_profile=_parse_surface_profile(raw.get("surface_profile")),
     )
 
 

--- a/tests/cloud/connectors/test_derivation.py
+++ b/tests/cloud/connectors/test_derivation.py
@@ -1,0 +1,94 @@
+# tests/cloud/connectors/test_derivation.py
+# Created: 2026-06-07 (M3 connector→skill auto-authoring) — pins the PURE
+#   derivation helper ``derive_surface_profile``: single connector → its profile;
+#   multiple → UNION of skills + allow + deny; a connector with no block →
+#   no contribution; empty set → None. Also checks determinism/idempotence
+#   (sorted, order-free) and that ripple_mode / system_message_override are left
+#   ``None`` (user-owned dims the helper never touches).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.connectors.derivation import derive_surface_profile
+from pocketpaw_ee.cloud.connectors.domain import (
+    AvailableConnector,
+    ConnectorSurfaceContribution,
+)
+
+
+def _conn(name: str, contribution: ConnectorSurfaceContribution | None) -> AvailableConnector:
+    return AvailableConnector(
+        name=name,
+        display_name=name.title(),
+        type="communication",
+        icon="plug",
+        auth_method="oauth2",
+        surface_profile=contribution,
+    )
+
+
+def test_single_connector_yields_its_profile() -> None:
+    c = _conn("gmail", ConnectorSurfaceContribution(skill="gmail"))
+    profile = derive_surface_profile([c])
+    assert profile is not None
+    assert profile.skill_names == ["gmail"]
+    # No tool patterns → no SDK-tool restriction (None), empty deny.
+    assert profile.allowed_sdk_tools is None
+    assert profile.deny_mcp_tool_ids == []
+    # User-owned dims untouched.
+    assert profile.ripple_mode is None
+    assert profile.system_message_override is None
+
+
+def test_multiple_connectors_union() -> None:
+    c1 = _conn(
+        "gmail",
+        ConnectorSurfaceContribution(
+            skill="gmail", allow_tools=("mcp__a",), deny_tools=("mcp__x",)
+        ),
+    )
+    c2 = _conn(
+        "cal",
+        ConnectorSurfaceContribution(
+            skill="gcalendar", allow_tools=("mcp__b",), deny_tools=("mcp__y",)
+        ),
+    )
+    profile = derive_surface_profile([c1, c2])
+    assert profile is not None
+    assert profile.skill_names == ["gcalendar", "gmail"]  # sorted
+    assert profile.allowed_sdk_tools == ["mcp__a", "mcp__b"]
+    assert profile.deny_mcp_tool_ids == ["mcp__x", "mcp__y"]
+
+
+def test_connector_without_block_contributes_nothing() -> None:
+    c1 = _conn("gmail", ConnectorSurfaceContribution(skill="gmail"))
+    c2 = _conn("airtable", None)
+    profile = derive_surface_profile([c1, c2])
+    assert profile is not None
+    assert profile.skill_names == ["gmail"]
+
+
+def test_only_blockless_connectors_yields_none() -> None:
+    profile = derive_surface_profile([_conn("airtable", None), _conn("stripe", None)])
+    assert profile is None
+
+
+def test_empty_set_yields_none() -> None:
+    assert derive_surface_profile([]) is None
+
+
+def test_idempotent_and_order_free() -> None:
+    c1 = _conn("gmail", ConnectorSurfaceContribution(skill="gmail", deny_tools=("mcp__x",)))
+    c2 = _conn("cal", ConnectorSurfaceContribution(skill="gcalendar"))
+    a = derive_surface_profile([c1, c2])
+    b = derive_surface_profile([c2, c1])
+    assert a == b
+    # Re-deriving from the same full set is stable.
+    assert derive_surface_profile([c1, c2]) == a
+
+
+def test_duplicate_skills_deduped() -> None:
+    c1 = _conn("g1", ConnectorSurfaceContribution(skill="gmail"))
+    c2 = _conn("g2", ConnectorSurfaceContribution(skill="gmail"))
+    profile = derive_surface_profile([c1, c2])
+    assert profile is not None
+    assert profile.skill_names == ["gmail"]

--- a/tests/cloud/connectors/test_surface_profile_authoring.py
+++ b/tests/cloud/connectors/test_surface_profile_authoring.py
@@ -1,0 +1,169 @@
+# tests/cloud/connectors/test_surface_profile_authoring.py
+# Created: 2026-06-07 (M3 connector→skill auto-authoring) — end-to-end pins for
+#   the bind/unbind auto-authoring path through Mongo (``mongo_db`` fixture):
+#     * enable(scope=pocket) for gmail WRITES the derived surface_profile onto
+#       the pocket (skill_names=["gmail"]).
+#     * disable RE-DERIVES — the dropped connector's contribution leaves the
+#       pocket (skill_names back to empty / cleared).
+#     * a multi-connector union (monkeypatched catalog) merges both skills.
+#     * a user-owned ripple_mode / system_message_override set on the pocket is
+#       PRESERVED across a re-derive (the helper only owns the connector dims).
+#     * a WORKSPACE-scoped enable does NOT touch any pocket surface_profile.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.domain import (
+    AvailableConnector,
+    ConnectorSurfaceContribution,
+)
+from pocketpaw_ee.cloud.connectors.dto import EnableConnectorRequest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest, UpdatePocketRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_m3"
+_USER = "user_m3"
+
+
+async def _make_pocket(name: str = "Inbox entity") -> str:
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name=name))
+    return wire["_id"]
+
+
+async def test_enable_pocket_scoped_gmail_writes_derived_profile() -> None:
+    """Binding Gmail to a pocket auto-authors skill_names=['gmail']."""
+    pocket_id = await _make_pocket()
+
+    await connectors_service.enable_connector(
+        _WS, "gmail", EnableConnectorRequest(scope="pocket", pocket_id=pocket_id)
+    )
+
+    fetched = await pockets_service.get(pocket_id, _USER)
+    assert fetched["surfaceProfile"] is not None
+    assert fetched["surfaceProfile"]["skill_names"] == ["gmail"]
+
+
+async def test_disable_rederives_and_drops_contribution() -> None:
+    """Unbinding Gmail re-derives — its skill drops off the pocket."""
+    pocket_id = await _make_pocket()
+    await connectors_service.enable_connector(
+        _WS, "gmail", EnableConnectorRequest(scope="pocket", pocket_id=pocket_id)
+    )
+    pre = await pockets_service.get(pocket_id, _USER)
+    assert pre["surfaceProfile"]["skill_names"] == ["gmail"]
+
+    await connectors_service.disable_connector(_WS, "gmail")
+
+    post = await pockets_service.get(pocket_id, _USER)
+    # Only gmail contributed and nothing else is set → override cleared to None.
+    assert post["surfaceProfile"] is None
+
+
+async def test_workspace_scope_does_not_touch_pocket(monkeypatch) -> None:
+    """A workspace-scoped enable never authors a pocket surface_profile."""
+    pocket_id = await _make_pocket()
+
+    await connectors_service.enable_connector(
+        _WS, "gmail", EnableConnectorRequest(scope="workspace")
+    )
+
+    fetched = await pockets_service.get(pocket_id, _USER)
+    assert fetched["surfaceProfile"] is None
+
+
+async def test_multi_connector_union(monkeypatch) -> None:
+    """Two pocket-scoped connectors UNION their skills on the pocket.
+
+    Patches the catalog so two connectors both carry surface_profile blocks
+    (the shipped catalog only tags gmail today). ``stripe`` is a real YAML
+    connector so the enable/NotFound guard passes; we override its catalog row.
+    """
+    pocket_id = await _make_pocket()
+
+    real = connectors_service._available_from_registry()
+    by_name = {a.name: a for a in real}
+
+    def _patched() -> list[AvailableConnector]:
+        out = []
+        for a in real:
+            if a.name == "gmail":
+                out.append(
+                    AvailableConnector(
+                        name=a.name,
+                        display_name=a.display_name,
+                        type=a.type,
+                        icon=a.icon,
+                        auth_method=a.auth_method,
+                        actions=a.actions,
+                        surface_profile=ConnectorSurfaceContribution(skill="gmail"),
+                    )
+                )
+            elif a.name == "stripe":
+                out.append(
+                    AvailableConnector(
+                        name=a.name,
+                        display_name=a.display_name,
+                        type=a.type,
+                        icon=a.icon,
+                        auth_method=a.auth_method,
+                        actions=a.actions,
+                        surface_profile=ConnectorSurfaceContribution(
+                            skill="payments", allow_tools=("mcp__pay",)
+                        ),
+                    )
+                )
+            else:
+                out.append(a)
+        return out
+
+    assert "stripe" in by_name  # guard: the connector must exist in the registry
+    monkeypatch.setattr(connectors_service, "_available_from_registry", _patched)
+
+    await connectors_service.enable_connector(
+        _WS, "gmail", EnableConnectorRequest(scope="pocket", pocket_id=pocket_id)
+    )
+    await connectors_service.enable_connector(
+        _WS, "stripe", EnableConnectorRequest(scope="pocket", pocket_id=pocket_id)
+    )
+
+    fetched = await pockets_service.get(pocket_id, _USER)
+    assert fetched["surfaceProfile"]["skill_names"] == ["gmail", "payments"]
+    assert fetched["surfaceProfile"]["allowed_sdk_tools"] == ["mcp__pay"]
+
+
+async def test_user_owned_dims_preserved_across_rederive() -> None:
+    """ripple_mode + system_message_override set by the user survive a re-derive."""
+    pocket_id = await _make_pocket()
+    # User hand-sets the user-owned dims (not the connector dims).
+    await pockets_service.update(
+        pocket_id,
+        _USER,
+        UpdatePocketRequest(
+            surfaceProfile={
+                "ripple_mode": "off",
+                "system_message_override": "be terse",
+            }
+        ),
+    )
+
+    await connectors_service.enable_connector(
+        _WS, "gmail", EnableConnectorRequest(scope="pocket", pocket_id=pocket_id)
+    )
+
+    fetched = await pockets_service.get(pocket_id, _USER)
+    sp = fetched["surfaceProfile"]
+    # Connector dim authored…
+    assert sp["skill_names"] == ["gmail"]
+    # …while the user-owned dims are preserved.
+    assert sp["ripple_mode"] == "off"
+    assert sp["system_message_override"] == "be terse"
+
+    # And on unbind, the connector dim drops but the user dims remain.
+    await connectors_service.disable_connector(_WS, "gmail")
+    after = await pockets_service.get(pocket_id, _USER)
+    assert after["surfaceProfile"]["skill_names"] == []
+    assert after["surfaceProfile"]["ripple_mode"] == "off"
+    assert after["surfaceProfile"]["system_message_override"] == "be terse"

--- a/tests/connectors/test_surface_profile_yaml.py
+++ b/tests/connectors/test_surface_profile_yaml.py
@@ -1,0 +1,105 @@
+# tests/connectors/test_surface_profile_yaml.py
+# Created: 2026-06-07 (M3 connector→skill auto-authoring) — pins the optional
+#   ``surface_profile:`` block on a connector YAML: a connector WITH a block
+#   exposes a parsed ``ConnectorSurfaceProfile`` on its ``ConnectorDef``; one
+#   WITHOUT a block parses fine (``surface_profile is None``). Also asserts the
+#   shipped gmail.yaml carries ``skill: gmail`` so the Gmail proof wires through.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.yaml_engine import (
+    ConnectorSurfaceProfile,
+    parse_connector_yaml,
+)
+
+
+def _write_yaml(tmp_path: Path, name: str, body: str) -> Path:
+    p = tmp_path / f"{name}.yaml"
+    p.write_text(body)
+    return p
+
+
+def test_connector_with_surface_profile_block_parses(tmp_path: Path) -> None:
+    """A connector YAML with a surface_profile block exposes it on the def."""
+    path = _write_yaml(
+        tmp_path,
+        "acme",
+        """
+name: acme
+display_name: Acme
+surface_profile:
+  skill: acme-skill
+  allow_tools: ["mcp__*acme*", "Bash"]
+  deny_tools: ["mcp__danger"]
+""",
+    )
+    defn = parse_connector_yaml(path)
+    assert isinstance(defn.surface_profile, ConnectorSurfaceProfile)
+    assert defn.surface_profile.skill == "acme-skill"
+    assert defn.surface_profile.allow_tools == ("mcp__*acme*", "Bash")
+    assert defn.surface_profile.deny_tools == ("mcp__danger",)
+
+
+def test_connector_without_block_parses_none(tmp_path: Path) -> None:
+    """A connector YAML with NO surface_profile block parses fine (None)."""
+    path = _write_yaml(
+        tmp_path,
+        "plain",
+        """
+name: plain
+display_name: Plain
+actions:
+  - name: ping
+    method: GET
+""",
+    )
+    defn = parse_connector_yaml(path)
+    assert defn.surface_profile is None
+
+
+def test_empty_block_yields_none(tmp_path: Path) -> None:
+    """A surface_profile block with no meaningful keys yields None, not a stub."""
+    path = _write_yaml(
+        tmp_path,
+        "blank",
+        """
+name: blank
+display_name: Blank
+surface_profile:
+  allow_tools: []
+  deny_tools: []
+""",
+    )
+    defn = parse_connector_yaml(path)
+    assert defn.surface_profile is None
+
+
+def test_skill_only_block_parses(tmp_path: Path) -> None:
+    """The common shape — skill only, no tool patterns — parses with empty tuples."""
+    path = _write_yaml(
+        tmp_path,
+        "skillonly",
+        """
+name: skillonly
+display_name: Skill Only
+surface_profile:
+  skill: gmail
+""",
+    )
+    defn = parse_connector_yaml(path)
+    assert defn.surface_profile is not None
+    assert defn.surface_profile.skill == "gmail"
+    assert defn.surface_profile.allow_tools == ()
+    assert defn.surface_profile.deny_tools == ()
+
+
+def test_shipped_gmail_yaml_carries_skill() -> None:
+    """The real gmail.yaml in /connectors maps to the bundled gmail skill."""
+    reg = ConnectorRegistry()
+    gmail = reg.get_definition("gmail")
+    assert gmail is not None
+    assert gmail.surface_profile is not None
+    assert gmail.surface_profile.skill == "gmail"


### PR DESCRIPTION
## What

Binding a connector to a pocket now auto-derives that pocket's `surface_profile` — the skills and tool policy the entity room needs — instead of making someone set it by hand. Built on the entity SurfaceProfile from #1343; this is the auto-authoring half (RFC 14 M3).

Proven with **Gmail**: bind the Gmail connector to a pocket → the room automatically loads the new `gmail` skill, no gear-fiddling.

## How

- Connectors declare their contribution in their own YAML:
  ```yaml
  surface_profile:        # optional
    skill: gmail
    allow_tools: []       # tool-id patterns (empty = no restriction)
    deny_tools: []
  ```
- A pure helper derives a `PocketSurfaceProfile` from the **union** of a pocket's enabled connectors. Enable *and* disable re-derive from the full set, so removing a connector drops its contribution.
- The Pocket write stays in `pockets.service` (`apply_derived_surface_profile`) so the connectors package never imports the Pocket model — the import-linter contract was extended to enforce it.
- Derivation owns the connector dims (skill_names / tool allow / deny) and preserves the user-owned `ripple_mode` / `system_message_override`.

## Scope / notes

- v1 covers the connector-bind trigger. Deriving defaults at pocket-create (from type/pattern) is a follow-up.
- Gmail's `allow_tools` is intentionally empty for now — its agent tools aren't wrapped as stable `mcp__*` ids yet, so the skill is the load-bearing contribution. Flip it on once those ids land.
- A hand-set skill on a pocket can be overwritten on the next bind — intentional; durable per-room intent belongs in ripple_mode / system_message_override, which derivation never touches.

## Checks

- ruff clean · import-linter 22 kept / 0 broken
- pytest `-k 'connector or surface or pocket or skill'`: 680 passed, 1 skipped (pre-existing)
- New: YAML parse, derivation union, enable/disable re-derive, user-dim preservation, workspace-scope-no-touch
- Docs: docs/CONNECTORS.md