### PR TITLE
Wire loom orientation binary into cloud chat as an MCP server (BS-1)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/loom.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/loom.py
@@ -1,0 +1,131 @@
+# loom.py — registers the loom codebase-orientation binary as an MCP server for
+# the claude_agent_sdk cloud chat backend. Created: 2026-06-10 (BS-1, Belt &
+# Pulley stations thin slice).
+#
+# What this file does (Path A — stdio config pass-through, NOT an in-process SDK
+# server): loom is a finished external Go binary that already speaks MCP over
+# stdio (`loom mcp -model <worldmodel.json>`, server name "loom", 5 read tools:
+# orient / locate / why / what_depends_on / boundaries). Rather than re-implement
+# those tools as an in-process SDK proxy, this module returns a stdio server
+# CONFIG DICT — the McpStdioServerConfig shape the claude_agent_sdk's
+# ``mcp_servers`` option accepts natively ({"type":"stdio","command":...,
+# "args":[...]}). The pocketpaw registration loop in
+# ``pocketpaw.agents.claude_sdk._get_mcp_servers`` does ``servers[name] =
+# cfg_entry`` with NO transformation (claude_sdk.py:738/751), and the existing
+# file-based stdio path already builds the same dict shape (claude_sdk.py:659),
+# so a config dict flows through to ``ClaudeAgentOptions.mcp_servers`` exactly
+# like an SDK server object would. No loop change was needed — see the PR body
+# spike for the file:line evidence.
+#
+# Tool ids namespace as ``mcp__loom__orient`` etc. (the binary's own server
+# name is "loom"), so the Claude Code allowlist machinery matches them.
+#
+# Graceful-by-default: ``build_loom_server`` returns None — never raising — when
+#   * ``loom_model_path`` is unset (loom disabled), or
+#   * the loom binary cannot be resolved on disk.
+# A None return means the entry-point loop simply skips registration; chat keeps
+# working without orientation. Binary resolution mirrors loom's own discovery
+# order: explicit ``loom_bin`` setting → PATH lookup → ~/go/bin/loom fallback.
+"""Agent-side registration of the loom codebase-orientation MCP server."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The loom binary names its own MCP server "loom" (serverInfo.name in the
+# initialize response), so the in-process namespace and tool ids key on it.
+SERVER_NAME = "loom"
+
+# Claude Code namespaces MCP tools as ``mcp__<server>__<tool>``. Allowlist
+# entries must use this exact form. loom exposes these 5 read tools.
+ORIENT_TOOL_ID = f"mcp__{SERVER_NAME}__orient"
+LOCATE_TOOL_ID = f"mcp__{SERVER_NAME}__locate"
+WHY_TOOL_ID = f"mcp__{SERVER_NAME}__why"
+WHAT_DEPENDS_ON_TOOL_ID = f"mcp__{SERVER_NAME}__what_depends_on"
+BOUNDARIES_TOOL_ID = f"mcp__{SERVER_NAME}__boundaries"
+
+LOOM_TOOL_IDS = (
+    ORIENT_TOOL_ID,
+    LOCATE_TOOL_ID,
+    WHY_TOOL_ID,
+    WHAT_DEPENDS_ON_TOOL_ID,
+    BOUNDARIES_TOOL_ID,
+)
+
+
+def _resolve_loom_bin(loom_bin: str) -> str | None:
+    """Resolve the loom binary path, mirroring loom's own discovery order.
+
+    Order: an explicit absolute/relative path that exists → a PATH lookup of the
+    given name → the ~/go/bin/loom fallback. Returns the resolved absolute path,
+    or None when nothing on disk matches (so the caller can degrade to None).
+    """
+    # 1. Explicit path that points at a real executable file.
+    candidate = Path(loom_bin).expanduser()
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+
+    # 2. PATH lookup (handles the bare-name default "loom").
+    on_path = shutil.which(loom_bin)
+    if on_path:
+        return on_path
+
+    # 3. ~/go/bin/loom fallback (the conventional Go install location).
+    go_bin = Path.home() / "go" / "bin" / "loom"
+    if go_bin.is_file() and os.access(go_bin, os.X_OK):
+        return str(go_bin)
+
+    return None
+
+
+def build_loom_server() -> tuple[str, Any] | None:
+    """Build the loom stdio MCP server config, or None when loom is unavailable.
+
+    Returns ``(SERVER_NAME, <McpStdioServerConfig dict>)`` when both the
+    world-model path is set in settings and the loom binary resolves on disk.
+    Returns None — never raising — when:
+      * ``loom_model_path`` is unset (loom disabled by default), or
+      * the configured world-model file does not exist, or
+      * the loom binary cannot be resolved.
+
+    The returned dict is the McpStdioServerConfig shape the claude_agent_sdk
+    consumes natively: ``loom mcp -model <model path>`` served over stdio.
+    """
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+
+    model_path = settings.loom_model_path
+    if not model_path:
+        logger.debug("loom MCP server disabled — loom_model_path is unset")
+        return None
+
+    model_file = Path(model_path).expanduser()
+    if not model_file.is_file():
+        logger.warning(
+            "loom MCP server not registered — world-model not found at %s", model_file
+        )
+        return None
+
+    loom_bin = _resolve_loom_bin(settings.loom_bin)
+    if loom_bin is None:
+        logger.warning(
+            "loom MCP server not registered — loom binary %r not found on PATH "
+            "or at ~/go/bin/loom",
+            settings.loom_bin,
+        )
+        return None
+
+    config: dict[str, Any] = {
+        "type": "stdio",
+        "command": loom_bin,
+        "args": ["mcp", "-model", str(model_file)],
+    }
+    logger.info("loom MCP server registered — model %s", model_file)
+    return SERVER_NAME, config

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -29,6 +29,17 @@ Updated: 2026-06-10 (feat/studio-code-migration) — added ``CloudMediaMcpProvid
 (``pocketpaw.mcp_servers`` entry ``media``) exposing the STUDIO image +
 video generation in-process server (``pocketpaw_media``) to the
 claude_agent_sdk cloud chat backend, mirroring ``CloudSitesMcpProvider``.
+
+Updated: 2026-06-10 (feat/belt-loom-mcp, BS-1) — added ``CloudLoomMcpProvider``
+(``pocketpaw.mcp_servers`` entry ``loom``) registering the external loom
+codebase-orientation binary as a STDIO MCP server (server name ``loom``;
+5 read tools: orient / locate / why / what_depends_on / boundaries) on the
+claude_agent_sdk cloud chat backend. Unlike the sibling providers this one
+returns a stdio config DICT (Path A), not an in-process SDK server object —
+the registration loop passes it through untouched. Ambient (not opt-in); the
+/belt surface scopes access via its profile allowlist. Returns None — and the
+loop skips it — when ``loom_model_path`` is unset or the binary is missing,
+so chat never breaks.
 """
 
 from __future__ import annotations
