### PR TITLE
feat(connectors): agent-callable connector tools in the cloud run (read-first)

### DIFF
--- a/connectors/github.yaml
+++ b/connectors/github.yaml
@@ -1,10 +1,34 @@
 # GitHub connector — repositories, issues, PRs, and code search.
 # Created: 2026-03-30
+# Updated: 2026-06-08 (feat/connector-mcp-execution / keystone) — added the
+#   optional ``surface_profile:`` block. When this connector is bound to a
+#   pocket (scope=pocket), the cloud derivation helper folds it into the
+#   pocket's PocketSurfaceProfile so the entity room auto-loads the bundled
+#   ``github`` skill, which teaches the read-first workflow over the
+#   ``mcp__pocketpaw_connectors__*`` execution tools (list_connector_actions /
+#   connector_execute). The 8 read actions below run via that tool surface;
+#   the one write action (create_issue, trust=confirm) is BLOCKED in v1.
 
 name: github
 display_name: GitHub
 type: developer
 icon: git-branch
+
+# Connector→skill/tool auto-authoring. When GitHub is bound to a pocket, the
+# entity room auto-loads the bundled "github" skill (which teaches the
+# list_connector_actions → connector_execute READ workflow over the actions
+# below).
+#
+# allow_tools is left EMPTY for the same reason Gmail's is: the agent-callable
+# execution tools live on the ambient ``pocketpaw_connectors`` MCP server (NOT
+# opt-in), so the agent can already reach ``connector_execute`` without an
+# additive allowlist entry. An empty allow means "no SDK-tool restriction" (the
+# resolver union only ADDS, never narrows), which is the correct default. The
+# skill is the load-bearing contribution here.
+surface_profile:
+  skill: github
+  allow_tools: []
+  deny_tools: []
 
 auth:
   method: bearer

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,11 @@
 <!--
   Connectors documentation.
