### PR TITLE
feat(sites): premium ripple-mode landings — marketing-hero, FAQ, CSS richness

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,12 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated 2026-06-09 (feat/landing-assembler-enrich): the create_landing_site
+# tool + content schema now document the OPTIONAL ``faqs`` copy field
+# ([{question, answer}]) the enriched ``assemble_landing_spec`` consumes to emit a
+# native-<details> FAQ section. No handler-logic change — the assembler owns the
+# structure; this just teaches the chat agent the new field exists.
+#
 # Updated: 2026-06-04 (feat/sites-svelte-engine) — added the SECOND deterministic
 # create tool ``create_svelte_site`` for the Paw Sites "Svelte track". It mirrors
 # ``create_landing_site`` (same direct ``agent_create`` persistence, same
@@ -290,9 +296,11 @@ def make_create_landing_site_tool(tool: Any) -> Any:
             "'TBD'/'Lorem ipsum'): brand (str); hero {eyebrow, title, subtitle, "
             "cta_label}; services [{title, desc, icon}]; testimonials [{quote, "
             "author, role}]; tiers [{name, price, period, features:[str], "
-            "popular, cta_label}]; cta_band {headline, subtext, button_label}; "
-            "contact {address, phone, email}; footer {copyright}. Variable-length "
-            "services/testimonials/tiers are handled. Returns {ok, pocket_id, "
+            "popular, cta_label}]; faqs [{question, answer}] (OPTIONAL — renders a "
+            "native-<details> FAQ section after pricing; omit it and no FAQ shows); "
+            "cta_band {headline, subtext, button_label}; contact {address, phone, "
+            "email}; footer {copyright}. Variable-length "
+            "services/testimonials/tiers/faqs are handled. Returns {ok, pocket_id, "
             "pocket}; hand `pocket_id` to "
             "`mcp__pocketpaw_sites_manager__publish` to publish. ok=false with an "
             "error means relay the reason, do NOT report a created pocket."
@@ -304,8 +312,9 @@ def make_create_landing_site_tool(tool: Any) -> Any:
                     "type": "object",
                     "description": (
                         "The COPY for the landing page — words only, no structure. "
-                        "brand, hero, services, testimonials, tiers, cta_band, "
-                        "contact, footer (see the tool description for the shape)."
+                        "brand, hero, services, testimonials, tiers, faqs "
+                        "(optional), cta_band, contact, footer (see the tool "
+                        "description for the shape)."
                     ),
                     "additionalProperties": True,
                 },

--- a/ee/pocketpaw_ee/sites/landing_assembler.py
+++ b/ee/pocketpaw_ee/sites/landing_assembler.py
@@ -12,26 +12,52 @@
 # ``mcp__pocketpaw_sites_manager__create_landing_site``, which runs this
 # assembler and persists the result directly.
 #
+# Updated 2026-06-09 (feat/landing-assembler-enrich — premium ripple marketing
+# pack, ripple PR #67):
+#   * The hero is now the bespoke ``marketing-hero`` widget (was the borrowed
+#     dashboard ``hero``). marketing-hero bakes in its OWN premium CSS visual — an
+#     asymmetric panel with a dot-grid texture, a slow CSS-@keyframes glow drift,
+#     and a static spec chip — all pure CSS, so it renders fully under csr=false
+#     (the resting state is complete with JS off; the drift is enhancement, not
+#     structure, and reduced-motion disables it). The borrowed ``hero`` dropped
+#     its CTA on the floor; marketing-hero carries a primary CTA (→ #book) plus an
+#     optional secondary "see services" ghost CTA (→ #services).
+#   * NEW optional FAQ section (the ``faq`` widget) between pricing and the CTA
+#     band — native <details>/<summary> disclosures that expand with ZERO client
+#     JS (JS-off safe), fed from a new ``faqs`` copy field. Omitted entirely when
+#     no faqs are supplied (the funnel stays lean).
+#   * csr/motion stance: these sites prerender with ``csr=false`` (verified in the
+#     generator's templates/src/routes/+layout.ts.tmpl). So JS-driven motion
+#     (ripple ``reveal``/``parallax``/``spotlight``) NEVER attaches and is NOT
+#     wired — it would be dead weight. All premium richness here is CSS-only
+#     (baked into marketing-hero) and therefore static-safe. Enabling hydration
+#     (csr=true) is what would unlock scroll-reveal motion; that is out of scope.
+#
 # The emitted structure mirrors the renderer-VALID bundled landing skeleton
 # (``src/pocketpaw/bundled_templates/_bundled/landing-page/ripple_spec.json``)
-# section-for-section — same widget kinds, same SSR-safe props — but every copy
-# value comes from ``content`` and the variable-length collections (services /
-# testimonials / tiers) drive real loops. The fixed conversion order is:
+# section-for-section — same SSR-safe props — but the hero is upgraded to
+# marketing-hero, an optional FAQ is added, every copy value comes from
+# ``content``, and the variable-length collections (services / testimonials /
+# tiers / faqs) drive real loops. The fixed conversion order is:
 #
-#   navbar → hero → section#services[feature-grid] → section#reviews[testimonial*
-#   (+ optional logo-cloud)] → section#pricing[pricing-table.tiers] → cta band →
-#   card#book[flat input/textarea/button lead form] → footer
+#   navbar → marketing-hero → section#services[feature-grid] →
+#   section#reviews[testimonial* (+ optional logo-cloud)] →
+#   section#pricing[pricing-table.tiers] → section#faq[faq] (optional) →
+#   cta band → card#book[flat input/textarea/button lead form] → footer
 #
 # Hard-coded SSR contract (all by construction, never the LLM's choice):
-#   * section/card ``id`` anchors (#services/#reviews/#pricing/#book) — marketing
-#     widgets carry no id of their own, so anchor targets live on the wrappers.
+#   * section/card ``id`` anchors (#services/#reviews/#pricing/#faq/#book) —
+#     marketing widgets carry no id of their own, so anchor targets live on the
+#     wrappers.
 #   * input/textarea ``name`` POST fields so the native outer-form submit maps a
 #     lead (rule 1: FLAT inputs, never a nested ``form``/``newsletter`` widget).
