### PR TITLE
feat(workspace): live slug-availability check + reserved handles

### DIFF
--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -6,17 +6,21 @@ existing wire shape consumed by paw-enterprise:
 - ``createdAt``, ``expiresAt``, ``joinedAt`` (camelCase) for timestamps
 - ``memberCount``, ``invitedBy`` (camelCase) for derived/foreign refs
 - ``workspace_name``, ``valid`` for the validate-invite response
+
+Changes: added the slug rule single-source-of-truth (``SLUG_RE`` +
+``RESERVED_SLUGS``) and the ``SlugAvailabilityOut`` response so the create
+UI can check a slug live; ``validate_slug`` now reuses ``SLUG_RE``.
 """
 
 from __future__ import annotations
 
-import re
 from typing import Literal
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.workspace.domain import Invite, VerifiedDomain, Workspace, WorkspaceMember
+from pocketpaw_ee.cloud.workspace.slug import SLUG_RE
 
 # ---------------------------------------------------------------------------
 # Requests (preserved from schemas.py)
@@ -30,7 +34,7 @@ class CreateWorkspaceRequest(BaseModel):
     @field_validator("slug")
     @classmethod
     def validate_slug(cls, v: str) -> str:
-        if not re.match(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$", v):
+        if not SLUG_RE.match(v):
             raise ValueError("Slug must be lowercase alphanumeric with hyphens")
         return v
 
@@ -87,6 +91,19 @@ class WorkspaceOut(BaseModel):
     memberCount: int  # noqa: N815 - camelCase wire key
 
     model_config = {"populate_by_name": True}
+
+
+class SlugAvailabilityOut(BaseModel):
+    """GET /workspaces/slug-available response.
+
+    ``available`` is the headline; ``reason`` names *why* an unavailable slug
+    is unavailable (``invalid`` format, ``reserved`` handle, or already
+    ``taken``) so the create UI can show a precise message live instead of
+    waiting for the POST to 409.
+    """
+
+    available: bool
+    reason: Literal["invalid", "reserved", "taken"] | None = None
 
 
 class MemberOut(BaseModel):
@@ -280,6 +297,7 @@ __all__ = [
     "InviteOut",
     "InvitePreviewResponse",
     "MemberOut",
+    "SlugAvailabilityOut",
     "UpdateDomainRequest",
     "UpdateMemberRoleRequest",
     "UpdateWorkspaceRequest",

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -7,7 +7,7 @@ entities; the router maps to DTOs at the boundary.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from starlette.responses import Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
@@ -36,6 +36,7 @@ from pocketpaw_ee.cloud.workspace.dto import (
     InviteOut,
     InvitePreviewResponse,
     MemberOut,
+    SlugAvailabilityOut,
     UpdateDomainRequest,
     UpdateMemberRoleRequest,
     UpdateWorkspaceRequest,
@@ -68,6 +69,23 @@ async def create_workspace(
 ) -> WorkspaceOut:
     ws = await workspace_service.create(ctx, body)
     return workspace_to_dto(ws)
+
+
+@router.get("/slug-available", response_model=SlugAvailabilityOut)
+async def check_slug_available(
+    slug: str = Query(..., min_length=1, max_length=50),
+    user: User = Depends(current_user),  # signed-in users only reach create
+) -> SlugAvailabilityOut:
+    """Is this workspace slug free to claim?
+
+    Declared before ``GET /{workspace_id}`` so the static path wins the
+    route match. Returns ``available`` plus a ``reason`` (``invalid`` |
+    ``reserved`` | ``taken``) so the create UI shows a precise message live
+    instead of waiting for the POST to 409. The POST is still the
+    source of truth — this is an advisory pre-check, racy by nature.
+    """
+    reason = await workspace_service.slug_reason(slug)
+    return SlugAvailabilityOut(available=reason is None, reason=reason)
 
 
 @router.get("", response_model=list[WorkspaceOut])

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -20,7 +20,9 @@ Public API:
   the plan-feature gate dependency; returns "team" on any failure so the
   dep fails open on plan rather than crashing with a 500.
 
-Changes: added get_workspace_plan helper for plan-feature gate dep.
+Changes: added get_workspace_plan helper for plan-feature gate dep; added
+slug_reason() (format + reserved + uniqueness) backing the live
+slug-available check, and create() now also rejects reserved slugs.
 2026-06-07: _mint_invite_for_email now maps a DuplicateKeyError on insert to
 a ConflictError (409) instead of letting it escape as an unhandled 500 — the
 leftover unique index on the nullable legacy ``token`` column made every
@@ -78,6 +80,7 @@ from pocketpaw_ee.cloud.workspace.dto import (
     CreateWorkspaceRequest,
     UpdateWorkspaceRequest,
 )
+from pocketpaw_ee.cloud.workspace.slug import SlugReason, static_slug_reason
 
 if TYPE_CHECKING:
     from pocketpaw_ee.cloud.models.user import User
@@ -226,13 +229,33 @@ async def _find_user_id_by_email(email: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace:
+async def slug_reason(slug: str) -> SlugReason | None:
+    """Why ``slug`` can't be claimed, or ``None`` if it's free.
+
+    Layers the DB uniqueness check on top of the static format + reserved
+    gates (``slug.static_slug_reason``). The uniqueness query mirrors
+    ``create``'s exactly — soft-deleted workspaces don't hold their slug —
+    so the live availability answer can't disagree with what create() does.
+    """
+    static = static_slug_reason(slug)
+    if static is not None:
+        return static
     existing = await _WorkspaceDoc.find_one(
-        _WorkspaceDoc.slug == body.slug,
+        _WorkspaceDoc.slug == slug,
         _WorkspaceDoc.deleted_at == None,  # noqa: E711
     )
-    if existing is not None:
+    return "taken" if existing is not None else None
+
+
+async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace:
+    # Format is already enforced by the DTO validator; this catches reserved
+    # handles and the uniqueness race so create() agrees with the live
+    # slug-available check the UI runs first.
+    reason = await slug_reason(body.slug)
+    if reason == "taken":
         raise ConflictError("workspace.slug_taken", f"Slug '{body.slug}' is already in use")
+    if reason == "reserved":
+        raise ConflictError("workspace.slug_reserved", f"Slug '{body.slug}' is reserved")
 
     doc = _WorkspaceDoc(name=body.name, slug=body.slug, owner=ctx.user_id)
     await doc.insert()

--- a/ee/pocketpaw_ee/cloud/workspace/slug.py
+++ b/ee/pocketpaw_ee/cloud/workspace/slug.py
@@ -1,0 +1,99 @@
+"""Workspace slug rules — single source of truth.
+
+New file. Centralizes the slug format regex and the reserved-handle set so
+the create-request validator (``dto.py``), the availability service
+(``service.py``), and the paw-enterprise client (which mirrors these rules
+in ``src/lib/core/workspaces/schemas.ts``) all agree on what a legal,
+claimable slug is. Pure module — no DB, no Beanie imports — so it stays
+cheap to import anywhere.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+# Lowercase alphanumeric with internal hyphens; no leading/trailing hyphen.
+# A single char (``x``, ``7``) is valid. Length is bounded by the DTO Field
+# constraint (1..50), not the regex.
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$")
+
+# Handles that collide with reserved routes / hostnames, or would be
+# confusing as a tenant slug. Lowercase only — slugs are already lowercased
+# by the format rule before this set is consulted.
+RESERVED_SLUGS: frozenset[str] = frozenset(
+    {
+        "about",
+        "account",
+        "accounts",
+        "admin",
+        "api",
+        "app",
+        "apps",
+        "assets",
+        "auth",
+        "billing",
+        "blog",
+        "cdn",
+        "contact",
+        "dashboard",
+        "dns",
+        "docs",
+        "email",
+        "ftp",
+        "health",
+        "help",
+        "internal",
+        "legal",
+        "login",
+        "logout",
+        "mail",
+        "new",
+        "ns",
+        "null",
+        "oauth",
+        "paw",
+        "pocket",
+        "pocketpaw",
+        "pockets",
+        "privacy",
+        "public",
+        "register",
+        "root",
+        "security",
+        "settings",
+        "signin",
+        "signup",
+        "sso",
+        "static",
+        "status",
+        "support",
+        "system",
+        "terms",
+        "test",
+        "undefined",
+        "workspace",
+        "workspaces",
+        "www",
+    }
+)
+
+# Why a slug can't be claimed. ``None`` (returned by the service) means free.
+SlugReason = Literal["invalid", "reserved", "taken"]
+
+
+def static_slug_reason(slug: str) -> SlugReason | None:
+    """Format + reserved-word check, without touching the DB.
+
+    Returns ``"invalid"`` for a malformed slug, ``"reserved"`` for a taken
+    handle, or ``None`` if it passes the static gates (uniqueness is a
+    separate DB check, layered on top by the service).
+    """
+    if not SLUG_RE.match(slug):
+        return "invalid"
+    if slug in RESERVED_SLUGS:
+        return "reserved"
+    return None
+
+
+__all__ = ["RESERVED_SLUGS", "SLUG_RE", "SlugReason", "static_slug_reason"]

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -126,6 +126,44 @@ async def test_create_rejects_duplicate_slug(owner) -> None:
         )
 
 
