### PR TITLE
feat(cloud): wire notifications into events with WS/push dedupe

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -812,6 +812,16 @@ def mount_cloud(app: FastAPI) -> None:
     register_meeting_notification_listeners()
     register_meeting_calendar_listeners()
 
+    # Push notifications fan-out (#1393) — v1 product events
+    # (agent.stream_end / instinct.approval.created / meeting.started) →
+    # ``dispatch.notify``, which forks WS-vs-Web-Push so a user with both the
+    # desktop app and a browser tab open is notified exactly once. Same
+    # constraint as the other bus subscribers: register AFTER init_realtime
+    # installed the singleton bus.
+    from pocketpaw_ee.cloud.push.listeners import register_push_event_listeners
+
+    register_push_event_listeners()
+
     # In-process daily-snapshot scheduler — opt-in via env var.
     #
     # Default OFF in tests + dev (each pytest run would otherwise spawn a

--- a/ee/pocketpaw_ee/cloud/chat/unread_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/unread_service.py
@@ -76,6 +76,27 @@ async def list_unreads(user_id: str, workspace_id: str) -> list[dict]:
     return out
 
 
+async def unread_count(user_id: str, group_id: str) -> int:
+    """Unread message count for a single ``(user, group)`` pair.
+
+    The per-group half of :func:`list_unreads`, exposed so callers that only
+    care about one conversation (e.g. the push new-message notifier) can get a
+    count without scanning every group the user belongs to. Same safe default:
+    a user with no ReadState row — or a row whose ``last_read_message_id`` is
+    the empty string — counts the group's full ``message_count`` (everything
+    is unread until a ``mark_read`` corrects it).
+    """
+    state = await _get_read_state(user_id, group_id)
+    if state is not None and state.last_read_message_id:
+        return await _count_messages_after(group_id, state.last_read_message_id)
+
+    try:
+        group = await _GroupDoc.get(PydanticObjectId(group_id))
+    except Exception:
+        group = None
+    return group.message_count if group else 0
+
+
 async def mark_read(user_id: str, group_id: str, last_message_id: str) -> None:
     """Upsert read state for (user, group). Resets mention_unread to 0.
 
@@ -123,4 +144,4 @@ async def bump_mention(user_id: str, group_id: str) -> None:
     )
 
 
-__all__ = ["bump_mention", "list_unreads", "mark_read"]
+__all__ = ["bump_mention", "list_unreads", "mark_read", "unread_count"]

--- a/ee/pocketpaw_ee/cloud/push/__init__.py
+++ b/ee/pocketpaw_ee/cloud/push/__init__.py
@@ -1,8 +1,14 @@
 # Web Push entity (pocketpaw#1391) — stores browser Web Push subscriptions
-# and serves the per-workspace VAPID public key. Storage + key only; sending
-# notifications (pywebpush dispatch + 410 pruning) is #1392, wiring real
-# events is #1393.
+# and serves the per-workspace VAPID public key. Storage + key (#1391),
+# pywebpush dispatch + 410 pruning (#1392), and product-event wiring with
+# WS-vs-Web-Push dedupe (#1393) all live here now.
 #
 # Follows the ee/cloud 4-file shape: domain.py (pure value objects),
 # dto.py (request/response wire models), service.py (sole Beanie writer),
-# router.py (thin HTTP boundary).
+# router.py (thin HTTP boundary). Two extra modules carry the #1393 wiring:
+# dispatch.py (``notify`` — the WS/Web-Push transport fork that never
+# double-notifies a user with both the desktop app and a browser tab open)
+# and listeners.py (the v1 product events — agent.stream_end /
+# instinct.approval.created / meeting.started — subscribed to the realtime
+# bus and routed through ``notify``). Neither writes Beanie directly, so the
+# "Push — Beanie writes only from service.py" contract still holds.

--- a/ee/pocketpaw_ee/cloud/push/coalesce.py
+++ b/ee/pocketpaw_ee/cloud/push/coalesce.py
@@ -1,0 +1,196 @@
+# Leading-edge push coalescer (feat/push-user-message-notifications).
+# Created: 2026-07-02 — throttles per-recipient notification sends so a burst of
+# messages in one conversation doesn't fan out one Web Push per message (which
+# wastes encrypt+POST work and can trip the push vendor's per-endpoint rate
+# limit with 429s). The OS already collapses same-``tag`` notifications on the
+# view side; this bounds the SEND side.
+#
+# Semantics — LEADING-EDGE throttle, keyed by (workspace_id, user_id, group_id):
+#   - First submit for an idle key   → emit IMMEDIATELY (zero added latency),
+#                                        then open a cooldown window.
+#   - Submits during the cooldown     → suppressed; the latest emit is remembered.
+#   - When the window elapses          → if anything was suppressed, emit ONCE
+#                                        (a trailing flush carrying the freshest
+#                                        payload + a recomputed count) and keep
+#                                        the window open one more cycle so a
+#                                        sustained stream fires at most once per
+#                                        window. An idle window closes and frees
+#                                        the key.
+#
+# So a 20-message burst becomes at most 2 sends (leading + one coalesced), the
+# recipient is still pinged the instant the first message lands, and a
+# continuous stream is capped at 1 send per window.
+#
+# Window length: ``CLOUD_PUSH_COALESCE_SECONDS`` (default 5.0). ``0`` disables
+# coalescing entirely — every submit emits immediately (pre-throttle behaviour).
+# Named ``CLOUD_*`` to match the sibling ``CLOUD_PUSH_CONTACT`` — this cloud
+# layer reads its own knobs from ``os.environ`` directly.
+#
+# Updated 2026-07-02: the leading edge now fires DETACHED (a background task,
+# like the trailing flush) instead of being awaited inline. ``submit`` is
+# awaited by the realtime bus handler, which the bus dispatches on the chat-send
+# request path — awaiting the push fan-out there coupled send latency to
+# delivery. ``submit`` now returns promptly and the leading push runs in the
+# background.
+#
+# Scope: in-process (single backend). The state lives in module-level dicts, so
+# two backend replicas would each fire their own leading push. That's the
+# documented v1 limit; the ``submit`` seam is the swap point for a Redis-backed
+# coordinator (POCKETPAW_REDIS_URL is already wired) when multi-replica push
+# delivery lands. NO Beanie writes happen here — the emit callback routes
+# through push/dispatch.py exactly as the direct path did.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+_ENV_SECONDS = "CLOUD_PUSH_COALESCE_SECONDS"
+_DEFAULT_SECONDS = 5.0
+
+# A key is (workspace_id, user_id, group_id). ``_tasks`` holds the open cooldown
+# window for a key; ``_pending`` holds the latest suppressed emit awaiting the
+# next flush. Both are cleared when a window closes.
+_Key = tuple[str, str, str]
+_Emit = Callable[[], Awaitable[None]]
+
+_tasks: dict[_Key, asyncio.Task] = {}
+_pending: dict[_Key, _Emit] = {}
+# In-flight DETACHED leading-edge emits. Held only to keep a strong reference so
+# the event loop can't garbage-collect a leading push mid-send; each removes
+# itself on completion. See ``_spawn_detached`` / ``submit``.
+_leading: set[asyncio.Task] = set()
+
+
+async def _guarded_emit(emit: _Emit) -> None:
+    """Await one emit, logging (not raising) on failure.
+
+    The leading edge runs detached (no caller to catch its exception), so a
+    failed send must be swallowed here or it would surface as an unretrieved
+    task exception.
+    """
+    try:
+        await emit()
+    except Exception:
+        logger.exception("push: leading-edge emit failed")
+
+
+def _spawn_detached(emit: _Emit) -> None:
+    """Fire one emit as a background task, decoupled from the caller.
+
+    ``submit`` is awaited by the realtime bus handler, which the bus dispatches
+    INLINE on the chat-send request path — awaiting delivery there would couple
+    send latency to the Web Push fan-out. Running the leading emit detached
+    (like the trailing flush already is) lets ``submit`` return promptly.
+    """
+    task = asyncio.create_task(_guarded_emit(emit))
+    _leading.add(task)
+    task.add_done_callback(_leading.discard)
+
+
+def _coalesce_seconds() -> float:
+    """Window length in seconds. ``<= 0`` (or unset-to-default) tunable via env.
+
+    Malformed values fall back to the default rather than raising — a bad env
+    value must not break notification delivery.
+    """
+    raw = os.environ.get(_ENV_SECONDS, "").strip()
+    if not raw:
+        return _DEFAULT_SECONDS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a number; using default %s", _ENV_SECONDS, raw, _DEFAULT_SECONDS
+        )
+        return _DEFAULT_SECONDS
+
+
+async def submit(key: _Key, emit: _Emit) -> None:
+    """Route one notification through the leading-edge throttle.
+
+    ``emit`` is an idempotent-safe coroutine that sends exactly one notification
+    when awaited (it recomputes the unread count at send time, so a trailing
+    flush carries a current count). It is called at most once on the leading
+    edge and at most once per window thereafter.
+
+    With coalescing disabled (window ``<= 0``) this is a pass-through: ``emit``
+    is awaited immediately and no window is opened.
+    """
+    seconds = _coalesce_seconds()
+    if seconds <= 0:
+        await emit()
+        return
+
+    if key in _tasks:
+        # Inside the cooldown window: suppress now, remember the freshest emit
+        # to fire at the next flush.
+        _pending[key] = emit
+        return
+
+    # Leading edge. Reserve the window SYNCHRONOUSLY (before scheduling) so a
+    # second submit arriving while this leading emit is in flight coalesces
+    # instead of racing to a second leading push. Fire the leading emit DETACHED
+    # (not awaited) so this ``submit`` — dispatched inline by the realtime bus on
+    # the chat-send request path — returns without blocking on the push fan-out.
+    _tasks[key] = asyncio.create_task(_cooldown(key, seconds))
+    _spawn_detached(emit)
+
+
+async def _cooldown(key: _Key, seconds: float) -> None:
+    """Hold a key's window open, flushing one coalesced emit per cycle.
+
+    Sleeps ``seconds``; if a submit was suppressed meanwhile, fires it once and
+    loops (so a sustained stream is capped at one send per window). An empty
+    cycle closes the window and frees the key.
+    """
+    try:
+        while True:
+            await asyncio.sleep(seconds)
+            emit = _pending.pop(key, None)
+            if emit is None:
+                return  # nothing suppressed this cycle → close the window
+            try:
+                await emit()
+            except Exception:
+                logger.exception("push: coalesced flush failed for key=%s", key)
+    finally:
+        _tasks.pop(key, None)
+
+
+def reset() -> None:
+    """Cancel all open windows and drop pending emits (best-effort, sync).
+
+    Fire-and-forget: it requests cancellation but does not await the tasks, so a
+    caller that needs the cancellations to finish cleanly on a live loop (tests,
+    graceful shutdown) should use :func:`aclose` instead.
+    """
+    for task in (*_tasks.values(), *_leading):
+        task.cancel()
+    _tasks.clear()
+    _pending.clear()
+    _leading.clear()
+
+
+async def aclose() -> None:
+    """Cancel all open windows and AWAIT their teardown on the running loop.
+
+    Awaiting the cancelled tasks lets each process ``CancelledError`` and run
+    its ``finally`` before the loop moves on, so no cancellation callback lands
+    on an already-closed loop.
+    """
+    tasks = [*_tasks.values(), *_leading]
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    _tasks.clear()
+    _pending.clear()
+    _leading.clear()
+
+
+__all__ = ["aclose", "reset", "submit"]

--- a/ee/pocketpaw_ee/cloud/push/dispatch.py
+++ b/ee/pocketpaw_ee/cloud/push/dispatch.py
@@ -1,0 +1,136 @@
+# Notification dispatch + WS-vs-Web-Push dedupe (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — adds ``notify`` on top of the
+# #1392 ``send_to_user`` Web Push fan-out. ``notify`` is the single dispatch
+# product events call: it forks the transport so a user who has BOTH the
+# desktop app (live WebSocket) and a browser tab (Web Push) open is never
+# double-notified.
+#
+# The dedupe rule (issue #1393 "prefer WS when live, else push"):
+#   - LIVE WebSocket connection  → deliver a ``notification.push`` WS event
+#     the desktop/Tauri client already renders; do NOT also send Web Push.
+#   - No live connection         → fall back to ``send_to_user`` (Web Push),
+#     so a browser-only / backgrounded user still gets the notification.
+#
+# This module is a thin orchestrator — it imports the push *service* for the
+# Web Push leg and the chat WS ConnectionManager for the liveness check + WS
+# leg. It performs NO Beanie writes itself (the import-linter "Push — Beanie
+# writes only from service.py" contract stays satisfied: the only writer is
+# ``service.send_to_user`` which prunes dead rows as before). The liveness
+# check and the chosen transport are surfaced on a returned ``NotifyResult``
+# so the fork is observable and unit-testable without real sockets.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from pocketpaw_ee.cloud.push import service as push_service
+from pocketpaw_ee.cloud.push.dto import PushPayload, SendResult
+
+logger = logging.getLogger(__name__)
+
+# The WS event type the desktop/Tauri client listens for to raise a native
+# notification. Distinct from the in-app ``notification.new`` bell event
+# (that one is the persisted-notification fan-out); this is the lightweight
+# "raise an OS/browser notification now" signal that mirrors what a Web Push
+# would have shown, so a live desktop client and a backgrounded browser tab
+# get the same notification through exactly one transport.
+WS_NOTIFICATION_TYPE = "notification.push"
+
+
+@dataclass
+class NotifyResult:
+    """Outcome of a single :func:`notify` dispatch.
+
+    ``transport`` is the leg actually taken — ``"ws"`` when the user had a
+    live WebSocket connection (Web Push was skipped) or ``"push"`` when it
+    fell back to Web Push. ``ws_delivered`` is True only on the WS leg.
+    ``send`` carries the Web Push fan-out summary on the push leg (None on
+    the WS leg, since Web Push never ran).
+    """
+
+    transport: str = "push"
+    ws_delivered: bool = False
+    send: SendResult | None = None
+
+
+# ---------------------------------------------------------------------------
+# Seams — injected so tests can drive the fork without real sockets. Both
+# default to the live chat ConnectionManager singleton (the same instance the
+# realtime bus fans WebSocket events through), imported lazily to avoid a
+# module-import cycle (chat.ws → schemas → ... → push at collection time).
+# ---------------------------------------------------------------------------
+
+
+def _is_user_live(user_id: str) -> bool:
+    """Return True when the user has at least one live WebSocket connection.
+
+    Backed by ``chat.ws.ConnectionManager.is_online`` (ws.py:89) on the
+    module singleton ``manager`` (ws.py:194) — the same registry the realtime
+    bus uses to fan events to sockets, so "live" here means exactly "the bus
+    could deliver to this user over WS right now".
+    """
+    from pocketpaw_ee.cloud.chat.ws import manager
+
+    return manager.is_online(user_id)
+
+
+async def _send_over_ws(user_id: str, payload: PushPayload) -> None:
+    """Push a lightweight notification event to a user's live sockets."""
+    from pocketpaw_ee.cloud.chat.schemas import WsOutbound
+    from pocketpaw_ee.cloud.chat.ws import manager
+
+    message = WsOutbound(
+        type=WS_NOTIFICATION_TYPE,
+        data=payload.model_dump(exclude_none=True),
+    )
+    await manager.send_to_user(user_id, message)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+async def notify(
+    workspace_id: str,
+    user_id: str,
+    payload: PushPayload | dict,
+) -> NotifyResult:
+    """Deliver one notification to a user, preferring WS over Web Push.
+
+    The dedupe contract: if the user has a live WebSocket connection the
+    notification is delivered over WS only — Web Push is intentionally NOT
+    sent, so a user with both the desktop app and a browser tab open sees the
+    notification exactly once. With no live connection the dispatch falls back
+    to Web Push (``send_to_user``), so a browser-only or backgrounded user
+    still gets it.
+
+    Validates ``payload`` at entry (rule 6) so internal callers (bus
+    listeners) may pass a raw dict. Returns a :class:`NotifyResult` recording
+    the transport taken, for observability and tests.
+    """
+    payload = PushPayload.model_validate(payload)
+
+    if _is_user_live(user_id):
+        # Live desktop/browser client → WS only, skip Web Push (the dedupe).
+        try:
+            await _send_over_ws(user_id, payload)
+        except Exception:
+            # A WS failure must not silently drop the notification, but the
+            # send_to_user fan-out is a separate path with its own pruning;
+            # we log and report the WS leg rather than double-sending.
+            logger.exception(
+                "ws notification delivery failed for workspace=%s user=%s",
+                workspace_id,
+                user_id,
+            )
+            return NotifyResult(transport="ws", ws_delivered=False)
+        return NotifyResult(transport="ws", ws_delivered=True)
+
+    # No live connection → Web Push fallback.
+    result = await push_service.send_to_user(workspace_id, user_id, payload)
+    return NotifyResult(transport="push", ws_delivered=False, send=result)
+
+
+__all__ = ["NotifyResult", "WS_NOTIFICATION_TYPE", "notify"]