+  Updated: 2026-06-08 (connector-mcp-execution / keystone) — documented the
+  agent-callable connector tool surface (list_connector_actions /
+  connector_execute on the pocketpaw_connectors MCP server), the v1
+  read-first / write-blocked policy, how a connector becomes usable in a room
+  (bind scope=pocket + token in config + the derived skill), and the GitHub +
+  Gmail examples.
   Updated: 2026-06-07 (M3 connector→skill auto-authoring) — documented the
   optional ``surface_profile`` YAML block and the connector→skill/tool
   auto-authoring path (derivation at bind/unbind from the full enabled set, the
@@ -182,6 +188,92 @@ classes (`gmail_search`, `gmail_send`, …) that are not yet wrapped as stable
 `mcp__<server>__<tool>` SDK tool ids. An empty allow means "no SDK-tool
 restriction" (the union only adds to the allowlist, never narrows it), so the
 skill is the load-bearing contribution until those ids exist.
+
+## Calling connectors from chat — the agent tool surface
+
+Loading a skill teaches the cloud chat agent *how* to use a connector; the
+**`pocketpaw_connectors` MCP server** is what lets it actually *call* one. The
+server exposes two tools to the agent, namespaced
+`mcp__pocketpaw_connectors__*`:
+
+| Tool | What it does |
+|------|--------------|
+| `list_connector_actions()` | Lists the connectors bound to the **current pocket** and, per connector, its READ actions (runnable) and WRITE actions (listed, blocked). No arguments — the pocket comes from the active chat. |
+| `connector_execute(connector_name, action, params)` | Runs ONE action. Read (auto-trust) actions execute; write actions are refused (see below). |
+
+The agent reads the pocket it is in from the per-run identity (the same
+mechanism that scopes pocket reads/writes), so the tools always act on the room
+the user is chatting in. Outside a chat stream — or in a chat not anchored to a
+pocket — the tools return a clear message instead of mis-scoping.
+
+### v1 policy: read-first, writes blocked
+
+v1 is deliberately **read-only**:
+
+- **Read actions** (`trust_level: auto`) execute. They run through the existing
+  cloud execution path (`connectors.service.execute`) in-process via the
+  `DirectRESTAdapter` / native adapter, using the connector's stored token.
+- **Write actions** (`trust_level: confirm` or `restricted`) are **listed but
+  blocked**. `connector_execute` refuses them with
+  *"This action modifies &lt;connector&gt; and needs approval (coming in v2).
+  Not executed."* and never calls the API. The agent surfaces that to the user
+  rather than pretending the write happened.
+
+The trust level on each action's YAML (`auto` / `confirm` / `restricted`) is the
+gate — the same trust level documented in [Trust Levels](#trust-levels). Mark
+reads `auto` and writes `confirm` and the tool surface does the rest.
+
+### Making a connector usable in a room
+
+Three things make a connector callable from a pocket's chat:
+
+1. **Bind it at `scope=pocket`** — enable the connector with the pocket's id.
+   The tools are tenant-scoped: a connector bound to pocket A is not reachable
+   from pocket B.
+2. **Put a token in the connector's config** — v1 auth is the PAT / API token
+   already stored in the connector config (no OAuth flow). For GitHub that's a
+   `GITHUB_TOKEN`; for a bearer/`api_key` connector it's the credential named in
+   the YAML's `auth.credentials`. Without it, read actions hit the API
+   unauthenticated and return an honest auth error.
+3. **The derived skill** — binding the connector auto-derives the pocket's
+   `surface_profile`, which loads the connector's bundled skill (see
+   [auto-authoring](#connector--skill--tool-auto-authoring)). The skill tells the
+   agent to call `list_connector_actions` first, then `connector_execute`.
+
+### GitHub example
+
+`connectors/github.yaml` ships a `surface_profile` (`skill: github`) and 9 read
+actions plus one write (`create_issue`, `confirm`). Bind it to a pocket with a
+`GITHUB_TOKEN` and the room can read issues, PRs, repos, releases, CI runs, and
+search code/issues:
+
+```
+list_connector_actions()
+  → github: read [list_issues, list_pull_requests, get_repo, search_code, …],
+    write-blocked [create_issue]
+
+connector_execute("github", "list_issues",
+                  {"owner": "acme", "repo": "api", "state": "open"})
+  → the repo's open issues
+
+connector_execute("github", "create_issue", {...})
+  → blocked: "needs approval (coming in v2). Not executed."
+```
+
+### Gmail example
+
+`connectors/gmail.yaml` ships `skill: gmail`. Bound to a pocket, the room can
+search and read mail; sending / labeling / trashing are confirm-trust writes and
+are blocked in v1:
+
+```
+connector_execute("gmail", "gmail_search",
+                  {"query": "from:acme.com subject:invoice", "max_results": 5})
+  → matching message stubs
+
+connector_execute("gmail", "gmail_send", {...})
+  → blocked: "needs approval (coming in v2). Not executed."
+```
 
 ## Using with Existing Integrations
 

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -1,0 +1,373 @@
+# connectors.py — in-process MCP server letting the cloud chat agent EXECUTE a
+#   pocket's bound connectors.
+# Created: 2026-06-08 (feat/connector-mcp-execution / keystone) — the missing
+#   tool surface. M3 wired connector→SKILL (the agent learns HOW to use a
+#   connector) but gave the cloud run no way to actually CALL connector actions —
+#   the connector tools existed only on the local CLI path. This server closes
+#   that: two tools, ``list_connector_actions`` (what can I do in this room?) and
+#   ``connector_execute`` (do a READ action). v1 is READ-FIRST: ``auto``-trust
+#   actions execute via the existing cloud ``connectors.service.execute`` path;
+#   ``confirm`` / ``restricted`` (write-shaped) actions are listed but BLOCKED
+#   with a "needs approval — coming in v2" refusal and are NEVER executed.
+#   Identity (workspace / user / pocket) comes from the per-stream ContextVars in
+#   ``ee.cloud.chat.agent_service`` — the same chokepoint the tasks / pockets /
+#   sites servers use. Tool ids namespace as ``mcp__pocketpaw_connectors__*``.
+#   OSS-EE boundary: this module imports only ``connectors.service`` (which owns
+#   the Beanie read), never the WorkspaceConnector doc directly.
+"""Agent-side MCP surface for executing a pocket's bound connectors.
+
+Tools registered:
+
+  - ``list_connector_actions()`` — for the CURRENT pocket (``pocket_id`` from
+    the per-stream ContextVar), list each enabled, pocket-scoped connector and
+    its READ actions (``trust=auto``) the agent may call, plus its WRITE actions
+    flagged "(needs approval — v2, blocked)". No pocket / no connectors → a clear
+    message rather than a silent empty list.
+  - ``connector_execute(connector_name, action, params)`` — run ONE read action.
+    Gates in order: (a) connector must be enabled + bound to THIS pocket
+    (tenant-scoped on workspace+pocket); (b) the action's trust level decides
+    read vs write; (c) ``auto`` → call ``connectors.service.execute`` and return
+    the result; (d) ``confirm`` / ``restricted`` → refuse with the v2 message,
+    never executing the write.
+
+Identity comes from ``agent_service.current_workspace_id`` /
+``current_user_id`` / ``current_pocket_id``. Outside an SSE chat stream those
+are empty → the tools return a clear error rather than silently mis-tenanting.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_connectors"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form.
+LIST_CONNECTOR_ACTIONS_TOOL_ID = f"mcp__{SERVER_NAME}__list_connector_actions"
+CONNECTOR_EXECUTE_TOOL_ID = f"mcp__{SERVER_NAME}__connector_execute"
+
+CONNECTOR_TOOL_IDS = (
+    LIST_CONNECTOR_ACTIONS_TOOL_ID,
+    CONNECTOR_EXECUTE_TOOL_ID,
+)
+
+# The agent-facing refusal for any write/confirm-trust action in v1. Kept as a
+# constant so the test asserts the exact contract and the skills quote it.
+_V2_BLOCK_MESSAGE = (
+    "This action modifies {connector} and needs approval (coming in v2). Not executed."
+)
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape the SDK expects."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None, str | None]:
+    """Resolve workspace / user / pocket from the per-stream ContextVars set by
+    ``run_core`` via ``agent_service.attach_agent_identity``.
+
+    Returns ``(workspace_id, user_id, pocket_id)``. Any may be ``None`` when the
+    tool is called outside an SSE chat stream (e.g. a unit test) — the handlers
+    treat a missing workspace/pocket as "no room context".
+    """
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_pocket_id,
+            current_user_id,
+            current_workspace_id,
+        )
+
+        return current_workspace_id(), current_user_id(), current_pocket_id()
+    except Exception:  # noqa: BLE001 — agent_service import only fails off-stream
+        return None, None, None
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def _list_connector_actions_handler(args: dict) -> dict:  # noqa: ARG001 — no args
+    workspace_id, _user_id, pocket_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "no active workspace — list_connector_actions can only be called "
+            "from inside a cloud chat stream"
+        )
+    if not pocket_id:
+        return _success_response(
+            {
+                "pocket_id": None,
+                "connectors": [],
+                "message": (
+                    "This chat isn't anchored to a pocket, so it has no bound "
+                    "connectors. Open this conversation inside a pocket/room and "
+                    "bind a connector to use connector actions."
+                ),
+            }
+        )
+
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    try:
+        connectors = await connectors_service.list_pocket_connectors(workspace_id, pocket_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("list_connector_actions failed", exc_info=True)
+        return _error_response(f"list_connector_actions failed: {exc}")
+
+    if not connectors:
+        return _success_response(
+            {
+                "pocket_id": pocket_id,
+                "connectors": [],
+                "message": (
+                    "No connectors are bound to this pocket yet. Bind one "
+                    "(scope=pocket) and add its token to the connector config to "
+                    "use its actions here."
+                ),
+            }
+        )
+
+    out: list[dict[str, Any]] = []
+    for c in connectors:
+        read_actions = [
+            {"action": a.name, "description": a.description} for a in c.actions if a.is_read
+        ]
+        write_actions = [
+            {
+                "action": a.name,
+                "description": a.description,
+                "status": "needs approval — v2, blocked",
+            }
+            for a in c.actions
+            if not a.is_read
+        ]
+        out.append(
+            {
+                "connector": c.name,
+                "display_name": c.display_name,
+                "type": c.type,
+                "read_actions": read_actions,
+                "write_actions_blocked": write_actions,
+            }
+        )
+
+    return _success_response(
+        {
+            "pocket_id": pocket_id,
+            "connectors": out,
+            "note": (
+                "Call connector_execute(connector_name, action, params) to run a "
+                "READ action. Write actions are blocked in v1 (need approval)."
+            ),
+        }
+    )
+
+
+async def _connector_execute_handler(args: dict) -> dict:
+    workspace_id, user_id, pocket_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "no active workspace — connector_execute can only be called from "
+            "inside a cloud chat stream"
+        )
+    if not pocket_id:
+        return _error_response(
+            "this chat isn't anchored to a pocket — connector_execute needs a "
+            "pocket-scoped room with a bound connector"
+        )
+
+    connector_name = args.get("connector_name")
+    if not isinstance(connector_name, str) or not connector_name:
+        return _error_response("connector_name is required (string)")
+    action = args.get("action")
+    if not isinstance(action, str) or not action:
+        return _error_response("action is required (string)")
+    params = args.get("params") or {}
+    if not isinstance(params, dict):
+        return _error_response("params must be an object (dict)")
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+
+    # Gate 1 — the connector must be enabled AND bound to THIS pocket. An agent
+    # in pocket A must never reach a connector bound only to pocket B / workspace.
+    try:
+        bound = await connectors_service.is_connector_bound_to_pocket(
+            workspace_id, pocket_id, connector_name
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("connector bind check failed", exc_info=True)
+        return _error_response(f"connector_execute failed: {exc}")
+    if not bound:
+        return _error_response(
+            f"connector '{connector_name}' is not bound to this pocket. "
+            "Call list_connector_actions to see what's available here."
+        )
+
+    # Gate 2 — look up the action's trust level. Unknown action → clear error.
+    trust = await connectors_service.get_action_trust(connector_name, action)
+    if trust is None:
+        return _error_response(
+            f"connector '{connector_name}' has no action '{action}'. "
+            "Call list_connector_actions for the available actions."
+        )
+
+    # Gate 3 — WRITE (confirm/restricted) actions are blocked in v1. Refuse
+    # BEFORE any execute call so a write can never run.
+    if not trust.is_read:
+        return _success_response(
+            {
+                "executed": False,
+                "blocked": True,
+                "connector": connector_name,
+                "action": action,
+                "trust_level": trust.trust_level,
+                "reason": _V2_BLOCK_MESSAGE.format(connector=connector_name),
+            }
+        )
+
+    # Gate 4 — READ (auto-trust): run via the existing cloud execute path. It
+    # uses the connector's stored config (PAT/token) through the
+    # DirectRESTAdapter / native adapter — no OAuth flow in v1.
+    body = ExecuteActionRequest(
+        action=action,
+        params=params,
+        scope="pocket",
+        pocket_id=pocket_id,
+    )
+    try:
+        result = await connectors_service.execute(
+            workspace_id, connector_name, body, user_id=user_id
+        )
+    except CloudError as exc:
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("connector_execute failed", exc_info=True)
+        return _error_response(f"connector_execute failed: {exc}")
+
+    return _success_response(
+        {
+            "executed": True,
+            "connector": connector_name,
+            "action": action,
+            "success": result.success,
+            "data": result.data,
+            "error": result.error,
+            "records_affected": result.records_affected,
+            "execution_mode": result.execution_mode,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Server factory
+# ---------------------------------------------------------------------------
+
+
+def build_connectors_context_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for connector execution, or return
+    ``None`` if the Claude Agent SDK isn't installed.
+
+    Matches the ``(name, server)`` shape the other servers return so the
+    backend's MCP registration loop in ``claude_sdk.py`` treats them uniformly.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_connectors MCP disabled")
+        return None
+
+    @tool(
+        "list_connector_actions",
+        (
+            "List the connectors bound to the CURRENT pocket/room and the "
+            "actions you can run on each. Call this FIRST whenever the user "
+            "wants to read from an integration (GitHub issues/PRs, Gmail "
+            "search, etc.) so you know which connector + action to use. "
+            "Returns each connector's READ actions (which you may run directly "
+            "via connector_execute) and its WRITE actions, which are listed but "
+            "BLOCKED in v1 (they need approval). No arguments — the pocket is "
+            "inferred from the active chat. If the chat isn't in a pocket, or "
+            "the pocket has no bound connectors, the result says so."
+        ),
+        {},
+    )
+    async def list_connector_actions(args):  # type: ignore[no-untyped-def]
+        return await _list_connector_actions_handler(args)
+
+    @tool(
+        "connector_execute",
+        (
+            "Execute ONE connector action for the current pocket. Use this to "
+            "READ from a bound integration — e.g. list a GitHub repo's issues "
+            "or PRs, search Gmail. Args: `connector_name` (e.g. 'github', "
+            "'gmail'), `action` (an action name from list_connector_actions, "
+            "e.g. 'list_issues', 'gmail_search'), and `params` (an object of "
+            "that action's parameters). Only READ (auto-trust) actions run; "
+            "WRITE actions (create/send/modify/delete) are refused with a "
+            "'needs approval — coming in v2' message and are NEVER executed. "
+            "The connector must be bound to THIS pocket and have a token in its "
+            "config; otherwise you get a clear error. Always call "
+            "list_connector_actions first to pick a valid connector + action."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "connector_name": {
+                    "type": "string",
+                    "description": "Registry name of the connector, e.g. 'github' or 'gmail'.",
+                },
+                "action": {
+                    "type": "string",
+                    "description": (
+                        "Action name from list_connector_actions, e.g. "
+                        "'list_issues' or 'gmail_search'. Read actions only."
+                    ),
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Object of the action's parameters (may be empty).",
+                },
+            },
+            "required": ["connector_name", "action"],
+        },
+    )
+    async def connector_execute(args):  # type: ignore[no-untyped-def]
+        return await _connector_execute_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[list_connector_actions, connector_execute],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "CONNECTOR_EXECUTE_TOOL_ID",
+    "CONNECTOR_TOOL_IDS",
+    "LIST_CONNECTOR_ACTIONS_TOOL_ID",
+    "SERVER_NAME",
+    "build_connectors_context_server",
+]

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -54,6 +54,14 @@ folds a pocket-entity's ``surface_profile`` override over the surface base).
 calling ``resolve_profile`` itself — so a pocket bound to a room can flip
 ripple off/on for that room. ``resolved_profile is None`` is the legacy /
 non-entity path → ripple ON, byte-identical to today.
+Changes: 2026-06-08 (feat/connector-mcp-execution / keystone) — the per-stream
+identity now carries the room's ``pocket_id`` too. ``attach_agent_identity``
+gained a ``pocket_id`` kwarg and ``current_pocket_id()`` was added beside
+``current_workspace_id`` / ``current_user_id``; both are set in
+``run_core`` and read by the connector-execution MCP server
+(``mcp_servers/connectors.py``) so its tools scope to the current pocket.
+The identity-token tuple grew from 3 to 4 entries; existing 3-arg callers are
+unaffected (``pocket_id`` defaults to ``None``).
 """
 
 from __future__ import annotations
@@ -107,27 +115,41 @@ _active_user_id: ContextVar[str | None] = ContextVar("agent_user_id", default=No
 _active_session_mongo_id: ContextVar[str | None] = ContextVar(
     "agent_session_mongo_id", default=None
 )
+# The Mongo ``Pocket._id`` this stream is anchored to, if any. Set alongside
+# workspace/user so in-process MCP tools that act on the CURRENT pocket — the
+# connector-execution server (``mcp_servers/connectors.py``) being the first —
+# can resolve which room they're in without a request scope. ``None`` when the
+# chat isn't bound to a pocket (a plain DM / group thread).
+_active_pocket_id: ContextVar[str | None] = ContextVar("agent_pocket_id", default=None)
 
 
 def attach_agent_identity(
-    *, workspace_id: str, user_id: str, session_mongo_id: str | None = None
-) -> tuple[Token, Token, Token]:
-    """Bind workspace / user / session identity for the active stream's
-    MCP tools. ``session_mongo_id`` is the ``Session._id`` the chat is
-    streaming through — used by ``create_pocket`` to link the active
-    session to the freshly-created pocket."""
+    *,
+    workspace_id: str,
+    user_id: str,
+    session_mongo_id: str | None = None,
+    pocket_id: str | None = None,
+) -> tuple[Token, Token, Token, Token]:
+    """Bind workspace / user / session / pocket identity for the active
+    stream's MCP tools. ``session_mongo_id`` is the ``Session._id`` the chat
+    is streaming through — used by ``create_pocket`` to link the active
+    session to the freshly-created pocket. ``pocket_id`` is the room the chat
+    is anchored to (when any) — read by the connector-execution MCP server to
+    scope ``list_connector_actions`` / ``connector_execute`` to this pocket."""
     return (
         _active_workspace_id.set(workspace_id),
         _active_user_id.set(user_id),
         _active_session_mongo_id.set(session_mongo_id),
+        _active_pocket_id.set(pocket_id),
     )
 
 
-def detach_agent_identity(tokens: tuple[Token, Token, Token]) -> None:
-    ws_token, user_token, session_token = tokens
+def detach_agent_identity(tokens: tuple[Token, Token, Token, Token]) -> None:
+    ws_token, user_token, session_token, pocket_token = tokens
     _active_workspace_id.reset(ws_token)
     _active_user_id.reset(user_token)
     _active_session_mongo_id.reset(session_token)
+    _active_pocket_id.reset(pocket_token)
 
 
 def current_workspace_id() -> str | None:
@@ -140,6 +162,10 @@ def current_user_id() -> str | None:
 
 def current_session_mongo_id() -> str | None:
     return _active_session_mongo_id.get()
+
+
+def current_pocket_id() -> str | None:
+    return _active_pocket_id.get()
 
 
 def push_sse_event(name: str, data: dict[str, Any]) -> None:

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,12 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-08 (feat/connector-mcp-execution / keystone) — the per-stream
+  identity binding now also passes ``pocket_id=ctx.pocket_id`` into
+  ``attach_agent_identity``, publishing the room's ``Pocket._id`` on the new
+  ``agent_service._active_pocket_id`` ContextVar. The connector-execution MCP
+  server reads it to scope ``list_connector_actions`` / ``connector_execute``
+  to the current pocket. ``None`` for non-pocket (DM/group) threads.
 - 2026-05-31 (RFC 13 M0 — inline-spec contract unification). The inline
   Ripple extractor now treats the ``ui-spec`` fence + ``{version, ui}`` envelope
   as the canonical path — the same contract the prompt (``pocketpaw.ripple._inline``)
@@ -631,6 +637,11 @@ async def _drive_agent_loop(
         workspace_id=ctx.workspace_id,
         user_id=ctx.user_id,
         session_mongo_id=session_mongo_id,
+        # Anchor the connector-execution MCP server to the room this stream is
+        # in: ``ctx.pocket_id`` is the Mongo ``Pocket._id`` for pocket-scoped
+        # chats (and session chats whose Session.pocket is set). ``None`` for
+        # plain DM/group threads — the connector tools then say "no pocket".
+        pocket_id=ctx.pocket_id,
     )
 
     if not history and ctx.session_id:

--- a/ee/pocketpaw_ee/cloud/connectors/domain.py
+++ b/ee/pocketpaw_ee/cloud/connectors/domain.py
@@ -8,6 +8,12 @@
 #   skill/tool contribution (mirrors the OSS ``ConnectorSurfaceProfile``). The
 #   pure derivation helper in ``derivation.py`` folds these across a pocket's
 #   enabled connectors into a ``PocketSurfaceProfile``.
+# Updated: 2026-06-08 (connector-mcp-execution / keystone) — added
+#   ``ConnectorActionInfo`` + ``PocketConnectorInfo`` value objects so
+#   ``service.list_pocket_connectors`` can hand the agent MCP server a
+#   JSON-friendly view of each enabled pocket-scoped connector and its actions
+#   (name + description + trust level + read/write classification) without the
+#   MCP layer importing Beanie or the OSS registry types.
 
 from __future__ import annotations
 
@@ -76,3 +82,36 @@ class AvailableConnector:
     # or ``None`` when the YAML has no ``surface_profile:`` block. Consumed by
     # the derivation helper when the connector is bound to a pocket.
     surface_profile: ConnectorSurfaceContribution | None = None
+
+
+@dataclass(frozen=True)
+class ConnectorActionInfo:
+    """One action on a connector, classified for the agent's tool surface.
+
+    Built in ``service.list_pocket_connectors`` from the adapter's
+    ``ActionSchema``. ``is_read`` is the v1 gate: ``auto``-trust actions are
+    read-first and the agent may execute them; ``confirm`` / ``restricted``
+    actions are write-shaped and BLOCKED in v1 (listed, never executed).
+    """
+
+    name: str
+    description: str
+    trust_level: str  # "auto" | "confirm" | "restricted"
+    execution_mode: str  # "cloud" | "local" | "sandbox"
+    is_read: bool  # True when trust_level == "auto" — agent may execute
+
+
+@dataclass(frozen=True)
+class PocketConnectorInfo:
+    """One enabled, pocket-scoped connector plus its actions.
+
+    Returned by ``service.list_pocket_connectors`` for the agent MCP server.
+    The MCP layer renders this straight to JSON — it never touches the Beanie
+    doc or the OSS registry.
+    """
+
+    name: str
+    display_name: str
+    type: str
+    icon: str
+    actions: tuple[ConnectorActionInfo, ...] = field(default_factory=tuple)

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -6,6 +6,14 @@
 #   and persists it via ``pockets.service.apply_derived_surface_profile`` (the
 #   Beanie-write boundary — this service never imports the Pocket doc). Derivation
 #   itself is the pure ``derivation.derive_surface_profile``.
+# Updated: 2026-06-08 (connector-mcp-execution / keystone) — added
+#   ``list_pocket_connectors`` so the cloud chat agent's in-process MCP server
+#   (``ee/pocketpaw_ee/agent/mcp_servers/connectors.py``) can enumerate a
+#   pocket's enabled, pocket-scoped connectors and each action's trust level /
+#   execution mode WITHOUT the MCP layer importing the WorkspaceConnector Beanie
+#   doc (OSS-EE boundary §2). The MCP ``connector_execute`` tool reuses the
+#   existing ``execute(...)`` for read (auto-trust) actions and blocks
+#   write/confirm-trust actions in v1.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -35,7 +43,9 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 )
 from pocketpaw_ee.cloud.connectors.domain import (
     AvailableConnector,
+    ConnectorActionInfo,
     ConnectorSurfaceContribution,
+    PocketConnectorInfo,
     WorkspaceConnector,
 )
 from pocketpaw_ee.cloud.connectors.dto import (
@@ -469,6 +479,112 @@ async def list_widget_recipes(workspace_id: str) -> list[WidgetRecipeResponse]:
     return recipes
 
 
+async def list_pocket_connectors(workspace_id: str, pocket_id: str) -> list[PocketConnectorInfo]:
+    """List the connectors enabled + bound to ONE pocket, with their actions.
+
+    The agent-facing companion to ``list_connectors``: where that returns the
+    whole catalog with workspace state, this returns only the connectors a
+    specific room (pocket) can actually use, each with its action surface
+    classified by trust level so the agent MCP server can show read actions as
+    callable and write actions as "needs approval (v2)".
+
+    Tenant-filtered on ``workspace`` AND ``pocket_id`` (cloud rule §7) and
+    further on ``scope == "pocket"`` + ``enabled``. The Beanie read lives here
+    (not in the MCP layer) so the OSS-EE boundary holds: the MCP server imports
+    this service, never the ``WorkspaceConnector`` doc.
+
+    Trust gating: ``auto``-trust actions are read-first (``is_read=True``);
+    ``confirm`` / ``restricted`` actions are write-shaped and marked
+    ``is_read=False`` so the caller blocks them in v1.
+    """
+    enabled_docs = await _WCDoc.find(
+        _WCDoc.workspace == workspace_id,
+        _WCDoc.pocket_id == pocket_id,
+        _WCDoc.scope == "pocket",
+        _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+    ).to_list()
+    if not enabled_docs:
+        return []
+
+    reg = _get_registry()
+    available = {a.name: a for a in _available_from_registry()}
+    out: list[PocketConnectorInfo] = []
+    for doc in enabled_docs:
+        a = available.get(doc.name)
+        defn = reg.get_definition(doc.name)
+        if a is None or defn is None:
+            continue
+        adapter = _adapter_for_definition(defn, doc.name)
+        try:
+            schemas = await adapter.actions()
+        except Exception as exc:  # noqa: BLE001 — a bad adapter shouldn't drop the list
+            logger.warning("actions() raised for %s: %s", doc.name, exc)
+            continue
+        action_infos = tuple(
+            ConnectorActionInfo(
+                name=s.name,
+                description=s.description,
+                trust_level=str(s.trust_level),
+                execution_mode=str(s.execution_mode),
+                is_read=str(s.trust_level) == "auto",
+            )
+            for s in schemas
+        )
+        out.append(
+            PocketConnectorInfo(
+                name=a.name,
+                display_name=a.display_name,
+                type=a.type,
+                icon=a.icon,
+                actions=action_infos,
+            )
+        )
+    return out
+
+
+async def get_action_trust(name: str, action: str) -> ConnectorActionInfo | None:
+    """Look up one action's trust classification on a connector.
+
+    Used by the agent MCP server's ``connector_execute`` gate to decide read
+    (auto → execute) vs write (confirm/restricted → block) BEFORE calling
+    ``execute``. Registry-only (no tenant read) — the action schema is static
+    catalog metadata. Returns ``None`` when the connector or action is unknown.
+    """
+    reg = _get_registry()
+    defn = reg.get_definition(name)
+    if defn is None:
+        return None
+    adapter = _adapter_for_definition(defn, name)
+    schemas = await adapter.actions()
+    schema = next((s for s in schemas if s.name == action), None)
+    if schema is None:
+        return None
+    return ConnectorActionInfo(
+        name=schema.name,
+        description=schema.description,
+        trust_level=str(schema.trust_level),
+        execution_mode=str(schema.execution_mode),
+        is_read=str(schema.trust_level) == "auto",
+    )
+
+
+async def is_connector_bound_to_pocket(workspace_id: str, pocket_id: str, name: str) -> bool:
+    """True when ``name`` is enabled at ``scope=pocket`` for this exact pocket.
+
+    The tenant gate the MCP ``connector_execute`` tool checks first: an agent in
+    pocket A must not run a connector only bound to pocket B (or workspace-wide
+    only). Tenant-filtered (cloud rule §7).
+    """
+    doc = await _WCDoc.find_one(
+        _WCDoc.workspace == workspace_id,
+        _WCDoc.pocket_id == pocket_id,
+        _WCDoc.scope == "pocket",
+        _WCDoc.name == name,
+        _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+    )
+    return doc is not None
+
+
 def _adapter_for_definition(defn, name: str):
     """Build an adapter without connecting — for static metadata reads.
 
@@ -578,8 +694,11 @@ __all__ = [
     "disable_connector",
     "enable_connector",
     "execute",
+    "get_action_trust",
     "get_connector",
+    "is_connector_bound_to_pocket",
     "list_connectors",
+    "list_pocket_connectors",
     "list_widget_recipes",
     "record_sync",
     "update_config",

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -389,6 +389,26 @@ class CloudTasksMcpProvider:
         return list(TASK_TOOL_IDS)
 
 
+class CloudConnectorsMcpProvider:
+    """`pocketpaw.mcp_servers` — the connector-execution in-process server.
+
+    Exposes ``list_connector_actions`` + ``connector_execute`` so the cloud
+    chat agent can READ from a pocket's bound connectors (GitHub issues/PRs,
+    Gmail search, …). Read-first: write actions are blocked until v2. Ambient
+    (not opt-in) so the M3-derived connector skills can reach it.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        from pocketpaw_ee.agent.mcp_servers.connectors import build_connectors_context_server
+
+        return build_connectors_context_server()
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.connectors import CONNECTOR_TOOL_IDS
+
+        return list(CONNECTOR_TOOL_IDS)
+
+
 class CloudMeetingsMcpProvider:
     """`pocketpaw.mcp_servers` — the meetings in-process server.
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -165,6 +165,7 @@ cloud = "pocketpaw_ee.extensions:CloudPocketWriter"
 
 [project.entry-points."pocketpaw.mcp_servers"]
 tasks = "pocketpaw_ee.extensions:CloudTasksMcpProvider"
+connectors = "pocketpaw_ee.extensions:CloudConnectorsMcpProvider"
 planner = "pocketpaw_ee.extensions:CloudPlannerMcpProvider"
 pocket_planner = "pocketpaw_ee.extensions:CloudPocketPlannerMcpProvider"
 pocket = "pocketpaw_ee.extensions:CloudPocketMcpProvider"

--- a/src/pocketpaw/bundled_skills/_bundled/skills/github/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/github/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: github
+description: |
+  Work with a GitHub repo, org, or account inside a pocket/room that has the
+  GitHub connector bound. Invoke when the user wants to read from GitHub in the
+  chat — "list the open issues on acme/api", "what PRs are waiting on review",
+  "show me the latest release", "search the org for where we set the timeout",
+  "is the build green". This skill teaches the GitHub read surface (issues, PRs,
+  repos, code/issue search, Actions runs, releases) and the read-first workflow:
+  you can read freely; writing (opening issues) needs approval and is blocked in
+  v1. It is auto-surfaced into a room when the GitHub connector is bound to that
+  pocket, so you only see it when GitHub is actually available.
+---
+
+# GitHub in a Room
+
+This room has the **GitHub connector** bound to it. You can read repositories,
+issues, pull requests, releases, and CI runs, and search code and issues — all
+on the user's behalf through the connector's actions. The connector holds the
+GitHub token and talks to the GitHub REST API; you call named actions with
+simple parameters and get structured JSON back.
+
+You reach those actions through two tools:
+
+- **`list_connector_actions`** — call this FIRST. It lists every connector bound
+  to this pocket and the actions you can run. For GitHub it returns the read
+  actions you may execute and the write actions that are blocked in v1.
+- **`connector_execute(connector_name, action, params)`** — run one action. For
+  GitHub, `connector_name` is `"github"`.
+
+Reading is cheap and safe. **Writing is not** — and in v1 it is blocked
+entirely (see Guardrails). Default to reading.
+
+## The action surface
+
+| Action | What it does | Trust |
+|--------|--------------|-------|
+| `list_repos` | List the authenticated user's repos | auto (read) |
+| `list_org_repos` | List an org's repos (`org`) | auto (read) |
+| `list_issues` | List a repo's issues (`owner`, `repo`, `state`) | auto (read) |
+| `list_pull_requests` | List a repo's PRs (`owner`, `repo`) | auto (read) |
+| `search_code` | Search code (`q`) | auto (read) |
+| `search_issues` | Search issues/PRs (`q`) | auto (read) |
+| `get_repo` | One repo's detail (`owner`, `repo`) | auto (read) |
+| `list_actions_runs` | Recent Actions runs (`owner`, `repo`) | auto (read) |
+| `list_releases` | A repo's releases (`owner`, `repo`) | auto (read) |
+| `create_issue` | Open a new issue | confirm (**blocked in v1**) |
+
+"Trust = auto" actions you may run directly. `create_issue` is "confirm" trust —
+a write — and `connector_execute` will **refuse** it with a "needs approval —
+coming in v2" message. Don't try to route around that; tell the user it's not
+available yet.
+
+## Core workflow: list, then read
+
+Almost every request is: figure out the action, run it, summarize.
+
+1. **Orient** — call `list_connector_actions` to confirm `github` is bound and
+   to see the exact action names.
+2. **Execute** the right read action with `connector_execute`. Most repo actions
+   need `owner` and `repo` (e.g. `acme` / `api` for `acme/api`). Parse these
+   from how the user names the repo ("acme/api" → owner `acme`, repo `api`).
+3. **Summarize** — don't dump raw JSON. Give the user the issue numbers +
+   titles, the PR titles + authors + review state, the release tag + date.
+   Offer the obvious next step ("want the full body of #142?").
+
+## Concrete examples
+
+List the open issues on a repo:
+
+```
+connector_execute(
+  connector_name="github",
+  action="list_issues",
+  params={"owner": "acme", "repo": "api", "state": "open"}
+)
+```
+
+List the pull requests waiting on a repo:
+
+```
+connector_execute(
+  connector_name="github",
+  action="list_pull_requests",
+  params={"owner": "acme", "repo": "api", "state": "open"}
+)
+```
+
+Get one repo's detail (stars, default branch, description):
+
+```
+connector_execute(
+  connector_name="github",
+  action="get_repo",
+  params={"owner": "acme", "repo": "api"}
+)
+```
+
+Search code across an org for where something is configured:
+
+```
+connector_execute(
+  connector_name="github",
+  action="search_code",
+  params={"q": "timeout filename:config.yaml org:acme"}
+)
+```
+
+Search issues by query (GitHub's issue search syntax):
+
+```
+connector_execute(
+  connector_name="github",
+  action="search_issues",
+  params={"q": "repo:acme/api is:open label:bug"}
+)
+```
+
+Check the latest CI runs or releases:
+
+```
+connector_execute(connector_name="github", action="list_actions_runs",
+  params={"owner": "acme", "repo": "api"})
+connector_execute(connector_name="github", action="list_releases",
+  params={"owner": "acme", "repo": "api"})
+```
+
+## Search syntax — the operators you'll actually use
+
+`search_code` and `search_issues` use GitHub's own query syntax:
+
+- `repo:owner/name` — scope to one repo
+- `org:name` / `user:name` — scope to an org or user
+- `is:open` / `is:closed` / `is:pr` / `is:issue`
+- `label:bug` / `author:octocat` / `assignee:octocat`
+- `filename:config.yaml` / `extension:py` / `path:src/`
+- `in:title` / `in:body` / `in:comments`
+
+Combine freely: `repo:acme/api is:open is:pr review:required`.
+
+## Pagination and volume
+
+The list actions take `per_page` (issues default 25, most others 10–100) and
+`page`. Don't pull everything — for "the open issues" the first page is usually
+enough. If the user wants a count or asks for "all", say how many the first page
+returned and offer to page further rather than fetching every page silently.
+
+## Guardrails
+
+- **Reads are free; writes are blocked in v1.** Every action in the table marked
+  "auto" you may run. `create_issue` (and any future write) is refused by
+  `connector_execute` with a "needs approval — coming in v2" message. When the
+  user asks to open an issue, comment, merge, or label, tell them GitHub writes
+  aren't available from chat yet — don't pretend it worked.
+- **The connector needs a token.** Reads only work if the GitHub connector has a
+  personal access token in its config. If `connector_execute` returns an auth
+  error, tell the user to add a GitHub token to the connector's config (the
+  connector is bound to this pocket but has no credential yet).
+- **Parse `owner`/`repo` carefully.** "acme/api" → owner `acme`, repo `api`. If
+  the user names a repo ambiguously, ask or use `list_repos` / `list_org_repos`
+  to find it rather than guessing.
+- **Summarize, don't dump.** Turn raw API JSON into a short, scannable answer
+  (numbers, titles, authors, dates) and offer the obvious follow-up.
+- **Stay in this account.** The connector is bound to one token's access; don't
+  assume reach into private repos the token can't see.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/gmail/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/gmail/SKILL.md
@@ -13,15 +13,36 @@ description: |
   Gmail is actually available.
 ---
 
+<!--
+  Updated: 2026-06-08 (feat/connector-mcp-execution / keystone) — the skill now
+  instructs the agent to invoke Gmail actions through the agent-callable
+  ``connector_execute`` tool (the new pocketpaw_connectors MCP server) instead
+  of the vague "call named actions". Read actions (search/read/list/summary)
+  run via connector_execute; the confirm-trust actions (send/trash/modify/...)
+  are BLOCKED in v1 by the tool, so the skill's confirm-before-act guidance now
+  also notes those are not executable from chat yet. The safety/workflow
+  guidance is otherwise unchanged.
+-->
+
 # Gmail in a Room
 
 This room has the **Gmail connector** bound to it. You can search, read,
-triage, and send email on the user's behalf through the connector's
-actions. The connector handles OAuth, MIME, and the Gmail API — you call
-named actions with simple parameters and get structured results back.
+and triage email on the user's behalf through the connector's actions.
+The connector handles OAuth, MIME, and the Gmail API.
+
+You reach those actions through two tools:
+
+- **`list_connector_actions`** — call this FIRST. It lists the connectors
+  bound to this pocket and the actions you can run. For Gmail it shows the
+  read actions you may execute and the write actions blocked in v1.
+- **`connector_execute(connector_name, action, params)`** — run one action.
+  For Gmail, `connector_name` is `"gmail"`. Example:
+  `connector_execute(connector_name="gmail", action="gmail_search",
+  params={"query": "from:acme.com subject:invoice", "max_results": 5})`.
 
 Treat the mailbox as the user's real inbox. Reading is cheap and safe;
-**sending and destroying are not**. Default to caution.
+**sending and destroying are not** — and in v1 those write actions are
+blocked by the tool (see Guardrails). Default to caution.
 
 ## The action surface
 
@@ -37,22 +58,29 @@ Treat the mailbox as the user's real inbox. Reading is cheap and safe;
 | `gmail_batch_modify` | Apply label changes to many messages | confirm |
 | `gmail_summary` | Inbox stats (unread / today) | auto |
 
-"Trust = confirm" means **show the user what you're about to do and get a
-yes before you do it.** Never send, trash, or relabel silently.
+"Trust = confirm" actions are **writes, and they are BLOCKED in v1.** When
+you call `connector_execute` for a send/trash/label/create-label action, the
+tool refuses it with a "needs approval — coming in v2" message and does NOT
+execute it. So today you can read and triage-by-reading, but you cannot send,
+trash, or relabel from chat. Don't pretend a blocked action succeeded — tell
+the user that Gmail writes aren't available from chat yet. (The "read before
+you act" workflow below still applies for when v2 lands.)
 
 ## Core workflow: read before you act
 
-Almost every request starts with a search, then a read.
+Almost every request starts with a search, then a read. Run each through
+`connector_execute(connector_name="gmail", action=..., params=...)`.
 
-1. **Search** to find the candidate messages. `gmail_search` takes a
-   `query` (Gmail's own search syntax) and an optional `max_results`
-   (default 5, capped at 20). It returns a list of message stubs, each
-   with an `id`, `from`, `subject`, and snippet.
-2. **Read** the specific message with `gmail_read` (pass the `message_id`
-   from the search result) when you need the full body — to summarize,
-   quote, or draft a reply.
-3. **Act** (send / label / trash) only after you've shown the user what
-   you found and they've confirmed the action.
+1. **Search** to find the candidate messages — `action="gmail_search"`,
+   `params={"query": <Gmail search syntax>, "max_results": <≤20>}`
+   (default 5). It returns a list of message stubs, each with an `id`,
+   `from`, `subject`, and snippet.
+2. **Read** the specific message — `action="gmail_read"`,
+   `params={"message_id": <id from the search result>}` — when you need the
+   full body to summarize, quote, or draft a reply.
+3. **Act** (send / label / trash) is a v1-blocked write: draft it in chat
+   and tell the user it can't be sent from here yet. (When writes unblock in
+   v2, the rule becomes: show the user, get a yes, then execute.)
 
 Don't dump raw search JSON at the user. Summarize: who, when, subject,
 and the one-line gist. Offer the obvious next step ("want me to open the
@@ -76,52 +104,56 @@ Examples:
 
 ```
 "unread email from my boss this week"
-  → gmail_search query="from:boss@company.com is:unread newer_than:7d"
+  → connector_execute(connector_name="gmail", action="gmail_search",
+      params={"query": "from:boss@company.com is:unread newer_than:7d"})
 
 "the latest invoice from Acme"
-  → gmail_search query="from:acme.com subject:invoice" max_results=5
-  → then gmail_read on the most recent id
+  → connector_execute(connector_name="gmail", action="gmail_search",
+      params={"query": "from:acme.com subject:invoice", "max_results": 5})
+  → then connector_execute(action="gmail_read",
+      params={"message_id": <most recent id>})
 ```
 
-## Sending mail
+## Sending mail (v1: blocked)
 
-`gmail_send` takes `to`, `subject`, and `body` (plain text). Before you
-call it:
+`gmail_send` is a confirm-trust write, so it is **blocked in v1** —
+`connector_execute` will refuse it. You can still help the user prepare:
 
 1. **Draft the full message in chat** — recipient, subject, and body.
-2. **Show it to the user verbatim** and ask for explicit confirmation.
-3. Only on a clear yes, call `gmail_send`.
+2. **Show it to the user verbatim.**
+3. Tell them sending from chat isn't available yet (coming in v2); they can
+   copy the draft into Gmail.
 
-For a reply, first `gmail_read` the original so your draft has the right
-context (quote sparingly, match the thread's subject). If the user edits
-your draft, re-show the final version before sending.
+For a reply, you can still `connector_execute(action="gmail_read", ...)` the
+original so your draft has the right context (quote sparingly, match the
+thread's subject).
 
 Never invent recipients. If the address is ambiguous, search for the
 person's recent mail to confirm the right one, or ask.
 
-## Triage: labels and trash
+## Triage: labels and trash (v1: writes blocked)
 
-- `gmail_list_labels` first if you need a label's id — labels are
-  referenced by id, not name, in `gmail_modify` / `gmail_batch_modify`.
-- `gmail_modify` changes labels on one message; `gmail_batch_modify`
-  takes a `message_ids` list for bulk relabeling (e.g. "archive all the
-  newsletters" → search, then batch-modify removing `INBOX`).
-- `gmail_trash` is reversible (Trash, not permanent delete) but still a
-  destructive action — confirm the specific message first.
-- `gmail_create_label` when the user asks for a label that doesn't exist
-  yet; confirm the name.
+Reading labels is allowed; changing them is a blocked write in v1.
+
+- `gmail_list_labels` (read) is fine — run it via `connector_execute` if you
+  need to see the mailbox's labels.
+- `gmail_modify` / `gmail_batch_modify` / `gmail_trash` / `gmail_create_label`
+  are confirm-trust writes and are **blocked in v1**. When the user asks to
+  archive, label, trash, or create a label, explain it's not available from
+  chat yet (coming in v2) rather than attempting it.
 
 ## A quick read on the inbox
 
-`gmail_summary` returns unread count and today's count cheaply — use it
-when the user asks "how's my inbox" or "anything new" before doing a
-heavier search.
+`gmail_summary` (read) returns unread count and today's count cheaply — run it
+via `connector_execute(connector_name="gmail", action="gmail_summary")` when
+the user asks "how's my inbox" or "anything new" before a heavier search.
 
 ## Guardrails
 
-- **Confirm every `confirm`-trust action** (send, trash, label changes,
-  create label). Read-only actions (search, read, list labels, summary)
-  need no confirmation.
+- **Writes are blocked in v1.** Read actions (search, read, list labels,
+  summary) run via `connector_execute`. Confirm-trust actions (send, trash,
+  label changes, create label) are refused by the tool with a "needs approval
+  — coming in v2" message — never claim a blocked action succeeded.
 - **Read the message before quoting or replying** — never paraphrase from
   a search snippet alone for anything that matters.
 - **Cap result volume** — `max_results` is capped at 20; for broad

--- a/tests/cloud/test_connectors_execute.py
+++ b/tests/cloud/test_connectors_execute.py
@@ -2,6 +2,12 @@
 # Created: 2026-05-03 — pins the mode-aware dispatch in
 # ee/cloud/connectors/service.execute() and the new endpoints
 # /widget-recipes + /{name}/execute on the cloud router.
+# Updated: 2026-06-08 (feat/connector-mcp-execution / keystone) — added
+#   service-level coverage for the agent-MCP helpers: list_pocket_connectors
+#   (pocket-scoped, trust-classified), is_connector_bound_to_pocket (tenant
+#   gate), and get_action_trust (read/write classification). Also pins the
+#   GitHub read path through the cloud execute() with a mocked adapter so the
+#   keystone's "github reads run via DirectRESTAdapter" claim is proven offline.
 #
 # Mode dispatch:
 #   cloud   → runs in-process, returns 200 + result
@@ -259,3 +265,120 @@ async def test_execute_unknown_action_404(client: AsyncClient):
     )
     assert resp.status_code == 404
     assert resp.json()["error"]["code"] == "connector.action.not_found"
+
+
+# ---------------------------------------------------------------------------
+# keystone — agent-MCP service helpers (list_pocket_connectors,
+# is_connector_bound_to_pocket, get_action_trust) + github read path
+#
+# These exercise the service functions directly against Beanie (the
+# ``mongo_db`` fixture initializes the in-memory mongomock-motor DB). They
+# insert the WorkspaceConnector doc straight through the model rather than the
+# HTTP /enable route — the route carries an auth dependency the lightweight
+# test app doesn't satisfy, and the keystone surface is service-level (the MCP
+# server calls these service functions, never the router).
+# ---------------------------------------------------------------------------
+
+
+async def _bind_pocket_connector(
+    name: str, pocket_id: str, *, workspace: str = "ws-1", config: dict | None = None
+) -> None:
+    """Insert an enabled, pocket-scoped WorkspaceConnector doc directly."""
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    await WorkspaceConnector(
+        workspace=workspace,
+        name=name,
+        enabled=True,
+        scope="pocket",
+        pocket_id=pocket_id,
+        config=config or {},
+    ).insert()
+
+
+@pytest.mark.asyncio
+async def test_list_pocket_connectors_classifies_github_read_vs_write(mongo_db):  # noqa: ARG001
+    """A github connector bound at scope=pocket lists its read actions and its
+    write actions, classified by trust level."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    await _bind_pocket_connector("github", "pk-1", config={"GITHUB_TOKEN": "x"})
+
+    infos = await connectors_service.list_pocket_connectors("ws-1", "pk-1")
+    gh = next(i for i in infos if i.name == "github")
+    reads = {a.name for a in gh.actions if a.is_read}
+    writes = {a.name for a in gh.actions if not a.is_read}
+    # list_issues is auto-trust (read); create_issue is confirm-trust (write).
+    assert "list_issues" in reads
+    assert "create_issue" in writes
+
+
+@pytest.mark.asyncio
+async def test_list_pocket_connectors_excludes_other_pockets(mongo_db):  # noqa: ARG001
+    """A connector bound to pocket A must not show for pocket B."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    await _bind_pocket_connector("github", "pk-A")
+    infos_b = await connectors_service.list_pocket_connectors("ws-1", "pk-B")
+    assert infos_b == []
+
+
+@pytest.mark.asyncio
+async def test_is_connector_bound_to_pocket_tenant_gate(mongo_db):  # noqa: ARG001
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    await _bind_pocket_connector("github", "pk-1")
+    assert await connectors_service.is_connector_bound_to_pocket("ws-1", "pk-1", "github")
+    # Wrong pocket / wrong connector / wrong workspace → not bound.
+    assert not await connectors_service.is_connector_bound_to_pocket("ws-1", "pk-2", "github")
+    assert not await connectors_service.is_connector_bound_to_pocket("ws-1", "pk-1", "gmail")
+    assert not await connectors_service.is_connector_bound_to_pocket("ws-OTHER", "pk-1", "github")
+
+
+@pytest.mark.asyncio
+async def test_get_action_trust_reads_vs_writes(mongo_db):  # noqa: ARG001
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    read = await connectors_service.get_action_trust("github", "list_issues")
+    assert read is not None and read.is_read and read.trust_level == "auto"
+
+    write = await connectors_service.get_action_trust("github", "create_issue")
+    assert write is not None and not write.is_read and write.trust_level == "confirm"
+
+    assert await connectors_service.get_action_trust("github", "nope") is None
+
+
+@pytest.mark.asyncio
+async def test_github_read_executes_via_direct_rest_adapter(mongo_db):  # noqa: ARG001
+    """The github read path runs through the cloud execute() → DirectRESTAdapter.
+
+    Proves the keystone claim that github read actions execute over the
+    existing CLOUD path with a bearer token from config. The HTTP call itself
+    is mocked (DirectRESTAdapter.execute) so the test stays offline."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+
+    from pocketpaw.connectors.protocol import ActionResult
+
+    await _bind_pocket_connector("github", "pk-1", config={"GITHUB_TOKEN": "ghp_test"})
+
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(
+            success=True, data=[{"number": 1, "title": "first"}], records_affected=1
+        ),
+    ):
+        resp = await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(
+                action="list_issues",
+                params={"owner": "acme", "repo": "api"},
+                scope="pocket",
+                pocket_id="pk-1",
+            ),
+            user_id="u-1",
+        )
+    assert resp.success is True
+    assert resp.execution_mode == "cloud"
+    assert resp.data[0]["title"] == "first"

--- a/tests/connectors/test_surface_profile_yaml.py
+++ b/tests/connectors/test_surface_profile_yaml.py
@@ -103,3 +103,13 @@ def test_shipped_gmail_yaml_carries_skill() -> None:
     assert gmail is not None
     assert gmail.surface_profile is not None
     assert gmail.surface_profile.skill == "gmail"
+
+
+def test_shipped_github_yaml_carries_skill() -> None:
+    """The real github.yaml in /connectors maps to the bundled github skill
+    (keystone — connector-mcp-execution)."""
+    reg = ConnectorRegistry()
+    github = reg.get_definition("github")
+    assert github is not None
+    assert github.surface_profile is not None
+    assert github.surface_profile.skill == "github"

--- a/tests/ee/agent/test_connectors_mcp_server/__init__.py
+++ b/tests/ee/agent/test_connectors_mcp_server/__init__.py
@@ -1,0 +1,2 @@
+# tests/ee/agent/test_connectors_mcp_server package marker.
+# Created: 2026-06-08 (feat/connector-mcp-execution / keystone).

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -1,0 +1,439 @@
+# tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+# Created: 2026-06-08 (feat/connector-mcp-execution / keystone) — coverage for
+#   the in-process ``pocketpaw_connectors`` MCP server. Mirrors the
+#   test_sites_mcp_server layout: registration assertions (server name, tool
+#   ids, build, provider allowlist publication, ambient-not-opt-in) plus
+#   per-handler tests that mock the identity ContextVars + the connectors
+#   service and inspect the MCP envelope the SDK returns. The handler tests
+#   prove the v1 contract: read (auto-trust) actions reach service.execute,
+#   write (confirm-trust) actions are blocked WITHOUT calling execute,
+#   connectors not bound to the pocket are rejected, and a missing pocket /
+#   workspace ContextVar (called off-stream) yields a clear error.
+"""MCP server registration + handler tests for connector execution."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.connectors.domain import (  # noqa: E402
+    ConnectorActionInfo,
+    PocketConnectorInfo,
+)
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorsMcpServerRegistration:
+    def test_server_name_and_tool_ids(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.connectors import (
+            CONNECTOR_EXECUTE_TOOL_ID,
+            CONNECTOR_TOOL_IDS,
+            LIST_CONNECTOR_ACTIONS_TOOL_ID,
+            SERVER_NAME,
+        )
+
+        assert SERVER_NAME == "pocketpaw_connectors"
+        # Allowlist entries must use the exact ``mcp__<server>__<tool>`` form.
+        assert LIST_CONNECTOR_ACTIONS_TOOL_ID == "mcp__pocketpaw_connectors__list_connector_actions"
+        assert CONNECTOR_EXECUTE_TOOL_ID == "mcp__pocketpaw_connectors__connector_execute"
+        assert LIST_CONNECTOR_ACTIONS_TOOL_ID in CONNECTOR_TOOL_IDS
+        assert CONNECTOR_EXECUTE_TOOL_ID in CONNECTOR_TOOL_IDS
+        assert len(CONNECTOR_TOOL_IDS) == 2
+
+    def test_extension_provider_advertises_tool_ids(self) -> None:
+        """The entry-point provider's ``tool_ids()`` feeds the claude_sdk
+        allowlist loop — both tool ids must come through it."""
+        from pocketpaw_ee.agent.mcp_servers.connectors import CONNECTOR_TOOL_IDS
+        from pocketpaw_ee.extensions import CloudConnectorsMcpProvider
+
+        advertised = CloudConnectorsMcpProvider().tool_ids()
+        for tid in CONNECTOR_TOOL_IDS:
+            assert tid in advertised
+
+    def test_provider_build_server_matches_shape(self) -> None:
+        from pocketpaw_ee.extensions import CloudConnectorsMcpProvider
+
+        out = CloudConnectorsMcpProvider().build_server()
+        if out is not None:
+            name, server = out
+            assert name == "pocketpaw_connectors"
+            assert server is not None
+
+    def test_build_server_returns_object(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.connectors import build_connectors_context_server
+
+        out = build_connectors_context_server()
+        if out is not None:
+            name, server = out
+            assert name == "pocketpaw_connectors"
+            assert server is not None
+
+    def test_provider_is_ambient_not_opt_in(self) -> None:
+        """The connectors server must NOT be opt-in — the M3-derived connector
+        skills reach connector_execute ambiently, with no per-agent opt-in."""
+        from pocketpaw.tools.policy import OPT_IN_MCP_SERVERS
+
+        assert "pocketpaw_connectors" not in OPT_IN_MCP_SERVERS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _decode_payload(envelope: dict) -> dict:
+    """MCP success responses pack the JSON body into ``content[0].text``."""
+    assert "content" in envelope
+    assert envelope["content"][0]["type"] == "text"
+    return json.loads(envelope["content"][0]["text"])
+
+
+def _patch_identity(workspace_id: str | None, user_id: str | None, pocket_id: str | None):
+    """Patch the per-stream identity accessors the handler reads via
+    ``_identity`` (imported function-locally from agent_service)."""
+    return (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            return_value=workspace_id,
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            return_value=user_id,
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_pocket_id",
+            return_value=pocket_id,
+        ),
+    )
+
+
+def _github_pocket_info() -> PocketConnectorInfo:
+    """A GitHub connector with one read action and one write action."""
+    return PocketConnectorInfo(
+        name="github",
+        display_name="GitHub",
+        type="developer",
+        icon="git-branch",
+        actions=(
+            ConnectorActionInfo(
+                name="list_issues",
+                description="List issues for a repository",
+                trust_level="auto",
+                execution_mode="cloud",
+                is_read=True,
+            ),
+            ConnectorActionInfo(
+                name="create_issue",
+                description="Create a new issue",
+                trust_level="confirm",
+                execution_mode="cloud",
+                is_read=False,
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handler — list_connector_actions
+# ---------------------------------------------------------------------------
+
+
+class TestListConnectorActionsHandler:
+    @pytest.mark.asyncio
+    async def test_lists_read_actions_and_marks_writes_blocked(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.list_pocket_connectors",
+                new=AsyncMock(return_value=[_github_pocket_info()]),
+            ) as mock_list,
+        ):
+            out = await connectors_mcp._list_connector_actions_handler({})
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["pocket_id"] == "pk_1"
+        assert len(body["connectors"]) == 1
+        gh = body["connectors"][0]
+        assert gh["connector"] == "github"
+        # Read action listed as runnable.
+        assert [a["action"] for a in gh["read_actions"]] == ["list_issues"]
+        # Write action listed but flagged blocked.
+        assert len(gh["write_actions_blocked"]) == 1
+        assert gh["write_actions_blocked"][0]["action"] == "create_issue"
+        assert "v2" in gh["write_actions_blocked"][0]["status"]
+        mock_list.assert_awaited_once_with("ws_1", "pk_1")
+
+    @pytest.mark.asyncio
+    async def test_no_pocket_returns_clear_message(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", None)
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.list_pocket_connectors",
+                new=AsyncMock(),
+            ) as mock_list,
+        ):
+            out = await connectors_mcp._list_connector_actions_handler({})
+
+        body = _decode_payload(out)
+        assert body["connectors"] == []
+        assert "isn't anchored to a pocket" in body["message"]
+        mock_list.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_connectors_returns_clear_message(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.list_pocket_connectors",
+                new=AsyncMock(return_value=[]),
+            ),
+        ):
+            out = await connectors_mcp._list_connector_actions_handler({})
+
+        body = _decode_payload(out)
+        assert body["connectors"] == []
+        assert "No connectors are bound" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity(None, None, None)
+        with ws_patch, user_patch, pocket_patch:
+            out = await connectors_mcp._list_connector_actions_handler({})
+
+        assert out.get("is_error") is True
+        assert "no active workspace" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Handler — connector_execute
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorExecuteHandler:
+    @pytest.mark.asyncio
+    async def test_read_action_calls_service_execute(self) -> None:
+        """An auto-trust (read) action reaches service.execute and returns the
+        result."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse
+
+        read_trust = ConnectorActionInfo(
+            name="list_issues",
+            description="List issues",
+            trust_level="auto",
+            execution_mode="cloud",
+            is_read=True,
+        )
+        exec_result = ExecuteActionResponse(
+            success=True,
+            data=[{"number": 1, "title": "first issue"}],
+            execution_mode="cloud",
+        )
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+                new=AsyncMock(return_value=read_trust),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.execute",
+                new=AsyncMock(return_value=exec_result),
+            ) as mock_execute,
+        ):
+            out = await connectors_mcp._connector_execute_handler(
+                {
+                    "connector_name": "github",
+                    "action": "list_issues",
+                    "params": {"owner": "acme", "repo": "api"},
+                }
+            )
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["executed"] is True
+        assert body["success"] is True
+        assert body["data"][0]["title"] == "first issue"
+        # The execute call carried the pocket id + scope.
+        mock_execute.assert_awaited_once()
+        call = mock_execute.await_args
+        assert call.args[0] == "ws_1"  # workspace_id
+        assert call.args[1] == "github"  # name
+        req = call.args[2]
+        assert req.action == "list_issues"
+        assert req.scope == "pocket"
+        assert req.pocket_id == "pk_1"
+
+    @pytest.mark.asyncio
+    async def test_write_action_blocked_without_calling_execute(self) -> None:
+        """A confirm-trust (write) action is refused and service.execute is
+        NEVER called."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        write_trust = ConnectorActionInfo(
+            name="create_issue",
+            description="Create an issue",
+            trust_level="confirm",
+            execution_mode="cloud",
+            is_read=False,
+        )
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+                new=AsyncMock(return_value=write_trust),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.execute",
+                new=AsyncMock(),
+            ) as mock_execute,
+        ):
+            out = await connectors_mcp._connector_execute_handler(
+                {"connector_name": "github", "action": "create_issue", "params": {}}
+            )
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["executed"] is False
+        assert body["blocked"] is True
+        assert "needs approval" in body["reason"]
+        assert "v2" in body["reason"]
+        mock_execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_connector_not_bound_is_rejected(self) -> None:
+        """A connector not bound to THIS pocket is rejected before trust lookup
+        or execute."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+                new=AsyncMock(),
+            ) as mock_trust,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.execute",
+                new=AsyncMock(),
+            ) as mock_execute,
+        ):
+            out = await connectors_mcp._connector_execute_handler(
+                {"connector_name": "github", "action": "list_issues", "params": {}}
+            )
+
+        assert out.get("is_error") is True
+        assert "not bound to this pocket" in out["content"][0]["text"]
+        mock_trust.assert_not_awaited()
+        mock_execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.execute",
+                new=AsyncMock(),
+            ) as mock_execute,
+        ):
+            out = await connectors_mcp._connector_execute_handler(
+                {"connector_name": "github", "action": "no_such_action", "params": {}}
+            )
+
+        assert out.get("is_error") is True
+        assert "no action 'no_such_action'" in out["content"][0]["text"]
+        mock_execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_off_stream_no_workspace_is_error(self) -> None:
+        """Called outside an SSE chat stream (no ContextVars) → clear error,
+        no service touched."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity(None, None, None)
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.execute",
+                new=AsyncMock(),
+            ) as mock_execute,
+        ):
+            out = await connectors_mcp._connector_execute_handler(
+                {"connector_name": "github", "action": "list_issues"}
+            )
+
+        assert out.get("is_error") is True
+        assert "no active workspace" in out["content"][0]["text"]
+        mock_execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_connector_name_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with ws_patch, user_patch, pocket_patch:
+            out = await connectors_mcp._connector_execute_handler({"action": "list_issues"})
+
+        assert out.get("is_error") is True
+        assert "connector_name is required" in out["content"][0]["text"]

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -1,5 +1,10 @@
 """Tests for MCP + Claude Agent SDK integration — Sprint 17.
 
