### PR TITLE
feat(workspace): carry optional admin context on invites

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/invite.py
+++ b/ee/pocketpaw_ee/cloud/models/invite.py
@@ -5,6 +5,11 @@ We persist sha256(plaintext) so a DB read cannot reconstruct a usable
 invite link. ``token`` is the legacy plaintext column kept Optional for
 backfill during the hashing rollout — new invites set ``token_hash``
 and leave ``token`` as None.
+
+2026-06-08 (pp#1365): added the optional embedded ``InviteContext`` and the
+nullable ``context`` field so an invite can carry admin-provided onboarding
+hints (``focus`` + ``profile_pic``) for a later VIP-onboarding flow. Fully
+optional — pre-existing invite rows read back with ``context=None``.
 """
 
 from __future__ import annotations
@@ -13,12 +18,25 @@ import hashlib
 from datetime import UTC, datetime, timedelta
 
 from beanie import Document, Indexed
-from pydantic import Field
+from pydantic import BaseModel, Field
 from pymongo import IndexModel
 
 
 def _default_expiry() -> datetime:
     return datetime.now(UTC) + timedelta(days=7)
+
+
+class InviteContext(BaseModel):
+    """Optional admin-provided onboarding hints carried on an invite.
+
+    Both fields are optional so the admin can supply either, both, or
+    neither. ``focus`` is a one-line description of what the new member
+    will own; ``profile_pic`` is a reference (e.g. an uploaded file id)
+    to a suggested avatar. Consumed by the downstream VIP-onboarding flow.
+    """
+
+    focus: str | None = None
+    profile_pic: str | None = None
 
 
 def hash_token(plaintext: str) -> str:
@@ -42,6 +60,7 @@ class Invite(Document):
     token: str | None = None  # legacy plaintext (deprecated; nulled after migration)
     token_hash: Indexed(str, unique=True) | None = None  # type: ignore[valid-type]
     group: str | None = None
+    context: InviteContext | None = None  # optional admin onboarding hints (pp#1365)
     accepted: bool = False
     revoked: bool = False
     revoked_reason: str | None = None  # e.g. "declined" when invitee declines vs inviter-revoke

--- a/ee/pocketpaw_ee/cloud/workspace/domain.py
+++ b/ee/pocketpaw_ee/cloud/workspace/domain.py
@@ -1,6 +1,6 @@
 """Domain value objects for the workspace module.
 
-Three frozen dataclasses, no Beanie / Pydantic / FastAPI imports:
+Frozen dataclasses, no Beanie / Pydantic / FastAPI imports:
 
 - ``Workspace`` mirrors the persistence ``Workspace`` document plus a
   derived ``member_count`` that the service computes per request.
@@ -10,6 +10,8 @@ Three frozen dataclasses, no Beanie / Pydantic / FastAPI imports:
 - ``Invite`` mirrors the persistence ``Invite`` document, with
   ``expired`` precomputed at the boundary so the domain entity stays
   pure (no clock dependency baked into a property).
+- ``InviteContext`` mirrors the optional admin onboarding hints embedded
+  on the invite (pp#1365); ``Invite.context`` is None when omitted.
 """
 
 from __future__ import annotations
@@ -59,6 +61,18 @@ class VerifiedDomain:
 
 
 @dataclass(frozen=True)
+class InviteContext:
+    """Optional admin-provided onboarding hints carried on an invite.
+
+    ``focus`` is a one-line description of what the new member will own;
+    ``profile_pic`` is a reference to a suggested avatar. Both optional —
+    the downstream VIP-onboarding flow reads whatever the admin supplied."""
+
+    focus: str | None = None
+    profile_pic: str | None = None
+
+
+@dataclass(frozen=True)
 class Invite:
     """A workspace invite. ``expired`` is computed by the repository at
     read time so the domain doesn't carry a clock dependency."""
@@ -74,6 +88,7 @@ class Invite:
     revoked: bool
     expired: bool
     expires_at: datetime
+    context: InviteContext | None = None  # optional admin onboarding hints (pp#1365)
 
 
-__all__ = ["Invite", "VerifiedDomain", "Workspace", "WorkspaceMember"]
+__all__ = ["Invite", "InviteContext", "VerifiedDomain", "Workspace", "WorkspaceMember"]

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -16,7 +16,13 @@ from typing import Literal
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from pocketpaw_ee.cloud._core.time import iso_utc
-from pocketpaw_ee.cloud.workspace.domain import Invite, VerifiedDomain, Workspace, WorkspaceMember
+from pocketpaw_ee.cloud.workspace.domain import (
+    Invite,
+    InviteContext,
+    VerifiedDomain,
+    Workspace,
+    WorkspaceMember,
+)
 
 # ---------------------------------------------------------------------------
 # Requests (preserved from schemas.py)
@@ -40,10 +46,24 @@ class UpdateWorkspaceRequest(BaseModel):
     settings: dict | None = None
 
 
+class InviteContextDTO(BaseModel):
+    """Optional admin-provided onboarding hints carried on an invite (pp#1365).
+
+    The same ``{focus, profile_pic}`` shape on both the create request and the
+    invite response. ``focus`` is a one-line description of what the new member
+    will own; ``profile_pic`` is a reference (e.g. an uploaded file id) to a
+    suggested avatar. Both optional — supply either, both, or neither. Consumed
+    by the downstream VIP-onboarding flow."""
+
+    focus: str | None = Field(default=None, max_length=280)
+    profile_pic: str | None = Field(default=None, max_length=512)
+
+
 class CreateInviteRequest(BaseModel):
     email: str
     role: str = Field(default="member", pattern="^(admin|member)$")
     group_id: str | None = None
+    context: InviteContextDTO | None = None
 
 
 class UpdateMemberRoleRequest(BaseModel):
@@ -114,6 +134,7 @@ class InviteOut(BaseModel):
     revoked: bool
     expired: bool
     expiresAt: str | None  # noqa: N815 - camelCase wire key
+    context: InviteContextDTO | None = None  # optional admin onboarding hints (pp#1365)
 
     model_config = {"populate_by_name": True}
 
@@ -229,6 +250,12 @@ def member_to_dto(m: WorkspaceMember) -> MemberOut:
     )
 
 
+def _context_to_dto(ctx: InviteContext | None) -> InviteContextDTO | None:
+    if ctx is None:
+        return None
+    return InviteContextDTO(focus=ctx.focus, profile_pic=ctx.profile_pic)
+
+
 def invite_to_dto(inv: Invite) -> InviteOut:
     return InviteOut(
         id=inv.id,
@@ -240,6 +267,7 @@ def invite_to_dto(inv: Invite) -> InviteOut:
         revoked=inv.revoked,
         expired=inv.expired,
         expiresAt=iso_utc(inv.expires_at),
+        context=_context_to_dto(inv.context),
     )
 
 
@@ -265,6 +293,7 @@ def invite_to_validate_dto(inv: Invite, workspace_name: str) -> ValidateInviteOu
         revoked=inv.revoked,
         expired=inv.expired,
         expiresAt=iso_utc(inv.expires_at),
+        context=_context_to_dto(inv.context),
         valid=not (inv.accepted or inv.revoked or inv.expired),
         workspace_name=workspace_name,
     )