-#   * anchor ``href`` CTAs everywhere (navbar.ctaHref, cta.href, footer/nav link
-#     hrefs) — never ``on_click`` (rule 4: a click handler is dead on a static
-#     page).
+#   * anchor ``href`` CTAs everywhere (navbar.ctaHref, marketing-hero.ctaHref +
+#     secondaryCtaHref, cta.href, footer/nav link hrefs) — never ``on_click``
+#     (rule 4: a click handler is dead on a static page).
 #   * pricing-table uses ``tiers`` (rule 2), currency is the ``$`` symbol, tier
 #     ``cta`` is a string label.
+#   * FAQ uses the ``faq`` widget (native <details>), NEVER ``accordion`` (rule 3:
+#     a bits-ui accordion won't open with JS off).
 
 from __future__ import annotations
 
@@ -42,6 +68,7 @@ from typing import Any
 _ANCHOR_SERVICES = "services"
 _ANCHOR_REVIEWS = "reviews"
 _ANCHOR_PRICING = "pricing"
+_ANCHOR_FAQ = "faq"
 _ANCHOR_BOOK = "book"
 
 # A small default icon rotation for services that omit an ``icon``, so a
@@ -86,18 +113,37 @@ def _navbar(content: dict[str, Any]) -> dict[str, Any]:
 
 
 def _hero(content: dict[str, Any]) -> dict[str, Any]:
+    """The page opener — the bespoke ``marketing-hero`` (NOT the borrowed
+    dashboard ``hero``).
+
+    marketing-hero carries the CTAs the old ``hero`` dropped: a primary CTA wired
+    to the lead-form anchor (``#book``) and an optional secondary "see services"
+    ghost CTA (``#services``). ``visual='grid'`` selects the premium asymmetric
+    panel (CSS dot-grid + a slow CSS-keyframes glow drift + a static spec chip);
+    it is pure CSS, so the panel renders as a finished composition under
+    ``csr=false`` with no client JS. ``align='left'`` keeps the split layout (the
+    widget forces center only when ``visual='plain'``). All four props are SSR-
+    inert — the only motion is the declarative CSS drift, disabled under
+    prefers-reduced-motion.
+    """
     hero = content.get("hero") or {}
-    # ``hero`` has no CTA prop — the call-to-action lives in the navbar + the cta
-    # band, so we don't emit one here (it would silently drop).
-    return {
-        "type": "hero",
-        "props": {
-            "eyebrow": _s(hero.get("eyebrow")),
-            "title": _s(hero.get("title"), "A headline that sells"),
-            "subtitle": _s(hero.get("subtitle")),
-            "align": "center",
-        },
+    cta_label = _s(hero.get("cta_label"), "Get in touch")
+    props: dict[str, Any] = {
+        "eyebrow": _s(hero.get("eyebrow")),
+        "title": _s(hero.get("title"), "A headline that sells"),
+        "subtitle": _s(hero.get("subtitle")),
+        # Primary CTA → the lead form. ``cta`` is a STRING label; the destination
+        # is the SEPARATE ``ctaHref`` (never nested) — same split as the navbar.
+        "cta": cta_label,
+        "ctaHref": f"#{_ANCHOR_BOOK}",
+        # Secondary ghost CTA jumps to the services section, which always renders.
+        "secondaryCta": "See our services",
+        "secondaryCtaHref": f"#{_ANCHOR_SERVICES}",
+        # Premium CSS visual panel; static-safe (no client JS needed to paint it).
+        "visual": "grid",
+        "align": "left",
     }
+    return {"type": "marketing-hero", "props": props}
 
 
 def _services_section(content: dict[str, Any]) -> dict[str, Any]:
@@ -196,6 +242,46 @@ def _pricing_section(content: dict[str, Any]) -> dict[str, Any]:
                 # ``currency`` is the SYMBOL, not a code; the required array prop
                 # is ``tiers`` (never ``plans``/``columns``).
                 "props": {"currency": "$", "tiers": tiers},
+            }
+        ],
+    }
+
+
+def _faq_section(content: dict[str, Any]) -> dict[str, Any] | None:
+    """The optional FAQ section — the ``faq`` widget wrapped in ``section#faq``.
+
+    Built from ``content['faqs']`` (a list of ``{question, answer}``). Returns
+    ``None`` when no usable Q/A pairs are supplied, so the funnel stays lean
+    rather than rendering an empty disclosure list. The ``faq`` widget emits
+    native ``<details>``/``<summary>`` — it expands with ZERO client JS, so the
+    answers live in the markup and a JS-off visitor reads the full section (rule
+    3: never an ``accordion``, which only opens under client JS). Placed between
+    pricing and the CTA band: a visitor weighing the price gets their objections
+    answered immediately before the final ask.
+    """
+    faqs_in = content.get("faqs") or []
+    items: list[dict[str, str]] = []
+    for faq in faqs_in:
+        if not isinstance(faq, dict):
+            continue
+        question = _s(faq.get("question") or faq.get("q"))
+        answer = _s(faq.get("answer") or faq.get("a"))
+        # A disclosure with no question is meaningless; require at least the
+        # question (an empty answer would still render an openable-but-blank row,
+        # so require both for a useful entry).
+        if not question or not answer:
+            continue
+        items.append({"question": question, "answer": answer})
+    if not items:
+        return None
+    title = _s(content.get("faq_title"), "Questions, answered")
+    return {
+        "type": "section",
+        "props": {"id": _ANCHOR_FAQ},
+        "children": [
+            {
+                "type": "faq",
+                "props": {"title": title, "items": items},
             }
         ],
     }
@@ -336,6 +422,9 @@ def assemble_landing_spec(content: dict[str, Any]) -> dict[str, Any]:
           "testimonials": [{"quote", "author", "role"}],     # variable length
           "tiers": [{"name", "price", "period", "features": [str],
                      "popular": bool, "cta_label": str}],     # variable length
+          "faqs": [{"question", "answer"}],                  # optional; section
+                                                             # omitted when empty
+          "faq_title": str,                                  # optional heading
           "cta_band": {"headline", "subtext", "button_label"},
           "contact": {"address", "phone", "email"},
           "footer": {"copyright"},
