### PR TITLE
feat(plugins): register a plugin's MCP servers on install

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -289,21 +289,49 @@ the 2 MB cap, the document is unparseable, or it carries no `paths`
 object. Every install is audit-logged with the workspace, the actor, and
 the resulting slug — never the spec contents.
 
-## Plugins — Install a `.claude-plugin`'s Skills
+## Plugins — Install a `.claude-plugin`'s Skills and MCP Servers
 
 PocketPaw adopts the `.claude-plugin` standard so a whole plugin's skills
-install in one step. This endpoint clones a GitHub repo, reads its
-`.claude-plugin/plugin.json`, copies each `skills/<name>/SKILL.md`
-directory into the skill loader path, reloads the loader, and records the
-install in a registry at `~/.pocketpaw/plugins.json`.
+and MCP servers install in one step. This endpoint clones a GitHub repo,
+reads its `.claude-plugin/plugin.json`, copies each `skills/<name>/SKILL.md`
+directory into the skill loader path, reloads the loader, registers and
+starts any MCP servers the bundle declares, and records the install in a
+registry at `~/.pocketpaw/plugins.json`.
 
-> Scope note: this slice installs **skills only**. A plugin's MCP servers
-> and the list/remove surface ship in follow-up endpoints.
+### MCP servers
+
+After the skills step, the installer reads the bundle's MCP config — a
+`.mcp.json` file at the plugin root in the standard
+`{"mcpServers": {name: spec}}` shape (a manifest `mcp_servers` path
+override is honoured if present). When there is no MCP config the step is
+recorded as `skipped`; it never fails the install.
+
+Each declared server is mapped to a PocketPaw MCP server config:
+`command`, `args`, and `env` carry over directly, and `transport` is
+derived from the spec's `type` (`stdio` is the default; `http`, `sse`, and
+`streamable-http` map through). To avoid cross-plugin collisions the
+registered name is namespaced as `plugin:<plugin_name>:<server_name>`.
+
+Every server is registered and started through the MCP manager — one step
+per server:
+
+- **`succeeded`** — the server started, **or** it registered but couldn't
+  start because it's missing required env. The latter is non-fatal and
+  carries a `needs env: KEY` detail so the operator knows to supply the
+  credential; the server is still recorded as installed.
+- **`failed`** — the server failed to start for any other reason.
+
+The namespaced server names appear in the registry entry under
+`mcp_servers` and on the report's `installed_mcp_servers`.
+
+> Scope note: this slice installs **skills and MCP servers**. The
+> list/remove surface ships in a follow-up endpoint.
 
 ### `POST /plugins/install`
 
-Install a plugin's skills from a GitHub source. Requires the **admin**
-scope — installing skills changes workspace-wide agent behaviour.
+Install a plugin's skills and MCP servers from a GitHub source. Requires
+the **admin** scope — installing a plugin changes workspace-wide agent
+behaviour.
 
 Request body:
 
@@ -314,7 +342,8 @@ Request body:
 `source` accepts `owner/repo`, `owner/repo/subdir` (when the plugin lives
 in a subdirectory), or a full GitHub URL (a `/tree/<ref>/<subdir>` path is
 honoured). The repo (or subdir) must contain a `.claude-plugin/plugin.json`
-manifest and at least one `skills/<name>/SKILL.md`.
+manifest and at least one `skills/<name>/SKILL.md`. An MCP `.mcp.json` is
+optional.
 
 Response `200` — a step-by-step install report:
 
@@ -326,20 +355,24 @@ Response `200` — a step-by-step install report:
     { "name": "read_manifest", "status": "succeeded", "detail": "my-plugin v1.2.3" },
     { "name": "skill:alpha", "status": "succeeded", "detail": "" },
     { "name": "reload_loader", "status": "succeeded", "detail": "" },
+    { "name": "mcp:weather", "status": "succeeded", "detail": "" },
+    { "name": "mcp:db", "status": "succeeded", "detail": "needs env: DB_URL" },
     { "name": "record_registry", "status": "succeeded", "detail": "" }
   ],