+Updated: 2026-06-08 (feat/connector-mcp-execution / keystone) —
+  ``_strip_builtin_servers`` now also drops ``pocketpaw_connectors`` (the new
+  always-on connector-execution server: list_connector_actions /
+  connector_execute), so the external-config assertions stay focused after the
+  connector MCP server became ambient. Same regime as pocketpaw_sites_manager.
 Updated: 2026-06-01 (Phase 4 — chat→create-site) — ``_strip_builtin_servers``
   now also drops ``pocketpaw_sites_manager`` (the new always-on Paw Sites
   publish server), so the external-config assertions stay focused after the
@@ -34,6 +39,7 @@ All SDK imports are mocked.
 import logging
 from unittest.mock import patch
 
+from pocketpaw_ee.agent.mcp_servers.connectors import SERVER_NAME as _CONNECTORS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.decisions import SERVER_NAME as _DECISIONS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.foresight import SERVER_NAME as _FORESIGHT_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.meetings import SERVER_NAME as _MEETINGS_MCP_SERVER_NAME
@@ -78,6 +84,9 @@ def _strip_builtin_servers(result: dict) -> dict:
     # ``pocketpaw_sites_manager`` is always-on too — the bundled
     # pocketpaw-create-site skill calls it without an explicit opt-in.
     out.pop(_SITES_MCP_SERVER_NAME, None)
