### PR TITLE
feat(senses): Sense catalog and the sense field on connectors

### DIFF
--- a/connectors/drive.yaml
+++ b/connectors/drive.yaml
@@ -9,6 +9,9 @@ display_name: Google Drive
 type: knowledge
 icon: cloud
 
+senses:
+  - paw.docs.v1
+
 auth:
   method: bearer
   credentials:

--- a/connectors/gcalendar.yaml
+++ b/connectors/gcalendar.yaml
@@ -7,6 +7,9 @@ display_name: Google Calendar
 type: communication
 icon: calendar
 
+senses:
+  - paw.calendar.v1
+
 auth:
   method: oauth2
   credentials:

--- a/connectors/gdocs.yaml
+++ b/connectors/gdocs.yaml
@@ -6,6 +6,9 @@ display_name: Google Docs
 type: knowledge
 icon: file-text
 
+senses:
+  - paw.docs.v1
+
 auth:
   method: oauth2
   credentials:

--- a/connectors/github.yaml
+++ b/connectors/github.yaml
@@ -30,6 +30,9 @@ surface_profile:
   allow_tools: []
   deny_tools: []
 
+senses:
+  - paw.code.v1
+
 auth:
   method: bearer
   headers:

--- a/connectors/gitlab.yaml
+++ b/connectors/gitlab.yaml
@@ -6,6 +6,9 @@ display_name: GitLab
 type: developer
 icon: git-merge
 
+senses:
+  - paw.code.v1
+
 auth:
   method: bearer
   credentials:

--- a/connectors/gmail.yaml
+++ b/connectors/gmail.yaml
@@ -41,6 +41,9 @@ surface_profile:
   allow_tools: []
   deny_tools: []
 
+senses:
+  - paw.email.v1
+
 auth:
   method: oauth2
   credentials:

--- a/connectors/mongodb.yaml
+++ b/connectors/mongodb.yaml
@@ -8,6 +8,9 @@ display_name: MongoDB
 type: database
 icon: database
 
+senses:
+  - paw.db.v1
+
 auth:
   method: none
   credentials:

--- a/connectors/postgresql.yaml
+++ b/connectors/postgresql.yaml
@@ -6,6 +6,9 @@ display_name: PostgreSQL
 type: database
 icon: server
 
+senses:
+  - paw.db.v1
+
 auth:
   method: none
   credentials:

--- a/connectors/stripe.yaml
+++ b/connectors/stripe.yaml
@@ -6,6 +6,9 @@ name: stripe
 display_name: Stripe
 type: payment
 icon: credit-card
+
+senses:
+  - paw.payments.v1
 auth:
   method: api_key
   credentials:

--- a/src/pocketpaw/connectors/yaml_engine.py
+++ b/src/pocketpaw/connectors/yaml_engine.py
@@ -6,6 +6,9 @@
 #   from the YAML. It is the per-connector mapping source for deriving a pocket's
 #   PocketSurfaceProfile when the connector is bound to a pocket. Backward-compat:
 #   connectors with no block parse with ``surface_profile=None``.
+# Updated: 2026-06-08 — Added `senses: list[str]` to ConnectorDef + parse-time
+#   validation via senses.validate_sense_id (Sense tier chunk 1). Unknown paw.*
+#   ids fail loudly; missing `senses:` key is backward compatible ([]).
 
 from __future__ import annotations
 
@@ -61,6 +64,9 @@ class ConnectorDef:
     # M3 — optional connector→skill/tool mapping. ``None`` when the YAML has
     # no ``surface_profile:`` block (the common case / backward-compat).
     surface_profile: ConnectorSurfaceProfile | None = None
+    # Sense tier — the provider-agnostic capabilities this connector fills
+    # (e.g. ["paw.email.v1"]). Empty when the YAML has no ``senses:`` key.
+    senses: list[str] = field(default_factory=list)
 
 
 def _parse_surface_profile(raw: Any) -> ConnectorSurfaceProfile | None:
@@ -89,8 +95,24 @@ def parse_connector_yaml(path: Path) -> ConnectorDef:
     with open(path) as f:
         raw = yaml.safe_load(f)
 