@@ -277,6 +306,7 @@ __all__ = [
     "BulkInviteSkip",
     "CreateInviteRequest",
     "CreateWorkspaceRequest",
+    "InviteContextDTO",
     "InviteOut",
     "InvitePreviewResponse",
     "MemberOut",

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -62,6 +62,7 @@ from pocketpaw_ee.cloud.auth import sessions as _sessions_service
 from pocketpaw_ee.cloud.models.agent import Agent as _AgentDoc
 from pocketpaw_ee.cloud.models.group import Group as _GroupDoc
 from pocketpaw_ee.cloud.models.invite import Invite as _InviteDoc
+from pocketpaw_ee.cloud.models.invite import InviteContext as _InviteContextDoc
 from pocketpaw_ee.cloud.models.invite import hash_token
 from pocketpaw_ee.cloud.models.notification import NotificationSource
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
@@ -71,11 +72,17 @@ from pocketpaw_ee.cloud.models.workspace import WorkspaceSettings
 from pocketpaw_ee.cloud.notifications import service as notifications_service
 from pocketpaw_ee.cloud.shared.events import event_bus
 from pocketpaw_ee.cloud.uploads.models import FileUpload as _FileUploadDoc
-from pocketpaw_ee.cloud.workspace.domain import Invite, Workspace, WorkspaceMember
+from pocketpaw_ee.cloud.workspace.domain import (
+    Invite,
+    InviteContext,
+    Workspace,
+    WorkspaceMember,
+)
 from pocketpaw_ee.cloud.workspace.dto import (
     BulkInviteRequest,
     CreateInviteRequest,
     CreateWorkspaceRequest,
+    InviteContextDTO,
     UpdateWorkspaceRequest,
 )
 
@@ -105,6 +112,12 @@ def _workspace_to_domain(doc: _WorkspaceDoc, *, member_count: int = 0) -> Worksp
     )
 
 
