### PR TITLE
feat(agents): per-agent skill_refs + plugins folded into run skill materialization (RFC 14 M2)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -455,6 +455,28 @@ serialised by a process-level lock and written via a temp file + atomic
 `os.replace`, so concurrent operations can't corrupt `plugins.json` or
 clobber each other's entries.
 
+### Per-agent skills (`skill_refs` + `plugins`)
+
+An agent's `config` carries two skill-bearing fields, set on
+`POST /agents` (create) or `PATCH /agents/{id}` (update — via either the
+nested `config` object or the flat top-level fields):
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `skill_refs` | `string[]` | Skill names this agent always materializes. |
+| `plugins` | `string[]` | Installed plugin names whose bundled skills this agent always materializes. |
+
+Both default to `[]`. Unlike a surface / entity-room `skill_names` subset
+— which only applies inside that room — an agent's `skill_refs` plus the
+skills of its enabled `plugins` fold into the per-run skill set on **every**
+run the agent does, regardless of surface. At run time the plugin names are
+resolved to their skills via the installed-plugin registry
+(`~/.pocketpaw/plugins.json`); an unknown plugin name is ignored and a
+missing / unreadable registry degrades to no plugin skills (it never fails
+the run). The agent set is UNIONed with any surface/entity skill subset, so
+both apply together. Per-agent MCP servers are **not** part of this — that
+is a separate, deferred slice.
+
 ## Pockets — Catalog-as-Allowlist Ingest Gate
 
 Increment 5. The Ripple renderer has a **closed widget registry**: a

--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -25,6 +25,8 @@ class AgentConfigSpec:
     temperature: float = 0.7
     max_tokens: int = 4096
     scopes: tuple[str, ...] = ()
+    skill_refs: tuple[str, ...] = ()
+    plugins: tuple[str, ...] = ()
     soul_enabled: bool = True
     soul_persona: str = ""
     soul_archetype: str = ""

--- a/ee/pocketpaw_ee/cloud/agents/dto.py
+++ b/ee/pocketpaw_ee/cloud/agents/dto.py
@@ -36,6 +36,8 @@ class CreateAgentRequest(BaseModel):
     trust_level: int | None = None
     system_prompt: str = ""
     scopes: list[str] | None = None
+    skill_refs: list[str] | None = None
+    plugins: list[str] | None = None
     soul_enabled: bool = True
     soul_archetype: str = ""
     soul_values: list[str] | None = None
@@ -61,6 +63,8 @@ class UpdateAgentRequest(BaseModel):
     trust_level: int | None = None
     system_prompt: str | None = None
     scopes: list[str] | None = None
+    skill_refs: list[str] | None = None
+    plugins: list[str] | None = None
     soul_enabled: bool | None = None
     soul_archetype: str | None = None
     soul_values: list[str] | None = None
@@ -109,6 +113,8 @@ def _config_to_dict(cfg: AgentConfigSpec) -> dict[str, Any]:
         "temperature": cfg.temperature,
         "max_tokens": cfg.max_tokens,
         "scopes": list(cfg.scopes),
+        "skill_refs": list(cfg.skill_refs),
+        "plugins": list(cfg.plugins),
         "soul_enabled": cfg.soul_enabled,
         "soul_persona": cfg.soul_persona,
         "soul_archetype": cfg.soul_archetype,

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -64,6 +64,8 @@ def _config_to_domain(c: _AgentConfigDoc) -> AgentConfigSpec:
         temperature=c.temperature,
         max_tokens=c.max_tokens,
         scopes=tuple(c.scopes),
+        skill_refs=tuple(c.skill_refs),
+        plugins=tuple(c.plugins),
         soul_enabled=c.soul_enabled,
         soul_persona=c.soul_persona,
         soul_archetype=c.soul_archetype,
@@ -82,6 +84,8 @@ def _config_to_doc(c: AgentConfigSpec) -> _AgentConfigDoc:
         temperature=c.temperature,
         max_tokens=c.max_tokens,
         scopes=list(c.scopes),