@@ -348,16 +437,26 @@ def assemble_landing_spec(content: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(content, dict):
         raise TypeError("assemble_landing_spec expects a content dict (copy only)")
 
+    # The fixed conversion funnel. The FAQ section is the one OPTIONAL node — it
+    # sits between pricing and the CTA band, and is dropped entirely when no
+    # usable Q/A pairs were supplied (``_faq_section`` returns None).
     children: list[dict[str, Any]] = [
         _navbar(content),
         _hero(content),
         _services_section(content),
         _reviews_section(content),
         _pricing_section(content),
-        _cta_band(content),
-        _lead_form_card(content),
-        _footer(content),
     ]
+    faq = _faq_section(content)
+    if faq is not None:
+        children.append(faq)
+    children.extend(
+        [
+            _cta_band(content),
+            _lead_form_card(content),
+            _footer(content),
+        ]
+    )
 
     return {
         "version": "1.0",

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
@@ -81,6 +81,11 @@ giving it real, on-domain words. The shape:
     { "name": "Whitening",        "price": "299",   "period": "one-time", "features": ["In-office session", "Up to 8 shades", "Take-home trays"], "popular": true, "cta_label": "Book" },
     { "name": "Invisalign",       "price": "3,900", "period": "full plan", "features": ["Custom aligners", "All visits", "Retainers included"],   "cta_label": "Free consult" }
   ],
+  "faqs": [
+    { "question": "How long does a first visit take?", "answer": "About 45 minutes — a cleaning, a full check, and a plan you'll actually understand." },
+    { "question": "Do you take my insurance?",         "answer": "We bill all major plans directly and confirm your coverage before the appointment." },
+    { "question": "Can I reschedule online?",          "answer": "Yes — change or cancel from the confirmation email up to 24 hours ahead." }
+  ],
   "cta_band": {
     "headline": "Ready for a healthier smile?",
     "subtext": "Same-week appointments are filling up.",
@@ -101,7 +106,10 @@ giving it real, on-domain words. The shape:
 - **`hero`** — `eyebrow` (short category line), `title` (the headline
   promise), `subtitle` (one sentence on the offer/location/why-easy),
   `cta_label` (the primary button label — the tool wires it to the lead
-  form anchor).
+  form anchor). The tool renders this as a premium **marketing hero**: a
+  bold headline with an asymmetric CSS visual panel and two CTAs (your
+  `cta_label` → the lead form, plus a "see our services" link). The visual
+  is pure CSS, so it looks finished even with JavaScript off.
 - **`services`** — a list of `{title, desc, icon}`. `icon` is a **lucide
   icon name** (e.g. `tooth`, `sparkles`, `shield`, `smile`); omit it and
   the tool picks one. Variable length — give as many as the business has.
@@ -111,6 +119,14 @@ giving it real, on-domain words. The shape:
   popular?, cta_label}`. `price` is a string or number **without** a
   currency symbol (the tool renders `$`); `features` is a list of strings;
   mark the recommended tier `"popular": true`. Variable length.
+- **`faqs`** — *optional* — a list of `{question, answer}` pairs. The tool
+  renders them as a FAQ section (native expand/collapse, no JavaScript
+  needed) placed right after pricing, where it answers objections before
+  the final ask. Omit it entirely and the section simply doesn't appear.
+  Each pair needs both a `question` and an `answer` — entries missing
+  either are dropped. Add a `faq_title` to override the default "Questions,
+  answered" heading. Worth including whenever the business has the obvious
+  "how long / how much / do you take my insurance" questions.
 - **`cta_band`** — the mid-page conversion nudge: `{headline, subtext,
   button_label}`.
 - **`contact`** — `{address, phone, email}`. Feeds the footer and the lead
@@ -164,29 +180,37 @@ maps to the page. The tool emits, top to bottom (the conversion funnel):
 | # | Section | Built from your copy |
 |---|---------|----------------------|
 | 1 | **navbar** (sticky, brand + anchor links + CTA) | `brand`, `hero.cta_label` |
-| 2 | **hero** (eyebrow + title + subtitle) | `hero` |
-| 3 | **feature-grid** under `#services` | `services[]` |
+| 2 | **marketing-hero** (eyebrow pill + headline + subtitle + two CTAs + CSS visual panel) | `hero` |
+| 3 | **feature-grid** (lucide icons) under `#services` | `services[]` |
 | 4 | **testimonial** per quote under `#reviews` | `testimonials[]` |
 | 5 | **pricing-table** (`tiers`) under `#pricing` | `tiers[]` |
-| 6 | **cta** band | `cta_band` |
-| 7 | **flat lead form** in a `#book` card (input/textarea/submit) | `contact`, `cta_band.button_label` |
-| 8 | **footer** (titled columns + copyright) | `contact`, `footer`, `brand` |
+| 6 | **faq** (native `<details>`) under `#faq` — *only if `faqs` supplied* | `faqs[]`, `faq_title` |
+| 7 | **cta** band | `cta_band` |
+| 8 | **flat lead form** in a `#book` card (input/textarea/submit) | `contact`, `cta_band.button_label` |
+| 9 | **footer** (titled columns + copyright) | `contact`, `footer`, `brand` |
 
 The page is **prerendered static HTML** (`csr=false`) — no client JS runs
-for the visitor on first paint. The tool bakes in every SSR rule by
-construction, so you never have to think about them:
+for the visitor on first paint. Everything visible is baked into the
+markup: the hero's CSS visual, every FAQ answer, the full page. Any
+premium polish is CSS-only (gradients, a slow background drift) so it
+paints with JavaScript off; nothing waits for a script. The tool bakes in
+every SSR rule by construction, so you never have to think about them:
 
 - The lead form is **flat** `input` / `textarea` / `button{type:submit}`
   with real `name`s — never a `form`/`newsletter` widget (which would emit
   a nested `<form>` and capture nothing). It rides the page's outer form
   and POSTs natively.
 - Every CTA is an **anchor `href`** (`#book`, `tel:`, `mailto:`), never an
-  `on_click` (a dead button on a static page).
+  `on_click` (a dead button on a static page). The hero's two CTAs are no
+  exception.
 - `pricing-table` uses `tiers` with a `$` currency symbol; the popular
   tier is highlighted.