--- a/ee/pocketpaw_ee/cloud/push/listeners.py
+++ b/ee/pocketpaw_ee/cloud/push/listeners.py
@@ -7,6 +7,14 @@
 # resolving recipients + a small {title, body, url?} payload, registered from
 # ``mount_cloud`` after ``init_realtime`` installs the singleton bus.
 #
+# Updated: 2026-07-02 (feat/push-user-message-notifications) — wired
+# ``message.sent`` → ``on_new_message`` so a human-to-human message notifies the
+# group's OTHER human members. The body is generic-with-a-count ("N new
+# messages") — the message text never reaches the OS notification surface
+# (lock-screen privacy). Only the human ``message_add`` path emits
+# ``message.sent``; agent replies ride ``agent.stream_end`` (on_agent_complete),
+# so there is no double-notify.
+#
 # v1 events wired (those with a real emission point + a resolvable recipient):
 #   - agent.stream_end           → agent-complete. Recipients = the group's
 #                                  human members (resolved off the group the
@@ -35,7 +43,7 @@ import logging
 from typing import Any
 
 from pocketpaw_ee.cloud._core.realtime.events import Event
-from pocketpaw_ee.cloud.push import dispatch
+from pocketpaw_ee.cloud.push import coalesce, dispatch
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +91,32 @@ async def _dispatch(workspace_id: str, user_id: str, payload: dict[str, Any]) ->
             workspace_id,
             user_id,
         )
