### PR TITLE
Belt station runs: trace each one as a single decision chain (BS-4)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/belt.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/belt.py
@@ -2,6 +2,22 @@
 # code-change gate to the claude_agent_sdk cloud chat backend. Created:
 # 2026-06-10 (feat/belt-gate, BS-3).
 #
+# Updated: 2026-06-10 (feat/belt-trace, BS-4 — Decision-Graph chain) —
+#   ``belt_propose_change`` now MINTS a Decision-Graph ``correlation_id``
+#   at propose time and emits the chain-opening ``agent.proposed`` event
+#   through ``journal_writer.record_agent_proposed`` (RFC 09). The
+#   correlation_id is stamped onto the ``_code_change`` blob (schema 2,
+#   mirroring the pocket-write bridge's ``_pocket_write.correlation_id``)
+#   so the Instinct router's approve / reject paths and the executor can
+#   close the SAME chain — one station run = one Decision chain. The
+#   emitted ``agent.proposed`` event id is stashed on the blob as
+#   ``proposed_event_id`` so the eventual ``human.corrected`` event can
+#   cite it as its ``causation_id``. Both the emit and the blob fields are
+#   best-effort: a Decision-Graph wiring failure must never fail the
+#   propose response (the Action is already durable; the Slice 4 reconciler
+#   is the safety net). The blob also carries the workspace/user on the
+#   chain actor + scope so visibility filters narrow correctly.
+#
 # What this file does: clones the media.py shape — a single
 # ``create_sdk_mcp_server`` with an SDK import-guard, ``SERVER_NAME`` /
 # ``*_TOOL_ID`` allowlist constants, ContextVar-sourced identity (the same
@@ -49,6 +65,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Any
+from uuid import UUID, uuid4
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +86,17 @@ CODE_CHANGE_KIND = "code_change"
 # pocket-write bridge's ``_pocket_write`` key. The router + executor dispatch on
 # this key being present.
 CODE_CHANGE_PARAM_KEY = "_code_change"
+
+# Schema version stamped on the ``_code_change`` blob.
+#   * schema 1 (BS-3): repo / base_branch / diff / summary / task + workspace +
+#     requester context, NO Decision-Graph chain.
+#   * schema 2 (BS-4, RFC 09): adds ``correlation_id`` (the chain id minted here
+#     at propose time, when ``agent.proposed`` fires) and ``proposed_event_id``
+#     (the id of that ``agent.proposed`` event, so the eventual
+#     ``human.corrected`` can chain its ``causation_id`` back to it). The
+#     executor's schema-mismatch guard fails a stale schema-1 blob approved
+#     post-deploy loud (same discipline as the pocket-write bridge).
+CODE_CHANGE_SCHEMA = 2
 
 # Diff size cap. A proposal over EITHER bound is refused with a "split the task"
 # error — a diff this large is a sign the station task wasn't decomposed, and a