-- Anchor targets (`#services` / `#reviews` / `#pricing` / `#book`) live on
-  wrapping `section` / `card` nodes, because the marketing widgets carry
-  no `id` of their own.
+- The FAQ (if you give `faqs`) is the **`faq` widget** — native
+  `<details>` disclosures that open with no JavaScript — never an
+  `accordion` (which needs client JS and stays shut on a static page).
+- Anchor targets (`#services` / `#reviews` / `#pricing` / `#faq` /
+  `#book`) live on wrapping `section` / `card` nodes, because the marketing
+  widgets carry no `id` of their own.
 - No dashboard widgets — no KPI `stat` grid, no charts, no `accordion`. A
   marketing page, not an internal tool.
 

--- a/tests/ee/sites/test_landing_assembler.py
+++ b/tests/ee/sites/test_landing_assembler.py
@@ -4,14 +4,21 @@
 # persistence end-to-end, the failure the three prior agent-mode fixes never
 # closed.
 #
+# Updated 2026-06-09 (feat/landing-assembler-enrich, ripple PR #67): the page
+# opener is now the bespoke ``marketing-hero`` (was the borrowed dashboard
+# ``hero``), and the sample copy carries ``faqs`` so the optional native-<details>
+# FAQ section is exercised. Widget-set assertions track ``marketing-hero``; new
+# cases pin the marketing-hero CTA split and the FAQ section (present with faqs,
+# omitted without).
+#
 # Two layers:
 #   1. Pure assembler (``assemble_landing_spec``) — given an LLM ``content`` copy
 #      object, CODE emits the fixed marketing-widget structure. Asserts the
-#      widget-type set CONTAINS navbar / hero / feature-grid / testimonial /
-#      pricing-table / cta / footer, a FLAT lead form (input/textarea/button, NO
-#      ``form`` widget), section ``id`` anchors + input ``name`` POST fields, the
-#      ``tiers`` (not ``plans``) pricing shape, and determinism (same content →
-#      identical structure; impossible to downgrade).
+#      widget-type set CONTAINS navbar / marketing-hero / feature-grid /
+#      testimonial / pricing-table / cta / footer, a FLAT lead form
+#      (input/textarea/button, NO ``form`` widget), section ``id`` anchors + input
+#      ``name`` POST fields, the ``tiers`` (not ``plans``) pricing shape, and
+#      determinism (same content → identical structure; impossible to downgrade).
 #   2. End-to-end create tool (``_create_landing_site_handler``) — against a real
 #      (mongomock) Beanie DB it persists the assembled spec via the pockets
 #      service ``agent_create`` path and reads the PERSISTED ``_PocketDoc`` back
@@ -86,6 +93,16 @@ def _sample_content() -> dict[str, Any]:
                 "cta_label": "Book",
             },
         ],
