### PR TITLE
Per-mode MCP tool allow-list (lean context for files / foresight / sites)

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -669,9 +669,15 @@ async def _drive_agent_loop(
         # None / empty so legacy and non-entity runs are byte-identical.
         surface_sys_override: str | None = None
         surface_skills: frozenset[str] = frozenset()
+        # Per-MODE restrictive MCP allow-list (lean per-mode tool set). ``None``
+        # = no restriction (broad surfaces like /chat keep every tool); a scoped
+        # mode keeps only its own tools plus the universal grant. Forwarded only
+        # when not None so legacy / broad runs are byte-identical.
+        surface_allow_mcp: frozenset[str] | None = None
         if ctx.resolved_profile is not None:
             surface_deny = ctx.resolved_profile.deny_mcp_tool_ids
             surface_allow = ctx.resolved_profile.allowed_sdk_tools or frozenset()
+            surface_allow_mcp = ctx.resolved_profile.allow_mcp_tool_ids
             surface_sys_override = ctx.resolved_profile.system_message_override
             surface_skills = ctx.resolved_profile.skill_names or frozenset()
         run_kwargs: dict[str, Any] = dict(
@@ -681,6 +687,8 @@ async def _drive_agent_loop(
             deny_mcp_tool_ids=surface_deny,
             allow_sdk_tools=surface_allow,
         )
+        if surface_allow_mcp is not None:
+            run_kwargs["allow_mcp_tool_ids"] = surface_allow_mcp
         # Forward the override only when the entity actually set one — withholding
         # keeps the prompt assembly untouched on every other run.
         if surface_sys_override is not None:

--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -179,6 +179,13 @@ class SurfaceProfile:
 
     ripple_mode: Literal["on", "off", "trim"]
     allowed_sdk_tools: frozenset[str] | None = None
+    # Restrictive per-MODE MCP allow-list (distinct from the additive
+    # ``allowed_sdk_tools``). ``None`` = no restriction (keep every MCP tool).
+    # When set, the OSS backend keeps only the MCP tools in this set PLUS the
+    # universal pocket-creation grant + ripple widgets, and anything from an
+    # always-allowed server (connectors / pocket lifecycle) — dropping the rest
+    # so a mode's agent context stays lean. Applied AFTER ``deny_mcp_tool_ids``.
+    allow_mcp_tool_ids: frozenset[str] | None = None
     deny_mcp_tool_ids: frozenset[str] = field(default_factory=frozenset)
     skill_names: frozenset[str] = field(default_factory=frozenset)
     system_message_override: str | None = None
@@ -206,6 +213,7 @@ class PocketSurfaceProfile(BaseModel):
 
     ripple_mode: Literal["on", "off", "trim"] | None = None
     allowed_sdk_tools: list[str] | None = None
+    allow_mcp_tool_ids: list[str] | None = None
     deny_mcp_tool_ids: list[str] = Field(default_factory=list)
     skill_names: list[str] = Field(default_factory=list)
     system_message_override: str | None = None

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -95,18 +95,71 @@ _SITES_SVELTE_CREATE_DENY: frozenset[str] = frozenset(
     }
 )
 
-# The /sites SVELTE-CREATE profile: hand-authored SvelteKit, so ripple OFF, the
-# two ripple-create tools denied, and the create-svelte-site skill surfaced.
-_SITES_SVELTE_CREATE_PROFILE = SurfaceProfile(
-    ripple_mode="off",
-    deny_mcp_tool_ids=_SITES_SVELTE_CREATE_DENY,
-    skill_names=frozenset({"create-svelte-site"}),
-)
+# Per-mode MCP-tool allow-lists keep a mode's agent context lean: only the
+# mode's SPECIALIZED tools are named here. The "general everywhere" set — ripple
+# widgets, the pocket lifecycle (read/create/edit/plan), and connectors
+# (composio) — is kept by the OSS backend itself, so a scoped mode still renders
+# UI, makes pockets, and uses connectors. Chat (and any unmapped kind) stays
+# unrestricted (``allow_mcp_tool_ids=None``).
+#
+# Built lazily + memoized: pulling the EE mcp-server tool-id constants at module
+# import could cycle with the agent layer, and ``resolve_profile`` is on the hot
+# path. A failed import degrades to no MCP restriction so tool-scoping can never
+# break chat.
+_PROFILE_CACHE: dict[str, Any] | None = None
 
-# Per-kind static overrides for NON-sites surfaces. Add a row only when a
-# surface needs to deviate from ``_DEFAULT_PROFILE``. /sites is NOT here — it is
-# resolved per-meta in ``resolve_profile``.
-_PROFILES: dict[SurfaceKind, SurfaceProfile] = {}
+
+def _build_profiles() -> dict[str, Any]:
+    loaded = True
+    foresight_allow: frozenset[str] | None
+    sites_allow: frozenset[str] | None
+    try:
+        from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS
+
+        foresight_allow = frozenset(FORESIGHT_TOOL_IDS)
+        sites_allow = frozenset(SITES_TOOL_IDS)
+    except Exception:  # noqa: BLE001 — degrade to no restriction, never break chat
+        logger.warning(
+            "surface: could not load mcp tool ids; per-mode MCP scoping disabled",
+            exc_info=True,
+        )
+        loaded = False
+        foresight_allow = None
+        sites_allow = None
+
+    return {
+        "by_kind": {
+            # Foresight: its scenario tools + the general-everywhere set.
+            SurfaceKind.FORESIGHT: SurfaceProfile(
+                ripple_mode="on", allow_mcp_tool_ids=foresight_allow
+            ),
+            # Files names no specialized MCP tools — document scaffolding rides
+            # the built-in Read/Write/Edit tools (never filtered). Empty allow =
+            # general-everywhere only; None when the import degraded.
+            SurfaceKind.FILES: SurfaceProfile(
+                ripple_mode="on",
+                allow_mcp_tool_ids=frozenset() if loaded else None,
+            ),
+        },
+        # /sites is meta-aware (below). Both modes scope to the sites authoring
+        # tools + general. svelte-create additionally denies the two ripple-create
+        # tools (deny runs AFTER allow) and drops ripple + surfaces the svelte skill.
+        "sites_default": SurfaceProfile(ripple_mode="on", allow_mcp_tool_ids=sites_allow),
+        "sites_svelte_create": SurfaceProfile(
+            ripple_mode="off",
+            deny_mcp_tool_ids=_SITES_SVELTE_CREATE_DENY,
+            allow_mcp_tool_ids=sites_allow,
+            skill_names=frozenset({"create-svelte-site"}),
+        ),
+    }
+
+
+def _profiles() -> dict[str, Any]:
+    global _PROFILE_CACHE
+    if _PROFILE_CACHE is None:
+        _PROFILE_CACHE = _build_profiles()
+    return _PROFILE_CACHE
 
 
 def resolve_profile(surface_kind: SurfaceKind, meta: SurfaceMeta) -> SurfaceProfile:
@@ -130,13 +183,14 @@ def resolve_profile(surface_kind: SurfaceKind, meta: SurfaceMeta) -> SurfaceProf
     matches the default) returns ``_DEFAULT_PROFILE`` (``ripple_mode="on"``), so
     the only surface that deviates from today's behavior is /sites svelte-create.
     """
+    profiles = _profiles()
     if surface_kind == SurfaceKind.SITES:
         # refine (pocket_id) edits the existing ripple landing spec → keep ripple.
         # It wins over engine, so check it FIRST.
         if meta.pocket_id is None and meta.engine == "svelte":
-            return _SITES_SVELTE_CREATE_PROFILE
-        return _DEFAULT_PROFILE
-    return _PROFILES.get(surface_kind, _DEFAULT_PROFILE)
+            return profiles["sites_svelte_create"]
+        return profiles["sites_default"]
+    return profiles["by_kind"].get(surface_kind, _DEFAULT_PROFILE)
 
 
 def compose_entity_profile(base: SurfaceProfile, override: dict[str, Any] | None) -> SurfaceProfile:
@@ -185,12 +239,23 @@ def compose_entity_profile(base: SurfaceProfile, override: dict[str, Any] | None
     else:
         allowed = (base.allowed_sdk_tools or frozenset()) | frozenset(entity_allow or ())
 
+    # allow_mcp_tool_ids: same None-aware UNION as allowed_sdk_tools — None on
+    # BOTH sides stays None (no MCP restriction); otherwise the entity's allowed
+    # MCP tools ADD to the mode's set. An empty frozenset would wrongly drop
+    # every non-grant MCP tool, so only build a set when a side contributes.
+    entity_allow_mcp = override.get("allow_mcp_tool_ids")
+    if base.allow_mcp_tool_ids is None and entity_allow_mcp is None:
+        allow_mcp: frozenset[str] | None = None
+    else:
+        allow_mcp = (base.allow_mcp_tool_ids or frozenset()) | frozenset(entity_allow_mcp or ())
+
     # system_message_override: entity wins when set, else base.
     sys_override = override.get("system_message_override") or base.system_message_override
 
     return SurfaceProfile(
         ripple_mode=ripple_mode,
         allowed_sdk_tools=allowed,
+        allow_mcp_tool_ids=allow_mcp,
         deny_mcp_tool_ids=deny,
         skill_names=skills,
         system_message_override=sys_override,

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -132,6 +132,40 @@ _DEFAULT_IDENTITY = (
 
 _HTTP_TRANSPORTS: frozenset[str] = frozenset({"http", "sse", "streamable-http"})
 
+# Universal pocket-creation grant. When a surface imposes a restrictive MCP
+# allow-list (``SurfaceProfile.allow_mcp_tool_ids``), these ids are always kept
+# so "create a pocket" works from every chat mode — the core capability. The
+# create-pocket SKILL is plugin-loaded (not an MCP tool), so it stays reachable
+# regardless. Plain ids (no EE import): allow/deny sets cross the OSS boundary
+# as bare ``frozenset[str]``.
+POCKET_CREATION_GRANT: frozenset[str] = frozenset(
+    {
+        "mcp__pocketpaw_pocket_specialist__create",
+        "mcp__pocketpaw_pocket_planner__plan_pocket",
+    }
+)
+
+# MCP servers whose tools survive ANY restrictive allow-list — the "general
+# tools everywhere" set: connectors (composio) + the pocket lifecycle (read /
+# widget edit / create / edit / plan). A mode's allow-list only names its
+# SPECIALIZED tools; these servers stay available so every mode can still use
+# connectors and build/edit pockets. Server is ``<server>`` in
+# ``mcp__<server>__<tool>``.
+ALWAYS_ALLOWED_MCP_SERVERS: frozenset[str] = frozenset(
+    {
+        "composio",
+        "pocketpaw_pocket",
+        "pocketpaw_pocket_specialist",
+        "pocketpaw_pocket_planner",
+    }
+)
+
+
+def _mcp_server_of(tool_id: str) -> str:
+    """Extract ``<server>`` from an ``mcp__<server>__<tool>`` id (else "")."""
+    parts = tool_id.split("__")
+    return parts[1] if len(parts) >= 2 and parts[0] == "mcp" else ""
+
 
 class ClaudeSDKBackend(BaseAgentBackend):
     """Claude Agent SDK backend — the recommended default.
