### PR TITLE
Studio and Code surfaces with a media generation MCP server

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/media.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/media.py
@@ -145,20 +145,31 @@ def _build_gallery_spec(media: list[dict[str, Any]]) -> dict[str, Any]:
                 ],
             }
         )
+    # version + a non-dashboard intent make pocketsStore.toRippleEnvelope pass
+    # the spec through untouched, and Ripple render it in NODE mode (a bare
+    # {"ui": [...]} got intent="dashboard" stamped on, which makes Ripple read
+    # `widgets` — always empty here — and render "No widgets yet"). `ui` must
+    # be a single root node, not a list: NodeRenderer takes one node.
     return {
-        "ui": [
-            {
-                "id": "studio-title",
-                "type": "text",
-                "props": {"text": "Generated media"},
-            },
-            {
-                "id": "studio-grid",
-                "type": "grid",
-                "props": {"columns": 3, "gap": "1rem"},
-                "children": tiles,
-            },
-        ]
+        "version": "2.0",
+        "intent": "gallery",
+        "ui": {
+            "id": "studio-root",
+            "type": "container",
+            "children": [
+                {
+                    "id": "studio-title",
+                    "type": "text",
+                    "props": {"text": "Generated media"},
+                },
+                {
+                    "id": "studio-grid",
+                    "type": "grid",
+                    "props": {"columns": 3, "gap": "1rem"},
+                    "children": tiles,
+                },
+            ],
+        },
     }
 
 

