### PR TITLE
feat(cloud): Web Push send + dead-subscription pruning

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -812,6 +812,16 @@ def mount_cloud(app: FastAPI) -> None:
     register_meeting_notification_listeners()
     register_meeting_calendar_listeners()
 
+    # Push notifications fan-out (#1393) — v1 product events
+    # (agent.stream_end / instinct.approval.created / meeting.started) →
+    # ``dispatch.notify``, which forks WS-vs-Web-Push so a user with both the
+    # desktop app and a browser tab open is notified exactly once. Same
+    # constraint as the other bus subscribers: register AFTER init_realtime
+    # installed the singleton bus.
+    from pocketpaw_ee.cloud.push.listeners import register_push_event_listeners
+
+    register_push_event_listeners()
+
     # In-process daily-snapshot scheduler — opt-in via env var.
     #
     # Default OFF in tests + dev (each pytest run would otherwise spawn a

--- a/ee/pocketpaw_ee/cloud/chat/unread_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/unread_service.py
@@ -76,6 +76,27 @@ async def list_unreads(user_id: str, workspace_id: str) -> list[dict]:
     return out
 
 
+async def unread_count(user_id: str, group_id: str) -> int:
+    """Unread message count for a single ``(user, group)`` pair.
+
+    The per-group half of :func:`list_unreads`, exposed so callers that only
+    care about one conversation (e.g. the push new-message notifier) can get a
+    count without scanning every group the user belongs to. Same safe default:
+    a user with no ReadState row — or a row whose ``last_read_message_id`` is
+    the empty string — counts the group's full ``message_count`` (everything
+    is unread until a ``mark_read`` corrects it).
+    """
+    state = await _get_read_state(user_id, group_id)
+    if state is not None and state.last_read_message_id:
+        return await _count_messages_after(group_id, state.last_read_message_id)
+
+    try:
+        group = await _GroupDoc.get(PydanticObjectId(group_id))
+    except Exception:
+        group = None
+    return group.message_count if group else 0
+
+
 async def mark_read(user_id: str, group_id: str, last_message_id: str) -> None:
     """Upsert read state for (user, group). Resets mention_unread to 0.
 
@@ -123,4 +144,4 @@ async def bump_mention(user_id: str, group_id: str) -> None:
     )
 
 
-__all__ = ["bump_mention", "list_unreads", "mark_read"]
+__all__ = ["bump_mention", "list_unreads", "mark_read", "unread_count"]

--- a/ee/pocketpaw_ee/cloud/push/__init__.py
+++ b/ee/pocketpaw_ee/cloud/push/__init__.py
@@ -1,8 +1,14 @@
 # Web Push entity (pocketpaw#1391) — stores browser Web Push subscriptions
-# and serves the per-workspace VAPID public key. Storage + key only; sending
-# notifications (pywebpush dispatch + 410 pruning) is #1392, wiring real
-# events is #1393.
+# and serves the per-workspace VAPID public key. Storage + key (#1391),
+# pywebpush dispatch + 410 pruning (#1392), and product-event wiring with
+# WS-vs-Web-Push dedupe (#1393) all live here now.
 #
 # Follows the ee/cloud 4-file shape: domain.py (pure value objects),
 # dto.py (request/response wire models), service.py (sole Beanie writer),
-# router.py (thin HTTP boundary).
+# router.py (thin HTTP boundary). Two extra modules carry the #1393 wiring:
+# dispatch.py (``notify`` — the WS/Web-Push transport fork that never
+# double-notifies a user with both the desktop app and a browser tab open)
+# and listeners.py (the v1 product events — agent.stream_end /
+# instinct.approval.created / meeting.started — subscribed to the realtime
+# bus and routed through ``notify``). Neither writes Beanie directly, so the
+# "Push — Beanie writes only from service.py" contract still holds.

--- a/ee/pocketpaw_ee/cloud/push/coalesce.py
+++ b/ee/pocketpaw_ee/cloud/push/coalesce.py
@@ -1,0 +1,196 @@
+# Leading-edge push coalescer (feat/push-user-message-notifications).
+# Created: 2026-07-02 — throttles per-recipient notification sends so a burst of
+# messages in one conversation doesn't fan out one Web Push per message (which
+# wastes encrypt+POST work and can trip the push vendor's per-endpoint rate
+# limit with 429s). The OS already collapses same-``tag`` notifications on the
+# view side; this bounds the SEND side.
+#
+# Semantics — LEADING-EDGE throttle, keyed by (workspace_id, user_id, group_id):
+#   - First submit for an idle key   → emit IMMEDIATELY (zero added latency),
+#                                        then open a cooldown window.
+#   - Submits during the cooldown     → suppressed; the latest emit is remembered.
+#   - When the window elapses          → if anything was suppressed, emit ONCE
+#                                        (a trailing flush carrying the freshest
+#                                        payload + a recomputed count) and keep
+#                                        the window open one more cycle so a
+#                                        sustained stream fires at most once per
+#                                        window. An idle window closes and frees
+#                                        the key.
+#
+# So a 20-message burst becomes at most 2 sends (leading + one coalesced), the
+# recipient is still pinged the instant the first message lands, and a
+# continuous stream is capped at 1 send per window.
+#
+# Window length: ``CLOUD_PUSH_COALESCE_SECONDS`` (default 5.0). ``0`` disables
+# coalescing entirely — every submit emits immediately (pre-throttle behaviour).
+# Named ``CLOUD_*`` to match the sibling ``CLOUD_PUSH_CONTACT`` — this cloud
+# layer reads its own knobs from ``os.environ`` directly.
+#
+# Updated 2026-07-02: the leading edge now fires DETACHED (a background task,
+# like the trailing flush) instead of being awaited inline. ``submit`` is
+# awaited by the realtime bus handler, which the bus dispatches on the chat-send
+# request path — awaiting the push fan-out there coupled send latency to
+# delivery. ``submit`` now returns promptly and the leading push runs in the
+# background.
+#
+# Scope: in-process (single backend). The state lives in module-level dicts, so
+# two backend replicas would each fire their own leading push. That's the
+# documented v1 limit; the ``submit`` seam is the swap point for a Redis-backed
+# coordinator (POCKETPAW_REDIS_URL is already wired) when multi-replica push
+# delivery lands. NO Beanie writes happen here — the emit callback routes
+# through push/dispatch.py exactly as the direct path did.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+_ENV_SECONDS = "CLOUD_PUSH_COALESCE_SECONDS"
+_DEFAULT_SECONDS = 5.0
+
+# A key is (workspace_id, user_id, group_id). ``_tasks`` holds the open cooldown
+# window for a key; ``_pending`` holds the latest suppressed emit awaiting the
+# next flush. Both are cleared when a window closes.
+_Key = tuple[str, str, str]
+_Emit = Callable[[], Awaitable[None]]
+
+_tasks: dict[_Key, asyncio.Task] = {}
+_pending: dict[_Key, _Emit] = {}
+# In-flight DETACHED leading-edge emits. Held only to keep a strong reference so
+# the event loop can't garbage-collect a leading push mid-send; each removes
+# itself on completion. See ``_spawn_detached`` / ``submit``.
+_leading: set[asyncio.Task] = set()
+
+
+async def _guarded_emit(emit: _Emit) -> None:
+    """Await one emit, logging (not raising) on failure.
+
+    The leading edge runs detached (no caller to catch its exception), so a
+    failed send must be swallowed here or it would surface as an unretrieved
+    task exception.
+    """
+    try:
+        await emit()
+    except Exception:
+        logger.exception("push: leading-edge emit failed")
+
+
+def _spawn_detached(emit: _Emit) -> None:
+    """Fire one emit as a background task, decoupled from the caller.
+
+    ``submit`` is awaited by the realtime bus handler, which the bus dispatches
+    INLINE on the chat-send request path — awaiting delivery there would couple
+    send latency to the Web Push fan-out. Running the leading emit detached
+    (like the trailing flush already is) lets ``submit`` return promptly.
+    """
+    task = asyncio.create_task(_guarded_emit(emit))
+    _leading.add(task)
+    task.add_done_callback(_leading.discard)
+
+
+def _coalesce_seconds() -> float:
+    """Window length in seconds. ``<= 0`` (or unset-to-default) tunable via env.
+
+    Malformed values fall back to the default rather than raising — a bad env
+    value must not break notification delivery.
+    """
+    raw = os.environ.get(_ENV_SECONDS, "").strip()
+    if not raw:
+        return _DEFAULT_SECONDS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a number; using default %s", _ENV_SECONDS, raw, _DEFAULT_SECONDS
+        )
+        return _DEFAULT_SECONDS
+
+
+async def submit(key: _Key, emit: _Emit) -> None:
+    """Route one notification through the leading-edge throttle.
+
+    ``emit`` is an idempotent-safe coroutine that sends exactly one notification
+    when awaited (it recomputes the unread count at send time, so a trailing
+    flush carries a current count). It is called at most once on the leading
+    edge and at most once per window thereafter.
+
+    With coalescing disabled (window ``<= 0``) this is a pass-through: ``emit``
+    is awaited immediately and no window is opened.
+    """
+    seconds = _coalesce_seconds()
+    if seconds <= 0:
+        await emit()
+        return
+
+    if key in _tasks:
+        # Inside the cooldown window: suppress now, remember the freshest emit
+        # to fire at the next flush.
+        _pending[key] = emit
+        return
+
+    # Leading edge. Reserve the window SYNCHRONOUSLY (before scheduling) so a
+    # second submit arriving while this leading emit is in flight coalesces
+    # instead of racing to a second leading push. Fire the leading emit DETACHED
+    # (not awaited) so this ``submit`` — dispatched inline by the realtime bus on
+    # the chat-send request path — returns without blocking on the push fan-out.
+    _tasks[key] = asyncio.create_task(_cooldown(key, seconds))
+    _spawn_detached(emit)
+
+
+async def _cooldown(key: _Key, seconds: float) -> None:
+    """Hold a key's window open, flushing one coalesced emit per cycle.
+
+    Sleeps ``seconds``; if a submit was suppressed meanwhile, fires it once and
+    loops (so a sustained stream is capped at one send per window). An empty
+    cycle closes the window and frees the key.
+    """
+    try:
+        while True:
+            await asyncio.sleep(seconds)
+            emit = _pending.pop(key, None)
+            if emit is None:
+                return  # nothing suppressed this cycle → close the window
+            try:
+                await emit()
+            except Exception:
+                logger.exception("push: coalesced flush failed for key=%s", key)
+    finally:
+        _tasks.pop(key, None)
+
+
+def reset() -> None:
+    """Cancel all open windows and drop pending emits (best-effort, sync).
+
+    Fire-and-forget: it requests cancellation but does not await the tasks, so a
+    caller that needs the cancellations to finish cleanly on a live loop (tests,
+    graceful shutdown) should use :func:`aclose` instead.
+    """
+    for task in (*_tasks.values(), *_leading):
+        task.cancel()
+    _tasks.clear()
+    _pending.clear()
+    _leading.clear()
+
+
+async def aclose() -> None:
+    """Cancel all open windows and AWAIT their teardown on the running loop.
+
+    Awaiting the cancelled tasks lets each process ``CancelledError`` and run
+    its ``finally`` before the loop moves on, so no cancellation callback lands
+    on an already-closed loop.
+    """
+    tasks = [*_tasks.values(), *_leading]
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    _tasks.clear()
+    _pending.clear()
+    _leading.clear()
+
+
+__all__ = ["aclose", "reset", "submit"]

--- a/ee/pocketpaw_ee/cloud/push/dispatch.py
+++ b/ee/pocketpaw_ee/cloud/push/dispatch.py
@@ -1,0 +1,136 @@
+# Notification dispatch + WS-vs-Web-Push dedupe (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — adds ``notify`` on top of the
+# #1392 ``send_to_user`` Web Push fan-out. ``notify`` is the single dispatch
+# product events call: it forks the transport so a user who has BOTH the
+# desktop app (live WebSocket) and a browser tab (Web Push) open is never
+# double-notified.
+#
+# The dedupe rule (issue #1393 "prefer WS when live, else push"):
+#   - LIVE WebSocket connection  → deliver a ``notification.push`` WS event
+#     the desktop/Tauri client already renders; do NOT also send Web Push.
+#   - No live connection         → fall back to ``send_to_user`` (Web Push),
+#     so a browser-only / backgrounded user still gets the notification.
+#
+# This module is a thin orchestrator — it imports the push *service* for the
+# Web Push leg and the chat WS ConnectionManager for the liveness check + WS
+# leg. It performs NO Beanie writes itself (the import-linter "Push — Beanie
+# writes only from service.py" contract stays satisfied: the only writer is
+# ``service.send_to_user`` which prunes dead rows as before). The liveness
+# check and the chosen transport are surfaced on a returned ``NotifyResult``
+# so the fork is observable and unit-testable without real sockets.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from pocketpaw_ee.cloud.push import service as push_service
+from pocketpaw_ee.cloud.push.dto import PushPayload, SendResult
+
+logger = logging.getLogger(__name__)
+
+# The WS event type the desktop/Tauri client listens for to raise a native
+# notification. Distinct from the in-app ``notification.new`` bell event
+# (that one is the persisted-notification fan-out); this is the lightweight
+# "raise an OS/browser notification now" signal that mirrors what a Web Push
+# would have shown, so a live desktop client and a backgrounded browser tab
+# get the same notification through exactly one transport.
+WS_NOTIFICATION_TYPE = "notification.push"
+
+
+@dataclass
+class NotifyResult:
+    """Outcome of a single :func:`notify` dispatch.
+
+    ``transport`` is the leg actually taken — ``"ws"`` when the user had a
+    live WebSocket connection (Web Push was skipped) or ``"push"`` when it
+    fell back to Web Push. ``ws_delivered`` is True only on the WS leg.
+    ``send`` carries the Web Push fan-out summary on the push leg (None on
+    the WS leg, since Web Push never ran).
+    """
+
+    transport: str = "push"
+    ws_delivered: bool = False
+    send: SendResult | None = None
+
+
+# ---------------------------------------------------------------------------
+# Seams — injected so tests can drive the fork without real sockets. Both
+# default to the live chat ConnectionManager singleton (the same instance the
+# realtime bus fans WebSocket events through), imported lazily to avoid a
+# module-import cycle (chat.ws → schemas → ... → push at collection time).
+# ---------------------------------------------------------------------------
+
+
+def _is_user_live(user_id: str) -> bool:
+    """Return True when the user has at least one live WebSocket connection.
+
+    Backed by ``chat.ws.ConnectionManager.is_online`` (ws.py:89) on the
+    module singleton ``manager`` (ws.py:194) — the same registry the realtime
+    bus uses to fan events to sockets, so "live" here means exactly "the bus
+    could deliver to this user over WS right now".
+    """
+    from pocketpaw_ee.cloud.chat.ws import manager
+
+    return manager.is_online(user_id)
+
+
+async def _send_over_ws(user_id: str, payload: PushPayload) -> None:
+    """Push a lightweight notification event to a user's live sockets."""
+    from pocketpaw_ee.cloud.chat.schemas import WsOutbound
+    from pocketpaw_ee.cloud.chat.ws import manager
+
+    message = WsOutbound(
+        type=WS_NOTIFICATION_TYPE,
+        data=payload.model_dump(exclude_none=True),
+    )
+    await manager.send_to_user(user_id, message)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+async def notify(
+    workspace_id: str,
+    user_id: str,
+    payload: PushPayload | dict,
+) -> NotifyResult:
+    """Deliver one notification to a user, preferring WS over Web Push.
+
+    The dedupe contract: if the user has a live WebSocket connection the
+    notification is delivered over WS only — Web Push is intentionally NOT
+    sent, so a user with both the desktop app and a browser tab open sees the
+    notification exactly once. With no live connection the dispatch falls back
+    to Web Push (``send_to_user``), so a browser-only or backgrounded user
+    still gets it.
+
+    Validates ``payload`` at entry (rule 6) so internal callers (bus
+    listeners) may pass a raw dict. Returns a :class:`NotifyResult` recording
+    the transport taken, for observability and tests.
+    """
+    payload = PushPayload.model_validate(payload)
+
+    if _is_user_live(user_id):
+        # Live desktop/browser client → WS only, skip Web Push (the dedupe).
+        try:
+            await _send_over_ws(user_id, payload)
+        except Exception:
+            # A WS failure must not silently drop the notification, but the
+            # send_to_user fan-out is a separate path with its own pruning;
+            # we log and report the WS leg rather than double-sending.
+            logger.exception(
+                "ws notification delivery failed for workspace=%s user=%s",
+                workspace_id,
+                user_id,
+            )
+            return NotifyResult(transport="ws", ws_delivered=False)
+        return NotifyResult(transport="ws", ws_delivered=True)
+
+    # No live connection → Web Push fallback.
+    result = await push_service.send_to_user(workspace_id, user_id, payload)
+    return NotifyResult(transport="push", ws_delivered=False, send=result)
+
+
+__all__ = ["NotifyResult", "WS_NOTIFICATION_TYPE", "notify"]