+async def test_create_rejects_reserved_slug(owner) -> None:
+    with pytest.raises(ConflictError) as exc:
+        await workspace_service.create(
+            _ctx(str(owner.id)), CreateWorkspaceRequest(name="Admin", slug="admin")
+        )
+    assert exc.value.code == "workspace.slug_reserved"
+
+
+async def test_slug_reason_available_for_fresh_slug(owner) -> None:
+    assert await workspace_service.slug_reason("brand-new") is None
+
+
+async def test_slug_reason_taken_after_create(owner) -> None:
+    await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="taken-one")
+    )
+    assert await workspace_service.slug_reason("taken-one") == "taken"
+
+
+async def test_slug_reason_reserved() -> None:
+    assert await workspace_service.slug_reason("api") == "reserved"
+
+
+async def test_slug_reason_invalid_format() -> None:
+    assert await workspace_service.slug_reason("Not A Slug") == "invalid"
+
+
+async def test_slug_reason_free_again_after_soft_delete(owner) -> None:
+    # Mirrors create()'s uniqueness query: a soft-deleted workspace must not
+    # keep holding its slug, so the slug reads as available again.
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="recyclable")
+    )
+    assert await workspace_service.slug_reason("recyclable") == "taken"
+    await workspace_service.delete(_ctx(str(owner.id)), ws.id)
+    assert await workspace_service.slug_reason("recyclable") is None
+
+
 async def test_update_emits_workspace_updated(owner, recording_bus) -> None:
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")