@@ -923,6 +957,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         session_key: str | None = None,
         deny_mcp_tool_ids: frozenset[str] = frozenset(),
         allow_sdk_tools: frozenset[str] = frozenset(),
+        allow_mcp_tool_ids: frozenset[str] | None = None,
         skill_names: frozenset[str] = frozenset(),
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
@@ -1215,6 +1250,32 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     logger.info(
                         "Surface tool-deny: excluded %s from allowlist",
                         sorted(deny_mcp_tool_ids),
+                    )
+
+            # Per-MODE restrictive MCP allow-list (distinct from the additive
+            # ``allow_sdk_tools`` above). ``None`` keeps every MCP tool (broad
+            # surfaces like /chat). When set, keep only MCP tools that are in the
+            # mode's set, in the pocket-creation grant, a ripple widget tool, OR
+            # from an always-allowed server (connectors + pocket lifecycle).
+            # Built-in SDK tools (Read/Write/Bash/...) are NEVER filtered here —
+            # only ``mcp__*`` ids — so scoping a mode can't strip core tools.
+            # Applied AFTER deny so a denied id can't sneak back via the grant.
+            if allow_mcp_tool_ids is not None:
+                from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+
+                grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT | frozenset(WIDGET_TOOL_IDS)
+                before_count = len(allowed_tools)
+                allowed_tools = [
+                    t
+                    for t in allowed_tools
+                    if not t.startswith("mcp__")
+                    or t in grant
+                    or _mcp_server_of(t) in ALWAYS_ALLOWED_MCP_SERVERS
+                ]
+                if len(allowed_tools) < before_count:
+                    logger.info(
+                        "Mode MCP-allow: scoped to %s (+ general grant)",
+                        sorted(allow_mcp_tool_ids),
                     )
 
             # Build hooks for security

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -193,6 +193,7 @@ class AgentPool:
         instructions: str = "",
         deny_mcp_tool_ids: frozenset[str] = frozenset(),
         allow_sdk_tools: frozenset[str] = frozenset(),