+
+
+async def _unread_count(user_id: str, group_id: str) -> int:
+    """Unread count for one (user, group), for the new-message body. Best-effort.
+
+    Falls back to ``1`` on any error so the notification body still reads
+    sensibly ("1 new message") rather than "0 new messages".
+    """
+    try:
+        from pocketpaw_ee.cloud.chat import unread_service
+
+        return await unread_service.unread_count(user_id, group_id)
+    except Exception:
+        logger.exception(
+            "push: unread count failed for user=%s group=%s", user_id, group_id
+        )
+        return 1
+
+
+def _count_body(count: int) -> str:
+    """Generic, content-free body carrying only the unread count.
+
+    The message text is deliberately NOT included — a human-to-human push
+    lands on the lock screen, so only the count crosses that surface.
+    """
+    return "1 new message" if count <= 1 else f"{count} new messages"
 
 
 # ---------------------------------------------------------------------------
@@ -160,6 +194,69 @@ async def on_meeting_started(event: Event) -> None:
         await _dispatch(workspace_id, recipient, payload)
 
 
+async def on_new_message(event: Event) -> None:
+    """message.sent → notify a group's OTHER human members of a new message.
+
+    Generic-with-a-count: the title names the sender, the body is only the
+    unread count ("N new messages") — the message text never reaches the OS
+    notification surface. The sender is excluded (no self-ping), and the
+    WS-vs-Web-Push dedupe in ``dispatch.notify`` means only members with no
+    live connection actually receive a Web Push.
+
+    Only the human ``message_add`` path emits ``message.sent``; the
+    ``senderType != "user"`` guard is defensive belt-and-braces so an
+    agent-authored message can never double-fire alongside
+    ``on_agent_complete`` (agent.stream_end).
+
+    ``message.sent`` carries the wire dict (camelCase ``senderName`` /
+    ``senderType``) plus ``group_id`` + ``sender_id`` but NO ``workspace_id``,
+    so the workspace is resolved from the group — mirroring on_agent_complete.
+
+    Each send is routed through the leading-edge coalescer (push/coalesce.py):
+    the first message pings instantly, a burst within the cooldown collapses to
+    one trailing send. The emit closure recomputes the unread count at send
+    time, so both the leading and any trailing push carry a current count.
+    """
+    data = event.data or {}
+    group_id = data.get("group_id")
+    if not group_id:
+        return
+    if data.get("senderType") not in (None, "user"):
+        return
+
+    workspace_id = await _group_workspace_id(group_id)
+    if not workspace_id:
+        return
+
+    sender_id = data.get("sender_id")
+    recipients = [uid for uid in await _group_member_ids(group_id) if uid != sender_id]
+    if not recipients:
+        return
+
+    title = data.get("senderName") or "New message"
+    url = f"/?join={group_id}"
+    for recipient in recipients:
+        # ``recipient`` is bound as a default arg so the closure captures THIS
+        # iteration's value (the other captured names are constant per call).
+        # The count is recomputed inside so a coalesced trailing send reflects
+        # the accumulated unread total. ``tag`` is the group id so the OS
+        # collapses a conversation's notifications into one updating toast.
+        async def _emit(recipient: str = recipient) -> None:
+            count = await _unread_count(recipient, group_id)
+            await _dispatch(
+                workspace_id,
+                recipient,
+                {
+                    "title": title,
+                    "body": _count_body(count),
+                    "url": url,
+                    "tag": group_id,
+                },
+            )
+
+        await coalesce.submit((workspace_id, recipient, group_id), _emit)
+
+
 # ---------------------------------------------------------------------------
 # Registration — called from mount_cloud() after init_realtime.
 # ---------------------------------------------------------------------------
