### PR TITLE
feat(plugins): list and remove installed plugins

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -324,9 +324,6 @@ per server:
 The namespaced server names appear in the registry entry under
 `mcp_servers` and on the report's `installed_mcp_servers`.
 
-> Scope note: this slice installs **skills and MCP servers**. The
-> list/remove surface ships in a follow-up endpoint.
-
 ### `POST /plugins/install`
 
 Install a plugin's skills and MCP servers from a GitHub source. Requires
@@ -384,6 +381,74 @@ preserved.
 
 Every install is audit-logged with the source, plugin name, version, and
 the installed skill names.
+
+### `GET /plugins`
+
+List every installed plugin from the registry
+(`~/.pocketpaw/plugins.json`). Requires the **admin** scope.
+
+Response `200` — an array of installed plugins:
+
+```json
+[
+  {
+    "name": "my-plugin",
+    "version": "1.2.3",
+    "source": "acme/widgets",
+    "skills": ["alpha", "beta"],
+    "mcp_servers": ["plugin:my-plugin:weather"],
+    "installed_at": "2026-06-08T12:00:00"
+  }
+]
+```
+
+### `POST /plugins/remove`
+
+Uninstall a plugin: delete each skill directory it installed, remove each
+of its namespaced MCP servers from the MCP manager, reload the skill
+loader, and drop its registry entry. Requires the **admin** scope.
+
+Request body:
+
+```json
+{ "name": "my-plugin" }
+```
+
+Response `200` — a step-by-step remove report (mirrors the install report):
+
+```json
+{
+  "plugin": "my-plugin",
+  "removed_at": "2026-06-08T12:05:00",
+  "steps": [
+    { "name": "skill:alpha", "status": "succeeded" },
+    { "name": "mcp:plugin:my-plugin:weather", "status": "succeeded" },
+    { "name": "reload_loader", "status": "succeeded" },
+    { "name": "drop_registry", "status": "succeeded" }
+  ],
+  "removed_skills": ["alpha", "beta"],
+  "removed_mcp_servers": ["plugin:my-plugin:weather"]
+}
+```
+
+Like install, each component is a step with status `succeeded` / `skipped`
+/ `failed`. A component that's already gone (a missing skill dir, an MCP
+server no longer registered) is `skipped` — the remove still completes and
+the registry entry is **always** dropped, so a half-removed plugin never
+lingers in the listing. The only up-front error is an unknown plugin:
+
+| Status | When |
+|--------|------|
+| `400` | Missing or invalid `name`. |
+| `404` | The named plugin is not installed. |
+
+Every removal is audit-logged (`action="plugin_remove"`) with the plugin
+name and the removed skill / MCP server names.
+
+The registry read-modify-write (shared by install and remove) is
+serialised by a process-level lock and written via a temp file + atomic
+`os.replace`, so concurrent operations can't corrupt `plugins.json` or
+clobber each other's entries.
 
 ## Pockets — Catalog-as-Allowlist Ingest Gate
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -404,9 +404,13 @@ Response `200` — an array of installed plugins:
 
 ### `POST /plugins/remove`
 
-Uninstall a plugin: delete each skill directory it installed, remove each
-of its namespaced MCP servers from the MCP manager, reload the skill
-loader, and drop its registry entry. Requires the **admin** scope.
+Uninstall a plugin: delete each skill directory it installed, **stop** each
+of its namespaced MCP servers and remove their configs from the MCP manager,
+reload the skill loader, and drop its registry entry. Stopping the live
+server (not just deleting its config) mirrors install, which both registers
+the config and starts the server — so remove tears down the running
+connection too, rather than leaving it up until the next restart. Requires
+the **admin** scope.
 
 Request body:
 
@@ -433,9 +437,10 @@ Response `200` — a step-by-step remove report (mirrors the install report):
 
 Like install, each component is a step with status `succeeded` / `skipped`
 / `failed`. A component that's already gone (a missing skill dir, an MCP
-server no longer registered) is `skipped` — the remove still completes and
-the registry entry is **always** dropped, so a half-removed plugin never
-lingers in the listing. The only up-front error is an unknown plugin:
+server that's neither running nor registered) is `skipped` — the remove
+still completes and the registry entry is **always** dropped, so a
+half-removed plugin never lingers in the listing. The only up-front error
+is an unknown plugin:
 
 | Status | When |
 |--------|------|

--- a/src/pocketpaw/api/v1/plugins.py
+++ b/src/pocketpaw/api/v1/plugins.py
@@ -2,9 +2,13 @@
 # Created: 2026-06-07 (feat/plugin-installer-skills) — Plugins router.
 # Updated: 2026-06-08 (feat/plugin-installer-mcp) — install now also
 # registers + starts a bundle's MCP servers (#1357).
+# Updated: 2026-06-08 (feat/plugin-installer-listremove, #1358) — added
+# GET /api/v1/plugins (list installed plugins) and POST /api/v1/plugins/remove
+# ({"name"} → uninstall skills + MCP servers, drop the registry entry).
+# Unknown plugin maps to 404. Both admin-scoped, audited in the installer.
 # POST /api/v1/plugins/install clones a .claude-plugin repo, installs its
 # skills and MCP servers, and returns a step-by-step PluginInstallReport.
-# Admin-scoped, mirroring api/v1/mcp.py. List/remove ships separately (#1358).
+# Admin-scoped, mirroring api/v1/mcp.py.
 """REST surface for the Plugin Installer (skills + MCP)."""
 
 from __future__ import annotations
@@ -15,7 +19,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from pocketpaw.api.deps import require_scope
 from pocketpaw.plugins.installer import PluginInstaller, PluginInstallError