-  "installed_skills": ["alpha"]
+  "installed_skills": ["alpha"],
+  "installed_mcp_servers": ["plugin:my-plugin:weather", "plugin:my-plugin:db"]
 }
 ```
 
 Each unit of work is a step with status `succeeded` / `skipped` /
-`failed`, so a per-skill copy failure surfaces in the report rather than
-aborting the whole install. Up-front failures return clear status codes
-instead of `500`:
+`failed`, so a per-skill copy failure or a single MCP server start failure
+surfaces in the report rather than aborting the whole install. When the
+bundle declares no MCP servers, a single `mcp` step is recorded as
+`skipped`. Up-front failures return clear status codes instead of `500`:
 
 | Status | When |
 |--------|------|
-| `400` | Missing or malformed `source`, or an invalid `plugin.json`. |
+| `400` | Missing or malformed `source`, an invalid `plugin.json`, or an invalid `.mcp.json`. |
 | `404` | No `.claude-plugin/plugin.json`, or no skills found in the plugin. |
 | `502` | The git clone failed. |
 | `504` | The git clone timed out. |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -372,10 +372,15 @@ bundle declares no MCP servers, a single `mcp` step is recorded as
 
 | Status | When |
 |--------|------|
-| `400` | Missing or malformed `source`, an invalid `plugin.json`, or an invalid `.mcp.json`. |
+| `400` | Missing or malformed `source`, or an invalid `plugin.json`. |
 | `404` | No `.claude-plugin/plugin.json`, or no skills found in the plugin. |
 | `502` | The git clone failed. |
 | `504` | The git clone timed out. |
+
+A malformed `.mcp.json` (parse error, or a wrong `mcpServers` shape) does
+**not** fail the request — it surfaces as a single `failed` `mcp` step in
+the report, so already-installed skills and the registry entry are
+preserved.
 
 Every install is audit-logged with the source, plugin name, version, and
 the installed skill names.

--- a/src/pocketpaw/api/v1/plugins.py
+++ b/src/pocketpaw/api/v1/plugins.py
@@ -1,10 +1,11 @@
 # src/pocketpaw/api/v1/plugins.py
 # Created: 2026-06-07 (feat/plugin-installer-skills) — Plugins router.
+# Updated: 2026-06-08 (feat/plugin-installer-mcp) — install now also
+# registers + starts a bundle's MCP servers (#1357).
 # POST /api/v1/plugins/install clones a .claude-plugin repo, installs its
-# skills, and returns a step-by-step PluginInstallReport. Admin-scoped,
-# mirroring api/v1/mcp.py. Skills-only slice — MCP + list/remove ship
-# separately (#1357, #1358).
-"""REST surface for the Plugin Installer (skills slice)."""
+# skills and MCP servers, and returns a step-by-step PluginInstallReport.
+# Admin-scoped, mirroring api/v1/mcp.py. List/remove ships separately (#1358).
+"""REST surface for the Plugin Installer (skills + MCP)."""
 
 from __future__ import annotations
 

--- a/src/pocketpaw/mcp/presets.py
+++ b/src/pocketpaw/mcp/presets.py
@@ -5,6 +5,11 @@ from the dashboard with just an API key paste.
 
 Created: 2026-02-09
 Updated: 2026-03-05 — Added google-workspace preset (gws CLI with MCP support).
+Updated: 2026-06-08 (feat/plugin-installer-mcp) — added ``spec_to_config``,
+which maps a standard ``.mcp.json`` server spec (``{command, args, env,
+type, url, ...}``) to an ``MCPServerConfig``. Mirrors ``preset_to_config``'s
+field mapping so the plugin installer and the preset catalog stay in sync
+on transport-name normalisation.
 """
 
 from __future__ import annotations
@@ -961,4 +966,48 @@ def preset_to_config(
         env=resolved_env,
         enabled=True,
         oauth=preset.oauth,
+    )
+
+
+# Map the standard ``.mcp.json`` ``type`` field to our transport names.
+# The standard uses "stdio" | "http" | "sse"; we additionally recognise
+# "streamable-http" (and its common aliases) as a distinct transport.
+_SPEC_TYPE_TO_TRANSPORT: dict[str, str] = {
+    "stdio": "stdio",
+    "http": "http",
+    "sse": "sse",
+    "streamable-http": "streamable-http",
+    "streamable_http": "streamable-http",
+    "streamablehttp": "streamable-http",
+}
+
+
+def spec_to_config(name: str, spec: dict) -> MCPServerConfig:
+    """Map a standard ``.mcp.json`` server spec to an ``MCPServerConfig``.
+
+    The ``.mcp.json`` shape is ``{"mcpServers": {name: spec}}`` where each
+    *spec* carries ``command`` / ``args`` / ``env`` for stdio servers, or a
+    ``url`` for remote ones, plus an optional ``type`` field. Transport is
+    derived from ``type`` (defaulting to ``stdio``); an unknown ``type``
+    falls back to ``stdio``. Mirrors :func:`preset_to_config`'s mapping so
+    the two entry points stay in sync.
+    """
+    spec = spec or {}
+    spec_type = str(spec.get("type") or "stdio").strip().lower()
+    transport = _SPEC_TYPE_TO_TRANSPORT.get(spec_type, "stdio")
+
+    raw_args = spec.get("args") or []
+    args = [str(a) for a in raw_args] if isinstance(raw_args, list) else []
+
+    raw_env = spec.get("env") or {}
+    env = {str(k): str(v) for k, v in raw_env.items()} if isinstance(raw_env, dict) else {}
+
+    return MCPServerConfig(
+        name=name,
+        transport=transport,
+        command=str(spec.get("command") or ""),
+        args=args,
+        url=str(spec.get("url") or ""),
+        env=env,
+        enabled=True,
     )

--- a/src/pocketpaw/plugins/installer.py
+++ b/src/pocketpaw/plugins/installer.py
@@ -77,6 +77,16 @@ class PluginInstallError(Exception):
         self.status_code = status_code
 
 
+class _MCPConfigError(Exception):
+    """Internal: a malformed ``.mcp.json`` (parse error / wrong shape).
+
+    Caught inside the installer and converted into a ``failed`` MCP step so
+    a bad MCP config degrades per-step instead of raising out of the
+    installer (which would orphan already-installed skills and skip the
+    registry write). Never escapes the module.
+    """
+
+
 def parse_source(source: str) -> tuple[str, str, str | None]:
     """Parse a plugin source string into ``(owner, repo, subdir)``.
 
@@ -320,6 +330,12 @@ class PluginInstaller:
         standard shape is ``{"mcpServers": {name: spec}}``. Returns None
         when no config file exists so the caller can skip cleanly; returns
         an empty dict when the file exists but declares no servers.
+
+        Raises:
+            _MCPConfigError: If the file exists but is malformed (JSON parse
+                error, top-level not a dict, ``mcpServers`` not a dict). The
+                caller turns this into a ``failed`` step so the install
+                degrades per-step rather than raising out of the installer.
         """
         if manifest.mcp_servers:
             mcp_path = plugin_root / manifest.mcp_servers
@@ -333,14 +349,14 @@ class PluginInstaller:
             raw = json.loads(mcp_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning("Plugin MCP config unreadable: %s", exc)
-            raise PluginInstallError("Invalid .mcp.json", 400) from exc
+            raise _MCPConfigError("invalid .mcp.json (parse error)") from exc
 
         if not isinstance(raw, dict):
-            raise PluginInstallError(".mcp.json must be a JSON object", 400)
+            raise _MCPConfigError(".mcp.json must be a JSON object")
 
         servers = raw.get("mcpServers", {})
         if not isinstance(servers, dict):
-            raise PluginInstallError(".mcp.json 'mcpServers' must be an object", 400)
+            raise _MCPConfigError(".mcp.json 'mcpServers' must be an object")
         return servers
 
     async def _install_mcp_servers(
@@ -358,8 +374,15 @@ class PluginInstaller:
         env is reported ``succeeded`` with a ``needs env: KEY`` detail
         (non-fatal); any other start failure is a ``failed`` step. Skips
         cleanly (one ``skipped`` step) when the bundle declares no MCP config.
+        A malformed ``.mcp.json`` becomes a single ``failed`` ``mcp`` step —
+        it never raises out of the installer, so installed skills aren't
+        orphaned and the registry write still happens.
         """
-        servers = self._read_mcp_config(plugin_root, manifest)
+        try:
+            servers = self._read_mcp_config(plugin_root, manifest)
+        except _MCPConfigError as exc:
+            report.steps.append(PluginInstallStep(name="mcp", status="failed", detail=str(exc)))
+            return []
         if servers is None:
             report.steps.append(
                 PluginInstallStep(name="mcp", status="skipped", detail="no .mcp.json")
@@ -429,6 +452,13 @@ class PluginInstaller:
         if ok:
             return PluginInstallStep(name=step_name, status="succeeded")
         if missing:
+            # Heuristic: we can't tell *why* start_server returned False, only
+            # that the spec declared an empty env var. So a server that failed
+            # to start for an unrelated reason while also having an empty env
+            # value is reported "succeeded / needs env" — a deliberate
+            # false-positive trade-off, not a bug. We'd rather nudge the
+            # operator to supply credentials than hard-fail a recoverable
+            # install. (#1358's list/remove surface will let them retry.)
             return PluginInstallStep(
                 name=step_name,
                 status="succeeded",

--- a/src/pocketpaw/plugins/installer.py
+++ b/src/pocketpaw/plugins/installer.py
@@ -6,8 +6,16 @@
 # .claude-plugin/plugin.json, copies each skills/<name>/SKILL.md into the
 # skill loader path, reloads the loader, records a registry entry under
 # ~/.pocketpaw/plugins.json, and returns a step-by-step PluginInstallReport.
-# Skills-only slice — MCP + list/remove ship separately (#1357, #1358).
-"""Install a ``.claude-plugin``'s skills from a GitHub repo.
+# Updated: 2026-06-08 (feat/plugin-installer-mcp) — also registers + starts
+# the MCP servers a bundle declares in its `.mcp.json` (or a manifest
+# `mcp_servers` path override). Each server maps via presets.spec_to_config,
+# is namespaced `plugin:<plugin>:<server>`, registered + started through the
+# MCP manager (one PluginInstallStep each; a server that registers but can't
+# start for lack of env is reported `succeeded` with a "needs env:" detail).
+# The namespaced names are recorded in the registry entry and on the report's
+# `installed_mcp_servers`. Imports the now-public `ignore_symlinks` and drops
+# the clone-factory `except TypeError` fallback. List/remove ships in #1358.
+"""Install a ``.claude-plugin``'s skills and MCP servers from a GitHub repo.
 
 Each unit of work is a :class:`PluginInstallStep` that never raises out of
 the installer — failures become ``failed``/``skipped`` steps so the caller
@@ -27,6 +35,9 @@ from contextlib import AbstractAsyncContextManager
 from pathlib import Path
 from typing import Any
 
+from pocketpaw.mcp.config import MCPServerConfig
+from pocketpaw.mcp.manager import get_mcp_manager
+from pocketpaw.mcp.presets import spec_to_config
 from pocketpaw.plugins.models import (
     PluginInstallReport,
     PluginInstallStep,
@@ -35,8 +46,8 @@ from pocketpaw.plugins.models import (
 from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
 from pocketpaw.skills.installer import (
     INSTALL_DIR,
-    _ignore_symlinks,
     clone_github_repo,
+    ignore_symlinks,
 )
 from pocketpaw.skills.loader import get_skill_loader
 
@@ -161,15 +172,11 @@ class PluginInstaller:
         """
         owner, repo, subdir = parse_source(source)
 
-        try:
-            clone_cm = self._clone(owner, repo, timeout=timeout)
-        except TypeError:
-            # Test fixtures may inject a clone factory with no timeout kwarg.
-            clone_cm = self._clone(owner, repo)
+        clone_cm = self._clone(owner, repo, timeout=timeout)
 
         try:
             async with clone_cm as repo_root:
-                return self._install_from_tree(
+                return await self._install_from_tree(
                     repo_root=repo_root,
                     subdir=subdir,
                     source=f"{owner}/{repo}",
@@ -180,7 +187,7 @@ class PluginInstaller:
             logger.warning("Plugin clone failed: %s", exc)
             raise PluginInstallError("Plugin clone failed", 502) from exc
 
-    def _install_from_tree(
+    async def _install_from_tree(
         self,
         *,
         repo_root: Path,
@@ -207,8 +214,13 @@ class PluginInstaller:
         installed = self._install_skills(skill_sources, report)
 
         report.steps.append(self._reload_loader())
-        report.steps.append(self._record_registry(manifest, source, installed))
+
+        # Route the bundle's MCP servers (skips cleanly when there are none).
+        mcp_servers = await self._install_mcp_servers(plugin_root, manifest, report)
+
+        report.steps.append(self._record_registry(manifest, source, installed, mcp_servers))
         report.installed_skills = installed
+        report.installed_mcp_servers = mcp_servers
 
         self._audit(source, manifest, installed, report.succeeded())
         return report
@@ -279,7 +291,7 @@ class PluginInstaller:
                 dest = self._install_dir / name
                 if dest.exists():
                     shutil.rmtree(dest)
-                shutil.copytree(src_dir, dest, ignore=_ignore_symlinks)
+                shutil.copytree(src_dir, dest, ignore=ignore_symlinks)
             except OSError as exc:
                 report.steps.append(
                     PluginInstallStep(name=step_name, status="failed", detail=str(exc))
@@ -298,8 +310,155 @@ class PluginInstaller:
             logger.warning("Skill loader reload failed: %s", exc)
             return PluginInstallStep(name="reload_loader", status="failed", detail=str(exc))
 
+    def _read_mcp_config(
+        self, plugin_root: Path, manifest: PluginManifest
+    ) -> dict[str, dict] | None:
+        """Read the bundle's MCP config, returning ``{name: spec}`` or None.
+
+        Looks at the manifest's ``mcp_servers`` path override when set,
+        otherwise the conventional ``.mcp.json`` at the plugin root. The
+        standard shape is ``{"mcpServers": {name: spec}}``. Returns None
+        when no config file exists so the caller can skip cleanly; returns
+        an empty dict when the file exists but declares no servers.
+        """
+        if manifest.mcp_servers:
+            mcp_path = plugin_root / manifest.mcp_servers
+        else:
+            mcp_path = plugin_root / ".mcp.json"
+
+        if not mcp_path.is_file():
+            return None
+
+        try:
+            raw = json.loads(mcp_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Plugin MCP config unreadable: %s", exc)
+            raise PluginInstallError("Invalid .mcp.json", 400) from exc
+
+        if not isinstance(raw, dict):
+            raise PluginInstallError(".mcp.json must be a JSON object", 400)
+
+        servers = raw.get("mcpServers", {})
+        if not isinstance(servers, dict):
+            raise PluginInstallError(".mcp.json 'mcpServers' must be an object", 400)
+        return servers
+
+    async def _install_mcp_servers(
+        self,
+        plugin_root: Path,
+        manifest: PluginManifest,
+        report: PluginInstallReport,
+    ) -> list[str]:
+        """Register + start the bundle's MCP servers. One step per server.
+
+        Each server is namespaced ``plugin:<plugin>:<server>`` to avoid
+        cross-plugin collisions, mapped to an :class:`MCPServerConfig` via
+        :func:`spec_to_config`, registered with the MCP manager, and started.
+        A server that registers but fails to start because it lacks required
+        env is reported ``succeeded`` with a ``needs env: KEY`` detail
+        (non-fatal); any other start failure is a ``failed`` step. Skips
+        cleanly (one ``skipped`` step) when the bundle declares no MCP config.
+        """
+        servers = self._read_mcp_config(plugin_root, manifest)
+        if servers is None:
+            report.steps.append(
+                PluginInstallStep(name="mcp", status="skipped", detail="no .mcp.json")
+            )
+            return []
+        if not servers:
+            report.steps.append(
+                PluginInstallStep(name="mcp", status="skipped", detail="no servers declared")
+            )
+            return []
+
+        manager = get_mcp_manager()
+        installed: list[str] = []
+        # Sequential per request — the manager's start_server holds a lock,
+        # so concurrent starts would serialise anyway; keep ordering stable.
+        for server_name in sorted(servers):
+            spec = servers[server_name]
+            step_name = f"mcp:{server_name}"
+            if server_name in (".", "..") or not _NAME_RE.match(server_name):
+                report.steps.append(
+                    PluginInstallStep(
+                        name=step_name, status="skipped", detail="invalid server name"
+                    )
+                )
+                continue
+            if not isinstance(spec, dict):
+                report.steps.append(
+                    PluginInstallStep(name=step_name, status="skipped", detail="invalid spec")
+                )
+                continue
+
+            namespaced = f"plugin:{manifest.name}:{server_name}"
+            cfg = spec_to_config(namespaced, spec)
+
+            step = await self._register_and_start(manager, cfg, spec, step_name)
+            report.steps.append(step)
+            if step.status != "failed":
+                installed.append(namespaced)
+        return installed
+
+    async def _register_and_start(
+        self,
+        manager: Any,
+        cfg: MCPServerConfig,
+        spec: dict,
+        step_name: str,
+    ) -> PluginInstallStep:
+        """Register a server config and start it, returning one step.
+
+        A start failure caused by missing required env is non-fatal: the
+        step is ``succeeded`` with a ``needs env: KEY`` detail so the user
+        knows to supply credentials later. Any other failure is ``failed``.
+        """
+        try:
+            manager.add_server_config(cfg)
+        except Exception as exc:  # registry write hiccup — non-recoverable for this server
+            logger.warning("MCP server '%s' registration failed: %s", cfg.name, exc)
+            return PluginInstallStep(name=step_name, status="failed", detail=str(exc))
+
+        missing = self._missing_env(spec, cfg)
+        try:
+            ok = await manager.start_server(cfg)
+        except Exception as exc:
+            logger.warning("MCP server '%s' start raised: %s", cfg.name, exc)
+            return PluginInstallStep(name=step_name, status="failed", detail=str(exc))
+
+        if ok:
+            return PluginInstallStep(name=step_name, status="succeeded")
+        if missing:
+            return PluginInstallStep(
+                name=step_name,
+                status="succeeded",
+                detail=f"needs env: {missing}",
+            )
+        return PluginInstallStep(name=step_name, status="failed", detail="server failed to start")
+
+    @staticmethod
+    def _missing_env(spec: dict, cfg: MCPServerConfig) -> str | None:
+        """Return the first declared env var the spec left unset, else None.
+
+        A bundle can declare required env in the spec's ``env`` block with an
+        empty / placeholder value (e.g. ``{"API_KEY": ""}``). When the value
+        is empty the server will start-fail for lack of credentials; we treat
+        that as a non-fatal "needs env" outcome rather than a hard failure.
+        """
+        raw_env = spec.get("env")
+        if not isinstance(raw_env, dict):
+            return None
+        for key, value in raw_env.items():
+            if not str(value).strip():
+                return str(key)
+        return None
+
     def _record_registry(
-        self, manifest: PluginManifest, source: str, installed: list[str]
+        self,
+        manifest: PluginManifest,
+        source: str,
+        installed: list[str],
+        mcp_servers: list[str] | None = None,
     ) -> PluginInstallStep:
         """Write the plugin entry to the registry (read-modify-write)."""
         from datetime import datetime
@@ -310,6 +469,7 @@ class PluginInstaller:
                 "version": manifest.version,
                 "source": source,
                 "skills": installed,
+                "mcp_servers": mcp_servers or [],
                 "installed_at": datetime.now().isoformat(),
             }
             self._registry_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/pocketpaw/plugins/models.py
+++ b/src/pocketpaw/plugins/models.py
@@ -3,6 +3,10 @@
 # the Plugin Installer. Mirrors the SHAPE of ee/pocketpaw_ee/fleet/models.py
 # (FleetInstallStep / FleetInstallReport) but copied into OSS so the core
 # never imports pocketpaw_ee (import-linter forbids it).
+# Updated: 2026-06-08 (feat/plugin-installer-mcp) — added
+# ``PluginManifest.mcp_servers`` (optional path override for the bundle's
+# MCP config) and ``PluginInstallReport.installed_mcp_servers`` (the
+# namespaced MCP server names registered on install).
 """Models for the .claude-plugin installer.
 
 ``PluginManifest`` is the structurally-validated view of a repo's
@@ -25,13 +29,18 @@ class PluginManifest(BaseModel):
     Only ``name`` is required; the rest mirror the optional fields the
     Claude Code plugin standard allows. ``skills`` is an optional path
     override for where the plugin's ``SKILL.md`` directories live (defaults
-    to the conventional ``skills/`` directory when unset).
+    to the conventional ``skills/`` directory when unset). ``mcp_servers``
+    is an optional path override for the bundle's MCP config file (defaults
+    to ``.mcp.json`` at the plugin root when unset).
     """
 
     name: str
     version: str = "0.0.0"
     description: str = ""
     skills: str | None = None
+    # Optional path override for the bundle's MCP config file. Defaults to
+    # the conventional ``.mcp.json`` at the plugin root when unset.
+    mcp_servers: str | None = None
 
 
 class PluginInstallStep(BaseModel):
@@ -54,6 +63,7 @@ class PluginInstallReport(BaseModel):
     installed_at: datetime = Field(default_factory=datetime.now)
     steps: list[PluginInstallStep] = Field(default_factory=list)
     installed_skills: list[str] = Field(default_factory=list)
+    installed_mcp_servers: list[str] = Field(default_factory=list)
 
     def succeeded(self) -> bool:
         return all(step.status != "failed" for step in self.steps)

--- a/src/pocketpaw/skills/installer.py
+++ b/src/pocketpaw/skills/installer.py
@@ -6,6 +6,10 @@ Updated: 2026-06-07 (feat/plugin-installer-skills) — extracted the
 ``clone_github_repo`` async context manager so the plugin installer can
 share the same clone path. ``install_skills_from_github`` now calls it;
 its behavior is unchanged.
+Updated: 2026-06-08 (feat/plugin-installer-mcp) — promoted the private
+``_ignore_symlinks`` copytree filter to a public ``ignore_symlinks``
+(``_ignore_symlinks`` kept as a backwards-compatible alias) so the plugin
+installer imports the public name.
 """
 
 from __future__ import annotations
@@ -28,9 +32,13 @@ logger = logging.getLogger(__name__)
 INSTALL_DIR = Path.home() / ".agents" / "skills"
 
 
-def _ignore_symlinks(src: str, names: list[str]) -> set[str]:
+def ignore_symlinks(src: str, names: list[str]) -> set[str]:
     """Return names that are symlinks so ``shutil.copytree`` skips them."""
     return {n for n in names if os.path.islink(os.path.join(src, n))}
+
+
+# Backwards-compatible alias for the now-public name.
+_ignore_symlinks = ignore_symlinks
 
 
 class SkillInstallError(Exception):
@@ -142,7 +150,7 @@ async def install_skills_from_github(
             dest = INSTALL_DIR / name
             if dest.exists():
                 shutil.rmtree(dest)
-            shutil.copytree(src_dir, dest, ignore=_ignore_symlinks)
+            shutil.copytree(src_dir, dest, ignore=ignore_symlinks)
             installed.append(name)
 
         logger.info("Installed %d skills from %s/%s", len(installed), owner, repo)

--- a/tests/test_mcp_presets.py
+++ b/tests/test_mcp_presets.py
@@ -1,6 +1,9 @@
 """Tests for MCP Server Presets — catalog registry + dashboard endpoints.
 
 Created: 2026-02-09
+Updated: 2026-06-08 (feat/plugin-installer-mcp) — added coverage for
+``spec_to_config`` (standard .mcp.json spec -> MCPServerConfig mapping,
+transport derivation from the spec ``type`` field).
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -15,7 +18,54 @@ from pocketpaw.mcp.presets import (
     get_preset,
     get_presets_by_category,
     preset_to_config,
+    spec_to_config,
 )
+
+# ======================================================================
+# spec_to_config (standard .mcp.json mapping)
+# ======================================================================
+
+
+class TestSpecToConfig:
+    def test_stdio_default(self):
+        cfg = spec_to_config(
+            "plugin:p:svc",
+            {"command": "npx", "args": ["-y", "svc-mcp"], "env": {"K": "v"}},
+        )
+        assert cfg.name == "plugin:p:svc"
+        assert cfg.transport == "stdio"
+        assert cfg.command == "npx"
+        assert cfg.args == ["-y", "svc-mcp"]
+        assert cfg.env == {"K": "v"}
+        assert cfg.enabled is True
+
+    @pytest.mark.parametrize(
+        "spec_type,expected",
+        [
+            ("http", "http"),
+            ("sse", "sse"),
+            ("streamable-http", "streamable-http"),
+            ("streamable_http", "streamable-http"),
+            ("STDIO", "stdio"),
+            ("unknown-thing", "stdio"),
+        ],
+    )
+    def test_transport_from_type(self, spec_type, expected):
+        cfg = spec_to_config("n", {"type": spec_type, "url": "https://x"})
+        assert cfg.transport == expected
+
+    def test_coerces_non_string_values(self):
+        cfg = spec_to_config("n", {"args": [1, 2], "env": {"K": 3}})
+        assert cfg.args == ["1", "2"]
+        assert cfg.env == {"K": "3"}
+
+    def test_empty_spec(self):
+        cfg = spec_to_config("n", {})
+        assert cfg.transport == "stdio"
+        assert cfg.command == ""
+        assert cfg.args == []
+        assert cfg.env == {}
+
 
 # ======================================================================
 # Registry tests

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -484,6 +484,50 @@ class TestMCPRouting:
         step = next(s for s in report.steps if s.name == "mcp")
         assert step.status == "skipped"
 
+    async def test_malformed_mcp_json_does_not_orphan_skills(self, tmp_path, monkeypatch):
+        # A bad .mcp.json must degrade to a failed mcp step — NOT raise — so
+        # the skills stay installed and the registry entry is still written.
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="p", skills=["alpha"])
+        (repo / ".mcp.json").write_text("{not valid json", encoding="utf-8")
+
+        inst = _installer(repo, tmp_path)
+        report = await inst.install("acme/widgets")  # must not raise
+
+        # Skills installed.
+        assert report.installed_skills == ["alpha"]
+        assert (tmp_path / "skills_install" / "alpha" / "SKILL.md").is_file()
+        # mcp step failed (not skipped), report not fully succeeded.
+        mcp_step = next(s for s in report.steps if s.name == "mcp")
+        assert mcp_step.status == "failed"
+        assert report.installed_mcp_servers == []
+        assert not report.succeeded()
+        # Registry entry still written — skills are NOT orphaned.
+        registry_path = tmp_path / "registry" / "plugins.json"
+        assert registry_path.is_file()
+        entry = json.loads(registry_path.read_text())["p"]
+        assert entry["skills"] == ["alpha"]
+        assert entry["mcp_servers"] == []
+        assert manager.added == []  # nothing registered from a bad config
+
+    async def test_malformed_mcp_servers_shape_is_failed_step(self, tmp_path, monkeypatch):
+        # Top-level dict but mcpServers is a list → failed step, no raise.
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="p", skills=["alpha"])
+        (repo / ".mcp.json").write_text(json.dumps({"mcpServers": []}), encoding="utf-8")
+
+        inst = _installer(repo, tmp_path)
+        report = await inst.install("acme/widgets")
+
+        assert report.installed_skills == ["alpha"]
+        mcp_step = next(s for s in report.steps if s.name == "mcp")
+        assert mcp_step.status == "failed"
+        assert (tmp_path / "registry" / "plugins.json").is_file()
+
     async def test_manifest_mcp_path_override(self, tmp_path, monkeypatch):
         manager = _FakeMCPManager()
         _patch_loader_and_manager(monkeypatch, manager)

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -4,7 +4,12 @@
 # source parsing, skills discovery/copy/reload, registry write, and error
 # paths (bad source, missing manifest, no skills). The clone is mocked by
 # injecting a clone factory that yields a local fixture .claude-plugin dir.
-"""Unit tests for pocketpaw.plugins (skills slice)."""
+# Updated: 2026-06-08 (feat/plugin-installer-mcp) — added the MCP-routing
+# slice: .mcp.json -> MCPServerConfig mapping, plugin:<p>:<server>
+# namespacing, registered-but-needs-env (succeeded + needs-env detail),
+# a skills+mcp bundle, and the no-.mcp.json skip. The MCP manager is mocked
+# via a fake injected with monkeypatch (no real servers are spawned).
+"""Unit tests for pocketpaw.plugins (skills + MCP slices)."""
 
 from __future__ import annotations
 
@@ -294,3 +299,206 @@ class TestInstallErrors:
         with pytest.raises(PluginInstallError) as exc:
             await inst.install("acme/widgets")
         assert exc.value.status_code == 504
+
+
+# --------------------------------------------------------------------------- #
+# MCP routing                                                                 #
+# --------------------------------------------------------------------------- #
+class _FakeMCPManager:
+    """Records add_server_config + start_server calls; never spawns servers.
+
+    ``start_results`` maps a (namespaced) server name to the bool returned
+    by ``start_server`` — defaults to True (started cleanly) when unset.
+    """
+
+    def __init__(self, start_results: dict[str, bool] | None = None):
+        self.added: list = []  # MCPServerConfig objects
+        self.started: list = []  # MCPServerConfig objects
+        self._start_results = start_results or {}
+
+    def add_server_config(self, config) -> None:
+        self.added.append(config)
+
+    async def start_server(self, config) -> bool:
+        self.started.append(config)
+        return self._start_results.get(config.name, True)
+
+
+def _write_mcp_json(plugin_root: Path, servers: dict) -> None:
+    (plugin_root / ".mcp.json").write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+
+
+def _patch_loader_and_manager(monkeypatch, manager: _FakeMCPManager) -> None:
+    monkeypatch.setattr(
+        "pocketpaw.plugins.installer.get_skill_loader",
+        lambda: type("L", (), {"reload": lambda self: None})(),
+    )
+    monkeypatch.setattr(
+        "pocketpaw.plugins.installer.get_mcp_manager",
+        lambda: manager,
+    )
+
+
+class TestMCPRouting:
+    async def test_no_mcp_json_skips_cleanly(self, fixture_repo, tmp_path, monkeypatch):
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        inst = _installer(fixture_repo, tmp_path)
+        report = await inst.install("acme/widgets")
+
+        assert report.installed_mcp_servers == []
+        assert report.succeeded()
+        mcp_steps = [s for s in report.steps if s.name == "mcp"]
+        assert mcp_steps and mcp_steps[0].status == "skipped"
+        assert manager.added == []
+
+    async def test_spec_maps_to_config_and_namespaces(self, tmp_path, monkeypatch):
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="my-plugin", skills=["alpha"])
+        _write_mcp_json(
+            repo,
+            {
+                "weather": {
+                    "command": "npx",
+                    "args": ["-y", "weather-mcp"],
+                    "env": {"REGION": "us"},
+                }
+            },
+        )
+
+        inst = _installer(repo, tmp_path)
+        report = await inst.install("acme/widgets")
+
+        assert report.installed_mcp_servers == ["plugin:my-plugin:weather"]
+        # Config mapped correctly.
+        assert len(manager.added) == 1
+        cfg = manager.added[0]
+        assert cfg.name == "plugin:my-plugin:weather"
+        assert cfg.transport == "stdio"  # default when type unset
+        assert cfg.command == "npx"
+        assert cfg.args == ["-y", "weather-mcp"]
+        assert cfg.env == {"REGION": "us"}
+        # Server was started.
+        assert [c.name for c in manager.started] == ["plugin:my-plugin:weather"]
+        # Step succeeded.
+        step = next(s for s in report.steps if s.name == "mcp:weather")
+        assert step.status == "succeeded"
+
+    async def test_http_transport_from_type(self, tmp_path, monkeypatch):
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="p", skills=["alpha"])
+        _write_mcp_json(
+            repo,
+            {
+                "remote": {"type": "streamable-http", "url": "https://mcp.example.com"},
+            },
+        )
+
+        inst = _installer(repo, tmp_path)
+        await inst.install("acme/widgets")
+
+        cfg = manager.added[0]
+        assert cfg.transport == "streamable-http"
+        assert cfg.url == "https://mcp.example.com"
+        assert cfg.command == ""
+
+    async def test_needs_env_is_non_fatal(self, tmp_path, monkeypatch):
+        # Server registers but start_server returns False; the spec declares
+        # an empty env var, so the step is succeeded with a needs-env detail.
+        ns_name = "plugin:p:db"
+        manager = _FakeMCPManager(start_results={ns_name: False})
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="p", skills=["alpha"])
+        _write_mcp_json(
+            repo,
+            {"db": {"command": "npx", "args": ["db-mcp"], "env": {"DB_URL": ""}}},
+        )
+
+        inst = _installer(repo, tmp_path)
+        report = await inst.install("acme/widgets")
+
+        step = next(s for s in report.steps if s.name == "mcp:db")
+        assert step.status == "succeeded"
+        assert "needs env: DB_URL" in step.detail
+        # Still recorded as installed (registered, just not running yet).
+        assert report.installed_mcp_servers == [ns_name]
+        assert report.succeeded()
+
+    async def test_hard_start_failure_is_failed(self, tmp_path, monkeypatch):
+        # start_server returns False AND there is no missing env → failed.
+        ns_name = "plugin:p:broken"
+        manager = _FakeMCPManager(start_results={ns_name: False})
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="p", skills=["alpha"])
+        _write_mcp_json(
+            repo,
+            {"broken": {"command": "npx", "args": ["broken-mcp"]}},
+        )
+
+        inst = _installer(repo, tmp_path)
+        report = await inst.install("acme/widgets")
+
+        step = next(s for s in report.steps if s.name == "mcp:broken")
+        assert step.status == "failed"
+        assert ns_name not in report.installed_mcp_servers
+        assert not report.succeeded()
+
+    async def test_skills_and_mcp_together(self, tmp_path, monkeypatch):
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="combo", skills=["alpha", "beta"])
+        _write_mcp_json(repo, {"svc": {"command": "uvx", "args": ["svc-mcp"]}})
+
+        inst = _installer(repo, tmp_path)
+        report = await inst.install("acme/widgets")
+
+        assert sorted(report.installed_skills) == ["alpha", "beta"]
+        assert report.installed_mcp_servers == ["plugin:combo:svc"]
+        assert report.succeeded()
+
+        # Registry entry records both skills and mcp servers.
+        registry_path = tmp_path / "registry" / "plugins.json"
+        entry = json.loads(registry_path.read_text())["combo"]
+        assert sorted(entry["skills"]) == ["alpha", "beta"]
+        assert entry["mcp_servers"] == ["plugin:combo:svc"]
+
+    async def test_empty_mcp_servers_skips(self, tmp_path, monkeypatch):
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="p", skills=["alpha"])
+        _write_mcp_json(repo, {})  # file exists, no servers
+
+        inst = _installer(repo, tmp_path)
+        report = await inst.install("acme/widgets")
+
+        assert report.installed_mcp_servers == []
+        step = next(s for s in report.steps if s.name == "mcp")
+        assert step.status == "skipped"
+
+    async def test_manifest_mcp_path_override(self, tmp_path, monkeypatch):
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="ov", skills=["alpha"])
+        # Point the manifest at a custom MCP config path.
+        manifest = repo / ".claude-plugin" / "plugin.json"
+        manifest.write_text(json.dumps({"name": "ov", "mcp_servers": "config/mcp.json"}))
+        custom = repo / "config"
+        custom.mkdir(parents=True)
+        (custom / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"svc": {"command": "npx", "args": ["svc"]}}})
+        )
+
+        inst = _installer(repo, tmp_path)
+        report = await inst.install("acme/widgets")
+
+        assert report.installed_mcp_servers == ["plugin:ov:svc"]


### PR DESCRIPTION
Closes #1357. Second slice of the Plugin Installer (RFC 14, M3). Stacks on #1356 (already in `integration/plugins`); targets the integration branch.

## What this ships

Installing a plugin now also registers and starts the MCP servers it declares. After the skills step, the installer reads the bundle's `.mcp.json` (`{"mcpServers": {name: spec}}`, or a manifest `mcp_servers` path override), maps each entry to an `MCPServerConfig`, namespaces the name as `plugin:<plugin>:<server>` to avoid cross-plugin collisions, and registers + starts it through the existing MCP manager. The install report gains one step per server plus an `installed_mcp_servers` list, and the registry entry records the namespaced names.

## Behavior

- A server that registers but can't start for lack of env is reported `succeeded` with a `needs env: KEY` detail (non-fatal) — a plugin can be installed now and configured later.
- A server that hard-fails to start is a `failed` step; a bundle with no `.mcp.json` is a `skipped` step.
- A malformed `.mcp.json` degrades to a single `failed` step and the install still completes (skills stay installed, registry entry still written) — it never aborts mid-install. (Caught in review.)

## Also in this PR

- New `presets.spec_to_config` (mirrors `preset_to_config`'s field mapping + transport-from-type).
- Two review nits folded in: `skills/installer._ignore_symlinks` promoted to a public `ignore_symlinks` (back-compat alias kept); the test-only `except TypeError` clone fallback removed.

## Tests

77 passing in the targeted set. New coverage: spec→config mapping + transport, namespacing, needs-env (non-fatal), hard start failure, skills+MCP together, no-`.mcp.json` skip, and the two malformed-`.mcp.json` no-orphan cases. MCP manager is mocked — no servers spawned. Skills slice (#1356) tests stay green.

Trust model unchanged: admin-gated install + audit; hooks still never auto-run.