--- a/ee/pocketpaw_ee/cloud/push/dto.py
+++ b/ee/pocketpaw_ee/cloud/push/dto.py
@@ -7,6 +7,11 @@
 # Updated: 2026-06-09 (review nits) — ``SubscriptionResponse`` exposes
 # ``created_at`` (the inherited ``createdAt``, ISO-UTC) instead of the removed
 # dead model field.
+# Updated: 2026-06-09 (feat/push-send-prune, pocketpaw#1392) — added the
+# ``PushPayload`` notification body (title/body + optional url/icon/tag) the
+# send path serializes to the browser, and ``SendResult`` (sent + pruned
+# counts) the fan-out returns to its caller. Both are pure wire models with
+# no key material.
 
 from __future__ import annotations
 
@@ -63,6 +68,37 @@ class VapidPublicKeyResponse(BaseModel):
     key: str
 
 
+class PushPayload(BaseModel):
+    """The notification body the send path serializes and ships to a browser.
+
+    Maps onto the fields the service worker's ``push`` handler reads when it
+    calls ``registration.showNotification(title, options)``. ``title`` and
+    ``body`` are the only required fields; ``url`` (deep-link opened on click),
+    ``icon``, and ``tag`` (collapse key — a later notification with the same
+    tag replaces an earlier one) are optional. The whole model is JSON-encoded
+    as the encrypted Web Push payload, so it carries no server secrets.
+    """
+
+    title: str
+    body: str
+    url: str | None = None
+    icon: str | None = None
+    tag: str | None = None
+
+
+class SendResult(BaseModel):
+    """Outcome of a fan-out send to one user's subscriptions.
+
+    ``sent`` counts endpoints the push service accepted; ``pruned`` counts
+    dead endpoints (404/410) deleted during the fan-out; ``failed`` counts
+    endpoints that errored for some other reason (logged, left in place).
+    """
+
+    sent: int = 0
+    pruned: int = 0
+    failed: int = 0
+
+
 def subscription_to_dto(sub: PushSubscription) -> SubscriptionResponse:
     """Map a domain ``PushSubscription`` to its wire DTO."""
     return SubscriptionResponse(
@@ -75,6 +111,8 @@ def subscription_to_dto(sub: PushSubscription) -> SubscriptionResponse:
 
 __all__ = [
     "PushKeysIn",
+    "PushPayload",
+    "SendResult",
     "SubscribeRequest",
     "SubscriptionResponse",
     "UnsubscribeRequest",

--- a/ee/pocketpaw_ee/cloud/push/listeners.py
+++ b/ee/pocketpaw_ee/cloud/push/listeners.py
@@ -1,0 +1,288 @@
+# Product events → notification dispatch (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — subscribes the v1 notification
+# event set to the realtime in-process bus and routes each to ``notify(...)``
+# (push/dispatch.py), which forks WS-vs-Web-Push so a user is never
+# double-notified. Mirrors the meeting-notifications bridge pattern
+# (meetings/bridges/notifications.py): one handler per event type, each
+# resolving recipients + a small {title, body, url?} payload, registered from
+# ``mount_cloud`` after ``init_realtime`` installs the singleton bus.
+#
+# Updated: 2026-07-02 (feat/push-user-message-notifications) — wired
+# ``message.sent`` → ``on_new_message`` so a human-to-human message notifies the
+# group's OTHER human members. The body is generic-with-a-count ("N new
+# messages") — the message text never reaches the OS notification surface
+# (lock-screen privacy). Only the human ``message_add`` path emits
+# ``message.sent``; agent replies ride ``agent.stream_end`` (on_agent_complete),
+# so there is no double-notify.
+#
+# v1 events wired (those with a real emission point + a resolvable recipient):
+#   - agent.stream_end           → agent-complete. Recipients = the group's
+#                                  human members (resolved off the group the
+#                                  payload names; the payload itself carries
+#                                  no workspace_id, so we read it from the
+#                                  group domain).
+#   - instinct.approval.created  → guardian-block. The Instinct/guardian layer
+#                                  gated an action into the approval queue;
+#                                  recipient = ``requested_by`` (the user whose
+#                                  action was blocked), workspace = the event's
+#                                  ``workspace_id``.
+#   - meeting.started            → meeting-start. Recipients = creator
+#                                  (recall) or every group member (livekit),
+#                                  matching the existing meeting bridge's
+#                                  recipient logic.
+#
+# Each handler is best-effort: a failure to resolve recipients or dispatch is
+# logged and swallowed so one bad event can't break the bus fan-out (the bus
+# already isolates handler exceptions, but we double-guard the DB/dispatch
+# calls). No Beanie writes happen here — the only writer remains
+# push/service.py via dispatch.notify → send_to_user.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw_ee.cloud._core.realtime.events import Event
+from pocketpaw_ee.cloud.push import coalesce, dispatch
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Recipient resolution helpers
+# ---------------------------------------------------------------------------
+
+
+async def _group_member_ids(group_id: str) -> list[str]:
+    """Human member user_ids for a group. Returns [] on any error."""
+    try:
+        from pocketpaw_ee.cloud.chat import group_service
+
+        return await group_service.list_member_ids(group_id)
+    except Exception:
+        logger.exception("push: failed to list members for group=%s", group_id)
+        return []
+
+
+async def _group_workspace_id(group_id: str) -> str | None:
+    """Resolve the workspace a group belongs to. None on any error/miss.
+
+    ``agent.stream_end`` carries ``group_id`` but no ``workspace_id``; the
+    Web Push leg needs the workspace to find the tenant's VAPID key, so we
+    read it from the group domain here.
+    """
+    try:
+        from pocketpaw_ee.cloud.chat import group_service
+
+        group = await group_service.get_for_dispatch(group_id)
+        return group.workspace_id if group else None
+    except Exception:
+        logger.exception("push: failed to resolve workspace for group=%s", group_id)
+        return None
+
+
+async def _dispatch(workspace_id: str, user_id: str, payload: dict[str, Any]) -> None:
+    """Route one notification through the WS/Web-Push dedupe. Best-effort."""
+    try:
+        await dispatch.notify(workspace_id, user_id, payload)
+    except Exception:
+        logger.exception(
+            "push: notify dispatch failed for workspace=%s user=%s",
+            workspace_id,
+            user_id,
+        )
+
+
+async def _unread_count(user_id: str, group_id: str) -> int:
+    """Unread count for one (user, group), for the new-message body. Best-effort.
+
+    Falls back to ``1`` on any error so the notification body still reads
+    sensibly ("1 new message") rather than "0 new messages".
+    """
+    try:
+        from pocketpaw_ee.cloud.chat import unread_service
+
+        return await unread_service.unread_count(user_id, group_id)
+    except Exception:
+        logger.exception(
+            "push: unread count failed for user=%s group=%s", user_id, group_id
+        )
+        return 1
+
+
+def _count_body(count: int) -> str:
+    """Generic, content-free body carrying only the unread count.
+
+    The message text is deliberately NOT included — a human-to-human push
+    lands on the lock screen, so only the count crosses that surface.
+    """
+    return "1 new message" if count <= 1 else f"{count} new messages"
+
+
+# ---------------------------------------------------------------------------
+# Handlers — one per event type
+# ---------------------------------------------------------------------------
+
+
+async def on_agent_complete(event: Event) -> None:
+    """agent.stream_end → notify the group's human members the agent replied."""
+    data = event.data or {}
+    group_id = data.get("group_id")
+    if not group_id:
+        return
+
+    workspace_id = await _group_workspace_id(group_id)
+    if not workspace_id:
+        return
+
+    recipients = await _group_member_ids(group_id)
+    if not recipients:
+        return
+
+    agent_name = data.get("agent_name") or "Your agent"
+    payload = {
+        "title": f"{agent_name} replied",
+        "body": "Your agent finished responding.",
+        "url": f"/?join={group_id}",
+    }
+    for recipient in recipients:
+        await _dispatch(workspace_id, recipient, payload)
+
+
+async def on_guardian_block(event: Event) -> None:
+    """instinct.approval.created → notify the user whose action was gated."""
+    data = event.data or {}
+    workspace_id = data.get("workspace_id")
+    recipient = data.get("requested_by")
+    if not (workspace_id and recipient):
+        return
+
+    action_name = data.get("action_name") or "An action"
+    payload = {
+        "title": "Action needs approval",
+        "body": f"{action_name} was held for your review.",
+        "url": "/?view=approvals",
+    }
+    await _dispatch(workspace_id, recipient, payload)
+
+
+async def on_meeting_started(event: Event) -> None:
+    """meeting.started → notify the meeting's recipients it has begun."""
+    data = event.data or {}
+    workspace_id = data.get("workspace_id")
+    meeting_id = data.get("meeting_id")
+    if not (workspace_id and meeting_id):
+        return
+
+    source = data.get("source", "recall")
+    group_id = data.get("group_id")
+    if source == "livekit" and group_id:
+        recipients = await _group_member_ids(group_id)
+    else:
+        creator = data.get("created_by") or data.get("organizer_user_id")
+        recipients = [creator] if creator else []
+
+    if not recipients:
+        return
+
+    payload = {
+        "title": "Meeting started",
+        "body": "A meeting has started.",
+        "url": f"/?join=meeting-{meeting_id}",
+    }
+    for recipient in recipients:
+        await _dispatch(workspace_id, recipient, payload)
+
+
+async def on_new_message(event: Event) -> None:
+    """message.sent → notify a group's OTHER human members of a new message.
+
+    Generic-with-a-count: the title names the sender, the body is only the
+    unread count ("N new messages") — the message text never reaches the OS
+    notification surface. The sender is excluded (no self-ping), and the
+    WS-vs-Web-Push dedupe in ``dispatch.notify`` means only members with no
+    live connection actually receive a Web Push.
+
+    Only the human ``message_add`` path emits ``message.sent``; the
+    ``senderType != "user"`` guard is defensive belt-and-braces so an
+    agent-authored message can never double-fire alongside
+    ``on_agent_complete`` (agent.stream_end).
+
+    ``message.sent`` carries the wire dict (camelCase ``senderName`` /
+    ``senderType``) plus ``group_id`` + ``sender_id`` but NO ``workspace_id``,
+    so the workspace is resolved from the group — mirroring on_agent_complete.
+
+    Each send is routed through the leading-edge coalescer (push/coalesce.py):
+    the first message pings instantly, a burst within the cooldown collapses to
+    one trailing send. The emit closure recomputes the unread count at send
+    time, so both the leading and any trailing push carry a current count.
+    """
+    data = event.data or {}
+    group_id = data.get("group_id")
+    if not group_id:
+        return
+    if data.get("senderType") not in (None, "user"):
+        return
+
+    workspace_id = await _group_workspace_id(group_id)
+    if not workspace_id:
+        return
+
+    sender_id = data.get("sender_id")
+    recipients = [uid for uid in await _group_member_ids(group_id) if uid != sender_id]
+    if not recipients:
+        return
+
+    title = data.get("senderName") or "New message"
+    url = f"/?join={group_id}"
+    for recipient in recipients:
+        # ``recipient`` is bound as a default arg so the closure captures THIS
+        # iteration's value (the other captured names are constant per call).
+        # The count is recomputed inside so a coalesced trailing send reflects
+        # the accumulated unread total. ``tag`` is the group id so the OS
+        # collapses a conversation's notifications into one updating toast.
+        async def _emit(recipient: str = recipient) -> None:
+            count = await _unread_count(recipient, group_id)
+            await _dispatch(
+                workspace_id,
+                recipient,
+                {
+                    "title": title,
+                    "body": _count_body(count),
+                    "url": url,
+                    "tag": group_id,
+                },
+            )
+
+        await coalesce.submit((workspace_id, recipient, group_id), _emit)
+
+
+# ---------------------------------------------------------------------------
+# Registration — called from mount_cloud() after init_realtime.
+# ---------------------------------------------------------------------------
+
+
+def register_push_event_listeners() -> None:
+    """Wire the v1 product events → notification dispatch. Idempotent-safe.
+
+    Subscribes on the realtime in-process bus (the same bus the WS fan-out
+    rides), so handlers fire whether or not any client is currently
+    subscribed. Must run AFTER ``init_realtime`` installs the singleton bus.
+    """
+    from pocketpaw_ee.cloud._core.realtime.bus import get_bus
+
+    bus = get_bus()
+    bus.subscribe("agent.stream_end", on_agent_complete)
+    bus.subscribe("instinct.approval.created", on_guardian_block)
+    bus.subscribe("meeting.started", on_meeting_started)
+    bus.subscribe("message.sent", on_new_message)
+    logger.info("registered v1 product events → push notification dispatch")
+
+
+__all__ = [
+    "on_agent_complete",
+    "on_guardian_block",
+    "on_meeting_started",
+    "on_new_message",
+    "register_push_event_listeners",
+]

--- a/ee/pocketpaw_ee/cloud/push/service.py
+++ b/ee/pocketpaw_ee/cloud/push/service.py
@@ -61,7 +61,7 @@ from pymongo.errors import DuplicateKeyError
 from pywebpush import WebPushException, webpush  # type: ignore[import-untyped]
 
 from pocketpaw_ee.cloud._core import crypto
-from pocketpaw_ee.cloud._core.errors import ConflictError, NotFound
+from pocketpaw_ee.cloud._core.errors import ConflictError, NotFound, ValidationError
 from pocketpaw_ee.cloud.models.push_subscription import PushKeys as _PushKeysDoc
 from pocketpaw_ee.cloud.models.push_subscription import PushSubscription as _PushSubscriptionDoc
 from pocketpaw_ee.cloud.models.vapid_keypair import VapidKeypair as _VapidKeypairDoc
@@ -89,6 +89,49 @@ def _vapid_contact() -> str:
     project default so no individual's address is ever hardcoded.
     """
     return os.environ.get(_PUSH_CONTACT_ENV, "").strip() or _DEFAULT_PUSH_CONTACT
+
+
+# Total request timeout (seconds) handed to ``webpush`` → ``requests.post``.
+# Never ``None`` — see the send loop for why an unbounded timeout is dangerous.
+_SEND_TIMEOUT_SECONDS = 10
+
+
+# Endpoint SSRF guard. A subscription ``endpoint`` is attacker-controlled (any
+# authenticated user POSTs it), stored verbatim, and later POSTed to by the
+# send path via ``requests``. Without validation a user could register
+# ``http://169.254.169.254/…`` (cloud metadata) or an internal host and then
+# self-trigger a send to make the backend fetch it (blind SSRF). We only ever
+# talk to the real browser push services, so allowlist their hosts and require
+# https. Suffix match so regional/sharded subdomains are covered.
+_ALLOWED_PUSH_HOST_SUFFIXES = (
+    "push.services.mozilla.com",  # Firefox (autopush)
+    "fcm.googleapis.com",  # Chrome / Chromium / Edge (FCM)
+    "web.push.apple.com",  # Safari / WebKit
+    "notify.windows.com",  # legacy Windows WNS (*.notify.windows.com)
+)
+
+
+def _validate_push_endpoint(endpoint: str) -> None:
+    """Reject any subscription endpoint that isn't a real push-service URL.
+
+    Requires ``https`` and a host under one of the known browser push-service
+    domains. Raises :class:`ValidationError` otherwise, so an SSRF payload
+    (internal host, metadata IP, non-https scheme) never reaches storage or the
+    outbound ``requests.post`` in the send path.
+    """
+    from urllib.parse import urlsplit
+
+    parts = urlsplit(endpoint)
+    host = (parts.hostname or "").lower()
+    ok = parts.scheme == "https" and any(
+        host == suffix or host.endswith("." + suffix) for suffix in _ALLOWED_PUSH_HOST_SUFFIXES
+    )
+    if not ok:
+        raise ValidationError(
+            "push.endpoint_invalid",
+            "Push endpoint must be an https URL of a known browser push service.",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Mapping helpers — Beanie doc ↔ domain
@@ -200,6 +243,9 @@ async def subscribe(
     the request header.
     """
     body = SubscribeRequest.model_validate(body)
+    # SSRF guard: only store endpoints that point at a real browser push
+    # service (see _validate_push_endpoint). Rejected before any DB write.
+    _validate_push_endpoint(body.endpoint)
     keys_doc = _PushKeysDoc(p256dh=body.keys.p256dh, auth=body.keys.auth)
 
     # Workspace-scoped precheck: only an endpoint already owned by THIS
@@ -288,9 +334,7 @@ async def _delete_by_endpoint(workspace_id: str, endpoint: str) -> None:
     gone (404/410). Kept here so this service stays the sole Beanie writer
     for the push collection (ee/cloud rule §2 + the import-linter contract).
     """
-    doc = await _PushSubscriptionDoc.find_one(
-        {"endpoint": endpoint, "workspace": workspace_id}
-    )
+    doc = await _PushSubscriptionDoc.find_one({"endpoint": endpoint, "workspace": workspace_id})
     if doc is not None:
         await doc.delete()  # no-event: dead-endpoint cleanup, no consumers until #1393
 
@@ -353,6 +397,13 @@ async def send_to_user(
                 # ``vapid_claims`` is mutated in place by py-vapid (it stamps
                 # ``exp``/``aud``), so hand each call its own copy.
                 vapid_claims=dict(vapid_claims),
+                # webpush() passes this straight to ``requests.post``; without
+                # it the default is ``timeout=None`` = block forever. Each send
+                # runs in an ``asyncio.to_thread`` worker, so one push endpoint
+                # that accepts the connection but never responds would park a
+                # thread-pool slot indefinitely — enough of them starve the
+                # shared pool and stall EVERY ``to_thread`` in the process.
+                timeout=_SEND_TIMEOUT_SECONDS,
             )
             result.sent += 1
         except WebPushException as exc:

--- a/ee/pocketpaw_ee/cloud/push/service.py
+++ b/ee/pocketpaw_ee/cloud/push/service.py
@@ -8,6 +8,18 @@
 # The cross-workspace collision is caught as a ``DuplicateKeyError`` (the
 # endpoint unique index) and surfaced as a ``ConflictError``, mirroring the
 # keypair race handling.
+# Updated: 2026-06-09 (feat/push-send-prune, pocketpaw#1392) — added the
+# Web Push SEND path: ``send_to_user`` fans a ``PushPayload`` out to every
+# stored subscription for a user, signing+encrypting each with the tenant's
+# VAPID private key (obtained via the existing ``get_decrypted_private_pem``
+# chokepoint — the private key never leaves the backend) and POSTing to the
+# browser vendor endpoint via ``pywebpush``. A 404/410 response means the
+# subscription is dead, so the row is deleted here (this service stays the
+# sole Beanie writer). Any other error is logged and skipped so one bad
+# endpoint can't abort the rest of the fan-out. Pruning a dead subscription
+# is a local cleanup with no downstream consumers, so it carries a
+# ``# no-event``; wiring sends to real product events + WS-vs-push dedupe is
+# the follow-up (#1393), NOT here.
 #
 # Responsibilities:
 #   - ``get_vapid_public_key(workspace_id)`` — return the workspace's VAPID
@@ -18,21 +30,28 @@
 #   - ``unsubscribe(workspace_id, user_id, body)`` — remove a subscription
 #     by endpoint (workspace-scoped).
 #   - ``list_for_user(...)`` — read a user's subscriptions (used by the
-#     send path in #1392).
+#     send path).
+#   - ``send_to_user(workspace_id, user_id, payload)`` — fan a notification
+#     out to the user's live subscriptions, pruning dead (404/410) ones.
 #
 # Tenancy: every read filters on ``workspace`` (ee/cloud rule §7), except the
 # one deliberate global read flagged with ``# global-read:``. The VAPID
 # private key is stored Fernet-encrypted (``_core.crypto``) and only ever
 # decrypted by the send path — it never crosses the wire.
 #
-# No events are emitted here: subscribe/unsubscribe are local persistence
-# with no downstream consumers until the send path lands (#1392). Each
-# mutating function carries an explicit ``# no-event`` per ee/cloud rule §9.
+# No events are emitted here: subscribe/unsubscribe/prune are local
+# persistence with no downstream consumers until event wiring lands (#1393).
+# Each mutating function carries an explicit ``# no-event`` per ee/cloud rule §9.
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import os
+
 from py_vapid import Vapid01, b64urlencode  # type: ignore[import-untyped]
 from pymongo.errors import DuplicateKeyError
+from pywebpush import WebPushException, webpush  # type: ignore[import-untyped]
 
 from pocketpaw_ee.cloud._core import crypto
 from pocketpaw_ee.cloud._core.errors import ConflictError, NotFound
@@ -40,7 +59,29 @@ from pocketpaw_ee.cloud.models.push_subscription import PushKeys as _PushKeysDoc
 from pocketpaw_ee.cloud.models.push_subscription import PushSubscription as _PushSubscriptionDoc
 from pocketpaw_ee.cloud.models.vapid_keypair import VapidKeypair as _VapidKeypairDoc
 from pocketpaw_ee.cloud.push.domain import PushKeys, PushSubscription
-from pocketpaw_ee.cloud.push.dto import SubscribeRequest, UnsubscribeRequest
+from pocketpaw_ee.cloud.push.dto import (
+    PushPayload,
+    SendResult,
+    SubscribeRequest,
+    UnsubscribeRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+# The VAPID ``sub`` claim — a contact (mailto: or https: URL) the push service
+# can reach if our sends misbehave. Operator-configurable via env; the default
+# is a non-personal project address, never a real individual's inbox.
+_PUSH_CONTACT_ENV = "CLOUD_PUSH_CONTACT"
+_DEFAULT_PUSH_CONTACT = "mailto:push@pocketpaw.app"
+
+
+def _vapid_contact() -> str:
+    """Return the VAPID ``sub`` claim (contact mailto:/URL).
+
+    Operator override via ``CLOUD_PUSH_CONTACT``; falls back to a non-personal
+    project default so no individual's address is ever hardcoded.
+    """
+    return os.environ.get(_PUSH_CONTACT_ENV, "").strip() or _DEFAULT_PUSH_CONTACT
 
 # ---------------------------------------------------------------------------
 # Mapping helpers — Beanie doc ↔ domain
@@ -228,10 +269,107 @@ async def get_decrypted_private_pem(workspace_id: str) -> str:
     return crypto.decrypt(doc.private_pem_encrypted)
 
 
+# ---------------------------------------------------------------------------
+# Send — fan a notification out to a user's subscriptions, prune the dead
+# ---------------------------------------------------------------------------
+
+
+async def _delete_by_endpoint(workspace_id: str, endpoint: str) -> None:
+    """Delete a dead subscription row by endpoint, workspace-scoped.
+
+    Called from the send path when the push service reports the endpoint
+    gone (404/410). Kept here so this service stays the sole Beanie writer
+    for the push collection (ee/cloud rule §2 + the import-linter contract).
+    """
+    doc = await _PushSubscriptionDoc.find_one(
+        {"endpoint": endpoint, "workspace": workspace_id}
+    )
+    if doc is not None:
+        await doc.delete()  # no-event: dead-endpoint cleanup, no consumers until #1393
+
+
+def _status_of(exc: WebPushException) -> int | None:
+    """Best-effort HTTP status from a WebPushException's vendor response."""
+    response = getattr(exc, "response", None)
+    return getattr(response, "status_code", None) if response is not None else None
+
+
+async def send_to_user(
+    workspace_id: str,
+    user_id: str,
+    payload: PushPayload | dict,
+) -> SendResult:
+    """Send a Web Push notification to every live subscription for a user.
+
+    Fans ``payload`` out to each of the user's stored subscriptions, signing
+    and encrypting per-endpoint with the tenant's VAPID private key (fetched
+    through the ``get_decrypted_private_pem`` chokepoint — the key is read
+    once per fan-out and never leaves this process). ``pywebpush.webpush`` is
+    synchronous (it POSTs via ``requests``), so each call runs in a worker
+    thread to keep the service async and the endpoints concurrent-friendly.
+
+    Dead-endpoint pruning: a ``404`` or ``410`` from the push service means
+    the browser dropped the subscription, so that row is deleted. Any other
+    error is logged and skipped — one unreachable endpoint must not abort the
+    rest of the fan-out. Returns a :class:`SendResult` summarizing the run.
+    """
+    payload = PushPayload.model_validate(payload)
+    subs = await list_for_user(workspace_id, user_id)
+    result = SendResult()
+    if not subs:
+        return result
+
+    # Single chokepoint read of the tenant private key for the whole fan-out.
+    private_pem = await get_decrypted_private_pem(workspace_id)
+    vapid_claims = {"sub": _vapid_contact()}
+    data = payload.model_dump_json(exclude_none=True)
+
+    for sub in subs:
+        subscription_info = {
+            "endpoint": sub.endpoint,
+            "keys": {"p256dh": sub.keys.p256dh, "auth": sub.keys.auth},
+        }
+        try:
+            await asyncio.to_thread(
+                webpush,
+                subscription_info=subscription_info,
+                data=data,
+                vapid_private_key=private_pem,
+                # ``vapid_claims`` is mutated in place by py-vapid (it stamps
+                # ``exp``/``aud``), so hand each call its own copy.
+                vapid_claims=dict(vapid_claims),
+            )
+            result.sent += 1
+        except WebPushException as exc:
+            status = _status_of(exc)
+            if status in (404, 410):
+                await _delete_by_endpoint(workspace_id, sub.endpoint)
+                result.pruned += 1
+            else:
+                result.failed += 1
+                logger.warning(
+                    "web push send failed (status=%s) for workspace=%s user=%s: %s",
+                    status,
+                    workspace_id,
+                    user_id,
+                    exc,
+                )
+        except Exception:  # noqa: BLE001 — never let one endpoint abort the fan-out
+            result.failed += 1
+            logger.exception(
+                "unexpected error sending web push for workspace=%s user=%s",
+                workspace_id,
+                user_id,
+            )
+
+    return result
+
+
 __all__ = [
     "get_decrypted_private_pem",
     "get_vapid_public_key",
     "list_for_user",
+    "send_to_user",
     "subscribe",
     "unsubscribe",
 ]

--- a/ee/pocketpaw_ee/cloud/push/service.py
+++ b/ee/pocketpaw_ee/cloud/push/service.py
@@ -21,6 +21,13 @@
 # ``# no-event``; wiring sends to real product events + WS-vs-push dedupe is
 # the follow-up (#1393), NOT here.
 #
+# Updated: 2026-07-02 (fix/push-vapid-pem-send) — the send path handed the raw
+# PKCS#8 PEM *string* to ``webpush(vapid_private_key=...)``, which routes it
+# through ``py_vapid.Vapid.from_string`` (raw/DER-base64 only) and failed EVERY
+# send with an ASN.1 "invalid length" error — no Web Push ever left the box.
+# Now we parse the PEM into a ``Vapid01`` instance (``from_pem``) once per
+# fan-out and hand webpush the instance, which it consumes directly.
+#
 # Responsibilities:
 #   - ``get_vapid_public_key(workspace_id)`` — return the workspace's VAPID
 #     public key, generating the keypair on first call (generate-once /
@@ -321,6 +328,14 @@ async def send_to_user(
 
     # Single chokepoint read of the tenant private key for the whole fan-out.
     private_pem = await get_decrypted_private_pem(workspace_id)
+    # Build the Vapid signer ONCE from the PEM. ``webpush`` accepts a Vapid01
+    # instance directly; passing the raw PEM *string* instead routes it through
+    # ``py_vapid.Vapid.from_string``, which only parses raw/DER base64 keys —
+    # given a PKCS#8 PEM it strips the newlines, base64-decodes the
+    # ``-----BEGIN-----`` header to garbage, and dies with an ASN.1
+    # "invalid length" error, failing EVERY send. ``from_pem`` handles the PEM
+    # our keypair generator emits, so hand webpush the parsed instance.
+    vapid = Vapid01.from_pem(private_pem.encode())
     vapid_claims = {"sub": _vapid_contact()}
     data = payload.model_dump_json(exclude_none=True)
 
@@ -334,7 +349,7 @@ async def send_to_user(
                 webpush,
                 subscription_info=subscription_info,
                 data=data,
-                vapid_private_key=private_pem,
+                vapid_private_key=vapid,
                 # ``vapid_claims`` is mutated in place by py-vapid (it stamps
                 # ``exp``/``aud``), so hand each call its own copy.
                 vapid_claims=dict(vapid_claims),

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -506,6 +506,8 @@ source_modules = [
     "pocketpaw_ee.cloud.push.router",
     "pocketpaw_ee.cloud.push.dto",
     "pocketpaw_ee.cloud.push.domain",
+    "pocketpaw_ee.cloud.push.dispatch",
+    "pocketpaw_ee.cloud.push.listeners",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.push_subscription",

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -150,6 +150,7 @@ dependencies = [
     # py-vapid signs the VAPID JWT for Web Push; ee/pocketpaw_ee/cloud/push/
     # uses it for the per-workspace keypair + subscribe/unsubscribe endpoints.
     "py-vapid>=1.9.0",
+    "pywebpush>=2.3.0",
 ]
 
 [project.optional-dependencies]

--- a/ee/uv.lock
+++ b/ee/uv.lock
@@ -1673,6 +1673,15 @@ wheels = [
 ]
 
 [[package]]
+name = "http-ece"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/af/249d1576653b69c20b9ac30e284b63bd94af6a175d72d87813235caf2482/http_ece-1.2.1.tar.gz", hash = "sha256:8c6ab23116bbf6affda894acfd5f2ca0fb8facbcbb72121c11c75c33e7ce8cff", size = 8830, upload-time = "2024-08-08T00:10:47.301Z" }
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -3316,6 +3325,7 @@ dependencies = [
     { name = "py-vapid" },
     { name = "pyotp" },
     { name = "python-socketio" },
+    { name = "pywebpush" },
     { name = "redis", extra = ["hiredis"] },
     { name = "slowapi" },
 ]
@@ -3364,6 +3374,7 @@ requires-dist = [
     { name = "pytesseract", marker = "extra == 'extraction'", specifier = ">=0.3.10" },
     { name = "python-docx", marker = "extra == 'extraction'", specifier = ">=1.1.0" },
     { name = "python-socketio", specifier = ">=5.11.0" },
+    { name = "pywebpush", specifier = ">=2.3.0" },
     { name = "redis", extras = ["hiredis"], specifier = ">=5.0.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "trafilatura", marker = "extra == 'extraction'" },
@@ -3944,6 +3955,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
+name = "pywebpush"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cryptography" },
+    { name = "http-ece" },
+    { name = "py-vapid" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/d9/e497a24bc9f659bfc0e570382a41e6b2d6726fbcfa4d85aaa23fe9c81ba2/pywebpush-2.3.0.tar.gz", hash = "sha256:d1e27db8de9e6757c1875f67292554bd54c41874c36f4b5c4ebb5442dce204f2", size = 28489, upload-time = "2026-02-09T23:30:18.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/d8/ac21241cf8007cb93255eabf318da4f425ec0f75d28c366992253aa8c1b2/pywebpush-2.3.0-py3-none-any.whl", hash = "sha256:3d97469fb14d4323c362319d438183737249a4115b50e146ce233e7f01e3cf98", size = 22851, upload-time = "2026-02-09T23:30:16.093Z" },
 ]
 
 [[package]]

--- a/tests/cloud/push/test_coalesce.py
+++ b/tests/cloud/push/test_coalesce.py
@@ -1,0 +1,123 @@
+# Tests for the leading-edge push coalescer (feat/push-user-message-notifications).
+# Created: 2026-07-02 — proves the throttle contract without real sockets or DB:
+#   - leading edge fires immediately (zero added latency);
+#   - a burst on one key collapses to leading + one trailing flush;
+#   - a sustained stream is capped at one send per window;
+#   - distinct keys throttle independently;
+#   - window <= 0 disables coalescing (pass-through).
+# Uses a tiny window (0.05s) and real asyncio.sleep so the timing is exercised
+# for real; ``reset()`` between cases prevents window state from leaking.
+#
+# Updated 2026-07-02: the leading edge now fires DETACHED (a background task) so
+# ``submit`` returns without blocking the caller. It still fires "immediately"
+# (next loop tick, sub-ms), but the tests must ``_drain()`` one tick before
+# asserting the leading emit has landed.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud.push import coalesce
+
+# Small enough to keep the suite fast; large enough to be robust on a loaded CI.
+_WINDOW = 0.05
+
+
+@pytest.fixture(autouse=True)
+async def _clean(monkeypatch):
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", str(_WINDOW))
+    await coalesce.aclose()
+    yield
+    # Await the cancellations so a still-sleeping window task can't schedule a
+    # callback on the loop after it closes.
+    await coalesce.aclose()
+
+
+def _counter():
+    calls: list[int] = []
+
+    async def emit() -> None:
+        calls.append(1)
+
+    return calls, emit
+
+
+async def _drain() -> None:
+    """Yield a loop tick so detached leading-edge emits run before we assert.
+
+    The leading edge is fired via ``asyncio.create_task``, so it runs on the
+    next tick rather than synchronously inside ``submit``. One short sleep lets
+    every currently-ready leading emit complete without waiting for a window.
+    """
+    await asyncio.sleep(0.01)
+
+
+async def test_leading_edge_fires_immediately() -> None:
+    calls, emit = _counter()
+    await coalesce.submit(("w", "u", "g"), emit)
+    await _drain()
+    # Fired on the leading edge (detached, next tick) — no wait for the window.
+    assert len(calls) == 1
+
+
+async def test_burst_collapses_to_leading_plus_one() -> None:
+    calls, emit = _counter()
+    key = ("w", "u", "g")
+    for _ in range(10):
+        await coalesce.submit(key, emit)
+
+    await _drain()
+    # Only the leading push has gone out so far; the other 9 are suppressed.
+    assert len(calls) == 1
+
+    # Let the window elapse: exactly one trailing flush for the whole burst.
+    await asyncio.sleep(_WINDOW * 3)
+    assert len(calls) == 2
+
+
+async def test_sustained_stream_capped_per_window() -> None:
+    calls, emit = _counter()
+    key = ("w", "u", "g")
+
+    # Leading push.
+    await coalesce.submit(key, emit)
+    await _drain()
+    assert len(calls) == 1
+
+    # Two more windows, each fed a suppressed message → each yields one flush.
+    for _ in range(2):
+        await coalesce.submit(key, emit)  # suppressed, remembered
+        await asyncio.sleep(_WINDOW * 2)  # window elapses → one trailing flush
+
+    # 1 leading + 2 per-window trailing flushes.
+    assert len(calls) == 3
+
+
+async def test_distinct_keys_are_independent() -> None:
+    calls, emit = _counter()
+    await coalesce.submit(("w", "alice", "g"), emit)
+    await coalesce.submit(("w", "bob", "g"), emit)
+    await _drain()
+    # Two different recipients → two leading pushes, neither suppresses the other.
+    assert len(calls) == 2
+
+
+async def test_disabled_is_passthrough(monkeypatch) -> None:
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "0")
+    calls, emit = _counter()
+    key = ("w", "u", "g")
+    for _ in range(3):
+        await coalesce.submit(key, emit)
+    # No throttling: every submit emits immediately.
+    assert len(calls) == 3
+
+
+async def test_malformed_window_uses_default(monkeypatch) -> None:
+    # A bad env value must not break delivery: it falls back to the default
+    # (a positive window), so the first submit still fires on the leading edge.
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "not-a-number")
+    calls, emit = _counter()
+    await coalesce.submit(("w", "u", "g"), emit)
+    await _drain()
+    assert len(calls) == 1

--- a/tests/cloud/push/test_dispatch.py
+++ b/tests/cloud/push/test_dispatch.py
@@ -1,0 +1,167 @@
+# Tests for the notification dispatch + WS-vs-Web-Push dedupe (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — exercises ``dispatch.notify``:
+#   - a LIVE user is delivered over WebSocket and Web Push is NEVER sent
+#     (the dedupe — verified by asserting send_to_user was not called);
+#   - an OFFLINE (browser-only / backgrounded) user falls back to Web Push;
+#   - a desktop-only live user takes the WS/native path;
+#   - the returned NotifyResult records the transport for observability;
+#   - a WS delivery failure is reported (not silently double-sent over push).
+# The WS layer and the push send path are both mocked — no real sockets, no
+# network. The liveness check and the WS send are patched via the module's
+# injectable seams (``_is_user_live`` / ``_send_over_ws``); one integration
+# test drives the real ConnectionManager singleton to prove the seam matches.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.push import dispatch
+from pocketpaw_ee.cloud.push.dto import PushPayload, SendResult
+
+_PAYLOAD = {"title": "Hi", "body": "There", "url": "/inbox"}
+
+
+# ---------------------------------------------------------------------------
+# Dedupe — live user gets WS only, offline user gets Web Push only.
+# ---------------------------------------------------------------------------
+
+
+async def test_live_user_delivers_ws_and_skips_web_push(monkeypatch) -> None:
+    monkeypatch.setattr(dispatch, "_is_user_live", lambda uid: True)
+
+    ws_sent: list[tuple[str, PushPayload]] = []
+
+    async def fake_ws(user_id: str, payload: PushPayload) -> None:
+        ws_sent.append((user_id, payload))
+
+    monkeypatch.setattr(dispatch, "_send_over_ws", fake_ws)
+
+    # Web Push must NOT be touched on the live path.
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append((workspace_id, user_id))
+        return SendResult(sent=1)
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "u1", _PAYLOAD)
+
+    assert result.transport == "ws"
+    assert result.ws_delivered is True
+    assert result.send is None
+    # Delivered over WS exactly once...
+    assert len(ws_sent) == 1
+    assert ws_sent[0][0] == "u1"
+    assert ws_sent[0][1].title == "Hi"
+    # ...and Web Push was never sent (the dedupe).
+    assert push_calls == []
+
+
+async def test_offline_user_falls_back_to_web_push(monkeypatch) -> None:
+    monkeypatch.setattr(dispatch, "_is_user_live", lambda uid: False)
+
+    ws_calls: list = []
+
+    async def fake_ws(user_id, payload):
+        ws_calls.append(user_id)
+
+    monkeypatch.setattr(dispatch, "_send_over_ws", fake_ws)
+
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append((workspace_id, user_id, payload))
+        return SendResult(sent=2, pruned=1)
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "u2", _PAYLOAD)
+
+    assert result.transport == "push"
+    assert result.ws_delivered is False
+    assert result.send is not None
+    assert result.send.sent == 2
+    assert result.send.pruned == 1
+    # Web Push got the call...
+    assert len(push_calls) == 1
+    assert push_calls[0][0] == "w1"
+    assert push_calls[0][1] == "u2"
+    # ...and WS was never used on the offline path.
+    assert ws_calls == []
+
+
+async def test_dispatch_validates_dict_payload(monkeypatch) -> None:
+    # A raw dict from a bus listener is validated into a PushPayload at entry.
+    monkeypatch.setattr(dispatch, "_is_user_live", lambda uid: True)
+    captured: dict = {}
+
+    async def fake_ws(user_id, payload):
+        captured["payload"] = payload
+
+    monkeypatch.setattr(dispatch, "_send_over_ws", fake_ws)
+
+    await dispatch.notify("w1", "u1", {"title": "T", "body": "B"})
+
+    assert isinstance(captured["payload"], PushPayload)
+    assert captured["payload"].title == "T"
+
+
+async def test_ws_failure_does_not_double_send_over_push(monkeypatch) -> None:
+    # If the WS leg raises, we report a failed WS delivery rather than also
+    # firing Web Push (no double-notify).
+    monkeypatch.setattr(dispatch, "_is_user_live", lambda uid: True)
+
+    async def boom(user_id, payload):
+        raise RuntimeError("socket closed")
+
+    monkeypatch.setattr(dispatch, "_send_over_ws", boom)
+
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append(user_id)
+        return SendResult()
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "u1", _PAYLOAD)
+
+    assert result.transport == "ws"
+    assert result.ws_delivered is False
+    assert push_calls == []  # Web Push was NOT used as a fallback.
+
+
+# ---------------------------------------------------------------------------
+# Integration — the real ConnectionManager singleton drives the liveness seam.
+# ---------------------------------------------------------------------------
+
+
+async def test_liveness_seam_reflects_connection_manager(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    from pocketpaw_ee.cloud.chat.ws import manager
+
+    # Web Push is mocked so the offline branch never hits the network.
+    async def fake_send(workspace_id, user_id, payload):
+        return SendResult()
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    # Browser-only user (no connection) → Web Push.
+    offline = await dispatch.notify("w1", "ghost", _PAYLOAD)
+    assert offline.transport == "push"
+
+    # Connect a fake socket for the user on the real singleton, then dispatch:
+    # the same manager the bus uses now reports the user live → WS path.
+    ws = AsyncMock()
+    await manager.connect(ws, "desktop-user")
+    try:
+        live = await dispatch.notify("w1", "desktop-user", _PAYLOAD)
+        assert live.transport == "ws"
+        assert live.ws_delivered is True
+        # The WS message was actually pushed to the fake socket.
+        assert ws.send_json.await_count == 1
+        sent = ws.send_json.await_args.args[0]
+        assert sent["type"] == dispatch.WS_NOTIFICATION_TYPE
+        assert sent["data"]["title"] == "Hi"
+    finally:
+        await manager.disconnect(ws)

--- a/tests/cloud/push/test_listeners.py
+++ b/tests/cloud/push/test_listeners.py
@@ -1,0 +1,277 @@
+# Tests for the product-event → notification dispatch listeners (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — proves each v1 handler resolves
+# the right recipients + payload and routes through ``dispatch.notify``:
+#   - on_agent_complete: resolves the group's workspace + members and notifies
+#     every human member (agent.stream_end carries no workspace_id);
+#   - on_guardian_block: notifies ``requested_by`` in the event's workspace;
+#   - on_meeting_started: notifies the creator (recall) or group members
+#     (livekit), mirroring the meeting bridge.
+# ``dispatch.notify`` is patched to record calls — no WS, no Web Push, no DB.
+# group_service lookups are patched so no Mongo is needed.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import (
+    AgentStreamEnd,
+    InstinctApprovalCreated,
+    MessageSent,
+)
+from pocketpaw_ee.cloud.meetings.events import MeetingStarted
+from pocketpaw_ee.cloud.push import listeners
+
+
+@pytest.fixture
+def notify_calls(monkeypatch):
+    calls: list[tuple[str, str, dict]] = []
+
+    async def fake_notify(workspace_id, user_id, payload):
+        calls.append((workspace_id, user_id, payload))
+
+    monkeypatch.setattr(listeners.dispatch, "notify", fake_notify)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _no_coalesce(monkeypatch):
+    """Run on_new_message with the coalescer OFF (pass-through) so these tests
+    assert the recipient/payload logic directly. The leading-edge throttle has
+    its own dedicated suite in test_coalesce.py. ``reset()`` clears any window
+    state so a lingering task can't leak into the next test."""
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "0")
+    listeners.coalesce.reset()
+    yield
+    listeners.coalesce.reset()
+
+
+# ---------------------------------------------------------------------------
+# agent-complete (agent.stream_end)
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_complete_notifies_group_members(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return "w-agent"
+
+    async def fake_members(group_id):
+        return ["alice", "bob"]
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+
+    event = AgentStreamEnd(data={"group_id": "g1", "agent_name": "Scout"})
+    await listeners.on_agent_complete(event)
+
+    assert {uid for _, uid, _ in notify_calls} == {"alice", "bob"}
+    assert all(ws == "w-agent" for ws, _, _ in notify_calls)
+    assert all("Scout" in p["title"] for _, _, p in notify_calls)
+
+
+async def test_agent_complete_noop_without_group(notify_calls) -> None:
+    await listeners.on_agent_complete(AgentStreamEnd(data={}))
+    assert notify_calls == []
+
+
+async def test_agent_complete_noop_when_workspace_unresolved(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return None
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    await listeners.on_agent_complete(AgentStreamEnd(data={"group_id": "g1"}))
+    assert notify_calls == []
+
+
+# ---------------------------------------------------------------------------
+# guardian-block (instinct.approval.created)
+# ---------------------------------------------------------------------------
+
+
+async def test_guardian_block_notifies_requester(notify_calls) -> None:
+    event = InstinctApprovalCreated(
+        data={
+            "workspace_id": "w1",
+            "requested_by": "carol",
+            "action_name": "send_email",
+        }
+    )
+    await listeners.on_guardian_block(event)
+
+    assert len(notify_calls) == 1
+    ws, uid, payload = notify_calls[0]
+    assert ws == "w1"
+    assert uid == "carol"
+    assert "send_email" in payload["body"]
+
+
+async def test_guardian_block_noop_without_recipient(notify_calls) -> None:
+    await listeners.on_guardian_block(InstinctApprovalCreated(data={"workspace_id": "w1"}))
+    assert notify_calls == []
+
+
+# ---------------------------------------------------------------------------
+# meeting-start (meeting.started)
+# ---------------------------------------------------------------------------
+
+
+async def test_meeting_started_notifies_creator_for_recall(notify_calls) -> None:
+    event = MeetingStarted(
+        data={
+            "workspace_id": "w1",
+            "meeting_id": "m1",
+            "source": "recall",
+            "created_by": "dave",
+        }
+    )
+    await listeners.on_meeting_started(event)
+
+    assert len(notify_calls) == 1
+    ws, uid, payload = notify_calls[0]
+    assert (ws, uid) == ("w1", "dave")
+    assert "meeting-m1" in payload["url"]
+
+
+async def test_meeting_started_notifies_group_for_livekit(notify_calls, monkeypatch) -> None:
+    async def fake_members(group_id):
+        return ["eve", "frank"]
+
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+
+    event = MeetingStarted(
+        data={
+            "workspace_id": "w1",
+            "meeting_id": "m2",
+            "source": "livekit",
+            "group_id": "g9",
+        }
+    )
+    await listeners.on_meeting_started(event)
+
+    assert {uid for _, uid, _ in notify_calls} == {"eve", "frank"}
+
+
+async def test_meeting_started_noop_without_meeting(notify_calls) -> None:
+    await listeners.on_meeting_started(MeetingStarted(data={"workspace_id": "w1"}))
+    assert notify_calls == []
+
+
+# ---------------------------------------------------------------------------
+# new-message (message.sent) — user↔user notifications
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def new_message_env(monkeypatch):
+    """Patch the group + unread lookups so on_new_message needs no Mongo."""
+
+    async def fake_ws_id(group_id):
+        return "w-msg"
+
+    async def fake_members(group_id):
+        return ["alice", "bob", "carol"]
+
+    async def fake_count(user_id, group_id):
+        return 3
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+    monkeypatch.setattr(listeners, "_unread_count", fake_count)
+
+
+async def test_new_message_notifies_other_members_with_count(
+    notify_calls, new_message_env
+) -> None:
+    event = MessageSent(
+        data={
+            "group_id": "g1",
+            "sender_id": "alice",
+            "senderName": "Alice",
+            "senderType": "user",
+        }
+    )
+    await listeners.on_new_message(event)
+
+    # Alice is the sender → excluded; only bob + carol are notified.
+    assert {uid for _, uid, _ in notify_calls} == {"bob", "carol"}
+    assert all(ws == "w-msg" for ws, _, _ in notify_calls)
+    # Title names the sender; body carries ONLY the count (no message text).
+    assert all(p["title"] == "Alice" for _, _, p in notify_calls)
+    assert all(p["body"] == "3 new messages" for _, _, p in notify_calls)
+    # Collapse per-conversation so a later message updates the same toast.
+    assert all(p["tag"] == "g1" for _, _, p in notify_calls)
+
+
+async def test_new_message_body_never_leaks_content(notify_calls, new_message_env) -> None:
+    secret = "wire me $10k to account 12345"
+    event = MessageSent(
+        data={
+            "group_id": "g1",
+            "sender_id": "alice",
+            "senderName": "Alice",
+            "senderType": "user",
+            "content": secret,
+        }
+    )
+    await listeners.on_new_message(event)
+
+    assert notify_calls  # sanity: it did notify
+    for _, _, payload in notify_calls:
+        assert secret not in payload["body"]
+        assert secret not in payload["title"]
+
+
+async def test_new_message_singular_count_body(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return "w"
+
+    async def fake_members(group_id):
+        return ["a", "b"]
+
+    async def fake_count(user_id, group_id):
+        return 1
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+    monkeypatch.setattr(listeners, "_unread_count", fake_count)
+
+    event = MessageSent(
+        data={"group_id": "g", "sender_id": "a", "senderName": "A", "senderType": "user"}
+    )
+    await listeners.on_new_message(event)
+
+    assert notify_calls
+    assert all(p["body"] == "1 new message" for _, _, p in notify_calls)
+
+
+async def test_new_message_skips_agent_authored(notify_calls, monkeypatch) -> None:
+    # An agent-authored message.sent (senderType != "user") must not fire here;
+    # agent replies are covered by on_agent_complete (agent.stream_end).
+    async def boom(*_a, **_k):
+        raise AssertionError("agent-authored message must not resolve recipients")
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", boom)
+
+    await listeners.on_new_message(
+        MessageSent(data={"group_id": "g", "sender_id": "bot", "senderType": "agent"})
+    )
+    assert notify_calls == []
+
+
+async def test_new_message_noop_without_group(notify_calls) -> None:
+    await listeners.on_new_message(MessageSent(data={"sender_id": "a", "senderType": "user"}))
+    assert notify_calls == []
+
+
+async def test_new_message_noop_when_sender_is_only_member(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return "w"
+
+    async def fake_members(group_id):
+        return ["solo"]
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+
+    await listeners.on_new_message(
+        MessageSent(data={"group_id": "g", "sender_id": "solo", "senderType": "user"})
+    )
+    assert notify_calls == []

--- a/tests/cloud/push/test_router.py
+++ b/tests/cloud/push/test_router.py
@@ -67,14 +67,14 @@ async def test_vapid_key_endpoint_serves_public_only(app_client, enc_key) -> Non
 
 async def test_subscribe_then_unsubscribe_round_trip(app_client) -> None:
     body = {
-        "endpoint": "https://push.example/xyz",
+        "endpoint": "https://fcm.googleapis.com/fcm/send/xyz",
         "keys": {"p256dh": "PUB", "auth": "AUTH"},
         "expirationTime": None,
     }
     sub_resp = await app_client.post("/api/v1/push/subscribe", json=body)
     assert sub_resp.status_code == 200
     sub = sub_resp.json()
-    assert sub["endpoint"] == "https://push.example/xyz"
+    assert sub["endpoint"] == "https://fcm.googleapis.com/fcm/send/xyz"
     assert "id" in sub
     # Response carries no key material at all.
     assert "keys" not in sub and "p256dh" not in sub_resp.text
@@ -84,14 +84,14 @@ async def test_subscribe_then_unsubscribe_round_trip(app_client) -> None:
     assert sub_resp2.json()["id"] == sub["id"]
 
     un_resp = await app_client.post(
-        "/api/v1/push/unsubscribe", json={"endpoint": "https://push.example/xyz"}
+        "/api/v1/push/unsubscribe", json={"endpoint": "https://fcm.googleapis.com/fcm/send/xyz"}
     )
     assert un_resp.status_code == 200
     assert un_resp.json() == {"removed": True}
 
     # Second unsubscribe is a no-op.
     un_resp2 = await app_client.post(
-        "/api/v1/push/unsubscribe", json={"endpoint": "https://push.example/xyz"}
+        "/api/v1/push/unsubscribe", json={"endpoint": "https://fcm.googleapis.com/fcm/send/xyz"}
     )
     assert un_resp2.json() == {"removed": False}
 
@@ -100,7 +100,7 @@ async def test_subscribe_captures_user_agent_header(app_client) -> None:
     from pocketpaw_ee.cloud.push import service as push_service
 
     body = {
-        "endpoint": "https://push.example/ua",
+        "endpoint": "https://fcm.googleapis.com/fcm/send/ua",
         "keys": {"p256dh": "PUB", "auth": "AUTH"},
         "expirationTime": None,
     }
@@ -119,7 +119,7 @@ async def test_subscribe_captures_user_agent_header(app_client) -> None:
 
 async def test_subscribe_response_exposes_created_at(app_client) -> None:
     body = {
-        "endpoint": "https://push.example/ts",
+        "endpoint": "https://fcm.googleapis.com/fcm/send/ts",
         "keys": {"p256dh": "PUB", "auth": "AUTH"},
         "expirationTime": None,
     }
@@ -135,7 +135,7 @@ async def test_subscribe_foreign_workspace_endpoint_returns_409(app_client) -> N
 
     # Seed an endpoint owned by a DIFFERENT workspace (w2).
     foreign = {
-        "endpoint": "https://push.example/owned-by-w2",
+        "endpoint": "https://fcm.googleapis.com/fcm/send/owned-by-w2",
         "keys": {"p256dh": "PUB", "auth": "AUTH"},
         "expirationTime": None,
     }

--- a/tests/cloud/push/test_send.py
+++ b/tests/cloud/push/test_send.py
@@ -7,6 +7,13 @@
 # patched in every test so NO network call is made; the patch records the
 # subscription_info / data / vapid args each call receives so we can assert
 # the send was signed with the tenant key and carried the payload.
+#
+# Updated: 2026-07-02 (fix/push-vapid-pem-send) — the signing assertions now
+# expect a parsed ``Vapid01`` instance (not the raw PEM string) as
+# ``vapid_private_key``, and a new ``test_send_vapid_key_is_consumable_by_pywebpush``
+# regression-guards that the key handed to webpush can actually sign — the
+# original bug passed a PEM string that pywebpush's ``from_string`` could not
+# parse, failing every send.
 
 from __future__ import annotations
 
@@ -100,12 +107,49 @@ async def test_send_signs_with_tenant_private_key(enc_key, monkeypatch) -> None:
 
     await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
 
-    # The PEM handed to webpush is the tenant key from the chokepoint, and it
-    # is a real private PEM (never the public key, never ciphertext).
-    assert captured["vapid_private_key"] == expected_pem
-    assert "BEGIN PRIVATE KEY" in captured["vapid_private_key"]
+    # The key handed to webpush is the tenant key from the chokepoint, parsed
+    # into a Vapid01 signer (NOT the raw PEM string — pywebpush's from_string
+    # can't parse a PKCS#8 PEM). Its private value matches the tenant PEM, so
+    # it's the real key (never the public key, never ciphertext).
+    from py_vapid import Vapid01
+
+    signer = captured["vapid_private_key"]
+    assert isinstance(signer, Vapid01)
+    expected_signer = Vapid01.from_pem(expected_pem.encode())
+    assert (
+        signer.private_key.private_numbers().private_value
+        == expected_signer.private_key.private_numbers().private_value
+    )
     # The contact claim is present and non-personal by default.
     assert captured["vapid_claims"]["sub"].startswith("mailto:")
+
+
+async def test_send_vapid_key_is_consumable_by_pywebpush(enc_key, monkeypatch) -> None:
+    # Regression for fix/push-vapid-pem-send: the value handed to webpush as
+    # vapid_private_key must be something pywebpush can actually sign with. The
+    # original bug passed the raw PKCS#8 PEM string, which pywebpush feeds to
+    # py_vapid.Vapid.from_string() — that only accepts raw/DER base64 keys and
+    # dies on a PEM ("ASN.1 parsing error: invalid length"), failing every
+    # send. This test proves the passed key both is a Vapid01 AND can sign a
+    # claim set without raising, i.e. it survives the real pywebpush path.
+    await _seed("w1", "u1", "https://push.example/a")
+    await push_service.get_vapid_public_key("w1")
+
+    captured: dict = {}
+
+    def fake_webpush(**kwargs):
+        captured.update(kwargs)
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+    result = await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
+
+    assert result.sent == 1
+    # Signing is exactly what webpush does internally with this value; if the
+    # key were a bare PEM string this would raise instead of returning headers.
+    signer = captured["vapid_private_key"]
+    headers = signer.sign({"sub": "mailto:x@example.test", "aud": "https://fcm.googleapis.com"})
+    assert "Authorization" in headers
 
 
 async def test_send_contact_is_configurable(enc_key, monkeypatch) -> None:

--- a/tests/cloud/push/test_send.py
+++ b/tests/cloud/push/test_send.py
@@ -1,0 +1,275 @@
+# Tests for the Web Push SEND path (pocketpaw#1392).
+# Created: 2026-06-09 (feat/push-send-prune) — exercises send_to_user's
+# fan-out to every stored subscription, the 404/410 dead-endpoint pruning,
+# the "one bad endpoint doesn't abort the rest" resilience, the private-key
+# chokepoint usage (signing pulls the tenant PEM, the key never leaves the
+# backend), and the no-op empty-subscription case. ``pywebpush.webpush`` is
+# patched in every test so NO network call is made; the patch records the
+# subscription_info / data / vapid args each call receives so we can assert
+# the send was signed with the tenant key and carried the payload.
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from cryptography.fernet import Fernet
+from pocketpaw_ee.cloud.push import service as push_service
+from pocketpaw_ee.cloud.push.dto import PushPayload
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_KEY_ENV = "CLOUD_ENCRYPTION_KEY"
+
+
+@pytest.fixture
+def enc_key(monkeypatch):
+    """Set a valid Fernet key so VAPID private-key encrypt/decrypt works."""
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv(_KEY_ENV, key)
+    return key
+
+
+def _sub_body(endpoint: str) -> dict:
+    return {
+        "endpoint": endpoint,
+        "keys": {"p256dh": "PUB256", "auth": "AUTHSECRET"},
+        "expirationTime": None,
+    }
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+def _web_push_exc(status_code: int):
+    """Build a WebPushException carrying a vendor response with a status."""
+    return push_service.WebPushException("dead", response=_FakeResponse(status_code))
+
+
+async def _seed(workspace: str, user: str, *endpoints: str) -> None:
+    for ep in endpoints:
+        await push_service.subscribe(workspace, user, _sub_body(ep))
+
+
+# ---------------------------------------------------------------------------
+# Fan-out — every subscription is attempted, signed with the tenant key
+# ---------------------------------------------------------------------------
+
+
+async def test_send_fans_out_to_all_subscriptions(enc_key, monkeypatch) -> None:
+    await _seed("w1", "u1", "https://push.example/a", "https://push.example/b")
+    # Generate the keypair so the send path can decrypt a private PEM.
+    await push_service.get_vapid_public_key("w1")
+
+    calls: list[dict] = []
+
+    def fake_webpush(**kwargs):
+        calls.append(kwargs)
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+
+    result = await push_service.send_to_user("w1", "u1", PushPayload(title="Hi", body="There"))
+
+    assert result.sent == 2
+    assert result.pruned == 0
+    assert result.failed == 0
+    # Both endpoints were attempted.
+    endpoints = {c["subscription_info"]["endpoint"] for c in calls}
+    assert endpoints == {"https://push.example/a", "https://push.example/b"}
+    # Each call carried the browser keys and the JSON payload.
+    for c in calls:
+        assert c["subscription_info"]["keys"] == {"p256dh": "PUB256", "auth": "AUTHSECRET"}
+        assert json.loads(c["data"]) == {"title": "Hi", "body": "There"}
+
+
+async def test_send_signs_with_tenant_private_key(enc_key, monkeypatch) -> None:
+    await _seed("w1", "u1", "https://push.example/a")
+    await push_service.get_vapid_public_key("w1")
+    expected_pem = await push_service.get_decrypted_private_pem("w1")
+
+    captured: dict = {}
+
+    def fake_webpush(**kwargs):
+        captured.update(kwargs)
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+
+    await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
+
+    # The PEM handed to webpush is the tenant key from the chokepoint, and it
+    # is a real private PEM (never the public key, never ciphertext).
+    assert captured["vapid_private_key"] == expected_pem
+    assert "BEGIN PRIVATE KEY" in captured["vapid_private_key"]
+    # The contact claim is present and non-personal by default.
+    assert captured["vapid_claims"]["sub"].startswith("mailto:")
+
+
+async def test_send_contact_is_configurable(enc_key, monkeypatch) -> None:
+    await _seed("w1", "u1", "https://push.example/a")
+    await push_service.get_vapid_public_key("w1")
+    monkeypatch.setenv("CLOUD_PUSH_CONTACT", "mailto:ops@example.test")
+
+    captured: dict = {}
+
+    def fake_webpush(**kwargs):
+        captured.update(kwargs)
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+    await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
+    assert captured["vapid_claims"]["sub"] == "mailto:ops@example.test"
+
+
+# ---------------------------------------------------------------------------
+# Pruning — 404/410 deletes the dead row
+# ---------------------------------------------------------------------------
+
+
+async def test_send_prunes_410_gone(enc_key, monkeypatch) -> None:
+    await _seed("w1", "u1", "https://push.example/dead")
+    await push_service.get_vapid_public_key("w1")
+
+    def fake_webpush(**kwargs):
+        raise _web_push_exc(410)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+
+    result = await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
+
+    assert result.pruned == 1
+    assert result.sent == 0
+    # The dead subscription row was deleted.
+    assert await push_service.list_for_user("w1", "u1") == []
+
+
+async def test_send_prunes_404(enc_key, monkeypatch) -> None:
+    await _seed("w1", "u1", "https://push.example/gone")
+    await push_service.get_vapid_public_key("w1")
+
+    monkeypatch.setattr(
+        push_service, "webpush", lambda **kw: (_ for _ in ()).throw(_web_push_exc(404))
+    )
+
+    result = await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
+    assert result.pruned == 1
+    assert await push_service.list_for_user("w1", "u1") == []
+
+
+async def test_send_only_prunes_the_dead_endpoint(enc_key, monkeypatch) -> None:
+    # Two endpoints, one dead (410) and one live — only the dead one is pruned,
+    # and the whole fan-out still completes.
+    await _seed("w1", "u1", "https://push.example/live", "https://push.example/dead")
+    await push_service.get_vapid_public_key("w1")
+
+    def fake_webpush(**kwargs):
+        if kwargs["subscription_info"]["endpoint"].endswith("/dead"):
+            raise _web_push_exc(410)
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+
+    result = await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
+
+    assert result.sent == 1
+    assert result.pruned == 1
+    remaining = await push_service.list_for_user("w1", "u1")
+    assert [s.endpoint for s in remaining] == ["https://push.example/live"]
+
+
+# ---------------------------------------------------------------------------
+# Resilience — a non-404/410 error doesn't abort the fan-out, isn't pruned
+# ---------------------------------------------------------------------------
+
+
+async def test_send_one_bad_endpoint_does_not_abort_rest(enc_key, monkeypatch) -> None:
+    await _seed(
+        "w1",
+        "u1",
+        "https://push.example/ok1",
+        "https://push.example/boom",
+        "https://push.example/ok2",
+    )
+    await push_service.get_vapid_public_key("w1")
+
+    def fake_webpush(**kwargs):
+        if kwargs["subscription_info"]["endpoint"].endswith("/boom"):
+            # A 500 (transient) — logged + counted, NOT pruned.
+            raise _web_push_exc(500)
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+
+    result = await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
+
+    assert result.sent == 2  # both good endpoints still got their send
+    assert result.failed == 1
+    assert result.pruned == 0
+    # The transient-failure endpoint is left in place (only 404/410 prune).
+    assert len(await push_service.list_for_user("w1", "u1")) == 3
+
+
+async def test_send_unexpected_exception_is_swallowed(enc_key, monkeypatch) -> None:
+    await _seed("w1", "u1", "https://push.example/a", "https://push.example/b")
+    await push_service.get_vapid_public_key("w1")
+
+    seen: list[str] = []
+
+    def fake_webpush(**kwargs):
+        ep = kwargs["subscription_info"]["endpoint"]
+        seen.append(ep)
+        if ep.endswith("/a"):
+            raise RuntimeError("connection reset")  # not a WebPushException
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+
+    result = await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
+
+    assert len(seen) == 2  # both endpoints attempted despite the first raising
+    assert result.sent == 1
+    assert result.failed == 1
+
+
+# ---------------------------------------------------------------------------
+# No-op — a user with no subscriptions doesn't touch the key or the network
+# ---------------------------------------------------------------------------
+
+
+async def test_send_no_subscriptions_is_noop(enc_key, monkeypatch) -> None:
+    called = False
+
+    def fake_webpush(**kwargs):
+        nonlocal called
+        called = True
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+
+    result = await push_service.send_to_user("w1", "ghost", PushPayload(title="t", body="b"))
+
+    assert result.sent == 0 and result.pruned == 0 and result.failed == 0
+    assert called is False  # no fan-out, so webpush was never invoked
+
+
+async def test_send_accepts_dict_payload(enc_key, monkeypatch) -> None:
+    await _seed("w1", "u1", "https://push.example/a")
+    await push_service.get_vapid_public_key("w1")
+
+    captured: dict = {}
+
+    def fake_webpush(**kwargs):
+        captured.update(kwargs)
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+
+    # Internal callers may pass a raw dict; the service validates it.
+    result = await push_service.send_to_user(
+        "w1", "u1", {"title": "Hi", "body": "B", "url": "/inbox"}
+    )
+    assert result.sent == 1
+    assert json.loads(captured["data"]) == {"title": "Hi", "body": "B", "url": "/inbox"}

--- a/tests/cloud/push/test_send.py
+++ b/tests/cloud/push/test_send.py
@@ -66,7 +66,9 @@ async def _seed(workspace: str, user: str, *endpoints: str) -> None:
 
 
 async def test_send_fans_out_to_all_subscriptions(enc_key, monkeypatch) -> None:
-    await _seed("w1", "u1", "https://push.example/a", "https://push.example/b")
+    await _seed(
+        "w1", "u1", "https://fcm.googleapis.com/fcm/send/a", "https://fcm.googleapis.com/fcm/send/b"
+    )
     # Generate the keypair so the send path can decrypt a private PEM.
     await push_service.get_vapid_public_key("w1")
 
@@ -85,7 +87,10 @@ async def test_send_fans_out_to_all_subscriptions(enc_key, monkeypatch) -> None:
     assert result.failed == 0
     # Both endpoints were attempted.
     endpoints = {c["subscription_info"]["endpoint"] for c in calls}
-    assert endpoints == {"https://push.example/a", "https://push.example/b"}
+    assert endpoints == {
+        "https://fcm.googleapis.com/fcm/send/a",
+        "https://fcm.googleapis.com/fcm/send/b",
+    }
     # Each call carried the browser keys and the JSON payload.
     for c in calls:
         assert c["subscription_info"]["keys"] == {"p256dh": "PUB256", "auth": "AUTHSECRET"}
@@ -93,7 +98,7 @@ async def test_send_fans_out_to_all_subscriptions(enc_key, monkeypatch) -> None:
 
 
 async def test_send_signs_with_tenant_private_key(enc_key, monkeypatch) -> None:
-    await _seed("w1", "u1", "https://push.example/a")
+    await _seed("w1", "u1", "https://fcm.googleapis.com/fcm/send/a")
     await push_service.get_vapid_public_key("w1")
     expected_pem = await push_service.get_decrypted_private_pem("w1")
 
@@ -132,7 +137,7 @@ async def test_send_vapid_key_is_consumable_by_pywebpush(enc_key, monkeypatch) -
     # dies on a PEM ("ASN.1 parsing error: invalid length"), failing every
     # send. This test proves the passed key both is a Vapid01 AND can sign a
     # claim set without raising, i.e. it survives the real pywebpush path.
-    await _seed("w1", "u1", "https://push.example/a")
+    await _seed("w1", "u1", "https://fcm.googleapis.com/fcm/send/a")
     await push_service.get_vapid_public_key("w1")
 
     captured: dict = {}
@@ -153,7 +158,7 @@ async def test_send_vapid_key_is_consumable_by_pywebpush(enc_key, monkeypatch) -
 
 
 async def test_send_contact_is_configurable(enc_key, monkeypatch) -> None:
-    await _seed("w1", "u1", "https://push.example/a")
+    await _seed("w1", "u1", "https://fcm.googleapis.com/fcm/send/a")
     await push_service.get_vapid_public_key("w1")
     monkeypatch.setenv("CLOUD_PUSH_CONTACT", "mailto:ops@example.test")
 
@@ -168,13 +173,34 @@ async def test_send_contact_is_configurable(enc_key, monkeypatch) -> None:
     assert captured["vapid_claims"]["sub"] == "mailto:ops@example.test"
 
 
+async def test_send_passes_a_bounded_timeout(enc_key, monkeypatch) -> None:
+    # Regression: webpush() must receive an explicit, finite timeout. Its default
+    # is timeout=None → requests.post blocks forever; since each send runs in an
+    # asyncio.to_thread worker, a dead endpoint would park a pool slot until the
+    # process dies and eventually starve every to_thread call.
+    await _seed("w1", "u1", "https://fcm.googleapis.com/fcm/send/a")
+    await push_service.get_vapid_public_key("w1")
+
+    captured: dict = {}
+
+    def fake_webpush(**kwargs):
+        captured.update(kwargs)
+        return _FakeResponse(201)
+
+    monkeypatch.setattr(push_service, "webpush", fake_webpush)
+    await push_service.send_to_user("w1", "u1", PushPayload(title="t", body="b"))
+
+    assert isinstance(captured.get("timeout"), (int, float))
+    assert captured["timeout"] > 0
+
+
 # ---------------------------------------------------------------------------
 # Pruning — 404/410 deletes the dead row
 # ---------------------------------------------------------------------------
 
 
 async def test_send_prunes_410_gone(enc_key, monkeypatch) -> None:
-    await _seed("w1", "u1", "https://push.example/dead")
+    await _seed("w1", "u1", "https://fcm.googleapis.com/fcm/send/dead")
     await push_service.get_vapid_public_key("w1")
 
     def fake_webpush(**kwargs):
@@ -191,7 +217,7 @@ async def test_send_prunes_410_gone(enc_key, monkeypatch) -> None:
 
 
 async def test_send_prunes_404(enc_key, monkeypatch) -> None:
-    await _seed("w1", "u1", "https://push.example/gone")
+    await _seed("w1", "u1", "https://fcm.googleapis.com/fcm/send/gone")
     await push_service.get_vapid_public_key("w1")
 
     monkeypatch.setattr(
@@ -206,7 +232,12 @@ async def test_send_prunes_404(enc_key, monkeypatch) -> None:
 async def test_send_only_prunes_the_dead_endpoint(enc_key, monkeypatch) -> None:
     # Two endpoints, one dead (410) and one live — only the dead one is pruned,
     # and the whole fan-out still completes.
-    await _seed("w1", "u1", "https://push.example/live", "https://push.example/dead")
+    await _seed(
+        "w1",
+        "u1",
+        "https://fcm.googleapis.com/fcm/send/live",
+        "https://fcm.googleapis.com/fcm/send/dead",
+    )
     await push_service.get_vapid_public_key("w1")
 
     def fake_webpush(**kwargs):
@@ -221,7 +252,7 @@ async def test_send_only_prunes_the_dead_endpoint(enc_key, monkeypatch) -> None:
     assert result.sent == 1
     assert result.pruned == 1
     remaining = await push_service.list_for_user("w1", "u1")
-    assert [s.endpoint for s in remaining] == ["https://push.example/live"]
+    assert [s.endpoint for s in remaining] == ["https://fcm.googleapis.com/fcm/send/live"]
 
 
 # ---------------------------------------------------------------------------
@@ -233,9 +264,9 @@ async def test_send_one_bad_endpoint_does_not_abort_rest(enc_key, monkeypatch) -
     await _seed(
         "w1",
         "u1",
-        "https://push.example/ok1",
-        "https://push.example/boom",
-        "https://push.example/ok2",
+        "https://fcm.googleapis.com/fcm/send/ok1",
+        "https://fcm.googleapis.com/fcm/send/boom",
+        "https://fcm.googleapis.com/fcm/send/ok2",
     )
     await push_service.get_vapid_public_key("w1")
 
@@ -257,7 +288,9 @@ async def test_send_one_bad_endpoint_does_not_abort_rest(enc_key, monkeypatch) -
 
 
 async def test_send_unexpected_exception_is_swallowed(enc_key, monkeypatch) -> None:
-    await _seed("w1", "u1", "https://push.example/a", "https://push.example/b")
+    await _seed(
+        "w1", "u1", "https://fcm.googleapis.com/fcm/send/a", "https://fcm.googleapis.com/fcm/send/b"
+    )
     await push_service.get_vapid_public_key("w1")
 
     seen: list[str] = []
@@ -300,7 +333,7 @@ async def test_send_no_subscriptions_is_noop(enc_key, monkeypatch) -> None:
 
 
 async def test_send_accepts_dict_payload(enc_key, monkeypatch) -> None:
-    await _seed("w1", "u1", "https://push.example/a")
+    await _seed("w1", "u1", "https://fcm.googleapis.com/fcm/send/a")
     await push_service.get_vapid_public_key("w1")
 
     captured: dict = {}

--- a/tests/cloud/push/test_service.py
+++ b/tests/cloud/push/test_service.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import pytest
 from cryptography.fernet import Fernet
-from pocketpaw_ee.cloud._core.errors import ConflictError
+from pocketpaw_ee.cloud._core.errors import ConflictError, ValidationError
 from pocketpaw_ee.cloud.models.vapid_keypair import VapidKeypair
 from pocketpaw_ee.cloud.push import service as push_service
 from pocketpaw_ee.cloud.push.dto import UnsubscribeRequest
@@ -33,12 +33,52 @@ def enc_key(monkeypatch):
     return key
 
 
-def _sub_body(endpoint: str = "https://push.example/abc") -> dict:
+def _sub_body(endpoint: str = "https://fcm.googleapis.com/fcm/send/abc") -> dict:
     return {
         "endpoint": endpoint,
         "keys": {"p256dh": "PUB256", "auth": "AUTHSECRET"},
         "expirationTime": None,
     }
+
+
+# ---------------------------------------------------------------------------
+# Subscribe — SSRF guard: only real push-service endpoints are accepted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata (http)
+        "https://169.254.169.254/latest/meta-data/",  # metadata over https
+        "http://localhost:8888/api/v1/anything",  # internal service
+        "https://evil.example.com/collect",  # arbitrary external host
+        "https://fcm.googleapis.com.evil.com/x",  # allowlist-suffix spoof
+        "ftp://fcm.googleapis.com/x",  # non-https scheme
+    ],
+)
+async def test_subscribe_rejects_non_push_endpoint(enc_key, endpoint) -> None:
+    # Regression for the SSRF guard: an attacker-controlled endpoint that is not
+    # an https URL of a known browser push service must be rejected before any
+    # DB write, so the send path can never be coerced into POSTing to an
+    # internal/metadata host.
+    with pytest.raises(ValidationError):
+        await push_service.subscribe("w1", "u1", _sub_body(endpoint))
+    # Nothing was persisted.
+    assert await push_service.list_for_user("w1", "u1") == []
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://fcm.googleapis.com/fcm/send/abc",
+        "https://updates.push.services.mozilla.com/wpush/v2/abc",
+        "https://web.push.apple.com/abc",
+    ],
+)
+async def test_subscribe_accepts_known_push_hosts(enc_key, endpoint) -> None:
+    sub = await push_service.subscribe("w1", "u1", _sub_body(endpoint))
+    assert sub.endpoint == endpoint
 
 
 # ---------------------------------------------------------------------------
@@ -48,7 +88,7 @@ def _sub_body(endpoint: str = "https://push.example/abc") -> dict:
 
 async def test_subscribe_persists() -> None:
     sub = await push_service.subscribe("w1", "u1", _sub_body())
-    assert sub.endpoint == "https://push.example/abc"
+    assert sub.endpoint == "https://fcm.googleapis.com/fcm/send/abc"
     assert sub.workspace_id == "w1"
     assert sub.user_id == "u1"
     assert sub.keys.p256dh == "PUB256"
@@ -97,12 +137,12 @@ async def test_subscribe_default_user_agent_is_empty() -> None:
 
 
 async def test_subscribe_distinct_endpoints_create_rows() -> None:
-    await push_service.subscribe("w1", "u1", _sub_body("https://push.example/one"))
-    await push_service.subscribe("w1", "u1", _sub_body("https://push.example/two"))
+    await push_service.subscribe("w1", "u1", _sub_body("https://fcm.googleapis.com/fcm/send/one"))
+    await push_service.subscribe("w1", "u1", _sub_body("https://fcm.googleapis.com/fcm/send/two"))
     rows = await push_service.list_for_user("w1", "u1")
     assert {r.endpoint for r in rows} == {
-        "https://push.example/one",
-        "https://push.example/two",
+        "https://fcm.googleapis.com/fcm/send/one",
+        "https://fcm.googleapis.com/fcm/send/two",
     }
 
 
@@ -147,21 +187,25 @@ async def test_subscribe_exposes_created_at() -> None:
 async def test_unsubscribe_removes_row() -> None:
     await push_service.subscribe("w1", "u1", _sub_body())
     removed = await push_service.unsubscribe(
-        "w1", "u1", UnsubscribeRequest(endpoint="https://push.example/abc")
+        "w1", "u1", UnsubscribeRequest(endpoint="https://fcm.googleapis.com/fcm/send/abc")
     )
     assert removed is True
     assert await push_service.list_for_user("w1", "u1") == []
 
 
 async def test_unsubscribe_missing_returns_false() -> None:
-    removed = await push_service.unsubscribe("w1", "u1", {"endpoint": "https://push.example/nope"})
+    removed = await push_service.unsubscribe(
+        "w1", "u1", {"endpoint": "https://fcm.googleapis.com/fcm/send/nope"}
+    )
     assert removed is False
 
 
 async def test_unsubscribe_is_workspace_scoped() -> None:
     await push_service.subscribe("w1", "u1", _sub_body())
     # Another workspace can't delete w1's row even with the right endpoint.
-    removed = await push_service.unsubscribe("w2", "u1", {"endpoint": "https://push.example/abc"})
+    removed = await push_service.unsubscribe(
+        "w2", "u1", {"endpoint": "https://fcm.googleapis.com/fcm/send/abc"}
+    )
     assert removed is False
     assert len(await push_service.list_for_user("w1", "u1")) == 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -2380,6 +2380,15 @@ wheels = [
 ]
 
 [[package]]
+name = "http-ece"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/af/249d1576653b69c20b9ac30e284b63bd94af6a175d72d87813235caf2482/http_ece-1.2.1.tar.gz", hash = "sha256:8c6ab23116bbf6affda894acfd5f2ca0fb8facbcbb72121c11c75c33e7ce8cff", size = 8830, upload-time = "2024-08-08T00:10:47.301Z" }
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -5315,6 +5324,7 @@ dependencies = [
     { name = "py-vapid" },
     { name = "pyotp" },
     { name = "python-socketio" },
+    { name = "pywebpush" },
     { name = "redis", extra = ["hiredis"] },
     { name = "slowapi" },
 ]
@@ -5352,6 +5362,7 @@ requires-dist = [
     { name = "pytesseract", marker = "extra == 'extraction'", specifier = ">=0.3.10" },
     { name = "python-docx", marker = "extra == 'extraction'", specifier = ">=1.1.0" },
     { name = "python-socketio", specifier = ">=5.11.0" },
+    { name = "pywebpush", specifier = ">=2.3.0" },
     { name = "redis", extras = ["hiredis"], specifier = ">=5.0.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "trafilatura", marker = "extra == 'extraction'" },
@@ -6389,6 +6400,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pywebpush"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cryptography" },
+    { name = "http-ece" },
+    { name = "py-vapid" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/d9/e497a24bc9f659bfc0e570382a41e6b2d6726fbcfa4d85aaa23fe9c81ba2/pywebpush-2.3.0.tar.gz", hash = "sha256:d1e27db8de9e6757c1875f67292554bd54c41874c36f4b5c4ebb5442dce204f2", size = 28489, upload-time = "2026-02-09T23:30:18.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/d8/ac21241cf8007cb93255eabf318da4f425ec0f75d28c366992253aa8c1b2/pywebpush-2.3.0-py3-none-any.whl", hash = "sha256:3d97469fb14d4323c362319d438183737249a4115b50e146ce233e7f01e3cf98", size = 22851, upload-time = "2026-02-09T23:30:16.093Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Adds the send side of browser Web Push: the backend can now push a notification to a user's stored subscriptions and clean up the ones that have gone dead. Builds on the subscription store from #1391. This is the push transport only — wiring it to real product events and the WebSocket-vs-push dedupe is the next PR (#1393).

> Stacked on #1391 (`feat/push-subscription-store`). Review/merge that one first.

## Changes

- `send_to_user(workspace_id, user_id, payload)` in the push service — fans out to every stored subscription for the user, signs each with the tenant's VAPID private key (via the existing decrypt chokepoint, so the key never leaves the backend), and POSTs to the browser vendor endpoint.
- The blocking `pywebpush` call runs off the event loop via `asyncio.to_thread`.
- On a `410 Gone` or `404` from the push service, the dead subscription is deleted — and only that one (matched by its unique endpoint). A transient error (5xx, network) is logged and skipped, never pruned, and never aborts the rest of the fan-out.
- `PushPayload` (title/body + optional url/icon/tag) and a `SendResult` summary (sent/pruned/failed counts).
- Contact for VAPID claims reads from `CLOUD_PUSH_CONTACT`, defaulting to a non-personal `mailto:`.

## Tests

12 new tests (30 total with #1391's): fan-out across multiple subscriptions, tenant-key signing, 410/404 pruning, pruning only the dead endpoint, one bad endpoint not aborting the rest, unexpected errors swallowed, the empty no-op case, and the configurable contact. `pywebpush.webpush` is mocked in every test — nothing hits the network.

## Notes

Part of the PWA + Web Push work (design + PRD in paw-workspace `docs/design/drafts/`). Follow-up: #1393 wires this into agent/guardian/meeting events with desktop-vs-browser dedupe.