+        allow_mcp_tool_ids: frozenset[str] | None = None,
         system_message_override: str | None = None,
         skill_names: frozenset[str] = frozenset(),
     ) -> AsyncIterator[Any]:
@@ -344,6 +345,11 @@ class AgentPool:
             # signature, so an entity allowlist is forwarded only when non-empty.
             if allow_sdk_tools:
                 run_kwargs["allow_sdk_tools"] = allow_sdk_tools
+            # Per-MODE restrictive MCP allow-list. Forwarded only when not None
+            # (the Claude SDK backend is the only consumer); None = no
+            # restriction, so broad surfaces / non-Claude backends are untouched.
+            if allow_mcp_tool_ids is not None:
+                run_kwargs["allow_mcp_tool_ids"] = allow_mcp_tool_ids
             # Per-entity skill subset (entity-rooms A2). Same withhold-when-empty
             # rule: only the Claude SDK backend accepts ``skill_names`` (it
             # materializes them into a per-run local plugin); the other backends

--- a/tests/cloud/test_entity_profile_compose.py
+++ b/tests/cloud/test_entity_profile_compose.py
@@ -117,3 +117,25 @@ def test_compose_full_entity_over_sites_base():
     assert out.skill_names == frozenset({"create-svelte-site", "github"})  # union
     assert out.allowed_sdk_tools == frozenset({"WebFetch"})
     assert out.system_message_override == "be terse"
