### PR TITLE
feat(senses): Sense capability tier (integration)

### DIFF
--- a/connectors/drive.yaml
+++ b/connectors/drive.yaml
@@ -9,6 +9,9 @@ display_name: Google Drive
 type: knowledge
 icon: cloud
 
+senses:
+  - paw.docs.v1
+
 auth:
   method: bearer
   credentials:

--- a/connectors/gcalendar.yaml
+++ b/connectors/gcalendar.yaml
@@ -7,6 +7,9 @@ display_name: Google Calendar
 type: communication
 icon: calendar
 
+senses:
+  - paw.calendar.v1
+
 auth:
   method: oauth2
   credentials:

--- a/connectors/gdocs.yaml
+++ b/connectors/gdocs.yaml
@@ -6,6 +6,9 @@ display_name: Google Docs
 type: knowledge
 icon: file-text
 
+senses:
+  - paw.docs.v1
+
 auth:
   method: oauth2
   credentials:

--- a/connectors/github.yaml
+++ b/connectors/github.yaml
@@ -30,6 +30,9 @@ surface_profile:
   allow_tools: []
   deny_tools: []
 
+senses:
+  - paw.code.v1
+
 auth:
   method: bearer
   headers:

--- a/connectors/gitlab.yaml
+++ b/connectors/gitlab.yaml
@@ -6,6 +6,9 @@ display_name: GitLab
 type: developer
 icon: git-merge
 
+senses:
+  - paw.code.v1
+
 auth:
   method: bearer
   credentials:

--- a/connectors/gmail.yaml
+++ b/connectors/gmail.yaml
@@ -41,6 +41,9 @@ surface_profile:
   allow_tools: []
   deny_tools: []
 
+senses:
+  - paw.email.v1
+
 auth:
   method: oauth2
   credentials:

--- a/connectors/mongodb.yaml
+++ b/connectors/mongodb.yaml
@@ -8,6 +8,9 @@ display_name: MongoDB
 type: database
 icon: database
 
+senses:
+  - paw.db.v1
+
 auth:
   method: none
   credentials:

--- a/connectors/postgresql.yaml
+++ b/connectors/postgresql.yaml
@@ -6,6 +6,9 @@ display_name: PostgreSQL
 type: database
 icon: server
 
+senses:
+  - paw.db.v1
+
 auth:
   method: none
   credentials:

--- a/connectors/stripe.yaml
+++ b/connectors/stripe.yaml
@@ -6,6 +6,9 @@ name: stripe
 display_name: Stripe
 type: payment
 icon: credit-card
+
+senses:
+  - paw.payments.v1
 auth:
   method: api_key
   credentials:

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,10 @@
 <!--
   Connectors documentation.
+  Updated: 2026-06-08 (sense-mcp / Sense tier chunk 4) — added the Senses
+  section: the "Sense" glossary entry, the sense-vs-connector distinction, and
+  the two new agent tools (list_senses / sense_execute on the same
+  pocketpaw_connectors MCP server) that address a capability instead of a
+  provider, with the resolver binding it to the tenant's enabled connector.
   Updated: 2026-06-08 (connector-mcp-execution / keystone) — documented the
   agent-callable connector tool surface (list_connector_actions /
   connector_execute on the pocketpaw_connectors MCP server), the v1
