### PR TITLE
fix: auto-unarchive DM group on send instead of raising Forbidden

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/message_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/message_service.py
@@ -39,6 +39,7 @@ from pocketpaw_ee.cloud.models.user import User as _UserDoc
 from pocketpaw_ee.cloud.notifications import service as notifications_service
 from pocketpaw_ee.cloud.realtime.emit import emit
 from pocketpaw_ee.cloud.realtime.events import (
+    GroupUpdated,
     MessageDeleted,
     MessageEdited,
     MessageNew,
@@ -393,7 +394,10 @@ async def send_message(group_id: str, user_id: str, body: SendMessageRequest) ->
         )
 
     if group.archived:
-        raise Forbidden("group.archived", "Cannot send messages to an archived group")
+        # Unarchive the group so the user can resume the conversation
+        # (DM "delete" only hides/archives, not permanently blocks).
+        await group_service._update_group_fields(group_id, archived=False)
+        await emit(GroupUpdated(data={"group_id": group_id, "archived": False}))
 
     domain_msg = await _create_group_message_doc(
         group_id=group_id,


### PR DESCRIPTION
## Bug

When a user deletes a DM chat (which archives the group) and then tries to send a new message to the same person, the backend raises `Forbidden("group.archived")` — blocking the send entirely. The frontend had already loaded the previous chat, but every WebSocket send attempt fails.

## Root cause

`send_message()` in `message_service.py` checks `group.archived` and raises `Forbidden` instead of allowing the conversation to resume naturally.

## Fix

Replace the `Forbidden` raise with an automatic unarchive of the group:
1. Call `group_service._update_group_fields(group_id, archived=False)` to clear the archived flag
2. Emit `GroupUpdated` to notify connected clients

This keeps the semantics clean: "delete DM" = archive (hide from active list), "send a new message to that same person" = unarchive + deliver. No data loss, no confusing error, natural resumption of conversation.