+
+
+def test_compose_allow_mcp_union_when_either_side_sets():
+    """allow_mcp_tool_ids folds like allowed_sdk_tools: UNION across sides."""
+    base = SurfaceProfile(ripple_mode="on", allow_mcp_tool_ids=frozenset({"mcp__a__x"}))
+    out = compose_entity_profile(base, {"allow_mcp_tool_ids": ["mcp__b__y"]})
+    assert out.allow_mcp_tool_ids == frozenset({"mcp__a__x", "mcp__b__y"})
+
+
+def test_compose_allow_mcp_none_both_sides_stays_none():
+    """None on both sides stays None — no MCP restriction (an empty frozenset
+    would wrongly drop every non-grant MCP tool)."""
+    base = SurfaceProfile(ripple_mode="on")  # allow_mcp_tool_ids defaults None
+    out = compose_entity_profile(base, {"allow_mcp_tool_ids": None})
+    assert out.allow_mcp_tool_ids is None
+
+
+def test_compose_allow_mcp_entity_only_restricts():
+    """Base unrestricted (None) + entity sets a list → entity restriction wins."""
+    base = SurfaceProfile(ripple_mode="on")
+    out = compose_entity_profile(base, {"allow_mcp_tool_ids": ["mcp__b__y"]})
+    assert out.allow_mcp_tool_ids == frozenset({"mcp__b__y"})

