### PR TITLE
feat(senses): resolver that binds a Sense to a tenant's connector

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -71,6 +71,7 @@ from pocketpaw_ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
 from pocketpaw_ee.cloud.models.pocket_backend import PocketBackendCredential
 from pocketpaw_ee.cloud.models.project import Project
 from pocketpaw_ee.cloud.models.read_state import ReadState
+from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
 from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
@@ -160,6 +161,7 @@ __all__ = [
     "Site",
     "SiteDomain",
     "SiteRateCounter",
+    "WorkspaceSensePreference",
     "Task",
     "TaskAssignee",
     "TaskSource",
@@ -219,6 +221,7 @@ def get_all_documents():
         Lead,
         Site,
         SiteRateCounter,
+        WorkspaceSensePreference,
         AuditEvent,
         AuditWebhook,
         AuthSession,

--- a/ee/pocketpaw_ee/cloud/models/sense_preference.py
+++ b/ee/pocketpaw_ee/cloud/models/sense_preference.py
@@ -1,0 +1,32 @@
+# WorkspaceSensePreference Beanie document — per-(workspace[,pocket],sense) provider pick.
+# Created: 2026-06-08 — Sense tier chunk 2 (EE SenseResolver). EE-side home
+# for the sense->connector preference used to disambiguate when more than one
+# enabled connector can fill a sense (e.g. github vs gitlab for paw.code.v1).
+# Soul-carried preferences are explicitly deferred to Phase 2 — this is the
+# v1 store and does NOT touch soul-protocol. One row per
+# (workspace, pocket_id, sense_id); workspace_id is required + indexed and
+# every read filters on it (ee/cloud rule §7).
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class WorkspaceSensePreference(TimestampedDocument):
+    """Preferred connector for one sense, scoped to a workspace (and optional pocket).
+
+    ``pocket_id`` is ``None`` for the workspace-level preference. The resolver
+    looks up the pocket-level row first when a ``pocket_id`` is supplied, then
+    falls back to the workspace-level row. Uniqueness per
+    (workspace, pocket_id, sense_id) is enforced at the service layer via
+    upsert-on-set, not a Mongo unique index, so set is idempotent.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    pocket_id: str | None = None
+    sense_id: str
+    connector_name: str
+
+    class Settings(TimestampedDocument.Settings):
+        name = "workspace_sense_preferences"

--- a/ee/pocketpaw_ee/cloud/senses/__init__.py
+++ b/ee/pocketpaw_ee/cloud/senses/__init__.py
@@ -1,0 +1,23 @@
+# Sense tier — EE cloud half (resolver + filler seam + preference store).
+# Created: 2026-06-08 — Sense tier chunk 2. Binds a provider-agnostic Sense
+# (e.g. paw.email.v1) to whichever connector a tenant ENABLED, then executes
+# via the EXISTING connectors_service path. READ-FIRST (v1): only auto-trust
+# (read) actions run; confirm/restricted (write) actions are blocked, never
+# executed. Imports OSS (pocketpaw.senses, pocketpaw.connectors) freely; OSS
+# never imports this package (import-linter contract).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.senses.resolver import (
+    ResolvedSense,
+    SenseExecutionResult,
+    execute_sense,
+    resolve,
+)
+
+__all__ = [
+    "ResolvedSense",
+    "SenseExecutionResult",
+    "execute_sense",
+    "resolve",
+]

--- a/ee/pocketpaw_ee/cloud/senses/filler.py
+++ b/ee/pocketpaw_ee/cloud/senses/filler.py
@@ -1,0 +1,79 @@
+# SenseFiller seam — the abstraction a future Skill/KB/Fabric filler plugs into.
+# Created: 2026-06-08 — Sense tier chunk 2. A SenseFiller knows which providers
+# (connector names) can fill a sense for a given workspace. v1 ships exactly
+# one filler — ConnectorSenseFiller — which intersects the static
+# connectors-for-sense index with the tenant's ENABLED connectors. The point
+# here is the seam, not a framework: register more fillers (skills, KB, fabric)
+# in a later phase by implementing the Protocol. Kept deliberately thin.
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from pocketpaw.senses import connectors_for_sense
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector as _WCDoc
+
+
+@runtime_checkable
+class SenseFiller(Protocol):
+    """A source of providers that can fill a sense for a workspace.
+
+    A filler answers one question: "which provider names can satisfy
+    ``sense_id`` for this workspace right now?" The resolver collects
+    candidates from the registered fillers and disambiguates. v1 has the
+    connector-backed filler only; a SkillFiller / KBFiller / FabricFiller can
+    register later without changing the resolver.
+    """
+
+    async def candidates(
+        self,
+        sense_id: str,
+        workspace_id: str,
+        *,
+        pocket_id: str | None = None,
+    ) -> list[str]:
+        """Provider names that can fill ``sense_id`` for this workspace."""
+        ...
+
+
+class ConnectorSenseFiller:
+    """The only v1 filler — connector-backed.
+
+    Candidates = connectors that DECLARE the sense (static registry index)
+    INTERSECT the connectors the workspace has ENABLED. The intersection is
+    what makes resolution tenant-aware: a connector that can fill a sense but
+    isn't enabled for the workspace is not a candidate.
+
+    For v1 enablement is read at workspace scope (every enabled doc for the
+    workspace counts, regardless of its own scope). ``pocket_id`` is accepted
+    for signature parity and a future pocket-scoped narrowing, but workspace
+    scope is the documented v1 behaviour.
+    """
+
+    def __init__(self, registry) -> None:
+        self._registry = registry
+
+    async def candidates(
+        self,
+        sense_id: str,
+        workspace_id: str,
+        *,
+        pocket_id: str | None = None,
+    ) -> list[str]:
+        # Which connectors CAN fill this sense (provider-agnostic, static).
+        declaring = set(connectors_for_sense(sense_id, self._registry.definitions))
+        if not declaring:
+            return []
+
+        # Which connectors the workspace has ENABLED (tenant-filtered read).
+        enabled_docs = await _WCDoc.find(
+            _WCDoc.workspace == workspace_id,
+            _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+        ).to_list()
+        enabled_names = {d.name for d in enabled_docs}
+
+        # Intersection, sorted for deterministic disambiguation.
+        return sorted(declaring & enabled_names)
+
+
+__all__ = ["ConnectorSenseFiller", "SenseFiller"]

--- a/ee/pocketpaw_ee/cloud/senses/preference.py
+++ b/ee/pocketpaw_ee/cloud/senses/preference.py
@@ -1,0 +1,73 @@
+# Sense->provider preference store — EE-side, v1 home for the pick.
+# Created: 2026-06-08 — Sense tier chunk 2. get/set a preferred connector per
+# (workspace_id[, pocket_id], sense_id). Backed by the WorkspaceSensePreference
+# Beanie doc. NOT in the .soul file — soul-carried prefs are deferred to
+# Phase 2 (do NOT touch soul-protocol). Every read filters by workspace_id
+# (ee/cloud rule §7); set upserts so it is idempotent (no Mongo unique index).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
+
+
+async def get_preference(
+    workspace_id: str,
+    sense_id: str,
+    *,
+    pocket_id: str | None = None,
+) -> str | None:
+    """Return the preferred connector name for a sense, or ``None`` if unset.
+
+    When ``pocket_id`` is supplied the pocket-scoped preference wins; if there
+    is none, fall back to the workspace-level (``pocket_id is None``) row. This
+    lets a pocket override the workspace default without losing it.
+    """
+    if pocket_id is not None:
+        doc = await WorkspaceSensePreference.find_one(
+            WorkspaceSensePreference.workspace == workspace_id,
+            WorkspaceSensePreference.pocket_id == pocket_id,
+            WorkspaceSensePreference.sense_id == sense_id,
+        )
+        if doc is not None:
+            return doc.connector_name
+
+    doc = await WorkspaceSensePreference.find_one(
+        WorkspaceSensePreference.workspace == workspace_id,
+        WorkspaceSensePreference.pocket_id == None,  # noqa: E711 — Beanie expects ==
+        WorkspaceSensePreference.sense_id == sense_id,
+    )
+    return doc.connector_name if doc is not None else None
+
+
+async def set_preference(
+    workspace_id: str,
+    sense_id: str,
+    connector_name: str,
+    *,
+    pocket_id: str | None = None,
+) -> None:
+    """Upsert the preferred connector for a (workspace[, pocket], sense).
+
+    Idempotent: re-setting the same triple updates the existing row rather
+    than inserting a duplicate. Uniqueness is enforced here, not by a Mongo
+    index, so the store stays forgiving on races.
+    """
+    doc = await WorkspaceSensePreference.find_one(
+        WorkspaceSensePreference.workspace == workspace_id,
+        WorkspaceSensePreference.pocket_id == pocket_id,
+        WorkspaceSensePreference.sense_id == sense_id,
+    )
+    if doc is None:
+        doc = WorkspaceSensePreference(
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            sense_id=sense_id,
+            connector_name=connector_name,
+        )
+        await doc.insert()
+    else:
+        doc.connector_name = connector_name
+        await doc.save()
+
+
+__all__ = ["get_preference", "set_preference"]

--- a/ee/pocketpaw_ee/cloud/senses/resolver.py
+++ b/ee/pocketpaw_ee/cloud/senses/resolver.py
@@ -1,0 +1,186 @@
+# SenseResolver — binds a provider-agnostic Sense to a tenant's enabled connector.
+# Created: 2026-06-08 — Sense tier chunk 2. A Sense (paw.email.v1) names a
+# capability; this resolver picks the connector that fills it for a workspace,
+# then executes via the EXISTING connectors_service path. READ-FIRST (v1): only
+# ``trust_level == "auto"`` actions run; confirm/restricted (and unknown/missing
+# trust) are BLOCKED and never sent to execute. Disambiguation: 0 candidates ->
+# None (caller prompts-to-connect); 1 -> that connector; >1 -> the stored
+# preference if it's among candidates, else the deterministic first with an
+# ``ambiguous`` flag so the caller can ask the user to set a preference.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from pocketpaw.senses import validate_sense_id
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+from pocketpaw_ee.cloud.senses import preference
+from pocketpaw_ee.cloud.senses.filler import ConnectorSenseFiller
+
+
+@dataclass(frozen=True)
+class ResolvedSense:
+    """The connector chosen to fill a sense for a workspace.
+
+    ``ambiguous`` is True when more than one enabled connector could fill the
+    sense and no stored preference disambiguated it — the caller should surface
+    a "set a preference" prompt. ``candidates`` is the full sorted candidate
+    set so the caller can render the choices.
+    """
+
+    sense_id: str
+    connector_name: str
+    ambiguous: bool = False
+    candidates: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SenseExecutionResult:
+    """Envelope for ``execute_sense``.
+
+    Structured (never an HTTP 500): ``ok`` is False with a stable ``error``
+    code for the two refusal paths — no provider for the sense, and the
+    read-first block on a non-auto action. On success ``data`` carries the
+    underlying ``ExecuteActionResponse`` and ``connector_name`` records which
+    provider ran.
+    """
+
+    ok: bool
+    sense_id: str
+    connector_name: str | None = None
+    action: str | None = None
+    error: str | None = None  # stable code: "sense.no_provider" | "sense.action_needs_approval"
+    message: str | None = None
+    data: object = None
+
+
+async def resolve(
+    sense_id: str,
+    workspace_id: str,
+    *,
+    pocket_id: str | None = None,
+) -> ResolvedSense | None:
+    """Bind ``sense_id`` to the connector that fills it for this workspace.
+
+    Returns ``None`` when no enabled connector can fill the sense (the caller
+    decides what to do — typically prompt-to-connect). Raises
+    ``SenseValidationError`` for an unknown ``paw.*`` id.
+    """
+    validate_sense_id(sense_id)
+
+    registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
+    filler = ConnectorSenseFiller(registry)
+    candidates = await filler.candidates(sense_id, workspace_id, pocket_id=pocket_id)
+
+    if not candidates:
+        return None
+
+    if len(candidates) == 1:
+        return ResolvedSense(
+            sense_id=sense_id,
+            connector_name=candidates[0],
+            ambiguous=False,
+            candidates=candidates,
+        )
+
+    # More than one candidate — let a stored preference decide.
+    preferred = await preference.get_preference(workspace_id, sense_id, pocket_id=pocket_id)
+    if preferred is not None and preferred in candidates:
+        return ResolvedSense(
+            sense_id=sense_id,
+            connector_name=preferred,
+            ambiguous=False,
+            candidates=candidates,
+        )
+
+    # No usable preference — pick deterministically and flag for the caller.
+    return ResolvedSense(
+        sense_id=sense_id,
+        connector_name=candidates[0],
+        ambiguous=True,
+        candidates=candidates,
+    )
+
+
+def _trust_for_action(registry, connector_name: str, action: str) -> str | None:
+    """Read ``trust_level`` for an action from the connector's ConnectorDef.
+
+    Returns the trust string (e.g. "auto" | "confirm" | "restricted") or
+    ``None`` when the connector, the action, or the trust field is missing.
+    ``None`` is treated by the gate as "not auto" -> blocked.
+    """
+    defn = registry.get_definition(connector_name)
+    if defn is None:
+        return None
+    for a in getattr(defn, "actions", None) or []:
+        if isinstance(a, dict) and a.get("name") == action:
+            return a.get("trust_level")
+    return None
+
+
+async def execute_sense(
+    sense_id: str,
+    action: str,
+    params: dict,
+    workspace_id: str,
+    *,
+    pocket_id: str | None = None,
+    user_id: str | None = None,
+) -> SenseExecutionResult:
+    """Resolve a sense, enforce the read-first gate, then delegate to execute.
+
+    1. ``resolve`` — if no provider, return a structured ``sense.no_provider``
+       result (never raise a 500).
+    2. READ-FIRST GATE — the action's ``trust_level`` on the resolved
+       connector must be exactly ``"auto"``. Anything else (confirm /
+       restricted / unknown / missing) is refused with
+       ``sense.action_needs_approval`` and ``connectors_service.execute`` is
+       NEVER called.
+    3. Delegate to the existing execute path with the resolved connector.
+    """
+    resolved = await resolve(sense_id, workspace_id, pocket_id=pocket_id)
+    if resolved is None:
+        return SenseExecutionResult(
+            ok=False,
+            sense_id=sense_id,
+            action=action,
+            error="sense.no_provider",
+            message=(
+                f"no enabled connector can fill {sense_id!r} for this workspace — "
+                "connect a provider for this sense and retry."
+            ),
+        )
+
+    connector_name = resolved.connector_name
+    registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
+    trust = _trust_for_action(registry, connector_name, action)
+    if trust != "auto":
+        return SenseExecutionResult(
+            ok=False,
+            sense_id=sense_id,
+            connector_name=connector_name,
+            action=action,
+            error="sense.action_needs_approval",
+            message=(
+                f"action {action!r} on {connector_name!r} needs approval "
+                f"(trust_level={trust!r}) — not executed in v1 (read-first)."
+            ),
+        )
+
+    response = await connectors_service.execute(
+        workspace_id,
+        connector_name,
+        ExecuteActionRequest(action=action, params=params, pocket_id=pocket_id),
+        user_id=user_id,
+    )
+    return SenseExecutionResult(
+        ok=True,
+        sense_id=sense_id,
+        connector_name=connector_name,
+        action=action,
+        data=response,
+    )
+
+
+__all__ = ["ResolvedSense", "SenseExecutionResult", "execute_sense", "resolve"]

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -3,6 +3,10 @@
 # Updated: 2026-03-30 — Native adapter support for database connectors.
 # Updated: 2026-04-01 — Added Firebase CLI adapter registration.
 # Updated: 2026-04-01 — Added GCP adapter for gcloud CLI integration.
+# Updated: 2026-06-08 — Added the public ``definitions`` property (full
+#   ConnectorDef list incl. ``.senses``) so the EE SenseResolver can index
+#   connectors by sense without reaching into the private ``_definitions``
+#   dict. OSS-only change; must not import pocketpaw_ee.
 
 from __future__ import annotations
 
@@ -143,6 +147,18 @@ class ConnectorRegistry:
             }
             for d in self._definitions.values()
         ]
+
+    @property
+    def definitions(self) -> list[ConnectorDef]:
+        """All parsed connector definitions, including their ``.senses``.
+
+        Public accessor over the internal ``_definitions`` map so consumers
+        (notably the EE SenseResolver) can index connectors by sense via
+        ``pocketpaw.senses.connectors_for_sense`` without reaching into the
+        private dict. Returns a fresh list; mutating it does not affect the
+        registry.
+        """
+        return list(self._definitions.values())
 
     def get_definition(self, name: str) -> ConnectorDef | None:
         """Get a connector definition by name."""

--- a/tests/cloud/senses/__init__.py
+++ b/tests/cloud/senses/__init__.py
@@ -1,0 +1,2 @@
+# Sense tier EE cloud tests package.
+# Created: 2026-06-08 — Sense tier chunk 2 (SenseResolver) test suite.

--- a/tests/cloud/senses/test_resolver.py
+++ b/tests/cloud/senses/test_resolver.py
@@ -1,0 +1,203 @@
+# SenseResolver tests — resolve disambiguation, preference, read-first gate, delegation.
+# Created: 2026-06-08 — Sense tier chunk 2. Exercises the real Beanie layer
+# (mongo_db fixture seeds enabled connectors + preferences through the actual
+# service / preference paths) and mocks connectors_service.execute so we can
+# assert the read-first gate never calls execute on a non-auto action, and that
+# an auto action delegates with the resolved connector. Real connectors from
+# repo /connectors back the registry: gmail (paw.email.v1, single provider),
+# github+gitlab (paw.code.v1, ambiguous).
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.dto import (
+    EnableConnectorRequest,
+    ExecuteActionResponse,
+)
+from pocketpaw_ee.cloud.senses import preference, resolver
+
+from pocketpaw.senses import SenseValidationError
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WS = "ws-sense-test"
+
+
+async def _enable(name: str) -> None:
+    await connectors_service.enable_connector(WS, name, EnableConnectorRequest(scope="workspace"))
+
+
+# ---------------------------------------------------------------------------
+# resolve — 0 / 1 / >1 providers
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_zero_providers_returns_none() -> None:
+    # paw.email.v1 is fillable by gmail, but nothing is enabled for this ws.
+    result = await resolver.resolve("paw.email.v1", WS)
+    assert result is None
+
+
+async def test_resolve_single_provider() -> None:
+    await _enable("gmail")
+    result = await resolver.resolve("paw.email.v1", WS)
+    assert result is not None
+    assert result.connector_name == "gmail"
+    assert result.ambiguous is False
+    assert result.candidates == ["gmail"]
+
+
+async def test_resolve_ignores_disabled_connector() -> None:
+    await _enable("gmail")
+    await connectors_service.disable_connector(WS, "gmail")
+    result = await resolver.resolve("paw.email.v1", WS)
+    assert result is None
+
+
+async def test_resolve_ambiguous_flag_when_no_preference() -> None:
+    # paw.code.v1 -> github + gitlab. No preference -> deterministic first +
+    # ambiguous flag set so the caller can ask the user to choose.
+    await _enable("github")
+    await _enable("gitlab")
+    result = await resolver.resolve("paw.code.v1", WS)
+    assert result is not None
+    assert result.candidates == ["github", "gitlab"]
+    assert result.ambiguous is True
+    assert result.connector_name == "github"  # sorted-first deterministic pick
+
+
+async def test_resolve_preference_wins() -> None:
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "gitlab")
+    result = await resolver.resolve("paw.code.v1", WS)
+    assert result is not None
+    assert result.connector_name == "gitlab"
+    assert result.ambiguous is False
+    assert result.candidates == ["github", "gitlab"]
+
+
+async def test_resolve_preference_not_a_candidate_falls_back_to_first() -> None:
+    # A stale preference (provider no longer enabled) is ignored — we fall back
+    # to the deterministic pick and re-flag ambiguous.
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "bitbucket")  # not enabled / not a candidate
+    result = await resolver.resolve("paw.code.v1", WS)
+    assert result is not None
+    assert result.connector_name == "github"
+    assert result.ambiguous is True
+
+
+async def test_resolve_unknown_paw_sense_raises() -> None:
+    with pytest.raises(SenseValidationError):
+        await resolver.resolve("paw.telepathy.v1", WS)
+
+
+# ---------------------------------------------------------------------------
+# preference store get/set + pocket override
+# ---------------------------------------------------------------------------
+
+
+async def test_preference_get_set_roundtrip() -> None:
+    assert await preference.get_preference(WS, "paw.code.v1") is None
+    await preference.set_preference(WS, "paw.code.v1", "github")
+    assert await preference.get_preference(WS, "paw.code.v1") == "github"
+    # idempotent update, not a duplicate insert
+    await preference.set_preference(WS, "paw.code.v1", "gitlab")
+    assert await preference.get_preference(WS, "paw.code.v1") == "gitlab"
+
+
+async def test_preference_pocket_overrides_workspace() -> None:
+    await preference.set_preference(WS, "paw.code.v1", "github")
+    await preference.set_preference(WS, "paw.code.v1", "gitlab", pocket_id="pk1")
+    # pocket-scoped pref wins for that pocket
+    assert await preference.get_preference(WS, "paw.code.v1", pocket_id="pk1") == "gitlab"
+    # other pockets fall back to the workspace default
+    assert await preference.get_preference(WS, "paw.code.v1", pocket_id="pk2") == "github"
+    # workspace level untouched
+    assert await preference.get_preference(WS, "paw.code.v1") == "github"
+
+
+# ---------------------------------------------------------------------------
+# execute_sense — read-first gate + delegation
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_sense_no_provider_is_structured_error() -> None:
+    result = await resolver.execute_sense("paw.email.v1", "gmail_search", {}, WS)
+    assert result.ok is False
+    assert result.error == "sense.no_provider"
+    assert result.connector_name is None
+
+
+async def test_execute_sense_blocks_confirm_action_never_calls_execute(monkeypatch) -> None:
+    await _enable("gmail")
+    spy = AsyncMock(return_value=ExecuteActionResponse(success=True))
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    # gmail_send is trust_level=confirm -> must be blocked, execute never called.
+    result = await resolver.execute_sense("paw.email.v1", "gmail_send", {"to": "x@y.com"}, WS)
+
+    assert result.ok is False
+    assert result.error == "sense.action_needs_approval"
+    assert result.connector_name == "gmail"
+    spy.assert_not_called()
+
+
+async def test_execute_sense_blocks_unknown_action(monkeypatch) -> None:
+    await _enable("gmail")
+    spy = AsyncMock(return_value=ExecuteActionResponse(success=True))
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    # An action with no trust_level in the def -> treated as not-auto -> blocked.
+    result = await resolver.execute_sense("paw.email.v1", "gmail_nonexistent", {}, WS)
+
+    assert result.ok is False
+    assert result.error == "sense.action_needs_approval"
+    spy.assert_not_called()
+
+
+async def test_execute_sense_delegates_auto_action(monkeypatch) -> None:
+    await _enable("gmail")
+    spy = AsyncMock(
+        return_value=ExecuteActionResponse(success=True, data={"messages": []}),
+    )
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    # gmail_search is trust_level=auto -> proceeds and delegates.
+    result = await resolver.execute_sense(
+        "paw.email.v1", "gmail_search", {"q": "is:unread"}, WS, user_id="u1"
+    )
+
+    assert result.ok is True
+    assert result.connector_name == "gmail"
+    assert result.data.success is True
+    spy.assert_awaited_once()
+    # delegated with the RESOLVED connector + right action/params.
+    call = spy.await_args
+    assert call.args[0] == WS
+    assert call.args[1] == "gmail"  # resolved connector name
+    req = call.args[2]
+    assert req.action == "gmail_search"
+    assert req.params == {"q": "is:unread"}
+    assert call.kwargs.get("user_id") == "u1"
+
+
+async def test_execute_sense_delegates_with_preferred_provider(monkeypatch) -> None:
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "github")
+    spy = AsyncMock(return_value=ExecuteActionResponse(success=True, data=[]))
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    # list_repos is trust_level=auto on github.
+    result = await resolver.execute_sense("paw.code.v1", "list_repos", {}, WS)
+
+    assert result.ok is True
+    assert result.connector_name == "github"
+    spy.assert_awaited_once()
+    assert spy.await_args.args[1] == "github"


### PR DESCRIPTION
Stacked on #1380 — review and merge that one first. This branch is based on `feat/sense-catalog`, so the diff here is only the resolver.

## What this adds

The EE half of the Sense tier. Given a Sense and a workspace, it picks the connector that fills the Sense and runs an action through the existing connector execution path.

## How it resolves

- Takes the connectors that declare the Sense (from the catalog) and intersects them with the connectors the workspace has actually enabled.
- None enabled: returns nothing, so the caller can prompt the user to connect a provider.
- Exactly one: uses it.
- More than one: uses a stored preference if there is one; otherwise picks deterministically and marks the result ambiguous so the caller can ask the user to choose.

## Read-first

`execute_sense()` only runs an action whose trust level is `auto` (the read tier). Anything that needs approval — confirm, restricted, or an action with no trust set — is refused and never reaches the execute call. Both refusals (no provider, needs approval) come back as structured results rather than 500s.

## Pieces

- `ee/pocketpaw_ee/cloud/senses/`: the resolver, the read-first execute path, a `SenseFiller` seam so a skill or KB filler can register later, and an EE-side preference store. The provider preference lives next to connector enablement, not in the soul file.
- A `definitions` accessor and `get_definition()` on the connector registry so EE reads the catalog without touching private state.

## Testing

`uv run pytest tests/cloud/senses tests/cloud/connectors` reports 21 passing. `lint-imports` is clean — OSS still does not import EE.

## Scope

Resolves at workspace scope for now; pocket-scoped narrowing is noted in the code for later. The agent-facing `sense_execute` MCP tool is a separate change that waits on the connector MCP work (#1376) landing on dev.
