### PR TITLE
feat(senses): pocket templates declare the Senses they need

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -89,6 +89,13 @@ dispatcher + temporal scheduler call to obtain a typed ``PocketTemplate``
 from a pocket. A stale / missing slug never breaks pocket creation: the
 loader's ``strict=False`` mode returns ``None`` and the rippleSpec is
 left unmodified so a later resolver run can retry.
+Changes: 2026-06-08 (feat/sense-template-needs, Sense tier chunk 6a) —
+``create`` now reads the template's ``needs:`` Sense ids and, for each,
+asks the EE Sense resolver whether an enabled connector fills it for the
+tenant (``_check_template_needs``). Senses with no provider are logged as
+a warning AND attached as ``missing_senses`` on the ``pocket.created``
+event so the UX can prompt-to-connect. This NEVER blocks creation —
+``needs`` is template metadata, not rippleSpec, so it is not merged.
 Changes: 2026-05-24 — added ``merge_spec`` (MVP entry point for the
 new ``POST /api/v1/pockets/{id}/spec/merge`` endpoint). Accepts either a
 ``{"replace": <full spec>}`` or a ``{"merge": <partial spec>}`` body,
@@ -471,7 +478,9 @@ async def _resolved_wire_dict(doc: _PocketDoc, viewer_user_id: str) -> dict:
     return pocket_to_wire_dict(pocket)
 
 
