### PR TITLE
feat(belt): Add a list_entity_types() pass-through to WorkspaceFabricReg

### DIFF
--- a/ee/pocketpaw_ee/fabric/registry.py
+++ b/ee/pocketpaw_ee/fabric/registry.py
@@ -6,6 +6,9 @@
 # Mutations stay on the store; the registry stays read-only by design
 # so wiring code can keep one Protocol type in its signatures and the
 # call-site stays simple (``WorkspaceFabricRegistry(store, ws_id)``).
+# 2026-06-10: added ``list_entity_types()`` pass-through — the registry
+# exposed exists/properties but no way to enumerate the workspace
+# ontology without reaching around to the store.
 """Concrete ``FabricRegistry`` implementation backed by
 :class:`WorkspaceFabricStore`.
 
@@ -89,6 +92,17 @@ class WorkspaceFabricRegistry:
         # so callers can mutate the returned value without affecting
         # the store. We return it directly to avoid a redundant copy.
         return self._store.get_properties(self._workspace_id, name)
+
+    def list_entity_types(self) -> list[str]:
+        """Names of every entity type registered in this workspace.
+
+        Pass-through to ``WorkspaceFabricStore.list_entity_types`` with
+        the bound ``workspace_id``. Completes the read surface: callers
+        holding a registry could check a known name or fetch its
+        properties, but had no way to enumerate the workspace ontology
+        without reaching around the wrapper to the store.
+        """
+        return self._store.list_entity_types(self._workspace_id)
 
 
 __all__ = [

--- a/tests/ee/test_fabric_registry.py
+++ b/tests/ee/test_fabric_registry.py
@@ -112,6 +112,21 @@ def test_get_entity_properties_for_unknown_returns_empty(
     assert reg.get_entity_properties("Ghost") == set()
 
 
+def test_list_entity_types_returns_workspace_ontology(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-b")
+    assert sorted(reg.list_entity_types()) == ["Customer", "Invoice"]
+
+
+def test_list_entity_types_is_workspace_isolated(
+    populated_store: WorkspaceFabricStore,
+) -> None:
+    reg_a = WorkspaceFabricRegistry(store=populated_store, workspace_id="ws-a")
+    assert sorted(reg_a.list_entity_types()) == ["Lease", "Property", "Tenant"]
+    assert "Customer" not in reg_a.list_entity_types()
+
+
 # ---------------------------------------------------------------------------
 # Empty store
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add a list_entity_types() pass-through to WorkspaceFabricRegistry. The registry exposed exists/properties but no way to enumerate the workspace ontology without reaching around the wrapper to the store. Found via loom orient() during the Belt & Pulley exit test; includes registry tests for ontology listing and workspace isolation.