--- a/tests/cloud/test_surface_profile.py
+++ b/tests/cloud/test_surface_profile.py
@@ -147,3 +147,44 @@ def test_resolve_profile_sites_refine_keeps_ripple():
         assert profile.deny_mcp_tool_ids == frozenset(), (
             f"refine meta {meta!r} must deny nothing — it edits an existing ripple spec"
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-mode restrictive MCP allow-list (feat/per-mode-mcp-allowlist). Foresight /
+# Files / Sites carry a lean allow_mcp_tool_ids; Chat stays unrestricted. The
+# "general everywhere" set (widgets, pocket lifecycle, connectors) is enforced
+# by the OSS backend, so these tests only pin the per-mode SPECIALIZED scoping.
+# ---------------------------------------------------------------------------
+
+
+def test_chat_profile_has_no_mcp_restriction():
+    assert resolve_profile(SurfaceKind.CHAT, SurfaceMeta()).allow_mcp_tool_ids is None
+
+
+def test_foresight_profile_scopes_to_foresight_mcp_tools():
+    from pocketpaw_ee.agent.mcp_servers.foresight import RUN_SCENARIO_TOOL_ID
+
+    allow = resolve_profile(SurfaceKind.FORESIGHT, SurfaceMeta()).allow_mcp_tool_ids
+    assert allow is not None
+    assert RUN_SCENARIO_TOOL_ID in allow
+    assert "mcp__pocketpaw_tasks__create_task" not in allow
+
+
+def test_files_profile_is_general_only():
+    # Empty allow-list = general-everywhere only (document scaffolding rides
+    # the built-in tools, which the allow-list never touches).
+    assert resolve_profile(SurfaceKind.FILES, SurfaceMeta()).allow_mcp_tool_ids == frozenset()
+
+
+def test_sites_profiles_scope_to_sites_mcp_tools():
+    from pocketpaw_ee.agent.mcp_servers.sites import CREATE_SVELTE_SITE_TOOL_ID
+
+    ripple_create = resolve_profile(SurfaceKind.SITES, SurfaceMeta())
+    assert ripple_create.allow_mcp_tool_ids is not None
+    assert CREATE_SVELTE_SITE_TOOL_ID in ripple_create.allow_mcp_tool_ids
+
+    svelte_create = resolve_profile(SurfaceKind.SITES, SurfaceMeta(engine="svelte"))
+    assert svelte_create.allow_mcp_tool_ids is not None
+    assert CREATE_SVELTE_SITE_TOOL_ID in svelte_create.allow_mcp_tool_ids
+    # deny still applies on top (runs after allow downstream).
+    assert "mcp__pocketpaw_sites_manager__create_landing_site" in svelte_create.deny_mcp_tool_ids

--- a/tests/test_claude_sdk_allow_mcp_tools.py
+++ b/tests/test_claude_sdk_allow_mcp_tools.py
@@ -1,0 +1,109 @@
+# tests/test_claude_sdk_allow_mcp_tools.py — Per-mode restrictive MCP allow-list.
+#
+# Companion to the additive allow_sdk_tools gate (test_claude_sdk_allow_sdk_tools)
+# and the deny gate. A chat mode can hand the backend an ``allow_mcp_tool_ids``
+# set so it carries ONLY its own MCP tools instead of every server's ids,
+# keeping the agent context lean. Invariants:
+#   1. built-in SDK tools (Read/Write/Bash/...) are NEVER filtered — only mcp__*.
+#   2. the pocket-creation grant, ripple widgets, and always-allowed servers
+#      (connectors + pocket lifecycle) survive even when not named — so every
+#      mode can still make pockets, render UI, and use connectors.
+#   3. None = no restriction (broad surfaces keep every tool).
+from __future__ import annotations
+
+import inspect
+
+from pocketpaw.agents.claude_sdk import (
+    ALWAYS_ALLOWED_MCP_SERVERS,
+    POCKET_CREATION_GRANT,
+    ClaudeSDKBackend,
+    _mcp_server_of,
+)
+
+_SPECIALIST_CREATE = "mcp__pocketpaw_pocket_specialist__create"
+_SPECIALIST_EDIT = "mcp__pocketpaw_pocket_specialist__edit"
+_PLAN_POCKET = "mcp__pocketpaw_pocket_planner__plan_pocket"
+_POCKET_GET = "mcp__pocketpaw_pocket__get_pocket"
+_WIDGET_SPEC = "mcp__pocketpaw_widgets__get_widget_spec"
+_COMPOSIO = "mcp__composio__GMAIL_SEND_EMAIL"
+_SCENARIO_RUN = "mcp__pocketpaw_foresight__run_scenario"
+_TASKS = "mcp__pocketpaw_tasks__create_task"
+_PUBLISH = "mcp__pocketpaw_sites_manager__publish"
+
+_FULL_TOOLSET = [
+    "Read",
+    "Write",
+    "Bash",
+    "Skill",
+    "WebSearch",
+    _WIDGET_SPEC,
+    _POCKET_GET,
+    _COMPOSIO,
+    _SCENARIO_RUN,
+    _TASKS,
+    _PUBLISH,
+    _SPECIALIST_CREATE,
+    _SPECIALIST_EDIT,
+    _PLAN_POCKET,
+]
+
+
+def _apply_allow(allowed_tools: list[str], allow_mcp_tool_ids: frozenset[str] | None) -> list[str]:
+    """Mirror the restrictive filter the backend runs inside ``run()``."""
+    if allow_mcp_tool_ids is None:
+        return list(allowed_tools)
+    grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT | {_WIDGET_SPEC}
+    return [
+        t
+        for t in allowed_tools
+        if not t.startswith("mcp__")
+        or t in grant
+        or _mcp_server_of(t) in ALWAYS_ALLOWED_MCP_SERVERS
+    ]
+
+
+def test_run_accepts_allow_mcp_kwarg_defaulting_none() -> None:
+    params = inspect.signature(ClaudeSDKBackend.run).parameters
+    assert "allow_mcp_tool_ids" in params
+    assert params["allow_mcp_tool_ids"].default is None, (
+        "allow_mcp_tool_ids must default to None so unscoped surfaces keep every tool"
+    )
+
+
+def test_none_allow_keeps_all_tools() -> None:
+    assert _apply_allow(_FULL_TOOLSET, None) == _FULL_TOOLSET
+
+
+def test_allow_scopes_mcp_but_keeps_general_everywhere() -> None:
+    """A foresight-style allow set keeps foresight tools + built-ins + the
+    general-everywhere set, and drops other modes' specialized tools."""
+    gated = _apply_allow(_FULL_TOOLSET, frozenset({_SCENARIO_RUN}))
+
+    assert _SCENARIO_RUN in gated  # the mode's own tool
+    assert _TASKS not in gated  # other-mode specialized → dropped
+    assert _PUBLISH not in gated
+    for builtin in ("Read", "Write", "Bash", "Skill", "WebSearch"):
+        assert builtin in gated  # built-ins never filtered
+    assert _SPECIALIST_CREATE in gated  # pocket-creation grant
+    assert _PLAN_POCKET in gated  # pocket-creation grant
+    assert _SPECIALIST_EDIT in gated  # pocket lifecycle (always-allowed server)
+    assert _POCKET_GET in gated  # pocket read (always-allowed server)
+    assert _WIDGET_SPEC in gated  # ripple rendering
+    assert _COMPOSIO in gated  # connectors (always-allowed server)
+
+
+def test_empty_allow_keeps_only_general() -> None:
+    """An empty allow set (e.g. Files mode) = general-everywhere only."""
+    gated = _apply_allow(_FULL_TOOLSET, frozenset())
+    assert _SCENARIO_RUN not in gated
+    assert _TASKS not in gated
+    assert _SPECIALIST_CREATE in gated
+    assert _COMPOSIO in gated
+    assert "Write" in gated
+
+
+def test_helpers_present() -> None:
+    assert _SPECIALIST_CREATE in POCKET_CREATION_GRANT
+    assert "composio" in ALWAYS_ALLOWED_MCP_SERVERS
+    assert _mcp_server_of(_COMPOSIO) == "composio"
+    assert _mcp_server_of("Read") == ""


### PR DESCRIPTION
Rebuild of the deferred per-mode tool isolation (was #1349), this time on top of dev's entity-rooms `SurfaceProfile` so nothing of that work is disturbed. Branches off current `dev` — clean, no merge tangle.

## Why

Every chat mode loaded every MCP tool, so the Files and Foresight agents carried the full pocket / sites / tasks / meetings / decisions / foresight surface even though they only need a slice. That bloats the context window.

## What stays available everywhere (no matter the mode)

The OSS backend always keeps:
- ripple widget tools (UI rendering),
- the pocket lifecycle — read / create / edit / plan (`ALWAYS_ALLOWED_MCP_SERVERS` + the pocket-creation grant), so you can make and edit pockets from any mode,
- connectors (composio), matched by server so its dynamic tool ids pass,
- built-in Read / Write / Bash / Web / Skill — the allow-list only narrows `mcp__*` ids.

## What each mode adds

- **Foresight** → the foresight scenario tools.
- **Files** → nothing extra (general only); document scaffolding rides built-in Write/Edit, so the mode is genuinely lean.
- **Sites** → sites authoring tools; svelte-create still denies the two ripple-create ids (deny runs after allow).
- **Chat** (and any unmapped kind) stays unrestricted.

## How it fits dev's architecture

`allow_mcp_tool_ids` is a new field on `SurfaceProfile` (+ the `PocketSurfaceProfile` mirror), **distinct** from dev's additive `allowed_sdk_tools`. It folds in `compose_entity_profile` with the same None-aware UNION, threads `resolved_profile → run_core → pool.run → claude_sdk` (forwarded only when not None), and is applied in claude_sdk **after** the deny subtraction. dev's `allowed_sdk_tools` / `skill_names` / `system_message_override` / entity-override behavior is untouched.

The per-mode profile table is built lazily + memoized and **degrades to no restriction** if the tool-id constants can't be imported — tool-scoping can never break chat.

## Tests

`tests/test_claude_sdk_allow_mcp_tools.py` (restrictive filter + grant + always-allowed servers), plus additions to `tests/cloud/test_surface_profile.py` (per-mode allow-lists, chat unrestricted, sites allow+deny) and `tests/cloud/test_entity_profile_compose.py` (allow_mcp fold). Full surface/runs/claude_sdk suites green (191 in the combined pass), ruff clean, no new mypy errors.

## For review

The general-vs-specialized split is a judgment call: tasks / meetings / decisions are treated as specialized (dropped from scoped modes, kept in broad chat). Easy to promote any to the general set if you'd rather they stay everywhere.

Closes #1349 once merged.