### PR TITLE
Belt code-change gate: propose a diff, approve it, get a PR (BS-3)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/belt.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/belt.py
@@ -1,0 +1,440 @@
+# belt.py — in-process MCP server exposing the Belt & Pulley develop-station
+# code-change gate to the claude_agent_sdk cloud chat backend. Created:
+# 2026-06-10 (feat/belt-gate, BS-3).
+#
+# What this file does: clones the media.py shape — a single
+# ``create_sdk_mcp_server`` with an SDK import-guard, ``SERVER_NAME`` /
+# ``*_TOOL_ID`` allowlist constants, ContextVar-sourced identity (the same
+# ``current_workspace_id`` / ``current_user_id`` / ``current_session_mongo_id``
+# accessors in ``ee.cloud.chat.agent_service`` the media / sites servers read),
+# and the ``_error_response`` / ``_success_response`` helpers. The single tool
+# id namespaces as ``mcp__pocketpaw_belt__belt_propose_change`` so the Claude
+# Code allowlist machinery matches it (a sibling PR hardcodes this exact id).
+#
+# One SDK @tool def:
+#   * belt_propose_change — the develop station agent produces a unified diff
+#     and proposes it THROUGH Instinct (the human approve/reject layer, "sudo
+#     for agents"). This tool does NOT apply anything: it validates the inputs
+#     (identity present; diff non-empty and under the size cap; repo resolves to
+#     an existing git repo INSIDE the settings-driven allowlist) and then files
+#     an Instinct Action carrying a ``_code_change`` blob. A human approves it
+#     in The Tray; the apply-on-approve executor (ee/cloud/belt/executor.py)
+#     then applies the diff in a FRESH worktree, commits, pushes, and opens a
+#     PR. The captain still merges on GitHub — Instinct is the MID gate, never
+#     an auto-merge.
+#
+# Contract pins (a sibling PR hardcodes these — do not deviate):
+#   * server name ``pocketpaw_belt``, tool ``belt_propose_change``
+#   * input {repo, base_branch, diff, summary, task, orient_ref?}
+#   * Action kind ``code_change`` (stored as the blob's ``kind`` discriminator
+#     under ``Action.parameters._code_change`` — the Action model has no literal
+#     ``kind`` column; the pocket-write bridge uses the same parameters-key
+#     discriminator pattern).
+#
+# Security: the diff is DATA — it is stored verbatim in the Action blob and only
+# ever written to a temp file + fed to ``git apply`` by the executor, never
+# echoed/eval'd. The repo path is allowlist-gated here at propose time AND
+# re-resolved at execute time (defense in depth). NO phantom successes: the tool
+# returns ok only after ``store.propose`` confirms the Action is durably stored.
+# Diff content is never logged — only action ids + changed-line counts.
+#
+# EE→OSS boundary: this module lives in pocketpaw_ee; the surface service loads
+# BELT_TOOL_IDS as a plain frozenset[str] inside a try/except (never importing a
+# pocketpaw_ee symbol into src/pocketpaw).
+"""Agent-side MCP surface for the Belt & Pulley code-change gate."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_belt"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form. A sibling PR hardcodes
+# ``mcp__pocketpaw_belt__belt_propose_change`` — keep it stable.
+PROPOSE_CHANGE_TOOL_ID = f"mcp__{SERVER_NAME}__belt_propose_change"
+
+BELT_TOOL_IDS = (PROPOSE_CHANGE_TOOL_ID,)
+
+# The Instinct Action kind discriminator for a Belt code-change proposal. The
+# executor + the router dispatch on the presence of this key under
+# ``Action.parameters``; the blob also carries ``kind="code_change"`` for
+# readers that introspect the blob directly.
+CODE_CHANGE_KIND = "code_change"
+# The parameters key under which the code-change blob rides — mirrors the
+# pocket-write bridge's ``_pocket_write`` key. The router + executor dispatch on
+# this key being present.
+CODE_CHANGE_PARAM_KEY = "_code_change"
+
+# Diff size cap. A proposal over EITHER bound is refused with a "split the task"
+# error — a diff this large is a sign the station task wasn't decomposed, and a
+# huge blob in Mongo + a sprawling PR defeats the human-review gate. Counts
+# ADDED/REMOVED lines (``+``/``-`` lines, excluding the ``+++``/``---`` file
+# headers), not context lines.
+MAX_CHANGED_LINES = 1500
+MAX_DIFF_BYTES = 200 * 1024  # 200 KB
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects. The agent
+    reads ``text`` and surfaces the reason."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None, str | None]:
+    """Resolve the active workspace + user + session id from the per-stream
+    ContextVars set by the cloud chat agent runtime. Returns
+    ``(workspace_id, user_id, session_mongo_id)``."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_session_mongo_id,
+            current_user_id,
+            current_workspace_id,
+        )
+
+        return current_workspace_id(), current_user_id(), current_session_mongo_id()
+    except Exception:  # noqa: BLE001
+        return None, None, None
+
+
+def _count_changed_lines(diff: str) -> int:
+    """Count added/removed lines in a unified diff.
+
+    A changed line starts with a single ``+`` or ``-`` but is NOT a file header
+    (``+++ ``/``--- ``). Context lines (leading space) and hunk headers (``@@``)
+    don't count. This is a heuristic line budget, not a parser — it only needs
+    to flag a task that should have been split.
+    """
+    count = 0
+    for line in diff.splitlines():
+        if line.startswith("+++ ") or line.startswith("--- "):
+            continue
+        if line.startswith("+") or line.startswith("-"):
+            count += 1
+    return count
+
+
+def _resolve_allowlist() -> list[Path]:
+    """Return the resolved allowlist roots a repo path must live under.
+
+    Settings-driven (``belt_repo_allowlist``). When empty, default to the
+    current working directory's PARENT — the workspace root that holds the
+    project checkouts — so a stock deployment still gates writes to the
+    workspace tree rather than the whole filesystem. Each root is resolved
+    (symlinks + ``..`` collapsed) so the containment check below can't be
+    defeated by a ``..`` traversal.
+    """
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    roots: list[Path] = []
+    for raw in settings.belt_repo_allowlist or []:
+        try:
+            roots.append(Path(raw).expanduser().resolve())
+        except (OSError, RuntimeError):
+            logger.warning("belt: skipping unresolvable allowlist root %r", raw)
+    if not roots:
+        # Default: the parent of cwd (the workspace root holding the checkouts).
+        roots.append(Path.cwd().resolve().parent)
+    return roots
+
+
+def _is_within_allowlist(repo_path: Path, roots: list[Path]) -> bool:
+    """True when ``repo_path`` is inside (or equal to) one of the allowlist
+    roots. ``repo_path`` MUST already be resolved by the caller."""
+    for root in roots:
+        try:
+            repo_path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _resolve_repo(repo: str) -> tuple[Path | None, str | None]:
+    """Resolve a proposal's ``repo`` field to an existing, allowlisted git repo.
+
+    ``repo`` is an absolute path or a registered name. (Registered-name
+    resolution is a follow-up — BS-3 ships the absolute-path form; a name that
+    isn't an existing path is refused with a clear error.) Returns
+    ``(resolved_path, None)`` on success or ``(None, error)`` on any refusal:
+    a non-existent path, a path that isn't a git repo, or a path outside the
+    allowlist. The allowlist check runs on the RESOLVED path so a ``..``
+    traversal can't escape the boundary.
+    """
+    if not repo or not isinstance(repo, str):
+        return None, "`repo` must be a non-empty absolute path (or registered name)."
+
+    try:
+        candidate = Path(repo).expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        return None, f"could not resolve repo path {repo!r}: {exc}"
+
+    roots = _resolve_allowlist()
+    # Allowlist FIRST — never leak whether an out-of-bounds path exists.
+    if not _is_within_allowlist(candidate, roots):
+        return None, (
+            f"repo path {repo!r} is outside the allowed roots "
+            f"({', '.join(str(r) for r in roots)}). Set "
+            "POCKETPAW_BELT_REPO_ALLOWLIST to authorize a new root."
+        )
+
+    if not candidate.is_dir():
+        return None, f"repo path {repo!r} does not exist or is not a directory."
+
+    if not (candidate / ".git").exists():
+        return None, f"repo path {repo!r} is not a git repository (no .git)."
+
+    return candidate, None
+
+
+async def _propose_change_handler(args: dict) -> dict:
+    """MCP handler for ``belt__belt_propose_change``.
+
+    Validates identity + inputs, then files an Instinct Action carrying the
+    ``_code_change`` blob. Returns ``{ok, action_id, tray_hint}`` on success,
+    or an ``is_error`` response with the reason. NO phantom successes: ok is
+    returned only after ``store.propose`` confirms the Action is stored.
+    """
+    workspace_id, user_id, session_mongo_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "belt_propose_change requires workspace and user context "
+            "(call from a cloud chat session)."
+        )
+
+    repo = args.get("repo")
+    base_branch = args.get("base_branch")
+    diff = args.get("diff")
+    summary = args.get("summary")
+    task = args.get("task")
+    orient_ref = args.get("orient_ref")
+
+    if not isinstance(base_branch, str) or not base_branch.strip():
+        return _error_response("belt_propose_change requires a non-empty `base_branch`.")
+    if not isinstance(summary, str) or not summary.strip():
+        return _error_response(
+            "belt_propose_change requires a non-empty `summary` (used as the commit body)."
+        )
+    if not isinstance(task, str) or not task.strip():
+        return _error_response(
+            "belt_propose_change requires the original `task` text the station was given."
+        )
+
+    # The diff is the payload — validate it hard before anything touches a store.
+    if not isinstance(diff, str) or not diff.strip():
+        return _error_response("belt_propose_change requires a non-empty unified `diff`.")
+
+    diff_bytes = len(diff.encode("utf-8"))
+    changed_lines = _count_changed_lines(diff)
+    if changed_lines > MAX_CHANGED_LINES or diff_bytes > MAX_DIFF_BYTES:
+        return _error_response(
+            f"diff too large to gate ({changed_lines} changed lines, "
+            f"{diff_bytes} bytes; cap is {MAX_CHANGED_LINES} lines / "
+            f"{MAX_DIFF_BYTES} bytes). Split the task into smaller, "
+            "independently reviewable changes and propose each separately."
+        )
+
+    repo_path, repo_err = _resolve_repo(repo if isinstance(repo, str) else "")
+    if repo_err is not None or repo_path is None:
+        return _error_response(repo_err or "could not resolve the repo path.")
+
+    orient_clean = (
+        orient_ref.strip() if isinstance(orient_ref, str) and orient_ref.strip() else None
+    )
+
+    # Build the code-change blob. ``kind`` is the discriminator the executor /
+    # router dispatch on (the Action model has no literal kind column). The diff
+    # rides verbatim — it is DATA, never interpolated into a shell.
+    blob: dict[str, Any] = {
+        "kind": CODE_CHANGE_KIND,
+        "schema": 1,
+        "repo": str(repo_path),
+        "base_branch": base_branch.strip(),
+        "diff": diff,
+        "summary": summary.strip(),
+        "task": task.strip(),
+        "orient_ref": orient_clean,
+        "workspace_id": workspace_id,
+        "requested_by": user_id,
+        # The proposing chat session — lets the executor / audit tie the PR back
+        # to the conversation that produced it.
+        "session_id": session_mongo_id,
+    }
+
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    # A short, content-free title/recommendation for The Tray. NEVER put diff
+    # content in the title — only the summary (the agent's own 1-3 sentence
+    # description) and the repo/branch.
+    repo_name = repo_path.name
+    title = f"Code change — {repo_name} ({base_branch.strip()})"
+    recommendation = (
+        f"Approve to apply this diff to {repo_name} on a new branch off "
+        f"{base_branch.strip()} and open a PR. {changed_lines} changed lines. "
+        f"Summary: {summary.strip()}"
+    )
+
+    trigger = ActionTrigger(
+        type="agent",
+        source="belt:develop",
+        reason="code change proposed by the develop station — requires human approval",
+    )
+
+    store = get_instinct_store()
+    try:
+        action = await store.propose(
+            # ``pocket_id`` carries the workspace for Belt actions — they aren't
+            # bound to a pocket the way Mission Control items are. The workspace
+            # also rides on the blob (the executor's tenancy gate reads it
+            # there); pocket_id mirrors it so the existing per-pocket queries
+            # still surface the row.
+            pocket_id=workspace_id,
+            title=title,
+            description=recommendation,
+            recommendation=recommendation,
+            trigger=trigger,
+            category=ActionCategory.EXTERNAL,
+            priority=ActionPriority.HIGH,
+            parameters={CODE_CHANGE_PARAM_KEY: blob},
+            assignee=user_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("belt: propose raised (no Action stored)", exc_info=True)
+        return _error_response(f"could not propose the change: {exc}")
+
+    # Confirm the Action is durably readable before claiming success — NO
+    # phantom success. ``propose`` returns the in-memory Action; a fetch proves
+    # the INSERT committed.
+    stored = await store.get_action(action.id)
+    if stored is None:
+        return _error_response("the change was not stored — please retry.")
+
+    logger.info(
+        "belt: proposed code_change action %s (repo=%s, base=%s, changed_lines=%d)",
+        action.id,
+        repo_name,
+        base_branch.strip(),
+        changed_lines,
+    )
+
+    return _success_response(
+        {
+            "ok": True,
+            "action_id": action.id,
+            "tray_hint": (
+                "Proposed for approval in The Tray. A human must approve before "
+                "the diff is applied and a PR is opened. Do not claim the change "
+                "is merged — Instinct is the mid gate; the captain merges on "
+                "GitHub."
+            ),
+        }
+    )
+
+
+def build_belt_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for the Belt code-change gate, or
+    return ``None`` if the Claude Agent SDK isn't installed.
+
+    Matches the shape returned by ``build_media_server`` (``(name, server)`` or
+    ``None``) so the backend's MCP registration loop treats it identically.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_belt MCP disabled")
+        return None
+
+    @tool(
+        "belt_propose_change",
+        (
+            "Propose a CODE CHANGE for human approval (the Belt & Pulley develop "
+            "station). Call this when you have produced a unified diff that should "
+            "be applied to a repo. This does NOT apply the diff or merge anything: "
+            "it files the change in The Tray for a human to approve or reject. On "
+            "approval, the change is applied to a fresh branch and a PR is opened "
+            "— the captain merges on GitHub. Args: `repo` (absolute path or "
+            "registered name of the git repo), `base_branch` (the branch to base "
+            "off, e.g. 'main'), `diff` (the full unified diff), `summary` (1-3 "
+            "sentences describing the change — used as the commit message body), "
+            "`task` (the original station task text), `orient_ref` (optional brief "
+            "reference to the orientation you used). Returns {ok, action_id, "
+            "tray_hint}. ok=false with an error means relay the reason (e.g. the "
+            "diff is too large — split the task) — do NOT claim the change landed."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Absolute path (or registered name) of the target git repo.",
+                },
+                "base_branch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Branch to base the change off (e.g. 'main').",
+                },
+                "diff": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The full unified diff to apply.",
+                },
+                "summary": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "1-3 sentence description; used as the commit message body.",
+                },
+                "task": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The original station task text.",
+                },
+                "orient_ref": {
+                    "type": "string",
+                    "description": "Optional brief reference to the orientation used.",
+                },
+            },
+            "required": ["repo", "base_branch", "diff", "summary", "task"],
+            "additionalProperties": False,
+        },
+    )
+    async def belt_propose_change(args):  # type: ignore[no-untyped-def]
+        return await _propose_change_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[belt_propose_change],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "BELT_TOOL_IDS",
+    "CODE_CHANGE_KIND",
+    "CODE_CHANGE_PARAM_KEY",
+    "PROPOSE_CHANGE_TOOL_ID",
+    "SERVER_NAME",
+    "build_belt_server",
+]