+    name = raw.get("name", path.stem)
+
+    # Validate any declared senses at parse time. An unknown paw.* id must fail
+    # loudly with a message naming the connector + the bad id — this is the
+    # "no fragmentation of the core" rule (Sense tier chunk 1).
+    from pocketpaw.senses import SenseValidationError, validate_sense_id
+
+    senses = raw.get("senses", [])
+    for sense_id in senses:
+        try:
+            validate_sense_id(sense_id)
+        except SenseValidationError as e:
+            raise SenseValidationError(
+                f"connector {name!r} declares invalid sense {sense_id!r}: {e}"
+            ) from e
+
     return ConnectorDef(
-        name=raw.get("name", path.stem),
+        name=name,
         display_name=raw.get("display_name", raw.get("name", path.stem)),
         type=raw.get("type", "generic"),
         icon=raw.get("icon", "plug"),
@@ -98,6 +120,7 @@ def parse_connector_yaml(path: Path) -> ConnectorDef:
         actions=raw.get("actions", []),
         sync=raw.get("sync", {}),
         surface_profile=_parse_surface_profile(raw.get("surface_profile")),
+        senses=senses,
     )
 
 

--- a/src/pocketpaw/senses/__init__.py
+++ b/src/pocketpaw/senses/__init__.py
@@ -1,0 +1,25 @@
+# Sense tier — provider-agnostic capability vocabulary above Connectors.
+# Created: 2026-06-08 — OSS catalog half (RFC Sense tier, chunk 1).
+# Exposes the curated core vocabulary, sense-id validation, and the static
+# connector index. The resolver (tenant binding) is built in a later EE chunk
+# and is NOT part of this package.
+
+from pocketpaw.senses.vocabulary import (
+    CORE_SENSES,
+    SENSE_VOCAB_VERSION,
+    CoreSense,
+    SenseValidationError,
+    connectors_for_sense,
+    is_core_sense,
+    validate_sense_id,
+)
+
+__all__ = [
+    "CORE_SENSES",
+    "SENSE_VOCAB_VERSION",
+    "CoreSense",
+    "SenseValidationError",
+    "connectors_for_sense",
+    "is_core_sense",
+    "validate_sense_id",
+]

--- a/src/pocketpaw/senses/vocabulary.py
+++ b/src/pocketpaw/senses/vocabulary.py
@@ -1,0 +1,132 @@
+# Sense vocabulary — the curated CORE capability vocabulary + validation + static index.
+# Created: 2026-06-08 — OSS catalog half (RFC Sense tier, chunk 1).
+# A Sense is a provider-agnostic capability above Connectors. Templates/agents
+# address a Sense (e.g. paw.email.v1); a resolver (built later, not here) binds
+# it to whatever connector a tenant enabled. This module owns:
+#   - CORE_SENSES: the in-repo, versioned curated vocabulary (id/name/description).
+#   - validate_sense_id / is_core_sense: the "no fragmentation of the core" rule.
+#   - connectors_for_sense: a pure static index over parsed ConnectorDefs.
+# Each core sense MUST be declared by at least one connector YAML (guard test).
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pocketpaw.connectors.yaml_engine import ConnectorDef
+
+# Bump when the core vocabulary changes. Core sense ids are themselves
+# versioned (paw.<domain>.vN); this version tracks the catalog as a whole.
+SENSE_VOCAB_VERSION = "1"
+
+# Core sense ids follow paw.<domain>.vN. Extension (vendor) ids follow
+# vendor.domain.vN and are accepted freely — the core is closed, the
+# extension space is open.
+_CORE_ID_PATTERN = re.compile(r"^paw\.[a-z0-9_]+\.v\d+$")
+_EXTENSION_ID_PATTERN = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+\.v\d+$")
+
+
+class SenseValidationError(ValueError):
+    """Raised when a sense id is malformed or an unknown paw.* core id."""
+
+
+@dataclass(frozen=True)
+class CoreSense:
+    """A single curated core capability in the versioned vocabulary."""
+
+    id: str
+    display_name: str
+    description: str
+
+
+# The v1 core vocabulary. Every entry here is backed by at least one connector
+# YAML in connectors/ (enforced by the guard test). Do NOT add a core sense
+# without a connector that can fill it — that is the anti-fragmentation rule.
+CORE_SENSES: tuple[CoreSense, ...] = (
+    CoreSense(
+        id="paw.email.v1",
+        display_name="Email",
+        description="Read, search, and send email across providers.",
+    ),
+    CoreSense(
+        id="paw.calendar.v1",
+        display_name="Calendar",
+        description="Read and manage calendar events and availability.",
+    ),
+    CoreSense(
+        id="paw.code.v1",
+        display_name="Code",
+        description="Access repositories, issues, pull requests, and code search.",
+    ),
+    CoreSense(
+        id="paw.payments.v1",
+        display_name="Payments",
+        description="Read payment, subscription, and billing data.",
+    ),
+    CoreSense(
+        id="paw.db.v1",
+        display_name="Database",
+        description="Query structured data in a relational or document database.",
+    ),
+    CoreSense(
+        id="paw.docs.v1",
+        display_name="Documents",
+        description="Read, search, and manage documents and files.",
+    ),
+)
+
+_CORE_IDS: frozenset[str] = frozenset(s.id for s in CORE_SENSES)
+
+
+def is_core_sense(sense_id: str) -> bool:
+    """True if ``sense_id`` is one of the curated core senses."""
+    return sense_id in _CORE_IDS
+
+
+def validate_sense_id(sense_id: str) -> str:
+    """Validate a sense id, returning it unchanged if valid.
+
+    Rules:
+      - A ``paw.*`` id is accepted ONLY if it is in the curated core set.
+        An unknown ``paw.*`` id raises — the core namespace is closed so
+        templates can't silently fragment it.
+      - A non-``paw.*`` id (vendor extension, format ``vendor.domain.vN``)
+        is accepted freely — the extension space is open.
+      - Anything that is neither a well-formed core id nor a well-formed
+        extension id raises.
+    """
+    if not isinstance(sense_id, str) or not sense_id:
+        raise SenseValidationError(f"sense id must be a non-empty string, got {sense_id!r}")
+
+    if sense_id.startswith("paw."):
+        if not _CORE_ID_PATTERN.match(sense_id):
+            raise SenseValidationError(
+                f"malformed core sense id {sense_id!r} (expected paw.<domain>.vN)"
+            )
+        if sense_id not in _CORE_IDS:
+            raise SenseValidationError(
+                f"unknown core sense id {sense_id!r}; the paw.* namespace is "
+                f"closed. Known core senses: {sorted(_CORE_IDS)}. "
+                f"Use a vendor.domain.vN id for custom capabilities."
+            )
+        return sense_id
+
+    # Extension (vendor) id — open namespace, just enforce the shape.
+    if not _EXTENSION_ID_PATTERN.match(sense_id):
+        raise SenseValidationError(
+            f"malformed extension sense id {sense_id!r} (expected vendor.domain.vN)"
+        )
+    return sense_id
+
+
+def connectors_for_sense(sense_id: str, connector_defs: list[ConnectorDef]) -> list[str]:
+    """Return the names of connectors that declare ``sense_id``.
+
+    Pure static index — given already-parsed ConnectorDefs, returns the
+    connector names whose ``senses`` list contains ``sense_id``. No tenant
+    state and no I/O beyond reading the passed-in defs. Results are sorted
+    for determinism.
+    """
+    return sorted(d.name for d in connector_defs if sense_id in getattr(d, "senses", []))