+        skill_refs=list(c.skill_refs),
+        plugins=list(c.plugins),
         soul_enabled=c.soul_enabled,
         soul_persona=c.soul_persona,
         soul_archetype=c.soul_archetype,
@@ -143,6 +147,10 @@ def _build_create_config(body: CreateAgentRequest) -> AgentConfigSpec:
         overrides["trust_level"] = body.trust_level
     if body.scopes is not None:
         overrides["scopes"] = tuple(body.scopes)
+    if body.skill_refs is not None:
+        overrides["skill_refs"] = tuple(body.skill_refs)
+    if body.plugins is not None:
+        overrides["plugins"] = tuple(body.plugins)
     if body.soul_values is not None:
         overrides["soul_values"] = tuple(body.soul_values)
     if body.soul_ocean is not None:
@@ -163,6 +171,8 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
             temperature=c.get("temperature", current.temperature),
             max_tokens=c.get("max_tokens", current.max_tokens),
             scopes=tuple(c.get("scopes", list(current.scopes))),
+            skill_refs=tuple(c.get("skill_refs", list(current.skill_refs))),
+            plugins=tuple(c.get("plugins", list(current.plugins))),
             soul_enabled=c.get("soul_enabled", current.soul_enabled),
             soul_persona=c.get("soul_persona", current.soul_persona),
             soul_archetype=c.get("soul_archetype", current.soul_archetype),
@@ -191,6 +201,10 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
         overrides["tools"] = tuple(body.tools)
     if body.scopes is not None:
         overrides["scopes"] = tuple(body.scopes)
+    if body.skill_refs is not None:
+        overrides["skill_refs"] = tuple(body.skill_refs)
+    if body.plugins is not None:
+        overrides["plugins"] = tuple(body.plugins)
     if body.soul_values is not None:
         overrides["soul_values"] = tuple(body.soul_values)
     if body.soul_ocean is not None:

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -43,6 +43,17 @@ Changes:
   equals the surface base → behavior byte-identical to today (zero regression).
   ``resolve_profile`` itself stays PURE/no-I/O; all entity I/O lives in the
   once-per-run async ``_resolve_entity_profile``.
