### PR TITLE
feat(workspace): surface admin context on the invite preview

### DIFF
--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -224,6 +224,10 @@ class InvitePreviewResponse(BaseModel):
     group: str | None = None
     group_name: str | None = None
     viewer_email: str | None = None
+    # Optional admin onboarding hints (pp#1365), surfaced on ready_* previews so
+    # the member-facing accept UI can carry focus + profile_pic into the
+    # downstream VIP-onboarding welcome. None/absent when the invite has none.
+    context: InviteContextDTO | None = None
 
 
 def workspace_to_dto(ws: Workspace) -> WorkspaceOut:

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -926,6 +926,18 @@ async def preview_invite(token: str, viewer_user_id: str | None) -> dict:
             else:
                 state = "ready_wrong_user"
 
+    # Surface the admin onboarding context (pp#1365) so the member-facing
+    # accept UI can carry the invitee's focus + profile_pic into the
+    # downstream VIP-onboarding welcome. None when the invite has no context.
+    context_domain = _context_doc_to_domain(invite_doc.context)
+    context_wire = (
+        InviteContextDTO(
+            focus=context_domain.focus, profile_pic=context_domain.profile_pic
+        ).model_dump()
+        if context_domain is not None
+        else None
+    )
+
     return {
         "state": state,
         "email": invite_doc.email,
@@ -934,6 +946,7 @@ async def preview_invite(token: str, viewer_user_id: str | None) -> dict:
         "group": invite_doc.group,
         "group_name": None,
         "viewer_email": viewer_email,
+        "context": context_wire,
     }
 
 

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -830,6 +830,52 @@ async def test_preview_invite_revoked_expired_accepted(
     assert out["email"] == "acc@x.c"
 
 
+async def test_preview_invite_surfaces_admin_context(owner, monkeypatch) -> None:
+    """preview_invite exposes the invite's admin context to the member-facing
+    accept UI so the downstream VIP-onboarding flow can carry the invitee's
+    focus + profile_pic forward (pp#1365)."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="VP", slug="vp")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="vippreview@x.c",
+            context=InviteContextDTO(focus="Owns the launch checklist", profile_pic="file_vip"),
+        ),
+    )
+
+    out = await workspace_service.preview_invite(invite.token, viewer_user_id=None)
+    assert out["state"] == "ready_new"
+    assert out["context"] is not None
+    assert out["context"]["focus"] == "Owns the launch checklist"
+    assert out["context"]["profile_pic"] == "file_vip"
+
+
+async def test_preview_invite_no_context_is_absent(owner, monkeypatch) -> None:
+    """An invite minted without admin context previews with context None —
+    no regression to the existing preview shape for the common case."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="VN", slug="vn")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(email="plainpreview@x.c", role="member"),
+    )
+
+    out = await workspace_service.preview_invite(invite.token, viewer_user_id=None)
+    assert out["state"] == "ready_new"
+    assert out["context"] is None
+
+
 async def test_create_invite_cleans_up_expired_rows(owner, monkeypatch) -> None:
     """A previously-expired invite must not block a fresh invite to the same email."""
     monkeypatch.setattr(


### PR DESCRIPTION
## What ships

The invite preview (`GET /workspaces/invites/{token}/preview`) now surfaces the admin's `context { focus, profile_pic }` on the ready states, so the member-facing accept → welcome flow can carry the invitee's focus + suggested pic forward (the invite itself is consumed at accept). Null when the invite has no admin context.

## Why

The member welcome (#368) needs `focus`/`pic` at welcome time, but the invite is gone by then. The frontend already calls preview before accepting — this is the cleanest place to surface it. It's the enabling slice for #368 and #369 (flagged as a follow-up in #1369).

## How

Reuses the existing `InviteContextDTO` (from #1365) on `InvitePreviewResponse`, mapped from the invite in `preview_invite`. Scoped to the `ready_*` states — the terminal states (expired / revoked / already_accepted / not_found) keep their minimal shape, consistent with how they already omit role / workspace_name.

## Tests

2 new tests (preview surfaces context; no-context is absent), written test-first (RED `KeyError: 'context'` → GREEN). `uv run pytest tests/cloud/workspace/` — 99 passing; the 4 failures are the pre-existing `delete_preview` / `domains-verify` ones, unrelated to invites.

## Stacked

Branches off `feat/vip-invite-context` (#1368) since it needs the invite `context` field — a sibling of #1369. Merge **#1368 first with `--rebase`**, then this rebases onto dev.