+    # ``pocketpaw_connectors`` is always-on — the M3-derived connector skills
+    # (gmail/github) call connector_execute without an explicit opt-in.
+    out.pop(_CONNECTORS_MCP_SERVER_NAME, None)
     return out
 
 


### PR DESCRIPTION
## What

Gives the cloud chat agent a real way to **use** a pocket's bound connectors, not just read about them. A new in-process MCP server (`pocketpaw_connectors`) exposes two tools to the agent:

- `list_connector_actions()` — the current pocket's bound connectors + their runnable read actions (write actions shown but flagged blocked)
- `connector_execute(connector, action, params)` — runs read actions through the existing cloud execute path

This closes the gap where M3 made the agent *learn* a connector's skill but it had no tool to *call* it. Stacked on #1363.

## v1 policy: read-first

- **Read** (trust=auto) actions execute. **Write** (confirm/restricted) actions are refused with a "needs approval — v2" message and are **never executed** (gated before any execute call).
- Auth = the token already in the connector's config (PAT); no OAuth flow yet.

## How

- The server reads the active workspace / user / **pocket** from the per-stream ContextVars in `agent_service` (a new `pocket_id` var, set by `run_core`; the identity tuple grew 3→4, backward-compatible).
- Execution reuses the existing `connectors.service.execute` CLOUD path (`DirectRESTAdapter` / native adapter) — no new execution engine. Beanie reads stay in the service; the MCP layer never imports the connector doc (import-linter clean).
- Registered via the `pocketpaw.mcp_servers` entry point, so the SDK backend picks it up like the other in-process servers.

## Proof

- **GitHub**: added a `surface_profile` block to `github.yaml` + a new `github` skill; its 9 read actions are trust=auto and execute via the REST adapter (bearer token from config), confirmed by an offline test of the real service path. `create_issue` is confirm → blocked in v1.
- **Gmail**: skill updated to call `connector_execute` (the real tool) instead of naming actions that weren't exposed.

## Checks

- 70 tests pass (MCP server, trust-gating, surface yaml, bundled skills, service)
- ruff clean · import-linter 22 kept / 0 broken
- Pre-existing note: 6 route tests in `test_connectors_execute.py` fail locally with 401 (auth-harness gap present on the base branch too; they pass in CI). Not from this change.

## Not in v1

- Write actions (need the Instinct-approval path — v2)
- OAuth / guided token entry
- A single "create connector-bound room" endpoint