### PR TITLE
feat(fabric): materialize a standalone Person entity on invite accept

### DIFF
--- a/ee/pocketpaw_ee/cloud/people/__init__.py
+++ b/ee/pocketpaw_ee/cloud/people/__init__.py
@@ -1,0 +1,15 @@
+# pocketpaw_ee/cloud/people/ — the workspace-member identity spine.
+#
+# Created: 2026-06-08 (feat/vip-fabric-person, pp#1366). Materializes a
+# standalone Fabric ``Person`` object for a member on invite accept, built
+# from the member's profile + the invite's admin context, provenance-tracked.
+# Read by a later VIP-onboarding flow. STANDALONE — models identity only,
+# independent of the per-pocket agent-policy surface profile.
+#
+# No router yet: the only entry point is the service function the workspace
+# accept_invite path calls. A read API can land in a later slice.
+
+from pocketpaw_ee.cloud.people.domain import Person
+from pocketpaw_ee.cloud.people.service import materialize_person_from_invite
+
+__all__ = ["Person", "materialize_person_from_invite"]

--- a/ee/pocketpaw_ee/cloud/people/domain.py
+++ b/ee/pocketpaw_ee/cloud/people/domain.py
@@ -1,0 +1,113 @@
+# domain.py — Cloud "people" entity value objects (the identity spine).
+#
+# Created: 2026-06-08 (feat/vip-fabric-person, pp#1366) — frozen dataclass
+# describing a workspace member materialized as a standalone Fabric
+# ``Person`` object on invite accept. Tenancy (``workspace_id``) is
+# required positionally with no default, matching the ee/cloud rule that
+# the workspace tag is impossible to forget — constructing a ``Person``
+# without one is a TypeError, not a silent leak.
+#
+# STANDALONE by design: this models *identity* (who the member is), a
+# different axis from the per-pocket agent-policy surface profile
+# (``PocketSurfaceProfile`` / entity-pocket-profile work). No import of,
+# or dependency on, that surface — Person never reaches across the seam.
+#
+# The ``Person`` mirrors the property bag written into the Fabric object
+# (``FabricObject.properties``) plus the provenance fields the journal
+# event carries. It exists so callers (tests, the later VIP-onboarding
+# read) get a typed view instead of poking a raw ``dict[str, Any]``.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# The Fabric object type this entity materializes as. A stable string id
+# (not a generated one) so the journal projection groups every Person row
+# under one ``type_id`` and ``query(type_name="Person")`` is exact.
+PERSON_TYPE_ID = "person"
+PERSON_TYPE_NAME = "Person"
+
+# Provenance marker stored on every Person written from an invite's admin
+# context. Surfaced both as ``FabricObject.source_connector`` and inside
+# the property bag (``source``) so a reader that only has the projected
+# object — not the journal event — can still tell where the row came from.
+SOURCE_ADMIN_CONTEXT = "admin_context"
+
+
+@dataclass(frozen=True)
+class Person:
+    """A workspace member's identity, materialized as a Fabric ``Person``.
+
+    Tenancy is enforced at construction — ``workspace_id`` is required
+    positionally with no default. Same rule as the rest of ``ee/cloud``.
+
+    Identity fields come from the member's own profile; onboarding fields
+    (``focus`` / ``profile_pic``) and ``role`` / ``group`` come from the
+    inviting admin's context. ``invited_by`` + ``source`` record the
+    provenance so the later VIP-onboarding flow knows the row was seeded
+    by an admin, not self-authored.
+
+    Fields:
+      * ``id`` — the Fabric object id. Deterministic
+        (``person-{workspace_id}-{user_id}``) so re-materializing the same
+        member updates the existing object instead of minting a duplicate.
+      * ``workspace_id`` — owning workspace. Tagged at construction.
+      * ``user_id`` — the member's cloud user id. The stable external key
+        the materializer keys idempotency off.
+      * ``name`` / ``email`` / ``avatar`` — from the member's own profile.
+      * ``role`` — workspace role from the invite (``member`` / ``admin``).
+      * ``group`` — team / group id from the invite. ``None`` when the
+        invite carried no group.
+      * ``focus`` — one-line "what they'll own", from the invite's admin
+        context. Empty string when the admin supplied none.
+      * ``profile_pic`` — suggested avatar reference, from the invite's
+        admin context. Empty string when the admin supplied none.
+      * ``invited_by`` — user id of the admin who sent the invite
+        (provenance).
+      * ``source`` — provenance marker; always ``admin_context`` for
+        invite-materialized people.
+    """
+
+    id: str
+    workspace_id: str
+    user_id: str
+    name: str
+    email: str
+    avatar: str
+    role: str
+    group: str | None
+    focus: str
+    profile_pic: str
+    invited_by: str
+    source: str = SOURCE_ADMIN_CONTEXT
+
+    def to_properties(self) -> dict[str, str | None]:
+        """Project the identity + provenance fields into the property bag
+        stored on ``FabricObject.properties``.
+
+        ``id`` / ``workspace_id`` are intentionally NOT duplicated into the
+        bag: the id is the object's own id, and the workspace is carried by
+        the journal event's scope (the canonical tenancy source). Folding
+        them into properties too would create two places to keep in sync.
+        """
+
+        return {
+            "user_id": self.user_id,
+            "name": self.name,
+            "email": self.email,
+            "avatar": self.avatar,
+            "role": self.role,
+            "group": self.group,
+            "focus": self.focus,
+            "profile_pic": self.profile_pic,
+            "invited_by": self.invited_by,
+            "source": self.source,
+        }
+
+
+__all__ = [
+    "PERSON_TYPE_ID",
+    "PERSON_TYPE_NAME",
+    "SOURCE_ADMIN_CONTEXT",
+    "Person",
+]