+- 2026-06-08 (feat/agent-plugin-fields, M2) — the AGENT now carries its own
+  skill set, folded into the per-run skill materialization so it applies on
+  EVERY run the agent does, regardless of surface. ``_agent_skill_set(instance)``
+  reads the agent's ``skill_refs`` (direct) UNION the skills of its enabled
+  ``plugins`` (resolved via the OSS ``PluginInstaller`` registry — plain read,
+  no clone, try/except → empty on failure so a missing registry never breaks a
+  run). ``_drive_agent_loop`` UNIONs that set into ``surface_skills`` BEFORE the
+  withhold-when-empty forward — including on the legacy ``resolved_profile is
+  None`` path — so agent skills materialize even on non-entity / non-profile
+  runs. The union still crosses into ``AgentPool.run`` as a plain
+  ``frozenset[str]`` (no EE symbol crosses into OSS). Per-agent MCP is DEFERRED.
 """
 
 from __future__ import annotations
@@ -582,6 +593,39 @@ async def _persist_and_complete(
     return assistant_id
 
 
+def _agent_skill_set(instance: Any) -> frozenset[str]:
+    """Resolve the agent's own skill set: direct ``skill_refs`` UNION the
+    skills bundled by its enabled ``plugins``.
+
+    ``instance.config`` is the raw config dict. ``plugins`` are resolved to
+    their skills via the OSS ``PluginInstaller`` registry (a plain read, no
+    clone). Unknown plugin names are ignored. The whole plugin resolution is
+    guarded in try/except → empty plugin set on any failure, so a missing /
+    unreadable registry can never break a run. Returns a plain
+    ``frozenset[str]`` — the type that crosses the EE→OSS ``AgentPool.run``
+    boundary (no EE symbol crosses into OSS).
+    """
+    config = getattr(instance, "config", None) or {}
+    direct = frozenset(config.get("skill_refs", []) or [])
+
+    enabled = config.get("plugins", []) or []
+    plugin_skills: frozenset[str] = frozenset()
+    if enabled:
+        try:
+            from pocketpaw.plugins.installer import PluginInstaller
+
+            by_name = {p.name: p for p in PluginInstaller().list_plugins()}
+            plugin_skills = frozenset(s for n in enabled if n in by_name for s in by_name[n].skills)
+        except Exception:
+            logger.warning(
+                "Plugin-skill resolution failed; agent plugin skills skipped this run",
+                exc_info=True,
+            )
+            plugin_skills = frozenset()
+
+    return direct | plugin_skills
+
+
 async def _drive_agent_loop(
     ctx: ScopeContext,
     *,
@@ -680,6 +724,12 @@ async def _drive_agent_loop(
             surface_allow_mcp = ctx.resolved_profile.allow_mcp_tool_ids
             surface_sys_override = ctx.resolved_profile.system_message_override
             surface_skills = ctx.resolved_profile.skill_names or frozenset()
+        # M2: fold the AGENT's own skill set (skill_refs + enabled-plugin skills)
+        # into the per-run skill materialization REGARDLESS of the resolved_profile
+        # guard above — so an agent's skills materialize on EVERY run it does,
+        # including the legacy ``resolved_profile is None`` path (no entity / no
+        # profile). Still a plain ``frozenset[str]`` crossing into the OSS pool.
+        surface_skills = surface_skills | _agent_skill_set(instance)
         run_kwargs: dict[str, Any] = dict(
             history=history,
             knowledge_context=knowledge_context,

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -3,6 +3,11 @@
 # ``scopes: list[str]`` to AgentConfig so ScopePicker assignments persist.
 # The field is a plain list of hierarchical scope tags (``org:sales:*``)
 # validated at the schema boundary via scope_rules.normalise_and_validate.
+# Updated 2026-06-08 (feat/agent-plugin-fields, M2): added
+# ``skill_refs: list[str]`` and ``plugins: list[str]`` so an agent carries
+# its own skill set (direct refs + enabled plugins). These fold into the
+# per-run skill materialization (run_core) so they apply on EVERY run the
+# agent does, independent of the surface/entity profile.
 
 """Agent configuration document."""
 
@@ -25,6 +30,12 @@ class AgentConfig(BaseModel):
     # Scope assignment — hierarchical tags that bound the agent's retrieval
     # surface. Empty list == "no scope narrowing" (agent sees whole workspace).
     scopes: list[str] = Field(default_factory=list)
+    # Per-agent skill set — folded into the per-run skill materialization so it
+    # applies on EVERY run this agent does (any surface). ``skill_refs`` are
+    # direct skill names; ``plugins`` are enabled plugin names whose bundled
+    # skills resolve via the OSS PluginInstaller registry at run time.
+    skill_refs: list[str] = Field(default_factory=list)
+    plugins: list[str] = Field(default_factory=list)
     # Soul integration
     soul_enabled: bool = True
     soul_persona: str = ""

--- a/tests/cloud/agents/test_skill_plugin_fields.py
+++ b/tests/cloud/agents/test_skill_plugin_fields.py
@@ -1,0 +1,114 @@
+# tests/cloud/agents/test_skill_plugin_fields.py
+# Created 2026-06-08 (feat/agent-plugin-fields, M2) — pins the per-agent
+# ``skill_refs`` + ``plugins`` fields end-to-end through the agents service:
+#   * create() persists both, round-tripping back through _to_domain.
+#   * update() via the body.config-dict branch sets/clears both.
+#   * update() via the flat-field branch sets/clears both.
+#   * the DTO wire dict (_config_to_dict) emits both for FE round-trip.
+"""Per-agent skill_refs + plugins round-trip through the agents service."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.agents.dto import (
+    CreateAgentRequest,
+    UpdateAgentRequest,
+    _config_to_dict,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _ctx(user_id: str = "u1", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _create_body(**kw) -> CreateAgentRequest:
+    # soul_enabled=False avoids the eager-soul import path (irrelevant here).
+    base = dict(name="Buddy", slug="buddy", soul_enabled=False)
+    base.update(kw)
+    return CreateAgentRequest(**base)
+
+
+async def test_create_persists_skill_refs_and_plugins(recording_bus) -> None:
+    agent = await agents_service.create(
+        _ctx(),
+        "w1",
+        _create_body(skill_refs=["github", "jira"], plugins=["acme-suite"]),
+    )
+    assert agent.config.skill_refs == ("github", "jira")
+    assert agent.config.plugins == ("acme-suite",)
+
+    # Re-read through the service to prove the values persisted to Mongo.
+    reloaded = await agents_service.get(agent.id)
+    assert reloaded.config.skill_refs == ("github", "jira")
+    assert reloaded.config.plugins == ("acme-suite",)
+
+
+async def test_create_defaults_empty(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    assert agent.config.skill_refs == ()
+    assert agent.config.plugins == ()
+
+
+async def test_update_via_config_dict_branch(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    updated = await agents_service.update(
+        _ctx(),
+        agent.id,
+        UpdateAgentRequest(config={"skill_refs": ["pdf"], "plugins": ["p1", "p2"]}),
+    )
+    assert updated.config.skill_refs == ("pdf",)
+    assert updated.config.plugins == ("p1", "p2")
+
+
+async def test_update_via_config_dict_preserves_when_omitted(recording_bus) -> None:
+    """The config-dict branch keeps current skill_refs/plugins when the dict
+    omits them (only touches what it carries)."""
+    agent = await agents_service.create(
+        _ctx(), "w1", _create_body(skill_refs=["keep"], plugins=["keep-plugin"])
+    )
+    updated = await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(config={"temperature": 0.4})
+    )
+    assert updated.config.skill_refs == ("keep",)
+    assert updated.config.plugins == ("keep-plugin",)
+
+
+async def test_update_via_flat_field_branch(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    updated = await agents_service.update(
+        _ctx(),
+        agent.id,
+        UpdateAgentRequest(skill_refs=["docx"], plugins=["flat-plugin"]),
+    )
+    assert updated.config.skill_refs == ("docx",)
+    assert updated.config.plugins == ("flat-plugin",)
+
+
+async def test_update_flat_field_can_clear_to_empty(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body(skill_refs=["x"], plugins=["y"]))
+    updated = await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(skill_refs=[], plugins=[])
+    )
+    assert updated.config.skill_refs == ()
+    assert updated.config.plugins == ()
+
+
+def test_config_to_dict_emits_skill_refs_and_plugins() -> None:
+    from pocketpaw_ee.cloud.agents.domain import AgentConfigSpec
+
+    spec = AgentConfigSpec(skill_refs=("a", "b"), plugins=("c",))
+    wire = _config_to_dict(spec)
+    assert wire["skill_refs"] == ["a", "b"]
+    assert wire["plugins"] == ["c"]

--- a/tests/cloud/runs/test_run_core_agent_skills.py
+++ b/tests/cloud/runs/test_run_core_agent_skills.py
@@ -1,0 +1,172 @@
+# tests/cloud/runs/test_run_core_agent_skills.py
+# Created 2026-06-08 (feat/agent-plugin-fields, M2) — pins the per-agent skill
+# fold into the per-run skill materialization in run_core:
+#   * _agent_skill_set: skill_refs only; plugins resolved via a monkeypatched
+#     PluginInstaller.list_plugins → union; unknown plugin name ignored;
+#     resolution failure → empty (no raise).
+#   * _drive_agent_loop: the agent's skills land in run_kwargs["skill_names"]
+#     alongside surface skills (resolved_profile set) AND on the legacy
+#     resolved_profile-None path. Withhold-when-empty stays intact.
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+
+# ---------------------------------------------------------------------------
+# _agent_skill_set
+# ---------------------------------------------------------------------------
+
+
+def _instance(config: dict[str, Any]) -> Any:
+    return SimpleNamespace(config=config)
+
+
+def test_agent_skill_set_skill_refs_only():
+    inst = _instance({"skill_refs": ["github", "jira"]})
+    assert run_core._agent_skill_set(inst) == frozenset({"github", "jira"})
+
+
+def test_agent_skill_set_no_fields_empty():
+    assert run_core._agent_skill_set(_instance({})) == frozenset()
+
+
+def test_agent_skill_set_resolves_plugins(monkeypatch):
+    """Enabled plugins resolve to their bundled skills via the registry; the
+    union with direct skill_refs is returned, unknown plugin names ignored."""
+
+    fake_plugins = [
+        SimpleNamespace(name="acme", skills=["alpha", "beta"]),
+        SimpleNamespace(name="other", skills=["gamma"]),
+    ]
+    monkeypatch.setattr(
+        "pocketpaw.plugins.installer.PluginInstaller.list_plugins",
+        lambda self: fake_plugins,
+    )
+
+    inst = _instance({"skill_refs": ["direct"], "plugins": ["acme", "unknown"]})
+    out = run_core._agent_skill_set(inst)
+    # direct ref + acme's two skills; "unknown" silently ignored; "other" not enabled.
+    assert out == frozenset({"direct", "alpha", "beta"})
+
+
+def test_agent_skill_set_missing_registry_returns_empty(monkeypatch):
+    """A failing registry read must never raise — plugin skills degrade to
+    empty, but the direct skill_refs still come through."""
+
+    def _boom(self):
+        raise RuntimeError("no registry on disk")
+
+    monkeypatch.setattr("pocketpaw.plugins.installer.PluginInstaller.list_plugins", _boom)
+
+    inst = _instance({"skill_refs": ["safe"], "plugins": ["acme"]})
+    assert run_core._agent_skill_set(inst) == frozenset({"safe"})
+
+
+# ---------------------------------------------------------------------------
+# _drive_agent_loop union into run_kwargs["skill_names"]
+# ---------------------------------------------------------------------------
+
+
+def _scope_ctx(*, resolved_profile=None) -> ScopeContext:
+    ctx = ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+    ctx.resolved_profile = resolved_profile
+    return ctx
+
+
+async def _drain_run_kwargs(monkeypatch, ctx, agent_config: dict[str, Any]) -> dict[str, Any]:
+    """Drive _drive_agent_loop just far enough to capture the run_kwargs the
+    pool.run seam receives, then stop. Mocks every collaborator the loop
+    touches before pool.run."""
+    captured: dict[str, Any] = {}
+
+    class _FakePool:
+        async def get(self, _agent_id):
+            return SimpleNamespace(config=agent_config, agent_name="A")
+
+        def run(self, agent_id, content, session_key, **run_kwargs):
+            captured["run_kwargs"] = run_kwargs
+
+            async def _gen():
+                # Empty async generator: the first __anext__ raises
+                # StopAsyncIteration, which the loop treats as "stream done"
+                # and breaks. (A bare `raise StopAsyncIteration` inside an
+                # async gen would become a RuntimeError under PEP 479.)
+                return
+                yield  # pragma: no cover
+
+            return _gen()
+
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: _FakePool())
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda ctx, backend_name=None: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda q: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda t: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda t: None)
+
+    async def _never_cancelled():
+        return False
+
+    gen = run_core._drive_agent_loop(
+        ctx,
+        user_content="hi",
+        attachments_in=None,
+        mentions_in=None,
+        history=None,
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    )
+    # Pull events until the loop terminates (StopAsyncIteration from the gen).
+    async for _ in gen:
+        pass
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_agent_skills_fold_in_with_resolved_profile(monkeypatch):
+    """surface skills (from resolved_profile) UNION agent skills → both land in
+    run_kwargs["skill_names"]."""
+
+    profile = SimpleNamespace(
+        deny_mcp_tool_ids=frozenset(),
+        allowed_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=None,
+        system_message_override=None,
+        skill_names=frozenset({"surface-skill"}),
+    )
+    ctx = _scope_ctx(resolved_profile=profile)
+    captured = await _drain_run_kwargs(monkeypatch, ctx, {"skill_refs": ["agent-skill"]})
+    assert captured["run_kwargs"]["skill_names"] == frozenset({"surface-skill", "agent-skill"})
+
+
+@pytest.mark.asyncio
+async def test_agent_skills_fold_in_on_resolved_profile_none(monkeypatch):
+    """Legacy path (resolved_profile is None): agent skills STILL materialize —
+    the fold happens regardless of the profile guard."""
+    ctx = _scope_ctx(resolved_profile=None)
+    captured = await _drain_run_kwargs(monkeypatch, ctx, {"skill_refs": ["agent-skill"]})
+    assert captured["run_kwargs"]["skill_names"] == frozenset({"agent-skill"})
+
+
+@pytest.mark.asyncio
+async def test_no_skills_withholds_skill_names(monkeypatch):
+    """No surface skills and no agent skills → skill_names is NOT set (the
+    withhold-when-empty contract for the narrower non-SDK backends)."""
+    ctx = _scope_ctx(resolved_profile=None)
+    captured = await _drain_run_kwargs(monkeypatch, ctx, {})
+    assert "skill_names" not in captured["run_kwargs"]


