### PR TITLE
Stamp the default agent on home and widget pocket chats

### DIFF
--- a/ee/pocketpaw_ee/cloud/memory/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/memory/mongo_store.py
@@ -10,6 +10,12 @@ this adapter is the sole write path for chat turns. It also auto-creates a
 ``Session`` doc for a new ``session_key`` so the "start chatting → session
 appears in the sidebar" UX works without a prior ``POST /sessions``.
 
+Recent change: ``_resolve_or_create_session`` now threads the pocket id out
+of ``entry.metadata`` (``pocket_context.id`` or the flat ``pocket_id``
+fallback) into ``auto_create_pocket_session`` so OSS-path home/widget chats
+get stamped with both the pocket id and the workspace's default agent —
+required for them to surface in the PocketPaw DM room.
+
 Tenant scope
 ------------
 Every row is stamped with a ``workspace_id`` so multi-tenant ee deployments
@@ -426,14 +432,25 @@ async def _resolve_or_create_session(
     """
     from pocketpaw_ee.cloud.sessions import service as sessions_service
 
-    md_ws = (entry.metadata or {}).get("workspace_id")
+    md = entry.metadata or {}
+    md_ws = md.get("workspace_id")
     md_ws = md_ws if isinstance(md_ws, str) and md_ws else None
+
+    # Pocket id lives at metadata["pocket_context"]["id"] for the OSS pocket
+    # chat path; fall back to a flat metadata["pocket_id"] when present.
+    pocket_ctx = md.get("pocket_context")
+    md_pocket = pocket_ctx.get("id") if isinstance(pocket_ctx, dict) else None
+    if not md_pocket:
+        md_pocket = md.get("pocket_id")
+    md_pocket = md_pocket if isinstance(md_pocket, str) and md_pocket else None
 
     session = await sessions_service.find_by_session_id(session_key)
     if session is not None:
         return session, md_ws or session.workspace
 
-    session = await sessions_service.auto_create_pocket_session(session_key, workspace_id=md_ws)
+    session = await sessions_service.auto_create_pocket_session(
+        session_key, workspace_id=md_ws, pocket_id=md_pocket
+    )
     if session is None:
         return None, md_ws
 

--- a/ee/pocketpaw_ee/cloud/sessions/service.py
+++ b/ee/pocketpaw_ee/cloud/sessions/service.py
@@ -3,6 +3,14 @@
 Sole owner of writes to the ``Session`` Beanie document. Module-level
 ``async def`` API, no class wrapper, no Protocol-based repository.
 
+Recent change: ``auto_create_pocket_session`` now stamps the workspace's
+default ``pocketpaw`` agent (and the pocket id when known) onto the
+``Session`` it creates. The OSS chat path (home page + widget "Ask agent")
+persists through this helper; without the agent stamp those sessions had
+``agent=None`` and never surfaced in the PocketPaw DM room (which lists via
+``list_by_agent`` keyed on ``Session.agent``). Agent/pocket resolution
+degrades gracefully to the prior behaviour when no default agent exists.
+
 Public API:
 - ``create(ctx, workspace_id, body)`` — create or upsert a session
 - ``list_for_owner(ctx, workspace_id)``
@@ -732,7 +740,7 @@ async def ensure_for_agent_scope(
 
 
 async def auto_create_pocket_session(
-    session_key: str, *, workspace_id: str | None = None
+    session_key: str, *, workspace_id: str | None = None, pocket_id: str | None = None
 ) -> _SessionDoc | None:
     """Create a pocket ``Session`` doc for ``session_key`` when none exists.
 
@@ -741,6 +749,11 @@ async def auto_create_pocket_session(
     Returns ``None`` if no suitable user exists. Used by the cloud
     memory store so its adapter doesn't have to import ``Session`` /
     ``User`` directly.
+
+    Stamps the workspace's default ``pocketpaw`` agent (and ``pocket_id``
+    when supplied) so OSS-path home/widget chats land in the PocketPaw DM
+    room, which lists by ``Session.agent``. Both degrade to ``None`` when
+    resolution fails — a missing agent must never block a chat save.
     """
     from pocketpaw_ee.cloud.models.user import User as _UserDoc
 
@@ -760,15 +773,39 @@ async def auto_create_pocket_session(
     if not workspace_id:
         return None
 
+    # Resolve the workspace's default ``pocketpaw`` agent so the session
+    # surfaces in the PocketPaw DM room. Lazy import: ``chat.agent_service``
+    # imports from this module, so a top-level import would cycle (same
+    # reason ``User`` is imported function-locally above).
+    agent_id: str | None = None
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import _get_default_workspace_agent_id
+
+        agent_id = await _get_default_workspace_agent_id(workspace_id)
+    except Exception:
+        logger.warning(
+            "auto_create_pocket_session: default agent lookup failed for ws=%s",
+            workspace_id,
+            exc_info=True,
+        )
+
     doc = _SessionDoc(
         sessionId=session_key,
         context_type="pocket",
         workspace=workspace_id,
         owner=str(user.id),
         title="Chat",
+        agent=agent_id,
+        pocket=pocket_id,
     )
     await doc.insert()
-    logger.info("auto-created pocket session: sessionId=%s owner=%s", session_key, user.id)
+    logger.info(
+        "auto-created pocket session: sessionId=%s owner=%s agent=%s pocket=%s",
+        session_key,
+        user.id,
+        agent_id,
+        pocket_id,
+    )
     return doc
 
 

--- a/scripts/backfill_pocket_session_agent.py
+++ b/scripts/backfill_pocket_session_agent.py
@@ -1,0 +1,105 @@
+"""Backfill the default agent onto orphaned pocket ``Session`` rows.
+
+New script. Companion to the OSS-path fix that stamps the workspace's default
+``pocketpaw`` agent (and pocket id) onto sessions created via
+``auto_create_pocket_session``. Existing sessions written before that fix have
+``agent=None`` and ``context_type="pocket"``, so they never surface in the
+PocketPaw DM room (``GET /sessions?agent_id=...`` -> ``list_by_agent`` keys on
+``Session.agent``). This script finds those rows, resolves each one's
+workspace's ``pocketpaw`` agent, and stamps it. ``pocket`` is left as-is when
+unknown (it is not recoverable from a Session row alone).
+
+Idempotent: only touches rows with ``agent == None`` and
+``context_type == "pocket"``, and skips a row when its workspace has no
+default agent. Safe to re-run.
+
+Usage:
+    uv run python scripts/backfill_pocket_session_agent.py            # apply
+    uv run python scripts/backfill_pocket_session_agent.py --dry-run  # report only
+
+    POCKETPAW_CLOUD_MONGO_URI=mongodb://localhost:27017/paw-cloud \\
+        uv run python scripts/backfill_pocket_session_agent.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+
+async def backfill(*, dry_run: bool) -> int:
+    """Stamp the workspace default agent onto orphaned pocket sessions.
+
+    Returns the number of rows updated (or that would be updated, in
+    ``--dry-run`` mode).
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import _get_default_workspace_agent_id
+    from pocketpaw_ee.cloud.models.session import Session
+
+    # Cache the per-workspace agent lookup so a backlog of sessions in one
+    # workspace costs a single agent query.
+    agent_cache: dict[str, str | None] = {}
+
+    async def _agent_for(workspace_id: str) -> str | None:
+        if workspace_id not in agent_cache:
+            agent_cache[workspace_id] = await _get_default_workspace_agent_id(workspace_id)
+        return agent_cache[workspace_id]
+
+    orphans = await Session.find(
+        Session.agent == None,  # noqa: E711
+        Session.context_type == "pocket",
+    ).to_list()
+
+    print(f"Found {len(orphans)} pocket session(s) with no agent.")
+
+    updated = 0
+    skipped_no_agent = 0
+    for doc in orphans:
+        workspace_id = doc.workspace
+        if not workspace_id:
+            skipped_no_agent += 1
+            continue
+        agent_id = await _agent_for(workspace_id)
+        if not agent_id:
+            skipped_no_agent += 1
+            continue
+        if dry_run:
+            print(f"  [dry-run] {doc.sessionId} ws={workspace_id} -> agent={agent_id}")
+            updated += 1
+            continue
+        doc.agent = agent_id
+        await doc.save()
+        updated += 1
+
+    verb = "Would update" if dry_run else "Updated"
+    print(f"{verb} {updated} session(s); skipped {skipped_no_agent} (no default agent).")
+    return updated
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing.",
+    )
+    args = parser.parse_args()
+
+    uri = os.environ.get("POCKETPAW_CLOUD_MONGO_URI", "mongodb://localhost:27017/paw-cloud")
+    print(f"Connecting to: {uri}")
+
+    from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
+
+    await init_cloud_db(uri)
+    try:
+        await backfill(dry_run=args.dry_run)
+    finally:
+        await close_cloud_db()
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(asyncio.run(main()))

--- a/tests/cloud/memory/test_pocket_chat_agent_stamp.py
+++ b/tests/cloud/memory/test_pocket_chat_agent_stamp.py
@@ -1,0 +1,263 @@
+"""Regression: home/widget OSS-path pocket chats must be stamped with the
+workspace's default ``pocketpaw`` agent (and the pocket id) so they surface
+in the PocketPaw DM room (``GET /sessions?agent_id=<pocketpaw-agent-id>`` ->
+``list_by_agent`` filters on ``Session.agent``).
+
+Before the fix, ``auto_create_pocket_session`` built the ``Session`` with no
+``agent`` and no ``pocket``, so these chats never appeared in that room. These
+tests assert the stamping at creation (OSS path) and verify the cloud
+agent-chat path already stamps an agent.
+
+New file — covers:
+- OSS path stamps ``agent`` + ``pocket`` via ``auto_create_pocket_session``.
+- OSS save path (``_resolve_or_create_session``) threads the pocket id from
+  ``entry.metadata["pocket_context"]["id"]`` and the flat ``pocket_id`` fallback.
+- Graceful degradation when no default agent exists.
+- Cloud path (``ensure_for_agent_scope`` kind="pocket") already stamps agent.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from pocketpaw.memory.protocol import MemoryEntry, MemoryType
+
+
+async def _seed_user_and_agent(workspace_id: str) -> str:
+    """Insert a workspace user and the default ``pocketpaw`` agent; return
+    the agent id."""
+    from pocketpaw_ee.cloud.models.agent import Agent
+    from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+
+    user = await User(
+        email=f"u-{uuid.uuid4().hex[:6]}@example.com",
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        workspaces=[WorkspaceMembership(workspace=workspace_id, role="owner")],
+    ).insert()
+    agent = await Agent(
+        workspace=workspace_id,
+        slug="pocketpaw",
+        name="PocketPaw",
+        owner=str(user.id),
+    ).insert()
+    return str(agent.id)
+
+
+class TestAutoCreatePocketSessionStamping:
+    async def test_stamps_default_agent_and_pocket(self, beanie_memory_db):
+        from pocketpaw_ee.cloud.sessions import service as sessions_service
+
+        ws = f"ws-{uuid.uuid4().hex[:6]}"
+        agent_id = await _seed_user_and_agent(ws)
+        pocket_id = f"pocket-{uuid.uuid4().hex[:6]}"
+        key = f"sess-{uuid.uuid4().hex[:8]}"
+
+        doc = await sessions_service.auto_create_pocket_session(
+            key, workspace_id=ws, pocket_id=pocket_id
+        )
+
+        assert doc is not None
+        assert doc.context_type == "pocket"
+        assert doc.agent == agent_id
+        assert doc.pocket == pocket_id
+
+    async def test_stamps_agent_without_pocket(self, beanie_memory_db):
+        from pocketpaw_ee.cloud.sessions import service as sessions_service
+
+        ws = f"ws-{uuid.uuid4().hex[:6]}"
+        agent_id = await _seed_user_and_agent(ws)
+        key = f"sess-{uuid.uuid4().hex[:8]}"
+
+        doc = await sessions_service.auto_create_pocket_session(key, workspace_id=ws)
+
+        assert doc is not None
+        assert doc.agent == agent_id
+        assert doc.pocket is None
+
+    async def test_degrades_when_no_default_agent(self, beanie_memory_db):
+        """A workspace user exists but no ``pocketpaw`` agent — the chat save
+        must still succeed, just without an agent stamp."""
+        from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+        from pocketpaw_ee.cloud.sessions import service as sessions_service
+
+        ws = f"ws-{uuid.uuid4().hex[:6]}"
+        await User(
+            email=f"u-{uuid.uuid4().hex[:6]}@example.com",
+            hashed_password="x",
+            is_active=True,
+            is_verified=True,
+            workspaces=[WorkspaceMembership(workspace=ws, role="owner")],
+        ).insert()
+        key = f"sess-{uuid.uuid4().hex[:8]}"
+
+        doc = await sessions_service.auto_create_pocket_session(key, workspace_id=ws)
+
+        assert doc is not None
+        assert doc.agent is None
+
+
+class TestResolveOrCreateThreadsPocket:
+    async def test_save_path_stamps_agent_and_pocket_from_metadata(self, store, beanie_memory_db):
+        """A pocket chat save (no pre-existing Session) auto-creates a Session
+        stamped with the default agent and the pocket id from
+        ``metadata['pocket_context']['id']``."""
+        from pocketpaw_ee.cloud.sessions import service as sessions_service
+
+        ws = f"ws-{uuid.uuid4().hex[:6]}"
+        agent_id = await _seed_user_and_agent(ws)
+        pocket_id = f"pocket-{uuid.uuid4().hex[:6]}"
+        key = f"sess-{uuid.uuid4().hex[:8]}"
+
+        entry = MemoryEntry(
+            id="",
+            type=MemoryType.SESSION,
+            content="hi from the home pocket",
+            role="user",
+            session_key=key,
+            metadata={
+                "workspace_id": ws,
+                "source": "pocket_chat",
+                "pocket_context": {"id": pocket_id},
+            },
+        )
+        await store.save(entry)
+
+        doc = await sessions_service.find_by_session_id(key)
+        assert doc is not None
+        assert doc.agent == agent_id
+        assert doc.pocket == pocket_id
+
+    async def test_save_path_uses_flat_pocket_id_fallback(self, store, beanie_memory_db):
+        from pocketpaw_ee.cloud.sessions import service as sessions_service
+
+        ws = f"ws-{uuid.uuid4().hex[:6]}"
+        agent_id = await _seed_user_and_agent(ws)
+        pocket_id = f"pocket-{uuid.uuid4().hex[:6]}"
+        key = f"sess-{uuid.uuid4().hex[:8]}"
+
+        entry = MemoryEntry(
+            id="",
+            type=MemoryType.SESSION,
+            content="hi",
+            role="user",
+            session_key=key,
+            metadata={"workspace_id": ws, "pocket_id": pocket_id},
+        )
+        await store.save(entry)
+
+        doc = await sessions_service.find_by_session_id(key)
+        assert doc is not None
+        assert doc.agent == agent_id
+        assert doc.pocket == pocket_id
+
+
+class TestCloudPathAlreadyStamps:
+    async def test_ensure_for_agent_scope_pocket_stamps_agent(self, beanie_memory_db):
+        """The cloud agent-chat path (``/cloud/chat/pocket/{id}/agent``) resolves
+        the default workspace agent and stamps it — the home pocket (no custom
+        agent) lands on ``slug=='pocketpaw'``. No code change; assert only."""
+        from pocketpaw_ee.cloud.sessions import service as sessions_service
+
+        ws = f"ws-{uuid.uuid4().hex[:6]}"
+        agent_id = await _seed_user_and_agent(ws)
+        pocket_id = f"pocket-{uuid.uuid4().hex[:6]}"
+
+        session_id = await sessions_service.ensure_for_agent_scope(
+            kind="pocket",
+            scope_id=pocket_id,
+            workspace_id=ws,
+            user_id="u1",
+            target_agent_id=agent_id,
+        )
+
+        assert session_id is not None
+        doc = await sessions_service.find_by_session_id(session_id)
+        assert doc is not None
+        assert doc.agent == agent_id
+        assert doc.pocket == pocket_id
+
+
+def _load_backfill_module():
+    """Import ``scripts/backfill_pocket_session_agent.py`` by path — the
+    scripts dir is not a package, so a normal import won't resolve."""
+    import importlib.util
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[3]
+    path = repo_root / "scripts" / "backfill_pocket_session_agent.py"
+    spec = importlib.util.spec_from_file_location("backfill_pocket_session_agent", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestBackfill:
+    async def test_stamps_orphaned_pocket_sessions(self, beanie_memory_db):
+        from pocketpaw_ee.cloud.models.session import Session
+
+        backfill_mod = _load_backfill_module()
+
+        ws = f"ws-{uuid.uuid4().hex[:6]}"
+        agent_id = await _seed_user_and_agent(ws)
+
+        orphan = await Session(
+            sessionId=f"sess-{uuid.uuid4().hex[:8]}",
+            context_type="pocket",
+            workspace=ws,
+            owner="u1",
+            title="Chat",
+        ).insert()
+        assert orphan.agent is None
+
+        updated = await backfill_mod.backfill(dry_run=False)
+        assert updated == 1
+
+        refetched = await Session.find_one(Session.sessionId == orphan.sessionId)
+        assert refetched is not None
+        assert refetched.agent == agent_id
+
+    async def test_is_idempotent_and_dry_run_writes_nothing(self, beanie_memory_db):
+        from pocketpaw_ee.cloud.models.session import Session
+
+        backfill_mod = _load_backfill_module()
+
+        ws = f"ws-{uuid.uuid4().hex[:6]}"
+        agent_id = await _seed_user_and_agent(ws)
+        orphan = await Session(
+            sessionId=f"sess-{uuid.uuid4().hex[:8]}",
+            context_type="pocket",
+            workspace=ws,
+            owner="u1",
+        ).insert()
+
+        # Dry run reports one candidate but writes nothing.
+        assert await backfill_mod.backfill(dry_run=True) == 1
+        still_orphan = await Session.find_one(Session.sessionId == orphan.sessionId)
+        assert still_orphan is not None and still_orphan.agent is None
+
+        # First apply stamps it; a second apply finds nothing to do.
+        assert await backfill_mod.backfill(dry_run=False) == 1
+        assert await backfill_mod.backfill(dry_run=False) == 0
+
+        stamped = await Session.find_one(Session.sessionId == orphan.sessionId)
+        assert stamped is not None and stamped.agent == agent_id
+
+    async def test_skips_session_when_no_default_agent(self, beanie_memory_db):
+        from pocketpaw_ee.cloud.models.session import Session
+
+        backfill_mod = _load_backfill_module()
+
+        ws = f"ws-{uuid.uuid4().hex[:6]}"  # no pocketpaw agent seeded
+        orphan = await Session(
+            sessionId=f"sess-{uuid.uuid4().hex[:8]}",
+            context_type="pocket",
+            workspace=ws,
+            owner="u1",
+        ).insert()
+
+        assert await backfill_mod.backfill(dry_run=False) == 0
+        unchanged = await Session.find_one(Session.sessionId == orphan.sessionId)
+        assert unchanged is not None and unchanged.agent is None


### PR DESCRIPTION
## What was broken

Chats started from the home page and the widget "Ask agent" box go through the OSS chat path. That path persisted their `Session` rows with no `agent` (and no `pocket`). The PocketPaw DM room lists sessions with `GET /sessions?agent_id=<pocketpaw-agent-id>`, which filters on `Session.agent`. Because these rows had `agent=None`, the chats never appeared in that room, not even under the All tab.

## The fix

- `auto_create_pocket_session` (sessions/service.py) now resolves the workspace's default `pocketpaw` agent and stamps it on the session, plus the pocket id when the caller passes one. The agent lookup is a function-local import of `_get_default_workspace_agent_id` to avoid the import cycle between `sessions/service.py` and `chat/agent_service.py` (same pattern the file already uses for `User`). Both the agent and the pocket degrade to the old behaviour when they can't be resolved, so a missing agent never blocks a chat save.
- `_resolve_or_create_session` (memory/mongo_store.py) threads the pocket id out of the chat metadata — `pocket_context.id` first, then a flat `pocket_id` fallback — into that helper.
- A backfill script (`scripts/backfill_pocket_session_agent.py`) stamps the same agent onto existing orphaned pocket sessions. It is idempotent and has a `--dry-run` mode.

## Cloud path

The cloud agent-chat path (`/cloud/chat/pocket/{id}/agent` → `ensure_for_agent_scope`) already stamps an agent — the home pocket, which has no custom agent, resolves to the workspace default `pocketpaw` agent via `_resolve_pocket`. No code change there; a test pins this so the two paths stay in sync.

## Tests

New file `tests/cloud/memory/test_pocket_chat_agent_stamp.py` (9 tests), red before the fix, green after:
- OSS path stamps agent + pocket through `auto_create_pocket_session`.
- OSS save path threads the pocket id from both metadata shapes.
- Graceful degradation when no default agent exists.
- Cloud path already stamps (assert-only).
- Backfill: stamps orphans, is idempotent, dry-run writes nothing, skips workspaces with no default agent.

## Running the backfill

```
uv run python scripts/backfill_pocket_session_agent.py --dry-run   # report
uv run python scripts/backfill_pocket_session_agent.py             # apply
```

Honours `POCKETPAW_CLOUD_MONGO_URI`. Only touches rows with `agent == None` and `context_type == "pocket"`; safe to re-run.

## Risk / heads-up

The backfill and the OSS-path fix stamp **every** orphaned pocket session with the workspace default `pocketpaw` agent. For the home pocket and any pocket without a custom agent this matches the cloud path exactly. If a workspace ever attaches a non-default agent to a pocket and its chats reach the OSS path, those sessions would still get stamped with the default agent rather than the custom one, because the OSS metadata carries only the pocket id, not a resolved agent id. In practice the OSS path is the home/widget surface, which always runs against the default agent, so this is the correct stamp today. Flagging it because the assumption is load-bearing if custom-agent pockets later route through this path.