+        "faqs": [
+            {
+                "question": "How long does a first visit take?",
+                "answer": "About 45 minutes — a cleaning, a check, and a plan.",
+            },
+            {
+                "question": "Do you take my insurance?",
+                "answer": "We bill all major plans directly.",
+            },
+        ],
         "cta_band": {
             "headline": "Ready for a healthier smile?",
             "button_label": "Request an appointment",
@@ -147,16 +164,19 @@ class TestAssembleLandingSpec:
         types = _widget_types(spec)
         for kind in (
             "navbar",
-            "hero",
+            "marketing-hero",
             "feature-grid",
             "testimonial",
             "pricing-table",
+            "faq",
             "cta",
             "footer",
         ):
             assert kind in types, (
                 f"marketing widget {kind!r} missing from assembled spec; got {sorted(types)}"
             )
+        # The borrowed dashboard hero is gone — the opener is marketing-hero.
+        assert "hero" not in types, "use `marketing-hero`, not the borrowed `hero`"
 
     def test_lead_form_is_flat_never_a_form_widget(self) -> None:
         from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
@@ -186,7 +206,7 @@ class TestAssembleLandingSpec:
         # Anchor targets live on wrapping section/card (marketing widgets carry
         # no id of their own). The navbar links to these.
         anchors = _section_ids(spec)
-        for anchor in ("services", "reviews", "pricing", "book"):
+        for anchor in ("services", "reviews", "pricing", "faq", "book"):
             assert anchor in anchors, (
                 f"missing section/card anchor id #{anchor}; got {sorted(anchors)}"
             )
@@ -229,6 +249,48 @@ class TestAssembleLandingSpec:
         ui = spec.get("ui") or spec
         for n in _iter_nodes(ui):
             assert "on_click" not in (n.get("props") or {}), "static site: no on_click CTAs"
+
+    def test_marketing_hero_carries_ctas_and_css_visual(self) -> None:
+        """The opener is `marketing-hero` with the hero copy mapped onto it, a
+        primary CTA wired to the lead form, a secondary CTA to services, and a
+        static-safe CSS `visual`. CTA destinations are sibling href props (never a
+        nested object), so they work as plain anchors under csr=false."""
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        spec = assemble_landing_spec(_sample_content())
+        heroes = _nodes_of_type(spec, "marketing-hero")
+        assert len(heroes) == 1
+        p = heroes[0]["props"]
+        assert p.get("eyebrow") == "Family & cosmetic dentistry"
+        assert p.get("title") and p.get("subtitle")
+        # Primary CTA → lead form, as a label + sibling href.
+        assert isinstance(p.get("cta"), str) and p["cta"] == "Book a visit"
+        assert p.get("ctaHref") == "#book"
+        # Secondary ghost CTA → services.
+        assert p.get("secondaryCtaHref") == "#services"
+        # Premium CSS visual treatment, all static-safe.
+        assert p.get("visual") in {"grid", "glow", "plain"}
+
+    def test_faq_section_present_with_faqs_and_omitted_without(self) -> None:
+        """The FAQ is OPTIONAL. With `faqs` in the copy the assembler emits a
+        `faq` widget (native <details>) under `section#faq`; with no `faqs` the
+        section is dropped entirely. Never an `accordion` (JS-only)."""
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        spec = assemble_landing_spec(_sample_content())
+        faqs = _nodes_of_type(spec, "faq")
+        assert len(faqs) == 1
+        items = faqs[0]["props"].get("items")
+        assert isinstance(items, list) and len(items) == 2
+        for it in items:
+            assert it.get("question") and it.get("answer")
+        assert "accordion" not in _widget_types(spec)
+
+        # Omitted when the copy has no faqs.
+        no_faq = {k: v for k, v in _sample_content().items() if k != "faqs"}
+        spec2 = assemble_landing_spec(no_faq)
+        assert "faq" not in _widget_types(spec2)
+        assert "faq" not in _section_ids(spec2)
 
     def test_handles_variable_length_collections(self) -> None:
         from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
@@ -275,9 +337,9 @@ class TestAssembleLandingSpec:
         spec = assemble_landing_spec(_sample_content())
         # brand on navbar
         assert (_nodes_of_type(spec, "navbar")[0]["props"]).get("brand") == "Bright Smile Dental"
-        # hero title
+        # hero title — on the marketing-hero
         assert (
-            (_nodes_of_type(spec, "hero")[0]["props"]).get("title")
+            (_nodes_of_type(spec, "marketing-hero")[0]["props"]).get("title")
             == "Care that fits your whole family"
         )
         # service titles flow into feature-grid features
@@ -377,18 +439,21 @@ class TestCreateLandingSiteEndToEnd:
         persisted_types = _widget_types(doc.rippleSpec)
         for kind in (
             "navbar",
-            "hero",
+            "marketing-hero",
             "feature-grid",
             "testimonial",
             "pricing-table",
+            "faq",
             "cta",
             "footer",
         ):
             assert kind in persisted_types, (
                 f"PERSISTED spec dropped marketing widget {kind!r}; got {sorted(persisted_types)}"
             )
-        # generic-downgrade guard: the page is NOT a hero+grid+card wireframe.
+        # generic-downgrade guard: the page is NOT a hero+grid+card wireframe, and
+        # the borrowed dashboard hero never sneaks back in.
         assert "input" in persisted_types and "form" not in persisted_types
+        assert "hero" not in persisted_types
 
     @pytest.mark.asyncio
     async def test_missing_identity_is_error(self) -> None:

--- a/tests/ee/sites/test_landing_render_e2e.py
+++ b/tests/ee/sites/test_landing_render_e2e.py
@@ -5,6 +5,18 @@
 # SHAPE that renders like the shippable "Option C" page, not the broken
 # "Option A" dashboard render.
 #
+# Updated 2026-06-09 (feat/landing-assembler-enrich): the canonical spec is now
+# the REAL output of ``assemble_landing_spec`` (the deterministic fast-path) on a
+# representative copy object, instead of a hand-maintained dict that drifted from
+# the assembler. So these guardrails track exactly what ships. Two new sections
+# the enriched assembler emits get their own cases:
+#   * the hero is the bespoke ``marketing-hero`` (premium CSS visual, CTAs as
+#     ``ctaHref``/``secondaryCtaHref`` siblings — never the borrowed dashboard
+#     ``hero``);
+#   * an optional ``faq`` section (native <details>, JS-off safe) — present when
+#     the copy carries ``faqs``, omitted when it doesn't, and NEVER an
+#     ``accordion``.
+#
 # This is a STATIC, deterministic guardrail over the spec tree — NOT a generator
 # render. A full @paw/sites-generator build (install + workerd smoke) is the gold
 # proof but is heavy and CI-fragile (Bun, network, a warm ripple tarball), so the
@@ -16,186 +28,93 @@
 #      inside the site template's outer POST form → zero leads captured).
 #   2. pricing-table uses `tiers` (not `plans`/`columns`) → populated pricing.
 #   3. No `accordion` node anywhere (bits-ui client primitive → FAQ won't open
-#      with JS off).
+#      with JS off). FAQ uses the native-<details> `faq` widget instead.
 #   4. Every CTA/button is an anchor href (or a form submit) — no on_click
 #      (dead on a static page).
-#   5. The hero is the marketing `hero` widget, never the dashboard `hero+grid`
-#      KPI layout (no `stat` tiles / charts on a sales page).
+#   5. The hero is the marketing `marketing-hero` widget, never the dashboard
+#      `hero+grid` KPI layout (no `stat` tiles / charts on a sales page).
 
 from __future__ import annotations
 
 from typing import Any
 
 import pytest
+from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+# A representative copy object — the Bright Smile dentist brief WITH faqs, so the
+# canonical spec exercises every section the assembler can emit (including the
+# optional FAQ). The assembler owns the structure; this is COPY only.
+_CANONICAL_CONTENT: dict[str, Any] = {
+    "brand": "Bright Smile Dental",
+    "hero": {
+        "eyebrow": "Family & cosmetic dentistry",
+        "title": "Care that fits your whole family",
+        "subtitle": "Gentle, modern dentistry in downtown Austin.",
+        "cta_label": "Book a visit",
+    },
+    "services": [
+        {"title": "New Patient Exams", "desc": "Full exam, X-rays, cleaning.", "icon": "tooth"},
+        {"title": "Teeth Whitening", "desc": "Up to 8 shades brighter.", "icon": "sparkles"},
+        {"title": "Invisalign", "desc": "Clear aligners, custom plan.", "icon": "smile"},
+        {"title": "Emergency Care", "desc": "Same-day relief.", "icon": "shield"},
+    ],
+    "testimonials": [
+        {
+            "quote": "Best dental experience I've had.",
+            "author": "Maria G.",
+            "role": "Patient since 2023",
+        },
+        {"quote": "Booking was one tap.", "author": "James T.", "role": "Patient since 2021"},
+    ],
+    "tiers": [
+        {
+            "name": "New Patient Exam",
+            "price": "89",
+            "period": "one-time",
+            "features": ["Full exam", "Digital X-rays", "Cleaning"],
+            "cta_label": "Book",
+        },
+        {
+            "name": "Whitening",
+            "price": "299",
+            "period": "one-time",
+            "popular": True,
+            "features": ["In-office session", "Up to 8 shades", "Take-home trays"],
+            "cta_label": "Book",
+        },
+        {
+            "name": "Invisalign",
+            "price": "3,900",
+            "period": "full plan",
+            "features": ["Custom aligners", "All visits", "Retainers included"],
+            "cta_label": "Free consult",
+        },
+    ],
+    "faqs": [
+        {"question": "How long does a visit take?", "answer": "Most first visits run 45 minutes."},
+        {"question": "Do you take my insurance?", "answer": "We bill all major plans directly."},
+        {"question": "Can I reschedule online?", "answer": "Yes — from the confirmation email."},
+    ],
+    "cta_band": {
+        "headline": "Ready for a healthier smile?",
+        "subtext": "Same-week appointments are filling up.",
+        "button_label": "Request an appointment",
+    },
+    "contact": {
+        "address": "421 Congress Ave, Austin TX",
+        "phone": "(555) 010-1234",
+        "email": "hello@brightsmile.com",
+    },
+    "footer": {"copyright": "© 2026 Bright Smile Dental"},
+}
 
 
 def _canonical_landing_spec() -> dict[str, Any]:
-    """The Bright Smile dentist landing spec — the exact conversion-ordered
-    shape the create-paw-site brain and the landing recipe produce. Kept inline
-    so the test is deterministic and never depends on the live generator."""
-    return {
-        "version": "1.0",
-        "ui": {
-            "type": "flex",
-            "props": {"direction": "column", "gap": "0"},
-            "children": [
-                {
-                    "type": "navbar",
-                    "props": {
-                        "brand": "Bright Smile Dental",
-                        "links": [
-                            {"label": "Services", "href": "#services"},
-                            {"label": "Pricing", "href": "#pricing"},
-                            {"label": "Reviews", "href": "#reviews"},
-                            {"label": "Book", "href": "#book"},
-                        ],
-                        "cta": {"label": "Book a visit", "href": "#book"},
-                    },
-                },
-                {
-                    "type": "hero",
-                    "props": {
-                        "eyebrow": "Family & cosmetic dentistry",
-                        "title": "Care that fits your whole family",
-                        "subtitle": "Gentle, modern dentistry in downtown Austin.",
-                        "cta": {"label": "Book your visit", "href": "#book"},
-                    },
-                },
-                {
-                    "type": "feature-grid",
-                    "props": {
-                        "id": "services",
-                        "title": "What we do",
-                        "features": [
-                            {
-                                "icon": "tooth",
-                                "title": "New Patient Exams",
-                                "description": "Full exam, X-rays, cleaning.",
-                            },
-                            {
-                                "icon": "sparkles",
-                                "title": "Teeth Whitening",
-                                "description": "Up to 8 shades brighter.",
-                            },
-                            {
-                                "icon": "smile",
-                                "title": "Invisalign",
-                                "description": "Clear aligners, custom plan.",
-                            },
-                            {
-                                "icon": "shield",
-                                "title": "Emergency Care",
-                                "description": "Same-day relief.",
-                            },
-                        ],
-                    },
-                },
-                {
-                    "type": "testimonial",
-                    "props": {
-                        "id": "reviews",
-                        "quote": "Best dental experience I've had.",
-                        "author": "Maria G.",
-                        "role": "Patient since 2023",
-                        "rating": 5,
-                    },
-                },
-                {
-                    "type": "pricing-table",
-                    "props": {
-                        "id": "pricing",
-                        "title": "Simple, upfront pricing",
-                        "currency": "USD",
-                        "tiers": [
-                            {
-                                "id": "exam",
-                                "name": "New Patient Exam",
-                                "price": "$89",
-                                "period": "one-time",
-                                "features": ["Full exam", "Digital X-rays", "Cleaning"],
-                                "cta": {"label": "Book", "href": "#book"},
-                            },
-                            {
-                                "id": "white",
-                                "name": "Whitening",
-                                "price": "$299",
-                                "period": "one-time",
-                                "popular": True,
-                                "features": [
-                                    "In-office session",
-                                    "Up to 8 shades",
-                                    "Take-home trays",
-                                ],
-                                "cta": {"label": "Book", "href": "#book"},
-                            },
-                            {
-                                "id": "invis",
-                                "name": "Invisalign",
-                                "price": "$3,900",
-                                "period": "full plan",
-                                "features": ["Custom aligners", "All visits", "Retainers included"],
-                                "cta": {"label": "Free consult", "href": "#book"},
-                            },
-                        ],
-                    },
-                },
-                {
-                    "type": "cta",
-                    "props": {
-                        "title": "Ready for a healthier smile?",
-                        "subtitle": "Same-week appointments are filling up.",
-                        "cta": {"label": "Request an appointment", "href": "#book"},
-                    },
-                },
-                {
-                    "type": "card",
-                    "props": {"id": "book", "title": "Book your visit"},
-                    "children": [
-                        {
-                            "type": "input",
-                            "props": {"name": "name", "label": "Your name", "required": True},
-                        },
-                        {
-                            "type": "input",
-                            "props": {
-                                "name": "email",
-                                "label": "Email",
-                                "type": "email",
-                                "required": True,
-                            },
-                        },
-                        {
-                            "type": "input",
-                            "props": {"name": "phone", "label": "Phone", "type": "tel"},
-                        },
-                        {
-                            "type": "textarea",
-                            "props": {"name": "message", "label": "What do you need?"},
-                        },
-                        {
-                            "type": "button",
-                            "props": {
-                                "label": "Request appointment",
-                                "type": "submit",
-                                "variant": "primary",
-                            },
-                        },
-                    ],
-                },
-                {
-                    "type": "footer",
-                    "props": {
-                        "brand": "Bright Smile Dental",
-                        "tagline": "421 Congress Ave, Austin TX",
-                        "links": [
-                            {"label": "Services", "href": "#services"},
-                            {"label": "Book", "href": "#book"},
-                        ],
-                    },
-                },
-            ],
-        },
-    }
+    """The Bright Smile dentist landing spec — the EXACT output of the
+    deterministic assembler on ``_CANONICAL_CONTENT``. Driving the real assembler
+    (instead of a hand-copied dict) means these guardrails can never silently
+    drift from what the create-paw-site fast-path actually ships."""
+    return assemble_landing_spec(_CANONICAL_CONTENT)
 
 
 # Tier-0 (CSS-only, static-safe) animation widgets. Anything else animated needs
@@ -274,17 +193,105 @@ def test_pricing_table_uses_tiers_not_plans() -> None:
     assert "tiers" in props and isinstance(props["tiers"], list) and props["tiers"]
     assert "plans" not in props
     assert "columns" not in props
-    # Tier objects have the canonical shape and an anchor-href cta.
+    assert props["currency"] == "$"
+    # Tier objects have the canonical shape and a STRING cta label (the
+    # pricing-table renders the button itself; tier cta is never a nested object).
     for tier in props["tiers"]:
         assert {"id", "name", "price"}.issubset(tier.keys())
-        assert "href" in tier["cta"]
+        assert isinstance(tier["cta"], str) and tier["cta"]
 
 
 def test_no_accordion_node_anywhere() -> None:
     """Rule 3 — no `accordion` (bits-ui client primitive; FAQ panels won't open
-    with JS off). FAQ, if present, is flat heading/text."""
+    with JS off). The FAQ section uses the native-<details> `faq` widget, which
+    expands with zero client JS, NOT an `accordion`."""
     spec = _canonical_landing_spec()
     assert "accordion" not in _node_types(spec)
+
+
+# ---------------------------------------------------------------------------
+# Enriched-assembler sections (feat/landing-assembler-enrich, ripple PR #67)
+# ---------------------------------------------------------------------------
+
+
+def test_hero_is_marketing_hero_with_premium_css_visual() -> None:
+    """The page opener is `marketing-hero` with its premium CSS `visual` set and
+    the CTAs wired as `ctaHref`/`secondaryCtaHref` siblings.
+
+    `visual` selects the bespoke CSS panel (dot-grid + glow drift + spec chip),
+    which is pure CSS and so paints fully under csr=false. The CTA destinations
+    are sibling href props (never a nested object, never on_click)."""
+    spec = _canonical_landing_spec()
+    heroes = _find(spec, "marketing-hero")
+    assert len(heroes) == 1, "exactly one marketing-hero, as the page opener"
+    p = heroes[0]["props"]
+
+    # Required headline plus the mapped hero copy.
+    assert p.get("title")
+    assert p.get("eyebrow") == "Family & cosmetic dentistry"
+    assert p.get("subtitle")
+
+    # Premium CSS visual — one of the static-safe panel treatments.
+    assert p.get("visual") in {"grid", "glow", "plain"}
+
+    # Primary CTA: string label + sibling href into the lead form.
+    assert isinstance(p.get("cta"), str) and p["cta"]
+    assert p.get("ctaHref") == "#book"
+
+    # Secondary ghost CTA jumps to services (which always renders).
+    assert p.get("secondaryCtaHref") == "#services"
+
+
+def test_faq_section_is_native_details_when_copy_supplies_faqs() -> None:
+    """When the copy carries `faqs`, the assembler emits a `faq` widget (native
+    <details>, JS-off safe) wrapped in `section#faq`, carrying the Q/A items —
+    and NEVER an `accordion`."""
+    spec = _canonical_landing_spec()
+    faqs = _find(spec, "faq")
+    assert len(faqs) == 1, "one faq widget when faqs are supplied"
+    items = faqs[0]["props"].get("items")
+    assert isinstance(items, list) and len(items) == 3
+    for it in items:
+        assert it.get("question") and it.get("answer")
+    # It is a native-details `faq`, not the JS-only `accordion`.
+    assert "accordion" not in _node_types(spec)
+    # The widget is wrapped in an anchored section (marketing widgets carry no id).
+    faq_sections = [c for c in spec["ui"]["children"] if c.get("props", {}).get("id") == "faq"]
+    assert len(faq_sections) == 1
+    assert faq_sections[0]["children"][0]["type"] == "faq"
+
+
+def test_faq_section_omitted_when_no_faqs_supplied() -> None:
+    """FAQ is OPTIONAL: with no `faqs` in the copy, the assembler emits no `faq`
+    widget and no `section#faq` — the funnel stays lean. Every other section
+    still renders."""
+    content = {k: v for k, v in _CANONICAL_CONTENT.items() if k != "faqs"}
+    spec = assemble_landing_spec(content)
+    assert "faq" not in _node_types(spec)
+    assert not any(c.get("props", {}).get("id") == "faq" for c in spec["ui"]["children"])
+    # The rest of the funnel is intact.
+    assert "marketing-hero" in _node_types(spec)
+    assert "pricing-table" in _node_types(spec)
+
+
+def test_faq_drops_entries_missing_question_or_answer() -> None:
+    """A faq entry with no question OR no answer is dropped (an openable-but-blank
+    disclosure helps no one); if every entry is unusable the whole section is
+    omitted."""
+    content = {
+        **{k: v for k, v in _CANONICAL_CONTENT.items() if k != "faqs"},
+        "faqs": [
+            {"question": "Real question?", "answer": "Real answer."},
+            {"question": "", "answer": "orphan answer"},  # no question → dropped
+            {"question": "orphan question", "answer": ""},  # no answer → dropped
+            "not-a-dict",  # not a dict → skipped
+        ],
+    }
+    spec = assemble_landing_spec(content)
+    faqs = _find(spec, "faq")
+    assert len(faqs) == 1
+    items = faqs[0]["props"]["items"]
+    assert len(items) == 1 and items[0]["question"] == "Real question?"
 
 
 def test_all_ctas_are_anchor_hrefs_not_on_click() -> None:
@@ -307,21 +314,38 @@ def test_all_ctas_are_anchor_hrefs_not_on_click() -> None:
         has_href = "href" in props
         assert is_submit or has_href, "a button must submit or link via href"
 
-    # The nav/hero/cta/footer CTAs all link by href.
-    for cta_host in _find(spec, "navbar") + _find(spec, "hero") + _find(spec, "cta"):
-        cta = cta_host["props"].get("cta")
-        if cta is not None:
-            assert "href" in cta
+    # The navbar + marketing-hero use a STRING `cta` label with the destination in
+    # a SEPARATE sibling prop (`ctaHref`), never a nested `{label, href}` object —
+    # and never an `on_click`. Assert the label/href split, not a nested href.
+    for host in _find(spec, "navbar") + _find(spec, "marketing-hero"):
+        p = host["props"]
+        assert isinstance(p.get("cta"), str) and p["cta"], "cta is a string label"
+        assert p.get("ctaHref", "").startswith("#"), "the destination rides ctaHref"
+
+    # marketing-hero's optional secondary CTA follows the same split.
+    for hero in _find(spec, "marketing-hero"):
+        p = hero["props"]
+        if p.get("secondaryCta"):
+            assert p.get("secondaryCtaHref", "").startswith("#")
+
+    # The cta band carries a string `button` label + a sibling `href`.
+    for band in _find(spec, "cta"):
+        p = band["props"]
+        assert isinstance(p.get("button"), str) and p["button"]
+        assert p.get("href", "").startswith("#")
 
 
 def test_hero_is_marketing_widget_not_dashboard_kpi_layout() -> None:
-    """Rule 5 — the page uses the marketing `hero` widget and carries NO
-    dashboard KPI widgets (`stat` tiles, charts). A KPI grid at the top is the
-    broken `hero+grid` dashboard render, not a landing page."""
+    """Rule 5 — the page uses the bespoke `marketing-hero` widget (NOT the
+    borrowed dashboard `hero`) and carries NO dashboard KPI widgets (`stat`
+    tiles, charts). A KPI grid at the top is the broken `hero+grid` dashboard
+    render, not a landing page."""
     spec = _canonical_landing_spec()
     types = _node_types(spec)
 
-    assert "hero" in types
+    assert "marketing-hero" in types
+    # The borrowed dashboard hero is gone — the page opener is marketing-hero.
+    assert "hero" not in types, "use `marketing-hero`, not the borrowed `hero`"
     # No dashboard/analytics widgets on a sales page.
     for dashboardy in ("stat", "chart", "page-header", "pipeline-dashboard", "analytics-dashboard"):
         assert dashboardy not in types, (
@@ -340,19 +364,33 @@ def test_any_animation_is_tier0_static_safe() -> None:
 
 def test_conversion_order_is_funnel_top_to_bottom() -> None:
     """The page reads as a funnel: nav → hero → services → proof → pricing →
