### PR TITLE
feat(agents): add an about-this-member block to the system message

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -54,6 +54,17 @@ folds a pocket-entity's ``surface_profile`` override over the surface base).
 calling ``resolve_profile`` itself — so a pocket bound to a room can flip
 ripple off/on for that room. ``resolved_profile is None`` is the legacy /
 non-entity path → ripple ON, byte-identical to today.
+Changes: 2026-06-08 (feat/vip-agent-block, pp#1367) — ``ScopeContext`` carries
+an optional ``about_member_block``: a concise, token-capped "about this member"
+string (name · role · team · one-line focus) rendered from the member's Fabric
+``Person`` (``people.service.get_person``). The resolvers pre-resolve it (async)
+via ``_resolve_about_member`` and stash it; ``build_behavior_instructions``
+APPENDS it to the base system message (additive — NOT a persona override) so the
+agent greets the member by name from the first turn. A member with no Person
+(pre-existing / non-invited user) → ``None`` → no block, behavior unchanged. The
+render is HARD-capped (``_ABOUT_MEMBER_CHAR_CAP``) to kill the prompt-bloat
+failure mode. Stays sync in ``build_behavior_instructions`` — the async read
+happens once in the resolver, mirroring ``backend_summary``.
 """
 
 from __future__ import annotations
@@ -63,7 +74,14 @@ import logging
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Type-only — the runtime read imports ``get_person`` lazily inside
+    # ``_resolve_about_member`` so importing this module never drags in the
+    # people service (and its journal accessor) for chat paths that never
+    # render an about-block.
+    from pocketpaw_ee.cloud.people.domain import Person
 
 from pocketpaw.ripple import (
     HOME_POCKET_PROMPT,
@@ -255,6 +273,16 @@ class ScopeContext:
     # summary via ``get_pocket_backend``). ``None`` for non-home scopes,
     # which read the summary lazily through ``get_pocket`` when needed.
     backend_summary: dict[str, Any] | None = None
+    # A concise, token-capped "about this member" block (name · role · team ·
+    # one-line focus) rendered from the member's Fabric ``Person``. The
+    # resolvers pre-resolve it (async, via ``_resolve_about_member``) and stash
+    # it here; ``build_behavior_instructions`` APPENDS it to the base system
+    # message (additive — never a persona override) so the agent greets the
+    # member by name from turn one. ``None`` when the member has no Person yet
+    # (a pre-existing / non-invited user, or the people read failed) — the
+    # agent then behaves exactly as before, no block. Stays a pre-rendered
+    # string so the sync ``build_behavior_instructions`` never has to await.
+    about_member_block: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -317,6 +345,106 @@ async def _home_backend_summary(
         logger.debug("home backend summary fetch failed for pocket %s", pocket_id, exc_info=True)
         return None
     return summary
+
+
+# ---------------------------------------------------------------------------
+# "About this member" block (agent orientation, pp#1367)
+# ---------------------------------------------------------------------------
+
+# HARD character cap on the rendered about-block. The known failure mode is
+# prompt bloat — a free-text focus line (or a degenerate name) ballooning the
+# always-on system prompt toward the ~20K-char tail we've been bitten by. The
+# block is name + role + team + a one-line focus, so it's tiny by design; this
+# is the backstop. ~4 chars/token ⇒ 1500 chars ≈ ~375 tokens, under the
+# ~400-token budget. We truncate the WHOLE rendered block (not just focus) so
+# no combination of fields can exceed it.
+_ABOUT_MEMBER_CHAR_CAP = 1500
+# The focus line is the only unbounded, member/admin-authored field, so it gets
+# its own tighter per-field clamp before assembly — keeps the block readable
+# instead of letting one long sentence eat the whole budget.
+_ABOUT_MEMBER_FOCUS_CHAR_CAP = 280
+
+
+def _render_about_member_block(person: Person) -> str:
+    """Render the concise, token-capped "about this member" block.
+
+    Shape: an ``<about-member>`` tag carrying ``name · role · team`` and an
+    optional one-line ``focus``. Only fields the Person actually has are
+    emitted (no empty ``team:`` / ``focus:`` lines). The whole block is HARD
+    truncated at ``_ABOUT_MEMBER_CHAR_CAP`` so it can never bloat the system
+    prompt, regardless of field contents.
+
+    Returns an empty string when the Person carries no usable identity (no
+    name) — the caller treats that the same as "no Person": no block.
+    """
+
+    name = (person.name or "").strip()
+    if not name:
+        # Nothing to orient the agent with — skip the block entirely rather
+        # than emit a nameless "you are talking to ." line.
+        return ""
+
+    role = (person.role or "").strip()
+    team = (person.group or "").strip()
+    focus = " ".join((person.focus or "").split())  # collapse whitespace/newlines
+    if len(focus) > _ABOUT_MEMBER_FOCUS_CHAR_CAP:
+        focus = focus[:_ABOUT_MEMBER_FOCUS_CHAR_CAP].rstrip() + "…"
+
+    # Identity line: name, then role/team as available, joined with " · ".
+    bits = [name]
+    if role:
+        bits.append(role)
+    if team:
+        bits.append(f"team {team}")
+    identity = " · ".join(bits)
+
+    lines = [
+        "<about-member>",
+        "You are talking to a member of this workspace. Greet them by name and",
+        "tailor your help to their role and focus.",
+        f"  who: {identity}",
+    ]
+    if focus:
+        lines.append(f"  focus: {focus}")
+    lines.append("</about-member>")
+    block = "\n".join(lines)
+
+    if len(block) > _ABOUT_MEMBER_CHAR_CAP:
+        # Backstop hard cap. Keep the closing tag readable by appending it
+        # after the truncation so the block stays well-formed.
+        block = block[:_ABOUT_MEMBER_CHAR_CAP].rstrip() + "…\n</about-member>"
+    return block
+
+
+async def _resolve_about_member(workspace_id: str, user_id: str) -> str | None:
+    """Fetch the member's Fabric ``Person`` and render the about-block, or ``None``.
+
+    Pre-resolved (async) by every scope resolver and stashed on
+    ``ScopeContext.about_member_block`` so the sync
+    ``build_behavior_instructions`` can append it without awaiting. Returns
+    ``None`` — meaning "no block, behave as today" — when:
+
+    * the member has no materialized Person (a pre-existing / non-invited user);
+    * the Person carries no usable name (render returns "");
+    * the people read raised (degrades gracefully — a Fabric hiccup must never
+      block scope resolution or change the agent's behavior).
+    """
+
+    if not workspace_id or not user_id:
+        return None
+    try:
+        from pocketpaw_ee.cloud.people.service import get_person
+
+        person = await get_person(workspace_id, user_id)
+    except Exception:  # noqa: BLE001 — a people-read failure must not block resolution
+        logger.debug(
+            "about-member person read failed for %s/%s", workspace_id, user_id, exc_info=True
+        )
+        return None
+    if person is None:
+        return None
+    block = _render_about_member_block(person)
+    return block or None
 
 
 async def _get_default_workspace_agent_id(workspace_id: str) -> str | None:
@@ -397,6 +525,7 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
                 pocket_type, str(getattr(session, "workspace", "")), str(pocket_id)
             )
 
+    workspace_id = str(getattr(session, "workspace", ""))
     target = agent_id_hint or getattr(session, "agent", None)
     if not target:
         # Sessions created via ``createPocketSession`` don't yet pin an agent
@@ -404,15 +533,19 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
         # rule ``_resolve_pocket`` applies). Keeps cold-start chats in a
         # newly-created pocket session working without the caller having to
         # explicitly pass ``agent_id``.
-        workspace_id = str(getattr(session, "workspace", ""))
         target = await _get_default_workspace_agent_id(workspace_id)
         if not target:
             raise CloudError(400, "session.no_agent", "Session has no agent")
 
+    # Orient the agent to who's chatting (pp#1367) — pre-render the capped
+    # about-block here (async) so the sync system-message assembly can append
+    # it. ``None`` when the member has no Person → no block, behavior unchanged.
+    about_member_block = await _resolve_about_member(workspace_id, user_id)
+
     return ScopeContext(
         kind=ScopeKind.SESSION,
         scope_id=scope_id,
-        workspace_id=str(getattr(session, "workspace", "")),
+        workspace_id=workspace_id,
         user_id=user_id,
         members=[user_id],
         target_agent_id=target,
@@ -421,6 +554,7 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
         pocket_id=str(pocket_id) if pocket_id else None,
         pocket_type=pocket_type,
         backend_summary=backend_summary,
+        about_member_block=about_member_block,
     )
 
 
@@ -451,14 +585,20 @@ async def _resolve_group_like(
 
     target = _pick_target_agent(agent_ids, agent_id_hint)
 
+    workspace_id = str(getattr(group, "workspace", ""))
+    # Orient the agent to the calling member (pp#1367) — pre-rendered capped
+    # block, ``None`` when the member has no Person.
+    about_member_block = await _resolve_about_member(workspace_id, user_id)
+
     return ScopeContext(
         kind=kind,
         scope_id=scope_id,
-        workspace_id=str(getattr(group, "workspace", "")),
+        workspace_id=workspace_id,
         user_id=user_id,
         members=members,
         target_agent_id=target,
         agent_ids_in_scope=agent_ids,
+        about_member_block=about_member_block,
     )
 
 
@@ -515,6 +655,9 @@ async def _resolve_pocket(scope_id: str, user_id: str, agent_id_hint: str | None
 
     pocket_type = getattr(pocket, "type", None)
     backend_summary = await _home_backend_summary(pocket_type, workspace_id, scope_id)
+    # Orient the agent to the calling member (pp#1367) — pre-rendered capped
+    # block, ``None`` when the member has no Person.
+    about_member_block = await _resolve_about_member(workspace_id, user_id)
 
     return ScopeContext(
         kind=ScopeKind.POCKET,
@@ -528,6 +671,7 @@ async def _resolve_pocket(scope_id: str, user_id: str, agent_id_hint: str | None
         pocket_id=scope_id,
         pocket_type=pocket_type,
         backend_summary=backend_summary,
+        about_member_block=about_member_block,
     )
 
 
@@ -702,6 +846,16 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
         parts.append(
             fill_current_pocket(HOME_POCKET_PROMPT, ctx.pocket_id or "", ctx.backend_summary)
         )
+    # ADDITIVE member orientation (pp#1367): append the pre-rendered, capped
+    # "about this member" block LAST so the agent greets the caller by name and
+    # tailors to their role/focus from turn one. It is pre-resolved on the
+    # ScopeContext (async, in the resolver) and APPENDED here — never injected
+    # via ``system_message_override`` (that field REPLACES the base persona).
+    # ``None`` for a member with no Person (pre-existing / non-invited user) ⇒
+    # nothing appended ⇒ behavior identical to before. The string is already
+    # hard-capped at render time, so this can't bloat the prompt.
+    if ctx.about_member_block:
+        parts.append(ctx.about_member_block)
     return "\n".join(parts)
 
 

--- a/ee/pocketpaw_ee/cloud/people/__init__.py
+++ b/ee/pocketpaw_ee/cloud/people/__init__.py
@@ -6,10 +6,15 @@
 # Read by a later VIP-onboarding flow. STANDALONE — models identity only,
 # independent of the per-pocket agent-policy surface profile.
 #
-# No router yet: the only entry point is the service function the workspace
-# accept_invite path calls. A read API can land in a later slice.
+# Changes: 2026-06-08 (feat/vip-agent-block, pp#1367) — exported the read
+# side, ``get_person``, so the agent-orientation flow can fetch a member's
+# Person to render an "about this member" block in the system prompt.
+#
+# No router yet: the entry points are the service functions the workspace
+# accept_invite path (write) and the chat agent-orientation path (read) call.
+# A read API can land in a later slice.
 
 from pocketpaw_ee.cloud.people.domain import Person
-from pocketpaw_ee.cloud.people.service import materialize_person_from_invite
+from pocketpaw_ee.cloud.people.service import get_person, materialize_person_from_invite
 
-__all__ = ["Person", "materialize_person_from_invite"]
+__all__ = ["Person", "get_person", "materialize_person_from_invite"]

--- a/ee/pocketpaw_ee/cloud/people/service.py
+++ b/ee/pocketpaw_ee/cloud/people/service.py
@@ -1,11 +1,18 @@
-"""People domain — materialize a workspace member as a Fabric ``Person``.
+"""People domain — materialize and read a workspace member's Fabric ``Person``.
 
 Created: 2026-06-08 (feat/vip-fabric-person, pp#1366).
+Changes: 2026-06-08 (feat/vip-agent-block, pp#1367) — added the read side,
+:func:`get_person`, that queries the journal projection for a member's
+deterministic Person id (workspace-scoped) and maps the projected object's
+property bag back to a typed :class:`Person`, or ``None`` when the member
+has no Person yet. The agent-orientation flow reads it to render an
+"about this member" block; the read mirrors the materializer's query +
+scope shape.
 
 When a workspace invite is accepted, ``accept_invite`` calls
 :func:`materialize_person_from_invite` to create (or update) a standalone
 Fabric ``Person`` object for the new member. The object is the identity
-"spine" a later VIP-onboarding flow reads.
+"spine" a later VIP-onboarding flow reads. :func:`get_person` is that read.
 
 Write path — the journal, not the legacy SQLite store
 -----------------------------------------------------
@@ -234,4 +241,73 @@ async def materialize_person_from_invite(
     return person
 
 
-__all__ = ["materialize_person_from_invite"]
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+
+def _person_from_object(obj: FabricObject, *, workspace_id: str) -> Person:
+    """Map a projected Fabric object back to a typed :class:`Person`.
+
+    The inverse of :meth:`Person.to_properties`. ``id`` comes from the
+    object's own id; ``workspace_id`` from the read scope (the journal does
+    NOT fold it into the property bag — it's carried by the event scope); the
+    remaining identity / provenance fields come straight from the property
+    bag. ``group`` stays ``None`` when the stored value is falsy.
+    """
+
+    props = obj.properties
+    return Person(
+        id=obj.id,
+        workspace_id=workspace_id,
+        user_id=str(props.get("user_id", "")),
+        name=str(props.get("name", "")),
+        email=str(props.get("email", "")),
+        avatar=str(props.get("avatar", "")),
+        role=str(props.get("role", "")),
+        group=props.get("group") or None,
+        focus=str(props.get("focus", "")),
+        profile_pic=str(props.get("profile_pic", "")),
+        invited_by=str(props.get("invited_by", "")),
+        source=str(props.get("source", SOURCE_ADMIN_CONTEXT)),
+    )
+
+
+async def get_person(
+    workspace_id: str,
+    user_id: str,
+    *,
+    store: FabricJournalStore | None = None,
+) -> Person | None:
+    """Read a member's materialized Fabric ``Person``, or ``None``.
+
+    Queries the journal projection for the ``Person`` type under the member's
+    own workspace scope and matches the deterministic id
+    (``person-{workspace_id}-{user_id}``). Returns the typed :class:`Person`
+    when present, ``None`` when this member was never materialized — e.g. a
+    pre-existing / non-invited user. The caller treats ``None`` as "no block",
+    never an error.
+
+    Tenant-scoped: ``requester_scopes`` is the single workspace scope, so the
+    read can only ever see this workspace's people. Mirrors the materializer's
+    query (same ``type_id`` + scope), then narrows to the deterministic id.
+
+    ``store`` is injectable for tests; production callers omit it and get the
+    process-wide journal-backed store.
+    """
+
+    fabric = store if store is not None else _default_store()
+    scope = _person_scope(workspace_id)
+    target_id = _person_object_id(workspace_id, user_id)
+
+    result = await fabric.query(
+        FabricQuery(type_id=PERSON_TYPE_ID, limit=10_000),
+        requester_scopes=scope,
+    )
+    for obj in result.objects:
+        if obj.id == target_id:
+            return _person_from_object(obj, workspace_id=workspace_id)
+    return None
+
+
+__all__ = ["get_person", "materialize_person_from_invite"]

--- a/tests/cloud/chat/test_about_member_block.py
+++ b/tests/cloud/chat/test_about_member_block.py
@@ -1,0 +1,223 @@
+# tests/cloud/chat/test_about_member_block.py — agent member-orientation block.
+# Created: 2026-06-08 (feat/vip-agent-block, pp#1367).
+#
+# Locks the contract for the "about this member" block that orients the chat
+# agent to who is talking (pp#1367):
+#
+#   1. WITH a Person — the rendered block is APPENDED to the assembled system
+#      message (build_behavior_instructions / build_context_block), carrying
+#      name · role · team · focus. Additive: the base persona (runtime-identity
+#      rule, ripple prompt) is still present — the block does NOT replace it.
+#   2. WITHOUT a Person — ctx.about_member_block is None → no block in the
+#      assembled message, and assembly does not raise. Behavior == today.
+#   3. The render is HARD char-capped (_ABOUT_MEMBER_CHAR_CAP) so a giant focus
+#      line can't bloat the always-on system prompt (the known ~20K-char mode).
+#   4. The async resolver (_resolve_about_member) degrades to None when the
+#      member has no Person and when the people read raises — never an error.
+#
+# The block is pre-rendered onto ScopeContext by the resolvers (async); the
+# sync assembly just appends it. So the assembly tests construct a ScopeContext
+# directly with about_member_block set (mirroring test_pocket_agent_context.py).
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import (
+    _ABOUT_MEMBER_CHAR_CAP,
+    ScopeContext,
+    ScopeKind,
+    _render_about_member_block,
+    _resolve_about_member,
+    build_behavior_instructions,
+    build_context_block,
+)
+from pocketpaw_ee.cloud.people.domain import Person
+
+
+def _person(
+    *,
+    name: str = "Ada Lovelace",
+    role: str = "admin",
+    group: str | None = "team-eng",
+    focus: str = "Own the billing rewrite",
+) -> Person:
+    return Person(
+        id="person-ws1-user-7",
+        workspace_id="ws1",
+        user_id="user-7",
+        name=name,
+        email="ada@x.c",
+        avatar="",
+        role=role,
+        group=group,
+        focus=focus,
+        profile_pic="",
+        invited_by="admin-1",
+    )
+
+
+def _ctx(*, about_member_block: str | None) -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="ws1",
+        user_id="user-7",
+        members=["user-7"],
+        target_agent_id="a1",
+        about_member_block=about_member_block,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. WITH a Person — block is appended to the assembled system message
+# ---------------------------------------------------------------------------
+
+
+class TestBlockPresentWithPerson:
+    def test_block_appended_to_behavior_instructions(self) -> None:
+        block = _render_about_member_block(_person())
+        ctx = _ctx(about_member_block=block)
+
+        assembled = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+
+        # The block — and its identity content — is in the assembled message.
+        assert "<about-member>" in assembled
+        assert "Ada Lovelace" in assembled
+        assert "admin" in assembled
+        assert "team team-eng" in assembled
+        assert "Own the billing rewrite" in assembled
+
+    def test_block_is_additive_not_a_replacement(self) -> None:
+        # The base persona content must still be present alongside the block —
+        # the block is APPENDED, it does not clobber the base system message.
+        block = _render_about_member_block(_person())
+        ctx = _ctx(about_member_block=block)
+
+        assembled = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+
+        # Base persona markers (runtime-identity rule + ripple law) survive.
+        assert "<runtime-identity>" in assembled
+        assert "<ripple>" in assembled
+        # And the block comes AFTER the base content (appended last).
+        assert assembled.index("<about-member>") > assembled.index("<runtime-identity>")
+
+    def test_block_present_via_build_context_block(self) -> None:
+        # The combined entry point used by tests / legacy callers also carries it.
+        block = _render_about_member_block(_person())
+        ctx = _ctx(about_member_block=block)
+
+        assembled = build_context_block(ctx, backend_name="claude_agent_sdk")
+        assert "<about-member>" in assembled
+        assert "Ada Lovelace" in assembled
+
+
+# ---------------------------------------------------------------------------
+# 2. WITHOUT a Person — no block, no error
+# ---------------------------------------------------------------------------
+
+
+class TestGracefullyAbsent:
+    def test_no_block_when_about_member_is_none(self) -> None:
+        ctx = _ctx(about_member_block=None)
+
+        assembled = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+
+        # No member block, and the base persona is unaffected.
+        assert "<about-member>" not in assembled
+        assert "<runtime-identity>" in assembled
+
+    def test_assembly_does_not_raise_without_person(self) -> None:
+        ctx = _ctx(about_member_block=None)
+        # Must not raise on any backend path.
+        build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+        build_behavior_instructions(ctx, backend_name="codex_cli")
+        build_context_block(ctx, backend_name="claude_agent_sdk")
+
+    def test_render_returns_empty_for_nameless_person(self) -> None:
+        # A Person with no usable name yields no block (treated as "no Person").
+        assert _render_about_member_block(_person(name="")) == ""
+        assert _render_about_member_block(_person(name="   ")) == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. Render is HARD char-capped (prompt-bloat backstop)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenCap:
+    def test_huge_focus_is_capped(self) -> None:
+        # A pathological 20K-char focus line must not produce a 20K-char block.
+        huge = "billing " * 4000  # ~32K chars
+        block = _render_about_member_block(_person(focus=huge))
+
+        assert len(block) <= _ABOUT_MEMBER_CHAR_CAP + len("…\n</about-member>")
+        # ~4 chars/token ⇒ comfortably under the ~400-token budget.
+        assert len(block) / 4 <= 400
+        # Still well-formed: opens and closes the tag.
+        assert block.startswith("<about-member>")
+        assert block.rstrip().endswith("</about-member>")
+
+    def test_cap_constant_is_within_budget(self) -> None:
+        # Guard the budget itself: the char cap must stay under ~400 tokens
+        # (~4 chars/token) so the block can never breach the stated limit.
+        assert _ABOUT_MEMBER_CHAR_CAP / 4 <= 400
+
+    def test_normal_block_is_small(self) -> None:
+        # A realistic block is a fraction of the cap — the cap is only a backstop.
+        block = _render_about_member_block(_person())
+        assert len(block) < _ABOUT_MEMBER_CHAR_CAP // 2
+
+    def test_focus_whitespace_is_collapsed(self) -> None:
+        # Newlines / runs of spaces in the focus are collapsed to a single line
+        # (keeps the block a tidy one-liner and helps the cap math).
+        block = _render_about_member_block(_person(focus="own\n\n  the   billing\trewrite"))
+        assert "own the billing rewrite" in block
+        assert "\n\n" not in block.split("focus:")[1]
+
+
+# ---------------------------------------------------------------------------
+# 4. _resolve_about_member degrades gracefully
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAboutMember:
+    @pytest.mark.asyncio
+    async def test_resolve_returns_block_for_member_with_person(self) -> None:
+        async def _fake_get_person(workspace_id: str, user_id: str):
+            return _person()
+
+        with patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_fake_get_person):
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert block is not None
+        assert "<about-member>" in block
+        assert "Ada Lovelace" in block
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_none_when_no_person(self) -> None:
+        async def _fake_get_person(workspace_id: str, user_id: str):
+            return None
+
+        with patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_fake_get_person):
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert block is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_none_when_read_raises(self) -> None:
+        async def _boom(workspace_id: str, user_id: str):
+            raise RuntimeError("journal exploded")
+
+        with patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_boom):
+            # Must swallow the error and degrade to None — never propagate.
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert block is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_none_on_empty_ids(self) -> None:
+        # No workspace / user ⇒ no read attempted, None returned.
+        assert await _resolve_about_member("", "user-7") is None
+        assert await _resolve_about_member("ws1", "") is None

--- a/tests/cloud/people/test_get_person.py
+++ b/tests/cloud/people/test_get_person.py
@@ -1,0 +1,215 @@
+# tests/cloud/people/test_get_person.py — Fabric Person read (get_person).
+# Created: 2026-06-08 (feat/vip-agent-block, pp#1367).
+#
+# Locks the contract for get_person (the people read side):
+#   1. A materialized member round-trips: write via the materializer, read via
+#      get_person → a typed Person with the same identity + provenance fields,
+#      mapped back from the journal projection's property bag.
+#   2. A member with no Person (never materialized) → None, no error. This is
+#      the "pre-existing / non-invited user" path the about-block relies on.
+#   3. Tenant isolation: get_person scoped to workspace A never sees a Person
+#      that lives in workspace B (same user_id), even when both share a store.
+#   4. The deterministic id is matched exactly — a different user in the same
+#      workspace doesn't return the wrong Person.
+#
+# Uses a throwaway FabricJournalStore over a tmp journal injected via the
+# service's ``store=`` arg — same fixture shape as test_materialize_person.py.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud.people.domain import SOURCE_ADMIN_CONTEXT
+from pocketpaw_ee.cloud.people.service import get_person, materialize_person_from_invite
+from pocketpaw_ee.cloud.workspace.domain import Invite, InviteContext
+from soul_protocol.engine.journal import open_journal
+
+from pocketpaw.fabric.journal_store import FabricJournalStore
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+@pytest.fixture
+def store(journal) -> FabricJournalStore:
+    s = FabricJournalStore(journal)
+    s.bootstrap()
+    return s
+
+
+def _invite(
+    *,
+    workspace_id: str = "ws1",
+    email: str = "member@x.c",
+    role: str = "member",
+    invited_by: str = "admin1",
+    group_id: str | None = "team-eng",
+    context: InviteContext | None = None,
+) -> Invite:
+    return Invite(
+        id="inv1",
+        workspace_id=workspace_id,
+        email=email,
+        role=role,
+        invited_by=invited_by,
+        token=None,
+        group_id=group_id,
+        accepted=True,
+        revoked=False,
+        expired=False,
+        expires_at=datetime.now(UTC),
+        context=context,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Round-trip — materialized member reads back as a typed Person
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    @pytest.mark.asyncio
+    async def test_get_person_returns_typed_person_with_all_fields(
+        self, store: FabricJournalStore
+    ) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada Lovelace",
+            email="member@x.c",
+            avatar="https://cdn/ada.png",
+            invite=_invite(
+                role="admin",
+                invited_by="admin-99",
+                group_id="team-eng",
+                context=InviteContext(focus="Own the billing rewrite", profile_pic="file-42"),
+            ),
+            store=store,
+        )
+
+        person = await get_person("ws1", "user-7", store=store)
+
+        assert person is not None
+        # id comes from the object's own id; workspace_id from the read scope.
+        assert person.id == "person-ws1-user-7"
+        assert person.workspace_id == "ws1"
+        # Identity + role/team + onboarding, mapped back from the property bag.
+        assert person.user_id == "user-7"
+        assert person.name == "Ada Lovelace"
+        assert person.email == "member@x.c"
+        assert person.avatar == "https://cdn/ada.png"
+        assert person.role == "admin"
+        assert person.group == "team-eng"
+        assert person.focus == "Own the billing rewrite"
+        assert person.profile_pic == "file-42"
+        # Provenance survives the round-trip.
+        assert person.invited_by == "admin-99"
+        assert person.source == SOURCE_ADMIN_CONTEXT
+
+    @pytest.mark.asyncio
+    async def test_get_person_no_context_maps_group_none(self, store: FabricJournalStore) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(context=None, group_id=None),
+            store=store,
+        )
+
+        person = await get_person("ws1", "user-7", store=store)
+
+        assert person is not None
+        assert person.group is None  # falsy stored value maps back to None
+        assert person.focus == ""
+        assert person.profile_pic == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Absent member — no Person → None, no error
+# ---------------------------------------------------------------------------
+
+
+class TestAbsent:
+    @pytest.mark.asyncio
+    async def test_unmaterialized_member_returns_none(self, store: FabricJournalStore) -> None:
+        # Empty store — this user was never invited / materialized.
+        person = await get_person("ws1", "ghost-user", store=store)
+        assert person is None
+
+    @pytest.mark.asyncio
+    async def test_other_user_in_same_workspace_returns_none(
+        self, store: FabricJournalStore
+    ) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(),
+            store=store,
+        )
+        # Different user id, same workspace — deterministic id won't match.
+        person = await get_person("ws1", "user-OTHER", store=store)
+        assert person is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Tenant isolation — workspace A can't read workspace B's Person
+# ---------------------------------------------------------------------------
+
+
+class TestTenantIsolation:
+    @pytest.mark.asyncio
+    async def test_get_person_is_scoped_to_its_workspace(self, store: FabricJournalStore) -> None:
+        # Same user id materialized in two different workspaces.
+        await materialize_person_from_invite(
+            workspace_id="ws-A",
+            user_id="user-7",
+            name="Ada in A",
+            email="a@x.c",
+            avatar="",
+            invite=_invite(workspace_id="ws-A"),
+            store=store,
+        )
+        await materialize_person_from_invite(
+            workspace_id="ws-B",
+            user_id="user-7",
+            name="Ada in B",
+            email="b@x.c",
+            avatar="",
+            invite=_invite(workspace_id="ws-B"),
+            store=store,
+        )
+
+        a = await get_person("ws-A", "user-7", store=store)
+        b = await get_person("ws-B", "user-7", store=store)
+
+        assert a is not None and a.name == "Ada in A"
+        assert a.id == "person-ws-A-user-7"
+        assert b is not None and b.name == "Ada in B"
+        assert b.id == "person-ws-B-user-7"
+
+    @pytest.mark.asyncio
+    async def test_workspace_with_no_people_returns_none(self, store: FabricJournalStore) -> None:
+        # A Person exists, but in a different workspace than we query.
+        await materialize_person_from_invite(
+            workspace_id="ws-A",
+            user_id="user-7",
+            name="Ada",
+            email="a@x.c",
+            avatar="",
+            invite=_invite(workspace_id="ws-A"),
+            store=store,
+        )
+        # Query a workspace that has no Person for this user.
+        person = await get_person("ws-EMPTY", "user-7", store=store)
+        assert person is None


### PR DESCRIPTION
## What ships

The workspace chat agent now greets an invited member by name from the very first turn, aware of their role, team, and focus. A concise "about this member" block (name · role · team · one-line focus) is rendered from the member's Fabric `Person` and added to the agent's system message.

## How it's wired

- A new `get_person(workspace_id, user_id)` read on the people service — queries the Fabric journal projection for the deterministic Person id and maps it back to a typed `Person`.
- The block is **appended** to the base system message in `build_behavior_instructions` — additive, never via `system_message_override` (which would swap the persona). The session's user + workspace come off `ScopeContext`; the async Person read happens once in the resolvers (matching the existing `backend_summary` pattern), and the rendered string is stashed for the sync assembly to append.
- Hard character cap (1500 chars ≈ ~375 tokens, under the ~400 budget) to kill the known prompt-bloat failure mode — the whole block is truncated, not just one field.
- Graceful: a member with no Person gets no block and the agent behaves exactly as today; read errors / empty ids degrade to no block, never raise.

Standalone — it reads identity (the Person), with no dependency on `PocketSurfaceProfile` / the entity-profile work.

## Tests

20 new (6 `get_person`: round-trip / absent / tenant isolation; 14 about-block: present + base-persona-survives, absent + no-raise, cap enforced, degradation paths). The broader `tests/cloud/people` + `tests/cloud/chat` + agent-context + runs suites — 279 passing, the existing system-message and entity-profile tests all green.

## Stacked

Branches off `feat/vip-fabric-person` (#1369) since it reads the Person. Merge order: **#1368 → #1369 → this**, each with `--rebase`.

Closes #1367