@@ -273,6 +278,57 @@ connector_execute("gmail", "gmail_search",
 
 connector_execute("gmail", "gmail_send", {...})
   → blocked: "needs approval (coming in v2). Not executed."
+```
+
+## Senses — provider-agnostic capabilities above connectors
+
+> **Glossary — Sense.** A provider-agnostic capability that sits one layer above
+> connectors. Templates and agents address a Sense (e.g. `paw.email.v1`,
+> `paw.code.v1`) instead of a specific connector; the resolver binds the Sense
+> to whichever connector the tenant enabled for that capability in the current
+> workspace. A Sense is the *what* (email, calendar, code); a connector is the
+> *how* (Gmail, Google Calendar, GitHub). This is the anti-fragmentation rule:
+> the core Sense vocabulary is closed and curated, so one template works across
+> every tenant regardless of which providers they connected.
+
+A **Sense** is a capability addressed by what it *does*, not by which vendor
+provides it. `paw.email.v1` means "email" regardless of whether the tenant
+enabled Gmail, Outlook, or anything else; `paw.code.v1` means
+"repos/issues/PRs" whether that's GitHub or GitLab. Templates and agents
+address a Sense, and the **resolver** binds it to whichever connector the
+tenant actually enabled in this workspace. This keeps templates portable: a
+"weekly digest" template asks for `paw.email.v1` and works for every tenant
+without hard-coding a provider.
+
+Two MCP tools on the same `pocketpaw_connectors` server expose Senses to the
+chat agent:
+
+| Tool | What it does |
+|------|--------------|
+| `list_senses()` | Lists the capabilities (Senses) that resolve to a connector in the **current pocket** — each with the bound `connector`, whether the choice was `ambiguous` (more than one provider, no preference set), and the `candidates`. No arguments; the pocket comes from the active chat. |
+| `sense_execute(sense, action, params)` | Runs ONE READ action against a Sense **without naming the connector** — the resolver picks the provider. Read (auto-trust) actions execute; writes are refused. |
+
+**Sense vs connector.** Use `connector_execute` when you already know the
+provider (the user said "GitHub" or "Gmail"); use `sense_execute` when the
+user asks by capability ("check my email", "list my open PRs") and you want
+the resolver to pick the enabled provider. `sense_execute` enforces the same
+read-first policy as `connector_execute` — the resolver only runs `auto`-trust
+actions; `confirm` / `restricted` (write-shaped) actions are refused with a
+"needs approval" message and never executed. When no enabled connector fills
+the sense, `sense_execute` returns a clear "no provider" error so the agent
+can prompt the user to connect one.
+
+```
+list_senses()
+  → [{"sense": "paw.email.v1", "connector": "gmail", "ambiguous": false, ...},
+     {"sense": "paw.code.v1",  "connector": "github", ...}]
+
+sense_execute("paw.email.v1", "gmail_search",
+             {"query": "from:acme.com subject:invoice"})
+  → runs against the resolved connector (gmail), returns matching stubs
+
+sense_execute("paw.email.v1", "gmail_send", {...})
+  → refused: "needs approval … not executed in v1 (read-first)."
 ```
 
 ## Using with Existing Integrations

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -303,8 +303,7 @@ async def _list_senses_handler(args: dict) -> dict:  # noqa: ARG001 — no args
     workspace_id, _user_id, pocket_id = _identity()
     if not workspace_id:
         return _error_response(
-            "no active workspace — list_senses can only be called from inside a "
-            "cloud chat stream"
+            "no active workspace — list_senses can only be called from inside a cloud chat stream"
         )
 
     from pocketpaw.senses import CORE_SENSES
@@ -368,8 +367,7 @@ async def _sense_execute_handler(args: dict) -> dict:
     workspace_id, user_id, pocket_id = _identity()
     if not workspace_id:
         return _error_response(
-            "no active workspace — sense_execute can only be called from inside a "
-            "cloud chat stream"
+            "no active workspace — sense_execute can only be called from inside a cloud chat stream"
         )
     if not pocket_id:
         return _error_response(

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -14,6 +14,16 @@
 #   sites servers use. Tool ids namespace as ``mcp__pocketpaw_connectors__*``.
 #   OSS-EE boundary: this module imports only ``connectors.service`` (which owns
 #   the Beanie read), never the WorkspaceConnector doc directly.
+# Updated: 2026-06-08 (feat/sense-mcp / Sense tier chunk 4) — added the Sense
+#   agent surface alongside the connector surface: two more tools,
+#   ``list_senses`` (which provider-agnostic capabilities resolve in this
+#   pocket?) and ``sense_execute`` (run a READ action against a Sense without
+#   naming the connector). Both delegate to ``cloud.senses.resolver`` —
+#   ``list_senses`` resolves each CORE_SENSES entry via ``resolve`` and reports
+#   the bound connector; ``sense_execute`` calls ``execute_sense``, which OWNS
+#   the read-first gate (only trust=auto runs) so this module does NOT re-gate.
+#   Tool ids namespace as ``mcp__pocketpaw_connectors__list_senses`` /
+#   ``…__sense_execute``.
 """Agent-side MCP surface for executing a pocket's bound connectors.
 
 Tools registered:
@@ -48,10 +58,14 @@ SERVER_NAME = "pocketpaw_connectors"
 # Allowlist entries must use this exact form.
 LIST_CONNECTOR_ACTIONS_TOOL_ID = f"mcp__{SERVER_NAME}__list_connector_actions"
 CONNECTOR_EXECUTE_TOOL_ID = f"mcp__{SERVER_NAME}__connector_execute"
+LIST_SENSES_TOOL_ID = f"mcp__{SERVER_NAME}__list_senses"
+SENSE_EXECUTE_TOOL_ID = f"mcp__{SERVER_NAME}__sense_execute"
 
 CONNECTOR_TOOL_IDS = (
     LIST_CONNECTOR_ACTIONS_TOOL_ID,
     CONNECTOR_EXECUTE_TOOL_ID,
+    LIST_SENSES_TOOL_ID,
+    SENSE_EXECUTE_TOOL_ID,
 )
 
 # The agent-facing refusal for any write/confirm-trust action in v1. Kept as a
@@ -281,6 +295,137 @@ async def _connector_execute_handler(args: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Tool handlers — Sense tier (provider-agnostic capabilities above connectors)
+# ---------------------------------------------------------------------------
+
+
+async def _list_senses_handler(args: dict) -> dict:  # noqa: ARG001 — no args
+    workspace_id, _user_id, pocket_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "no active workspace — list_senses can only be called from inside a "
+            "cloud chat stream"
+        )
+
+    from pocketpaw.senses import CORE_SENSES
+    from pocketpaw_ee.cloud.senses.resolver import resolve
+
+    senses_out: list[dict[str, Any]] = []
+    for sense in CORE_SENSES:
+        try:
+            resolved = await resolve(sense.id, workspace_id, pocket_id=pocket_id)
+        except Exception as exc:  # noqa: BLE001 — never let one sense break the list
+            logger.warning("list_senses: resolve(%s) failed", sense.id, exc_info=True)
+            return _error_response(f"list_senses failed: {exc}")
+        if resolved is None:
+            # No enabled connector fills this sense for the workspace — skip it
+            # so the agent only sees capabilities it can actually use.
+            continue
+        senses_out.append(
+            {
+                "sense": sense.id,
+                "display_name": sense.display_name,
+                "description": sense.description,
+                "connector": resolved.connector_name,
+                "ambiguous": resolved.ambiguous,
+                "candidates": resolved.candidates,
+            }
+        )
+
+    if not senses_out:
+        return _success_response(
+            {
+                "pocket_id": pocket_id,
+                "senses": [],
+                "message": (
+                    "No capabilities (Senses) are available here yet — no enabled "
+                    "connector fills any core sense for this workspace. Connect a "
+                    "provider (email, calendar, code, etc.) to use senses."
+                ),
+            }
+        )
+
+    return _success_response(
+        {
+            "pocket_id": pocket_id,
+            "senses": senses_out,
+            "note": (
+                "Call sense_execute(sense, action, params) to run a READ action "
+                "against a capability without naming the connector. If a sense is "
+                "ambiguous, the resolver picked the first candidate — the user can "
+                "set a preference to disambiguate. Write actions are blocked in v1."
+            ),
+        }
+    )
+
+
+async def _sense_execute_handler(args: dict) -> dict:
+    workspace_id, user_id, pocket_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "no active workspace — sense_execute can only be called from inside a "
+            "cloud chat stream"
+        )
+    if not pocket_id:
+        return _error_response(
+            "this chat isn't anchored to a pocket — sense_execute needs a "
+            "pocket-scoped room with a bound connector"
+        )
+
+    sense = args.get("sense")
+    if not isinstance(sense, str) or not sense:
+        return _error_response("sense is required (string, e.g. 'paw.email.v1')")
+    action = args.get("action")
+    if not isinstance(action, str) or not action:
+        return _error_response("action is required (string)")
+    params = args.get("params") or {}
+    if not isinstance(params, dict):
+        return _error_response("params must be an object (dict)")
+
+    from pocketpaw.senses import SenseValidationError
+    from pocketpaw_ee.cloud.senses.resolver import execute_sense
+
+    try:
+        result = await execute_sense(
+            sense,
+            action,
+            params,
+            workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+        )
+    except SenseValidationError as exc:
+        return _error_response(f"unknown sense {sense!r}: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("sense_execute failed", exc_info=True)
+        return _error_response(f"sense_execute failed: {exc}")
+
+    # execute_sense OWNS the read-first gate. A False result is a structured
+    # refusal (sense.no_provider / sense.action_needs_approval), not a crash.
+    if not result.ok:
+        return _error_response(result.message or result.error or "sense_execute refused")
+
+    # result.data is the underlying ExecuteActionResponse. Flatten it into the
+    # SAME shape connector_execute returns (json.dumps uses default=str, so a
+    # nested Pydantic model would serialize as an opaque repr the agent can't
+    # read) — keep the two tools' success payloads structurally identical.
+    resp = result.data
+    return _success_response(
+        {
+            "executed": True,
+            "sense": result.sense_id,
+            "connector": result.connector_name,
+            "action": result.action,
+            "success": getattr(resp, "success", True),
+            "data": getattr(resp, "data", None),
+            "error": getattr(resp, "error", None),
+            "records_affected": getattr(resp, "records_affected", 0),
+            "execution_mode": getattr(resp, "execution_mode", "cloud"),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # Server factory
 # ---------------------------------------------------------------------------
 
@@ -356,10 +501,75 @@ def build_connectors_context_server() -> tuple[str, Any] | None:
     async def connector_execute(args):  # type: ignore[no-untyped-def]
         return await _connector_execute_handler(args)
 
+    @tool(
+        "list_senses",
+        (
+            "List the capabilities (Senses) you can use in the CURRENT "
+            "pocket/room. A Sense is a provider-agnostic capability (e.g. "
+            "'paw.email.v1' = email, 'paw.code.v1' = repos/issues/PRs) that the "
+            "resolver binds to whichever connector the tenant enabled — so you "
+            "address the capability, not a specific provider. Call this FIRST "
+            "when the user asks for something by capability ('check my email', "
+            "'what's on my calendar') rather than by provider name. Returns only "
+            "senses that resolve to a connector here, each with the bound "
+            "`connector`, whether the choice was `ambiguous` (more than one "
+            "provider, no preference set), and the `candidates`. No arguments — "
+            "the pocket is inferred from the active chat. Then call sense_execute "
+            "to run a READ action."
+        ),
+        {},
+    )
+    async def list_senses(args):  # type: ignore[no-untyped-def]
+        return await _list_senses_handler(args)
+
+    @tool(
+        "sense_execute",
+        (
+            "Run ONE READ action against a capability (Sense) for the current "
+            "pocket WITHOUT naming the provider. Use this when the user asks by "
+            "capability ('search my email for the invoice', 'list my open PRs') "
+            "and you want the resolver to pick the connector the tenant enabled. "
+            "Args: `sense` (a sense id from list_senses, e.g. 'paw.email.v1'), "
+            "`action` (an action name, e.g. 'gmail_search' or 'list_issues'), and "
+            "`params` (an object of that action's parameters). READ-FIRST: only "
+            "read (auto-trust) actions run; WRITE actions (create/send/modify/"
+            "delete) are refused with a 'needs approval' message and are NEVER "
+            "executed. If no connector fills the sense for this workspace you get "
+            "a clear 'no provider' error. Always call list_senses first to see "
+            "which senses resolve and pick a valid action."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "sense": {
+                    "type": "string",
+                    "description": (
+                        "Sense id from list_senses, e.g. 'paw.email.v1' or "
+                        "'paw.code.v1'. Names the capability, not a connector."
+                    ),
+                },
+                "action": {
+                    "type": "string",
+                    "description": (
+                        "Action name to run, e.g. 'gmail_search' or 'list_issues'. "
+                        "Read actions only — writes are refused."
+                    ),
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Object of the action's parameters (may be empty).",
+                },
+            },
+            "required": ["sense", "action"],
+        },
+    )
+    async def sense_execute(args):  # type: ignore[no-untyped-def]
+        return await _sense_execute_handler(args)
+
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
-        version="1.0.0",
-        tools=[list_connector_actions, connector_execute],
+        version="1.1.0",
+        tools=[list_connector_actions, connector_execute, list_senses, sense_execute],
     )
     return SERVER_NAME, server
 
@@ -368,6 +578,8 @@ __all__ = [
     "CONNECTOR_EXECUTE_TOOL_ID",
     "CONNECTOR_TOOL_IDS",
     "LIST_CONNECTOR_ACTIONS_TOOL_ID",
+    "LIST_SENSES_TOOL_ID",
+    "SENSE_EXECUTE_TOOL_ID",
     "SERVER_NAME",
     "build_connectors_context_server",
 ]

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -308,15 +308,20 @@ async def _list_senses_handler(args: dict) -> dict:  # noqa: ARG001 — no args
         )
 
     from pocketpaw.senses import CORE_SENSES
-    from pocketpaw_ee.cloud.senses.resolver import resolve
+    from pocketpaw_ee.cloud.senses.resolver import resolve_many
+
+    # One enabled-connector read for all CORE_SENSES (was one query per sense).
+    try:
+        resolved_map = await resolve_many(
+            [s.id for s in CORE_SENSES], workspace_id, pocket_id=pocket_id
+        )
+    except Exception as exc:  # noqa: BLE001 — never let one sense break the list
+        logger.warning("list_senses: resolve_many failed", exc_info=True)
+        return _error_response(f"list_senses failed: {exc}")
 
     senses_out: list[dict[str, Any]] = []
     for sense in CORE_SENSES:
-        try:
-            resolved = await resolve(sense.id, workspace_id, pocket_id=pocket_id)
-        except Exception as exc:  # noqa: BLE001 — never let one sense break the list
-            logger.warning("list_senses: resolve(%s) failed", sense.id, exc_info=True)
-            return _error_response(f"list_senses failed: {exc}")
+        resolved = resolved_map.get(sense.id)
         if resolved is None:
             # No enabled connector fills this sense for the workspace — skip it
             # so the agent only sees capabilities it can actually use.

--- a/ee/pocketpaw_ee/agent/pocket_router/router.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/router.py
@@ -229,6 +229,7 @@ async def _run_tier0(
             auth_header=auth_header,
             token=token,
             only_source=classification.op_args.get("source"),
+            workspace_id=workspace_id,
         )
         errors = result.get("errors") or []
         if errors:

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -71,6 +71,7 @@ from pocketpaw_ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
 from pocketpaw_ee.cloud.models.pocket_backend import PocketBackendCredential
 from pocketpaw_ee.cloud.models.project import Project
 from pocketpaw_ee.cloud.models.read_state import ReadState
+from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
 from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
@@ -160,6 +161,7 @@ __all__ = [
     "Site",
     "SiteDomain",
     "SiteRateCounter",
+    "WorkspaceSensePreference",
     "Task",
     "TaskAssignee",
     "TaskSource",
@@ -219,6 +221,7 @@ def get_all_documents():
         Lead,
         Site,
         SiteRateCounter,
+        WorkspaceSensePreference,
         AuditEvent,
         AuditWebhook,
         AuthSession,

--- a/ee/pocketpaw_ee/cloud/models/sense_preference.py
+++ b/ee/pocketpaw_ee/cloud/models/sense_preference.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 from beanie import Indexed
+
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
 

--- a/ee/pocketpaw_ee/cloud/models/sense_preference.py
+++ b/ee/pocketpaw_ee/cloud/models/sense_preference.py
@@ -1,0 +1,32 @@
+# WorkspaceSensePreference Beanie document — per-(workspace[,pocket],sense) provider pick.
+# Created: 2026-06-08 — Sense tier chunk 2 (EE SenseResolver). EE-side home
+# for the sense->connector preference used to disambiguate when more than one
+# enabled connector can fill a sense (e.g. github vs gitlab for paw.code.v1).
+# Soul-carried preferences are explicitly deferred to Phase 2 — this is the
+# v1 store and does NOT touch soul-protocol. One row per
+# (workspace, pocket_id, sense_id); workspace_id is required + indexed and
+# every read filters on it (ee/cloud rule §7).
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class WorkspaceSensePreference(TimestampedDocument):
+    """Preferred connector for one sense, scoped to a workspace (and optional pocket).
+
+    ``pocket_id`` is ``None`` for the workspace-level preference. The resolver
+    looks up the pocket-level row first when a ``pocket_id`` is supplied, then
+    falls back to the workspace-level row. Uniqueness per
+    (workspace, pocket_id, sense_id) is enforced at the service layer via
+    upsert-on-set, not a Mongo unique index, so set is idempotent.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    pocket_id: str | None = None
+    sense_id: str
+    connector_name: str
+
+    class Settings(TimestampedDocument.Settings):
+        name = "workspace_sense_preferences"

--- a/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
+++ b/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
@@ -163,6 +163,7 @@ async def _refresh_one_pocket(pocket: dict) -> None:
                 auth_header=auth_header,
                 token=token,
                 only_source=key,
+                workspace_id=workspace_id,
             )
             if result.get("errors"):
                 logger.debug(

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -697,6 +697,7 @@ async def run_pocket_sources(
         token=token,
         trigger=body.trigger,
         only_source=body.source,
+        workspace_id=workspace_id,
     )
 
 
@@ -782,6 +783,7 @@ async def webhook_refresh_source(
         auth_header=auth_header,
         token=token,
         only_source=source,
+        workspace_id=workspace_id,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -89,6 +89,13 @@ dispatcher + temporal scheduler call to obtain a typed ``PocketTemplate``
 from a pocket. A stale / missing slug never breaks pocket creation: the
 loader's ``strict=False`` mode returns ``None`` and the rippleSpec is
 left unmodified so a later resolver run can retry.
+Changes: 2026-06-08 (feat/sense-template-needs, Sense tier chunk 6a) —
+``create`` now reads the template's ``needs:`` Sense ids and, for each,
+asks the EE Sense resolver whether an enabled connector fills it for the
+tenant (``_check_template_needs``). Senses with no provider are logged as
+a warning AND attached as ``missing_senses`` on the ``pocket.created``
+event so the UX can prompt-to-connect. This NEVER blocks creation —
+``needs`` is template metadata, not rippleSpec, so it is not merged.
 Changes: 2026-05-24 — added ``merge_spec`` (MVP entry point for the
 new ``POST /api/v1/pockets/{id}/spec/merge`` endpoint). Accepts either a
 ``{"replace": <full spec>}`` or a ``{"merge": <partial spec>}`` body,
@@ -471,7 +478,9 @@ async def _resolved_wire_dict(doc: _PocketDoc, viewer_user_id: str) -> dict:
     return pocket_to_wire_dict(pocket)
 
 
-async def _pocket_event_payload(doc: _PocketDoc) -> dict:
+async def _pocket_event_payload(
+    doc: _PocketDoc, *, missing_senses: list[str] | None = None
+) -> dict:
     """Build the realtime event payload for a pocket mutation.
 
     Always includes ``recipient_ids`` (owner + shared_with). For
@@ -498,6 +507,12 @@ async def _pocket_event_payload(doc: _PocketDoc) -> dict:
     }
     if doc.visibility == "workspace":
         payload["workspace_id"] = doc.workspace
+    # Sense tier chunk 6a — when a template declared ``needs:`` Senses that no
+    # enabled connector fills for this tenant, surface them so the UX can
+    # prompt-to-connect. Only present on the create path when non-empty; the
+    # absence of the key means "nothing missing".
+    if missing_senses:
+        payload["missing_senses"] = list(missing_senses)
     return payload
 
 
@@ -857,6 +872,48 @@ def _merge_compile_into_ripple_spec(
     return out
 
 
+async def _check_template_needs(loaded: dict[str, Any] | None, workspace_id: str) -> list[str]:
+    """Return the template's declared Sense ids that NO enabled connector fills.
+
+    A vertical template may declare ``needs: ["paw.payments.v1", ...]`` — the
+    provider-agnostic capabilities it expects the tenant to have wired up. For
+    each need, ask the EE Sense resolver whether an enabled connector fills it
+    for ``workspace_id``; ids that resolve to ``None`` are returned as the
+    ``missing`` set so the caller can surface a prompt-to-connect.
+
+    Tolerance: this never raises and never blocks. A ``None`` loaded result, a
+    missing/empty ``needs``, or a resolver error all yield ``[]`` (or skip the
+    offending id) — mirrors the ``strict=False`` posture used elsewhere here.
+    """
+    if not isinstance(loaded, dict):
+        return []
+    meta = loaded.get("meta")
+    if not isinstance(meta, dict):
+        return []
+    needs = meta.get("needs")
+    if not needs:
+        return []
+
+    # Lazy import — keep the EE Sense resolver off the eager import path.
+    from pocketpaw_ee.cloud.senses.resolver import resolve
+
+    missing: list[str] = []
+    for sense_id in needs:
+        try:
+            resolved = await resolve(sense_id, workspace_id)
+        except Exception as exc:  # noqa: BLE001 — never block create on a resolver hiccup
+            logger.warning(
+                "template needs: resolve(%r) raised for workspace=%s: %s",
+                sense_id,
+                workspace_id,
+                exc,
+            )
+            continue
+        if resolved is None:
+            missing.append(sense_id)
+    return missing
+
+
 async def resolve_pocket_template(
     workspace_id: str,
     pocket_id: str,
@@ -944,6 +1001,7 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     # docstring above ``_merge_compile_into_ripple_spec``). A stale /
     # missing slug logs a warning and leaves the rippleSpec unchanged —
     # the pocket still gets created and keeps the slug for retry.
+    loaded: dict[str, Any] | None = None
     if body.template_slug:
         from pocketpaw.bundled_templates import load_template
 
@@ -986,7 +1044,22 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
     if body.session_id:
         await sessions_service.link_pocket(workspace_id, body.session_id, pocket.id)
 
-    await emit(PocketCreated(data=await _pocket_event_payload(doc)))
+    # Sense tier chunk 6a — a template can declare the Senses it needs. For each,
+    # check the tenant has an enabled provider; collect the ids with none. This
+    # NEVER blocks creation (the pocket is already inserted) — it logs a warning
+    # and rides out on the pocket.created event so the UX can prompt-to-connect.
+    missing_senses = await _check_template_needs(loaded, workspace_id)
+    if missing_senses:
+        logger.warning(
+            "template needs: pocket=%s slug=%r workspace=%s has no enabled "
+            "provider for senses %s — pocket created, prompt-to-connect surfaced",
+            str(doc.id),
+            body.template_slug,
+            workspace_id,
+            missing_senses,
+        )
+
+    await emit(PocketCreated(data=await _pocket_event_payload(doc, missing_senses=missing_senses)))
     return await _resolved_wire_dict(doc, user_id)
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -895,23 +895,20 @@ async def _check_template_needs(loaded: dict[str, Any] | None, workspace_id: str
         return []
 
     # Lazy import — keep the EE Sense resolver off the eager import path.
-    from pocketpaw_ee.cloud.senses.resolver import resolve
+    from pocketpaw_ee.cloud.senses.resolver import resolve_many
 
-    missing: list[str] = []
-    for sense_id in needs:
-        try:
-            resolved = await resolve(sense_id, workspace_id)
-        except Exception as exc:  # noqa: BLE001 — never block create on a resolver hiccup
-            logger.warning(
-                "template needs: resolve(%r) raised for workspace=%s: %s",
-                sense_id,
-                workspace_id,
-                exc,
-            )
-            continue
-        if resolved is None:
-            missing.append(sense_id)
-    return missing
+    # One enabled-connector read for ALL needs (was one query per need).
+    try:
+        resolved = await resolve_many(list(needs), workspace_id)
+    except Exception as exc:  # noqa: BLE001 — never block create on a resolver hiccup
+        logger.warning(
+            "template needs: resolve_many raised for workspace=%s: %s",
+            workspace_id,
+            exc,
+        )
+        return []
+
+    return [sense_id for sense_id in needs if resolved.get(sense_id) is None]
 
 
 async def resolve_pocket_template(

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -49,6 +49,14 @@
 #   evaluation). `path` is now optional (required only for http, enforced at
 #   run). `run_sources` gained an optional `workspace_id`, threaded with the
 #   existing `pocket_id`/`user_id` into `_run_one` for sense resolution.
+# Updated: 2026-06-08 (sense-tier robustness fix) — `run_sources`'s
+#   `workspace_id` is now REQUIRED (`str`, no default). All four callers
+#   already pass a real value; omitting it should be a loud TypeError, not a
+#   None that flows into a sense resolve and silently returns "no provider".
+#   DEFENSE: `_run_sense_binding` now rejects a falsy `workspace_id` up front
+#   with a `_SourceError(code="bad_source")` so a missing workspace context
+#   lands in the errors aggregation as a CLEAR error (mirrors the http-no-path
+#   guard), never a silent no-provider.
 
 from __future__ import annotations
 
@@ -264,6 +272,14 @@ async def _run_sense_binding(
 
     ``params`` are STATIC in v1 — passed through as-is (no ``{state.x}``).
     """
+    # DEFENSE: a sense source resolves a provider FOR A WORKSPACE. A falsy
+    # workspace context would flow into the resolver and silently come back as
+    # "no provider"; surface it as a CLEAR per-source error instead (mirrors
+    # the http-no-path guard). ``run_sources`` now requires workspace_id, so
+    # this is a belt-and-braces guard against a future internal caller.
+    if not workspace_id:
+        raise _SourceError("sense source requires a workspace context", code="bad_source")
+
     # Lazy import: avoids a top-level cycle and keeps the SSRF/http core of
     # this module importable without the senses subsystem.
     from pocketpaw_ee.cloud.senses.resolver import execute_sense
@@ -366,7 +382,7 @@ async def run_sources(
     token: str,
     trigger: str | None = None,
     only_source: str | None = None,
-    workspace_id: str | None = None,
+    workspace_id: str,
 ) -> dict:
     """Run the pocket's selected read-only sources and return the results.
 
@@ -381,6 +397,11 @@ async def run_sources(
 
     ``user_id`` keys the rate limiter (per pocket *and* per user) and is the
     actor on the audit-log entry written for every run.
+
+    ``workspace_id`` is REQUIRED — a sense source resolves a provider for a
+    workspace, and a None would silently mis-resolve to "no provider". All
+    callers already pass a real value, so a caller that omits it raises a loud
+    TypeError rather than running a mis-resolved sense.
     """
     # D16 — per-(pocket, user) rate limit. On breach, return a source-level
     # error for every selected source without making any call.

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -36,6 +36,19 @@
 # IMPORT-LINTER: must NOT import `pocketpaw_ee.cloud.models.*`. The executor
 # receives base_url / auth / spec by parameter only — `pockets/service.py`
 # owns all Beanie access.
+#
+# Updated: 2026-06-08 (feat/sense-source, Sense tier chunk 6b) — a source
+#   binding can now be `type: "sense"`: it resolves a provider-agnostic Sense
+#   via `senses.resolver.execute_sense` instead of an HTTP GET, unwraps the
+#   ExecuteActionResponse to its `.data` payload, and binds that into state
+#   with the SAME `{source, bind, value}` row shape the http path returns. A
+#   resolver refusal (ok=False) maps to a per-source `_SourceError` so the
+#   error-aggregation loop treats it exactly like an http failure — siblings
+#   keep running. `SourceBinding` gained `type` (default "http"), optional
+#   `sense_id`/`action`/`params` (params are STATIC in v1 — no `{state.x}`
+#   evaluation). `path` is now optional (required only for http, enforced at
+#   run). `run_sources` gained an optional `workspace_id`, threaded with the
+#   existing `pocket_id`/`user_id` into `_run_one` for sense resolution.
 
 from __future__ import annotations
 
@@ -102,11 +115,20 @@ class SourceBinding(BaseModel):
     honored. ``None`` means "use the floor as the interval".
     """
 
+    type: Literal["http", "sense"] = "http"
     method: Literal["GET"] = "GET"
-    path: str
+    # ``path`` is required for http sources, unused for sense sources. Kept
+    # optional here so a sense entry survives parse; the http path raises a
+    # clean per-source error if a misconfigured http source has no path.
+    path: str | None = None
     bind: str
     refresh: list[RefreshTrigger] = Field(default_factory=lambda: _DEFAULT_REFRESH.copy())
     refresh_interval_seconds: int | None = Field(default=None, ge=1)
+    # Sense-source fields (type == "sense"). ``params`` are STATIC in v1 —
+    # passed through to the Sense resolver as-is (no ``{state.x}`` evaluation).
+    sense_id: str | None = None
+    action: str | None = None
+    params: dict | None = None
 
 
 def _normalize_bind(bind: str) -> str:
@@ -222,6 +244,52 @@ def _parse_bindings(ripple_spec: dict) -> tuple[dict[str, SourceBinding], list[d
     return bindings, errors
 
 
+async def _run_sense_binding(
+    *,
+    key: str,
+    binding: SourceBinding,
+    workspace_id: str | None,
+    pocket_id: str,
+    user_id: str,
+) -> dict:
+    """Resolve a ``type="sense"`` source via the Sense resolver.
+
+    Returns the SAME success row shape the http path returns —
+    ``{"source", "bind", "value"}`` — with ``value`` UNWRAPPED to the
+    underlying ``ExecuteActionResponse.data`` payload (state gets the actual
+    data, not the envelope). On a resolver refusal (``ok=False`` — no
+    provider, or read-first approval gate) it raises ``_SourceError`` with
+    the resolver's stable code/message, so the aggregation loop treats it as
+    a per-source error exactly like an http failure (does NOT abort siblings).
+
+    ``params`` are STATIC in v1 — passed through as-is (no ``{state.x}``).
+    """
+    # Lazy import: avoids a top-level cycle and keeps the SSRF/http core of
+    # this module importable without the senses subsystem.
+    from pocketpaw_ee.cloud.senses.resolver import execute_sense
+
+    result = await execute_sense(
+        binding.sense_id,
+        binding.action,
+        binding.params or {},
+        workspace_id,
+        pocket_id=pocket_id,
+        user_id=user_id,
+    )
+    if not result.ok:
+        # Map the resolver refusal onto the same per-source error shape http
+        # failures use, so ``run_sources``'s error aggregation is unchanged.
+        raise _SourceError(
+            result.message or "sense source failed",
+            code=result.error or "sense_error",
+        )
+
+    # result.data is the ExecuteActionResponse; result.data.data is the
+    # payload that should land in pocket state.
+    payload = getattr(result.data, "data", None)
+    return {"source": key, "bind": _normalize_bind(binding.bind), "value": payload}
+
+
 async def _run_one(
     *,
     client: httpx.AsyncClient,
@@ -229,10 +297,30 @@ async def _run_one(
     binding: SourceBinding,
     base_url: str,
     headers: dict[str, str],
+    workspace_id: str | None,
+    pocket_id: str,
+    user_id: str,
 ) -> dict:
     """Fetch a single source. Returns a ``ran`` row; raises ``_GuardError``
     (the shared guard rejections) or its ``_SourceError`` subclass (the
-    read executor's own per-source failures)."""
+    read executor's own per-source failures).
+
+    Branches on ``binding.type``: a ``"sense"`` source resolves via the
+    Sense resolver (``_run_sense_binding``); the default ``"http"`` source
+    runs the SSRF-guarded GET below, unchanged."""
+    if binding.type == "sense":
+        return await _run_sense_binding(
+            key=key,
+            binding=binding,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+        )
+
+    if not binding.path:
+        # An http source with no path is a misconfiguration — surface it as a
+        # clean per-source error rather than crashing _resolve_url.
+        raise _SourceError("http source has no path", code="bad_source")
     url = _resolve_url(base_url, binding.path)
     await _assert_host_external(urllib.parse.urlsplit(url).hostname or "")
 
@@ -278,6 +366,7 @@ async def run_sources(
     token: str,
     trigger: str | None = None,
     only_source: str | None = None,
+    workspace_id: str | None = None,
 ) -> dict:
     """Run the pocket's selected read-only sources and return the results.
 
@@ -363,6 +452,9 @@ async def run_sources(
                         binding=binding,
                         base_url=base_url,
                         headers=headers,
+                        workspace_id=workspace_id,
+                        pocket_id=pocket_id,
+                        user_id=user_id,
                     ),
                     timeout=_PER_SOURCE_TIMEOUT_S,
                 )

--- a/ee/pocketpaw_ee/cloud/senses/__init__.py
+++ b/ee/pocketpaw_ee/cloud/senses/__init__.py
@@ -1,0 +1,23 @@
+# Sense tier — EE cloud half (resolver + filler seam + preference store).
+# Created: 2026-06-08 — Sense tier chunk 2. Binds a provider-agnostic Sense
+# (e.g. paw.email.v1) to whichever connector a tenant ENABLED, then executes
+# via the EXISTING connectors_service path. READ-FIRST (v1): only auto-trust
+# (read) actions run; confirm/restricted (write) actions are blocked, never
+# executed. Imports OSS (pocketpaw.senses, pocketpaw.connectors) freely; OSS
+# never imports this package (import-linter contract).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.senses.resolver import (
+    ResolvedSense,
+    SenseExecutionResult,
+    execute_sense,
+    resolve,
+)
+
+__all__ = [
+    "ResolvedSense",
+    "SenseExecutionResult",
+    "execute_sense",
+    "resolve",
+]

--- a/ee/pocketpaw_ee/cloud/senses/filler.py
+++ b/ee/pocketpaw_ee/cloud/senses/filler.py
@@ -1,0 +1,79 @@
+# SenseFiller seam — the abstraction a future Skill/KB/Fabric filler plugs into.
+# Created: 2026-06-08 — Sense tier chunk 2. A SenseFiller knows which providers
+# (connector names) can fill a sense for a given workspace. v1 ships exactly
+# one filler — ConnectorSenseFiller — which intersects the static
+# connectors-for-sense index with the tenant's ENABLED connectors. The point
+# here is the seam, not a framework: register more fillers (skills, KB, fabric)
+# in a later phase by implementing the Protocol. Kept deliberately thin.
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from pocketpaw.senses import connectors_for_sense
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector as _WCDoc
+
+
+@runtime_checkable
+class SenseFiller(Protocol):
+    """A source of providers that can fill a sense for a workspace.
+
+    A filler answers one question: "which provider names can satisfy
+    ``sense_id`` for this workspace right now?" The resolver collects
+    candidates from the registered fillers and disambiguates. v1 has the
+    connector-backed filler only; a SkillFiller / KBFiller / FabricFiller can
+    register later without changing the resolver.
+    """
+
+    async def candidates(
+        self,
+        sense_id: str,
+        workspace_id: str,
+        *,
+        pocket_id: str | None = None,
+    ) -> list[str]:
+        """Provider names that can fill ``sense_id`` for this workspace."""
+        ...
+
+
+class ConnectorSenseFiller:
+    """The only v1 filler — connector-backed.
+
+    Candidates = connectors that DECLARE the sense (static registry index)
+    INTERSECT the connectors the workspace has ENABLED. The intersection is
+    what makes resolution tenant-aware: a connector that can fill a sense but
+    isn't enabled for the workspace is not a candidate.
+
+    For v1 enablement is read at workspace scope (every enabled doc for the
+    workspace counts, regardless of its own scope). ``pocket_id`` is accepted
+    for signature parity and a future pocket-scoped narrowing, but workspace
+    scope is the documented v1 behaviour.
+    """
+
+    def __init__(self, registry) -> None:
+        self._registry = registry
+
+    async def candidates(
+        self,
+        sense_id: str,
+        workspace_id: str,
+        *,
+        pocket_id: str | None = None,
+    ) -> list[str]:
+        # Which connectors CAN fill this sense (provider-agnostic, static).
+        declaring = set(connectors_for_sense(sense_id, self._registry.definitions))
+        if not declaring:
+            return []
+
+        # Which connectors the workspace has ENABLED (tenant-filtered read).
+        enabled_docs = await _WCDoc.find(
+            _WCDoc.workspace == workspace_id,
+            _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+        ).to_list()
+        enabled_names = {d.name for d in enabled_docs}
+
+        # Intersection, sorted for deterministic disambiguation.
+        return sorted(declaring & enabled_names)
+
+
+__all__ = ["ConnectorSenseFiller", "SenseFiller"]

--- a/ee/pocketpaw_ee/cloud/senses/filler.py
+++ b/ee/pocketpaw_ee/cloud/senses/filler.py
@@ -5,6 +5,12 @@
 # connectors-for-sense index with the tenant's ENABLED connectors. The point
 # here is the seam, not a framework: register more fillers (skills, KB, fabric)
 # in a later phase by implementing the Protocol. Kept deliberately thin.
+# Updated: 2026-06-08 (sense-tier efficiency fix) — split ConnectorSenseFiller
+#   .candidates() into a one-shot enabled-connector READ (enabled_connector_names)
+#   and a PURE intersection (candidates_from) so a batch caller (resolve_many)
+#   can fetch the workspace's enabled connectors ONCE and reuse the set across
+#   N senses instead of re-querying Beanie per sense. candidates() is kept as
+#   the compose of the two so existing single-sense callers/tests are unchanged.
 
 from __future__ import annotations
 
@@ -53,6 +59,39 @@ class ConnectorSenseFiller:
     def __init__(self, registry) -> None:
         self._registry = registry
 
+    async def enabled_connector_names(
+        self,
+        workspace_id: str,
+        *,
+        pocket_id: str | None = None,  # noqa: ARG002 — parity / future pocket scope
+    ) -> set[str]:
+        """The connector names the workspace has ENABLED (tenant-filtered read).
+
+        This is the ONE Beanie query a batch resolution needs: fetch it once,
+        then intersect it (via :meth:`candidates_from`) against each sense's
+        declaring set. v1 reads at workspace scope — every enabled doc for the
+        workspace counts, regardless of its own scope. ``pocket_id`` is accepted
+        for parity / a future pocket-scoped narrowing.
+        """
+        enabled_docs = await _WCDoc.find(
+            _WCDoc.workspace == workspace_id,
+            _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+        ).to_list()
+        return {d.name for d in enabled_docs}
+
+    def candidates_from(self, sense_id: str, enabled_names: set[str]) -> list[str]:
+        """PURE intersection — no I/O.
+
+        Connectors that DECLARE ``sense_id`` (static registry index) INTERSECT
+        the already-fetched ``enabled_names`` set, sorted for deterministic
+        disambiguation. Split out of :meth:`candidates` so a batch caller can
+        reuse one ``enabled_names`` read across many senses.
+        """
+        declaring = set(connectors_for_sense(sense_id, self._registry.definitions))
+        if not declaring:
+            return []
+        return sorted(declaring & enabled_names)
+
     async def candidates(
         self,
         sense_id: str,
@@ -60,20 +99,10 @@ class ConnectorSenseFiller:
         *,
         pocket_id: str | None = None,
     ) -> list[str]:
-        # Which connectors CAN fill this sense (provider-agnostic, static).
-        declaring = set(connectors_for_sense(sense_id, self._registry.definitions))
-        if not declaring:
-            return []
-
-        # Which connectors the workspace has ENABLED (tenant-filtered read).
-        enabled_docs = await _WCDoc.find(
-            _WCDoc.workspace == workspace_id,
-            _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
-        ).to_list()
-        enabled_names = {d.name for d in enabled_docs}
-
-        # Intersection, sorted for deterministic disambiguation.
-        return sorted(declaring & enabled_names)
+        # The single-sense path: one enabled-connector read + the pure
+        # intersection. Identical result to the pre-split implementation.
+        enabled_names = await self.enabled_connector_names(workspace_id, pocket_id=pocket_id)
+        return self.candidates_from(sense_id, enabled_names)
 
 
 __all__ = ["ConnectorSenseFiller", "SenseFiller"]

--- a/ee/pocketpaw_ee/cloud/senses/preference.py
+++ b/ee/pocketpaw_ee/cloud/senses/preference.py
@@ -1,0 +1,73 @@
+# Sense->provider preference store — EE-side, v1 home for the pick.
+# Created: 2026-06-08 — Sense tier chunk 2. get/set a preferred connector per
+# (workspace_id[, pocket_id], sense_id). Backed by the WorkspaceSensePreference
+# Beanie doc. NOT in the .soul file — soul-carried prefs are deferred to
+# Phase 2 (do NOT touch soul-protocol). Every read filters by workspace_id
+# (ee/cloud rule §7); set upserts so it is idempotent (no Mongo unique index).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
+
+
+async def get_preference(
+    workspace_id: str,
+    sense_id: str,
+    *,
+    pocket_id: str | None = None,
+) -> str | None:
+    """Return the preferred connector name for a sense, or ``None`` if unset.
+
+    When ``pocket_id`` is supplied the pocket-scoped preference wins; if there
+    is none, fall back to the workspace-level (``pocket_id is None``) row. This
+    lets a pocket override the workspace default without losing it.
+    """
+    if pocket_id is not None:
+        doc = await WorkspaceSensePreference.find_one(
+            WorkspaceSensePreference.workspace == workspace_id,
+            WorkspaceSensePreference.pocket_id == pocket_id,
+            WorkspaceSensePreference.sense_id == sense_id,
+        )
+        if doc is not None:
+            return doc.connector_name
+
+    doc = await WorkspaceSensePreference.find_one(
+        WorkspaceSensePreference.workspace == workspace_id,
+        WorkspaceSensePreference.pocket_id == None,  # noqa: E711 — Beanie expects ==
+        WorkspaceSensePreference.sense_id == sense_id,
+    )
+    return doc.connector_name if doc is not None else None
+
+
+async def set_preference(
+    workspace_id: str,
+    sense_id: str,
+    connector_name: str,
+    *,
+    pocket_id: str | None = None,
+) -> None:
+    """Upsert the preferred connector for a (workspace[, pocket], sense).
+
+    Idempotent: re-setting the same triple updates the existing row rather
+    than inserting a duplicate. Uniqueness is enforced here, not by a Mongo
+    index, so the store stays forgiving on races.
+    """
+    doc = await WorkspaceSensePreference.find_one(
+        WorkspaceSensePreference.workspace == workspace_id,
+        WorkspaceSensePreference.pocket_id == pocket_id,
+        WorkspaceSensePreference.sense_id == sense_id,
+    )
+    if doc is None:
+        doc = WorkspaceSensePreference(
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            sense_id=sense_id,
+            connector_name=connector_name,
+        )
+        await doc.insert()
+    else:
+        doc.connector_name = connector_name
+        await doc.save()
+
+
+__all__ = ["get_preference", "set_preference"]

--- a/ee/pocketpaw_ee/cloud/senses/resolver.py
+++ b/ee/pocketpaw_ee/cloud/senses/resolver.py
@@ -1,0 +1,186 @@
+# SenseResolver — binds a provider-agnostic Sense to a tenant's enabled connector.
+# Created: 2026-06-08 — Sense tier chunk 2. A Sense (paw.email.v1) names a
+# capability; this resolver picks the connector that fills it for a workspace,
+# then executes via the EXISTING connectors_service path. READ-FIRST (v1): only
+# ``trust_level == "auto"`` actions run; confirm/restricted (and unknown/missing
+# trust) are BLOCKED and never sent to execute. Disambiguation: 0 candidates ->
+# None (caller prompts-to-connect); 1 -> that connector; >1 -> the stored
+# preference if it's among candidates, else the deterministic first with an
+# ``ambiguous`` flag so the caller can ask the user to set a preference.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from pocketpaw.senses import validate_sense_id
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+from pocketpaw_ee.cloud.senses import preference
+from pocketpaw_ee.cloud.senses.filler import ConnectorSenseFiller
+
+
+@dataclass(frozen=True)
+class ResolvedSense:
+    """The connector chosen to fill a sense for a workspace.
+
+    ``ambiguous`` is True when more than one enabled connector could fill the
+    sense and no stored preference disambiguated it — the caller should surface
+    a "set a preference" prompt. ``candidates`` is the full sorted candidate
+    set so the caller can render the choices.
+    """
+
+    sense_id: str
+    connector_name: str
+    ambiguous: bool = False
+    candidates: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SenseExecutionResult:
+    """Envelope for ``execute_sense``.
+
+    Structured (never an HTTP 500): ``ok`` is False with a stable ``error``
+    code for the two refusal paths — no provider for the sense, and the
+    read-first block on a non-auto action. On success ``data`` carries the
+    underlying ``ExecuteActionResponse`` and ``connector_name`` records which
+    provider ran.
+    """
+
+    ok: bool
+    sense_id: str
+    connector_name: str | None = None
+    action: str | None = None
+    error: str | None = None  # stable code: "sense.no_provider" | "sense.action_needs_approval"
+    message: str | None = None
+    data: object = None
+
+
+async def resolve(
+    sense_id: str,
+    workspace_id: str,
+    *,
+    pocket_id: str | None = None,
+) -> ResolvedSense | None:
+    """Bind ``sense_id`` to the connector that fills it for this workspace.
+
+    Returns ``None`` when no enabled connector can fill the sense (the caller
+    decides what to do — typically prompt-to-connect). Raises
+    ``SenseValidationError`` for an unknown ``paw.*`` id.
+    """
+    validate_sense_id(sense_id)
+
+    registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
+    filler = ConnectorSenseFiller(registry)
+    candidates = await filler.candidates(sense_id, workspace_id, pocket_id=pocket_id)
+
+    if not candidates:
+        return None
+
+    if len(candidates) == 1:
+        return ResolvedSense(
+            sense_id=sense_id,
+            connector_name=candidates[0],
+            ambiguous=False,
+            candidates=candidates,
+        )
+
+    # More than one candidate — let a stored preference decide.
+    preferred = await preference.get_preference(workspace_id, sense_id, pocket_id=pocket_id)
+    if preferred is not None and preferred in candidates:
+        return ResolvedSense(
+            sense_id=sense_id,
+            connector_name=preferred,
+            ambiguous=False,
+            candidates=candidates,
+        )
+
+    # No usable preference — pick deterministically and flag for the caller.
+    return ResolvedSense(
+        sense_id=sense_id,
+        connector_name=candidates[0],
+        ambiguous=True,
+        candidates=candidates,
+    )
+
+
+def _trust_for_action(registry, connector_name: str, action: str) -> str | None:
+    """Read ``trust_level`` for an action from the connector's ConnectorDef.
+
+    Returns the trust string (e.g. "auto" | "confirm" | "restricted") or
+    ``None`` when the connector, the action, or the trust field is missing.
+    ``None`` is treated by the gate as "not auto" -> blocked.
+    """
+    defn = registry.get_definition(connector_name)
+    if defn is None:
+        return None
+    for a in getattr(defn, "actions", None) or []:
+        if isinstance(a, dict) and a.get("name") == action:
+            return a.get("trust_level")
+    return None
+
+
+async def execute_sense(
+    sense_id: str,
+    action: str,
+    params: dict,
+    workspace_id: str,
+    *,
+    pocket_id: str | None = None,
+    user_id: str | None = None,
+) -> SenseExecutionResult:
+    """Resolve a sense, enforce the read-first gate, then delegate to execute.
+
+    1. ``resolve`` — if no provider, return a structured ``sense.no_provider``
+       result (never raise a 500).
+    2. READ-FIRST GATE — the action's ``trust_level`` on the resolved
+       connector must be exactly ``"auto"``. Anything else (confirm /
+       restricted / unknown / missing) is refused with
+       ``sense.action_needs_approval`` and ``connectors_service.execute`` is
+       NEVER called.
+    3. Delegate to the existing execute path with the resolved connector.
+    """
+    resolved = await resolve(sense_id, workspace_id, pocket_id=pocket_id)
+    if resolved is None:
+        return SenseExecutionResult(
+            ok=False,
+            sense_id=sense_id,
+            action=action,
+            error="sense.no_provider",
+            message=(
+                f"no enabled connector can fill {sense_id!r} for this workspace — "
+                "connect a provider for this sense and retry."
+            ),
+        )
+
+    connector_name = resolved.connector_name
+    registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
+    trust = _trust_for_action(registry, connector_name, action)
+    if trust != "auto":
+        return SenseExecutionResult(
+            ok=False,
+            sense_id=sense_id,
+            connector_name=connector_name,
+            action=action,
+            error="sense.action_needs_approval",
+            message=(
+                f"action {action!r} on {connector_name!r} needs approval "
+                f"(trust_level={trust!r}) — not executed in v1 (read-first)."
+            ),
+        )
+
+    response = await connectors_service.execute(
+        workspace_id,
+        connector_name,
+        ExecuteActionRequest(action=action, params=params, pocket_id=pocket_id),
+        user_id=user_id,
+    )
+    return SenseExecutionResult(
+        ok=True,
+        sense_id=sense_id,
+        connector_name=connector_name,
+        action=action,
+        data=response,
+    )
+
+
+__all__ = ["ResolvedSense", "SenseExecutionResult", "execute_sense", "resolve"]

--- a/ee/pocketpaw_ee/cloud/senses/resolver.py
+++ b/ee/pocketpaw_ee/cloud/senses/resolver.py
@@ -7,6 +7,13 @@
 # None (caller prompts-to-connect); 1 -> that connector; >1 -> the stored
 # preference if it's among candidates, else the deterministic first with an
 # ``ambiguous`` flag so the caller can ask the user to set a preference.
+# Updated: 2026-06-08 (sense-tier efficiency fix) — extracted the disambiguation
+#   (0/1/>1 + preference) into ``_disambiguate`` so ``resolve`` and the new
+#   ``resolve_many`` share ONE implementation. ``resolve_many(sense_ids, ...)``
+#   fetches the workspace's enabled connectors ONCE (one Beanie query for N
+#   senses) and runs the pure intersection + shared disambiguation per id —
+#   replacing the per-sense ``resolve`` loops in ``_check_template_needs`` and
+#   the list_senses MCP handler. Behaviour is identical, just fewer queries.
 
 from __future__ import annotations
 
@@ -55,24 +62,21 @@ class SenseExecutionResult:
     data: object = None
 
 
-async def resolve(
+async def _disambiguate(
     sense_id: str,
+    candidates: list[str],
     workspace_id: str,
     *,
     pocket_id: str | None = None,
 ) -> ResolvedSense | None:
-    """Bind ``sense_id`` to the connector that fills it for this workspace.
+    """Pick the connector from a sorted candidate set — the ONE rule both
+    ``resolve`` and ``resolve_many`` use.
 
-    Returns ``None`` when no enabled connector can fill the sense (the caller
-    decides what to do — typically prompt-to-connect). Raises
-    ``SenseValidationError`` for an unknown ``paw.*`` id.
+    0 candidates -> ``None`` (caller prompts-to-connect); 1 -> that connector;
+    >1 -> the stored preference if it's among candidates, else the deterministic
+    sorted-first with ``ambiguous=True``. The per-sense preference lookup only
+    runs on the rare >1 branch.
     """
-    validate_sense_id(sense_id)
-
-    registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
-    filler = ConnectorSenseFiller(registry)
-    candidates = await filler.candidates(sense_id, workspace_id, pocket_id=pocket_id)
-
     if not candidates:
         return None
 
@@ -101,6 +105,62 @@ async def resolve(
         ambiguous=True,
         candidates=candidates,
     )
+
+
+async def resolve(
+    sense_id: str,
+    workspace_id: str,
+    *,
+    pocket_id: str | None = None,
+) -> ResolvedSense | None:
+    """Bind ``sense_id`` to the connector that fills it for this workspace.
+
+    Returns ``None`` when no enabled connector can fill the sense (the caller
+    decides what to do — typically prompt-to-connect). Raises
+    ``SenseValidationError`` for an unknown ``paw.*`` id.
+    """
+    validate_sense_id(sense_id)
+
+    registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
+    filler = ConnectorSenseFiller(registry)
+    candidates = await filler.candidates(sense_id, workspace_id, pocket_id=pocket_id)
+    return await _disambiguate(sense_id, candidates, workspace_id, pocket_id=pocket_id)
+
+
+async def resolve_many(
+    sense_ids: list[str],
+    workspace_id: str,
+    *,
+    pocket_id: str | None = None,
+) -> dict[str, ResolvedSense | None]:
+    """Resolve many senses with ONE enabled-connector read.
+
+    Fetches the workspace's enabled connector names a single time, then runs
+    the PURE intersection + the SAME ``_disambiguate`` rule ``resolve`` uses for
+    each id. Equivalent to calling ``resolve`` per id, but it collapses N
+    identical enabled-connector queries into one. Returns a dict mapping every
+    input id to its ``ResolvedSense`` (or ``None`` when no provider fills it).
+
+    Raises ``SenseValidationError`` if any id is not a known ``paw.*`` sense
+    (validated up front, same as ``resolve``). Duplicate ids collapse to one
+    key. The >1-candidate preference lookup still runs per ambiguous id — that
+    branch is rare, so it stays as-is.
+    """
+    for sense_id in sense_ids:
+        validate_sense_id(sense_id)
+
+    registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
+    filler = ConnectorSenseFiller(registry)
+    # The ONE Beanie read shared across every sense in the batch.
+    enabled_names = await filler.enabled_connector_names(workspace_id, pocket_id=pocket_id)
+
+    out: dict[str, ResolvedSense | None] = {}
+    for sense_id in sense_ids:
+        candidates = filler.candidates_from(sense_id, enabled_names)
+        out[sense_id] = await _disambiguate(
+            sense_id, candidates, workspace_id, pocket_id=pocket_id
+        )
+    return out
 
 
 def _trust_for_action(registry, connector_name: str, action: str) -> str | None:
@@ -183,4 +243,4 @@ async def execute_sense(
     )
 
 
-__all__ = ["ResolvedSense", "SenseExecutionResult", "execute_sense", "resolve"]
+__all__ = ["ResolvedSense", "SenseExecutionResult", "execute_sense", "resolve", "resolve_many"]

--- a/ee/pocketpaw_ee/cloud/senses/resolver.py
+++ b/ee/pocketpaw_ee/cloud/senses/resolver.py
@@ -157,9 +157,7 @@ async def resolve_many(
     out: dict[str, ResolvedSense | None] = {}
     for sense_id in sense_ids:
         candidates = filler.candidates_from(sense_id, enabled_names)
-        out[sense_id] = await _disambiguate(
-            sense_id, candidates, workspace_id, pocket_id=pocket_id
-        )
+        out[sense_id] = await _disambiguate(sense_id, candidates, workspace_id, pocket_id=pocket_id)
     return out
 
 

--- a/src/pocketpaw/bundled_templates/schema.py
+++ b/src/pocketpaw/bundled_templates/schema.py
@@ -11,6 +11,13 @@
 # (a Paw Site composed by conversion role) validates. The landing-page
 # template uses shape:"custom", which is already exempt from the
 # columns-required and default_view-matrix rules — no shape change needed.
+# Modified: 2026-06-08 (feat/sense-template-needs, Sense tier chunk 6a) —
+# added `needs: list[str]` to PocketTemplate: the Sense ids a vertical
+# template requires (e.g. ["paw.payments.v1"]). Each id is validated at
+# template-load via senses.validate_sense_id (a malformed / unknown paw.*
+# id raises SenseValidationError), mirroring the connector `senses:` field.
+# `needs` is tenant-capability METADATA, not ripple spec — it is read at
+# pocket-create to surface a prompt-to-connect when a provider is missing.
 """Pydantic v2 model for the RFC 03 v2 Pocket Template Schema.
 
 This module is the **schema chokepoint** — every bundled template, every
@@ -376,6 +383,10 @@ class PocketTemplate(BaseModel):
     state: StateBinding
     actions: list[ActionDef] = Field(default_factory=list)
     connectors: list[str] = Field(default_factory=list)
+    needs: list[str] = Field(
+        default_factory=list,
+        description="Sense ids this template requires, e.g. ['paw.email.v1'].",
+    )
     agents: list[AgentDef] = Field(default_factory=list)
     triggers: list[TriggerDef] = Field(default_factory=list)
     outcomes: list[str] = Field(default_factory=list)
@@ -408,6 +419,19 @@ class PocketTemplate(BaseModel):
     def _vertical_is_lower_slug(cls, v: str) -> str:
         if not v or v != v.lower() or any(ch.isspace() for ch in v):
             raise ValueError("vertical must be a lower-case slug")
+        return v
+
+    @field_validator("needs")
+    @classmethod
+    def _needs_are_valid_senses(cls, v: list[str]) -> list[str]:
+        # Validate each declared sense id at template-load — a malformed or
+        # unknown paw.* id raises SenseValidationError, consistent with the
+        # connector ``senses:`` validation. Imported inside the validator to
+        # avoid a top-level import cycle with the senses catalog.
+        from pocketpaw.senses import validate_sense_id
+
+        for sense_id in v:
+            validate_sense_id(sense_id)
         return v
 
     @model_validator(mode="after")

--- a/src/pocketpaw/bundled_templates/schema.py
+++ b/src/pocketpaw/bundled_templates/schema.py
@@ -18,6 +18,13 @@
 # id raises SenseValidationError), mirroring the connector `senses:` field.
 # `needs` is tenant-capability METADATA, not ripple spec — it is read at
 # pocket-create to surface a prompt-to-connect when a provider is missing.
+# Modified: 2026-06-08 (feat/sense-source, Sense tier chunk 6b) — DataSourceDef
+# gains a `type: "http"|"sense"` field (default "http", backward compatible).
+# `path` is now optional (required only for http via the type validator);
+# sense sources add `sense_id`, `action`, `params`. A model validator enforces
+# path-required-for-http and sense_id+action-required-for-sense, and validates
+# sense_id via senses.validate_sense_id. The resolved Sense value binds into
+# state like any HTTP source, so Ripple needs no changes.
 """Pydantic v2 model for the RFC 03 v2 Pocket Template Schema.
 
 This module is the **schema chokepoint** — every bundled template, every
@@ -303,27 +310,62 @@ class TriggerDef(BaseModel):
 
 
 class DataSourceDef(BaseModel):
-    """One read-only source that hydrates state at runtime (RFC 04)."""
+    """One read-only source that hydrates state at runtime (RFC 04).
+
+    Two source ``type``s:
+
+    * ``http`` (default, backward-compatible) — a relative-path HTTP GET.
+      ``path`` is required.
+    * ``sense`` — resolves a provider-agnostic Sense (Sense tier chunk 6b).
+      ``sense_id`` + ``action`` are required; the resolved value lands in
+      ``bind`` like any other source, so Ripple needs no changes. ``params``
+      are STATIC in v1 (no ``{state.x}`` evaluation yet).
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     name: str
+    type: Literal["http", "sense"] = "http"
     method: DataSourceMethodT = "GET"
-    path: str = Field(
-        ...,
-        description="Relative path; never absolute (SSRF-safe by RFC 04).",
+    path: str | None = Field(
+        default=None,
+        description="Relative path (http sources); never absolute (SSRF-safe by RFC 04).",
     )
     bind: str = Field(..., description="state path that receives the result.")
     refresh: list[str] = Field(default_factory=lambda: ["pocket_open", "manual"])
     transform: str | None = None
+    # Sense-source fields (type == "sense").
+    sense_id: str | None = None
+    action: str | None = None
+    params: dict[str, Any] | None = None
 
     @field_validator("path")
     @classmethod
-    def _path_is_relative(cls, v: str) -> str:
-        # SSRF safety per RFC 04: relative paths only.
-        if v.startswith(("http://", "https://", "//", "ftp://")):
+    def _path_is_relative(cls, v: str | None) -> str | None:
+        # SSRF safety per RFC 04: relative paths only. Only enforced when
+        # present — a sense source has no path.
+        if v is not None and v.startswith(("http://", "https://", "//", "ftp://")):
             raise ValueError("data_sources[].path must be relative, not absolute")
         return v
+
+    @model_validator(mode="after")
+    def _type_conditionals(self) -> DataSourceDef:
+        if self.type == "http":
+            if not self.path:
+                raise ValueError("data_sources[].path is required when type='http'")
+        elif self.type == "sense":
+            if not self.sense_id or not self.action:
+                raise ValueError(
+                    "data_sources[].sense_id and .action are required when type='sense'"
+                )
+            # Validate the sense id at template-load, consistent with the
+            # connector ``senses:`` and template ``needs:`` validation. Imported
+            # inside the validator to avoid a top-level import cycle with the
+            # senses catalog. A malformed/unknown paw.* id raises.
+            from pocketpaw.senses import validate_sense_id
+
+            validate_sense_id(self.sense_id)
+        return self
 
 
 class PermissionsDef(BaseModel):

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -3,6 +3,10 @@
 # Updated: 2026-03-30 — Native adapter support for database connectors.
 # Updated: 2026-04-01 — Added Firebase CLI adapter registration.
 # Updated: 2026-04-01 — Added GCP adapter for gcloud CLI integration.
+# Updated: 2026-06-08 — Added the public ``definitions`` property (full
+#   ConnectorDef list incl. ``.senses``) so the EE SenseResolver can index
+#   connectors by sense without reaching into the private ``_definitions``
+#   dict. OSS-only change; must not import pocketpaw_ee.
 
 from __future__ import annotations
 
@@ -143,6 +147,18 @@ class ConnectorRegistry:
             }
             for d in self._definitions.values()
         ]
+
+    @property
+    def definitions(self) -> list[ConnectorDef]:
+        """All parsed connector definitions, including their ``.senses``.
+
+        Public accessor over the internal ``_definitions`` map so consumers
+        (notably the EE SenseResolver) can index connectors by sense via
+        ``pocketpaw.senses.connectors_for_sense`` without reaching into the
+        private dict. Returns a fresh list; mutating it does not affect the
+        registry.
+        """
+        return list(self._definitions.values())
 
     def get_definition(self, name: str) -> ConnectorDef | None:
         """Get a connector definition by name."""

--- a/src/pocketpaw/connectors/yaml_engine.py
+++ b/src/pocketpaw/connectors/yaml_engine.py
@@ -6,6 +6,9 @@
 #   from the YAML. It is the per-connector mapping source for deriving a pocket's
 #   PocketSurfaceProfile when the connector is bound to a pocket. Backward-compat:
 #   connectors with no block parse with ``surface_profile=None``.
+# Updated: 2026-06-08 — Added `senses: list[str]` to ConnectorDef + parse-time
+#   validation via senses.validate_sense_id (Sense tier chunk 1). Unknown paw.*
+#   ids fail loudly; missing `senses:` key is backward compatible ([]).
 
 from __future__ import annotations
 
@@ -61,6 +64,9 @@ class ConnectorDef:
     # M3 — optional connector→skill/tool mapping. ``None`` when the YAML has
     # no ``surface_profile:`` block (the common case / backward-compat).
     surface_profile: ConnectorSurfaceProfile | None = None
+    # Sense tier — the provider-agnostic capabilities this connector fills
+    # (e.g. ["paw.email.v1"]). Empty when the YAML has no ``senses:`` key.
+    senses: list[str] = field(default_factory=list)
 
 
 def _parse_surface_profile(raw: Any) -> ConnectorSurfaceProfile | None:
@@ -89,8 +95,24 @@ def parse_connector_yaml(path: Path) -> ConnectorDef:
     with open(path) as f:
         raw = yaml.safe_load(f)
 
+    name = raw.get("name", path.stem)
+
+    # Validate any declared senses at parse time. An unknown paw.* id must fail
+    # loudly with a message naming the connector + the bad id — this is the
+    # "no fragmentation of the core" rule (Sense tier chunk 1).
+    from pocketpaw.senses import SenseValidationError, validate_sense_id
+
+    senses = raw.get("senses", [])
+    for sense_id in senses:
+        try:
+            validate_sense_id(sense_id)
+        except SenseValidationError as e:
+            raise SenseValidationError(
+                f"connector {name!r} declares invalid sense {sense_id!r}: {e}"
+            ) from e
+
     return ConnectorDef(
-        name=raw.get("name", path.stem),
+        name=name,
         display_name=raw.get("display_name", raw.get("name", path.stem)),
         type=raw.get("type", "generic"),
         icon=raw.get("icon", "plug"),
@@ -98,6 +120,7 @@ def parse_connector_yaml(path: Path) -> ConnectorDef:
         actions=raw.get("actions", []),
         sync=raw.get("sync", {}),
         surface_profile=_parse_surface_profile(raw.get("surface_profile")),
+        senses=senses,
     )
 
 

--- a/src/pocketpaw/senses/__init__.py
+++ b/src/pocketpaw/senses/__init__.py
@@ -1,0 +1,25 @@
+# Sense tier — provider-agnostic capability vocabulary above Connectors.
+# Created: 2026-06-08 — OSS catalog half (RFC Sense tier, chunk 1).
+# Exposes the curated core vocabulary, sense-id validation, and the static
+# connector index. The resolver (tenant binding) is built in a later EE chunk
+# and is NOT part of this package.
+
+from pocketpaw.senses.vocabulary import (
+    CORE_SENSES,
+    SENSE_VOCAB_VERSION,
+    CoreSense,
+    SenseValidationError,
+    connectors_for_sense,
+    is_core_sense,
+    validate_sense_id,
+)
+
+__all__ = [
+    "CORE_SENSES",
+    "SENSE_VOCAB_VERSION",
+    "CoreSense",
+    "SenseValidationError",
+    "connectors_for_sense",
+    "is_core_sense",
+    "validate_sense_id",
+]

--- a/src/pocketpaw/senses/vocabulary.py
+++ b/src/pocketpaw/senses/vocabulary.py
@@ -1,0 +1,132 @@
+# Sense vocabulary — the curated CORE capability vocabulary + validation + static index.
+# Created: 2026-06-08 — OSS catalog half (RFC Sense tier, chunk 1).
+# A Sense is a provider-agnostic capability above Connectors. Templates/agents
+# address a Sense (e.g. paw.email.v1); a resolver (built later, not here) binds
+# it to whatever connector a tenant enabled. This module owns:
+#   - CORE_SENSES: the in-repo, versioned curated vocabulary (id/name/description).
+#   - validate_sense_id / is_core_sense: the "no fragmentation of the core" rule.
+#   - connectors_for_sense: a pure static index over parsed ConnectorDefs.
+# Each core sense MUST be declared by at least one connector YAML (guard test).
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pocketpaw.connectors.yaml_engine import ConnectorDef
+
+# Bump when the core vocabulary changes. Core sense ids are themselves
+# versioned (paw.<domain>.vN); this version tracks the catalog as a whole.
+SENSE_VOCAB_VERSION = "1"
+
+# Core sense ids follow paw.<domain>.vN. Extension (vendor) ids follow
+# vendor.domain.vN and are accepted freely — the core is closed, the
+# extension space is open.
+_CORE_ID_PATTERN = re.compile(r"^paw\.[a-z0-9_]+\.v\d+$")
+_EXTENSION_ID_PATTERN = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+\.v\d+$")
+
+
+class SenseValidationError(ValueError):
+    """Raised when a sense id is malformed or an unknown paw.* core id."""
+
+
+@dataclass(frozen=True)
+class CoreSense:
+    """A single curated core capability in the versioned vocabulary."""
+
+    id: str
+    display_name: str
+    description: str
+
+
+# The v1 core vocabulary. Every entry here is backed by at least one connector
+# YAML in connectors/ (enforced by the guard test). Do NOT add a core sense
+# without a connector that can fill it — that is the anti-fragmentation rule.
+CORE_SENSES: tuple[CoreSense, ...] = (
+    CoreSense(
+        id="paw.email.v1",
+        display_name="Email",
+        description="Read, search, and send email across providers.",
+    ),
+    CoreSense(
+        id="paw.calendar.v1",
+        display_name="Calendar",
+        description="Read and manage calendar events and availability.",
+    ),
+    CoreSense(
+        id="paw.code.v1",
+        display_name="Code",
+        description="Access repositories, issues, pull requests, and code search.",
+    ),
+    CoreSense(
+        id="paw.payments.v1",
+        display_name="Payments",
+        description="Read payment, subscription, and billing data.",
+    ),
+    CoreSense(
+        id="paw.db.v1",
+        display_name="Database",
+        description="Query structured data in a relational or document database.",
+    ),
+    CoreSense(
+        id="paw.docs.v1",
+        display_name="Documents",
+        description="Read, search, and manage documents and files.",
+    ),
+)
+
+_CORE_IDS: frozenset[str] = frozenset(s.id for s in CORE_SENSES)
+
+
+def is_core_sense(sense_id: str) -> bool:
+    """True if ``sense_id`` is one of the curated core senses."""
+    return sense_id in _CORE_IDS
+
+
+def validate_sense_id(sense_id: str) -> str:
+    """Validate a sense id, returning it unchanged if valid.
+
+    Rules:
+      - A ``paw.*`` id is accepted ONLY if it is in the curated core set.
+        An unknown ``paw.*`` id raises — the core namespace is closed so
+        templates can't silently fragment it.
+      - A non-``paw.*`` id (vendor extension, format ``vendor.domain.vN``)
+        is accepted freely — the extension space is open.
+      - Anything that is neither a well-formed core id nor a well-formed
+        extension id raises.
+    """
+    if not isinstance(sense_id, str) or not sense_id:
+        raise SenseValidationError(f"sense id must be a non-empty string, got {sense_id!r}")
+
+    if sense_id.startswith("paw."):
+        if not _CORE_ID_PATTERN.match(sense_id):
+            raise SenseValidationError(
+                f"malformed core sense id {sense_id!r} (expected paw.<domain>.vN)"
+            )
+        if sense_id not in _CORE_IDS:
+            raise SenseValidationError(
+                f"unknown core sense id {sense_id!r}; the paw.* namespace is "
+                f"closed. Known core senses: {sorted(_CORE_IDS)}. "
+                f"Use a vendor.domain.vN id for custom capabilities."
+            )
+        return sense_id
+
+    # Extension (vendor) id — open namespace, just enforce the shape.
+    if not _EXTENSION_ID_PATTERN.match(sense_id):
+        raise SenseValidationError(
+            f"malformed extension sense id {sense_id!r} (expected vendor.domain.vN)"
+        )
+    return sense_id
+
+
+def connectors_for_sense(sense_id: str, connector_defs: list[ConnectorDef]) -> list[str]:
+    """Return the names of connectors that declare ``sense_id``.
+
+    Pure static index — given already-parsed ConnectorDefs, returns the
+    connector names whose ``senses`` list contains ``sense_id``. No tenant
+    state and no I/O beyond reading the passed-in defs. Results are sorted
+    for determinism.
+    """
+    return sorted(d.name for d in connector_defs if sense_id in getattr(d, "senses", []))

--- a/tests/cloud/pockets/test_template_needs.py
+++ b/tests/cloud/pockets/test_template_needs.py
@@ -47,10 +47,13 @@ def _loaded_with_needs(needs: list[str]) -> dict:
 async def test_check_returns_empty_when_all_senses_resolve() -> None:
     """Every declared sense has an enabled provider → no missing ids."""
     loaded = _loaded_with_needs(["paw.email.v1", "paw.payments.v1"])
-    resolved = ResolvedSense(sense_id="x", connector_name="gmail")
+
+    async def _fake_resolve_many(sense_ids, workspace_id, **_kw):
+        return {sid: ResolvedSense(sense_id=sid, connector_name="gmail") for sid in sense_ids}
+
     with patch(
-        "pocketpaw_ee.cloud.senses.resolver.resolve",
-        new=AsyncMock(return_value=resolved),
+        "pocketpaw_ee.cloud.senses.resolver.resolve_many",
+        new=_fake_resolve_many,
     ):
         missing = await pockets_service._check_template_needs(loaded, _WS)
     assert missing == []
@@ -58,16 +61,21 @@ async def test_check_returns_empty_when_all_senses_resolve() -> None:
 
 @pytest.mark.asyncio
 async def test_check_returns_missing_ids_when_some_resolve_none() -> None:
-    """A sense with no enabled provider (resolve → None) is collected."""
+    """A sense with no enabled provider (resolve_many value → None) is collected."""
     loaded = _loaded_with_needs(["paw.email.v1", "paw.payments.v1"])
 
-    async def _fake_resolve(sense_id: str, workspace_id: str, **_kw):
+    async def _fake_resolve_many(sense_ids, workspace_id, **_kw):
         # email is wired, payments is not
-        if sense_id == "paw.email.v1":
-            return ResolvedSense(sense_id=sense_id, connector_name="gmail")
-        return None
+        return {
+            sid: (
+                ResolvedSense(sense_id=sid, connector_name="gmail")
+                if sid == "paw.email.v1"
+                else None
+            )
+            for sid in sense_ids
+        }
 
-    with patch("pocketpaw_ee.cloud.senses.resolver.resolve", new=_fake_resolve):
+    with patch("pocketpaw_ee.cloud.senses.resolver.resolve_many", new=_fake_resolve_many):
         missing = await pockets_service._check_template_needs(loaded, _WS)
     assert missing == ["paw.payments.v1"]
 
@@ -91,7 +99,7 @@ async def test_check_swallows_resolver_error() -> None:
     create() must not blow up on a resolver hiccup."""
     loaded = _loaded_with_needs(["paw.email.v1"])
     with patch(
-        "pocketpaw_ee.cloud.senses.resolver.resolve",
+        "pocketpaw_ee.cloud.senses.resolver.resolve_many",
         new=AsyncMock(side_effect=RuntimeError("registry down")),
     ):
         missing = await pockets_service._check_template_needs(loaded, _WS)
@@ -117,8 +125,8 @@ async def test_create_not_blocked_and_emits_missing_senses(recording_bus) -> Non
         # No compile output → rippleSpec untouched (we only care about needs).
         patch.object(pockets_service, "_compile_template_to_runtime_dict", return_value=None),
         patch(
-            "pocketpaw_ee.cloud.senses.resolver.resolve",
-            new=AsyncMock(return_value=None),
+            "pocketpaw_ee.cloud.senses.resolver.resolve_many",
+            new=AsyncMock(return_value={"paw.payments.v1": None}),
         ),
     ):
         wire = await pockets_service.create(
@@ -146,9 +154,11 @@ async def test_create_omits_missing_senses_when_all_resolve(recording_bus) -> No
         patch("pocketpaw.bundled_templates.load_template", return_value=loaded),
         patch.object(pockets_service, "_compile_template_to_runtime_dict", return_value=None),
         patch(
-            "pocketpaw_ee.cloud.senses.resolver.resolve",
+            "pocketpaw_ee.cloud.senses.resolver.resolve_many",
             new=AsyncMock(
-                return_value=ResolvedSense(sense_id="paw.email.v1", connector_name="gmail")
+                return_value={
+                    "paw.email.v1": ResolvedSense(sense_id="paw.email.v1", connector_name="gmail")
+                }
             ),
         ),
     ):

--- a/tests/cloud/pockets/test_template_needs.py
+++ b/tests/cloud/pockets/test_template_needs.py
@@ -1,0 +1,174 @@
+# tests/cloud/pockets/test_template_needs.py
+# Created: 2026-06-08 (feat/sense-template-needs, Sense tier chunk 6a) — pins
+# the pocket-create path's handling of a template's declared ``needs:`` Senses.
+# A vertical template can require provider-agnostic capabilities (e.g.
+# paw.payments.v1). At create() the service asks the EE Sense resolver whether
+# an enabled connector fills each; ids with no provider are collected and:
+#   - surfaced as ``missing_senses`` on the pocket.created event (the seam the
+#     prompt-to-connect UX consumes), and
+#   - NEVER block creation (mirrors the strict=False template tolerance).
+#
+# Tests mock both the OSS ``load_template`` (so no real template file is needed)
+# and the EE ``resolve`` (so no connector registry / Mongo connector state is
+# needed). Uses the shared ``mongo_db`` + autouse RecordingBus fixtures from
+# tests/cloud/conftest.py so create()'s insert + emit() succeed and the emitted
+# event is inspectable via the ``recording_bus`` fixture.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+from pocketpaw_ee.cloud.senses.resolver import ResolvedSense
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_needs"
+_USER = "user_needs"
+
+
+def _loaded_with_needs(needs: list[str]) -> dict:
+    """A minimal ``load_template`` result shape: {"meta": {...}, ...}.
+
+    ``_check_template_needs`` only reads ``loaded["meta"]["needs"]``, so the
+    rest of the meta can be empty for these tests.
+    """
+    return {"meta": {"needs": needs}, "ripple_spec": None}
+
+
+# ---------------------------------------------------------------------------
+# _check_template_needs — the pure-ish helper (resolve mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_returns_empty_when_all_senses_resolve() -> None:
+    """Every declared sense has an enabled provider → no missing ids."""
+    loaded = _loaded_with_needs(["paw.email.v1", "paw.payments.v1"])
+    resolved = ResolvedSense(sense_id="x", connector_name="gmail")
+    with patch(
+        "pocketpaw_ee.cloud.senses.resolver.resolve",
+        new=AsyncMock(return_value=resolved),
+    ):
+        missing = await pockets_service._check_template_needs(loaded, _WS)
+    assert missing == []
+
+
+@pytest.mark.asyncio
+async def test_check_returns_missing_ids_when_some_resolve_none() -> None:
+    """A sense with no enabled provider (resolve → None) is collected."""
+    loaded = _loaded_with_needs(["paw.email.v1", "paw.payments.v1"])
+
+    async def _fake_resolve(sense_id: str, workspace_id: str, **_kw):
+        # email is wired, payments is not
+        if sense_id == "paw.email.v1":
+            return ResolvedSense(sense_id=sense_id, connector_name="gmail")
+        return None
+
+    with patch("pocketpaw_ee.cloud.senses.resolver.resolve", new=_fake_resolve):
+        missing = await pockets_service._check_template_needs(loaded, _WS)
+    assert missing == ["paw.payments.v1"]
+
+
+@pytest.mark.asyncio
+async def test_check_guards_none_loaded() -> None:
+    """A None loaded result (stale/unknown slug) yields no missing ids."""
+    assert await pockets_service._check_template_needs(None, _WS) == []
+
+
+@pytest.mark.asyncio
+async def test_check_guards_no_needs() -> None:
+    """A template with no needs yields no missing ids."""
+    assert await pockets_service._check_template_needs(_loaded_with_needs([]), _WS) == []
+    assert await pockets_service._check_template_needs({"meta": {}}, _WS) == []
+
+
+@pytest.mark.asyncio
+async def test_check_swallows_resolver_error() -> None:
+    """A resolver exception never propagates — the offending id is skipped,
+    create() must not blow up on a resolver hiccup."""
+    loaded = _loaded_with_needs(["paw.email.v1"])
+    with patch(
+        "pocketpaw_ee.cloud.senses.resolver.resolve",
+        new=AsyncMock(side_effect=RuntimeError("registry down")),
+    ):
+        missing = await pockets_service._check_template_needs(loaded, _WS)
+    assert missing == []
+
+
+# ---------------------------------------------------------------------------
+# create() — surfaces missing_senses on the event, NEVER blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_not_blocked_and_emits_missing_senses(recording_bus) -> None:
+    """Creating a pocket from a template with an unfilled need still succeeds
+    AND attaches the missing sense id to the pocket.created event."""
+    loaded = _loaded_with_needs(["paw.payments.v1"])
+
+    with (
+        patch(
+            "pocketpaw.bundled_templates.load_template",
+            return_value=loaded,
+        ),
+        # No compile output → rippleSpec untouched (we only care about needs).
+        patch.object(pockets_service, "_compile_template_to_runtime_dict", return_value=None),
+        patch(
+            "pocketpaw_ee.cloud.senses.resolver.resolve",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        wire = await pockets_service.create(
+            _WS,
+            _USER,
+            CreatePocketRequest(name="Invoice chaser", template_slug="invoice-chaser"),
+        )
+
+    # Creation was NOT blocked.
+    assert wire["name"] == "Invoice chaser"
+    assert wire["_id"]
+
+    # The pocket.created event carries the missing sense for the UX.
+    created = [e for e in recording_bus.events if e.EVENT_TYPE == "pocket.created"]
+    assert len(created) == 1
+    assert created[0].data.get("missing_senses") == ["paw.payments.v1"]
+
+
+@pytest.mark.asyncio
+async def test_create_omits_missing_senses_when_all_resolve(recording_bus) -> None:
+    """When every need resolves, the event carries no missing_senses key."""
+    loaded = _loaded_with_needs(["paw.email.v1"])
+
+    with (
+        patch("pocketpaw.bundled_templates.load_template", return_value=loaded),
+        patch.object(pockets_service, "_compile_template_to_runtime_dict", return_value=None),
+        patch(
+            "pocketpaw_ee.cloud.senses.resolver.resolve",
+            new=AsyncMock(
+                return_value=ResolvedSense(sense_id="paw.email.v1", connector_name="gmail")
+            ),
+        ),
+    ):
+        wire = await pockets_service.create(
+            _WS,
+            _USER,
+            CreatePocketRequest(name="Mail thing", template_slug="mail-thing"),
+        )
+
+    assert wire["name"] == "Mail thing"
+    created = [e for e in recording_bus.events if e.EVENT_TYPE == "pocket.created"]
+    assert len(created) == 1
+    assert "missing_senses" not in created[0].data
+
+
+@pytest.mark.asyncio
+async def test_create_without_template_has_no_missing_senses(recording_bus) -> None:
+    """A plain pocket (no template_slug) never carries missing_senses."""
+    wire = await pockets_service.create(_WS, _USER, CreatePocketRequest(name="plain"))
+    assert wire["name"] == "plain"
+    created = [e for e in recording_bus.events if e.EVENT_TYPE == "pocket.created"]
+    assert len(created) == 1
+    assert "missing_senses" not in created[0].data

--- a/tests/cloud/senses/__init__.py
+++ b/tests/cloud/senses/__init__.py
@@ -1,0 +1,2 @@
+# Sense tier EE cloud tests package.
+# Created: 2026-06-08 — Sense tier chunk 2 (SenseResolver) test suite.

--- a/tests/cloud/senses/test_resolver.py
+++ b/tests/cloud/senses/test_resolver.py
@@ -6,6 +6,10 @@
 # an auto action delegates with the resolved connector. Real connectors from
 # repo /connectors back the registry: gmail (paw.email.v1, single provider),
 # github+gitlab (paw.code.v1, ambiguous).
+# Updated: 2026-06-08 (sense-tier efficiency fix) — coverage for resolve_many:
+# all-resolve, partial-None, ambiguity preserved, and a query-count assertion
+# that the enabled-connector READ runs exactly ONCE for N senses (spying on
+# ConnectorSenseFiller.enabled_connector_names).
 
 from __future__ import annotations
 
@@ -17,6 +21,7 @@ from pocketpaw_ee.cloud.connectors.dto import (
     EnableConnectorRequest,
     ExecuteActionResponse,
 )
+from pocketpaw_ee.cloud.senses import filler as filler_mod
 from pocketpaw_ee.cloud.senses import preference, resolver
 
 from pocketpaw.senses import SenseValidationError
@@ -95,6 +100,81 @@ async def test_resolve_preference_not_a_candidate_falls_back_to_first() -> None:
 async def test_resolve_unknown_paw_sense_raises() -> None:
     with pytest.raises(SenseValidationError):
         await resolver.resolve("paw.telepathy.v1", WS)
+
+
+# ---------------------------------------------------------------------------
+# resolve_many — batch resolution with ONE enabled-connector read
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_many_all_resolve() -> None:
+    await _enable("gmail")
+    await _enable("github")
+    out = await resolver.resolve_many(["paw.email.v1", "paw.code.v1"], WS)
+    assert set(out) == {"paw.email.v1", "paw.code.v1"}
+    assert out["paw.email.v1"].connector_name == "gmail"
+    # github only (gitlab not enabled) -> single, unambiguous.
+    assert out["paw.code.v1"].connector_name == "github"
+    assert out["paw.code.v1"].ambiguous is False
+
+
+async def test_resolve_many_partial_none() -> None:
+    # Only email is wired; payments has no provider for this workspace.
+    await _enable("gmail")
+    out = await resolver.resolve_many(["paw.email.v1", "paw.payments.v1"], WS)
+    assert out["paw.email.v1"] is not None
+    assert out["paw.email.v1"].connector_name == "gmail"
+    assert out["paw.payments.v1"] is None
+
+
+async def test_resolve_many_preserves_ambiguity() -> None:
+    await _enable("github")
+    await _enable("gitlab")
+    out = await resolver.resolve_many(["paw.code.v1"], WS)
+    res = out["paw.code.v1"]
+    assert res is not None
+    assert res.candidates == ["github", "gitlab"]
+    assert res.ambiguous is True
+    assert res.connector_name == "github"  # sorted-first deterministic pick
+
+
+async def test_resolve_many_matches_resolve_per_sense() -> None:
+    """resolve_many produces the SAME result as calling resolve() per id."""
+    await _enable("gmail")
+    await _enable("github")
+    ids = ["paw.email.v1", "paw.code.v1", "paw.payments.v1"]
+    batch = await resolver.resolve_many(ids, WS)
+    for sid in ids:
+        single = await resolver.resolve(sid, WS)
+        assert batch[sid] == single
+
+
+async def test_resolve_many_reads_enabled_connectors_once(monkeypatch) -> None:
+    """The enabled-connector query runs EXACTLY ONCE for N senses — the whole
+    point of the batch path (was one query per sense)."""
+    await _enable("gmail")
+    await _enable("github")
+
+    real = filler_mod.ConnectorSenseFiller.enabled_connector_names
+
+    # Count calls to the enabled-connector read, delegating to the real impl.
+    calls = {"n": 0}
+
+    async def _counting(self, workspace_id, *, pocket_id=None):
+        calls["n"] += 1
+        return await real(self, workspace_id, pocket_id=pocket_id)
+
+    monkeypatch.setattr(filler_mod.ConnectorSenseFiller, "enabled_connector_names", _counting)
+
+    out = await resolver.resolve_many(["paw.email.v1", "paw.code.v1", "paw.payments.v1"], WS)
+    assert set(out) == {"paw.email.v1", "paw.code.v1", "paw.payments.v1"}
+    # ONE read for THREE senses.
+    assert calls["n"] == 1
+
+
+async def test_resolve_many_validates_ids() -> None:
+    with pytest.raises(SenseValidationError):
+        await resolver.resolve_many(["paw.email.v1", "paw.telepathy.v1"], WS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/senses/test_resolver.py
+++ b/tests/cloud/senses/test_resolver.py
@@ -1,0 +1,203 @@
+# SenseResolver tests — resolve disambiguation, preference, read-first gate, delegation.
+# Created: 2026-06-08 — Sense tier chunk 2. Exercises the real Beanie layer
+# (mongo_db fixture seeds enabled connectors + preferences through the actual
+# service / preference paths) and mocks connectors_service.execute so we can
+# assert the read-first gate never calls execute on a non-auto action, and that
+# an auto action delegates with the resolved connector. Real connectors from
+# repo /connectors back the registry: gmail (paw.email.v1, single provider),
+# github+gitlab (paw.code.v1, ambiguous).
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.dto import (
+    EnableConnectorRequest,
+    ExecuteActionResponse,
+)
+from pocketpaw_ee.cloud.senses import preference, resolver
+
+from pocketpaw.senses import SenseValidationError
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WS = "ws-sense-test"
+
+
+async def _enable(name: str) -> None:
+    await connectors_service.enable_connector(WS, name, EnableConnectorRequest(scope="workspace"))
+
+
+# ---------------------------------------------------------------------------
+# resolve — 0 / 1 / >1 providers
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_zero_providers_returns_none() -> None:
+    # paw.email.v1 is fillable by gmail, but nothing is enabled for this ws.
+    result = await resolver.resolve("paw.email.v1", WS)
+    assert result is None
+
+
+async def test_resolve_single_provider() -> None:
+    await _enable("gmail")
+    result = await resolver.resolve("paw.email.v1", WS)
+    assert result is not None
+    assert result.connector_name == "gmail"
+    assert result.ambiguous is False
+    assert result.candidates == ["gmail"]
+
+
+async def test_resolve_ignores_disabled_connector() -> None:
+    await _enable("gmail")
+    await connectors_service.disable_connector(WS, "gmail")
+    result = await resolver.resolve("paw.email.v1", WS)
+    assert result is None
+
+
+async def test_resolve_ambiguous_flag_when_no_preference() -> None:
+    # paw.code.v1 -> github + gitlab. No preference -> deterministic first +
+    # ambiguous flag set so the caller can ask the user to choose.
+    await _enable("github")
+    await _enable("gitlab")
+    result = await resolver.resolve("paw.code.v1", WS)
+    assert result is not None
+    assert result.candidates == ["github", "gitlab"]
+    assert result.ambiguous is True
+    assert result.connector_name == "github"  # sorted-first deterministic pick
+
+
+async def test_resolve_preference_wins() -> None:
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "gitlab")
+    result = await resolver.resolve("paw.code.v1", WS)
+    assert result is not None
+    assert result.connector_name == "gitlab"
+    assert result.ambiguous is False
+    assert result.candidates == ["github", "gitlab"]
+
+
+async def test_resolve_preference_not_a_candidate_falls_back_to_first() -> None:
+    # A stale preference (provider no longer enabled) is ignored — we fall back
+    # to the deterministic pick and re-flag ambiguous.
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "bitbucket")  # not enabled / not a candidate
+    result = await resolver.resolve("paw.code.v1", WS)
+    assert result is not None
+    assert result.connector_name == "github"
+    assert result.ambiguous is True
+
+
+async def test_resolve_unknown_paw_sense_raises() -> None:
+    with pytest.raises(SenseValidationError):
+        await resolver.resolve("paw.telepathy.v1", WS)
+
+
+# ---------------------------------------------------------------------------
+# preference store get/set + pocket override
+# ---------------------------------------------------------------------------
+
+
+async def test_preference_get_set_roundtrip() -> None:
+    assert await preference.get_preference(WS, "paw.code.v1") is None
+    await preference.set_preference(WS, "paw.code.v1", "github")
+    assert await preference.get_preference(WS, "paw.code.v1") == "github"
+    # idempotent update, not a duplicate insert
+    await preference.set_preference(WS, "paw.code.v1", "gitlab")
+    assert await preference.get_preference(WS, "paw.code.v1") == "gitlab"
+
+
+async def test_preference_pocket_overrides_workspace() -> None:
+    await preference.set_preference(WS, "paw.code.v1", "github")
+    await preference.set_preference(WS, "paw.code.v1", "gitlab", pocket_id="pk1")
+    # pocket-scoped pref wins for that pocket
+    assert await preference.get_preference(WS, "paw.code.v1", pocket_id="pk1") == "gitlab"
+    # other pockets fall back to the workspace default
+    assert await preference.get_preference(WS, "paw.code.v1", pocket_id="pk2") == "github"
+    # workspace level untouched
+    assert await preference.get_preference(WS, "paw.code.v1") == "github"
+
+
+# ---------------------------------------------------------------------------
+# execute_sense — read-first gate + delegation
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_sense_no_provider_is_structured_error() -> None:
+    result = await resolver.execute_sense("paw.email.v1", "gmail_search", {}, WS)
+    assert result.ok is False
+    assert result.error == "sense.no_provider"
+    assert result.connector_name is None
+
+
+async def test_execute_sense_blocks_confirm_action_never_calls_execute(monkeypatch) -> None:
+    await _enable("gmail")
+    spy = AsyncMock(return_value=ExecuteActionResponse(success=True))
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    # gmail_send is trust_level=confirm -> must be blocked, execute never called.
+    result = await resolver.execute_sense("paw.email.v1", "gmail_send", {"to": "x@y.com"}, WS)
+
+    assert result.ok is False
+    assert result.error == "sense.action_needs_approval"
+    assert result.connector_name == "gmail"
+    spy.assert_not_called()
+
+
+async def test_execute_sense_blocks_unknown_action(monkeypatch) -> None:
+    await _enable("gmail")
+    spy = AsyncMock(return_value=ExecuteActionResponse(success=True))
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    # An action with no trust_level in the def -> treated as not-auto -> blocked.
+    result = await resolver.execute_sense("paw.email.v1", "gmail_nonexistent", {}, WS)
+
+    assert result.ok is False
+    assert result.error == "sense.action_needs_approval"
+    spy.assert_not_called()
+
+
+async def test_execute_sense_delegates_auto_action(monkeypatch) -> None:
+    await _enable("gmail")
+    spy = AsyncMock(
+        return_value=ExecuteActionResponse(success=True, data={"messages": []}),
+    )
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    # gmail_search is trust_level=auto -> proceeds and delegates.
+    result = await resolver.execute_sense(
+        "paw.email.v1", "gmail_search", {"q": "is:unread"}, WS, user_id="u1"
+    )
+
+    assert result.ok is True
+    assert result.connector_name == "gmail"
+    assert result.data.success is True
+    spy.assert_awaited_once()
+    # delegated with the RESOLVED connector + right action/params.
+    call = spy.await_args
+    assert call.args[0] == WS
+    assert call.args[1] == "gmail"  # resolved connector name
+    req = call.args[2]
+    assert req.action == "gmail_search"
+    assert req.params == {"q": "is:unread"}
+    assert call.kwargs.get("user_id") == "u1"
+
+
+async def test_execute_sense_delegates_with_preferred_provider(monkeypatch) -> None:
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "github")
+    spy = AsyncMock(return_value=ExecuteActionResponse(success=True, data=[]))
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    # list_repos is trust_level=auto on github.
+    result = await resolver.execute_sense("paw.code.v1", "list_repos", {}, WS)
+
+    assert result.ok is True
+    assert result.connector_name == "github"
+    spy.assert_awaited_once()
+    assert spy.await_args.args[1] == "github"

--- a/tests/cloud/test_pocket_source_executor.py
+++ b/tests/cloud/test_pocket_source_executor.py
@@ -7,6 +7,11 @@
 # required user_id; added coverage for basic-auth base64 encoding, the
 # per-(pocket, user) rate-limit key, the async-safe limiter under
 # asyncio.gather, and the audit-log entry written for every run.
+# Updated: 2026-06-08 (feat/sense-source, Sense tier chunk 6b) — coverage for
+# the new type="sense" source: a mocked execute_sense ok-result binds the
+# unwrapped .data.data payload to state in the same {source,bind,value} row
+# shape; an ok=False result lands in the errors aggregation with the
+# resolver's stable code/message and does NOT abort a sibling http source.
 #
 # What this pins:
 #   - SSRF rejections: absolute-URL path, `..` traversal, path to a
@@ -638,3 +643,173 @@ async def test_rate_limited_run_audits_as_rate_limited(monkeypatch):
             token="",
         )
     assert logged[-1].status == "rate-limited"
+
+
+# ---------------------------------------------------------------------------
+# Sense sources (Sense tier chunk 6b) — type="sense" resolves via the Sense
+# resolver, NOT httpx. execute_sense is mocked; no connectors are needed.
+# ---------------------------------------------------------------------------
+
+
+def _patch_execute_sense(monkeypatch, fake):
+    """Patch the lazily-imported ``execute_sense`` on the resolver module.
+
+    ``_run_sense_binding`` does ``from ...senses.resolver import execute_sense``
+    at call time, so patching the attribute on that module is what takes
+    effect.
+    """
+    import pocketpaw_ee.cloud.senses.resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "execute_sense", fake)
+
+
+async def test_sense_source_binds_unwrapped_payload(monkeypatch):
+    """An ok sense result writes ``result.data.data`` (the unwrapped payload)
+    to the bound state path, in the same ``{source, bind, value}`` row shape
+    the http path returns."""
+    from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+    class _Resp:
+        # Stand-in for ExecuteActionResponse — only `.data` is read.
+        data = [{"id": "m1", "subject": "hello"}]
+        success = True
+
+    captured = {}
+
+    async def _fake(sense_id, action, params, workspace_id, *, pocket_id=None, user_id=None):
+        captured.update(
+            sense_id=sense_id,
+            action=action,
+            params=params,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+        )
+        return SenseExecutionResult(
+            ok=True, sense_id=sense_id, connector_name="gmail", action=action, data=_Resp()
+        )
+
+    _patch_execute_sense(monkeypatch, _fake)
+
+    spec = {
+        "sources": {
+            "inbox": {
+                "type": "sense",
+                "sense_id": "paw.email.v1",
+                "action": "gmail_search",
+                "params": {"q": "is:unread"},
+                "bind": "state.inbox",
+            }
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+    )
+
+    assert result["errors"] == []
+    assert len(result["ran"]) == 1
+    ran = result["ran"][0]
+    assert ran["source"] == "inbox"
+    assert ran["bind"] == "inbox"  # `state.` stripped
+    assert ran["value"] == [{"id": "m1", "subject": "hello"}]  # unwrapped .data.data
+    # Identity + static params threaded through to the resolver.
+    assert captured["sense_id"] == "paw.email.v1"
+    assert captured["action"] == "gmail_search"
+    assert captured["params"] == {"q": "is:unread"}
+    assert captured["workspace_id"] == "ws-1"
+    assert captured["pocket_id"] == "p1"
+    assert captured["user_id"] == "runner-1"
+
+
+async def test_sense_source_failure_lands_in_errors(monkeypatch):
+    """A sense result with ok=False lands in the errors aggregation with the
+    resolver's stable code/message — it does NOT crash the run."""
+    from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+    async def _fake(sense_id, action, params, workspace_id, *, pocket_id=None, user_id=None):
+        return SenseExecutionResult(
+            ok=False,
+            sense_id=sense_id,
+            error="sense.no_provider",
+            message="no connector fills paw.email.v1 for this workspace",
+        )
+
+    _patch_execute_sense(monkeypatch, _fake)
+
+    spec = {
+        "sources": {
+            "inbox": {
+                "type": "sense",
+                "sense_id": "paw.email.v1",
+                "action": "gmail_search",
+                "bind": "state.inbox",
+            }
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+    )
+
+    assert result["ran"] == []
+    assert len(result["errors"]) == 1
+    err = result["errors"][0]
+    assert err["source"] == "inbox"
+    assert err["code"] == "sense.no_provider"
+    assert "no connector fills" in err["error"]
+
+
+async def test_failed_sense_does_not_abort_sibling_http_source(monkeypatch):
+    """A failed sense source is contained — a sibling http source in the same
+    run still completes."""
+    from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+    async def _fake(sense_id, action, params, workspace_id, *, pocket_id=None, user_id=None):
+        return SenseExecutionResult(
+            ok=False, sense_id=sense_id, error="sense.no_provider", message="no provider"
+        )
+
+    _patch_execute_sense(monkeypatch, _fake)
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"ok": True}))
+
+    spec = {
+        "sources": {
+            "inbox": {
+                "type": "sense",
+                "sense_id": "paw.email.v1",
+                "action": "gmail_search",
+                "bind": "state.inbox",
+            },
+            "prs": {"method": "GET", "path": "/pulls", "bind": "state.prs"},
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+    )
+
+    # The http sibling succeeds; the sense source is the only error.
+    ran_sources = {r["source"] for r in result["ran"]}
+    err_sources = {e["source"] for e in result["errors"]}
+    assert ran_sources == {"prs"}
+    assert err_sources == {"inbox"}
+    assert result["ran"][0]["value"] == {"ok": True}

--- a/tests/cloud/test_pocket_source_executor.py
+++ b/tests/cloud/test_pocket_source_executor.py
@@ -92,6 +92,7 @@ async def test_happy_path_returns_parsed_json(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -112,6 +113,7 @@ async def test_bind_without_state_prefix_passes_through(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -132,6 +134,7 @@ async def test_absolute_url_path_rejected(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -149,6 +152,7 @@ async def test_dotdot_traversal_rejected(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -165,6 +169,7 @@ async def test_encoded_dotdot_traversal_rejected(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -182,6 +187,7 @@ async def test_protocol_relative_path_to_other_host_rejected(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -199,6 +205,7 @@ async def test_internal_base_url_rejected(monkeypatch):
         await source_executor.run_sources(
             pocket_id="p1",
             user_id="runner-1",
+            workspace_id="ws-test",
             ripple_spec=spec,
             base_url="http://127.0.0.1",
             auth_type="none",
@@ -220,6 +227,7 @@ async def test_host_resolving_internal_rejected(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -247,6 +255,7 @@ async def test_oversize_response_rejected(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -282,6 +291,7 @@ async def test_trigger_pocket_open_selects_open_sources(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=_multi_source_spec(),
         base_url=BASE,
         auth_type="none",
@@ -298,6 +308,7 @@ async def test_trigger_manual_selects_manual_sources(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=_multi_source_spec(),
         base_url=BASE,
         auth_type="none",
@@ -314,6 +325,7 @@ async def test_only_source_runs_just_that_source(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=_multi_source_spec(),
         base_url=BASE,
         auth_type="none",
@@ -329,6 +341,7 @@ async def test_no_trigger_runs_all_sources(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=_multi_source_spec(),
         base_url=BASE,
         auth_type="none",
@@ -352,6 +365,7 @@ async def test_redirect_becomes_source_error(monkeypatch):
     result = await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -376,6 +390,7 @@ async def test_rate_limit_breach_returns_rate_limited(monkeypatch):
         await source_executor.run_sources(
             pocket_id="p-rl",
             user_id="runner-1",
+            workspace_id="ws-test",
             ripple_spec=spec,
             base_url=BASE,
             auth_type="none",
@@ -386,6 +401,7 @@ async def test_rate_limit_breach_returns_rate_limited(monkeypatch):
     breach = await source_executor.run_sources(
         pocket_id="p-rl",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -403,6 +419,7 @@ async def test_rate_limit_is_per_pocket(monkeypatch):
         await source_executor.run_sources(
             pocket_id="pocket-a",
             user_id="runner-1",
+            workspace_id="ws-test",
             ripple_spec=spec,
             base_url=BASE,
             auth_type="none",
@@ -413,6 +430,7 @@ async def test_rate_limit_is_per_pocket(monkeypatch):
     other = await source_executor.run_sources(
         pocket_id="pocket-b",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -439,6 +457,7 @@ async def test_bearer_auth_header(monkeypatch):
     await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="bearer",
@@ -460,6 +479,7 @@ async def test_api_key_custom_header(monkeypatch):
     await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="api_key",
@@ -484,6 +504,7 @@ async def test_basic_auth_header_is_base64_encoded(monkeypatch):
     await source_executor.run_sources(
         pocket_id="p1",
         user_id="runner-1",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="basic",
@@ -512,6 +533,7 @@ async def test_rate_limit_is_per_user(monkeypatch):
         await source_executor.run_sources(
             pocket_id="shared-pocket",
             user_id="alice",
+            workspace_id="ws-test",
             ripple_spec=spec,
             base_url=BASE,
             auth_type="none",
@@ -521,6 +543,7 @@ async def test_rate_limit_is_per_user(monkeypatch):
     alice_breach = await source_executor.run_sources(
         pocket_id="shared-pocket",
         user_id="alice",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -533,6 +556,7 @@ async def test_rate_limit_is_per_user(monkeypatch):
     bob = await source_executor.run_sources(
         pocket_id="shared-pocket",
         user_id="bob",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE,
         auth_type="none",
@@ -559,6 +583,7 @@ async def test_rate_limit_async_safe_under_gather(monkeypatch):
             source_executor.run_sources(
                 pocket_id="race-pocket",
                 user_id="racer",
+                workspace_id="ws-test",
                 ripple_spec=spec,
                 base_url=BASE,
                 auth_type="none",
@@ -599,6 +624,7 @@ async def test_run_writes_audit_entry(monkeypatch):
     await source_executor.run_sources(
         pocket_id="audited-pocket",
         user_id="auditor",
+        workspace_id="ws-test",
         ripple_spec=spec,
         base_url=BASE + "/?token=leak",
         auth_type="bearer",
@@ -636,6 +662,7 @@ async def test_rate_limited_run_audits_as_rate_limited(monkeypatch):
         await source_executor.run_sources(
             pocket_id="rl-audit",
             user_id="auditor",
+            workspace_id="ws-test",
             ripple_spec=spec,
             base_url=BASE,
             auth_type="none",
@@ -813,3 +840,67 @@ async def test_failed_sense_does_not_abort_sibling_http_source(monkeypatch):
     assert ran_sources == {"prs"}
     assert err_sources == {"inbox"}
     assert result["ran"][0]["value"] == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# workspace_id robustness (sense-tier robustness fix)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_sources_requires_workspace_id():
+    """``workspace_id`` is keyword-required — omitting it is a loud TypeError,
+    not a silent None that mis-resolves a sense to "no provider"."""
+    with pytest.raises(TypeError):
+        await source_executor.run_sources(
+            pocket_id="p1",
+            user_id="runner-1",
+            ripple_spec={"sources": {}},
+            base_url=BASE,
+            auth_type="none",
+            auth_header=None,
+            token="",
+        )
+
+
+async def test_sense_source_with_falsy_workspace_is_clear_bad_source(monkeypatch):
+    """DEFENSE: a sense source run with a falsy workspace_id yields a CLEAR
+    bad_source error and NEVER calls the resolver — so it can never come back
+    as a silent no-provider."""
+    called = {"execute_sense": False}
+
+    async def _fake(sense_id, action, params, workspace_id, *, pocket_id=None, user_id=None):
+        called["execute_sense"] = True
+        raise AssertionError("execute_sense must not be called without a workspace")
+
+    _patch_execute_sense(monkeypatch, _fake)
+
+    spec = {
+        "sources": {
+            "inbox": {
+                "type": "sense",
+                "sense_id": "paw.email.v1",
+                "action": "gmail_search",
+                "bind": "state.inbox",
+            }
+        }
+    }
+    # An empty-string workspace is falsy — the guard must catch it before
+    # the resolver runs. (run_sources itself requires the kwarg.)
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="",
+    )
+
+    assert called["execute_sense"] is False
+    assert result["ran"] == []
+    assert len(result["errors"]) == 1
+    err = result["errors"][0]
+    assert err["source"] == "inbox"
+    assert err["code"] == "bad_source"
+    assert "workspace" in err["error"]

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -45,7 +45,8 @@ class TestConnectorsMcpServerRegistration:
         assert CONNECTOR_EXECUTE_TOOL_ID == "mcp__pocketpaw_connectors__connector_execute"
         assert LIST_CONNECTOR_ACTIONS_TOOL_ID in CONNECTOR_TOOL_IDS
         assert CONNECTOR_EXECUTE_TOOL_ID in CONNECTOR_TOOL_IDS
-        assert len(CONNECTOR_TOOL_IDS) == 2
+        # The server now also carries the two Sense-tier tools (chunk 4).
+        assert len(CONNECTOR_TOOL_IDS) == 4
 
     def test_extension_provider_advertises_tool_ids(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk
@@ -437,3 +438,217 @@ class TestConnectorExecuteHandler:
 
         assert out.get("is_error") is True
         assert "connector_name is required" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Handlers — Sense tier (list_senses / sense_execute)
+# ---------------------------------------------------------------------------
+
+
+class TestSenseTools:
+    @pytest.mark.asyncio
+    async def test_list_senses_reports_only_resolvable_senses(self) -> None:
+        """list_senses returns the senses that resolve to an enabled connector
+        for the workspace, and skips the ones with no provider."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.senses.resolver import ResolvedSense
+
+        async def fake_resolve(sense_id, workspace_id, *, pocket_id=None):
+            if sense_id == "paw.email.v1":
+                return ResolvedSense(
+                    sense_id="paw.email.v1",
+                    connector_name="gmail",
+                    ambiguous=False,
+                    candidates=["gmail"],
+                )
+            return None  # no provider for the rest
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.resolve",
+                new=AsyncMock(side_effect=fake_resolve),
+            ),
+        ):
+            out = await connectors_mcp._list_senses_handler({})
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        ids = [s["sense"] for s in body["senses"]]
+        assert ids == ["paw.email.v1"]
+        assert body["senses"][0]["connector"] == "gmail"
+
+    @pytest.mark.asyncio
+    async def test_list_senses_no_workspace_errors(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity(None, None, None)
+        with ws_patch, user_patch, pocket_patch:
+            out = await connectors_mcp._list_senses_handler({})
+
+        assert out.get("is_error") is True
+        assert "no active workspace" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_success_flattens_response(self) -> None:
+        """A successful sense_execute flattens the underlying
+        ExecuteActionResponse into the SAME shape connector_execute returns —
+        not a nested Pydantic repr (json.dumps uses default=str)."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+        exec_result = SenseExecutionResult(
+            ok=True,
+            sense_id="paw.email.v1",
+            connector_name="gmail",
+            action="gmail_search",
+            data=ExecuteActionResponse(
+                success=True,
+                data=[{"id": "m1", "subject": "hello"}],
+                execution_mode="cloud",
+            ),
+        )
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.execute_sense",
+                new=AsyncMock(return_value=exec_result),
+            ) as mock_exec,
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search", "params": {"q": "hi"}}
+            )
+
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        # Flat shape, structurally identical to connector_execute's success.
+        assert body["executed"] is True
+        assert body["sense"] == "paw.email.v1"
+        assert body["connector"] == "gmail"
+        assert body["success"] is True
+        assert body["data"][0]["subject"] == "hello"
+        assert body["execution_mode"] == "cloud"
+        # Delegated to execute_sense with the resolved identity.
+        mock_exec.assert_awaited_once()
+        call = mock_exec.await_args
+        assert call.args[0] == "paw.email.v1"  # sense
+        assert call.args[1] == "gmail_search"  # action
+        assert call.kwargs["pocket_id"] == "pk_1"
+        assert call.kwargs["user_id"] == "u_1"
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_refusal_is_delegated_not_self_gated(self) -> None:
+        """A write/needs-approval refusal comes back as an error envelope, and
+        the handler still DELEGATED to execute_sense (it does not gate itself)."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+        refused = SenseExecutionResult(
+            ok=False,
+            sense_id="paw.email.v1",
+            connector_name="gmail",
+            action="gmail_send",
+            error="sense.action_needs_approval",
+            message="action 'gmail_send' needs approval — not executed in v1 (read-first).",
+        )
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.execute_sense",
+                new=AsyncMock(return_value=refused),
+            ) as mock_exec,
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_send", "params": {}}
+            )
+
+        assert out.get("is_error") is True
+        assert "needs approval" in out["content"][0]["text"]
+        mock_exec.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_no_provider_errors(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+        none_result = SenseExecutionResult(
+            ok=False,
+            sense_id="paw.email.v1",
+            action="gmail_search",
+            error="sense.no_provider",
+            message="no enabled connector can fill 'paw.email.v1' for this workspace.",
+        )
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.execute_sense",
+                new=AsyncMock(return_value=none_result),
+            ),
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search"}
+            )
+
+        assert out.get("is_error") is True
+        assert "no enabled connector" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_guards_and_validation(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        # No pocket → refused.
+        ws_p, u_p, pk_p = _patch_identity("ws_1", "u_1", None)
+        with ws_p, u_p, pk_p:
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search"}
+            )
+        assert out.get("is_error") is True
+        assert "pocket" in out["content"][0]["text"]
+
+        # Missing sense → refused.
+        ws_p, u_p, pk_p = _patch_identity("ws_1", "u_1", "pk_1")
+        with ws_p, u_p, pk_p:
+            out = await connectors_mcp._sense_execute_handler({"action": "gmail_search"})
+        assert out.get("is_error") is True
+        assert "sense is required" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_unknown_sense_is_clean_error(self) -> None:
+        """An unknown paw.* id raises SenseValidationError inside execute_sense;
+        the handler turns it into a clean error, not a crash."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        from pocketpaw.senses import SenseValidationError
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.execute_sense",
+                new=AsyncMock(side_effect=SenseValidationError("unknown core sense id")),
+            ),
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.unknown.v1", "action": "x"}
+            )
+
+        assert out.get("is_error") is True
+        assert "unknown sense" in out["content"][0]["text"]

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -453,15 +453,20 @@ class TestSenseTools:
         from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
         from pocketpaw_ee.cloud.senses.resolver import ResolvedSense
 
-        async def fake_resolve(sense_id, workspace_id, *, pocket_id=None):
-            if sense_id == "paw.email.v1":
-                return ResolvedSense(
-                    sense_id="paw.email.v1",
-                    connector_name="gmail",
-                    ambiguous=False,
-                    candidates=["gmail"],
+        async def fake_resolve_many(sense_ids, workspace_id, *, pocket_id=None):
+            return {
+                sid: (
+                    ResolvedSense(
+                        sense_id="paw.email.v1",
+                        connector_name="gmail",
+                        ambiguous=False,
+                        candidates=["gmail"],
+                    )
+                    if sid == "paw.email.v1"
+                    else None  # no provider for the rest
                 )
-            return None  # no provider for the rest
+                for sid in sense_ids
+            }
 
         ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
         with (
@@ -469,8 +474,8 @@ class TestSenseTools:
             user_patch,
             pocket_patch,
             patch(
-                "pocketpaw_ee.cloud.senses.resolver.resolve",
-                new=AsyncMock(side_effect=fake_resolve),
+                "pocketpaw_ee.cloud.senses.resolver.resolve_many",
+                new=AsyncMock(side_effect=fake_resolve_many),
             ),
         ):
             out = await connectors_mcp._list_senses_handler({})

--- a/tests/senses/__init__.py
+++ b/tests/senses/__init__.py
@@ -1,0 +1,2 @@
+# Sense tier test package.
+# Created: 2026-06-08 — RFC Sense tier chunk 1.

--- a/tests/senses/test_sense_catalog.py
+++ b/tests/senses/test_sense_catalog.py
@@ -1,0 +1,127 @@
+# Sense catalog tests — vocabulary validation, static index, and anti-drift guard.
+# Created: 2026-06-08 — RFC Sense tier chunk 1.
+# The guard test (test_every_core_sense_has_a_connector) is the anti-drift
+# rule: every core sense MUST be backed by at least one connector YAML, or the
+# vocabulary and the connector catalog have drifted apart.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.connectors.yaml_engine import ConnectorDef, parse_connector_yaml
+from pocketpaw.senses import (
+    CORE_SENSES,
+    SenseValidationError,
+    connectors_for_sense,
+    is_core_sense,
+    validate_sense_id,
+)
+
+# Repo-root connectors/ directory (worktree root is two parents up from this file).
+CONNECTORS_DIR = Path(__file__).resolve().parents[2] / "connectors"
+
+
+def _all_connector_defs() -> list[ConnectorDef]:
+    """Parse every connector YAML in the repo (same path the registry scans)."""
+    defs: list[ConnectorDef] = []
+    for path in sorted(CONNECTORS_DIR.glob("*.yaml")):
+        defs.append(parse_connector_yaml(path))
+    return defs
+
+
+# --- validate_sense_id ------------------------------------------------------
+
+
+def test_core_ids_are_accepted():
+    for sense in CORE_SENSES:
+        assert validate_sense_id(sense.id) == sense.id
+        assert is_core_sense(sense.id)
+
+
+def test_unknown_paw_id_is_rejected():
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("paw.crm.v1")
+    assert not is_core_sense("paw.crm.v1")
+
+
+def test_malformed_paw_id_is_rejected():
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("paw.email")  # missing version
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("paw.Email.v1")  # uppercase
+
+
+def test_vendor_extension_id_is_accepted_freely():
+    assert validate_sense_id("acme.crm.v1") == "acme.crm.v1"
+    assert validate_sense_id("salesforce.leads.v2") == "salesforce.leads.v2"
+    assert not is_core_sense("acme.crm.v1")
+
+
+def test_malformed_extension_id_is_rejected():
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("justone")
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("acme.crm")  # missing version
+
+
+def test_empty_id_is_rejected():
+    with pytest.raises(SenseValidationError):
+        validate_sense_id("")
+
+
+# --- connectors_for_sense ---------------------------------------------------
+
+
+def test_connectors_for_sense_returns_matching_names():
+    defs = [
+        ConnectorDef(name="gmail", display_name="Gmail", senses=["paw.email.v1"]),
+        ConnectorDef(name="github", display_name="GitHub", senses=["paw.code.v1"]),
+        ConnectorDef(name="airtable", display_name="Airtable"),  # no senses
+    ]
+    assert connectors_for_sense("paw.email.v1", defs) == ["gmail"]
+    assert connectors_for_sense("paw.code.v1", defs) == ["github"]
+    assert connectors_for_sense("paw.payments.v1", defs) == []
+
+
+def test_connectors_for_sense_handles_multi_sense_connector():
+    defs = [
+        ConnectorDef(
+            name="gworkspace",
+            display_name="Google Workspace",
+            senses=["paw.email.v1", "paw.calendar.v1", "paw.docs.v1"],
+        ),
+        ConnectorDef(name="gmail", display_name="Gmail", senses=["paw.email.v1"]),
+    ]
+    assert connectors_for_sense("paw.email.v1", defs) == ["gmail", "gworkspace"]
+    assert connectors_for_sense("paw.calendar.v1", defs) == ["gworkspace"]
+    assert connectors_for_sense("paw.docs.v1", defs) == ["gworkspace"]
+
+
+def test_connectors_with_no_senses_key_default_to_empty():
+    defs = [ConnectorDef(name="airtable", display_name="Airtable")]
+    assert defs[0].senses == []
+    assert connectors_for_sense("paw.email.v1", defs) == []
+
+
+# --- anti-drift guard -------------------------------------------------------
+
+
+def test_every_core_sense_has_a_connector():
+    """Every core sense must be declared by at least one connector YAML."""
+    defs = _all_connector_defs()
+    assert defs, "no connector YAMLs found — check CONNECTORS_DIR"
+    for sense in CORE_SENSES:
+        matches = connectors_for_sense(sense.id, defs)
+        assert matches, (
+            f"core sense {sense.id!r} has no connector declaring it; "
+            f"either annotate a connector YAML or drop it from CORE_SENSES"
+        )
+
+
+def test_all_declared_senses_validate():
+    """Every senses entry across all connector YAMLs must be a valid id."""
+    for path in sorted(CONNECTORS_DIR.glob("*.yaml")):
+        # parse_connector_yaml validates at parse time; a bad id would raise.
+        parse_connector_yaml(path)

--- a/tests/unit/test_template_schema.py
+++ b/tests/unit/test_template_schema.py
@@ -562,3 +562,117 @@ def test_needs_with_malformed_sense_raises() -> None:
     underlying = exc_info.value.errors()[0]["ctx"]["error"]
     assert isinstance(underlying, SenseValidationError)
     assert "malformed core sense id" in str(underlying)
+
+
+# ---------------------------------------------------------------------------
+# DataSourceDef — http (default) + sense source types (Sense tier chunk 6b)
+# ---------------------------------------------------------------------------
+
+
+def test_data_source_http_default_parses() -> None:
+    """A bare source (no ``type``) defaults to http and requires ``path`` — the
+    backward-compatible shape every pre-Sense source uses."""
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    src = DataSourceDef.model_validate({"name": "prs", "path": "/api/prs", "bind": "state.prs"})
+    assert src.type == "http"
+    assert src.path == "/api/prs"
+    assert src.sense_id is None
+
+
+def test_data_source_http_missing_path_raises() -> None:
+    """An http source with no ``path`` fails — the type validator requires it."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate({"name": "prs", "bind": "state.prs"})
+    assert "path is required when type='http'" in str(exc_info.value)
+
+
+def test_data_source_sense_parses() -> None:
+    """A sense source (type=sense, sense_id+action) validates and round-trips;
+    ``path`` is not required."""
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    src = DataSourceDef.model_validate(
+        {
+            "name": "inbox",
+            "type": "sense",
+            "sense_id": "paw.email.v1",
+            "action": "gmail_search",
+            "params": {"q": "is:unread"},
+            "bind": "state.inbox",
+        }
+    )
+    assert src.type == "sense"
+    assert src.sense_id == "paw.email.v1"
+    assert src.action == "gmail_search"
+    assert src.params == {"q": "is:unread"}
+    assert src.path is None
+
+
+def test_data_source_sense_missing_sense_id_raises() -> None:
+    """A sense source without ``sense_id`` fails the type validator."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate(
+            {"name": "inbox", "type": "sense", "action": "gmail_search", "bind": "state.inbox"}
+        )
+    assert "sense_id and .action are required" in str(exc_info.value)
+
+
+def test_data_source_sense_missing_action_raises() -> None:
+    """A sense source without ``action`` fails the type validator."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate(
+            {"name": "inbox", "type": "sense", "sense_id": "paw.email.v1", "bind": "state.inbox"}
+        )
+    assert "sense_id and .action are required" in str(exc_info.value)
+
+
+def test_data_source_sense_unknown_paw_id_raises() -> None:
+    """A sense source with an unknown paw.* id fails — sense_id is validated via
+    ``validate_sense_id`` at parse, mirroring the template ``needs:`` rule."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+    from pocketpaw.senses import SenseValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate(
+            {
+                "name": "inbox",
+                "type": "sense",
+                "sense_id": "paw.telepathy.v1",
+                "action": "read_minds",
+                "bind": "state.inbox",
+            }
+        )
+    # The SenseValidationError surfaces as the underlying cause of the model
+    # validator error.
+    msg = str(exc_info.value)
+    assert "unknown core sense id" in msg or isinstance(
+        exc_info.value.errors()[0].get("ctx", {}).get("error"), SenseValidationError
+    )
+
+
+def test_data_source_http_absolute_path_still_rejected() -> None:
+    """The relative-path SSRF guard still fires for http sources."""
+    from pydantic import ValidationError
+
+    from pocketpaw.bundled_templates.schema import DataSourceDef
+
+    with pytest.raises(ValidationError) as exc_info:
+        DataSourceDef.model_validate(
+            {"name": "prs", "path": "https://evil.example/api", "bind": "state.prs"}
+        )
+    assert "must be relative" in str(exc_info.value)

--- a/tests/unit/test_template_schema.py
+++ b/tests/unit/test_template_schema.py
@@ -499,3 +499,66 @@ def test_loader_strict_default_is_false_for_back_compat(tmp_path: Path) -> None:
     # No ``strict`` kwarg at all — should NOT raise.
     result = load_template("bad-template", templates_dir=tmp_path)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Sense tier chunk 6a — PocketTemplate.needs (declared Sense ids)
+# ---------------------------------------------------------------------------
+
+
+def test_needs_defaults_empty() -> None:
+    """A template with no ``needs:`` key reads back an empty list — the
+    field is backwards-compatible with every pre-Sense template."""
+    template = PocketTemplate.model_validate(_minimal_v2_dict())
+    assert template.needs == []
+
+
+def test_needs_with_valid_core_senses_parses() -> None:
+    """A template declaring valid core Sense ids validates and round-trips."""
+    meta = _minimal_v2_dict()
+    meta["needs"] = ["paw.payments.v1", "paw.email.v1"]
+    template = PocketTemplate.model_validate(meta)
+    assert template.needs == ["paw.payments.v1", "paw.email.v1"]
+
+
+def test_needs_with_valid_extension_sense_parses() -> None:
+    """A vendor-namespace (extension) sense id is accepted freely."""
+    meta = _minimal_v2_dict()
+    meta["needs"] = ["acme.crm.v1"]
+    template = PocketTemplate.model_validate(meta)
+    assert template.needs == ["acme.crm.v1"]
+
+
+def test_needs_with_unknown_paw_sense_raises() -> None:
+    """An unknown paw.* id fails validation — the core namespace is closed, so
+    a template can't silently fragment it. The ``needs`` field_validator calls
+    ``validate_sense_id``, which raises ``SenseValidationError``; Pydantic wraps
+    that in a ``ValidationError`` whose underlying cause is the SenseValidationError
+    (a ``ValueError`` subclass)."""
+    from pydantic import ValidationError
+
+    from pocketpaw.senses import SenseValidationError
+
+    meta = _minimal_v2_dict()
+    meta["needs"] = ["paw.telepathy.v1"]
+    with pytest.raises(ValidationError) as exc_info:
+        PocketTemplate.model_validate(meta)
+    underlying = exc_info.value.errors()[0]["ctx"]["error"]
+    assert isinstance(underlying, SenseValidationError)
+    assert "unknown core sense id" in str(underlying)
+
+
+def test_needs_with_malformed_sense_raises() -> None:
+    """A malformed sense id (no version suffix) fails validation — the
+    underlying error is a SenseValidationError raised by validate_sense_id."""
+    from pydantic import ValidationError
+
+    from pocketpaw.senses import SenseValidationError
+
+    meta = _minimal_v2_dict()
+    meta["needs"] = ["paw.email"]
+    with pytest.raises(ValidationError) as exc_info:
+        PocketTemplate.model_validate(meta)
+    underlying = exc_info.value.errors()[0]["ctx"]["error"]
+    assert isinstance(underlying, SenseValidationError)
+    assert "malformed core sense id" in str(underlying)


### PR DESCRIPTION
The whole Sense capability tier as one branch. The five stacked PRs (#1380, #1381, #1383, #1384, #1385) carry the same commits split for granular review — this is the unified surface for reviewing and merging the feature as a unit.

## What a Sense is

A provider-agnostic capability that sits above connectors. Templates and agents address a Sense (`paw.email.v1`) instead of a connector; a resolver binds it to whichever connector the tenant has enabled. The point is portable vertical templates — one template runs across tenants with different connector stacks.

## What's in the branch (five commits)

1. **catalog** — `src/pocketpaw/senses/`: a curated core vocabulary (email, calendar, code, payments, db, docs), a `senses:` list on connectors, and a guard test that keeps the vocabulary and the connector annotations in sync. The `paw.*` namespace is closed; vendor ids are open.
2. **resolver** — `ee/pocketpaw_ee/cloud/senses/`: resolves a Sense to the tenant's enabled connector, disambiguates when more than one fills it, and runs read actions through the existing connector execute path. Read-first: writes are refused, never executed.
3. **agent tools** — `list_senses` and `sense_execute` on the `pocketpaw_connectors` MCP server, so the cloud agent can work by capability instead of by provider.
4. **template needs** — a template declares `needs: [paw.payments.v1, ...]`; pocket-create surfaces unfilled Senses on the `pocket.created` event without blocking.
5. **sense source** — a pocket data source can be `{type: "sense", ...}` to hydrate state from a Sense. Server-side; ripple is unchanged.

## Boundaries and testing

OSS owns the catalog; EE owns the resolver and the consumers; the Soul is untouched (provider preference lives EE-side in v1). The OSS→EE import boundary holds across the branch. 219 tests pass across the sense, connector, MCP, template, and pocket-source surfaces.

## Out of scope (deferred)

Capability tokens, a standalone Sense service, provider routing/failover, non-connector fillers (the seam is in place), and expression evaluation in sense-source params.