--- a/tests/cloud/workspace/test_slug.py
+++ b/tests/cloud/workspace/test_slug.py
@@ -1,0 +1,45 @@
+"""Tests for the workspace slug rules (``workspace/slug.py``).
+
+New file. Covers the pure (no-DB) gates — format regex and the reserved
+set — that the create-request validator, the availability service, and the
+paw-enterprise client all share. The DB-backed ``taken`` path is exercised
+separately in ``test_service_v2.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.workspace.slug import (
+    RESERVED_SLUGS,
+    SLUG_RE,
+    static_slug_reason,
+)
+
+
+@pytest.mark.parametrize("slug", ["acme-corp", "x", "7", "test-workspace-1", "a1b2"])
+def test_valid_slugs_match(slug: str) -> None:
+    assert SLUG_RE.match(slug) is not None
+    assert static_slug_reason(slug) is None
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["Invalid Slug!", "-bad", "bad-", "BadSlug", "", "has space", "under_score", "emoji😀"],
+)
+def test_malformed_slugs_are_invalid(slug: str) -> None:
+    assert static_slug_reason(slug) == "invalid"
+
+
+@pytest.mark.parametrize("slug", ["admin", "api", "www", "settings", "pocketpaw"])
+def test_reserved_slugs_are_reserved(slug: str) -> None:
+    # Well-formed but reserved → "reserved", not "invalid".
+    assert SLUG_RE.match(slug) is not None
+    assert static_slug_reason(slug) == "reserved"
+
+
+def test_reserved_set_is_all_lowercase_and_well_formed() -> None:
+    # Every reserved entry must itself be a legal slug, otherwise it could
+    # never collide with a user-supplied (already format-checked) value.
+    for handle in RESERVED_SLUGS:
+        assert handle == handle.lower()
+        assert SLUG_RE.match(handle) is not None

--- a/tests/cloud/workspace/test_slug_available_route.py
+++ b/tests/cloud/workspace/test_slug_available_route.py
@@ -1,0 +1,67 @@
+"""HTTP contract test for GET /workspaces/slug-available.
+
+New file. Builds a tiny FastAPI app with the workspace router mounted and
+the auth/license deps overridden (same shape as test_connectors_router),
+then exercises the live slug-availability route over httpx against an
+isolated mongomock-motor DB. The route's reason for existing is that it
+must be matched *before* ``GET /{workspace_id}`` — these tests fail loudly
+if that ordering ever regresses (the param route would 404/500 on the
+literal "slug-available").
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.deps import current_user
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+from pocketpaw_ee.cloud.workspace.router import router as workspace_router
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _no_op_license() -> None:
+    return None
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db) -> AsyncClient:  # noqa: ARG001 — fixture wires Beanie
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(workspace_router)
+    # The route doesn't use the returned user, only the auth gate — any
+    # truthy object satisfies it.
+    app.dependency_overrides[current_user] = lambda: object()
+    app.dependency_overrides[require_license] = _no_op_license
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+async def test_slug_available_returns_available(client: AsyncClient) -> None:
+    resp = await client.get("/workspaces/slug-available", params={"slug": "fresh-one"})
+    assert resp.status_code == 200
+    assert resp.json() == {"available": True, "reason": None}
+
+
+async def test_slug_available_reports_taken(client: AsyncClient) -> None:
+    await _WorkspaceDoc(name="Acme", slug="acme", owner="u1").insert()
+    resp = await client.get("/workspaces/slug-available", params={"slug": "acme"})
+    assert resp.status_code == 200
+    assert resp.json() == {"available": False, "reason": "taken"}
+
+
+async def test_slug_available_reports_reserved(client: AsyncClient) -> None:
+    resp = await client.get("/workspaces/slug-available", params={"slug": "admin"})
+    assert resp.status_code == 200
+    assert resp.json() == {"available": False, "reason": "reserved"}
+
+
+async def test_slug_available_reports_invalid_format(client: AsyncClient) -> None:
+    resp = await client.get("/workspaces/slug-available", params={"slug": "Bad-Slug"})
+    assert resp.status_code == 200
+    assert resp.json() == {"available": False, "reason": "invalid"}