+def _context_doc_to_domain(ctx: _InviteContextDoc | None) -> InviteContext | None:
+    if ctx is None:
+        return None
+    return InviteContext(focus=ctx.focus, profile_pic=ctx.profile_pic)
+
+
 def _invite_to_domain(doc: _InviteDoc, *, plaintext_token: str | None = None) -> Invite:
     return Invite(
         id=str(doc.id),
@@ -118,6 +131,7 @@ def _invite_to_domain(doc: _InviteDoc, *, plaintext_token: str | None = None) ->
         revoked=doc.revoked,
         expired=doc.expired,
         expires_at=doc.expires_at,
+        context=_context_doc_to_domain(doc.context),
     )
 
 
@@ -647,11 +661,15 @@ async def _mint_invite_for_email(
     email: str,
     role: str,
     group_id: str | None,
+    context: InviteContextDTO | None = None,
 ) -> Invite:
     """Pre-clean expired/stale rows, reject duplicate pending, insert the
     hashed invite. Shared between ``create_invite`` (single) and
     ``bulk_create_invites`` (batch) so token hashing + pre-cleanup stay
     in lockstep. Does NOT emit or notify — the caller handles side-effects.
+
+    ``context`` is the optional admin onboarding payload (pp#1365); persisted
+    verbatim on the invite document and None when omitted.
     """
     # Mongo TTL is the long-term GC; this pre-cleanup makes the
     # collision check below honest about what's "still pending."
@@ -692,6 +710,11 @@ async def _mint_invite_for_email(
         token=None,  # plaintext never persisted for new invites
         token_hash=hash_token(plaintext),
         group=group_id,
+        context=(
+            _InviteContextDoc(focus=context.focus, profile_pic=context.profile_pic)
+            if context is not None
+            else None
+        ),
     )
     try:
         await invite_doc.insert()
@@ -728,7 +751,9 @@ async def create_invite(
     if member_count >= doc.seats:
         raise SeatLimitError(doc.seats)
 
-    invite = await _mint_invite_for_email(ctx, workspace_id, body.email, body.role, body.group_id)
+    invite = await _mint_invite_for_email(
+        ctx, workspace_id, body.email, body.role, body.group_id, body.context
+    )
 
     invited_user_id = await _find_user_id_by_email(body.email)
 

--- a/tests/cloud/workspace/test_dto.py
+++ b/tests/cloud/workspace/test_dto.py
@@ -102,7 +102,10 @@ def test_invite_dto_wire_keys() -> None:
         "revoked",
         "expired",
         "expiresAt",
+        "context",
     }
+    # No admin context on a plain invite — the key is present but null.
+    assert dump["context"] is None
 
 
 def test_invite_dto_values() -> None:

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -41,7 +41,9 @@ from pocketpaw_ee.cloud.workspace.dto import (
     BulkInviteRequest,
     CreateInviteRequest,
     CreateWorkspaceRequest,
+    InviteContextDTO,
     UpdateWorkspaceRequest,
+    invite_to_dto,
 )
 
 pytestmark = pytest.mark.usefixtures("mongo_db")
@@ -605,6 +607,119 @@ async def test_accept_invite_case_insensitive_email(mongo_db: Any, monkeypatch) 
     )
     # Should succeed — email comparison is case-insensitive.
     await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+
