### PR TITLE
fix(pockets): stop sources/run 400ing on a pocket with nothing to run

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -1,5 +1,16 @@
 """Pockets domain — FastAPI router.
 
+Updated: 2026-06-08 (fix/pocket-sources-run-400) — ``POST /{id}/sources/run``
+no longer 400s when the pocket has no backend configured. The frontend runs
+declared sources on every ``pocket_open``, so a blank/starter pocket (no
+backend, nothing to fetch) was 400ing on open — surfacing as a noisy
+``pocket_open sources run failed: HttpError: Bad Request``. The route now
+computes the selected sources first (via ``source_executor.selected_source_keys``)
+and returns a clean ``{"ran": [], "errors": []}`` 200 when nothing is
+selected; when a runnable source IS authored but no backend is bound it
+returns per-source ``pocket_backend.not_configured`` errors (200), matching
+the soft/non-fatal handling every other source-run call site already uses.
+
 Updated: 2026-06-03 (Sites fix A) — the desktop ``GET /pockets`` gallery
 route now hides pockets that have been published as Paw Sites (they show
 under ``/sites`` instead). It calls ``sites_service.site_pocket_ids`` (a
@@ -673,18 +684,38 @@ async def run_pocket_sources(
     pocket = await pockets_service.get(pocket_id, user_id)
     ripple_spec = pocket.get("rippleSpec") or {}
 
+    from pocketpaw_ee.cloud.pockets import source_executor
+
     creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, pocket_id)
     if creds is None:
-        raise CloudError(
-            400,
-            "pocket_backend.not_configured",
-            "This pocket has no backend configured — set one via PUT /pockets/{id}/backend",
+        # No backend bound. The frontend runs declared sources on EVERY
+        # pocket_open, so a blank/starter pocket (no backend, nothing to
+        # fetch) hits this path on every open. Don't 400 it — that surfaced
+        # as a noisy "pocket_open sources run failed: HttpError: Bad Request"
+        # in the browser. Decide by whether anything would actually run:
+        #   * nothing selected  -> clean no-op (200, empty result)
+        #   * source(s) selected -> a real misconfiguration: a runnable source
+        #     was authored but no backend is bound. Report it as a per-source
+        #     error (200), matching every other source-run call site
+        #     (agent pocket_router, temporal_dispatcher, bulk_dispatch) which
+        #     treat "no backend" as soft/non-fatal — never a hard 400.
+        selected = source_executor.selected_source_keys(
+            ripple_spec, trigger=body.trigger, only_source=body.source
         )
+        return {
+            "ran": [],
+            "errors": [
+                {
+                    "source": key,
+                    "error": "This pocket has no backend configured",
+                    "code": "pocket_backend.not_configured",
+                }
+                for key in selected
+            ],
+        }
     # M2b.1 — the executor-creds tuple gained `allowed_writes` (M2a) and
     # `approval_route` (M2b.1); read-only source runs need neither.
     base_url, auth_type, auth_header, token, _allowed_writes, _approval_route = creds
-
-    from pocketpaw_ee.cloud.pockets import source_executor
 
     # no-event: source hydration is response-body delivery, not persisted
     return await source_executor.run_sources(

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -25,6 +25,12 @@
 #   AUTO-refresh: they re-run a source with no human in the loop, so they
 #   are metered by the per-pocket budget in `_refresh_budget.py` —
 #   SEPARATE from the manual per-(pocket, user) `_run_log` limiter here.
+# Updated: 2026-06-08 (fix/pocket-sources-run-400) — added the public
+#   `selected_source_keys()` helper (reuses `_parse_bindings` +
+#   `_select_sources`) so a caller can ask "would this (trigger, only_source)
+#   request run anything?" without a backend call. The `sources/run` route
+#   uses it to turn the implicit on-open run of a blank/starter pocket (no
+#   backend bound, nothing to fetch) into a clean no-op instead of a hard 400.
 #
 # SSRF BOUNDARY. The outbound-HTTP defenses now live in `_http_guard.py` —
 # the ONE canonical guard module both executors import. Every defense from
@@ -198,6 +204,30 @@ def _select_sources(
     if trigger is not None:
         return {k: b for k, b in bindings.items() if trigger in b.refresh}
     return dict(bindings)
+
+
+def selected_source_keys(
+    ripple_spec: dict,
+    *,
+    trigger: str | None = None,
+    only_source: str | None = None,
+) -> list[str]:
+    """Return the source keys a ``(trigger, only_source)`` request would run.
+
+    Reuses the same ``_parse_bindings`` + ``_select_sources`` logic the run
+    path uses, so callers can answer "is there anything to run?" WITHOUT
+    making a backend call or duplicating the selection rules. Malformed
+    entries (which ``_parse_bindings`` turns into parse errors, not bindings)
+    are correctly excluded — they are never runnable.
+
+    Used by the ``sources/run`` route to decide, when no backend is
+    configured, whether the request is a benign no-op (nothing selected →
+    empty result) or a real misconfiguration (a runnable source was authored
+    but the pocket has no backend bound).
+    """
+    bindings, _parse_errors = _parse_bindings(ripple_spec)
+    selected = _select_sources(bindings, trigger=trigger, only_source=only_source)
+    return list(selected.keys())
 
 
 def _parse_bindings(ripple_spec: dict) -> tuple[dict[str, SourceBinding], list[dict]]:
@@ -404,4 +434,4 @@ async def run_sources(
     return {"ran": ran, "errors": errors}
 
 
-__all__ = ["run_sources", "SourceBinding", "RefreshTrigger"]
+__all__ = ["run_sources", "selected_source_keys", "SourceBinding", "RefreshTrigger"]

--- a/tests/cloud/pockets/test_sources_run_endpoint.py
+++ b/tests/cloud/pockets/test_sources_run_endpoint.py
@@ -1,0 +1,183 @@
+# tests/cloud/pockets/test_sources_run_endpoint.py
+# Created: 2026-06-08 (fix/pocket-sources-run-400) — route-level coverage for
+#   ``POST /pockets/{id}/sources/run`` (the handler ``run_pocket_sources``).
+#
+# Regression gate for the on-open 400 bug: the frontend runs a pocket's
+# declared ``rippleSpec.sources`` on open (trigger="pocket_open"). For a
+# blank/starter pocket — no backend bound and no runnable sources — that
+# implicit run is semantically a NO-OP (nothing to fetch), yet the route used
+# to raise ``CloudError(400, "pocket_backend.not_configured")`` BEFORE checking
+# whether any source was selected. The browser surfaced it as
+# ``pocket_open sources run failed: HttpError: Bad Request`` on every open of a
+# backend-less pocket. Every other source-run call site (agent pocket_router,
+# temporal_dispatcher, bulk_dispatch) already treats "no backend" as a soft,
+# non-fatal condition — only this REST route hard-400'd.
+#
+# What's covered:
+#   - blank/starter pocket (no backend, no sources) on pocket_open → clean
+#     {"ran": [], "errors": []} 200, NOT a 400  [the RED→GREEN repro]
+#   - empty ``sources: {}`` block, no backend → same clean no-op
+#   - a configured backend still runs the executor unchanged (no regression)
+#   - a pocket that DECLARES sources but has no backend still surfaces the
+#     not-configured condition (an authored source genuinely can't run) — so
+#     the fix scopes the no-op to "nothing to run", not "swallow every error"
+#   - an explicit single-source request naming a source that exists but with
+#     no backend still surfaces not-configured (explicit intent is honored)
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+import importlib  # noqa: E402
+
+from pocketpaw_ee.cloud.pockets.dto import RunSourcesRequest  # noqa: E402
+
+# ``pockets/__init__.py`` rebinds the name ``router`` to the APIRouter
+# instance, so ``from pocketpaw_ee.cloud.pockets import router`` returns the
+# instance, not the module. Pull the actual module object explicitly so we can
+# patch the module-level ``pockets_service`` seam and call the handler.
+pockets_router = importlib.import_module("pocketpaw_ee.cloud.pockets.router")
+
+_WS = "w1"
+_USER = "u1"
+_PID = "507f1f77bcf86cd799439011"
+
+# A source the executor would run — used in the "declares sources but no
+# backend" and "configured backend" cases.
+_REVENUE_SOURCE = {
+    "method": "GET",
+    "path": "/revenue/today",
+    "bind": "state.revenue",
+    "refresh": ["pocket_open", "manual"],
+}
+
+
+def _pocket(ripple_spec: dict | None) -> dict:
+    """Minimal pocket wire dict as ``pockets_service.get`` returns it."""
+    return {"_id": _PID, "workspace": _WS, "owner": _USER, "rippleSpec": ripple_spec}
+
+
+def _patch_service(*, pocket: dict, creds):
+    """Patch the two service seams the route calls: ``get`` (pocket fetch)
+    and ``get_pocket_backend_for_executor`` (backend creds, or None)."""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch.object(
+            pockets_router.pockets_service,
+            "get",
+            new=AsyncMock(return_value=pocket),
+        )
+    )
+    stack.enter_context(
+        patch.object(
+            pockets_router.pockets_service,
+            "get_pocket_backend_for_executor",
+            new=AsyncMock(return_value=creds),
+        )
+    )
+    return stack
+
+
+async def _run(body: RunSourcesRequest):
+    return await pockets_router.run_pocket_sources(_PID, body, workspace_id=_WS, user_id=_USER)
+
+
+# ---------------------------------------------------------------------------
+# RED → GREEN repro: blank/starter pocket on pocket_open is a clean no-op.
+# ---------------------------------------------------------------------------
+
+
+async def test_pocket_open_no_backend_no_sources_is_clean_noop():
+    """The bug: opening a blank/starter pocket (no backend bound, no sources
+    declared) POSTs ``sources/run`` with trigger="pocket_open" and used to
+    400. It must instead return a clean ``{"ran": [], "errors": []}`` 200."""
+    pocket = _pocket({"version": "1.0", "ui": {"id": "n_root0000", "type": "flex"}})
+    with _patch_service(pocket=pocket, creds=None):
+        result = await _run(RunSourcesRequest(trigger="pocket_open"))
+    assert result == {"ran": [], "errors": []}
+
+
+async def test_pocket_open_empty_sources_block_no_backend_is_noop():
+    """An explicit empty ``sources: {}`` with no backend is also a no-op."""
+    pocket = _pocket({"version": "1.0", "sources": {}, "ui": {"id": "n_r", "type": "flex"}})
+    with _patch_service(pocket=pocket, creds=None):
+        result = await _run(RunSourcesRequest(trigger="pocket_open"))
+    assert result == {"ran": [], "errors": []}
+
+
+async def test_pocket_open_no_ripple_spec_no_backend_is_noop():
+    """A pocket with a missing/None rippleSpec (truly empty) is a no-op."""
+    pocket = _pocket(None)
+    with _patch_service(pocket=pocket, creds=None):
+        result = await _run(RunSourcesRequest(trigger="pocket_open"))
+    assert result == {"ran": [], "errors": []}
+
+
+# ---------------------------------------------------------------------------
+# No regression: a configured backend still drives the executor.
+# ---------------------------------------------------------------------------
+
+
+async def test_configured_backend_runs_executor():
+    """With a backend bound, the route delegates to the executor unchanged."""
+    pocket = _pocket({"version": "1.0", "sources": {"revenue": dict(_REVENUE_SOURCE)}, "ui": {}})
+    creds = ("https://api.example.com", "bearer", None, "tok", [], None)
+    executor_result = {"ran": [{"source": "revenue", "bind": "revenue", "value": 42}], "errors": []}
+    with _patch_service(pocket=pocket, creds=creds):
+        with patch(
+            "pocketpaw_ee.cloud.pockets.source_executor.run_sources",
+            new=AsyncMock(return_value=executor_result),
+        ) as run_mock:
+            result = await _run(RunSourcesRequest(trigger="pocket_open"))
+    assert result == executor_result
+    run_mock.assert_awaited_once()
+    # The executor got the pocket's spec + backend creds.
+    kwargs = run_mock.await_args.kwargs
+    assert kwargs["base_url"] == "https://api.example.com"
+    assert kwargs["trigger"] == "pocket_open"
+
+
+# ---------------------------------------------------------------------------
+# Scope guard: the no-op is "nothing to run", not "swallow not-configured".
+# A pocket that DECLARES runnable sources but has no backend still surfaces it.
+# ---------------------------------------------------------------------------
+
+
+async def test_declares_sources_but_no_backend_still_surfaces_not_configured():
+    """A pocket that authored a real source but never bound a backend is a
+    genuine misconfiguration — the fix must NOT swallow it into a silent
+    no-op. The selected source is reported as a not-configured error."""
+    pocket = _pocket({"version": "1.0", "sources": {"revenue": dict(_REVENUE_SOURCE)}, "ui": {}})
+    with _patch_service(pocket=pocket, creds=None):
+        result = await _run(RunSourcesRequest(trigger="pocket_open"))
+    assert result["ran"] == []
+    assert len(result["errors"]) == 1
+    err = result["errors"][0]
+    assert err["source"] == "revenue"
+    assert err["code"] == "pocket_backend.not_configured"
+
+
+async def test_explicit_named_source_no_backend_surfaces_not_configured():
+    """An explicit single-source request (source="revenue") that selects a
+    real declared source still surfaces not-configured when no backend is
+    bound — explicit intent is honored, not silently dropped."""
+    pocket = _pocket({"version": "1.0", "sources": {"revenue": dict(_REVENUE_SOURCE)}, "ui": {}})
+    with _patch_service(pocket=pocket, creds=None):
+        result = await _run(RunSourcesRequest(source="revenue"))
+    assert result["ran"] == []
+    assert [e["code"] for e in result["errors"]] == ["pocket_backend.not_configured"]
+
+
+async def test_explicit_named_unknown_source_no_backend_is_noop():
+    """An explicit source name that does NOT exist in the spec selects
+    nothing, so even with no backend it is a clean no-op (no error)."""
+    pocket = _pocket({"version": "1.0", "sources": {"revenue": dict(_REVENUE_SOURCE)}, "ui": {}})
+    with _patch_service(pocket=pocket, creds=None):
+        result = await _run(RunSourcesRequest(source="does_not_exist"))
+    assert result == {"ran": [], "errors": []}


### PR DESCRIPTION
## The bug

Opening a pocket fired a 400 in the console — `pocket_open sources run failed: Bad Request`. `POST /pockets/{id}/sources/run` hard-raised `400 pocket_backend.not_configured` whenever no backend was bound, *before* checking whether any source would actually run. So the frontend's implicit "run the sources on open" 400'd for every blank/starter pocket (and any pocket without a bound backend) — console noise, and the on-open run broke.

## The fix

Compute the selected sources first, then branch:

- nothing to run → a clean `{"ran": [], "errors": []}` (200)
- a runnable source but no backend bound → a per-source `pocket_backend.not_configured` error inside the 200 body (matching every other source-run call site), not a top-level 400
- a valid backend-bound run → unchanged

Opening a pocket with no / empty declared sources is now a clean no-op instead of a hard failure.

## Tests

Reproduce-first: a new route-level test (`tests/cloud/pockets/test_sources_run_endpoint.py`) went 6 RED → 7 GREEN. Full pockets suite: 78 passing. ruff + import-linter clean.

Found while testing locally (the same `pocket_open sources run` 400 from before). Pre-existing on `dev`, separate from the VIP onboarding work.