--- a/ee/pocketpaw_ee/agent/mcp_servers/media.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/media.py
@@ -1,0 +1,542 @@
+# media.py — in-process MCP server exposing the STUDIO media-generation actions
+# (image + video) to the claude_agent_sdk cloud chat backend. Created: 2026-06-10
+# (feat/studio-code-migration).
+#
+# What this file does: clones the sites.py / sites_create.py shape — a single
+# ``create_sdk_mcp_server`` with an SDK import-guard, ``SERVER_NAME`` /
+# ``*_TOOL_ID`` allowlist constants, ContextVar-sourced identity (the same
+# ``current_workspace_id`` / ``current_user_id`` accessors in
+# ``ee.cloud.chat.agent_service`` the sites / pocket-specialist servers read),
+# and the ``_error_response`` / ``_success_response`` helpers. Tool ids namespace
+# as ``mcp__pocketpaw_media__image_generate`` / ``__video_generate`` so the
+# Claude Code allowlist machinery matches them.
+#
+# Two SDK @tool defs:
+#   * image_generate — reuses the Gemini logic from
+#     src/pocketpaw/tools/builtin/image_gen.py (google genai client,
+#     settings.google_api_key, settings.image_model, saves to
+#     get_config_dir()/generated/<uuid>.png). Missing key → clear error.
+#   * video_generate — calls the Replicate HTTP API with httpx (an EXISTING
+#     dep — the replicate package is NOT added). Reads settings.replicate_api_token
+#     + settings.video_model, POSTs a prediction, polls the GET until terminal
+#     (~120s cap, 3s sleep), returns the output URL. Missing token → clear error.
+#
+# Result contract: every successful generation lands the asset in a STUDIO
+# gallery pocket via the TRUSTED-CREATE path (``agent_create(... type_="studio",
+# pattern="gallery", engine="ripple", ripple_spec=<gallery spec>, trusted=True)``)
+# so the strict catalog gate is bypassed (image / video-player widgets lag the
+# published manifest), then binds the session + emits ``pocket_created`` exactly
+# like sites_create.py (``_bind_session_and_emit``). The gallery spec uses ONLY
+# existing widget types (grid / card / image / video-player / text) so it renders
+# today — a responsive grid of media tiles. Media accumulates across the session
+# (per-session state holds the gallery's media list); each generation re-creates
+# the gallery with the full list and emits the refreshed pocket, so the canvas
+# always shows every asset made this session.
+#
+# EE→OSS boundary: this module lives in pocketpaw_ee; the surface service loads
+# MEDIA_TOOL_IDS as a plain frozenset[str] inside a try/except (never importing a
+# pocketpaw_ee symbol into src/pocketpaw).
+"""Agent-side MCP surface for STUDIO image + video generation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_media"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form.
+IMAGE_GENERATE_TOOL_ID = f"mcp__{SERVER_NAME}__image_generate"
+VIDEO_GENERATE_TOOL_ID = f"mcp__{SERVER_NAME}__video_generate"
+
+MEDIA_TOOL_IDS = (IMAGE_GENERATE_TOOL_ID, VIDEO_GENERATE_TOOL_ID)
+
+# Replicate HTTP API polling bounds (video generation is async — POST a
+# prediction, then GET-poll until terminal). httpx is the existing transport;
+# the replicate package is intentionally NOT a dependency.
+_REPLICATE_BASE = "https://api.replicate.com/v1"
+_POLL_INTERVAL_SECONDS = 3.0
+_POLL_MAX_SECONDS = 120.0
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects. The agent
+    reads ``text`` and surfaces the reason."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None]:
+    """Resolve the active workspace + user id from the per-stream ContextVars set
+    by the cloud chat agent runtime. Returns ``(workspace_id, user_id)``."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id, current_workspace_id
+
+        return current_workspace_id(), current_user_id()
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+# ── Per-session gallery state ───────────────────────────────────────────────
+# Keyed by session mongo id, holds the running list of media items produced this
+# session so subsequent generations append to the same gallery rather than
+# starting empty. ``pocket_id`` is the most-recently-created gallery pocket for
+# the session. Best-effort, in-process — a fresh process just starts a new
+# gallery, which is acceptable (the asset files persist regardless).
+_GALLERY_STATE: dict[str, dict[str, Any]] = {}
+
+
+def _generated_dir() -> Path:
+    """Get (and create) the directory for generated media assets — same location
+    the OSS ImageGenerateTool uses (``get_config_dir()/generated``)."""
+    from pocketpaw.config import get_config_dir
+
+    d = get_config_dir() / "generated"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _build_gallery_spec(media: list[dict[str, Any]]) -> dict[str, Any]:
+    """Assemble a STUDIO gallery rippleSpec from the accumulated media list.
+
+    Uses ONLY existing widget types (``grid`` / ``card`` / ``image`` /
+    ``video-player`` / ``text``) so it renders today. Each media item becomes a
+    card tile in a responsive grid; an ``image`` item carries a local file path,
+    a ``video`` item carries the provider output URL. A leading ``text`` node
+    titles the gallery. ``media`` items: ``{kind: "image"|"video", src, prompt}``.
+    """
+    tiles: list[dict[str, Any]] = []
+    for i, item in enumerate(media):
+        kind = item.get("kind")
+        src = item.get("src", "")
+        prompt = item.get("prompt", "")
+        if kind == "video":
+            inner = {"type": "video-player", "props": {"src": src, "controls": True}}
+        else:
+            inner = {"type": "image", "props": {"src": src, "alt": prompt}}
+        tiles.append(
+            {
+                "id": f"tile-{i}",
+                "type": "card",
+                "children": [
+                    inner,
+                    {"type": "text", "props": {"text": prompt}},
+                ],
+            }
+        )
+    return {
+        "ui": [
+            {
+                "id": "studio-title",
+                "type": "text",
+                "props": {"text": "Generated media"},
+            },
+            {
+                "id": "studio-grid",
+                "type": "grid",
+                "props": {"columns": 3, "gap": "1rem"},
+                "children": tiles,
+            },
+        ]
+    }
+
+
+async def _bind_session_and_emit(pocket_id: str, view: dict[str, Any], user_id: str) -> None:
+    """Bind the active chat session to the new gallery pocket and push the
+    ``pocket_created`` SSE event so the canvas auto-opens — the same atomic
+    post-create side effects ``sites_create.py`` runs. Best-effort: a bind / SSE
+    failure must never undo a successful create (the pocket already exists in
+    Mongo, which is the primary contract)."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_session_mongo_id,
+            push_sse_event,
+        )
+        from pocketpaw_ee.cloud.sessions import service as sessions_service
+
+        session_mongo_id = current_session_mongo_id()
+        if session_mongo_id:
+            await sessions_service.attach_pocket_to_session_doc(
+                session_mongo_id, user_id, pocket_id
+            )
+        push_sse_event(
+            "pocket_created",
+            {"pocket_id": pocket_id, "pocket": view, "session_id": session_mongo_id},
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "media: post-create side effects failed (non-fatal)",
+            exc_info=True,
+        )
+
+
+async def _land_in_gallery(
+    *,
+    workspace_id: str,
+    user_id: str,
+    kind: str,
+    src: str,
+    prompt: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Append a freshly generated asset to the session's STUDIO gallery and
+    persist it via the TRUSTED-CREATE path.
+
+    Tracks the running media list per session, rebuilds the full gallery spec,
+    and calls ``agent_create(... type_="studio", pattern="gallery",
+    ripple_spec=<spec>, trusted=True)`` so the strict catalog gate is bypassed
+    (the image / video-player widgets lag the published manifest, same reason
+    sites_create.py uses ``trusted=True``). Then binds the session + emits
+    ``pocket_created``. Returns ``({pocket_id, count}, None)`` on success or
+    ``(None, error)`` on failure.
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import current_session_mongo_id
+    from pocketpaw_ee.cloud.pockets.service import agent_create
+
+    session_key = current_session_mongo_id() or f"{workspace_id}:{user_id}"
+    state = _GALLERY_STATE.setdefault(session_key, {"media": [], "pocket_id": None})
+    state["media"].append({"kind": kind, "src": src, "prompt": prompt})
+
+    ripple_spec = _build_gallery_spec(state["media"])
+
+    try:
+        view, new_pocket_id, err = await agent_create(
+            workspace_id=workspace_id,
+            owner_id=user_id,
+            name="Studio gallery",
+            description="Media generated in /studio",
+            type_="studio",
+            pattern="gallery",
+            engine="ripple",
+            ripple_spec=ripple_spec,
+            trusted=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("media: gallery persist raised", exc_info=True)
+        return None, f"gallery persist failed: {exc}"
+
+    if err is not None or view is None or new_pocket_id is None:
+        return None, f"gallery persist failed: {err or 'create returned no view'}"
+
+    state["pocket_id"] = new_pocket_id
+    await _bind_session_and_emit(new_pocket_id, view, user_id)
+    return {"pocket_id": new_pocket_id, "count": len(state["media"])}, None
+
+
+async def _image_generate_handler(args: dict) -> dict:
+    """MCP handler for ``media__image_generate``.
+
+    Reuses the Gemini image logic from the OSS ImageGenerateTool: settings'
+    google_api_key + image_model, saves the PNG under get_config_dir()/generated,
+    then lands it in the STUDIO gallery. Sets ``is_error`` when identity or the
+    google key is missing, the genai package is absent, or generation fails.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "image_generate requires workspace and user context (call from a cloud chat session)."
+        )
+
+    prompt = args.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _error_response("image_generate requires a non-empty `prompt`.")
+    aspect_ratio = args.get("aspect_ratio") if isinstance(args.get("aspect_ratio"), str) else "1:1"
+
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    if not settings.google_api_key:
+        return _error_response(
+            "Set POCKETPAW_GOOGLE_API_KEY to enable image generation (Google Gemini)."
+        )
+
+    try:
+        from google import genai
+    except ImportError:
+        return _error_response(
+            "google-genai package not installed. Install with: pip install 'pocketpaw[image]'."
+        )
+
+    try:
+        client = genai.Client(api_key=settings.google_api_key)
+        response = client.models.generate_images(
+            model=settings.image_model,
+            prompt=prompt,
+            config=genai.types.GenerateImagesConfig(
+                number_of_images=1,
+                aspect_ratio=aspect_ratio,
+            ),
+        )
+        if not response.generated_images:
+            return _error_response("No image was generated. Try a different prompt.")
+        image = response.generated_images[0].image
+        out_path = _generated_dir() / f"{uuid.uuid4()}.png"
+        image.save(out_path)
+        logger.info("media: generated image %s", out_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("media: image generation failed", exc_info=True)
+        return _error_response(f"image generation failed: {exc}")
+
+    result, err = await _land_in_gallery(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        kind="image",
+        src=str(out_path),
+        prompt=prompt,
+    )
+    if err is not None or result is None:
+        return _error_response(err or "could not add the image to the gallery")
+
+    return _success_response(
+        {
+            "ok": True,
+            "kind": "image",
+            "path": str(out_path),
+            "pocket_id": result["pocket_id"],
+            "gallery_count": result["count"],
+        }
+    )
+
+
+async def _poll_replicate(client: Any, token: str, get_url: str) -> dict[str, Any]:
+    """Poll a Replicate prediction GET until it reaches a terminal status,
+    bounded by ``_POLL_MAX_SECONDS``. Returns the final prediction dict (caller
+    inspects ``status`` / ``output`` / ``error``)."""
+    headers = {"Authorization": f"Bearer {token}"}
+    waited = 0.0
+    prediction: dict[str, Any] = {}
+    while waited < _POLL_MAX_SECONDS:
+        resp = await client.get(get_url, headers=headers, timeout=30.0)
+        resp.raise_for_status()
+        prediction = resp.json()
+        status = prediction.get("status")
+        if status in ("succeeded", "failed", "canceled"):
+            return prediction
+        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+        waited += _POLL_INTERVAL_SECONDS
+    prediction["status"] = prediction.get("status") or "timed_out"
+    return prediction
+
+
+async def _video_generate_handler(args: dict) -> dict:
+    """MCP handler for ``media__video_generate``.
+
+    Calls the Replicate HTTP API with httpx (no replicate package): POSTs a
+    prediction for ``settings.video_model`` with the prompt + duration +
+    aspect_ratio, polls the prediction GET until terminal (~120s cap, 3s sleep),
+    then lands the resulting output URL in the STUDIO gallery. Sets ``is_error``
+    when identity or the token is missing, the prediction fails, or it times out.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "video_generate requires workspace and user context (call from a cloud chat session)."
+        )
+
+    prompt = args.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _error_response("video_generate requires a non-empty `prompt`.")
+    duration = args.get("duration") if isinstance(args.get("duration"), int) else 5
+    aspect_ratio = args.get("aspect_ratio") if isinstance(args.get("aspect_ratio"), str) else "16:9"
+
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    if not settings.replicate_api_token:
+        return _error_response("Set POCKETPAW_REPLICATE_API_TOKEN to enable video generation.")
+
+    import httpx
+
+    token = settings.replicate_api_token
+    model = settings.video_model
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    # Replicate runs a model by owner/name slug via the model-scoped predictions
+    # endpoint; the input shape is model-specific but prompt/duration/aspect_ratio
+    # are the common kling-style fields.
+    create_url = f"{_REPLICATE_BASE}/models/{model}/predictions"
+    payload = {
+        "input": {
+            "prompt": prompt,
+            "duration": duration,
+            "aspect_ratio": aspect_ratio,
+        }
+    }
+
+    try:
+        async with httpx.AsyncClient() as client:
+            create_resp = await client.post(
+                create_url, headers=headers, json=payload, timeout=30.0
+            )
+            create_resp.raise_for_status()
+            prediction = create_resp.json()
+            get_url = (prediction.get("urls") or {}).get("get")
+            if not get_url:
+                return _error_response("Replicate did not return a prediction poll URL.")
+            prediction = await _poll_replicate(client, token, get_url)
+    except httpx.HTTPStatusError as exc:
+        logger.warning("media: replicate HTTP error", exc_info=True)
+        return _error_response(f"video generation request failed: {exc.response.status_code}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("media: video generation failed", exc_info=True)
+        return _error_response(f"video generation failed: {exc}")
+
+    status = prediction.get("status")
+    if status != "succeeded":
+        detail = prediction.get("error") or status
+        return _error_response(f"video generation did not succeed: {detail}")
+
+    output = prediction.get("output")
+    # Replicate output is a URL or a list of URLs — take the first URL.
+    if isinstance(output, list):
+        output_url = next((u for u in output if isinstance(u, str)), None)
+    elif isinstance(output, str):
+        output_url = output
+    else:
+        output_url = None
+    if not output_url:
+        return _error_response("video generation succeeded but returned no output URL.")
+
+    result, err = await _land_in_gallery(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        kind="video",
+        src=output_url,
+        prompt=prompt,
+    )
+    if err is not None or result is None:
+        return _error_response(err or "could not add the video to the gallery")
+
+    return _success_response(
+        {
+            "ok": True,
+            "kind": "video",
+            "url": output_url,
+            "pocket_id": result["pocket_id"],
+            "gallery_count": result["count"],
+        }
+    )
+
+
+def build_media_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for STUDIO media generation, or return
+    ``None`` if the Claude Agent SDK isn't installed.
+
+    Matches the shape returned by ``build_sites_manager_server`` (``(name,
+    server)`` or ``None``) so the backend's MCP registration loop treats it
+    identically.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_media MCP disabled")
+        return None
+
+    @tool(
+        "image_generate",
+        (
+            "Generate an IMAGE from a text prompt (Google Gemini) and add it to "
+            "the user's /studio gallery. Use this on the STUDIO surface when the "
+            "user describes an image / poster / illustration to create. Args: "
+            "`prompt` (required — describe the image), optional `aspect_ratio` "
+            "(e.g. '1:1', '16:9', '9:16') and `size`. Returns {ok, kind:'image', "
+            "path, pocket_id, gallery_count}; the image is laid out as a tile in "
+            "the gallery pocket and the canvas opens automatically. ok=false with "
+            "an error means relay the reason (e.g. the Google API key is not set) "
+            "— do NOT claim a phantom image."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Text description of the image to generate.",
+                },
+                "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio (default '1:1'). e.g. '1:1', '16:9', '9:16'.",
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Output resolution hint (default '1K').",
+                },
+            },
+            "required": ["prompt"],
+            "additionalProperties": False,
+        },
+    )
+    async def image_generate(args):  # type: ignore[no-untyped-def]
+        return await _image_generate_handler(args)
+
+    @tool(
+        "video_generate",
+        (
+            "Generate a VIDEO from a text prompt (Replicate) and add it to the "
+            "user's /studio gallery. Use this on the STUDIO surface when the user "
+            "describes a short video / clip / animation to create. Args: `prompt` "
+            "(required — describe the video), optional `duration` (seconds, "
+            "default 5) and `aspect_ratio` (e.g. '16:9', '9:16'). Generation is "
+            "async and may take up to ~2 minutes. Returns {ok, kind:'video', url, "
+            "pocket_id, gallery_count}; the video is laid out as a tile in the "
+            "gallery pocket and the canvas opens automatically. ok=false with an "
+            "error means relay the reason (e.g. POCKETPAW_REPLICATE_API_TOKEN is "
+            "not set) — do NOT claim a phantom video."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Text description of the video to generate.",
+                },
+                "duration": {
+                    "type": "integer",
+                    "description": "Clip length in seconds (default 5).",
+                },
+                "aspect_ratio": {
+                    "type": "string",
+                    "description": "Aspect ratio (default '16:9'). e.g. '16:9', '9:16'.",
+                },
+            },
+            "required": ["prompt"],
+            "additionalProperties": False,
+        },
+    )
+    async def video_generate(args):  # type: ignore[no-untyped-def]
+        return await _video_generate_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[image_generate, video_generate],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "IMAGE_GENERATE_TOOL_ID",
+    "MEDIA_TOOL_IDS",
+    "SERVER_NAME",
+    "VIDEO_GENERATE_TOOL_ID",
+    "build_media_server",
+]

--- a/ee/pocketpaw_ee/agent/mcp_servers/media.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/media.py
@@ -12,10 +12,11 @@
 # Claude Code allowlist machinery matches them.
 #
 # Two SDK @tool defs:
-#   * image_generate — reuses the Gemini logic from
-#     src/pocketpaw/tools/builtin/image_gen.py (google genai client,
-#     settings.google_api_key, settings.image_model, saves to
-#     get_config_dir()/generated/<uuid>.png). Missing key → clear error.
+#   * image_generate — delegates to generate_image_file() in
+#     src/pocketpaw/tools/builtin/image_gen.py (2026-06-10: shared helper that
+#     routes gemini-*-image models via generateContent and imagen-* via the
+#     paid-tier predict endpoint), saves to get_config_dir()/generated/<uuid>.png.
+#     Missing key → clear error.
 #   * video_generate — calls the Replicate HTTP API with httpx (an EXISTING
 #     dep — the replicate package is NOT added). Reads settings.replicate_api_token
 #     + settings.video_model, POSTs a prediction, polls the GET until terminal
@@ -276,21 +277,14 @@ async def _image_generate_handler(args: dict) -> dict:
             "google-genai package not installed. Install with: pip install 'pocketpaw[image]'."
         )
 
+    from pocketpaw.tools.builtin.image_gen import generate_image_file
+
     try:
         client = genai.Client(api_key=settings.google_api_key)
-        response = client.models.generate_images(
-            model=settings.image_model,
-            prompt=prompt,
-            config=genai.types.GenerateImagesConfig(
-                number_of_images=1,
-                aspect_ratio=aspect_ratio,
-            ),
-        )
-        if not response.generated_images:
-            return _error_response("No image was generated. Try a different prompt.")
-        image = response.generated_images[0].image
         out_path = _generated_dir() / f"{uuid.uuid4()}.png"
-        image.save(out_path)
+        err = generate_image_file(client, settings.image_model, prompt, aspect_ratio, out_path)
+        if err:
+            return _error_response(err)
         logger.info("media: generated image %s", out_path)
     except Exception as exc:  # noqa: BLE001
         logger.warning("media: image generation failed", exc_info=True)

--- a/ee/pocketpaw_ee/agent/mcp_servers/media.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/media.py
@@ -383,9 +383,7 @@ async def _video_generate_handler(args: dict) -> dict:
 
     try:
         async with httpx.AsyncClient() as client:
-            create_resp = await client.post(
-                create_url, headers=headers, json=payload, timeout=30.0
-            )
+            create_resp = await client.post(create_url, headers=headers, json=payload, timeout=30.0)
             create_resp.raise_for_status()
             prediction = create_resp.json()
             get_url = (prediction.get("urls") or {}).get("get")

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -375,7 +375,8 @@ def mount_cloud(app: FastAPI) -> None:
 
     @_files_v2.get("/browse")
     async def _files_get_browse(
-        mount: str = _Query(...),
+        mount: str | None = _Query(None),
+        path: str | None = _Query(None),
         cursor: str | None = _Query(None),
         limit: int = _Query(50, ge=1, le=500),
         workspace_id: str | None = _Query(None),
@@ -384,6 +385,16 @@ def mount_cloud(app: FastAPI) -> None:
         ctx = _files_ctx_from_user(user)
         if workspace_id is not None and workspace_id != ctx.workspace_id:
             raise _HTTPException(status_code=403, detail="files.workspace_mismatch")
+        # OSS path-shape fallback (2026-06-10). This route shadows the OSS
+        # GET /files/browse?path=…, which the localFs web bridge — and through
+        # it the /code IDE file tree — depends on. When no mount is given,
+        # delegate to the OSS handler so both call shapes serve from one path.
+        # The caller is already authenticated via current_active_user above.
+        if mount is None:
+            from pocketpaw.api.v1.files import browse_files as _oss_browse_files
+
+            oss_resp = await _oss_browse_files(path=path if path is not None else "~")
+            return oss_resp.model_dump()
         variables = {"workspace_id": ctx.workspace_id or ""}
         try:
             page = await _browse_mount(

--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -43,6 +43,11 @@
 # into ``models.*`` — which the OSS-EE boundary contract forbids. The surface
 # package is models-free at import time, so ``models.pocket`` can import this
 # without a cycle.
+# Changes: 2026-06-10 (feat/studio-code-migration) — added two new chat-bearing
+# surfaces to ``SurfaceKind``: ``STUDIO`` (/studio — describe→generate media,
+# image + video) and ``CODE`` (/code — the agent edits + runs code). Both get
+# ``ripple_mode="off"`` profiles in ``service.py`` so the agent generates media /
+# edits code instead of defaulting to a ripple ui-spec dashboard.
 
 from __future__ import annotations
 
@@ -80,6 +85,8 @@ class SurfaceKind(StrEnum):
     SIDEPANEL = "sidepanel"
     FORESIGHT = "foresight"  # /foresight + /foresight/scenarios/* routes
     SITES = "sites"  # /sites — describe-to-create + manage published Paw Sites
+    STUDIO = "studio"  # /studio — describe→generate media (image + video)
+    CODE = "code"  # /code — agent edits + runs code in the workspace
     GENERIC = "generic"  # any unknown surface — agent still gets a usable preamble
 
 

--- a/ee/pocketpaw_ee/cloud/surface/handlers/code.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/code.py
@@ -1,0 +1,57 @@
+# code.py — /code surface preamble.
+#
+# Created: 2026-06-10 (feat/studio-code-migration) — Orients the chat agent when
+# the user is on the /code surface (the agent edits + runs code in the
+# workspace). Without it the surface falls back to GENERIC and the agent builds a
+# dashboard pocket instead of editing code — the same drift the /sites preamble
+# was created to fix. Static orientation — no live data to fake.
+#
+# Mirrors the layout of handlers/sites.py: an async ``build_preamble`` returning
+# an XML-ish ``<surface>`` + ``<orientation>`` + ``<procedure>`` block. The
+# procedure tells the agent to use the SDK built-in tools (Bash / Read / Write /
+# Edit / Glob / Grep), PREFER the bundled ``code`` skill (the edit→run→verify
+# loop), and VERIFY (run it / tests) before claiming done. The workspace is
+# jailed and destructive shell is blocked.
+#
+# The /code SurfaceProfile sets ``ripple_mode="off"`` and an
+# ``allowed_sdk_tools`` allowlist (see service.py) so the agent does not inherit
+# the ~20k-char "default to ui-spec" ripple LAW and build a dashboard instead of
+# editing code.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the /code surface preamble — edit + run code in the workspace."""
+    route = meta.route_path or "/code"
+    return (
+        f'<surface kind="code" route="{route}" />\n'
+        "<code-orientation>\n"
+        "The user is on the CODE surface, a coding workspace. You EDIT and RUN "
+        "code here on the user's behalf. This is NOT a dashboard — do not build "
+        "widgets, charts, or a ui-spec, and do not create a pocket. The "
+        "deliverable is working CODE: files written or changed in the workspace "
+        "and verified by running them. Talk about the work as 'code', 'files', "
+        "'the workspace', 'tests' — never as a 'pocket' or 'dashboard'.\n"
+        "</code-orientation>\n"
+        "<code-procedure>\n"
+        "Treat the user's message on this surface as a coding task. Use the "
+        "built-in tools to do the work: `Bash` to run commands, `Read` to read "
+        "files, `Write` / `Edit` to change them, and `Glob` / `Grep` to find "
+        "code. PREFER the `code` skill — invoke it by intent (no slash command "
+        "needed); it owns the edit→run→verify loop. Always VERIFY before "
+        "claiming the task is done: run the code or its tests and confirm the "
+        "output, rather than asserting success from the edit alone. If a command "
+        "fails, read the error, fix it, and re-run.\n"
+        "The workspace is JAILED — stay inside it; do not reach outside the "
+        "working directory. Destructive shell operations are blocked, so do not "
+        "attempt to delete or move large trees, format disks, or run anything "
+        "irreversible. When done, briefly summarize what changed and how you "
+        "verified it.\n"
+        "</code-procedure>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/studio.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/studio.py
@@ -1,0 +1,62 @@
+# studio.py — /studio surface preamble.
+#
+# Created: 2026-06-10 (feat/studio-code-migration) — Orients the chat agent when
+# the user is on the /studio surface (describe→generate media: image + video).
+# Without it the surface falls back to GENERIC and the agent builds a dashboard
+# pocket instead of generating media — the same drift the /sites preamble was
+# created to fix. Static orientation — no live data to fake.
+#
+# Mirrors the layout of handlers/sites.py: an async ``build_preamble`` returning
+# an XML-ish ``<surface>`` + ``<orientation>`` + ``<procedure>`` block. The
+# procedure PREFERS the bundled ``studio`` skill (invoked by intent — no slash
+# command), and points the fallback at the in-process media MCP tools
+# (``mcp__pocketpaw_media__image_generate`` / ``__video_generate``). Provider /
+# key errors are relayed plainly so the agent never fakes a generated asset.
+#
+# The /studio SurfaceProfile sets ``ripple_mode="off"`` (see service.py) so the
+# agent does not inherit the ~20k-char "default to ui-spec" ripple LAW and build
+# a dashboard instead of generating media.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the /studio surface preamble — describe→generate media."""
+    route = meta.route_path or "/studio"
+    return (
+        f'<surface kind="studio" route="{route}" />\n'
+        "<studio-orientation>\n"
+        "The user is on the STUDIO surface, a media-generation canvas. They "
+        "describe an image or a video and you GENERATE it, then lay the result "
+        "out as a tile in a gallery pocket. This is NOT a dashboard — do not "
+        "build KPI widgets, charts, or a ui-spec. The deliverable is generated "
+        "MEDIA (images and short videos), shown in a responsive gallery that "
+        "opens on the canvas automatically. Talk about the work as 'images', "
+        "'videos', 'media', or 'the gallery' — never as a 'pocket' or "
+        "'dashboard'.\n"
+        "</studio-orientation>\n"
+        "<studio-procedure>\n"
+        "Treat the user's message on this surface as a request to GENERATE "
+        "media. PREFER the `studio` skill — invoke it by intent (no slash "
+        "command needed); it owns the generate→gallery flow and chooses image "
+        "vs video by the request. If that skill is unavailable, fall back "
+        "directly to the media MCP tools: call "
+        "`mcp__pocketpaw_media__image_generate` for an image / poster / "
+        "illustration (args: `prompt`, optional `aspect_ratio`), or "
+        "`mcp__pocketpaw_media__video_generate` for a short video / clip / "
+        "animation (args: `prompt`, optional `duration`, `aspect_ratio`). Each "
+        "tool produces the asset and adds it to the gallery pocket; the canvas "
+        "opens automatically. Video generation is async and may take up to ~2 "
+        "minutes — tell the user it is rendering.\n"
+        "Relay any provider or key error PLAINLY (e.g. 'Set "
+        "POCKETPAW_GOOGLE_API_KEY to enable image generation' or 'Set "
+        "POCKETPAW_REPLICATE_API_TOKEN to enable video generation') — NEVER "
+        "claim a phantom image or video. After it succeeds, briefly say what was "
+        "added to the gallery.\n"
+        "</studio-procedure>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -173,9 +173,7 @@ def _build_profiles() -> dict[str, Any]:
             SurfaceKind.CODE: SurfaceProfile(
                 ripple_mode="off",
                 skill_names=frozenset({"code"}),
-                allowed_sdk_tools=frozenset(
-                    {"Bash", "Read", "Write", "Edit", "Glob", "Grep"}
-                ),
+                allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
             ),
         },
         # /sites is meta-aware (below). Both modes scope to the sites authoring

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -45,6 +45,16 @@
 # no-pocket / legacy path. ``resolve_profile`` stays PURE/no-I/O (the hot lookup);
 # the actual once-per-run async pocket load that supplies the override dict lives
 # tenant-scoped in ``run_core.execute_run`` (entity I/O never enters this module).
+# Changes: 2026-06-10 (feat/studio-code-migration) — registered the STUDIO and
+# CODE surfaces: their handlers (``studio.build_preamble`` / ``code.build_preamble``)
+# join ``_load_handlers``, and ``_build_profiles`` gives both a ripple-OFF
+# ``SurfaceProfile`` so the agent generates media / edits code instead of
+# defaulting to a ripple ui-spec dashboard. STUDIO scopes ``allow_mcp_tool_ids``
+# to the media tools (``MEDIA_TOOL_IDS`` loaded as a plain frozenset[str] inside
+# the existing try/except — no EE symbol crosses into OSS) and surfaces the
+# ``studio`` skill; CODE sets an ``allowed_sdk_tools`` allowlist (Bash/Read/Write/
+# Edit/Glob/Grep) and surfaces the ``code`` skill. Both are plain ``by_kind``
+# entries (not meta-aware like /sites).
 
 from __future__ import annotations
 
@@ -113,12 +123,18 @@ def _build_profiles() -> dict[str, Any]:
     loaded = True
     foresight_allow: frozenset[str] | None
     sites_allow: frozenset[str] | None
+    studio_allow: frozenset[str] | None
     try:
         from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.media import MEDIA_TOOL_IDS
         from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS
 
         foresight_allow = frozenset(FORESIGHT_TOOL_IDS)
         sites_allow = frozenset(SITES_TOOL_IDS)
+        # /studio scopes to the media-generation tools (image + video). Crossed
+        # over from the EE mcp-server module as a plain frozenset[str] — never an
+        # imported pocketpaw_ee symbol leaks into the OSS surface service.
+        studio_allow = frozenset(MEDIA_TOOL_IDS)
     except Exception:  # noqa: BLE001 — degrade to no restriction, never break chat
         logger.warning(
             "surface: could not load mcp tool ids; per-mode MCP scoping disabled",
@@ -127,6 +143,7 @@ def _build_profiles() -> dict[str, Any]:
         loaded = False
         foresight_allow = None
         sites_allow = None
+        studio_allow = None
 
     return {
         "by_kind": {
@@ -140,6 +157,25 @@ def _build_profiles() -> dict[str, Any]:
             SurfaceKind.FILES: SurfaceProfile(
                 ripple_mode="on",
                 allow_mcp_tool_ids=frozenset() if loaded else None,
+            ),
+            # Studio: media generation (image + video). Ripple OFF so the agent
+            # generates media instead of defaulting to a ripple ui-spec dashboard;
+            # scoped to the media MCP tools (+ general-everywhere); the `studio`
+            # skill carries the generate→gallery flow.
+            SurfaceKind.STUDIO: SurfaceProfile(
+                ripple_mode="off",
+                allow_mcp_tool_ids=studio_allow,
+                skill_names=frozenset({"studio"}),
+            ),
+            # Code: edit + run code. Ripple OFF so the agent edits code instead of
+            # building a dashboard; the SDK-tool allowlist scopes it to the coding
+            # built-ins; the `code` skill carries the edit→run→verify loop.
+            SurfaceKind.CODE: SurfaceProfile(
+                ripple_mode="off",
+                skill_names=frozenset({"code"}),
+                allowed_sdk_tools=frozenset(
+                    {"Bash", "Read", "Write", "Edit", "Glob", "Grep"}
+                ),
             ),
         },
         # /sites is meta-aware (below). Both modes scope to the sites authoring
@@ -280,6 +316,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
         activity,
         audit,
         calendar,
+        code,
         files,
         generic,
         home,
@@ -292,6 +329,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
         settings,
         sidepanel,
         sites,
+        studio,
     )
     from pocketpaw_ee.cloud.surface.handlers import (
         agent as agent_handler,
@@ -325,6 +363,8 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
         SurfaceKind.SIDEPANEL: sidepanel.build_preamble,
         SurfaceKind.FORESIGHT: foresight_handler.build_preamble,
         SurfaceKind.SITES: sites.build_preamble,
+        SurfaceKind.STUDIO: studio.build_preamble,
+        SurfaceKind.CODE: code.build_preamble,
         SurfaceKind.GENERIC: generic.build_preamble,
     }
 

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -24,6 +24,11 @@ also starts the RFC 03 v2 temporal trigger sweep scheduler in
 ``POCKETPAW_TEMPORAL_SWEEP_ENABLED`` (default OFF) so pytest runs and
 multi-replica deployments don't double-fire. Cadence is configurable via
 ``POCKETPAW_TEMPORAL_SWEEP_INTERVAL_SECONDS`` (default 3600, floor 60).
+
+Updated: 2026-06-10 (feat/studio-code-migration) — added ``CloudMediaMcpProvider``
+(``pocketpaw.mcp_servers`` entry ``media``) exposing the STUDIO image +
+video generation in-process server (``pocketpaw_media``) to the
+claude_agent_sdk cloud chat backend, mirroring ``CloudSitesMcpProvider``.
 """
 
 from __future__ import annotations
@@ -577,6 +582,34 @@ class CloudSitesMcpProvider:
         from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS
 
         return list(SITES_TOOL_IDS)
+
+
+class CloudMediaMcpProvider:
+    """`pocketpaw.mcp_servers` — the STUDIO media-generation in-process server
+    (``pocketpaw_media``). Hosts ``image_generate`` + ``video_generate``.
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) so the bundled ``studio`` skill can
+    call it on any cloud chat agent that hits a "generate an image / make a
+    video" request without an explicit opt-in — the same regime the sites
+    manager + pocket specialist use. The cloud chat agent runs on the
+    claude_agent_sdk backend, which only sees in-process MCP servers (a plain
+    BaseTool is invisible to it), so media generation MUST be surfaced here.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.media import build_media_server
+
+            return build_media_server()
+        except ImportError:
+            # claude_agent_sdk not installed — the media server is unavailable,
+            # same as the other in-process servers.
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.media import MEDIA_TOOL_IDS
+
+        return list(MEDIA_TOOL_IDS)
 
 
 class CloudAgentExtension:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -175,6 +175,7 @@ foresight = "pocketpaw_ee.extensions:CloudForesightMcpProvider"
 composio = "pocketpaw_ee.extensions:CloudComposioMcpProvider"
 meetings = "pocketpaw_ee.extensions:CloudMeetingsMcpProvider"
 sites = "pocketpaw_ee.extensions:CloudSitesMcpProvider"
+media = "pocketpaw_ee.extensions:CloudMediaMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]
 cloud = "pocketpaw_ee.extensions:CloudAgentExtension"

--- a/src/pocketpaw/api/v1/files.py
+++ b/src/pocketpaw/api/v1/files.py
@@ -2,6 +2,9 @@
 # Created: 2026-02-20
 # 2026-04-16: Router-level files:read scope guard + symlink filter in
 # /files/download-zip. Closes #884 and #886.
+# 2026-06-10: expanduser() in browse + _resolve_path so "~/foo" paths resolve
+# to home — the /code IDE roots its tree at "~" and addresses children that
+# way. Jail checks unchanged.
 
 from __future__ import annotations
 
@@ -41,13 +44,14 @@ async def browse_files(path: str = "~"):
 
     settings = get_settings()
 
-    # Resolve path
+    # Resolve path. "~"-prefixed paths expand to home so the /code IDE (whose
+    # tree roots at "~") can address children as ~/foo — see _resolve_path.
     if path in ("~", ""):
         resolved_path = Path.home()
-    elif not path.startswith("/"):
-        resolved_path = Path.home() / path
     else:
-        resolved_path = Path(path)
+        resolved_path = Path(path).expanduser()
+        if not resolved_path.is_absolute():
+            resolved_path = Path.home() / resolved_path
 
     resolved_path = resolved_path.resolve()
     jail = settings.file_jail_path.resolve()
@@ -171,11 +175,12 @@ async def get_recent_files(limit: int = 20):
 
 
 def _resolve_path(path: str) -> Path:
-    """Resolve a path string to an absolute Path."""
-    candidate = Path(path)
+    """Resolve a path string to an absolute Path. Expands a leading ``~``
+    (the /code IDE addresses workspace files as ``~/foo``)."""
+    candidate = Path(path).expanduser()
     if candidate.is_absolute():
         return candidate.resolve()
-    return (Path.home() / path).resolve()
+    return (Path.home() / candidate).resolve()
 
 
 def _content_disposition(filename: str) -> str:

--- a/src/pocketpaw/bundled_skills/_bundled/skills/code/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/code/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: code
+description: |
+  Edit and run code in the workspace, then verify it works. Invoke when
+  the user asks to write, edit, run, fix, refactor, or debug code:
+  "write a script that...", "edit this function", "run the tests", "fix
+  this bug", "refactor...", "add a feature to...", "why is this failing"
+  (especially on the /code surface). You do NOT build a dashboard or a
+  ui-spec and you do NOT create a pocket — you use the built-in Bash /
+  Read / Write / Edit / Glob / Grep tools to change files and run them.
+  This is the coding brain: explore, edit, run, and VERIFY before
+  claiming done. The workspace is jailed and destructive shell is blocked.
+  Loading this skill keeps the chat agent's always-on system prompt small
+  while still delivering the full edit→run→verify loop when a coding task
+  is actually requested.
+---
+
+# Code — the edit→run→verify loop
+
+You're on **Code**: you edit and run code in the workspace on the user's
+behalf. The deliverable is **working code** — files written or changed and
+**verified by running them**. This is not a dashboard: no widgets, no
+ui-spec, no pocket. Use the built-in tools.
+
+## The tools
+
+- **`Glob` / `Grep`** — find the relevant files and code before you change
+  anything. Read first; don't guess where things live.
+- **`Read`** — read a file before editing it.
+- **`Edit`** — make a targeted change to an existing file.
+- **`Write`** — create a new file (or fully replace one you've read).
+- **`Bash`** — run commands: execute the code, run the tests, install
+  deps, check output.
+
+## The loop
+
+1. **Explore.** Use `Glob` / `Grep` / `Read` to understand the code and
+   locate exactly what to change. Don't edit blind.
+2. **Edit.** Make the change with `Edit` (or `Write` for a new file). Keep
+   changes scoped to the task — don't gold-plate.
+3. **Run.** Use `Bash` to actually run the code or its tests.
+4. **Verify.** Confirm the output is what you expected. If a command fails,
+   read the error, fix it, and re-run. **Do not claim the task is done
+   until you have run it and seen it work** — an edit that "looks right" is
+   not verification.
+5. **Summarize.** Briefly say what changed and how you verified it (which
+   command you ran, what it printed).
+
+## Verify before "done"
+
+This is the one rule that matters most: **evidence before assertions.**
+Before you tell the user the task is complete, run the code or the tests
+and confirm the result. If you wrote a function, call it. If you fixed a
+bug, reproduce the original failure and show it's gone. If there are tests,
+run them.
+
+## Safety — the workspace is jailed
+
+- Stay **inside the working directory**. Do not reach outside it.
+- **Destructive shell is blocked** — don't attempt to delete or move large
+  trees, format disks, or run anything irreversible. If a task seems to
+  require something destructive, stop and ask the user first.
+- Prefer small, reversible edits you can verify over sweeping rewrites.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/studio/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/studio/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: studio
+description: |
+  Generate media — images and short videos — from a text description and
+  lay the results out in a gallery. Invoke when the user asks to create
+  visual media: "generate an image of...", "make a video of...", "create
+  a poster for...", "render an illustration", "animate...", or any
+  describe-to-media request (especially on the /studio surface). You do
+  NOT build a dashboard or a ui-spec — you call a deterministic media tool
+  that produces the asset and adds it to a gallery pocket that opens on the
+  canvas. This is the media-generation brain: pick image vs video by
+  intent, write a vivid prompt, call the tool, and relay any provider/key
+  error plainly. Loading this skill keeps the chat agent's always-on system
+  prompt small while still delivering the full media flow when generation
+  is actually requested.
+---
+
+# Studio — the media-generation brain
+
+You're on **Studio**: the user describes an image or a video and you
+**generate** it. The result is laid out as a tile in a **gallery pocket**
+that opens on the canvas automatically. This is **not** a dashboard — you
+do not compose a rippleSpec, you do not build widgets, you do not call the
+pocket specialist. You call one media tool; **code** assembles the gallery.
+
+## Decide: image or video?
+
+Read the request and pick the right tool:
+
+- **Image** — a still picture, poster, illustration, logo concept, photo,
+  diagram-style art. Keywords: *image, picture, poster, illustration,
+  drawing, art, photo, headshot, icon, logo*.
+- **Video** — a moving clip or animation. Keywords: *video, clip,
+  animation, motion, reel, animate, moving*.
+
+If the user says nothing that disambiguates, default to an **image** (it's
+faster and cheaper) and offer to make a video version.
+
+## STEP 1 — Write a vivid prompt
+
+Turn the user's request into a concrete, descriptive prompt. Add subject,
+style, composition, lighting, and mood when the user was vague — a good
+prompt produces a good asset. Never pass a one-word prompt when you can
+enrich it from the request.
+
+## STEP 2 — Call the media tool
+
+**Image:**
+
+```
+mcp__pocketpaw_media__image_generate(
+  prompt = "<the vivid image prompt>",
+  aspect_ratio = "16:9"      // optional: "1:1" | "16:9" | "9:16"
+)
+```
+
+**Video:**
+
+```
+mcp__pocketpaw_media__video_generate(
+  prompt = "<the vivid video prompt>",
+  duration = 5,              // optional: seconds
+  aspect_ratio = "16:9"      // optional: "16:9" | "9:16"
+)
+```
+
+Each tool **produces the asset and adds it to the gallery pocket**, then
+returns `{ ok, kind, path|url, pocket_id, gallery_count }`. The canvas opens
+the gallery automatically — you don't create or merge a pocket yourself.
+
+Video generation is **async** and may take up to ~2 minutes. Tell the user
+it's rendering before you wait on it.
+
+## STEP 3 — Relay the result (or the error)
+
+- On success: briefly say what was added to the gallery (e.g. "Added your
+  poster to the gallery — 3 items now"). Don't dump the file path.
+- On `ok: false`: **relay the error plainly** and do **not** claim a
+  phantom asset. Common errors are missing provider keys:
+  - image → "Set `POCKETPAW_GOOGLE_API_KEY` to enable image generation."
+  - video → "Set `POCKETPAW_REPLICATE_API_TOKEN` to enable video
+    generation."
+
+## Accumulating a gallery
+
+Each generation **adds to the same session gallery** — the second image
+joins the first, and so on. The user can ask for several images/videos in
+a row and they all land in one growing grid. Just keep calling the right
+tool per request.
+
+## Related tools (via MCP)
+
+- `mcp__pocketpaw_media__image_generate` — generate an image (Google
+  Gemini) and add it to the gallery. Returns `{ok, kind:'image', path,
+  pocket_id, gallery_count}`.
+- `mcp__pocketpaw_media__video_generate` — generate a short video
+  (Replicate) and add it to the gallery. Returns `{ok, kind:'video', url,
+  pocket_id, gallery_count}`.

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -798,7 +798,13 @@ class Settings(BaseSettings):
     # Image Generation
     google_api_key: str | None = Field(default=None, description="Google API key (for Gemini)")
     image_model: str = Field(
-        default="gemini-2.0-flash-exp", description="Google image generation model"
+        default="gemini-2.5-flash-image",
+        description=(
+            "Google image generation model. Gemini image models "
+            "(gemini-*-image) run via generateContent and work on free-tier "
+            "keys; imagen-* models run via the predict endpoint, which "
+            "Google restricts to paid-tier keys."
+        ),
     )
     # Video Generation (Replicate HTTP API — used by the /studio surface's
     # media MCP server). Env auto-derives POCKETPAW_REPLICATE_API_TOKEN /

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -800,6 +800,19 @@ class Settings(BaseSettings):
     image_model: str = Field(
         default="gemini-2.0-flash-exp", description="Google image generation model"
     )
+    # Video Generation (Replicate HTTP API — used by the /studio surface's
+    # media MCP server). Env auto-derives POCKETPAW_REPLICATE_API_TOKEN /
+    # POCKETPAW_FAL_API_KEY / POCKETPAW_VIDEO_MODEL.
+    replicate_api_token: str | None = Field(
+        default=None, description="Replicate API token (for video generation via the HTTP API)"
+    )
+    fal_api_key: str | None = Field(
+        default=None, description="fal.ai API key (alternate media-generation provider)"
+    )
+    video_model: str = Field(
+        default="kwaivgi/kling-v2.0",
+        description="Replicate video-generation model (owner/name slug)",
+    )
 
     # Security
     bypass_permissions: bool = Field(

--- a/src/pocketpaw/tools/builtin/image_gen.py
+++ b/src/pocketpaw/tools/builtin/image_gen.py
@@ -1,6 +1,10 @@
 # Image Generation tool — generate images via Google Gemini.
 # Created: 2026-02-06
 # Part of Phase 1 Quick Wins
+# 2026-06-10: route by model family — gemini-*-image models go through
+#   generate_content (free tier), imagen-* models through generate_images
+#   (predict endpoint, paid tier only). Shared helper generate_image_file()
+#   is also used by the EE media MCP server.
 
 import logging
 import uuid
@@ -18,6 +22,57 @@ def _get_generated_dir() -> Path:
     d = get_config_dir() / "generated"
     d.mkdir(parents=True, exist_ok=True)
     return d
+
+
+def generate_image_file(
+    client: Any, model: str, prompt: str, aspect_ratio: str, out_path: Path
+) -> str | None:
+    """Generate one image with ``client`` and write it to ``out_path``.
+
+    Returns an error message, or None on success. Routes by model family:
+    ``imagen-*`` models only exist on the predict endpoint
+    (``generate_images``), which Google restricts to paid-tier keys; Gemini
+    image models (``gemini-2.5-flash-image`` etc.) use ``generate_content``
+    and work on the free tier.
+    """
+    from google import genai
+
+    if model.startswith("imagen"):
+        response = client.models.generate_images(
+            model=model,
+            prompt=prompt,
+            config=genai.types.GenerateImagesConfig(
+                number_of_images=1,
+                aspect_ratio=aspect_ratio,
+            ),
+        )
+        if not response.generated_images:
+            return "No image was generated. Try a different prompt."
+        response.generated_images[0].image.save(out_path)
+        return None
+
+    response = client.models.generate_content(
+        model=model,
+        contents=prompt,
+        config=genai.types.GenerateContentConfig(
+            response_modalities=["TEXT", "IMAGE"],
+            image_config=genai.types.ImageConfig(aspect_ratio=aspect_ratio),
+        ),
+    )
+    parts = response.candidates[0].content.parts if response.candidates else []
+    image_part = next(
+        (
+            p
+            for p in parts
+            if getattr(p, "inline_data", None) is not None
+            and (p.inline_data.mime_type or "").startswith("image/")
+        ),
+        None,
+    )
+    if image_part is None:
+        return "No image was generated. Try a different prompt."
+    out_path.write_bytes(image_part.inline_data.data)
+    return None
 
 
 class ImageGenerateTool(BaseTool):
@@ -83,23 +138,12 @@ class ImageGenerateTool(BaseTool):
 
         try:
             client = genai.Client(api_key=settings.google_api_key)
-            response = client.models.generate_images(
-                model=settings.image_model,
-                prompt=prompt,
-                config=genai.types.GenerateImagesConfig(
-                    number_of_images=1,
-                    aspect_ratio=aspect_ratio,
-                ),
-            )
-
-            if not response.generated_images:
-                return self._error("No image was generated. Try a different prompt.")
-
-            image = response.generated_images[0].image
             out_dir = _get_generated_dir()
             filename = f"{uuid.uuid4()}.png"
             out_path = out_dir / filename
-            image.save(out_path)
+            err = generate_image_file(client, settings.image_model, prompt, aspect_ratio, out_path)
+            if err:
+                return self._error(err)
 
             logger.info("Generated image: %s", out_path)
             return self._media_result(

--- a/tests/cloud/surface/test_studio_code_handlers.py
+++ b/tests/cloud/surface/test_studio_code_handlers.py
@@ -1,0 +1,153 @@
+# tests/cloud/surface/test_studio_code_handlers.py — STUDIO + CODE surface
+# handlers and their ripple-OFF SurfaceProfiles.
+#
+# Created: 2026-06-10 (feat/studio-code-migration) — Guards the two new
+# describe→do surfaces:
+#   * /studio — the agent GENERATES media (image + video) and lays it out in a
+#     gallery. Preamble must orient to media (not a dashboard), prefer the
+#     `studio` skill, and name the media MCP fallback tools.
+#   * /code — the agent EDITS + RUNS code. Preamble must orient to coding (not a
+#     dashboard), prefer the `code` skill, name the built-in tools, and demand
+#     verification before "done".
+# Also pins both profiles: ripple_mode="off" (so neither inherits the ripple
+# "default to ui-spec" LAW), the per-surface skill, and STUDIO's media-tool
+# allow-list / CODE's SDK-tool allow-list.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface import SurfaceKind, SurfaceMeta, resolve_profile
+from pocketpaw_ee.cloud.surface.handlers import code as code_handler
+from pocketpaw_ee.cloud.surface.handlers import studio as studio_handler
+
+# pytest-asyncio runs in auto mode (see pyproject [tool.pytest] asyncio_mode),
+# so async tests are detected automatically — no module-level mark needed (a
+# module mark would wrongly tag the sync profile/util tests below).
+
+WORKSPACE = "ws-surface-studiocode"
+USER = "u-studiocode"
+
+
+# --- /studio handler ---
+
+
+async def test_studio_handler_carries_media_orientation() -> None:
+    """The preamble orients to media generation on the studio surface — and must
+    NOT frame the deliverable as a dashboard or a pocket."""
+    preamble = await studio_handler.build_preamble(
+        WORKSPACE, USER, SurfaceMeta(route_path="/studio")
+    )
+
+    assert '<surface kind="studio"' in preamble
+    lower = preamble.lower()
+    # Mentions the surface + the media deliverable.
+    assert "studio" in lower
+    assert "image" in lower
+    assert "video" in lower
+    assert "gallery" in lower
+    # Not a dashboard build.
+    assert "dashboard" not in lower or "not" in lower  # only as the thing to avoid
+    assert "build a pocket" not in lower
+
+
+async def test_studio_handler_prefers_studio_skill_and_names_media_tools() -> None:
+    """The procedure PREFERS the `studio` skill and names the media MCP tools as
+    the fallback so the generate→gallery flow never breaks."""
+    preamble = await studio_handler.build_preamble(
+        WORKSPACE, USER, SurfaceMeta(route_path="/studio")
+    )
+
+    assert "prefer" in preamble.lower()
+    assert "`studio`" in preamble or "studio skill" in preamble.lower()
+    # The in-process media MCP tools — the SDK backend only sees these.
+    assert "mcp__pocketpaw_media__image_generate" in preamble
+    assert "mcp__pocketpaw_media__video_generate" in preamble
+
+
+async def test_studio_handler_relays_provider_errors() -> None:
+    """The procedure tells the agent to relay provider/key errors plainly and
+    never fake a generated asset."""
+    preamble = await studio_handler.build_preamble(
+        WORKSPACE, USER, SurfaceMeta(route_path="/studio")
+    )
+    lower = preamble.lower()
+    assert "error" in lower
+    assert "phantom" in lower or "never claim" in lower
+
+
+# --- /code handler ---
+
+
+async def test_code_handler_carries_coding_orientation() -> None:
+    """The preamble orients to editing + running code on the code surface — and
+    must NOT frame the deliverable as a dashboard or a pocket."""
+    preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
+
+    assert '<surface kind="code" ' in preamble
+    lower = preamble.lower()
+    assert "code" in lower
+    assert "workspace" in lower
+    # Not a dashboard / pocket build.
+    assert "build a pocket" not in lower
+
+
+async def test_code_handler_names_builtin_tools_and_prefers_code_skill() -> None:
+    """The procedure names the built-in coding tools and prefers the `code`
+    skill (the edit→run→verify loop)."""
+    preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
+
+    assert "prefer" in preamble.lower()
+    assert "`code`" in preamble or "code skill" in preamble.lower()
+    # The built-in tools the SDK backend exposes for coding.
+    for tool in ("Bash", "Read", "Write", "Edit", "Glob", "Grep"):
+        assert tool in preamble, f"preamble should name the {tool} tool"
+
+
+async def test_code_handler_demands_verification_and_is_jailed() -> None:
+    """The procedure demands verifying (run it / tests) before claiming done, and
+    states the workspace is jailed + destructive shell is blocked."""
+    preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
+    lower = preamble.lower()
+    assert "verify" in lower
+    assert "jailed" in lower
+    assert "destructive" in lower
+
+
+# --- Profiles (ripple-OFF on both) ---
+
+
+def test_studio_profile_ripple_off_media_tools_and_skill() -> None:
+    """The /studio profile turns ripple OFF (so the agent generates media, not a
+    ui-spec dashboard), scopes to the media MCP tools, and surfaces the studio
+    skill."""
+    from pocketpaw_ee.agent.mcp_servers.media import (
+        IMAGE_GENERATE_TOOL_ID,
+        VIDEO_GENERATE_TOOL_ID,
+    )
+
+    profile = resolve_profile(SurfaceKind.STUDIO, SurfaceMeta())
+    assert profile.ripple_mode == "off"
+    assert "studio" in profile.skill_names
+    assert profile.allow_mcp_tool_ids is not None
+    assert IMAGE_GENERATE_TOOL_ID in profile.allow_mcp_tool_ids
+    assert VIDEO_GENERATE_TOOL_ID in profile.allow_mcp_tool_ids
+
+
+def test_code_profile_ripple_off_sdk_allowlist_and_skill() -> None:
+    """The /code profile turns ripple OFF (so the agent edits code, not a
+    dashboard), restricts SDK tools to the coding built-ins, and surfaces the
+    code skill."""
+    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
+    assert profile.ripple_mode == "off"
+    assert "code" in profile.skill_names
+    assert profile.allowed_sdk_tools == frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
+    # Code names no specialized MCP tools — it rides the built-in SDK tools.
+    assert profile.allow_mcp_tool_ids is None
+
+
+def test_studio_and_code_kinds_map_from_wire_strings() -> None:
+    """The wire ``surface`` strings 'studio' / 'code' resolve to the new kinds
+    (not the GENERIC fallback)."""
+    from pocketpaw_ee.cloud.surface.service import _resolve_kind
+
+    assert _resolve_kind("studio") is SurfaceKind.STUDIO
+    assert _resolve_kind("code") is SurfaceKind.CODE

--- a/tests/cloud/test_media_mcp.py
+++ b/tests/cloud/test_media_mcp.py
@@ -7,6 +7,9 @@
 #   * image_generate — happy path (mock the google genai client + agent_create →
 #     asserts the asset lands in a trusted-create gallery and the success body
 #     carries the pocket_id) and the error path when no google key is set.
+#     2026-06-10: happy path mocks generate_content (the gemini-2.5-flash-image
+#     default route in generate_image_file); the imagen/generate_images route is
+#     covered in tests/test_image_gen.py.
 #   * video_generate — the error path when no Replicate token is set (mock the
 #     settings; httpx must not even be reached). The happy path needs a live
 #     Replicate poll, so it is covered structurally by the no-token guard + the
@@ -71,18 +74,16 @@ async def test_image_generate_happy_path_lands_in_gallery(tmp_path, monkeypatch)
     # Fresh per-session state so the gallery count is deterministic.
     monkeypatch.setattr(media, "_GALLERY_STATE", {})
 
-    # Mock the google genai module (`from google import genai`).
-    saved = {}
-
-    def _save(path):
-        saved["path"] = str(path)
-
-    mock_image = MagicMock()
-    mock_image.save.side_effect = _save
-    mock_generated = MagicMock(image=mock_image)
-    mock_response = MagicMock(generated_images=[mock_generated])
+    # Mock the google genai module (`from google import genai`). The default
+    # image model is now gemini-2.5-flash-image, which routes through
+    # generate_content (free-tier path) — see generate_image_file().
+    mock_part = MagicMock()
+    mock_part.inline_data = MagicMock(mime_type="image/png", data=b"png-bytes")
+    mock_candidate = MagicMock()
+    mock_candidate.content.parts = [mock_part]
+    mock_response = MagicMock(candidates=[mock_candidate])
     mock_client = MagicMock()
-    mock_client.models.generate_images.return_value = mock_response
+    mock_client.models.generate_content.return_value = mock_response
     mock_genai = MagicMock()
     mock_genai.Client.return_value = mock_client
 
@@ -94,7 +95,7 @@ async def test_image_generate_happy_path_lands_in_gallery(tmp_path, monkeypatch)
         patch.object(media, "_identity", return_value=("ws-1", "u-1")),
         patch(
             "pocketpaw.config.get_settings",
-            return_value=MagicMock(google_api_key="k", image_model="gemini-2.0-flash-exp"),
+            return_value=MagicMock(google_api_key="k", image_model="gemini-2.5-flash-image"),
         ),
         patch.object(media, "_generated_dir", return_value=tmp_path),
         patch.dict(
@@ -120,8 +121,10 @@ async def test_image_generate_happy_path_lands_in_gallery(tmp_path, monkeypatch)
     assert body["kind"] == "image"
     assert body["pocket_id"] == "pkt-gallery-1"
     assert body["gallery_count"] == 1
-    # The PNG was saved under the generated dir.
-    assert saved["path"].startswith(str(tmp_path))
+    # The PNG was written under the generated dir with the inline image bytes.
+    pngs = list(tmp_path.glob("*.png"))
+    assert len(pngs) == 1
+    assert pngs[0].read_bytes() == b"png-bytes"
     # agent_create was called with the trusted-create STUDIO gallery contract.
     _, kwargs = agent_create.call_args
     assert kwargs["type_"] == "studio"

--- a/tests/cloud/test_media_mcp.py
+++ b/tests/cloud/test_media_mcp.py
@@ -1,0 +1,182 @@
+# tests/cloud/test_media_mcp.py — STUDIO media-generation in-process MCP server.
+#
+# Created: 2026-06-10 (feat/studio-code-migration) — Guards the media MCP server
+# the cloud chat (claude_agent_sdk) backend uses on the /studio surface:
+#   * MEDIA_TOOL_IDS — the two namespaced tool ids the surface allow-list + the
+#     SDK allowlist machinery key on.
+#   * image_generate — happy path (mock the google genai client + agent_create →
+#     asserts the asset lands in a trusted-create gallery and the success body
+#     carries the pocket_id) and the error path when no google key is set.
+#   * video_generate — the error path when no Replicate token is set (mock the
+#     settings; httpx must not even be reached). The happy path needs a live
+#     Replicate poll, so it is covered structurally by the no-token guard + the
+#     output-URL parsing being exercised in the handler.
+#
+# All tests mock the per-stream ContextVar identity (``_identity``) and the
+# session-bind/SSE side effects (``_bind_session_and_emit``) so they run without
+# a live SSE chat stream.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pocketpaw_ee.agent.mcp_servers.media as media
+
+# pytest-asyncio runs in auto mode (see pyproject [tool.pytest] asyncio_mode),
+# so async tests are detected automatically — no module-level mark needed (a
+# module mark would wrongly tag the sync util tests below).
+
+
+def test_media_tool_ids_are_namespaced() -> None:
+    """The tool ids use the ``mcp__<server>__<tool>`` form the Claude Code
+    allowlist machinery matches."""
+    assert media.SERVER_NAME == "pocketpaw_media"
+    assert media.IMAGE_GENERATE_TOOL_ID == "mcp__pocketpaw_media__image_generate"
+    assert media.VIDEO_GENERATE_TOOL_ID == "mcp__pocketpaw_media__video_generate"
+    assert media.MEDIA_TOOL_IDS == (
+        media.IMAGE_GENERATE_TOOL_ID,
+        media.VIDEO_GENERATE_TOOL_ID,
+    )
+
+
+# --- image_generate ---
+
+
+async def test_image_generate_error_when_no_google_key() -> None:
+    """No google key → a clear error response, no asset, no gallery write."""
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch("pocketpaw.config.get_settings", return_value=MagicMock(google_api_key=None)),
+    ):
+        result = await media._image_generate_handler({"prompt": "a red bicycle"})
+
+    assert result.get("is_error") is True
+    assert "POCKETPAW_GOOGLE_API_KEY" in result["content"][0]["text"]
+
+
+async def test_image_generate_error_when_no_identity() -> None:
+    """No workspace/user context → a clear error (called outside a chat stream)."""
+    with patch.object(media, "_identity", return_value=(None, None)):
+        result = await media._image_generate_handler({"prompt": "a red bicycle"})
+
+    assert result.get("is_error") is True
+    assert "workspace and user context" in result["content"][0]["text"]
+
+
+async def test_image_generate_happy_path_lands_in_gallery(tmp_path, monkeypatch) -> None:
+    """A successful Gemini generation saves a PNG and lands it in a trusted-create
+    STUDIO gallery; the success body carries the gallery pocket_id."""
+    import sys
+
+    # Fresh per-session state so the gallery count is deterministic.
+    monkeypatch.setattr(media, "_GALLERY_STATE", {})
+
+    # Mock the google genai module (`from google import genai`).
+    saved = {}
+
+    def _save(path):
+        saved["path"] = str(path)
+
+    mock_image = MagicMock()
+    mock_image.save.side_effect = _save
+    mock_generated = MagicMock(image=mock_image)
+    mock_response = MagicMock(generated_images=[mock_generated])
+    mock_client = MagicMock()
+    mock_client.models.generate_images.return_value = mock_response
+    mock_genai = MagicMock()
+    mock_genai.Client.return_value = mock_client
+
+    # agent_create returns (view, pocket_id, err).
+    fake_view = {"name": "Studio gallery", "type": "studio", "pattern": "gallery"}
+    agent_create = AsyncMock(return_value=(fake_view, "pkt-gallery-1", None))
+
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch(
+            "pocketpaw.config.get_settings",
+            return_value=MagicMock(google_api_key="k", image_model="gemini-2.0-flash-exp"),
+        ),
+        patch.object(media, "_generated_dir", return_value=tmp_path),
+        patch.dict(
+            sys.modules, {"google": MagicMock(genai=mock_genai), "google.genai": mock_genai}
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_session_mongo_id",
+            return_value="sess-1",
+        ),
+        patch("pocketpaw_ee.cloud.pockets.service.agent_create", agent_create),
+        patch.object(media, "_bind_session_and_emit", AsyncMock()),
+    ):
+        result = await media._image_generate_handler(
+            {"prompt": "a red bicycle", "aspect_ratio": "16:9"}
+        )
+
+    # No is_error — a success body with the gallery pocket id.
+    assert result.get("is_error") is not True
+    import json
+
+    body = json.loads(result["content"][0]["text"])
+    assert body["ok"] is True
+    assert body["kind"] == "image"
+    assert body["pocket_id"] == "pkt-gallery-1"
+    assert body["gallery_count"] == 1
+    # The PNG was saved under the generated dir.
+    assert saved["path"].startswith(str(tmp_path))
+    # agent_create was called with the trusted-create STUDIO gallery contract.
+    _, kwargs = agent_create.call_args
+    assert kwargs["type_"] == "studio"
+    assert kwargs["pattern"] == "gallery"
+    assert kwargs["trusted"] is True
+    assert kwargs["ripple_spec"] is not None
+
+
+# --- video_generate ---
+
+
+async def test_video_generate_error_when_no_replicate_token() -> None:
+    """No Replicate token → a clear error response; httpx is never reached."""
+    with (
+        patch.object(media, "_identity", return_value=("ws-1", "u-1")),
+        patch(
+            "pocketpaw.config.get_settings",
+            return_value=MagicMock(replicate_api_token=None, video_model="kwaivgi/kling-v2.0"),
+        ),
+    ):
+        result = await media._video_generate_handler({"prompt": "a drone shot of a city"})
+
+    assert result.get("is_error") is True
+    assert "POCKETPAW_REPLICATE_API_TOKEN" in result["content"][0]["text"]
+
+
+async def test_video_generate_error_when_no_identity() -> None:
+    """No workspace/user context → a clear error."""
+    with patch.object(media, "_identity", return_value=(None, None)):
+        result = await media._video_generate_handler({"prompt": "a drone shot"})
+
+    assert result.get("is_error") is True
+    assert "workspace and user context" in result["content"][0]["text"]
+
+
+# --- gallery spec assembly (existing widget types only) ---
+
+
+def test_gallery_spec_uses_only_existing_widget_types() -> None:
+    """The assembled gallery spec uses ONLY grid / card / image / video-player /
+    text so it renders today."""
+    spec = media._build_gallery_spec(
+        [
+            {"kind": "image", "src": "/tmp/a.png", "prompt": "a"},
+            {"kind": "video", "src": "https://x/v.mp4", "prompt": "b"},
+        ]
+    )
+    allowed = {"grid", "card", "image", "video-player", "text"}
+
+    def _walk(nodes):
+        for n in nodes:
+            assert n["type"] in allowed, f"unexpected widget type {n['type']!r}"
+            _walk(n.get("children", []))
+
+    _walk(spec["ui"])
+    # The grid holds one tile per media item.
+    grid = next(n for n in spec["ui"] if n["type"] == "grid")
+    assert len(grid["children"]) == 2

--- a/tests/cloud/test_media_mcp.py
+++ b/tests/cloud/test_media_mcp.py
@@ -164,22 +164,30 @@ async def test_video_generate_error_when_no_identity() -> None:
 
 
 def test_gallery_spec_uses_only_existing_widget_types() -> None:
-    """The assembled gallery spec uses ONLY grid / card / image / video-player /
-    text so it renders today."""
+    """The assembled gallery spec uses ONLY container / grid / card / image /
+    video-player / text so it renders today, and carries version + a
+    non-dashboard intent so toRippleEnvelope passes it through untouched and
+    Ripple renders it in node mode (2026-06-10 — a bare {ui: [...]} got
+    intent=dashboard stamped on and rendered "No widgets yet")."""
     spec = media._build_gallery_spec(
         [
             {"kind": "image", "src": "/tmp/a.png", "prompt": "a"},
             {"kind": "video", "src": "https://x/v.mp4", "prompt": "b"},
         ]
     )
-    allowed = {"grid", "card", "image", "video-player", "text"}
+    assert spec["version"] == "2.0"
+    assert spec["intent"] != "dashboard"
+    allowed = {"container", "grid", "card", "image", "video-player", "text"}
 
     def _walk(nodes):
         for n in nodes:
             assert n["type"] in allowed, f"unexpected widget type {n['type']!r}"
             _walk(n.get("children", []))
 
-    _walk(spec["ui"])
+    # `ui` is a single root node — NodeRenderer takes one node, not a list.
+    root = spec["ui"]
+    assert isinstance(root, dict)
+    _walk([root])
     # The grid holds one tile per media item.
-    grid = next(n for n in spec["ui"] if n["type"] == "grid")
+    grid = next(n for n in root["children"] if n["type"] == "grid")
     assert len(grid["children"]) == 2

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -1,5 +1,10 @@
 """Tests for MCP + Claude Agent SDK integration — Sprint 17.
 
+Updated: 2026-06-10 (feat/studio-code-migration) — ``_strip_builtin_servers``
+  now also drops ``pocketpaw_media`` (the new always-on STUDIO media-generation
+  server: image_generate / video_generate), so the external-config assertions
+  stay focused after the media MCP server became ambient. Same regime as
+  pocketpaw_sites_manager / pocketpaw_connectors.
 Updated: 2026-06-08 (feat/connector-mcp-execution / keystone) —
   ``_strip_builtin_servers`` now also drops ``pocketpaw_connectors`` (the new
   always-on connector-execution server: list_connector_actions /
@@ -42,6 +47,7 @@ from unittest.mock import patch
 from pocketpaw_ee.agent.mcp_servers.connectors import SERVER_NAME as _CONNECTORS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.decisions import SERVER_NAME as _DECISIONS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.foresight import SERVER_NAME as _FORESIGHT_MCP_SERVER_NAME
+from pocketpaw_ee.agent.mcp_servers.media import SERVER_NAME as _MEDIA_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.meetings import SERVER_NAME as _MEETINGS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.planner import (
     POCKET_PLANNER_SERVER_NAME as _POCKET_PLANNER_MCP_SERVER_NAME,
@@ -87,6 +93,9 @@ def _strip_builtin_servers(result: dict) -> dict:
     # ``pocketpaw_connectors`` is always-on — the M3-derived connector skills
     # (gmail/github) call connector_execute without an explicit opt-in.
     out.pop(_CONNECTORS_MCP_SERVER_NAME, None)
+    # ``pocketpaw_media`` is always-on too — the bundled `studio` skill calls
+    # image_generate / video_generate without an explicit opt-in.
+    out.pop(_MEDIA_MCP_SERVER_NAME, None)
     return out
 
 

--- a/tests/test_image_gen.py
+++ b/tests/test_image_gen.py
@@ -1,5 +1,8 @@
 # Tests for Feature 4: ImageGenerateTool
 # Created: 2026-02-06
+# 2026-06-10: added TestGenerateImageFile — route tests for the shared
+#   generate_image_file helper (gemini-*-image → generate_content,
+#   imagen-* → generate_images).
 
 import tempfile
 from pathlib import Path
@@ -156,3 +159,61 @@ class TestImageGenerateTool:
                 d = _get_generated_dir()
                 assert d.exists()
                 assert d.name == "generated"
+
+
+class TestGenerateImageFile:
+    """Route tests for generate_image_file (2026-06-10): gemini-*-image models
+    go through generate_content; imagen-* models through generate_images."""
+
+    def test_gemini_model_uses_generate_content(self):
+        from pocketpaw.tools.builtin.image_gen import generate_image_file
+
+        part = MagicMock()
+        part.inline_data = MagicMock(mime_type="image/png", data=b"png-bytes")
+        candidate = MagicMock()
+        candidate.content.parts = [part]
+        response = MagicMock(candidates=[candidate])
+        client = MagicMock()
+        client.models.generate_content.return_value = response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = Path(tmpdir) / "out.png"
+            err = generate_image_file(client, "gemini-2.5-flash-image", "a cat", "1:1", out_path)
+            assert err is None
+            assert out_path.read_bytes() == b"png-bytes"
+
+        client.models.generate_content.assert_called_once()
+        client.models.generate_images.assert_not_called()
+
+    def test_imagen_model_uses_generate_images(self):
+        from pocketpaw.tools.builtin.image_gen import generate_image_file
+
+        image = MagicMock()
+        response = MagicMock(generated_images=[MagicMock(image=image)])
+        client = MagicMock()
+        client.models.generate_images.return_value = response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = Path(tmpdir) / "out.png"
+            err = generate_image_file(client, "imagen-4.0-generate-001", "a cat", "16:9", out_path)
+            assert err is None
+            image.save.assert_called_once_with(out_path)
+
+        client.models.generate_content.assert_not_called()
+
+    def test_gemini_model_no_image_part_returns_error(self):
+        from pocketpaw.tools.builtin.image_gen import generate_image_file
+
+        text_part = MagicMock()
+        text_part.inline_data = None
+        candidate = MagicMock()
+        candidate.content.parts = [text_part]
+        response = MagicMock(candidates=[candidate])
+        client = MagicMock()
+        client.models.generate_content.return_value = response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = Path(tmpdir) / "out.png"
+            err = generate_image_file(client, "gemini-2.5-flash-image", "a cat", "1:1", out_path)
+            assert err is not None
+            assert not out_path.exists()


### PR DESCRIPTION
## What this adds

Two new chat surfaces, built the same way `/sites` is:

- **Studio** (`surface=studio`) — the user describes an image or video, the agent generates it, and the result lands in a gallery pocket. Backed by a new in-process MCP server `pocketpaw_media` with two tools: `image_generate` (Gemini, reusing the existing image path) and `video_generate` (Replicate/Kling over httpx, polled to completion).
- **Code** (`surface=code`) — the agent edits and runs code in the workspace with the SDK's Bash/Read/Write/Edit/Glob/Grep tools. No new execution layer; the surface profile scopes the toolset and a `code` skill drives the edit → run → verify loop.

Both profiles set `ripple_mode="off"` so the agent generates media or edits code rather than trying to build a Ripple dashboard.

## Why an MCP server instead of a Tool

The cloud chat agent runs on the Claude Agent SDK backend, which only sees SDK built-ins plus MCP servers registered through the `pocketpaw.mcp_servers` entry point. A plain `BaseTool` is invisible to it, so media generation is wired as `CloudMediaMcpProvider`.

## Files

- `ee/pocketpaw_ee/agent/mcp_servers/media.py` — the media MCP server
- `ee/pocketpaw_ee/cloud/surface/handlers/{studio,code}.py` + enum/registration in `domain.py` and `service.py`
- `src/pocketpaw/bundled_skills/_bundled/skills/{studio,code}/SKILL.md`
- `config.py` — `replicate_api_token`, `fal_api_key`, `video_model`
- tests under `tests/cloud/`

## To run it live

- Image generation uses the existing `POCKETPAW_GOOGLE_API_KEY` (Gemini).
- Video generation needs `POCKETPAW_REPLICATE_API_TOKEN` (model defaults to `kwaivgi/kling-v2.0`). Until that's set, `video_generate` returns a plain "set the token" error rather than failing oddly.

## Tests

77 cloud tests (surface/studio/code/media) and 240 tool tests pass; `ruff` is clean. Two pre-existing collection errors in `tests/cloud/extraction/` (missing `pypdf`) are unrelated and were skipped.

## Notes

Pairs with the paw-enterprise PR that adds the `/studio` and `/code` routes. Frontend expects a `pocket_created` event with `pocket.type == "studio"` / `pattern == "gallery"` after each Studio generation. Not for merge yet — this is for review and a morning smoke.