--- a/ee/pocketpaw_ee/cloud/belt/__init__.py
+++ b/ee/pocketpaw_ee/cloud/belt/__init__.py
@@ -1,0 +1,7 @@
+# ee/pocketpaw_ee/cloud/belt/__init__.py — the Belt & Pulley cloud package.
+# Created: 2026-06-10 (feat/belt-gate, BS-3).
+#
+# Home of the apply-on-approve executor (``executor.py``) for the Belt develop
+# station's code-change gate. A code-change Instinct Action proposed by the
+# ``pocketpaw_belt`` MCP server is applied here — in a fresh worktree — after a
+# human approves it, mirroring the pocket-write bridge's propose/execute split.

--- a/ee/pocketpaw_ee/cloud/belt/executor.py
+++ b/ee/pocketpaw_ee/cloud/belt/executor.py
@@ -1,0 +1,439 @@
+# executor.py — applies an approved Belt code-change Action and opens a PR.
+# Created: 2026-06-10 (feat/belt-gate, BS-3).
+#
+# What this module does (the apply-on-approve half of the Belt code-change
+# gate): the ``pocketpaw_belt`` MCP server proposes a unified diff THROUGH
+# Instinct (the human approve/reject layer). After a human approves the Action,
+# the ee instinct router's ``approve_action`` fires ``execute_approved_change``
+# here — exactly mirroring how ``instinct_bridge.execute_approved_write`` is
+# fired for a parked pocket write. This function:
+#
+#   1. Reads the ``_code_change`` blob from ``action.parameters``. A missing or
+#      schema-mismatched blob → mark_failed, return.
+#   2. RE-resolves the repo path against the allowlist (defense in depth — the
+#      allowlist may have tightened between propose and approve).
+#   3. Creates a FRESH git worktree (one per action id, under a tmp dir; NEVER
+#      the repo's live checkout) at ``origin/<base_branch>`` after a fetch.
+#   4. ``git apply --3way`` the diff (written to a temp FILE — never echoed/
+#      interpolated into a shell).
+#   5. Branches ``feat/belt-<action-id-short>``, commits (Conventional Commits;
+#      the agent's summary as the body; NO AI attribution), pushes.
+#   6. Opens a PR via an injectable opener (default shells ``gh pr create``;
+#      tests inject a fake).
+#   7. ``mark_executed`` with outcome ``{pr_url, branch, files_changed}``.
+#   8. ALWAYS removes the worktree — on success or any failure. On apply
+#      conflict / any error → ``mark_failed`` with a clear outcome (the agent /
+#      user can re-propose); never leave half-state.
+#
+# Security (this code moves diffs into git + runs subprocesses):
+#   * subprocess arg LISTS only — never ``shell=True``, never string-interpolate
+#     user input into a command. Repo path, branch, diff path are all argv
+#     elements.
+#   * the diff is DATA — written to a temp file and fed to ``git apply <file>``;
+#     never echoed, eval'd, or passed on a command line.
+#   * the repo path is re-resolved INSIDE the allowlist; a path that escaped the
+#     boundary (or the boundary tightened) is refused, not applied.
+#   * NO secrets in logs — only action ids, branch names, and file counts. Diff
+#     content is never logged.
+#   * destructive ops are confined to a throwaway worktree dir that is removed
+#     in a finally block; the live checkout is never touched.
+#
+# Why a separate module (not in pockets/): the Belt code-change path is its own
+# subsystem — it doesn't touch backend credentials or the pockets service. It
+# mirrors instinct_bridge's propose/execute SHAPE without sharing its plumbing.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Schema version stamped on the ``_code_change`` blob. Bump when the blob shape
+# changes so a stale pending Action approved after a deploy fails loud instead
+# of applying a misinterpreted diff (same discipline as the pocket-write
+# bridge's ``_POCKET_WRITE_SCHEMA``).
+_CODE_CHANGE_SCHEMA = 1
+
+# The parameters key the blob rides under — kept in sync with the MCP server's
+# ``CODE_CHANGE_PARAM_KEY``. Duplicated as a literal here so the executor has no
+# import dependency on the agent-side MCP module.
+_CODE_CHANGE_PARAM_KEY = "_code_change"
+
+# Subprocess timeout for any single git / gh call (seconds). A hung remote
+# operation must not wedge the approve path forever.
+_SUBPROCESS_TIMEOUT = 120.0
+
+
+class PrOpener(Protocol):
+    """Injectable PR-opening interface.
+
+    The default implementation shells ``gh pr create``; tests inject a fake to
+    assert the call args without touching GitHub. Returns the PR URL (or a
+    best-effort placeholder string if ``gh`` printed nothing parseable)."""
+
+    async def open_pr(
+        self,
+        *,
+        repo_path: Path,
+        branch: str,
+        base_branch: str,
+        title: str,
+        body: str,
+    ) -> str: ...
+
+
+class GhCliPrOpener:
+    """Default ``PrOpener`` — shells ``gh pr create`` from the worktree.
+
+    ``gh`` reads the repo's remote + the authenticated user's token from the
+    environment; no secret is passed on the command line. The title/body are
+    argv elements (never interpolated into a shell string)."""
+
+    async def open_pr(
+        self,
+        *,
+        repo_path: Path,
+        branch: str,
+        base_branch: str,
+        title: str,
+        body: str,
+    ) -> str:
+        code, out, err = await _run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--base",
+                base_branch,
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            cwd=repo_path,
+        )
+        if code != 0:
+            raise RuntimeError(f"gh pr create failed (exit {code}): {err.strip() or out.strip()}")
+        # `gh pr create` prints the PR URL on stdout. Take the last non-empty
+        # line that looks like a URL.
+        for line in reversed(out.splitlines()):
+            line = line.strip()
+            if line.startswith("http"):
+                return line
+        return out.strip() or "<pr-created>"
+
+
+async def _run(
+    argv: list[str], *, cwd: Path | None = None, stdin: bytes | None = None
+) -> tuple[int, str, str]:
+    """Run a subprocess from an ARG LIST (never a shell), bounded by a timeout.
+
+    Returns ``(returncode, stdout, stderr)``. NEVER uses ``shell=True`` and
+    never interpolates user input into a command string — every element of
+    ``argv`` is passed literally. This is the single subprocess chokepoint for
+    the executor."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        cwd=str(cwd) if cwd else None,
+        stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out_b, err_b = await asyncio.wait_for(
+            proc.communicate(input=stdin), timeout=_SUBPROCESS_TIMEOUT
+        )
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        sub = argv[1] if len(argv) > 1 else ""
+        raise RuntimeError(
+            f"command timed out after {_SUBPROCESS_TIMEOUT}s: {argv[0]} {sub}"
+        ) from None
+    return (
+        proc.returncode or 0,
+        out_b.decode("utf-8", "replace"),
+        err_b.decode("utf-8", "replace"),
+    )
+
+
+def _re_resolve_repo(repo: str) -> tuple[Path | None, str | None]:
+    """Re-resolve + re-allowlist the repo path at EXECUTE time (defense in
+    depth). Reuses the MCP server's resolver so propose and execute share one
+    boundary definition. Returns ``(path, None)`` or ``(None, error)``."""
+    try:
+        from pocketpaw_ee.agent.mcp_servers.belt import _resolve_repo
+    except Exception:  # noqa: BLE001 — agent module shouldn't fail to import, but be defensive
+        # Fall back to a minimal inline check if the agent module is absent.
+        candidate = Path(repo).expanduser().resolve()
+        if not candidate.is_dir() or not (candidate / ".git").exists():
+            return None, f"repo path {repo!r} is not a git repository"
+        return candidate, None
+    return _resolve_repo(repo)
+
+
+def _short_id(action_id: str) -> str:
+    """A short, branch-safe slug from an action id (drop any ``act-`` prefix,
+    keep the last 12 hex chars)."""
+    raw = action_id.split("-", 1)[-1] if "-" in action_id else action_id
+    safe = "".join(ch for ch in raw if ch.isalnum())
+    return safe[-12:] or "change"
+
+
+async def execute_approved_change(
+    action: Any,
+    *,
+    pr_opener: PrOpener | None = None,
+) -> None:
+    """Apply the code change carried by a freshly-approved Instinct Action.
+
+    Called best-effort from the instinct router's ``approve_action`` after
+    ``store.approve()`` succeeds — the same hook shape the pocket-write bridge
+    uses. ``action`` is the approved Action. ``pr_opener`` lets tests inject a
+    fake; production passes ``None`` and gets the ``gh pr create`` opener.
+
+    Never raises — a failure here must not break the approve response. The
+    router wraps the call too; this is belt-and-braces. The worktree is ALWAYS
+    cleaned up (success or failure); the Action is marked executed on success
+    or failed with a clear outcome on any error.
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    opener: PrOpener = pr_opener or GhCliPrOpener()
+
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(_CODE_CHANGE_PARAM_KEY)
+    if not isinstance(blob, dict):
+        logger.warning("approved action %s carries no _code_change blob", action.id)
+        return
+    if blob.get("schema") != _CODE_CHANGE_SCHEMA:
+        await store.mark_failed(
+            action.id,
+            "code-change schema mismatch — the change blob is from an "
+            "incompatible build and cannot be applied",
+        )
+        return
+
+    repo = str(blob.get("repo") or "")
+    base_branch = str(blob.get("base_branch") or "")
+    diff = blob.get("diff")
+    summary = str(blob.get("summary") or "")
+    task = str(blob.get("task") or "")
+
+    if not base_branch or not isinstance(diff, str) or not diff.strip():
+        await store.mark_failed(action.id, "code-change blob is missing base_branch or diff")
+        return
+
+    # Defense in depth — re-resolve + re-allowlist the repo at execute time.
+    repo_path, repo_err = _re_resolve_repo(repo)
+    if repo_err is not None or repo_path is None:
+        await store.mark_failed(action.id, f"repo no longer valid at approval time: {repo_err}")
+        return
+
+    branch = f"feat/belt-{_short_id(str(action.id))}"
+
+    # One throwaway worktree dir per action id, under a tmp/belt-actions root.
+    # NEVER the repo's live checkout. Cleaned up in the finally block below.
+    tmp_root = Path(tempfile.gettempdir()) / "belt-actions"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+    worktree_dir = tmp_root / f"act-{_short_id(str(action.id))}"
+    diff_file: Path | None = None
+    worktree_created = False
+
+    try:
+        # 1. Fetch the latest base so we branch off the freshest origin tip.
+        code, _out, err = await _run(["git", "fetch", "origin", base_branch], cwd=repo_path)
+        if code != 0:
+            await store.mark_failed(
+                action.id, f"git fetch origin {base_branch} failed: {err.strip()[:300]}"
+            )
+            return
+
+        # 2. Fresh worktree at origin/<base_branch>. If the dir somehow exists
+        #    from a prior crash, remove it first so add doesn't refuse.
+        if worktree_dir.exists():
+            await _force_remove_worktree(repo_path, worktree_dir)
+        code, _out, err = await _run(
+            ["git", "worktree", "add", str(worktree_dir), f"origin/{base_branch}"],
+            cwd=repo_path,
+        )
+        if code != 0:
+            await store.mark_failed(
+                action.id, f"git worktree add failed: {err.strip()[:300]}"
+            )
+            return
+        worktree_created = True
+
+        # 3. Branch off the detached worktree head.
+        code, _out, err = await _run(["git", "checkout", "-b", branch], cwd=worktree_dir)
+        if code != 0:
+            await store.mark_failed(
+                action.id, f"git checkout -b {branch} failed: {err.strip()[:300]}"
+            )
+            return
+
+        # 4. Write the diff to a temp FILE and apply it — the diff is DATA, it
+        #    never touches a command line beyond the file path argument.
+        fd_path = worktree_dir / ".belt-change.diff"
+        fd_path.write_text(diff, encoding="utf-8")
+        diff_file = fd_path
+        code, _out, err = await _run(
+            ["git", "apply", "--3way", "--whitespace=nowarn", str(fd_path)], cwd=worktree_dir
+        )
+        # Remove the diff file before committing so it never lands in the PR.
+        with _suppress():
+            fd_path.unlink()
+            diff_file = None
+        if code != 0:
+            await store.mark_failed(
+                action.id,
+                "diff did not apply cleanly (conflict or stale base) — "
+                f"re-propose against the current {base_branch}. git apply: {err.strip()[:300]}",
+            )
+            return
+
+        # 5. Stage everything the diff touched, capture the changed-file list,
+        #    then commit. Conventional Commits; the agent's summary as the body;
+        #    NO AI attribution.
+        code, _out, err = await _run(["git", "add", "-A"], cwd=worktree_dir)
+        if code != 0:
+            await store.mark_failed(action.id, f"git add failed: {err.strip()[:300]}")
+            return
+
+        files_changed = await _changed_files(worktree_dir)
+        if not files_changed:
+            await store.mark_failed(
+                action.id, "diff produced no staged changes — nothing to commit"
+            )
+            return
+
+        commit_title = _commit_title(task, summary)
+        commit_body = summary or task
+        code, _out, err = await _run(
+            ["git", "commit", "-m", commit_title, "-m", commit_body], cwd=worktree_dir
+        )
+        if code != 0:
+            await store.mark_failed(action.id, f"git commit failed: {err.strip()[:300]}")
+            return
+
+        # 6. Push the branch.
+        code, _out, err = await _run(
+            ["git", "push", "-u", "origin", branch], cwd=worktree_dir
+        )
+        if code != 0:
+            await store.mark_failed(action.id, f"git push failed: {err.strip()[:300]}")
+            return
+
+        # 7. Open the PR via the injectable opener.
+        try:
+            pr_url = await opener.open_pr(
+                repo_path=worktree_dir,
+                branch=branch,
+                base_branch=base_branch,
+                title=commit_title,
+                body=commit_body,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("belt: PR open failed for action %s", action.id, exc_info=True)
+            # The branch is pushed but no PR — record the partial so a human can
+            # open the PR by hand. This is NOT a clean success.
+            await store.mark_failed(
+                action.id,
+                f"branch '{branch}' pushed but PR open failed: {exc}. "
+                "Open the PR manually or re-propose.",
+            )
+            return
+
+        # 8. Mark executed with the structured outcome.
+        await store.mark_executed(
+            action.id,
+            f"PR opened: {pr_url} (branch '{branch}', {len(files_changed)} file(s) changed)",
+        )
+        logger.info(
+            "belt: applied code_change action %s → branch %s, %d file(s), PR %s",
+            action.id,
+            branch,
+            len(files_changed),
+            pr_url,
+        )
+    except Exception:  # noqa: BLE001 — never let an executor crash break approve
+        logger.warning(
+            "belt: code_change execution crashed for action %s", action.id, exc_info=True
+        )
+        with _suppress():
+            await store.mark_failed(action.id, "code-change executor crashed — re-propose")
+    finally:
+        # ALWAYS clean up — leave no half-state. Remove the temp diff file (if
+        # the apply path bailed before unlinking it) and the worktree.
+        if diff_file is not None:
+            with _suppress():
+                diff_file.unlink()
+        if worktree_created or worktree_dir.exists():
+            await _force_remove_worktree(repo_path, worktree_dir)
+
+
+async def _changed_files(worktree_dir: Path) -> list[str]:
+    """Return the staged file paths in the worktree (``git diff --cached
+    --name-only``). Empty list on any error — the caller treats empty as
+    'nothing to commit'."""
+    code, out, _err = await _run(
+        ["git", "diff", "--cached", "--name-only"], cwd=worktree_dir
+    )
+    if code != 0:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+async def _force_remove_worktree(repo_path: Path, worktree_dir: Path) -> None:
+    """Remove a worktree and prune the registration — best-effort, never
+    raises. Falls back to an ``rmtree`` if ``git worktree remove`` refuses."""
+    with _suppress():
+        await _run(
+            ["git", "worktree", "remove", "--force", str(worktree_dir)], cwd=repo_path
+        )
+    with _suppress():
+        await _run(["git", "worktree", "prune"], cwd=repo_path)
+    # If git left the directory behind (e.g. the add half-failed), nuke it.
+    if worktree_dir.exists():
+        with _suppress():
+            shutil.rmtree(worktree_dir, ignore_errors=True)
+
+
+def _commit_title(task: str, summary: str) -> str:
+    """Build a Conventional-Commits title from the task / summary.
+
+    Keeps it under ~72 chars and prefixes ``feat(belt):`` so the commit reads as
+    a Belt-applied change. The first sentence of the summary (falling back to
+    the task) becomes the subject. NO AI attribution anywhere."""
+    source = (summary or task or "apply code change").strip()
+    # First sentence / first line only.
+    first = source.replace("\n", " ").split(". ", 1)[0].strip().rstrip(".")
+    subject = first[:60].strip() or "apply code change"
+    return f"feat(belt): {subject}"
+
+
+class _suppress:
+    """Tiny context manager that swallows any exception — for best-effort
+    cleanup / mark_failed in the crash + finally paths where a second failure
+    must never mask the first."""
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return True
+
+
+__all__ = [
+    "GhCliPrOpener",
+    "PrOpener",
+    "execute_approved_change",
+]

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -40,6 +40,14 @@ the registration loop passes it through untouched. Ambient (not opt-in); the
 /belt surface scopes access via its profile allowlist. Returns None — and the
 loop skips it — when ``loom_model_path`` is unset or the binary is missing,
 so chat never breaks.
+
+Updated: 2026-06-10 (feat/belt-gate, BS-3) — added ``CloudBeltMcpProvider``
+(``pocketpaw.mcp_servers`` entry ``belt``) exposing the Belt & Pulley
+code-change gate in-process server (``pocketpaw_belt``; one tool
+``belt_propose_change``) to the claude_agent_sdk cloud chat backend, mirroring
+``CloudMediaMcpProvider``. The develop station proposes a diff through Instinct;
+the ee instinct router fires ``ee.cloud.belt.executor.execute_approved_change``
+on approval. Ambient (not opt-in).
 """
 
 from __future__ import annotations
@@ -650,6 +658,38 @@ class CloudLoomMcpProvider:
         from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
 
         return list(LOOM_TOOL_IDS)
+
+
+class CloudBeltMcpProvider:
+    """`pocketpaw.mcp_servers` — the Belt & Pulley code-change gate in-process
+    server (``pocketpaw_belt``). Hosts ``belt_propose_change`` only.
+
+    The develop station agent on the /belt surface produces a unified diff and
+    proposes it THROUGH Instinct (the human approve/reject layer) via this tool.
+    On approval the ee instinct router fires
+    ``ee.cloud.belt.executor.execute_approved_change`` to apply the diff in a
+    fresh worktree and open a PR — the captain still merges on GitHub.
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — the /belt surface scopes access
+    via its profile allowlist, the same regime the sibling loom / media / sites
+    servers use. ``build_belt_server`` returns None — and the loop skips it —
+    when the claude_agent_sdk isn't installed, so chat never breaks.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.belt import build_belt_server
+
+            return build_belt_server()
+        except ImportError:
+            # claude_agent_sdk not installed — the belt server is unavailable,
+            # same as the other in-process servers.
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.belt import BELT_TOOL_IDS
+
+        return list(BELT_TOOL_IDS)
 
 
 class CloudAgentExtension:

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -88,6 +88,21 @@
 #     the per-item chain emits. No semantic change to the bulk-reject
 #     response shape (``BulkActionResponse`` with shared ``bulk_id``).
 #
+# Updated: 2026-06-10 (feat/belt-gate, BS-3 — Belt code-change dispatch) —
+#   ``approve_action`` / ``bulk_approve_actions`` now ALSO dispatch a Belt
+#   develop-station code change. When the approved Action carries a
+#   ``_code_change`` blob (the ``pocketpaw_belt`` MCP server stores it under
+#   ``Action.parameters._code_change``), the route lazy-imports
+#   ``ee.cloud.belt.executor`` and calls ``execute_approved_change`` — same
+#   best-effort / lazy-import / never-break-the-response shape as the
+#   pocket-write hook, keyed on a distinct parameters key so the two paths never
+#   cross. ``_assert_code_change_workspace`` (the code-change peer of
+#   ``_assert_pocket_write_workspace``) binds the Action to the approver's
+#   workspace on approve / reject / bulk paths. The executor applies the diff in
+#   a fresh worktree, commits, pushes, and opens a PR — it NEVER merges (the
+#   captain merges on GitHub; Instinct is the mid gate). The reject path needs
+#   no code-change-specific handling: ``store.reject`` round-trips any kind.
+#
 # Updated: 2026-05-26 (RFC 09 Slice 4 — approve-side policy.evaluated emit) —
 #   * Captain Decision 12 (chain symmetry) follow-up — ``approve_action``
 #     and ``bulk_approve_actions`` now emit a second
@@ -158,6 +173,46 @@ def _pocket_write_blob(action: Any) -> dict[str, Any] | None:
         return None
     blob = params.get("_pocket_write")
     return blob if isinstance(blob, dict) else None
+
+
+def _code_change_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_code_change`` blob on an Action, or ``None``.
+
+    The blob is the Belt develop-station payload the ``pocketpaw_belt`` MCP
+    server stores under ``Action.parameters._code_change`` (repo / base_branch /
+    diff / summary / task + the originating ``workspace_id``). This is the
+    code-change peer of ``_pocket_write_blob`` — the approve path dispatches the
+    apply-on-approve executor on its presence, exactly as it dispatches the
+    pocket-write bridge on ``_pocket_write``. Anything that is not a dict is
+    treated as "no code change".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_code_change")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_code_change_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving a Belt code change from another workspace.
+
+    Mirror of ``_assert_pocket_write_workspace`` for the ``_code_change`` blob.
+    ``require_action_any_workspace("instinct.approve")`` only proves the caller
+    holds the role SOMEWHERE; this binds the code-change Action to the caller's
+    active workspace. A code change carries no pocket the way a parked write
+    does, so its tenancy lives entirely on the blob's ``workspace_id``. A blob
+    whose ``workspace_id`` differs from the caller's active workspace → 403.
+    A non-code-change Action (no blob) is unaffected.
+    """
+    blob = _code_change_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This code change belongs to a different workspace",
+        )
 
 
 def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
@@ -692,6 +747,7 @@ async def bulk_approve_actions(
         action = await store.get_action(action_id)
         if action is not None:
             _assert_pocket_write_workspace(action, workspace_id)
+            _assert_code_change_workspace(action, workspace_id)
 
     approved, missing, bulk_id = await store.bulk_approve(
         list(req.ids), approver=approver_id, note=req.note
@@ -709,6 +765,23 @@ async def bulk_approve_actions(
     # the bulk bar). The bridge owns the chain close on the approve
     # path so we do NOT emit ``decision.completed`` here.
     for action in approved:
+        # BS-3 — a Belt ``_code_change`` Action fires the apply-on-approve
+        # executor. It carries no parked-write chain (no correlation_id), so
+        # the Decision-Graph emits below are skipped for it; only the executor
+        # runs. Same best-effort shape as the pocket-write hook.
+        code_change_blob = _code_change_blob(action)
+        if code_change_blob is not None:
+            try:
+                from pocketpaw_ee.cloud.belt import executor as belt_executor
+
+                await belt_executor.execute_approved_change(action)
+            except Exception:
+                logger.exception(
+                    "bulk-approve belt code-change execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
         action_blob = _pocket_write_blob(action)
         if action_blob is None:
             continue
@@ -783,6 +856,7 @@ async def bulk_reject_actions(
         action = await store.get_action(action_id)
         if action is not None:
             _assert_pocket_write_workspace(action, workspace_id)
+            _assert_code_change_workspace(action, workspace_id)
 
     rejected, missing, bulk_id = await store.bulk_reject(
         list(req.ids), reason=req.reason, rejector=rejector_id
@@ -849,6 +923,9 @@ async def approve_action(
     # caller holds ``instinct.approve`` somewhere; this binds the Action
     # to the caller's workspace.
     _assert_pocket_write_workspace(before, workspace_id)
+    # Same tenancy gate for a Belt code-change Action (BS-3) — its
+    # ``_code_change`` blob carries the workspace, not a pocket.
+    _assert_code_change_workspace(before, workspace_id)
 
     req = req or ApproveRequest()
     # SHOULD-FIX 1 — the audit actor is the authenticated identity, not
@@ -925,6 +1002,21 @@ async def approve_action(
         except Exception:
             logger.exception("pocket-write execution after approval failed (non-fatal)")
 
+    # BS-3 — when the approved Action carries a Belt ``_code_change`` blob,
+    # apply the diff in a fresh worktree and open a PR. Same best-effort,
+    # lazy-import, never-break-the-approve-response shape as the pocket-write
+    # hook above; the executor records success / failure on the Action itself.
+    # A non-code-change Action skips this. The captain still merges on GitHub —
+    # this opens the PR, it does NOT merge.
+    code_change_blob = _code_change_blob(approved)
+    if code_change_blob is not None:
+        try:
+            from pocketpaw_ee.cloud.belt import executor as belt_executor
+
+            await belt_executor.execute_approved_change(approved)
+        except Exception:
+            logger.exception("belt code-change execution after approval failed (non-fatal)")
+
     return ApproveResponse(action=approved, correction=correction)
 
 
@@ -984,6 +1076,7 @@ async def reject_action(
 
     # Touch-time security fix — same gate the approve path runs.
     _assert_pocket_write_workspace(before, workspace_id)
+    _assert_code_change_workspace(before, workspace_id)
 
     reason = req.reason if req else ""
     rejector_id = str(user.id)

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -177,6 +177,7 @@ meetings = "pocketpaw_ee.extensions:CloudMeetingsMcpProvider"
 sites = "pocketpaw_ee.extensions:CloudSitesMcpProvider"
 media = "pocketpaw_ee.extensions:CloudMediaMcpProvider"
 loom = "pocketpaw_ee.extensions:CloudLoomMcpProvider"
+belt = "pocketpaw_ee.extensions:CloudBeltMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]
 cloud = "pocketpaw_ee.extensions:CloudAgentExtension"

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,10 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-10: Added ``belt_repo_allowlist`` — the security boundary for the
+    Belt & Pulley code-change gate (BS-3). A ``belt_propose_change`` proposal's
+    repo path must resolve inside one of these roots; empty defaults to the
+    cwd's parent. Env: POCKETPAW_BELT_REPO_ALLOWLIST (JSON list).
   - 2026-06-10: Added ``loom_bin`` + ``loom_model_path`` — the codebase
     orientation (loom) MCP server settings. ``loom_model_path`` defaults
     to None, which disables the loom MCP server; set it to a built
@@ -844,6 +848,24 @@ class Settings(BaseSettings):
             "Path to a loom world-model JSON (built via `loom build`). When "
             "unset, the loom MCP server is not registered — orientation is "
             "disabled. The binary is served as `loom mcp -model <this path>`."
+        ),
+    )
+
+    # Belt & Pulley — the develop station's code-change gate. The
+    # ``belt_propose_change`` MCP tool proposes a unified diff through Instinct
+    # (the human approve/reject layer); on approval the executor applies it in a
+    # fresh worktree and opens a PR. ``belt_repo_allowlist`` is the security
+    # boundary: a proposed ``repo`` path must resolve INSIDE one of these roots,
+    # so the agent can never move a diff into an arbitrary filesystem location.
+    # When empty, the allowlist defaults to the current working directory's
+    # parent (the workspace root that holds the project checkouts). Env auto-
+    # derives POCKETPAW_BELT_REPO_ALLOWLIST (JSON list).
+    belt_repo_allowlist: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Allowlisted root directories a Belt code-change proposal's repo "
+            "must live under. A repo path resolving outside every root is "
+            "refused. Empty → defaults to the cwd's parent (the workspace root)."
         ),
     )
 

--- a/tests/cloud/test_belt_gate.py
+++ b/tests/cloud/test_belt_gate.py
@@ -1,0 +1,508 @@
+# tests/cloud/test_belt_gate.py — Belt & Pulley code-change gate (BS-3).
+#
+# Created: 2026-06-10 (feat/belt-gate, Belt & Pulley stations thin slice).
+#
+# What this pins — the WHOLE gate, driven through the REAL path with a local
+# git fixture (a bare repo as origin + a seeded working clone):
+#   * belt_propose_change (the real MCP handler) validates identity + inputs,
+#     files an Instinct Action carrying the ``_code_change`` blob, and returns
+#     {ok, action_id, tray_hint} — only after the store confirms the Action.
+#   * the apply-on-approve executor, on a REAL git repo: fresh worktree off
+#     origin/<base>, git apply --3way, branch feat/belt-<id>, Conventional-
+#     Commits commit (summary as body, NO AI attribution), push, PR via an
+#     INJECTED fake opener, mark_executed with {pr_url, branch, files_changed}.
+#     The branch + commit land in the BARE origin; the worktree is removed.
+#   * two actions run back-to-back with no cross-contamination (distinct
+#     branches, distinct PRs, distinct outcomes).
+#   * reject round-trips for a code_change Action (status REJECTED, recorded
+#     reason, NO worktree, NO PR).
+#   * apply conflict (doctored diff against a mutated base) → action FAILED,
+#     worktree cleaned, no branch pushed.
+#   * size-cap rejection (over the changed-line / byte budget).
+#   * identity-missing error (no workspace/user ContextVars).
+#   * repo-outside-allowlist refusal.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The handler reads
+# identity through ee.cloud.chat.agent_service ContextVars (set in-test via
+# attach_agent_identity) and the store through pocketpaw.stores.get_instinct_store
+# (patched to a tmp-file store so nothing touches ~/.pocketpaw/instinct.db).
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_PATH = os.environ.get("PATH", "/usr/bin:/bin")
+
+pytest.importorskip("pocketpaw_ee")
+
+import pocketpaw_ee.agent.mcp_servers.belt as belt  # noqa: E402
+from pocketpaw_ee.cloud.belt import executor as belt_executor  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers + fixtures
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    """Run git from an arg list (no shell), assert success, return stdout."""
+    res = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "Belt Test",
+            "GIT_AUTHOR_EMAIL": "belt@test.local",
+            "GIT_COMMITTER_NAME": "Belt Test",
+            "GIT_COMMITTER_EMAIL": "belt@test.local",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "PATH": _PATH,
+            "HOME": str(cwd),
+        },
+    )
+    return res.stdout
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A bare repo as origin + a seeded working clone.
+
+    Returns the WORKING CLONE path (the thing a proposal's ``repo`` points at).
+    The clone has ``origin`` pointing at the bare repo, a committed ``app.py`` on
+    ``main``, and ``main`` pushed to origin — so the executor can fetch
+    origin/main and branch off it.
+    """
+    bare = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", str(bare))
+
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", str(bare), str(work))
+    # Local identity on the clone so commits succeed regardless of global config.
+    _git(work, "config", "user.name", "Belt Test")
+    _git(work, "config", "user.email", "belt@test.local")
+
+    (work / "app.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
+    _git(work, "add", "app.py")
+    _git(work, "commit", "-m", "init")
+    # Ensure the default branch is named 'main' regardless of git's init default.
+    _git(work, "branch", "-M", "main")
+    _git(work, "push", "-u", "origin", "main")
+    return work
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired in everywhere the gate
+    reads it (the MCP handler + the executor both lazy-import
+    ``pocketpaw.stores.get_instinct_store``)."""
+    st = InstinctStore(tmp_path / "instinct_belt_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+@pytest.fixture
+def allowlist(repo: Path, monkeypatch) -> None:
+    """Point belt_repo_allowlist at the repo's parent so the real repo resolves
+    inside the boundary. Patches get_settings to carry the field."""
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+
+    class _S:
+        belt_repo_allowlist = [str(repo.parent)]
+
+        def __getattr__(self, name):  # delegate everything else to real settings
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+
+class _identity:
+    """Context manager that sets the workspace/user/session ContextVars the
+    handler reads, then resets them."""
+
+    def __init__(self, *, workspace="w1", user="u1", session="sess-1"):
+        self._ws, self._user, self._sess = workspace, user, session
+        self._tokens = None
+
+    def __enter__(self):
+        self._tokens = attach_agent_identity(
+            workspace_id=self._ws, user_id=self._user, session_mongo_id=self._sess
+        )
+        return self
+
+    def __exit__(self, *exc):
+        detach_agent_identity(self._tokens)
+        return False
+
+
+class FakePrOpener:
+    """An injectable PrOpener that records its call args and returns a fixed
+    URL — never touches GitHub."""
+
+    def __init__(self, url="https://github.com/acme/repo/pull/1"):
+        self.url = url
+        self.calls: list[dict] = []
+
+    async def open_pr(self, *, repo_path, branch, base_branch, title, body) -> str:
+        self.calls.append(
+            {
+                "repo_path": Path(repo_path),
+                "branch": branch,
+                "base_branch": base_branch,
+                "title": title,
+                "body": body,
+            }
+        )
+        return self.url
+
+
+async def _result_body(res: dict) -> dict:
+    """Parse the JSON body out of a success MCP response."""
+    assert res.get("is_error") is not True, res
+    return json.loads(res["content"][0]["text"])
+
+
+def _good_diff() -> str:
+    """A diff that applies cleanly to the seeded app.py — changes the return
+    value on line 2."""
+    return (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        " def hello():\n"
+        "-    return 'hi'\n"
+        "+    return 'hello world'\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# tool-id / provider contract pins
+# ---------------------------------------------------------------------------
+
+
+def test_tool_id_contract_pin() -> None:
+    """The server + tool id are the exact strings the sibling PR hardcodes."""
+    assert belt.SERVER_NAME == "pocketpaw_belt"
+    assert belt.PROPOSE_CHANGE_TOOL_ID == "mcp__pocketpaw_belt__belt_propose_change"
+    assert belt.BELT_TOOL_IDS == ("mcp__pocketpaw_belt__belt_propose_change",)
+    assert belt.CODE_CHANGE_KIND == "code_change"
+
+
+# ---------------------------------------------------------------------------
+# the REAL end-to-end path: propose → approve → apply → PR
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_then_approve_applies_and_opens_pr(repo, store, allowlist):
+    """Drive the whole gate: propose via the real handler, execute via the real
+    executor with a fake PR opener, assert the branch + commit land in the bare
+    origin, the opener gets the right args, and mark_executed carries the PR
+    url."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": _good_diff(),
+                "summary": "Return a friendlier greeting from hello().",
+                "task": "Make hello() return a greeting.",
+                "orient_ref": "loom: app.py is the entrypoint",
+            }
+        )
+    body = await _result_body(res)
+    assert body["ok"] is True
+    action_id = body["action_id"]
+    assert "tray_hint" in body
+
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+    blob = action.parameters["_code_change"]
+    assert blob["kind"] == "code_change"
+    assert blob["base_branch"] == "main"
+    assert blob["workspace_id"] == "w1"
+    assert blob["requested_by"] == "u1"
+    # The diff is stored verbatim — it's data.
+    assert "hello world" in blob["diff"]
+
+    # Approve via the real store, then run the real executor with a fake opener.
+    approved = await store.approve(action_id, approver="u1")
+    opener = FakePrOpener()
+    await belt_executor.execute_approved_change(approved, pr_opener=opener)
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+    outcome = final.outcome if isinstance(final.outcome, str) else str(final.outcome)
+    assert "github.com/acme/repo/pull/1" in outcome
+
+    # The fake opener was called with the belt branch + base.
+    assert len(opener.calls) == 1
+    call = opener.calls[0]
+    assert call["base_branch"] == "main"
+    assert call["branch"].startswith("feat/belt-")
+    # Conventional Commits title, NO AI attribution.
+    assert call["title"].startswith("feat(belt):")
+    assert "claude" not in (call["title"] + call["body"]).lower()
+    assert "co-authored-by" not in (call["title"] + call["body"]).lower()
+
+    # The branch + commit actually landed in the BARE origin.
+    bare = repo.parent / "origin.git"
+    branches = _git(bare, "branch", "--list", call["branch"])
+    assert call["branch"] in branches
+    log = _git(bare, "log", call["branch"], "--oneline", "-1")
+    assert "feat(belt)" in log
+    # The applied content is on that branch in origin.
+    blob_on_branch = _git(bare, "show", f"{call['branch']}:app.py")
+    assert "hello world" in blob_on_branch
+
+    # The worktree was cleaned up — nothing left under tmp/belt-actions for it.
+    leftover = (
+        list((repo / ".git" / "worktrees").glob("*"))
+        if (repo / ".git" / "worktrees").exists()
+        else []
+    )
+    # worktree registration is pruned
+    assert not any("act-" in p.name for p in leftover)
+
+
+async def test_two_actions_no_cross_contamination(repo, store, allowlist):
+    """Two proposals applied back-to-back land on DISTINCT branches with
+    DISTINCT PRs and DISTINCT outcomes — no shared worktree state leaks."""
+
+    async def _propose(summary: str, new_val: str) -> str:
+        diff = (
+            "--- a/app.py\n"
+            "+++ b/app.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            " def hello():\n"
+            "-    return 'hi'\n"
+            f"+    return '{new_val}'\n"
+        )
+        with _identity():
+            res = await belt._propose_change_handler(
+                {
+                    "repo": str(repo),
+                    "base_branch": "main",
+                    "diff": diff,
+                    "summary": summary,
+                    "task": "change greeting",
+                }
+            )
+        return (await _result_body(res))["action_id"]
+
+    id_a = await _propose("First greeting change.", "first")
+    id_b = await _propose("Second greeting change.", "second")
+
+    opener_a = FakePrOpener(url="https://github.com/acme/repo/pull/10")
+    opener_b = FakePrOpener(url="https://github.com/acme/repo/pull/11")
+
+    await belt_executor.execute_approved_change(
+        await store.approve(id_a, approver="u1"), pr_opener=opener_a
+    )
+    await belt_executor.execute_approved_change(
+        await store.approve(id_b, approver="u1"), pr_opener=opener_b
+    )
+
+    fa = await store.get_action(id_a)
+    fb = await store.get_action(id_b)
+    assert fa.status == ActionStatus.EXECUTED
+    assert fb.status == ActionStatus.EXECUTED
+    branch_a = opener_a.calls[0]["branch"]
+    branch_b = opener_b.calls[0]["branch"]
+    assert branch_a != branch_b
+
+    bare = repo.parent / "origin.git"
+    assert "first" in _git(bare, "show", f"{branch_a}:app.py")
+    assert "second" in _git(bare, "show", f"{branch_b}:app.py")
+    # The second branch must NOT carry the first's change (clean base each time).
+    assert "first" not in _git(bare, "show", f"{branch_b}:app.py")
+
+
+# ---------------------------------------------------------------------------
+# reject path
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_round_trips_for_code_change(repo, store, allowlist):
+    """A code_change Action rejects cleanly through the real store: status
+    REJECTED, reason recorded, no PR, no executor run."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": _good_diff(),
+                "summary": "A change to reject.",
+                "task": "change greeting",
+            }
+        )
+    action_id = (await _result_body(res))["action_id"]
+
+    rejected = await store.reject(action_id, reason="not now", rejector="u1")
+    assert rejected is not None
+    assert rejected.status == ActionStatus.REJECTED
+    assert rejected.rejected_reason == "not now"
+
+    # No branch was pushed to origin (the executor never ran).
+    bare = repo.parent / "origin.git"
+    branches = _git(bare, "branch", "--list", "feat/belt-*")
+    assert branches.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# apply-conflict path
+# ---------------------------------------------------------------------------
+
+
+async def test_apply_conflict_marks_failed_and_cleans_up(repo, store, allowlist):
+    """A diff that cannot apply (it edits a line the base no longer has) →
+    the Action is marked FAILED, no branch is pushed, the worktree is cleaned."""
+    # A diff that targets content NOT present in the seeded app.py — git apply
+    # --3way can't reconcile it, so it fails.
+    bad_diff = (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,3 +1,3 @@\n"
+        " def hello():\n"
+        "-    return 'NONEXISTENT LINE THAT IS NOT IN THE FILE'\n"
+        "+    return 'whatever'\n"
+        " trailing context that does not match\n"
+    )
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": bad_diff,
+                "summary": "A conflicting change.",
+                "task": "change greeting",
+            }
+        )
+    action_id = (await _result_body(res))["action_id"]
+
+    opener = FakePrOpener()
+    await belt_executor.execute_approved_change(
+        await store.approve(action_id, approver="u1"), pr_opener=opener
+    )
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.FAILED
+    assert opener.calls == []  # no PR opened
+    # Nothing pushed to origin.
+    bare = repo.parent / "origin.git"
+    assert _git(bare, "branch", "--list", "feat/belt-*").strip() == ""
+    # The worktree dir is gone.
+
+    leftover = Path(tempfile.gettempdir()) / "belt-actions"
+    if leftover.exists():
+        assert not any(p.is_dir() for p in leftover.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# input validation: size cap, identity, allowlist
+# ---------------------------------------------------------------------------
+
+
+async def test_size_cap_rejection(repo, store, allowlist):
+    """A diff over the changed-line budget is refused with a split-the-task
+    error — and no Action is filed."""
+    # Build a diff with > MAX_CHANGED_LINES added lines.
+    added = "\n".join(f"+line {i}" for i in range(belt.MAX_CHANGED_LINES + 5))
+    big_diff = "--- a/app.py\n+++ b/app.py\n@@ -1,1 +1,9999 @@\n" + added + "\n"
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": big_diff,
+                "summary": "Way too big.",
+                "task": "change greeting",
+            }
+        )
+    assert res.get("is_error") is True
+    assert "split the task" in res["content"][0]["text"].lower()
+    # No action filed.
+    assert await store.list_actions() == []
+
+
+async def test_identity_missing_errors(repo, store, allowlist):
+    """Called without workspace/user ContextVars → an explicit error, no
+    Action."""
+    res = await belt._propose_change_handler(
+        {
+            "repo": str(repo),
+            "base_branch": "main",
+            "diff": _good_diff(),
+            "summary": "No identity.",
+            "task": "change greeting",
+        }
+    )
+    assert res.get("is_error") is True
+    assert "workspace and user context" in res["content"][0]["text"]
+    assert await store.list_actions() == []
+
+
+async def test_repo_outside_allowlist_refused(repo, store, monkeypatch, tmp_path):
+    """A repo path outside the allowlist roots is refused — even if it's a real
+    git repo on disk."""
+    # Allowlist points somewhere ELSE, not the repo's parent.
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+    other_root = tmp_path / "elsewhere"
+    other_root.mkdir()
+
+    class _S:
+        belt_repo_allowlist = [str(other_root)]
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": _good_diff(),
+                "summary": "Out of bounds.",
+                "task": "change greeting",
+            }
+        )
+    assert res.get("is_error") is True
+    assert "outside the allowed roots" in res["content"][0]["text"]
+    assert await store.list_actions() == []
+
+
+async def test_empty_diff_refused(repo, store, allowlist):
+    """An empty / whitespace diff is refused before anything is stored."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": "   \n  ",
+                "summary": "Empty.",
+                "task": "change greeting",
+            }
+        )
+    assert res.get("is_error") is True
+    assert "non-empty unified `diff`" in res["content"][0]["text"]
+    assert await store.list_actions() == []