@@ -178,6 +275,7 @@ def register_push_event_listeners() -> None:
     bus.subscribe("agent.stream_end", on_agent_complete)
     bus.subscribe("instinct.approval.created", on_guardian_block)
     bus.subscribe("meeting.started", on_meeting_started)
+    bus.subscribe("message.sent", on_new_message)
     logger.info("registered v1 product events → push notification dispatch")
 
 
@@ -185,5 +283,6 @@ __all__ = [
     "on_agent_complete",
     "on_guardian_block",
     "on_meeting_started",
+    "on_new_message",
     "register_push_event_listeners",
 ]

--- a/ee/pocketpaw_ee/cloud/push/listeners.py
+++ b/ee/pocketpaw_ee/cloud/push/listeners.py
@@ -1,0 +1,189 @@
+# Product events → notification dispatch (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — subscribes the v1 notification
+# event set to the realtime in-process bus and routes each to ``notify(...)``
+# (push/dispatch.py), which forks WS-vs-Web-Push so a user is never
+# double-notified. Mirrors the meeting-notifications bridge pattern
+# (meetings/bridges/notifications.py): one handler per event type, each
+# resolving recipients + a small {title, body, url?} payload, registered from
+# ``mount_cloud`` after ``init_realtime`` installs the singleton bus.
+#
+# v1 events wired (those with a real emission point + a resolvable recipient):
+#   - agent.stream_end           → agent-complete. Recipients = the group's
+#                                  human members (resolved off the group the
+#                                  payload names; the payload itself carries
+#                                  no workspace_id, so we read it from the
+#                                  group domain).
+#   - instinct.approval.created  → guardian-block. The Instinct/guardian layer
+#                                  gated an action into the approval queue;
+#                                  recipient = ``requested_by`` (the user whose
+#                                  action was blocked), workspace = the event's
+#                                  ``workspace_id``.
+#   - meeting.started            → meeting-start. Recipients = creator
+#                                  (recall) or every group member (livekit),
+#                                  matching the existing meeting bridge's
+#                                  recipient logic.
+#
+# Each handler is best-effort: a failure to resolve recipients or dispatch is
+# logged and swallowed so one bad event can't break the bus fan-out (the bus
+# already isolates handler exceptions, but we double-guard the DB/dispatch
+# calls). No Beanie writes happen here — the only writer remains
+# push/service.py via dispatch.notify → send_to_user.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw_ee.cloud._core.realtime.events import Event
+from pocketpaw_ee.cloud.push import dispatch
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Recipient resolution helpers
+# ---------------------------------------------------------------------------
+
+
+async def _group_member_ids(group_id: str) -> list[str]:
+    """Human member user_ids for a group. Returns [] on any error."""
+    try:
+        from pocketpaw_ee.cloud.chat import group_service
+
+        return await group_service.list_member_ids(group_id)
+    except Exception:
+        logger.exception("push: failed to list members for group=%s", group_id)
+        return []
+
+
+async def _group_workspace_id(group_id: str) -> str | None:
+    """Resolve the workspace a group belongs to. None on any error/miss.
+
+    ``agent.stream_end`` carries ``group_id`` but no ``workspace_id``; the
+    Web Push leg needs the workspace to find the tenant's VAPID key, so we
+    read it from the group domain here.
+    """
+    try:
+        from pocketpaw_ee.cloud.chat import group_service
+
+        group = await group_service.get_for_dispatch(group_id)
+        return group.workspace_id if group else None
+    except Exception:
+        logger.exception("push: failed to resolve workspace for group=%s", group_id)
+        return None
+
+
+async def _dispatch(workspace_id: str, user_id: str, payload: dict[str, Any]) -> None:
+    """Route one notification through the WS/Web-Push dedupe. Best-effort."""
+    try:
+        await dispatch.notify(workspace_id, user_id, payload)
+    except Exception:
+        logger.exception(
+            "push: notify dispatch failed for workspace=%s user=%s",
+            workspace_id,
+            user_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Handlers — one per event type
+# ---------------------------------------------------------------------------
+
+
+async def on_agent_complete(event: Event) -> None:
+    """agent.stream_end → notify the group's human members the agent replied."""
+    data = event.data or {}
+    group_id = data.get("group_id")
+    if not group_id:
+        return
+
+    workspace_id = await _group_workspace_id(group_id)
+    if not workspace_id:
+        return
+
+    recipients = await _group_member_ids(group_id)
+    if not recipients:
+        return
+
+    agent_name = data.get("agent_name") or "Your agent"
+    payload = {
+        "title": f"{agent_name} replied",
+        "body": "Your agent finished responding.",
+        "url": f"/?join={group_id}",
+    }
+    for recipient in recipients:
+        await _dispatch(workspace_id, recipient, payload)
+
+
+async def on_guardian_block(event: Event) -> None:
+    """instinct.approval.created → notify the user whose action was gated."""
+    data = event.data or {}
+    workspace_id = data.get("workspace_id")
+    recipient = data.get("requested_by")
+    if not (workspace_id and recipient):
+        return
+
+    action_name = data.get("action_name") or "An action"
+    payload = {
+        "title": "Action needs approval",
+        "body": f"{action_name} was held for your review.",
+        "url": "/?view=approvals",
+    }
+    await _dispatch(workspace_id, recipient, payload)
+
+
+async def on_meeting_started(event: Event) -> None:
+    """meeting.started → notify the meeting's recipients it has begun."""
+    data = event.data or {}
+    workspace_id = data.get("workspace_id")
+    meeting_id = data.get("meeting_id")
+    if not (workspace_id and meeting_id):
+        return
+
+    source = data.get("source", "recall")
+    group_id = data.get("group_id")
+    if source == "livekit" and group_id:
+        recipients = await _group_member_ids(group_id)
+    else:
+        creator = data.get("created_by") or data.get("organizer_user_id")
+        recipients = [creator] if creator else []
+
+    if not recipients:
+        return
+
+    payload = {
+        "title": "Meeting started",
+        "body": "A meeting has started.",
+        "url": f"/?join=meeting-{meeting_id}",
+    }
+    for recipient in recipients:
+        await _dispatch(workspace_id, recipient, payload)
+
+
+# ---------------------------------------------------------------------------
+# Registration — called from mount_cloud() after init_realtime.
+# ---------------------------------------------------------------------------
+
+
+def register_push_event_listeners() -> None:
+    """Wire the v1 product events → notification dispatch. Idempotent-safe.
+
+    Subscribes on the realtime in-process bus (the same bus the WS fan-out
+    rides), so handlers fire whether or not any client is currently
+    subscribed. Must run AFTER ``init_realtime`` installs the singleton bus.
+    """
+    from pocketpaw_ee.cloud._core.realtime.bus import get_bus
+
+    bus = get_bus()
+    bus.subscribe("agent.stream_end", on_agent_complete)
+    bus.subscribe("instinct.approval.created", on_guardian_block)
+    bus.subscribe("meeting.started", on_meeting_started)
+    logger.info("registered v1 product events → push notification dispatch")
+
+
+__all__ = [
+    "on_agent_complete",
+    "on_guardian_block",
+    "on_meeting_started",
+    "register_push_event_listeners",
+]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -506,6 +506,8 @@ source_modules = [
     "pocketpaw_ee.cloud.push.router",
     "pocketpaw_ee.cloud.push.dto",
     "pocketpaw_ee.cloud.push.domain",
+    "pocketpaw_ee.cloud.push.dispatch",
+    "pocketpaw_ee.cloud.push.listeners",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.push_subscription",

--- a/tests/cloud/push/test_coalesce.py
+++ b/tests/cloud/push/test_coalesce.py
@@ -1,0 +1,123 @@
+# Tests for the leading-edge push coalescer (feat/push-user-message-notifications).
+# Created: 2026-07-02 — proves the throttle contract without real sockets or DB:
+#   - leading edge fires immediately (zero added latency);
+#   - a burst on one key collapses to leading + one trailing flush;
+#   - a sustained stream is capped at one send per window;
+#   - distinct keys throttle independently;
+#   - window <= 0 disables coalescing (pass-through).
+# Uses a tiny window (0.05s) and real asyncio.sleep so the timing is exercised
+# for real; ``reset()`` between cases prevents window state from leaking.
+#
+# Updated 2026-07-02: the leading edge now fires DETACHED (a background task) so
+# ``submit`` returns without blocking the caller. It still fires "immediately"
+# (next loop tick, sub-ms), but the tests must ``_drain()`` one tick before
+# asserting the leading emit has landed.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud.push import coalesce
+
+# Small enough to keep the suite fast; large enough to be robust on a loaded CI.
+_WINDOW = 0.05
+
+
+@pytest.fixture(autouse=True)
+async def _clean(monkeypatch):
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", str(_WINDOW))
+    await coalesce.aclose()
+    yield
+    # Await the cancellations so a still-sleeping window task can't schedule a
+    # callback on the loop after it closes.
+    await coalesce.aclose()
+
+
+def _counter():
+    calls: list[int] = []
+
+    async def emit() -> None:
+        calls.append(1)
+
+    return calls, emit
+
+
+async def _drain() -> None:
+    """Yield a loop tick so detached leading-edge emits run before we assert.
+
+    The leading edge is fired via ``asyncio.create_task``, so it runs on the
+    next tick rather than synchronously inside ``submit``. One short sleep lets
+    every currently-ready leading emit complete without waiting for a window.
+    """
+    await asyncio.sleep(0.01)
+
+
+async def test_leading_edge_fires_immediately() -> None:
+    calls, emit = _counter()
+    await coalesce.submit(("w", "u", "g"), emit)
+    await _drain()
+    # Fired on the leading edge (detached, next tick) — no wait for the window.
+    assert len(calls) == 1
+
+
+async def test_burst_collapses_to_leading_plus_one() -> None:
+    calls, emit = _counter()
+    key = ("w", "u", "g")
+    for _ in range(10):
+        await coalesce.submit(key, emit)
+
+    await _drain()
+    # Only the leading push has gone out so far; the other 9 are suppressed.
+    assert len(calls) == 1
+
+    # Let the window elapse: exactly one trailing flush for the whole burst.
+    await asyncio.sleep(_WINDOW * 3)
+    assert len(calls) == 2
+
+
+async def test_sustained_stream_capped_per_window() -> None:
+    calls, emit = _counter()
+    key = ("w", "u", "g")
+
+    # Leading push.
+    await coalesce.submit(key, emit)
+    await _drain()
+    assert len(calls) == 1
+
+    # Two more windows, each fed a suppressed message → each yields one flush.
+    for _ in range(2):
+        await coalesce.submit(key, emit)  # suppressed, remembered
+        await asyncio.sleep(_WINDOW * 2)  # window elapses → one trailing flush
+
+    # 1 leading + 2 per-window trailing flushes.
+    assert len(calls) == 3
+
+
+async def test_distinct_keys_are_independent() -> None:
+    calls, emit = _counter()
+    await coalesce.submit(("w", "alice", "g"), emit)
+    await coalesce.submit(("w", "bob", "g"), emit)
+    await _drain()
+    # Two different recipients → two leading pushes, neither suppresses the other.
+    assert len(calls) == 2
+
+
+async def test_disabled_is_passthrough(monkeypatch) -> None:
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "0")
+    calls, emit = _counter()
+    key = ("w", "u", "g")
+    for _ in range(3):
+        await coalesce.submit(key, emit)
+    # No throttling: every submit emits immediately.
+    assert len(calls) == 3
+
+
+async def test_malformed_window_uses_default(monkeypatch) -> None:
+    # A bad env value must not break delivery: it falls back to the default
+    # (a positive window), so the first submit still fires on the leading edge.
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "not-a-number")
+    calls, emit = _counter()
+    await coalesce.submit(("w", "u", "g"), emit)
+    await _drain()
+    assert len(calls) == 1

