### PR TITLE
feat(senses): list_senses + sense_execute MCP tools

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,10 @@
 <!--
   Connectors documentation.
+  Updated: 2026-06-08 (sense-mcp / Sense tier chunk 4) — added the Senses
+  section: the "Sense" glossary entry, the sense-vs-connector distinction, and
+  the two new agent tools (list_senses / sense_execute on the same
+  pocketpaw_connectors MCP server) that address a capability instead of a
+  provider, with the resolver binding it to the tenant's enabled connector.
   Updated: 2026-06-08 (connector-mcp-execution / keystone) — documented the
   agent-callable connector tool surface (list_connector_actions /
   connector_execute on the pocketpaw_connectors MCP server), the v1
@@ -273,6 +278,57 @@ connector_execute("gmail", "gmail_search",
 
 connector_execute("gmail", "gmail_send", {...})
   → blocked: "needs approval (coming in v2). Not executed."
+```
+
+## Senses — provider-agnostic capabilities above connectors
+
+> **Glossary — Sense.** A provider-agnostic capability that sits one layer above
+> connectors. Templates and agents address a Sense (e.g. `paw.email.v1`,
+> `paw.code.v1`) instead of a specific connector; the resolver binds the Sense
+> to whichever connector the tenant enabled for that capability in the current
+> workspace. A Sense is the *what* (email, calendar, code); a connector is the
+> *how* (Gmail, Google Calendar, GitHub). This is the anti-fragmentation rule:
+> the core Sense vocabulary is closed and curated, so one template works across
+> every tenant regardless of which providers they connected.
+
+A **Sense** is a capability addressed by what it *does*, not by which vendor
+provides it. `paw.email.v1` means "email" regardless of whether the tenant
+enabled Gmail, Outlook, or anything else; `paw.code.v1` means
+"repos/issues/PRs" whether that's GitHub or GitLab. Templates and agents
+address a Sense, and the **resolver** binds it to whichever connector the
+tenant actually enabled in this workspace. This keeps templates portable: a
+"weekly digest" template asks for `paw.email.v1` and works for every tenant
+without hard-coding a provider.
+
+Two MCP tools on the same `pocketpaw_connectors` server expose Senses to the
+chat agent:
+
+| Tool | What it does |
+|------|--------------|
+| `list_senses()` | Lists the capabilities (Senses) that resolve to a connector in the **current pocket** — each with the bound `connector`, whether the choice was `ambiguous` (more than one provider, no preference set), and the `candidates`. No arguments; the pocket comes from the active chat. |
+| `sense_execute(sense, action, params)` | Runs ONE READ action against a Sense **without naming the connector** — the resolver picks the provider. Read (auto-trust) actions execute; writes are refused. |
+
+**Sense vs connector.** Use `connector_execute` when you already know the
+provider (the user said "GitHub" or "Gmail"); use `sense_execute` when the
+user asks by capability ("check my email", "list my open PRs") and you want
+the resolver to pick the enabled provider. `sense_execute` enforces the same
+read-first policy as `connector_execute` — the resolver only runs `auto`-trust
+actions; `confirm` / `restricted` (write-shaped) actions are refused with a
+"needs approval" message and never executed. When no enabled connector fills
+the sense, `sense_execute` returns a clear "no provider" error so the agent
+can prompt the user to connect one.
+
+```
+list_senses()
+  → [{"sense": "paw.email.v1", "connector": "gmail", "ambiguous": false, ...},
+     {"sense": "paw.code.v1",  "connector": "github", ...}]
+
+sense_execute("paw.email.v1", "gmail_search",
+             {"query": "from:acme.com subject:invoice"})
+  → runs against the resolved connector (gmail), returns matching stubs
+
+sense_execute("paw.email.v1", "gmail_send", {...})
+  → refused: "needs approval … not executed in v1 (read-first)."
 ```
 
 ## Using with Existing Integrations

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -14,6 +14,16 @@
 #   sites servers use. Tool ids namespace as ``mcp__pocketpaw_connectors__*``.
 #   OSS-EE boundary: this module imports only ``connectors.service`` (which owns
 #   the Beanie read), never the WorkspaceConnector doc directly.
+# Updated: 2026-06-08 (feat/sense-mcp / Sense tier chunk 4) — added the Sense
+#   agent surface alongside the connector surface: two more tools,
+#   ``list_senses`` (which provider-agnostic capabilities resolve in this
+#   pocket?) and ``sense_execute`` (run a READ action against a Sense without
+#   naming the connector). Both delegate to ``cloud.senses.resolver`` —
+#   ``list_senses`` resolves each CORE_SENSES entry via ``resolve`` and reports
+#   the bound connector; ``sense_execute`` calls ``execute_sense``, which OWNS
+#   the read-first gate (only trust=auto runs) so this module does NOT re-gate.
+#   Tool ids namespace as ``mcp__pocketpaw_connectors__list_senses`` /
+#   ``…__sense_execute``.
 """Agent-side MCP surface for executing a pocket's bound connectors.
 
 Tools registered:
@@ -48,10 +58,14 @@ SERVER_NAME = "pocketpaw_connectors"
 # Allowlist entries must use this exact form.
 LIST_CONNECTOR_ACTIONS_TOOL_ID = f"mcp__{SERVER_NAME}__list_connector_actions"
 CONNECTOR_EXECUTE_TOOL_ID = f"mcp__{SERVER_NAME}__connector_execute"
+LIST_SENSES_TOOL_ID = f"mcp__{SERVER_NAME}__list_senses"
+SENSE_EXECUTE_TOOL_ID = f"mcp__{SERVER_NAME}__sense_execute"
 
 CONNECTOR_TOOL_IDS = (
     LIST_CONNECTOR_ACTIONS_TOOL_ID,
     CONNECTOR_EXECUTE_TOOL_ID,
+    LIST_SENSES_TOOL_ID,
+    SENSE_EXECUTE_TOOL_ID,
 )
 
 # The agent-facing refusal for any write/confirm-trust action in v1. Kept as a
@@ -281,6 +295,137 @@ async def _connector_execute_handler(args: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Tool handlers — Sense tier (provider-agnostic capabilities above connectors)
+# ---------------------------------------------------------------------------
+
+
+async def _list_senses_handler(args: dict) -> dict:  # noqa: ARG001 — no args
+    workspace_id, _user_id, pocket_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "no active workspace — list_senses can only be called from inside a "
+            "cloud chat stream"
+        )
+
+    from pocketpaw.senses import CORE_SENSES
+    from pocketpaw_ee.cloud.senses.resolver import resolve
+
+    senses_out: list[dict[str, Any]] = []
+    for sense in CORE_SENSES:
+        try:
+            resolved = await resolve(sense.id, workspace_id, pocket_id=pocket_id)
+        except Exception as exc:  # noqa: BLE001 — never let one sense break the list
+            logger.warning("list_senses: resolve(%s) failed", sense.id, exc_info=True)
+            return _error_response(f"list_senses failed: {exc}")
+        if resolved is None:
+            # No enabled connector fills this sense for the workspace — skip it
+            # so the agent only sees capabilities it can actually use.
+            continue
+        senses_out.append(
+            {
+                "sense": sense.id,
+                "display_name": sense.display_name,
+                "description": sense.description,
+                "connector": resolved.connector_name,
+                "ambiguous": resolved.ambiguous,
+                "candidates": resolved.candidates,
+            }
+        )
+
+    if not senses_out:
+        return _success_response(
+            {
+                "pocket_id": pocket_id,
+                "senses": [],
+                "message": (
+                    "No capabilities (Senses) are available here yet — no enabled "
+                    "connector fills any core sense for this workspace. Connect a "
+                    "provider (email, calendar, code, etc.) to use senses."
+                ),
+            }
+        )
+
+    return _success_response(
+        {
+            "pocket_id": pocket_id,
+            "senses": senses_out,
+            "note": (
+                "Call sense_execute(sense, action, params) to run a READ action "
+                "against a capability without naming the connector. If a sense is "
+                "ambiguous, the resolver picked the first candidate — the user can "
+                "set a preference to disambiguate. Write actions are blocked in v1."
+            ),
+        }
+    )
+
+
+async def _sense_execute_handler(args: dict) -> dict:
+    workspace_id, user_id, pocket_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "no active workspace — sense_execute can only be called from inside a "
+            "cloud chat stream"
+        )
+    if not pocket_id:
+        return _error_response(
+            "this chat isn't anchored to a pocket — sense_execute needs a "
+            "pocket-scoped room with a bound connector"
+        )
+
+    sense = args.get("sense")
+    if not isinstance(sense, str) or not sense:
+        return _error_response("sense is required (string, e.g. 'paw.email.v1')")
+    action = args.get("action")
+    if not isinstance(action, str) or not action:
+        return _error_response("action is required (string)")
+    params = args.get("params") or {}
+    if not isinstance(params, dict):
+        return _error_response("params must be an object (dict)")
+
+    from pocketpaw.senses import SenseValidationError
+    from pocketpaw_ee.cloud.senses.resolver import execute_sense
+
+    try:
+        result = await execute_sense(
+            sense,
+            action,
+            params,
+            workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+        )
+    except SenseValidationError as exc:
+        return _error_response(f"unknown sense {sense!r}: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("sense_execute failed", exc_info=True)
+        return _error_response(f"sense_execute failed: {exc}")
+
+    # execute_sense OWNS the read-first gate. A False result is a structured
+    # refusal (sense.no_provider / sense.action_needs_approval), not a crash.
+    if not result.ok:
+        return _error_response(result.message or result.error or "sense_execute refused")
+
+    # result.data is the underlying ExecuteActionResponse. Flatten it into the
+    # SAME shape connector_execute returns (json.dumps uses default=str, so a
+    # nested Pydantic model would serialize as an opaque repr the agent can't
+    # read) — keep the two tools' success payloads structurally identical.
+    resp = result.data
+    return _success_response(
+        {
+            "executed": True,
+            "sense": result.sense_id,
+            "connector": result.connector_name,
+            "action": result.action,
+            "success": getattr(resp, "success", True),
+            "data": getattr(resp, "data", None),
+            "error": getattr(resp, "error", None),
+            "records_affected": getattr(resp, "records_affected", 0),
+            "execution_mode": getattr(resp, "execution_mode", "cloud"),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # Server factory
 # ---------------------------------------------------------------------------
 
@@ -356,10 +501,75 @@ def build_connectors_context_server() -> tuple[str, Any] | None:
     async def connector_execute(args):  # type: ignore[no-untyped-def]
         return await _connector_execute_handler(args)
 
+    @tool(
+        "list_senses",
+        (
+            "List the capabilities (Senses) you can use in the CURRENT "
+            "pocket/room. A Sense is a provider-agnostic capability (e.g. "
+            "'paw.email.v1' = email, 'paw.code.v1' = repos/issues/PRs) that the "
+            "resolver binds to whichever connector the tenant enabled — so you "
+            "address the capability, not a specific provider. Call this FIRST "
+            "when the user asks for something by capability ('check my email', "
+            "'what's on my calendar') rather than by provider name. Returns only "
+            "senses that resolve to a connector here, each with the bound "
+            "`connector`, whether the choice was `ambiguous` (more than one "
+            "provider, no preference set), and the `candidates`. No arguments — "
+            "the pocket is inferred from the active chat. Then call sense_execute "
+            "to run a READ action."
+        ),
+        {},
+    )
+    async def list_senses(args):  # type: ignore[no-untyped-def]
+        return await _list_senses_handler(args)
+
+    @tool(
+        "sense_execute",
+        (
+            "Run ONE READ action against a capability (Sense) for the current "
+            "pocket WITHOUT naming the provider. Use this when the user asks by "
+            "capability ('search my email for the invoice', 'list my open PRs') "
+            "and you want the resolver to pick the connector the tenant enabled. "
+            "Args: `sense` (a sense id from list_senses, e.g. 'paw.email.v1'), "
+            "`action` (an action name, e.g. 'gmail_search' or 'list_issues'), and "
+            "`params` (an object of that action's parameters). READ-FIRST: only "
+            "read (auto-trust) actions run; WRITE actions (create/send/modify/"
+            "delete) are refused with a 'needs approval' message and are NEVER "
+            "executed. If no connector fills the sense for this workspace you get "
+            "a clear 'no provider' error. Always call list_senses first to see "
+            "which senses resolve and pick a valid action."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "sense": {
+                    "type": "string",
+                    "description": (
+                        "Sense id from list_senses, e.g. 'paw.email.v1' or "
+                        "'paw.code.v1'. Names the capability, not a connector."
+                    ),
+                },
+                "action": {
+                    "type": "string",
+                    "description": (
+                        "Action name to run, e.g. 'gmail_search' or 'list_issues'. "
+                        "Read actions only — writes are refused."
+                    ),
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Object of the action's parameters (may be empty).",
+                },
+            },
+            "required": ["sense", "action"],
+        },
+    )
+    async def sense_execute(args):  # type: ignore[no-untyped-def]
+        return await _sense_execute_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.0.0",
-        tools=[list_connector_actions, connector_execute],
+        version="1.1.0",
+        tools=[list_connector_actions, connector_execute, list_senses, sense_execute],
     )
     return SERVER_NAME, server
 
@@ -368,6 +578,8 @@ __all__ = [
     "CONNECTOR_EXECUTE_TOOL_ID",
     "CONNECTOR_TOOL_IDS",
     "LIST_CONNECTOR_ACTIONS_TOOL_ID",
+    "LIST_SENSES_TOOL_ID",
+    "SENSE_EXECUTE_TOOL_ID",
     "SERVER_NAME",
     "build_connectors_context_server",
 ]

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -45,7 +45,8 @@ class TestConnectorsMcpServerRegistration:
         assert CONNECTOR_EXECUTE_TOOL_ID == "mcp__pocketpaw_connectors__connector_execute"
         assert LIST_CONNECTOR_ACTIONS_TOOL_ID in CONNECTOR_TOOL_IDS
         assert CONNECTOR_EXECUTE_TOOL_ID in CONNECTOR_TOOL_IDS
-        assert len(CONNECTOR_TOOL_IDS) == 2
+        # The server now also carries the two Sense-tier tools (chunk 4).
+        assert len(CONNECTOR_TOOL_IDS) == 4
 
     def test_extension_provider_advertises_tool_ids(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk
@@ -437,3 +438,217 @@ class TestConnectorExecuteHandler:
 
         assert out.get("is_error") is True
         assert "connector_name is required" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Handlers — Sense tier (list_senses / sense_execute)
+# ---------------------------------------------------------------------------
+
+
+class TestSenseTools:
+    @pytest.mark.asyncio
+    async def test_list_senses_reports_only_resolvable_senses(self) -> None:
+        """list_senses returns the senses that resolve to an enabled connector
+        for the workspace, and skips the ones with no provider."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.senses.resolver import ResolvedSense
+
+        async def fake_resolve(sense_id, workspace_id, *, pocket_id=None):
+            if sense_id == "paw.email.v1":
+                return ResolvedSense(
+                    sense_id="paw.email.v1",
+                    connector_name="gmail",
+                    ambiguous=False,
+                    candidates=["gmail"],
+                )
+            return None  # no provider for the rest
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.resolve",
+                new=AsyncMock(side_effect=fake_resolve),
+            ),
+        ):
+            out = await connectors_mcp._list_senses_handler({})
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        ids = [s["sense"] for s in body["senses"]]
+        assert ids == ["paw.email.v1"]
+        assert body["senses"][0]["connector"] == "gmail"
+
+    @pytest.mark.asyncio
+    async def test_list_senses_no_workspace_errors(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity(None, None, None)
+        with ws_patch, user_patch, pocket_patch:
+            out = await connectors_mcp._list_senses_handler({})
+
+        assert out.get("is_error") is True
+        assert "no active workspace" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_success_flattens_response(self) -> None:
+        """A successful sense_execute flattens the underlying
+        ExecuteActionResponse into the SAME shape connector_execute returns —
+        not a nested Pydantic repr (json.dumps uses default=str)."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+        exec_result = SenseExecutionResult(
+            ok=True,
+            sense_id="paw.email.v1",
+            connector_name="gmail",
+            action="gmail_search",
+            data=ExecuteActionResponse(
+                success=True,
+                data=[{"id": "m1", "subject": "hello"}],
+                execution_mode="cloud",
+            ),
+        )
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.execute_sense",
+                new=AsyncMock(return_value=exec_result),
+            ) as mock_exec,
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search", "params": {"q": "hi"}}
+            )
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        # Flat shape, structurally identical to connector_execute's success.
+        assert body["executed"] is True
+        assert body["sense"] == "paw.email.v1"
+        assert body["connector"] == "gmail"
+        assert body["success"] is True
+        assert body["data"][0]["subject"] == "hello"
+        assert body["execution_mode"] == "cloud"
+        # Delegated to execute_sense with the resolved identity.
+        mock_exec.assert_awaited_once()
+        call = mock_exec.await_args
+        assert call.args[0] == "paw.email.v1"  # sense
+        assert call.args[1] == "gmail_search"  # action
+        assert call.kwargs["pocket_id"] == "pk_1"
+        assert call.kwargs["user_id"] == "u_1"
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_refusal_is_delegated_not_self_gated(self) -> None:
+        """A write/needs-approval refusal comes back as an error envelope, and
+        the handler still DELEGATED to execute_sense (it does not gate itself)."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+        refused = SenseExecutionResult(
+            ok=False,
+            sense_id="paw.email.v1",
+            connector_name="gmail",
+            action="gmail_send",
+            error="sense.action_needs_approval",
+            message="action 'gmail_send' needs approval — not executed in v1 (read-first).",
+        )
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.execute_sense",
+                new=AsyncMock(return_value=refused),
+            ) as mock_exec,
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_send", "params": {}}
+            )
+
+        assert out.get("is_error") is True
+        assert "needs approval" in out["content"][0]["text"]
+        mock_exec.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_no_provider_errors(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+        none_result = SenseExecutionResult(
+            ok=False,
+            sense_id="paw.email.v1",
+            action="gmail_search",
+            error="sense.no_provider",
+            message="no enabled connector can fill 'paw.email.v1' for this workspace.",
+        )
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.execute_sense",
+                new=AsyncMock(return_value=none_result),
+            ),
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search"}
+            )
+
+        assert out.get("is_error") is True
+        assert "no enabled connector" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_guards_and_validation(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        # No pocket → refused.
+        ws_p, u_p, pk_p = _patch_identity("ws_1", "u_1", None)
+        with ws_p, u_p, pk_p:
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search"}
+            )
+        assert out.get("is_error") is True
+        assert "pocket" in out["content"][0]["text"]
+
+        # Missing sense → refused.
+        ws_p, u_p, pk_p = _patch_identity("ws_1", "u_1", "pk_1")
+        with ws_p, u_p, pk_p:
+            out = await connectors_mcp._sense_execute_handler({"action": "gmail_search"})
+        assert out.get("is_error") is True
+        assert "sense is required" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_unknown_sense_is_clean_error(self) -> None:
+        """An unknown paw.* id raises SenseValidationError inside execute_sense;
+        the handler turns it into a clean error, not a crash."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        from pocketpaw.senses import SenseValidationError
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.execute_sense",
+                new=AsyncMock(side_effect=SenseValidationError("unknown core sense id")),
+            ),
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.unknown.v1", "action": "x"}
+            )
+
+        assert out.get("is_error") is True
+        assert "unknown sense" in out["content"][0]["text"]


### PR DESCRIPTION
Stacked on #1381 (which is on #1380). Review and merge those first — the diff here is only the two MCP tools.

## What this adds

The agent-facing consumer of the Sense tier. Two tools on the existing `pocketpaw_connectors` MCP server let the cloud chat agent work by capability instead of by provider:

- `list_senses()` — the capabilities (Senses) that resolve to an enabled connector in the current pocket, each with the bound connector and whether the choice was ambiguous.
- `sense_execute(sense, action, params)` — runs one read action against a Sense without naming the connector. The resolver picks the provider.

So the agent can be told "check my email" and reach Gmail (or whatever fills `paw.email` for that tenant) without the prompt naming a connector.

## Read-first

Both tools delegate to the resolver's `execute_sense()`, which owns the read-first gate. The MCP layer does not gate on its own — it translates the resolver's structured result into the MCP envelope. A write or an unmapped action comes back as a refusal, never an execution. A successful call flattens the underlying `ExecuteActionResponse` into the same shape `connector_execute` returns, so the agent gets structured fields rather than a stringified object.

## Pieces

- Two handlers + two `@tool` registrations added to `ee/pocketpaw_ee/agent/mcp_servers/connectors.py`, reusing the identity and response helpers that the connector tools already use.
- A Sense glossary entry and a sense-vs-connector section in `docs/CONNECTORS.md`.

## Testing

`uv run pytest tests/ee/agent/test_connectors_mcp_server` reports 22 passing (15 existing plus 7 for the new tools). The success-path test runs a real `ExecuteActionResponse` through `sense_execute` and asserts the flattened fields, so the serialization stays correct. `lint-imports` is clean.

## Scope

This is the agent consumer. The template `needs:[]` clause and the declarative UI binding are a separate change.