@@ -610,6 +621,35 @@ class CloudMediaMcpProvider:
         from pocketpaw_ee.agent.mcp_servers.media import MEDIA_TOOL_IDS
 
         return list(MEDIA_TOOL_IDS)
+
+
+class CloudLoomMcpProvider:
+    """`pocketpaw.mcp_servers` — the loom codebase-orientation MCP server.
+
+    Registers the external loom binary (``loom mcp -model <worldmodel.json>``)
+    as a STDIO MCP server — server name ``loom``, 5 read tools (orient /
+    locate / why / what_depends_on / boundaries). Unlike the sibling
+    providers, ``build_server`` returns a stdio CONFIG DICT, not an
+    in-process SDK server object (Path A): the claude_agent_sdk's
+    ``mcp_servers`` option accepts stdio configs natively and the pocketpaw
+    registration loop passes the dict through untouched.
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — the /belt surface scopes
+    access via its profile allowlist; surfaces whose allowlists don't name
+    the loom tool ids simply never see them. ``build_loom_server`` returns
+    None (loop skips it) when ``loom_model_path`` is unset or the binary is
+    missing, so chat keeps working with orientation simply absent.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        from pocketpaw_ee.agent.mcp_servers.loom import build_loom_server
+
+        return build_loom_server()
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
+
+        return list(LOOM_TOOL_IDS)
 
 
 class CloudAgentExtension:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -176,6 +176,7 @@ composio = "pocketpaw_ee.extensions:CloudComposioMcpProvider"
 meetings = "pocketpaw_ee.extensions:CloudMeetingsMcpProvider"
 sites = "pocketpaw_ee.extensions:CloudSitesMcpProvider"
 media = "pocketpaw_ee.extensions:CloudMediaMcpProvider"
+loom = "pocketpaw_ee.extensions:CloudLoomMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]
 cloud = "pocketpaw_ee.extensions:CloudAgentExtension"

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,11 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-10: Added ``loom_bin`` + ``loom_model_path`` — the codebase
+    orientation (loom) MCP server settings. ``loom_model_path`` defaults
+    to None, which disables the loom MCP server; set it to a built
+    world-model JSON to enable orient / locate / why / what_depends_on /
+    boundaries for the cloud chat agent (BS-1, Belt & Pulley stations).
   - 2026-05-26: Added ``foresight_use_skill`` — env gate for the
     ``foresight-create-sim`` bundled skill (default OFF). The SKILL.md
     still auto-installs; this flag toggles the chat-surface affordance
@@ -818,6 +823,28 @@ class Settings(BaseSettings):
     video_model: str = Field(
         default="kwaivgi/kling-v2.0",
         description="Replicate video-generation model (owner/name slug)",
+    )
+
+    # Codebase orientation (loom) — the loom binary serves an MCP server over
+    # stdio that orients the cloud chat agent to a codebase (orient / locate /
+    # why / what_depends_on / boundaries). Wired into the claude_agent_sdk
+    # backend via CloudLoomMcpProvider. Env auto-derives POCKETPAW_LOOM_BIN /
+    # POCKETPAW_LOOM_MODEL_PATH.
+    loom_bin: str = Field(
+        default="loom",
+        description=(
+            "Path to the loom binary. Resolved as: this explicit setting → "
+            "PATH lookup → ~/go/bin/loom fallback. The default 'loom' relies on "
+            "PATH; set an absolute path to pin a specific build."
+        ),
+    )
+    loom_model_path: str | None = Field(
+        default=None,
+        description=(
+            "Path to a loom world-model JSON (built via `loom build`). When "
+            "unset, the loom MCP server is not registered — orientation is "
+            "disabled. The binary is served as `loom mcp -model <this path>`."
+        ),
     )
 
     # Security

--- a/tests/cloud/test_loom_mcp.py
+++ b/tests/cloud/test_loom_mcp.py
@@ -1,0 +1,232 @@
+# tests/cloud/test_loom_mcp.py — loom codebase-orientation MCP server (BS-1).
+#
+# Created: 2026-06-10 (feat/belt-loom-mcp, Belt & Pulley stations thin slice).
+# Guards the loom MCP wiring for the cloud chat (claude_agent_sdk) backend:
+#   * LOOM_TOOL_IDS — the 5 namespaced tool ids (mcp__loom__orient etc.) the
+#     surface allow-list + the SDK allowlist machinery key on.
+#   * CloudLoomMcpProvider.build_server() — returns None when loom_model_path is
+#     unset, None when the binary can't be resolved, and the correct
+#     ("loom", <stdio config dict>) when both the model file and binary exist.
+#   * _resolve_loom_bin — explicit path → PATH → ~/go/bin/loom discovery order.
+#   * Path A registration: the stdio config dict the provider returns flows
+#     through the real ClaudeAgentSDK._get_mcp_servers registration loop with
+#     ``type: "stdio"`` intact (the spike verdict — no loop change needed).
+#
+# build_loom_server reads its config through pocketpaw.config.get_settings (a
+# cached singleton, the same pattern the sibling media / sites servers use), so
+# every test that needs loom enabled patches get_settings — not the SDK's
+# injected Settings instance.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pocketpaw_ee.agent.mcp_servers.loom as loom
+from pocketpaw_ee.extensions import CloudLoomMcpProvider
+
+from pocketpaw.agents.claude_sdk import OPT_IN_MCP_SERVERS, ClaudeAgentSDK
+from pocketpaw.config import Settings
+
+
+def _settings(*, model_path: str | None, loom_bin: str = "loom") -> MagicMock:
+    """A stand-in for get_settings() carrying only the loom fields the server
+    reads."""
+    return MagicMock(loom_model_path=model_path, loom_bin=loom_bin)
+
+
+# --- tool ids ---------------------------------------------------------------
+
+
+def test_loom_tool_ids_are_namespaced() -> None:
+    """The 5 tool ids use the ``mcp__<server>__<tool>`` form the Claude Code
+    allowlist machinery matches, under the binary's own server name ``loom``."""
+    assert loom.SERVER_NAME == "loom"
+    assert loom.ORIENT_TOOL_ID == "mcp__loom__orient"
+    assert loom.LOCATE_TOOL_ID == "mcp__loom__locate"
+    assert loom.WHY_TOOL_ID == "mcp__loom__why"
+    assert loom.WHAT_DEPENDS_ON_TOOL_ID == "mcp__loom__what_depends_on"
+    assert loom.BOUNDARIES_TOOL_ID == "mcp__loom__boundaries"
+    assert loom.LOOM_TOOL_IDS == (
+        loom.ORIENT_TOOL_ID,
+        loom.LOCATE_TOOL_ID,
+        loom.WHY_TOOL_ID,
+        loom.WHAT_DEPENDS_ON_TOOL_ID,
+        loom.BOUNDARIES_TOOL_ID,
+    )
+
+
+def test_provider_tool_ids_match_module() -> None:
+    """The provider surfaces exactly the module's tool ids for the allowlist."""
+    assert CloudLoomMcpProvider().tool_ids() == list(loom.LOOM_TOOL_IDS)
+
+
+# --- build_server: disabled / degraded paths -------------------------------
+
+
+def test_build_server_none_when_model_path_unset() -> None:
+    """loom_model_path unset → loom disabled → build returns None (chat keeps
+    working without orientation)."""
+    with patch("pocketpaw.config.get_settings", return_value=_settings(model_path=None)):
+        assert CloudLoomMcpProvider().build_server() is None
+        assert loom.build_loom_server() is None
+
+
+def test_build_server_none_when_model_file_missing(tmp_path) -> None:
+    """A configured world-model path that does not exist → None, not a crash."""
+    missing = str(tmp_path / "does-not-exist.json")
+    with patch("pocketpaw.config.get_settings", return_value=_settings(model_path=missing)):
+        assert loom.build_loom_server() is None
+
+
+def test_build_server_none_when_binary_missing(tmp_path) -> None:
+    """A real model file but an unresolvable binary → None (binary-missing
+    degrades gracefully)."""
+    model = tmp_path / "worldmodel.json"
+    model.write_text("{}")
+    # A bogus binary name that is neither an existing file, on PATH, nor at
+    # ~/go/bin. Also patch ~/go/bin discovery off via a HOME with no go/bin.
+    empty_home = tmp_path / "home"
+    empty_home.mkdir()
+    with (
+        patch(
+            "pocketpaw.config.get_settings",
+            return_value=_settings(model_path=str(model), loom_bin="loom-nonexistent-xyz"),
+        ),
+        patch("pocketpaw_ee.agent.mcp_servers.loom.Path.home", return_value=empty_home),
+    ):
+        assert loom.build_loom_server() is None
+
+
+# --- build_server: happy path ----------------------------------------------
+
+
+def test_build_server_returns_stdio_config_when_set(tmp_path) -> None:
+    """Model file + resolvable binary → ("loom", <McpStdioServerConfig dict>)
+    with the command resolved and the `mcp -model <path>` args."""
+    model = tmp_path / "worldmodel.json"
+    model.write_text("{}")
+    fake_bin = tmp_path / "loom"
+    fake_bin.write_text("#!/bin/sh\n")
+    fake_bin.chmod(0o755)
+
+    with patch(
+        "pocketpaw.config.get_settings",
+        return_value=_settings(model_path=str(model), loom_bin=str(fake_bin)),
+    ):
+        built = loom.build_loom_server()
+
+    assert built is not None
+    name, config = built
+    assert name == "loom"
+    assert config["type"] == "stdio"
+    assert config["command"] == str(fake_bin)
+    assert config["args"] == ["mcp", "-model", str(model)]
+
+
+# --- binary resolution order -----------------------------------------------
+
+
+def test_resolve_bin_prefers_explicit_path(tmp_path) -> None:
+    """An explicit executable path is returned verbatim (resolved)."""
+    explicit = tmp_path / "loom"
+    explicit.write_text("#!/bin/sh\n")
+    explicit.chmod(0o755)
+    assert loom._resolve_loom_bin(str(explicit)) == str(explicit)
+
+
+def test_resolve_bin_falls_back_to_path(tmp_path) -> None:
+    """A bare name not on disk resolves via PATH (shutil.which)."""
+    found = str(tmp_path / "loom-on-path")
+    with patch("pocketpaw_ee.agent.mcp_servers.loom.shutil.which", return_value=found):
+        assert loom._resolve_loom_bin("loom") == found
+
+
+def test_resolve_bin_falls_back_to_go_bin(tmp_path) -> None:
+    """Not an explicit file and not on PATH → ~/go/bin/loom fallback."""
+    home = tmp_path / "home"
+    (home / "go" / "bin").mkdir(parents=True)
+    go_loom = home / "go" / "bin" / "loom"
+    go_loom.write_text("#!/bin/sh\n")
+    go_loom.chmod(0o755)
+    with (
+        patch("pocketpaw_ee.agent.mcp_servers.loom.shutil.which", return_value=None),
+        patch("pocketpaw_ee.agent.mcp_servers.loom.Path.home", return_value=home),
+    ):
+        assert loom._resolve_loom_bin("loom") == str(go_loom)
+
+
+def test_resolve_bin_returns_none_when_nothing_found(tmp_path) -> None:
+    """Nothing on disk matches → None so the caller degrades to None."""
+    empty_home = tmp_path / "home"
+    empty_home.mkdir()
+    with (
+        patch("pocketpaw_ee.agent.mcp_servers.loom.shutil.which", return_value=None),
+        patch("pocketpaw_ee.agent.mcp_servers.loom.Path.home", return_value=empty_home),
+    ):
+        assert loom._resolve_loom_bin("loom-nope") is None
+
+
+# --- Path A: the registration loop accepts the stdio config shape ----------
+
+
+class TestLoomRegistrationLoop:
+    """The spike verdict, pinned as a test: the stdio CONFIG DICT the loom
+    provider returns flows through the real ``_get_mcp_servers`` loop untouched
+    (Path A — no loop change). The loop does ``servers[name] = cfg_entry`` with
+    no transformation, so a dict registers identically to an SDK server object.
+    """
+
+    def _make_sdk(self) -> ClaudeAgentSDK:
+        settings = Settings(anthropic_api_key="test-key", tool_profile="full")
+        with patch.object(ClaudeAgentSDK, "_initialize"):
+            sdk = ClaudeAgentSDK(settings)
+            sdk._sdk_available = False
+        return sdk
+
+    def test_loom_is_ambient_not_opt_in(self) -> None:
+        """loom is ambient — the /belt surface scopes it via its profile
+        allowlist, so it must NOT be in the opt-in set."""
+        assert loom.SERVER_NAME not in OPT_IN_MCP_SERVERS
+
+    def test_registration_accepts_stdio_config(self, tmp_path) -> None:
+        """When loom is enabled, the registration loop accepts the stdio config
+        dict and keeps ``type: "stdio"`` intact — proving Path A end to end."""
+        model = tmp_path / "worldmodel.json"
+        model.write_text("{}")
+        fake_bin = tmp_path / "loom"
+        fake_bin.write_text("#!/bin/sh\n")
+        fake_bin.chmod(0o755)
+
+        sdk = self._make_sdk()
+        loom_settings = _settings(model_path=str(model), loom_bin=str(fake_bin))
+        with (
+            patch("pocketpaw.mcp.config.load_mcp_config", return_value=[]),
+            patch("pocketpaw.config.get_settings", return_value=loom_settings),
+        ):
+            servers = sdk._get_mcp_servers()
+
+        assert loom.SERVER_NAME in servers
+        entry = servers[loom.SERVER_NAME]
+        assert entry["type"] == "stdio"
+        assert entry["command"] == str(fake_bin)
+        assert entry["args"] == ["mcp", "-model", str(model)]
+
+    def test_loom_absent_when_disabled(self, tmp_path) -> None:
+        """loom_model_path unset → loom not registered, other servers unaffected."""
+        sdk = self._make_sdk()
+        loom_settings = _settings(model_path=None)
+        with (
+            patch("pocketpaw.mcp.config.load_mcp_config", return_value=[]),
+            patch("pocketpaw.config.get_settings", return_value=loom_settings),
+        ):
+            servers = sdk._get_mcp_servers()
+        assert loom.SERVER_NAME not in servers
+
+    def test_loom_tool_ids_on_allowlist(self) -> None:
+        """The loom tool ids are on the in-process allowlist by default (ambient,
+        no opt-in) — the agent can call ``mcp__loom__orient`` once the surface
+        allowlist permits it."""
+        sdk = self._make_sdk()
+        ids = sdk._collect_mcp_tool_ids()
+        for tool_id in loom.LOOM_TOOL_IDS:
+            assert tool_id in ids