-    CTA → lead form → footer. We assert the relative order of the anchor roles."""
+    FAQ → CTA → lead form → footer. We assert the relative order of the roles.
+
+    Anchored sections wrap their marketing widget in a `section`/`card`, so we
+    index by the wrapper's anchor id (services/pricing/faq/book) rather than the
+    inner widget type."""
     spec = _canonical_landing_spec()
-    # Top-level section order (direct children of the root flex).
     top = [c["type"] for c in spec["ui"]["children"]]
-    assert top.index("navbar") < top.index("hero")
-    assert top.index("hero") < top.index("feature-grid")
-    assert top.index("feature-grid") < top.index("pricing-table")
-    assert top.index("pricing-table") < top.index("footer")
-    # The lead form (the `book` card) comes before the footer.
-    book_idx = next(
-        i for i, c in enumerate(spec["ui"]["children"]) if c.get("props", {}).get("id") == "book"
-    )
-    assert book_idx < top.index("footer")
+
+    def anchor_idx(anchor: str) -> int:
+        return next(
+            i
+            for i, c in enumerate(spec["ui"]["children"])
+            if c.get("props", {}).get("id") == anchor
+        )
+
+    # navbar → marketing-hero → services → pricing → footer (top-level types).
+    assert top.index("navbar") < top.index("marketing-hero")
+    assert top.index("marketing-hero") < anchor_idx("services")
+    assert anchor_idx("services") < anchor_idx("pricing")
+    assert anchor_idx("pricing") < top.index("footer")
+    # FAQ sits between pricing and the closing CTA band (objections answered
+    # right before the final ask).
+    assert anchor_idx("pricing") < anchor_idx("faq")
+    assert anchor_idx("faq") < top.index("cta")
+    # The lead form (the `book` card) comes after the CTA band, before the footer.
+    assert top.index("cta") < anchor_idx("book")
+    assert anchor_idx("book") < top.index("footer")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What this does