--- a/tests/cloud/test_ee_instinct.py
+++ b/tests/cloud/test_ee_instinct.py
@@ -1,5 +1,15 @@
 # tests/test_ee_instinct.py — Comprehensive tests for ee/instinct (store + router).
 # Created: 2026-03-28 — Initial store tests.
+# Updated: 2026-06-10 (feat/belt-gate, BS-3) — added TestBeltCodeChangeRouterSeam:
+#   proves the approve/bulk-approve/reject routes dispatch the Belt
+#   apply-on-approve executor ONLY for a ``_code_change`` Action and NEVER for a
+#   plain (non-code-change) one — the kind-gated dispatch seam the spec security
+#   checklist requires ("the executor cannot be reached for non-code_change
+#   kinds"). The executor itself is patched (its real git behaviour is covered
+#   in test_belt_gate.py); these tests pin the router's routing decision, not
+#   the apply. The cross-workspace code-change 403 lives in
+#   test_instinct_approval_security.py beside its pocket-write peer (that app
+#   registers the CloudError → 403 handler).
 # Updated: 2026-05-21 (feat/instinct-outcome-verification) — issue #1162:
 #   added the outcome-verification e2e — an Action runs, the deterministic
 #   verifier checks the result against captured success_criteria, and the
@@ -1305,3 +1315,104 @@ class TestOutcomeVerificationE2E:
         assert "action_proposed" in events
         assert "action_approved" in events
         assert "action_executed" in events