### PR DESCRIPTION
## What this does

Wires `loom` — the codebase-orientation binary — into the cloud chat agent as an MCP server. loom is a finished external Go binary: `loom mcp -model <worldmodel.json>` serves an MCP server over stdio with five read tools (orient, locate, why, what_depends_on, boundaries) under the server name `loom`. With this change, the claude_agent_sdk backend registers it ambiently, so the agent can orient itself to a codebase.

This is BS-1 of the Belt & Pulley stations thin slice. BS-2 and BS-3 stack on this branch.

## The spike: Path A (no loop change)

The brief asked whether the registration loop / `ClaudeAgentOptions.mcp_servers` accepts a stdio config dict, or whether a stdio config has to be wrapped in an in-process SDK proxy server.

Verdict: **Path A — a stdio config dict passes straight through.** No change to `claude_sdk.py`.

Evidence:

- `src/pocketpaw/agents/claude_sdk.py:738` and `:751` — the entry-point loop does `servers[name] = cfg_entry`, with no transformation of what a provider returns. Whatever the provider hands back goes into the servers dict as-is.
- `src/pocketpaw/agents/claude_sdk.py:629` — `_get_mcp_servers(self) -> dict[str, dict]`, and `:646` declares `servers: dict[str, dict]`. The return type is already a dict-of-dicts.
- `src/pocketpaw/agents/claude_sdk.py:659-664` — the existing file-based MCP path already builds the exact stdio shape `{"type": "stdio", "command": ..., "args": ..., "env": ...}` and registers it at `:678`. A provider returning the same shape is indistinguishable.
- `.venv/.../claude_agent_sdk/types.py:549` — `McpStdioServerConfig` is `{type: "stdio", command: str, args, env}`, and `:582` `McpServerConfig` is the union (`McpStdioServerConfig | McpSSEServerConfig | McpHttpServerConfig | McpSdkServerConfig`) that `ClaudeAgentOptions.mcp_servers` accepts (`:1491`). The SDK supports stdio configs natively.
- `src/pocketpaw/agents/claude_sdk.py:1430-1432` — the assembled `servers` dict flows straight to `options_kwargs["mcp_servers"]`.