--- a/tests/senses/__init__.py
+++ b/tests/senses/__init__.py
@@ -1,0 +1,2 @@
+# Sense tier test package.
+# Created: 2026-06-08 — RFC Sense tier chunk 1.

--- a/tests/senses/test_sense_catalog.py
+++ b/tests/senses/test_sense_catalog.py
@@ -1,0 +1,127 @@
+# Sense catalog tests — vocabulary validation, static index, and anti-drift guard.
+# Created: 2026-06-08 — RFC Sense tier chunk 1.
+# The guard test (test_every_core_sense_has_a_connector) is the anti-drift
+# rule: every core sense MUST be backed by at least one connector YAML, or the
+# vocabulary and the connector catalog have drifted apart.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.connectors.yaml_engine import ConnectorDef, parse_connector_yaml
+from pocketpaw.senses import (
+    CORE_SENSES,
+    SenseValidationError,
+    connectors_for_sense,
+    is_core_sense,
+    validate_sense_id,
+)
+
+# Repo-root connectors/ directory (worktree root is two parents up from this file).
+CONNECTORS_DIR = Path(__file__).resolve().parents[2] / "connectors"
+
+
+def _all_connector_defs() -> list[ConnectorDef]:
+    """Parse every connector YAML in the repo (same path the registry scans)."""
+    defs: list[ConnectorDef] = []
+    for path in sorted(CONNECTORS_DIR.glob("*.yaml")):
+        defs.append(parse_connector_yaml(path))
+    return defs
+
+
+# --- validate_sense_id ------------------------------------------------------
+
+
+def test_core_ids_are_accepted():
+    for sense in CORE_SENSES:
+        assert validate_sense_id(sense.id) == sense.id
+        assert is_core_sense(sense.id)
+
+
+def test_unknown_paw_id_is_rejected():
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("paw.crm.v1")
+    assert not is_core_sense("paw.crm.v1")
+
+
+def test_malformed_paw_id_is_rejected():
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("paw.email")  # missing version
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("paw.Email.v1")  # uppercase
+
+
+def test_vendor_extension_id_is_accepted_freely():
+    assert validate_sense_id("acme.crm.v1") == "acme.crm.v1"
+    assert validate_sense_id("salesforce.leads.v2") == "salesforce.leads.v2"
+    assert not is_core_sense("acme.crm.v1")
+
+
+def test_malformed_extension_id_is_rejected():
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("justone")
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("acme.crm")  # missing version
+
+
+def test_empty_id_is_rejected():
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("")
+
+
+# --- connectors_for_sense ---------------------------------------------------
+
+
+def test_connectors_for_sense_returns_matching_names():
+    defs = [
+        ConnectorDef(name="gmail", display_name="Gmail", senses=["paw.email.v1"]),
+        ConnectorDef(name="github", display_name="GitHub", senses=["paw.code.v1"]),
+        ConnectorDef(name="airtable", display_name="Airtable"),  # no senses
+    ]
+    assert connectors_for_sense("paw.email.v1", defs) == ["gmail"]
+    assert connectors_for_sense("paw.code.v1", defs) == ["github"]
+    assert connectors_for_sense("paw.payments.v1", defs) == []
+
+
+def test_connectors_for_sense_handles_multi_sense_connector():
+    defs = [
+        ConnectorDef(
+            name="gworkspace",
+            display_name="Google Workspace",
+            senses=["paw.email.v1", "paw.calendar.v1", "paw.docs.v1"],
+        ),
+        ConnectorDef(name="gmail", display_name="Gmail", senses=["paw.email.v1"]),
+    ]
+    assert connectors_for_sense("paw.email.v1", defs) == ["gmail", "gworkspace"]
+    assert connectors_for_sense("paw.calendar.v1", defs) == ["gworkspace"]
+    assert connectors_for_sense("paw.docs.v1", defs) == ["gworkspace"]
+
+
+def test_connectors_with_no_senses_key_default_to_empty():
+    defs = [ConnectorDef(name="airtable", display_name="Airtable")]
+    assert defs[0].senses == []
+    assert connectors_for_sense("paw.email.v1", defs) == []
+
+
+# --- anti-drift guard -------------------------------------------------------
+
+
+def test_every_core_sense_has_a_connector():
+    """Every core sense must be declared by at least one connector YAML."""
+    defs = _all_connector_defs()
+    assert defs, "no connector YAMLs found — check CONNECTORS_DIR"
+    for sense in CORE_SENSES:
+        matches = connectors_for_sense(sense.id, defs)
+        assert matches, (
+            f"core sense {sense.id!r} has no connector declaring it; "
+            f"either annotate a connector YAML or drop it from CORE_SENSES"
+        )
+
+
+def test_all_declared_senses_validate():
+    """Every senses entry across all connector YAMLs must be a valid id."""
+    for path in sorted(CONNECTORS_DIR.glob("*.yaml")):
+        # parse_connector_yaml validates at parse time; a bad id would raise.
+        parse_connector_yaml(path)


