### PR TITLE
feat(mission-control): due date + attachments for work items

### DIFF
--- a/ee/pocketpaw_ee/cloud/mission_control/domain.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/domain.py
@@ -93,6 +93,7 @@ class WorkItem:
     pocket_name: str = ""  # display name
     fabric_refs: tuple[str, ...] = field(default_factory=tuple)
     blocked_by: tuple[str, ...] = field(default_factory=tuple)
+    due_at: datetime | None = None
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/mission_control/dto.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/dto.py
@@ -46,6 +46,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.mission_control.domain import (
     AssigneeKind,
     WorkItem,
@@ -262,6 +263,7 @@ class WorkItemResponse(BaseModel):
     pocket_name: str = ""  # display name
     fabric_refs: list[str] = Field(default_factory=list)
     blocked_by: list[str] = Field(default_factory=list)
+    due_at: str | None = None
 
 
 def work_item_to_response(item: WorkItem) -> WorkItemResponse:
@@ -287,6 +289,7 @@ def work_item_to_response(item: WorkItem) -> WorkItemResponse:
         pocket_name=item.pocket_name,
         fabric_refs=list(item.fabric_refs),
         blocked_by=list(item.blocked_by),
+        due_at=iso_utc(item.due_at),
     )
 
 

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -278,6 +278,14 @@ def _task_to_work_item(task: Any, workspace_id: str, pocket_name: str = "") -> W
     section = _task_section(task.status, assignee.kind)
     blocked_by_raw = getattr(task, "blocked_by", None) or ()
     blocked_by = tuple(f"task:{dep_id}" for dep_id in blocked_by_raw)