-from pocketpaw.plugins.models import PluginInstallReport
+from pocketpaw.plugins.models import (
+    InstalledPlugin,
+    PluginInstallReport,
+    PluginRemoveReport,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,3 +49,35 @@ async def install_plugin(request: Request) -> PluginInstallReport:
     except Exception:
         logger.exception("Plugin install failed")
         raise HTTPException(status_code=500, detail="Plugin install failed")
+
+
+@router.get("/plugins", response_model=list[InstalledPlugin])
+async def list_plugins() -> list[InstalledPlugin]:
+    """List installed plugins from the registry.
+
+    Returns each plugin's name, version, source, installed skills, namespaced
+    MCP servers, and install timestamp.
+    """
+    return PluginInstaller().list_plugins()
+
+
+@router.post("/plugins/remove", response_model=PluginRemoveReport)
+async def remove_plugin(request: Request) -> PluginRemoveReport:
+    """Uninstall a plugin's skills and MCP servers, drop its registry entry.
+
+    Body: ``{"name": "my-plugin"}``. Returns a :class:`PluginRemoveReport`.
+    An unknown plugin maps to 404; per-component cleanup failures surface as
+    ``failed`` steps in the report rather than aborting the request.
+    """
+    data = await request.json()
+    name = (data.get("name") or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Missing 'name' field")
+
+    try:
+        return await PluginInstaller().remove(name)
+    except PluginInstallError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+    except Exception:
+        logger.exception("Plugin remove failed")
+        raise HTTPException(status_code=500, detail="Plugin remove failed")

--- a/src/pocketpaw/plugins/installer.py
+++ b/src/pocketpaw/plugins/installer.py
@@ -14,7 +14,17 @@
 # start for lack of env is reported `succeeded` with a "needs env:" detail).
 # The namespaced names are recorded in the registry entry and on the report's
 # `installed_mcp_servers`. Imports the now-public `ignore_symlinks` and drops
-# the clone-factory `except TypeError` fallback. List/remove ships in #1358.
+# the clone-factory `except TypeError` fallback.
+# Updated: 2026-06-08 (feat/plugin-installer-listremove, #1358) — final slice:
+# `list_plugins()` reads the registry into `InstalledPlugin` views;
+# `remove(name)` deletes the plugin's skill dirs, removes its namespaced MCP
+# servers via `get_mcp_manager().remove_server_config`, reloads the loader,
+# drops the registry entry, and audit-logs (`action="plugin_remove"`) — per
+# component failures degrade to failed/skipped steps; only an unknown plugin
+# raises (404). The registry read-modify-write is now concurrency-safe: a
+# module-level lock guards the r-m-w and the write goes through a temp file +
+# atomic `os.replace`, so install and remove can't corrupt the JSON or clobber
+# each other's entries.
 """Install a ``.claude-plugin``'s skills and MCP servers from a GitHub repo.
 
 Each unit of work is a :class:`PluginInstallStep` that never raises out of
@@ -28,8 +38,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
+import threading
 from collections.abc import Callable
 from contextlib import AbstractAsyncContextManager
 from pathlib import Path
@@ -39,9 +51,11 @@ from pocketpaw.mcp.config import MCPServerConfig
 from pocketpaw.mcp.manager import get_mcp_manager
 from pocketpaw.mcp.presets import spec_to_config
 from pocketpaw.plugins.models import (
+    InstalledPlugin,
     PluginInstallReport,
     PluginInstallStep,
     PluginManifest,
+    PluginRemoveReport,
 )
 from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
 from pocketpaw.skills.installer import (
@@ -55,6 +69,17 @@ logger = logging.getLogger(__name__)
 
 # Registry of installed plugins (read-modify-write JSON).
 REGISTRY_PATH = Path.home() / ".pocketpaw" / "plugins.json"
+
+# Guards the registry read-modify-write. Both install and remove read the
+# whole registry, mutate one entry, and write it all back, so two concurrent
+# operations could otherwise lose one entry (last-writer-wins on the file).
+# A threading.Lock (not asyncio.Lock) is correct here: the r-m-w itself is
+# synchronous, fast, and CPU/IO-bound — holding a threading lock across it
+# serialises both the async install path (which only awaits the clone/MCP
+# work *outside* the critical section) and any threaded caller. The paired
+# atomic temp-file + os.replace write means a crash mid-write can't leave a
+# truncated/corrupt registry behind either.
+_REGISTRY_LOCK = threading.Lock()
 
 # GitHub naming rules — reused from skills/installer.py validation regexes.
 _OWNER_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
@@ -494,18 +519,18 @@ class PluginInstaller:
         from datetime import datetime
 
         try:
-            registry = self._load_registry()
-            registry[manifest.name] = {
-                "version": manifest.version,
-                "source": source,
-                "skills": installed,
-                "mcp_servers": mcp_servers or [],
-                "installed_at": datetime.now().isoformat(),
-            }
-            self._registry_path.parent.mkdir(parents=True, exist_ok=True)
-            self._registry_path.write_text(
-                json.dumps(registry, indent=2, sort_keys=True), encoding="utf-8"
-            )
+            # Lock the whole read-modify-write so a concurrent install/remove
+            # can't read a stale copy and clobber this entry on write-back.
+            with _REGISTRY_LOCK:
+                registry = self._load_registry()
+                registry[manifest.name] = {
+                    "version": manifest.version,
+                    "source": source,
+                    "skills": installed,
+                    "mcp_servers": mcp_servers or [],
+                    "installed_at": datetime.now().isoformat(),
+                }
+                self._save_registry(registry)
             return PluginInstallStep(name="record_registry", status="succeeded")
         except OSError as exc:
             logger.warning("Plugin registry write failed: %s", exc)
@@ -521,6 +546,20 @@ class PluginInstaller:
             logger.warning("Plugin registry unreadable; starting fresh")
             return {}
         return data if isinstance(data, dict) else {}
+
+    def _save_registry(self, registry: dict[str, Any]) -> None:
+        """Atomically write the registry: temp file + ``os.replace``.
+
+        Writing to a sibling temp file and renaming it over the target means a
+        crash mid-write can't leave a truncated/corrupt ``plugins.json`` — the
+        old file stays intact until the rename, and the rename is atomic on the
+        same filesystem. Callers must hold ``_REGISTRY_LOCK`` around the
+        surrounding read-modify-write.
+        """
+        self._registry_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._registry_path.with_suffix(self._registry_path.suffix + f".tmp.{os.getpid()}")
+        tmp.write_text(json.dumps(registry, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, self._registry_path)
 
     def _audit(self, source: str, manifest: PluginManifest, installed: list[str], ok: bool) -> None:
         """Audit-log the install (best-effort; precedent: skills installer)."""
@@ -539,6 +578,177 @@ class PluginInstaller:
             )
         except Exception:  # audit must never break the install
             logger.warning("Plugin install audit log failed", exc_info=True)
+
+    # --------------------------------------------------------------------- #
+    # List                                                                  #
+    # --------------------------------------------------------------------- #
+    def list_plugins(self) -> list[InstalledPlugin]:
+        """Return every installed plugin from the registry.
+
+        Reads ``~/.pocketpaw/plugins.json`` and projects each entry into an
+        :class:`InstalledPlugin`. Malformed or partial entries degrade to
+        defaults (rather than failing the whole listing). Sorted by name for a
+        stable surface.
+        """
+        with _REGISTRY_LOCK:
+            registry = self._load_registry()
+        plugins: list[InstalledPlugin] = []
+        for name, entry in sorted(registry.items()):
+            if not isinstance(entry, dict):
+                continue
+            plugins.append(
+                InstalledPlugin(
+                    name=name,
+                    version=str(entry.get("version", "0.0.0")),
+                    source=str(entry.get("source", "")),
+                    skills=[str(s) for s in entry.get("skills", []) if isinstance(s, str)],
+                    mcp_servers=[
+                        str(s) for s in entry.get("mcp_servers", []) if isinstance(s, str)
+                    ],
+                    installed_at=str(entry.get("installed_at", "")),
+                )
+            )
+        return plugins
+
+    # --------------------------------------------------------------------- #
+    # Remove                                                                #
+    # --------------------------------------------------------------------- #
+    async def remove(self, name: str) -> PluginRemoveReport:
+        """Uninstall a plugin: skills, MCP servers, registry entry.
+
+        Reads the plugin's registry entry, deletes each skill dir it installed,
+        removes each of its namespaced MCP servers via the manager, reloads the
+        skill loader, drops the registry entry, and audit-logs the removal.
+
+        Only an unknown plugin is an up-front error (raises
+        :class:`PluginInstallError` 404). Every per-component failure degrades
+        to a ``failed`` / ``skipped`` step — the same contract as install — so
+        a partial cleanup never raises out mid-remove and the registry entry is
+        still dropped (a half-removed plugin must never linger in the listing).
+
+        Args:
+            name: The installed plugin's name (registry key).
+
+        Returns:
+            A :class:`PluginRemoveReport` describing every step.
+
+        Raises:
+            PluginInstallError: 400 for an invalid name, 404 if the plugin is
+                not installed.
+        """
+        if name in (".", "..") or not _NAME_RE.match(name or ""):
+            raise PluginInstallError("Invalid plugin name", 400)
+
+        with _REGISTRY_LOCK:
+            entry = self._load_registry().get(name)
+        if not isinstance(entry, dict):
+            raise PluginInstallError(f"Plugin '{name}' is not installed", 404)
+
+        report = PluginRemoveReport(plugin=name)
+
+        skills = [s for s in entry.get("skills", []) if isinstance(s, str)]
+        mcp_servers = [s for s in entry.get("mcp_servers", []) if isinstance(s, str)]
+
+        report.removed_skills = self._remove_skills(skills, report)
+        report.removed_mcp_servers = self._remove_mcp_servers(mcp_servers, report)
+        report.steps.append(self._reload_loader())
+        report.steps.append(self._drop_registry_entry(name))
+
+        self._audit_remove(name, report)
+        return report
+
+    def _remove_skills(self, skills: list[str], report: PluginRemoveReport) -> list[str]:
+        """Delete each skill dir this plugin installed. One step per skill.
+
+        A skill whose name is invalid is ``skipped`` (never used to build a
+        path); a dir that's already gone is ``skipped`` (idempotent — nothing
+        orphaned); a delete error is ``failed``. Never raises.
+        """
+        removed: list[str] = []
+        for skill in skills:
+            step_name = f"skill:{skill}"
+            if skill in (".", "..") or not _NAME_RE.match(skill):
+                report.steps.append(
+                    PluginInstallStep(name=step_name, status="skipped", detail="invalid skill name")
+                )
+                continue
+            dest = self._install_dir / skill
+            if not dest.exists():
+                report.steps.append(
+                    PluginInstallStep(name=step_name, status="skipped", detail="already removed")
+                )
+                continue
+            try:
+                shutil.rmtree(dest)
+            except OSError as exc:
+                report.steps.append(
+                    PluginInstallStep(name=step_name, status="failed", detail=str(exc))
+                )
+                continue
+            removed.append(skill)
+            report.steps.append(PluginInstallStep(name=step_name, status="succeeded"))
+        return removed
+
+    def _remove_mcp_servers(self, servers: list[str], report: PluginRemoveReport) -> list[str]:
+        """Remove each namespaced MCP server config. One step per server.
+
+        ``remove_server_config`` returns False when the server isn't in the
+        manager's config — treated as ``skipped`` (already gone, idempotent).
+        A raise from the manager is ``failed``. Never raises out.
+        """
+        if not servers:
+            return []
+        manager = get_mcp_manager()
+        removed: list[str] = []
+        for server in servers:
+            step_name = f"mcp:{server}"
+            try:
+                found = manager.remove_server_config(server)
+            except Exception as exc:  # manager hiccup — don't abort the remove
+                logger.warning("MCP server '%s' removal raised: %s", server, exc)
+                report.steps.append(
+                    PluginInstallStep(name=step_name, status="failed", detail=str(exc))
+                )
+                continue
+            if found:
+                removed.append(server)
+                report.steps.append(PluginInstallStep(name=step_name, status="succeeded"))
+            else:
+                report.steps.append(
+                    PluginInstallStep(name=step_name, status="skipped", detail="not registered")
+                )
+        return removed
+
+    def _drop_registry_entry(self, name: str) -> PluginInstallStep:
+        """Remove the plugin's registry entry (atomic, locked r-m-w)."""
+        try:
+            with _REGISTRY_LOCK:
+                registry = self._load_registry()
+                registry.pop(name, None)
+                self._save_registry(registry)
+            return PluginInstallStep(name="drop_registry", status="succeeded")
+        except OSError as exc:
+            logger.warning("Plugin registry write failed: %s", exc)
+            return PluginInstallStep(name="drop_registry", status="failed", detail=str(exc))
+
+    def _audit_remove(self, name: str, report: PluginRemoveReport) -> None:
+        """Audit-log the removal (best-effort; mirrors ``_audit``)."""
+        ok = report.succeeded()
+        try:
+            get_audit_logger().log(
+                AuditEvent.create(
+                    severity=AuditSeverity.INFO if ok else AuditSeverity.WARNING,
+                    actor=self._actor,
+                    action="plugin_remove",
+                    target=name,
+                    status="success" if ok else "partial",
+                    plugin=name,
+                    removed_skills=report.removed_skills,
+                    removed_mcp_servers=report.removed_mcp_servers,
+                )
+            )
+        except Exception:  # audit must never break the remove
+            logger.warning("Plugin remove audit log failed", exc_info=True)
 
 
 __all__ = [

--- a/src/pocketpaw/plugins/installer.py
+++ b/src/pocketpaw/plugins/installer.py
@@ -17,11 +17,14 @@
 # the clone-factory `except TypeError` fallback.
 # Updated: 2026-06-08 (feat/plugin-installer-listremove, #1358) — final slice:
 # `list_plugins()` reads the registry into `InstalledPlugin` views;
-# `remove(name)` deletes the plugin's skill dirs, removes its namespaced MCP
-# servers via `get_mcp_manager().remove_server_config`, reloads the loader,
-# drops the registry entry, and audit-logs (`action="plugin_remove"`) — per
-# component failures degrade to failed/skipped steps; only an unknown plugin
-# raises (404). The registry read-modify-write is now concurrency-safe: a
+# `remove(name)` deletes the plugin's skill dirs, stops + deregisters its
+# namespaced MCP servers via `get_mcp_manager().stop_server` +
+# `.remove_server_config` (symmetric with install, which both registers AND
+# starts the server — so remove must tear down the live connection too, not
+# just the persisted config), reloads the loader, drops the registry entry,
+# and audit-logs (`action="plugin_remove"`) — per component failures degrade
+# to failed/skipped steps; only an unknown plugin raises (404). The registry
+# read-modify-write is now concurrency-safe: a
 # module-level lock guards the r-m-w and the write goes through a temp file +
 # atomic `os.replace`, so install and remove can't corrupt the JSON or clobber
 # each other's entries.
@@ -639,6 +642,11 @@ class PluginInstaller:
         if name in (".", "..") or not _NAME_RE.match(name or ""):
             raise PluginInstallError("Invalid plugin name", 400)
 
+        # Known edge: this read and the later _drop_registry_entry write are
+        # two separate locked sections, so a concurrent install+remove of the
+        # SAME plugin name has a TOCTOU window. Accepted — the atomic write
+        # means no corruption, only a last-writer-wins outcome on that one
+        # entry, and same-name concurrent install/remove is very unlikely.
         with _REGISTRY_LOCK:
             entry = self._load_registry().get(name)
         if not isinstance(entry, dict):
@@ -650,7 +658,7 @@ class PluginInstaller:
         mcp_servers = [s for s in entry.get("mcp_servers", []) if isinstance(s, str)]
 
         report.removed_skills = self._remove_skills(skills, report)
-        report.removed_mcp_servers = self._remove_mcp_servers(mcp_servers, report)
+        report.removed_mcp_servers = await self._remove_mcp_servers(mcp_servers, report)
         report.steps.append(self._reload_loader())
         report.steps.append(self._drop_registry_entry(name))
 
@@ -689,12 +697,22 @@ class PluginInstaller:
             report.steps.append(PluginInstallStep(name=step_name, status="succeeded"))
         return removed
 
-    def _remove_mcp_servers(self, servers: list[str], report: PluginRemoveReport) -> list[str]:
-        """Remove each namespaced MCP server config. One step per server.
+    async def _remove_mcp_servers(
+        self, servers: list[str], report: PluginRemoveReport
+    ) -> list[str]:
+        """Stop + deregister each namespaced MCP server. One step per server.
 
-        ``remove_server_config`` returns False when the server isn't in the
-        manager's config — treated as ``skipped`` (already gone, idempotent).
-        A raise from the manager is ``failed``. Never raises out.
+        Install both *registers* the config and *starts* the live server, so
+        remove must undo both halves to be symmetric — otherwise the running
+        server process/connection lingers until the next app restart. For each
+        server we first ``stop_server`` (tears down the live connection, pops
+        it from the manager) then ``remove_server_config`` (drops the persisted
+        config).
+
+        Degradation mirrors the rest of remove: a raise from either manager
+        call is a ``failed`` step; a server that was neither running nor in the
+        config is ``skipped`` (already gone, idempotent); never raises out. The
+        server counts as removed if either half found something to clean up.
         """
         if not servers:
             return []
@@ -703,19 +721,22 @@ class PluginInstaller:
         for server in servers:
             step_name = f"mcp:{server}"
             try:
-                found = manager.remove_server_config(server)
+                stopped = await manager.stop_server(server)
+                deregistered = manager.remove_server_config(server)
             except Exception as exc:  # manager hiccup — don't abort the remove
                 logger.warning("MCP server '%s' removal raised: %s", server, exc)
                 report.steps.append(
                     PluginInstallStep(name=step_name, status="failed", detail=str(exc))
                 )
                 continue
-            if found:
+            if stopped or deregistered:
                 removed.append(server)
                 report.steps.append(PluginInstallStep(name=step_name, status="succeeded"))
             else:
                 report.steps.append(
-                    PluginInstallStep(name=step_name, status="skipped", detail="not registered")
+                    PluginInstallStep(
+                        name=step_name, status="skipped", detail="not running or registered"
+                    )
                 )
         return removed
 

--- a/src/pocketpaw/plugins/models.py
+++ b/src/pocketpaw/plugins/models.py
@@ -7,6 +7,10 @@
 # ``PluginManifest.mcp_servers`` (optional path override for the bundle's
 # MCP config) and ``PluginInstallReport.installed_mcp_servers`` (the
 # namespaced MCP server names registered on install).
+# Updated: 2026-06-08 (feat/plugin-installer-listremove) — added the
+# list/remove models: ``InstalledPlugin`` (a registry entry view returned
+# by ``list_plugins``) and ``PluginRemoveReport`` (a step-by-step remove
+# run, mirroring ``PluginInstallReport``'s per-component degradation).
 """Models for the .claude-plugin installer.
 
 ``PluginManifest`` is the structurally-validated view of a repo's
@@ -64,6 +68,47 @@ class PluginInstallReport(BaseModel):
     steps: list[PluginInstallStep] = Field(default_factory=list)
     installed_skills: list[str] = Field(default_factory=list)
     installed_mcp_servers: list[str] = Field(default_factory=list)
+
+    def succeeded(self) -> bool:
+        return all(step.status != "failed" for step in self.steps)
+
+    def failed_steps(self) -> list[PluginInstallStep]:
+        return [s for s in self.steps if s.status == "failed"]
+
+
+class InstalledPlugin(BaseModel):
+    """A single installed-plugin view, sourced from the registry entry.
+
+    Returned by ``list_plugins``. ``installed_at`` is kept as a plain string
+    (the registry stores an ISO timestamp produced by ``datetime.isoformat``)
+    so a malformed/legacy entry can never make the whole listing fail to
+    serialise.
+    """
+
+    name: str
+    version: str = "0.0.0"
+    source: str = ""
+    skills: list[str] = Field(default_factory=list)
+    mcp_servers: list[str] = Field(default_factory=list)
+    installed_at: str = ""
+
+
+class PluginRemoveReport(BaseModel):
+    """Full report of a plugin removal run.
+
+    Mirrors :class:`PluginInstallReport`: each component (skill dir, MCP
+    server) is one :class:`PluginInstallStep`, and a per-component failure
+    degrades to a ``failed`` / ``skipped`` step rather than raising mid-remove
+    (only an unknown plugin raises up front). The registry entry is dropped
+    even when some components could not be cleaned up, so a half-removed
+    plugin never lingers in the listing.
+    """
+
+    plugin: str
+    removed_at: datetime = Field(default_factory=datetime.now)
+    steps: list[PluginInstallStep] = Field(default_factory=list)
+    removed_skills: list[str] = Field(default_factory=list)
+    removed_mcp_servers: list[str] = Field(default_factory=list)
 
     def succeeded(self) -> bool:
         return all(step.status != "failed" for step in self.steps)

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -9,6 +9,11 @@
 # namespacing, registered-but-needs-env (succeeded + needs-env detail),
 # a skills+mcp bundle, and the no-.mcp.json skip. The MCP manager is mocked
 # via a fake injected with monkeypatch (no real servers are spawned).
+# Updated: 2026-06-08 (feat/plugin-installer-listremove, #1358) — added the
+# list/remove slice: install-then-list, install-then-remove (deletes exactly
+# this plugin's skill dirs + MCP servers, drops the registry entry, leaves
+# nothing orphaned), unknown-plugin raises 404, degraded remove (a missing
+# component still completes + drops the entry), and the atomic registry write.
 """Unit tests for pocketpaw.plugins (skills + MCP slices)."""
 
 from __future__ import annotations
@@ -314,14 +319,26 @@ class _FakeMCPManager:
     def __init__(self, start_results: dict[str, bool] | None = None):
         self.added: list = []  # MCPServerConfig objects
         self.started: list = []  # MCPServerConfig objects
+        self.removed: list[str] = []  # names passed to remove_server_config
         self._start_results = start_results or {}
+        # Names the fake "knows about" so remove_server_config can report
+        # found/not-found. Defaults to whatever was added.
+        self.known: set[str] = set()
 
     def add_server_config(self, config) -> None:
         self.added.append(config)
+        self.known.add(config.name)
 
     async def start_server(self, config) -> bool:
         self.started.append(config)
         return self._start_results.get(config.name, True)
+
+    def remove_server_config(self, name) -> bool:
+        self.removed.append(name)
+        if name in self.known:
+            self.known.discard(name)
+            return True
+        return False
 
 
 def _write_mcp_json(plugin_root: Path, servers: dict) -> None:
@@ -546,3 +563,195 @@ class TestMCPRouting:
         report = await inst.install("acme/widgets")
 
         assert report.installed_mcp_servers == ["plugin:ov:svc"]
+
+
+# --------------------------------------------------------------------------- #
+# List + remove (#1358)                                                       #
+# --------------------------------------------------------------------------- #
+class TestListPlugins:
+    async def test_install_then_list(self, tmp_path, monkeypatch):
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+
+        repo = _write_plugin(tmp_path / "repo", name="combo", skills=["alpha", "beta"])
+        _write_mcp_json(repo, {"svc": {"command": "uvx", "args": ["svc-mcp"]}})
+
+        inst = _installer(repo, tmp_path)
+        await inst.install("acme/widgets")
+
+        plugins = inst.list_plugins()
+        assert len(plugins) == 1
+        p = plugins[0]
+        assert p.name == "combo"
+        assert p.version == "1.2.3"
+        assert p.source == "acme/widgets"
+        assert sorted(p.skills) == ["alpha", "beta"]
+        assert p.mcp_servers == ["plugin:combo:svc"]
+        assert p.installed_at  # ISO timestamp recorded
+
+    def test_list_empty_when_no_registry(self, tmp_path):
+        inst = _installer(tmp_path, tmp_path)
+        assert inst.list_plugins() == []
+
+    def test_list_skips_malformed_entry(self, tmp_path):
+        registry_path = tmp_path / "registry" / "plugins.json"
+        registry_path.parent.mkdir(parents=True)
+        registry_path.write_text(json.dumps({"good": {"version": "1"}, "bad": "not-a-dict"}))
+        inst = _installer(tmp_path, tmp_path)
+        plugins = inst.list_plugins()
+        assert [p.name for p in plugins] == ["good"]
+
+
+class TestRemovePlugin:
+    async def _install_one(self, tmp_path, monkeypatch, *, name="combo", skills, mcp):
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+        repo = _write_plugin(tmp_path / "repo", name=name, skills=skills)
+        if mcp:
+            _write_mcp_json(repo, mcp)
+        inst = _installer(repo, tmp_path)
+        await inst.install("acme/widgets")
+        return inst, manager
+
+    async def test_install_then_remove_cleans_everything(self, tmp_path, monkeypatch):
+        inst, manager = await self._install_one(
+            tmp_path,
+            monkeypatch,
+            skills=["alpha", "beta"],
+            mcp={"svc": {"command": "uvx", "args": ["svc-mcp"]}},
+        )
+        install_dir = tmp_path / "skills_install"
+        assert (install_dir / "alpha").is_dir()
+        assert (install_dir / "beta").is_dir()
+
+        report = await inst.remove("combo")
+
+        assert report.succeeded()
+        assert sorted(report.removed_skills) == ["alpha", "beta"]
+        assert report.removed_mcp_servers == ["plugin:combo:svc"]
+        # Skill dirs gone.
+        assert not (install_dir / "alpha").exists()
+        assert not (install_dir / "beta").exists()
+        # MCP manager asked to remove the namespaced name.
+        assert manager.removed == ["plugin:combo:svc"]
+        # Registry entry dropped.
+        registry_path = tmp_path / "registry" / "plugins.json"
+        assert "combo" not in json.loads(registry_path.read_text())
+        assert inst.list_plugins() == []
+
+    async def test_remove_leaves_other_plugins_untouched(self, tmp_path, monkeypatch):
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+        # Install plugin A.
+        repo_a = _write_plugin(tmp_path / "repo_a", name="aaa", skills=["alpha"])
+        inst = _installer(repo_a, tmp_path)
+        await inst.install("acme/aaa")
+        # Install plugin B sharing the same install_dir + registry.
+        repo_b = _write_plugin(tmp_path / "repo_b", name="bbb", skills=["beta"])
+        inst._clone = _clone_factory(repo_b)
+        await inst.install("acme/bbb")
+
+        await inst.remove("aaa")
+
+        install_dir = tmp_path / "skills_install"
+        assert not (install_dir / "alpha").exists()
+        assert (install_dir / "beta").is_dir()  # B's skill untouched
+        names = [p.name for p in inst.list_plugins()]
+        assert names == ["bbb"]
+
+    async def test_remove_unknown_plugin_raises_404(self, tmp_path):
+        inst = _installer(tmp_path, tmp_path)
+        with pytest.raises(PluginInstallError) as exc:
+            await inst.remove("ghost")
+        assert exc.value.status_code == 404
+
+    async def test_remove_invalid_name_raises_400(self, tmp_path):
+        inst = _installer(tmp_path, tmp_path)
+        with pytest.raises(PluginInstallError) as exc:
+            await inst.remove("../etc")
+        assert exc.value.status_code == 400
+
+    async def test_remove_with_missing_skill_dir_degrades(self, tmp_path, monkeypatch):
+        # One component already missing → step skipped, remove still completes
+        # and drops the entry.
+        inst, manager = await self._install_one(
+            tmp_path,
+            monkeypatch,
+            skills=["alpha", "beta"],
+            mcp=None,
+        )
+        # Manually delete one skill dir before remove.
+        import shutil as _sh
+
+        _sh.rmtree(tmp_path / "skills_install" / "alpha")
+
+        report = await inst.remove("combo")
+
+        alpha_step = next(s for s in report.steps if s.name == "skill:alpha")
+        assert alpha_step.status == "skipped"
+        beta_step = next(s for s in report.steps if s.name == "skill:beta")
+        assert beta_step.status == "succeeded"
+        # alpha was already gone, so it's not in removed_skills.
+        assert report.removed_skills == ["beta"]
+        # Entry still dropped — nothing lingers.
+        assert inst.list_plugins() == []
+
+    async def test_remove_with_unregistered_mcp_degrades(self, tmp_path, monkeypatch):
+        # MCP server recorded in registry but not in the manager → skipped,
+        # remove still completes.
+        inst, manager = await self._install_one(
+            tmp_path,
+            monkeypatch,
+            skills=["alpha"],
+            mcp={"svc": {"command": "uvx", "args": ["svc"]}},
+        )
+        # Drop it from the manager so remove_server_config returns False.
+        manager.known.discard("plugin:combo:svc")
+
+        report = await inst.remove("combo")
+
+        mcp_step = next(s for s in report.steps if s.name == "mcp:plugin:combo:svc")
+        assert mcp_step.status == "skipped"
+        assert report.removed_mcp_servers == []
+        assert inst.list_plugins() == []
+
+    async def test_remove_audit_logs_plugin_remove(self, tmp_path, monkeypatch):
+        inst, _ = await self._install_one(tmp_path, monkeypatch, skills=["alpha"], mcp=None)
+        logged: list = []
+        monkeypatch.setattr(
+            "pocketpaw.plugins.installer.get_audit_logger",
+            lambda: type("A", (), {"log": lambda self, ev: logged.append(ev)})(),
+        )
+        await inst.remove("combo")
+        assert any(getattr(ev, "action", None) == "plugin_remove" for ev in logged)
+
+
+class TestAtomicRegistryWrite:
+    async def test_sequential_writes_do_not_corrupt(self, tmp_path, monkeypatch):
+        # Install two plugins back-to-back sharing one registry; the
+        # temp-file + os.replace path must leave a valid, complete JSON.
+        manager = _FakeMCPManager()
+        _patch_loader_and_manager(monkeypatch, manager)
+        repo_a = _write_plugin(tmp_path / "a", name="aaa", skills=["alpha"])
+        inst = _installer(repo_a, tmp_path)
+        await inst.install("acme/aaa")
+        repo_b = _write_plugin(tmp_path / "b", name="bbb", skills=["beta"])
+        inst._clone = _clone_factory(repo_b)
+        await inst.install("acme/bbb")
+
+        registry_path = tmp_path / "registry" / "plugins.json"
+        data = json.loads(registry_path.read_text())  # parses → not corrupt
+        assert set(data) == {"aaa", "bbb"}
+        # No leftover temp files in the registry dir.
+        leftovers = list(registry_path.parent.glob("*.tmp.*"))
+        assert leftovers == []
+
+    def test_save_registry_replaces_atomically(self, tmp_path):
+        inst = _installer(tmp_path, tmp_path)
+        inst._save_registry({"x": {"version": "1"}})
+        registry_path = tmp_path / "registry" / "plugins.json"
+        assert json.loads(registry_path.read_text()) == {"x": {"version": "1"}}
+        # Overwrite with new content; old file must be cleanly replaced.
+        inst._save_registry({"y": {"version": "2"}})
+        assert json.loads(registry_path.read_text()) == {"y": {"version": "2"}}
+        assert list(registry_path.parent.glob("*.tmp.*")) == []

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -14,6 +14,11 @@
 # this plugin's skill dirs + MCP servers, drops the registry entry, leaves
 # nothing orphaned), unknown-plugin raises 404, degraded remove (a missing
 # component still completes + drops the entry), and the atomic registry write.
+# Updated: 2026-06-08 (review fix) — remove now STOPS the live MCP server
+# (manager.stop_server) as well as removing its config, symmetric with
+# install's register+start. The fake manager tracks running servers + stop
+# calls; tests assert stop was called and cover stop/config-gone + a mid-remove
+# manager raise degrading to a failed step.
 """Unit tests for pocketpaw.plugins (skills + MCP slices)."""
 
 from __future__ import annotations
@@ -320,10 +325,14 @@ class _FakeMCPManager:
         self.added: list = []  # MCPServerConfig objects
         self.started: list = []  # MCPServerConfig objects
         self.removed: list[str] = []  # names passed to remove_server_config
+        self.stopped: list[str] = []  # names passed to stop_server
         self._start_results = start_results or {}
-        # Names the fake "knows about" so remove_server_config can report
+        # Names with a persisted config so remove_server_config can report
         # found/not-found. Defaults to whatever was added.
         self.known: set[str] = set()
+        # Names of *live* (running) servers so stop_server can report
+        # was-running/not. A server that started cleanly is added here.
+        self.running: set[str] = set()
 
     def add_server_config(self, config) -> None:
         self.added.append(config)
@@ -331,7 +340,17 @@ class _FakeMCPManager:
 
     async def start_server(self, config) -> bool:
         self.started.append(config)
-        return self._start_results.get(config.name, True)
+        ok = self._start_results.get(config.name, True)
+        if ok:
+            self.running.add(config.name)
+        return ok
+
+    async def stop_server(self, name) -> bool:
+        self.stopped.append(name)
+        if name in self.running:
+            self.running.discard(name)
+            return True
+        return False
 
     def remove_server_config(self, name) -> bool:
         self.removed.append(name)
@@ -632,8 +651,12 @@ class TestRemovePlugin:
         # Skill dirs gone.
         assert not (install_dir / "alpha").exists()
         assert not (install_dir / "beta").exists()
-        # MCP manager asked to remove the namespaced name.
+        # MCP manager asked to STOP the live server AND remove its config —
+        # both halves, symmetric with install (register + start).
+        assert manager.stopped == ["plugin:combo:svc"]
         assert manager.removed == ["plugin:combo:svc"]
+        # The live server is no longer running.
+        assert "plugin:combo:svc" not in manager.running
         # Registry entry dropped.
         registry_path = tmp_path / "registry" / "plugins.json"
         assert "combo" not in json.loads(registry_path.read_text())
@@ -696,16 +719,18 @@ class TestRemovePlugin:
         # Entry still dropped — nothing lingers.
         assert inst.list_plugins() == []
 
-    async def test_remove_with_unregistered_mcp_degrades(self, tmp_path, monkeypatch):
-        # MCP server recorded in registry but not in the manager → skipped,
-        # remove still completes.
+    async def test_remove_with_gone_mcp_degrades(self, tmp_path, monkeypatch):
+        # MCP server recorded in registry but neither running nor in the
+        # manager's config → skipped, remove still completes.
         inst, manager = await self._install_one(
             tmp_path,
             monkeypatch,
             skills=["alpha"],
             mcp={"svc": {"command": "uvx", "args": ["svc"]}},
         )
-        # Drop it from the manager so remove_server_config returns False.
+        # Drop it from the manager entirely (not running, no config) so both
+        # stop_server and remove_server_config return False.
+        manager.running.discard("plugin:combo:svc")
         manager.known.discard("plugin:combo:svc")
 
         report = await inst.remove("combo")
@@ -713,6 +738,53 @@ class TestRemovePlugin:
         mcp_step = next(s for s in report.steps if s.name == "mcp:plugin:combo:svc")
         assert mcp_step.status == "skipped"
         assert report.removed_mcp_servers == []
+        # Both halves were still attempted.
+        assert manager.stopped == ["plugin:combo:svc"]
+        assert manager.removed == ["plugin:combo:svc"]
+        assert inst.list_plugins() == []
+
+    async def test_remove_stops_server_even_if_config_already_gone(self, tmp_path, monkeypatch):
+        # Live server still running but its persisted config was already
+        # removed → stop_server cleans up the live connection, so the server
+        # still counts as removed (succeeded), not skipped.
+        inst, manager = await self._install_one(
+            tmp_path,
+            monkeypatch,
+            skills=["alpha"],
+            mcp={"svc": {"command": "uvx", "args": ["svc"]}},
+        )
+        manager.known.discard("plugin:combo:svc")  # config gone; still running
+
+        report = await inst.remove("combo")
+
+        mcp_step = next(s for s in report.steps if s.name == "mcp:plugin:combo:svc")
+        assert mcp_step.status == "succeeded"
+        assert report.removed_mcp_servers == ["plugin:combo:svc"]
+        assert manager.stopped == ["plugin:combo:svc"]
+        assert "plugin:combo:svc" not in manager.running
+
+    async def test_remove_mcp_failure_is_failed_step(self, tmp_path, monkeypatch):
+        # A raise from the manager mid-remove degrades to a failed step and
+        # never aborts the remove — the registry entry is still dropped.
+        inst, manager = await self._install_one(
+            tmp_path,
+            monkeypatch,
+            skills=["alpha"],
+            mcp={"svc": {"command": "uvx", "args": ["svc"]}},
+        )
+
+        async def _boom(name):
+            raise RuntimeError("teardown blew up")
+
+        manager.stop_server = _boom
+
+        report = await inst.remove("combo")
+
+        mcp_step = next(s for s in report.steps if s.name == "mcp:plugin:combo:svc")
+        assert mcp_step.status == "failed"
+        assert "teardown blew up" in mcp_step.detail
+        assert not report.succeeded()
+        # Entry still dropped despite the failure.
         assert inst.list_plugins() == []
 
     async def test_remove_audit_logs_plugin_remove(self, tmp_path, monkeypatch):

--- a/tests/v1/test_api_v1_plugins.py
+++ b/tests/v1/test_api_v1_plugins.py
@@ -3,8 +3,11 @@
 # Plugins router: missing source -> 400, PluginInstallError status passthrough,
 # and a successful install returning the report. require_scope is bypassed via
 # tests/v1/conftest.py's _TESTING_FULL_ACCESS escape hatch.
+# Updated: 2026-06-08 (feat/plugin-installer-listremove, #1358) — added tests
+# for GET /plugins (list) and POST /plugins/remove (missing name -> 400,
+# unknown plugin -> 404, successful remove returns the report).
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -12,7 +15,12 @@ from fastapi.testclient import TestClient
 
 from pocketpaw.api.v1.plugins import router
 from pocketpaw.plugins.installer import PluginInstallError
-from pocketpaw.plugins.models import PluginInstallReport, PluginInstallStep
+from pocketpaw.plugins.models import (
+    InstalledPlugin,
+    PluginInstallReport,
+    PluginInstallStep,
+    PluginRemoveReport,
+)
 
 
 @pytest.fixture
@@ -56,3 +64,70 @@ class TestInstallPlugin:
         assert data["plugin"] == "my-plugin"
         assert data["installed_skills"] == ["alpha"]
         assert data["steps"][0]["name"] == "read_manifest"
+
+
+class TestListPlugins:
+    def test_list_returns_installed_plugins(self, client):
+        plugins = [
+            InstalledPlugin(
+                name="my-plugin",
+                version="1.2.3",
+                source="acme/widgets",
+                skills=["alpha"],
+                mcp_servers=["plugin:my-plugin:svc"],
+                installed_at="2026-06-08T00:00:00",
+            )
+        ]
+        with patch(
+            "pocketpaw.api.v1.plugins.PluginInstaller.list_plugins",
+            new=MagicMock(return_value=plugins),
+        ):
+            resp = client.get("/api/v1/plugins")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "my-plugin"
+        assert data[0]["skills"] == ["alpha"]
+        assert data[0]["mcp_servers"] == ["plugin:my-plugin:svc"]
+
+    def test_list_empty(self, client):
+        with patch(
+            "pocketpaw.api.v1.plugins.PluginInstaller.list_plugins",
+            new=MagicMock(return_value=[]),
+        ):
+            resp = client.get("/api/v1/plugins")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestRemovePlugin:
+    def test_missing_name(self, client):
+        resp = client.post("/api/v1/plugins/remove", json={"name": ""})
+        assert resp.status_code == 400
+
+    def test_unknown_plugin_maps_to_404(self, client):
+        with patch(
+            "pocketpaw.api.v1.plugins.PluginInstaller.remove",
+            new=AsyncMock(side_effect=PluginInstallError("not installed", 404)),
+        ):
+            resp = client.post("/api/v1/plugins/remove", json={"name": "ghost"})
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "not installed"
+
+    def test_successful_remove_returns_report(self, client):
+        report = PluginRemoveReport(
+            plugin="my-plugin",
+            steps=[PluginInstallStep(name="skill:alpha", status="succeeded")],
+            removed_skills=["alpha"],
+            removed_mcp_servers=["plugin:my-plugin:svc"],
+        )
+        with patch(
+            "pocketpaw.api.v1.plugins.PluginInstaller.remove",
+            new=AsyncMock(return_value=report),
+        ):
+            resp = client.post("/api/v1/plugins/remove", json={"name": "my-plugin"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["plugin"] == "my-plugin"
+        assert data["removed_skills"] == ["alpha"]
+        assert data["removed_mcp_servers"] == ["plugin:my-plugin:svc"]


### PR DESCRIPTION
Closes #1358. Final slice of the Plugin Installer (RFC 14, M3). Stacks on #1356 + #1357 (both in `integration/plugins`); targets the integration branch. With this, the M3 first slice — install · MCP · list/remove — is complete.

## What this ships

- `GET /api/v1/plugins` — lists installed plugins from the `~/.pocketpaw/plugins.json` registry (name, version, source, skills, MCP servers, installed_at).
- `POST /api/v1/plugins/remove {"name": ...}` — removes a plugin cleanly: deletes exactly the skill dirs it installed, **stops and deregisters** its namespaced MCP servers, reloads the loader, drops the registry entry, audit-logs. Both admin-gated.

Remove degrades per component (a missing skill dir or an already-stopped server becomes a `skipped`/`failed` step, never an abort), and the registry entry is always dropped so nothing lingers. Unknown plugin → 404.

## Hardening folded in

- The registry read-modify-write is now concurrency-safe: a module lock plus an atomic temp-file + `os.replace` write, shared by install and remove — a crash mid-write can't corrupt or clobber the JSON. (This was the deferred minor from the #1357 review; it matters now that remove also mutates the registry.)
- Install/remove symmetry: install starts the MCP server, so remove stops it (not just its config) — caught in review.

## Tests

96 passing in the targeted set (+ the new list/remove cases): list happy/empty/malformed-skip, remove deletes exactly this plugin's components and leaves others untouched, server stop asserted, unknown → 404, partial-missing-component degrades, atomic-write integrity. MCP manager mocked — no real servers. #1356/#1357 tests stay green.

## Known edge (documented, not fixed)

A concurrent install + remove of the *same* plugin name can interleave at the operation level (each individual registry write is still atomic and never corrupts). Low likelihood for an admin single-operator endpoint; noted inline.