--- a/ee/pocketpaw_ee/cloud/people/service.py
+++ b/ee/pocketpaw_ee/cloud/people/service.py
@@ -1,0 +1,237 @@
+"""People domain — materialize a workspace member as a Fabric ``Person``.
+
+Created: 2026-06-08 (feat/vip-fabric-person, pp#1366).
+
+When a workspace invite is accepted, ``accept_invite`` calls
+:func:`materialize_person_from_invite` to create (or update) a standalone
+Fabric ``Person`` object for the new member. The object is the identity
+"spine" a later VIP-onboarding flow reads.
+
+Write path — the journal, not the legacy SQLite store
+-----------------------------------------------------
+
+Object lifecycle goes through :class:`FabricJournalStore` (the Wave 3 /
+Org Architecture path), not the legacy ``FabricStore``. Two reasons:
+
+1. It is the blessed object path — ``pocketpaw.fabric``'s own ``__init__``
+   defers object lifecycle + scope-filtered queries to the journal store.
+2. Provenance and tenancy are native there. The inviting admin becomes the
+   journal ``Actor``; the workspace becomes the event ``scope``; and the
+   ``fabric.object.created`` / ``fabric.object.updated`` events ARE the
+   emit-on-write (the decisions subsystem already folds them) — so this
+   module needs no separate cloud realtime event.
+
+Idempotency
+-----------
+
+The Fabric object id is deterministic — ``person-{workspace_id}-{user_id}``
+— so re-accepting (or otherwise re-materializing) the same member UPDATES
+the existing object rather than minting a duplicate. The materializer
+queries the projection for that id first: present → ``update``, absent →
+``create``. The journal projection also overwrites by object id on replay,
+so even a stray duplicate ``created`` event would not produce two rows.
+
+STANDALONE
+----------
+
+This models identity only. It does NOT import or depend on the per-pocket
+agent-policy surface profile (``PocketSurfaceProfile`` / entity-pocket
+work) — that is a different axis. Keep them separate.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+from soul_protocol.spec.journal import Actor
+
+from pocketpaw.fabric.journal_store import FabricJournalStore
+from pocketpaw.fabric.models import FabricObject, FabricQuery
+from pocketpaw_ee.cloud.people.domain import (
+    PERSON_TYPE_ID,
+    PERSON_TYPE_NAME,
+    SOURCE_ADMIN_CONTEXT,
+    Person,
+)
+from pocketpaw_ee.cloud.workspace.domain import Invite
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Journal-backed store accessor
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _default_store() -> FabricJournalStore:
+    """Build the process-wide ``FabricJournalStore`` over the org journal.
+
+    Lazily imports ``get_journal`` (the same dependency the decisions +
+    pockets paths use) so importing this module doesn't drag the journal
+    open in test / smoke contexts that never materialize a Person. The
+    store is cached for the life of the process; ``bootstrap()`` warms the
+    projection from genesis so a read-after-write sees prior rows.
+
+    Tests override the store by passing ``store=`` to
+    :func:`materialize_person_from_invite`; they should not poke this cache.
+    """
+
+    from pocketpaw.journal_dep import get_journal
+
+    store = FabricJournalStore(get_journal())
+    store.bootstrap()
+    return store
+
+
+def _person_object_id(workspace_id: str, user_id: str) -> str:
+    """Deterministic Fabric object id for a member's Person.
+
+    Stable across re-accepts so materialization is an upsert keyed on
+    ``(workspace_id, user_id)`` rather than a fresh insert each time.
+    """
+
+    return f"person-{workspace_id}-{user_id}"
+
+
+def _person_scope(workspace_id: str) -> list[str]:
+    """Journal scope for a Person write.
+
+    A single workspace-rooted scope string (matching ``ScopeKind.WORKSPACE``
+    = ``"workspace"``). The journal's EventEntry invariant requires a
+    non-empty scope, and tenancy is enforced by this list — a query scoped
+    to one workspace never sees another's people.
+    """
+
+    return [f"workspace:{workspace_id}"]
+
+
+# ---------------------------------------------------------------------------
+# Materialization
+# ---------------------------------------------------------------------------
+
+
+def _build_person(
+    *,
+    workspace_id: str,
+    user_id: str,
+    name: str,
+    email: str,
+    avatar: str,
+    invite: Invite,
+) -> Person:
+    """Assemble the :class:`Person` from member profile + invite context.
+
+    Identity fields (``name`` / ``email`` / ``avatar``) come from the
+    member's own profile. ``role`` / ``group`` and the onboarding fields
+    (``focus`` / ``profile_pic``) come from the invite. When
+    ``invite.context`` is ``None`` the onboarding fields fall back to empty
+    strings — the Person is still created from the available identity.
+    """
+
+    # ``context`` is None when the admin supplied no onboarding hints; even
+    # when present, ``focus`` / ``profile_pic`` are individually optional.
+    # Either way the Person is still created — the onboarding fields just
+    # fall back to empty strings.
+    context = invite.context
+    focus = context.focus if context and context.focus else ""
+    profile_pic = context.profile_pic if context and context.profile_pic else ""
+
+    return Person(
+        id=_person_object_id(workspace_id, user_id),
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=name,
+        email=email,
+        avatar=avatar,
+        role=invite.role,
+        group=invite.group_id,
+        focus=focus,
+        profile_pic=profile_pic,
+        invited_by=invite.invited_by,
+        source=SOURCE_ADMIN_CONTEXT,
+    )
+
+
+async def materialize_person_from_invite(
+    *,
+    workspace_id: str,
+    user_id: str,
+    name: str,
+    email: str,
+    avatar: str,
+    invite: Invite,
+    store: FabricJournalStore | None = None,
+) -> Person:
+    """Create or update the standalone Fabric ``Person`` for a new member.
+
+    Called from ``accept_invite`` after the membership is written. Builds a
+    :class:`Person` from the member's profile (``name`` / ``email`` /
+    ``avatar``) plus the invite's admin context (``role`` / ``group`` /
+    ``focus`` / ``profile_pic``), records provenance (``invited_by`` +
+    ``source=admin_context``), and writes it to the Fabric journal under a
+    workspace-scoped event attributed to the inviting admin.
+
+    Idempotent: the object id is deterministic, so a second call for the
+    same member UPDATES the existing object — never a duplicate.
+
+    ``store`` is injectable for tests; production callers omit it and get
+    the process-wide journal-backed store.
+
+    Returns the materialized :class:`Person` (the caller's view; the
+    journal write is fire-and-confirm via the projection).
+    """
+
+    fabric = store if store is not None else _default_store()
+    person = _build_person(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=name,
+        email=email,
+        avatar=avatar,
+        invite=invite,
+    )
+    scope = _person_scope(workspace_id)
+
+    # Provenance: the inviting admin is the journal Actor. The scope_context
+    # mirrors the write scope so the recorded actor identity carries the
+    # same tenancy bound as the event.
+    actor = Actor(
+        kind="user",
+        id=f"user:{person.invited_by}",
+        scope_context=list(scope),
+    )
+
+    properties = person.to_properties()
+
+    # Idempotency probe: is this member already materialized? Query the
+    # projection for the Person type and look for our deterministic id.
+    existing = await fabric.query(
+        FabricQuery(type_id=PERSON_TYPE_ID, limit=10_000),
+        requester_scopes=scope,
+    )
+    already = any(obj.id == person.id for obj in existing.objects)
+
+    if already:
+        # Update merges onto existing properties — every field we write is
+        # supplied here, so a changed profile / context overwrites cleanly.
+        await fabric.update(person.id, properties, scope=scope, actor=actor)
+    else:
+        obj = FabricObject(
+            id=person.id,
+            type_id=PERSON_TYPE_ID,
+            type_name=PERSON_TYPE_NAME,
+            properties=properties,
+            # Native Fabric provenance, in addition to the property-bag
+            # copy: source_connector flags the origin, source_id is the
+            # member's user id (the external key this row tracks).
+            source_connector=SOURCE_ADMIN_CONTEXT,
+            source_id=user_id,
+        )
+        await fabric.create(obj, scope=scope, actor=actor)
+
+    return person
+
+
+__all__ = ["materialize_person_from_invite"]

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -70,6 +70,7 @@ from pocketpaw_ee.cloud.models.user import WorkspaceMembership as _Membership
 from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
 from pocketpaw_ee.cloud.models.workspace import WorkspaceSettings
 from pocketpaw_ee.cloud.notifications import service as notifications_service
+from pocketpaw_ee.cloud.people import service as people_service
 from pocketpaw_ee.cloud.shared.events import event_bus
 from pocketpaw_ee.cloud.uploads.models import FileUpload as _FileUploadDoc
 from pocketpaw_ee.cloud.workspace.domain import (
@@ -1021,6 +1022,33 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
             ctx.user_id,
             role=invite.role,
             set_active=True,
+        )
+
+    # Materialize the member as a standalone Fabric ``Person`` — the
+    # identity spine a later VIP-onboarding flow reads (pp#1366). Built
+    # from the member's own profile + the invite's admin context, with
+    # provenance (invited_by + source=admin_context). Idempotent on the
+    # member's user id, so re-accepting updates rather than duplicating.
+    # The journal ``fabric.object.*`` event is the emit-on-write here.
+    # Wrapped defensively: membership is the source of truth, the Person
+    # is a derived projection — a Fabric/journal hiccup must not roll back
+    # an accepted invite.
+    try:
+        await people_service.materialize_person_from_invite(
+            workspace_id=invite.workspace_id,
+            user_id=ctx.user_id,
+            name=viewer.full_name,
+            email=viewer.email or invite.email,
+            avatar=viewer.avatar,
+            invite=invite,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Fabric Person materialization skipped for user=%s workspace=%s — "
+            "invite accept proceeds; the Person can be re-materialized later",
+            ctx.user_id,
+            invite.workspace_id,
+            exc_info=True,
         )
 
     await event_bus.emit(

--- a/tests/cloud/people/__init__.py
+++ b/tests/cloud/people/__init__.py
@@ -1,0 +1,2 @@
+# tests/cloud/people/ — coverage for the workspace-member identity spine.
+# Created: 2026-06-08 (feat/vip-fabric-person, pp#1366).

--- a/tests/cloud/people/test_materialize_person.py
+++ b/tests/cloud/people/test_materialize_person.py
@@ -1,0 +1,295 @@
+# tests/cloud/people/test_materialize_person.py — Fabric Person materialization.
+# Created: 2026-06-08 (feat/vip-fabric-person, pp#1366).
+#
+# Locks the contract for materialize_person_from_invite (the people service):
+#   1. Accept → a typed Fabric Person exists with the expected fields, drawn
+#      from the member's profile + the invite's admin context.
+#   2. Provenance — invited_by + source=admin_context, recorded both in the
+#      property bag and as the journal Actor / FabricObject.source_*.
+#   3. Idempotent — a second materialize for the same member UPDATES the
+#      existing Person (no duplicate row); changed context is reflected.
+#   4. No-context invite — still creates a Person from the identity fields,
+#      with focus / profile_pic empty.
+#
+# Uses a throwaway FabricJournalStore over a tmp journal (same fixture shape
+# as tests/ee/test_fabric_journal.py) injected via the service's ``store=``
+# arg — no real org journal, no Mongo needed for these unit-level checks.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud.people.domain import (
+    PERSON_TYPE_ID,
+    PERSON_TYPE_NAME,
+    SOURCE_ADMIN_CONTEXT,
+)
+from pocketpaw_ee.cloud.people.service import materialize_person_from_invite
+from pocketpaw_ee.cloud.workspace.domain import Invite, InviteContext
+from soul_protocol.engine.journal import open_journal
+
+from pocketpaw.fabric.events import ACTION_OBJECT_CREATED, ACTION_OBJECT_UPDATED
+from pocketpaw.fabric.journal_store import FabricJournalStore
+from pocketpaw.fabric.models import FabricQuery
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+@pytest.fixture
+def store(journal) -> FabricJournalStore:
+    s = FabricJournalStore(journal)
+    s.bootstrap()
+    return s
+
+
+def _invite(
+    *,
+    workspace_id: str = "ws1",
+    email: str = "member@x.c",
+    role: str = "member",
+    invited_by: str = "admin1",
+    group_id: str | None = "team-eng",
+    context: InviteContext | None = None,
+) -> Invite:
+    return Invite(
+        id="inv1",
+        workspace_id=workspace_id,
+        email=email,
+        role=role,
+        invited_by=invited_by,
+        token=None,
+        group_id=group_id,
+        accepted=True,
+        revoked=False,
+        expired=False,
+        expires_at=datetime.now(UTC),
+        context=context,
+    )
+
+
+async def _all_people(store: FabricJournalStore) -> list:
+    result = await store.query(
+        FabricQuery(type_id=PERSON_TYPE_ID, limit=10_000),
+        requester_scopes=None,
+    )
+    return result.objects
+
+
+# ---------------------------------------------------------------------------
+# 1. Accept → Person exists with the expected fields
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeCreatesPerson:
+    @pytest.mark.asyncio
+    async def test_person_holds_identity_and_context_fields(
+        self, store: FabricJournalStore
+    ) -> None:
+        invite = _invite(
+            context=InviteContext(focus="Own the billing rewrite", profile_pic="file-42"),
+        )
+
+        person = await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada Lovelace",
+            email="member@x.c",
+            avatar="https://cdn/ada.png",
+            invite=invite,
+            store=store,
+        )
+
+        # Returned typed view.
+        assert person.id == "person-ws1-user-7"
+        assert person.workspace_id == "ws1"
+        assert person.user_id == "user-7"
+
+        # Persisted Fabric object.
+        people = await _all_people(store)
+        assert len(people) == 1
+        obj = people[0]
+        assert obj.id == "person-ws1-user-7"
+        assert obj.type_id == PERSON_TYPE_ID
+        assert obj.type_name == PERSON_TYPE_NAME
+
+        props = obj.properties
+        # Identity — from the member's own profile.
+        assert props["name"] == "Ada Lovelace"
+        assert props["email"] == "member@x.c"
+        assert props["avatar"] == "https://cdn/ada.png"
+        # Role + group + onboarding — from the invite / admin context.
+        assert props["role"] == "member"
+        assert props["group"] == "team-eng"
+        assert props["focus"] == "Own the billing rewrite"
+        assert props["profile_pic"] == "file-42"
+
+    @pytest.mark.asyncio
+    async def test_person_is_queryable_by_type_name(self, store: FabricJournalStore) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(),
+            store=store,
+        )
+
+        by_name = await store.query(
+            FabricQuery(type_name=PERSON_TYPE_NAME, limit=10),
+            requester_scopes=None,
+        )
+        assert by_name.total == 1
+        assert by_name.objects[0].properties["name"] == "Ada"
+
+
+# ---------------------------------------------------------------------------
+# 2. Provenance — invited_by + source=admin_context
+# ---------------------------------------------------------------------------
+
+
+class TestProvenance:
+    @pytest.mark.asyncio
+    async def test_provenance_in_property_bag_and_object(self, store: FabricJournalStore) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(invited_by="admin-99"),
+            store=store,
+        )
+
+        obj = (await _all_people(store))[0]
+        # Property-bag provenance (readable from the projected object alone).
+        assert obj.properties["invited_by"] == "admin-99"
+        assert obj.properties["source"] == SOURCE_ADMIN_CONTEXT
+        # Native Fabric provenance fields.
+        assert obj.source_connector == SOURCE_ADMIN_CONTEXT
+        assert obj.source_id == "user-7"
+
+    @pytest.mark.asyncio
+    async def test_journal_actor_is_the_inviting_admin(
+        self, store: FabricJournalStore, journal
+    ) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(invited_by="admin-99"),
+            store=store,
+        )
+
+        events = journal.query(action=ACTION_OBJECT_CREATED)
+        assert len(events) == 1
+        assert events[0].actor.kind == "user"
+        assert events[0].actor.id == "user:admin-99"
+        # Tenancy: the write scope is the workspace, not global.
+        assert events[0].scope == ["workspace:ws1"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotent — re-materialize updates, never duplicates
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotent:
+    @pytest.mark.asyncio
+    async def test_second_call_updates_no_duplicate(self, store: FabricJournalStore) -> None:
+        first = _invite(context=InviteContext(focus="Initial focus", profile_pic="pic-1"))
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="av-1",
+            invite=first,
+            store=store,
+        )
+
+        # Re-accept with a changed profile + context.
+        second = _invite(
+            role="admin",
+            context=InviteContext(focus="Revised focus", profile_pic="pic-2"),
+        )
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada L.",
+            email="member@x.c",
+            avatar="av-2",
+            invite=second,
+            store=store,
+        )
+
+        people = await _all_people(store)
+        assert len(people) == 1  # NOT two — same deterministic id.
+        props = people[0].properties
+        assert props["name"] == "Ada L."
+        assert props["avatar"] == "av-2"
+        assert props["role"] == "admin"
+        assert props["focus"] == "Revised focus"
+        assert props["profile_pic"] == "pic-2"
+
+    @pytest.mark.asyncio
+    async def test_second_call_emits_update_event(self, store: FabricJournalStore, journal) -> None:
+        for _ in range(2):
+            await materialize_person_from_invite(
+                workspace_id="ws1",
+                user_id="user-7",
+                name="Ada",
+                email="member@x.c",
+                avatar="",
+                invite=_invite(),
+                store=store,
+            )
+
+        created = journal.query(action=ACTION_OBJECT_CREATED)
+        updated = journal.query(action=ACTION_OBJECT_UPDATED)
+        # Exactly one create, the rest are updates — never two creates.
+        assert len(created) == 1
+        assert len(updated) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. No-context invite — still creates a Person, focus/pic empty
+# ---------------------------------------------------------------------------
+
+
+class TestNoContext:
+    @pytest.mark.asyncio
+    async def test_none_context_creates_person_with_empty_onboarding(
+        self, store: FabricJournalStore
+    ) -> None:
+        invite = _invite(context=None, group_id=None)
+
+        person = await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="av",
+            invite=invite,
+            store=store,
+        )
+
+        assert person.focus == ""
+        assert person.profile_pic == ""
+
+        obj = (await _all_people(store))[0]
+        assert obj.properties["name"] == "Ada"
+        assert obj.properties["focus"] == ""
+        assert obj.properties["profile_pic"] == ""
+        assert obj.properties["group"] is None
+        # Provenance still recorded even with no context.
+        assert obj.properties["source"] == SOURCE_ADMIN_CONTEXT

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -36,6 +36,8 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 )
 from pocketpaw_ee.cloud.models.invite import Invite as _InviteDoc
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.people import service as people_service
+from pocketpaw_ee.cloud.people.domain import PERSON_TYPE_ID, SOURCE_ADMIN_CONTEXT
 from pocketpaw_ee.cloud.workspace import service as workspace_service
 from pocketpaw_ee.cloud.workspace.dto import (
     BulkInviteRequest,
@@ -101,6 +103,35 @@ def resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
 @pytest.fixture
 async def owner() -> _UserDoc:
     return await _seed_user(email="owner@x.c", full_name="Owner")
+
+
+@pytest.fixture
+def person_store(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Inject a throwaway journal-backed FabricJournalStore into the people
+    service so accept_invite materializes the Person against an isolated
+    tmp journal instead of opening the real org journal at ~/.soul/.
+    Returns the store so tests can read back the materialized Person.
+    """
+    from soul_protocol.engine.journal import open_journal
+
+    from pocketpaw.fabric.journal_store import FabricJournalStore
+
+    journal = open_journal(tmp_path / "people_journal.db")
+    store = FabricJournalStore(journal)
+    store.bootstrap()
+    monkeypatch.setattr(people_service, "_default_store", lambda: store)
+    yield store
+    journal.close()
+
+
+async def _materialized_people(store) -> list:
+    from pocketpaw.fabric.models import FabricQuery
+
+    result = await store.query(
+        FabricQuery(type_id=PERSON_TYPE_ID, limit=10_000),
+        requester_scopes=None,
+    )
+    return result.objects
 
 
 # ---------------------------------------------------------------------------