@@ -207,6 +235,135 @@ def _resolve_repo(repo: str) -> tuple[Path | None, str | None]:
     return candidate, None
 
 
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    repo_name: str,
+    base_branch: str,
+    summary: str,
+    task: str,
+    changed_lines: int,
+    workspace_id: str,
+    user_id: str,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a Belt code change.
+
+    Mirrors ``action_executor``'s ``agent.proposed`` emit for pocket writes:
+    the develop station is the actor that PROPOSED the change, so the chain
+    actor is ``kind="agent"`` with the requesting user on its id and the
+    workspace on its scope_context. The Belt action isn't bound to a pocket —
+    its tenancy is the workspace — so ``pocket_id`` on the chain carries the
+    workspace id (matching how the Action's ``pocket_id`` field carries the
+    workspace, see ``_propose_change_handler``). The projection's
+    ``_fold_proposed`` reads ``intent`` / ``action`` / ``pocket_id`` /
+    ``inputs`` off the payload.
+
+    Returns the emitted event id (``UUID``) so the caller can persist it on the
+    blob's ``proposed_event_id`` field for the ``human.corrected`` causation
+    chain, or ``None`` when the emit raised — best-effort per RFC 09; the Slice
+    4 reconciler / abandon-sweeper picks up any orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"code change to {repo_name} ({base_branch}) — {changed_lines} changed lines"
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "code_change",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator / a future swap to
+        # soul-protocol's ``build_proposal_event(AgentProposal(...))``.
+        "proposal_kind": "code_change",
+        "summary": summary,
+        "proposal": {
+            "repo": repo_name,
+            "base_branch": base_branch,
+            "task": task,
+            "changed_lines": changed_lines,
+        },
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "belt agent.proposed emit failed for correlation_id=%s (action_id=%s) "
+            "— Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._code_change`` blob after ``agent.proposed`` fired.
+
+    The blob is built with these fields already set from the in-memory values,
+    so this re-write only matters when the proposed event id was unknown at
+    propose-build time. We mint the correlation_id BEFORE building the blob, so
+    that field is already correct on the stored row; ``proposed_event_id`` is
+    the one this back-write fills in. Direct SQL update — same pattern as the
+    pocket-write bridge's ``_persist_parked_policy_event_id``. Best-effort:
+    failure leaves ``proposed_event_id`` None and the eventual
+    ``human.corrected`` emits without a causation_id (the chain still folds;
+    causation_id is optional on EventEntry).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(CODE_CHANGE_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[CODE_CHANGE_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "belt: failed to persist chain ids onto action %s — the chain's "
+            "human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
 async def _propose_change_handler(args: dict) -> dict:
     """MCP handler for ``belt__belt_propose_change``.
 
@@ -262,12 +419,22 @@ async def _propose_change_handler(args: dict) -> dict:
         orient_ref.strip() if isinstance(orient_ref, str) and orient_ref.strip() else None
     )
 
+    # BS-4 — mint the Decision-Graph chain correlation_id BEFORE building the
+    # blob so the stored Action carries it from the first write. The same id
+    # threads through approve / reject (router) and apply (executor) so the
+    # whole station run folds into ONE Decision chain.
+    correlation_id = uuid4()
+
     # Build the code-change blob. ``kind`` is the discriminator the executor /
     # router dispatch on (the Action model has no literal kind column). The diff
     # rides verbatim — it is DATA, never interpolated into a shell.
+    #
+    # Schema 2 (BS-4, RFC 09) — carries the chain ``correlation_id`` and
+    # ``proposed_event_id`` (the latter back-written after ``agent.proposed``
+    # fires; None here, filled by ``_persist_chain_ids`` below).
     blob: dict[str, Any] = {
         "kind": CODE_CHANGE_KIND,
-        "schema": 1,
+        "schema": CODE_CHANGE_SCHEMA,
         "repo": str(repo_path),
         "base_branch": base_branch.strip(),
         "diff": diff,
@@ -279,6 +446,9 @@ async def _propose_change_handler(args: dict) -> dict:
         # The proposing chat session — lets the executor / audit tie the PR back
         # to the conversation that produced it.
         "session_id": session_mongo_id,
+        # RFC 09 chain-correlation fields (schema 2).
+        "correlation_id": str(correlation_id),
+        "proposed_event_id": None,
     }
 
     from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
@@ -330,12 +500,39 @@ async def _propose_change_handler(args: dict) -> dict:
     if stored is None:
         return _error_response("the change was not stored — please retry.")
 
+    # BS-4 — open the Decision-Graph chain now that the Action is durable.
+    # ``agent.proposed`` is the chain origin; its event id is back-written onto
+    # the blob so the router's ``human.corrected`` can cite it as causation.
+    # Best-effort: a Decision-Graph wiring failure must NOT fail the propose
+    # response — the Action is already stored; the Slice 4 reconciler closes
+    # any chain that never opened.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=correlation_id,
+        action_id=action.id,
+        repo_name=repo_name,
+        base_branch=base_branch.strip(),
+        summary=summary.strip(),
+        task=task.strip(),
+        changed_lines=changed_lines,
+        workspace_id=workspace_id,
+        user_id=user_id,
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action.id,
+            correlation_id=str(correlation_id),
+            proposed_event_id=str(proposed_event_id),
+        )
+
     logger.info(
-        "belt: proposed code_change action %s (repo=%s, base=%s, changed_lines=%d)",
+        "belt: proposed code_change action %s (repo=%s, base=%s, changed_lines=%d, "
+        "correlation_id=%s)",
         action.id,
         repo_name,
         base_branch.strip(),
         changed_lines,
+        correlation_id,
     )
 
     return _success_response(
@@ -434,6 +631,7 @@ __all__ = [
     "BELT_TOOL_IDS",
     "CODE_CHANGE_KIND",
     "CODE_CHANGE_PARAM_KEY",
+    "CODE_CHANGE_SCHEMA",
     "PROPOSE_CHANGE_TOOL_ID",
     "SERVER_NAME",
     "build_belt_server",

--- a/ee/pocketpaw_ee/cloud/belt/executor.py
+++ b/ee/pocketpaw_ee/cloud/belt/executor.py
@@ -1,6 +1,28 @@
 # executor.py — applies an approved Belt code-change Action and opens a PR.
 # Created: 2026-06-10 (feat/belt-gate, BS-3).
 #
+# Updated: 2026-06-10 (feat/belt-trace, BS-4 — Decision-Graph chain close) —
+#   ``execute_approved_change`` now CLOSES the Decision-Graph chain the
+#   propose path opened (RFC 09). It reads the ``correlation_id`` off the
+#   schema-2 ``_code_change`` blob and emits the terminal
+#   ``decision.completed`` event:
+#     * SUCCESS (mark_executed) → ``passed=True, action_outcome="landed"``
+#       with the ``pr_url`` / ``branch`` / ``files_changed`` on the payload.
+#     * FAILURE (any mark_failed branch) → ``passed=False,
+#       action_outcome="failed"`` with the ``error_class`` / ``reason`` so the
+#       explain narrator can say WHY it failed.
+#   The router threads the ``human.corrected`` event id it just emitted into
+#   ``execute_approved_change(..., human_event_id=...)`` so the terminal event
+#   chains its ``causation_id`` back to the human approval — one clean causal
+#   walk ``agent.proposed → human.corrected → decision.completed``. Exactly ONE
+#   terminal fires per run: every error path RETURNS right after its single
+#   ``_emit_chain_close`` + ``mark_failed`` pair, and the success path emits
+#   once at the end — no doubled terminals. The schema literal is bumped 1 → 2
+#   to match belt.py's schema-2 blob (a stale schema-1 blob approved post-deploy
+#   still fails loud on the mismatch guard). Both the emit and the read are
+#   best-effort: a Decision-Graph wiring failure must never break the approve
+#   response (the Slice 4 abandon-sweeper closes any chain left open).
+#
 # What this module does (the apply-on-approve half of the Belt code-change
 # gate): the ``pocketpaw_belt`` MCP server proposes a unified diff THROUGH
 # Instinct (the human approve/reject layer). After a human approves the Action,
@@ -57,7 +79,12 @@ logger = logging.getLogger(__name__)
 # changes so a stale pending Action approved after a deploy fails loud instead
 # of applying a misinterpreted diff (same discipline as the pocket-write
 # bridge's ``_POCKET_WRITE_SCHEMA``).
-_CODE_CHANGE_SCHEMA = 1
+#
+# Schema 2 (BS-4) — the blob carries the Decision-Graph ``correlation_id`` +
+# ``proposed_event_id`` set by belt.py at propose time. Kept in sync with the
+# MCP server's ``CODE_CHANGE_SCHEMA`` literal; duplicated here so the executor
+# has no import dependency on the agent-side MCP module.
+_CODE_CHANGE_SCHEMA = 2
 
 # The parameters key the blob rides under — kept in sync with the MCP server's
 # ``CODE_CHANGE_PARAM_KEY``. Duplicated as a literal here so the executor has no
@@ -187,10 +214,110 @@ def _short_id(action_id: str) -> str:
     return safe[-12:] or "change"
 
 
+def _coerce_uuid(raw: Any) -> Any | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be. Accepts an
+    existing ``UUID`` (returned as-is) or a string; anything else → None."""
+    from uuid import UUID
+
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _blob_correlation_id(blob: dict[str, Any]) -> Any | None:
+    """Pull the Decision-Graph chain ``correlation_id`` off a schema-2
+    ``_code_change`` blob, or ``None`` if missing / malformed. Without it the
+    chain-close emit no-ops — the Slice 4 abandon-sweeper closes any orphan."""
+    return _coerce_uuid(blob.get("correlation_id"))
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: Any | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: Any | None,
+    pr_url: str | None = None,
+    branch: str | None = None,
+    files_changed: int | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a Belt code-change run.
+
+    Mirrors ``instinct_bridge._emit_bridge_chain_close`` — the executor owns
+    the chain close on the apply path, exactly as the pocket-write bridge owns
+    it on its re-entry path. ``correlation_id`` is read off the schema-2 blob;
+    ``causation_id`` is the ``human.corrected`` event the router emitted just
+    before approval so the terminal chains back to the human approval.
+
+    Returns early when ``correlation_id`` is None (a blob with a malformed /
+    missing id, or a schema-1 blob): there is no chain to close. The Slice 4
+    abandon-sweeper will close any chain that accumulates without a terminal.
+
+    Best-effort: a Decision-Graph wiring failure must never break the approve
+    response — the journal write is the source of truth; the Slice 4 reconciler
+    is the safety net.
+    """
+    if correlation_id is None:
+        return
+
+    # Late imports — keep the executor's import surface small and avoid a
+    # circular import with the decisions package.
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if pr_url:
+        payload["pr_url"] = pr_url
+    if branch:
+        payload["branch"] = branch
+    if files_changed is not None:
+        payload["files_changed"] = files_changed
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "belt decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
 async def execute_approved_change(
     action: Any,
     *,
     pr_opener: PrOpener | None = None,
+    human_event_id: Any | None = None,
 ) -> None:
     """Apply the code change carried by a freshly-approved Instinct Action.
 
@@ -199,10 +326,18 @@ async def execute_approved_change(
     uses. ``action`` is the approved Action. ``pr_opener`` lets tests inject a
     fake; production passes ``None`` and gets the ``gh pr create`` opener.
 
+    ``human_event_id`` (BS-4) is the id of the ``human.corrected`` event the
+    router emitted just before calling this — threaded through so the terminal
+    ``decision.completed`` event can chain its ``causation_id`` back to the
+    approval, completing the causal walk ``agent.proposed → human.corrected →
+    decision.completed``. ``None`` is tolerated (the chain still folds via the
+    shared ``correlation_id``).
+
     Never raises — a failure here must not break the approve response. The
     router wraps the call too; this is belt-and-braces. The worktree is ALWAYS
     cleaned up (success or failure); the Action is marked executed on success
-    or failed with a clear outcome on any error.
+    or failed with a clear outcome on any error. BS-4: every terminal path
+    (success or any failure) closes the Decision-Graph chain exactly once.
     """
     from pocketpaw.stores import get_instinct_store
 
@@ -212,13 +347,41 @@ async def execute_approved_change(
     params = getattr(action, "parameters", None) or {}
     blob = params.get(_CODE_CHANGE_PARAM_KEY)
     if not isinstance(blob, dict):
+        # Not a Belt code-change Action at all — no chain was ever opened for
+        # it, so there is nothing to close. Return without a terminal emit.
         logger.warning("approved action %s carries no _code_change blob", action.id)
         return
+
+    # BS-4 — read the chain correlation_id off the schema-2 blob up front so
+    # EVERY terminal path below can close the chain it opened. Defensive: a
+    # malformed / missing id falls through to None and the chain-close helper
+    # no-ops (the Slice 4 abandon-sweeper closes any chain left open).
+    correlation_id = _blob_correlation_id(blob)
+    workspace_id = str(blob.get("workspace_id") or "")
+    requested_by = str(blob.get("requested_by") or "")
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Mark the Action failed AND close the chain with one terminal —
+        the single failure-path chokepoint so a path can never both fail
+        and double-fire the terminal."""
+        await store.mark_failed(action.id, reason)
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=requested_by,
+            causation_id=causation,
+        )
+
     if blob.get("schema") != _CODE_CHANGE_SCHEMA:
-        await store.mark_failed(
-            action.id,
+        await _fail(
             "code-change schema mismatch — the change blob is from an "
             "incompatible build and cannot be applied",
+            error_class="SchemaMismatch",
         )
         return
 
@@ -229,13 +392,19 @@ async def execute_approved_change(
     task = str(blob.get("task") or "")
 
     if not base_branch or not isinstance(diff, str) or not diff.strip():
-        await store.mark_failed(action.id, "code-change blob is missing base_branch or diff")
+        await _fail(
+            "code-change blob is missing base_branch or diff",
+            error_class="MalformedBlob",
+        )
         return
 
     # Defense in depth — re-resolve + re-allowlist the repo at execute time.
     repo_path, repo_err = _re_resolve_repo(repo)
     if repo_err is not None or repo_path is None:
-        await store.mark_failed(action.id, f"repo no longer valid at approval time: {repo_err}")
+        await _fail(
+            f"repo no longer valid at approval time: {repo_err}",
+            error_class="RepoInvalid",
+        )
         return
 
     branch = f"feat/belt-{_short_id(str(action.id))}"
@@ -252,8 +421,9 @@ async def execute_approved_change(
         # 1. Fetch the latest base so we branch off the freshest origin tip.
         code, _out, err = await _run(["git", "fetch", "origin", base_branch], cwd=repo_path)
         if code != 0:
-            await store.mark_failed(
-                action.id, f"git fetch origin {base_branch} failed: {err.strip()[:300]}"
+            await _fail(
+                f"git fetch origin {base_branch} failed: {err.strip()[:300]}",
+                error_class="GitFetchFailed",
             )
             return
 
@@ -266,8 +436,9 @@ async def execute_approved_change(
             cwd=repo_path,
         )
         if code != 0:
-            await store.mark_failed(
-                action.id, f"git worktree add failed: {err.strip()[:300]}"
+            await _fail(
+                f"git worktree add failed: {err.strip()[:300]}",
+                error_class="GitWorktreeAddFailed",
             )
             return
         worktree_created = True
@@ -275,8 +446,9 @@ async def execute_approved_change(
         # 3. Branch off the detached worktree head.
         code, _out, err = await _run(["git", "checkout", "-b", branch], cwd=worktree_dir)
         if code != 0:
-            await store.mark_failed(
-                action.id, f"git checkout -b {branch} failed: {err.strip()[:300]}"
+            await _fail(
+                f"git checkout -b {branch} failed: {err.strip()[:300]}",
+                error_class="GitCheckoutFailed",
             )
             return
 
@@ -293,10 +465,10 @@ async def execute_approved_change(
             fd_path.unlink()
             diff_file = None
         if code != 0:
-            await store.mark_failed(
-                action.id,
+            await _fail(
                 "diff did not apply cleanly (conflict or stale base) — "
                 f"re-propose against the current {base_branch}. git apply: {err.strip()[:300]}",
+                error_class="ApplyConflict",
             )
             return
 
@@ -305,13 +477,14 @@ async def execute_approved_change(
         #    NO AI attribution.
         code, _out, err = await _run(["git", "add", "-A"], cwd=worktree_dir)
         if code != 0:
-            await store.mark_failed(action.id, f"git add failed: {err.strip()[:300]}")
+            await _fail(f"git add failed: {err.strip()[:300]}", error_class="GitAddFailed")
             return
 
         files_changed = await _changed_files(worktree_dir)
         if not files_changed:
-            await store.mark_failed(
-                action.id, "diff produced no staged changes — nothing to commit"
+            await _fail(
+                "diff produced no staged changes — nothing to commit",
+                error_class="NothingToCommit",
             )
             return
 
@@ -321,7 +494,7 @@ async def execute_approved_change(
             ["git", "commit", "-m", commit_title, "-m", commit_body], cwd=worktree_dir
         )
         if code != 0:
-            await store.mark_failed(action.id, f"git commit failed: {err.strip()[:300]}")
+            await _fail(f"git commit failed: {err.strip()[:300]}", error_class="GitCommitFailed")
             return
 
         # 6. Push the branch.
@@ -329,7 +502,7 @@ async def execute_approved_change(
             ["git", "push", "-u", "origin", branch], cwd=worktree_dir
         )
         if code != 0:
-            await store.mark_failed(action.id, f"git push failed: {err.strip()[:300]}")
+            await _fail(f"git push failed: {err.strip()[:300]}", error_class="GitPushFailed")
             return
 
         # 7. Open the PR via the injectable opener.
@@ -345,10 +518,10 @@ async def execute_approved_change(
             logger.warning("belt: PR open failed for action %s", action.id, exc_info=True)
             # The branch is pushed but no PR — record the partial so a human can
             # open the PR by hand. This is NOT a clean success.
-            await store.mark_failed(
-                action.id,
+            await _fail(
                 f"branch '{branch}' pushed but PR open failed: {exc}. "
                 "Open the PR manually or re-propose.",
+                error_class="PrOpenFailed",
             )
             return
 
@@ -356,6 +529,24 @@ async def execute_approved_change(
         await store.mark_executed(
             action.id,
             f"PR opened: {pr_url} (branch '{branch}', {len(files_changed)} file(s) changed)",
+        )
+        # BS-4 — close the chain on the SUCCESS path. ``action_outcome="landed"``
+        # + the PR url / branch / file count ride on the payload for the explain
+        # narrator. This is the ONLY terminal on the happy path (every failure
+        # path above closed via ``_fail`` and returned), so exactly one
+        # ``decision.completed`` lands per run.
+        _emit_chain_close(
+            passed=True,
+            action_outcome="landed",
+            error_class=None,
+            reason=None,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=requested_by,
+            causation_id=causation,
+            pr_url=pr_url,
+            branch=branch,
+            files_changed=len(files_changed),
         )
         logger.info(
             "belt: applied code_change action %s → branch %s, %d file(s), PR %s",
@@ -369,7 +560,7 @@ async def execute_approved_change(
             "belt: code_change execution crashed for action %s", action.id, exc_info=True
         )
         with _suppress():
-            await store.mark_failed(action.id, "code-change executor crashed — re-propose")
+            await _fail("code-change executor crashed — re-propose", error_class="ExecutorCrash")
     finally:
         # ALWAYS clean up — leave no half-state. Remove the temp diff file (if
         # the apply path bailed before unlinking it) and the worktree.

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -100,8 +100,29 @@
 #   ``_assert_pocket_write_workspace``) binds the Action to the approver's
 #   workspace on approve / reject / bulk paths. The executor applies the diff in
 #   a fresh worktree, commits, pushes, and opens a PR — it NEVER merges (the
-#   captain merges on GitHub; Instinct is the mid gate). The reject path needs
-#   no code-change-specific handling: ``store.reject`` round-trips any kind.
+#   captain merges on GitHub; Instinct is the mid gate).
+#
+# Updated: 2026-06-10 (feat/belt-trace, BS-4 — Belt Decision-Graph chain) —
+#   the Belt code-change path now lands in the Decision Graph as ONE chain per
+#   station run, mirroring the pocket-write chain. The propose path (belt.py)
+#   mints the ``correlation_id`` + emits ``agent.proposed``; this router emits
+#   the human-action + terminal events:
+#     * approve / bulk-approve — emit ``human.corrected(accepted|edited)`` for
+#       the ``_code_change`` blob, threading the ``agent.proposed`` event id
+#       (from the blob's ``proposed_event_id``) as causation, then pass the
+#       emitted ``human.corrected`` id into ``execute_approved_change(...,
+#       human_event_id=...)`` so the executor's terminal ``decision.completed``
+#       chains back to it. The executor owns the CLOSE on the approve path
+#       (success → landed, failure → failed) — the router does NOT emit a
+#       terminal here, so there is no double close.
+#     * reject / bulk-reject — emit ``human.corrected(rejected)`` THEN
+#       ``decision.completed(passed=False, action_outcome="rejected")`` here
+#       (the executor never runs on reject, so the router owns the close), each
+#       chaining causation to the prior event. The reason text rides as the
+#       rejection comment on the terminal payload.
+#   ``_code_change_proposed_event_id`` is the code-change peer of
+#   ``_parked_policy_event_id``. All emits are best-effort (the chain folds via
+#   ``correlation_id`` even if a causation_id is missing).
 #
 # Updated: 2026-05-26 (RFC 09 Slice 4 — approve-side policy.evaluated emit) —
 #   * Captain Decision 12 (chain symmetry) follow-up — ``approve_action``
@@ -309,6 +330,24 @@ def _parked_correlation_id(blob: dict[str, Any]) -> Any:
         return None
 
 
+def _code_change_proposed_event_id(blob: dict[str, Any]) -> Any:
+    """Pull the ``proposed_event_id`` UUID off a schema-2 ``_code_change``
+    blob, or ``None`` if missing / malformed. belt.py writes this back onto
+    the Action after the chain-opening ``agent.proposed`` event fires; using
+    it as the ``causation_id`` on the ``human.corrected`` event gives the
+    Belt chain a clean ``agent.proposed → human.corrected`` cause-arrow. The
+    code-change peer of ``_parked_policy_event_id``."""
+    from uuid import UUID
+
+    raw = blob.get("proposed_event_id")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return UUID(raw)
+    except ValueError:
+        return None
+
+
 def _emit_human_corrected(
     *,
     blob: dict[str, Any],
@@ -317,6 +356,7 @@ def _emit_human_corrected(
     workspace_id: str,
     disposition: str,
     note: str | None,
+    causation_override: Any | None = None,
 ) -> Any | None:
     """Best-effort ``human.corrected`` emit for an approve / reject /
     bulk-approve / bulk-reject item.
@@ -331,6 +371,13 @@ def _emit_human_corrected(
     a write without minting one). The Slice 4 reconciler / abandon
     sweeper will deal with the orphan.
 
+    ``causation_override`` (BS-4) — when provided, it is used as the
+    ``causation_id`` instead of the parked-policy-event lookup. The Belt
+    code-change path passes the ``agent.proposed`` event id here (a Belt
+    proposal has no parked ``policy.evaluated`` event to chain back to —
+    the proposal IS the chain origin). Pocket-write callers omit it and
+    fall back to ``_parked_policy_event_id``.
+
     Returns the emitted event id (``UUID``) on success, or ``None`` when
     the emit was skipped (missing correlation_id) or raised. Slice 4's
     approve-side ``policy.evaluated`` emit uses this as its
@@ -344,7 +391,11 @@ def _emit_human_corrected(
         return None
 
     pocket_id = str(getattr(action, "pocket_id", "") or "")
-    causation = _parked_policy_event_id(blob)
+    causation = (
+        causation_override
+        if causation_override is not None
+        else _parked_policy_event_id(blob)
+    )
     payload: dict[str, Any] = {
         "disposition": disposition,
         "action_id": str(getattr(action, "id", "") or ""),
@@ -381,6 +432,7 @@ def _emit_decision_completed_rejected(
     user_id: str,
     workspace_id: str,
     reason: str,
+    causation_override: Any | None = None,
 ) -> None:
     """Best-effort ``decision.completed(passed=False, action_outcome=
     "rejected")`` chain-close for a reject / bulk-reject item.
@@ -389,6 +441,12 @@ def _emit_decision_completed_rejected(
     ``_emit_human_corrected``. The reject path owns the close because
     the bridge is never invoked on rejection — for the approve path the
     bridge's ``_emit_bridge_chain_close`` owns the close instead.
+
+    ``causation_override`` (BS-4) — the Belt code-change reject path passes
+    the just-emitted ``human.corrected`` event id so the terminal chains its
+    causation back to the human rejection. Pocket-write callers omit it (their
+    terminal doesn't currently set a causation_id; the chain still folds via
+    ``correlation_id``).
     """
     from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
 
@@ -412,6 +470,7 @@ def _emit_decision_completed_rejected(
             ),
             scope=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
             payload=payload,
+            causation_id=causation_override,
         )
     except Exception:  # noqa: BLE001 — chain close is best-effort
         logger.warning(
@@ -765,16 +824,31 @@ async def bulk_approve_actions(
     # the bulk bar). The bridge owns the chain close on the approve
     # path so we do NOT emit ``decision.completed`` here.
     for action in approved:
-        # BS-3 — a Belt ``_code_change`` Action fires the apply-on-approve
-        # executor. It carries no parked-write chain (no correlation_id), so
-        # the Decision-Graph emits below are skipped for it; only the executor
-        # runs. Same best-effort shape as the pocket-write hook.
+        # BS-3/BS-4 — a Belt ``_code_change`` Action fires the apply-on-approve
+        # executor. BS-4: it now carries a Decision-Graph chain
+        # (``correlation_id`` minted at propose). Emit the per-item
+        # ``human.corrected(accepted)`` here (bulk-approve has no edit surface,
+        # so disposition is always ``accepted``), thread its event id into the
+        # executor so the terminal ``decision.completed`` chains its causation
+        # back to the human approval, then run the executor (which owns the
+        # chain close). Same best-effort shape as the pocket-write hook.
         code_change_blob = _code_change_blob(action)
         if code_change_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=code_change_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(code_change_blob),
+            )
             try:
                 from pocketpaw_ee.cloud.belt import executor as belt_executor
 
-                await belt_executor.execute_approved_change(action)
+                await belt_executor.execute_approved_change(
+                    action, human_event_id=human_event_id
+                )
             except Exception:
                 logger.exception(
                     "bulk-approve belt code-change execution failed for %s (non-fatal)",
@@ -862,30 +936,52 @@ async def bulk_reject_actions(
         list(req.ids), reason=req.reason, rejector=rejector_id
     )
 
-    # RFC 09 Slice 3 — per-item ``human.corrected`` + ``decision.
+    # RFC 09 Slice 3 / BS-4 — per-item ``human.corrected`` + ``decision.
     # completed(rejected)`` emit loop. The store's bulk_reject already
     # iterates per item internally for the audit log; this loop adds
-    # the chain emits. Non-pocket-write Actions (no blob) skip both
-    # emits — there's no chain to close.
+    # the chain emits. An item carries EITHER a ``_pocket_write`` blob OR
+    # a ``_code_change`` blob (BS-4) — both close their chain on reject
+    # here (the executor never runs on reject). An Action with neither
+    # blob has no chain to close and is skipped.
     for action in rejected:
         action_blob = _pocket_write_blob(action)
-        if action_blob is None:
+        if action_blob is not None:
+            _emit_human_corrected(
+                blob=action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+            )
+            _emit_decision_completed_rejected(
+                blob=action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+            )
             continue
-        _emit_human_corrected(
-            blob=action_blob,
-            action=action,
-            user_id=rejector_id,
-            workspace_id=workspace_id,
-            disposition="rejected",
-            note=req.reason or None,
-        )
-        _emit_decision_completed_rejected(
-            blob=action_blob,
-            action=action,
-            user_id=rejector_id,
-            workspace_id=workspace_id,
-            reason=req.reason,
-        )
+
+        code_change_blob = _code_change_blob(action)
+        if code_change_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=code_change_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(code_change_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=code_change_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
 
     return BulkActionResponse(bulk_id=bulk_id, affected=rejected, missing=missing)
 
@@ -1008,12 +1104,35 @@ async def approve_action(
     # hook above; the executor records success / failure on the Action itself.
     # A non-code-change Action skips this. The captain still merges on GitHub —
     # this opens the PR, it does NOT merge.
+    #
+    # BS-4 — this is part of the Belt Decision-Graph chain. Emit the
+    # ``human.corrected`` event for the code-change approval HERE (the router
+    # owns the human-action emit on every approve path), then thread its event
+    # id into the executor so the terminal ``decision.completed`` chains its
+    # causation back to the approval: ``agent.proposed → human.corrected →
+    # decision.completed`` under one correlation_id. The executor owns the
+    # chain CLOSE (success or failure) — the router does NOT emit
+    # ``decision.completed`` for code_change, mirroring how the pocket-write
+    # bridge owns the close on its approve path. No double terminal.
     code_change_blob = _code_change_blob(approved)
     if code_change_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=code_change_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(code_change_blob),
+        )
         try:
             from pocketpaw_ee.cloud.belt import executor as belt_executor
 
-            await belt_executor.execute_approved_change(approved)
+            await belt_executor.execute_approved_change(
+                approved, human_event_id=human_event_id
+            )
         except Exception:
             logger.exception("belt code-change execution after approval failed (non-fatal)")
 
@@ -1104,6 +1223,32 @@ async def reject_action(
             user_id=rejector_id,
             workspace_id=workspace_id,
             reason=reason,
+        )
+
+    # BS-4 — a rejected Belt ``_code_change`` Action closes its chain HERE
+    # (the executor never runs on reject). ``human.corrected(rejected)`` cites
+    # the ``agent.proposed`` event as causation; ``decision.completed(rejected,
+    # outcome=reason+comment)`` cites the human event so the chain reads
+    # ``agent.proposed → human.corrected → decision.completed`` cleanly. The
+    # reason text rides as the rejection comment on the terminal payload.
+    code_change_blob = _code_change_blob(action)
+    if code_change_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=code_change_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(code_change_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=code_change_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
         )
 
     return action

--- a/tests/cloud/test_belt_trace.py
+++ b/tests/cloud/test_belt_trace.py
@@ -1,0 +1,606 @@
+# tests/cloud/test_belt_trace.py — Belt & Pulley Decision-Graph chain (BS-4).
+#
+# Created: 2026-06-10 (feat/belt-trace, BS-4 — one station run = ONE Decision
+# chain).
+#
+# THE HARD GATE — this drives the REAL production path with NO stubs at the
+# seams between propose / approve / execute (the chain-doubling lesson,
+# 2026-05-26): the real ``belt.py`` propose handler (ContextVars set in-test),
+# the real Instinct store, the real Instinct router dispatch over a TestClient,
+# and the real ``ee.cloud.belt.executor`` against a LOCAL bare-repo git fixture
+# (reused from BS-3's ``test_belt_gate.py``). The ONLY fake is the PR opener —
+# that is the one genuine external boundary (``gh pr create``), allowed. The
+# Decision Graph journal + projection are the REAL singletons wired into the
+# lazy global lookups (same fixture shape as ``test_instinct_decision_events``).
+#
+# Expected chain shape (documented per the brief) — N = 3 events, ONE chain per
+# station run, sharing ONE correlation_id minted at propose:
+#
+#   EXECUTED (propose → approve → apply → PR):
+#     agent.proposed                                  (belt.py propose)
+#       → human.corrected(disposition=accepted)       (router approve)
+#       → decision.completed(passed=True,             (executor mark_executed)
+#                            action_outcome="landed",
+#                            pr_url=..., branch=..., files_changed=N)
+#
+#   REJECTED (propose → reject):
+#     agent.proposed                                  (belt.py propose)
+#       → human.corrected(disposition=rejected)       (router reject)
+#       → decision.completed(passed=False,            (router reject — executor
+#                            action_outcome="rejected", never runs)
+#                            reason=<comment>)
+#
+#   FAILED (propose → approve → apply conflict):
+#     agent.proposed → human.corrected(accepted)
+#       → decision.completed(passed=False, action_outcome="failed",
+#                            error_class="ApplyConflict", reason=...)
+#
+# Causation walk: agent.proposed (origin, causation_id=None) ←
+#   human.corrected (caused by agent.proposed) ← decision.completed (caused by
+#   human.corrected). Each event cites the prior via causation_id.
+#
+# The doubled-terminal trap is the thing under test: every assertion counts the
+# terminal events and proves EXACTLY ONE decision.completed lands per run, and a
+# SECOND full cycle produces a SECOND distinct, clean chain.
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+_PATH = os.environ.get("PATH", "/usr/bin:/bin")
+
+pytest.importorskip("pocketpaw_ee")
+
+from unittest.mock import AsyncMock  # noqa: E402
+
+import pocketpaw_ee.agent.mcp_servers.belt as belt  # noqa: E402
+import pocketpaw_ee.cloud.belt.executor as belt_executor_module  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# Workspace + user the in-test identity binds. The Belt action's pocket_id
+# carries the workspace (belt.py), so the chain scope is workspace-only.
+WS = "w1"
+USER = "u1"
+
+
+# ---------------------------------------------------------------------------
+# git bare-repo fixture (reused shape from test_belt_gate.py)
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    res = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "Belt Test",
+            "GIT_AUTHOR_EMAIL": "belt@test.local",
+            "GIT_COMMITTER_NAME": "Belt Test",
+            "GIT_COMMITTER_EMAIL": "belt@test.local",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "PATH": _PATH,
+            "HOME": str(cwd),
+        },
+    )
+    return res.stdout
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A bare repo as origin + a seeded working clone (returns the clone)."""
+    bare = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", str(bare))
+
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", str(bare), str(work))
+    _git(work, "config", "user.name", "Belt Test")
+    _git(work, "config", "user.email", "belt@test.local")
+
+    (work / "app.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
+    _git(work, "add", "app.py")
+    _git(work, "commit", "-m", "init")
+    _git(work, "branch", "-M", "main")
+    _git(work, "push", "-u", "origin", "main")
+    return work
+
+
+# ---------------------------------------------------------------------------
+# decision-graph + journal + store wiring (real singletons)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    """Fresh on-disk journal wired into the lazy ``get_journal`` lookup the
+    ``journal_writer`` helper resolves — production code and the test read the
+    same singleton."""
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    """Fresh DecisionGraph as the process-global singleton."""
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore wired everywhere the gate reads it (the MCP
+    handler, the router's ``_store``, and the executor all resolve through
+    ``pocketpaw.stores.get_instinct_store`` or the router indirection)."""
+    st = InstinctStore(tmp_path / "instinct.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    return st
+
+
+@pytest.fixture
+def allowlist(repo: Path, monkeypatch) -> None:
+    """Point belt_repo_allowlist at the repo's parent so the real repo resolves
+    inside the boundary."""
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+
+    class _S:
+        belt_repo_allowlist = [str(repo.parent)]
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+
+# ---------------------------------------------------------------------------
+# identity + router client + fake PR opener (the ONE allowed external fake)
+# ---------------------------------------------------------------------------
+
+
+class _identity:
+    """Sets the workspace/user/session ContextVars the belt handler reads."""
+
+    def __init__(self, *, workspace=WS, user=USER, session="sess-1"):
+        self._ws, self._user, self._sess = workspace, user, session
+        self._tokens = None
+
+    def __enter__(self):
+        self._tokens = attach_agent_identity(
+            workspace_id=self._ws, user_id=self._user, session_mongo_id=self._sess
+        )
+        return self
+
+    def __exit__(self, *exc):
+        detach_agent_identity(self._tokens)
+        return False
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = USER, workspace_id: str = WS) -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+
+        class _M:
+            def __init__(self, ws):
+                self.workspace = ws
+                self.role = "admin"
+
+        self.workspaces = [_M(workspace_id)]
+
+
+class FakePrOpener:
+    """Records its call args, returns a fixed URL — never touches GitHub. This
+    is the ONLY seam faked: the genuine external boundary (``gh pr create``)."""
+
+    instances: list[FakePrOpener] = []
+
+    def __init__(self, url: str = "https://github.com/acme/repo/pull/1"):
+        self.url = url
+        self.calls: list[dict] = []
+        FakePrOpener.instances.append(self)
+
+    async def open_pr(self, *, repo_path, branch, base_branch, title, body) -> str:
+        self.calls.append({"branch": branch, "base_branch": base_branch, "title": title})
+        return self.url
+
+
+def _make_client(store: InstinctStore, user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _patch_pr_opener(monkeypatch, url: str = "https://github.com/acme/repo/pull/1") -> None:
+    """Make the executor's DEFAULT opener (the one the router triggers, since
+    the router passes no ``pr_opener``) the fake. This keeps the router→executor
+    seam REAL — only the external ``gh`` boundary is replaced."""
+    monkeypatch.setattr(belt_executor_module, "GhCliPrOpener", lambda: FakePrOpener(url=url))
+
+
+def _good_diff() -> str:
+    return (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        " def hello():\n"
+        "-    return 'hi'\n"
+        "+    return 'hello world'\n"
+    )
+
+
+def _conflict_diff() -> str:
+    """A diff that cannot apply against the seeded app.py (line not present)."""
+    return (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,3 +1,3 @@\n"
+        " def hello():\n"
+        "-    return 'NONEXISTENT LINE THAT IS NOT IN THE FILE'\n"
+        "+    return 'whatever'\n"
+        " trailing context that does not match\n"
+    )
+
+
+async def _propose(repo: Path, diff: str, summary: str = "Friendlier greeting.") -> str:
+    """Drive the REAL belt propose handler and return the action id."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": diff,
+                "summary": summary,
+                "task": "Make hello() return a greeting.",
+            }
+        )
+    assert res.get("is_error") is not True, res
+    return json.loads(res["content"][0]["text"])["action_id"]
+
+
+def _events(journal, action: str) -> list:
+    return [e for e in journal.replay_from(0) if e.action == action]
+
+
+def _chain(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+async def _correlation_for(store: InstinctStore, action_id: str) -> UUID:
+    action = await store.get_action(action_id)
+    blob = action.parameters["_code_change"]
+    return UUID(blob["correlation_id"])
+
+
+# ---------------------------------------------------------------------------
+# EXECUTED path — propose → approve → apply → PR → ONE clean chain (N=3)
+# ---------------------------------------------------------------------------
+
+
+async def test_executed_run_is_one_clean_three_event_chain(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """The whole executed station run lands as ONE chain of EXACTLY three
+    events sharing one correlation_id minted at propose:
+    agent.proposed → human.corrected(accepted) → decision.completed(landed).
+    No doubled terminal. The Decision row is queryable via the graph."""
+    _patch_pr_opener(monkeypatch)
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+
+    action_id = await _propose(repo, _good_diff())
+    corr = await _correlation_for(store, action_id)
+
+    # agent.proposed fired at propose, before any approval.
+    proposed = _events(journal, "agent.proposed")
+    assert len(proposed) == 1
+    assert proposed[0].correlation_id == corr
+    assert proposed[0].causation_id is None  # chain origin
+    assert proposed[0].payload["action"] == "code_change"
+
+    # Approve over HTTP — the REAL router dispatch fires human.corrected then
+    # the REAL executor applies + closes the chain.
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+
+    # EXACTLY three events, one chain, in causal order.
+    chain = _chain(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+
+    proposed_e, human_e, completed_e = chain
+    # Causation walk: each event cites the prior.
+    assert proposed_e.causation_id is None
+    assert human_e.causation_id == proposed_e.id
+    assert completed_e.causation_id == human_e.id
+
+    # human.corrected — accepted, the human user is the actor.
+    assert human_e.payload["disposition"] == "accepted"
+    assert human_e.actor.kind == "user"
+    assert human_e.actor.id == f"user:{USER}"
+
+    # decision.completed — landed, carries the PR url + branch + file count.
+    assert completed_e.payload["passed"] is True
+    assert completed_e.payload["action_outcome"] == "landed"
+    assert "github.com/acme/repo/pull/1" in completed_e.payload["pr_url"]
+    assert completed_e.payload["branch"].startswith("feat/belt-")
+    assert completed_e.payload["files_changed"] == 1
+
+    # EXACTLY ONE terminal — the doubled-terminal trap.
+    assert len(_events(journal, "decision.completed")) == 1
+    assert len(_events(journal, "agent.proposed")) == 1
+    assert len(_events(journal, "human.corrected")) == 1
+
+    # The folded Decision row is queryable and not rejected.
+    assert graph.store.count() == 1
+    decisions = await graph.find()
+    assert len(decisions) == 1
+    d = decisions[0]
+    assert d.correlation_id == corr
+    assert d.action == "code_change"
+    assert len(d.approvers) == 1
+    assert d.approvers[0].actor.id == f"user:{USER}"
+    assert d.outcome is None or d.outcome.status != "rejected"
+
+
+# ---------------------------------------------------------------------------
+# TWO cycles — back-to-back runs form TWO distinct clean chains
+# ---------------------------------------------------------------------------
+
+
+async def test_two_cycles_form_two_distinct_clean_chains(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """A second full executed cycle produces a SECOND distinct chain — two
+    correlation_ids, each a clean 3-event chain, no cross-contamination and no
+    doubled terminals across the two runs."""
+    _patch_pr_opener(monkeypatch)
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+
+    # Cycle 1
+    id_a = await _propose(repo, _good_diff(), summary="First change.")
+    corr_a = await _correlation_for(store, id_a)
+    assert client.post(f"/instinct/actions/{id_a}/approve").status_code == 200
+
+    # Cycle 2 (a distinct diff value so the two branches differ)
+    diff_b = (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        " def hello():\n"
+        "-    return 'hi'\n"
+        "+    return 'second'\n"
+    )
+    id_b = await _propose(repo, diff_b, summary="Second change.")
+    corr_b = await _correlation_for(store, id_b)
+    assert client.post(f"/instinct/actions/{id_b}/approve").status_code == 200
+
+    assert corr_a != corr_b
+
+    # Each chain is its own clean 3-event walk.
+    for corr in (corr_a, corr_b):
+        actions = [e.action for e in _chain(journal, corr)]
+        assert actions == [
+            "agent.proposed",
+            "human.corrected",
+            "decision.completed",
+        ], (corr, actions)
+
+    # Two terminals total — one per run, none doubled.
+    assert len(_events(journal, "agent.proposed")) == 2
+    assert len(_events(journal, "human.corrected")) == 2
+    assert len(_events(journal, "decision.completed")) == 2
+
+    # Two distinct Decision rows.
+    assert graph.store.count() == 2
+    decisions = await graph.find()
+    corrs = {d.correlation_id for d in decisions}
+    assert corrs == {corr_a, corr_b}
+
+
+# ---------------------------------------------------------------------------
+# REJECT path — propose → reject → ONE clean chain (N=3), router owns close
+# ---------------------------------------------------------------------------
+
+
+async def test_rejected_run_is_one_clean_three_event_chain(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """A rejected station run lands as ONE clean chain:
+    agent.proposed → human.corrected(rejected) → decision.completed(rejected,
+    reason=<comment>). The executor never runs (no PR opener call), the router
+    owns the close, and there is exactly one terminal."""
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+    FakePrOpener.instances.clear()
+
+    action_id = await _propose(repo, _good_diff(), summary="A change to reject.")
+    corr = await _correlation_for(store, action_id)
+
+    resp = client.post(
+        f"/instinct/actions/{action_id}/reject",
+        json={"reason": "not now — out of scope"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED
+
+    chain = _chain(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+
+    proposed_e, human_e, completed_e = chain
+    assert human_e.causation_id == proposed_e.id
+    assert completed_e.causation_id == human_e.id
+
+    assert human_e.payload["disposition"] == "rejected"
+    assert human_e.payload["note"] == "not now — out of scope"
+
+    assert completed_e.payload["passed"] is False
+    assert completed_e.payload["action_outcome"] == "rejected"
+    assert completed_e.payload["reason"] == "not now — out of scope"
+
+    # Exactly one terminal; the executor never ran (no PR opener instantiated).
+    assert len(_events(journal, "decision.completed")) == 1
+    assert FakePrOpener.instances == []
+
+    # The folded Decision row is marked rejected.
+    decisions = await graph.find()
+    assert len(decisions) == 1
+    assert decisions[0].outcome is not None
+    assert decisions[0].outcome.status == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# FAILED path — propose → approve → apply conflict → ONE chain (failed terminal)
+# ---------------------------------------------------------------------------
+
+
+async def test_failed_apply_is_one_clean_three_event_chain(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """An approved run whose diff cannot apply closes the chain with a single
+    failed terminal: agent.proposed → human.corrected(accepted) →
+    decision.completed(passed=False, action_outcome="failed",
+    error_class="ApplyConflict"). No PR opened, no doubled terminal."""
+    _patch_pr_opener(monkeypatch)
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+    FakePrOpener.instances.clear()
+
+    action_id = await _propose(repo, _conflict_diff(), summary="A conflicting change.")
+    corr = await _correlation_for(store, action_id)
+
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.FAILED
+
+    chain = _chain(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+
+    proposed_e, human_e, completed_e = chain
+    assert human_e.causation_id == proposed_e.id
+    assert completed_e.causation_id == human_e.id
+
+    assert human_e.payload["disposition"] == "accepted"
+    assert completed_e.payload["passed"] is False
+    assert completed_e.payload["action_outcome"] == "failed"
+    assert completed_e.payload["error_class"] == "ApplyConflict"
+
+    # Exactly one terminal; the apply conflict means the PR opener was never
+    # reached (the executor bails before the push/PR step).
+    assert len(_events(journal, "decision.completed")) == 1
+    assert FakePrOpener.instances == [] or FakePrOpener.instances[0].calls == []
+
+
+# ---------------------------------------------------------------------------
+# bulk-approve — code_change item lands as one clean chain too
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_approve_code_change_is_one_clean_chain(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """A code_change Action approved via the BULK endpoint forms the same
+    clean 3-event chain — bulk-approve has no edit surface, so disposition is
+    accepted, and the executor still owns a single landed terminal."""
+    _patch_pr_opener(monkeypatch)
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+
+    action_id = await _propose(repo, _good_diff(), summary="Bulk change.")
+    corr = await _correlation_for(store, action_id)
+
+    resp = client.post(
+        "/instinct/actions/bulk-approve",
+        json={"ids": [action_id], "note": "ship it"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()["affected"]) == 1
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+
+    chain = _chain(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert chain[1].payload["disposition"] == "accepted"
+    assert chain[1].payload.get("note") == "ship it"
+    assert chain[2].payload["action_outcome"] == "landed"
+    assert len(_events(journal, "decision.completed")) == 1


### PR DESCRIPTION
Stacks on #1409 (BS-3 — the code-change gate).

## What this adds

A Belt code-change station run now shows up in the Decision Graph as one chain instead of being invisible. On the BS-3 base, the code_change path emitted zero decision events — the router explicitly skipped them. BS-4 wires the chain end to end so a single run reads as one connected decision: the agent proposed a diff, a human approved or rejected it, and it landed (or failed, or was rejected).

## The chain

One correlation_id is minted at propose time and carried through approve/reject and apply. Every run is exactly three events:

- `agent.proposed` — at propose (belt.py)
- `human.corrected` — at approve or reject (instinct router)
- `decision.completed` — at the terminal:
  - executed → `passed=true, action_outcome="landed"` with the PR url, branch, and file count (executor, on mark_executed)
  - failed → `passed=false, action_outcome="failed"` with an error class (executor, on mark_failed)
  - rejected → `passed=false, action_outcome="rejected"` with the reject comment (router, since the executor never runs on reject)

Each event cites the prior one through `causation_id`, so the chain walks `agent.proposed → human.corrected → decision.completed` cleanly.

## Where the correlation lives

On the Action's `_code_change` blob, alongside the diff — the same place the pocket-write path keeps its `correlation_id` on `_pocket_write`. The blob bumps to schema 2 (`correlation_id` + `proposed_event_id`); the executor's schema literal moves to 2 to match. No new parallel mechanism — it mirrors the existing pocket-write wire.

## No doubled terminals

This is the thing the test guards. The executor owns the close on the approve path; the router owns it on reject. Every failure path marks failed and closes the chain through one chokepoint, then returns — so exactly one `decision.completed` fires per run. A prior incident had stubbed seams double-emitting the terminal, so the test drives the real path with no stubs between propose, approve, and execute: the real propose handler, the real store, the real router dispatch, and the real executor against a local bare-repo git fixture. The only fake is the PR opener — that's the genuine external boundary.

## Test evidence

`tests/cloud/test_belt_trace.py` asserts:
- executed run is one clean three-event chain with the right causation walk
- two back-to-back runs form two distinct clean chains, no cross-contamination
- reject path is its own clean chain (router owns the close, executor never runs)
- apply-conflict run closes with a single failed terminal
- bulk-approve of a code_change Action lands the same clean chain

```
uv run pytest tests/cloud/test_belt_gate.py tests/cloud/test_ee_instinct.py tests/ee/test_instinct_decision_events.py tests/cloud/test_belt_trace.py -q
101 passed in 6.88s
```

Broader sweep (`-k "decision or instinct or belt or bridge"`): 316 passed, 1 skipped.