### PR TITLE
Add the /belt develop-station surface (BS-2)

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -48,6 +48,12 @@
 # image + video) and ``CODE`` (/code — the agent edits + runs code). Both get
 # ``ripple_mode="off"`` profiles in ``service.py`` so the agent generates media /
 # edits code instead of defaulting to a ripple ui-spec dashboard.
+# Changes: 2026-06-10 (feat/belt-surface, BS-2 Belt & Pulley stations thin
+# slice) — added the ``BELT`` surface (/belt — the develop station). Its
+# ``ripple_mode="off"`` profile in ``service.py`` scopes the agent to the loom
+# orientation tools + the Instinct gate tool so it orients first, develops in a
+# station worktree, and proposes the diff through the gate — never applying to the
+# user's branches directly.
 
 from __future__ import annotations
 
@@ -87,6 +93,7 @@ class SurfaceKind(StrEnum):
     SITES = "sites"  # /sites — describe-to-create + manage published Paw Sites
     STUDIO = "studio"  # /studio — describe→generate media (image + video)
     CODE = "code"  # /code — agent edits + runs code in the workspace
+    BELT = "belt"  # /belt — the develop station (orient→develop→propose via gate)
     GENERIC = "generic"  # any unknown surface — agent still gets a usable preamble
 
 

--- a/ee/pocketpaw_ee/cloud/surface/handlers/belt.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/belt.py
@@ -1,0 +1,82 @@
+# belt.py — /belt surface preamble (the develop station).
+#
+# Created: 2026-06-10 (feat/belt-surface, BS-2 Belt & Pulley stations thin
+# slice) — Orients the chat agent when the user is on the /belt surface, the
+# develop station of the Belt & Pulley assembly line. The agent takes a coding
+# task, GROUNDS itself with loom's orient() first, implements in a station
+# worktree, and PROPOSES the resulting diff through the Instinct gate — it never
+# applies changes directly and never claims success unless the gate tool returned
+# ok. Without this preamble the surface falls back to GENERIC and the agent
+# builds a dashboard pocket instead of running the station loop.
+#
+# Mirrors handlers/code.py: an async ``build_preamble`` returning an XML-ish
+# ``<surface>`` + ``<orientation>`` + ``<procedure>`` block. The procedure
+# enforces the three-stage station loop:
+#   * ORIENT FIRST — call ``mcp__loom__orient`` with the task before reading any
+#     code; drill down with locate / why / what_depends_on as needed.
+#   * DEVELOP — implement in the station worktree with Bash/Read/Write/Edit/Glob/
+#     Grep; run targeted tests; keep the diff small (large changes → split).
+#   * PROPOSE VIA THE GATE — produce a clean unified diff and call
+#     ``mcp__pocketpaw_belt__belt_propose_change``; NEVER apply to the user's
+#     branches, NEVER push or merge; if the gate is unavailable/errors, say so —
+#     no phantom successes.
+#
+# The /belt SurfaceProfile sets ``ripple_mode="off"`` (so the agent doesn't
+# inherit the ~20k-char "default to ui-spec" ripple LAW and build a dashboard)
+# and scopes ``allow_mcp_tool_ids`` to the loom orientation tools + the gate
+# tool (see service.py).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the /belt surface preamble — the develop station loop."""
+    route = meta.route_path or "/belt"
+    return (
+        f'<surface kind="belt" route="{route}" />\n'
+        "<belt-orientation>\n"
+        "The user is on the BELT surface, the develop station of the Belt & "
+        "Pulley assembly line. You take a coding task, GROUND yourself in the "
+        "codebase, implement the change in a station worktree, and PROPOSE the "
+        "resulting diff through the Instinct gate for a human to review. This is "
+        "NOT a dashboard — do not build widgets, charts, or a ui-spec, and do "
+        "not create a pocket. The deliverable is a PROPOSED CHANGE: a clean "
+        "unified diff handed to the gate, waiting in the Tray for human "
+        "approval. You NEVER apply changes to the user's branches directly, and "
+        "you NEVER claim the change was proposed unless the gate tool actually "
+        "returned ok. Talk about the work as 'the change', 'the diff', 'the "
+        "station', 'the gate', 'the Tray' — never as a 'pocket' or 'dashboard'.\n"
+        "</belt-orientation>\n"
+        "<belt-procedure>\n"
+        "Treat the user's message on this surface as a coding task and run the "
+        "station loop in three stages — in order.\n"
+        "1. ORIENT FIRST. Before reading any code, call `mcp__loom__orient` with "
+        "the user's task. Use the returned brief — scope, blast-radius, "
+        "entrypoints — to plan your approach. Drill down with `mcp__loom__locate` "
+        "(find where something lives), `mcp__loom__why` (understand a decision), "
+        "and `mcp__loom__what_depends_on` (find blast radius) as needed. Do NOT "
+        "start reading or editing code until you have oriented.\n"
+        "2. DEVELOP. Implement the change in the station worktree using the "
+        "built-in tools: `Bash` to run commands, `Read` to read files, `Write` / "
+        "`Edit` to change them, and `Glob` / `Grep` to find code. Run TARGETED "
+        "tests for what you touched. Keep the diff SMALL and focused — one task, "
+        "one change. If the task genuinely needs a large change, tell the user to "
+        "split it into smaller tasks rather than proposing a sprawling diff.\n"
+        "3. PROPOSE VIA THE GATE. Produce a clean unified diff of your change and "
+        "call `mcp__pocketpaw_belt__belt_propose_change` with `{repo, "
+        "base_branch, diff, summary, task}`. This is the ONLY way a change leaves "
+        "the station. NEVER apply your change to the user's branches directly, "
+        "NEVER `git push`, NEVER `git merge`. If the gate tool is unavailable or "
+        "returns an error, say so PLAINLY — do NOT claim the change was proposed "
+        "(no phantom successes). After the gate accepts the proposal, tell the "
+        "user the change is waiting in the Tray for review, and that on approve it "
+        "is applied in a worktree, branched, and opened as a PR.\n"
+        "The workspace is JAILED — stay inside the station worktree; do not reach "
+        "outside it. Destructive shell operations are blocked.\n"
+        "</belt-procedure>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -55,6 +55,17 @@
 # ``studio`` skill; CODE sets an ``allowed_sdk_tools`` allowlist (Bash/Read/Write/
 # Edit/Glob/Grep) and surfaces the ``code`` skill. Both are plain ``by_kind``
 # entries (not meta-aware like /sites).
+# Changes: 2026-06-10 (feat/belt-surface, BS-2 Belt & Pulley stations thin
+# slice) — registered the BELT surface (the develop station). Its handler
+# (``belt.build_preamble``) joins ``_load_handlers``, and ``_build_profiles``
+# gives it a ripple-OFF ``SurfaceProfile`` so the agent runs the station loop
+# instead of building a dashboard: ``allowed_sdk_tools`` = the coding built-ins
+# (Bash/Read/Write/Edit/Glob/Grep), ``skill_names`` = {"belt"}, and
+# ``allow_mcp_tool_ids`` = the loom orientation tools (``LOOM_TOOL_IDS``, loaded
+# in the existing try/except as a plain frozenset[str]) UNION the Instinct gate
+# tool (``_BELT_GATE_TOOL_IDS``). The gate tool id is a literal here because its
+# constant lives in a SIBLING branch's ``agent/mcp_servers/belt.py`` — the
+# import reconciles when both PRs land.
 
 from __future__ import annotations
 
@@ -105,6 +116,16 @@ _SITES_SVELTE_CREATE_DENY: frozenset[str] = frozenset(
     }
 )
 