+# ---------------------------------------------------------------------------
+# Invite admin context — optional VIP-onboarding payload (pp#1365)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_invite_persists_admin_context(owner, monkeypatch) -> None:
+    """create_invite(...) with a context round-trips: the returned domain
+    object carries it AND the persisted row stores it."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="vip@x.c",
+            context=InviteContextDTO(focus="Owns the Q3 pricing rollout", profile_pic="file_abc"),
+        ),
+    )
+
+    # Returned domain object carries the context.
+    assert invite.context is not None
+    assert invite.context.focus == "Owns the Q3 pricing rollout"
+    assert invite.context.profile_pic == "file_abc"
+
+    # The persisted row stores it too.
+    row = await _InviteDoc.find_one(_InviteDoc.id == PydanticObjectId(invite.id))
+    assert row is not None
+    assert row.context is not None
+    assert row.context.focus == "Owns the Q3 pricing rollout"
+    assert row.context.profile_pic == "file_abc"
+
+
+async def test_create_invite_context_surfaces_on_validate_dto(owner, monkeypatch) -> None:
+    """The context survives the read path: validate_invite -> invite_to_dto
+    returns it on the wire response (the shape paw-enterprise consumes)."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="vip2@x.c",
+            context=InviteContextDTO(focus="Leads onboarding"),
+        ),
+    )
+
+    read_invite, _ws_name = await workspace_service.validate_invite(invite.token)
+    dto = invite_to_dto(read_invite)
+    assert dto.context is not None
+    assert dto.context.focus == "Leads onboarding"
+    assert dto.context.profile_pic is None
+
+
+async def test_accept_invite_context_readable(owner, resolver_mock, monkeypatch) -> None:
+    """At accept time the invite's admin context is readable for the
+    downstream VIP-onboarding flow."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    invitee = await _seed_user(email="acceptctx@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="acceptctx@x.c",
+            context=InviteContextDTO(focus="Drives the design system", profile_pic="pic_xyz"),
+        ),
+    )
+
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+    # The accepted row still carries the context — readable in the accept
+    # path / by any downstream onboarding consumer.
+    row = await _InviteDoc.find_one(_InviteDoc.id == PydanticObjectId(invite.id))
+    assert row is not None
+    assert row.accepted is True
+    assert row.context is not None
+    assert row.context.focus == "Drives the design system"
+    assert row.context.profile_pic == "pic_xyz"
+
+
+async def test_create_invite_without_context_is_unchanged(owner, monkeypatch) -> None:
+    """Omitting context behaves exactly as before — no context stored,
+    no context on the returned domain object or DTO."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="plain@x.c")
+    )
+
+    assert invite.context is None
+    assert invite_to_dto(invite).context is None
+
+    row = await _InviteDoc.find_one(_InviteDoc.id == PydanticObjectId(invite.id))
+    assert row is not None
+    assert row.context is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What ships

Workspace invites can now carry optional admin context — a one-line `focus` (what the new member will own) and a `profile_pic` reference. It's accepted on create, stored on the invite, returned on the invite response, and readable when the invite is accepted. Fully optional: omit it and invites behave exactly as before.

This is the first slice of VIP onboarding. It defines the context shape the rest of the flow reads — the personalized welcome (#368), the member's Person entity (#1366), and the agent that greets them (#1367).

## How it's wired

Threaded through the EE four-file shape: an `InviteContext` on the Beanie model, a frozen domain mirror with no Beanie import, and an `InviteContextDTO` on both the create request and the invite response, with mappers in `service.py`. `focus` and `profile_pic` are length-capped on the DTO.

## Tests

`uv run pytest tests/cloud/workspace/` — 97 passing, including 4 new tests for the round-trip (create → store → response → accept-readable) and the empty/optional path.

Heads up: 4 unrelated tests fail on this branch (`test_delete_preview_*`, `test_domains::*verify*`). I confirmed they fail the same way on a clean `dev` — pre-existing (DNS-domain verification + a delete-preview count drift), nothing to do with invites.

## Out of scope

The Fabric Person (#1366), the agent block (#1367), and the invite-modal UI (#367) — separate issues.

Closes #1365