-async def _pocket_event_payload(doc: _PocketDoc) -> dict:
+async def _pocket_event_payload(
+    doc: _PocketDoc, *, missing_senses: list[str] | None = None
+) -> dict:
     """Build the realtime event payload for a pocket mutation.
 
     Always includes ``recipient_ids`` (owner + shared_with). For
@@ -498,6 +507,12 @@ async def _pocket_event_payload(doc: _PocketDoc) -> dict:
     }
     if doc.visibility == "workspace":
         payload["workspace_id"] = doc.workspace
+    # Sense tier chunk 6a — when a template declared ``needs:`` Senses that no
+    # enabled connector fills for this tenant, surface them so the UX can
+    # prompt-to-connect. Only present on the create path when non-empty; the
+    # absence of the key means "nothing missing".
+    if missing_senses:
+        payload["missing_senses"] = list(missing_senses)
     return payload
 
 
@@ -857,6 +872,48 @@ def _merge_compile_into_ripple_spec(
     return out
 
 
+async def _check_template_needs(loaded: dict[str, Any] | None, workspace_id: str) -> list[str]:
+    """Return the template's declared Sense ids that NO enabled connector fills.
+
+    A vertical template may declare ``needs: ["paw.payments.v1", ...]`` — the
+    provider-agnostic capabilities it expects the tenant to have wired up. For
+    each need, ask the EE Sense resolver whether an enabled connector fills it
+    for ``workspace_id``; ids that resolve to ``None`` are returned as the
+    ``missing`` set so the caller can surface a prompt-to-connect.
+
+    Tolerance: this never raises and never blocks. A ``None`` loaded result, a
+    missing/empty ``needs``, or a resolver error all yield ``[]`` (or skip the
+    offending id) — mirrors the ``strict=False`` posture used elsewhere here.
+    """
+    if not isinstance(loaded, dict):
+        return []
+    meta = loaded.get("meta")
+    if not isinstance(meta, dict):
+        return []
+    needs = meta.get("needs")
+    if not needs:
+        return []
+
+    # Lazy import — keep the EE Sense resolver off the eager import path.
+    from pocketpaw_ee.cloud.senses.resolver import resolve
+
+    missing: list[str] = []
+    for sense_id in needs:
+        try:
+            resolved = await resolve(sense_id, workspace_id)
+        except Exception as exc:  # noqa: BLE001 — never block create on a resolver hiccup
+            logger.warning(
+                "template needs: resolve(%r) raised for workspace=%s: %s",
+                sense_id,
+                workspace_id,
+                exc,
+            )
+            continue
+        if resolved is None:
+            missing.append(sense_id)
+    return missing
+
+
 async def resolve_pocket_template(
     workspace_id: str,
     pocket_id: str,
@@ -944,6 +1001,7 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     # docstring above ``_merge_compile_into_ripple_spec``). A stale /
     # missing slug logs a warning and leaves the rippleSpec unchanged —
     # the pocket still gets created and keeps the slug for retry.
+    loaded: dict[str, Any] | None = None
     if body.template_slug:
         from pocketpaw.bundled_templates import load_template
 
@@ -986,7 +1044,22 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     if body.session_id:
         await sessions_service.link_pocket(workspace_id, body.session_id, pocket.id)
 
-    await emit(PocketCreated(data=await _pocket_event_payload(doc)))
+    # Sense tier chunk 6a — a template can declare the Senses it needs. For each,
+    # check the tenant has an enabled provider; collect the ids with none. This
+    # NEVER blocks creation (the pocket is already inserted) — it logs a warning
+    # and rides out on the pocket.created event so the UX can prompt-to-connect.
+    missing_senses = await _check_template_needs(loaded, workspace_id)
+    if missing_senses:
+        logger.warning(
+            "template needs: pocket=%s slug=%r workspace=%s has no enabled "
+            "provider for senses %s — pocket created, prompt-to-connect surfaced",
+            str(doc.id),
+            body.template_slug,
+            workspace_id,
+            missing_senses,
+        )
+
+    await emit(PocketCreated(data=await _pocket_event_payload(doc, missing_senses=missing_senses)))
     return await _resolved_wire_dict(doc, user_id)
 
 

--- a/src/pocketpaw/bundled_templates/schema.py
+++ b/src/pocketpaw/bundled_templates/schema.py
@@ -11,6 +11,13 @@
 # (a Paw Site composed by conversion role) validates. The landing-page
 # template uses shape:"custom", which is already exempt from the
 # columns-required and default_view-matrix rules — no shape change needed.
+# Modified: 2026-06-08 (feat/sense-template-needs, Sense tier chunk 6a) —
+# added `needs: list[str]` to PocketTemplate: the Sense ids a vertical
+# template requires (e.g. ["paw.payments.v1"]). Each id is validated at
+# template-load via senses.validate_sense_id (a malformed / unknown paw.*
+# id raises SenseValidationError), mirroring the connector `senses:` field.
+# `needs` is tenant-capability METADATA, not ripple spec — it is read at
+# pocket-create to surface a prompt-to-connect when a provider is missing.
 """Pydantic v2 model for the RFC 03 v2 Pocket Template Schema.
 
 This module is the **schema chokepoint** — every bundled template, every
@@ -376,6 +383,10 @@ class PocketTemplate(BaseModel):
     state: StateBinding
     actions: list[ActionDef] = Field(default_factory=list)
     connectors: list[str] = Field(default_factory=list)
+    needs: list[str] = Field(
+        default_factory=list,
+        description="Sense ids this template requires, e.g. ['paw.email.v1'].",
+    )
     agents: list[AgentDef] = Field(default_factory=list)
     triggers: list[TriggerDef] = Field(default_factory=list)
     outcomes: list[str] = Field(default_factory=list)
@@ -408,6 +419,19 @@ class PocketTemplate(BaseModel):
     def _vertical_is_lower_slug(cls, v: str) -> str:
         if not v or v != v.lower() or any(ch.isspace() for ch in v):
             raise ValueError("vertical must be a lower-case slug")
+        return v
+
+    @field_validator("needs")
+    @classmethod
+    def _needs_are_valid_senses(cls, v: list[str]) -> list[str]:
+        # Validate each declared sense id at template-load — a malformed or
+        # unknown paw.* id raises SenseValidationError, consistent with the
+        # connector ``senses:`` validation. Imported inside the validator to
+        # avoid a top-level import cycle with the senses catalog.
+        from pocketpaw.senses import validate_sense_id
+
+        for sense_id in v:
+            validate_sense_id(sense_id)
         return v
 
     @model_validator(mode="after")