+# The Instinct gate tool the /belt develop station proposes its diff through.
+# Spelled as a LITERAL because its canonical constant
+# (``BELT_PROPOSE_CHANGE_TOOL_ID`` / ``BELT_TOOL_IDS``) lives in a SIBLING
+# branch's ``ee/pocketpaw_ee/agent/mcp_servers/belt.py`` — not importable on this
+# base. When both PRs land, swap this literal for the imported constant (same
+# None-degrade path as the loom/media imports below). Do NOT drift the id.
+_BELT_GATE_TOOL_IDS: frozenset[str] = frozenset(
+    {"mcp__pocketpaw_belt__belt_propose_change"}
+)
+
 # Per-mode MCP-tool allow-lists keep a mode's agent context lean: only the
 # mode's SPECIALIZED tools are named here. The "general everywhere" set — ripple
 # widgets, the pocket lifecycle (read/create/edit/plan), and connectors
@@ -124,8 +145,10 @@ def _build_profiles() -> dict[str, Any]:
     foresight_allow: frozenset[str] | None
     sites_allow: frozenset[str] | None
     studio_allow: frozenset[str] | None
+    belt_allow: frozenset[str] | None
     try:
         from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
         from pocketpaw_ee.agent.mcp_servers.media import MEDIA_TOOL_IDS
         from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS
 