@@ -699,6 +730,169 @@ async def test_accept_invite_context_readable(owner, resolver_mock, monkeypatch)
     assert row.context is not None
     assert row.context.focus == "Drives the design system"
     assert row.context.profile_pic == "pic_xyz"
+
+
+# ---------------------------------------------------------------------------
+# accept_invite → Fabric Person materialization (pp#1366)
+# ---------------------------------------------------------------------------
+
+
+async def test_accept_invite_materializes_person(
+    owner, resolver_mock, person_store, monkeypatch
+) -> None:
+    """Accepting an invite materializes a standalone Fabric Person holding
+    the member's identity + the invite's admin context, provenance-tracked."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    invitee = await _seed_user(email="newhire@x.c", full_name="New Hire")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="newhire@x.c",
+            role="admin",
+            context=InviteContextDTO(focus="Owns onboarding", profile_pic="pic_42"),
+        ),
+    )
+
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+    people = await _materialized_people(person_store)
+    assert len(people) == 1
+    obj = people[0]
+    assert obj.id == f"person-{ws.id}-{invitee.id}"
+    props = obj.properties
+    # Identity — from the member's own profile.
+    assert props["name"] == "New Hire"
+    assert props["email"] == "newhire@x.c"
+    # Role + onboarding — from the invite's admin context.
+    assert props["role"] == "admin"
+    assert props["focus"] == "Owns onboarding"
+    assert props["profile_pic"] == "pic_42"
+    # Provenance.
+    assert props["invited_by"] == str(owner.id)
+    assert props["source"] == SOURCE_ADMIN_CONTEXT
+    assert obj.source_connector == SOURCE_ADMIN_CONTEXT
+    assert obj.source_id == str(invitee.id)
+
+
+async def test_accept_invite_no_context_still_materializes_person(
+    owner, resolver_mock, person_store, monkeypatch
+) -> None:
+    """An invite with no admin context still produces a Person from the
+    member's identity — focus / profile_pic just empty."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    invitee = await _seed_user(email="plainhire@x.c", full_name="Plain Hire")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="B", slug="b")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="plainhire@x.c")
+    )
+
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+    people = await _materialized_people(person_store)
+    assert len(people) == 1
+    props = people[0].properties
+    assert props["name"] == "Plain Hire"
+    assert props["focus"] == ""
+    assert props["profile_pic"] == ""
+    assert props["source"] == SOURCE_ADMIN_CONTEXT
+
+
+async def test_accept_invite_person_is_idempotent_no_duplicate(
+    owner, resolver_mock, person_store, monkeypatch
+) -> None:
+    """Re-materializing the same member (e.g. a second invite + accept)
+    UPDATES the existing Person — one row, never a duplicate."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    invitee = await _seed_user(email="dup@x.c", full_name="Dup User")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="C", slug="c")
+    )
+
+    # First invite + accept.
+    invite1 = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="dup@x.c",
+            context=InviteContextDTO(focus="First focus"),
+        ),
+    )
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite1.token)
+
+    # Re-materialize directly with a revised invite context (same member /
+    # workspace) — simulates a re-run of the onboarding flow. Going through
+    # accept_invite a second time would 409 on the consumed token, so this
+    # exercises the materializer's upsert path head-on.
+    from pocketpaw_ee.cloud.workspace.domain import Invite, InviteContext
+
+    revised = Invite(
+        id=invite1.id,
+        workspace_id=ws.id,
+        email="dup@x.c",
+        role="member",
+        invited_by=str(owner.id),
+        token=None,
+        group_id=None,
+        accepted=True,
+        revoked=False,
+        expired=False,
+        expires_at=datetime.now(UTC),
+        context=InviteContext(focus="Second focus"),
+    )
+    await people_service.materialize_person_from_invite(
+        workspace_id=ws.id,
+        user_id=str(invitee.id),
+        name="Dup User",
+        email="dup@x.c",
+        avatar="",
+        invite=revised,
+    )
+
+    people = await _materialized_people(person_store)
+    assert len(people) == 1  # still one — not duplicated.
+    assert people[0].properties["focus"] == "Second focus"
+
+
+async def test_accept_invite_survives_person_materialization_failure(
+    owner, resolver_mock, monkeypatch
+) -> None:
+    """A Fabric/journal hiccup during materialization must NOT roll back an
+    accepted invite — membership is the source of truth."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+
+    async def _boom(**_kwargs):
+        raise RuntimeError("journal exploded")
+
+    monkeypatch.setattr(people_service, "materialize_person_from_invite", _boom)
+
+    invitee = await _seed_user(email="resilient@x.c", full_name="Resilient")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="D", slug="d")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="resilient@x.c")
+    )
+
+    # Should not raise despite the materialization failure.
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+    refreshed = await _UserDoc.get(invitee.id)
+    assert refreshed is not None
+    assert any(m.workspace == ws.id for m in refreshed.workspaces)
 
 
 async def test_create_invite_without_context_is_unchanged(owner, monkeypatch) -> None:


### PR DESCRIPTION
## What ships

Accepting a workspace invite now materializes a standalone Fabric `Person` for the new member — the identity "spine" the VIP-onboarding flow reads. It's built from the member's own profile (name, email, avatar) plus the inviting admin's context (role, team, focus, suggested pic), with provenance recorded (who invited them, and that it was admin-seeded).

## How it's wired

A new `ee/cloud/people` module (a frozen `Person` domain + a materializer service). Writes go through the Fabric journal store, not the legacy SQLite store — that's the blessed object-lifecycle path, it's natively multi-tenant via the event scope, and the `fabric.object.*` events are the emit-on-write. The object id is deterministic (`person-{workspace}-{user}`), so re-accepting updates the existing Person rather than duplicating it. The materialize call in `accept_invite` is wrapped defensively: a journal hiccup never rolls back the accepted invite — the Person can be re-materialized later.

Standalone by design — it models identity, a different axis from the per-pocket `PocketSurfaceProfile` / entity-profile work. No import, no dependency.

## Tests

`uv run pytest tests/cloud/people/ tests/cloud/workspace/` — 108 passing, including 11 new (7 materializer unit tests + 4 accept-path: create-with-fields, idempotent-no-dup, no-context-still-creates, survives-materialization-failure). The 4 failing tests are the pre-existing `delete_preview` / `domains-verify` ones, unrelated to invites (same on a clean dev).

## Follow-ups (next slices, not this PR)

- No read API yet — the member-facing read surface (so the welcome can show the context) lands with the wave-3 work.
- C4: this adds a small `people` module under ee/cloud; I'll fold the C4 regen into the feature's final pass rather than per-slice.

## Stacked

This branches off `feat/vip-invite-context` (#1368) since it reads the new invite `context` field, so the diff shows only the Person changes. When #1368 merges, **merge it with `--rebase`** (not squash) so this stays clean — then this rebases onto dev.

Closes #1366