--- a/tests/cloud/pockets/test_template_needs.py
+++ b/tests/cloud/pockets/test_template_needs.py
@@ -1,0 +1,174 @@
+# tests/cloud/pockets/test_template_needs.py
+# Created: 2026-06-08 (feat/sense-template-needs, Sense tier chunk 6a) — pins
+# the pocket-create path's handling of a template's declared ``needs:`` Senses.
+# A vertical template can require provider-agnostic capabilities (e.g.
+# paw.payments.v1). At create() the service asks the EE Sense resolver whether
+# an enabled connector fills each; ids with no provider are collected and:
+#   - surfaced as ``missing_senses`` on the pocket.created event (the seam the
+#     prompt-to-connect UX consumes), and
+#   - NEVER block creation (mirrors the strict=False template tolerance).
+#
+# Tests mock both the OSS ``load_template`` (so no real template file is needed)
+# and the EE ``resolve`` (so no connector registry / Mongo connector state is
+# needed). Uses the shared ``mongo_db`` + autouse RecordingBus fixtures from
+# tests/cloud/conftest.py so create()'s insert + emit() succeed and the emitted
+# event is inspectable via the ``recording_bus`` fixture.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+from pocketpaw_ee.cloud.senses.resolver import ResolvedSense
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_needs"
+_USER = "user_needs"
+
+
+def _loaded_with_needs(needs: list[str]) -> dict:
+    """A minimal ``load_template`` result shape: {"meta": {...}, ...}.
+
+    ``_check_template_needs`` only reads ``loaded["meta"]["needs"]``, so the
+    rest of the meta can be empty for these tests.
+    """
+    return {"meta": {"needs": needs}, "ripple_spec": None}
+
+
+# ---------------------------------------------------------------------------
+# _check_template_needs — the pure-ish helper (resolve mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_returns_empty_when_all_senses_resolve() -> None:
+    """Every declared sense has an enabled provider → no missing ids."""
+    loaded = _loaded_with_needs(["paw.email.v1", "paw.payments.v1"])
+    resolved = ResolvedSense(sense_id="x", connector_name="gmail")
+    with patch(
+        "pocketpaw_ee.cloud.senses.resolver.resolve",
+        new=AsyncMock(return_value=resolved),
+    ):
+        missing = await pockets_service._check_template_needs(loaded, _WS)
+    assert missing == []
+
+
+@pytest.mark.asyncio
+async def test_check_returns_missing_ids_when_some_resolve_none() -> None:
+    """A sense with no enabled provider (resolve → None) is collected."""
+    loaded = _loaded_with_needs(["paw.email.v1", "paw.payments.v1"])
+
+    async def _fake_resolve(sense_id: str, workspace_id: str, **_kw):
+        # email is wired, payments is not
+        if sense_id == "paw.email.v1":
+            return ResolvedSense(sense_id=sense_id, connector_name="gmail")
+        return None
+
+    with patch("pocketpaw_ee.cloud.senses.resolver.resolve", new=_fake_resolve):
+        missing = await pockets_service._check_template_needs(loaded, _WS)
+    assert missing == ["paw.payments.v1"]
+
+
+@pytest.mark.asyncio
+async def test_check_guards_none_loaded() -> None:
+    """A None loaded result (stale/unknown slug) yields no missing ids."""
+    assert await pockets_service._check_template_needs(None, _WS) == []
+
+
+@pytest.mark.asyncio
+async def test_check_guards_no_needs() -> None:
+    """A template with no needs yields no missing ids."""
+    assert await pockets_service._check_template_needs(_loaded_with_needs([]), _WS) == []
+    assert await pockets_service._check_template_needs({"meta": {}}, _WS) == []
+
+
+@pytest.mark.asyncio
+async def test_check_swallows_resolver_error() -> None:
+    """A resolver exception never propagates — the offending id is skipped,
+    create() must not blow up on a resolver hiccup."""
+    loaded = _loaded_with_needs(["paw.email.v1"])
+    with patch(
+        "pocketpaw_ee.cloud.senses.resolver.resolve",
+        new=AsyncMock(side_effect=RuntimeError("registry down")),
+    ):
+        missing = await pockets_service._check_template_needs(loaded, _WS)
+    assert missing == []
+
+
+# ---------------------------------------------------------------------------
+# create() — surfaces missing_senses on the event, NEVER blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_not_blocked_and_emits_missing_senses(recording_bus) -> None:
+    """Creating a pocket from a template with an unfilled need still succeeds
+    AND attaches the missing sense id to the pocket.created event."""
+    loaded = _loaded_with_needs(["paw.payments.v1"])
+
+    with (
+        patch(
+            "pocketpaw.bundled_templates.load_template",
+            return_value=loaded,
+        ),
+        # No compile output → rippleSpec untouched (we only care about needs).
+        patch.object(pockets_service, "_compile_template_to_runtime_dict", return_value=None),
+        patch(
+            "pocketpaw_ee.cloud.senses.resolver.resolve",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        wire = await pockets_service.create(
+            _WS,
+            _USER,
+            CreatePocketRequest(name="Invoice chaser", template_slug="invoice-chaser"),
+        )
+
+    # Creation was NOT blocked.
+    assert wire["name"] == "Invoice chaser"
+    assert wire["_id"]
+
+    # The pocket.created event carries the missing sense for the UX.
+    created = [e for e in recording_bus.events if e.EVENT_TYPE == "pocket.created"]
+    assert len(created) == 1
+    assert created[0].data.get("missing_senses") == ["paw.payments.v1"]
+
+
+@pytest.mark.asyncio
+async def test_create_omits_missing_senses_when_all_resolve(recording_bus) -> None:
+    """When every need resolves, the event carries no missing_senses key."""
+    loaded = _loaded_with_needs(["paw.email.v1"])
+
+    with (
+        patch("pocketpaw.bundled_templates.load_template", return_value=loaded),
+        patch.object(pockets_service, "_compile_template_to_runtime_dict", return_value=None),
+        patch(
+            "pocketpaw_ee.cloud.senses.resolver.resolve",
+            new=AsyncMock(
+                return_value=ResolvedSense(sense_id="paw.email.v1", connector_name="gmail")
+            ),
+        ),
+    ):
+        wire = await pockets_service.create(
+            _WS,
+            _USER,
+            CreatePocketRequest(name="Mail thing", template_slug="mail-thing"),
+        )
+
+    assert wire["name"] == "Mail thing"
+    created = [e for e in recording_bus.events if e.EVENT_TYPE == "pocket.created"]
+    assert len(created) == 1
+    assert "missing_senses" not in created[0].data
+
+
+@pytest.mark.asyncio
+async def test_create_without_template_has_no_missing_senses(recording_bus) -> None:
+    """A plain pocket (no template_slug) never carries missing_senses."""
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name="plain"))
+    assert wire["name"] == "plain"
+    created = [e for e in recording_bus.events if e.EVENT_TYPE == "pocket.created"]
+    assert len(created) == 1
+    assert "missing_senses" not in created[0].data