+    due_at = getattr(task, "due_at", None)
+    # The task may be a domain Task (due_at is datetime | None) or a
+    # TaskResponse DTO (due_at is str | None). Normalise to datetime.
+    if isinstance(due_at, str):
+        try:
+            due_at = datetime.fromisoformat(due_at.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            due_at = None
     return WorkItem(
         id=f"task:{task.id}",
         workspace_id=workspace_id,
@@ -295,6 +303,7 @@ def _task_to_work_item(task: Any, workspace_id: str, pocket_name: str = "") -> W
         source_kind="task",
         source_id=task.id,
         priority=task.priority,
+        due_at=due_at,
         created_at=task.created_at,
         updated_at=task.updated_at,
         fabric_refs=(),

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -76,6 +76,7 @@ from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
 from pocketpaw_ee.cloud.models.task import Task, TaskAssignee, TaskSource
+from pocketpaw_ee.cloud.models.task_attachment import TaskAttachment
 from pocketpaw_ee.cloud.models.task_event import TaskEvent
 from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc
 from pocketpaw_ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
@@ -165,6 +166,7 @@ __all__ = [
     "WorkspaceSensePreference",
     "Task",
     "TaskAssignee",
+    "TaskAttachment",
     "TaskSource",
     "TaskEvent",
     "TemporalSweepStateDoc",
@@ -202,6 +204,7 @@ def get_all_documents():
         Message,
         ReadState,
         Task,
+        TaskAttachment,
         TemporalSweepStateDoc,
         Cycle,
         Project,

--- a/ee/pocketpaw_ee/cloud/models/task_attachment.py
+++ b/ee/pocketpaw_ee/cloud/models/task_attachment.py
@@ -1,0 +1,44 @@
+"""TaskAttachment document — files linked to a Task.
+
+Each attachment references an uploaded file (via ``file_id`` pointing to
+a ``FileUpload`` document) and stores denormalised metadata so list
+queries don't need a join. The actual file bytes live in the StorageAdapter
+behind the uploads service.
+
+Only ``ee.cloud.tasks.service`` may import this module; the import-linter
+contract enforces the rule.
+"""
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class TaskAttachment(TimestampedDocument):
+    """A file attached to a Task.
+
+    ``file_id`` references the ``FileUpload`` document in the uploads
+    provider. ``filename``, ``mime``, and ``size`` are denormalised so
+    the attachment list in the work-item detail panel can render without
+    a cross-collection query.
+    """
+
+    task_id: Indexed(str)  # type: ignore[valid-type]
+    workspace_id: str
+    creator_id: str
+    file_id: str
+    filename: str
+    mime: str
+    size: int
+
+    class Settings:
+        name = "task_attachments"
+        indexes = [
+            [("task_id", 1), ("createdAt", -1)],
+            [("workspace_id", 1), ("createdAt", -1)],
+        ]
+
+
+__all__ = ["TaskAttachment"]

--- a/ee/pocketpaw_ee/cloud/tasks/dto.py
+++ b/ee/pocketpaw_ee/cloud/tasks/dto.py
@@ -273,8 +273,49 @@ def task_event_to_dto(event: Any) -> TaskEventResponse:
     )
 
 
+# ---------------------------------------------------------------------------
+# Attachment DTOs
+# ---------------------------------------------------------------------------
+
+
+class TaskAttachmentResponse(BaseModel):
+    """Wire shape for a file attached to a task."""
+
+    id: str
+    task_id: str
+    file_id: str
+    filename: str
+    mime: str
+    size: int
+    creator_id: str
+    created_at: str | None = None
+
+
+class AttachFilesRequest(BaseModel):
+    """Body for ``POST /tasks/{id}/attachments``."""
+
+    file_ids: list[str] = Field(min_length=1, max_length=50)
+
+
+def task_attachment_to_dto(att: Any) -> TaskAttachmentResponse:
+    """Map a ``TaskAttachment`` Beanie doc to its wire DTO."""
+    from pocketpaw_ee.cloud._core.time import iso_utc
+
+    return TaskAttachmentResponse(
+        id=str(att.id),
+        task_id=att.task_id,
+        file_id=att.file_id,
+        filename=att.filename,
+        mime=att.mime,
+        size=att.size,
+        creator_id=att.creator_id,
+        created_at=iso_utc(getattr(att, "createdAt", None)),
+    )
+
+
 __all__ = [
     "AssigneeDTO",
+    "AttachFilesRequest",
     "BlockTaskRequest",
     "BulkReassignRequest",
     "ClaimTaskRequest",
@@ -284,9 +325,11 @@ __all__ = [
     "ListTasksRequest",
     "ReassignTaskRequest",
     "SourceDTO",
+    "TaskAttachmentResponse",
     "TaskEventResponse",
     "TaskResponse",
     "UpdateTaskRequest",
+    "task_attachment_to_dto",
     "task_event_to_dto",
     "task_to_dto",
 ]

--- a/ee/pocketpaw_ee/cloud/tasks/router.py
+++ b/ee/pocketpaw_ee/cloud/tasks/router.py
@@ -20,12 +20,13 @@ Endpoints:
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.tasks import service as tasks_service
 from pocketpaw_ee.cloud.tasks.dto import (
+    AttachFilesRequest,
     BlockTaskRequest,
     ClaimTaskRequest,
     CompleteTaskRequest,
@@ -33,6 +34,7 @@ from pocketpaw_ee.cloud.tasks.dto import (
     CreateTaskRequest,
     ListTasksRequest,
     ReassignTaskRequest,
+    TaskAttachmentResponse,
     TaskEventResponse,
     TaskResponse,
     UpdateTaskRequest,
@@ -131,6 +133,46 @@ async def reassign_task(
     ctx: RequestContext = Depends(request_context),
 ) -> TaskResponse:
     return await tasks_service.agent_reassign_task(ctx, task_id, body)
+
+
+@router.post(
+    "/{task_id}/attachments",
+    response_model=list[TaskAttachmentResponse],
+    status_code=201,
+)
+async def attach_files(
+    task_id: str,
+    body: AttachFilesRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> list[TaskAttachmentResponse]:
+    """Link previously-uploaded files to a task."""
+    return await tasks_service.agent_attach_files(ctx, task_id, body)
+
+
+@router.get(
+    "/{task_id}/attachments",
+    response_model=list[TaskAttachmentResponse],
+)
+async def list_attachments(
+    task_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> list[TaskAttachmentResponse]:
+    """List all files attached to a task."""
+    return await tasks_service.agent_list_attachments(ctx, task_id)
+
+
+@router.delete(
+    "/{task_id}/attachments/{attachment_id}",
+    status_code=204,
+)
+async def delete_attachment(
+    task_id: str,
+    attachment_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    """Remove a file attachment from a task."""
+    await tasks_service.agent_delete_attachment(ctx, task_id, attachment_id)
+    return Response(status_code=204)
 
 
 @router.post("/{task_id}/events", response_model=TaskEventResponse, status_code=201)

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -74,6 +74,7 @@ from pocketpaw_ee.cloud.models.task import TaskSource as _SourceDoc
 from pocketpaw_ee.cloud.models.task_event import TaskEvent as _TaskEventDoc
 from pocketpaw_ee.cloud.tasks.domain import Task, TaskAssignee, TaskSource
 from pocketpaw_ee.cloud.tasks.dto import (
+    AttachFilesRequest,
     BlockTaskRequest,
     ClaimTaskRequest,
     CompleteTaskRequest,
@@ -81,9 +82,11 @@ from pocketpaw_ee.cloud.tasks.dto import (
     CreateTaskRequest,
     ListTasksRequest,
     ReassignTaskRequest,
+    TaskAttachmentResponse,
     TaskEventResponse,
     TaskResponse,
     UpdateTaskRequest,
+    task_attachment_to_dto,
     task_event_to_dto,
     task_to_dto,
 )
@@ -324,7 +327,9 @@ async def agent_update_task(
         # field defaults to ``[]`` for old docs so the assignment is
         # always safe.
         doc.blocked_by = list(body.blocked_by)
-    if body.due_at is not None:
+    if "due_at" in body.model_fields_set:
+        # ``model_fields_set`` distinguishes explicit ``null`` (clears the
+        # field) from "not provided" (leaves the current value untouched).
         doc.due_at = body.due_at
 
     # success_criteria / preconditions are deliberately NOT patchable
@@ -640,6 +645,94 @@ async def unassign_project_on_tasks(workspace_id: str, project_id: str) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Attachments — link uploaded files to a task
+# ---------------------------------------------------------------------------
+
+
+async def agent_attach_files(
+    ctx: RequestContext, task_id: str, body: AttachFilesRequest
+) -> list[TaskAttachmentResponse]:
+    """Link one or more previously-uploaded files to a task.
+
+    Accepts a list of ``file_ids`` returned from ``POST /api/v1/uploads``.
+    Each ``file_id`` is resolved against the workspace-scoped uploads
+    service to verify it exists and belongs to the caller's workspace.
+    Skips ids that are already linked to this task (idempotent).
+
+    Returns the list of ``TaskAttachmentResponse`` DTOs for the newly
+    linked files.
+    """
+    from pocketpaw_ee.cloud.models.task_attachment import TaskAttachment as _AttachmentDoc
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    body = AttachFilesRequest.model_validate(body)
+    await _fetch_task(ctx, task_id)  # tenant guard
+
+    # Resolve each file_id against the workspace-scoped uploads store
+    file_store = MongoFileStore()
+    attached: list[TaskAttachmentResponse] = []
+    for file_id in body.file_ids:
+        file_doc = await file_store.get_doc_scoped(file_id, workspace=ctx.workspace_id)
+        if file_doc is None:
+            continue
+        # Check if already linked
+        existing = await _AttachmentDoc.find_one(
+            _AttachmentDoc.task_id == task_id,
+            _AttachmentDoc.file_id == file_id,
+        )
+        if existing is not None:
+            continue
+        att_doc = _AttachmentDoc(
+            task_id=task_id,
+            workspace_id=ctx.workspace_id,
+            creator_id=ctx.user_id,
+            file_id=file_id,
+            filename=file_doc.filename,
+            mime=file_doc.mime,
+            size=file_doc.size,
+        )
+        await att_doc.insert()
+        attached.append(task_attachment_to_dto(att_doc))
+
+    return attached
+
+
+async def agent_list_attachments(ctx: RequestContext, task_id: str) -> list[TaskAttachmentResponse]:
+    """List all files attached to a task."""
+    from pocketpaw_ee.cloud.models.task_attachment import TaskAttachment as _AttachmentDoc
+
+    _ = await _fetch_task(ctx, task_id)  # tenant guard
+    docs = (
+        await _AttachmentDoc.find(_AttachmentDoc.task_id == task_id)
+        .sort(-_AttachmentDoc.createdAt)  # type: ignore[operator]
+        .to_list()
+    )
+    return [task_attachment_to_dto(d) for d in docs]
+
+
+async def agent_delete_attachment(ctx: RequestContext, task_id: str, attachment_id: str) -> None:
+    """Remove a file attachment from a task.
+
+    Only the creator of the attachment or a workspace owner may delete it.
+    The underlying uploaded file is NOT deleted — only the task link.
+    """
+    from pocketpaw_ee.cloud.models.task_attachment import TaskAttachment as _AttachmentDoc
+
+    _ = await _fetch_task(ctx, task_id)  # tenant guard
+    att = await _AttachmentDoc.get(attachment_id)
+    if att is None or att.task_id != task_id or att.workspace_id != ctx.workspace_id:
+        raise NotFound("attachment", attachment_id)
+    if att.creator_id != ctx.user_id and not await _is_workspace_owner(
+        ctx.user_id, ctx.workspace_id
+    ):
+        raise Forbidden(
+            "attachment.delete_denied",
+            "Only the creator or workspace owner can delete attachments",
+        )
+    await att.delete()
+
+
+# ---------------------------------------------------------------------------
 # Task Event (comments/activity on a task)
 # ---------------------------------------------------------------------------
 
@@ -696,12 +789,15 @@ async def agent_list_task_events(
 
 
 __all__ = [
+    "agent_attach_files",
     "agent_block_task",
     "agent_claim_task",
     "agent_complete_task",
     "agent_create_task",
     "agent_create_task_event",
+    "agent_delete_attachment",
     "agent_get_task",
+    "agent_list_attachments",
     "agent_list_task_events",
     "agent_list_tasks",
     "agent_reassign_task",


### PR DESCRIPTION
feat(mission-control): due date + attachments for work items
    
    Backend changes:
    - Add due_at field to WorkItem domain, DTO, and service projection
    - Create TaskAttachment model (task_attachment.py) for file links
    - Add attach/list/delete attachment endpoints to tasks router
    - Add agent_attach_files, agent_list_attachments, agent_delete_atta
chment services
    - Register TaskAttachment in Beanie model init
    - Fix update_task to support clearing due_at via model_fields_set
    - Thread due_at through mission-control facade projection