So `CloudLoomMcpProvider.build_server()` returns a stdio config dict instead of an in-process SDK server object, and the loop registers it exactly like every other provider. Proven end to end by `TestLoomRegistrationLoop::test_registration_accepts_stdio_config`, which runs the real `_get_mcp_servers` and asserts `servers["loom"]["type"] == "stdio"` with the resolved command and `mcp -model <path>` args.

## Changes

- `src/pocketpaw/config.py` — `loom_bin` (binary path; resolved explicit → PATH → `~/go/bin/loom`) and `loom_model_path` (world-model JSON; `None` disables loom). Env: `POCKETPAW_LOOM_BIN` / `POCKETPAW_LOOM_MODEL_PATH`.
- `ee/pocketpaw_ee/agent/mcp_servers/loom.py` (new) — `SERVER_NAME = "loom"`, `LOOM_TOOL_IDS` (the five namespaced ids), `_resolve_loom_bin` (discovery order), and `build_loom_server()` returning `("loom", <stdio config dict>)` or `None` when the model path is unset, the model file is missing, or the binary can't be resolved. Never raises — chat keeps working with orientation simply absent.
- `ee/pocketpaw_ee/extensions.py` — `CloudLoomMcpProvider` (build_server + tool_ids), cloned from `CloudMediaMcpProvider`.
- `ee/pyproject.toml` — the `loom` entry-point under `pocketpaw.mcp_servers`.