--- a/tests/cloud/push/test_dispatch.py
+++ b/tests/cloud/push/test_dispatch.py
@@ -1,0 +1,167 @@
+# Tests for the notification dispatch + WS-vs-Web-Push dedupe (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — exercises ``dispatch.notify``:
+#   - a LIVE user is delivered over WebSocket and Web Push is NEVER sent
+#     (the dedupe — verified by asserting send_to_user was not called);
+#   - an OFFLINE (browser-only / backgrounded) user falls back to Web Push;
+#   - a desktop-only live user takes the WS/native path;
+#   - the returned NotifyResult records the transport for observability;
+#   - a WS delivery failure is reported (not silently double-sent over push).
+# The WS layer and the push send path are both mocked — no real sockets, no
+# network. The liveness check and the WS send are patched via the module's
+# injectable seams (``_is_user_live`` / ``_send_over_ws``); one integration
+# test drives the real ConnectionManager singleton to prove the seam matches.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.push import dispatch
+from pocketpaw_ee.cloud.push.dto import PushPayload, SendResult
+
+_PAYLOAD = {"title": "Hi", "body": "There", "url": "/inbox"}
+
+
+# ---------------------------------------------------------------------------
+# Dedupe — live user gets WS only, offline user gets Web Push only.
+# ---------------------------------------------------------------------------
+
+
+async def test_live_user_delivers_ws_and_skips_web_push(monkeypatch) -> None:
+    monkeypatch.setattr(dispatch, "_is_user_live", lambda uid: True)
+
+    ws_sent: list[tuple[str, PushPayload]] = []
+
+    async def fake_ws(user_id: str, payload: PushPayload) -> None:
+        ws_sent.append((user_id, payload))
+
+    monkeypatch.setattr(dispatch, "_send_over_ws", fake_ws)
+
+    # Web Push must NOT be touched on the live path.
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append((workspace_id, user_id))
+        return SendResult(sent=1)
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "u1", _PAYLOAD)
+
+    assert result.transport == "ws"
+    assert result.ws_delivered is True
+    assert result.send is None
+    # Delivered over WS exactly once...
+    assert len(ws_sent) == 1
+    assert ws_sent[0][0] == "u1"
+    assert ws_sent[0][1].title == "Hi"
+    # ...and Web Push was never sent (the dedupe).
+    assert push_calls == []
+
+
+async def test_offline_user_falls_back_to_web_push(monkeypatch) -> None:
+    monkeypatch.setattr(dispatch, "_is_user_live", lambda uid: False)
+
+    ws_calls: list = []
+
+    async def fake_ws(user_id, payload):
+        ws_calls.append(user_id)
+
+    monkeypatch.setattr(dispatch, "_send_over_ws", fake_ws)
+
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append((workspace_id, user_id, payload))
+        return SendResult(sent=2, pruned=1)
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "u2", _PAYLOAD)
+
+    assert result.transport == "push"
+    assert result.ws_delivered is False
+    assert result.send is not None
+    assert result.send.sent == 2
+    assert result.send.pruned == 1
+    # Web Push got the call...
+    assert len(push_calls) == 1
+    assert push_calls[0][0] == "w1"
+    assert push_calls[0][1] == "u2"
+    # ...and WS was never used on the offline path.
+    assert ws_calls == []
+
+
+async def test_dispatch_validates_dict_payload(monkeypatch) -> None:
+    # A raw dict from a bus listener is validated into a PushPayload at entry.
+    monkeypatch.setattr(dispatch, "_is_user_live", lambda uid: True)
+    captured: dict = {}
+
+    async def fake_ws(user_id, payload):
+        captured["payload"] = payload
+
+    monkeypatch.setattr(dispatch, "_send_over_ws", fake_ws)
+
+    await dispatch.notify("w1", "u1", {"title": "T", "body": "B"})
+
+    assert isinstance(captured["payload"], PushPayload)
+    assert captured["payload"].title == "T"
+
+
+async def test_ws_failure_does_not_double_send_over_push(monkeypatch) -> None:
+    # If the WS leg raises, we report a failed WS delivery rather than also
+    # firing Web Push (no double-notify).
+    monkeypatch.setattr(dispatch, "_is_user_live", lambda uid: True)
+
+    async def boom(user_id, payload):
+        raise RuntimeError("socket closed")
+
+    monkeypatch.setattr(dispatch, "_send_over_ws", boom)
+
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append(user_id)
+        return SendResult()
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "u1", _PAYLOAD)
+
+    assert result.transport == "ws"
+    assert result.ws_delivered is False
+    assert push_calls == []  # Web Push was NOT used as a fallback.
+
+
+# ---------------------------------------------------------------------------
+# Integration — the real ConnectionManager singleton drives the liveness seam.
+# ---------------------------------------------------------------------------
+
+
+async def test_liveness_seam_reflects_connection_manager(monkeypatch) -> None:
+    from unittest.mock import AsyncMock
+
+    from pocketpaw_ee.cloud.chat.ws import manager
+
+    # Web Push is mocked so the offline branch never hits the network.
+    async def fake_send(workspace_id, user_id, payload):
+        return SendResult()
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    # Browser-only user (no connection) → Web Push.
+    offline = await dispatch.notify("w1", "ghost", _PAYLOAD)
+    assert offline.transport == "push"
+
+    # Connect a fake socket for the user on the real singleton, then dispatch:
+    # the same manager the bus uses now reports the user live → WS path.
+    ws = AsyncMock()
+    await manager.connect(ws, "desktop-user")
+    try:
+        live = await dispatch.notify("w1", "desktop-user", _PAYLOAD)
+        assert live.transport == "ws"
+        assert live.ws_delivered is True
+        # The WS message was actually pushed to the fake socket.
+        assert ws.send_json.await_count == 1
+        sent = ws.send_json.await_args.args[0]
+        assert sent["type"] == dispatch.WS_NOTIFICATION_TYPE
+        assert sent["data"]["title"] == "Hi"
+    finally:
+        await manager.disconnect(ws)