### PR DESCRIPTION
RFC 14 **M2** (skills-only slice). Gives an agent its own kit: `AgentConfig.skill_refs[]` (skill names the agent always has) and `AgentConfig.plugins[]` (enabled plugin names → their skills), folded into the per-run skill materialization on **every** run the agent does — regardless of surface. This is what makes "an agent carries its plugins everywhere" real, and it's what the FE per-agent toggle (paw-enterprise #374, Half 2) writes to.

Stacks on the plugin installer + the #1343 surface/materialization keystone (both already on `integration/plugins`, which this branch brought up to current dev).

## What changed

- `AgentConfig` (+ frozen `AgentConfigSpec` mirror) gain `skill_refs` / `plugins`; threaded through both serializers, the create + both update branches, and the Create/Update DTOs + round-trip.
- `run_core`: a new `_agent_skill_set(instance)` resolves `skill_refs ∪ (skills of enabled plugins)` — plugins resolved by a plain read of the OSS `PluginInstaller` registry (no clone), guarded so a missing/broken registry yields an empty set, never breaks a run. The agent set is unioned into `surface_skills` **outside** the resolved-profile guard so it applies on every run (including the legacy no-profile path); the existing withhold-when-empty behavior is preserved, so nothing materializes when both agent and surface skills are empty.

## Boundary

EE imports the OSS `PluginInstaller` (allowed direction); the resolved set crosses to `pool.run` as a plain `frozenset[str]` — the same pattern as `deny_mcp_tool_ids`/`skill_names`. No `pocketpaw_ee` symbol enters OSS; `pool.py` untouched.

## Scope / deferred

Skills only. **Per-agent MCP** (folding a plugin's namespaced MCP servers into the per-agent tool policy) is deferred to a later slice — it touches the policy/namespace contract in `pool._build` and is riskier.

## Tests

61 green in the targeted set (broader sweep 304): config round-trip (both update branches + preserve-on-omit + clear), `_agent_skill_set` (refs-only / plugins union / unknown ignored / failing registry → empty), and the run_core union on both the profile-set and profile-None paths + withhold-when-empty. Two-stage review clean; agent-controlled skill/plugin names hit the existing `_safe_slug` + installed-only gate in `materialize_run_skills` (no new path surface).