Registration is ambient (not in `OPT_IN_MCP_SERVERS`). The /belt surface scopes access via its profile allowlist; surfaces whose allowlists don't name the loom tool ids never see them.

## Tests

New file `tests/cloud/test_loom_mcp.py`, cloned from `test_media_mcp.py` + `test_mcp_claude_sdk.py`:

- tool ids are namespaced and the provider surfaces them
- `build_server` returns `None` when the model path is unset, when the model file is missing, and when the binary can't be resolved
- `build_server` returns the correct `("loom", stdio-config)` when both exist
- `_resolve_loom_bin` discovery order: explicit path → PATH → `~/go/bin/loom` → None
- Path A: the real `_get_mcp_servers` loop accepts the stdio config with `type: "stdio"` intact; loom is ambient (not opt-in); loom is absent when disabled; the tool ids land on the in-process allowlist

```
$ uv run pytest tests/ee/test_mcp_claude_sdk.py tests/cloud/test_media_mcp.py tests/cloud/test_loom_mcp.py -x -q
.....................................................                    [100%]
53 passed in 1.57s

$ uv run ruff check src/pocketpaw/config.py ee/pocketpaw_ee/agent/mcp_servers/loom.py ee/pocketpaw_ee/extensions.py tests/cloud/test_loom_mcp.py
All checks passed!
```

## Notes

- No new dependencies — loom is an external binary the operator installs; `uv.lock` is unchanged.
- Do not merge — BS-2 and BS-3 stack on this branch.
