### PR TITLE
feat(senses): pocket data source can read from a Sense

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_router/router.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/router.py
@@ -229,6 +229,7 @@ async def _run_tier0(
             auth_header=auth_header,
             token=token,
             only_source=classification.op_args.get("source"),
+            workspace_id=workspace_id,
         )
         errors = result.get("errors") or []
         if errors:

--- a/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
+++ b/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
@@ -163,6 +163,7 @@ async def _refresh_one_pocket(pocket: dict) -> None:
                 auth_header=auth_header,
                 token=token,
                 only_source=key,
+                workspace_id=workspace_id,
             )
             if result.get("errors"):
                 logger.debug(

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -697,6 +697,7 @@ async def run_pocket_sources(
         token=token,
         trigger=body.trigger,
         only_source=body.source,
+        workspace_id=workspace_id,
     )
 
 
@@ -782,6 +783,7 @@ async def webhook_refresh_source(
         auth_header=auth_header,
         token=token,
         only_source=source,
+        workspace_id=workspace_id,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -36,6 +36,19 @@
 # IMPORT-LINTER: must NOT import `pocketpaw_ee.cloud.models.*`. The executor
 # receives base_url / auth / spec by parameter only — `pockets/service.py`
 # owns all Beanie access.
+#
+# Updated: 2026-06-08 (feat/sense-source, Sense tier chunk 6b) — a source
+#   binding can now be `type: "sense"`: it resolves a provider-agnostic Sense
+#   via `senses.resolver.execute_sense` instead of an HTTP GET, unwraps the
+#   ExecuteActionResponse to its `.data` payload, and binds that into state
+#   with the SAME `{source, bind, value}` row shape the http path returns. A
+#   resolver refusal (ok=False) maps to a per-source `_SourceError` so the
+#   error-aggregation loop treats it exactly like an http failure — siblings
+#   keep running. `SourceBinding` gained `type` (default "http"), optional
+#   `sense_id`/`action`/`params` (params are STATIC in v1 — no `{state.x}`
+#   evaluation). `path` is now optional (required only for http, enforced at
+#   run). `run_sources` gained an optional `workspace_id`, threaded with the
+#   existing `pocket_id`/`user_id` into `_run_one` for sense resolution.
 
 from __future__ import annotations
 
@@ -102,11 +115,20 @@ class SourceBinding(BaseModel):
     honored. ``None`` means "use the floor as the interval".
     """
 
+    type: Literal["http", "sense"] = "http"
     method: Literal["GET"] = "GET"
-    path: str
+    # ``path`` is required for http sources, unused for sense sources. Kept
+    # optional here so a sense entry survives parse; the http path raises a
+    # clean per-source error if a misconfigured http source has no path.
+    path: str | None = None
     bind: str
     refresh: list[RefreshTrigger] = Field(default_factory=lambda: _DEFAULT_REFRESH.copy())
     refresh_interval_seconds: int | None = Field(default=None, ge=1)
+    # Sense-source fields (type == "sense"). ``params`` are STATIC in v1 —
+    # passed through to the Sense resolver as-is (no ``{state.x}`` evaluation).
+    sense_id: str | None = None
+    action: str | None = None
+    params: dict | None = None
 
 
 def _normalize_bind(bind: str) -> str:
@@ -222,6 +244,52 @@ def _parse_bindings(ripple_spec: dict) -> tuple[dict[str, SourceBinding], list[d
     return bindings, errors
 
 
+async def _run_sense_binding(
+    *,
+    key: str,
+    binding: SourceBinding,
+    workspace_id: str | None,
+    pocket_id: str,
+    user_id: str,
+) -> dict:
+    """Resolve a ``type="sense"`` source via the Sense resolver.
+
+    Returns the SAME success row shape the http path returns —
+    ``{"source", "bind", "value"}`` — with ``value`` UNWRAPPED to the
+    underlying ``ExecuteActionResponse.data`` payload (state gets the actual
+    data, not the envelope). On a resolver refusal (``ok=False`` — no
+    provider, or read-first approval gate) it raises ``_SourceError`` with
+    the resolver's stable code/message, so the aggregation loop treats it as
+    a per-source error exactly like an http failure (does NOT abort siblings).
+
+    ``params`` are STATIC in v1 — passed through as-is (no ``{state.x}``).
+    """
+    # Lazy import: avoids a top-level cycle and keeps the SSRF/http core of
+    # this module importable without the senses subsystem.
+    from pocketpaw_ee.cloud.senses.resolver import execute_sense
+
+    result = await execute_sense(
+        binding.sense_id,
+        binding.action,
+        binding.params or {},
+        workspace_id,
+        pocket_id=pocket_id,
+        user_id=user_id,
+    )
+    if not result.ok:
+        # Map the resolver refusal onto the same per-source error shape http
+        # failures use, so ``run_sources``'s error aggregation is unchanged.
+        raise _SourceError(
+            result.message or "sense source failed",
+            code=result.error or "sense_error",
+        )
+
+    # result.data is the ExecuteActionResponse; result.data.data is the
+    # payload that should land in pocket state.
+    payload = getattr(result.data, "data", None)
+    return {"source": key, "bind": _normalize_bind(binding.bind), "value": payload}
+
+
 async def _run_one(
     *,
     client: httpx.AsyncClient,
@@ -229,10 +297,30 @@ async def _run_one(
     binding: SourceBinding,
     base_url: str,
     headers: dict[str, str],
+    workspace_id: str | None,
+    pocket_id: str,
+    user_id: str,
 ) -> dict:
     """Fetch a single source. Returns a ``ran`` row; raises ``_GuardError``
     (the shared guard rejections) or its ``_SourceError`` subclass (the
-    read executor's own per-source failures)."""
+    read executor's own per-source failures).
+
+    Branches on ``binding.type``: a ``"sense"`` source resolves via the
+    Sense resolver (``_run_sense_binding``); the default ``"http"`` source
+    runs the SSRF-guarded GET below, unchanged."""
+    if binding.type == "sense":
+        return await _run_sense_binding(
+            key=key,
+            binding=binding,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+        )
+
+    if not binding.path:
+        # An http source with no path is a misconfiguration — surface it as a
+        # clean per-source error rather than crashing _resolve_url.
+        raise _SourceError("http source has no path", code="bad_source")
     url = _resolve_url(base_url, binding.path)
     await _assert_host_external(urllib.parse.urlsplit(url).hostname or "")
 
@@ -278,6 +366,7 @@ async def run_sources(
     token: str,
     trigger: str | None = None,
     only_source: str | None = None,
+    workspace_id: str | None = None,
 ) -> dict:
     """Run the pocket's selected read-only sources and return the results.
 
@@ -363,6 +452,9 @@ async def run_sources(
                         binding=binding,
                         base_url=base_url,
                         headers=headers,
+                        workspace_id=workspace_id,
+                        pocket_id=pocket_id,
+                        user_id=user_id,
                     ),
                     timeout=_PER_SOURCE_TIMEOUT_S,
                 )

--- a/src/pocketpaw/bundled_templates/schema.py
+++ b/src/pocketpaw/bundled_templates/schema.py
@@ -18,6 +18,13 @@
 # id raises SenseValidationError), mirroring the connector `senses:` field.
 # `needs` is tenant-capability METADATA, not ripple spec — it is read at
 # pocket-create to surface a prompt-to-connect when a provider is missing.
+# Modified: 2026-06-08 (feat/sense-source, Sense tier chunk 6b) — DataSourceDef
+# gains a `type: "http"|"sense"` field (default "http", backward compatible).
+# `path` is now optional (required only for http via the type validator);
+# sense sources add `sense_id`, `action`, `params`. A model validator enforces
+# path-required-for-http and sense_id+action-required-for-sense, and validates
+# sense_id via senses.validate_sense_id. The resolved Sense value binds into
+# state like any HTTP source, so Ripple needs no changes.
 """Pydantic v2 model for the RFC 03 v2 Pocket Template Schema.
 
 This module is the **schema chokepoint** — every bundled template, every
@@ -303,27 +310,62 @@ class TriggerDef(BaseModel):
 
 
 class DataSourceDef(BaseModel):
-    """One read-only source that hydrates state at runtime (RFC 04)."""
+    """One read-only source that hydrates state at runtime (RFC 04).
+
+    Two source ``type``s:
+
+    * ``http`` (default, backward-compatible) — a relative-path HTTP GET.
+      ``path`` is required.
+    * ``sense`` — resolves a provider-agnostic Sense (Sense tier chunk 6b).
+      ``sense_id`` + ``action`` are required; the resolved value lands in
+      ``bind`` like any other source, so Ripple needs no changes. ``params``
+      are STATIC in v1 (no ``{state.x}`` evaluation yet).
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     name: str
+    type: Literal["http", "sense"] = "http"
     method: DataSourceMethodT = "GET"
-    path: str = Field(
-        ...,
-        description="Relative path; never absolute (SSRF-safe by RFC 04).",
+    path: str | None = Field(
+        default=None,
+        description="Relative path (http sources); never absolute (SSRF-safe by RFC 04).",
     )
     bind: str = Field(..., description="state path that receives the result.")
     refresh: list[str] = Field(default_factory=lambda: ["pocket_open", "manual"])
     transform: str | None = None
+    # Sense-source fields (type == "sense").
+    sense_id: str | None = None
+    action: str | None = None
+    params: dict[str, Any] | None = None
 
     @field_validator("path")
     @classmethod
-    def _path_is_relative(cls, v: str) -> str:
-        # SSRF safety per RFC 04: relative paths only.
-        if v.startswith(("http://", "https://", "//", "ftp://")):
+    def _path_is_relative(cls, v: str | None) -> str | None:
+        # SSRF safety per RFC 04: relative paths only. Only enforced when
+        # present — a sense source has no path.
+        if v is not None and v.startswith(("http://", "https://", "//", "ftp://")):
             raise ValueError("data_sources[].path must be relative, not absolute")
         return v
+
+    @model_validator(mode="after")
+    def _type_conditionals(self) -> DataSourceDef:
+        if self.type == "http":
+            if not self.path:
+                raise ValueError("data_sources[].path is required when type='http'")
+        elif self.type == "sense":
+            if not self.sense_id or not self.action:
+                raise ValueError(
+                    "data_sources[].sense_id and .action are required when type='sense'"
+                )
+            # Validate the sense id at template-load, consistent with the
+            # connector ``senses:`` and template ``needs:`` validation. Imported
+            # inside the validator to avoid a top-level import cycle with the
+            # senses catalog. A malformed/unknown paw.* id raises.
+            from pocketpaw.senses import validate_sense_id
+
+            validate_sense_id(self.sense_id)
+        return self
 
 
 class PermissionsDef(BaseModel):

--- a/tests/cloud/test_pocket_source_executor.py
+++ b/tests/cloud/test_pocket_source_executor.py
@@ -7,6 +7,11 @@
 # required user_id; added coverage for basic-auth base64 encoding, the
 # per-(pocket, user) rate-limit key, the async-safe limiter under
 # asyncio.gather, and the audit-log entry written for every run.
+# Updated: 2026-06-08 (feat/sense-source, Sense tier chunk 6b) — coverage for
+# the new type="sense" source: a mocked execute_sense ok-result binds the
+# unwrapped .data.data payload to state in the same {source,bind,value} row
+# shape; an ok=False result lands in the errors aggregation with the
+# resolver's stable code/message and does NOT abort a sibling http source.
 #
 # What this pins:
 #   - SSRF rejections: absolute-URL path, `..` traversal, path to a
@@ -638,3 +643,173 @@ async def test_rate_limited_run_audits_as_rate_limited(monkeypatch):
             token="",
         )
     assert logged[-1].status == "rate-limited"
+
+
+# ---------------------------------------------------------------------------
+# Sense sources (Sense tier chunk 6b) — type="sense" resolves via the Sense
+# resolver, NOT httpx. execute_sense is mocked; no connectors are needed.
+# ---------------------------------------------------------------------------
+
+
+def _patch_execute_sense(monkeypatch, fake):
+    """Patch the lazily-imported ``execute_sense`` on the resolver module.
+
+    ``_run_sense_binding`` does ``from ...senses.resolver import execute_sense``
+    at call time, so patching the attribute on that module is what takes
+    effect.
+    """
+    import pocketpaw_ee.cloud.senses.resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "execute_sense", fake)
+
+
+async def test_sense_source_binds_unwrapped_payload(monkeypatch):
+    """An ok sense result writes ``result.data.data`` (the unwrapped payload)
+    to the bound state path, in the same ``{source, bind, value}`` row shape
+    the http path returns."""
+    from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+    class _Resp:
+        # Stand-in for ExecuteActionResponse — only `.data` is read.
+        data = [{"id": "m1", "subject": "hello"}]
+        success = True
+
+    captured = {}
+
+    async def _fake(sense_id, action, params, workspace_id, *, pocket_id=None, user_id=None):
+        captured.update(
+            sense_id=sense_id,
+            action=action,
+            params=params,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+        )
+        return SenseExecutionResult(
+            ok=True, sense_id=sense_id, connector_name="gmail", action=action, data=_Resp()
+        )
+
+    _patch_execute_sense(monkeypatch, _fake)
+
+    spec = {
+        "sources": {
+            "inbox": {
+                "type": "sense",
+                "sense_id": "paw.email.v1",
+                "action": "gmail_search",
+                "params": {"q": "is:unread"},
+                "bind": "state.inbox",
+            }
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+    )
+
+    assert result["errors"] == []
+    assert len(result["ran"]) == 1
+    ran = result["ran"][0]
+    assert ran["source"] == "inbox"
+    assert ran["bind"] == "inbox"  # `state.` stripped
+    assert ran["value"] == [{"id": "m1", "subject": "hello"}]  # unwrapped .data.data
+    # Identity + static params threaded through to the resolver.
+    assert captured["sense_id"] == "paw.email.v1"
+    assert captured["action"] == "gmail_search"
+    assert captured["params"] == {"q": "is:unread"}
+    assert captured["workspace_id"] == "ws-1"
+    assert captured["pocket_id"] == "p1"
+    assert captured["user_id"] == "runner-1"
+
+
+async def test_sense_source_failure_lands_in_errors(monkeypatch):
+    """A sense result with ok=False lands in the errors aggregation with the
+    resolver's stable code/message — it does NOT crash the run."""
+    from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+    async def _fake(sense_id, action, params, workspace_id, *, pocket_id=None, user_id=None):
+        return SenseExecutionResult(
+            ok=False,
+            sense_id=sense_id,
+            error="sense.no_provider",
+            message="no connector fills paw.email.v1 for this workspace",
+        )
+
+    _patch_execute_sense(monkeypatch, _fake)
+
+    spec = {
+        "sources": {
+            "inbox": {
+                "type": "sense",
+                "sense_id": "paw.email.v1",
+                "action": "gmail_search",
+                "bind": "state.inbox",
+            }
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+    )
+
+    assert result["ran"] == []
+    assert len(result["errors"]) == 1
+    err = result["errors"][0]
+    assert err["source"] == "inbox"
+    assert err["code"] == "sense.no_provider"
+    assert "no connector fills" in err["error"]
+
+
+async def test_failed_sense_does_not_abort_sibling_http_source(monkeypatch):
+    """A failed sense source is contained — a sibling http source in the same
+    run still completes."""
+    from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+    async def _fake(sense_id, action, params, workspace_id, *, pocket_id=None, user_id=None):
+        return SenseExecutionResult(
+            ok=False, sense_id=sense_id, error="sense.no_provider", message="no provider"
+        )
+
+    _patch_execute_sense(monkeypatch, _fake)
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": True}))
+
+    spec = {
+        "sources": {
+            "inbox": {
+                "type": "sense",
+                "sense_id": "paw.email.v1",
+                "action": "gmail_search",
+                "bind": "state.inbox",
+            },
+            "prs": {"method": "GET", "path": "/pulls", "bind": "state.prs"},
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+    )
+
+    # The http sibling succeeds; the sense source is the only error.
+    ran_sources = {r["source"] for r in result["ran"]}
+    err_sources = {e["source"] for e in result["errors"]}
+    assert ran_sources == {"prs"}
+    assert err_sources == {"inbox"}
+    assert result["ran"][0]["value"] == {"ok": True}

--- a/tests/unit/test_template_schema.py
+++ b/tests/unit/test_template_schema.py
@@ -562,3 +562,117 @@ def test_needs_with_malformed_sense_raises() -> None:
     underlying = exc_info.value.errors()[0]["ctx"]["error"]
     assert isinstance(underlying, SenseValidationError)
     assert "malformed core sense id" in str(underlying)
+
+
+# ---------------------------------------------------------------------------
+# DataSourceDef — http (default) + sense source types (Sense tier chunk 6b)
+# ---------------------------------------------------------------------------
+
+
+def test_data_source_http_default_parses() -> None:
+    """A bare source (no ``type``) defaults to http and requires ``path`` — the
+    backward-compatible shape every pre-Sense source uses."""
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    src = DataSourceDef.model_validate({"name": "prs", "path": "/api/prs", "bind": "state.prs"})
+    assert src.type == "http"
+    assert src.path == "/api/prs"
+    assert src.sense_id is None
+
+
+def test_data_source_http_missing_path_raises() -> None:
+    """An http source with no ``path`` fails — the type validator requires it."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate({"name": "prs", "bind": "state.prs"})
+    assert "path is required when type='http'" in str(exc_info.value)
+
+
+def test_data_source_sense_parses() -> None:
+    """A sense source (type=sense, sense_id+action) validates and round-trips;
+    ``path`` is not required."""
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    src = DataSourceDef.model_validate(
+        {
+            "name": "inbox",
+            "type": "sense",
+            "sense_id": "paw.email.v1",
+            "action": "gmail_search",
+            "params": {"q": "is:unread"},
+            "bind": "state.inbox",
+        }
+    )
+    assert src.type == "sense"
+    assert src.sense_id == "paw.email.v1"
+    assert src.action == "gmail_search"
+    assert src.params == {"q": "is:unread"}
+    assert src.path is None
+
+
+def test_data_source_sense_missing_sense_id_raises() -> None:
+    """A sense source without ``sense_id`` fails the type validator."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate(
+            {"name": "inbox", "type": "sense", "action": "gmail_search", "bind": "state.inbox"}
+        )
+    assert "sense_id and .action are required" in str(exc_info.value)
+
+
+def test_data_source_sense_missing_action_raises() -> None:
+    """A sense source without ``action`` fails the type validator."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate(
+            {"name": "inbox", "type": "sense", "sense_id": "paw.email.v1", "bind": "state.inbox"}
+        )
+    assert "sense_id and .action are required" in str(exc_info.value)
+
+
+def test_data_source_sense_unknown_paw_id_raises() -> None:
+    """A sense source with an unknown paw.* id fails — sense_id is validated via
+    ``validate_sense_id`` at parse, mirroring the template ``needs:`` rule."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+    from pocketpaw.senses import SenseValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate(
+            {
+                "name": "inbox",
+                "type": "sense",
+                "sense_id": "paw.telepathy.v1",
+                "action": "read_minds",
+                "bind": "state.inbox",
+            }
+        )
+    # The SenseValidationError surfaces as the underlying cause of the model
+    # validator error.
+    msg = str(exc_info.value)
+    assert "unknown core sense id" in msg or isinstance(
+        exc_info.value.errors()[0].get("ctx", {}).get("error"), SenseValidationError
+    )
+
+
+def test_data_source_http_absolute_path_still_rejected() -> None:
+    """The relative-path SSRF guard still fires for http sources."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate(
+            {"name": "prs", "path": "https://evil.example/api", "bind": "state.prs"}
+        )
+    assert "must be relative" in str(exc_info.value)


### PR DESCRIPTION
Stacked on #1384 (→ #1383 → #1381 → #1380). Review and merge the base chain first.

## What this adds

A pocket data source can read from a Sense. Until now RFC-04 sources hydrated state from an HTTP GET only. This adds a `sense` source type:

```json
{
  "name": "inbox",
  "type": "sense",
  "sense_id": "paw.email.v1",
  "action": "gmail_search",
  "params": { "q": "is:unread" },
  "bind": "state.inbox"
}
```

The executor resolves the Sense to the tenant's connector, runs the read action, and writes the result into `state.inbox`. So a pocket spec can bind live data by capability without naming the provider — the declarative counterpart to the agent's `sense_execute` tool.

## Ripple needs no change

The resolved value lands in `state` like any other source, so ripple reads it through the existing expression resolver. This is entirely server-side.

## Read-first and failure handling

Execution goes through the resolver's `execute_sense`, which owns the read-first gate, so a write or unmapped action is refused and never runs. A refusal or a no-provider result folds into the same per-source error aggregation HTTP failures already use, so one bad source never aborts its siblings. `params` are static in v1 — no `{state.x}` evaluation yet.

## Pieces

- `DataSourceDef` (template schema) and `SourceBinding` (runtime) gain `type` (default `http`, backward compatible), `sense_id`, `action`, `params`. `path` becomes optional; a validator requires `path` for http and `sense_id`+`action` for sense.
- `_run_sense_binding()` in the executor, branched ahead of the HTTP path. `run_sources` gained an optional `workspace_id`, threaded from the four callers that already had it in scope.

## Testing

`uv run pytest tests/unit/test_template_schema.py tests/cloud/test_pocket_source_executor.py` reports 70 passing (14 new). Full sense + connector + pocket-source regression is green (219). `lint-imports` clean.

## Known follow-up

`run_sources` still validates the backend base URL even when every selected source is a Sense, so a sense-only pocket with no HTTP backend would be rejected at that gate. Out of scope here; worth revisiting if sense-only pockets become a real shape.