### PR DESCRIPTION
## What this adds

A capability vocabulary that sits above connectors. A Sense like `paw.email.v1` names what an agent can do; a connector declares which Senses it fills through a new `senses:` list in its YAML. A later change binds a Sense to whichever connector a tenant has enabled, so a pocket template can ask for `paw.email` and run on Gmail for one tenant and Outlook for another without edits.

This PR is the catalog half only. No resolver, no execution, no EE code.

## What's in it

- `src/pocketpaw/senses/` with the v1 core vocabulary: email, calendar, code, payments, db, docs. The `paw.*` namespace is closed, so an unknown `paw.*` id is rejected at parse time and the core can't fragment. Vendor ids in the `vendor.domain.vN` shape are accepted freely for the long tail.
- A `senses: list[str]` field on `ConnectorDef`, parsed and validated when a connector YAML loads. Connectors without the key keep working with an empty list.
- Nine connectors annotated: gmail, gcalendar, github, gitlab, stripe, postgresql, mongodb, gdocs, drive.
- `connectors_for_sense()`, a pure index from a Sense to the connectors that declare it.
- A guard test that fails if any core Sense has no connector behind it, so the vocabulary and the annotations can't drift apart.

## Testing

`uv run pytest tests/senses tests/connectors` reports 107 passing.

## One thing to know

`registry._scan()` swallows per-connector parse errors, so a bad `paw.*` id on a connector added at runtime would drop that connector quietly instead of erroring. The guard test catches it for in-repo connectors before merge; hardening the runtime path is left for a later change.

## Next

A stacked PR adds the resolver that binds a Sense to a tenant's connector and runs read actions through it.