@@ -135,6 +158,12 @@ def _build_profiles() -> dict[str, Any]:
         # over from the EE mcp-server module as a plain frozenset[str] — never an
         # imported pocketpaw_ee symbol leaks into the OSS surface service.
         studio_allow = frozenset(MEDIA_TOOL_IDS)
+        # /belt (the develop station) scopes to the loom orientation tools (so
+        # the agent grounds itself before coding) UNION the Instinct gate tool
+        # (so it proposes the diff through the gate). LOOM_TOOL_IDS is importable
+        # on this base; the gate tool id is the literal _BELT_GATE_TOOL_IDS until
+        # its sibling-branch constant lands.
+        belt_allow = frozenset(LOOM_TOOL_IDS) | _BELT_GATE_TOOL_IDS
     except Exception:  # noqa: BLE001 — degrade to no restriction, never break chat
         logger.warning(
             "surface: could not load mcp tool ids; per-mode MCP scoping disabled",
@@ -144,6 +173,7 @@ def _build_profiles() -> dict[str, Any]:
         foresight_allow = None
         sites_allow = None
         studio_allow = None
+        belt_allow = None
 
     return {
         "by_kind": {
@@ -174,6 +204,18 @@ def _build_profiles() -> dict[str, Any]:
                 ripple_mode="off",
                 skill_names=frozenset({"code"}),
                 allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
+            ),
+            # Belt: the develop station (orient→develop→propose via gate). Ripple
+            # OFF so the agent runs the station loop instead of building a
+            # dashboard. SDK-tool allowlist scopes it to the coding built-ins; the
+            # `belt` skill carries the station playbook; the MCP allow-list is the
+            # loom orientation tools (ground first) UNION the Instinct gate tool
+            # (propose the diff). belt_allow is None when the import degraded.
+            SurfaceKind.BELT: SurfaceProfile(
+                ripple_mode="off",
+                skill_names=frozenset({"belt"}),
+                allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
+                allow_mcp_tool_ids=belt_allow,
             ),
         },
         # /sites is meta-aware (below). Both modes scope to the sites authoring
@@ -313,6 +355,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
     from pocketpaw_ee.cloud.surface.handlers import (
         activity,
         audit,
+        belt,
         calendar,
         code,
         files,
@@ -363,6 +406,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
         SurfaceKind.SITES: sites.build_preamble,
         SurfaceKind.STUDIO: studio.build_preamble,
         SurfaceKind.CODE: code.build_preamble,
+        SurfaceKind.BELT: belt.build_preamble,
         SurfaceKind.GENERIC: generic.build_preamble,
     }
 

--- a/src/pocketpaw/bundled_skills/_bundled/skills/belt/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/belt/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: belt
+description: |
+  Run the Belt & Pulley develop station: take a coding task, ORIENT in the
+  codebase first, develop the change in a station worktree, then PROPOSE the
+  diff through the Instinct gate for a human to review. Invoke when the user
+  asks to write, edit, fix, refactor, or implement code on the /belt surface:
+  "implement this", "fix this bug", "add this feature", "refactor...". You do
+  NOT build a dashboard or a ui-spec and you do NOT create a pocket. You NEVER
+  apply the change to the user's branches directly, NEVER push, NEVER merge —
+  every change leaves the station ONLY as a proposal through
+  mcp__pocketpaw_belt__belt_propose_change, and you NEVER claim success unless
+  the gate tool returned ok. The loop is orient → develop → propose. Loading
+  this skill keeps the chat agent's always-on system prompt small while still
+  delivering the full station playbook when a develop-station task is actually
+  requested.
+---
+
+# Belt — the develop station (orient → develop → propose)
+
+You're on **Belt**: the develop station of the Belt & Pulley assembly line.
+You take a coding task, ground yourself in the codebase, implement the change
+in a **station worktree**, and **propose** the resulting diff through the
+**Instinct gate** for a human to review. This is not a dashboard: no widgets,
+no ui-spec, no pocket. The deliverable is a **proposed change** — a clean
+unified diff waiting in the **Tray** for human approval.
+
+Two rules govern everything below:
+
+- **No direct apply.** You NEVER apply your change to the user's branches, you
+  NEVER `git push`, and you NEVER `git merge`. The gate is the only way out.
+- **No phantom success.** You NEVER claim the change was proposed unless
+  `mcp__pocketpaw_belt__belt_propose_change` actually returned ok. If the gate
+  is unavailable or errors, say so plainly.
+
+## The loop
+
+### 1. Orient first
+
+Before you read or edit any code, call **`mcp__loom__orient`** with the user's
+task. Use the brief it returns — scope, blast-radius, entrypoints — to plan
+your approach. Drill down as you need to:
+
+- **`mcp__loom__locate`** — find where something lives.
+- **`mcp__loom__why`** — understand why a decision was made.
+- **`mcp__loom__what_depends_on`** — find the blast radius of a change.
+
+Do not start reading code blindly. Orient, then plan.
+
+### 2. Develop
+
+Implement the change in the **station worktree** using the built-in tools:
+
+- **`Glob` / `Grep`** — find the files and code to change.
+- **`Read`** — read a file before editing it.
+- **`Edit`** — make a targeted change to an existing file.
+- **`Write`** — create a new file (or fully replace one you've read).
+- **`Bash`** — run commands and **targeted tests** for what you touched.
+
+Keep the diff **small and focused** — one task, one change. Don't gold-plate.
+If the task genuinely needs a large change, **tell the user to split it** into
+smaller tasks rather than proposing a sprawling diff.
+
+### 3. Propose via the gate
+
+Produce a **clean unified diff** of your change and call the gate tool. This is
+the only way a change leaves the station.
+
+```
+mcp__pocketpaw_belt__belt_propose_change({
+  "repo": "pocketpaw",
+  "base_branch": "dev",
+  "diff": "diff --git a/src/foo.py b/src/foo.py\n--- a/src/foo.py\n+++ b/src/foo.py\n@@ -10,6 +10,7 @@\n def handler():\n-    return None\n+    return compute()\n",
+  "summary": "Return the computed value from handler() instead of None",
+  "task": "Fix handler() returning None instead of the computed result"
+})
+```
+
+If the call returns ok, the proposal is queued. If it is unavailable or returns
+an error, **say so plainly** — do not pretend the change was proposed.
+
+## After proposing
+
+Tell the user the change is **waiting in the Tray** for review. On **approve**,
+the proposal is applied in a worktree, branched, and opened as a PR. You do not
+do any of that yourself — you only proposed it.
+
+## Safety — the workspace is jailed
+
+- Stay **inside the station worktree**. Do not reach outside it.
+- **Destructive shell is blocked** — don't delete or move large trees, format
+  disks, or run anything irreversible.
+- Never `git push`, `git merge`, or apply to the user's branches. The gate is
+  the only exit.

--- a/tests/cloud/surface/test_belt_handler.py
+++ b/tests/cloud/surface/test_belt_handler.py
@@ -1,0 +1,111 @@
+# tests/cloud/surface/test_belt_handler.py — BELT surface handler + its
+# ripple-OFF, station-scoped SurfaceProfile.
+#
+# Created: 2026-06-10 (feat/belt-surface, BS-2 Belt & Pulley stations thin
+# slice) — Guards the /belt develop station:
+#   * the preamble orients to the station loop (not a dashboard), enforces
+#     ORIENT FIRST via loom, names the Instinct gate tool, and states the
+#     no-direct-apply / no-phantom-success rules;
+#   * the profile pins ripple_mode="off" (so it doesn't inherit the ripple
+#     "default to ui-spec" LAW), the exact coding SDK-tool allowlist, the `belt`
+#     skill, and an MCP allow-list that contains the 5 loom ids + the gate id;
+#   * the wire string "belt" resolves to SurfaceKind.BELT (not GENERIC).
+#
+# Mirrors test_studio_code_handlers.py. pytest-asyncio runs in auto mode (see
+# pyproject [tool.pytest] asyncio_mode), so async tests are detected
+# automatically — no module-level mark (it would wrongly tag the sync tests).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface import SurfaceKind, SurfaceMeta, resolve_profile
+from pocketpaw_ee.cloud.surface.handlers import belt as belt_handler
+
+WORKSPACE = "ws-surface-belt"
+USER = "u-belt"
+
+# The Instinct gate tool id the station proposes its diff through. Literal here
+# (and in service.py) until the sibling-branch constant lands.
+GATE_TOOL_ID = "mcp__pocketpaw_belt__belt_propose_change"
+
+
+# --- /belt handler ---
+
+
+async def test_belt_handler_carries_station_orientation() -> None:
+    """The preamble orients to the develop station — and must NOT frame the
+    deliverable as a dashboard or a pocket."""
+    preamble = await belt_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/belt"))
+
+    assert '<surface kind="belt" ' in preamble
+    lower = preamble.lower()
+    assert "belt" in lower
+    assert "station" in lower
+    # The change is proposed through a gate, not applied directly.
+    assert "gate" in lower
+    assert "diff" in lower
+    # Not a dashboard / pocket build.
+    assert "build a pocket" not in lower
+    assert "ui-spec" not in lower or "not" in lower
+
+
+async def test_belt_handler_enforces_orient_first() -> None:
+    """The procedure makes the agent ORIENT FIRST via loom before touching code."""
+    preamble = await belt_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/belt"))
+
+    lower = preamble.lower()
+    assert "orient" in lower
+    # Names the loom orient tool by id so the agent calls it, not just "look around".
+    assert "mcp__loom__orient" in preamble
+
+
+async def test_belt_handler_names_gate_tool_and_forbids_direct_apply() -> None:
+    """The procedure names the Instinct gate tool and forbids applying / pushing /
+    merging directly — every change leaves the station ONLY as a proposal."""
+    preamble = await belt_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/belt"))
+
+    # The gate tool the agent must propose through.
+    assert GATE_TOOL_ID in preamble
+    lower = preamble.lower()
+    # The no-direct-apply rule.
+    assert "never apply" in lower
+    assert "directly" in lower
+    # And no phantom successes when the gate is unavailable.
+    assert "phantom" in lower or "do not claim" in lower
+
+
+async def test_belt_handler_names_builtin_dev_tools() -> None:
+    """The develop stage names the built-in coding tools used in the worktree."""
+    preamble = await belt_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/belt"))
+
+    for tool in ("Bash", "Read", "Write", "Edit", "Glob", "Grep"):
+        assert tool in preamble, f"preamble should name the {tool} tool"
+
+
+# --- Profile (ripple-OFF, station-scoped) ---
+
+
+def test_belt_profile_ripple_off_sdk_allowlist_skill_and_mcp_scope() -> None:
+    """The /belt profile turns ripple OFF, restricts SDK tools to the coding
+    built-ins, surfaces the `belt` skill, and scopes MCP to the loom orientation
+    tools + the Instinct gate tool."""
+    from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
+
+    profile = resolve_profile(SurfaceKind.BELT, SurfaceMeta())
+
+    assert profile.ripple_mode == "off"
+    assert "belt" in profile.skill_names
+    assert profile.allowed_sdk_tools == frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
+    # MCP allow-list: the 5 loom orientation tools + the gate tool.
+    assert profile.allow_mcp_tool_ids is not None
+    assert len(LOOM_TOOL_IDS) == 5
+    for loom_id in LOOM_TOOL_IDS:
+        assert loom_id in profile.allow_mcp_tool_ids
+    assert GATE_TOOL_ID in profile.allow_mcp_tool_ids
+
+
+def test_belt_kind_maps_from_wire_string() -> None:
+    """The wire ``surface`` string 'belt' resolves to SurfaceKind.BELT (not the
+    GENERIC fallback)."""
+    from pocketpaw_ee.cloud.surface.service import _resolve_kind
+
+    assert _resolve_kind("belt") is SurfaceKind.BELT


### PR DESCRIPTION
Stacks on #1407 (the loom MCP wiring) — review and merge that first.

Adds the `/belt` surface: the develop station of the Belt & Pulley line. The agent on it takes a coding task, grounds itself with loom's `orient()` before reading any code, implements the change in a station worktree, then proposes the resulting diff through the Instinct gate for a human to review. It never applies to the user's branches directly, never pushes or merges, and never claims success unless the gate tool returned ok.

## What's here

- `SurfaceKind.BELT` in `domain.py`.
- A ripple-off `SurfaceProfile` in `service.py`: the coding SDK-tool allowlist (Bash/Read/Write/Edit/Glob/Grep), the `belt` skill, and an MCP allow-list built from the 5 loom orientation tools (`LOOM_TOOL_IDS`, imported from this branch's base) plus the gate tool. It loads through the existing try/except degraded path, so a failed import drops to no MCP restriction rather than breaking chat.
- `handlers/belt.py` — the preamble that enforces the station loop: orient first via loom, develop in the worktree, propose via the gate.
- A bundled `belt` skill carrying the same playbook in skill form, with a worked `belt_propose_change` example.
- Tests for the handler, the profile, and the `belt` wire-string mapping.

## Gate tool id

The Instinct gate tool (`mcp__pocketpaw_belt__belt_propose_change`) is built in a sibling branch (`agent/mcp_servers/belt.py`), so its constant isn't importable here yet. I used the literal id with a comment naming the sibling module; the import reconciles when both PRs land.

## Test evidence

`uv run pytest tests/cloud/surface/ -q`

```
................................................................         [100%]
64 passed in 0.91s
```

`uv run ruff check` on all touched files: `All checks passed!`