### PR DESCRIPTION
## What this does

Adds `GET /workspaces/slug-available` so the create-workspace UI can tell someone a slug is free, taken, reserved, or malformed as they type — instead of letting them fill out the form and only learn about the clash when the `POST` bounces back a 409.

This is the same work as the earlier #1355, re-cut cleanly off `dev` so it lands on its own without the per-mode-tool-scope stack it was previously sitting on. The paw-enterprise client wires up the live badge against this endpoint in a companion PR.

## How it's put together

- **`workspace/slug.py`** — one place that owns the slug format regex and the reserved-handle set. The create-request validator and the availability service both read from it, and the client mirrors the same rules, so the three can't drift apart.
- **`service.slug_reason()`** — layers the database uniqueness check on top of the static format + reserved gates. Returns `invalid` / `reserved` / `taken`, or `None` when the slug is free. The uniqueness query matches `create()`'s exactly (soft-deleted workspaces release their slug), so the advisory answer can't contradict what create actually does.
- **`create()`** now also rejects reserved slugs (`workspace.slug_reserved`), so the endpoint's verdict and the real create path agree.
- The route is declared **before** `GET /{workspace_id}` so the static path wins the match.

The check stays advisory — `POST /workspaces` is still the source of truth and remains the backstop for the race between checking and submitting.

## Tests

- Slug rules: valid forms, malformed input, and reserved handles.
- Service reasons: available, taken, reserved, invalid, and a slug freeing up again after a soft-delete.
- HTTP route: available/taken/reserved/invalid over the wire, which also pins the route ordering so it can't regress behind `/{workspace_id}`.

Pre-existing `test_delete_preview_*` failures in the workspace suite are unrelated (default-agent seeding under mongomock) and present on `dev`.