--- a/tests/cloud/push/test_listeners.py
+++ b/tests/cloud/push/test_listeners.py
@@ -1,0 +1,141 @@
+# Tests for the product-event → notification dispatch listeners (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — proves each v1 handler resolves
+# the right recipients + payload and routes through ``dispatch.notify``:
+#   - on_agent_complete: resolves the group's workspace + members and notifies
+#     every human member (agent.stream_end carries no workspace_id);
+#   - on_guardian_block: notifies ``requested_by`` in the event's workspace;
+#   - on_meeting_started: notifies the creator (recall) or group members
+#     (livekit), mirroring the meeting bridge.
+# ``dispatch.notify`` is patched to record calls — no WS, no Web Push, no DB.
+# group_service lookups are patched so no Mongo is needed.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import (
+    AgentStreamEnd,
+    InstinctApprovalCreated,
+)
+from pocketpaw_ee.cloud.meetings.events import MeetingStarted
+from pocketpaw_ee.cloud.push import listeners
+
+
+@pytest.fixture
+def notify_calls(monkeypatch):
+    calls: list[tuple[str, str, dict]] = []
+
+    async def fake_notify(workspace_id, user_id, payload):
+        calls.append((workspace_id, user_id, payload))
+
+    monkeypatch.setattr(listeners.dispatch, "notify", fake_notify)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# agent-complete (agent.stream_end)
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_complete_notifies_group_members(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return "w-agent"
+
+    async def fake_members(group_id):
+        return ["alice", "bob"]
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+
+    event = AgentStreamEnd(data={"group_id": "g1", "agent_name": "Scout"})
+    await listeners.on_agent_complete(event)
+
+    assert {uid for _, uid, _ in notify_calls} == {"alice", "bob"}
+    assert all(ws == "w-agent" for ws, _, _ in notify_calls)
+    assert all("Scout" in p["title"] for _, _, p in notify_calls)
+
+
+async def test_agent_complete_noop_without_group(notify_calls) -> None:
+    await listeners.on_agent_complete(AgentStreamEnd(data={}))
+    assert notify_calls == []
+
+
+async def test_agent_complete_noop_when_workspace_unresolved(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return None
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    await listeners.on_agent_complete(AgentStreamEnd(data={"group_id": "g1"}))
+    assert notify_calls == []
+
+
+# ---------------------------------------------------------------------------
+# guardian-block (instinct.approval.created)
+# ---------------------------------------------------------------------------
+
+
+async def test_guardian_block_notifies_requester(notify_calls) -> None:
+    event = InstinctApprovalCreated(
+        data={
+            "workspace_id": "w1",
+            "requested_by": "carol",
+            "action_name": "send_email",
+        }
+    )
+    await listeners.on_guardian_block(event)
+
+    assert len(notify_calls) == 1
+    ws, uid, payload = notify_calls[0]
+    assert ws == "w1"
+    assert uid == "carol"
+    assert "send_email" in payload["body"]
+
+
+async def test_guardian_block_noop_without_recipient(notify_calls) -> None:
+    await listeners.on_guardian_block(InstinctApprovalCreated(data={"workspace_id": "w1"}))
+    assert notify_calls == []
+
+
+# ---------------------------------------------------------------------------
+# meeting-start (meeting.started)
+# ---------------------------------------------------------------------------
+
+
+async def test_meeting_started_notifies_creator_for_recall(notify_calls) -> None:
+    event = MeetingStarted(
+        data={
+            "workspace_id": "w1",
+            "meeting_id": "m1",
+            "source": "recall",
+            "created_by": "dave",
+        }
+    )
+    await listeners.on_meeting_started(event)
+
+    assert len(notify_calls) == 1
+    ws, uid, payload = notify_calls[0]
+    assert (ws, uid) == ("w1", "dave")
+    assert "meeting-m1" in payload["url"]
+
+
+async def test_meeting_started_notifies_group_for_livekit(notify_calls, monkeypatch) -> None:
+    async def fake_members(group_id):
+        return ["eve", "frank"]
+
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+
+    event = MeetingStarted(
+        data={
+            "workspace_id": "w1",
+            "meeting_id": "m2",
+            "source": "livekit",
+            "group_id": "g9",
+        }
+    )
+    await listeners.on_meeting_started(event)
+
+    assert {uid for _, uid, _ in notify_calls} == {"eve", "frank"}
+
+
+async def test_meeting_started_noop_without_meeting(notify_calls) -> None:
+    await listeners.on_meeting_started(MeetingStarted(data={"workspace_id": "w1"}))
+    assert notify_calls == []

--- a/tests/cloud/push/test_listeners.py
+++ b/tests/cloud/push/test_listeners.py
@@ -15,6 +15,7 @@ import pytest
 from pocketpaw_ee.cloud._core.realtime.events import (
     AgentStreamEnd,
     InstinctApprovalCreated,
+    MessageSent,
 )
 from pocketpaw_ee.cloud.meetings.events import MeetingStarted
 from pocketpaw_ee.cloud.push import listeners
@@ -29,6 +30,18 @@ def notify_calls(monkeypatch):
 
     monkeypatch.setattr(listeners.dispatch, "notify", fake_notify)
     return calls
+
+
+@pytest.fixture(autouse=True)
+def _no_coalesce(monkeypatch):
+    """Run on_new_message with the coalescer OFF (pass-through) so these tests
+    assert the recipient/payload logic directly. The leading-edge throttle has
+    its own dedicated suite in test_coalesce.py. ``reset()`` clears any window
+    state so a lingering task can't leak into the next test."""
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "0")
+    listeners.coalesce.reset()
+    yield
+    listeners.coalesce.reset()
 
 
 # ---------------------------------------------------------------------------
@@ -138,4 +151,127 @@ async def test_meeting_started_notifies_group_for_livekit(notify_calls, monkeypa
 
 async def test_meeting_started_noop_without_meeting(notify_calls) -> None:
     await listeners.on_meeting_started(MeetingStarted(data={"workspace_id": "w1"}))
+    assert notify_calls == []
+
+
+# ---------------------------------------------------------------------------
+# new-message (message.sent) — user↔user notifications
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def new_message_env(monkeypatch):
+    """Patch the group + unread lookups so on_new_message needs no Mongo."""
+
+    async def fake_ws_id(group_id):
+        return "w-msg"
+
+    async def fake_members(group_id):
+        return ["alice", "bob", "carol"]
+
+    async def fake_count(user_id, group_id):
+        return 3
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+    monkeypatch.setattr(listeners, "_unread_count", fake_count)
+
+
+async def test_new_message_notifies_other_members_with_count(
+    notify_calls, new_message_env
+) -> None:
+    event = MessageSent(
+        data={
+            "group_id": "g1",
+            "sender_id": "alice",
+            "senderName": "Alice",
+            "senderType": "user",
+        }
+    )
+    await listeners.on_new_message(event)
+
+    # Alice is the sender → excluded; only bob + carol are notified.
+    assert {uid for _, uid, _ in notify_calls} == {"bob", "carol"}
+    assert all(ws == "w-msg" for ws, _, _ in notify_calls)
+    # Title names the sender; body carries ONLY the count (no message text).
+    assert all(p["title"] == "Alice" for _, _, p in notify_calls)
+    assert all(p["body"] == "3 new messages" for _, _, p in notify_calls)
+    # Collapse per-conversation so a later message updates the same toast.
+    assert all(p["tag"] == "g1" for _, _, p in notify_calls)
+
+
+async def test_new_message_body_never_leaks_content(notify_calls, new_message_env) -> None:
+    secret = "wire me $10k to account 12345"
+    event = MessageSent(
+        data={
+            "group_id": "g1",
+            "sender_id": "alice",
+            "senderName": "Alice",
+            "senderType": "user",
+            "content": secret,
+        }
+    )
+    await listeners.on_new_message(event)
+
+    assert notify_calls  # sanity: it did notify
+    for _, _, payload in notify_calls:
+        assert secret not in payload["body"]
+        assert secret not in payload["title"]
+
+
+async def test_new_message_singular_count_body(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return "w"
+
+    async def fake_members(group_id):
+        return ["a", "b"]
+
+    async def fake_count(user_id, group_id):
+        return 1
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+    monkeypatch.setattr(listeners, "_unread_count", fake_count)
+
+    event = MessageSent(
+        data={"group_id": "g", "sender_id": "a", "senderName": "A", "senderType": "user"}
+    )
+    await listeners.on_new_message(event)
+
+    assert notify_calls
+    assert all(p["body"] == "1 new message" for _, _, p in notify_calls)
+
+
+async def test_new_message_skips_agent_authored(notify_calls, monkeypatch) -> None:
+    # An agent-authored message.sent (senderType != "user") must not fire here;
+    # agent replies are covered by on_agent_complete (agent.stream_end).
+    async def boom(*_a, **_k):
+        raise AssertionError("agent-authored message must not resolve recipients")
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", boom)
+
+    await listeners.on_new_message(
+        MessageSent(data={"group_id": "g", "sender_id": "bot", "senderType": "agent"})
+    )
+    assert notify_calls == []
+
+
+async def test_new_message_noop_without_group(notify_calls) -> None:
+    await listeners.on_new_message(MessageSent(data={"sender_id": "a", "senderType": "user"}))
+    assert notify_calls == []
+
+
+async def test_new_message_noop_when_sender_is_only_member(notify_calls, monkeypatch) -> None:
+    async def fake_ws_id(group_id):
+        return "w"
+
+    async def fake_members(group_id):
+        return ["solo"]
+
+    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
+    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
+
+    await listeners.on_new_message(
+        MessageSent(data={"group_id": "g", "sender_id": "solo", "senderType": "user"})
+    )
     assert notify_calls == []


### PR DESCRIPTION
## What this does

Wires the v1 product events into a single `notify(workspace_id, user_id, payload)` dispatch with a transport fork that avoids double-notifying a user who has both the desktop app (live WebSocket) and a browser tab (Web Push) open. Builds on #1392's send path.

> Stacked on #1392 (`feat/push-send-prune`). Review/merge that chain first.

## Changes

- `push/dispatch.py` — `notify(...)`: if the user has a live WebSocket connection, deliver over WS and skip Web Push; otherwise fall back to `send_to_user` (Web Push). Never both. Returns a `NotifyResult(transport, ...)` so the fork is observable/testable. No Beanie writes.
- `push/listeners.py` — subscribes three events to the realtime bus and routes each through `notify`:
  - **agent-complete** ← `agent.stream_end` (resolves workspace + human members off the group, since the event carries no workspace_id)
  - **guardian-block** ← `instinct.approval.created` (recipient = `requested_by`)
  - **meeting-start** ← `meeting.started` (recipient = creator / group members)
- Registered in `mount_cloud` after `init_realtime`. WS liveness via `ConnectionManager.is_online`, behind an injectable seam for testing.

## Tests

13 new tests (43 total with #1391/#1392): the dedupe both ways (WS-live → push NOT called; offline → push called), recipient resolution per event, and the liveness seam wired to the real `manager`. lint-imports "Push — Beanie writes only from service.py" contract KEPT; mypy clean.

## ⚠️ Open integration item (needs a call before this delivers end-to-end on desktop)

The WS leg emits a `notification.push` WS message, but the **paw-enterprise client does not currently consume that type** — it handles `notification.new` / `read` / `cleared` (the bell → `browser-notification.ts` native toast), not `notification.push`. So as-is, a desktop-only user's WS-leg delivery is dropped client-side while Web Push is (correctly) suppressed.

Two ways to close it, your call:
1. **Rewire the WS leg onto the existing `notification.new` path** (via `notifications_service.create`) so the client's existing native-toast handler fires — but that also persists a bell entry for every notification, which may or may not be wanted for agent-complete.
2. **Add a small `notification.push` handler** in paw-enterprise that raises a native notification (a follow-up client PR), keeping push notifications separate from the persisted bell.

The backend dedupe logic here is correct and tested regardless of which path you pick; this is purely about which client-side delivery channel the WS leg should land on.

## Notes

Part of the PWA + Web Push work (design + PRD in paw-workspace `docs/design/drafts/`). Final issue of the chain: #1391 → #1392 → #1393 (backend), #384 → #385 (client).