--- a/tests/unit/test_template_schema.py
+++ b/tests/unit/test_template_schema.py
@@ -499,3 +499,66 @@ def test_loader_strict_default_is_false_for_back_compat(tmp_path: Path) -> None:
     # No ``strict`` kwarg at all — should NOT raise.
     result = load_template("bad-template", templates_dir=tmp_path)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Sense tier chunk 6a — PocketTemplate.needs (declared Sense ids)
+# ---------------------------------------------------------------------------
+
+
+def test_needs_defaults_empty() -> None:
+    """A template with no ``needs:`` key reads back an empty list — the
+    field is backwards-compatible with every pre-Sense template."""
+    template = PocketTemplate.model_validate(_minimal_v2_dict())
+    assert template.needs == []
+
+
+def test_needs_with_valid_core_senses_parses() -> None:
+    """A template declaring valid core Sense ids validates and round-trips."""
+    meta = _minimal_v2_dict()
+    meta["needs"] = ["paw.payments.v1", "paw.email.v1"]
+    template = PocketTemplate.model_validate(meta)
+    assert template.needs == ["paw.payments.v1", "paw.email.v1"]
+
+
+def test_needs_with_valid_extension_sense_parses() -> None:
+    """A vendor-namespace (extension) sense id is accepted freely."""
+    meta = _minimal_v2_dict()
+    meta["needs"] = ["acme.crm.v1"]
+    template = PocketTemplate.model_validate(meta)
+    assert template.needs == ["acme.crm.v1"]
+
+
+def test_needs_with_unknown_paw_sense_raises() -> None:
+    """An unknown paw.* id fails validation — the core namespace is closed, so
+    a template can't silently fragment it. The ``needs`` field_validator calls
+    ``validate_sense_id``, which raises ``SenseValidationError``; Pydantic wraps
+    that in a ``ValidationError`` whose underlying cause is the SenseValidationError
+    (a ``ValueError`` subclass)."""
+    from pydantic import ValidationError
+
+    from pocketpaw.senses import SenseValidationError
+
+    meta = _minimal_v2_dict()
+    meta["needs"] = ["paw.telepathy.v1"]
+    with pytest.raises(ValidationError) as exc_info:
+        PocketTemplate.model_validate(meta)
+    underlying = exc_info.value.errors()[0]["ctx"]["error"]
+    assert isinstance(underlying, SenseValidationError)
+    assert "unknown core sense id" in str(underlying)
+
+
+def test_needs_with_malformed_sense_raises() -> None:
+    """A malformed sense id (no version suffix) fails validation — the
+    underlying error is a SenseValidationError raised by validate_sense_id."""
+    from pydantic import ValidationError
+
+    from pocketpaw.senses import SenseValidationError
+
+    meta = _minimal_v2_dict()
+    meta["needs"] = ["paw.email"]
+    with pytest.raises(ValidationError) as exc_info:
+        PocketTemplate.model_validate(meta)
+    underlying = exc_info.value.errors()[0]["ctx"]["error"]
+    assert isinstance(underlying, SenseValidationError)
+    assert "malformed core sense id" in str(underlying)


