### PR TITLE
VIP onboarding — full feature (v1 warm welcome + Phase B pre-briefed agent)

### DIFF
--- a/docs/playbooks/2026-06-08-vip-onboarding-phaseb-smoke-test.md
+++ b/docs/playbooks/2026-06-08-vip-onboarding-phaseb-smoke-test.md
@@ -1,0 +1,305 @@
+<!--
+VIP Onboarding Phase B — Manual Smoke Test Checklist
+Created 2026-06-08 alongside the cross-cutting e2e suite
+(tests/cloud/test_phaseb_e2e.py). Internal working aid for the captain's
+local walk-through of the assembled Phase B feature: a workspace member
+connects their own Gmail/Calendar at onboarding, lands on home, and the agent
+greets them knowing their day + an intent board shows it — while a SECOND
+member sees none of it. Grounded in the feat/phaseb-e2e branch code
+(member_ingest, member_day_digest, chat gate, kb scope validator, purge).
+-->
+
+# VIP Onboarding Phase B — Manual Smoke Test
+
+**Date:** 2026-06-08  **Branch:** `feat/phaseb-e2e` (full Phase B backend stack)
+
+This walks the assembled VIP-onboarding flow end to end by hand: an admin
+invites a member, the member connects their **own** Gmail + Calendar during
+onboarding, lands on home, and the agent greets them already knowing their day
+while the intent board renders it. Then a **second** member proves the
+isolation: none of the first member's data reaches them through any door.
+
+> **What the automated suite already covers (so you don't re-test it):**
+> `tests/cloud/test_phaseb_e2e.py` proves the leak-prevention across every door
+> (chat gate, REST kb router, digest API, shared room) plus the happy path and
+> purge, with the kb-go subprocess and the Gmail/Calendar reads mocked. This
+> checklist is the **real-stack** pass — live OAuth, a real kb binary, the
+> actual UI — that mocks can't give you. Run the suite first; treat this as the
+> confirmation that the wiring holds with real I/O.
+
+---
+
+## 0. What you're verifying
+
+| # | Behaviour | "Working" looks like |
+|---|-----------|----------------------|
+| **A** | Member connects own Gmail/Calendar at onboarding | OAuth completes; a **per-user** (`scope="user"`) connector row appears for that member |
+| **B** | First ingest lands in the member's private KB | Their `user:{id}` KB scope fills with recent mail + upcoming events (no other member's) |
+| **C** | Agent greets the member knowing their day | In the member's **own** chat, the agent proactively references today's meetings / unread mail |
+| **D** | Intent board shows the member's day | `GET /api/v1/member-day-digest` returns the member's events + unread count; the board renders it |
+| **E** | **Isolation** — a second member sees none of it | Member B's chat, KB search, digest, and any shared room contain **zero** of A's data |
+| **F** | Disconnect / offboard purges everything | After `/me/disconnect`, A's `user:{id}` KB is empty, tokens gone, digest empty |
+
+---
+
+## 1. Prerequisites
+
+### 1a. Google OAuth credentials (the real-path prerequisite)
+
+The member-ingest worker and the digest both read with the member's **own**
+per-user Google token. For a true end-to-end pass you need Google OAuth set up
+so a member can actually authorize Gmail + Calendar:
+
+- A Google Cloud OAuth client (`POCKETPAW_GOOGLE_CLIENT_ID` /
+  `POCKETPAW_GOOGLE_CLIENT_SECRET`) with the Gmail readonly + Calendar
+  readonly scopes enabled, and your redirect URI registered.
+- Per-user tokens are stored under the service keys `google_gmail` and
+  `google_calendar`, bucketed by the member's cloud user id (this is what the
+  per-user `GmailClient(user_id)` / `CalendarClient(user_id)` resolve).
+
+**No OAuth creds?** Use the **manual-seed fallback** in §1c — you can exercise
+B, C, E, and F (the KB-scope side of the chain) without ever touching Google.
+Only the live-digest pieces of C/D (the "right now" calendar + unread count)
+need real tokens.
+
+### 1b. kb-go binary
+
+The private KB scope is a real kb-go scope. Make sure the `kb` binary is on
+`PATH` or point at it explicitly:
+
+```bash
+export POCKETPAW_KB_BIN=/path/to/kb-go/kb
+kb --help   # sanity
+```
+
+### 1c. Manual-seed fallback (test the KB chain without OAuth)
+
+You can prove the whole KB side of the feature — ingest target, the agent's
+private retrieval, the leak gate, and purge — by dropping a doc straight into a
+member's `user:{id}` scope with the keyless `accept` path (no LLM, no API key):
+
+```bash
+# Replace MEMBER_ID with the member's cloud user id (see §2 for how to get it).
+echo '{"scope":"user:MEMBER_ID","articles":[{
+  "title":"Email: Re: PROJECT-NIGHTINGALE merger",
+  "content":"From: ceo@acme.test\n\nConfidential: PROJECT-NIGHTINGALE closes Friday.",
+  "summary":"merger closes Friday",
+  "categories":["email","gmail"]
+}]}' | "$POCKETPAW_KB_BIN" accept --scope "user:MEMBER_ID" --json
+
+# Confirm it landed:
+"$POCKETPAW_KB_BIN" search "PROJECT-NIGHTINGALE" --scope "user:MEMBER_ID" --json
+```
+
+This is exactly what `member_ingest.service` does internally on a real connect,
+so a seeded scope is indistinguishable from an ingested one for steps B/C/E/F.
+
+---
+
+## 2. Bring up the stack & get two members
+
+```bash
+# Backend (cloud / ee). From the repo root:
+uv run pocketpaw serve          # binds 127.0.0.1:8888 by default
+```
+
+You need **two** members in one workspace:
+
+1. As **admin**, invite a member (`POST /api/v1/workspaces/{ws}/invites`) — this
+   is **Alice**. Accept the invite as Alice in a second browser/profile.
+2. Invite a second member — this is **Bob**. Accept as Bob.
+
+Grab each member's **user id** and a bearer token. The id is what keys the
+`user:{id}` scope and the per-user token bucket. Easiest source:
+
+```bash
+# As each member, hit /me and note the id field:
+curl -s -H "Authorization: Bearer $ALICE_TOKEN" http://127.0.0.1:8888/api/v1/me
+curl -s -H "Authorization: Bearer $BOB_TOKEN"   http://127.0.0.1:8888/api/v1/me
+```
+
+Keep `ALICE_ID`, `BOB_ID`, `ALICE_TOKEN`, `BOB_TOKEN`, and the workspace id
+(`WS`) handy.
+
+---
+
+## 3. The walk-through
+
+### A — Alice connects her own Gmail + Calendar (onboarding)
+
+**UI path:** As Alice, go through onboarding / Settings → Connectors and
+connect **Gmail** and **Google Calendar** as *your* accounts. Complete the
+Google OAuth consent for each.
+
+**API check** — a per-user connector row now exists for Alice:
+
+```bash
+# The enable step records intent + scope; OAuth itself runs via the
+# oauth_integrations flow during the UI connect.
+curl -s -H "Authorization: Bearer $ALICE_TOKEN" \
+  http://127.0.0.1:8888/api/v1/connectors | python3 -m json.tool
+```
+
+- [ ] **A1** Gmail + Calendar show as connected for Alice, at `scope="user"`.
+- [ ] **A2** They are connected to **Alice's** Google account, not a shared one.
+
+> No OAuth creds? Skip A and use the §1c seed for Alice's `user:{ALICE_ID}`
+> scope. B's KB assertions, C's retrieval, E, and F all still hold.
+
+### B — First ingest fills Alice's private KB
+
+The sweep runs on an interval (default **5 min**; override with
+`POCKETPAW_MEMBER_INGEST_INTERVAL_SECONDS`). To avoid waiting, trigger one
+ingest tick directly, or just wait for the scheduler.
+
+```bash
+# One sweep tick across all connected members (or call ingest_member for Alice).
+# (From a Python shell against the running app, or wait for the 5-min loop.)
+python3 - <<'PY'
+import asyncio
+from pocketpaw_ee.cloud.member_ingest import service
+print(asyncio.run(service.ingest_member("WS", "ALICE_ID")))
+PY
+
+# Confirm Alice's mail/calendar text is searchable in HER scope:
+"$POCKETPAW_KB_BIN" search "merger" --scope "user:ALICE_ID" --json
+```
+
+- [ ] **B1** Alice's `user:{ALICE_ID}` scope now carries recent mail + upcoming
+  events (the ingest result reports `status:ok`, `documents > 0`).
+- [ ] **B2** Nothing landed in any **other** member's scope
+  (`kb search "<alice term>" --scope user:BOB_ID` → empty).
+
+### C — Agent greets Alice knowing her day
+
+**UI path:** As **Alice**, open her **own** chat (a solo session — just her and
+the agent). Send a neutral opener like "hey".
+
+- [ ] **C1** The agent's reply is **anticipatory** — it references today's
+  meetings and/or her unread mail without being asked (a `<your-day>` briefing
+  was injected into its prompt). Ask "what's on my plate today?" if the opener
+  was too generic.
+- [ ] **C2** Ask the agent something only the ingested mail would know (e.g.
+  "what did the CEO say about the merger?"). It answers from her private KB.
+
+### D — Intent board shows Alice's day
+
+**API check** — the digest the board renders, for the **authenticated** caller:
+
+```bash
+curl -s -H "Authorization: Bearer $ALICE_TOKEN" \
+  http://127.0.0.1:8888/api/v1/member-day-digest | python3 -m json.tool
+```
+
+- [ ] **D1** Returns `member_id == ALICE_ID`, with `events[]` (next ~7 days)
+  and `unread_mail_count`.
+- [ ] **D2** The intent board UI on Alice's home renders those events + the
+  unread count.
+
+> Note: the digest is a **live pull** (current calendar + unread), distinct
+> from the ingested KB. With seeded-only data (no OAuth), the digest is empty —
+> that's correct; D needs real tokens. B/C's KB side does not.
+
+### E — Isolation: Bob sees NONE of Alice's data (the centerpiece)
+
+Do all of these as **Bob**.
+
+- [ ] **E1 — chat:** In Bob's **own** chat, the agent does **not** know
+  anything about Alice's day or her mail. Ask "what's on the merger?" → it has
+  no idea (Bob's private scope is empty / only his own).
+- [ ] **E2 — REST kb (read):** Bob tries to read Alice's private scope directly
+  → **403**, never any of Alice's content:
+
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -H "Authorization: Bearer $BOB_TOKEN" -H "Content-Type: application/json" \
+    -X POST http://127.0.0.1:8888/api/v1/kb/search \
+    -d '{"query":"merger","scope":"user:ALICE_ID"}'
+  # expect: 403
+  ```
+
+- [ ] **E3 — REST kb (write/poison):** Bob tries to ingest into Alice's scope →
+  **403**, and Alice's scope is unchanged:
+
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -H "Authorization: Bearer $BOB_TOKEN" -H "Content-Type: application/json" \
+    -X POST http://127.0.0.1:8888/api/v1/kb/ingest/text \
+    -d '{"text":"poison","source":"evil","scope":"user:ALICE_ID"}'
+  # expect: 403
+  ```
+
+- [ ] **E4 — digest API:** Bob's digest is **his own**, never Alice's. There is
+  no `member_id` parameter to abuse:
+
+  ```bash
+  curl -s -H "Authorization: Bearer $BOB_TOKEN" \
+    http://127.0.0.1:8888/api/v1/member-day-digest | python3 -m json.tool
+  # member_id must be BOB_ID; none of Alice's content present.
+  ```
+
+- [ ] **E5 — shared room:** Put Alice + Bob in a **shared** group/room with an
+  agent. In that room the agent gets **no** member-private briefing for anyone
+  — Alice's `<your-day>` does not appear, and neither member's private KB is
+  searched. (Confirm the agent can't surface Alice's merger detail in the
+  shared room even when Alice is present.)
+
+### F — Disconnect / offboard purges everything
+
+As **Alice**, disconnect her accounts (UI: Settings → Connectors → Disconnect;
+or the API below). This runs the full purge.
+
+```bash
+curl -s -H "Authorization: Bearer $ALICE_TOKEN" \
+  -X POST http://127.0.0.1:8888/api/v1/connectors/me/disconnect | python3 -m json.tool
+```
+
+- [ ] **F1** Response shows `status:ok`, `kb_cleared:true`, and the token /
+  connector / ingest-state counts.
+- [ ] **F2** Alice's KB scope is empty: `kb search "merger" --scope
+  user:ALICE_ID --json` → no hits.
+- [ ] **F3** Alice's digest is now empty (`empty:true`, no events, unread 0),
+  and her chat agent no longer greets her with a day briefing.
+- [ ] **F4** Re-running the disconnect is a clean no-op (idempotent).
+
+---
+
+## 4. Pass/fail summary
+
+| Check | Pass? | Notes |
+|-------|:-----:|-------|
+| A1 per-user Gmail/Calendar connected |  |  |
+| A2 connected to Alice's own account |  |  |
+| B1 ingest fills Alice's `user:` KB |  |  |
+| B2 nothing in other members' scopes |  |  |
+| C1 agent gives proactive day briefing |  |  |
+| C2 agent answers from private KB |  |  |
+| D1 digest API returns Alice's day |  |  |
+| D2 intent board renders it |  |  |
+| **E1 Bob's chat has none of Alice's data** |  |  |
+| **E2 Bob → Alice KB read = 403** |  |  |
+| **E3 Bob → Alice KB write = 403** |  |  |
+| **E4 Bob's digest is his own only** |  |  |
+| **E5 shared room: no private briefing** |  |  |
+| F1 disconnect purge ok |  |  |
+| F2 KB scope empty after purge |  |  |
+| F3 digest + briefing empty after purge |  |  |
+| F4 disconnect idempotent |  |  |
+
+---
+
+## 5. Expected-not-bugs
+
+- **A member with no connected accounts gets an *empty* digest, not an error.**
+  `GET /api/v1/member-day-digest` returns `empty:true` and the chat agent simply
+  omits the `<your-day>` block — it behaves exactly as a pre-Phase-B agent.
+- **The digest can be empty while the KB has data** (and vice-versa). The digest
+  is a live pull from the per-user clients; the KB is the ingested snapshot.
+  After a disconnect the live digest empties immediately; the KB empties via the
+  purge. Seeded-only (no-OAuth) testing shows KB data but an empty digest — both
+  correct.
+- **A 403 on a foreign `user:` scope is the feature, not a failure.** The kb
+  router binds every client `scope` override to the caller; a denial is also
+  written to the RBAC audit log at ALERT.
+- **The intent board / briefing only appears in a member's *own* solo session.**
+  Shared and multi-member rooms intentionally show no member-private day data.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -661,6 +661,26 @@ def mount_cloud(app: FastAPI) -> None:
 
             await stop_in_process_scheduler(app)
 
+    # Per-user member-ingest sweep (VIP Onboarding Phase B). Every 5 minutes
+    # (POCKETPAW_MEMBER_INGEST_INTERVAL_SECONDS override) it backfills/
+    # incrementally syncs each consented member's Gmail + Calendar into their
+    # private ``user:{member_id}`` KB scope. Same scheduler gate as the
+    # cycle/decisions loops so pytest runs never spawn a background loop that
+    # outlives the test; production sets POCKETPAW_CLOUD_SCHEDULER_ENABLED=true.
+    if _os.environ.get("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "").lower() == "true":
+        from pocketpaw_ee.cloud.member_ingest.scheduler import (
+            start_member_ingest,
+            stop_member_ingest,
+        )
+
+        @app.on_event("startup")
+        async def _start_member_ingest() -> None:
+            await start_member_ingest(app)
+
+        @app.on_event("shutdown")
+        async def _stop_member_ingest() -> None:
+            await stop_member_ingest(app)
+
     # Mission Control activity buffer — per-workspace ring buffer fed by
     # agent.* bus events. Same constraint as the upload listeners: subscribe
     # AFTER init_realtime installed the singleton bus.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -251,6 +251,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.kb.router import router as kb_router
     from pocketpaw_ee.cloud.leads.router import router as leads_router
     from pocketpaw_ee.cloud.livekit.router import router as livekit_router
+    from pocketpaw_ee.cloud.member_day_digest.router import router as member_day_digest_router
     from pocketpaw_ee.cloud.mission_control.router import router as mission_control_router
     from pocketpaw_ee.cloud.notifications.router import router as notifications_router
     from pocketpaw_ee.cloud.outcomes.router import router as outcomes_router
@@ -281,6 +282,12 @@ def mount_cloud(app: FastAPI) -> None:
     # ``resolve_instinct`` returns ``ESCALATE_APPROVAL``; this router
     # exposes the operator-facing read + decision surface.
     app.include_router(instinct_approvals_router, prefix="/api/v1")
+
+    # Member-day digest — VIP Onboarding Phase B chunk 6. Gated GET
+    # /api/v1/member-day-digest returns the AUTHENTICATED caller's OWN
+    # structured "your day" digest (the chunk-5 service) for the intent
+    # board. No member_id param — a caller can only fetch their own.
+    app.include_router(member_day_digest_router, prefix="/api/v1")
 
     # Paw Sites — RFC 12 capture surface. Public POST /sites/{id}/capture
     # (origin-pinned + per-site signed key, no user auth — the edge Queue

--- a/ee/pocketpaw_ee/cloud/_core/deps.py
+++ b/ee/pocketpaw_ee/cloud/_core/deps.py
@@ -20,6 +20,7 @@ is a member — fixes joined members being locked out of workspace reads.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Coroutine
 from typing import Any
 
@@ -31,6 +32,8 @@ from pocketpaw_ee.cloud.models.user import User
 from pocketpaw_ee.guards.audit import log_denial
 from pocketpaw_ee.guards.deps import check_workspace_action
 from pocketpaw_ee.guards.rbac import Forbidden as GuardForbidden
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Identity / workspace extraction
@@ -54,6 +57,12 @@ async def current_workspace_id(user: User = Depends(current_active_user)) -> str
     that the client UI handles, not a denial) only when the user belongs
     to no workspace at all.
     """
+    logger.info(
+        "[diag current_workspace_id] user=%s active_workspace=%r memberships=%s",
+        user.id,
+        user.active_workspace,
+        [getattr(m, "workspace", "?") for m in (getattr(user, "workspaces", None) or [])],
+    )
     if user.active_workspace:
         return user.active_workspace
     # A user who has joined a workspace (invite accept / verified-domain

--- a/ee/pocketpaw_ee/cloud/_core/deps.py
+++ b/ee/pocketpaw_ee/cloud/_core/deps.py
@@ -12,7 +12,10 @@ the actual policy lookup. We translate platform ``GuardForbidden``
 exceptions to cloud-native ``Forbidden`` so the standard error envelope
 applies.
 
-Changes: added require_plan_feature dependency for plan-tier feature gating.
+Changes: added require_plan_feature dependency for plan-tier feature gating;
+current_workspace_id now falls back to the user's first membership (and
+persists it) instead of 400-ing when active_workspace is unset but the user
+is a member — fixes joined members being locked out of workspace reads.
 """
 
 from __future__ import annotations
@@ -48,12 +51,22 @@ async def current_workspace_id(user: User = Depends(current_active_user)) -> str
     """Extract active workspace ID from the authenticated user.
 
     Raises HTTP 400 (not a CloudError — this surfaces as a setup error
-    that the client UI handles, not a denial) when the user has no
-    active workspace.
+    that the client UI handles, not a denial) only when the user belongs
+    to no workspace at all.
     """
-    if not user.active_workspace:
-        raise HTTPException(400, "No active workspace. Create or join a workspace first.")
-    return user.active_workspace
+    if user.active_workspace:
+        return user.active_workspace
+    # A user who has joined a workspace (invite accept / verified-domain
+    # auto-join) but whose active_workspace was never set must not be locked
+    # out of every workspace-scoped read. Default to their first membership and
+    # persist it so the choice sticks. Only a user with NO memberships at all
+    # genuinely needs to create/join one.
+    if user.workspaces:
+        wid = user.workspaces[0].workspace
+        user.active_workspace = wid
+        await user.save()
+        return wid
+    raise HTTPException(400, "No active workspace. Create or join a workspace first.")
 
 
 async def optional_workspace_id(

--- a/ee/pocketpaw_ee/cloud/_core/deps.py
+++ b/ee/pocketpaw_ee/cloud/_core/deps.py
@@ -57,7 +57,7 @@ async def current_workspace_id(user: User = Depends(current_active_user)) -> str
     that the client UI handles, not a denial) only when the user belongs
     to no workspace at all.
     """
-    logger.info(
+    logger.warning(
         "[diag current_workspace_id] user=%s active_workspace=%r memberships=%s",
         user.id,
         user.active_workspace,

--- a/ee/pocketpaw_ee/cloud/_core/deps.py
+++ b/ee/pocketpaw_ee/cloud/_core/deps.py
@@ -20,7 +20,6 @@ is a member — fixes joined members being locked out of workspace reads.
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable, Coroutine
 from typing import Any
 
@@ -32,8 +31,6 @@ from pocketpaw_ee.cloud.models.user import User
 from pocketpaw_ee.guards.audit import log_denial
 from pocketpaw_ee.guards.deps import check_workspace_action
 from pocketpaw_ee.guards.rbac import Forbidden as GuardForbidden
-
-logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Identity / workspace extraction
@@ -57,12 +54,6 @@ async def current_workspace_id(user: User = Depends(current_active_user)) -> str
     that the client UI handles, not a denial) only when the user belongs
     to no workspace at all.
     """
-    logger.warning(
-        "[diag current_workspace_id] user=%s active_workspace=%r memberships=%s",
-        user.id,
-        user.active_workspace,
-        [getattr(m, "workspace", "?") for m in (getattr(user, "workspaces", None) or [])],
-    )
     if user.active_workspace:
         return user.active_workspace
     # A user who has joined a workspace (invite accept / verified-domain

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -748,6 +748,17 @@ class MemberIngestCompleted(Event):
     EVENT_TYPE: ClassVar[str] = "member_ingest.completed"
 
 
+# member_ingest.purged — fan-out when a member's Phase B per-user data is
+# deleted (member disconnected their accounts, or was offboarded from the
+# workspace). data: workspace_id, member_id, scope, status, and the per-store
+# delete counts (kb_cleared, tokens_deleted, connectors_deleted,
+# ingest_state_deleted). Downstream consumers (soul memory, the member's home
+# surface, search index) react by dropping anything keyed on that scope.
+@dataclass
+class MemberDataPurged(Event):
+    EVENT_TYPE: ClassVar[str] = "member_ingest.purged"
+
+
 # Calls — call.notes_posted. The lifecycle events (call.started / call.ended)
 # are defined above with the rest of the LiveKit group-call types; this is the
 # post-call notes fan-out, audience = the group's members.

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -740,6 +740,14 @@ class ConnectorSyncRecorded(Event):
     EVENT_TYPE: ClassVar[str] = "connector.sync_recorded"
 
 
+# Member ingest — VIP Onboarding Phase B. Fired when the per-user ingest
+# worker finishes a member's Gmail/Calendar → private-KB sync (backfill or
+# incremental). data: workspace_id, member_id, scope, mode, status, documents.
+@dataclass
+class MemberIngestCompleted(Event):
+    EVENT_TYPE: ClassVar[str] = "member_ingest.completed"
+
+
 # Calls — call.notes_posted. The lifecycle events (call.started / call.ended)
 # are defined above with the rest of the LiveKit group-call types; this is the
 # post-call notes fan-out, audience = the group's members.

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -62,6 +62,15 @@ gained a ``pocket_id`` kwarg and ``current_pocket_id()`` was added beside
 (``mcp_servers/connectors.py``) so its tools scope to the current pocket.
 The identity-token tuple grew from 3 to 4 entries; existing 3-arg callers are
 unaffected (``pocket_id`` defaults to ``None``).
+Changes: 2026-06-08 (VIP Onboarding Phase B — session-user isolation gate) —
+``_kb_scopes_for_context`` now prepends a member-private ``user:{member_id}``
+KB scope, GATED by the new ``_member_private_user_scope`` helper. The gate
+emits the scope ONLY when ``ctx.members == [ctx.user_id]`` (the member's own
+solo session) and suppresses it in every shared / multi-member room, so one
+member's private Gmail/calendar KB is never injected into another member's
+agent context. ``ctx.user_id`` (an opaque cloud user id) is the scope id —
+no email, so kb-go's on-disk ``:``→``_`` sanitize can't alias two members.
+Mirrors the OSS ``KbContext.user_id`` / ``_resolve_kb_scopes`` priority.
 """
 
 from __future__ import annotations
@@ -935,15 +944,59 @@ def _file_reference_terms(
     return terms
 
 
+def _member_private_user_scope(ctx: ScopeContext) -> str | None:
+    """The session-user isolation gate (VIP Onboarding Phase B).
+
+    Returns the member-private ``user:{member_id}`` KB scope ONLY when this
+    chat is the member's OWN solo context, and ``None`` otherwise. The single
+    airtight rule:
+
+        emit ``user:{ctx.user_id}``  ⟺  ctx.members == [ctx.user_id]
+
+    i.e. exactly one member AND it is the authenticated session principal.
+    This is the tightest possible test and it closes every leak path:
+
+    * a shared / multi-member room (``len(members) > 1``) → ``None``. A
+      member's private Gmail/calendar KB is NEVER injected where another
+      member can see the agent's context.
+    * a room whose sole member is NOT the caller (stale membership, a route
+      that resolved a different principal) → ``None``. We never emit a
+      ``user:`` scope for anyone but the proven-solo authenticated member.
+    * a member's own solo SESSION (``members == [user_id]``, the shape
+      ``_resolve_session`` always builds) or a private solo POCKET/DM →
+      ``user:{user_id}``.
+
+    ``ctx.user_id`` is the authenticated cloud user id (opaque Mongo
+    ObjectId / uuid), so it is safe to use verbatim as a kb-go scope id —
+    kb-go's on-disk ``:``→``_`` sanitize can't alias two opaque ids the way
+    it could alias two emails.
+    """
+    uid = ctx.user_id
+    if not uid:
+        return None
+    if list(ctx.members) != [uid]:
+        return None
+    return f"user:{uid}"
+
+
 def _kb_scopes_for_context(ctx: ScopeContext) -> list[str]:
     """Return KB scopes to search for cloud-agent prompt context.
 
-    Ordered most-specific-first (pocket > agent > workspace) so that
+    Ordered most-specific-first (user > pocket > agent > workspace) so that
     the limited KB budget is allocated to the most relevant scope first.
+
+    The leading member-private ``user:`` scope is GATED by
+    ``_member_private_user_scope`` — it is present only in a member's own
+    solo session and is suppressed in every shared / multi-member room, so
+    one member's private mail/calendar KB never bleeds into another member's
+    agent context. Mirrors the OSS ``_resolve_kb_scopes`` priority; the gate
+    is the cloud-side decision (the OSS resolver only honors the field it is
+    handed).
     """
     scopes: list[str] = []
     seen: set[str] = set()
     for candidate in (
+        _member_private_user_scope(ctx),
         f"pocket:{ctx.pocket_id}" if ctx.pocket_id else None,
         f"agent:{ctx.target_agent_id}" if ctx.target_agent_id else None,
         f"workspace:{ctx.workspace_id}" if ctx.workspace_id else None,

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -71,12 +71,23 @@ member's private Gmail/calendar KB is never injected into another member's
 agent context. ``ctx.user_id`` (an opaque cloud user id) is the scope id —
 no email, so kb-go's on-disk ``:``→``_`` sanitize can't alias two members.
 Mirrors the OSS ``KbContext.user_id`` / ``_resolve_kb_scopes`` priority.
+Changes: 2026-06-08 (VIP Onboarding Phase B chunk 5 — the "your day" briefing)
+— ``_member_briefing_block`` builds a concise, capped (``_BRIEFING_MAX_CHARS``
+≈ 400 tokens) "your day" block from the structured ``MemberDayDigest`` (the
+per-member live mail/calendar pull) and ``build_knowledge_context`` PREPENDS
+it. It is GATED by the SAME ``_member_private_user_scope`` decision as the
+private ``user:`` KB scope — present ONLY in the member's solo session,
+ABSENT (and the digest never even pulled) in every shared / multi-member
+room. Graceful: an empty digest (no connected accounts) or a digest that
+raises → ``""``, so unconnected and non-solo sessions are byte-identical to
+before.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -979,6 +990,117 @@ def _member_private_user_scope(ctx: ScopeContext) -> str | None:
     return f"user:{uid}"
 
 
+# Hard cap on the "your day" briefing block. The block shares the
+# system-prompt budget, so it must never grow unbounded with a busy day.
+# ~400 tokens ≈ 1600 chars (English ≈ 4 chars/token); we cap on chars (a
+# cheap, deterministic proxy — no tokenizer dependency) and truncate with an
+# ellipsis if a rendered block would exceed it.
+_BRIEFING_MAX_CHARS = 1600
+
+
+async def _member_briefing_block(
+    ctx: ScopeContext,
+    *,
+    digest_fn: Callable[[str, str], Awaitable[Any]] | None = None,
+) -> str:
+    """Return the concise, capped "your day" briefing for the member's OWN
+    solo session, or ``""`` when it must be absent.
+
+    GATED EXACTLY like the member-private ``user:`` KB scope: we reuse
+    ``_member_private_user_scope`` as the single source of truth for the
+    "is this the member's solo session?" decision. When it returns ``None``
+    (a shared / multi-member room, or a room whose sole member is not the
+    authenticated principal) we emit NOTHING and never even pull the digest —
+    so one member's mail/calendar is never read or surfaced in a context
+    another member can see. This is the same airtight rule that keeps the
+    private KB scope out of shared rooms.
+
+    The block is built from the structured ``MemberDayDigest`` (the per-member
+    live pull, keyed on ``ctx.user_id`` — the authenticated principal, NEVER a
+    caller-supplied id) and rendered down to a capped string. Graceful: an
+    EMPTY digest (no connected accounts) → ``""`` (the agent behaves as
+    today); a digest that RAISES → ``""`` (a flaky mail/calendar pull never
+    sinks the stream).
+
+    ``digest_fn`` defaults to ``member_day_digest.service.member_day_digest``;
+    tests inject a fake so the suite needs no OAuth/network.
+    """
+    # The gate: identical decision to the private ``user:`` KB scope. A
+    # ``None`` here means "not the member's solo session" → no block, no pull.
+    scope = _member_private_user_scope(ctx)
+    if scope is None:
+        return ""
+    member_id = ctx.user_id  # proven == the sole member by the gate above
+
+    pull: Callable[[str, str], Awaitable[Any]]
+    if digest_fn is not None:
+        pull = digest_fn
+    else:
+        try:
+            from pocketpaw_ee.cloud.member_day_digest.service import member_day_digest
+
+            pull = member_day_digest
+        except Exception:
+            logger.debug("member_day_digest unavailable; skipping briefing", exc_info=True)
+            return ""
+
+    try:
+        digest = await pull(ctx.workspace_id, member_id)
+    except Exception:
+        # A briefing is a nicety — a failed mail/calendar pull must never
+        # break the chat. Degrade silently to no block.
+        logger.debug("member day digest failed; skipping briefing", exc_info=True)
+        return ""
+
+    if digest is None or digest.empty:
+        return ""
+
+    return _render_briefing(digest)
+
+
+def _render_briefing(digest: Any) -> str:
+    """Render a ``MemberDayDigest`` into the capped <your-day> system block.
+
+    Concise by construction: a short heading, the upcoming events, and a mail
+    summary line + top subjects. The whole thing is truncated to
+    ``_BRIEFING_MAX_CHARS`` so it can never eat the prompt budget on a busy
+    day. The framing tells the agent this is proactive context to weave in
+    naturally, not a list to read back verbatim.
+    """
+    lines: list[str] = [
+        "<your-day>",
+        "Proactive briefing for the member you're helping — their day at a "
+        "glance. Use it to be helpful and anticipatory; don't read it back "
+        "verbatim unless asked.",
+    ]
+
+    if digest.events:
+        lines.append("")
+        lines.append("Upcoming (next 7 days):")
+        for ev in digest.events:
+            when = ev.start or "(time TBD)"
+            where = f" @ {ev.location}" if ev.location else ""
+            lines.append(f"- {when}: {ev.summary}{where}")
+
+    if digest.unread_mail_count or digest.top_mail:
+        lines.append("")
+        lines.append(f"Unread mail: {digest.unread_mail_count}")
+        for m in digest.top_mail:
+            sender = f" — from {m.sender}" if m.sender else ""
+            lines.append(f"- {m.subject}{sender}")
+
+    lines.append("</your-day>")
+    block = "\n".join(lines)
+
+    # Hard cap. Truncate mid-block and re-close the tag so the agent never
+    # sees a dangling open tag, and the budget is respected exactly.
+    if len(block) > _BRIEFING_MAX_CHARS:
+        closing = "\n…\n</your-day>"
+        budget = _BRIEFING_MAX_CHARS - len(closing)
+        block = block[:budget].rstrip() + closing
+    return block
+
+
 def _kb_scopes_for_context(ctx: ScopeContext) -> list[str]:
     """Return KB scopes to search for cloud-agent prompt context.
 
@@ -1036,6 +1158,16 @@ async def build_knowledge_context(
         query = f"{query}\nReferenced uploads: {ref_line}" if query else ref_line
 
     sections: list[str] = []
+
+    # The proactive "your day" briefing — FIRST, so the agent is oriented to
+    # the member's day before any retrieval. GATED to the member's OWN solo
+    # session (the same ``members == [user_id]`` rule as the private ``user:``
+    # KB scope); ``""`` in a shared/multi-member room and when the member has
+    # no connected accounts, so non-solo and unconnected sessions are
+    # byte-identical to before.
+    briefing = await _member_briefing_block(ctx)
+    if briefing:
+        sections.append(briefing)
 
     attachments_block = await _build_attachments_block(ctx, attachments)
     if attachments_block:

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -54,6 +54,17 @@ folds a pocket-entity's ``surface_profile`` override over the surface base).
 calling ``resolve_profile`` itself — so a pocket bound to a room can flip
 ripple off/on for that room. ``resolved_profile is None`` is the legacy /
 non-entity path → ripple ON, byte-identical to today.
+Changes: 2026-06-08 (feat/vip-agent-block, pp#1367) — ``ScopeContext`` carries
+an optional ``about_member_block``: a concise, token-capped "about this member"
+string (name · role · team · one-line focus) rendered from the member's Fabric
+``Person`` (``people.service.get_person``). The resolvers pre-resolve it (async)
+via ``_resolve_about_member`` and stash it; ``build_behavior_instructions``
+APPENDS it to the base system message (additive — NOT a persona override) so the
+agent greets the member by name from the first turn. A member with no Person
+(pre-existing / non-invited user) → ``None`` → no block, behavior unchanged. The
+render is HARD-capped (``_ABOUT_MEMBER_CHAR_CAP``) to kill the prompt-bloat
+failure mode. Stays sync in ``build_behavior_instructions`` — the async read
+happens once in the resolver, mirroring ``backend_summary``.
 """
 
 from __future__ import annotations
@@ -63,7 +74,14 @@ import logging
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    # Type-only — the runtime read imports ``get_person`` lazily inside
+    # ``_resolve_about_member`` so importing this module never drags in the
+    # people service (and its journal accessor) for chat paths that never
+    # render an about-block.
+    from pocketpaw_ee.cloud.people.domain import Person
 
 from pocketpaw.ripple import (
     HOME_POCKET_PROMPT,
@@ -255,6 +273,16 @@ class ScopeContext:
     # summary via ``get_pocket_backend``). ``None`` for non-home scopes,
     # which read the summary lazily through ``get_pocket`` when needed.
     backend_summary: dict[str, Any] | None = None
+    # A concise, token-capped "about this member" block (name · role · team ·
+    # one-line focus) rendered from the member's Fabric ``Person``. The
+    # resolvers pre-resolve it (async, via ``_resolve_about_member``) and stash
+    # it here; ``build_behavior_instructions`` APPENDS it to the base system
+    # message (additive — never a persona override) so the agent greets the
+    # member by name from turn one. ``None`` when the member has no Person yet
+    # (a pre-existing / non-invited user, or the people read failed) — the
+    # agent then behaves exactly as before, no block. Stays a pre-rendered
+    # string so the sync ``build_behavior_instructions`` never has to await.
+    about_member_block: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -317,6 +345,106 @@ async def _home_backend_summary(
         logger.debug("home backend summary fetch failed for pocket %s", pocket_id, exc_info=True)
         return None
     return summary
+
+
+# ---------------------------------------------------------------------------
+# "About this member" block (agent orientation, pp#1367)
+# ---------------------------------------------------------------------------
+
+# HARD character cap on the rendered about-block. The known failure mode is
+# prompt bloat — a free-text focus line (or a degenerate name) ballooning the
+# always-on system prompt toward the ~20K-char tail we've been bitten by. The
+# block is name + role + team + a one-line focus, so it's tiny by design; this
+# is the backstop. ~4 chars/token ⇒ 1500 chars ≈ ~375 tokens, under the
+# ~400-token budget. We truncate the WHOLE rendered block (not just focus) so
+# no combination of fields can exceed it.
+_ABOUT_MEMBER_CHAR_CAP = 1500
+# The focus line is the only unbounded, member/admin-authored field, so it gets
+# its own tighter per-field clamp before assembly — keeps the block readable
+# instead of letting one long sentence eat the whole budget.
+_ABOUT_MEMBER_FOCUS_CHAR_CAP = 280
+
+
+def _render_about_member_block(person: Person) -> str:
+    """Render the concise, token-capped "about this member" block.
+
+    Shape: an ``<about-member>`` tag carrying ``name · role · team`` and an
+    optional one-line ``focus``. Only fields the Person actually has are
+    emitted (no empty ``team:`` / ``focus:`` lines). The whole block is HARD
+    truncated at ``_ABOUT_MEMBER_CHAR_CAP`` so it can never bloat the system
+    prompt, regardless of field contents.
+
+    Returns an empty string when the Person carries no usable identity (no
+    name) — the caller treats that the same as "no Person": no block.
+    """
+
+    name = (person.name or "").strip()
+    if not name:
+        # Nothing to orient the agent with — skip the block entirely rather
+        # than emit a nameless "you are talking to ." line.
+        return ""
+
+    role = (person.role or "").strip()
+    team = (person.group or "").strip()
+    focus = " ".join((person.focus or "").split())  # collapse whitespace/newlines
+    if len(focus) > _ABOUT_MEMBER_FOCUS_CHAR_CAP:
+        focus = focus[:_ABOUT_MEMBER_FOCUS_CHAR_CAP].rstrip() + "…"
+
+    # Identity line: name, then role/team as available, joined with " · ".
+    bits = [name]
+    if role:
+        bits.append(role)
+    if team:
+        bits.append(f"team {team}")
+    identity = " · ".join(bits)
+
+    lines = [
+        "<about-member>",
+        "You are talking to a member of this workspace. Greet them by name and",
+        "tailor your help to their role and focus.",
+        f"  who: {identity}",
+    ]
+    if focus:
+        lines.append(f"  focus: {focus}")
+    lines.append("</about-member>")
+    block = "\n".join(lines)
+
+    if len(block) > _ABOUT_MEMBER_CHAR_CAP:
+        # Backstop hard cap. Keep the closing tag readable by appending it
+        # after the truncation so the block stays well-formed.
+        block = block[:_ABOUT_MEMBER_CHAR_CAP].rstrip() + "…\n</about-member>"
+    return block
+
+
+async def _resolve_about_member(workspace_id: str, user_id: str) -> str | None:
+    """Fetch the member's Fabric ``Person`` and render the about-block, or ``None``.
+
+    Pre-resolved (async) by every scope resolver and stashed on
+    ``ScopeContext.about_member_block`` so the sync
+    ``build_behavior_instructions`` can append it without awaiting. Returns
+    ``None`` — meaning "no block, behave as today" — when:
+
+    * the member has no materialized Person (a pre-existing / non-invited user);
+    * the Person carries no usable name (render returns "");
+    * the people read raised (degrades gracefully — a Fabric hiccup must never
+      block scope resolution or change the agent's behavior).
+    """
+
+    if not workspace_id or not user_id:
+        return None
+    try:
+        from pocketpaw_ee.cloud.people.service import get_person
+
+        person = await get_person(workspace_id, user_id)
+    except Exception:  # noqa: BLE001 — a people-read failure must not block resolution
+        logger.debug(
+            "about-member person read failed for %s/%s", workspace_id, user_id, exc_info=True
+        )
+        return None
+    if person is None:
+        return None
+    block = _render_about_member_block(person)
+    return block or None
 
 
 async def _get_default_workspace_agent_id(workspace_id: str) -> str | None:
@@ -397,6 +525,7 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
                 pocket_type, str(getattr(session, "workspace", "")), str(pocket_id)
             )
 
+    workspace_id = str(getattr(session, "workspace", ""))
     target = agent_id_hint or getattr(session, "agent", None)
     if not target:
         # Sessions created via ``createPocketSession`` don't yet pin an agent
@@ -404,15 +533,19 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
         # rule ``_resolve_pocket`` applies). Keeps cold-start chats in a
         # newly-created pocket session working without the caller having to
         # explicitly pass ``agent_id``.
-        workspace_id = str(getattr(session, "workspace", ""))
         target = await _get_default_workspace_agent_id(workspace_id)
         if not target:
             raise CloudError(400, "session.no_agent", "Session has no agent")
 
+    # Orient the agent to who's chatting (pp#1367) — pre-render the capped
+    # about-block here (async) so the sync system-message assembly can append
+    # it. ``None`` when the member has no Person → no block, behavior unchanged.
+    about_member_block = await _resolve_about_member(workspace_id, user_id)
+
     return ScopeContext(
         kind=ScopeKind.SESSION,
         scope_id=scope_id,
-        workspace_id=str(getattr(session, "workspace", "")),
+        workspace_id=workspace_id,
         user_id=user_id,
         members=[user_id],
         target_agent_id=target,
@@ -421,6 +554,7 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
         pocket_id=str(pocket_id) if pocket_id else None,
         pocket_type=pocket_type,
         backend_summary=backend_summary,
+        about_member_block=about_member_block,
     )
 
 
@@ -451,14 +585,20 @@ async def _resolve_group_like(
 
     target = _pick_target_agent(agent_ids, agent_id_hint)
 
+    workspace_id = str(getattr(group, "workspace", ""))
+    # Orient the agent to the calling member (pp#1367) — pre-rendered capped
+    # block, ``None`` when the member has no Person.
+    about_member_block = await _resolve_about_member(workspace_id, user_id)
+
     return ScopeContext(
         kind=kind,
         scope_id=scope_id,
-        workspace_id=str(getattr(group, "workspace", "")),
+        workspace_id=workspace_id,
         user_id=user_id,
         members=members,
         target_agent_id=target,
         agent_ids_in_scope=agent_ids,
+        about_member_block=about_member_block,
     )
 
 
@@ -515,6 +655,9 @@ async def _resolve_pocket(scope_id: str, user_id: str, agent_id_hint: str | None
 
     pocket_type = getattr(pocket, "type", None)
     backend_summary = await _home_backend_summary(pocket_type, workspace_id, scope_id)
+    # Orient the agent to the calling member (pp#1367) — pre-rendered capped
+    # block, ``None`` when the member has no Person.
+    about_member_block = await _resolve_about_member(workspace_id, user_id)
 
     return ScopeContext(
         kind=ScopeKind.POCKET,
@@ -528,6 +671,7 @@ async def _resolve_pocket(scope_id: str, user_id: str, agent_id_hint: str | None
         pocket_id=scope_id,
         pocket_type=pocket_type,
         backend_summary=backend_summary,
+        about_member_block=about_member_block,
     )
 
 
@@ -702,6 +846,16 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
         parts.append(
             fill_current_pocket(HOME_POCKET_PROMPT, ctx.pocket_id or "", ctx.backend_summary)
         )
+    # ADDITIVE member orientation (pp#1367): append the pre-rendered, capped
+    # "about this member" block LAST so the agent greets the caller by name and
+    # tailors to their role/focus from turn one. It is pre-resolved on the
+    # ScopeContext (async, in the resolver) and APPENDED here — never injected
+    # via ``system_message_override`` (that field REPLACES the base persona).
+    # ``None`` for a member with no Person (pre-existing / non-invited user) ⇒
+    # nothing appended ⇒ behavior identical to before. The string is already
+    # hard-capped at render time, so this can't bloat the prompt.
+    if ctx.about_member_block:
+        parts.append(ctx.about_member_block)
     return "\n".join(parts)
 
 

--- a/ee/pocketpaw_ee/cloud/connectors/dto.py
+++ b/ee/pocketpaw_ee/cloud/connectors/dto.py
@@ -1,5 +1,8 @@
 # Connectors — request / response schemas.
 # Created: 2026-05-03 — PR-1 of Phase 1 connector consolidation.
+# Updated: 2026-06-08 (Phase B chunk 7) — added DisconnectMemberResponse, the
+#   wire shape for the member self-disconnect endpoint (POST /cloud/connectors/
+#   me/disconnect): it reports what the per-user data purge removed.
 # Every request schema is distinct from every response schema (cloud
 # rule §4). The wire shape mirrors the existing
 # src/pocketpaw/api/v1/connectors.py ``ConnectorInfo`` so the frontend
@@ -123,3 +126,25 @@ class ExecuteActionResponse(BaseModel):
     error: str | None = None
     records_affected: int = 0
     execution_mode: str = "cloud"
+
+
+# ---------------------------------------------------------------------------
+# Phase B chunk 7 — member self-disconnect (the purge path's disconnect door)
+# ---------------------------------------------------------------------------
+
+
+class DisconnectMemberResponse(BaseModel):
+    """Result envelope for POST /cloud/connectors/me/disconnect.
+
+    Reports what the per-user data purge removed so the client can confirm the
+    member's personal data is gone. ``status`` is ``ok`` unless a store delete
+    failed (the purge is best-effort and idempotent; a partial failure still
+    deletes what it can and surfaces here).
+    """
+
+    status: str  # "ok" | "error"
+    scope: str  # the member's own "user:{id}" scope that was cleared
+    kb_cleared: bool = False
+    tokens_deleted: int = 0
+    connectors_deleted: int = 0
+    ingest_state_deleted: bool = False

--- a/ee/pocketpaw_ee/cloud/connectors/router.py
+++ b/ee/pocketpaw_ee/cloud/connectors/router.py
@@ -9,6 +9,16 @@
 # to all mutation endpoints. execute → connector.execute (MEMBER); enable /
 # disable / config → connector.manage (ADMIN). Read-only routes (GET list,
 # GET detail, GET widget-recipes) retain require_license only.
+# Updated: 2026-06-08 (Phase B chunk 7) — added the member self-disconnect
+#   endpoint POST /cloud/connectors/me/disconnect. It purges the CALLER's own
+#   per-user Phase B data (KB scope, OAuth tokens, connector rows, ingest
+#   state). Auth note: unlike the ADMIN-gated workspace-management mutations
+#   (enable/disable/config — ``connector.manage``), this acts on the member's
+#   OWN personal data, so it is MEMBER-level and hard-bound to ``current_user_
+#   id``. The self-binding (member_id == caller) IS the protection — it mirrors
+#   the chat-path KB gate's per-user scope binding, the correct sibling for a
+#   per-user data operation. Admin-gating would wrongly block a member from
+#   disconnecting their own accounts.
 
 from __future__ import annotations
 
@@ -18,6 +28,7 @@ from pocketpaw_ee.cloud.connectors import service as connectors_service
 from pocketpaw_ee.cloud.connectors.dto import (
     ConnectorDetailResponse,
     ConnectorResponse,
+    DisconnectMemberResponse,
     EnableConnectorRequest,
     ExecuteActionRequest,
     ExecuteActionResponse,
@@ -134,6 +145,33 @@ async def disable_connector(
 ) -> ConnectorResponse:
     """Soft-disable a connector. Config + history survive."""
     return await connectors_service.disable_connector(workspace_id, name)
+
+
+@router.post("/me/disconnect", response_model=DisconnectMemberResponse)
+async def disconnect_member(
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> DisconnectMemberResponse:
+    """Disconnect the CALLER's own per-user accounts and purge their data.
+
+    A member ending their Phase B connection: deletes their private
+    ``user:{id}`` KB scope (ingested mail/calendar), their per-user OAuth
+    tokens, their per-user connector rows, and their ingest-state. Bound to the
+    authenticated caller (``user_id`` IS the member id) so no member can ever
+    purge another's data. Idempotent — re-disconnecting is a clean no-op.
+
+    MEMBER-level by design (no ``connector.manage`` admin guard): a member must
+    be able to disconnect their own personal accounts. See the module header.
+    """
+    result = await connectors_service.disconnect_member(workspace_id, user_id)
+    return DisconnectMemberResponse(
+        status=result["status"],
+        scope=result["scope"],
+        kb_cleared=result["kb_cleared"],
+        tokens_deleted=result["tokens_deleted"],
+        connectors_deleted=result["connectors_deleted"],
+        ingest_state_deleted=result["ingest_state_deleted"],
+    )
 
 
 @router.patch(

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -6,6 +6,11 @@
 #   and persists it via ``pockets.service.apply_derived_surface_profile`` (the
 #   Beanie-write boundary — this service never imports the Pocket doc). Derivation
 #   itself is the pure ``derivation.derive_surface_profile``.
+# Updated: 2026-06-08 (Phase B chunk 7 — purge path) — added
+#   ``disconnect_member``: the member-facing "disconnect my accounts" path. It
+#   delegates to member_ingest.purge.purge_member_data to delete the caller's
+#   own per-user KB scope, OAuth tokens, connector rows, and ingest-state.
+#   Bound to the authenticated caller at the router (member_id == caller).
 # Updated: 2026-06-08 (connector-mcp-execution / keystone) — added
 #   ``list_pocket_connectors`` so the cloud chat agent's in-process MCP server
 #   (``ee/pocketpaw_ee/agent/mcp_servers/connectors.py``) can enumerate a
@@ -690,8 +695,37 @@ async def execute(
     )
 
 
+async def disconnect_member(workspace_id: str, member_id: str) -> dict:
+    """Disconnect a member's own per-user connectors and purge their data.
+
+    The member-facing "disconnect my accounts" path (Phase B chunk 7). A
+    member connected their PERSONAL Gmail/calendar as a per-user connector and
+    we ingested it into their private ``user:{member_id}`` KB scope; when they
+    disconnect, all of that — KB scope, per-user OAuth tokens, connector rows,
+    ingest-state — must be deleted. It's their personal data.
+
+    ``member_id`` is bound to the authenticated caller at the router (a member
+    only ever disconnects THEIR OWN accounts), so the scope this touches is a
+    pure function of the caller's id — no member can purge another's data.
+
+    Idempotent: ``purge_member_data`` is safe to call when nothing exists, so a
+    double-tap or a re-disconnect is a clean no-op. Returns the purge summary.
+    """
+    # Lazy import — keeps the connectors service free of a member_ingest
+    # dependency at module load (member_ingest already reads WorkspaceConnector
+    # cross-entity, so a top-level import here would risk a cycle).
+    from pocketpaw_ee.cloud.member_ingest.purge import purge_member_data
+
+    # purge_member_data deletes the member's user-scoped connector rows along
+    # with their tokens, KB scope, and ingest-state — so a self-disconnect is
+    # exactly "purge everything keyed on this member". The MemberDataPurged
+    # event it emits is the canonical signal the home surface reacts to.
+    return await purge_member_data(workspace_id, member_id)
+
+
 __all__ = [
     "disable_connector",
+    "disconnect_member",
     "enable_connector",
     "execute",
     "get_action_trust",

--- a/ee/pocketpaw_ee/cloud/kb/router.py
+++ b/ee/pocketpaw_ee/cloud/kb/router.py
@@ -1,4 +1,13 @@
 # router.py — Knowledge base domain router for ee/cloud.
+# Updated: 2026-06-08 (VIP Onboarding Phase B) — bound the client ``scope``
+# override to the caller. The four override-accepting endpoints (search,
+# ingest/text, ingest/url, lint) now resolve ``body.scope`` through
+# ``kb.service.validate_scope_override``, an allowlist (own workspace + visible
+# pockets + workspace agents + the caller's OWN user:) that rejects anything
+# else with Forbidden("kb.scope_forbidden"). This closes the cross-member leak
+# where any authenticated member could read or poison another member's private
+# ``user:{victim}`` KB via the REST door — the same boundary the chat-path gate
+# enforces. Denials are audit-logged at ALERT via ``log_denial``.
 # Updated: 2026-04-07 — Switched from Python knowledge_base package to kb Go binary.
 # All operations delegate to the kb binary via subprocess. Same REST API surface.
 """Knowledge base domain — FastAPI router.
@@ -14,6 +23,7 @@ import logging
 from fastapi import APIRouter, Depends
 
 from pocketpaw_ee.cloud.agents.knowledge import _extract_url, _kb
+from pocketpaw_ee.cloud.kb import service as kb_service
 from pocketpaw_ee.cloud.kb.dto import (
     IngestTextRequest,
     IngestUrlRequest,
@@ -26,7 +36,8 @@ from pocketpaw_ee.cloud.shared.deps import (
     current_workspace_id,
     require_action_any_workspace,
 )
-from pocketpaw_ee.cloud.shared.errors import CloudError, NotFound
+from pocketpaw_ee.cloud.shared.errors import CloudError, Forbidden, NotFound
+from pocketpaw_ee.guards.audit import log_denial
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +45,43 @@ router = APIRouter(prefix="/kb", tags=["Knowledge Base"], dependencies=[Depends(
 
 
 def _scope(workspace_id: str, override: str | None = None) -> str:
+    """Scope for the GET endpoints that accept NO client override.
+
+    These read the caller's active workspace only (``override`` is never
+    threaded from the wire), so the permissive resolve is safe here. The
+    override-accepting POST endpoints use ``_resolve_scope`` instead, which
+    binds the override to the caller via the allowlist validator.
+    """
     return override or f"workspace:{workspace_id}"
+
+
+async def _resolve_scope(
+    workspace_id: str,
+    user_id: str,
+    override: str | None,
+    *,
+    action: str,
+) -> str:
+    """Validate a client-supplied ``scope`` override against the caller's allowlist.
+
+    Delegates to ``kb.service.validate_scope_override`` (own workspace + visible
+    pockets + workspace agents + the caller's OWN ``user:``). On denial, audits
+    the attempt at ALERT before re-raising so a probing member shows up in the
+    RBAC denial log, then re-raises ``Forbidden`` for ``_core.http`` to map to a
+    403 JSON body. Never raises ``HTTPException``.
+    """
+    try:
+        return await kb_service.validate_scope_override(workspace_id, user_id, override)
+    except Forbidden:
+        log_denial(
+            actor=user_id,
+            action=action,
+            code="kb.scope_forbidden",
+            resource_id=override or "",
+            workspace_id=workspace_id,
+            detail="KB scope override not bound to caller",
+        )
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +96,7 @@ async def search_kb(
     user_id: str = Depends(current_user_id),
 ) -> dict:
     """Search KB articles — returns metadata + snippet."""
-    scope = _scope(workspace_id, body.scope)
+    scope = await _resolve_scope(workspace_id, user_id, body.scope, action="kb.read")
     results = _kb("search", body.query, "--scope", scope, "--limit", str(body.limit))
     if not isinstance(results, list):
         results = []
@@ -68,7 +115,7 @@ async def ingest_text(
     user_id: str = Depends(current_user_id),
 ) -> dict:
     """Ingest plain text into the workspace knowledge base."""
-    scope = _scope(workspace_id, body.scope)
+    scope = await _resolve_scope(workspace_id, user_id, body.scope, action="kb.write")
     try:
         return _kb("ingest", "--scope", scope, "--source", body.source, input_text=body.text)
     except Exception as exc:
@@ -83,7 +130,7 @@ async def ingest_url(
     user_id: str = Depends(current_user_id),
 ) -> dict:
     """Fetch and ingest a URL into the workspace knowledge base."""
-    scope = _scope(workspace_id, body.scope)
+    scope = await _resolve_scope(workspace_id, user_id, body.scope, action="kb.write")
     try:
         text = await _extract_url(body.url)
         return _kb("ingest", "--scope", scope, "--source", body.url, input_text=text)
@@ -104,7 +151,7 @@ async def lint_kb(
     user_id: str = Depends(current_user_id),
 ) -> dict:
     """Run health checks on the knowledge base."""
-    scope = _scope(workspace_id, body.scope)
+    scope = await _resolve_scope(workspace_id, user_id, body.scope, action="kb.read")
     issues = _kb("lint", "--scope", scope)
     if not isinstance(issues, list):
         issues = []

--- a/ee/pocketpaw_ee/cloud/kb/service.py
+++ b/ee/pocketpaw_ee/cloud/kb/service.py
@@ -1,5 +1,15 @@
 # service.py — Workspace-level KB scope listing.
 #
+# Updated: 2026-06-08 (VIP Onboarding Phase B) — added the REST-door scope
+# allowlist validator ``validate_scope_override``. The ``/api/v1/kb/*`` router
+# accepted a free-form client ``scope`` override with no scope-to-caller
+# binding, so any authenticated member could read or poison another member's
+# private ``user:{victim}`` KB. The validator reuses ``_candidate_scopes``
+# (workspace + visible pockets + workspace agents) plus the caller's OWN
+# ``user:{caller}`` entry as the allowlist, mirroring the chat-path gate's
+# boundary — both doors now enforce the SAME set. Any ``user:``-prefixed
+# override that isn't the caller's own is hard-denied as defense-in-depth.
+#
 # Updated: 2026-05-24 — Bounded the probe fan-out via a module-level
 # ``_PROBE_CONCURRENCY=8`` semaphore. The previous unbounded
 # ``asyncio.gather`` could spawn one kb-go subprocess per candidate
@@ -51,6 +61,8 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
+
+from pocketpaw_ee.cloud._core.errors import Forbidden
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +139,64 @@ async def list_scopes(
         return_exceptions=False,
     )
     return [scope for scope, has_articles in zip(candidates, results) if has_articles]
+
+
+async def validate_scope_override(
+    workspace_id: str,
+    user_id: str,
+    override: str | None,
+) -> str:
+    """Resolve a client-supplied KB scope override to a scope the caller may use.
+
+    This is the REST-door counterpart to the chat-path gate
+    (``chat.agent_service._member_private_user_scope``). Both bind a scope to
+    the caller; this one validates an *explicit* override against an allowlist
+    instead of synthesizing the scope set from the room.
+
+    Resolution:
+
+    * ``override is None`` → ``workspace:{workspace_id}`` (the caller's active
+      workspace). No allowlist probe — the active workspace is already the
+      caller's by ``current_workspace_id``.
+    * Otherwise the override is accepted ONLY if it is in the allowlist:
+      ``_candidate_scopes(workspace_id, user_id)`` (the workspace, every pocket
+      the caller can SEE via ``pockets_service.list_pockets``, every agent in
+      the workspace) PLUS the single self entry ``user:{user_id}``.
+
+    Defense-in-depth: ANY ``user:``-prefixed override that is not exactly the
+    caller's own ``user:{user_id}`` is hard-denied up front, before the
+    candidate set is even built — the ``user:`` tier is the most sensitive
+    class (a member's private Gmail/calendar KB) and must never be reachable
+    cross-principal even if a future candidate-enumeration bug widened the set.
+
+    Raises
+    ------
+    Forbidden
+        ``kb.scope_forbidden`` when the override is not bound to the caller.
+    """
+    if override is None:
+        return f"workspace:{workspace_id}"
+
+    # Belt 1 — the user: tier is hard-bound to the caller. A foreign user:
+    # override is rejected before any candidate lookup so no enumeration path
+    # can ever widen access to another member's private KB.
+    if override.startswith("user:") and override != f"user:{user_id}":
+        raise Forbidden(
+            "kb.scope_forbidden",
+            "The requested KB scope is not available to you.",
+        )
+
+    # Belt 2 — the override must be in the caller's bound scope set: their own
+    # workspace, a pocket they can see, a workspace agent, or their own user:.
+    allowed = set(await _candidate_scopes(workspace_id, user_id))
+    allowed.add(f"user:{user_id}")
+    if override in allowed:
+        return override
+
+    raise Forbidden(
+        "kb.scope_forbidden",
+        "The requested KB scope is not available to you.",
+    )
 
 
 async def _candidate_scopes(workspace_id: str, user_id: str) -> list[str]:
@@ -208,4 +278,4 @@ def _default_kb_list(scope: str) -> list[Any]:
     return result if isinstance(result, list) else []
 
 
-__all__ = ["list_scopes"]
+__all__ = ["list_scopes", "validate_scope_override"]

--- a/ee/pocketpaw_ee/cloud/member_day_digest/__init__.py
+++ b/ee/pocketpaw_ee/cloud/member_day_digest/__init__.py
@@ -1,0 +1,40 @@
+# member_day_digest — The structured "your day" digest service (Phase B chunk 5).
+# Created: 2026-06-08 — VIP Onboarding Phase B (the synthesized "your day").
+"""A reusable, per-member structured digest of the member's day.
+
+Pieces
+------
+* ``service.member_day_digest(workspace_id, member_id)`` — read one member's
+  upcoming calendar (next ~7 days) + recent/unread mail (count + top items)
+  LIVE with THEIR per-user Gmail/Calendar token (chunk 1), and return a
+  structured ``MemberDayDigest``. Per-member isolation is structural: the
+  per-user clients are keyed on ``member_id`` (a different token bucket per
+  member), and the returned ``member_id`` is the argument echoed back — there
+  is no caller-supplied member-id surface.
+* ``dto.MemberDayDigest`` (+ ``DigestEvent`` / ``DigestMail``) — the reusable
+  structured shape. The agent briefing renders it to a capped string; chunk
+  6's intent board reads the same shape.
+
+Why LIVE (not the chunk-4 KB ingest)
+------------------------------------
+The chunk-4 ingest feeds the agent's DEEP retrieval over the private
+``user:{id}`` KB scope. This digest is the COMPLEMENTARY structured "what's on
+today" — pulled live so the briefing is current to the minute, not as of the
+last ingest tick. They are two faces of the same per-user data.
+
+Consumers
+---------
+* The agent "your day" briefing — ``chat.agent_service._member_briefing_block``
+  renders this digest down to a concise capped block, GATED to the member's
+  OWN solo session (the same ``members == [user_id]`` rule as the private
+  ``user:`` KB scope).
+* (next) chunk 6's intent board reads the structured shape directly.
+
+Follow-ups (v1 ships a solid, bounded slice)
+--------------------------------------------
+* A status/read router (``GET /api/v1/member-day-digest``) over the
+  structured shape for operator visibility / a UI card.
+* Per-session caching so a chatty session doesn't re-pull every turn (today
+  the briefing path pulls once per system-message build; the gate already
+  short-circuits in shared rooms so no wasted I/O there).
+"""

--- a/ee/pocketpaw_ee/cloud/member_day_digest/dto.py
+++ b/ee/pocketpaw_ee/cloud/member_day_digest/dto.py
@@ -1,0 +1,79 @@
+# dto.py — Request/response schemas for the member-day digest service.
+# Created: 2026-06-08 — VIP Onboarding Phase B chunk 5 (the synthesized
+#   "your day" digest + the agent briefing).
+# Per cloud rule §4 (request/response split) and §6 (validate at entry): the
+# service re-parses its inputs through ``MemberDayDigestRequest`` even when
+# called by internal callers (the agent briefing, chunk 6's intent board) —
+# not just over HTTP. The response models are the reusable structured shape
+# chunk 6 consumes; the agent briefing renders them down to a capped string.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class MemberDayDigestRequest(BaseModel):
+    """Input to ``member_day_digest`` — the tenant + member to summarize.
+
+    ``member_id`` is the opaque cloud user id; it keys the per-user OAuth
+    token bucket AND (downstream, in the agent gate) the ``user:{id}`` scope.
+    We forbid empty/whitespace ids so a blank id can never collapse into a
+    cross-member read.
+    """
+
+    workspace_id: str = Field(min_length=1)
+    member_id: str = Field(min_length=1)
+
+    def __init__(self, **data: object) -> None:
+        super().__init__(**data)
+        if not self.workspace_id.strip():
+            raise ValueError("workspace_id must not be blank")
+        if not self.member_id.strip():
+            raise ValueError("member_id must not be blank")
+
+
+class DigestEvent(BaseModel):
+    """One upcoming calendar event in the digest (next ~7 days)."""
+
+    summary: str = ""
+    start: str = ""
+    end: str = ""
+    location: str = ""
+
+
+class DigestMail(BaseModel):
+    """One recent/unread mail item in the digest (top items only)."""
+
+    subject: str = ""
+    sender: str = ""
+    date: str = ""
+
+
+class MemberDayDigest(BaseModel):
+    """The structured "your day" digest for one member.
+
+    Reusable: chunk 6's intent board reads this same shape; the agent
+    briefing (``agent_service._member_briefing_block``) renders it down to a
+    short capped string. ``member_id`` is echoed so a consumer can assert the
+    digest belongs to the member it asked about — the per-member isolation
+    guarantee is that this field always equals the ``member_id`` argument
+    (never a caller-supplied value).
+    """
+
+    workspace_id: str
+    member_id: str
+    # Forward-looking calendar (next ~7 days), soonest first.
+    events: list[DigestEvent] = Field(default_factory=list)
+    # Recent/unread mail — top items only.
+    unread_mail_count: int = 0
+    top_mail: list[DigestMail] = Field(default_factory=list)
+    # Per-source errors (auth/transient). Non-fatal: a source that errored
+    # simply contributes nothing. ``empty`` is True when BOTH sources yielded
+    # no data (no connected accounts, or genuinely nothing) — the briefing
+    # uses it to emit no block at all rather than an empty heading.
+    errors: list[str] = Field(default_factory=list)
+
+    @property
+    def empty(self) -> bool:
+        """True when there is nothing to brief: no events AND no mail."""
+        return not self.events and self.unread_mail_count == 0 and not self.top_mail

--- a/ee/pocketpaw_ee/cloud/member_day_digest/router.py
+++ b/ee/pocketpaw_ee/cloud/member_day_digest/router.py
@@ -1,0 +1,75 @@
+# router.py — Gated GET surface over the member-day digest (Phase B chunk 6).
+# Created: 2026-06-08 — VIP Onboarding Phase B chunk 6 (the intent board's
+#   read API). Exposes ``GET /api/v1/member-day-digest`` → the AUTHENTICATED
+#   caller's OWN ``MemberDayDigest`` so the frontend intent board can render
+#   the structured "your day" shape the chunk-5 service already produces.
+#
+# Per-member isolation (the load-bearing invariant)
+# --------------------------------------------------
+# ``member_id`` is the authenticated principal (``ctx.user_id``) and NOTHING
+# else — there is NO ``member_id`` query/body param, so a caller can ONLY ever
+# get their OWN digest. ``workspace_id`` likewise comes from the active-
+# workspace context, never the wire. This is the same "tenancy from auth, never
+# the wire" stance as ``outcomes/router.py`` and the chat-path briefing gate the
+# digest already sits behind: member B can structurally never fetch member A's.
+#
+# Thin by design (cloud rule §5/§10): parse nothing from the wire, delegate to
+# ``member_day_digest.service.member_day_digest``, return the structured DTO.
+# Never raises ``HTTPException`` — a missing active workspace is a 400 CloudError
+# that ``_core.http`` maps to the standard JSON envelope.
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.member_day_digest.dto import MemberDayDigest
+from pocketpaw_ee.cloud.member_day_digest.service import member_day_digest
+from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/member-day-digest",
+    tags=["Member Day Digest"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.get(
+    "",
+    response_model=MemberDayDigest,
+    dependencies=[Depends(require_action_any_workspace("session.read_own"))],
+)
+async def get_member_day_digest(
+    ctx: RequestContext = Depends(request_context),
+) -> MemberDayDigest:
+    """Return the AUTHENTICATED caller's OWN structured "your day" digest.
+
+    The digest (upcoming calendar + unread/top mail) is built for
+    ``ctx.user_id`` — the authenticated principal — and ONLY them. There is no
+    ``member_id`` parameter: a caller cannot request another member's digest,
+    which is the per-member isolation guarantee carried to the REST door. A
+    member with no connected accounts gets an EMPTY digest (never an error).
+    """
+    # Tenancy from auth context, never the wire. A missing active workspace is
+    # a setup error (400), not a denial — surface it before touching the
+    # service so a tenant-less call can never collapse into a cross-member read.
+    if not ctx.workspace_id:
+        raise CloudError(
+            400,
+            "member_day_digest.no_active_workspace",
+            "No active workspace. Create or join a workspace first.",
+        )
+
+    # ``member_id`` IS the principal (``ctx.user_id``) — the structural per-
+    # member isolation. The service keys its per-user Gmail/Calendar clients on
+    # this id, so a second principal resolves a different OAuth-token bucket.
+    return await member_day_digest(workspace_id=ctx.workspace_id, member_id=ctx.user_id)
+
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/member_day_digest/service.py
+++ b/ee/pocketpaw_ee/cloud/member_day_digest/service.py
@@ -1,0 +1,210 @@
+# service.py — The member-day digest: a structured "your day" pull.
+# Created: 2026-06-08 — VIP Onboarding Phase B chunk 5.
+#
+# What this does
+# --------------
+# Builds a concise, STRUCTURED "your day" digest for one workspace member:
+# their upcoming calendar (next ~7 days) + recent/unread mail (count + top
+# items), read LIVE with THAT member's OWN per-user Gmail/Calendar token
+# (chunk 1's per-user OAuth). It is a reusable SERVICE — the agent briefing
+# (chunk 5's gated system-prompt block) renders it down to a capped string,
+# and chunk 6's intent board will read the same structured shape.
+#
+# Live pull, NOT the KB ingest
+# ----------------------------
+# Chunk 4's ingest writes the member's mail/calendar into their private
+# ``user:{id}`` KB for the agent's DEEP retrieval. This digest is the
+# COMPLEMENTARY structured "what's on today" — a live, current pull straight
+# from the per-user clients (``calendar_list`` for events, ``gmail_search``
+# for recent/unread), so the briefing reflects the member's day as it is RIGHT
+# NOW, not as of the last ingest tick.
+#
+# Per-member isolation (the load-bearing invariant)
+# --------------------------------------------------
+# The digest is keyed on the opaque cloud ``member_id``: the per-user clients
+# are constructed as ``GmailClient(user_id=member_id)`` /
+# ``CalendarClient(user_id=member_id)``, so each member resolves THEIR OWN
+# token bucket and a second member structurally gets a different bucket. The
+# returned ``MemberDayDigest.member_id`` is the SAME argument echoed back —
+# there is no caller-supplied member id surface (the agent gate derives it
+# from the authenticated principal, ``ctx.user_id``). Member B's digest can
+# therefore NEVER contain member A's data.
+#
+# Graceful by design
+# ------------------
+# A member with no connected accounts → both per-user reads raise "not
+# authenticated"; each source is isolated, the error is recorded, and the
+# digest comes back EMPTY (``digest.empty is True``) — never an exception. The
+# briefing then emits no block and the agent behaves exactly as today. A
+# single flaky source is isolated the same way: the healthy source still
+# contributes.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+from pocketpaw_ee.cloud.member_day_digest.dto import (
+    DigestEvent,
+    DigestMail,
+    MemberDayDigest,
+    MemberDayDigestRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+# --- Tunables (bounded by design — the digest is "your day", not "everything") ---
+
+# Calendar look-ahead: the next ~7 days of events ("upcoming").
+DIGEST_WINDOW_DAYS = 7
+# Recent-mail window for the Gmail query.
+MAIL_RECENT_DAYS = 7
+# Caps so one huge inbox / calendar can't blow the structured shape the
+# briefing and chunk 6's intent board consume.
+MAX_EVENTS = 10
+MAX_TOP_MAIL = 5
+# Gmail query: recent + unread, the "needs-attention" set for a day briefing.
+_MAIL_QUERY = f"is:unread newer_than:{MAIL_RECENT_DAYS}d"
+
+
+# --------------------------------------------------------------------------
+# Reader protocols — the service depends on these narrow shapes, not the
+# concrete clients, so tests inject fakes with no network / OAuth. Mirrors
+# the member_ingest precedent.
+# --------------------------------------------------------------------------
+
+
+class GmailReader(Protocol):
+    async def search(self, query: str, max_results: int = 10) -> list[dict[str, Any]]: ...
+
+
+class CalendarReader(Protocol):
+    async def list_events(
+        self,
+        time_min: datetime | None = ...,
+        time_max: datetime | None = ...,
+        max_results: int = ...,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]: ...
+
+
+# member_day_digest(workspace_id, member_id) -> MemberDayDigest. The async
+# contract the agent briefing (and chunk 6) calls; aliased here for callers
+# that want to inject a fake digest.
+DigestFn = Callable[[str, str], Awaitable[MemberDayDigest]]
+
+
+# --------------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------------
+
+
+async def member_day_digest(
+    workspace_id: str,
+    member_id: str,
+    *,
+    gmail_reader: GmailReader | None = None,
+    calendar_reader: CalendarReader | None = None,
+    now: datetime | None = None,
+) -> MemberDayDigest:
+    """Build the structured "your day" digest for one member.
+
+    Reads upcoming calendar (next ~7 days) + recent/unread mail with THIS
+    member's per-user token. ``gmail_reader`` / ``calendar_reader`` default to
+    the real per-user clients (``GmailClient(user_id=member_id)`` /
+    ``CalendarClient(user_id=member_id)``) — the structural per-member
+    isolation. Tests inject fakes.
+
+    Per-source failures are isolated and recorded in ``digest.errors``; a
+    member with no connected accounts comes back EMPTY (never raises). The
+    returned ``member_id`` is exactly the argument — the caller cannot swap
+    which member the digest is for.
+    """
+    # Validate at entry (cloud rule §6) — internal callers (the agent briefing,
+    # chunk 6's intent board) get the same guard an HTTP body would. A blank
+    # member id is rejected so it can never collapse into a cross-member read.
+    body = MemberDayDigestRequest.model_validate(
+        {"workspace_id": workspace_id, "member_id": member_id}
+    )
+    workspace_id, member_id = body.workspace_id, body.member_id
+
+    now = now or datetime.now(UTC)
+
+    # Lazy-construct the real per-user clients only when no fake was injected.
+    # Importing here keeps the module import-light and avoids pulling the OSS
+    # client stack into pure-unit tests. ``user_id=member_id`` is the only
+    # identity threaded in — never a caller-supplied id.
+    if gmail_reader is None or calendar_reader is None:
+        from pocketpaw.clients.gcalendar import CalendarClient
+        from pocketpaw.clients.gmail import GmailClient
+
+        gmail_reader = gmail_reader or GmailClient(user_id=member_id)
+        calendar_reader = calendar_reader or CalendarClient(user_id=member_id)
+
+    errors: list[str] = []
+    events: list[DigestEvent] = []
+    unread_count = 0
+    top_mail: list[DigestMail] = []
+
+    # --- Calendar: upcoming events, next ~7 days, soonest first ---
+    try:
+        time_min = now
+        time_max = now + timedelta(days=DIGEST_WINDOW_DAYS)
+        raw_events = await calendar_reader.list_events(
+            time_min=time_min,
+            time_max=time_max,
+            max_results=MAX_EVENTS,
+        )
+        for e in raw_events[:MAX_EVENTS]:
+            events.append(
+                DigestEvent(
+                    summary=(e.get("summary") or "(no title)").strip(),
+                    start=(e.get("start") or "").strip(),
+                    end=(e.get("end") or "").strip(),
+                    location=(e.get("location") or "").strip(),
+                )
+            )
+    except Exception as exc:  # noqa: BLE001 — isolate per-source so one bad
+        # source never sinks the other or raises into the briefing path.
+        logger.warning(
+            "member_day_digest: calendar read failed for member=%s ws=%s: %s",
+            member_id,
+            workspace_id,
+            exc,
+        )
+        errors.append(f"calendar: {exc}")
+
+    # --- Mail: recent/unread, count + top items ---
+    try:
+        raw_mail = await gmail_reader.search(_MAIL_QUERY, max_results=MAX_TOP_MAIL)
+        unread_count = len(raw_mail)
+        for m in raw_mail[:MAX_TOP_MAIL]:
+            top_mail.append(
+                DigestMail(
+                    subject=(m.get("subject") or "(no subject)").strip(),
+                    sender=(m.get("from") or "").strip(),
+                    date=(m.get("date") or "").strip(),
+                )
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "member_day_digest: gmail read failed for member=%s ws=%s: %s",
+            member_id,
+            workspace_id,
+            exc,
+        )
+        errors.append(f"gmail: {exc}")
+
+    return MemberDayDigest(
+        workspace_id=workspace_id,
+        member_id=member_id,
+        events=events,
+        unread_mail_count=unread_count,
+        top_mail=top_mail,
+        errors=errors,
+    )
+
+
+__all__ = ["member_day_digest", "MAX_EVENTS", "MAX_TOP_MAIL"]

--- a/ee/pocketpaw_ee/cloud/member_ingest/__init__.py
+++ b/ee/pocketpaw_ee/cloud/member_ingest/__init__.py
@@ -1,0 +1,36 @@
+# member_ingest — Per-user Gmail/Calendar → private-KB ingest worker.
+# Created: 2026-06-08 — VIP Onboarding Phase B (per-user ingest worker).
+"""Per-member ingest of recent mail + upcoming calendar into the member's
+strictly-private ``user:{member_id}`` KB scope.
+
+Pieces
+------
+* ``service.ingest_member`` — read one member's Gmail/Calendar with THEIR
+  per-user token (chunk 1) and write the text into ``user:{member_id}``
+  (chunk 2) via the KEYLESS ``kb accept`` path (chunk 0). Backfill on first
+  run, incremental thereafter. Per-member isolation is structural: the scope
+  is a pure function of ``member_id``.
+* ``service.list_connected_members`` — enumerate (workspace, member) pairs
+  with a per-user Gmail/Calendar connector enabled.
+* ``service.run_ingest_sweep`` — fan out ``ingest_member`` across all
+  connected members under a bounded concurrency cap; per-member failures are
+  isolated.
+* ``scheduler.MemberIngestScheduler`` — the periodic background sweep (every
+  5 min, same shape as the ChatRunDoc sweeper), gated on
+  ``POCKETPAW_CLOUD_SCHEDULER_ENABLED`` and wired into ``mount_cloud``.
+* ``models.member_ingest_state.MemberIngestState`` — per-member sync status
+  (last_sync_at, status, backfill_done, per-source cursors).
+
+Follow-ups (v1 deliberately ships a solid-but-bounded slice — see the chunk
+report's CONCERNS):
+* True Gmail incremental via ``historyId`` cursors + per-message dedup
+  (today: a ``newer_than:Nd`` window + accept's title-slug upsert; safe but
+  re-reads the overlap window each tick).
+* Full message-body extraction (today: metadata + snippet for mail; the
+  GmailClient.read full-body path is available but not yet wired into the
+  bulk loop to keep the backfill cheap).
+* A first-connect trigger that kicks an immediate backfill on the
+  ``connector.enabled`` event instead of waiting for the next sweep tick.
+* A status/read router (``GET /api/v1/member-ingest/status``) over
+  ``MemberIngestStatusResponse`` for operator visibility.
+"""

--- a/ee/pocketpaw_ee/cloud/member_ingest/__init__.py
+++ b/ee/pocketpaw_ee/cloud/member_ingest/__init__.py
@@ -20,6 +20,13 @@ Pieces
   ``POCKETPAW_CLOUD_SCHEDULER_ENABLED`` and wired into ``mount_cloud``.
 * ``models.member_ingest_state.MemberIngestState`` — per-member sync status
   (last_sync_at, status, backfill_done, per-source cursors).
+* ``purge.purge_member_data`` — the INVERSE of ``ingest_member`` (chunk 7).
+  When a member disconnects their accounts or is offboarded, deletes ALL of
+  their per-user data keyed on the opaque member id: the ``user:{member_id}``
+  KB scope, their per-user OAuth tokens, their per-user WorkspaceConnector
+  rows, and their MemberIngestState. Idempotent + per-member isolated. Wired
+  to (a) connectors.service.disconnect_member (the member self-disconnect
+  endpoint) and (b) workspace.service.remove_member (the offboard cascade).
 
 Follow-ups (v1 deliberately ships a solid-but-bounded slice — see the chunk
 report's CONCERNS):

--- a/ee/pocketpaw_ee/cloud/member_ingest/dto.py
+++ b/ee/pocketpaw_ee/cloud/member_ingest/dto.py
@@ -1,0 +1,49 @@
+# dto.py — Request/response schemas for the member-ingest worker.
+# Created: 2026-06-08 — VIP Onboarding Phase B (per-user ingest worker).
+# Per cloud rule §4 (request/response split) and §6 (validate at entry): the
+# service functions re-parse their inputs through these even when called by
+# internal callers (the sweep, the scheduler, jobs) — not just HTTP.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class IngestMemberRequest(BaseModel):
+    """Input to ``ingest_member`` — the tenant + member to sync.
+
+    ``member_id`` is the opaque cloud user id; it becomes the ``user:{id}``
+    KB scope verbatim, so we forbid empty/whitespace ids that would collapse
+    to the bare ``user:`` scope and leak across members.
+    """
+
+    workspace_id: str = Field(min_length=1)
+    member_id: str = Field(min_length=1)
+
+    def __init__(self, **data: object) -> None:
+        super().__init__(**data)
+        if not self.workspace_id.strip():
+            raise ValueError("workspace_id must not be blank")
+        if not self.member_id.strip():
+            raise ValueError("member_id must not be blank")
+
+
+class SweepRequest(BaseModel):
+    """Input to ``run_ingest_sweep`` — the concurrency cap for the fan-out."""
+
+    concurrency: int = Field(default=4, ge=1, le=64)
+
+
+class MemberIngestStatusResponse(BaseModel):
+    """Wire shape for a per-member ingest status row (for a future status
+    endpoint / operator visibility). Distinct from the request models above."""
+
+    workspace_id: str
+    member_id: str
+    status: str
+    backfill_done: bool
+    last_sync_at: datetime | None = None
+    last_error: str = ""
+    documents_ingested: int = 0

--- a/ee/pocketpaw_ee/cloud/member_ingest/dto.py
+++ b/ee/pocketpaw_ee/cloud/member_ingest/dto.py
@@ -1,5 +1,9 @@
 # dto.py — Request/response schemas for the member-ingest worker.
 # Created: 2026-06-08 — VIP Onboarding Phase B (per-user ingest worker).
+# Updated: 2026-06-08 — chunk 7 (purge path): added PurgeMemberRequest, the
+#   input to ``purge.purge_member_data``. Same non-blank guards as
+#   IngestMemberRequest so a blank member_id can never collapse the derived
+#   ``user:`` scope and clear the wrong (or every) member's KB.
 # Per cloud rule §4 (request/response split) and §6 (validate at entry): the
 # service functions re-parse their inputs through these even when called by
 # internal callers (the sweep, the scheduler, jobs) — not just HTTP.
@@ -34,6 +38,27 @@ class SweepRequest(BaseModel):
     """Input to ``run_ingest_sweep`` — the concurrency cap for the fan-out."""
 
     concurrency: int = Field(default=4, ge=1, le=64)
+
+
+class PurgeMemberRequest(BaseModel):
+    """Input to ``purge_member_data`` — the tenant + member to wipe.
+
+    ``member_id`` is the opaque cloud user id; it becomes the ``user:{id}`` KB
+    scope verbatim, exactly as the ingest path derives it. A blank id is
+    forbidden because the bare ``user:`` scope would target every member's
+    private KB — the single most dangerous mistake this whole chunk exists to
+    prevent — so the guard mirrors IngestMemberRequest's.
+    """
+
+    workspace_id: str = Field(min_length=1)
+    member_id: str = Field(min_length=1)
+
+    def __init__(self, **data: object) -> None:
+        super().__init__(**data)
+        if not self.workspace_id.strip():
+            raise ValueError("workspace_id must not be blank")
+        if not self.member_id.strip():
+            raise ValueError("member_id must not be blank")
 
 
 class MemberIngestStatusResponse(BaseModel):

--- a/ee/pocketpaw_ee/cloud/member_ingest/purge.py
+++ b/ee/pocketpaw_ee/cloud/member_ingest/purge.py
@@ -95,9 +95,7 @@ async def purge_member_data(
     # cascade, the disconnect endpoint) get the same blank-id guard an HTTP
     # body would, so a blank member_id can never collapse the scope to a bare
     # ``user:`` and wipe the wrong member.
-    body = PurgeMemberRequest.model_validate(
-        {"workspace_id": workspace_id, "member_id": member_id}
-    )
+    body = PurgeMemberRequest.model_validate({"workspace_id": workspace_id, "member_id": member_id})
     workspace_id, member_id = body.workspace_id, body.member_id
 
     # The scope is a pure function of the opaque member id. Nothing else.
@@ -119,9 +117,7 @@ async def purge_member_data(
         kb_cleared = True
     except Exception as exc:  # noqa: BLE001 — isolate per store so one failing
         # step (e.g. a missing kb binary) never blocks the other three deletes.
-        logger.warning(
-            "purge: kb clear failed for scope=%s ws=%s: %s", scope, workspace_id, exc
-        )
+        logger.warning("purge: kb clear failed for scope=%s ws=%s: %s", scope, workspace_id, exc)
         errors.append(f"kb: {exc}")
 
     # --- 2. Per-user OAuth tokens: Gmail + Calendar buckets for this member. ---

--- a/ee/pocketpaw_ee/cloud/member_ingest/purge.py
+++ b/ee/pocketpaw_ee/cloud/member_ingest/purge.py
@@ -1,0 +1,306 @@
+# purge.py — Delete ALL of a member's Phase B per-user data (the purge path).
+# Created: 2026-06-08 — VIP Onboarding Phase B, chunk 7.
+#
+# Why this exists
+# ---------------
+# Phase B ingests a consented member's PERSONAL Gmail/calendar into their
+# strictly-private ``user:{member_id}`` KB scope (member_ingest.service). When
+# the member leaves — they disconnect their accounts, or an admin offboards
+# them from the workspace — that personal data MUST be deleted. It's their
+# mail; leaving must purge it. This module is the exact inverse of
+# ``ingest_member``: same opaque member id, same derived scope, four deletes.
+#
+# What gets purged (all keyed on the opaque member id)
+# ----------------------------------------------------
+#   1. the ``user:{member_id}`` kb-go scope — their ingested mail/cal text,
+#      wiped via the KEYLESS ``kb clear --scope user:{member_id}`` subprocess
+#      (no LLM call, no API key — same keyless posture as the ingest accept).
+#   2. their per-user OAuth tokens — ``token_store.delete`` for BOTH the
+#      Gmail (``google_gmail``) and Calendar (``google_calendar``) services
+#      under this member's bucket (chunk 1's per-user keying).
+#   3. their per-user WorkspaceConnector rows — scope="user", pinned on BOTH
+#      workspace AND user_id so a workspace-scoped row of the same connector
+#      never gets swept.
+#   4. their MemberIngestState sync-state doc — pinned on workspace + member_id.
+#
+# Per-member isolation (the load-bearing invariant)
+# -------------------------------------------------
+# The scope is DERIVED as ``user:{member_id}`` inside this function — there is
+# no caller-supplied scope surface. The token deletes pass member_id as the
+# bucket; the Beanie deletes pin workspace + member/user id. Purging member A
+# therefore can NEVER touch member B's KB, tokens, connectors, or state — every
+# delete target is a pure function of A's opaque id.
+#
+# Idempotent + best-effort
+# ------------------------
+# Safe to call twice and safe when nothing exists: token delete returns False
+# when absent, ``kb clear`` on an empty scope is a no-op, and the Beanie
+# deletes match zero rows. Each store is wrapped in its own try/except so one
+# failing step (e.g. a missing kb binary) never blocks the others — the same
+# best-effort cascade shape as workspace.service.remove_member. The returned
+# summary records what was deleted and any per-store errors; status is
+# ``error`` if any step failed, else ``ok``.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import MemberDataPurged
+from pocketpaw_ee.cloud.member_ingest.dto import PurgeMemberRequest
+
+logger = logging.getLogger(__name__)
+
+# Token store service names the per-user clients load under. GmailClient(
+# user_id) -> service="google_gmail"; CalendarClient(user_id) ->
+# service="google_calendar". These are the SERVICE keys in token_store, NOT
+# the connector registry names ("gmail"/"gcalendar"); the purge must delete
+# both buckets for the member.
+_TOKEN_SERVICES = ("google_gmail", "google_calendar")
+
+# kb_clear(scope) -> result dict. Async by contract. Injected in tests so the
+# purge runs without a kb binary; defaults to the keyless ``kb clear`` wrapper.
+KbClearFn = Callable[[str], Awaitable[dict[str, Any]]]
+
+
+async def purge_member_data(
+    workspace_id: str,
+    member_id: str,
+    *,
+    kb_clear: KbClearFn | None = None,
+    token_store: Any | None = None,
+) -> dict[str, Any]:
+    """Delete every Phase B per-user store for ``member_id`` in ``workspace_id``.
+
+    Triggered on (a) a member disconnecting their accounts and (b) a member
+    being offboarded from the workspace. Deletes the four stores listed in the
+    module docstring, idempotently and best-effort.
+
+    The KB scope is derived internally as ``user:{member_id}`` — the only scope
+    this function ever clears, which is the per-member isolation guarantee.
+
+    ``kb_clear`` defaults to the keyless ``kb clear`` subprocess wrapper;
+    ``token_store`` defaults to a fresh ``TokenStore`` (the on-disk OAuth
+    store). Both are injectable so the unit tests run with no kb binary and a
+    tmp-rooted store.
+
+    Returns a summary dict: ``status`` (``ok``/``error``), ``scope``,
+    ``kb_cleared`` (bool), ``tokens_deleted`` (int), ``connectors_deleted``
+    (int), ``ingest_state_deleted`` (bool), and any per-store ``errors``.
+    """
+    # Validate at entry (cloud rule §6) — internal callers (the offboard
+    # cascade, the disconnect endpoint) get the same blank-id guard an HTTP
+    # body would, so a blank member_id can never collapse the scope to a bare
+    # ``user:`` and wipe the wrong member.
+    body = PurgeMemberRequest.model_validate(
+        {"workspace_id": workspace_id, "member_id": member_id}
+    )
+    workspace_id, member_id = body.workspace_id, body.member_id
+
+    # The scope is a pure function of the opaque member id. Nothing else.
+    scope = f"user:{member_id}"
+    clear = kb_clear or _default_kb_clear
+    if token_store is None:
+        # Import here so a pure-unit test that injects a store doesn't pull the
+        # OSS client stack in, and so the module stays import-light.
+        from pocketpaw.clients.token_store import TokenStore
+
+        token_store = TokenStore()
+
+    errors: list[str] = []
+
+    # --- 1. KB scope: clear the member's private mail/calendar articles. ---
+    kb_cleared = False
+    try:
+        await clear(scope)
+        kb_cleared = True
+    except Exception as exc:  # noqa: BLE001 — isolate per store so one failing
+        # step (e.g. a missing kb binary) never blocks the other three deletes.
+        logger.warning(
+            "purge: kb clear failed for scope=%s ws=%s: %s", scope, workspace_id, exc
+        )
+        errors.append(f"kb: {exc}")
+
+    # --- 2. Per-user OAuth tokens: Gmail + Calendar buckets for this member. ---
+    tokens_deleted = 0
+    for service in _TOKEN_SERVICES:
+        try:
+            # token_store.delete returns True only when a file was removed, so
+            # the count is the number of real tokens this member had — and a
+            # second purge naturally counts zero (idempotent).
+            if token_store.delete(service, member_id):
+                tokens_deleted += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "purge: token delete failed for service=%s member=%s: %s",
+                service,
+                member_id,
+                exc,
+            )
+            errors.append(f"token[{service}]: {exc}")
+
+    # --- 3. Per-user WorkspaceConnector rows for this member. ---
+    connectors_deleted = 0
+    try:
+        connectors_deleted = await _delete_user_connectors(workspace_id, member_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "purge: connector-row delete failed for member=%s ws=%s: %s",
+            member_id,
+            workspace_id,
+            exc,
+        )
+        errors.append(f"connectors: {exc}")
+
+    # --- 4. MemberIngestState sync-state doc for this member. ---
+    ingest_state_deleted = False
+    try:
+        ingest_state_deleted = await _delete_ingest_state(workspace_id, member_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "purge: ingest-state delete failed for member=%s ws=%s: %s",
+            member_id,
+            workspace_id,
+            exc,
+        )
+        errors.append(f"ingest_state: {exc}")
+
+    status = "error" if errors else "ok"
+
+    # Emit on write (cloud rule §9) — downstream consumers (soul memory, the
+    # member's home surface, search index) drop anything keyed on this scope.
+    await emit(
+        MemberDataPurged(
+            data={
+                "workspace_id": workspace_id,
+                "member_id": member_id,
+                "scope": scope,
+                "status": status,
+                "kb_cleared": kb_cleared,
+                "tokens_deleted": tokens_deleted,
+                "connectors_deleted": connectors_deleted,
+                "ingest_state_deleted": ingest_state_deleted,
+            }
+        )
+    )
+
+    logger.info(
+        "purge: member=%s ws=%s status=%s kb=%s tokens=%d connectors=%d state=%s",
+        member_id,
+        workspace_id,
+        status,
+        kb_cleared,
+        tokens_deleted,
+        connectors_deleted,
+        ingest_state_deleted,
+    )
+
+    return {
+        "workspace_id": workspace_id,
+        "member_id": member_id,
+        "scope": scope,
+        "status": status,
+        "kb_cleared": kb_cleared,
+        "tokens_deleted": tokens_deleted,
+        "connectors_deleted": connectors_deleted,
+        "ingest_state_deleted": ingest_state_deleted,
+        "errors": errors,
+    }
+
+
+# --------------------------------------------------------------------------
+# Beanie deletes — both pinned on the tenant + the opaque member id.
+# --------------------------------------------------------------------------
+
+
+async def _delete_user_connectors(workspace_id: str, member_id: str) -> int:
+    """Delete the member's per-user connector rows, returning the count.
+
+    Pins workspace AND user_id AND scope="user" (cloud rule §7 tenant filter):
+    a workspace-scoped row of the same connector name (``user_id=None``) is
+    never swept, and another member's rows are never touched. WorkspaceConnector
+    is owned by connectors/service.py; we read its doc directly here for the
+    same reason member_ingest.service.list_connected_members does — the
+    connector service exposes no user-scoped delete helper yet (flagged for a
+    future ``connectors.service.delete_user_connectors`` extraction).
+    """
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    rows = await WorkspaceConnector.find(
+        WorkspaceConnector.workspace == workspace_id,  # tenant filter
+        WorkspaceConnector.scope == "user",
+        WorkspaceConnector.user_id == member_id,
+    ).to_list()
+    count = 0
+    for row in rows:
+        await row.delete()
+        count += 1
+    return count
+
+
+async def _delete_ingest_state(workspace_id: str, member_id: str) -> bool:
+    """Delete the member's ingest-state doc; True when a row was removed.
+
+    Pinned on workspace + member_id (cloud rule §7) — the same composite key
+    member_ingest.service._load_or_create_state writes, so two members never
+    share state and no cross-tenant row is touched.
+    """
+    from pocketpaw_ee.cloud.models.member_ingest_state import MemberIngestState
+
+    state = await MemberIngestState.find_one(
+        MemberIngestState.workspace == workspace_id,
+        MemberIngestState.member_id == member_id,
+    )
+    if state is None:
+        return False
+    await state.delete()
+    return True
+
+
+# --------------------------------------------------------------------------
+# The keyless ``kb clear`` subprocess wrapper (mirrors _default_kb_accept).
+# --------------------------------------------------------------------------
+
+
+async def _default_kb_clear(scope: str) -> dict[str, Any]:
+    """Wipe a kb-go scope via ``kb clear --scope <scope>`` (no LLM, no key).
+
+    kb-go's ``clear`` removes every article in a scope and rebuilds the index
+    with no Anthropic call — usable on this keyless cloud backend, the same
+    posture as the ingest accept path. ``KnowledgeService.clear`` hard-codes
+    ``agent:{id}``; this wrapper passes the member's ``user:`` scope verbatim.
+    """
+    import subprocess
+
+    from pocketpaw_ee.cloud.agents.knowledge import KB_BIN
+
+    def _run() -> dict[str, Any]:
+        try:
+            result = subprocess.run(
+                [KB_BIN, "clear", "--scope", scope, "--json"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=120,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"kb binary not found at {KB_BIN!r}. Install kb-go or set POCKETPAW_KB_BIN."
+            ) from exc
+        if result.returncode != 0:
+            raise RuntimeError(f"kb clear failed: {result.stderr[:200]}")
+        try:
+            import json
+
+            return json.loads(result.stdout)
+        except Exception:  # noqa: BLE001
+            return {"raw": result.stdout.strip()}
+
+    return await asyncio.to_thread(_run)
+
+
+__all__ = ["purge_member_data"]

--- a/ee/pocketpaw_ee/cloud/member_ingest/scheduler.py
+++ b/ee/pocketpaw_ee/cloud/member_ingest/scheduler.py
@@ -1,0 +1,177 @@
+# scheduler.py — Periodic background sweep for the member-ingest worker.
+# Created: 2026-06-08 — VIP Onboarding Phase B (per-user ingest worker).
+#
+# Mirrors the ChatRunDoc sweeper / decisions reconciler shape (the cloud's
+# established periodic-task pattern): a class with a testable ``tick()`` (one
+# sweep, no background task), a ``_run_loop()`` that wakes on a timeout OR a
+# stop event so ``stop()`` returns promptly, ``start()``/``stop()`` lifecycle,
+# and a module singleton wired onto ``app.state`` by ``mount_cloud`` under the
+# ``POCKETPAW_CLOUD_SCHEDULER_ENABLED`` gate (so pytest runs never spawn a loop
+# that outlives the test).
+#
+# Cadence: every 5 minutes by default — the same shape as the ChatRunDoc
+# sweeper the PRD points at. Each tick runs ``run_ingest_sweep`` across every
+# connected member (initial backfill on first sight, incremental thereafter).
+# Override the interval via POCKETPAW_MEMBER_INGEST_INTERVAL_SECONDS.
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from typing import Any
+
+from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+_TASK_KEY = "_member_ingest_scheduler"
+_DEFAULT_INTERVAL_SECONDS = 300  # 5 minutes — same cadence as the run sweeper
+_ENV_INTERVAL = "POCKETPAW_MEMBER_INGEST_INTERVAL_SECONDS"
+
+
+def _interval_seconds() -> int:
+    """Read the sweep interval from env, default 300s (5 min)."""
+    raw = os.environ.get(_ENV_INTERVAL, "").strip()
+    if not raw:
+        return _DEFAULT_INTERVAL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an int — falling back to %d seconds",
+            _ENV_INTERVAL,
+            raw,
+            _DEFAULT_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_INTERVAL_SECONDS
+    return max(1, value)
+
+
+class MemberIngestScheduler:
+    """In-process periodic sweep for per-user Gmail/Calendar ingest.
+
+    Use:
+        scheduler = MemberIngestScheduler()
+        await scheduler.start()   # spawn the background loop
+        ...
+        await scheduler.stop()    # cancel + await cleanly
+
+    For unit tests:
+        scheduler = MemberIngestScheduler()
+        await scheduler.tick()    # one sweep, no background task
+    """
+
+    def __init__(self, interval_seconds: int | None = None) -> None:
+        self._interval = interval_seconds if interval_seconds is not None else _interval_seconds()
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event: asyncio.Event = asyncio.Event()
+
+    @property
+    def interval_seconds(self) -> int:
+        return self._interval
+
+    async def tick(self) -> dict[str, Any]:
+        """Run a single ingest sweep. Safe to call from tests without
+        ``start()``. Returns the sweep summary; never raises — a sweep
+        failure is logged and reported as an empty summary so the loop
+        survives a transient DB/connector hiccup."""
+        # Import inside so a test exercising ``tick()`` directly doesn't have
+        # to bootstrap the whole cloud module, and so a monkeypatch of
+        # ``service.run_ingest_sweep`` is observed (late binding).
+        from pocketpaw_ee.cloud.member_ingest import service as ingest_service
+
+        try:
+            summary = await ingest_service.run_ingest_sweep()
+            logger.info(
+                "member_ingest.scheduler: tick members=%s ok=%s errors=%s",
+                summary.get("members"),
+                summary.get("ok"),
+                summary.get("errors"),
+            )
+            return summary
+        except Exception:  # noqa: BLE001 — keep the loop alive across hiccups
+            logger.exception("member_ingest.scheduler: sweep tick raised")
+            return {"members": 0, "ok": 0, "errors": 0}
+
+    async def _run_loop(self) -> None:
+        """Background loop body. Wakes on the interval OR the stop event."""
+        logger.info("member_ingest.scheduler: loop started (interval=%ds)", self._interval)
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self._interval)
+                # Reached here without TimeoutError → stop was signalled.
+                break
+            except TimeoutError:
+                pass
+            except asyncio.CancelledError:
+                logger.info("member_ingest.scheduler: loop cancelled — exiting")
+                raise
+            await self.tick()
+
+    async def start(self) -> None:
+        """Spawn the background loop. Idempotent."""
+        if self._task is not None and not self._task.done():
+            return
+        self._stop_event = asyncio.Event()
+        self._task = asyncio.create_task(self._run_loop(), name="member-ingest-scheduler")
+
+    async def stop(self) -> None:
+        """Cancel + await the loop. Safe to call multiple times."""
+        if self._task is None:
+            return
+        self._stop_event.set()
+        if not self._task.done():
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._task
+        self._task = None
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — mount_cloud installs one onto app.state.
+# ---------------------------------------------------------------------------
+
+
+_SCHEDULER: MemberIngestScheduler | None = None
+
+
+def get_scheduler() -> MemberIngestScheduler:
+    """Return the process singleton, constructing one lazily if needed."""
+    global _SCHEDULER
+    if _SCHEDULER is None:
+        _SCHEDULER = MemberIngestScheduler()
+    return _SCHEDULER
+
+
+def reset_scheduler_for_tests() -> None:
+    """Drop the singleton so each test gets a fresh instance."""
+    global _SCHEDULER
+    _SCHEDULER = None
+
+
+async def start_member_ingest(app: FastAPI) -> None:
+    """Wire the singleton onto ``app.state`` and spawn the loop.
+    Mirrors ``decisions.reconciler.start_reconciler``."""
+    scheduler = get_scheduler()
+    setattr(app.state, _TASK_KEY, scheduler)
+    await scheduler.start()
+
+
+async def stop_member_ingest(app: FastAPI) -> None:
+    """Cancel + await the loop attached to ``app.state``."""
+    scheduler: MemberIngestScheduler | None = getattr(app.state, _TASK_KEY, None)
+    if scheduler is None:
+        return
+    await scheduler.stop()
+    setattr(app.state, _TASK_KEY, None)
+
+
+__all__ = [
+    "MemberIngestScheduler",
+    "get_scheduler",
+    "reset_scheduler_for_tests",
+    "start_member_ingest",
+    "stop_member_ingest",
+]

--- a/ee/pocketpaw_ee/cloud/member_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/member_ingest/service.py
@@ -1,0 +1,568 @@
+# service.py — Per-user Gmail/Calendar → private-KB ingest worker (Phase B).
+# Created: 2026-06-08 — VIP Onboarding Phase B (per-user ingest worker).
+#
+# What this does
+# --------------
+# For a consented workspace member who connected Gmail and/or Google Calendar
+# as a PER-USER connector (chunk 1's per-user OAuth tokens), this worker reads
+# their recent mail + upcoming calendar with THEIR OWN token and writes the
+# text into their strictly-private ``user:{member_id}`` KB scope (chunk 2's
+# gated scope). An initial bounded backfill runs on first connect; an
+# incremental pass runs on the periodic schedule thereafter.
+#
+# Why the keyless ``accept`` path (NOT ``ingest``/``build``)
+# ----------------------------------------------------------
+# kb-go's ``ingest``/``build`` LLM-compile each article by calling Anthropic
+# directly (kb.go:cmdIngest reads ANTHROPIC_API_KEY and fatals without it).
+# This cloud backend has no API key. ``kb accept`` stores the raw article +
+# rebuilds the BM25 search index with NO LLM call (kb.go:cmdAccept), so the
+# mail/calendar text is searchable without a key. We therefore write every
+# item through ``_kb_accept`` (the missing keyless wrapper — agents.knowledge
+# .KnowledgeService only exposes the ``ingest`` path).
+#
+# Per-user isolation (the load-bearing invariant)
+# ------------------------------------------------
+# Every write targets ``user:{member_id}`` where ``member_id`` is the clean
+# opaque cloud user id — the SAME value chat.agent_service uses verbatim as a
+# kb-go scope (opaque ids can't alias the way two emails could under kb-go's
+# ``:``→``_`` sanitize). The scope is DERIVED from ``member_id`` inside
+# ``ingest_member``; there is no caller-supplied scope surface to abuse. A
+# second member's ingest can never write into the first's scope because the
+# scope string is a pure function of that member's id.
+#
+# Robustness scope (v1)
+# ---------------------
+# Token refresh on expiry is handled upstream by ``OAuthManager.get_valid_
+# token`` (chunk 1 threaded ``user_id`` through the refresh path), so the
+# per-user client refreshes transparently; an auth failure surfaces as a read
+# exception which this module catches → status=error, nothing written.
+# Reads are wrapped in a small bounded exponential backoff for 429/5xx. The
+# sweep bounds concurrency with a semaphore so N member-syncs don't swamp the
+# box. Deeper robustness (true Gmail historyId cursors, per-message dedup,
+# attachment/body extraction) is noted as a follow-up — see the module
+# docstring tail in __init__.py.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import MemberIngestCompleted
+from pocketpaw_ee.cloud.member_ingest.dto import (
+    IngestMemberRequest,
+    SweepRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+# --- Tunables (bounded by design — Phase B is "recent", not "everything") ---
+
+# Backfill window: how far back the first run reaches. "Recent mail" per the
+# PRD — last 30 days of mail, next 30 days of calendar.
+_BACKFILL_DAYS = 30
+# Incremental window: a small overlap re-read so a missed item on the boundary
+# still lands. Bounded so a long outage re-reads days, not years.
+_INCREMENTAL_DAYS = 2
+# Per-source item caps so one member's huge inbox can't wedge a sweep tick.
+_MAX_MAIL = 100
+_MAX_EVENTS = 100
+# Backoff for transient read errors (429 / 5xx). Small + bounded — a sweep
+# tick must not block for minutes on one flaky member.
+_BACKOFF_BASE_SECONDS = 0.5
+_BACKOFF_MAX_RETRIES = 3
+# Default sweep fan-out cap so N member-syncs don't swamp the box.
+_DEFAULT_SWEEP_CONCURRENCY = 4
+
+# Connector registry names that carry per-user mail/calendar data.
+_GMAIL_NAME = "gmail"
+_GCAL_NAME = "gcalendar"
+
+
+# --------------------------------------------------------------------------
+# Reader protocols — the worker depends on these narrow shapes, not on the
+# concrete clients, so tests inject fakes with no network / OAuth.
+# --------------------------------------------------------------------------
+
+
+class GmailReader(Protocol):
+    async def search(self, query: str, max_results: int = 10) -> list[dict[str, Any]]: ...
+
+
+class CalendarReader(Protocol):
+    async def list_events(
+        self,
+        time_min: datetime | None = ...,
+        time_max: datetime | None = ...,
+        max_results: int = ...,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]: ...
+
+
+# kb_accept(scope, articles) -> result dict. Async by contract.
+KbAcceptFn = Callable[[str, list[dict[str, Any]]], Awaitable[dict[str, Any]]]
+# ingest_fn(workspace_id, member_id, **kw) -> result dict. The per-member unit
+# the sweep dispatches; defaults to ``ingest_member`` but injectable for tests.
+IngestFn = Callable[..., Awaitable[dict[str, Any]]]
+
+
+# --------------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------------
+
+
+async def ingest_member(
+    workspace_id: str,
+    member_id: str,
+    *,
+    gmail_reader: GmailReader | None = None,
+    calendar_reader: CalendarReader | None = None,
+    kb_accept: KbAcceptFn | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Read one member's recent mail + upcoming calendar and write it into
+    their private ``user:{member_id}`` KB scope.
+
+    The scope is derived internally as ``user:{member_id}`` and is the only
+    scope this function ever writes — the per-member isolation guarantee.
+
+    ``gmail_reader`` / ``calendar_reader`` default to the real per-user
+    clients (``GmailClient(member_id)`` / ``CalendarClient(member_id)``),
+    which resolve THIS member's OAuth token and refresh it on expiry. Tests
+    inject fakes. ``kb_accept`` defaults to the keyless ``kb accept``
+    subprocess wrapper.
+
+    Backfill-vs-incremental is decided by the persisted
+    ``MemberIngestState.backfill_done`` flag. Returns a result dict with
+    ``status`` (``ok``/``error``), ``mode`` (``backfill``/``incremental``),
+    ``documents``, and any per-source ``errors``.
+    """
+    # Validate at entry (cloud rule §6) — internal callers (the sweep, the
+    # scheduler) get the same guard as an HTTP body would.
+    body = IngestMemberRequest.model_validate(
+        {"workspace_id": workspace_id, "member_id": member_id}
+    )
+    workspace_id, member_id = body.workspace_id, body.member_id
+
+    # The scope is a pure function of the opaque member id. Nothing else.
+    scope = f"user:{member_id}"
+    now = now or datetime.now(UTC)
+    accept = kb_accept or _default_kb_accept
+
+    # Lazy-construct the real per-user clients only when no fake was injected.
+    # Importing here keeps the module import-light and avoids pulling the
+    # OSS client stack into pure-unit tests.
+    if gmail_reader is None or calendar_reader is None:
+        from pocketpaw.clients.gcalendar import CalendarClient
+        from pocketpaw.clients.gmail import GmailClient
+
+        gmail_reader = gmail_reader or GmailClient(user_id=member_id)
+        calendar_reader = calendar_reader or CalendarClient(user_id=member_id)
+
+    state = await _load_or_create_state(workspace_id, member_id)
+    mode = "backfill" if not state.backfill_done else "incremental"
+    state.status = "running"
+    await state.save()  # no-event: transient in-progress marker, not a domain change
+
+    errors: list[str] = []
+    documents = 0
+
+    # --- Gmail ---
+    try:
+        articles = await _read_gmail(
+            gmail_reader,
+            mode=mode,
+            cursor=state.gmail_cursor,
+            now=now,
+        )
+        if articles:
+            await accept(scope, articles)
+            documents += len(articles)
+            # Advance the high-water cursor to this run's wall clock. We use
+            # the run timestamp (not per-message dates, which Gmail returns in
+            # non-uniform header formats) as a coarse but monotonic watermark.
+            state.gmail_cursor = now.isoformat()
+    except Exception as exc:  # noqa: BLE001 — isolate per-source so one bad
+        # source never sinks the other or crashes the sweep.
+        logger.warning(
+            "member_ingest: gmail read failed for member=%s ws=%s: %s",
+            member_id,
+            workspace_id,
+            exc,
+        )
+        errors.append(f"gmail: {exc}")
+
+    # --- Calendar ---
+    try:
+        articles = await _read_calendar(
+            calendar_reader,
+            mode=mode,
+            now=now,
+        )
+        if articles:
+            await accept(scope, articles)
+            documents += len(articles)
+            state.calendar_cursor = now.isoformat()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "member_ingest: calendar read failed for member=%s ws=%s: %s",
+            member_id,
+            workspace_id,
+            exc,
+        )
+        errors.append(f"calendar: {exc}")
+
+    # --- Persist outcome ---
+    both_failed = len(errors) == 2
+    status = "error" if both_failed else "ok"
+    state.status = status
+    state.last_error = "; ".join(errors)
+    state.documents_ingested += documents
+    if status == "ok":
+        # Only flip backfill_done on a run that actually completed without a
+        # total failure — a failed backfill retries (wide window) next time.
+        state.backfill_done = True
+        state.last_sync_at = now
+    await state.save()  # no-event: domain event emitted explicitly below.
+
+    await emit(
+        MemberIngestCompleted(
+            data={
+                "workspace_id": workspace_id,
+                "member_id": member_id,
+                "scope": scope,
+                "mode": mode,
+                "status": status,
+                "documents": documents,
+            }
+        )
+    )
+
+    return {
+        "workspace_id": workspace_id,
+        "member_id": member_id,
+        "scope": scope,
+        "mode": mode,
+        "status": status,
+        "documents": documents,
+        "errors": errors,
+    }
+
+
+async def list_connected_members(workspace_id: str | None = None) -> list[dict[str, str]]:
+    """Enumerate (workspace, member) pairs that have a per-user Gmail/Calendar
+    connector enabled.
+
+    Returns one entry per (workspace, member) even when a member connected
+    BOTH Gmail and Calendar — the worker ingests both sources in a single
+    ``ingest_member`` call, so we don't want to dispatch them twice.
+
+    Tenant filter (cloud rule §7): when ``workspace_id`` is given, the Beanie
+    query pins it; the global form (``None``) is the scheduler's cross-tenant
+    sweep and is explicitly intended.
+    """
+    # service.py is the only legal reader of its own model class (cloud
+    # rule §2). WorkspaceConnector is owned by connectors/service.py; we read
+    # it cross-entity here, which the connector service already exposes via a
+    # listing helper — but that helper returns Response DTOs that drop the
+    # ``scope``/``user_id`` we need. Reading the doc directly with the tenant
+    # filter is the minimal correct path; flagged for a future
+    # ``connectors.service.list_user_connectors`` extraction.
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    query: dict[str, Any] = {
+        "scope": "user",
+        "enabled": True,
+        "name": {"$in": [_GMAIL_NAME, _GCAL_NAME]},
+    }
+    if workspace_id:
+        query["workspace"] = workspace_id  # tenant filter
+    # else: global-read — the scheduler sweeps every tenant's connected members
+
+    docs = await WorkspaceConnector.find(query).to_list()
+
+    seen: set[tuple[str, str]] = set()
+    members: list[dict[str, str]] = []
+    for d in docs:
+        if not d.user_id:
+            continue
+        key = (d.workspace, d.user_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        members.append({"workspace_id": d.workspace, "member_id": d.user_id})
+    return members
+
+
+async def run_ingest_sweep(
+    *,
+    workspace_id: str | None = None,
+    concurrency: int = _DEFAULT_SWEEP_CONCURRENCY,
+    ingest_fn: IngestFn | None = None,
+) -> dict[str, Any]:
+    """Ingest every connected member, bounded by a concurrency cap.
+
+    One member failing never aborts the others — each unit is isolated.
+    Returns a summary dict ``{members, ok, errors}``. ``ingest_fn`` defaults
+    to ``ingest_member`` (real readers + real accept); tests inject a fake.
+    """
+    body = SweepRequest.model_validate({"concurrency": concurrency})
+    concurrency = body.concurrency
+    fn = ingest_fn or ingest_member
+
+    members = await list_connected_members(workspace_id=workspace_id)
+    if not members:
+        return {"members": 0, "ok": 0, "errors": 0}
+
+    sem = asyncio.Semaphore(concurrency)
+    ok = 0
+    errors = 0
+
+    async def _one(entry: dict[str, str]) -> None:
+        nonlocal ok, errors
+        async with sem:
+            try:
+                result = await fn(entry["workspace_id"], entry["member_id"])
+            except Exception as exc:  # noqa: BLE001 — isolate per member so a
+                # single blown token doesn't abort the whole sweep.
+                logger.warning(
+                    "member_ingest: sweep unit failed ws=%s member=%s: %s",
+                    entry["workspace_id"],
+                    entry["member_id"],
+                    exc,
+                )
+                errors += 1
+                return
+            # The unit completed; count its self-reported status.
+            if isinstance(result, dict) and result.get("status") == "error":
+                errors += 1
+            else:
+                ok += 1
+
+    await asyncio.gather(*(_one(m) for m in members))
+    logger.info(
+        "member_ingest: sweep complete members=%d ok=%d errors=%d (ws=%s)",
+        len(members),
+        ok,
+        errors,
+        workspace_id or "ALL",
+    )
+    return {"members": len(members), "ok": ok, "errors": errors}
+
+
+# --------------------------------------------------------------------------
+# Reads → accept articles
+# --------------------------------------------------------------------------
+
+
+async def _read_gmail(
+    reader: GmailReader,
+    *,
+    mode: str,
+    cursor: str,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    """Search recent mail and shape each message into an accept article.
+
+    Backfill uses ``newer_than:30d`` (the wide window); incremental uses the
+    narrow ``newer_than:2d`` overlap. Gmail's ``newer_than`` is the simplest
+    bounded-recency filter that works without a historyId cursor — true
+    incremental sync via historyId is a documented follow-up.
+    """
+    days = _BACKFILL_DAYS if mode == "backfill" else _INCREMENTAL_DAYS
+    query = f"newer_than:{days}d"
+    messages = await _with_backoff(lambda: reader.search(query, max_results=_MAX_MAIL))
+
+    articles: list[dict[str, Any]] = []
+    for m in messages:
+        subject = (m.get("subject") or "(no subject)").strip()
+        sender = (m.get("from") or "").strip()
+        date = (m.get("date") or "").strip()
+        snippet = (m.get("snippet") or "").strip()
+        body = m.get("body") or snippet
+        content_lines = [
+            f"From: {sender}",
+            f"Date: {date}",
+            "",
+            body,
+        ]
+        articles.append(
+            {
+                "title": f"Email: {subject}",
+                "content": "\n".join(content_lines).strip() or subject,
+                "summary": snippet[:200],
+                "source": f"gmail:{m.get('id', '')}",
+                "categories": ["email", "gmail"],
+            }
+        )
+    return articles
+
+
+async def _read_calendar(
+    reader: CalendarReader,
+    *,
+    mode: str,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    """List upcoming events and shape each into an accept article.
+
+    Calendar is forward-looking ("upcoming") — the window is ``now`` →
+    ``now + 30d`` for both backfill and incremental (the set of upcoming
+    events is small and re-reading it each tick keeps the KB fresh as events
+    are added/changed; accept upserts by title slug so re-ingest is cheap).
+    """
+    time_min = now
+    time_max = now + timedelta(days=_BACKFILL_DAYS)
+    events = await _with_backoff(
+        lambda: reader.list_events(
+            time_min=time_min,
+            time_max=time_max,
+            max_results=_MAX_EVENTS,
+        )
+    )
+
+    articles: list[dict[str, Any]] = []
+    for e in events:
+        summary = (e.get("summary") or "(no title)").strip()
+        start = (e.get("start") or "").strip()
+        end = (e.get("end") or "").strip()
+        location = (e.get("location") or "").strip()
+        description = (e.get("description") or "").strip()
+        attendees = e.get("attendees") or []
+        content_lines = [
+            f"When: {start} — {end}",
+            f"Where: {location}",
+            f"Attendees: {', '.join(attendees)}",
+            "",
+            description,
+        ]
+        articles.append(
+            {
+                "title": f"Event: {summary}",
+                "content": "\n".join(content_lines).strip() or summary,
+                "summary": description[:200] or summary,
+                "source": f"gcalendar:{e.get('id', '')}",
+                "categories": ["calendar", "event"],
+            }
+        )
+    return articles
+
+
+# --------------------------------------------------------------------------
+# Backoff + state helpers
+# --------------------------------------------------------------------------
+
+
+async def _with_backoff(coro_factory: Callable[[], Awaitable[Any]]) -> Any:
+    """Run an async read with bounded exponential backoff on transient errors.
+
+    Retries on 429 / 5xx-shaped failures (detected from the exception text,
+    since the per-user clients raise ``httpx.HTTPStatusError`` whose str
+    carries the status). Auth failures (RuntimeError "not authenticated")
+    are NOT retried — they need re-consent, not a retry, so they propagate
+    immediately to be recorded as an error.
+    """
+    attempt = 0
+    while True:
+        try:
+            return await coro_factory()
+        except Exception as exc:  # noqa: BLE001
+            text = str(exc).lower()
+            transient = (
+                "429" in text
+                or "rate" in text
+                or "500" in text
+                or "502" in text
+                or "503" in text
+                or "504" in text
+                or "timeout" in text
+                or "timed out" in text
+            )
+            if not transient or attempt >= _BACKOFF_MAX_RETRIES:
+                raise
+            delay = _BACKOFF_BASE_SECONDS * (2**attempt)
+            logger.info(
+                "member_ingest: transient read error (attempt %d/%d), backing off %.1fs: %s",
+                attempt + 1,
+                _BACKOFF_MAX_RETRIES,
+                delay,
+                exc,
+            )
+            await asyncio.sleep(delay)
+            attempt += 1
+
+
+async def _load_or_create_state(workspace_id: str, member_id: str):
+    """Fetch the per-member ingest state, creating a fresh row on first run.
+
+    Tenant filter on the read (cloud rule §7): both ``workspace`` and
+    ``member_id`` pin the row so two members never share state and no
+    cross-tenant row is ever touched.
+    """
+    from pocketpaw_ee.cloud.models.member_ingest_state import MemberIngestState
+
+    state = await MemberIngestState.find_one(
+        MemberIngestState.workspace == workspace_id,
+        MemberIngestState.member_id == member_id,
+    )
+    if state is None:
+        state = MemberIngestState(workspace=workspace_id, member_id=member_id)
+        await state.insert()
+    return state
+
+
+# --------------------------------------------------------------------------
+# The keyless ``accept`` subprocess wrapper (the missing path)
+# --------------------------------------------------------------------------
+
+
+async def _default_kb_accept(scope: str, articles: list[dict[str, Any]]) -> dict[str, Any]:
+    """Write articles into a kb-go scope via the KEYLESS ``kb accept`` path.
+
+    ``KnowledgeService.ingest_text_to_scope`` uses ``kb ingest`` which
+    LLM-compiles via Anthropic — unusable here (no API key). ``kb accept``
+    reads ``{"scope": ..., "articles": [...]}`` on stdin, stores each raw
+    article, and rebuilds the BM25 index with no LLM call (kb.go:cmdAccept).
+    We pass ``--scope`` explicitly AND in the payload (cmdAccept honors the
+    flag first) so the scope is unambiguous.
+    """
+    import subprocess
+
+    from pocketpaw_ee.cloud.agents.knowledge import KB_BIN
+
+    payload = json.dumps({"scope": scope, "articles": articles})
+
+    def _run() -> dict[str, Any]:
+        try:
+            result = subprocess.run(
+                [KB_BIN, "accept", "--scope", scope, "--json"],
+                input=payload,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=120,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"kb binary not found at {KB_BIN!r}. Install kb-go or set POCKETPAW_KB_BIN."
+            ) from exc
+        if result.returncode != 0:
+            raise RuntimeError(f"kb accept failed: {result.stderr[:200]}")
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return {"raw": result.stdout.strip()}
+
+    return await asyncio.to_thread(_run)
+
+
+__all__ = [
+    "ingest_member",
+    "list_connected_members",
+    "run_ingest_sweep",
+]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -64,6 +64,7 @@ from pocketpaw_ee.cloud.models.meeting import (
     MeetingsSettings,
     MeetingTranscript,
 )
+from pocketpaw_ee.cloud.models.member_ingest_state import MemberIngestState
 from pocketpaw_ee.cloud.models.message import Attachment, Mention, Message, Reaction
 from pocketpaw_ee.cloud.models.notification import Notification, NotificationSource
 from pocketpaw_ee.cloud.models.planner import PlanSession, PlanSessionAgentGap
@@ -145,6 +146,7 @@ __all__ = [
     "MeetingProviderCredentials",
     "MeetingsSettings",
     "MeetingTranscript",
+    "MemberIngestState",
     "Mention",
     "Message",
     "Notification",
@@ -206,6 +208,7 @@ def get_all_documents():
         MeetingTranscript,
         MeetingProviderCredentials,
         MeetingsSettings,
+        MemberIngestState,
         # Calendar — sibling enterprise package.
         _CalendarDoc,
         _EventDoc,

--- a/ee/pocketpaw_ee/cloud/models/invite.py
+++ b/ee/pocketpaw_ee/cloud/models/invite.py
@@ -5,6 +5,11 @@ We persist sha256(plaintext) so a DB read cannot reconstruct a usable
 invite link. ``token`` is the legacy plaintext column kept Optional for
 backfill during the hashing rollout — new invites set ``token_hash``
 and leave ``token`` as None.
+
+2026-06-08 (pp#1365): added the optional embedded ``InviteContext`` and the
+nullable ``context`` field so an invite can carry admin-provided onboarding
+hints (``focus`` + ``profile_pic``) for a later VIP-onboarding flow. Fully
+optional — pre-existing invite rows read back with ``context=None``.
 """
 
 from __future__ import annotations
@@ -13,12 +18,25 @@ import hashlib
 from datetime import UTC, datetime, timedelta
 
 from beanie import Document, Indexed
-from pydantic import Field
+from pydantic import BaseModel, Field
 from pymongo import IndexModel
 
 
 def _default_expiry() -> datetime:
     return datetime.now(UTC) + timedelta(days=7)
+
+
+class InviteContext(BaseModel):
+    """Optional admin-provided onboarding hints carried on an invite.
+
+    Both fields are optional so the admin can supply either, both, or
+    neither. ``focus`` is a one-line description of what the new member
+    will own; ``profile_pic`` is a reference (e.g. an uploaded file id)
+    to a suggested avatar. Consumed by the downstream VIP-onboarding flow.
+    """
+
+    focus: str | None = None
+    profile_pic: str | None = None
 
 
 def hash_token(plaintext: str) -> str:
@@ -42,6 +60,7 @@ class Invite(Document):
     token: str | None = None  # legacy plaintext (deprecated; nulled after migration)
     token_hash: Indexed(str, unique=True) | None = None  # type: ignore[valid-type]
     group: str | None = None
+    context: InviteContext | None = None  # optional admin onboarding hints (pp#1365)
     accepted: bool = False
     revoked: bool = False
     revoked_reason: str | None = None  # e.g. "declined" when invitee declines vs inviter-revoke

--- a/ee/pocketpaw_ee/cloud/models/member_ingest_state.py
+++ b/ee/pocketpaw_ee/cloud/models/member_ingest_state.py
@@ -1,0 +1,52 @@
+# MemberIngestState Beanie document — per-member Gmail/Calendar ingest status.
+# Created: 2026-06-08 — VIP Onboarding Phase B (per-user ingest worker).
+# One row per (workspace, member_id) tracking the private-KB ingest worker's
+# state for that member: whether the initial bounded backfill has run
+# (``backfill_done`` drives backfill-vs-incremental), the per-source
+# high-water cursors used to bound the incremental window, and the last
+# run's status/error for operator visibility. Distinct from
+# WorkspaceConnector.last_sync_* (which is one row per (workspace, connector
+# name) and is the connector's own health, not the per-member ingest
+# bookkeeping the worker needs). The member id stored here is the clean
+# opaque cloud user_id — the same value used verbatim as the ``user:{id}``
+# kb-go scope (see chat.agent_service._member_private_user_scope).
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class MemberIngestState(TimestampedDocument):
+    """Per-member ingest bookkeeping for the Phase B private-KB worker.
+
+    Tenancy: ``workspace`` is required and indexed; every read filters on it
+    (cloud rule §7). ``member_id`` is the opaque cloud user id — paired with
+    ``workspace`` it is unique per member, enforced at the service layer
+    (upsert-on-write, no Mongo unique index so re-runs are forgiving).
+
+    The ``*_cursor`` fields hold the RFC3339 timestamp of the newest item
+    ingested from that source on the last successful run. The incremental
+    pass uses ``max(cursor, now - INCREMENTAL_WINDOW)`` as its lower bound so
+    a long gap still re-reads a bounded window rather than the whole history.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    member_id: str
+    status: str = "never"  # "never" | "running" | "ok" | "error"
+    backfill_done: bool = False
+    last_sync_at: datetime | None = None
+    last_error: str = ""
+    # High-water marks (RFC3339 strings) for the incremental window. Empty
+    # until the first successful read of that source.
+    gmail_cursor: str = ""
+    calendar_cursor: str = ""
+    # Running totals — handy for an operator/status endpoint without a
+    # separate metrics store. Not load-bearing for correctness.
+    documents_ingested: int = 0
+
+    class Settings(TimestampedDocument.Settings):
+        name = "member_ingest_state"

--- a/ee/pocketpaw_ee/cloud/people/__init__.py
+++ b/ee/pocketpaw_ee/cloud/people/__init__.py
@@ -6,10 +6,15 @@
 # Read by a later VIP-onboarding flow. STANDALONE — models identity only,
 # independent of the per-pocket agent-policy surface profile.
 #
-# No router yet: the only entry point is the service function the workspace
-# accept_invite path calls. A read API can land in a later slice.
+# Changes: 2026-06-08 (feat/vip-agent-block, pp#1367) — exported the read
+# side, ``get_person``, so the agent-orientation flow can fetch a member's
+# Person to render an "about this member" block in the system prompt.
+#
+# No router yet: the entry points are the service functions the workspace
+# accept_invite path (write) and the chat agent-orientation path (read) call.
+# A read API can land in a later slice.
 
 from pocketpaw_ee.cloud.people.domain import Person
-from pocketpaw_ee.cloud.people.service import materialize_person_from_invite
+from pocketpaw_ee.cloud.people.service import get_person, materialize_person_from_invite
 
-__all__ = ["Person", "materialize_person_from_invite"]
+__all__ = ["Person", "get_person", "materialize_person_from_invite"]

--- a/ee/pocketpaw_ee/cloud/people/__init__.py
+++ b/ee/pocketpaw_ee/cloud/people/__init__.py
@@ -1,0 +1,15 @@
+# pocketpaw_ee/cloud/people/ — the workspace-member identity spine.
+#
+# Created: 2026-06-08 (feat/vip-fabric-person, pp#1366). Materializes a
+# standalone Fabric ``Person`` object for a member on invite accept, built
+# from the member's profile + the invite's admin context, provenance-tracked.
+# Read by a later VIP-onboarding flow. STANDALONE — models identity only,
+# independent of the per-pocket agent-policy surface profile.
+#
+# No router yet: the only entry point is the service function the workspace
+# accept_invite path calls. A read API can land in a later slice.
+
+from pocketpaw_ee.cloud.people.domain import Person
+from pocketpaw_ee.cloud.people.service import materialize_person_from_invite
+
+__all__ = ["Person", "materialize_person_from_invite"]

--- a/ee/pocketpaw_ee/cloud/people/domain.py
+++ b/ee/pocketpaw_ee/cloud/people/domain.py
@@ -1,0 +1,113 @@
+# domain.py — Cloud "people" entity value objects (the identity spine).
+#
+# Created: 2026-06-08 (feat/vip-fabric-person, pp#1366) — frozen dataclass
+# describing a workspace member materialized as a standalone Fabric
+# ``Person`` object on invite accept. Tenancy (``workspace_id``) is
+# required positionally with no default, matching the ee/cloud rule that
+# the workspace tag is impossible to forget — constructing a ``Person``
+# without one is a TypeError, not a silent leak.
+#
+# STANDALONE by design: this models *identity* (who the member is), a
+# different axis from the per-pocket agent-policy surface profile
+# (``PocketSurfaceProfile`` / entity-pocket-profile work). No import of,
+# or dependency on, that surface — Person never reaches across the seam.
+#
+# The ``Person`` mirrors the property bag written into the Fabric object
+# (``FabricObject.properties``) plus the provenance fields the journal
+# event carries. It exists so callers (tests, the later VIP-onboarding
+# read) get a typed view instead of poking a raw ``dict[str, Any]``.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# The Fabric object type this entity materializes as. A stable string id
+# (not a generated one) so the journal projection groups every Person row
+# under one ``type_id`` and ``query(type_name="Person")`` is exact.
+PERSON_TYPE_ID = "person"
+PERSON_TYPE_NAME = "Person"
+
+# Provenance marker stored on every Person written from an invite's admin
+# context. Surfaced both as ``FabricObject.source_connector`` and inside
+# the property bag (``source``) so a reader that only has the projected
+# object — not the journal event — can still tell where the row came from.
+SOURCE_ADMIN_CONTEXT = "admin_context"
+
+
+@dataclass(frozen=True)
+class Person:
+    """A workspace member's identity, materialized as a Fabric ``Person``.
+
+    Tenancy is enforced at construction — ``workspace_id`` is required
+    positionally with no default. Same rule as the rest of ``ee/cloud``.
+
+    Identity fields come from the member's own profile; onboarding fields
+    (``focus`` / ``profile_pic``) and ``role`` / ``group`` come from the
+    inviting admin's context. ``invited_by`` + ``source`` record the
+    provenance so the later VIP-onboarding flow knows the row was seeded
+    by an admin, not self-authored.
+
+    Fields:
+      * ``id`` — the Fabric object id. Deterministic
+        (``person-{workspace_id}-{user_id}``) so re-materializing the same
+        member updates the existing object instead of minting a duplicate.
+      * ``workspace_id`` — owning workspace. Tagged at construction.
+      * ``user_id`` — the member's cloud user id. The stable external key
+        the materializer keys idempotency off.
+      * ``name`` / ``email`` / ``avatar`` — from the member's own profile.
+      * ``role`` — workspace role from the invite (``member`` / ``admin``).
+      * ``group`` — team / group id from the invite. ``None`` when the
+        invite carried no group.
+      * ``focus`` — one-line "what they'll own", from the invite's admin
+        context. Empty string when the admin supplied none.
+      * ``profile_pic`` — suggested avatar reference, from the invite's
+        admin context. Empty string when the admin supplied none.
+      * ``invited_by`` — user id of the admin who sent the invite
+        (provenance).
+      * ``source`` — provenance marker; always ``admin_context`` for
+        invite-materialized people.
+    """
+
+    id: str
+    workspace_id: str
+    user_id: str
+    name: str
+    email: str
+    avatar: str
+    role: str
+    group: str | None
+    focus: str
+    profile_pic: str
+    invited_by: str
+    source: str = SOURCE_ADMIN_CONTEXT
+
+    def to_properties(self) -> dict[str, str | None]:
+        """Project the identity + provenance fields into the property bag
+        stored on ``FabricObject.properties``.
+
+        ``id`` / ``workspace_id`` are intentionally NOT duplicated into the
+        bag: the id is the object's own id, and the workspace is carried by
+        the journal event's scope (the canonical tenancy source). Folding
+        them into properties too would create two places to keep in sync.
+        """
+
+        return {
+            "user_id": self.user_id,
+            "name": self.name,
+            "email": self.email,
+            "avatar": self.avatar,
+            "role": self.role,
+            "group": self.group,
+            "focus": self.focus,
+            "profile_pic": self.profile_pic,
+            "invited_by": self.invited_by,
+            "source": self.source,
+        }
+
+
+__all__ = [
+    "PERSON_TYPE_ID",
+    "PERSON_TYPE_NAME",
+    "SOURCE_ADMIN_CONTEXT",
+    "Person",
+]

--- a/ee/pocketpaw_ee/cloud/people/service.py
+++ b/ee/pocketpaw_ee/cloud/people/service.py
@@ -1,11 +1,18 @@
-"""People domain — materialize a workspace member as a Fabric ``Person``.
+"""People domain — materialize and read a workspace member's Fabric ``Person``.
 
 Created: 2026-06-08 (feat/vip-fabric-person, pp#1366).
+Changes: 2026-06-08 (feat/vip-agent-block, pp#1367) — added the read side,
+:func:`get_person`, that queries the journal projection for a member's
+deterministic Person id (workspace-scoped) and maps the projected object's
+property bag back to a typed :class:`Person`, or ``None`` when the member
+has no Person yet. The agent-orientation flow reads it to render an
+"about this member" block; the read mirrors the materializer's query +
+scope shape.
 
 When a workspace invite is accepted, ``accept_invite`` calls
 :func:`materialize_person_from_invite` to create (or update) a standalone
 Fabric ``Person`` object for the new member. The object is the identity
-"spine" a later VIP-onboarding flow reads.
+"spine" a later VIP-onboarding flow reads. :func:`get_person` is that read.
 
 Write path — the journal, not the legacy SQLite store
 -----------------------------------------------------
@@ -234,4 +241,73 @@ async def materialize_person_from_invite(
     return person
 
 
-__all__ = ["materialize_person_from_invite"]
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+
+def _person_from_object(obj: FabricObject, *, workspace_id: str) -> Person:
+    """Map a projected Fabric object back to a typed :class:`Person`.
+
+    The inverse of :meth:`Person.to_properties`. ``id`` comes from the
+    object's own id; ``workspace_id`` from the read scope (the journal does
+    NOT fold it into the property bag — it's carried by the event scope); the
+    remaining identity / provenance fields come straight from the property
+    bag. ``group`` stays ``None`` when the stored value is falsy.
+    """
+
+    props = obj.properties
+    return Person(
+        id=obj.id,
+        workspace_id=workspace_id,
+        user_id=str(props.get("user_id", "")),
+        name=str(props.get("name", "")),
+        email=str(props.get("email", "")),
+        avatar=str(props.get("avatar", "")),
+        role=str(props.get("role", "")),
+        group=props.get("group") or None,
+        focus=str(props.get("focus", "")),
+        profile_pic=str(props.get("profile_pic", "")),
+        invited_by=str(props.get("invited_by", "")),
+        source=str(props.get("source", SOURCE_ADMIN_CONTEXT)),
+    )
+
+
+async def get_person(
+    workspace_id: str,
+    user_id: str,
+    *,
+    store: FabricJournalStore | None = None,
+) -> Person | None:
+    """Read a member's materialized Fabric ``Person``, or ``None``.
+
+    Queries the journal projection for the ``Person`` type under the member's
+    own workspace scope and matches the deterministic id
+    (``person-{workspace_id}-{user_id}``). Returns the typed :class:`Person`
+    when present, ``None`` when this member was never materialized — e.g. a
+    pre-existing / non-invited user. The caller treats ``None`` as "no block",
+    never an error.
+
+    Tenant-scoped: ``requester_scopes`` is the single workspace scope, so the
+    read can only ever see this workspace's people. Mirrors the materializer's
+    query (same ``type_id`` + scope), then narrows to the deterministic id.
+
+    ``store`` is injectable for tests; production callers omit it and get the
+    process-wide journal-backed store.
+    """
+
+    fabric = store if store is not None else _default_store()
+    scope = _person_scope(workspace_id)
+    target_id = _person_object_id(workspace_id, user_id)
+
+    result = await fabric.query(
+        FabricQuery(type_id=PERSON_TYPE_ID, limit=10_000),
+        requester_scopes=scope,
+    )
+    for obj in result.objects:
+        if obj.id == target_id:
+            return _person_from_object(obj, workspace_id=workspace_id)
+    return None
+
+
+__all__ = ["get_person", "materialize_person_from_invite"]

--- a/ee/pocketpaw_ee/cloud/people/service.py
+++ b/ee/pocketpaw_ee/cloud/people/service.py
@@ -1,0 +1,237 @@
+"""People domain — materialize a workspace member as a Fabric ``Person``.
+
+Created: 2026-06-08 (feat/vip-fabric-person, pp#1366).
+
+When a workspace invite is accepted, ``accept_invite`` calls
+:func:`materialize_person_from_invite` to create (or update) a standalone
+Fabric ``Person`` object for the new member. The object is the identity
+"spine" a later VIP-onboarding flow reads.
+
+Write path — the journal, not the legacy SQLite store
+-----------------------------------------------------
+
+Object lifecycle goes through :class:`FabricJournalStore` (the Wave 3 /
+Org Architecture path), not the legacy ``FabricStore``. Two reasons:
+
+1. It is the blessed object path — ``pocketpaw.fabric``'s own ``__init__``
+   defers object lifecycle + scope-filtered queries to the journal store.
+2. Provenance and tenancy are native there. The inviting admin becomes the
+   journal ``Actor``; the workspace becomes the event ``scope``; and the
+   ``fabric.object.created`` / ``fabric.object.updated`` events ARE the
+   emit-on-write (the decisions subsystem already folds them) — so this
+   module needs no separate cloud realtime event.
+
+Idempotency
+-----------
+
+The Fabric object id is deterministic — ``person-{workspace_id}-{user_id}``
+— so re-accepting (or otherwise re-materializing) the same member UPDATES
+the existing object rather than minting a duplicate. The materializer
+queries the projection for that id first: present → ``update``, absent →
+``create``. The journal projection also overwrites by object id on replay,
+so even a stray duplicate ``created`` event would not produce two rows.
+
+STANDALONE
+----------
+
+This models identity only. It does NOT import or depend on the per-pocket
+agent-policy surface profile (``PocketSurfaceProfile`` / entity-pocket
+work) — that is a different axis. Keep them separate.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+from soul_protocol.spec.journal import Actor
+
+from pocketpaw.fabric.journal_store import FabricJournalStore
+from pocketpaw.fabric.models import FabricObject, FabricQuery
+from pocketpaw_ee.cloud.people.domain import (
+    PERSON_TYPE_ID,
+    PERSON_TYPE_NAME,
+    SOURCE_ADMIN_CONTEXT,
+    Person,
+)
+from pocketpaw_ee.cloud.workspace.domain import Invite
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Journal-backed store accessor
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _default_store() -> FabricJournalStore:
+    """Build the process-wide ``FabricJournalStore`` over the org journal.
+
+    Lazily imports ``get_journal`` (the same dependency the decisions +
+    pockets paths use) so importing this module doesn't drag the journal
+    open in test / smoke contexts that never materialize a Person. The
+    store is cached for the life of the process; ``bootstrap()`` warms the
+    projection from genesis so a read-after-write sees prior rows.
+
+    Tests override the store by passing ``store=`` to
+    :func:`materialize_person_from_invite`; they should not poke this cache.
+    """
+
+    from pocketpaw.journal_dep import get_journal
+
+    store = FabricJournalStore(get_journal())
+    store.bootstrap()
+    return store
+
+
+def _person_object_id(workspace_id: str, user_id: str) -> str:
+    """Deterministic Fabric object id for a member's Person.
+
+    Stable across re-accepts so materialization is an upsert keyed on
+    ``(workspace_id, user_id)`` rather than a fresh insert each time.
+    """
+
+    return f"person-{workspace_id}-{user_id}"
+
+
+def _person_scope(workspace_id: str) -> list[str]:
+    """Journal scope for a Person write.
+
+    A single workspace-rooted scope string (matching ``ScopeKind.WORKSPACE``
+    = ``"workspace"``). The journal's EventEntry invariant requires a
+    non-empty scope, and tenancy is enforced by this list — a query scoped
+    to one workspace never sees another's people.
+    """
+
+    return [f"workspace:{workspace_id}"]
+
+
+# ---------------------------------------------------------------------------
+# Materialization
+# ---------------------------------------------------------------------------
+
+
+def _build_person(
+    *,
+    workspace_id: str,
+    user_id: str,
+    name: str,
+    email: str,
+    avatar: str,
+    invite: Invite,
+) -> Person:
+    """Assemble the :class:`Person` from member profile + invite context.
+
+    Identity fields (``name`` / ``email`` / ``avatar``) come from the
+    member's own profile. ``role`` / ``group`` and the onboarding fields
+    (``focus`` / ``profile_pic``) come from the invite. When
+    ``invite.context`` is ``None`` the onboarding fields fall back to empty
+    strings — the Person is still created from the available identity.
+    """
+
+    # ``context`` is None when the admin supplied no onboarding hints; even
+    # when present, ``focus`` / ``profile_pic`` are individually optional.
+    # Either way the Person is still created — the onboarding fields just
+    # fall back to empty strings.
+    context = invite.context
+    focus = context.focus if context and context.focus else ""
+    profile_pic = context.profile_pic if context and context.profile_pic else ""
+
+    return Person(
+        id=_person_object_id(workspace_id, user_id),
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=name,
+        email=email,
+        avatar=avatar,
+        role=invite.role,
+        group=invite.group_id,
+        focus=focus,
+        profile_pic=profile_pic,
+        invited_by=invite.invited_by,
+        source=SOURCE_ADMIN_CONTEXT,
+    )
+
+
+async def materialize_person_from_invite(
+    *,
+    workspace_id: str,
+    user_id: str,
+    name: str,
+    email: str,
+    avatar: str,
+    invite: Invite,
+    store: FabricJournalStore | None = None,
+) -> Person:
+    """Create or update the standalone Fabric ``Person`` for a new member.
+
+    Called from ``accept_invite`` after the membership is written. Builds a
+    :class:`Person` from the member's profile (``name`` / ``email`` /
+    ``avatar``) plus the invite's admin context (``role`` / ``group`` /
+    ``focus`` / ``profile_pic``), records provenance (``invited_by`` +
+    ``source=admin_context``), and writes it to the Fabric journal under a
+    workspace-scoped event attributed to the inviting admin.
+
+    Idempotent: the object id is deterministic, so a second call for the
+    same member UPDATES the existing object — never a duplicate.
+
+    ``store`` is injectable for tests; production callers omit it and get
+    the process-wide journal-backed store.
+
+    Returns the materialized :class:`Person` (the caller's view; the
+    journal write is fire-and-confirm via the projection).
+    """
+
+    fabric = store if store is not None else _default_store()
+    person = _build_person(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=name,
+        email=email,
+        avatar=avatar,
+        invite=invite,
+    )
+    scope = _person_scope(workspace_id)
+
+    # Provenance: the inviting admin is the journal Actor. The scope_context
+    # mirrors the write scope so the recorded actor identity carries the
+    # same tenancy bound as the event.
+    actor = Actor(
+        kind="user",
+        id=f"user:{person.invited_by}",
+        scope_context=list(scope),
+    )
+
+    properties = person.to_properties()
+
+    # Idempotency probe: is this member already materialized? Query the
+    # projection for the Person type and look for our deterministic id.
+    existing = await fabric.query(
+        FabricQuery(type_id=PERSON_TYPE_ID, limit=10_000),
+        requester_scopes=scope,
+    )
+    already = any(obj.id == person.id for obj in existing.objects)
+
+    if already:
+        # Update merges onto existing properties — every field we write is
+        # supplied here, so a changed profile / context overwrites cleanly.
+        await fabric.update(person.id, properties, scope=scope, actor=actor)
+    else:
+        obj = FabricObject(
+            id=person.id,
+            type_id=PERSON_TYPE_ID,
+            type_name=PERSON_TYPE_NAME,
+            properties=properties,
+            # Native Fabric provenance, in addition to the property-bag
+            # copy: source_connector flags the origin, source_id is the
+            # member's user id (the external key this row tracks).
+            source_connector=SOURCE_ADMIN_CONTEXT,
+            source_id=user_id,
+        )
+        await fabric.create(obj, scope=scope, actor=actor)
+
+    return person
+
+
+__all__ = ["materialize_person_from_invite"]

--- a/ee/pocketpaw_ee/cloud/workspace/domain.py
+++ b/ee/pocketpaw_ee/cloud/workspace/domain.py
@@ -1,6 +1,6 @@
 """Domain value objects for the workspace module.
 
-Three frozen dataclasses, no Beanie / Pydantic / FastAPI imports:
+Frozen dataclasses, no Beanie / Pydantic / FastAPI imports:
 
 - ``Workspace`` mirrors the persistence ``Workspace`` document plus a
   derived ``member_count`` that the service computes per request.
@@ -10,6 +10,8 @@ Three frozen dataclasses, no Beanie / Pydantic / FastAPI imports:
 - ``Invite`` mirrors the persistence ``Invite`` document, with
   ``expired`` precomputed at the boundary so the domain entity stays
   pure (no clock dependency baked into a property).
+- ``InviteContext`` mirrors the optional admin onboarding hints embedded
+  on the invite (pp#1365); ``Invite.context`` is None when omitted.
 """
 
 from __future__ import annotations
@@ -59,6 +61,18 @@ class VerifiedDomain:
 
 
 @dataclass(frozen=True)
+class InviteContext:
+    """Optional admin-provided onboarding hints carried on an invite.
+
+    ``focus`` is a one-line description of what the new member will own;
+    ``profile_pic`` is a reference to a suggested avatar. Both optional —
+    the downstream VIP-onboarding flow reads whatever the admin supplied."""
+
+    focus: str | None = None
+    profile_pic: str | None = None
+
+
+@dataclass(frozen=True)
 class Invite:
     """A workspace invite. ``expired`` is computed by the repository at
     read time so the domain doesn't carry a clock dependency."""
@@ -74,6 +88,7 @@ class Invite:
     revoked: bool
     expired: bool
     expires_at: datetime
+    context: InviteContext | None = None  # optional admin onboarding hints (pp#1365)
 
 
-__all__ = ["Invite", "VerifiedDomain", "Workspace", "WorkspaceMember"]
+__all__ = ["Invite", "InviteContext", "VerifiedDomain", "Workspace", "WorkspaceMember"]

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -16,7 +16,13 @@ from typing import Literal
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from pocketpaw_ee.cloud._core.time import iso_utc
-from pocketpaw_ee.cloud.workspace.domain import Invite, VerifiedDomain, Workspace, WorkspaceMember
+from pocketpaw_ee.cloud.workspace.domain import (
+    Invite,
+    InviteContext,
+    VerifiedDomain,
+    Workspace,
+    WorkspaceMember,
+)
 
 # ---------------------------------------------------------------------------
 # Requests (preserved from schemas.py)
@@ -40,10 +46,24 @@ class UpdateWorkspaceRequest(BaseModel):
     settings: dict | None = None
 
 
+class InviteContextDTO(BaseModel):
+    """Optional admin-provided onboarding hints carried on an invite (pp#1365).
+
+    The same ``{focus, profile_pic}`` shape on both the create request and the
+    invite response. ``focus`` is a one-line description of what the new member
+    will own; ``profile_pic`` is a reference (e.g. an uploaded file id) to a
+    suggested avatar. Both optional — supply either, both, or neither. Consumed
+    by the downstream VIP-onboarding flow."""
+
+    focus: str | None = Field(default=None, max_length=280)
+    profile_pic: str | None = Field(default=None, max_length=512)
+
+
 class CreateInviteRequest(BaseModel):
     email: str
     role: str = Field(default="member", pattern="^(admin|member)$")
     group_id: str | None = None
+    context: InviteContextDTO | None = None
 
 
 class UpdateMemberRoleRequest(BaseModel):
@@ -114,6 +134,7 @@ class InviteOut(BaseModel):
     revoked: bool
     expired: bool
     expiresAt: str | None  # noqa: N815 - camelCase wire key
+    context: InviteContextDTO | None = None  # optional admin onboarding hints (pp#1365)
 
     model_config = {"populate_by_name": True}
 
@@ -229,6 +250,12 @@ def member_to_dto(m: WorkspaceMember) -> MemberOut:
     )
 
 
+def _context_to_dto(ctx: InviteContext | None) -> InviteContextDTO | None:
+    if ctx is None:
+        return None
+    return InviteContextDTO(focus=ctx.focus, profile_pic=ctx.profile_pic)
+
+
 def invite_to_dto(inv: Invite) -> InviteOut:
     return InviteOut(
         id=inv.id,
@@ -240,6 +267,7 @@ def invite_to_dto(inv: Invite) -> InviteOut:
         revoked=inv.revoked,
         expired=inv.expired,
         expiresAt=iso_utc(inv.expires_at),
+        context=_context_to_dto(inv.context),
     )
 
 
@@ -265,6 +293,7 @@ def invite_to_validate_dto(inv: Invite, workspace_name: str) -> ValidateInviteOu
         revoked=inv.revoked,
         expired=inv.expired,
         expiresAt=iso_utc(inv.expires_at),
+        context=_context_to_dto(inv.context),
         valid=not (inv.accepted or inv.revoked or inv.expired),
         workspace_name=workspace_name,
     )
@@ -277,6 +306,7 @@ __all__ = [
     "BulkInviteSkip",
     "CreateInviteRequest",
     "CreateWorkspaceRequest",
+    "InviteContextDTO",
     "InviteOut",
     "InvitePreviewResponse",
     "MemberOut",

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -224,6 +224,10 @@ class InvitePreviewResponse(BaseModel):
     group: str | None = None
     group_name: str | None = None
     viewer_email: str | None = None
+    # Optional admin onboarding hints (pp#1365), surfaced on ready_* previews so
+    # the member-facing accept UI can carry focus + profile_pic into the
+    # downstream VIP-onboarding welcome. None/absent when the invite has none.
+    context: InviteContextDTO | None = None
 
 
 def workspace_to_dto(ws: Workspace) -> WorkspaceOut:

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -27,6 +27,11 @@ slug-available check, and create() now also rejects reserved slugs.
 a ConflictError (409) instead of letting it escape as an unhandled 500 — the
 leftover unique index on the nullable legacy ``token`` column made every
 second invite collide on ``token=null``.
+2026-06-08 (Phase B chunk 7): remove_member now runs a 4th best-effort cascade
+— purge_member_data — so an offboarded member's personal Gmail/calendar (their
+private ``user:{id}`` KB scope), per-user OAuth tokens, connector rows, and
+ingest-state are deleted. The purge counts land in the audit row's cascade
+metadata.
 """
 
 from __future__ import annotations
@@ -613,6 +618,27 @@ async def remove_member(
             exc_info=True,
         )
 
+    # Phase B per-user data purge — an offboarded member's PERSONAL Gmail/
+    # calendar (ingested into their private ``user:{id}`` KB scope), their
+    # per-user OAuth tokens, connector rows, and ingest-state must be deleted:
+    # it's their personal data; leaving the workspace must purge it. Lazy
+    # import keeps the workspace service free of a member_ingest dependency at
+    # module load. Best-effort like the cascades above — purge_member_data is
+    # itself idempotent and isolates per-store failures, so a worst case here
+    # is one logged warning, never a blocked offboard.
+    member_data_purged: dict | None = None
+    try:
+        from pocketpaw_ee.cloud.member_ingest.purge import purge_member_data
+
+        member_data_purged = await purge_member_data(workspace_id, target_user_id)
+    except Exception:
+        logger.warning(
+            "remove_member: member-data purge failed for user=%s ws=%s",
+            target_user_id,
+            workspace_id,
+            exc_info=True,
+        )
+
     await event_bus.emit(
         "member.removed",
         {
@@ -647,6 +673,9 @@ async def remove_member(
                 "api_keys_revoked": api_keys_revoked,
                 "sessions_revoked": sessions_revoked,
                 "invites_revoked": invites_revoked,
+                # Phase B: what the per-user data purge removed (None if the
+                # purge step itself raised — the warning above has the detail).
+                "member_data_purged": member_data_purged,
             },
         },
     )

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -926,6 +926,18 @@ async def preview_invite(token: str, viewer_user_id: str | None) -> dict:
             else:
                 state = "ready_wrong_user"
 
+    # Surface the admin onboarding context (pp#1365) so the member-facing
+    # accept UI can carry the invitee's focus + profile_pic into the
+    # downstream VIP-onboarding welcome. None when the invite has no context.
+    context_domain = _context_doc_to_domain(invite_doc.context)
+    context_wire = (
+        InviteContextDTO(
+            focus=context_domain.focus, profile_pic=context_domain.profile_pic
+        ).model_dump()
+        if context_domain is not None
+        else None
+    )
+
     return {
         "state": state,
         "email": invite_doc.email,
@@ -934,6 +946,7 @@ async def preview_invite(token: str, viewer_user_id: str | None) -> dict:
         "group": invite_doc.group,
         "group_name": None,
         "viewer_email": viewer_email,
+        "context": context_wire,
     }
 
 

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -1027,11 +1027,6 @@ async def _heal_or_conflict(ctx: RequestContext, existing: _InviteDoc) -> None:
     workspace_id = existing.workspace
     already = await _get_member_role(workspace_id, ctx.user_id) is not None
     if not already:
-        logger.warning(
-            "[diag accept_invite] self-heal: added missing membership user=%s workspace=%s",
-            ctx.user_id,
-            workspace_id,
-        )
         await _add_member(workspace_id, ctx.user_id, role=existing.role, set_active=True)
         return
     raise ConflictError("invite.already_accepted", "This invite has already been accepted")
@@ -1122,12 +1117,6 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
         raise NotFound("workspace", invite.workspace_id)
 
     already_member = await _get_member_role(invite.workspace_id, ctx.user_id) is not None
-    logger.warning(
-        "[diag accept_invite] user=%s workspace=%s already_member=%s",
-        ctx.user_id,
-        invite.workspace_id,
-        already_member,
-    )
     if not already_member:
         member_count = await _count_members(invite.workspace_id)
         if member_count >= ws_doc.seats:
@@ -1141,11 +1130,6 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
             ctx.user_id,
             role=invite.role,
             set_active=True,
-        )
-        logger.warning(
-            "[diag accept_invite] _add_member done (set_active=True) user=%s workspace=%s",
-            ctx.user_id,
-            invite.workspace_id,
         )
 
     # Materialize the member as a standalone Fabric ``Person`` — the

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -62,6 +62,7 @@ from pocketpaw_ee.cloud.auth import sessions as _sessions_service
 from pocketpaw_ee.cloud.models.agent import Agent as _AgentDoc
 from pocketpaw_ee.cloud.models.group import Group as _GroupDoc
 from pocketpaw_ee.cloud.models.invite import Invite as _InviteDoc
+from pocketpaw_ee.cloud.models.invite import InviteContext as _InviteContextDoc
 from pocketpaw_ee.cloud.models.invite import hash_token
 from pocketpaw_ee.cloud.models.notification import NotificationSource
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
@@ -71,11 +72,17 @@ from pocketpaw_ee.cloud.models.workspace import WorkspaceSettings
 from pocketpaw_ee.cloud.notifications import service as notifications_service
 from pocketpaw_ee.cloud.shared.events import event_bus
 from pocketpaw_ee.cloud.uploads.models import FileUpload as _FileUploadDoc
-from pocketpaw_ee.cloud.workspace.domain import Invite, Workspace, WorkspaceMember
+from pocketpaw_ee.cloud.workspace.domain import (
+    Invite,
+    InviteContext,
+    Workspace,
+    WorkspaceMember,
+)
 from pocketpaw_ee.cloud.workspace.dto import (
     BulkInviteRequest,
     CreateInviteRequest,
     CreateWorkspaceRequest,
+    InviteContextDTO,
     UpdateWorkspaceRequest,
 )
 
@@ -105,6 +112,12 @@ def _workspace_to_domain(doc: _WorkspaceDoc, *, member_count: int = 0) -> Worksp
     )
 
 
+def _context_doc_to_domain(ctx: _InviteContextDoc | None) -> InviteContext | None:
+    if ctx is None:
+        return None
+    return InviteContext(focus=ctx.focus, profile_pic=ctx.profile_pic)
+
+
 def _invite_to_domain(doc: _InviteDoc, *, plaintext_token: str | None = None) -> Invite:
     return Invite(
         id=str(doc.id),
@@ -118,6 +131,7 @@ def _invite_to_domain(doc: _InviteDoc, *, plaintext_token: str | None = None) ->
         revoked=doc.revoked,
         expired=doc.expired,
         expires_at=doc.expires_at,
+        context=_context_doc_to_domain(doc.context),
     )
 
 
@@ -647,11 +661,15 @@ async def _mint_invite_for_email(
     email: str,
     role: str,
     group_id: str | None,
+    context: InviteContextDTO | None = None,
 ) -> Invite:
     """Pre-clean expired/stale rows, reject duplicate pending, insert the
     hashed invite. Shared between ``create_invite`` (single) and
     ``bulk_create_invites`` (batch) so token hashing + pre-cleanup stay
     in lockstep. Does NOT emit or notify — the caller handles side-effects.
+
+    ``context`` is the optional admin onboarding payload (pp#1365); persisted
+    verbatim on the invite document and None when omitted.
     """
     # Mongo TTL is the long-term GC; this pre-cleanup makes the
     # collision check below honest about what's "still pending."
@@ -692,6 +710,11 @@ async def _mint_invite_for_email(
         token=None,  # plaintext never persisted for new invites
         token_hash=hash_token(plaintext),
         group=group_id,
+        context=(
+            _InviteContextDoc(focus=context.focus, profile_pic=context.profile_pic)
+            if context is not None
+            else None
+        ),
     )
     try:
         await invite_doc.insert()
@@ -728,7 +751,9 @@ async def create_invite(
     if member_count >= doc.seats:
         raise SeatLimitError(doc.seats)
 
-    invite = await _mint_invite_for_email(ctx, workspace_id, body.email, body.role, body.group_id)
+    invite = await _mint_invite_for_email(
+        ctx, workspace_id, body.email, body.role, body.group_id, body.context
+    )
 
     invited_user_id = await _find_user_id_by_email(body.email)
 

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -32,6 +32,13 @@ second invite collide on ``token=null``.
 private ``user:{id}`` KB scope), per-user OAuth tokens, connector rows, and
 ingest-state are deleted. The purge counts land in the audit row's cascade
 metadata.
+2026-06-09: accept_invite is now self-healing. The atomic claim and the
+membership write aren't transactional, so an accept interrupted mid-flight
+(backend restart) could leave an invite accepted=True with no membership,
+locking the invitee out of every workspace read. Both already_accepted
+raise-sites now route through _heal_or_conflict: a rightful invitee missing
+the membership gets it added (idempotent) instead of a 409; a genuine
+duplicate (already a member) still raises invite.already_accepted.
 """
 
 from __future__ import annotations
@@ -1003,7 +1010,42 @@ async def preview_invite(token: str, viewer_user_id: str | None) -> dict:
     }
 
 
+async def _heal_or_conflict(ctx: RequestContext, existing: _InviteDoc) -> None:
+    """Self-heal an accepted invite whose membership never landed.
+
+    Reached only after the identity check passed, so ``ctx.user_id`` is the
+    rightful, email-matched invitee. The accept flow is non-atomic: it
+    atomically claims the invite (accepted=True), then several awaits later
+    writes the membership. If the request dies between those steps (backend
+    restart, handler abort), the invite is burned with no membership and the
+    user is locked out of every workspace read with no recovery path.
+
+    Converge instead of raising: if the invitee has no membership, add it
+    (``_add_member`` is idempotent) and treat it as success. Only a genuine
+    duplicate — the invitee is already a member — still raises 409.
+    """
+    workspace_id = existing.workspace
+    already = await _get_member_role(workspace_id, ctx.user_id) is not None
+    if not already:
+        logger.warning(
+            "[diag accept_invite] self-heal: added missing membership user=%s workspace=%s",
+            ctx.user_id,
+            workspace_id,
+        )
+        await _add_member(workspace_id, ctx.user_id, role=existing.role, set_active=True)
+        return
+    raise ConflictError("invite.already_accepted", "This invite has already been accepted")
+
+
 async def accept_invite(ctx: RequestContext, token: str) -> None:
+    """Accept a workspace invite for the logged-in user.
+
+    Self-healing: the claim (accepted=True) and the membership write are not
+    wrapped in a transaction, so a backend restart between them can burn an
+    invite with no membership. Re-accepting by the rightful invitee adds the
+    missing membership instead of raising — see ``_heal_or_conflict``. A
+    genuine duplicate (already a member) still raises ``invite.already_accepted``.
+    """
     th = hash_token(token)
 
     # Identity check: the logged-in user's email must match the invitee's.
@@ -1043,7 +1085,10 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
         if existing is None:
             raise NotFound("invite")
         if existing.accepted:
-            raise ConflictError("invite.already_accepted", "This invite has already been accepted")
+            # Already claimed. Either a genuine duplicate accept, or the
+            # claim landed but the membership write never did (non-atomic
+            # accept interrupted mid-flight). Self-heal the latter.
+            return await _heal_or_conflict(ctx, existing)
         if existing.revoked:
             raise Forbidden("invite.revoked", "This invite has been revoked")
         if existing.expired:
@@ -1058,7 +1103,10 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
             return_document=False,
         )
         if claimed is None:
-            raise ConflictError("invite.already_accepted", "This invite has already been accepted")
+            # Backfilled row was already accepted (duplicate or a burned
+            # accept that never wrote the membership). Self-heal the burn;
+            # ``existing`` carries the stable workspace + role for it.
+            return await _heal_or_conflict(ctx, existing)
 
     # Rebuild the domain object from the BEFORE doc so downstream emit/
     # membership logic has the data it needs.

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -1074,7 +1074,7 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
         raise NotFound("workspace", invite.workspace_id)
 
     already_member = await _get_member_role(invite.workspace_id, ctx.user_id) is not None
-    logger.info(
+    logger.warning(
         "[diag accept_invite] user=%s workspace=%s already_member=%s",
         ctx.user_id,
         invite.workspace_id,
@@ -1094,7 +1094,7 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
             role=invite.role,
             set_active=True,
         )
-        logger.info(
+        logger.warning(
             "[diag accept_invite] _add_member done (set_active=True) user=%s workspace=%s",
             ctx.user_id,
             invite.workspace_id,

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -1074,6 +1074,12 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
         raise NotFound("workspace", invite.workspace_id)
 
     already_member = await _get_member_role(invite.workspace_id, ctx.user_id) is not None
+    logger.info(
+        "[diag accept_invite] user=%s workspace=%s already_member=%s",
+        ctx.user_id,
+        invite.workspace_id,
+        already_member,
+    )
     if not already_member:
         member_count = await _count_members(invite.workspace_id)
         if member_count >= ws_doc.seats:
@@ -1087,6 +1093,11 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
             ctx.user_id,
             role=invite.role,
             set_active=True,
+        )
+        logger.info(
+            "[diag accept_invite] _add_member done (set_active=True) user=%s workspace=%s",
+            ctx.user_id,
+            invite.workspace_id,
         )
 
     # Materialize the member as a standalone Fabric ``Person`` — the

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -70,6 +70,7 @@ from pocketpaw_ee.cloud.models.user import WorkspaceMembership as _Membership
 from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
 from pocketpaw_ee.cloud.models.workspace import WorkspaceSettings
 from pocketpaw_ee.cloud.notifications import service as notifications_service
+from pocketpaw_ee.cloud.people import service as people_service
 from pocketpaw_ee.cloud.shared.events import event_bus
 from pocketpaw_ee.cloud.uploads.models import FileUpload as _FileUploadDoc
 from pocketpaw_ee.cloud.workspace.domain import (
@@ -1021,6 +1022,33 @@ async def accept_invite(ctx: RequestContext, token: str) -> None:
             ctx.user_id,
             role=invite.role,
             set_active=True,
+        )
+
+    # Materialize the member as a standalone Fabric ``Person`` — the
+    # identity spine a later VIP-onboarding flow reads (pp#1366). Built
+    # from the member's own profile + the invite's admin context, with
+    # provenance (invited_by + source=admin_context). Idempotent on the
+    # member's user id, so re-accepting updates rather than duplicating.
+    # The journal ``fabric.object.*`` event is the emit-on-write here.
+    # Wrapped defensively: membership is the source of truth, the Person
+    # is a derived projection — a Fabric/journal hiccup must not roll back
+    # an accepted invite.
+    try:
+        await people_service.materialize_person_from_invite(
+            workspace_id=invite.workspace_id,
+            user_id=ctx.user_id,
+            name=viewer.full_name,
+            email=viewer.email or invite.email,
+            avatar=viewer.avatar,
+            invite=invite,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Fabric Person materialization skipped for user=%s workspace=%s — "
+            "invite accept proceeds; the Person can be re-materialized later",
+            ctx.user_id,
+            invite.workspace_id,
+            exc_info=True,
         )
 
     await event_bus.emit(

--- a/src/pocketpaw/api/v1/oauth_integrations.py
+++ b/src/pocketpaw/api/v1/oauth_integrations.py
@@ -1,6 +1,10 @@
 # OAuth Integration routes — authorize + callback for Google, Spotify, etc.
 # Created: 2026-03-31
 # Extracted from dashboard.py so these work in both dashboard and serve modes.
+# 2026-06-08: authorize accepts an optional user_id and embeds it in the OAuth
+#   ``state`` (provider:service:user_id); the callback parses it back out and
+#   stores tokens in that user's bucket (VIP Onboarding Phase B). Omitting
+#   user_id keeps the shared single-user flow (state stays provider:service).
 
 from __future__ import annotations
 
@@ -33,8 +37,16 @@ OAUTH_SCOPES: dict[str, list[str]] = {
 
 
 @router.get("/oauth/integrations/authorize")
-async def oauth_authorize(service: str = Query("google_gmail")):
-    """Start OAuth flow — redirects user to provider consent screen."""
+async def oauth_authorize(
+    service: str = Query("google_gmail"),
+    user_id: str = Query(""),
+):
+    """Start OAuth flow — redirects user to provider consent screen.
+
+    ``user_id`` (optional) scopes the resulting token to a single member so
+    each person connects their own account (VIP Onboarding Phase B). When
+    omitted, tokens land in the shared single-user bucket.
+    """
     from fastapi.responses import RedirectResponse
 
     from pocketpaw.config import Settings
@@ -66,7 +78,10 @@ async def oauth_authorize(service: str = Query("google_gmail")):
 
     manager = OAuthManager()
     redirect_uri = f"http://localhost:{settings.web_port}/api/v1/oauth/integrations/callback"
-    state = f"{provider}:{service}"
+    # Carry an optional user_id as a third state segment so the callback can
+    # store the token in that member's bucket. Stays provider:service when
+    # no user_id is supplied (back-compat with the single-user flow).
+    state = f"{provider}:{service}:{user_id}" if user_id else f"{provider}:{service}"
 
     auth_url = manager.get_auth_url(
         provider=provider,
@@ -101,9 +116,11 @@ async def oauth_callback(
         settings = Settings.load()
         manager = OAuthManager(TokenStore())
 
-        parts = state.split(":", 1)
+        # state shape: "provider:service" (legacy) or "provider:service:user_id".
+        parts = state.split(":", 2)
         provider = parts[0] if parts else "google"
         service = parts[1] if len(parts) > 1 else "google_gmail"
+        user_id = parts[2] if len(parts) > 2 and parts[2] else None
 
         redirect_uri = f"http://localhost:{settings.web_port}/api/v1/oauth/integrations/callback"
         scopes = OAUTH_SCOPES.get(service, [])
@@ -123,6 +140,7 @@ async def oauth_callback(
             client_secret=client_secret,
             redirect_uri=redirect_uri,
             scopes=scopes,
+            user_id=user_id,
         )
 
         return HTMLResponse(

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -1,6 +1,15 @@
 """
 Builder for assembling the full agent context.
 Created: 2026-02-02
+Updated: 2026-06-08 (VIP Onboarding Phase B — session-gated per-user KB scope)
+— ``KbContext`` gains an optional ``user_id``; ``_resolve_kb_scopes`` emits a
+member-private ``user:{user_id}`` scope at the HEAD of the list (highest
+priority, ahead of pocket/agent/workspace) ONLY when ``user_id`` is set. This
+is the read-side of the VIP isolation gate: a member's private Gmail/calendar
+KB is injected into the agent context only in that member's own session. The
+caller (the EE cloud chat gate) decides whether to set ``user_id`` based on
+room membership; this resolver only honors the field. ``user_id`` absent →
+legacy ordering is byte-identical.
 Updated: 2026-06-07 (feat/entity-pocket-profile-field, entity-rooms A2) —
 ``build_system_prompt`` accepts an optional ``skill_names: frozenset[str]``.
 When non-empty, the "Available Skills" block (#8) advertises ONLY those skills —
@@ -59,24 +68,48 @@ class KbContext:
     ``ScopeContext`` and threads it into the system-prompt builder so KB
     queries hit the most-specific scope available. Channels and CLI keep
     using the static ``settings.kb_scopes`` fallback.
+
+    ``user_id`` (VIP Onboarding Phase B) carries a MEMBER-PRIVATE scope id —
+    the cloud user id (opaque Mongo ObjectId / uuid, never an email, so
+    kb-go's on-disk ``:``→``_`` sanitize can't alias two members). When set,
+    ``_resolve_kb_scopes`` emits ``user:{user_id}`` at the HEAD of the scope
+    list so a member's private mail/calendar KB outranks every shared scope.
+    The CALLER is solely responsible for the isolation decision: it must set
+    ``user_id`` ONLY in that member's own solo session and NEVER in a shared /
+    multi-member room (see the EE gate ``_member_private_user_scope`` /
+    ``_kb_scopes_for_context`` in ``cloud/chat/agent_service.py``). This
+    resolver does not — and cannot — know room membership; it just honors the
+    field. Leaving ``user_id`` unset keeps the legacy pocket/agent/workspace
+    ordering byte-identical.
     """
 
     pocket_id: str | None = None
     agent_id: str | None = None
     workspace_id: str | None = None
+    user_id: str | None = None
 
 
 def _resolve_kb_scopes(ctx: KbContext | None, settings) -> list[str]:
     """Build the prioritised scope list for a request.
 
-    Priority: pocket > agent > workspace > whatever's in ``settings.kb_scopes``.
-    Most-specific wins. The static settings list is the fallback for runtime
-    paths that don't carry a context (CLI, channels without ee/cloud) and for
-    requests that arrive with an empty ``KbContext``.
+    Priority: user > pocket > agent > workspace > whatever's in
+    ``settings.kb_scopes``. Most-specific wins, and a member-private
+    ``user:`` scope (when present) outranks every shared scope. The static
+    settings list is the fallback for runtime paths that don't carry a
+    context (CLI, channels without ee/cloud) and for requests that arrive
+    with an empty ``KbContext``.
+
+    The ``user:`` tier is emitted ONLY when ``ctx.user_id`` is set. The
+    caller (the EE cloud chat gate) is responsible for setting it ONLY in a
+    member's own solo session — never a shared room — so one member's private
+    data never lands in another member's context. This function trusts the
+    field; it has no visibility into room membership.
     """
     if ctx is None:
         return list(settings.kb_scopes or [])
     scopes: list[str] = []
+    if ctx.user_id:
+        scopes.append(f"user:{ctx.user_id}")
     if ctx.pocket_id:
         scopes.append(f"pocket:{ctx.pocket_id}")
     if ctx.agent_id:
@@ -497,8 +530,10 @@ class AgentContextBuilder:
         scope cannot break the prompt build.
 
         When ``kb_ctx`` is provided (Stage 3.E), scope priority is
-        ``pocket:{id} > agent:{id} > workspace:{id}`` — most-specific wins.
-        Without a ``kb_ctx`` (channel paths, CLI), the static
+        ``user:{id} > pocket:{id} > agent:{id} > workspace:{id}`` —
+        most-specific wins, and a member-private ``user:`` scope (set by the
+        cloud chat gate only in a member's own session) outranks every shared
+        scope. Without a ``kb_ctx`` (channel paths, CLI), the static
         ``settings.kb_scopes`` list is used unchanged.
 
         When ``image_bytes`` is set and a multimodal embedder is configured,

--- a/src/pocketpaw/clients/gcalendar.py
+++ b/src/pocketpaw/clients/gcalendar.py
@@ -1,6 +1,10 @@
 # Google Calendar Client — HTTP client for Calendar API using OAuth tokens.
 # Created: 2026-02-07
 # Part of Phase 2 Integration Ecosystem
+# 2026-06-08: CalendarClient takes an optional user_id so each member uses their
+#   OWN calendar token (VIP Onboarding Phase B). Pass it to the constructor;
+#   _get_token resolves the token from that user's bucket. Default None keeps
+#   the shared single-user behavior.
 
 from __future__ import annotations
 
@@ -25,16 +29,18 @@ class CalendarClient:
     Uses OAuth bearer tokens from the token store.
     """
 
-    def __init__(self):
+    def __init__(self, user_id: str | None = None):
         self._oauth = OAuthManager(TokenStore())
+        self._user_id = user_id
 
     async def _get_token(self) -> str:
-        """Get a valid OAuth access token for Calendar."""
+        """Get a valid OAuth access token for Calendar (scoped to this client's user)."""
         settings = get_settings()
         token = await self._oauth.get_valid_token(
             service="google_calendar",
             client_id=settings.google_oauth_client_id or "",
             client_secret=settings.google_oauth_client_secret or "",
+            user_id=self._user_id,
         )
         if not token:
             raise RuntimeError(

--- a/src/pocketpaw/clients/gdocs.py
+++ b/src/pocketpaw/clients/gdocs.py
@@ -1,6 +1,8 @@
 # Google Docs Client — HTTP client for Docs API using OAuth tokens.
 # Created: 2026-02-09
 # Part of Phase 4 Media Integrations
+# 2026-06-08: DocsClient takes an optional user_id so each member can use their
+#   OWN Docs token (VIP Onboarding Phase B). Default None = shared bucket.
 
 from __future__ import annotations
 
@@ -25,16 +27,18 @@ class DocsClient:
     Uses OAuth bearer tokens from the token store.
     """
 
-    def __init__(self):
+    def __init__(self, user_id: str | None = None):
         self._oauth = OAuthManager(TokenStore())
+        self._user_id = user_id
 
     async def _get_token(self) -> str:
-        """Get a valid OAuth access token for Docs."""
+        """Get a valid OAuth access token for Docs (scoped to this client's user)."""
         settings = get_settings()
         token = await self._oauth.get_valid_token(
             service="google_docs",
             client_id=settings.google_oauth_client_id or "",
             client_secret=settings.google_oauth_client_secret or "",
+            user_id=self._user_id,
         )
         if not token:
             raise RuntimeError(

--- a/src/pocketpaw/clients/gdrive.py
+++ b/src/pocketpaw/clients/gdrive.py
@@ -1,6 +1,8 @@
 # Google Drive Client — HTTP client for Drive API using OAuth tokens.
 # Created: 2026-02-09
 # Part of Phase 4 Media Integrations
+# 2026-06-08: DriveClient takes an optional user_id so each member can use their
+#   OWN Drive token (VIP Onboarding Phase B). Default None = shared bucket.
 
 from __future__ import annotations
 
@@ -34,16 +36,18 @@ class DriveClient:
     Uses OAuth bearer tokens from the token store.
     """
 
-    def __init__(self):
+    def __init__(self, user_id: str | None = None):
         self._oauth = OAuthManager(TokenStore())
+        self._user_id = user_id
 
     async def _get_token(self) -> str:
-        """Get a valid OAuth access token for Drive."""
+        """Get a valid OAuth access token for Drive (scoped to this client's user)."""
         settings = get_settings()
         token = await self._oauth.get_valid_token(
             service="google_drive",
             client_id=settings.google_oauth_client_id or "",
             client_secret=settings.google_oauth_client_secret or "",
+            user_id=self._user_id,
         )
         if not token:
             raise RuntimeError(

--- a/src/pocketpaw/clients/gmail.py
+++ b/src/pocketpaw/clients/gmail.py
@@ -1,6 +1,10 @@
 # Gmail Client — HTTP client for Gmail API using OAuth tokens.
 # Created: 2026-02-07
 # Part of Phase 2 Integration Ecosystem
+# 2026-06-08: GmailClient takes an optional user_id so each member uses their
+#   OWN Gmail token (VIP Onboarding Phase B). Pass it to the constructor;
+#   _get_token resolves the token from that user's bucket. Default None keeps
+#   the shared single-user behavior.
 
 from __future__ import annotations
 
@@ -27,16 +31,18 @@ class GmailClient:
     beyond httpx (already a core dep).
     """
 
-    def __init__(self):
+    def __init__(self, user_id: str | None = None):
         self._oauth = OAuthManager(TokenStore())
+        self._user_id = user_id
 
     async def _get_token(self) -> str:
-        """Get a valid OAuth access token for Gmail."""
+        """Get a valid OAuth access token for Gmail (scoped to this client's user)."""
         settings = get_settings()
         token = await self._oauth.get_valid_token(
             service="google_gmail",
             client_id=settings.google_oauth_client_id or "",
             client_secret=settings.google_oauth_client_secret or "",
+            user_id=self._user_id,
         )
         if not token:
             raise RuntimeError(

--- a/src/pocketpaw/clients/oauth.py
+++ b/src/pocketpaw/clients/oauth.py
@@ -1,6 +1,10 @@
 # OAuth Manager — Google OAuth 2.0 auth code flow + token refresh.
 # Created: 2026-02-07
 # Part of Phase 2 Integration Ecosystem
+# 2026-06-08: threaded an optional ``user_id`` through exchange_code,
+#   exchange_account_credentials, refresh_token, and get_valid_token so tokens
+#   route to the per-user bucket in TokenStore (VIP Onboarding Phase B). All
+#   user_id params default to None — service-only callers are unchanged.
 
 from __future__ import annotations
 
@@ -105,6 +109,7 @@ class OAuthManager:
         client_secret: str,
         redirect_uri: str,
         scopes: list[str] | None = None,
+        user_id: str | None = None,
     ) -> OAuthTokens:
         """Exchange an authorization code for access + refresh tokens.
 
@@ -116,6 +121,9 @@ class OAuthManager:
             client_secret: OAuth client secret.
             redirect_uri: Same redirect URI used in the auth request.
             scopes: Scopes that were requested (stored with tokens).
+            user_id: When set, tokens are stored in this user's bucket so
+                two members connecting the same service don't collide. None
+                (default) uses the shared single-user bucket.
 
         Returns:
             OAuthTokens with access and refresh tokens.
@@ -146,6 +154,7 @@ class OAuthManager:
             token_type=data.get("token_type", "Bearer"),
             expires_at=time.time() + expires_in,
             scopes=scopes or [],
+            user_id=user_id,
         )
 
         self.store.save(tokens)
@@ -160,6 +169,7 @@ class OAuthManager:
         client_secret: str,
         account_id: str,
         scopes: list[str] | None = None,
+        user_id: str | None = None,
     ) -> OAuthTokens:
         """Server-to-Server OAuth (account_credentials grant).
 
@@ -204,6 +214,7 @@ class OAuthManager:
                 "client_id": client_id,
                 "client_secret": client_secret,
             },
+            user_id=user_id,
         )
 
         self.store.save(tokens)
@@ -216,12 +227,16 @@ class OAuthManager:
         service: str,
         client_id: str,
         client_secret: str,
+        user_id: str | None = None,
     ) -> OAuthTokens | None:
         """Refresh an expired access token.
 
         For standard 3-leg providers uses the stored refresh_token.
         For S2S (account_credentials) providers re-requests via the
         original account_id, which is read from tokens.extra.
+
+        ``user_id`` selects which user's token row to refresh and re-save;
+        None (default) uses the shared single-user bucket.
 
         Returns updated OAuthTokens, or None if refresh fails.
         """
@@ -230,7 +245,7 @@ class OAuthManager:
             return None
 
         if config.get("grant_type") == "account_credentials":
-            tokens = self.store.load(service)
+            tokens = self.store.load(service, user_id=user_id)
             if not tokens:
                 return None
             account_id = tokens.extra.get("account_id")
@@ -239,13 +254,19 @@ class OAuthManager:
                 return None
             try:
                 return await self.exchange_account_credentials(
-                    provider, service, client_id, client_secret, account_id, tokens.scopes
+                    provider,
+                    service,
+                    client_id,
+                    client_secret,
+                    account_id,
+                    tokens.scopes,
+                    user_id=user_id,
                 )
             except Exception as e:
                 logger.warning("S2S token refresh failed for %s: %s", service, e)
                 return None
 
-        tokens = self.store.load(service)
+        tokens = self.store.load(service, user_id=user_id)
         if not tokens or not tokens.refresh_token:
             return None
 
@@ -283,12 +304,16 @@ class OAuthManager:
         client_id: str,
         client_secret: str,
         provider: str = "google",
+        user_id: str | None = None,
     ) -> str | None:
         """Get a valid access token, refreshing if expired.
 
+        ``user_id`` scopes the lookup + refresh to a single user; None
+        (default) uses the shared single-user bucket.
+
         Returns the access token string, or None if unavailable.
         """
-        tokens = self.store.load(service)
+        tokens = self.store.load(service, user_id=user_id)
         if not tokens:
             return None
 
@@ -297,7 +322,9 @@ class OAuthManager:
             return tokens.access_token
 
         # Try to refresh
-        refreshed = await self.refresh_token(provider, service, client_id, client_secret)
+        refreshed = await self.refresh_token(
+            provider, service, client_id, client_secret, user_id=user_id
+        )
         if refreshed:
             return refreshed.access_token
 

--- a/src/pocketpaw/clients/spotify.py
+++ b/src/pocketpaw/clients/spotify.py
@@ -1,6 +1,8 @@
 # Spotify Client — HTTP client for Spotify Web API using OAuth tokens.
 # Created: 2026-02-09
 # Part of Phase 4 Media Integrations
+# 2026-06-08: SpotifyClient takes an optional user_id so each member can use
+#   their OWN Spotify token (per-user token store). Default None = shared bucket.
 
 from __future__ import annotations
 
@@ -27,17 +29,19 @@ class SpotifyClient:
     Uses OAuth bearer tokens from the token store.
     """
 
-    def __init__(self):
+    def __init__(self, user_id: str | None = None):
         self._oauth = OAuthManager(TokenStore())
+        self._user_id = user_id
 
     async def _get_token(self) -> str:
-        """Get a valid OAuth access token for Spotify."""
+        """Get a valid OAuth access token for Spotify (scoped to this client's user)."""
         settings = get_settings()
         token = await self._oauth.get_valid_token(
             service="spotify",
             client_id=settings.spotify_client_id or "",
             client_secret=settings.spotify_client_secret or "",
             provider="spotify",
+            user_id=self._user_id,
         )
         if not token:
             raise RuntimeError(

--- a/src/pocketpaw/clients/token_store.py
+++ b/src/pocketpaw/clients/token_store.py
@@ -1,12 +1,20 @@
 # Token Store — file-based OAuth token persistence at ~/.pocketpaw/oauth/.
 # Created: 2026-02-07
 # Part of Phase 2 Integration Ecosystem
+# 2026-06-08: re-keyed tokens by (service, user_id) so two users on the same
+#   service no longer collide (VIP Onboarding Phase B foundation). Back-compat:
+#   user_id=None keeps the legacy ``{service}.json`` path untouched; per-user
+#   tokens land in ``{service}__{sanitized_user_id}.json``. user_id is sanitized
+#   so emails / path chars can't escape the oauth dir. OAuthTokens carries an
+#   optional user_id so ``save(tokens)`` knows which bucket to write.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
+import re
 import stat
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -16,10 +24,25 @@ from pocketpaw.config import get_config_dir
 
 logger = logging.getLogger(__name__)
 
+# Characters safe to use verbatim in the on-disk user segment. Anything else
+# (e.g. ``@``, ``/``, ``..``) is replaced so a user_id can never path-traverse
+# out of the oauth dir or collide with the service segment separator.
+_SAFE_USER_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+# Separator between the service segment and the user segment in a filename.
+# Double underscore keeps a single underscore inside service/user names from
+# being mistaken for the boundary.
+_USER_SEP = "__"
+
 
 @dataclass
 class OAuthTokens:
-    """OAuth 2.0 token set for a service."""
+    """OAuth 2.0 token set for a service.
+
+    ``user_id`` scopes the token to a single user (e.g. an invited workspace
+    member connecting their own Gmail). ``None`` is the shared / single-user
+    default and maps to the legacy service-only storage path.
+    """
 
     service: str
     access_token: str
@@ -28,6 +51,7 @@ class OAuthTokens:
     expires_at: float | None = None  # Unix timestamp
     scopes: list[str] = field(default_factory=list)
     extra: dict[str, Any] = field(default_factory=dict)
+    user_id: str | None = None
 
 
 def _get_oauth_dir() -> Path:
@@ -37,43 +61,95 @@ def _get_oauth_dir() -> Path:
     return d
 
 
+def _user_segment(user_id: str) -> str:
+    """Build a filesystem-safe, collision-resistant segment for a user_id.
+
+    We keep a sanitized, human-readable prefix for debuggability, then append
+    a short hash of the *raw* user_id so two distinct ids that sanitize to the
+    same prefix (``a@x.com`` vs ``a/x.com``) never share a file.
+    """
+    safe = _SAFE_USER_CHARS.sub("-", user_id).strip("-") or "u"
+    digest = hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:8]
+    return f"{safe}-{digest}"
+
+
+def _token_filename(service: str, user_id: str | None) -> str:
+    """Map (service, user_id) to a token filename.
+
+    ``user_id=None`` returns the legacy ``{service}.json`` path so existing
+    single-user installs keep loading without migration.
+    """
+    if user_id is None:
+        return f"{service}.json"
+    return f"{service}{_USER_SEP}{_user_segment(user_id)}.json"
+
+
 class TokenStore:
-    """File-based token store at ~/.pocketpaw/oauth/{service}.json.
+    """File-based token store at ~/.pocketpaw/oauth/.
+
+    Tokens are keyed by (service, user_id):
+    - ``user_id=None`` (default) → ``{service}.json`` (legacy, single-user).
+    - ``user_id="alice"`` → ``{service}__alice-<hash>.json`` (per-user isolation).
 
     Files are chmod 0600 (owner-only read/write).
     """
 
-    def save(self, tokens: OAuthTokens) -> None:
-        """Save tokens for a service."""
-        path = _get_oauth_dir() / f"{tokens.service}.json"
+    def save(self, tokens: OAuthTokens, user_id: str | None = None) -> None:
+        """Save tokens for a (service, user_id).
+
+        ``user_id`` precedence: an explicit argument wins; otherwise the
+        ``tokens.user_id`` field is used. This lets callers either pass the
+        scope alongside the data or stamp it onto the dataclass — both land
+        in the same bucket.
+        """
+        effective_user = user_id if user_id is not None else tokens.user_id
+        # Keep the persisted blob's user_id in sync with where it's stored.
+        tokens.user_id = effective_user
+        path = _get_oauth_dir() / _token_filename(tokens.service, effective_user)
         data = asdict(tokens)
         path.write_text(json.dumps(data, indent=2))
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
-        logger.info("Saved OAuth tokens for %s", tokens.service)
+        logger.info(
+            "Saved OAuth tokens for %s%s",
+            tokens.service,
+            f" (user {effective_user})" if effective_user else "",
+        )
 
-    def load(self, service: str) -> OAuthTokens | None:
-        """Load tokens for a service. Returns None if not found."""
-        path = _get_oauth_dir() / f"{service}.json"
+    def load(self, service: str, user_id: str | None = None) -> OAuthTokens | None:
+        """Load tokens for a (service, user_id). Returns None if not found."""
+        path = _get_oauth_dir() / _token_filename(service, user_id)
         if not path.exists():
             return None
 
         try:
             data = json.loads(path.read_text())
+            # Legacy files (written before the per-user key) have no user_id
+            # field; OAuthTokens defaults it to None, so old blobs still load.
             return OAuthTokens(**data)
         except Exception as e:
             logger.warning("Failed to load tokens for %s: %s", service, e)
             return None
 
-    def delete(self, service: str) -> bool:
-        """Delete tokens for a service. Returns True if deleted."""
-        path = _get_oauth_dir() / f"{service}.json"
+    def delete(self, service: str, user_id: str | None = None) -> bool:
+        """Delete tokens for a (service, user_id). Returns True if deleted."""
+        path = _get_oauth_dir() / _token_filename(service, user_id)
         if path.exists():
             path.unlink()
-            logger.info("Deleted OAuth tokens for %s", service)
+            logger.info(
+                "Deleted OAuth tokens for %s%s",
+                service,
+                f" (user {user_id})" if user_id else "",
+            )
             return True
         return False
 
     def list_services(self) -> list[str]:
-        """List all services with stored tokens."""
+        """List all services that have stored tokens (deduped across users).
+
+        A service connected by several users still appears once. The service
+        segment is everything before the ``__`` user separator (legacy
+        single-user files have no separator, so the whole stem is the service).
+        """
         oauth_dir = _get_oauth_dir()
-        return [f.stem for f in oauth_dir.glob("*.json")]
+        services = {f.stem.split(_USER_SEP, 1)[0] for f in oauth_dir.glob("*.json")}
+        return sorted(services)

--- a/tests/bootstrap/test_kb_resolve_scopes.py
+++ b/tests/bootstrap/test_kb_resolve_scopes.py
@@ -2,6 +2,12 @@
 # Created: 2026-05-03 — Stage 3.E "Files as Knowledge". Verifies the
 # per-request scope resolver builds the right scope list ahead of the
 # static settings fallback. Most-specific wins.
+# Updated: 2026-06-08 (VIP Onboarding Phase B) — added the optional
+# ``KbContext.user_id`` tier. A set ``user_id`` emits ``user:{id}`` at the
+# HEAD of the scope list (highest priority, ahead of pocket/agent/workspace)
+# so a member's private mail/calendar KB outranks shared scopes in that
+# member's own session. Absent ``user_id`` keeps the legacy ordering
+# byte-identical — the regression guard tests below pin that.
 """``_resolve_kb_scopes(KbContext, settings)`` priority + fallback."""
 
 from __future__ import annotations
@@ -19,6 +25,39 @@ def test_pocket_agent_workspace_priority_order():
     """Most-specific wins: pocket > agent > workspace."""
     ctx = KbContext(pocket_id="P", agent_id="A", workspace_id="W")
     out = _resolve_kb_scopes(ctx, _settings(["fallback"]))
+    assert out == ["pocket:P", "agent:A", "workspace:W"]
+
+
+# --- VIP Onboarding Phase B: optional user: scope (highest priority) ---
+
+
+def test_user_scope_is_highest_priority_when_set():
+    """A set user_id emits ``user:{id}`` ahead of pocket/agent/workspace —
+    the member's private mail/calendar KB outranks every shared scope."""
+    ctx = KbContext(user_id="U", pocket_id="P", agent_id="A", workspace_id="W")
+    out = _resolve_kb_scopes(ctx, _settings(["fallback"]))
+    assert out == ["user:U", "pocket:P", "agent:A", "workspace:W"]
+
+
+def test_user_scope_alone():
+    """user_id set, nothing else → just the user scope."""
+    ctx = KbContext(user_id="U")
+    out = _resolve_kb_scopes(ctx, _settings(["fallback"]))
+    assert out == ["user:U"]
+
+
+def test_user_scope_with_workspace_only():
+    ctx = KbContext(user_id="U", workspace_id="W")
+    out = _resolve_kb_scopes(ctx, _settings())
+    assert out == ["user:U", "workspace:W"]
+
+
+def test_no_user_scope_when_user_id_absent():
+    """Regression guard: without user_id the ordering is byte-identical to
+    the pre-Phase-B behavior — no ``user:`` scope ever appears."""
+    ctx = KbContext(pocket_id="P", agent_id="A", workspace_id="W")
+    out = _resolve_kb_scopes(ctx, _settings(["fallback"]))
+    assert all(not s.startswith("user:") for s in out)
     assert out == ["pocket:P", "agent:A", "workspace:W"]
 
 

--- a/tests/cloud/chat/test_about_member_block.py
+++ b/tests/cloud/chat/test_about_member_block.py
@@ -1,0 +1,223 @@
+# tests/cloud/chat/test_about_member_block.py — agent member-orientation block.
+# Created: 2026-06-08 (feat/vip-agent-block, pp#1367).
+#
+# Locks the contract for the "about this member" block that orients the chat
+# agent to who is talking (pp#1367):
+#
+#   1. WITH a Person — the rendered block is APPENDED to the assembled system
+#      message (build_behavior_instructions / build_context_block), carrying
+#      name · role · team · focus. Additive: the base persona (runtime-identity
+#      rule, ripple prompt) is still present — the block does NOT replace it.
+#   2. WITHOUT a Person — ctx.about_member_block is None → no block in the
+#      assembled message, and assembly does not raise. Behavior == today.
+#   3. The render is HARD char-capped (_ABOUT_MEMBER_CHAR_CAP) so a giant focus
+#      line can't bloat the always-on system prompt (the known ~20K-char mode).
+#   4. The async resolver (_resolve_about_member) degrades to None when the
+#      member has no Person and when the people read raises — never an error.
+#
+# The block is pre-rendered onto ScopeContext by the resolvers (async); the
+# sync assembly just appends it. So the assembly tests construct a ScopeContext
+# directly with about_member_block set (mirroring test_pocket_agent_context.py).
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import (
+    _ABOUT_MEMBER_CHAR_CAP,
+    ScopeContext,
+    ScopeKind,
+    _render_about_member_block,
+    _resolve_about_member,
+    build_behavior_instructions,
+    build_context_block,
+)
+from pocketpaw_ee.cloud.people.domain import Person
+
+
+def _person(
+    *,
+    name: str = "Ada Lovelace",
+    role: str = "admin",
+    group: str | None = "team-eng",
+    focus: str = "Own the billing rewrite",
+) -> Person:
+    return Person(
+        id="person-ws1-user-7",
+        workspace_id="ws1",
+        user_id="user-7",
+        name=name,
+        email="ada@x.c",
+        avatar="",
+        role=role,
+        group=group,
+        focus=focus,
+        profile_pic="",
+        invited_by="admin-1",
+    )
+
+
+def _ctx(*, about_member_block: str | None) -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="ws1",
+        user_id="user-7",
+        members=["user-7"],
+        target_agent_id="a1",
+        about_member_block=about_member_block,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. WITH a Person — block is appended to the assembled system message
+# ---------------------------------------------------------------------------
+
+
+class TestBlockPresentWithPerson:
+    def test_block_appended_to_behavior_instructions(self) -> None:
+        block = _render_about_member_block(_person())
+        ctx = _ctx(about_member_block=block)
+
+        assembled = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+
+        # The block — and its identity content — is in the assembled message.
+        assert "<about-member>" in assembled
+        assert "Ada Lovelace" in assembled
+        assert "admin" in assembled
+        assert "team team-eng" in assembled
+        assert "Own the billing rewrite" in assembled
+
+    def test_block_is_additive_not_a_replacement(self) -> None:
+        # The base persona content must still be present alongside the block —
+        # the block is APPENDED, it does not clobber the base system message.
+        block = _render_about_member_block(_person())
+        ctx = _ctx(about_member_block=block)
+
+        assembled = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+
+        # Base persona markers (runtime-identity rule + ripple law) survive.
+        assert "<runtime-identity>" in assembled
+        assert "<ripple>" in assembled
+        # And the block comes AFTER the base content (appended last).
+        assert assembled.index("<about-member>") > assembled.index("<runtime-identity>")
+
+    def test_block_present_via_build_context_block(self) -> None:
+        # The combined entry point used by tests / legacy callers also carries it.
+        block = _render_about_member_block(_person())
+        ctx = _ctx(about_member_block=block)
+
+        assembled = build_context_block(ctx, backend_name="claude_agent_sdk")
+        assert "<about-member>" in assembled
+        assert "Ada Lovelace" in assembled
+
+
+# ---------------------------------------------------------------------------
+# 2. WITHOUT a Person — no block, no error
+# ---------------------------------------------------------------------------
+
+
+class TestGracefullyAbsent:
+    def test_no_block_when_about_member_is_none(self) -> None:
+        ctx = _ctx(about_member_block=None)
+
+        assembled = build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+
+        # No member block, and the base persona is unaffected.
+        assert "<about-member>" not in assembled
+        assert "<runtime-identity>" in assembled
+
+    def test_assembly_does_not_raise_without_person(self) -> None:
+        ctx = _ctx(about_member_block=None)
+        # Must not raise on any backend path.
+        build_behavior_instructions(ctx, backend_name="claude_agent_sdk")
+        build_behavior_instructions(ctx, backend_name="codex_cli")
+        build_context_block(ctx, backend_name="claude_agent_sdk")
+
+    def test_render_returns_empty_for_nameless_person(self) -> None:
+        # A Person with no usable name yields no block (treated as "no Person").
+        assert _render_about_member_block(_person(name="")) == ""
+        assert _render_about_member_block(_person(name="   ")) == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. Render is HARD char-capped (prompt-bloat backstop)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenCap:
+    def test_huge_focus_is_capped(self) -> None:
+        # A pathological 20K-char focus line must not produce a 20K-char block.
+        huge = "billing " * 4000  # ~32K chars
+        block = _render_about_member_block(_person(focus=huge))
+
+        assert len(block) <= _ABOUT_MEMBER_CHAR_CAP + len("…\n</about-member>")
+        # ~4 chars/token ⇒ comfortably under the ~400-token budget.
+        assert len(block) / 4 <= 400
+        # Still well-formed: opens and closes the tag.
+        assert block.startswith("<about-member>")
+        assert block.rstrip().endswith("</about-member>")
+
+    def test_cap_constant_is_within_budget(self) -> None:
+        # Guard the budget itself: the char cap must stay under ~400 tokens
+        # (~4 chars/token) so the block can never breach the stated limit.
+        assert _ABOUT_MEMBER_CHAR_CAP / 4 <= 400
+
+    def test_normal_block_is_small(self) -> None:
+        # A realistic block is a fraction of the cap — the cap is only a backstop.
+        block = _render_about_member_block(_person())
+        assert len(block) < _ABOUT_MEMBER_CHAR_CAP // 2
+
+    def test_focus_whitespace_is_collapsed(self) -> None:
+        # Newlines / runs of spaces in the focus are collapsed to a single line
+        # (keeps the block a tidy one-liner and helps the cap math).
+        block = _render_about_member_block(_person(focus="own\n\n  the   billing\trewrite"))
+        assert "own the billing rewrite" in block
+        assert "\n\n" not in block.split("focus:")[1]
+
+
+# ---------------------------------------------------------------------------
+# 4. _resolve_about_member degrades gracefully
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAboutMember:
+    @pytest.mark.asyncio
+    async def test_resolve_returns_block_for_member_with_person(self) -> None:
+        async def _fake_get_person(workspace_id: str, user_id: str):
+            return _person()
+
+        with patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_fake_get_person):
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert block is not None
+        assert "<about-member>" in block
+        assert "Ada Lovelace" in block
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_none_when_no_person(self) -> None:
+        async def _fake_get_person(workspace_id: str, user_id: str):
+            return None
+
+        with patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_fake_get_person):
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert block is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_none_when_read_raises(self) -> None:
+        async def _boom(workspace_id: str, user_id: str):
+            raise RuntimeError("journal exploded")
+
+        with patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_boom):
+            # Must swallow the error and degrade to None — never propagate.
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert block is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_none_on_empty_ids(self) -> None:
+        # No workspace / user ⇒ no read attempted, None returned.
+        assert await _resolve_about_member("", "user-7") is None
+        assert await _resolve_about_member("ws1", "") is None

--- a/tests/cloud/kb/test_router_scope.py
+++ b/tests/cloud/kb/test_router_scope.py
@@ -1,0 +1,266 @@
+# tests/cloud/kb/test_router_scope.py — REST-door scope-override leak-prevention.
+#
+# Created: 2026-06-08 (VIP Onboarding Phase B) — the SECOND door into the
+# kb-go scope store. The chat-path gate (``_member_private_user_scope`` in
+# chat/agent_service.py) is closed, but the ``/api/v1/kb/*`` REST router
+# accepts a free-form ``scope`` override with no scope-to-caller binding. Any
+# authenticated member could ``POST /api/v1/kb/search {"scope":"user:{victim}"}``
+# and read another member's private Gmail/calendar KB, or ``ingest`` into it to
+# poison the victim's own agent.
+#
+# This suite mirrors tests/cloud/test_agent_service_scope.py's leak matrix for
+# the REST door: a cross-principal ``user:`` override is rejected for READ
+# (search/lint) AND WRITE (ingest text/url), while every legitimate scope
+# (own workspace, a visible pocket, a workspace agent, the caller's OWN
+# ``user:``) still reaches kb-go. The cross-principal 403 tests are RED before
+# the allowlist validator lands and GREEN after.
+#
+# The router endpoints are plain async functions, so the tests call them
+# directly with the FastAPI ``Depends`` values supplied positionally. ``_kb``
+# is patched to a spy (no kb-go binary on the runner) and ``_candidate_scopes``
+# is patched to a fixed allowlist so the validator's decision — not Mongo —
+# is what's under test.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.kb import router as kb_router
+from pocketpaw_ee.cloud.kb.dto import (
+    IngestTextRequest,
+    IngestUrlRequest,
+    LintRequest,
+    SearchRequest,
+)
+from pocketpaw_ee.cloud.shared.errors import Forbidden
+
+WORKSPACE = "w1"
+CALLER = "memberA"
+OTHER = "memberB"
+VISIBLE_POCKET = "p_visible"
+WORKSPACE_AGENT = "a_ws"
+
+# The allowlist the candidate enumerator returns for CALLER in WORKSPACE:
+# the workspace itself, one pocket the caller can see, one workspace agent.
+# The caller's own ``user:`` is added by the validator on top of this set.
+_ALLOWED_CANDIDATES = [
+    f"workspace:{WORKSPACE}",
+    f"pocket:{VISIBLE_POCKET}",
+    f"agent:{WORKSPACE_AGENT}",
+]
+
+
+def _patch_candidates():
+    """Patch ``_candidate_scopes`` to the fixed allowlist for CALLER."""
+    return patch(
+        "pocketpaw_ee.cloud.kb.service._candidate_scopes",
+        AsyncMock(return_value=list(_ALLOWED_CANDIDATES)),
+    )
+
+
+def _patch_kb(spy):
+    """Patch the kb-go subprocess wrapper the router calls.
+
+    ``_kb`` is a SYNC function invoked without ``await`` in the router, so the
+    spy is a plain ``MagicMock`` — an ``AsyncMock`` would record the call but
+    return an un-awaited coroutine that the router's ``isinstance(.., list)``
+    guard rejects, masking the happy-path assertions.
+    """
+    return patch.object(kb_router, "_kb", spy)
+
+
+# ===========================================================================
+# LEAK MATRIX — cross-principal ``user:`` override must 403 (RED → GREEN).
+#
+# These are the centerpiece. Before the allowlist validator, the override is
+# passed straight to kb-go and the foreign user: scope is read/written. After,
+# each endpoint raises Forbidden("kb.scope_forbidden") and never touches _kb.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_foreign_user_scope():
+    """READ leak: searching ``user:{other}`` is denied — never reaches kb-go."""
+    spy = MagicMock()
+    with _patch_candidates(), _patch_kb(spy):
+        with pytest.raises(Forbidden) as exc:
+            await kb_router.search_kb(
+                SearchRequest(query="invoices", scope=f"user:{OTHER}"),
+                workspace_id=WORKSPACE,
+                user_id=CALLER,
+            )
+    assert exc.value.code == "kb.scope_forbidden"
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lint_rejects_foreign_user_scope():
+    """Metadata oracle: linting ``user:{other}`` is denied."""
+    spy = MagicMock()
+    with _patch_candidates(), _patch_kb(spy):
+        with pytest.raises(Forbidden) as exc:
+            await kb_router.lint_kb(
+                LintRequest(scope=f"user:{OTHER}"),
+                workspace_id=WORKSPACE,
+                user_id=CALLER,
+            )
+    assert exc.value.code == "kb.scope_forbidden"
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ingest_text_rejects_foreign_user_scope():
+    """WRITE/poison: ingesting text into ``user:{other}`` is denied."""
+    spy = MagicMock()
+    with _patch_candidates(), _patch_kb(spy):
+        with pytest.raises(Forbidden) as exc:
+            await kb_router.ingest_text(
+                IngestTextRequest(text="poison", source="x", scope=f"user:{OTHER}"),
+                workspace_id=WORKSPACE,
+                user_id=CALLER,
+            )
+    assert exc.value.code == "kb.scope_forbidden"
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ingest_url_rejects_foreign_user_scope():
+    """WRITE/poison: ingesting a URL into ``user:{other}`` is denied — denied
+    before the URL is ever fetched."""
+    spy = MagicMock()
+    with (
+        _patch_candidates(),
+        _patch_kb(spy),
+        patch.object(kb_router, "_extract_url", AsyncMock(return_value="text")) as ex,
+    ):
+        with pytest.raises(Forbidden) as exc:
+            await kb_router.ingest_url(
+                IngestUrlRequest(url="https://evil.test", scope=f"user:{OTHER}"),
+                workspace_id=WORKSPACE,
+                user_id=CALLER,
+            )
+    assert exc.value.code == "kb.scope_forbidden"
+    spy.assert_not_called()
+    ex.assert_not_called()  # short-circuit before fetch
+
+
+# ===========================================================================
+# Defense-in-depth: an unauthorized pocket / agent override is denied too —
+# the validator's allowlist is the full candidate set, not just user:.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_unauthorized_pocket_scope():
+    spy = MagicMock()
+    with _patch_candidates(), _patch_kb(spy):
+        with pytest.raises(Forbidden) as exc:
+            await kb_router.search_kb(
+                SearchRequest(query="q", scope="pocket:p_not_mine"),
+                workspace_id=WORKSPACE,
+                user_id=CALLER,
+            )
+    assert exc.value.code == "kb.scope_forbidden"
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_foreign_workspace_scope():
+    spy = MagicMock()
+    with _patch_candidates(), _patch_kb(spy):
+        with pytest.raises(Forbidden) as exc:
+            await kb_router.search_kb(
+                SearchRequest(query="q", scope="workspace:w_other"),
+                workspace_id=WORKSPACE,
+                user_id=CALLER,
+            )
+    assert exc.value.code == "kb.scope_forbidden"
+    spy.assert_not_called()
+
+
+# ===========================================================================
+# Legitimate scopes still work — the gate must not break the happy path.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_search_no_override_uses_caller_workspace():
+    """No override → the caller's own active workspace, no candidate probe."""
+    spy = MagicMock(return_value=[])
+    with _patch_candidates(), _patch_kb(spy):
+        await kb_router.search_kb(
+            SearchRequest(query="q"),
+            workspace_id=WORKSPACE,
+            user_id=CALLER,
+        )
+    args = spy.call_args.args
+    assert "--scope" in args
+    assert args[args.index("--scope") + 1] == f"workspace:{WORKSPACE}"
+
+
+@pytest.mark.asyncio
+async def test_search_allows_own_workspace_override():
+    spy = MagicMock(return_value=[])
+    with _patch_candidates(), _patch_kb(spy):
+        await kb_router.search_kb(
+            SearchRequest(query="q", scope=f"workspace:{WORKSPACE}"),
+            workspace_id=WORKSPACE,
+            user_id=CALLER,
+        )
+    args = spy.call_args.args
+    assert args[args.index("--scope") + 1] == f"workspace:{WORKSPACE}"
+
+
+@pytest.mark.asyncio
+async def test_search_allows_visible_pocket_override():
+    spy = MagicMock(return_value=[])
+    with _patch_candidates(), _patch_kb(spy):
+        await kb_router.search_kb(
+            SearchRequest(query="q", scope=f"pocket:{VISIBLE_POCKET}"),
+            workspace_id=WORKSPACE,
+            user_id=CALLER,
+        )
+    args = spy.call_args.args
+    assert args[args.index("--scope") + 1] == f"pocket:{VISIBLE_POCKET}"
+
+
+@pytest.mark.asyncio
+async def test_search_allows_workspace_agent_override():
+    spy = MagicMock(return_value=[])
+    with _patch_candidates(), _patch_kb(spy):
+        await kb_router.search_kb(
+            SearchRequest(query="q", scope=f"agent:{WORKSPACE_AGENT}"),
+            workspace_id=WORKSPACE,
+            user_id=CALLER,
+        )
+    args = spy.call_args.args
+    assert args[args.index("--scope") + 1] == f"agent:{WORKSPACE_AGENT}"
+
+
+@pytest.mark.asyncio
+async def test_search_allows_own_user_override():
+    """The caller's OWN ``user:{caller}`` scope is allowed (their private KB)."""
+    spy = MagicMock(return_value=[])
+    with _patch_candidates(), _patch_kb(spy):
+        await kb_router.search_kb(
+            SearchRequest(query="q", scope=f"user:{CALLER}"),
+            workspace_id=WORKSPACE,
+            user_id=CALLER,
+        )
+    args = spy.call_args.args
+    assert args[args.index("--scope") + 1] == f"user:{CALLER}"
+
+
+@pytest.mark.asyncio
+async def test_ingest_text_allows_own_user_override():
+    """WRITE to the caller's OWN private KB is allowed."""
+    spy = MagicMock(return_value={"ok": True})
+    with _patch_candidates(), _patch_kb(spy):
+        await kb_router.ingest_text(
+            IngestTextRequest(text="note", source="manual", scope=f"user:{CALLER}"),
+            workspace_id=WORKSPACE,
+            user_id=CALLER,
+        )
+    args = spy.call_args.args
+    assert args[args.index("--scope") + 1] == f"user:{CALLER}"

--- a/tests/cloud/member_day_digest/test_member_day_digest_router.py
+++ b/tests/cloud/member_day_digest/test_member_day_digest_router.py
@@ -1,0 +1,208 @@
+# tests/cloud/member_day_digest/test_member_day_digest_router.py
+# Created: 2026-06-08 — VIP Onboarding Phase B chunk 6 (the intent board's
+#   read API). Pins the gated GET surface over the chunk-5 digest service.
+#
+# The centerpiece is the per-member isolation guarantee carried to the REST
+# door: the digest is built for the AUTHENTICATED principal (``ctx.user_id``)
+# and ONLY them — there is NO ``member_id`` query/body param, so a caller can
+# structurally NEVER request another member's digest. This mirrors the
+# outcomes router's "tenancy from auth context, never the wire" stance and the
+# chat-path gate that the same digest already sits behind.
+#
+# The router endpoint is a plain async function, so the tests call it directly
+# with the FastAPI ``Depends`` values (a ``RequestContext``) supplied by
+# keyword. The digest service is patched to a spy so no Gmail/Calendar/OAuth
+# I/O happens and the test asserts WHICH member id the router threaded in.
+
+from __future__ import annotations
+
+import inspect
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind  # noqa: E402
+from pocketpaw_ee.cloud._core.errors import CloudError  # noqa: E402
+from pocketpaw_ee.cloud.member_day_digest import router as digest_router  # noqa: E402
+from pocketpaw_ee.cloud.member_day_digest.dto import (  # noqa: E402
+    DigestEvent,
+    DigestMail,
+    MemberDayDigest,
+)
+
+pytestmark = pytest.mark.asyncio
+
+WORKSPACE = "w1"
+CALLER = "member-alice-objid"
+OTHER = "member-bob-objid"
+
+
+def _ctx(user_id: str = CALLER, workspace_id: str | None = WORKSPACE) -> RequestContext:
+    """Build an authed RequestContext the way ``request_context`` would."""
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="req-test",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _sample_digest(member_id: str = CALLER, workspace_id: str = WORKSPACE) -> MemberDayDigest:
+    """A populated digest the spy returns — every field the board renders."""
+    return MemberDayDigest(
+        workspace_id=workspace_id,
+        member_id=member_id,
+        events=[
+            DigestEvent(
+                summary="Standup",
+                start="2026-06-10T09:00:00Z",
+                end="2026-06-10T09:15:00Z",
+                location="Room A",
+            )
+        ],
+        unread_mail_count=3,
+        top_mail=[DigestMail(subject="Invoice", sender="ap@acme.test", date="")],
+        errors=[],
+    )
+
+
+def _patch_service(spy):
+    """Patch the digest service the router delegates to."""
+    return patch.object(digest_router, "member_day_digest", spy)
+
+
+# ===========================================================================
+# Happy path — GET returns the CALLER's OWN digest.
+# ===========================================================================
+
+
+async def test_get_returns_callers_own_digest():
+    """The endpoint returns the digest for the authenticated principal, with
+    every field the intent board renders (events + unread count + top mail)."""
+    spy = AsyncMock(return_value=_sample_digest())
+    with _patch_service(spy):
+        result = await digest_router.get_member_day_digest(ctx=_ctx())
+
+    assert isinstance(result, MemberDayDigest)
+    assert result.member_id == CALLER
+    assert result.workspace_id == WORKSPACE
+    assert len(result.events) == 1
+    assert result.events[0].summary == "Standup"
+    assert result.unread_mail_count == 3
+    assert len(result.top_mail) == 1
+    assert result.top_mail[0].subject == "Invoice"
+    assert result.empty is False
+
+
+async def test_empty_digest_passes_through():
+    """A member with nothing on / no connected accounts gets an EMPTY digest,
+    not an error — the same graceful shape the briefing relies on."""
+    empty = MemberDayDigest(workspace_id=WORKSPACE, member_id=CALLER)
+    spy = AsyncMock(return_value=empty)
+    with _patch_service(spy):
+        result = await digest_router.get_member_day_digest(ctx=_ctx())
+
+    assert result.member_id == CALLER
+    assert result.empty is True
+    assert result.events == []
+    assert result.unread_mail_count == 0
+    assert result.top_mail == []
+
+
+# ===========================================================================
+# THE ISOLATION INVARIANT — member_id is the AUTHENTICATED principal, never
+# the wire. The caller can only ever get their OWN digest.
+# ===========================================================================
+
+
+async def test_member_id_is_the_authenticated_principal():
+    """The service is called with ``member_id == ctx.user_id`` and
+    ``workspace_id == ctx.workspace_id`` — both taken from auth, never a
+    param. A second principal would resolve a different member id."""
+    spy = AsyncMock(return_value=_sample_digest())
+    with _patch_service(spy):
+        await digest_router.get_member_day_digest(ctx=_ctx(user_id=CALLER))
+
+    spy.assert_awaited_once()
+    # Tolerate positional or keyword delegation — assert by value, not arity.
+    bound = inspect.signature(_dummy_service).bind(*spy.await_args.args, **spy.await_args.kwargs)
+    bound.apply_defaults()
+    assert bound.arguments["member_id"] == CALLER
+    assert bound.arguments["workspace_id"] == WORKSPACE
+
+
+async def test_different_principal_gets_their_own_digest():
+    """A different authenticated caller resolves to THEIR id — the router
+    never reuses one member's id for another (no shared/cached id surface)."""
+    spy = AsyncMock(side_effect=lambda workspace_id, member_id, **_: _sample_digest(member_id))
+    with _patch_service(spy):
+        a = await digest_router.get_member_day_digest(ctx=_ctx(user_id=CALLER))
+        b = await digest_router.get_member_day_digest(ctx=_ctx(user_id=OTHER))
+
+    assert a.member_id == CALLER
+    assert b.member_id == OTHER
+
+
+async def test_no_member_id_param_on_endpoint():
+    """STRUCTURAL guarantee: the endpoint exposes NO ``member_id`` (nor any
+    user-id / override) parameter. The only inputs are FastAPI deps, so a
+    caller CANNOT request another member's digest via query or body. This is
+    the leak-prevention contract, asserted on the signature itself."""
+    params = set(inspect.signature(digest_router.get_member_day_digest).parameters)
+    forbidden = {"member_id", "user_id", "member", "for_member", "principal", "target"}
+    assert params.isdisjoint(forbidden), (
+        f"endpoint must not accept a member-id override; found {params & forbidden}"
+    )
+
+
+async def test_missing_active_workspace_is_rejected():
+    """No active workspace → a 400 CloudError (setup error), never a
+    cross-tenant collapse and never an HTTPException leaking past _core.http.
+    The service must not be called when tenancy is missing."""
+    spy = AsyncMock(return_value=_sample_digest())
+    with _patch_service(spy):
+        with pytest.raises(CloudError) as exc:
+            await digest_router.get_member_day_digest(ctx=_ctx(workspace_id=None))
+
+    assert exc.value.status_code == 400
+    spy.assert_not_awaited()
+
+
+# ===========================================================================
+# Mount — the router carries the canonical route and is registered where the
+# other cloud routers are (asserted on source, since building the full app
+# pulls Mongo/realtime init that a unit test should not require).
+# ===========================================================================
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestWarning")
+def test_router_exposes_the_canonical_get_route():
+    """The router defines exactly the gated GET at ``/member-day-digest``
+    (``/api/v1`` is prepended at mount). A single read route, no override."""
+    routes = [
+        r for r in digest_router.router.routes if getattr(r, "path", None) == "/member-day-digest"
+    ]
+    assert len(routes) == 1, "router must expose exactly the /member-day-digest route"
+    assert routes[0].methods == {"GET"}
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestWarning")
+def test_router_is_included_in_cloud_mount_block():
+    """The intent board can reach the endpoint: the router is wired into the
+    cloud app's include_router block under the ``/api/v1`` prefix."""
+    import pocketpaw_ee.cloud as cloud_pkg
+
+    src = inspect.getsource(cloud_pkg)
+    assert "member_day_digest_router" in src, (
+        "member_day_digest router is not included in cloud __init__ mount block"
+    )
+
+
+# A reference signature mirroring the digest service so the happy-path test can
+# bind the spy's call args by name regardless of positional/keyword delegation.
+def _dummy_service(workspace_id, member_id, **_kwargs):  # pragma: no cover - shape only
+    ...

--- a/tests/cloud/member_day_digest/test_member_day_digest_service.py
+++ b/tests/cloud/member_day_digest/test_member_day_digest_service.py
@@ -1,0 +1,287 @@
+# tests/cloud/member_day_digest/test_member_day_digest_service.py
+# Created: 2026-06-08 — VIP Onboarding Phase B chunk 5 (the "your day" digest).
+#
+# Pins the per-member day-digest contract. The isolation tests come FIRST
+# (TDD) because the whole point is that member B's digest can NEVER contain
+# member A's mail/calendar — and it is keyed on the opaque member id, never a
+# caller-supplied id:
+#
+#   1. the digest reads THIS member's mail/calendar (per-user clients) and
+#      echoes the member id it was asked about.
+#   2. member B's digest is built from B's readers only — A's data can't
+#      appear (the readers are per-member; the service constructs them from
+#      member_id, so two members get two different token buckets).
+#   3. the per-user clients are constructed with user_id == member_id (the
+#      structural isolation: a second member always gets a different bucket).
+#   4. a member with NO connected accounts / empty pulls → an empty digest,
+#      no error, no crash (graceful — the agent then emits no block).
+#   5. a read failure on one source is isolated → the other source still
+#      contributes; the error is recorded, the digest is not lost.
+#   6. the digest is bounded (event/mail caps) so one huge inbox can't blow
+#      the shape chunk 6 / the briefing consume.
+#
+# All Gmail/Calendar reads are injected as fakes so the suite runs with no
+# network and no OAuth.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.member_day_digest import service as digest_service  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# Fakes — capture what the digest would read without any I/O.
+# --------------------------------------------------------------------------
+
+
+class FakeGmailReader:
+    """Stands in for ``GmailClient``. Records the queries it was asked for."""
+
+    def __init__(self, messages: list[dict] | None = None) -> None:
+        self._messages = messages or []
+        self.queries: list[str] = []
+
+    async def search(self, query: str, max_results: int = 10) -> list[dict]:
+        self.queries.append(query)
+        return list(self._messages[:max_results])
+
+
+class FakeCalendarReader:
+    def __init__(self, events: list[dict] | None = None) -> None:
+        self._events = events or []
+        self.calls: list[tuple] = []
+
+    async def list_events(self, time_min=None, time_max=None, max_results=10, **_kw):
+        self.calls.append((time_min, time_max, max_results))
+        return list(self._events[:max_results])
+
+
+def _sample_messages(n: int = 2) -> list[dict]:
+    return [
+        {
+            "id": f"m{i}",
+            "subject": f"Subject {i}",
+            "from": f"sender{i}@example.com",
+            "date": "Wed, 04 Jun 2026 10:00:00 +0000",
+            "snippet": f"body snippet {i}",
+        }
+        for i in range(n)
+    ]
+
+
+def _sample_events(n: int = 2) -> list[dict]:
+    return [
+        {
+            "id": f"e{i}",
+            "summary": f"Event {i}",
+            "start": "2026-06-10T09:00:00Z",
+            "end": "2026-06-10T10:00:00Z",
+            "location": "Room A",
+            "description": f"agenda {i}",
+            "attendees": ["a@example.com"],
+        }
+        for i in range(n)
+    ]
+
+
+# --------------------------------------------------------------------------
+# 1 — the digest reads this member's data and echoes the member id.
+# --------------------------------------------------------------------------
+
+
+async def test_digest_returns_structured_shape_for_member():
+    member = "member-alice-objid"
+    digest = await digest_service.member_day_digest(
+        workspace_id="w1",
+        member_id=member,
+        gmail_reader=FakeGmailReader(_sample_messages(3)),
+        calendar_reader=FakeCalendarReader(_sample_events(2)),
+    )
+
+    # The digest is keyed on the member it was asked about.
+    assert digest.workspace_id == "w1"
+    assert digest.member_id == member
+    # Calendar events came through, soonest first, structured.
+    assert len(digest.events) == 2
+    assert digest.events[0].summary == "Event 0"
+    assert digest.events[0].start == "2026-06-10T09:00:00Z"
+    # Mail counts + top items came through.
+    assert digest.unread_mail_count == 3
+    assert len(digest.top_mail) == 3
+    assert digest.top_mail[0].subject == "Subject 0"
+    assert digest.top_mail[0].sender == "sender0@example.com"
+    assert not digest.empty
+
+
+# --------------------------------------------------------------------------
+# 2 + 3 — THE ISOLATION INVARIANT. The member id keys the read; member B's
+# digest is built from B's readers, never A's; and the real per-user clients
+# are constructed with user_id == member_id (different bucket per member).
+# --------------------------------------------------------------------------
+
+
+async def test_member_b_digest_never_contains_member_a_data():
+    alice = "alice-objid"
+    bob = "bob-objid"
+
+    alice_digest = await digest_service.member_day_digest(
+        workspace_id="w1",
+        member_id=alice,
+        gmail_reader=FakeGmailReader(
+            [{"id": "ma", "subject": "ALICE SECRET", "from": "x@a.com", "date": "", "snippet": ""}]
+        ),
+        calendar_reader=FakeCalendarReader([]),
+    )
+    bob_digest = await digest_service.member_day_digest(
+        workspace_id="w1",
+        member_id=bob,
+        gmail_reader=FakeGmailReader(
+            [{"id": "mb", "subject": "BOB ONLY", "from": "y@b.com", "date": "", "snippet": ""}]
+        ),
+        calendar_reader=FakeCalendarReader([]),
+    )
+
+    assert alice_digest.member_id == alice
+    assert bob_digest.member_id == bob
+    # Bob's digest contains only Bob's mail subject — never Alice's.
+    bob_subjects = [m.subject for m in bob_digest.top_mail]
+    assert "BOB ONLY" in bob_subjects
+    assert "ALICE SECRET" not in bob_subjects
+
+
+async def test_per_user_clients_keyed_on_member_id(monkeypatch):
+    """When no reader is injected, the digest constructs the REAL per-user
+    clients with ``user_id == member_id`` — the structural isolation: member
+    B always gets a different OAuth-token bucket than member A. No
+    caller-supplied user id is ever threaded into the client."""
+    constructed: list[tuple[str, str]] = []
+
+    class _SpyGmail:
+        def __init__(self, user_id=None):
+            constructed.append(("gmail", user_id))
+
+        async def search(self, *_a, **_k):
+            return []
+
+    class _SpyCalendar:
+        def __init__(self, user_id=None):
+            constructed.append(("calendar", user_id))
+
+        async def list_events(self, *_a, **_k):
+            return []
+
+    monkeypatch.setattr("pocketpaw.clients.gmail.GmailClient", _SpyGmail)
+    monkeypatch.setattr("pocketpaw.clients.gcalendar.CalendarClient", _SpyCalendar)
+
+    await digest_service.member_day_digest(workspace_id="w1", member_id="member-xyz")
+
+    # Both clients were constructed for THIS member's id and no other.
+    assert ("gmail", "member-xyz") in constructed
+    assert ("calendar", "member-xyz") in constructed
+    assert all(uid == "member-xyz" for _, uid in constructed)
+
+
+async def test_digest_member_id_is_not_caller_overridable():
+    """The echoed ``member_id`` is exactly the argument — there is no body
+    field or reader attribute that can swap which member the digest is for."""
+    member = "victim-objid"
+    digest = await digest_service.member_day_digest(
+        workspace_id="w1",
+        member_id=member,
+        gmail_reader=FakeGmailReader(_sample_messages(1)),
+        calendar_reader=FakeCalendarReader([]),
+    )
+    assert digest.member_id == member
+
+
+# --------------------------------------------------------------------------
+# 4 — graceful empty: no connected accounts / empty pulls → empty digest.
+# --------------------------------------------------------------------------
+
+
+async def test_no_accounts_yields_empty_digest_no_error():
+    """A member who connected nothing: both readers raise the "not
+    authenticated" error → the digest is EMPTY but does not raise, and the
+    errors are recorded (so the agent emits no block, behaves as today)."""
+
+    class Unauth:
+        async def search(self, *_a, **_k):
+            raise RuntimeError("Gmail not authenticated. Complete OAuth flow first")
+
+        async def list_events(self, *_a, **_k):
+            raise RuntimeError("Google Calendar not authenticated")
+
+    digest = await digest_service.member_day_digest(
+        workspace_id="w1",
+        member_id="m-empty",
+        gmail_reader=Unauth(),
+        calendar_reader=Unauth(),
+    )
+    assert digest.empty
+    assert digest.events == []
+    assert digest.top_mail == []
+    assert digest.unread_mail_count == 0
+    # Both failures recorded — non-fatal.
+    assert len(digest.errors) == 2
+
+
+async def test_empty_pulls_yield_empty_digest():
+    """Connected accounts but genuinely nothing → empty digest, no errors."""
+    digest = await digest_service.member_day_digest(
+        workspace_id="w1",
+        member_id="m-quiet",
+        gmail_reader=FakeGmailReader([]),
+        calendar_reader=FakeCalendarReader([]),
+    )
+    assert digest.empty
+    assert digest.errors == []
+
+
+# --------------------------------------------------------------------------
+# 5 — a one-source failure is isolated; the other source still contributes.
+# --------------------------------------------------------------------------
+
+
+async def test_partial_failure_keeps_healthy_source():
+    class BoomGmail:
+        async def search(self, *_a, **_k):
+            raise RuntimeError("429 rate limited")
+
+    digest = await digest_service.member_day_digest(
+        workspace_id="w1",
+        member_id="m-partial",
+        gmail_reader=BoomGmail(),
+        calendar_reader=FakeCalendarReader(_sample_events(2)),
+    )
+    # Calendar still landed; mail errored.
+    assert len(digest.events) == 2
+    assert digest.unread_mail_count == 0
+    assert any("gmail" in e.lower() for e in digest.errors)
+    assert not digest.empty  # calendar gives it content
+
+
+# --------------------------------------------------------------------------
+# 6 — bounded: caps cap the event/mail counts.
+# --------------------------------------------------------------------------
+
+
+async def test_digest_caps_events_and_mail():
+    digest = await digest_service.member_day_digest(
+        workspace_id="w1",
+        member_id="m-big",
+        gmail_reader=FakeGmailReader(_sample_messages(50)),
+        calendar_reader=FakeCalendarReader(_sample_events(50)),
+    )
+    # The structured digest is bounded so the briefing/intent-board stay small.
+    assert len(digest.events) <= digest_service.MAX_EVENTS
+    assert len(digest.top_mail) <= digest_service.MAX_TOP_MAIL
+
+
+async def test_blank_member_id_rejected():
+    with pytest.raises(Exception):
+        await digest_service.member_day_digest(workspace_id="w1", member_id="   ")

--- a/tests/cloud/member_ingest/test_member_ingest_service.py
+++ b/tests/cloud/member_ingest/test_member_ingest_service.py
@@ -1,0 +1,339 @@
+# tests/cloud/member_ingest/test_member_ingest_service.py
+# Created: 2026-06-08 — VIP Onboarding Phase B (per-user ingest worker).
+#
+# Pins the per-member Gmail/Calendar → private-KB ingest contract. The
+# isolation tests come FIRST (TDD) because the whole point of the chunk is
+# that one member's mail/calendar can NEVER land in another member's KB
+# scope:
+#
+#   1. ingest writes to the member's OWN ``user:{member_id}`` scope.
+#   2. member B's ingest NEVER touches member A's scope (the airtight rule).
+#   3. backfill path — first run flips ``backfill_done`` and uses the wide
+#      window; produces one accept call per source with documents.
+#   4. incremental path — second run uses the narrow window and advances
+#      the cursors; backfill is not repeated.
+#   5. a read failure (e.g. token refresh failed) → status=error, no crash,
+#      and NOTHING is written to the scope.
+#   6. the keyless ``accept`` path is used (NOT ``ingest`` — no API key on
+#      this backend) — asserted via the injected kb_accept capturing the
+#      kb-go argv.
+#
+# All Gmail/Calendar reads and the kb-go accept subprocess are injected as
+# fakes so the suite runs with no network, no OAuth, and no kb binary.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.member_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.models.member_ingest_state import MemberIngestState  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# Fakes — capture what the worker would read / write without any I/O.
+# --------------------------------------------------------------------------
+
+
+class FakeGmailReader:
+    """Stands in for ``GmailClient.search``. Records the query it was asked
+    for so tests can assert the backfill-vs-incremental window."""
+
+    def __init__(self, messages: list[dict] | None = None) -> None:
+        self._messages = messages or []
+        self.queries: list[str] = []
+
+    async def search(self, query: str, max_results: int = 10) -> list[dict]:
+        self.queries.append(query)
+        return list(self._messages[:max_results])
+
+
+class FakeCalendarReader:
+    def __init__(self, events: list[dict] | None = None) -> None:
+        self._events = events or []
+        self.calls: list[tuple] = []
+
+    async def list_events(self, time_min=None, time_max=None, max_results=10, **_kw):
+        self.calls.append((time_min, time_max, max_results))
+        return list(self._events[:max_results])
+
+
+class CapturingAccept:
+    """Captures every kb ``accept`` call: (scope, articles). The real impl
+    shells out to ``kb accept --scope <s>`` with the articles JSON on stdin;
+    we record the resolved scope + parsed articles so a test can prove the
+    scope is the member's own and nobody else's."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, list[dict]]] = []
+
+    async def __call__(self, scope: str, articles: list[dict]) -> dict:
+        self.calls.append((scope, [dict(a) for a in articles]))
+        return {"accepted": len(articles), "articles": len(articles)}
+
+    def scopes_written(self) -> set[str]:
+        return {scope for scope, _ in self.calls}
+
+    def articles_for(self, scope: str) -> list[dict]:
+        out: list[dict] = []
+        for s, arts in self.calls:
+            if s == scope:
+                out.extend(arts)
+        return out
+
+
+def _sample_messages(n: int = 2) -> list[dict]:
+    return [
+        {
+            "id": f"m{i}",
+            "subject": f"Subject {i}",
+            "from": f"sender{i}@example.com",
+            "date": "Wed, 04 Jun 2026 10:00:00 +0000",
+            "snippet": f"body snippet {i}",
+        }
+        for i in range(n)
+    ]
+
+
+def _sample_events(n: int = 2) -> list[dict]:
+    return [
+        {
+            "id": f"e{i}",
+            "summary": f"Event {i}",
+            "start": "2026-06-10T09:00:00Z",
+            "end": "2026-06-10T10:00:00Z",
+            "location": "Room A",
+            "description": f"agenda {i}",
+            "attendees": ["a@example.com"],
+        }
+        for i in range(n)
+    ]
+
+
+# --------------------------------------------------------------------------
+# 1 + 6 — writes to the member's OWN scope via the keyless accept path.
+# --------------------------------------------------------------------------
+
+
+async def test_ingest_writes_to_member_user_scope(mongo_db):  # noqa: ARG001
+    member = "member-alice-objid"
+    accept = CapturingAccept()
+
+    result = await ingest_service.ingest_member(
+        workspace_id="w1",
+        member_id=member,
+        gmail_reader=FakeGmailReader(_sample_messages(2)),
+        calendar_reader=FakeCalendarReader(_sample_events(2)),
+        kb_accept=accept,
+    )
+
+    assert result["status"] == "ok"
+    # Every write targets exactly the member's own scope — nothing else.
+    assert accept.scopes_written() == {f"user:{member}"}
+    # Both sources contributed documents (2 mail + 2 events = 4).
+    arts = accept.articles_for(f"user:{member}")
+    assert len(arts) == 4
+    # Each article carries title + content (the accept minimum, keyless).
+    for a in arts:
+        assert a["title"]
+        assert a["content"]
+
+
+# --------------------------------------------------------------------------
+# 2 — THE ISOLATION INVARIANT. Member B's ingest never touches member A.
+# --------------------------------------------------------------------------
+
+
+async def test_member_b_ingest_never_writes_to_member_a_scope(mongo_db):  # noqa: ARG001
+    alice = "alice-objid"
+    bob = "bob-objid"
+
+    accept = CapturingAccept()
+
+    # Alice ingests first.
+    await ingest_service.ingest_member(
+        workspace_id="w1",
+        member_id=alice,
+        gmail_reader=FakeGmailReader(_sample_messages(3)),
+        calendar_reader=FakeCalendarReader(_sample_events(1)),
+        kb_accept=accept,
+    )
+    # Then Bob, on the SAME workspace, with his own (different) data.
+    await ingest_service.ingest_member(
+        workspace_id="w1",
+        member_id=bob,
+        gmail_reader=FakeGmailReader(_sample_messages(2)),
+        calendar_reader=FakeCalendarReader(_sample_events(2)),
+        kb_accept=accept,
+    )
+
+    # The two members' writes are perfectly partitioned by scope.
+    assert accept.scopes_written() == {f"user:{alice}", f"user:{bob}"}
+    # Bob's run produced ONLY user:bob writes — never user:alice.
+    alice_arts = accept.articles_for(f"user:{alice}")
+    bob_arts = accept.articles_for(f"user:{bob}")
+    assert len(alice_arts) == 4  # 3 mail + 1 event
+    assert len(bob_arts) == 4  # 2 mail + 2 events
+    # Belt-and-suspenders: no article that originated from Bob's reader text
+    # ("body snippet"/"Event") can be found under alice's scope beyond her own
+    # legitimate count, and the scope sets are disjoint by construction above.
+    assert f"user:{alice}" != f"user:{bob}"
+
+
+async def test_ingest_member_scope_ignores_caller_supplied_scope(mongo_db):  # noqa: ARG001
+    """The scope is DERIVED from member_id, never passed in. Even if a
+    caller had a foreign id in hand, ingest_member binds the write to
+    ``user:{member_id}`` — there is no scope override surface to abuse."""
+    member = "victim-objid"
+    accept = CapturingAccept()
+    await ingest_service.ingest_member(
+        workspace_id="w1",
+        member_id=member,
+        gmail_reader=FakeGmailReader(_sample_messages(1)),
+        calendar_reader=FakeCalendarReader([]),
+        kb_accept=accept,
+    )
+    # Only the member's own scope, derived internally.
+    assert accept.scopes_written() == {f"user:{member}"}
+
+
+# --------------------------------------------------------------------------
+# 3 — backfill path: first run, wide window, backfill_done flips true.
+# --------------------------------------------------------------------------
+
+
+async def test_backfill_first_run_sets_state_and_uses_wide_window(mongo_db):  # noqa: ARG001
+    member = "m-backfill"
+    gmail = FakeGmailReader(_sample_messages(2))
+    accept = CapturingAccept()
+
+    result = await ingest_service.ingest_member(
+        workspace_id="w1",
+        member_id=member,
+        gmail_reader=gmail,
+        calendar_reader=FakeCalendarReader(_sample_events(1)),
+        kb_accept=accept,
+    )
+
+    assert result["mode"] == "backfill"
+    # Persisted state: backfill done, status ok, cursors set.
+    state = await MemberIngestState.find_one(
+        MemberIngestState.workspace == "w1",
+        MemberIngestState.member_id == member,
+    )
+    assert state is not None
+    assert state.backfill_done is True
+    assert state.status == "ok"
+    assert state.last_sync_at is not None
+    # Backfill window is the wide one (default 30d) on the Gmail query.
+    assert any("newer_than:30d" in q for q in gmail.queries)
+
+
+# --------------------------------------------------------------------------
+# 4 — incremental path: second run, narrow window, no repeat backfill.
+# --------------------------------------------------------------------------
+
+
+async def test_incremental_second_run_uses_narrow_window(mongo_db):  # noqa: ARG001
+    member = "m-incr"
+    accept = CapturingAccept()
+
+    # First run = backfill.
+    await ingest_service.ingest_member(
+        workspace_id="w1",
+        member_id=member,
+        gmail_reader=FakeGmailReader(_sample_messages(2)),
+        calendar_reader=FakeCalendarReader(_sample_events(1)),
+        kb_accept=accept,
+    )
+
+    # Second run = incremental. Fresh reader to capture the new query.
+    gmail2 = FakeGmailReader(_sample_messages(1))
+    result2 = await ingest_service.ingest_member(
+        workspace_id="w1",
+        member_id=member,
+        gmail_reader=gmail2,
+        calendar_reader=FakeCalendarReader(_sample_events(1)),
+        kb_accept=accept,
+    )
+
+    assert result2["mode"] == "incremental"
+    # Incremental uses the narrow window, NOT the 30d backfill window.
+    assert gmail2.queries
+    assert all("newer_than:30d" not in q for q in gmail2.queries)
+    assert any("newer_than:" in q for q in gmail2.queries)
+
+    state = await MemberIngestState.find_one(
+        MemberIngestState.workspace == "w1",
+        MemberIngestState.member_id == member,
+    )
+    assert state.backfill_done is True  # still true, not re-run
+
+
+# --------------------------------------------------------------------------
+# 5 — a read failure does NOT crash and writes nothing; status=error.
+# --------------------------------------------------------------------------
+
+
+async def test_read_failure_marks_error_and_writes_nothing(mongo_db):  # noqa: ARG001
+    member = "m-fail"
+    accept = CapturingAccept()
+
+    class BoomGmail:
+        async def search(self, *_a, **_k):
+            raise RuntimeError("Gmail not authenticated. Complete OAuth flow first")
+
+    class BoomCalendar:
+        async def list_events(self, *_a, **_k):
+            raise RuntimeError("Google Calendar not authenticated")
+
+    result = await ingest_service.ingest_member(
+        workspace_id="w1",
+        member_id=member,
+        gmail_reader=BoomGmail(),
+        calendar_reader=BoomCalendar(),
+        kb_accept=accept,
+    )
+
+    assert result["status"] == "error"
+    # Nothing was written to ANY scope when both sources failed.
+    assert accept.calls == []
+    state = await MemberIngestState.find_one(
+        MemberIngestState.workspace == "w1",
+        MemberIngestState.member_id == member,
+    )
+    assert state is not None
+    assert state.status == "error"
+    assert state.last_error
+    # Backfill not marked done on a failed run, so it retries next time.
+    assert state.backfill_done is False
+
+
+async def test_partial_failure_still_ingests_healthy_source(mongo_db):  # noqa: ARG001
+    """Gmail fails but Calendar succeeds → the calendar docs still land in
+    the member's scope, and status reflects a partial error (still 'ok' for
+    the run since at least one source produced data, but last_error noted)."""
+    member = "m-partial"
+    accept = CapturingAccept()
+
+    class BoomGmail:
+        async def search(self, *_a, **_k):
+            raise RuntimeError("429 rate limited")
+
+    result = await ingest_service.ingest_member(
+        workspace_id="w1",
+        member_id=member,
+        gmail_reader=BoomGmail(),
+        calendar_reader=FakeCalendarReader(_sample_events(2)),
+        kb_accept=accept,
+    )
+
+    # Calendar docs landed in the member's own scope.
+    assert accept.scopes_written() == {f"user:{member}"}
+    assert len(accept.articles_for(f"user:{member}")) == 2
+    # The run still records the partial failure.
+    assert result["status"] in {"ok", "error"}
+    assert result["errors"]

--- a/tests/cloud/member_ingest/test_member_ingest_sweep.py
+++ b/tests/cloud/member_ingest/test_member_ingest_sweep.py
@@ -1,0 +1,171 @@
+# tests/cloud/member_ingest/test_member_ingest_sweep.py
+# Created: 2026-06-08 — VIP Onboarding Phase B (per-user ingest worker).
+#
+# Pins the sweep + scheduler contract:
+#
+#   1. list_connected_members enumerates ONLY scope=user, enabled, gmail/
+#      gcalendar connector rows — and never a disabled or workspace-scoped
+#      one.
+#   2. run_ingest_sweep ingests every connected member into THEIR OWN scope
+#      (cross-member isolation holds across the whole sweep), under a bounded
+#      concurrency cap (never more than the limit run at once).
+#   3. one member's ingest failing does not abort the sweep for the others.
+#   4. the scheduler start()/stop() lifecycle spawns and cancels cleanly, and
+#      tick() runs a single sweep without a background task.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.member_ingest import scheduler as sched_mod  # noqa: E402
+from pocketpaw_ee.cloud.member_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_connector(workspace, name, *, scope, user_id=None, enabled=True):
+    doc = WorkspaceConnector(
+        workspace=workspace,
+        name=name,
+        enabled=enabled,
+        scope=scope,
+        user_id=user_id,
+    )
+    await doc.insert()
+    return doc
+
+
+async def test_list_connected_members_only_user_scoped_enabled(mongo_db):  # noqa: ARG001
+    # Two members with per-user Gmail, one with gcalendar, plus noise rows
+    # that must be excluded.
+    await _seed_connector("w1", "gmail", scope="user", user_id="alice")
+    await _seed_connector("w1", "gcalendar", scope="user", user_id="alice")
+    await _seed_connector("w1", "gmail", scope="user", user_id="bob")
+    # Noise: workspace-scoped gmail (not per-user) — excluded.
+    await _seed_connector("w1", "gmail", scope="workspace", user_id=None)
+    # Noise: disabled per-user gmail — excluded.
+    await _seed_connector("w1", "gmail", scope="user", user_id="carol", enabled=False)
+    # Noise: an unrelated connector — excluded.
+    await _seed_connector("w1", "stripe", scope="user", user_id="alice")
+    # Noise: another workspace — excluded when we filter by w1.
+    await _seed_connector("w2", "gmail", scope="user", user_id="dave")
+
+    members = await ingest_service.list_connected_members(workspace_id="w1")
+
+    # Grouped by (workspace, member) — alice appears once even with 2 sources.
+    pairs = {(m["workspace_id"], m["member_id"]) for m in members}
+    assert pairs == {("w1", "alice"), ("w1", "bob")}
+    assert "carol" not in {m["member_id"] for m in members}
+    assert "dave" not in {m["member_id"] for m in members}
+
+
+async def test_sweep_isolates_members_and_bounds_concurrency(mongo_db):  # noqa: ARG001
+    await _seed_connector("w1", "gmail", scope="user", user_id="alice")
+    await _seed_connector("w1", "gmail", scope="user", user_id="bob")
+    await _seed_connector("w1", "gmail", scope="user", user_id="carol")
+    await _seed_connector("w1", "gcalendar", scope="user", user_id="dave")
+
+    written_scopes: list[str] = []
+    in_flight = 0
+    max_in_flight = 0
+    lock = asyncio.Lock()
+
+    async def fake_ingest_member(workspace_id, member_id, **_kw):
+        nonlocal in_flight, max_in_flight
+        async with lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        try:
+            await asyncio.sleep(0.01)  # hold the slot so concurrency is observable
+            written_scopes.append(f"user:{member_id}")
+            return {"status": "ok", "member_id": member_id}
+        finally:
+            async with lock:
+                in_flight -= 1
+
+    summary = await ingest_service.run_ingest_sweep(
+        workspace_id="w1",
+        concurrency=2,
+        ingest_fn=fake_ingest_member,
+    )
+
+    # Every connected member was swept into their OWN scope, all distinct.
+    assert set(written_scopes) == {
+        "user:alice",
+        "user:bob",
+        "user:carol",
+        "user:dave",
+    }
+    assert len(written_scopes) == len(set(written_scopes))  # no double-write
+    # Concurrency was actually bounded by the cap.
+    assert max_in_flight <= 2
+    assert summary["members"] == 4
+    assert summary["ok"] == 4
+
+
+async def test_sweep_one_member_failure_does_not_abort_others(mongo_db):  # noqa: ARG001
+    await _seed_connector("w1", "gmail", scope="user", user_id="alice")
+    await _seed_connector("w1", "gmail", scope="user", user_id="bob")
+    await _seed_connector("w1", "gmail", scope="user", user_id="carol")
+
+    done: list[str] = []
+
+    async def flaky_ingest(workspace_id, member_id, **_kw):
+        if member_id == "bob":
+            raise RuntimeError("bob's token is toast")
+        done.append(member_id)
+        return {"status": "ok", "member_id": member_id}
+
+    summary = await ingest_service.run_ingest_sweep(
+        workspace_id="w1",
+        concurrency=3,
+        ingest_fn=flaky_ingest,
+    )
+
+    # Alice + Carol completed despite Bob blowing up.
+    assert set(done) == {"alice", "carol"}
+    assert summary["members"] == 3
+    assert summary["ok"] == 2
+    assert summary["errors"] == 1
+
+
+async def test_scheduler_tick_runs_one_sweep(mongo_db, monkeypatch):  # noqa: ARG001
+    calls: list[int] = []
+
+    async def fake_sweep(**_kw):
+        calls.append(1)
+        return {"members": 0, "ok": 0, "errors": 0}
+
+    monkeypatch.setattr(ingest_service, "run_ingest_sweep", fake_sweep)
+    sched_mod.reset_scheduler_for_tests()
+
+    scheduler = sched_mod.MemberIngestScheduler(interval_seconds=1)
+    swept = await scheduler.tick()
+
+    assert calls == [1]
+    assert swept["members"] == 0
+
+
+async def test_scheduler_start_stop_lifecycle(mongo_db, monkeypatch):  # noqa: ARG001
+    async def fake_sweep(**_kw):
+        return {"members": 0, "ok": 0, "errors": 0}
+
+    monkeypatch.setattr(ingest_service, "run_ingest_sweep", fake_sweep)
+    sched_mod.reset_scheduler_for_tests()
+
+    scheduler = sched_mod.MemberIngestScheduler(interval_seconds=60)
+    await scheduler.start()
+    # Idempotent — second start is a no-op, not a second task.
+    await scheduler.start()
+    assert scheduler._task is not None  # noqa: SLF001
+    assert not scheduler._task.done()  # noqa: SLF001
+
+    await scheduler.stop()
+    assert scheduler._task is None  # noqa: SLF001
+    # Safe to stop twice.
+    await scheduler.stop()

--- a/tests/cloud/member_ingest/test_member_purge.py
+++ b/tests/cloud/member_ingest/test_member_purge.py
@@ -1,0 +1,386 @@
+# tests/cloud/member_ingest/test_member_purge.py
+# Created: 2026-06-08 — VIP Onboarding Phase B, chunk 7 (the purge path).
+#
+# Pins the per-member data-purge contract. When a member disconnects their
+# accounts or is offboarded, ALL of their Phase B per-user data MUST be
+# deleted — it's the member's personal Gmail/calendar; leaving must purge it.
+# The four stores, all keyed on the opaque member id:
+#   1. the ``user:{member_id}`` kb-go scope (their ingested mail/cal),
+#   2. their per-user OAuth tokens (token_store: google_gmail / google_calendar),
+#   3. their per-user WorkspaceConnector rows (scope="user"),
+#   4. their MemberIngestState sync-state doc.
+#
+# The ISOLATION test comes FIRST (TDD), mirroring the ingest suite: purging
+# member A must NEVER touch member B's data. Then all-four-deleted, then
+# idempotency (safe to call twice; safe when nothing exists).
+#
+# The kb-go ``clear`` subprocess and the on-disk token store are injected /
+# redirected so the suite runs with no kb binary and no real ~/.pocketpaw.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.member_ingest import purge as purge_mod  # noqa: E402
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector  # noqa: E402
+from pocketpaw_ee.cloud.models.member_ingest_state import (  # noqa: E402
+    MemberIngestState,
+)
+
+from pocketpaw.clients.token_store import OAuthTokens, TokenStore  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+# Token store service names the per-user Gmail/Calendar clients load under.
+# GmailClient(user_id) -> service="google_gmail"; CalendarClient(user_id) ->
+# service="google_calendar". The purge MUST delete BOTH for the member.
+_GMAIL_SERVICE = "google_gmail"
+_CAL_SERVICE = "google_calendar"
+
+
+class CapturingKbClear:
+    """Stands in for the keyless ``kb clear --scope <s>`` subprocess. Records
+    every scope it was asked to clear so a test can prove the purge clears the
+    member's OWN scope and nobody else's."""
+
+    def __init__(self) -> None:
+        self.scopes_cleared: list[str] = []
+
+    async def __call__(self, scope: str) -> dict:
+        self.scopes_cleared.append(scope)
+        return {"cleared": scope}
+
+
+@pytest.fixture
+def token_store(tmp_path, monkeypatch) -> TokenStore:
+    """A TokenStore rooted at a tmp dir (never the real ~/.pocketpaw/oauth).
+
+    token_store builds its dir via ``pocketpaw.config.get_config_dir`` resolved
+    at call time, so redirecting that function isolates the on-disk tokens.
+    """
+    monkeypatch.setattr(
+        "pocketpaw.clients.token_store.get_config_dir",
+        lambda: tmp_path,
+    )
+    return TokenStore()
+
+
+def _seed_tokens(store: TokenStore, user_id: str) -> None:
+    """Write per-user Gmail + Calendar tokens for ``user_id``."""
+    store.save(
+        OAuthTokens(service=_GMAIL_SERVICE, access_token="g-tok"),
+        user_id=user_id,
+    )
+    store.save(
+        OAuthTokens(service=_CAL_SERVICE, access_token="c-tok"),
+        user_id=user_id,
+    )
+
+
+async def _seed_connectors(workspace_id: str, user_id: str) -> None:
+    """Insert the member's per-user gmail + gcalendar connector rows."""
+    await WorkspaceConnector(
+        workspace=workspace_id, name="gmail", scope="user", user_id=user_id
+    ).insert()
+    await WorkspaceConnector(
+        workspace=workspace_id, name="gcalendar", scope="user", user_id=user_id
+    ).insert()
+
+
+async def _seed_state(workspace_id: str, member_id: str) -> None:
+    await MemberIngestState(
+        workspace=workspace_id, member_id=member_id, backfill_done=True, status="ok"
+    ).insert()
+
+
+# --------------------------------------------------------------------------
+# 1 — THE ISOLATION INVARIANT. Purging member A never touches member B.
+# --------------------------------------------------------------------------
+
+
+async def test_purge_member_a_never_touches_member_b(mongo_db, token_store):  # noqa: ARG001
+    alice = "alice-objid"
+    bob = "bob-objid"
+    ws = "w1"
+
+    # Seed BOTH members across all four stores.
+    _seed_tokens(token_store, alice)
+    _seed_tokens(token_store, bob)
+    await _seed_connectors(ws, alice)
+    await _seed_connectors(ws, bob)
+    await _seed_state(ws, alice)
+    await _seed_state(ws, bob)
+
+    kb_clear = CapturingKbClear()
+
+    await purge_mod.purge_member_data(ws, alice, kb_clear=kb_clear, token_store=token_store)
+
+    # KB: only alice's scope was cleared — never bob's.
+    assert kb_clear.scopes_cleared == [f"user:{alice}"]
+    assert f"user:{bob}" not in kb_clear.scopes_cleared
+
+    # Tokens: alice's are gone, bob's survive untouched.
+    assert token_store.load(_GMAIL_SERVICE, alice) is None
+    assert token_store.load(_CAL_SERVICE, alice) is None
+    assert token_store.load(_GMAIL_SERVICE, bob) is not None
+    assert token_store.load(_CAL_SERVICE, bob) is not None
+
+    # Connector rows: alice's user-scoped rows gone, bob's remain.
+    alice_rows = await WorkspaceConnector.find(
+        WorkspaceConnector.workspace == ws,
+        WorkspaceConnector.user_id == alice,
+    ).to_list()
+    bob_rows = await WorkspaceConnector.find(
+        WorkspaceConnector.workspace == ws,
+        WorkspaceConnector.user_id == bob,
+    ).to_list()
+    assert alice_rows == []
+    assert len(bob_rows) == 2
+
+    # Ingest state: alice's gone, bob's remains.
+    assert (
+        await MemberIngestState.find_one(
+            MemberIngestState.workspace == ws,
+            MemberIngestState.member_id == alice,
+        )
+        is None
+    )
+    assert (
+        await MemberIngestState.find_one(
+            MemberIngestState.workspace == ws,
+            MemberIngestState.member_id == bob,
+        )
+        is not None
+    )
+
+
+# --------------------------------------------------------------------------
+# 2 — purge deletes ALL FOUR stores for the member.
+# --------------------------------------------------------------------------
+
+
+async def test_purge_deletes_all_four_stores(mongo_db, token_store):  # noqa: ARG001
+    member = "member-to-purge"
+    ws = "w1"
+
+    _seed_tokens(token_store, member)
+    await _seed_connectors(ws, member)
+    await _seed_state(ws, member)
+
+    kb_clear = CapturingKbClear()
+    result = await purge_mod.purge_member_data(
+        ws, member, kb_clear=kb_clear, token_store=token_store
+    )
+
+    # 1. KB scope cleared (the member's own, derived internally).
+    assert kb_clear.scopes_cleared == [f"user:{member}"]
+    assert result["scope"] == f"user:{member}"
+    assert result["kb_cleared"] is True
+
+    # 2. Both per-user tokens deleted.
+    assert token_store.load(_GMAIL_SERVICE, member) is None
+    assert token_store.load(_CAL_SERVICE, member) is None
+    assert result["tokens_deleted"] == 2
+
+    # 3. Both per-user connector rows deleted.
+    rows = await WorkspaceConnector.find(
+        WorkspaceConnector.workspace == ws,
+        WorkspaceConnector.user_id == member,
+    ).to_list()
+    assert rows == []
+    assert result["connectors_deleted"] == 2
+
+    # 4. Ingest state deleted.
+    assert (
+        await MemberIngestState.find_one(
+            MemberIngestState.workspace == ws,
+            MemberIngestState.member_id == member,
+        )
+        is None
+    )
+    assert result["ingest_state_deleted"] is True
+
+    assert result["status"] == "ok"
+
+
+# --------------------------------------------------------------------------
+# 3 — idempotent: safe to call twice; safe when nothing exists.
+# --------------------------------------------------------------------------
+
+
+async def test_purge_is_idempotent_second_call_is_noop(mongo_db, token_store):  # noqa: ARG001
+    member = "twice"
+    ws = "w1"
+
+    _seed_tokens(token_store, member)
+    await _seed_connectors(ws, member)
+    await _seed_state(ws, member)
+
+    kb_clear = CapturingKbClear()
+
+    first = await purge_mod.purge_member_data(
+        ws, member, kb_clear=kb_clear, token_store=token_store
+    )
+    # Second call must not raise and must report nothing left to delete.
+    second = await purge_mod.purge_member_data(
+        ws, member, kb_clear=kb_clear, token_store=token_store
+    )
+
+    assert first["status"] == "ok"
+    assert second["status"] == "ok"
+    # Second pass deletes zero rows / zero tokens — everything is already gone.
+    assert second["tokens_deleted"] == 0
+    assert second["connectors_deleted"] == 0
+    assert second["ingest_state_deleted"] is False
+
+
+async def test_purge_when_member_has_no_data(mongo_db, token_store):  # noqa: ARG001
+    """A member who never connected anything — purge is a clean no-op."""
+    kb_clear = CapturingKbClear()
+    result = await purge_mod.purge_member_data(
+        "w1", "ghost-member", kb_clear=kb_clear, token_store=token_store
+    )
+    assert result["status"] == "ok"
+    assert result["tokens_deleted"] == 0
+    assert result["connectors_deleted"] == 0
+    assert result["ingest_state_deleted"] is False
+
+
+# --------------------------------------------------------------------------
+# 4 — only the member's OWN connector rows + state are removed, even when a
+#     second member shares the same workspace AND a workspace-scoped row of
+#     the same connector name exists (must not be swept by the user purge).
+# --------------------------------------------------------------------------
+
+
+async def test_purge_leaves_workspace_scoped_connector_rows(mongo_db, token_store):  # noqa: ARG001
+    member = "m1"
+    ws = "w1"
+    # A WORKSPACE-scoped gmail connector (no user_id) must survive a per-user purge.
+    await WorkspaceConnector(workspace=ws, name="gmail", scope="workspace", user_id=None).insert()
+    await _seed_connectors(ws, member)
+
+    kb_clear = CapturingKbClear()
+    await purge_mod.purge_member_data(ws, member, kb_clear=kb_clear, token_store=token_store)
+
+    # The user-scoped rows are gone; the workspace-scoped row remains.
+    survivors = await WorkspaceConnector.find(WorkspaceConnector.workspace == ws).to_list()
+    assert len(survivors) == 1
+    assert survivors[0].scope == "workspace"
+    assert survivors[0].user_id is None
+
+
+# --------------------------------------------------------------------------
+# 5 — emit-on-write: a MemberDataPurged event fires on a successful purge.
+# --------------------------------------------------------------------------
+
+
+async def test_purge_emits_member_data_purged_event(mongo_db, token_store, monkeypatch):  # noqa: ARG001
+    member = "emit-me"
+    ws = "w1"
+    await _seed_state(ws, member)
+
+    captured: list = []
+
+    async def _fake_emit(event) -> None:
+        captured.append(event)
+
+    monkeypatch.setattr(purge_mod, "emit", _fake_emit)
+
+    await purge_mod.purge_member_data(
+        ws, member, kb_clear=CapturingKbClear(), token_store=token_store
+    )
+
+    assert len(captured) == 1
+    evt = captured[0]
+    assert evt.type == "member_ingest.purged"
+    assert evt.data["workspace_id"] == ws
+    assert evt.data["member_id"] == member
+    assert evt.data["scope"] == f"user:{member}"
+
+
+# --------------------------------------------------------------------------
+# 6 — a failing store delete does not abort the others (best-effort cascade).
+# --------------------------------------------------------------------------
+
+
+async def test_purge_continues_when_kb_clear_fails(mongo_db, token_store):  # noqa: ARG001
+    member = "partial"
+    ws = "w1"
+    _seed_tokens(token_store, member)
+    await _seed_connectors(ws, member)
+    await _seed_state(ws, member)
+
+    async def _boom_kb_clear(scope: str) -> dict:
+        raise RuntimeError("kb binary not found")
+
+    result = await purge_mod.purge_member_data(
+        ws, member, kb_clear=_boom_kb_clear, token_store=token_store
+    )
+
+    # kb clear failed, but tokens / connectors / state were still purged.
+    assert result["kb_cleared"] is False
+    assert result["errors"]
+    assert token_store.load(_GMAIL_SERVICE, member) is None
+    rows = await WorkspaceConnector.find(
+        WorkspaceConnector.workspace == ws,
+        WorkspaceConnector.user_id == member,
+    ).to_list()
+    assert rows == []
+    assert (
+        await MemberIngestState.find_one(
+            MemberIngestState.workspace == ws,
+            MemberIngestState.member_id == member,
+        )
+        is None
+    )
+    # Status reflects the partial failure.
+    assert result["status"] == "error"
+
+
+# --------------------------------------------------------------------------
+# 7 — the disconnect trigger: connectors.service.disconnect_member purges the
+#     member's data (the member-facing "disconnect my accounts" door).
+# --------------------------------------------------------------------------
+
+
+async def test_disconnect_member_purges_caller_data(mongo_db, token_store, monkeypatch):  # noqa: ARG001
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    member = "self-disconnecter"
+    ws = "w1"
+    _seed_tokens(token_store, member)
+    await _seed_connectors(ws, member)
+    await _seed_state(ws, member)
+
+    # disconnect_member delegates to purge_member_data with the REAL defaults
+    # (no kb_clear/token_store injection point on that surface), so redirect the
+    # purge module's token store + kb clear here.
+    monkeypatch.setattr(
+        "pocketpaw.clients.token_store.TokenStore",
+        lambda: token_store,
+    )
+
+    async def _fake_kb_clear(scope: str) -> dict:
+        return {"cleared": scope}
+
+    monkeypatch.setattr(purge_mod, "_default_kb_clear", _fake_kb_clear)
+
+    result = await connectors_service.disconnect_member(ws, member)
+
+    assert result["status"] == "ok"
+    assert result["scope"] == f"user:{member}"
+    assert result["tokens_deleted"] == 2
+    assert result["connectors_deleted"] == 2
+    assert result["ingest_state_deleted"] is True
+    # The member's stores are actually gone.
+    assert token_store.load(_GMAIL_SERVICE, member) is None
+    assert (
+        await MemberIngestState.find_one(
+            MemberIngestState.workspace == ws,
+            MemberIngestState.member_id == member,
+        )
+        is None
+    )

--- a/tests/cloud/people/__init__.py
+++ b/tests/cloud/people/__init__.py
@@ -1,0 +1,2 @@
+# tests/cloud/people/ — coverage for the workspace-member identity spine.
+# Created: 2026-06-08 (feat/vip-fabric-person, pp#1366).

--- a/tests/cloud/people/test_get_person.py
+++ b/tests/cloud/people/test_get_person.py
@@ -1,0 +1,215 @@
+# tests/cloud/people/test_get_person.py — Fabric Person read (get_person).
+# Created: 2026-06-08 (feat/vip-agent-block, pp#1367).
+#
+# Locks the contract for get_person (the people read side):
+#   1. A materialized member round-trips: write via the materializer, read via
+#      get_person → a typed Person with the same identity + provenance fields,
+#      mapped back from the journal projection's property bag.
+#   2. A member with no Person (never materialized) → None, no error. This is
+#      the "pre-existing / non-invited user" path the about-block relies on.
+#   3. Tenant isolation: get_person scoped to workspace A never sees a Person
+#      that lives in workspace B (same user_id), even when both share a store.
+#   4. The deterministic id is matched exactly — a different user in the same
+#      workspace doesn't return the wrong Person.
+#
+# Uses a throwaway FabricJournalStore over a tmp journal injected via the
+# service's ``store=`` arg — same fixture shape as test_materialize_person.py.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud.people.domain import SOURCE_ADMIN_CONTEXT
+from pocketpaw_ee.cloud.people.service import get_person, materialize_person_from_invite
+from pocketpaw_ee.cloud.workspace.domain import Invite, InviteContext
+from soul_protocol.engine.journal import open_journal
+
+from pocketpaw.fabric.journal_store import FabricJournalStore
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+@pytest.fixture
+def store(journal) -> FabricJournalStore:
+    s = FabricJournalStore(journal)
+    s.bootstrap()
+    return s
+
+
+def _invite(
+    *,
+    workspace_id: str = "ws1",
+    email: str = "member@x.c",
+    role: str = "member",
+    invited_by: str = "admin1",
+    group_id: str | None = "team-eng",
+    context: InviteContext | None = None,
+) -> Invite:
+    return Invite(
+        id="inv1",
+        workspace_id=workspace_id,
+        email=email,
+        role=role,
+        invited_by=invited_by,
+        token=None,
+        group_id=group_id,
+        accepted=True,
+        revoked=False,
+        expired=False,
+        expires_at=datetime.now(UTC),
+        context=context,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Round-trip — materialized member reads back as a typed Person
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    @pytest.mark.asyncio
+    async def test_get_person_returns_typed_person_with_all_fields(
+        self, store: FabricJournalStore
+    ) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada Lovelace",
+            email="member@x.c",
+            avatar="https://cdn/ada.png",
+            invite=_invite(
+                role="admin",
+                invited_by="admin-99",
+                group_id="team-eng",
+                context=InviteContext(focus="Own the billing rewrite", profile_pic="file-42"),
+            ),
+            store=store,
+        )
+
+        person = await get_person("ws1", "user-7", store=store)
+
+        assert person is not None
+        # id comes from the object's own id; workspace_id from the read scope.
+        assert person.id == "person-ws1-user-7"
+        assert person.workspace_id == "ws1"
+        # Identity + role/team + onboarding, mapped back from the property bag.
+        assert person.user_id == "user-7"
+        assert person.name == "Ada Lovelace"
+        assert person.email == "member@x.c"
+        assert person.avatar == "https://cdn/ada.png"
+        assert person.role == "admin"
+        assert person.group == "team-eng"
+        assert person.focus == "Own the billing rewrite"
+        assert person.profile_pic == "file-42"
+        # Provenance survives the round-trip.
+        assert person.invited_by == "admin-99"
+        assert person.source == SOURCE_ADMIN_CONTEXT
+
+    @pytest.mark.asyncio
+    async def test_get_person_no_context_maps_group_none(self, store: FabricJournalStore) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(context=None, group_id=None),
+            store=store,
+        )
+
+        person = await get_person("ws1", "user-7", store=store)
+
+        assert person is not None
+        assert person.group is None  # falsy stored value maps back to None
+        assert person.focus == ""
+        assert person.profile_pic == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Absent member — no Person → None, no error
+# ---------------------------------------------------------------------------
+
+
+class TestAbsent:
+    @pytest.mark.asyncio
+    async def test_unmaterialized_member_returns_none(self, store: FabricJournalStore) -> None:
+        # Empty store — this user was never invited / materialized.
+        person = await get_person("ws1", "ghost-user", store=store)
+        assert person is None
+
+    @pytest.mark.asyncio
+    async def test_other_user_in_same_workspace_returns_none(
+        self, store: FabricJournalStore
+    ) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(),
+            store=store,
+        )
+        # Different user id, same workspace — deterministic id won't match.
+        person = await get_person("ws1", "user-OTHER", store=store)
+        assert person is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Tenant isolation — workspace A can't read workspace B's Person
+# ---------------------------------------------------------------------------
+
+
+class TestTenantIsolation:
+    @pytest.mark.asyncio
+    async def test_get_person_is_scoped_to_its_workspace(self, store: FabricJournalStore) -> None:
+        # Same user id materialized in two different workspaces.
+        await materialize_person_from_invite(
+            workspace_id="ws-A",
+            user_id="user-7",
+            name="Ada in A",
+            email="a@x.c",
+            avatar="",
+            invite=_invite(workspace_id="ws-A"),
+            store=store,
+        )
+        await materialize_person_from_invite(
+            workspace_id="ws-B",
+            user_id="user-7",
+            name="Ada in B",
+            email="b@x.c",
+            avatar="",
+            invite=_invite(workspace_id="ws-B"),
+            store=store,
+        )
+
+        a = await get_person("ws-A", "user-7", store=store)
+        b = await get_person("ws-B", "user-7", store=store)
+
+        assert a is not None and a.name == "Ada in A"
+        assert a.id == "person-ws-A-user-7"
+        assert b is not None and b.name == "Ada in B"
+        assert b.id == "person-ws-B-user-7"
+
+    @pytest.mark.asyncio
+    async def test_workspace_with_no_people_returns_none(self, store: FabricJournalStore) -> None:
+        # A Person exists, but in a different workspace than we query.
+        await materialize_person_from_invite(
+            workspace_id="ws-A",
+            user_id="user-7",
+            name="Ada",
+            email="a@x.c",
+            avatar="",
+            invite=_invite(workspace_id="ws-A"),
+            store=store,
+        )
+        # Query a workspace that has no Person for this user.
+        person = await get_person("ws-EMPTY", "user-7", store=store)
+        assert person is None

--- a/tests/cloud/people/test_materialize_person.py
+++ b/tests/cloud/people/test_materialize_person.py
@@ -1,0 +1,295 @@
+# tests/cloud/people/test_materialize_person.py — Fabric Person materialization.
+# Created: 2026-06-08 (feat/vip-fabric-person, pp#1366).
+#
+# Locks the contract for materialize_person_from_invite (the people service):
+#   1. Accept → a typed Fabric Person exists with the expected fields, drawn
+#      from the member's profile + the invite's admin context.
+#   2. Provenance — invited_by + source=admin_context, recorded both in the
+#      property bag and as the journal Actor / FabricObject.source_*.
+#   3. Idempotent — a second materialize for the same member UPDATES the
+#      existing Person (no duplicate row); changed context is reflected.
+#   4. No-context invite — still creates a Person from the identity fields,
+#      with focus / profile_pic empty.
+#
+# Uses a throwaway FabricJournalStore over a tmp journal (same fixture shape
+# as tests/ee/test_fabric_journal.py) injected via the service's ``store=``
+# arg — no real org journal, no Mongo needed for these unit-level checks.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud.people.domain import (
+    PERSON_TYPE_ID,
+    PERSON_TYPE_NAME,
+    SOURCE_ADMIN_CONTEXT,
+)
+from pocketpaw_ee.cloud.people.service import materialize_person_from_invite
+from pocketpaw_ee.cloud.workspace.domain import Invite, InviteContext
+from soul_protocol.engine.journal import open_journal
+
+from pocketpaw.fabric.events import ACTION_OBJECT_CREATED, ACTION_OBJECT_UPDATED
+from pocketpaw.fabric.journal_store import FabricJournalStore
+from pocketpaw.fabric.models import FabricQuery
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    yield j
+    j.close()
+
+
+@pytest.fixture
+def store(journal) -> FabricJournalStore:
+    s = FabricJournalStore(journal)
+    s.bootstrap()
+    return s
+
+
+def _invite(
+    *,
+    workspace_id: str = "ws1",
+    email: str = "member@x.c",
+    role: str = "member",
+    invited_by: str = "admin1",
+    group_id: str | None = "team-eng",
+    context: InviteContext | None = None,
+) -> Invite:
+    return Invite(
+        id="inv1",
+        workspace_id=workspace_id,
+        email=email,
+        role=role,
+        invited_by=invited_by,
+        token=None,
+        group_id=group_id,
+        accepted=True,
+        revoked=False,
+        expired=False,
+        expires_at=datetime.now(UTC),
+        context=context,
+    )
+
+
+async def _all_people(store: FabricJournalStore) -> list:
+    result = await store.query(
+        FabricQuery(type_id=PERSON_TYPE_ID, limit=10_000),
+        requester_scopes=None,
+    )
+    return result.objects
+
+
+# ---------------------------------------------------------------------------
+# 1. Accept → Person exists with the expected fields
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeCreatesPerson:
+    @pytest.mark.asyncio
+    async def test_person_holds_identity_and_context_fields(
+        self, store: FabricJournalStore
+    ) -> None:
+        invite = _invite(
+            context=InviteContext(focus="Own the billing rewrite", profile_pic="file-42"),
+        )
+
+        person = await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada Lovelace",
+            email="member@x.c",
+            avatar="https://cdn/ada.png",
+            invite=invite,
+            store=store,
+        )
+
+        # Returned typed view.
+        assert person.id == "person-ws1-user-7"
+        assert person.workspace_id == "ws1"
+        assert person.user_id == "user-7"
+
+        # Persisted Fabric object.
+        people = await _all_people(store)
+        assert len(people) == 1
+        obj = people[0]
+        assert obj.id == "person-ws1-user-7"
+        assert obj.type_id == PERSON_TYPE_ID
+        assert obj.type_name == PERSON_TYPE_NAME
+
+        props = obj.properties
+        # Identity — from the member's own profile.
+        assert props["name"] == "Ada Lovelace"
+        assert props["email"] == "member@x.c"
+        assert props["avatar"] == "https://cdn/ada.png"
+        # Role + group + onboarding — from the invite / admin context.
+        assert props["role"] == "member"
+        assert props["group"] == "team-eng"
+        assert props["focus"] == "Own the billing rewrite"
+        assert props["profile_pic"] == "file-42"
+
+    @pytest.mark.asyncio
+    async def test_person_is_queryable_by_type_name(self, store: FabricJournalStore) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(),
+            store=store,
+        )
+
+        by_name = await store.query(
+            FabricQuery(type_name=PERSON_TYPE_NAME, limit=10),
+            requester_scopes=None,
+        )
+        assert by_name.total == 1
+        assert by_name.objects[0].properties["name"] == "Ada"
+
+
+# ---------------------------------------------------------------------------
+# 2. Provenance — invited_by + source=admin_context
+# ---------------------------------------------------------------------------
+
+
+class TestProvenance:
+    @pytest.mark.asyncio
+    async def test_provenance_in_property_bag_and_object(self, store: FabricJournalStore) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(invited_by="admin-99"),
+            store=store,
+        )
+
+        obj = (await _all_people(store))[0]
+        # Property-bag provenance (readable from the projected object alone).
+        assert obj.properties["invited_by"] == "admin-99"
+        assert obj.properties["source"] == SOURCE_ADMIN_CONTEXT
+        # Native Fabric provenance fields.
+        assert obj.source_connector == SOURCE_ADMIN_CONTEXT
+        assert obj.source_id == "user-7"
+
+    @pytest.mark.asyncio
+    async def test_journal_actor_is_the_inviting_admin(
+        self, store: FabricJournalStore, journal
+    ) -> None:
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="",
+            invite=_invite(invited_by="admin-99"),
+            store=store,
+        )
+
+        events = journal.query(action=ACTION_OBJECT_CREATED)
+        assert len(events) == 1
+        assert events[0].actor.kind == "user"
+        assert events[0].actor.id == "user:admin-99"
+        # Tenancy: the write scope is the workspace, not global.
+        assert events[0].scope == ["workspace:ws1"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotent — re-materialize updates, never duplicates
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotent:
+    @pytest.mark.asyncio
+    async def test_second_call_updates_no_duplicate(self, store: FabricJournalStore) -> None:
+        first = _invite(context=InviteContext(focus="Initial focus", profile_pic="pic-1"))
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="av-1",
+            invite=first,
+            store=store,
+        )
+
+        # Re-accept with a changed profile + context.
+        second = _invite(
+            role="admin",
+            context=InviteContext(focus="Revised focus", profile_pic="pic-2"),
+        )
+        await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada L.",
+            email="member@x.c",
+            avatar="av-2",
+            invite=second,
+            store=store,
+        )
+
+        people = await _all_people(store)
+        assert len(people) == 1  # NOT two — same deterministic id.
+        props = people[0].properties
+        assert props["name"] == "Ada L."
+        assert props["avatar"] == "av-2"
+        assert props["role"] == "admin"
+        assert props["focus"] == "Revised focus"
+        assert props["profile_pic"] == "pic-2"
+
+    @pytest.mark.asyncio
+    async def test_second_call_emits_update_event(self, store: FabricJournalStore, journal) -> None:
+        for _ in range(2):
+            await materialize_person_from_invite(
+                workspace_id="ws1",
+                user_id="user-7",
+                name="Ada",
+                email="member@x.c",
+                avatar="",
+                invite=_invite(),
+                store=store,
+            )
+
+        created = journal.query(action=ACTION_OBJECT_CREATED)
+        updated = journal.query(action=ACTION_OBJECT_UPDATED)
+        # Exactly one create, the rest are updates — never two creates.
+        assert len(created) == 1
+        assert len(updated) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. No-context invite — still creates a Person, focus/pic empty
+# ---------------------------------------------------------------------------
+
+
+class TestNoContext:
+    @pytest.mark.asyncio
+    async def test_none_context_creates_person_with_empty_onboarding(
+        self, store: FabricJournalStore
+    ) -> None:
+        invite = _invite(context=None, group_id=None)
+
+        person = await materialize_person_from_invite(
+            workspace_id="ws1",
+            user_id="user-7",
+            name="Ada",
+            email="member@x.c",
+            avatar="av",
+            invite=invite,
+            store=store,
+        )
+
+        assert person.focus == ""
+        assert person.profile_pic == ""
+
+        obj = (await _all_people(store))[0]
+        assert obj.properties["name"] == "Ada"
+        assert obj.properties["focus"] == ""
+        assert obj.properties["profile_pic"] == ""
+        assert obj.properties["group"] is None
+        # Provenance still recorded even with no context.
+        assert obj.properties["source"] == SOURCE_ADMIN_CONTEXT

--- a/tests/cloud/test_agent_service_scope.py
+++ b/tests/cloud/test_agent_service_scope.py
@@ -2,6 +2,14 @@
 
 Uses AsyncMock-substituted Beanie finders so tests stay unit-scoped.
 The real Mongo path is exercised by the router integration tests.
+
+Updated: 2026-06-08 (VIP Onboarding Phase B) — added the session-user
+isolation gate tests for ``_kb_scopes_for_context``. The centerpiece is the
+leak-prevention matrix: member A's private ``user:{A}`` scope must NEVER
+appear in member B's resolved scopes nor in any multi-member room — it is
+emitted ONLY in A's own solo session. These are the RED-before / GREEN-after
+tests for the gate that keeps one member's Gmail/calendar KB out of every
+other member's agent context.
 """
 
 from __future__ import annotations
@@ -12,10 +20,33 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pocketpaw_ee.cloud.chat.agent_service import (
     InvalidScope,
+    ScopeContext,
     ScopeKind,
+    _kb_scopes_for_context,
     resolve_scope_context,
 )
 from pocketpaw_ee.cloud.shared.errors import CloudError, NotFound
+
+
+def _ctx(
+    *,
+    kind: ScopeKind,
+    user_id: str,
+    members: list[str],
+    workspace_id: str = "w1",
+    pocket_id: str | None = None,
+    target_agent_id: str = "a1",
+) -> ScopeContext:
+    """Minimal ScopeContext for the KB-scope gate matrix."""
+    return ScopeContext(
+        kind=kind,
+        scope_id="scope-1",
+        workspace_id=workspace_id,
+        user_id=user_id,
+        members=list(members),
+        target_agent_id=target_agent_id,
+        pocket_id=pocket_id,
+    )
 
 
 @pytest.mark.asyncio
@@ -433,3 +464,104 @@ async def test_session_scope_no_agent_errors():
                 scope="session", scope_id="s1", user_id="u1", agent_id_hint=None
             )
     assert exc.value.code == "session.no_agent"
+
+
+# ===========================================================================
+# VIP Onboarding Phase B — session-user isolation gate for KB scopes.
+#
+# The gate decides whether ``_kb_scopes_for_context`` emits the member-private
+# ``user:{member_id}`` scope. Rule: emit it ONLY when the room is the member's
+# own solo context (exactly one member == the authenticated principal). NEVER
+# in a multi-member room. This keeps one member's Gmail/calendar KB out of
+# every other member's agent session.
+# ===========================================================================
+
+
+def test_solo_session_emits_member_private_user_scope():
+    """A member's own solo session injects their private ``user:{id}`` scope,
+    at the HEAD of the list (highest priority, ahead of workspace)."""
+    ctx = _ctx(kind=ScopeKind.SESSION, user_id="memberA", members=["memberA"])
+    scopes = _kb_scopes_for_context(ctx)
+    assert scopes[0] == "user:memberA"
+    assert "user:memberA" in scopes
+
+
+def test_leak_prevention_member_A_scope_absent_from_member_B_session():
+    """CENTERPIECE LEAK TEST: member A's private scope must NEVER surface in
+    member B's resolved scopes. B's solo session yields ``user:B`` and never
+    ``user:A``."""
+    ctx_b = _ctx(kind=ScopeKind.SESSION, user_id="memberB", members=["memberB"])
+    scopes_b = _kb_scopes_for_context(ctx_b)
+    assert "user:memberA" not in scopes_b
+    assert "user:memberB" in scopes_b
+
+
+def test_leak_prevention_no_member_private_scope_in_multi_member_room():
+    """CENTERPIECE LEAK TEST: a shared room (>1 member) emits NO member-private
+    ``user:`` scope for ANY participant — not the caller's, not anyone's."""
+    ctx = _ctx(
+        kind=ScopeKind.GROUP,
+        user_id="memberA",
+        members=["memberA", "memberB", "memberC"],
+        workspace_id="w1",
+    )
+    scopes = _kb_scopes_for_context(ctx)
+    assert "user:memberA" not in scopes
+    assert "user:memberB" not in scopes
+    assert "user:memberC" not in scopes
+    assert not any(s.startswith("user:") for s in scopes)
+    # The shared workspace scope is still present — only the private tier is gated.
+    assert "workspace:w1" in scopes
+
+
+def test_leak_prevention_dm_with_peer_has_no_member_private_scope():
+    """A 2-person DM is a shared room: no member-private ``user:`` scope, even
+    though the caller is an authenticated member."""
+    ctx = _ctx(
+        kind=ScopeKind.DM,
+        user_id="memberA",
+        members=["memberA", "memberB"],
+    )
+    scopes = _kb_scopes_for_context(ctx)
+    assert not any(s.startswith("user:") for s in scopes)
+
+
+def test_member_private_scope_gated_off_when_principal_not_sole_member():
+    """Defense-in-depth: even a single-other-member room (principal NOT in the
+    member list, or a stale member set) must not leak a ``user:`` scope. The
+    gate keys on ``members == [user_id]`` exactly."""
+    # Principal is memberA but the sole listed member is someone else.
+    ctx = _ctx(kind=ScopeKind.POCKET, user_id="memberA", members=["memberX"], pocket_id="p1")
+    scopes = _kb_scopes_for_context(ctx)
+    assert "user:memberA" not in scopes
+    assert "user:memberX" not in scopes
+
+
+def test_solo_pocket_owner_session_emits_user_scope_above_pocket():
+    """A private pocket whose only member is the owner is a solo own-context:
+    the user scope is emitted and outranks the pocket scope."""
+    ctx = _ctx(
+        kind=ScopeKind.POCKET,
+        user_id="memberA",
+        members=["memberA"],
+        pocket_id="p1",
+    )
+    scopes = _kb_scopes_for_context(ctx)
+    assert scopes[0] == "user:memberA"
+    assert scopes.index("user:memberA") < scopes.index("pocket:p1")
+
+
+def test_no_user_scope_regression_existing_ordering_preserved():
+    """Regression guard: a multi-member room's NON-user scopes keep their exact
+    pocket > agent > workspace ordering — the gate adds nothing when off."""
+    ctx = ScopeContext(
+        kind=ScopeKind.GROUP,
+        scope_id="g1",
+        workspace_id="w1",
+        user_id="memberA",
+        members=["memberA", "memberB"],
+        target_agent_id="agentZ",
+        pocket_id="p1",
+    )
+    scopes = _kb_scopes_for_context(ctx)
+    assert scopes == ["pocket:p1", "agent:agentZ", "workspace:w1"]

--- a/tests/cloud/test_deps_active_workspace.py
+++ b/tests/cloud/test_deps_active_workspace.py
@@ -1,0 +1,64 @@
+"""Tests for current_workspace_id membership fallback in ee.cloud._core.deps.
+
+New file: reproduces and guards the "joined member locked out of every
+workspace-scoped read" bug. A user who is a valid member of a workspace
+(invite accept / verified-domain auto-join) but whose ``active_workspace``
+field was never set must NOT get HTTP 400 on workspace-scoped GETs. The
+dep now falls back to the first membership and persists it. A user with no
+memberships at all still raises 400 (genuine create/join-first case).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from pocketpaw_ee.cloud._core.deps import current_workspace_id
+
+
+class _StubMembership:
+    def __init__(self, workspace: str, role: str = "member") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _StubUser:
+    """Stand-in for the Beanie User doc with an async ``save()``."""
+
+    def __init__(
+        self,
+        active_workspace: str | None,
+        workspaces: list[_StubMembership] | None = None,
+    ) -> None:
+        self.active_workspace = active_workspace
+        self.workspaces = workspaces or []
+        self.save = AsyncMock()
+
+
+async def test_falls_back_to_first_membership_when_active_unset() -> None:
+    """Member with active_workspace=None resolves to their first membership
+    and persists it — instead of raising 400."""
+    user = _StubUser(
+        active_workspace=None,
+        workspaces=[_StubMembership("w_joined"), _StubMembership("w_other")],
+    )
+
+    wid = await current_workspace_id(user=user)  # type: ignore[arg-type]
+
+    assert wid == "w_joined"
+    # The fallback persists the choice so it sticks across requests.
+    assert user.active_workspace == "w_joined"
+    user.save.assert_awaited_once()
+
+
+async def test_raises_400_when_no_memberships() -> None:
+    """A user with no memberships at all genuinely needs to create/join one."""
+    user = _StubUser(active_workspace=None, workspaces=[])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await current_workspace_id(user=user)  # type: ignore[arg-type]
+
+    assert exc_info.value.status_code == 400
+    assert "No active workspace" in str(exc_info.value.detail)
+    user.save.assert_not_awaited()

--- a/tests/cloud/test_member_briefing.py
+++ b/tests/cloud/test_member_briefing.py
@@ -1,0 +1,239 @@
+# tests/cloud/test_member_briefing.py
+# Created: 2026-06-08 — VIP Onboarding Phase B chunk 5 (the agent "your day"
+#   briefing). RED-before / GREEN-after tests for the briefing block that the
+#   agent receives at the top of the member's OWN solo session.
+#
+# The centerpiece is the gate parity with the KB ``user:`` scope: the "your
+# day" block is injected ONLY in the member's solo session (``members ==
+# [user_id]``) and is ABSENT in every shared / multi-member room — the exact
+# same rule that keeps one member's private mail/calendar out of another
+# member's agent context. Plus:
+#   * the block is CAPPED (≤ ~400 tokens → a hard char cap) so it can't eat
+#     the system-prompt budget.
+#   * an EMPTY digest (no connected accounts) → NO block, no error (the agent
+#     behaves exactly as today).
+#   * a digest that RAISES → NO block, no crash (the stream is never sunk by a
+#     flaky mail/calendar pull).
+#
+# The digest pull is injected as a fake (``digest_fn=``) so the suite needs no
+# OAuth, no network, no Mongo.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    ScopeContext,
+    ScopeKind,
+    _member_briefing_block,
+    build_knowledge_context,
+)
+from pocketpaw_ee.cloud.member_day_digest.dto import (  # noqa: E402
+    DigestEvent,
+    DigestMail,
+    MemberDayDigest,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _ctx(*, user_id: str, members: list[str], kind: ScopeKind = ScopeKind.SESSION) -> ScopeContext:
+    return ScopeContext(
+        kind=kind,
+        scope_id="scope-1",
+        workspace_id="w1",
+        user_id=user_id,
+        members=list(members),
+        target_agent_id="a1",
+    )
+
+
+def _full_digest(member_id: str) -> MemberDayDigest:
+    return MemberDayDigest(
+        workspace_id="w1",
+        member_id=member_id,
+        events=[
+            DigestEvent(summary="Standup", start="2026-06-09T09:00:00Z", end="", location="Zoom"),
+            DigestEvent(summary="1:1 with Sam", start="2026-06-09T14:00:00Z", end="", location=""),
+        ],
+        unread_mail_count=4,
+        top_mail=[
+            DigestMail(subject="Invoice from Acme", sender="billing@acme.com", date=""),
+            DigestMail(subject="Re: launch plan", sender="sam@team.com", date=""),
+        ],
+    )
+
+
+def _digest_fn_returning(digest: MemberDayDigest):
+    async def _fn(workspace_id: str, member_id: str):
+        return digest
+
+    return _fn
+
+
+# --------------------------------------------------------------------------
+# 1 — solo session: the block is PRESENT and carries the member's day.
+# --------------------------------------------------------------------------
+
+
+async def test_briefing_present_in_solo_session():
+    member = "memberA"
+    ctx = _ctx(user_id=member, members=[member])
+    block = await _member_briefing_block(ctx, digest_fn=_digest_fn_returning(_full_digest(member)))
+
+    assert block  # non-empty
+    # It carries the member's real day content.
+    assert "Standup" in block
+    assert "Invoice from Acme" in block
+    # And is wrapped in the dedicated "your day" briefing marker, not a raw dump.
+    assert "<your-day>" in block
+
+
+# --------------------------------------------------------------------------
+# 2 — THE GATE. A shared / multi-member room gets NO block. Same rule as the
+# KB ``user:`` scope: emit ⟺ members == [user_id].
+# --------------------------------------------------------------------------
+
+
+async def test_briefing_absent_in_multi_member_room():
+    ctx = _ctx(
+        user_id="memberA",
+        members=["memberA", "memberB", "memberC"],
+        kind=ScopeKind.GROUP,
+    )
+    # Even if the (would-be) digest is rich, the gate suppresses it entirely:
+    block = await _member_briefing_block(
+        ctx, digest_fn=_digest_fn_returning(_full_digest("memberA"))
+    )
+    assert block == ""
+
+
+async def test_briefing_absent_in_two_person_dm():
+    ctx = _ctx(user_id="memberA", members=["memberA", "memberB"], kind=ScopeKind.DM)
+    block = await _member_briefing_block(
+        ctx, digest_fn=_digest_fn_returning(_full_digest("memberA"))
+    )
+    assert block == ""
+
+
+async def test_briefing_absent_when_principal_not_sole_member():
+    """Defense-in-depth: a single-member room whose member is NOT the caller
+    (stale membership / wrong principal) gets no block."""
+    ctx = _ctx(user_id="memberA", members=["memberX"], kind=ScopeKind.POCKET)
+    block = await _member_briefing_block(
+        ctx, digest_fn=_digest_fn_returning(_full_digest("memberX"))
+    )
+    assert block == ""
+
+
+async def test_briefing_gate_does_not_even_pull_digest_in_shared_room():
+    """The gate short-circuits BEFORE the digest pull — a shared room never
+    triggers a member's mail/calendar read at all (no wasted I/O, and no path
+    where another member's session could cause a private pull)."""
+    pulled: list[str] = []
+
+    async def _spy(workspace_id: str, member_id: str):
+        pulled.append(member_id)
+        return _full_digest(member_id)
+
+    ctx = _ctx(user_id="memberA", members=["memberA", "memberB"], kind=ScopeKind.GROUP)
+    block = await _member_briefing_block(ctx, digest_fn=_spy)
+    assert block == ""
+    assert pulled == []  # digest was never pulled in a shared room
+
+
+# --------------------------------------------------------------------------
+# 3 — capped: the block is bounded so it can't eat the prompt budget.
+# --------------------------------------------------------------------------
+
+
+async def test_briefing_is_capped():
+    member = "memberA"
+    # A huge digest — many events + many mail items.
+    big = MemberDayDigest(
+        workspace_id="w1",
+        member_id=member,
+        events=[
+            DigestEvent(summary="Event " + "x" * 200, start="2026-06-09T09:00:00Z")
+            for _ in range(50)
+        ],
+        unread_mail_count=999,
+        top_mail=[DigestMail(subject="Subject " + "y" * 200, sender="a@b.com") for _ in range(50)],
+    )
+    ctx = _ctx(user_id=member, members=[member])
+    block = await _member_briefing_block(ctx, digest_fn=_digest_fn_returning(big))
+
+    # Hard char cap (~400 tokens ≈ 1600 chars). The module exposes the cap so
+    # the test pins the same constant the impl uses.
+    from pocketpaw_ee.cloud.chat import agent_service
+
+    assert len(block) <= agent_service._BRIEFING_MAX_CHARS
+    assert block  # still produced something
+
+
+# --------------------------------------------------------------------------
+# 4 — empty digest → NO block (no connected accounts; behave as today).
+# --------------------------------------------------------------------------
+
+
+async def test_briefing_empty_digest_yields_no_block():
+    member = "memberA"
+    empty = MemberDayDigest(workspace_id="w1", member_id=member)
+    assert empty.empty
+    ctx = _ctx(user_id=member, members=[member])
+    block = await _member_briefing_block(ctx, digest_fn=_digest_fn_returning(empty))
+    assert block == ""
+
+
+# --------------------------------------------------------------------------
+# 5 — a digest that RAISES → NO block, no crash.
+# --------------------------------------------------------------------------
+
+
+async def test_briefing_digest_failure_is_swallowed():
+    member = "memberA"
+
+    async def _boom(workspace_id: str, member_id: str):
+        raise RuntimeError("calendar API exploded")
+
+    ctx = _ctx(user_id=member, members=[member])
+    block = await _member_briefing_block(ctx, digest_fn=_boom)
+    assert block == ""  # no crash, no block
+
+
+# --------------------------------------------------------------------------
+# 6 — integration: build_knowledge_context INCLUDES the briefing in a solo
+# session and EXCLUDES it in a shared room.
+# --------------------------------------------------------------------------
+
+
+async def test_knowledge_context_includes_briefing_in_solo_session(monkeypatch):
+    member = "memberA"
+
+    async def _fn(workspace_id: str, member_id: str):
+        return _full_digest(member_id)
+
+    # Patch the digest entry point the knowledge-context path calls so no
+    # OAuth/network is needed.
+    monkeypatch.setattr("pocketpaw_ee.cloud.member_day_digest.service.member_day_digest", _fn)
+
+    ctx = _ctx(user_id=member, members=[member])
+    out = await build_knowledge_context(ctx, user_message="hi")
+    assert "Standup" in out
+    assert "<your-day>" in out
+
+
+async def test_knowledge_context_excludes_briefing_in_shared_room(monkeypatch):
+    member = "memberA"
+
+    async def _fn(workspace_id: str, member_id: str):
+        return _full_digest(member_id)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.member_day_digest.service.member_day_digest", _fn)
+
+    ctx = _ctx(user_id=member, members=[member, "memberB"], kind=ScopeKind.GROUP)
+    out = await build_knowledge_context(ctx, user_message="hi")
+    assert "Standup" not in out
+    assert "<your-day>" not in out

--- a/tests/cloud/test_phaseb_e2e.py
+++ b/tests/cloud/test_phaseb_e2e.py
@@ -1,0 +1,731 @@
+# tests/cloud/test_phaseb_e2e.py
+# Created: 2026-06-08 — VIP Onboarding Phase B, FINAL chunk: cross-cutting
+#   e2e / integration tests over the ASSEMBLED Phase B backend.
+#
+# Each Phase B piece is unit-tested in isolation (member_ingest, member_day_
+# digest, the chat-path gate, the REST kb scope validator, purge). This suite
+# proves the WHOLE CHAIN holds together — and, above all, that no member's data
+# leaks across ANY door when every door is wired up at once.
+#
+# What's REAL vs MOCKED (the task's "real assembled modules" rule)
+# ----------------------------------------------------------------
+# REAL (exercised, not faked): member_ingest.service.ingest_member,
+# member_ingest.purge.purge_member_data, member_day_digest.service.
+# member_day_digest, member_day_digest.router.get_member_day_digest,
+# chat.agent_service._kb_scopes_for_context / _member_briefing_block /
+# build_knowledge_context, kb.service.validate_scope_override, kb.router's
+# search/ingest/lint endpoints.
+# MOCKED (the external boundary ONLY): the per-user Gmail/Calendar reads
+# (injected fake readers — no OAuth, no network) and the kb-go subprocess (a
+# single in-memory FakeKbStore that the ingest ACCEPT path writes to, the
+# chat KB-search + REST router read from, and purge CLEARS — so the kb scope
+# store is genuinely shared across every door, just without a binary).
+#
+# The three acts
+# --------------
+#   1. HAPPY PATH — ingest member A's mail/calendar into A's user:{A} scope,
+#      then prove A's OWN briefing AND A's OWN digest surface A's data, and a
+#      KB search in A's solo session finds the ingested text.
+#   2. LEAK-ACROSS-ALL-DOORS (the centerpiece) — member B gets NONE of A's
+#      data, exercised across EVERY door together: (a) the chat gate, (b) the
+#      REST kb router (403), (c) the digest API (B's own, never A's), (d) a
+#      shared/multi-member room (no member-private scope for anyone).
+#   3. PURGE — after purge_member_data for A, A's data is gone from all paths:
+#      the user:{A} KB scope is cleared, and A's briefing + digest go empty.
+
+from __future__ import annotations
+
+import inspect
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.context import RequestContext  # noqa: E402
+from pocketpaw_ee.cloud._core.context import ScopeKind as CtxScopeKind
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    ScopeContext,
+    ScopeKind,
+    _kb_scopes_for_context,
+    _member_briefing_block,
+    build_knowledge_context,
+)
+from pocketpaw_ee.cloud.kb import router as kb_router  # noqa: E402
+from pocketpaw_ee.cloud.kb import service as kb_service  # noqa: E402
+from pocketpaw_ee.cloud.kb.dto import IngestTextRequest, SearchRequest  # noqa: E402
+from pocketpaw_ee.cloud.member_day_digest import router as digest_router  # noqa: E402
+from pocketpaw_ee.cloud.member_day_digest.dto import MemberDayDigest  # noqa: E402
+from pocketpaw_ee.cloud.member_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.member_ingest.purge import purge_member_data  # noqa: E402
+from pocketpaw_ee.cloud.shared.errors import Forbidden  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+# The two members exercised across every door. Opaque cloud ids (as the real
+# system uses), so they double as kb-go scope ids verbatim.
+WS = "w1"
+ALICE = "alice-objid"
+BOB = "bob-objid"
+
+# A signature that text from Alice's mail/calendar carries, so the leak tests
+# can scan any surface for "did Alice's content escape into Bob's view?".
+ALICE_SECRET = "PROJECT-NIGHTINGALE-merger"
+
+
+# ===========================================================================
+# The shared in-memory kb-go fake — the ONE mocked seam for the scope store.
+#
+# Every door that touches kb-go in the assembled chain funnels through this:
+#   * ingest ACCEPT  -> store.accept(scope, articles)   (via injected kb_accept)
+#   * chat KB search -> store.kb("search", ..., "--scope", S, "--context")
+#   * REST kb router -> store.kb("search"/"ingest"/"lint", "--scope", S, ...)
+#   * scope-probe    -> store.kb("list", "--scope", S)
+#   * purge CLEAR    -> store.clear(scope)              (via injected kb_clear)
+# Because it's a single dict keyed on the literal scope string, a cross-scope
+# read can only ever return what was written under THAT scope — exactly the
+# property the leak tests assert against.
+# ===========================================================================
+
+
+class FakeKbStore:
+    """An in-memory stand-in for the kb-go binary, keyed on scope string."""
+
+    def __init__(self) -> None:
+        # scope -> list of article dicts ({title, content, summary, ...}).
+        self.scopes: dict[str, list[dict[str, Any]]] = {}
+
+    # -- write paths -------------------------------------------------------
+
+    async def accept(self, scope: str, articles: list[dict[str, Any]]) -> dict[str, Any]:
+        """The keyless ``kb accept`` seam the ingest worker writes through."""
+        self.scopes.setdefault(scope, []).extend(dict(a) for a in articles)
+        return {"accepted": len(articles)}
+
+    async def clear(self, scope: str) -> dict[str, Any]:
+        """The keyless ``kb clear`` seam the purge path clears through."""
+        removed = len(self.scopes.pop(scope, []))
+        return {"cleared": removed}
+
+    # -- the _kb subprocess seam (sync, called as _kb(*args, input_text=)) --
+
+    def kb(self, *args: str, input_text: str | None = None, timeout: int = 120) -> Any:
+        """Mimics ``agents.knowledge._kb`` over the in-memory store.
+
+        Honours the ``--scope`` flag (every door passes it) and dispatches on
+        the verb. ``search``/``list`` return rows from THAT scope only; the
+        ``--context`` form returns the formatted string the chat path expects.
+        ``ingest`` writes a row to the scope (the REST write door).
+        """
+        if not args:
+            return []
+        verb = args[0]
+        scope = _flag(args, "--scope")
+        rows = self.scopes.get(scope, [])
+
+        if verb == "search":
+            query = args[1] if len(args) > 1 else ""
+            hits = [r for r in rows if _matches(r, query)] or rows
+            if "--context" in args:
+                # The chat path consumes a single formatted string.
+                if not hits:
+                    return ""
+                return "\n\n".join(
+                    f"{h.get('title', '')}\n{h.get('content', '')}".strip() for h in hits
+                )
+            return [
+                {"title": h.get("title", ""), "summary": h.get("summary", h.get("content", ""))}
+                for h in hits
+            ]
+        if verb == "list":
+            return [{"title": r.get("title", "")} for r in rows]
+        if verb == "ingest":
+            source = _flag(args, "--source") or "manual"
+            self.scopes.setdefault(scope, []).append(
+                {"title": source, "content": input_text or "", "summary": (input_text or "")[:200]}
+            )
+            return {"ingested": 1, "scope": scope}
+        if verb == "lint":
+            return []
+        if verb == "stats":
+            return {"articles": len(rows)}
+        return []
+
+
+def _flag(args: tuple[str, ...] | list[str], name: str) -> str:
+    """Return the value following ``name`` in an argv-style list, or ''."""
+    for i, a in enumerate(args):
+        if a == name and i + 1 < len(args):
+            return args[i + 1]
+    return ""
+
+
+def _matches(row: dict[str, Any], query: str) -> bool:
+    if not query:
+        return True
+    hay = f"{row.get('title', '')} {row.get('content', '')} {row.get('summary', '')}".lower()
+    return any(tok in hay for tok in query.lower().split())
+
+
+# ===========================================================================
+# Fake per-user Gmail/Calendar readers — the EXTERNAL boundary (no OAuth).
+#
+# Keyed by member so each member resolves THEIR OWN data, mirroring how the
+# real per-user clients resolve per-member OAuth-token buckets. The leak tests
+# rely on this: a reader built for Bob can only ever return Bob's data.
+# ===========================================================================
+
+
+class FakeGmailReader:
+    def __init__(self, messages: list[dict] | None = None) -> None:
+        self._messages = messages or []
+        self.queries: list[str] = []
+
+    async def search(self, query: str, max_results: int = 10) -> list[dict]:
+        self.queries.append(query)
+        return list(self._messages[:max_results])
+
+
+class FakeCalendarReader:
+    def __init__(self, events: list[dict] | None = None) -> None:
+        self._events = events or []
+
+    async def list_events(self, time_min=None, time_max=None, max_results=10, **_kw):
+        return list(self._events[:max_results])
+
+
+def _alice_mail() -> list[dict]:
+    return [
+        {
+            "id": "m-alice-1",
+            "subject": f"Re: {ALICE_SECRET}",
+            "from": "ceo@acme.test",
+            "date": "Wed, 04 Jun 2026 10:00:00 +0000",
+            "snippet": f"Confidential: {ALICE_SECRET} closes Friday.",
+        }
+    ]
+
+
+def _alice_events() -> list[dict]:
+    return [
+        {
+            "id": "e-alice-1",
+            "summary": f"{ALICE_SECRET} sync",
+            "start": "2026-06-10T09:00:00Z",
+            "end": "2026-06-10T10:00:00Z",
+            "location": "War Room",
+            "description": f"Final terms for {ALICE_SECRET}.",
+            "attendees": ["ceo@acme.test"],
+        }
+    ]
+
+
+def _bob_mail() -> list[dict]:
+    return [
+        {
+            "id": "m-bob-1",
+            "subject": "Standup notes",
+            "from": "teammate@acme.test",
+            "date": "Wed, 04 Jun 2026 11:00:00 +0000",
+            "snippet": "Bob's own mundane standup notes.",
+        }
+    ]
+
+
+def _bob_events() -> list[dict]:
+    return [
+        {
+            "id": "e-bob-1",
+            "summary": "Bob 1:1",
+            "start": "2026-06-11T15:00:00Z",
+            "end": "2026-06-11T15:30:00Z",
+            "location": "",
+            "description": "Bob's own 1:1.",
+            "attendees": [],
+        }
+    ]
+
+
+# Per-member reader registries so a digest/ingest for member X structurally
+# only ever sees X's data — the in-test analogue of per-user OAuth buckets.
+_GMAIL = {ALICE: _alice_mail(), BOB: _bob_mail()}
+_CAL = {ALICE: _alice_events(), BOB: _bob_events()}
+
+
+def _readers_for(member_id: str) -> tuple[FakeGmailReader, FakeCalendarReader]:
+    return FakeGmailReader(_GMAIL.get(member_id, [])), FakeCalendarReader(_CAL.get(member_id, []))
+
+
+def _digest_fn(store_unused: Any = None):
+    """A digest entry point that reads the per-member fake readers LIVE.
+
+    This is the real ``member_day_digest`` service with its external Gmail/
+    Calendar boundary replaced — it is NOT a KB read (the digest is a live
+    pull by design), so a member's digest is keyed purely on member_id.
+    """
+
+    async def _fn(workspace_id: str, member_id: str) -> MemberDayDigest:
+        gmail, cal = _readers_for(member_id)
+        from pocketpaw_ee.cloud.member_day_digest.service import member_day_digest
+
+        return await member_day_digest(
+            workspace_id, member_id, gmail_reader=gmail, calendar_reader=cal
+        )
+
+    return _fn
+
+
+# ===========================================================================
+# RequestContext / ScopeContext builders (mirror the real resolvers).
+# ===========================================================================
+
+
+def _req_ctx(user_id: str, workspace_id: str | None = WS) -> RequestContext:
+    """An authed RequestContext as ``request_context`` would build it — the
+    shape the digest REST router consumes."""
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="req-e2e",
+        scope=CtxScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _solo_ctx(member_id: str) -> ScopeContext:
+    """A member's OWN solo session — ``members == [member_id]`` (the shape
+    ``_resolve_session`` always builds for a single-user session)."""
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id=f"s-{member_id}",
+        workspace_id=WS,
+        user_id=member_id,
+        members=[member_id],
+        target_agent_id="a1",
+    )
+
+
+def _shared_room_ctx(caller: str, members: list[str]) -> ScopeContext:
+    """A shared/multi-member room (group)."""
+    return ScopeContext(
+        kind=ScopeKind.GROUP,
+        scope_id="g-shared",
+        workspace_id=WS,
+        user_id=caller,
+        members=list(members),
+        target_agent_id="a-shared",
+    )
+
+
+def _patch_kb(store: FakeKbStore):
+    """Point the chat-path KB search, the REST kb router, and the scope-probe
+    at the shared in-memory store.
+
+    All three resolve the kb-go subprocess through ``agents.knowledge._kb``
+    (the chat path and the scope-probe import it lazily inside their bodies;
+    the router binds it at module import), so patching it there is the single
+    seam that makes the kb store shared and binary-free across every door.
+    """
+    return patch("pocketpaw_ee.cloud.agents.knowledge._kb", store.kb)
+
+
+def _patch_router_kb(store: FakeKbStore):
+    """The REST kb router binds ``_kb`` at import time, so it needs its own
+    patch target (the module-level name in kb.router)."""
+    return patch.object(kb_router, "_kb", store.kb)
+
+
+async def _seed_ingest(store: FakeKbStore, member_id: str) -> dict:
+    """Run the REAL ingest worker for one member against the shared store and
+    the member's fake readers — the upstream of the whole chain."""
+    gmail, cal = _readers_for(member_id)
+    return await ingest_service.ingest_member(
+        workspace_id=WS,
+        member_id=member_id,
+        gmail_reader=gmail,
+        calendar_reader=cal,
+        kb_accept=store.accept,
+    )
+
+
+# ===========================================================================
+# ACT 1 — HAPPY PATH. Ingest A → A's briefing, A's digest, A's KB search all
+# surface A's data.
+# ===========================================================================
+
+
+async def test_happy_ingest_lands_in_alice_scope(mongo_db):  # noqa: ARG001 — Beanie init
+    """The assembled upstream: ingest writes A's mail+calendar into user:{A}
+    and ONLY user:{A}, via the keyless accept seam."""
+    store = FakeKbStore()
+    result = await _seed_ingest(store, ALICE)
+
+    assert result["status"] == "ok"
+    assert result["scope"] == f"user:{ALICE}"
+    # The store now carries Alice's data under exactly her scope.
+    assert set(store.scopes) == {f"user:{ALICE}"}
+    arts = store.scopes[f"user:{ALICE}"]
+    assert len(arts) == 2  # 1 mail + 1 event
+    assert any(ALICE_SECRET in a["content"] for a in arts)
+
+
+async def test_happy_alice_briefing_surfaces_her_day(mongo_db):  # noqa: ARG001
+    """A's OWN solo session: the proactive <your-day> briefing carries her
+    real calendar + mail (the live digest pull, keyed on her id)."""
+    block = await _member_briefing_block(_solo_ctx(ALICE), digest_fn=_digest_fn())
+
+    assert block
+    assert "<your-day>" in block
+    assert f"{ALICE_SECRET} sync" in block  # her calendar event
+    assert "Unread mail:" in block
+
+
+async def test_happy_alice_digest_api_returns_her_data(mongo_db):  # noqa: ARG001
+    """A's OWN digest via the REST door: events + unread mail, keyed on the
+    authenticated principal."""
+    with patch.object(digest_router, "member_day_digest", _digest_fn()):
+        digest = await digest_router.get_member_day_digest(ctx=_req_ctx(ALICE))
+
+    assert isinstance(digest, MemberDayDigest)
+    assert digest.member_id == ALICE
+    assert digest.empty is False
+    assert any(ALICE_SECRET in e.summary for e in digest.events)
+    assert digest.unread_mail_count == 1
+
+
+async def test_happy_alice_kb_search_finds_ingested_text(mongo_db):  # noqa: ARG001
+    """The full chain end-to-end: after ingest, a KB search in A's OWN solo
+    session retrieves the ingested mail/calendar text. Proves the gate ADMITS
+    user:{A} for A and the search reads the scope ingest wrote."""
+    store = FakeKbStore()
+    await _seed_ingest(store, ALICE)
+
+    # The gate emits user:{A} at the head for A's solo session.
+    scopes = _kb_scopes_for_context(_solo_ctx(ALICE))
+    assert scopes[0] == f"user:{ALICE}"
+
+    with _patch_kb(store):
+        kb_block = await build_knowledge_context(
+            _solo_ctx(ALICE),
+            user_message=ALICE_SECRET,
+        )
+    # The ingested confidential text is retrievable in A's own session.
+    assert ALICE_SECRET in kb_block
+    assert f"### user:{ALICE}" in kb_block
+
+
+# ===========================================================================
+# ACT 2 — LEAK-ACROSS-ALL-DOORS (THE CENTERPIECE).
+#
+# Member A has ingested + has a busy day. Member B gets NONE of it, across
+# EVERY door exercised together in one suite.
+# ===========================================================================
+
+
+async def test_leak_door_a_chat_gate_no_alice_scope_for_bob(mongo_db):  # noqa: ARG001
+    """DOOR (a) — the chat KB-scope gate. B's solo session yields user:{B}
+    and NEVER user:{A}; the gate keys on members==[user_id] exactly."""
+    scopes_b = _kb_scopes_for_context(_solo_ctx(BOB))
+    assert f"user:{BOB}" in scopes_b
+    assert f"user:{ALICE}" not in scopes_b
+    assert not any(s.startswith(f"user:{ALICE}") for s in scopes_b)
+
+
+async def test_leak_door_a_chat_search_returns_only_bobs_scope(mongo_db):  # noqa: ARG001
+    """DOOR (a), deeper — even with both members' data in the SAME store, a
+    KB search in B's session can only read user:{B}; A's secret never appears
+    because the gate never hands B the user:{A} scope to search."""
+    store = FakeKbStore()
+    await _seed_ingest(store, ALICE)  # Alice's secret is in the store...
+    await _seed_ingest(store, BOB)  # ...alongside Bob's own mundane data.
+
+    with _patch_kb(store):
+        kb_block = await build_knowledge_context(
+            _solo_ctx(BOB),
+            user_message=ALICE_SECRET,  # Bob even SEARCHES for Alice's secret
+        )
+    # ...and still gets nothing of Alice's: his scope doesn't contain it.
+    assert ALICE_SECRET not in kb_block
+    assert f"### user:{ALICE}" not in kb_block
+
+
+async def test_leak_door_b_rest_kb_search_foreign_user_scope_403(mongo_db):  # noqa: ARG001
+    """DOOR (b) — the REST kb router. B POSTs /api/v1/kb/search with
+    {"scope":"user:{A}"} → Forbidden, and kb-go is NEVER reached."""
+    store = FakeKbStore()
+    await _seed_ingest(store, ALICE)  # Alice's private KB exists...
+
+    # B's allowlist: B's own workspace only (no visible pockets/agents here).
+    with (
+        patch.object(
+            kb_service,
+            "_candidate_scopes",
+            _async_return([f"workspace:{WS}"]),
+        ),
+        _patch_router_kb(store),
+    ):
+        with pytest.raises(Forbidden) as exc:
+            await kb_router.search_kb(
+                SearchRequest(query=ALICE_SECRET, scope=f"user:{ALICE}"),
+                workspace_id=WS,
+                user_id=BOB,
+            )
+    assert exc.value.code == "kb.scope_forbidden"
+    # Belt: the store was never touched — denial happens before kb-go.
+    assert store.scopes.get(f"user:{ALICE}")  # Alice's data still intact
+    # And nothing of Alice's was returned to Bob (no result object at all).
+
+
+async def test_leak_door_b_rest_kb_ingest_poison_foreign_scope_403(mongo_db):  # noqa: ARG001
+    """DOOR (b), WRITE side — B cannot POISON A's private KB via the REST
+    ingest door either. The foreign user: scope is hard-denied before write."""
+    store = FakeKbStore()
+    await _seed_ingest(store, ALICE)
+    alice_before = list(store.scopes[f"user:{ALICE}"])
+
+    with (
+        patch.object(kb_service, "_candidate_scopes", _async_return([f"workspace:{WS}"])),
+        _patch_router_kb(store),
+    ):
+        with pytest.raises(Forbidden) as exc:
+            await kb_router.ingest_text(
+                IngestTextRequest(text="malware", source="evil", scope=f"user:{ALICE}"),
+                workspace_id=WS,
+                user_id=BOB,
+            )
+    assert exc.value.code == "kb.scope_forbidden"
+    # Alice's scope is byte-identical — Bob's poison never landed.
+    assert store.scopes[f"user:{ALICE}"] == alice_before
+
+
+async def test_leak_door_c_digest_api_gives_bob_his_own_never_alices(mongo_db):  # noqa: ARG001
+    """DOOR (c) — the digest REST API. B's GET returns B's OWN digest (his
+    mundane data), and structurally never A's: the router has no member_id
+    param, so member_id == ctx.user_id always."""
+    with patch.object(digest_router, "member_day_digest", _digest_fn()):
+        digest_b = await digest_router.get_member_day_digest(ctx=_req_ctx(BOB))
+
+    assert digest_b.member_id == BOB
+    # Bob sees his own day...
+    assert any("Bob" in e.summary for e in digest_b.events)
+    # ...and NONE of Alice's confidential content leaks into it.
+    blob = digest_b.model_dump_json()
+    assert ALICE_SECRET not in blob
+    assert f"user:{ALICE}" not in blob
+
+
+async def test_leak_door_c_digest_endpoint_has_no_member_id_param(mongo_db):  # noqa: ARG001
+    """DOOR (c), structural — the endpoint exposes NO member-id / override
+    parameter, so B cannot even ASK for A's digest. The contract is on the
+    signature itself, asserted alongside the runtime leak test above."""
+    params = set(inspect.signature(digest_router.get_member_day_digest).parameters)
+    forbidden = {"member_id", "user_id", "member", "for_member", "principal", "target"}
+    assert params.isdisjoint(forbidden), f"endpoint leaks an id override: {params & forbidden}"
+
+
+async def test_leak_door_d_shared_room_no_member_private_scope(mongo_db):  # noqa: ARG001
+    """DOOR (d) — a shared/multi-member room. NO member-private user: scope is
+    emitted for ANYONE (not the caller's, not any participant's), and the
+    briefing is suppressed too — one member's mail/calendar never bleeds into
+    a context another member can see."""
+    members = [ALICE, BOB]
+    ctx = _shared_room_ctx(caller=ALICE, members=members)
+
+    # The scope gate: no user: tier at all in a shared room.
+    scopes = _kb_scopes_for_context(ctx)
+    assert not any(s.startswith("user:") for s in scopes), scopes
+    assert f"workspace:{WS}" in scopes  # the shared workspace scope survives
+
+    # The briefing: suppressed entirely, even though Alice IS the caller and
+    # HAS a rich day — and the digest is never even pulled.
+    pulled: list[str] = []
+
+    async def _spy(workspace_id: str, member_id: str) -> MemberDayDigest:
+        pulled.append(member_id)
+        return await _digest_fn()(workspace_id, member_id)
+
+    block = await _member_briefing_block(ctx, digest_fn=_spy)
+    assert block == ""
+    assert pulled == []  # no private mail/calendar pull in a shared room
+
+
+async def test_leak_all_doors_one_pass(mongo_db):  # noqa: ARG001
+    """THE ASSEMBLED LEAK GUARANTEE, all doors in a single pass.
+
+    With Alice ingested + a busy day, walk every Phase B door AS BOB and prove
+    none of them yields a byte of Alice's data:
+        (a) chat gate          -> no user:{A} scope, search returns nothing
+        (b) REST kb router      -> 403 on user:{A}, store untouched
+        (c) digest API          -> Bob's own digest, no ALICE_SECRET
+        (d) shared room         -> no user: scope for anyone
+    """
+    store = FakeKbStore()
+    await _seed_ingest(store, ALICE)
+    await _seed_ingest(store, BOB)
+
+    # (a) chat gate + search as Bob
+    with _patch_kb(store):
+        bob_kb = await build_knowledge_context(_solo_ctx(BOB), user_message=ALICE_SECRET)
+    assert ALICE_SECRET not in bob_kb
+
+    # (b) REST kb door as Bob -> 403, Alice's data intact
+    alice_before = list(store.scopes[f"user:{ALICE}"])
+    with (
+        patch.object(kb_service, "_candidate_scopes", _async_return([f"workspace:{WS}"])),
+        _patch_router_kb(store),
+    ):
+        with pytest.raises(Forbidden):
+            await kb_router.search_kb(
+                SearchRequest(query=ALICE_SECRET, scope=f"user:{ALICE}"),
+                workspace_id=WS,
+                user_id=BOB,
+            )
+    assert store.scopes[f"user:{ALICE}"] == alice_before
+
+    # (c) digest API as Bob -> his own, never Alice's
+    with patch.object(digest_router, "member_day_digest", _digest_fn()):
+        bob_digest = await digest_router.get_member_day_digest(ctx=_req_ctx(BOB))
+    assert bob_digest.member_id == BOB
+    assert ALICE_SECRET not in bob_digest.model_dump_json()
+
+    # (d) shared room -> no member-private scope for anyone
+    shared = _kb_scopes_for_context(_shared_room_ctx(caller=BOB, members=[ALICE, BOB]))
+    assert not any(s.startswith("user:") for s in shared)
+
+
+# ===========================================================================
+# ACT 3 — PURGE. After purge_member_data for A, A's data is gone everywhere.
+# ===========================================================================
+
+
+async def test_purge_clears_alice_scope_and_emits(mongo_db, recording_bus):  # noqa: ARG001
+    """The REAL purge path against the shared store: A's user:{A} KB scope is
+    cleared and a MemberDataPurged event is emitted."""
+    store = FakeKbStore()
+    await _seed_ingest(store, ALICE)
+    assert store.scopes.get(f"user:{ALICE}")  # present before
+
+    # A no-op token store so the OAuth-token deletes don't need an on-disk one.
+    class _NoTokens:
+        def delete(self, service: str, member_id: str) -> bool:  # noqa: ARG002
+            return False
+
+    result = await purge_member_data(
+        workspace_id=WS,
+        member_id=ALICE,
+        kb_clear=store.clear,
+        token_store=_NoTokens(),
+    )
+
+    assert result["status"] == "ok"
+    assert result["scope"] == f"user:{ALICE}"
+    assert result["kb_cleared"] is True
+    # The scope is gone from the store entirely.
+    assert f"user:{ALICE}" not in store.scopes
+    # A purge event was emitted for downstream consumers.
+    assert any(type(e).__name__ == "MemberDataPurged" for e in recording_bus.events)
+
+
+async def test_purge_then_kb_search_finds_nothing(mongo_db):  # noqa: ARG001
+    """After purge, a KB search in A's OWN solo session finds nothing — the
+    scope the gate admits is now empty. The chain's read door reflects the
+    purge with no extra wiring."""
+    store = FakeKbStore()
+    await _seed_ingest(store, ALICE)
+
+    class _NoTokens:
+        def delete(self, *_a, **_k) -> bool:
+            return False
+
+    await purge_member_data(
+        workspace_id=WS, member_id=ALICE, kb_clear=store.clear, token_store=_NoTokens()
+    )
+
+    with _patch_kb(store):
+        kb_block = await build_knowledge_context(_solo_ctx(ALICE), user_message=ALICE_SECRET)
+    assert ALICE_SECRET not in kb_block
+
+
+async def test_purge_then_briefing_and_digest_empty(mongo_db):  # noqa: ARG001
+    """After purge AND disconnect, A's briefing + digest go empty.
+
+    The digest is a LIVE pull, so emptiness comes from the disconnected
+    accounts (both per-user reads raise "not authenticated"), not from the KB
+    clear — this models the real offboard: purge wipes the KB, account
+    disconnection empties the live digest. Together: no block, empty digest."""
+    store = FakeKbStore()
+    await _seed_ingest(store, ALICE)
+
+    class _NoTokens:
+        def delete(self, *_a, **_k) -> bool:
+            return False
+
+    await purge_member_data(
+        workspace_id=WS, member_id=ALICE, kb_clear=store.clear, token_store=_NoTokens()
+    )
+
+    # Post-disconnect digest: both sources raise "not authenticated".
+    class _Disconnected:
+        async def search(self, *_a, **_k):
+            raise RuntimeError("Gmail not authenticated. Complete OAuth flow first")
+
+        async def list_events(self, *_a, **_k):
+            raise RuntimeError("Google Calendar not authenticated")
+
+    async def _disconnected_digest(workspace_id: str, member_id: str) -> MemberDayDigest:
+        from pocketpaw_ee.cloud.member_day_digest.service import member_day_digest
+
+        return await member_day_digest(
+            workspace_id,
+            member_id,
+            gmail_reader=_Disconnected(),
+            calendar_reader=_Disconnected(),
+        )
+
+    # Briefing: empty (gated solo session, but the digest is empty → no block).
+    block = await _member_briefing_block(_solo_ctx(ALICE), digest_fn=_disconnected_digest)
+    assert block == ""
+
+    # Digest API: empty digest, never an error.
+    with patch.object(digest_router, "member_day_digest", _disconnected_digest):
+        digest = await digest_router.get_member_day_digest(ctx=_req_ctx(ALICE))
+    assert digest.empty is True
+    assert digest.events == []
+    assert digest.unread_mail_count == 0
+
+
+async def test_purge_is_isolated_to_alice_bob_untouched(mongo_db):  # noqa: ARG001
+    """Purging A leaves B's scope fully intact — the purge target is a pure
+    function of A's opaque id, so it can never reach B's data."""
+    store = FakeKbStore()
+    await _seed_ingest(store, ALICE)
+    await _seed_ingest(store, BOB)
+    bob_before = list(store.scopes[f"user:{BOB}"])
+
+    class _NoTokens:
+        def delete(self, *_a, **_k) -> bool:
+            return False
+
+    await purge_member_data(
+        workspace_id=WS, member_id=ALICE, kb_clear=store.clear, token_store=_NoTokens()
+    )
+
+    assert f"user:{ALICE}" not in store.scopes  # Alice gone
+    assert store.scopes[f"user:{BOB}"] == bob_before  # Bob untouched
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _async_return(value: Any):
+    """A coroutine function that returns ``value`` — for patching the async
+    ``_candidate_scopes`` with a fixed allowlist."""
+
+    async def _fn(*_a: Any, **_k: Any) -> Any:
+        return value
+
+    return _fn

--- a/tests/cloud/workspace/test_dto.py
+++ b/tests/cloud/workspace/test_dto.py
@@ -102,7 +102,10 @@ def test_invite_dto_wire_keys() -> None:
         "revoked",
         "expired",
         "expiresAt",
+        "context",
     }
+    # No admin context on a plain invite — the key is present but null.
+    assert dump["context"] is None
 
 
 def test_invite_dto_values() -> None:

--- a/tests/cloud/workspace/test_remove_member_cascade.py
+++ b/tests/cloud/workspace/test_remove_member_cascade.py
@@ -6,6 +6,9 @@ Asserts that ``remove_member`` cascades through:
   populated for the per-token denylist)
 - Pending invites the user issued for this workspace
   (``revoked_reason='inviter_removed'``)
+- Phase B per-user data purge (chunk 7): the offboarded member's private
+  ``user:{id}`` KB scope, per-user OAuth tokens, per-user connector rows, and
+  ingest-state are deleted — a SECOND member in the same workspace is untouched
 - An audit-log row with the cascade counts in ``metadata``
 """
 
@@ -184,11 +187,17 @@ async def test_remove_member_audit_counts_zero_when_nothing_to_revoke(fake_redis
     ).to_list()
     assert len(audit_rows) == 1
     cascade = audit_rows[0].metadata.get("cascade") or {}
-    assert cascade == {
-        "api_keys_revoked": 0,
-        "sessions_revoked": 0,
-        "invites_revoked": 0,
-    }
+    # Phase B chunk 7 added the member-data purge as a 4th cascade. With nothing
+    # connected, the purge runs cleanly and reports zero deletes.
+    assert cascade["api_keys_revoked"] == 0
+    assert cascade["sessions_revoked"] == 0
+    assert cascade["invites_revoked"] == 0
+    purged = cascade["member_data_purged"]
+    assert purged is not None
+    assert purged["status"] == "ok"
+    assert purged["tokens_deleted"] == 0
+    assert purged["connectors_deleted"] == 0
+    assert purged["ingest_state_deleted"] is False
 
 
 async def test_remove_member_skips_already_revoked_api_keys(fake_redis) -> None:
@@ -218,3 +227,98 @@ async def test_remove_member_skips_already_revoked_api_keys(fake_redis) -> None:
         AuditEvent.action == "workspace.member_removed",
     ).to_list()
     assert audit_rows[0].metadata["cascade"]["api_keys_revoked"] == 1
+
+
+async def test_remove_member_purges_phase_b_data_and_isolates_other_member(
+    fake_redis, tmp_path, monkeypatch
+) -> None:
+    """Offboarding a member purges their Phase B per-user data; a SECOND member
+    in the same workspace keeps theirs (the isolation invariant at the trigger
+    level, not just inside purge_member_data)."""
+    from pocketpaw.clients.token_store import OAuthTokens, TokenStore
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+    from pocketpaw_ee.cloud.models.member_ingest_state import MemberIngestState
+
+    # Root the token store at a tmp dir + stub kb clear so no kb binary is hit.
+    monkeypatch.setattr("pocketpaw.clients.token_store.get_config_dir", lambda: tmp_path)
+    cleared: list[str] = []
+
+    async def _fake_kb_clear(scope: str) -> dict:
+        cleared.append(scope)
+        return {"cleared": scope}
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.member_ingest.purge._default_kb_clear", _fake_kb_clear)
+
+    owner = await _seed_user(email="owner@x.c")
+    target = await _seed_user(email="target@x.c")
+    bystander = await _seed_user(email="bystander@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service._add_member(ws.id, str(target.id), role="member")
+    await workspace_service._add_member(ws.id, str(bystander.id), role="member")
+
+    tid, bid = str(target.id), str(bystander.id)
+    store = TokenStore()
+
+    # Seed Phase B data for BOTH the target and the bystander.
+    for uid in (tid, bid):
+        store.save(OAuthTokens(service="google_gmail", access_token="g"), user_id=uid)
+        store.save(OAuthTokens(service="google_calendar", access_token="c"), user_id=uid)
+        await WorkspaceConnector(workspace=ws.id, name="gmail", scope="user", user_id=uid).insert()
+        await MemberIngestState(
+            workspace=ws.id, member_id=uid, backfill_done=True, status="ok"
+        ).insert()
+
+    # Offboard the target.
+    await workspace_service.remove_member(ws.id, tid, str(owner.id))
+
+    # Target's Phase B data is gone.
+    assert cleared == [f"user:{tid}"]
+    assert store.load("google_gmail", tid) is None
+    assert store.load("google_calendar", tid) is None
+    assert (
+        await WorkspaceConnector.find(
+            WorkspaceConnector.workspace == ws.id,
+            WorkspaceConnector.user_id == tid,
+        ).to_list()
+        == []
+    )
+    assert (
+        await MemberIngestState.find_one(
+            MemberIngestState.workspace == ws.id,
+            MemberIngestState.member_id == tid,
+        )
+        is None
+    )
+
+    # The bystander's Phase B data is fully intact.
+    assert store.load("google_gmail", bid) is not None
+    assert store.load("google_calendar", bid) is not None
+    assert (
+        len(
+            await WorkspaceConnector.find(
+                WorkspaceConnector.workspace == ws.id,
+                WorkspaceConnector.user_id == bid,
+            ).to_list()
+        )
+        == 1
+    )
+    assert (
+        await MemberIngestState.find_one(
+            MemberIngestState.workspace == ws.id,
+            MemberIngestState.member_id == bid,
+        )
+        is not None
+    )
+
+    # Audit row records what the purge removed.
+    audit_rows = await AuditEvent.find(
+        AuditEvent.workspace == ws.id,
+        AuditEvent.action == "workspace.member_removed",
+    ).to_list()
+    purged = audit_rows[0].metadata["cascade"]["member_data_purged"]
+    assert purged["status"] == "ok"
+    assert purged["tokens_deleted"] == 2
+    assert purged["connectors_deleted"] == 1
+    assert purged["ingest_state_deleted"] is True

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -830,6 +830,52 @@ async def test_preview_invite_revoked_expired_accepted(
     assert out["email"] == "acc@x.c"
 
 
+async def test_preview_invite_surfaces_admin_context(owner, monkeypatch) -> None:
+    """preview_invite exposes the invite's admin context to the member-facing
+    accept UI so the downstream VIP-onboarding flow can carry the invitee's
+    focus + profile_pic forward (pp#1365)."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="VP", slug="vp")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="vippreview@x.c",
+            context=InviteContextDTO(focus="Owns the launch checklist", profile_pic="file_vip"),
+        ),
+    )
+
+    out = await workspace_service.preview_invite(invite.token, viewer_user_id=None)
+    assert out["state"] == "ready_new"
+    assert out["context"] is not None
+    assert out["context"]["focus"] == "Owns the launch checklist"
+    assert out["context"]["profile_pic"] == "file_vip"
+
+
+async def test_preview_invite_no_context_is_absent(owner, monkeypatch) -> None:
+    """An invite minted without admin context previews with context None —
+    no regression to the existing preview shape for the common case."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="VN", slug="vn")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(email="plainpreview@x.c", role="member"),
+    )
+
+    out = await workspace_service.preview_invite(invite.token, viewer_user_id=None)
+    assert out["state"] == "ready_new"
+    assert out["context"] is None
+
+
 async def test_create_invite_cleans_up_expired_rows(owner, monkeypatch) -> None:
     """A previously-expired invite must not block a fresh invite to the same email."""
     monkeypatch.setattr(

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -36,6 +36,8 @@ from pocketpaw_ee.cloud._core.realtime.events import (
 )
 from pocketpaw_ee.cloud.models.invite import Invite as _InviteDoc
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.people import service as people_service
+from pocketpaw_ee.cloud.people.domain import PERSON_TYPE_ID, SOURCE_ADMIN_CONTEXT
 from pocketpaw_ee.cloud.workspace import service as workspace_service
 from pocketpaw_ee.cloud.workspace.dto import (
     BulkInviteRequest,
@@ -101,6 +103,35 @@ def resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
 @pytest.fixture
 async def owner() -> _UserDoc:
     return await _seed_user(email="owner@x.c", full_name="Owner")
+
+
+@pytest.fixture
+def person_store(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Inject a throwaway journal-backed FabricJournalStore into the people
+    service so accept_invite materializes the Person against an isolated
+    tmp journal instead of opening the real org journal at ~/.soul/.
+    Returns the store so tests can read back the materialized Person.
+    """
+    from soul_protocol.engine.journal import open_journal
+
+    from pocketpaw.fabric.journal_store import FabricJournalStore
+
+    journal = open_journal(tmp_path / "people_journal.db")
+    store = FabricJournalStore(journal)
+    store.bootstrap()
+    monkeypatch.setattr(people_service, "_default_store", lambda: store)
+    yield store
+    journal.close()
+
+
+async def _materialized_people(store) -> list:
+    from pocketpaw.fabric.models import FabricQuery
+
+    result = await store.query(
+        FabricQuery(type_id=PERSON_TYPE_ID, limit=10_000),
+        requester_scopes=None,
+    )
+    return result.objects
 
 
 # ---------------------------------------------------------------------------
@@ -699,6 +730,169 @@ async def test_accept_invite_context_readable(owner, resolver_mock, monkeypatch)
     assert row.context is not None
     assert row.context.focus == "Drives the design system"
     assert row.context.profile_pic == "pic_xyz"
+
+
+# ---------------------------------------------------------------------------
+# accept_invite → Fabric Person materialization (pp#1366)
+# ---------------------------------------------------------------------------
+
+
+async def test_accept_invite_materializes_person(
+    owner, resolver_mock, person_store, monkeypatch
+) -> None:
+    """Accepting an invite materializes a standalone Fabric Person holding
+    the member's identity + the invite's admin context, provenance-tracked."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    invitee = await _seed_user(email="newhire@x.c", full_name="New Hire")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="newhire@x.c",
+            role="admin",
+            context=InviteContextDTO(focus="Owns onboarding", profile_pic="pic_42"),
+        ),
+    )
+
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+    people = await _materialized_people(person_store)
+    assert len(people) == 1
+    obj = people[0]
+    assert obj.id == f"person-{ws.id}-{invitee.id}"
+    props = obj.properties
+    # Identity — from the member's own profile.
+    assert props["name"] == "New Hire"
+    assert props["email"] == "newhire@x.c"
+    # Role + onboarding — from the invite's admin context.
+    assert props["role"] == "admin"
+    assert props["focus"] == "Owns onboarding"
+    assert props["profile_pic"] == "pic_42"
+    # Provenance.
+    assert props["invited_by"] == str(owner.id)
+    assert props["source"] == SOURCE_ADMIN_CONTEXT
+    assert obj.source_connector == SOURCE_ADMIN_CONTEXT
+    assert obj.source_id == str(invitee.id)
+
+
+async def test_accept_invite_no_context_still_materializes_person(
+    owner, resolver_mock, person_store, monkeypatch
+) -> None:
+    """An invite with no admin context still produces a Person from the
+    member's identity — focus / profile_pic just empty."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    invitee = await _seed_user(email="plainhire@x.c", full_name="Plain Hire")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="B", slug="b")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="plainhire@x.c")
+    )
+
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+    people = await _materialized_people(person_store)
+    assert len(people) == 1
+    props = people[0].properties
+    assert props["name"] == "Plain Hire"
+    assert props["focus"] == ""
+    assert props["profile_pic"] == ""
+    assert props["source"] == SOURCE_ADMIN_CONTEXT
+
+
+async def test_accept_invite_person_is_idempotent_no_duplicate(
+    owner, resolver_mock, person_store, monkeypatch
+) -> None:
+    """Re-materializing the same member (e.g. a second invite + accept)
+    UPDATES the existing Person — one row, never a duplicate."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    invitee = await _seed_user(email="dup@x.c", full_name="Dup User")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="C", slug="c")
+    )
+
+    # First invite + accept.
+    invite1 = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="dup@x.c",
+            context=InviteContextDTO(focus="First focus"),
+        ),
+    )
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite1.token)
+
+    # Re-materialize directly with a revised invite context (same member /
+    # workspace) — simulates a re-run of the onboarding flow. Going through
+    # accept_invite a second time would 409 on the consumed token, so this
+    # exercises the materializer's upsert path head-on.
+    from pocketpaw_ee.cloud.workspace.domain import Invite, InviteContext
+
+    revised = Invite(
+        id=invite1.id,
+        workspace_id=ws.id,
+        email="dup@x.c",
+        role="member",
+        invited_by=str(owner.id),
+        token=None,
+        group_id=None,
+        accepted=True,
+        revoked=False,
+        expired=False,
+        expires_at=datetime.now(UTC),
+        context=InviteContext(focus="Second focus"),
+    )
+    await people_service.materialize_person_from_invite(
+        workspace_id=ws.id,
+        user_id=str(invitee.id),
+        name="Dup User",
+        email="dup@x.c",
+        avatar="",
+        invite=revised,
+    )
+
+    people = await _materialized_people(person_store)
+    assert len(people) == 1  # still one — not duplicated.
+    assert people[0].properties["focus"] == "Second focus"
+
+
+async def test_accept_invite_survives_person_materialization_failure(
+    owner, resolver_mock, monkeypatch
+) -> None:
+    """A Fabric/journal hiccup during materialization must NOT roll back an
+    accepted invite — membership is the source of truth."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+
+    async def _boom(**_kwargs):
+        raise RuntimeError("journal exploded")
+
+    monkeypatch.setattr(people_service, "materialize_person_from_invite", _boom)
+
+    invitee = await _seed_user(email="resilient@x.c", full_name="Resilient")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="D", slug="d")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="resilient@x.c")
+    )
+
+    # Should not raise despite the materialization failure.
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+    refreshed = await _UserDoc.get(invitee.id)
+    assert refreshed is not None
+    assert any(m.workspace == ws.id for m in refreshed.workspaces)
 
 
 async def test_create_invite_without_context_is_unchanged(owner, monkeypatch) -> None:

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -35,6 +35,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
     WorkspaceUpdated,
 )
 from pocketpaw_ee.cloud.models.invite import Invite as _InviteDoc
+from pocketpaw_ee.cloud.models.invite import hash_token
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
 from pocketpaw_ee.cloud.people import service as people_service
 from pocketpaw_ee.cloud.people.domain import PERSON_TYPE_ID, SOURCE_ADMIN_CONTEXT
@@ -490,6 +491,72 @@ async def test_accept_invite_rejects_revoked(owner, monkeypatch) -> None:
     assert exc.value.code == "invite.revoked"
 
 
+async def test_accept_invite_self_heals_missing_membership(owner, monkeypatch) -> None:
+    """An invite stamped accepted=True but with NO membership written (the
+    backend was restarted between the atomic claim and _add_member) must
+    converge on re-accept: the rightful invitee gets the membership instead
+    of an ``invite.already_accepted`` 409 that would lock them out forever.
+    """
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    # Simulate the burned invite: claimed (accepted=True) but the membership
+    # never landed, so the invitee has workspaces=[] and active_workspace=None.
+    invite_doc = _InviteDoc(
+        workspace=ws.id,
+        email="invitee@x.c",
+        role="member",
+        invited_by=str(owner.id),
+        token_hash=hash_token("tok-burned"),
+        accepted=True,
+        accepted_at=datetime.now(UTC),
+    )
+    await invite_doc.insert()
+    invitee = await _seed_user(email="invitee@x.c")
+    assert await workspace_service._get_member_role(ws.id, str(invitee.id)) is None
+
+    # Must NOT raise — it heals the missing membership.
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), "tok-burned")
+
+    assert await workspace_service._get_member_role(ws.id, str(invitee.id)) == "member"
+    refreshed = await _UserDoc.get(invitee.id)
+    assert refreshed is not None
+    assert refreshed.active_workspace == ws.id
+
+
+async def test_accept_invite_genuine_duplicate_still_raises(owner, monkeypatch) -> None:
+    """A user who IS already a member re-accepting an accepted invite still
+    hits ``invite.already_accepted`` — the self-heal only fires when the
+    membership is actually missing, not for real duplicate accepts.
+    """
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite_doc = _InviteDoc(
+        workspace=ws.id,
+        email="invitee@x.c",
+        role="member",
+        invited_by=str(owner.id),
+        token_hash=hash_token("tok-dup"),
+        accepted=True,
+        accepted_at=datetime.now(UTC),
+    )
+    await invite_doc.insert()
+    invitee = await _seed_user(email="invitee@x.c")
+    # This user is already a member of the workspace.
+    await workspace_service._add_member(ws.id, str(invitee.id), role="member")
+
+    with pytest.raises(ConflictError) as exc:
+        await workspace_service.accept_invite(_ctx(str(invitee.id)), "tok-dup")
+    assert exc.value.code == "invite.already_accepted"
+
+
 async def test_revoke_invite_emits_invite_revoked(owner, recording_bus, monkeypatch) -> None:
     monkeypatch.setattr(
         "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
@@ -552,7 +619,6 @@ async def test_create_invite_hashes_token_at_rest(
 
     # The DB row stores the HASH, not the plaintext.
     from pocketpaw_ee.cloud.models.invite import Invite as _D
-    from pocketpaw_ee.cloud.models.invite import hash_token
 
     row = await _D.find_one(_D.token_hash == hash_token(invite.token))
     assert row is not None
@@ -1426,8 +1492,6 @@ async def test_resend_invite_returns_new_plaintext(owner, monkeypatch) -> None:
     new_plaintext = result["token"]
     assert isinstance(new_plaintext, str) and len(new_plaintext) >= 32
     assert new_plaintext != original.token
-
-    from pocketpaw_ee.cloud.models.invite import hash_token
 
     row = await _InviteDoc.get(PydanticObjectId(original.id))
     assert row is not None

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -41,7 +41,9 @@ from pocketpaw_ee.cloud.workspace.dto import (
     BulkInviteRequest,
     CreateInviteRequest,
     CreateWorkspaceRequest,
+    InviteContextDTO,
     UpdateWorkspaceRequest,
+    invite_to_dto,
 )
 
 pytestmark = pytest.mark.usefixtures("mongo_db")
@@ -605,6 +607,119 @@ async def test_accept_invite_case_insensitive_email(mongo_db: Any, monkeypatch) 
     )
     # Should succeed — email comparison is case-insensitive.
     await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+
+# ---------------------------------------------------------------------------
+# Invite admin context — optional VIP-onboarding payload (pp#1365)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_invite_persists_admin_context(owner, monkeypatch) -> None:
+    """create_invite(...) with a context round-trips: the returned domain
+    object carries it AND the persisted row stores it."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="vip@x.c",
+            context=InviteContextDTO(focus="Owns the Q3 pricing rollout", profile_pic="file_abc"),
+        ),
+    )
+
+    # Returned domain object carries the context.
+    assert invite.context is not None
+    assert invite.context.focus == "Owns the Q3 pricing rollout"
+    assert invite.context.profile_pic == "file_abc"
+
+    # The persisted row stores it too.
+    row = await _InviteDoc.find_one(_InviteDoc.id == PydanticObjectId(invite.id))
+    assert row is not None
+    assert row.context is not None
+    assert row.context.focus == "Owns the Q3 pricing rollout"
+    assert row.context.profile_pic == "file_abc"
+
+
+async def test_create_invite_context_surfaces_on_validate_dto(owner, monkeypatch) -> None:
+    """The context survives the read path: validate_invite -> invite_to_dto
+    returns it on the wire response (the shape paw-enterprise consumes)."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="vip2@x.c",
+            context=InviteContextDTO(focus="Leads onboarding"),
+        ),
+    )
+
+    read_invite, _ws_name = await workspace_service.validate_invite(invite.token)
+    dto = invite_to_dto(read_invite)
+    assert dto.context is not None
+    assert dto.context.focus == "Leads onboarding"
+    assert dto.context.profile_pic is None
+
+
+async def test_accept_invite_context_readable(owner, resolver_mock, monkeypatch) -> None:
+    """At accept time the invite's admin context is readable for the
+    downstream VIP-onboarding flow."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    invitee = await _seed_user(email="acceptctx@x.c")
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)),
+        ws.id,
+        CreateInviteRequest(
+            email="acceptctx@x.c",
+            context=InviteContextDTO(focus="Drives the design system", profile_pic="pic_xyz"),
+        ),
+    )
+
+    await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
+
+    # The accepted row still carries the context — readable in the accept
+    # path / by any downstream onboarding consumer.
+    row = await _InviteDoc.find_one(_InviteDoc.id == PydanticObjectId(invite.id))
+    assert row is not None
+    assert row.accepted is True
+    assert row.context is not None
+    assert row.context.focus == "Drives the design system"
+    assert row.context.profile_pic == "pic_xyz"
+
+
+async def test_create_invite_without_context_is_unchanged(owner, monkeypatch) -> None:
+    """Omitting context behaves exactly as before — no context stored,
+    no context on the returned domain object or DTO."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
+    )
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    invite = await workspace_service.create_invite(
+        _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="plain@x.c")
+    )
+
+    assert invite.context is None
+    assert invite_to_dto(invite).context is None
+
+    row = await _InviteDoc.find_one(_InviteDoc.id == PydanticObjectId(invite.id))
+    assert row is not None
+    assert row.context is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -1,10 +1,18 @@
 # Tests for integrations/gmail.py and tools/builtin/gmail.py
 # Created: 2026-02-07
+# 2026-06-08: added TestGmailClientPerUser to lock GmailClient(user_id=...)
+#   resolving its token from that user's bucket end-to-end (VIP Onboarding
+#   Phase B), proving the user_id threads constructor -> OAuthManager ->
+#   TokenStore.
 
 import base64
+import time
 from unittest.mock import patch
 
+import pytest
+
 from pocketpaw.clients.gmail import GmailClient
+from pocketpaw.clients.token_store import OAuthTokens, TokenStore
 from pocketpaw.tools.builtin.gmail import GmailReadTool, GmailSearchTool, GmailSendTool
 
 # ---------------------------------------------------------------------------
@@ -117,3 +125,52 @@ async def test_gmail_send_no_auth():
     ):
         result = await tool.execute(to="x@x.com", subject="Hi", body="Test")
         assert "Error" in result
+
+
+# ---------------------------------------------------------------------------
+# GmailClient per-user token resolution (VIP Onboarding Phase B)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def oauth_dir(tmp_path, monkeypatch):
+    """Point the token store at a temp oauth dir for both store + manager."""
+    monkeypatch.setattr("pocketpaw.clients.token_store._get_oauth_dir", lambda: tmp_path)
+    return tmp_path
+
+
+async def test_gmail_client_resolves_per_user_token(oauth_dir):
+    """GmailClient(user_id='alice') pulls alice's fresh token, not bob's.
+
+    End-to-end through the real OAuthManager + TokenStore — proves the
+    user_id threads constructor -> get_valid_token -> store.load(user_id=...).
+    """
+    store = TokenStore()
+    store.save(
+        OAuthTokens(
+            service="google_gmail", access_token="alice_tok", expires_at=time.time() + 3600
+        ),
+        user_id="alice",
+    )
+    store.save(
+        OAuthTokens(service="google_gmail", access_token="bob_tok", expires_at=time.time() + 3600),
+        user_id="bob",
+    )
+
+    assert await GmailClient(user_id="alice")._get_token() == "alice_tok"
+    assert await GmailClient(user_id="bob")._get_token() == "bob_tok"
+
+
+async def test_gmail_client_default_user_is_shared_bucket(oauth_dir):
+    """GmailClient() (no user_id) keeps reading the legacy shared bucket."""
+    store = TokenStore()
+    store.save(
+        OAuthTokens(
+            service="google_gmail", access_token="shared_tok", expires_at=time.time() + 3600
+        )
+    )
+
+    assert await GmailClient()._get_token() == "shared_tok"
+    # A per-user client must NOT see the shared token.
+    with pytest.raises(RuntimeError, match="not authenticated"):
+        await GmailClient(user_id="alice")._get_token()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,5 +1,8 @@
 # Tests for integrations/oauth.py and integrations/token_store.py
 # Created: 2026-02-07
+# 2026-06-08: added TestTokenStorePerUser + TestOAuthManagerPerUser to lock
+#   per-(service, user_id) token isolation and the user_id=None back-compat
+#   default (foundation for VIP Onboarding Phase B).
 
 import stat
 import sys
@@ -71,6 +74,115 @@ class TestTokenStore:
         assert mode & stat.S_IWUSR
         assert not (mode & stat.S_IRGRP)
         assert not (mode & stat.S_IROTH)
+
+
+# ---------------------------------------------------------------------------
+# TokenStore — per-user isolation (VIP Onboarding Phase B foundation)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenStorePerUser:
+    """Tokens are keyed by (service, user_id), not service alone.
+
+    Back-compat invariant: user_id=None writes/reads the legacy
+    ``{service}.json`` path so existing single-user installs keep working.
+    """
+
+    def test_two_users_same_service_do_not_collide(self, store):
+        """Alice and Bob both connect Gmail — their tokens stay separate."""
+        store.save(OAuthTokens(service="google_gmail", access_token="alice_tok"), user_id="alice")
+        store.save(OAuthTokens(service="google_gmail", access_token="bob_tok"), user_id="bob")
+
+        alice = store.load("google_gmail", user_id="alice")
+        bob = store.load("google_gmail", user_id="bob")
+        assert alice is not None and alice.access_token == "alice_tok"
+        assert bob is not None and bob.access_token == "bob_tok"
+
+    def test_user_scoped_token_invisible_to_default_bucket(self, store):
+        """A per-user token must not leak into the service-only (None) bucket."""
+        store.save(OAuthTokens(service="google_gmail", access_token="alice_tok"), user_id="alice")
+        assert store.load("google_gmail") is None
+        assert store.load("google_gmail", user_id="bob") is None
+
+    def test_default_bucket_is_legacy_path(self, store, tmp_path):
+        """user_id=None writes the exact legacy ``{service}.json`` file."""
+        store.save(OAuthTokens(service="google_gmail", access_token="legacy"))
+        assert (tmp_path / "google_gmail.json").exists()
+        loaded = store.load("google_gmail")
+        assert loaded is not None and loaded.access_token == "legacy"
+
+    def test_legacy_file_still_loads_after_rekey(self, store, tmp_path):
+        """A token file written the OLD way (no user_id) still loads.
+
+        Simulates an existing install: the file predates the per-user key,
+        so it has no ``user_id`` field in its JSON. ``user_id=None`` load
+        must find it.
+        """
+        import json
+
+        legacy = {
+            "service": "google_calendar",
+            "access_token": "old_access",
+            "refresh_token": "old_refresh",
+            "token_type": "Bearer",
+            "expires_at": None,
+            "scopes": [],
+            "extra": {},
+        }
+        (tmp_path / "google_calendar.json").write_text(json.dumps(legacy))
+
+        loaded = store.load("google_calendar")
+        assert loaded is not None
+        assert loaded.access_token == "old_access"
+        assert loaded.refresh_token == "old_refresh"
+
+    def test_delete_is_user_scoped(self, store):
+        """Deleting alice's token leaves bob's and the default bucket intact."""
+        store.save(OAuthTokens(service="google_gmail", access_token="default"))
+        store.save(OAuthTokens(service="google_gmail", access_token="alice"), user_id="alice")
+        store.save(OAuthTokens(service="google_gmail", access_token="bob"), user_id="bob")
+
+        assert store.delete("google_gmail", user_id="alice") is True
+        assert store.load("google_gmail", user_id="alice") is None
+        # Bob and the default bucket untouched.
+        assert store.load("google_gmail", user_id="bob").access_token == "bob"
+        assert store.load("google_gmail").access_token == "default"
+
+    def test_email_like_user_id_is_filesystem_safe(self, store):
+        """A user_id that looks like an email (or has path chars) is sanitized.
+
+        It must not escape the oauth dir and must round-trip cleanly.
+        """
+        store.save(
+            OAuthTokens(service="google_gmail", access_token="email_tok"),
+            user_id="prakash@snctm.com",
+        )
+        loaded = store.load("google_gmail", user_id="prakash@snctm.com")
+        assert loaded is not None and loaded.access_token == "email_tok"
+        # Distinct user_ids that sanitize to the same disk name must not
+        # be possible to confuse — a different email is a different bucket.
+        assert store.load("google_gmail", user_id="other@snctm.com") is None
+
+    def test_user_id_with_path_traversal_is_contained(self, store, tmp_path):
+        """A malicious user_id can't write outside the oauth dir."""
+        store.save(
+            OAuthTokens(service="google_gmail", access_token="evil"),
+            user_id="../../etc/passwd",
+        )
+        # Nothing was written above tmp_path.
+        assert not (tmp_path.parent / "etc").exists()
+        # But it still round-trips within the store.
+        loaded = store.load("google_gmail", user_id="../../etc/passwd")
+        assert loaded is not None and loaded.access_token == "evil"
+
+    def test_list_services_dedupes_across_users(self, store):
+        """list_services reports each service once even with multiple users."""
+        store.save(OAuthTokens(service="google_gmail", access_token="a"), user_id="alice")
+        store.save(OAuthTokens(service="google_gmail", access_token="b"), user_id="bob")
+        store.save(OAuthTokens(service="google_calendar", access_token="c"))
+
+        services = store.list_services()
+        assert sorted(services) == ["google_calendar", "google_gmail"]
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +283,133 @@ async def test_get_valid_token_not_found(store):
         client_secret="secret",
     )
     assert token is None
+
+
+# ---------------------------------------------------------------------------
+# OAuthManager — per-user threading (VIP Onboarding Phase B foundation)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_valid_token_is_user_scoped(store):
+    """get_valid_token(user_id=...) only sees that user's fresh token."""
+    store.save(
+        OAuthTokens(
+            service="google_gmail",
+            access_token="alice_fresh",
+            expires_at=time.time() + 3600,
+        ),
+        user_id="alice",
+    )
+    manager = OAuthManager(store)
+
+    alice = await manager.get_valid_token(
+        service="google_gmail", client_id="id", client_secret="secret", user_id="alice"
+    )
+    assert alice == "alice_fresh"
+    # Bob has nothing; the default bucket has nothing.
+    assert (
+        await manager.get_valid_token(
+            service="google_gmail", client_id="id", client_secret="secret", user_id="bob"
+        )
+        is None
+    )
+    assert (
+        await manager.get_valid_token(
+            service="google_gmail", client_id="id", client_secret="secret"
+        )
+        is None
+    )
+
+
+async def test_exchange_code_persists_under_user_id(store, monkeypatch):
+    """exchange_code(user_id=...) stamps + stores the token in that user's bucket."""
+    from unittest.mock import MagicMock, patch
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, data=None):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json = MagicMock(
+                return_value={
+                    "access_token": "alice_access",
+                    "refresh_token": "alice_refresh",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }
+            )
+            return resp
+
+    with patch("pocketpaw.clients.oauth.httpx.AsyncClient", _FakeClient):
+        manager = OAuthManager(store)
+        tokens = await manager.exchange_code(
+            provider="google",
+            service="google_gmail",
+            code="auth_code",
+            client_id="cid",
+            client_secret="csec",
+            redirect_uri="http://localhost/cb",
+            scopes=["https://mail.google.com/"],
+            user_id="alice",
+        )
+
+    assert tokens.access_token == "alice_access"
+    # Landed in alice's bucket, NOT the default one.
+    assert store.load("google_gmail", user_id="alice").access_token == "alice_access"
+    assert store.load("google_gmail") is None
+
+
+async def test_refresh_token_is_user_scoped(store):
+    """refresh_token(user_id=...) refreshes + re-saves that user's row only."""
+    from unittest.mock import MagicMock, patch
+
+    store.save(
+        OAuthTokens(
+            service="google_gmail",
+            access_token="stale",
+            refresh_token="alice_refresh",
+            expires_at=time.time() - 60,
+        ),
+        user_id="alice",
+    )
+
+    class _FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, data=None):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json = MagicMock(return_value={"access_token": "alice_new", "expires_in": 3600})
+            return resp
+
+    with patch("pocketpaw.clients.oauth.httpx.AsyncClient", _FakeClient):
+        manager = OAuthManager(store)
+        refreshed = await manager.refresh_token(
+            provider="google",
+            service="google_gmail",
+            client_id="cid",
+            client_secret="csec",
+            user_id="alice",
+        )
+
+    assert refreshed is not None and refreshed.access_token == "alice_new"
+    # Re-saved into alice's bucket.
+    assert store.load("google_gmail", user_id="alice").access_token == "alice_new"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# VIP Onboarding — full feature (v1 Warm Welcome + Phase B Pre-Briefed agent)

Consolidates both phases of VIP onboarding onto one branch off `dev` so the whole arc reviews + tests together.

## What an invited member gets
1. **Warm welcome (v1):** an admin invites them with context — role · team · a one-line focus · a profile pic. That context rides the invite, materializes them as a Fabric `Person` on accept, and the workspace agent greets them by name from the first turn.
2. **Pre-briefed agent (Phase B):** at onboarding they consent to connect their *own* Gmail + calendar. It ingests — privately, per-member — into a `user:{id}` KB scope, and the agent is briefed with their real day, plus a "your day" digest. Strictly member-private: one member's data never reaches another member's session.

## Backend (this repo)
- **v1:** invite `context`, Fabric `Person` on accept, context on the invite preview, the additive about-member block in the system message.
- **Phase B:** per-user OAuth tokens, the session-gated `user:` KB scope (plus the REST scope-override guard that closed a P0 cross-member leak — and a pre-existing cross-pocket one), the per-user ingest worker, the digest service + gated read API, and purge on disconnect/offboard.

## Verification
The merge was checked: v1's about-block and Phase B's gate/briefing coexist — **70 tests pass** across the about-block, isolation gate, briefing, and the cross-cutting e2e (which walks all four leak doors as one member trying to reach another's data). Each chunk was unit-tested + reviewed before merge; a security pass found and closed the P0 leak.

Supersedes #1375 (v1 backend). Frontend half: paw-enterprise `integration/vip-onboarding-full`. Smoke test: `docs/playbooks/2026-06-08-vip-onboarding-phaseb-smoke-test.md`.
