### PR TITLE
Link unfurl endpoint for composer previews

### DIFF
--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -13,6 +13,10 @@
 # Updated: 2026-06-07 (feat/plugin-installer-skills) — Added the Plugins
 #   router (POST /api/v1/plugins/install) for the .claude-plugin installer
 #   (skills slice). Non-critical: mounts best-effort like the rest.
+# Updated: 2026-06-10 (feat/link-unfurl) — Added the Unfurl router
+#   (GET /api/v1/unfurl?url=...) so the paw-enterprise composer can render
+#   OG link previews. Serves in both OSS and cloud since the core mount runs
+#   in both; the path is collision-free with ee/cloud's /files/* routes.
 #
 # mount_v1_routers(app) registers all domain routers at /api/v1/ (canonical).
 # Existing dashboard.py endpoints at /api/ remain as backward-compat aliases.
@@ -48,6 +52,7 @@ _V1_ROUTERS: list[tuple[str, str, str]] = [
     ("pocketpaw.api.v1.reminders", "router", "Reminders"),
     ("pocketpaw.api.v1.intentions", "router", "Intentions"),
     ("pocketpaw.api.v1.files", "router", "Files"),
+    ("pocketpaw.api.v1.unfurl", "router", "Unfurl"),
     ("pocketpaw.api.v1.plan_mode", "router", "Plan Mode"),
     ("pocketpaw.api.v1.remote", "router", "Remote"),
     ("pocketpaw.api.v1.telegram", "router", "Telegram"),

--- a/src/pocketpaw/api/v1/schemas/unfurl.py
+++ b/src/pocketpaw/api/v1/schemas/unfurl.py
@@ -1,0 +1,24 @@
+# Link-unfurl (Open Graph preview) response schema.
+# Created: 2026-06-10 — frozen wire contract for GET /api/v1/unfurl so the
+#   paw-enterprise composer can render OG previews (title/description/image)
+#   for pasted URLs. All metadata fields are nullable: a 200 with every field
+#   null is valid (the page carried no usable OG/Twitter/<title> tags).
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class UnfurlResponse(BaseModel):
+    """Open Graph / link-preview metadata for a single URL.
+
+    ``url`` is the final URL after redirects. The remaining fields are the
+    scraped metadata, each null when the page did not provide it.
+    """
+
+    url: str
+    title: str | None = None
+    description: str | None = None
+    image: str | None = None
+    site_name: str | None = None
+    favicon: str | None = None

--- a/src/pocketpaw/api/v1/unfurl.py
+++ b/src/pocketpaw/api/v1/unfurl.py
@@ -1,0 +1,260 @@
+# Link-unfurl router — GET /api/v1/unfurl?url=... returns Open Graph preview
+# metadata (title/description/image/site_name/favicon) for a pasted URL.
+# Created: 2026-06-10 — the paw-enterprise composer cannot fetch third-party
+#   pages itself (CORS), so the backend scrapes the OG tags. Fetching reuses
+#   the SSRF-guarded streaming path in pocketpaw.security.safe_fetch (DNS
+#   pinned per hop, IP validated public, Host/SNI preserved, 5-hop redirect
+#   cap, ~512KB body cut, text/html-only, ~8s total timeout). Metadata is
+#   parsed with the stdlib html.parser (no new dependencies). A 15-minute
+#   in-process TTL cache (cap 500 entries) keyed by normalized URL keeps chat
+#   sessions from hammering the same links.
+#
+# Wire contract (frozen — frontend built against it in parallel):
+#   GET /api/v1/unfurl?url=<urlencoded>
+#     200 {"url","title","description","image","site_name","favicon"}
+#     400 detail "invalid_url"  — non-http(s) / unparseable
+#     400 detail "unsafe_url"   — SSRF-blocked (internal/loopback/private)
+#     502 detail "fetch_failed" — timeout / connection error / non-HTML /
+#                                 oversized / DNS failure
+#   Never 500. All metadata fields nullable; an all-null 200 is valid.
+
+from __future__ import annotations
+
+import logging
+import time
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlsplit, urlunsplit
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from pocketpaw.api.deps import require_scope
+from pocketpaw.api.v1.schemas.unfurl import UnfurlResponse
+from pocketpaw.security.safe_fetch import (
+    BlockedURLError,
+    FetchFailedError,
+    UnsupportedSchemeError,
+    safe_get_streamed,
+)
+from pocketpaw.security.url_validators import host_is_internal
+from pocketpaw.tools.builtin.url_extract import _extract_title
+
+logger = logging.getLogger(__name__)
+
+# Fetch limits — see file-top comment for the contract rationale.
+_MAX_BODY_BYTES = 512 * 1024  # ~512 KB
+_TOTAL_TIMEOUT_SECONDS = 8.0
+
+# In-process TTL cache.
+_CACHE_TTL_SECONDS = 15 * 60  # 15 minutes
+_CACHE_MAX_ENTRIES = 500
+# url -> (stored_monotonic, UnfurlResponse). Module-level: one cache per
+# process, shared across requests, which is exactly what we want so repeated
+# pastes of the same link in a chat session hit the cache.
+_cache: dict[str, tuple[float, UnfurlResponse]] = {}
+
+
+# A read endpoint serving page metadata — sits alongside files:read, the
+# scope the sibling read routers already use. No new scope system invented.
+router = APIRouter(tags=["Unfurl"], dependencies=[Depends(require_scope("files:read"))])
+
+
+def _normalize_cache_key(url: str) -> str:
+    """Normalize a URL for cache keying: lowercase scheme+host, drop the
+    fragment (it never reaches the server and never changes the metadata)."""
+    parts = urlsplit(url)
+    return urlunsplit(
+        (
+            parts.scheme.lower(),
+            parts.netloc.lower(),
+            parts.path,
+            parts.query,
+            "",  # strip fragment
+        )
+    )
+
+
+def _cache_get(key: str) -> UnfurlResponse | None:
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+    stored_at, value = entry
+    if time.monotonic() - stored_at > _CACHE_TTL_SECONDS:
+        _cache.pop(key, None)
+        return None
+    return value
+
+
+def _cache_put(key: str, value: UnfurlResponse) -> None:
+    # Drop expired entries opportunistically, then evict oldest if still over
+    # the cap. Simple insertion-order eviction — dict preserves insertion order
+    # in CPython 3.7+, so the first key is the oldest stored.
+    now = time.monotonic()
+    if len(_cache) >= _CACHE_MAX_ENTRIES:
+        expired = [k for k, (ts, _) in _cache.items() if now - ts > _CACHE_TTL_SECONDS]
+        for k in expired:
+            _cache.pop(k, None)
+        while len(_cache) >= _CACHE_MAX_ENTRIES:
+            oldest = next(iter(_cache))
+            _cache.pop(oldest, None)
+    _cache[key] = (now, value)
+
+
+class _MetaParser(HTMLParser):
+    """Collect Open Graph / Twitter / standard meta + icon links from HTML.
+
+    Stdlib only. Tolerant: malformed markup, missing attributes, and the
+    parser raising on bad input are all swallowed by the caller. We keep the
+    first non-empty value seen for each property (OG tags appear in <head>
+    near the top, so first-wins matches author intent)."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        # meta property/name -> content
+        self.meta: dict[str, str] = {}
+        # icon href, with rel preference order resolved in handle_starttag
+        self.icon_href: str | None = None
+        self._icon_rank = 0  # higher = more preferred icon rel
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr = {k.lower(): (v or "") for k, v in attrs}
+        if tag == "meta":
+            key = (attr.get("property") or attr.get("name") or "").strip().lower()
+            content = attr.get("content", "").strip()
+            if key and content and key not in self.meta:
+                self.meta[key] = content
+        elif tag == "link":
+            rel = attr.get("rel", "").strip().lower()
+            href = attr.get("href", "").strip()
+            if not href:
+                return
+            # Prefer a plain "icon"/"shortcut icon" over apple-touch-icon, and
+            # any declared icon over none. Rank keeps the best one.
+            rank = 0
+            if "icon" in rel.split():
+                rank = 3 if rel in ("icon", "shortcut icon") else 2
+            elif "apple-touch-icon" in rel:
+                rank = 1
+            if rank > self._icon_rank:
+                self._icon_rank = rank
+                self.icon_href = href
+
+
+def _first(meta: dict[str, str], *keys: str) -> str | None:
+    for key in keys:
+        val = meta.get(key)
+        if val:
+            return val
+    return None
+
+
+def _absolutize(base_url: str, value: str | None) -> str | None:
+    """Resolve a possibly-relative URL against the final page URL.
+
+    Returns None for empty input or anything that doesn't resolve to an
+    http(s) URL (e.g. data: URIs we won't echo back as an image)."""
+    if not value:
+        return None
+    try:
+        resolved = urljoin(base_url, value)
+    except ValueError:
+        return None
+    scheme = urlsplit(resolved).scheme.lower()
+    if scheme not in ("http", "https"):
+        return None
+    return resolved
+
+
+def _parse_metadata(html: str, final_url: str) -> UnfurlResponse:
+    """Parse OG/Twitter/standard metadata out of an HTML document.
+
+    Mapping (first non-empty wins per field):
+      title       og:title -> twitter:title -> <title>
+      description og:description -> twitter:description -> meta description
+      image       og:image -> og:image:url -> twitter:image -> twitter:image:src
+      site_name   og:site_name -> twitter:site
+      favicon     <link rel=icon|shortcut icon|apple-touch-icon> href
+    Image and favicon are resolved to absolute URLs against ``final_url``."""
+    parser = _MetaParser()
+    try:
+        parser.feed(html)
+    except Exception:  # noqa: BLE001 — never let a malformed page 500
+        logger.debug("HTML parse raised; using whatever metadata was collected", exc_info=True)
+    meta = parser.meta
+
+    title = _first(meta, "og:title", "twitter:title")
+    if not title:
+        extracted = _extract_title(html)
+        # _extract_title falls back to the literal "Untitled" sentinel — map
+        # that to None so the contract's "no title" case stays null.
+        title = extracted if extracted and extracted != "Untitled" else None
+
+    description = _first(meta, "og:description", "twitter:description", "description")
+    site_name = _first(meta, "og:site_name", "twitter:site")
+    image = _absolutize(
+        final_url, _first(meta, "og:image", "og:image:url", "twitter:image", "twitter:image:src")
+    )
+    favicon = _absolutize(final_url, parser.icon_href)
+
+    return UnfurlResponse(
+        url=final_url,
+        title=title,
+        description=description,
+        image=image,
+        site_name=site_name,
+        favicon=favicon,
+    )
+
+
+@router.get("/unfurl", response_model=UnfurlResponse)
+async def unfurl(url: str = Query(..., description="The URL to unfurl (urlencoded).")):
+    """Fetch a URL server-side and return its Open Graph preview metadata.
+
+    See the file-top comment for the frozen wire contract. This handler must
+    never raise a 500 — every failure maps to 400 (invalid_url / unsafe_url)
+    or 502 (fetch_failed)."""
+    # 1. Validate the URL shape. urlsplit never raises for normal input, but
+    #    guard the parse anyway so a pathological string can't 500.
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="invalid_url") from None
+
+    if parts.scheme.lower() not in ("http", "https") or not parts.hostname:
+        raise HTTPException(status_code=400, detail="invalid_url")
+
+    # 2. SSRF pre-check on a literal host (IP / localhost). DNS hostnames are
+    #    re-checked at fetch time after resolution by safe_get_streamed.
+    if host_is_internal(parts.hostname):
+        raise HTTPException(status_code=400, detail="unsafe_url")
+
+    cache_key = _normalize_cache_key(url)
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    # 3. Fetch (SSRF-guarded stream) + parse.
+    try:
+        result = await safe_get_streamed(
+            url,
+            max_bytes=_MAX_BODY_BYTES,
+            timeout=_TOTAL_TIMEOUT_SECONDS,
+            allowed_content_types=("text/html",),
+        )
+    except UnsupportedSchemeError:
+        # Scheme/host became invalid (e.g. a redirect to a non-http scheme).
+        raise HTTPException(status_code=400, detail="invalid_url") from None
+    except BlockedURLError:
+        # Resolved to a non-public IP, or redirect-rebinding / hop-cap hit.
+        raise HTTPException(status_code=400, detail="unsafe_url") from None
+    except (FetchFailedError, httpx.HTTPError, OSError):
+        # DNS failure, disallowed content-type, timeout, connection reset,
+        # malformed redirect — anything that isn't an SSRF block.
+        raise HTTPException(status_code=502, detail="fetch_failed") from None
+    except Exception:  # noqa: BLE001 — belt-and-braces; never 500
+        logger.warning("Unexpected unfurl fetch error", exc_info=True)
+        raise HTTPException(status_code=502, detail="fetch_failed") from None
+
+    response = _parse_metadata(result.text, result.final_url)
+    _cache_put(cache_key, response)
+    return response

--- a/src/pocketpaw/security/safe_fetch.py
+++ b/src/pocketpaw/security/safe_fetch.py
@@ -1,0 +1,310 @@
+# SSRF-safe HTTP fetch primitives — DNS-pinned transport, redirect-hop
+# validation, and a streaming byte-capped GET.
+# Created: 2026-06-10 — extracted from tools/builtin/url_extract.py so both
+#   the url_extract tool and the /api/v1/unfurl link-preview endpoint share
+#   one hardened fetch path (IPPinningTransport defeats DNS rebinding by
+#   resolving once, pinning the IP, and preserving Host/SNI; the SSRF check
+#   re-runs on every redirect hop). Added safe_get_streamed() for callers
+#   that need a body-size cap + final-URL tracking (link unfurl).
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+
+import httpx
+
+_ALLOWED_SCHEMES = {"http", "https"}
+_MAX_REDIRECT_HOPS = 5
+_REDIRECT_STATUS = {301, 302, 303, 307, 308}
+
+
+# Typed errors — all subclass ValueError so existing call sites that catch
+# ValueError (url_extract's _extract_local) keep working unchanged, while
+# new callers (the /unfurl endpoint) can map each class to the right HTTP
+# status without string-matching the message.
+class SafeFetchError(ValueError):
+    """Base for any blocked / failed safe fetch."""
+
+
+class UnsupportedSchemeError(SafeFetchError):
+    """The URL scheme is not http/https (or the URL has no host)."""
+
+
+class BlockedURLError(SafeFetchError):
+    """The URL is SSRF-blocked — resolved to a non-public IP, or the
+    redirect chain exceeded the hop cap."""
+
+
+class FetchFailedError(SafeFetchError):
+    """The fetch failed for a non-SSRF reason — DNS resolution failure,
+    disallowed content-type, or a malformed redirect."""
+
+
+class IPPinningTransport(httpx.AsyncBaseTransport):
+    """Transport that connects to a pre-resolved IP while preserving Host/SNI."""
+
+    def __init__(
+        self,
+        pinned_ip: str,
+        original_host: str,
+        host_header: str | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._pinned_ip = pinned_ip
+        self._original_host = original_host
+        self._host_header = host_header or original_host
+        self._transport = transport or httpx.AsyncHTTPTransport()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        request.url = request.url.copy_with(host=self._pinned_ip)
+        request.headers = request.headers.copy()
+        request.headers["host"] = self._host_header
+        request.extensions = {**request.extensions, "sni_hostname": self._original_host}
+        return await self._transport.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._transport.aclose()
+
+
+def _get_running_loop() -> asyncio.AbstractEventLoop:
+    return asyncio.get_running_loop()
+
+
+def _normalize_ip_address(raw_ip: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    parsed = ipaddress.ip_address(raw_ip)
+    if isinstance(parsed, ipaddress.IPv6Address) and parsed.ipv4_mapped is not None:
+        return parsed.ipv4_mapped
+    return parsed
+
+
+def _ensure_supported_url(url: httpx.URL) -> None:
+    if url.scheme not in _ALLOWED_SCHEMES:
+        raise UnsupportedSchemeError("Blocked URL: only http and https URLs are allowed.")
+    if not url.host:
+        raise UnsupportedSchemeError("Blocked URL: hostname is required.")
+
+
+def _port_for_url(url: httpx.URL) -> int:
+    if url.port is not None:
+        return url.port
+    return 443 if url.scheme == "https" else 80
+
+
+def _validate_public_ip(raw_ip: str) -> str:
+    parsed_ip = _normalize_ip_address(raw_ip)
+    if not parsed_ip.is_global:
+        raise BlockedURLError("Blocked URL: resolved to non-public IP address.")
+
+    return str(parsed_ip)
+
+
+async def _resolve_public_ip(hostname: str, port: int) -> str:
+    try:
+        literal_ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        literal_ip = None
+
+    if literal_ip is not None:
+        return _validate_public_ip(hostname)
+
+    loop = _get_running_loop()
+    try:
+        addrinfo = await loop.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise FetchFailedError("Could not resolve URL hostname.") from exc
+
+    if not addrinfo:
+        raise FetchFailedError("Could not resolve URL hostname.")
+
+    candidate_ips: list[str] = []
+    for record in addrinfo:
+        sockaddr = record[4]
+        if not sockaddr:
+            continue
+        raw_ip = sockaddr[0]
+        candidate_ips.append(_validate_public_ip(raw_ip))
+
+    if not candidate_ips:
+        raise FetchFailedError("Could not resolve URL hostname.")
+
+    return candidate_ips[0]
+
+
+def _next_redirect_url(current_url: httpx.URL, location: str) -> httpx.URL:
+    next_url = current_url.join(location)
+    _ensure_supported_url(next_url)
+    return next_url
+
+
+async def safe_get(
+    url: str,
+    timeout: float = 30,
+) -> httpx.Response:
+    """Fetch a URL with SSRF protection, following redirects manually.
+
+    Resolves DNS once per hop, validates the resolved IP is public, then
+    connects to the pinned IP while preserving Host/SNI. Re-runs the SSRF
+    check on every redirect hop (defeats DNS-rebinding TOCTOU). Reads the
+    full response body. Raises ``ValueError`` on any blocked URL.
+    """
+    current_url = httpx.URL(url)
+    _ensure_supported_url(current_url)
+
+    for _ in range(_MAX_REDIRECT_HOPS + 1):
+        if current_url.host is None:
+            raise UnsupportedSchemeError("Blocked URL: hostname is required.")
+
+        pinned_ip = await _resolve_public_ip(current_url.host, _port_for_url(current_url))
+
+        transport = IPPinningTransport(
+            pinned_ip=pinned_ip,
+            original_host=current_url.host,
+        )
+
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=False,
+            transport=transport,
+        ) as client:
+            response = await client.get(str(current_url))
+
+        if response.status_code in _REDIRECT_STATUS:
+            location = response.headers.get("location")
+            if not location:
+                return response
+
+            current_url = _next_redirect_url(current_url, location)
+            continue
+
+        return response
+
+    raise BlockedURLError("Blocked URL: too many redirects.")
+
+
+class FetchResult:
+    """Result of a streamed safe fetch.
+
+    Attributes mirror only what link-preview callers need: the final URL
+    after redirects, the response status, headers, content-type, and the
+    (possibly truncated) decoded body text.
+    """
+
+    __slots__ = ("final_url", "status_code", "content_type", "text", "truncated")
+
+    def __init__(
+        self,
+        *,
+        final_url: str,
+        status_code: int,
+        content_type: str,
+        text: str,
+        truncated: bool,
+    ) -> None:
+        self.final_url = final_url
+        self.status_code = status_code
+        self.content_type = content_type
+        self.text = text
+        self.truncated = truncated
+
+
+async def safe_get_streamed(
+    url: str,
+    *,
+    max_bytes: int,
+    timeout: float,
+    allowed_content_types: tuple[str, ...] = ("text/html",),
+) -> FetchResult:
+    """Stream a URL with SSRF protection, capping the body at ``max_bytes``.
+
+    Same SSRF guarantees as :func:`safe_get` (DNS pinned per hop, IP
+    validated public, Host/SNI preserved, redirect cap, per-hop re-check),
+    but streams the body so an oversized response is cut at ``max_bytes``
+    instead of buffered whole. Validates the response content-type against
+    ``allowed_content_types`` BEFORE reading the body — a non-matching type
+    raises ``ValueError`` without downloading the payload.
+
+    Returns a :class:`FetchResult` carrying the final URL (after redirects),
+    so callers can resolve relative metadata URLs against it. Raises
+    ``ValueError`` on any blocked URL, unsupported scheme, too many
+    redirects, or disallowed content-type.
+    """
+    current_url = httpx.URL(url)
+    _ensure_supported_url(current_url)
+
+    for _ in range(_MAX_REDIRECT_HOPS + 1):
+        if current_url.host is None:
+            raise UnsupportedSchemeError("Blocked URL: hostname is required.")
+
+        pinned_ip = await _resolve_public_ip(current_url.host, _port_for_url(current_url))
+
+        transport = IPPinningTransport(
+            pinned_ip=pinned_ip,
+            original_host=current_url.host,
+        )
+
+        async with (
+            httpx.AsyncClient(
+                timeout=timeout,
+                follow_redirects=False,
+                transport=transport,
+            ) as client,
+            client.stream("GET", str(current_url)) as response,
+        ):
+            if response.status_code in _REDIRECT_STATUS:
+                location = response.headers.get("location")
+                if not location:
+                    # A redirect status with no Location header — treat as
+                    # a hard failure rather than serving an empty preview.
+                    raise FetchFailedError("Blocked URL: redirect without Location header.")
+                # Re-run the SSRF check on the next hop (defeats DNS-rebinding
+                # TOCTOU). Closing the stream context, then continuing, picks
+                # the new URL up on the next loop iteration.
+                current_url = _next_redirect_url(current_url, location)
+                continue
+
+            content_type = response.headers.get("content-type", "")
+            ct_main = content_type.split(";", 1)[0].strip().lower()
+            if ct_main not in allowed_content_types:
+                raise FetchFailedError(f"Blocked URL: unsupported content-type '{content_type}'.")
+
+            chunks: list[bytes] = []
+            total = 0
+            truncated = False
+            async for chunk in response.aiter_bytes():
+                chunks.append(chunk)
+                total += len(chunk)
+                if total >= max_bytes:
+                    truncated = True
+                    break
+
+            body = b"".join(chunks)[:max_bytes]
+            # Decode using the response charset when known, else utf-8.
+            encoding = response.charset_encoding or "utf-8"
+            try:
+                text = body.decode(encoding, errors="replace")
+            except (LookupError, ValueError):
+                text = body.decode("utf-8", errors="replace")
+
+            return FetchResult(
+                final_url=str(current_url),
+                status_code=response.status_code,
+                content_type=content_type,
+                text=text,
+                truncated=truncated,
+            )
+
+    raise BlockedURLError("Blocked URL: too many redirects.")
+
+
+__all__ = [
+    "BlockedURLError",
+    "FetchFailedError",
+    "FetchResult",
+    "IPPinningTransport",
+    "SafeFetchError",
+    "UnsupportedSchemeError",
+    "safe_get",
+    "safe_get_streamed",
+]

--- a/src/pocketpaw/tools/builtin/url_extract.py
+++ b/src/pocketpaw/tools/builtin/url_extract.py
@@ -1,15 +1,36 @@
 # URL Extract tool — fetch clean content from URLs via Parallel AI or local fallback.
 # Created: 2026-02-06
+# Updated: 2026-06-10 — extracted the SSRF-safe fetch primitives
+#   (IPPinningTransport, DNS-pinned resolution, redirect-hop validation,
+#   _safe_get) into pocketpaw.security.safe_fetch so the new /api/v1/unfurl
+#   link-preview endpoint shares the exact same hardened fetch path. The
+#   symbols are re-exported here for backward compatibility.
 
-import asyncio
-import ipaddress
 import logging
-import socket
 from typing import Any
 
 import httpx
 
 from pocketpaw.config import get_settings
+from pocketpaw.security.safe_fetch import (
+    IPPinningTransport as IPPinningTransport,
+)
+
+# SSRF-safe fetch primitives now live in security.safe_fetch (shared with the
+# /unfurl link-preview endpoint). Re-exported here so existing callers and
+# tests that reference them via this module keep working.
+from pocketpaw.security.safe_fetch import (
+    _ensure_supported_url,
+    _get_running_loop,
+    _next_redirect_url,
+    _normalize_ip_address,
+    _port_for_url,
+    _resolve_public_ip,
+    _validate_public_ip,
+)
+from pocketpaw.security.safe_fetch import (
+    safe_get as _safe_get,
+)
 from pocketpaw.tools.protocol import BaseTool
 
 logger = logging.getLogger(__name__)
@@ -17,142 +38,19 @@ logger = logging.getLogger(__name__)
 _PARALLEL_EXTRACT_URL = "https://api.parallel.ai/v1beta/extract"
 _MAX_CONTENT_CHARS = 50_000
 _DEFAULT_HTTP_TIMEOUT = 30
-_MAX_REDIRECT_HOPS = 5
-_ALLOWED_SCHEMES = {"http", "https"}
 
-
-class IPPinningTransport(httpx.AsyncBaseTransport):
-    """Transport that connects to a pre-resolved IP while preserving Host/SNI."""
-
-    def __init__(
-        self,
-        pinned_ip: str,
-        original_host: str,
-        host_header: str | None = None,
-        transport: httpx.AsyncBaseTransport | None = None,
-    ) -> None:
-        self._pinned_ip = pinned_ip
-        self._original_host = original_host
-        self._host_header = host_header or original_host
-        self._transport = transport or httpx.AsyncHTTPTransport()
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        request.url = request.url.copy_with(host=self._pinned_ip)
-        request.headers = request.headers.copy()
-        request.headers["host"] = self._host_header
-        request.extensions = {**request.extensions, "sni_hostname": self._original_host}
-        return await self._transport.handle_async_request(request)
-
-    async def aclose(self) -> None:
-        await self._transport.aclose()
-
-
-def _get_running_loop() -> asyncio.AbstractEventLoop:
-    return asyncio.get_running_loop()
-
-
-def _normalize_ip_address(raw_ip: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
-    parsed = ipaddress.ip_address(raw_ip)
-    if isinstance(parsed, ipaddress.IPv6Address) and parsed.ipv4_mapped is not None:
-        return parsed.ipv4_mapped
-    return parsed
-
-
-def _ensure_supported_url(url: httpx.URL) -> None:
-    if url.scheme not in _ALLOWED_SCHEMES:
-        raise ValueError("Blocked URL: only http and https URLs are allowed.")
-    if not url.host:
-        raise ValueError("Blocked URL: hostname is required.")
-
-
-def _port_for_url(url: httpx.URL) -> int:
-    if url.port is not None:
-        return url.port
-    return 443 if url.scheme == "https" else 80
-
-
-def _validate_public_ip(raw_ip: str) -> str:
-    parsed_ip = _normalize_ip_address(raw_ip)
-    if not parsed_ip.is_global:
-        raise ValueError("Blocked URL: resolved to non-public IP address.")
-
-    return str(parsed_ip)
-
-
-async def _resolve_public_ip(hostname: str, port: int) -> str:
-    try:
-        literal_ip = ipaddress.ip_address(hostname)
-    except ValueError:
-        literal_ip = None
-
-    if literal_ip is not None:
-        return _validate_public_ip(hostname)
-
-    loop = _get_running_loop()
-    try:
-        addrinfo = await loop.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
-    except socket.gaierror as exc:
-        raise ValueError("Could not resolve URL hostname.") from exc
-
-    if not addrinfo:
-        raise ValueError("Could not resolve URL hostname.")
-
-    candidate_ips: list[str] = []
-    for record in addrinfo:
-        sockaddr = record[4]
-        if not sockaddr:
-            continue
-        raw_ip = sockaddr[0]
-        candidate_ips.append(_validate_public_ip(raw_ip))
-
-    if not candidate_ips:
-        raise ValueError("Could not resolve URL hostname.")
-
-    return candidate_ips[0]
-
-
-def _next_redirect_url(current_url: httpx.URL, location: str) -> httpx.URL:
-    next_url = current_url.join(location)
-    _ensure_supported_url(next_url)
-    return next_url
-
-
-async def _safe_get(
-    url: str,
-    timeout: float = _DEFAULT_HTTP_TIMEOUT,
-) -> httpx.Response:
-    current_url = httpx.URL(url)
-    _ensure_supported_url(current_url)
-
-    for _ in range(_MAX_REDIRECT_HOPS + 1):
-        if current_url.host is None:
-            raise ValueError("Blocked URL: hostname is required.")
-
-        pinned_ip = await _resolve_public_ip(current_url.host, _port_for_url(current_url))
-
-        transport = IPPinningTransport(
-            pinned_ip=pinned_ip,
-            original_host=current_url.host,
-        )
-
-        async with httpx.AsyncClient(
-            timeout=timeout,
-            follow_redirects=False,
-            transport=transport,
-        ) as client:
-            response = await client.get(str(current_url))
-
-        if response.status_code in {301, 302, 303, 307, 308}:
-            location = response.headers.get("location")
-            if not location:
-                return response
-
-            current_url = _next_redirect_url(current_url, location)
-            continue
-
-        return response
-
-    raise ValueError("Blocked URL: too many redirects.")
+__all__ = [
+    "IPPinningTransport",
+    "UrlExtractTool",
+    "_ensure_supported_url",
+    "_get_running_loop",
+    "_next_redirect_url",
+    "_normalize_ip_address",
+    "_port_for_url",
+    "_resolve_public_ip",
+    "_safe_get",
+    "_validate_public_ip",
+]
 
 
 class UrlExtractTool(BaseTool):

--- a/tests/test_url_extract.py
+++ b/tests/test_url_extract.py
@@ -1,5 +1,7 @@
 # Tests for UrlExtractTool
 # Created: 2026-02-06
+# Updated: 2026-06-10 — SSRF-safe fetch primitives moved to
+#   pocketpaw.security.safe_fetch; patch targets repointed there.
 
 import socket
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -206,7 +208,7 @@ class TestUrlExtractTool:
 
         with (
             patch(
-                "pocketpaw.tools.builtin.url_extract._resolve_public_ip",
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
                 AsyncMock(return_value="93.184.216.34"),
             ),
             patch("httpx.AsyncClient") as mock_client_cls,
@@ -241,7 +243,7 @@ class TestUrlExtractTool:
 
         with (
             patch(
-                "pocketpaw.tools.builtin.url_extract._resolve_public_ip",
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
                 AsyncMock(return_value="93.184.216.34"),
             ),
             patch("httpx.AsyncClient") as mock_client_cls,
@@ -314,7 +316,7 @@ class TestUrlExtractTool:
 
         with (
             patch(
-                "pocketpaw.tools.builtin.url_extract._resolve_public_ip",
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
                 AsyncMock(side_effect=["93.184.216.34", "93.184.216.35"]),
             ),
             patch("httpx.AsyncClient") as mock_client_cls,
@@ -376,7 +378,7 @@ class TestUrlExtractTool:
         loop.getaddrinfo = AsyncMock(return_value=_addrinfo("127.0.0.1"))
 
         with (
-            patch("pocketpaw.tools.builtin.url_extract._get_running_loop", return_value=loop),
+            patch("pocketpaw.security.safe_fetch._get_running_loop", return_value=loop),
             patch("httpx.AsyncClient") as mock_client_cls,
             patch.dict("sys.modules", {"html2text": mock_html2text}),
         ):
@@ -405,7 +407,7 @@ class TestUrlExtractTool:
         loop.getaddrinfo = AsyncMock(return_value=_addrinfo("::ffff:127.0.0.1", socket.AF_INET6))
 
         with (
-            patch("pocketpaw.tools.builtin.url_extract._get_running_loop", return_value=loop),
+            patch("pocketpaw.security.safe_fetch._get_running_loop", return_value=loop),
             patch("httpx.AsyncClient") as mock_client_cls,
             patch.dict("sys.modules", {"html2text": mock_html2text}),
         ):
@@ -449,7 +451,7 @@ class TestUrlExtractTool:
         redirect_resp.is_redirect = True
 
         with (
-            patch("pocketpaw.tools.builtin.url_extract._get_running_loop", return_value=loop),
+            patch("pocketpaw.security.safe_fetch._get_running_loop", return_value=loop),
             patch("httpx.AsyncClient") as mock_client_cls,
             patch.dict("sys.modules", {"html2text": mock_html2text}),
         ):
@@ -484,7 +486,7 @@ class TestUrlExtractTool:
 
         with (
             patch(
-                "pocketpaw.tools.builtin.url_extract._resolve_public_ip",
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
                 AsyncMock(
                     side_effect=[
                         "93.184.216.34",
@@ -530,9 +532,9 @@ class TestUrlExtractTool:
         mock_transport.aclose = AsyncMock()
 
         with (
-            patch("pocketpaw.tools.builtin.url_extract._get_running_loop", return_value=loop),
+            patch("pocketpaw.security.safe_fetch._get_running_loop", return_value=loop),
             patch(
-                "pocketpaw.tools.builtin.url_extract.httpx.AsyncHTTPTransport",
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
                 return_value=mock_transport,
             ),
         ):

--- a/tests/v1/test_api_v1_unfurl.py
+++ b/tests/v1/test_api_v1_unfurl.py
@@ -1,0 +1,420 @@
+# Tests for the API v1 link-unfurl router (GET /api/v1/unfurl).
+# Created: 2026-06-10 — covers the frozen wire contract: happy-path OG scrape,
+#   twitter/<title> fallbacks, relative image+favicon resolved absolute,
+#   SSRF-blocked URLs -> 400 unsafe_url, non-html/timeout/oversized -> 502
+#   fetch_failed, the 15-min TTL cache (second call doesn't re-fetch), and a
+#   YouTube-shaped fixture. Mocks the SSRF-safe fetch by pinning DNS to a
+#   public IP and swapping IPPinningTransport's inner transport for an
+#   httpx.MockTransport so the real safe_get_streamed (streaming, content-type
+#   check, byte cap, final-URL tracking) is exercised end to end.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import pocketpaw.api.v1.unfurl as unfurl_module
+from pocketpaw.api.v1.unfurl import router
+
+# ---------------------------------------------------------------------------
+# HTML fixtures
+# ---------------------------------------------------------------------------
+
+FULL_OG_HTML = """<!doctype html>
+<html><head>
+  <meta property="og:title" content="The Title">
+  <meta property="og:description" content="A great description.">
+  <meta property="og:image" content="https://cdn.example.com/img.png">
+  <meta property="og:site_name" content="Example Site">
+  <link rel="icon" href="https://example.com/favicon.ico">
+  <title>Fallback Title</title>
+</head><body><h1>hi</h1></body></html>
+"""
+
+TWITTER_FALLBACK_HTML = """<!doctype html>
+<html><head>
+  <meta name="twitter:title" content="Tweet Title">
+  <meta name="twitter:description" content="Tweet desc.">
+  <meta name="twitter:image" content="https://cdn.example.com/tw.png">
+  <title>Doc Title</title>
+</head><body></body></html>
+"""
+
+TITLE_ONLY_HTML = """<!doctype html>
+<html><head><title>Just A Title</title></head><body>no og tags</body></html>
+"""
+
+RELATIVE_ASSETS_HTML = """<!doctype html>
+<html><head>
+  <meta property="og:title" content="Rel">
+  <meta property="og:image" content="/assets/cover.jpg">
+  <link rel="shortcut icon" href="favicon.png">
+</head><body></body></html>
+"""
+
+NO_META_HTML = "<html><head></head><body><p>nothing here</p></body></html>"
+
+YOUTUBE_HTML = """<!doctype html>
+<html><head>
+  <meta property="og:title" content="Rick Astley - Never Gonna Give You Up">
+  <meta property="og:description" content="The official video">
+  <meta property="og:image" content="https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg">
+  <meta property="og:site_name" content="YouTube">
+  <link rel="icon" href="https://www.youtube.com/s/desktop/favicon.ico">
+  <title>Rick Astley - Never Gonna Give You Up - YouTube</title>
+</head><body></body></html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + fetch-mock helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """The unfurl cache is module-level; isolate every test."""
+    unfurl_module._cache.clear()
+    yield
+    unfurl_module._cache.clear()
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def _mock_transport_returning(
+    body: str | bytes,
+    *,
+    content_type: str = "text/html; charset=utf-8",
+    status_code: int = 200,
+    final_path: str = "/",
+):
+    """Build an httpx.MockTransport handler that returns a fixed response.
+
+    Tracks call count on the returned handler's ``calls`` attribute.
+    """
+    content = body.encode("utf-8") if isinstance(body, str) else body
+    state = {"calls": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        state["calls"] += 1
+        return httpx.Response(
+            status_code,
+            headers={"content-type": content_type},
+            content=content,
+        )
+
+    return handler, state
+
+
+# The SSRF-safe fetch is mocked by (1) pinning DNS to a public IP and (2)
+# swapping IPPinningTransport's *inner* transport for an httpx.MockTransport.
+# IPPinningTransport(transport=...) accepts an inner transport, but the patch
+# on httpx.AsyncHTTPTransport (its default) is simpler and covers the loop's
+# real construction path. Each test installs these patches inline.
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestUnfurlContract:
+    def test_full_og_tags(self, client):
+        handler, state = _mock_transport_returning(FULL_OG_HTML)
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "https://example.com/page"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["url"] == "https://example.com/page"
+        assert data["title"] == "The Title"
+        assert data["description"] == "A great description."
+        assert data["image"] == "https://cdn.example.com/img.png"
+        assert data["site_name"] == "Example Site"
+        assert data["favicon"] == "https://example.com/favicon.ico"
+
+    def test_twitter_and_title_fallbacks(self, client):
+        handler, _ = _mock_transport_returning(TWITTER_FALLBACK_HTML)
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "https://example.com/t"})
+        assert resp.status_code == 200
+        data = resp.json()
+        # og:title absent -> twitter:title wins over <title>
+        assert data["title"] == "Tweet Title"
+        assert data["description"] == "Tweet desc."
+        assert data["image"] == "https://cdn.example.com/tw.png"
+
+    def test_title_only_page(self, client):
+        handler, _ = _mock_transport_returning(TITLE_ONLY_HTML)
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "https://example.com/x"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["title"] == "Just A Title"
+        assert data["description"] is None
+        assert data["image"] is None
+        assert data["site_name"] is None
+
+    def test_all_null_metadata_is_valid_200(self, client):
+        handler, _ = _mock_transport_returning(NO_META_HTML)
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "https://example.com/empty"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["url"] == "https://example.com/empty"
+        assert data["title"] is None
+        assert data["description"] is None
+        assert data["image"] is None
+        assert data["site_name"] is None
+        assert data["favicon"] is None
+
+    def test_relative_image_and_favicon_resolved_absolute(self, client):
+        handler, _ = _mock_transport_returning(RELATIVE_ASSETS_HTML)
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "https://example.com/dir/article"})
+        assert resp.status_code == 200
+        data = resp.json()
+        # /assets/cover.jpg is root-relative; favicon.png is path-relative.
+        assert data["image"] == "https://example.com/assets/cover.jpg"
+        assert data["favicon"] == "https://example.com/dir/favicon.png"
+
+    def test_youtube_shaped_fixture(self, client):
+        handler, _ = _mock_transport_returning(YOUTUBE_HTML)
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get(
+                "/api/v1/unfurl",
+                params={"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "Never Gonna Give You Up" in data["title"]
+        assert data["image"] == "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg"
+        assert data["site_name"] == "YouTube"
+
+    def test_returns_final_url_after_redirect(self, client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            if "start" in request.url.path:
+                return httpx.Response(
+                    302, headers={"location": "https://final.example.com/landing"}
+                )
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                content=FULL_OG_HTML.encode("utf-8"),
+            )
+
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "https://example.com/start"})
+        assert resp.status_code == 200
+        # The contract's url field is the final URL after redirects, and
+        # relative metadata resolves against it.
+        assert resp.json()["url"] == "https://final.example.com/landing"
+
+
+class TestUnfurlInvalidAndUnsafe:
+    def test_non_http_scheme_400_invalid_url(self, client):
+        resp = client.get("/api/v1/unfurl", params={"url": "ftp://example.com/x"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "invalid_url"
+
+    def test_no_host_400_invalid_url(self, client):
+        resp = client.get("/api/v1/unfurl", params={"url": "not a url at all"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "invalid_url"
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "http://localhost/admin",
+            "http://127.0.0.1:8080/",
+            "http://10.0.0.5/",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://192.168.1.1/",
+        ],
+    )
+    def test_internal_host_400_unsafe_url(self, client, bad_url):
+        resp = client.get("/api/v1/unfurl", params={"url": bad_url})
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "unsafe_url"
+
+    def test_dns_resolves_to_private_ip_400_unsafe_url(self, client):
+        # Hostname is public-looking; DNS resolution lands on a private IP.
+        with patch(
+            "pocketpaw.security.safe_fetch._resolve_public_ip",
+            AsyncMock(side_effect=unfurl_module.BlockedURLError("non-public")),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "http://rebind.example.com/"})
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "unsafe_url"
+
+
+class TestUnfurlFetchFailures:
+    def test_non_html_content_type_502(self, client):
+        handler, _ = _mock_transport_returning(b'{"k": "v"}', content_type="application/json")
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "https://example.com/data.json"})
+        assert resp.status_code == 502
+        assert resp.json()["detail"] == "fetch_failed"
+
+    def test_timeout_502(self, client):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectTimeout("too slow", request=request)
+
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "https://slow.example.com/"})
+        assert resp.status_code == 502
+        assert resp.json()["detail"] == "fetch_failed"
+
+    def test_dns_failure_502(self, client):
+        with patch(
+            "pocketpaw.security.safe_fetch._resolve_public_ip",
+            AsyncMock(side_effect=unfurl_module.FetchFailedError("Could not resolve")),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "http://no-such-host.example.com/"})
+        assert resp.status_code == 502
+        assert resp.json()["detail"] == "fetch_failed"
+
+    def test_oversized_body_is_cut_and_parsed(self, client):
+        # A valid OG title near the top, then megabytes of filler. The fetch
+        # cuts at ~512KB; the title (in <head>) survives, so we still get 200.
+        filler = "<p>x</p>" * 200_000  # ~1.6 MB, well past the 512 KB cap
+        big_html = (
+            "<html><head><meta property='og:title' content='Big Page'>"
+            "</head><body>" + filler + "</body></html>"
+        )
+        handler, _ = _mock_transport_returning(big_html)
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            resp = client.get("/api/v1/unfurl", params={"url": "https://example.com/big"})
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Big Page"
+
+
+class TestUnfurlCache:
+    def test_second_call_within_ttl_does_not_refetch(self, client):
+        handler, state = _mock_transport_returning(FULL_OG_HTML)
+        mock_transport = httpx.MockTransport(handler)
+        with (
+            patch(
+                "pocketpaw.security.safe_fetch._resolve_public_ip",
+                AsyncMock(return_value="93.184.216.34"),
+            ),
+            patch(
+                "pocketpaw.security.safe_fetch.httpx.AsyncHTTPTransport",
+                return_value=mock_transport,
+            ),
+        ):
+            r1 = client.get("/api/v1/unfurl", params={"url": "https://example.com/cached"})
+            r2 = client.get("/api/v1/unfurl", params={"url": "https://example.com/cached"})
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r1.json() == r2.json()
+        # Transport was hit exactly once — the second call served from cache.
+        assert state["calls"] == 1


### PR DESCRIPTION
## What this adds

`GET /api/v1/unfurl?url=…` — fetches a page server-side and returns its OG metadata so the composer can render link preview cards (paw-enterprise #394 consumes this; browsers can't read third-party pages cross-origin, so the unfurl has to happen here).

Response: `{url, title, description, image, site_name, favicon}` — `url` is the final URL after redirects, image/favicon come back absolute, every metadata field is nullable. 400 `invalid_url`/`unsafe_url`, 502 `fetch_failed`; a catch-all maps anything unexpected to 502 so it never 500s.

## How it stays safe

The fetch path reuses the SSRF machinery the url-extract tool already trusts, now extracted into `security/safe_fetch.py` so both call sites share it: the host blocklist from `url_validators`, DNS resolution pinned per hop (`IPPinningTransport`, defeats rebinding), 5-redirect cap with the SSRF check re-applied on every hop, text/html only, 512KB body cap, ~8s total timeout. Parsing is stdlib `html.parser` — no new dependencies. `files:read` scope guard like the sibling read routers, and a 15-minute in-process TTL cache (500 entries) so repeated pastes don't re-fetch.

## Tests

20 new tests on the endpoint (full OG, twitter/title fallbacks, relative→absolute resolution, a YouTube-shaped fixture, redirect handling, the SSRF rejections including DNS-to-private, non-HTML/timeout/DNS-fail → 502, oversized-body cut, cache hit skips the refetch). The url-extract suite (20) stays green after the refactor — its mock targets moved to `safe_fetch` with re-exports kept for compatibility. ruff clean.

## Merge order

This is the backend half of a pair — merge before paw-enterprise #394's preview cards go live. The frontend degrades to plain link chips until this lands, so ordering is safe either way.