The deterministic landing assembler (`assemble_landing_spec`) now builds a richer page using ripple's enriched marketing pack (ripple PR #67). Two changes, both driven from copy only — code still owns the structure.

**Hero → `marketing-hero`.** The page opener was the borrowed dashboard `hero`, which silently dropped its CTA. It's now the bespoke `marketing-hero`: same eyebrow/title/subtitle copy, but with the CTAs wired back in (primary to the lead form, plus a "see our services" ghost CTA to the services section) and `visual="grid"` for the premium panel — a CSS dot-grid, a slow glow drift, and a spec chip.

**Optional FAQ section.** A new `faq` section sits between pricing and the closing CTA, where a visitor weighing the price gets their objections answered before the ask. It's fed from a new `faqs` field on the create-paw-site content object (`[{question, answer}]`), uses the `faq` widget (native `<details>`/`<summary>`), and is omitted entirely when no faqs are supplied. Entries missing a question or an answer get dropped.

## The csr / motion finding

These sites prerender with `csr=false`. I checked the generator's `templates/src/routes/+layout.ts.tmpl` (`export const prerender = true; export const csr = false;`) and then confirmed it in the produced HTML: no `_app/immutable` chunks, no `<script src>`. Zero client JS reaches the visitor.

That settles the motion question. JS-driven scroll motion (ripple's `reveal` / `parallax` / `spotlight`) can't run on a page that ships no JS, so wiring it would animate nothing. I didn't wire any. All the premium richness here is CSS-only, baked into `marketing-hero`'s own styles, so it paints fully with JavaScript off. If we want scroll-reveal motion on these pages later, the unlock is turning on hydration (`csr=true`), not adding motion props to the spec.

The iron rule holds: a JS-off visitor sees the whole page — the hero visual, every FAQ answer, all the content. Nothing waits for a script.

## How it was verified (rendered, not just unit-tested)

I generated a sample dentist landing through the real static generator against the reviewed ripple 0.5.0 tarball (`PAW_SITES_RIPPLE_DEP=file:.../ripple-ui-svelte-0.5.0.tgz`), ran the full generate → install → build, and read the prerendered JS-off HTML:

- `marketing-hero` renders with its CSS visual (`ripple-mhero-grid` + `ripple-mhero-glow` in the markup), the headline, the eyebrow, and both CTAs as anchor hrefs (`#book`, `#services`)
- the FAQ renders as exactly 3 native `<details>` with all three answers in the markup
- feature cards show their icons as SVG
- zero client JS chunks (the csr=false proof)

Tests: `uv run pytest tests/ee/sites/` is green (141 passed, 1 skipped — the opt-in integration test), including the five SSR-trap guardrails and new cases for the marketing-hero CTA split and the FAQ section (present with faqs, omitted without). The e2e guardrail now drives the real assembler instead of a hand-maintained dict, so it can't drift from what ships.

## Notes

- The `trusted=True` catalog-gate bypass in `sites_create.py` is untouched.
- The bundled `landing-page` template skeleton (the older template-splice path) still uses the borrowed `hero`, and I left it alone on purpose — this PR scopes to the deterministic fast-path the create-paw-site skill actually uses. A follow-up could bring the skeleton up to the same bar.