### PR DESCRIPTION
Stacked on #1383 (→ #1381 → #1380). Review and merge those first.

## What this adds

A pocket template can declare the capabilities it needs, by Sense rather than by connector:

```yaml
needs:
  - paw.payments.v1
  - paw.email.v1
```

At pocket-create time, each need is checked against the tenant's enabled connectors. If something has no provider, the create still goes through and the unfilled Senses come back on the `pocket.created` event as `missing_senses`, so the UX can prompt the user to connect one. This is the piece that lets one vertical template run across tenants with different connector stacks.

## Why it doesn't block

Creation is never blocked on a missing provider — it mirrors the existing `strict=False` tolerance in the create path. A missing Sense is a prompt, not an error. A resolver hiccup is swallowed and logged, never fatal.

## Pieces

- `needs: list[str]` on `PocketTemplate`, with a validator that runs each id through the Sense validator at template-load (a malformed or unknown `paw.*` id is rejected, same rule as the connector `senses:` field).
- `_check_template_needs()` in the pocket service: resolves each need for the workspace and returns the unfilled ones. `create()` logs a warning and attaches `missing_senses` to the `pocket.created` event. No new model field, no migration.

## Testing

`uv run pytest tests/unit/test_template_schema.py tests/cloud/pockets/test_template_needs.py` reports 45 passing. `lint-imports` clean. `needs` is template metadata, so it is not merged into the rippleSpec — the compile path is unchanged.