+
+
+# ---------------------------------------------------------------------------
+# BS-3 — Belt code-change router dispatch seam
+# ---------------------------------------------------------------------------
+
+
+class TestBeltCodeChangeRouterSeam:
+    """The approve / reject routes must dispatch the Belt apply-on-approve
+    executor ONLY when the Action carries a ``_code_change`` blob — and never
+    for a plain Action. This pins the kind-gated seam the spec's security
+    checklist requires; the executor's real git work is covered end-to-end in
+    test_belt_gate.py, so here it is patched to a recorder."""
+
+    async def _seed(self, store: InstinctStore, *, parameters: dict) -> str:
+        action = await store.propose(
+            pocket_id="ws-test",  # the approver's active workspace (see _FakeUser)
+            title="seam test",
+            description="",
+            recommendation="",
+            trigger=make_trigger(),
+            parameters=parameters,
+        )
+        return action.id
+
+    @pytest.mark.asyncio
+    async def test_approve_code_change_dispatches_executor(
+        self, client: TestClient, router_store: InstinctStore
+    ) -> None:
+        """Approving a ``_code_change`` Action through the route fires
+        ``execute_approved_change`` exactly once with the approved Action."""
+        blob = {"kind": "code_change", "schema": 1, "workspace_id": "ws-test", "diff": "x"}
+        action_id = await self._seed(router_store, parameters={"_code_change": blob})
+
+        with patch(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+
+        assert resp.status_code == 200
+        assert mock_exec.await_count == 1
+        dispatched = mock_exec.await_args.args[0]
+        assert dispatched.id == action_id
+        assert dispatched.status == ActionStatus.APPROVED
+
+    @pytest.mark.asyncio
+    async def test_approve_plain_action_never_dispatches_executor(
+        self, client: TestClient, router_store: InstinctStore
+    ) -> None:
+        """A plain (non-code-change) Action must NEVER reach the Belt executor."""
+        action_id = await self._seed(router_store, parameters={"note": "ordinary action"})
+
+        with patch(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+
+        assert resp.status_code == 200
+        mock_exec.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bulk_approve_code_change_dispatches_executor(
+        self, client: TestClient, router_store: InstinctStore
+    ) -> None:
+        """Bulk-approve mirrors the single-approve seam: a ``_code_change`` item
+        fires the executor; a plain item in the same batch does not."""
+        blob = {"kind": "code_change", "schema": 1, "workspace_id": "ws-test", "diff": "x"}
+        code_id = await self._seed(router_store, parameters={"_code_change": blob})
+        plain_id = await self._seed(router_store, parameters={"note": "ordinary"})
+
+        with patch(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            resp = client.post("/instinct/actions/bulk-approve", json={"ids": [code_id, plain_id]})
+
+        assert resp.status_code == 200
+        # Exactly one dispatch — the code-change item, not the plain one.
+        assert mock_exec.await_count == 1
+        assert mock_exec.await_args.args[0].id == code_id
+
+    @pytest.mark.asyncio
+    async def test_reject_code_change_never_dispatches_executor(
+        self, client: TestClient, router_store: InstinctStore
+    ) -> None:
+        """Rejecting a ``_code_change`` Action round-trips to REJECTED without
+        ever reaching the executor — the reject path applies nothing."""
+        blob = {"kind": "code_change", "schema": 1, "workspace_id": "ws-test", "diff": "x"}
+        action_id = await self._seed(router_store, parameters={"_code_change": blob})
+
+        with patch(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
+
+        assert resp.status_code == 200
+        mock_exec.assert_not_awaited()
+        assert resp.json()["status"] == ActionStatus.REJECTED.value

--- a/tests/cloud/test_instinct_approval_security.py
+++ b/tests/cloud/test_instinct_approval_security.py
@@ -28,6 +28,15 @@
 #   403 with the same ``instinct.cross_workspace_approval`` code, and
 #   (b) same-workspace reject still succeeds + the rejected Action
 #   transitions to ``rejected``.
+#
+# Updated: 2026-06-10 (feat/belt-gate, BS-3) — added
+#   ``TestBeltCodeChangeCrossWorkspace``: the code-change peer of the
+#   pocket-write tenancy gate. ``_assert_code_change_workspace`` refuses a
+#   ``_code_change`` Action whose blob ``workspace_id`` differs from the
+#   approver's active workspace with the same 403 +
+#   ``instinct.cross_workspace_approval`` code on the approve / bulk-approve /
+#   reject paths, and a same-tenant approval passes the gate and dispatches the
+#   (here patched-off) Belt executor.
 
 from __future__ import annotations
 
@@ -106,6 +115,28 @@ def _pocket_write_params(workspace_id: str, outcome: str | None = "renewal_compl
             # ``parked_policy_event_id`` is populated by Slice 3.
             "correlation_id": None,
             "parked_policy_event_id": None,
+        }
+    }
+
+
+def _code_change_params(workspace_id: str) -> dict:
+    """An Action ``parameters`` payload carrying a Belt ``_code_change`` blob —
+    the shape ``belt._propose_change_handler`` stores. A code change carries no
+    pocket the way a parked write does, so its tenancy lives entirely on the
+    blob's ``workspace_id`` (BS-3). The schema/diff/branch are minimal — these
+    tests pin the cross-workspace gate, not the apply (covered in
+    test_belt_gate.py)."""
+    return {
+        "_code_change": {
+            "kind": "code_change",
+            "schema": 1,
+            "repo": "/tmp/belt-repo",
+            "base_branch": "main",
+            "diff": "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n",
+            "summary": "tenancy-gate fixture",
+            "task": "tenancy-gate fixture",
+            "workspace_id": workspace_id,
+            "requested_by": "requester-9",
         }
     }
 
@@ -499,3 +530,106 @@ async def test_count_outcomes_skips_foreign_workspace_rows(tmp_path: Path) -> No
         assert "leaked" not in counts.by_outcome
     finally:
         outcomes_service.set_ledger_dir("~/.pocketpaw/outcomes")
+
+
+# ---------------------------------------------------------------------------
+# BS-3 — Belt code-change cross-workspace tenancy gate
+# ---------------------------------------------------------------------------
+
+
+class TestBeltCodeChangeCrossWorkspace:
+    """``_assert_code_change_workspace`` is the code-change peer of
+    ``_assert_pocket_write_workspace``: a ``_code_change`` blob whose
+    ``workspace_id`` differs from the approver's active workspace must be
+    refused with the same 403 + ``instinct.cross_workspace_approval`` code on
+    the approve, bulk-approve, and reject paths. A code change carries no
+    pocket, so without this gate a ws-A admin could approve (and APPLY) a ws-B
+    diff. The executor is patched off so a same-tenant approval doesn't try to
+    drive real git."""
+
+    def test_single_approve_of_foreign_workspace_code_change_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B code change",
+                parameters=_code_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_bulk_approve_of_foreign_workspace_code_change_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A code change",
+                parameters=_code_change_params(workspace_id="ws-A"),
+            )
+            foreign = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B code change",
+                parameters=_code_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post(
+                "/instinct/actions/bulk-approve",
+                json={"ids": [own, foreign]},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            # The whole batch is rejected — nothing flipped.
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+    def test_single_reject_of_foreign_workspace_code_change_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B code change",
+                parameters=_code_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post(
+                f"/instinct/actions/{action_id}/reject",
+                json={"reason": "nope"},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_single_approve_of_own_workspace_code_change_dispatches(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A same-tenant approval passes the gate and reaches the executor
+        (patched off here — the real apply is covered in test_belt_gate.py)."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+
+        async def _noop_execute(_action):
+            return None
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            _noop_execute,
+        )
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A code change",
+                parameters=_code_change_params(workspace_id="ws-A"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["action"]["status"] == "approved"


### PR DESCRIPTION
Stacks on #1407 (review that first — this branch is based on `feat/belt-loom-mcp`).

## What this does

The Belt & Pulley develop station now has a way to ship code without ever touching the live checkout on its own. The station produces a unified diff and proposes it through Instinct — the human approve/reject layer. A person approves it in The Tray, and only then does an executor apply the diff on a fresh branch and open a PR. The captain still merges on GitHub. Instinct is the mid gate, not an auto-merge.

The two halves mirror the existing pocket-write bridge so there's no new pattern to learn.

**Propose side — `pocketpaw_belt` MCP server (`belt_propose_change`)**
- Checks workspace/user identity from the chat session's ContextVars
- Refuses an empty diff, and caps size at ~1500 changed lines / 200KB with a "split the task" message
- Resolves the `repo` path inside a settings-driven allowlist and refuses anything outside it
- Files an Instinct Action carrying the change as a `_code_change` blob, and returns `ok` only after the store confirms the row — no phantom success. The diff rides verbatim; it's data, never interpolated.

**Apply side — executor (fires on approve)**
- Fetch origin, make a fresh per-action worktree off `origin/<base>`, `git apply --3way` from a temp file
- Branch `feat/belt-<id>`, Conventional-Commits commit (no AI attribution), push
- Open the PR through an injectable opener (default shells `gh pr create`; tests inject a fake)
- `mark_executed` with the PR url, branch, and file count
- The worktree is always removed. An apply conflict or any failure marks the Action failed with a clear reason and leaves no half-state.

**Dispatch wiring**
- The instinct router's approve / bulk-approve routes dispatch the executor by action kind, keyed on the `_code_change` blob. The pocket-write path is untouched.
- `_assert_code_change_workspace` binds a code-change Action to the approver's workspace on the approve, bulk-approve, and reject paths.

Plus the `CloudBeltMcpProvider` entry point and the `belt_repo_allowlist` setting (the allowlist boundary, defaulting to the workspace root when unset).

## Security checklist

- No `shell=True`, no string-interpolated commands — every git/gh call is an argv list through one `_run` chokepoint
- The diff is data: written to a temp file and fed to `git apply <file>`, never echoed or put on a command line. The temp file is removed before commit and in the finally block.
- The repo path is allowlist-gated before any git op, on a resolved path (so `..` can't escape), and re-resolved at execute time (defense in depth)
- No diff content and no secrets in any log line — only action ids, branch names, and file counts
- The worktree is cleaned up on every path, success or failure
- The executor cannot be reached for non-`code_change` kinds — proven by the router-seam tests below

## Tests

`tests/cloud/test_belt_gate.py` drives the whole gate through the real path against a local bare repo (origin) + a seeded clone:
- propose -> approve -> apply: branch + commit land in the bare origin, the fake opener gets the right args, `mark_executed` carries the PR url
- two actions back-to-back with no cross-contamination (distinct branches/PRs, clean base each time)
- reject round-trips for a code_change Action (no PR, no executor run)
- apply conflict -> Action failed, worktree cleaned, nothing pushed
- size-cap rejection, missing identity, repo-outside-allowlist refusal, empty diff

`tests/cloud/test_ee_instinct.py` and `tests/cloud/test_instinct_approval_security.py` add the router-seam coverage the e2e file doesn't reach:
- approve / bulk-approve dispatch the executor only for a `_code_change` Action, never for a plain one
- reject never reaches the executor
- cross-workspace code-change approval / bulk-approval / rejection returns 403 (`instinct.cross_workspace_approval`), and a same-tenant approval passes the gate

Targeted run green: 203 passed across the belt gate + every instinct test module. `ruff check` clean on all touched files.

## Docs

Internal subsystem — the new `belt_repo_allowlist` setting carries its own description in `config.py`. No public CLI/API reference change.