### PR TITLE
Belt & Pulley thin slice: one develop-station end to end

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/belt.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/belt.py
@@ -1,0 +1,440 @@
+# belt.py — in-process MCP server exposing the Belt & Pulley develop-station
+# code-change gate to the claude_agent_sdk cloud chat backend. Created:
+# 2026-06-10 (feat/belt-gate, BS-3).
+#
+# What this file does: clones the media.py shape — a single
+# ``create_sdk_mcp_server`` with an SDK import-guard, ``SERVER_NAME`` /
+# ``*_TOOL_ID`` allowlist constants, ContextVar-sourced identity (the same
+# ``current_workspace_id`` / ``current_user_id`` / ``current_session_mongo_id``
+# accessors in ``ee.cloud.chat.agent_service`` the media / sites servers read),
+# and the ``_error_response`` / ``_success_response`` helpers. The single tool
+# id namespaces as ``mcp__pocketpaw_belt__belt_propose_change`` so the Claude
+# Code allowlist machinery matches it (a sibling PR hardcodes this exact id).
+#
+# One SDK @tool def:
+#   * belt_propose_change — the develop station agent produces a unified diff
+#     and proposes it THROUGH Instinct (the human approve/reject layer, "sudo
+#     for agents"). This tool does NOT apply anything: it validates the inputs
+#     (identity present; diff non-empty and under the size cap; repo resolves to
+#     an existing git repo INSIDE the settings-driven allowlist) and then files
+#     an Instinct Action carrying a ``_code_change`` blob. A human approves it
+#     in The Tray; the apply-on-approve executor (ee/cloud/belt/executor.py)
+#     then applies the diff in a FRESH worktree, commits, pushes, and opens a
+#     PR. The captain still merges on GitHub — Instinct is the MID gate, never
+#     an auto-merge.
+#
+# Contract pins (a sibling PR hardcodes these — do not deviate):
+#   * server name ``pocketpaw_belt``, tool ``belt_propose_change``
+#   * input {repo, base_branch, diff, summary, task, orient_ref?}
+#   * Action kind ``code_change`` (stored as the blob's ``kind`` discriminator
+#     under ``Action.parameters._code_change`` — the Action model has no literal
+#     ``kind`` column; the pocket-write bridge uses the same parameters-key
+#     discriminator pattern).
+#
+# Security: the diff is DATA — it is stored verbatim in the Action blob and only
+# ever written to a temp file + fed to ``git apply`` by the executor, never
+# echoed/eval'd. The repo path is allowlist-gated here at propose time AND
+# re-resolved at execute time (defense in depth). NO phantom successes: the tool
+# returns ok only after ``store.propose`` confirms the Action is durably stored.
+# Diff content is never logged — only action ids + changed-line counts.
+#
+# EE→OSS boundary: this module lives in pocketpaw_ee; the surface service loads
+# BELT_TOOL_IDS as a plain frozenset[str] inside a try/except (never importing a
+# pocketpaw_ee symbol into src/pocketpaw).
+"""Agent-side MCP surface for the Belt & Pulley code-change gate."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_belt"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form. A sibling PR hardcodes
+# ``mcp__pocketpaw_belt__belt_propose_change`` — keep it stable.
+PROPOSE_CHANGE_TOOL_ID = f"mcp__{SERVER_NAME}__belt_propose_change"
+
+BELT_TOOL_IDS = (PROPOSE_CHANGE_TOOL_ID,)
+
+# The Instinct Action kind discriminator for a Belt code-change proposal. The
+# executor + the router dispatch on the presence of this key under
+# ``Action.parameters``; the blob also carries ``kind="code_change"`` for
+# readers that introspect the blob directly.
+CODE_CHANGE_KIND = "code_change"
+# The parameters key under which the code-change blob rides — mirrors the
+# pocket-write bridge's ``_pocket_write`` key. The router + executor dispatch on
+# this key being present.
+CODE_CHANGE_PARAM_KEY = "_code_change"
+
+# Diff size cap. A proposal over EITHER bound is refused with a "split the task"
+# error — a diff this large is a sign the station task wasn't decomposed, and a
+# huge blob in Mongo + a sprawling PR defeats the human-review gate. Counts
+# ADDED/REMOVED lines (``+``/``-`` lines, excluding the ``+++``/``---`` file
+# headers), not context lines.
+MAX_CHANGED_LINES = 1500
+MAX_DIFF_BYTES = 200 * 1024  # 200 KB
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects. The agent
+    reads ``text`` and surfaces the reason."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None, str | None]:
+    """Resolve the active workspace + user + session id from the per-stream
+    ContextVars set by the cloud chat agent runtime. Returns
+    ``(workspace_id, user_id, session_mongo_id)``."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_session_mongo_id,
+            current_user_id,
+            current_workspace_id,
+        )
+
+        return current_workspace_id(), current_user_id(), current_session_mongo_id()
+    except Exception:  # noqa: BLE001
+        return None, None, None
+
+
+def _count_changed_lines(diff: str) -> int:
+    """Count added/removed lines in a unified diff.
+
+    A changed line starts with a single ``+`` or ``-`` but is NOT a file header
+    (``+++ ``/``--- ``). Context lines (leading space) and hunk headers (``@@``)
+    don't count. This is a heuristic line budget, not a parser — it only needs
+    to flag a task that should have been split.
+    """
+    count = 0
+    for line in diff.splitlines():
+        if line.startswith("+++ ") or line.startswith("--- "):
+            continue
+        if line.startswith("+") or line.startswith("-"):
+            count += 1
+    return count
+
+
+def _resolve_allowlist() -> list[Path]:
+    """Return the resolved allowlist roots a repo path must live under.
+
+    Settings-driven (``belt_repo_allowlist``). When empty, default to the
+    current working directory's PARENT — the workspace root that holds the
+    project checkouts — so a stock deployment still gates writes to the
+    workspace tree rather than the whole filesystem. Each root is resolved
+    (symlinks + ``..`` collapsed) so the containment check below can't be
+    defeated by a ``..`` traversal.
+    """
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    roots: list[Path] = []
+    for raw in settings.belt_repo_allowlist or []:
+        try:
+            roots.append(Path(raw).expanduser().resolve())
+        except (OSError, RuntimeError):
+            logger.warning("belt: skipping unresolvable allowlist root %r", raw)
+    if not roots:
+        # Default: the parent of cwd (the workspace root holding the checkouts).
+        roots.append(Path.cwd().resolve().parent)
+    return roots
+
+
+def _is_within_allowlist(repo_path: Path, roots: list[Path]) -> bool:
+    """True when ``repo_path`` is inside (or equal to) one of the allowlist
+    roots. ``repo_path`` MUST already be resolved by the caller."""
+    for root in roots:
+        try:
+            repo_path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _resolve_repo(repo: str) -> tuple[Path | None, str | None]:
+    """Resolve a proposal's ``repo`` field to an existing, allowlisted git repo.
+
+    ``repo`` is an absolute path or a registered name. (Registered-name
+    resolution is a follow-up — BS-3 ships the absolute-path form; a name that
+    isn't an existing path is refused with a clear error.) Returns
+    ``(resolved_path, None)`` on success or ``(None, error)`` on any refusal:
+    a non-existent path, a path that isn't a git repo, or a path outside the
+    allowlist. The allowlist check runs on the RESOLVED path so a ``..``
+    traversal can't escape the boundary.
+    """
+    if not repo or not isinstance(repo, str):
+        return None, "`repo` must be a non-empty absolute path (or registered name)."
+
+    try:
+        candidate = Path(repo).expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        return None, f"could not resolve repo path {repo!r}: {exc}"
+
+    roots = _resolve_allowlist()
+    # Allowlist FIRST — never leak whether an out-of-bounds path exists.
+    if not _is_within_allowlist(candidate, roots):
+        return None, (
+            f"repo path {repo!r} is outside the allowed roots "
+            f"({', '.join(str(r) for r in roots)}). Set "
+            "POCKETPAW_BELT_REPO_ALLOWLIST to authorize a new root."
+        )
+
+    if not candidate.is_dir():
+        return None, f"repo path {repo!r} does not exist or is not a directory."
+
+    if not (candidate / ".git").exists():
+        return None, f"repo path {repo!r} is not a git repository (no .git)."
+
+    return candidate, None
+
+
+async def _propose_change_handler(args: dict) -> dict:
+    """MCP handler for ``belt__belt_propose_change``.
+
+    Validates identity + inputs, then files an Instinct Action carrying the
+    ``_code_change`` blob. Returns ``{ok, action_id, tray_hint}`` on success,
+    or an ``is_error`` response with the reason. NO phantom successes: ok is
+    returned only after ``store.propose`` confirms the Action is stored.
+    """
+    workspace_id, user_id, session_mongo_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "belt_propose_change requires workspace and user context "
+            "(call from a cloud chat session)."
+        )
+
+    repo = args.get("repo")
+    base_branch = args.get("base_branch")
+    diff = args.get("diff")
+    summary = args.get("summary")
+    task = args.get("task")
+    orient_ref = args.get("orient_ref")
+
+    if not isinstance(base_branch, str) or not base_branch.strip():
+        return _error_response("belt_propose_change requires a non-empty `base_branch`.")
+    if not isinstance(summary, str) or not summary.strip():
+        return _error_response(
+            "belt_propose_change requires a non-empty `summary` (used as the commit body)."
+        )
+    if not isinstance(task, str) or not task.strip():
+        return _error_response(
+            "belt_propose_change requires the original `task` text the station was given."
+        )
+
+    # The diff is the payload — validate it hard before anything touches a store.
+    if not isinstance(diff, str) or not diff.strip():
+        return _error_response("belt_propose_change requires a non-empty unified `diff`.")
+
+    diff_bytes = len(diff.encode("utf-8"))
+    changed_lines = _count_changed_lines(diff)
+    if changed_lines > MAX_CHANGED_LINES or diff_bytes > MAX_DIFF_BYTES:
+        return _error_response(
+            f"diff too large to gate ({changed_lines} changed lines, "
+            f"{diff_bytes} bytes; cap is {MAX_CHANGED_LINES} lines / "
+            f"{MAX_DIFF_BYTES} bytes). Split the task into smaller, "
+            "independently reviewable changes and propose each separately."
+        )
+
+    repo_path, repo_err = _resolve_repo(repo if isinstance(repo, str) else "")
+    if repo_err is not None or repo_path is None:
+        return _error_response(repo_err or "could not resolve the repo path.")
+
+    orient_clean = (
+        orient_ref.strip() if isinstance(orient_ref, str) and orient_ref.strip() else None
+    )
+
+    # Build the code-change blob. ``kind`` is the discriminator the executor /
+    # router dispatch on (the Action model has no literal kind column). The diff
+    # rides verbatim — it is DATA, never interpolated into a shell.
+    blob: dict[str, Any] = {
+        "kind": CODE_CHANGE_KIND,
+        "schema": 1,
+        "repo": str(repo_path),
+        "base_branch": base_branch.strip(),
+        "diff": diff,
+        "summary": summary.strip(),
+        "task": task.strip(),
+        "orient_ref": orient_clean,
+        "workspace_id": workspace_id,
+        "requested_by": user_id,
+        # The proposing chat session — lets the executor / audit tie the PR back
+        # to the conversation that produced it.
+        "session_id": session_mongo_id,
+    }
+
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    # A short, content-free title/recommendation for The Tray. NEVER put diff
+    # content in the title — only the summary (the agent's own 1-3 sentence
+    # description) and the repo/branch.
+    repo_name = repo_path.name
+    title = f"Code change — {repo_name} ({base_branch.strip()})"
+    recommendation = (
+        f"Approve to apply this diff to {repo_name} on a new branch off "
+        f"{base_branch.strip()} and open a PR. {changed_lines} changed lines. "
+        f"Summary: {summary.strip()}"
+    )
+
+    trigger = ActionTrigger(
+        type="agent",
+        source="belt:develop",
+        reason="code change proposed by the develop station — requires human approval",
+    )
+
+    store = get_instinct_store()
+    try:
+        action = await store.propose(
+            # ``pocket_id`` carries the workspace for Belt actions — they aren't
+            # bound to a pocket the way Mission Control items are. The workspace
+            # also rides on the blob (the executor's tenancy gate reads it
+            # there); pocket_id mirrors it so the existing per-pocket queries
+            # still surface the row.
+            pocket_id=workspace_id,
+            title=title,
+            description=recommendation,
+            recommendation=recommendation,
+            trigger=trigger,
+            category=ActionCategory.EXTERNAL,
+            priority=ActionPriority.HIGH,
+            parameters={CODE_CHANGE_PARAM_KEY: blob},
+            assignee=user_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("belt: propose raised (no Action stored)", exc_info=True)
+        return _error_response(f"could not propose the change: {exc}")
+
+    # Confirm the Action is durably readable before claiming success — NO
+    # phantom success. ``propose`` returns the in-memory Action; a fetch proves
+    # the INSERT committed.
+    stored = await store.get_action(action.id)
+    if stored is None:
+        return _error_response("the change was not stored — please retry.")
+
+    logger.info(
+        "belt: proposed code_change action %s (repo=%s, base=%s, changed_lines=%d)",
+        action.id,
+        repo_name,
+        base_branch.strip(),
+        changed_lines,
+    )
+
+    return _success_response(
+        {
+            "ok": True,
+            "action_id": action.id,
+            "tray_hint": (
+                "Proposed for approval in The Tray. A human must approve before "
+                "the diff is applied and a PR is opened. Do not claim the change "
+                "is merged — Instinct is the mid gate; the captain merges on "
+                "GitHub."
+            ),
+        }
+    )
+
+
+def build_belt_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for the Belt code-change gate, or
+    return ``None`` if the Claude Agent SDK isn't installed.
+
+    Matches the shape returned by ``build_media_server`` (``(name, server)`` or
+    ``None``) so the backend's MCP registration loop treats it identically.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_belt MCP disabled")
+        return None
+
+    @tool(
+        "belt_propose_change",
+        (
+            "Propose a CODE CHANGE for human approval (the Belt & Pulley develop "
+            "station). Call this when you have produced a unified diff that should "
+            "be applied to a repo. This does NOT apply the diff or merge anything: "
+            "it files the change in The Tray for a human to approve or reject. On "
+            "approval, the change is applied to a fresh branch and a PR is opened "
+            "— the captain merges on GitHub. Args: `repo` (absolute path or "
+            "registered name of the git repo), `base_branch` (the branch to base "
+            "off, e.g. 'main'), `diff` (the full unified diff), `summary` (1-3 "
+            "sentences describing the change — used as the commit message body), "
+            "`task` (the original station task text), `orient_ref` (optional brief "
+            "reference to the orientation you used). Returns {ok, action_id, "
+            "tray_hint}. ok=false with an error means relay the reason (e.g. the "
+            "diff is too large — split the task) — do NOT claim the change landed."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Absolute path (or registered name) of the target git repo.",
+                },
+                "base_branch": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Branch to base the change off (e.g. 'main').",
+                },
+                "diff": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The full unified diff to apply.",
+                },
+                "summary": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "1-3 sentence description; used as the commit message body.",
+                },
+                "task": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The original station task text.",
+                },
+                "orient_ref": {
+                    "type": "string",
+                    "description": "Optional brief reference to the orientation used.",
+                },
+            },
+            "required": ["repo", "base_branch", "diff", "summary", "task"],
+            "additionalProperties": False,
+        },
+    )
+    async def belt_propose_change(args):  # type: ignore[no-untyped-def]
+        return await _propose_change_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[belt_propose_change],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "BELT_TOOL_IDS",
+    "CODE_CHANGE_KIND",
+    "CODE_CHANGE_PARAM_KEY",
+    "PROPOSE_CHANGE_TOOL_ID",
+    "SERVER_NAME",
+    "build_belt_server",
+]

--- a/ee/pocketpaw_ee/agent/mcp_servers/belt.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/belt.py
@@ -2,6 +2,22 @@
 # code-change gate to the claude_agent_sdk cloud chat backend. Created:
 # 2026-06-10 (feat/belt-gate, BS-3).
 #
+# Updated: 2026-06-10 (feat/belt-trace, BS-4 — Decision-Graph chain) —
+#   ``belt_propose_change`` now MINTS a Decision-Graph ``correlation_id``
+#   at propose time and emits the chain-opening ``agent.proposed`` event
+#   through ``journal_writer.record_agent_proposed`` (RFC 09). The
+#   correlation_id is stamped onto the ``_code_change`` blob (schema 2,
+#   mirroring the pocket-write bridge's ``_pocket_write.correlation_id``)
+#   so the Instinct router's approve / reject paths and the executor can
+#   close the SAME chain — one station run = one Decision chain. The
+#   emitted ``agent.proposed`` event id is stashed on the blob as
+#   ``proposed_event_id`` so the eventual ``human.corrected`` event can
+#   cite it as its ``causation_id``. Both the emit and the blob fields are
+#   best-effort: a Decision-Graph wiring failure must never fail the
+#   propose response (the Action is already durable; the Slice 4 reconciler
+#   is the safety net). The blob also carries the workspace/user on the
+#   chain actor + scope so visibility filters narrow correctly.
+#
 # What this file does: clones the media.py shape — a single
 # ``create_sdk_mcp_server`` with an SDK import-guard, ``SERVER_NAME`` /
 # ``*_TOOL_ID`` allowlist constants, ContextVar-sourced identity (the same
@@ -49,6 +65,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Any
+from uuid import UUID, uuid4
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +86,17 @@ CODE_CHANGE_KIND = "code_change"
 # pocket-write bridge's ``_pocket_write`` key. The router + executor dispatch on
 # this key being present.
 CODE_CHANGE_PARAM_KEY = "_code_change"
+
+# Schema version stamped on the ``_code_change`` blob.
+#   * schema 1 (BS-3): repo / base_branch / diff / summary / task + workspace +
+#     requester context, NO Decision-Graph chain.
+#   * schema 2 (BS-4, RFC 09): adds ``correlation_id`` (the chain id minted here
+#     at propose time, when ``agent.proposed`` fires) and ``proposed_event_id``
+#     (the id of that ``agent.proposed`` event, so the eventual
+#     ``human.corrected`` can chain its ``causation_id`` back to it). The
+#     executor's schema-mismatch guard fails a stale schema-1 blob approved
+#     post-deploy loud (same discipline as the pocket-write bridge).
+CODE_CHANGE_SCHEMA = 2
 
 # Diff size cap. A proposal over EITHER bound is refused with a "split the task"
 # error — a diff this large is a sign the station task wasn't decomposed, and a
@@ -207,6 +235,135 @@ def _resolve_repo(repo: str) -> tuple[Path | None, str | None]:
     return candidate, None
 
 
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    repo_name: str,
+    base_branch: str,
+    summary: str,
+    task: str,
+    changed_lines: int,
+    workspace_id: str,
+    user_id: str,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a Belt code change.
+
+    Mirrors ``action_executor``'s ``agent.proposed`` emit for pocket writes:
+    the develop station is the actor that PROPOSED the change, so the chain
+    actor is ``kind="agent"`` with the requesting user on its id and the
+    workspace on its scope_context. The Belt action isn't bound to a pocket —
+    its tenancy is the workspace — so ``pocket_id`` on the chain carries the
+    workspace id (matching how the Action's ``pocket_id`` field carries the
+    workspace, see ``_propose_change_handler``). The projection's
+    ``_fold_proposed`` reads ``intent`` / ``action`` / ``pocket_id`` /
+    ``inputs`` off the payload.
+
+    Returns the emitted event id (``UUID``) so the caller can persist it on the
+    blob's ``proposed_event_id`` field for the ``human.corrected`` causation
+    chain, or ``None`` when the emit raised — best-effort per RFC 09; the Slice
+    4 reconciler / abandon-sweeper picks up any orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"code change to {repo_name} ({base_branch}) — {changed_lines} changed lines"
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "code_change",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator / a future swap to
+        # soul-protocol's ``build_proposal_event(AgentProposal(...))``.
+        "proposal_kind": "code_change",
+        "summary": summary,
+        "proposal": {
+            "repo": repo_name,
+            "base_branch": base_branch,
+            "task": task,
+            "changed_lines": changed_lines,
+        },
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "belt agent.proposed emit failed for correlation_id=%s (action_id=%s) "
+            "— Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._code_change`` blob after ``agent.proposed`` fired.
+
+    The blob is built with these fields already set from the in-memory values,
+    so this re-write only matters when the proposed event id was unknown at
+    propose-build time. We mint the correlation_id BEFORE building the blob, so
+    that field is already correct on the stored row; ``proposed_event_id`` is
+    the one this back-write fills in. Direct SQL update — same pattern as the
+    pocket-write bridge's ``_persist_parked_policy_event_id``. Best-effort:
+    failure leaves ``proposed_event_id`` None and the eventual
+    ``human.corrected`` emits without a causation_id (the chain still folds;
+    causation_id is optional on EventEntry).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(CODE_CHANGE_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[CODE_CHANGE_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "belt: failed to persist chain ids onto action %s — the chain's "
+            "human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
 async def _propose_change_handler(args: dict) -> dict:
     """MCP handler for ``belt__belt_propose_change``.
 
@@ -262,12 +419,22 @@ async def _propose_change_handler(args: dict) -> dict:
         orient_ref.strip() if isinstance(orient_ref, str) and orient_ref.strip() else None
     )
 
+    # BS-4 — mint the Decision-Graph chain correlation_id BEFORE building the
+    # blob so the stored Action carries it from the first write. The same id
+    # threads through approve / reject (router) and apply (executor) so the
+    # whole station run folds into ONE Decision chain.
+    correlation_id = uuid4()
+
     # Build the code-change blob. ``kind`` is the discriminator the executor /
     # router dispatch on (the Action model has no literal kind column). The diff
     # rides verbatim — it is DATA, never interpolated into a shell.
+    #
+    # Schema 2 (BS-4, RFC 09) — carries the chain ``correlation_id`` and
+    # ``proposed_event_id`` (the latter back-written after ``agent.proposed``
+    # fires; None here, filled by ``_persist_chain_ids`` below).
     blob: dict[str, Any] = {
         "kind": CODE_CHANGE_KIND,
-        "schema": 1,
+        "schema": CODE_CHANGE_SCHEMA,
         "repo": str(repo_path),
         "base_branch": base_branch.strip(),
         "diff": diff,
@@ -279,6 +446,9 @@ async def _propose_change_handler(args: dict) -> dict:
         # The proposing chat session — lets the executor / audit tie the PR back
         # to the conversation that produced it.
         "session_id": session_mongo_id,
+        # RFC 09 chain-correlation fields (schema 2).
+        "correlation_id": str(correlation_id),
+        "proposed_event_id": None,
     }
 
     from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
@@ -330,12 +500,39 @@ async def _propose_change_handler(args: dict) -> dict:
     if stored is None:
         return _error_response("the change was not stored — please retry.")
 
+    # BS-4 — open the Decision-Graph chain now that the Action is durable.
+    # ``agent.proposed`` is the chain origin; its event id is back-written onto
+    # the blob so the router's ``human.corrected`` can cite it as causation.
+    # Best-effort: a Decision-Graph wiring failure must NOT fail the propose
+    # response — the Action is already stored; the Slice 4 reconciler closes
+    # any chain that never opened.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=correlation_id,
+        action_id=action.id,
+        repo_name=repo_name,
+        base_branch=base_branch.strip(),
+        summary=summary.strip(),
+        task=task.strip(),
+        changed_lines=changed_lines,
+        workspace_id=workspace_id,
+        user_id=user_id,
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action.id,
+            correlation_id=str(correlation_id),
+            proposed_event_id=str(proposed_event_id),
+        )
+
     logger.info(
-        "belt: proposed code_change action %s (repo=%s, base=%s, changed_lines=%d)",
+        "belt: proposed code_change action %s (repo=%s, base=%s, changed_lines=%d, "
+        "correlation_id=%s)",
         action.id,
         repo_name,
         base_branch.strip(),
         changed_lines,
+        correlation_id,
     )
 
     return _success_response(
@@ -434,6 +631,7 @@ __all__ = [
     "BELT_TOOL_IDS",
     "CODE_CHANGE_KIND",
     "CODE_CHANGE_PARAM_KEY",
+    "CODE_CHANGE_SCHEMA",
     "PROPOSE_CHANGE_TOOL_ID",
     "SERVER_NAME",
     "build_belt_server",

--- a/ee/pocketpaw_ee/agent/mcp_servers/loom.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/loom.py
@@ -1,0 +1,131 @@
+# loom.py — registers the loom codebase-orientation binary as an MCP server for
+# the claude_agent_sdk cloud chat backend. Created: 2026-06-10 (BS-1, Belt &
+# Pulley stations thin slice).
+#
+# What this file does (Path A — stdio config pass-through, NOT an in-process SDK
+# server): loom is a finished external Go binary that already speaks MCP over
+# stdio (`loom mcp -model <worldmodel.json>`, server name "loom", 5 read tools:
+# orient / locate / why / what_depends_on / boundaries). Rather than re-implement
+# those tools as an in-process SDK proxy, this module returns a stdio server
+# CONFIG DICT — the McpStdioServerConfig shape the claude_agent_sdk's
+# ``mcp_servers`` option accepts natively ({"type":"stdio","command":...,
+# "args":[...]}). The pocketpaw registration loop in
+# ``pocketpaw.agents.claude_sdk._get_mcp_servers`` does ``servers[name] =
+# cfg_entry`` with NO transformation (claude_sdk.py:738/751), and the existing
+# file-based stdio path already builds the same dict shape (claude_sdk.py:659),
+# so a config dict flows through to ``ClaudeAgentOptions.mcp_servers`` exactly
+# like an SDK server object would. No loop change was needed — see the PR body
+# spike for the file:line evidence.
+#
+# Tool ids namespace as ``mcp__loom__orient`` etc. (the binary's own server
+# name is "loom"), so the Claude Code allowlist machinery matches them.
+#
+# Graceful-by-default: ``build_loom_server`` returns None — never raising — when
+#   * ``loom_model_path`` is unset (loom disabled), or
+#   * the loom binary cannot be resolved on disk.
+# A None return means the entry-point loop simply skips registration; chat keeps
+# working without orientation. Binary resolution mirrors loom's own discovery
+# order: explicit ``loom_bin`` setting → PATH lookup → ~/go/bin/loom fallback.
+"""Agent-side registration of the loom codebase-orientation MCP server."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The loom binary names its own MCP server "loom" (serverInfo.name in the
+# initialize response), so the in-process namespace and tool ids key on it.
+SERVER_NAME = "loom"
+
+# Claude Code namespaces MCP tools as ``mcp__<server>__<tool>``. Allowlist
+# entries must use this exact form. loom exposes these 5 read tools.
+ORIENT_TOOL_ID = f"mcp__{SERVER_NAME}__orient"
+LOCATE_TOOL_ID = f"mcp__{SERVER_NAME}__locate"
+WHY_TOOL_ID = f"mcp__{SERVER_NAME}__why"
+WHAT_DEPENDS_ON_TOOL_ID = f"mcp__{SERVER_NAME}__what_depends_on"
+BOUNDARIES_TOOL_ID = f"mcp__{SERVER_NAME}__boundaries"
+
+LOOM_TOOL_IDS = (
+    ORIENT_TOOL_ID,
+    LOCATE_TOOL_ID,
+    WHY_TOOL_ID,
+    WHAT_DEPENDS_ON_TOOL_ID,
+    BOUNDARIES_TOOL_ID,
+)
+
+
+def _resolve_loom_bin(loom_bin: str) -> str | None:
+    """Resolve the loom binary path, mirroring loom's own discovery order.
+
+    Order: an explicit absolute/relative path that exists → a PATH lookup of the
+    given name → the ~/go/bin/loom fallback. Returns the resolved absolute path,
+    or None when nothing on disk matches (so the caller can degrade to None).
+    """
+    # 1. Explicit path that points at a real executable file.
+    candidate = Path(loom_bin).expanduser()
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+
+    # 2. PATH lookup (handles the bare-name default "loom").
+    on_path = shutil.which(loom_bin)
+    if on_path:
+        return on_path
+
+    # 3. ~/go/bin/loom fallback (the conventional Go install location).
+    go_bin = Path.home() / "go" / "bin" / "loom"
+    if go_bin.is_file() and os.access(go_bin, os.X_OK):
+        return str(go_bin)
+
+    return None
+
+
+def build_loom_server() -> tuple[str, Any] | None:
+    """Build the loom stdio MCP server config, or None when loom is unavailable.
+
+    Returns ``(SERVER_NAME, <McpStdioServerConfig dict>)`` when both the
+    world-model path is set in settings and the loom binary resolves on disk.
+    Returns None — never raising — when:
+      * ``loom_model_path`` is unset (loom disabled by default), or
+      * the configured world-model file does not exist, or
+      * the loom binary cannot be resolved.
+
+    The returned dict is the McpStdioServerConfig shape the claude_agent_sdk
+    consumes natively: ``loom mcp -model <model path>`` served over stdio.
+    """
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+
+    model_path = settings.loom_model_path
+    if not model_path:
+        logger.debug("loom MCP server disabled — loom_model_path is unset")
+        return None
+
+    model_file = Path(model_path).expanduser()
+    if not model_file.is_file():
+        logger.warning(
+            "loom MCP server not registered — world-model not found at %s", model_file
+        )
+        return None
+
+    loom_bin = _resolve_loom_bin(settings.loom_bin)
+    if loom_bin is None:
+        logger.warning(
+            "loom MCP server not registered — loom binary %r not found on PATH "
+            "or at ~/go/bin/loom",
+            settings.loom_bin,
+        )
+        return None
+
+    config: dict[str, Any] = {
+        "type": "stdio",
+        "command": loom_bin,
+        "args": ["mcp", "-model", str(model_file)],
+    }
+    logger.info("loom MCP server registered — model %s", model_file)
+    return SERVER_NAME, config

--- a/ee/pocketpaw_ee/agent/mcp_servers/loom.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/loom.py
@@ -108,16 +108,13 @@ def build_loom_server() -> tuple[str, Any] | None:
 
     model_file = Path(model_path).expanduser()
     if not model_file.is_file():
-        logger.warning(
-            "loom MCP server not registered — world-model not found at %s", model_file
-        )
+        logger.warning("loom MCP server not registered — world-model not found at %s", model_file)
         return None
 
     loom_bin = _resolve_loom_bin(settings.loom_bin)
     if loom_bin is None:
         logger.warning(
-            "loom MCP server not registered — loom binary %r not found on PATH "
-            "or at ~/go/bin/loom",
+            "loom MCP server not registered — loom binary %r not found on PATH or at ~/go/bin/loom",
             settings.loom_bin,
         )
         return None

--- a/ee/pocketpaw_ee/cloud/belt/__init__.py
+++ b/ee/pocketpaw_ee/cloud/belt/__init__.py
@@ -1,0 +1,7 @@
+# ee/pocketpaw_ee/cloud/belt/__init__.py — the Belt & Pulley cloud package.
+# Created: 2026-06-10 (feat/belt-gate, BS-3).
+#
+# Home of the apply-on-approve executor (``executor.py``) for the Belt develop
+# station's code-change gate. A code-change Instinct Action proposed by the
+# ``pocketpaw_belt`` MCP server is applied here — in a fresh worktree — after a
+# human approves it, mirroring the pocket-write bridge's propose/execute split.

--- a/ee/pocketpaw_ee/cloud/belt/executor.py
+++ b/ee/pocketpaw_ee/cloud/belt/executor.py
@@ -1,6 +1,28 @@
 # executor.py — applies an approved Belt code-change Action and opens a PR.
 # Created: 2026-06-10 (feat/belt-gate, BS-3).
 #
+# Updated: 2026-06-10 (feat/belt-trace, BS-4 — Decision-Graph chain close) —
+#   ``execute_approved_change`` now CLOSES the Decision-Graph chain the
+#   propose path opened (RFC 09). It reads the ``correlation_id`` off the
+#   schema-2 ``_code_change`` blob and emits the terminal
+#   ``decision.completed`` event:
+#     * SUCCESS (mark_executed) → ``passed=True, action_outcome="landed"``
+#       with the ``pr_url`` / ``branch`` / ``files_changed`` on the payload.
+#     * FAILURE (any mark_failed branch) → ``passed=False,
+#       action_outcome="failed"`` with the ``error_class`` / ``reason`` so the
+#       explain narrator can say WHY it failed.
+#   The router threads the ``human.corrected`` event id it just emitted into
+#   ``execute_approved_change(..., human_event_id=...)`` so the terminal event
+#   chains its ``causation_id`` back to the human approval — one clean causal
+#   walk ``agent.proposed → human.corrected → decision.completed``. Exactly ONE
+#   terminal fires per run: every error path RETURNS right after its single
+#   ``_emit_chain_close`` + ``mark_failed`` pair, and the success path emits
+#   once at the end — no doubled terminals. The schema literal is bumped 1 → 2
+#   to match belt.py's schema-2 blob (a stale schema-1 blob approved post-deploy
+#   still fails loud on the mismatch guard). Both the emit and the read are
+#   best-effort: a Decision-Graph wiring failure must never break the approve
+#   response (the Slice 4 abandon-sweeper closes any chain left open).
+#
 # What this module does (the apply-on-approve half of the Belt code-change
 # gate): the ``pocketpaw_belt`` MCP server proposes a unified diff THROUGH
 # Instinct (the human approve/reject layer). After a human approves the Action,
@@ -57,7 +79,12 @@ logger = logging.getLogger(__name__)
 # changes so a stale pending Action approved after a deploy fails loud instead
 # of applying a misinterpreted diff (same discipline as the pocket-write
 # bridge's ``_POCKET_WRITE_SCHEMA``).
-_CODE_CHANGE_SCHEMA = 1
+#
+# Schema 2 (BS-4) — the blob carries the Decision-Graph ``correlation_id`` +
+# ``proposed_event_id`` set by belt.py at propose time. Kept in sync with the
+# MCP server's ``CODE_CHANGE_SCHEMA`` literal; duplicated here so the executor
+# has no import dependency on the agent-side MCP module.
+_CODE_CHANGE_SCHEMA = 2
 
 # The parameters key the blob rides under — kept in sync with the MCP server's
 # ``CODE_CHANGE_PARAM_KEY``. Duplicated as a literal here so the executor has no
@@ -187,10 +214,110 @@ def _short_id(action_id: str) -> str:
     return safe[-12:] or "change"
 
 
+def _coerce_uuid(raw: Any) -> Any | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be. Accepts an
+    existing ``UUID`` (returned as-is) or a string; anything else → None."""
+    from uuid import UUID
+
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _blob_correlation_id(blob: dict[str, Any]) -> Any | None:
+    """Pull the Decision-Graph chain ``correlation_id`` off a schema-2
+    ``_code_change`` blob, or ``None`` if missing / malformed. Without it the
+    chain-close emit no-ops — the Slice 4 abandon-sweeper closes any orphan."""
+    return _coerce_uuid(blob.get("correlation_id"))
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: Any | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: Any | None,
+    pr_url: str | None = None,
+    branch: str | None = None,
+    files_changed: int | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a Belt code-change run.
+
+    Mirrors ``instinct_bridge._emit_bridge_chain_close`` — the executor owns
+    the chain close on the apply path, exactly as the pocket-write bridge owns
+    it on its re-entry path. ``correlation_id`` is read off the schema-2 blob;
+    ``causation_id`` is the ``human.corrected`` event the router emitted just
+    before approval so the terminal chains back to the human approval.
+
+    Returns early when ``correlation_id`` is None (a blob with a malformed /
+    missing id, or a schema-1 blob): there is no chain to close. The Slice 4
+    abandon-sweeper will close any chain that accumulates without a terminal.
+
+    Best-effort: a Decision-Graph wiring failure must never break the approve
+    response — the journal write is the source of truth; the Slice 4 reconciler
+    is the safety net.
+    """
+    if correlation_id is None:
+        return
+
+    # Late imports — keep the executor's import surface small and avoid a
+    # circular import with the decisions package.
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if pr_url:
+        payload["pr_url"] = pr_url
+    if branch:
+        payload["branch"] = branch
+    if files_changed is not None:
+        payload["files_changed"] = files_changed
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "belt decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
 async def execute_approved_change(
     action: Any,
     *,
     pr_opener: PrOpener | None = None,
+    human_event_id: Any | None = None,
 ) -> None:
     """Apply the code change carried by a freshly-approved Instinct Action.
 
@@ -199,10 +326,18 @@ async def execute_approved_change(
     uses. ``action`` is the approved Action. ``pr_opener`` lets tests inject a
     fake; production passes ``None`` and gets the ``gh pr create`` opener.
 
+    ``human_event_id`` (BS-4) is the id of the ``human.corrected`` event the
+    router emitted just before calling this — threaded through so the terminal
+    ``decision.completed`` event can chain its ``causation_id`` back to the
+    approval, completing the causal walk ``agent.proposed → human.corrected →
+    decision.completed``. ``None`` is tolerated (the chain still folds via the
+    shared ``correlation_id``).
+
     Never raises — a failure here must not break the approve response. The
     router wraps the call too; this is belt-and-braces. The worktree is ALWAYS
     cleaned up (success or failure); the Action is marked executed on success
-    or failed with a clear outcome on any error.
+    or failed with a clear outcome on any error. BS-4: every terminal path
+    (success or any failure) closes the Decision-Graph chain exactly once.
     """
     from pocketpaw.stores import get_instinct_store
 
@@ -212,13 +347,41 @@ async def execute_approved_change(
     params = getattr(action, "parameters", None) or {}
     blob = params.get(_CODE_CHANGE_PARAM_KEY)
     if not isinstance(blob, dict):
+        # Not a Belt code-change Action at all — no chain was ever opened for
+        # it, so there is nothing to close. Return without a terminal emit.
         logger.warning("approved action %s carries no _code_change blob", action.id)
         return
+
+    # BS-4 — read the chain correlation_id off the schema-2 blob up front so
+    # EVERY terminal path below can close the chain it opened. Defensive: a
+    # malformed / missing id falls through to None and the chain-close helper
+    # no-ops (the Slice 4 abandon-sweeper closes any chain left open).
+    correlation_id = _blob_correlation_id(blob)
+    workspace_id = str(blob.get("workspace_id") or "")
+    requested_by = str(blob.get("requested_by") or "")
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Mark the Action failed AND close the chain with one terminal —
+        the single failure-path chokepoint so a path can never both fail
+        and double-fire the terminal."""
+        await store.mark_failed(action.id, reason)
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=requested_by,
+            causation_id=causation,
+        )
+
     if blob.get("schema") != _CODE_CHANGE_SCHEMA:
-        await store.mark_failed(
-            action.id,
+        await _fail(
             "code-change schema mismatch — the change blob is from an "
             "incompatible build and cannot be applied",
+            error_class="SchemaMismatch",
         )
         return
 
@@ -229,13 +392,19 @@ async def execute_approved_change(
     task = str(blob.get("task") or "")
 
     if not base_branch or not isinstance(diff, str) or not diff.strip():
-        await store.mark_failed(action.id, "code-change blob is missing base_branch or diff")
+        await _fail(
+            "code-change blob is missing base_branch or diff",
+            error_class="MalformedBlob",
+        )
         return
 
     # Defense in depth — re-resolve + re-allowlist the repo at execute time.
     repo_path, repo_err = _re_resolve_repo(repo)
     if repo_err is not None or repo_path is None:
-        await store.mark_failed(action.id, f"repo no longer valid at approval time: {repo_err}")
+        await _fail(
+            f"repo no longer valid at approval time: {repo_err}",
+            error_class="RepoInvalid",
+        )
         return
 
     branch = f"feat/belt-{_short_id(str(action.id))}"
@@ -252,8 +421,9 @@ async def execute_approved_change(
         # 1. Fetch the latest base so we branch off the freshest origin tip.
         code, _out, err = await _run(["git", "fetch", "origin", base_branch], cwd=repo_path)
         if code != 0:
-            await store.mark_failed(
-                action.id, f"git fetch origin {base_branch} failed: {err.strip()[:300]}"
+            await _fail(
+                f"git fetch origin {base_branch} failed: {err.strip()[:300]}",
+                error_class="GitFetchFailed",
             )
             return
 
@@ -266,8 +436,9 @@ async def execute_approved_change(
             cwd=repo_path,
         )
         if code != 0:
-            await store.mark_failed(
-                action.id, f"git worktree add failed: {err.strip()[:300]}"
+            await _fail(
+                f"git worktree add failed: {err.strip()[:300]}",
+                error_class="GitWorktreeAddFailed",
             )
             return
         worktree_created = True
@@ -275,8 +446,9 @@ async def execute_approved_change(
         # 3. Branch off the detached worktree head.
         code, _out, err = await _run(["git", "checkout", "-b", branch], cwd=worktree_dir)
         if code != 0:
-            await store.mark_failed(
-                action.id, f"git checkout -b {branch} failed: {err.strip()[:300]}"
+            await _fail(
+                f"git checkout -b {branch} failed: {err.strip()[:300]}",
+                error_class="GitCheckoutFailed",
             )
             return
 
@@ -293,10 +465,10 @@ async def execute_approved_change(
             fd_path.unlink()
             diff_file = None
         if code != 0:
-            await store.mark_failed(
-                action.id,
+            await _fail(
                 "diff did not apply cleanly (conflict or stale base) — "
                 f"re-propose against the current {base_branch}. git apply: {err.strip()[:300]}",
+                error_class="ApplyConflict",
             )
             return
 
@@ -305,13 +477,14 @@ async def execute_approved_change(
         #    NO AI attribution.
         code, _out, err = await _run(["git", "add", "-A"], cwd=worktree_dir)
         if code != 0:
-            await store.mark_failed(action.id, f"git add failed: {err.strip()[:300]}")
+            await _fail(f"git add failed: {err.strip()[:300]}", error_class="GitAddFailed")
             return
 
         files_changed = await _changed_files(worktree_dir)
         if not files_changed:
-            await store.mark_failed(
-                action.id, "diff produced no staged changes — nothing to commit"
+            await _fail(
+                "diff produced no staged changes — nothing to commit",
+                error_class="NothingToCommit",
             )
             return
 
@@ -321,7 +494,7 @@ async def execute_approved_change(
             ["git", "commit", "-m", commit_title, "-m", commit_body], cwd=worktree_dir
         )
         if code != 0:
-            await store.mark_failed(action.id, f"git commit failed: {err.strip()[:300]}")
+            await _fail(f"git commit failed: {err.strip()[:300]}", error_class="GitCommitFailed")
             return
 
         # 6. Push the branch.
@@ -329,7 +502,7 @@ async def execute_approved_change(
             ["git", "push", "-u", "origin", branch], cwd=worktree_dir
         )
         if code != 0:
-            await store.mark_failed(action.id, f"git push failed: {err.strip()[:300]}")
+            await _fail(f"git push failed: {err.strip()[:300]}", error_class="GitPushFailed")
             return
 
         # 7. Open the PR via the injectable opener.
@@ -345,10 +518,10 @@ async def execute_approved_change(
             logger.warning("belt: PR open failed for action %s", action.id, exc_info=True)
             # The branch is pushed but no PR — record the partial so a human can
             # open the PR by hand. This is NOT a clean success.
-            await store.mark_failed(
-                action.id,
+            await _fail(
                 f"branch '{branch}' pushed but PR open failed: {exc}. "
                 "Open the PR manually or re-propose.",
+                error_class="PrOpenFailed",
             )
             return
 
@@ -356,6 +529,24 @@ async def execute_approved_change(
         await store.mark_executed(
             action.id,
             f"PR opened: {pr_url} (branch '{branch}', {len(files_changed)} file(s) changed)",
+        )
+        # BS-4 — close the chain on the SUCCESS path. ``action_outcome="landed"``
+        # + the PR url / branch / file count ride on the payload for the explain
+        # narrator. This is the ONLY terminal on the happy path (every failure
+        # path above closed via ``_fail`` and returned), so exactly one
+        # ``decision.completed`` lands per run.
+        _emit_chain_close(
+            passed=True,
+            action_outcome="landed",
+            error_class=None,
+            reason=None,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=requested_by,
+            causation_id=causation,
+            pr_url=pr_url,
+            branch=branch,
+            files_changed=len(files_changed),
         )
         logger.info(
             "belt: applied code_change action %s → branch %s, %d file(s), PR %s",
@@ -369,7 +560,7 @@ async def execute_approved_change(
             "belt: code_change execution crashed for action %s", action.id, exc_info=True
         )
         with _suppress():
-            await store.mark_failed(action.id, "code-change executor crashed — re-propose")
+            await _fail("code-change executor crashed — re-propose", error_class="ExecutorCrash")
     finally:
         # ALWAYS clean up — leave no half-state. Remove the temp diff file (if
         # the apply path bailed before unlinking it) and the worktree.

--- a/ee/pocketpaw_ee/cloud/belt/executor.py
+++ b/ee/pocketpaw_ee/cloud/belt/executor.py
@@ -498,9 +498,7 @@ async def execute_approved_change(
             return
 
         # 6. Push the branch.
-        code, _out, err = await _run(
-            ["git", "push", "-u", "origin", branch], cwd=worktree_dir
-        )
+        code, _out, err = await _run(["git", "push", "-u", "origin", branch], cwd=worktree_dir)
         if code != 0:
             await _fail(f"git push failed: {err.strip()[:300]}", error_class="GitPushFailed")
             return
@@ -575,9 +573,7 @@ async def _changed_files(worktree_dir: Path) -> list[str]:
     """Return the staged file paths in the worktree (``git diff --cached
     --name-only``). Empty list on any error — the caller treats empty as
     'nothing to commit'."""
-    code, out, _err = await _run(
-        ["git", "diff", "--cached", "--name-only"], cwd=worktree_dir
-    )
+    code, out, _err = await _run(["git", "diff", "--cached", "--name-only"], cwd=worktree_dir)
     if code != 0:
         return []
     return [line.strip() for line in out.splitlines() if line.strip()]
@@ -587,9 +583,7 @@ async def _force_remove_worktree(repo_path: Path, worktree_dir: Path) -> None:
     """Remove a worktree and prune the registration — best-effort, never
     raises. Falls back to an ``rmtree`` if ``git worktree remove`` refuses."""
     with _suppress():
-        await _run(
-            ["git", "worktree", "remove", "--force", str(worktree_dir)], cwd=repo_path
-        )
+        await _run(["git", "worktree", "remove", "--force", str(worktree_dir)], cwd=repo_path)
     with _suppress():
         await _run(["git", "worktree", "prune"], cwd=repo_path)
     # If git left the directory behind (e.g. the add half-failed), nuke it.

--- a/ee/pocketpaw_ee/cloud/belt/executor.py
+++ b/ee/pocketpaw_ee/cloud/belt/executor.py
@@ -1,0 +1,439 @@
+# executor.py — applies an approved Belt code-change Action and opens a PR.
+# Created: 2026-06-10 (feat/belt-gate, BS-3).
+#
+# What this module does (the apply-on-approve half of the Belt code-change
+# gate): the ``pocketpaw_belt`` MCP server proposes a unified diff THROUGH
+# Instinct (the human approve/reject layer). After a human approves the Action,
+# the ee instinct router's ``approve_action`` fires ``execute_approved_change``
+# here — exactly mirroring how ``instinct_bridge.execute_approved_write`` is
+# fired for a parked pocket write. This function:
+#
+#   1. Reads the ``_code_change`` blob from ``action.parameters``. A missing or
+#      schema-mismatched blob → mark_failed, return.
+#   2. RE-resolves the repo path against the allowlist (defense in depth — the
+#      allowlist may have tightened between propose and approve).
+#   3. Creates a FRESH git worktree (one per action id, under a tmp dir; NEVER
+#      the repo's live checkout) at ``origin/<base_branch>`` after a fetch.
+#   4. ``git apply --3way`` the diff (written to a temp FILE — never echoed/
+#      interpolated into a shell).
+#   5. Branches ``feat/belt-<action-id-short>``, commits (Conventional Commits;
+#      the agent's summary as the body; NO AI attribution), pushes.
+#   6. Opens a PR via an injectable opener (default shells ``gh pr create``;
+#      tests inject a fake).
+#   7. ``mark_executed`` with outcome ``{pr_url, branch, files_changed}``.
+#   8. ALWAYS removes the worktree — on success or any failure. On apply
+#      conflict / any error → ``mark_failed`` with a clear outcome (the agent /
+#      user can re-propose); never leave half-state.
+#
+# Security (this code moves diffs into git + runs subprocesses):
+#   * subprocess arg LISTS only — never ``shell=True``, never string-interpolate
+#     user input into a command. Repo path, branch, diff path are all argv
+#     elements.
+#   * the diff is DATA — written to a temp file and fed to ``git apply <file>``;
+#     never echoed, eval'd, or passed on a command line.
+#   * the repo path is re-resolved INSIDE the allowlist; a path that escaped the
+#     boundary (or the boundary tightened) is refused, not applied.
+#   * NO secrets in logs — only action ids, branch names, and file counts. Diff
+#     content is never logged.
+#   * destructive ops are confined to a throwaway worktree dir that is removed
+#     in a finally block; the live checkout is never touched.
+#
+# Why a separate module (not in pockets/): the Belt code-change path is its own
+# subsystem — it doesn't touch backend credentials or the pockets service. It
+# mirrors instinct_bridge's propose/execute SHAPE without sharing its plumbing.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Schema version stamped on the ``_code_change`` blob. Bump when the blob shape
+# changes so a stale pending Action approved after a deploy fails loud instead
+# of applying a misinterpreted diff (same discipline as the pocket-write
+# bridge's ``_POCKET_WRITE_SCHEMA``).
+_CODE_CHANGE_SCHEMA = 1
+
+# The parameters key the blob rides under — kept in sync with the MCP server's
+# ``CODE_CHANGE_PARAM_KEY``. Duplicated as a literal here so the executor has no
+# import dependency on the agent-side MCP module.
+_CODE_CHANGE_PARAM_KEY = "_code_change"
+
+# Subprocess timeout for any single git / gh call (seconds). A hung remote
+# operation must not wedge the approve path forever.
+_SUBPROCESS_TIMEOUT = 120.0
+
+
+class PrOpener(Protocol):
+    """Injectable PR-opening interface.
+
+    The default implementation shells ``gh pr create``; tests inject a fake to
+    assert the call args without touching GitHub. Returns the PR URL (or a
+    best-effort placeholder string if ``gh`` printed nothing parseable)."""
+
+    async def open_pr(
+        self,
+        *,
+        repo_path: Path,
+        branch: str,
+        base_branch: str,
+        title: str,
+        body: str,
+    ) -> str: ...
+
+
+class GhCliPrOpener:
+    """Default ``PrOpener`` — shells ``gh pr create`` from the worktree.
+
+    ``gh`` reads the repo's remote + the authenticated user's token from the
+    environment; no secret is passed on the command line. The title/body are
+    argv elements (never interpolated into a shell string)."""
+
+    async def open_pr(
+        self,
+        *,
+        repo_path: Path,
+        branch: str,
+        base_branch: str,
+        title: str,
+        body: str,
+    ) -> str:
+        code, out, err = await _run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--base",
+                base_branch,
+                "--head",
+                branch,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+            cwd=repo_path,
+        )
+        if code != 0:
+            raise RuntimeError(f"gh pr create failed (exit {code}): {err.strip() or out.strip()}")
+        # `gh pr create` prints the PR URL on stdout. Take the last non-empty
+        # line that looks like a URL.
+        for line in reversed(out.splitlines()):
+            line = line.strip()
+            if line.startswith("http"):
+                return line
+        return out.strip() or "<pr-created>"
+
+
+async def _run(
+    argv: list[str], *, cwd: Path | None = None, stdin: bytes | None = None
+) -> tuple[int, str, str]:
+    """Run a subprocess from an ARG LIST (never a shell), bounded by a timeout.
+
+    Returns ``(returncode, stdout, stderr)``. NEVER uses ``shell=True`` and
+    never interpolates user input into a command string — every element of
+    ``argv`` is passed literally. This is the single subprocess chokepoint for
+    the executor."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        cwd=str(cwd) if cwd else None,
+        stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        out_b, err_b = await asyncio.wait_for(
+            proc.communicate(input=stdin), timeout=_SUBPROCESS_TIMEOUT
+        )
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        sub = argv[1] if len(argv) > 1 else ""
+        raise RuntimeError(
+            f"command timed out after {_SUBPROCESS_TIMEOUT}s: {argv[0]} {sub}"
+        ) from None
+    return (
+        proc.returncode or 0,
+        out_b.decode("utf-8", "replace"),
+        err_b.decode("utf-8", "replace"),
+    )
+
+
+def _re_resolve_repo(repo: str) -> tuple[Path | None, str | None]:
+    """Re-resolve + re-allowlist the repo path at EXECUTE time (defense in
+    depth). Reuses the MCP server's resolver so propose and execute share one
+    boundary definition. Returns ``(path, None)`` or ``(None, error)``."""
+    try:
+        from pocketpaw_ee.agent.mcp_servers.belt import _resolve_repo
+    except Exception:  # noqa: BLE001 — agent module shouldn't fail to import, but be defensive
+        # Fall back to a minimal inline check if the agent module is absent.
+        candidate = Path(repo).expanduser().resolve()
+        if not candidate.is_dir() or not (candidate / ".git").exists():
+            return None, f"repo path {repo!r} is not a git repository"
+        return candidate, None
+    return _resolve_repo(repo)
+
+
+def _short_id(action_id: str) -> str:
+    """A short, branch-safe slug from an action id (drop any ``act-`` prefix,
+    keep the last 12 hex chars)."""
+    raw = action_id.split("-", 1)[-1] if "-" in action_id else action_id
+    safe = "".join(ch for ch in raw if ch.isalnum())
+    return safe[-12:] or "change"
+
+
+async def execute_approved_change(
+    action: Any,
+    *,
+    pr_opener: PrOpener | None = None,
+) -> None:
+    """Apply the code change carried by a freshly-approved Instinct Action.
+
+    Called best-effort from the instinct router's ``approve_action`` after
+    ``store.approve()`` succeeds — the same hook shape the pocket-write bridge
+    uses. ``action`` is the approved Action. ``pr_opener`` lets tests inject a
+    fake; production passes ``None`` and gets the ``gh pr create`` opener.
+
+    Never raises — a failure here must not break the approve response. The
+    router wraps the call too; this is belt-and-braces. The worktree is ALWAYS
+    cleaned up (success or failure); the Action is marked executed on success
+    or failed with a clear outcome on any error.
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    opener: PrOpener = pr_opener or GhCliPrOpener()
+
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(_CODE_CHANGE_PARAM_KEY)
+    if not isinstance(blob, dict):
+        logger.warning("approved action %s carries no _code_change blob", action.id)
+        return
+    if blob.get("schema") != _CODE_CHANGE_SCHEMA:
+        await store.mark_failed(
+            action.id,
+            "code-change schema mismatch — the change blob is from an "
+            "incompatible build and cannot be applied",
+        )
+        return
+
+    repo = str(blob.get("repo") or "")
+    base_branch = str(blob.get("base_branch") or "")
+    diff = blob.get("diff")
+    summary = str(blob.get("summary") or "")
+    task = str(blob.get("task") or "")
+
+    if not base_branch or not isinstance(diff, str) or not diff.strip():
+        await store.mark_failed(action.id, "code-change blob is missing base_branch or diff")
+        return
+
+    # Defense in depth — re-resolve + re-allowlist the repo at execute time.
+    repo_path, repo_err = _re_resolve_repo(repo)
+    if repo_err is not None or repo_path is None:
+        await store.mark_failed(action.id, f"repo no longer valid at approval time: {repo_err}")
+        return
+
+    branch = f"feat/belt-{_short_id(str(action.id))}"
+
+    # One throwaway worktree dir per action id, under a tmp/belt-actions root.
+    # NEVER the repo's live checkout. Cleaned up in the finally block below.
+    tmp_root = Path(tempfile.gettempdir()) / "belt-actions"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+    worktree_dir = tmp_root / f"act-{_short_id(str(action.id))}"
+    diff_file: Path | None = None
+    worktree_created = False
+
+    try:
+        # 1. Fetch the latest base so we branch off the freshest origin tip.
+        code, _out, err = await _run(["git", "fetch", "origin", base_branch], cwd=repo_path)
+        if code != 0:
+            await store.mark_failed(
+                action.id, f"git fetch origin {base_branch} failed: {err.strip()[:300]}"
+            )
+            return
+
+        # 2. Fresh worktree at origin/<base_branch>. If the dir somehow exists
+        #    from a prior crash, remove it first so add doesn't refuse.
+        if worktree_dir.exists():
+            await _force_remove_worktree(repo_path, worktree_dir)
+        code, _out, err = await _run(
+            ["git", "worktree", "add", str(worktree_dir), f"origin/{base_branch}"],
+            cwd=repo_path,
+        )
+        if code != 0:
+            await store.mark_failed(
+                action.id, f"git worktree add failed: {err.strip()[:300]}"
+            )
+            return
+        worktree_created = True
+
+        # 3. Branch off the detached worktree head.
+        code, _out, err = await _run(["git", "checkout", "-b", branch], cwd=worktree_dir)
+        if code != 0:
+            await store.mark_failed(
+                action.id, f"git checkout -b {branch} failed: {err.strip()[:300]}"
+            )
+            return
+
+        # 4. Write the diff to a temp FILE and apply it — the diff is DATA, it
+        #    never touches a command line beyond the file path argument.
+        fd_path = worktree_dir / ".belt-change.diff"
+        fd_path.write_text(diff, encoding="utf-8")
+        diff_file = fd_path
+        code, _out, err = await _run(
+            ["git", "apply", "--3way", "--whitespace=nowarn", str(fd_path)], cwd=worktree_dir
+        )
+        # Remove the diff file before committing so it never lands in the PR.
+        with _suppress():
+            fd_path.unlink()
+            diff_file = None
+        if code != 0:
+            await store.mark_failed(
+                action.id,
+                "diff did not apply cleanly (conflict or stale base) — "
+                f"re-propose against the current {base_branch}. git apply: {err.strip()[:300]}",
+            )
+            return
+
+        # 5. Stage everything the diff touched, capture the changed-file list,
+        #    then commit. Conventional Commits; the agent's summary as the body;
+        #    NO AI attribution.
+        code, _out, err = await _run(["git", "add", "-A"], cwd=worktree_dir)
+        if code != 0:
+            await store.mark_failed(action.id, f"git add failed: {err.strip()[:300]}")
+            return
+
+        files_changed = await _changed_files(worktree_dir)
+        if not files_changed:
+            await store.mark_failed(
+                action.id, "diff produced no staged changes — nothing to commit"
+            )
+            return
+
+        commit_title = _commit_title(task, summary)
+        commit_body = summary or task
+        code, _out, err = await _run(
+            ["git", "commit", "-m", commit_title, "-m", commit_body], cwd=worktree_dir
+        )
+        if code != 0:
+            await store.mark_failed(action.id, f"git commit failed: {err.strip()[:300]}")
+            return
+
+        # 6. Push the branch.
+        code, _out, err = await _run(
+            ["git", "push", "-u", "origin", branch], cwd=worktree_dir
+        )
+        if code != 0:
+            await store.mark_failed(action.id, f"git push failed: {err.strip()[:300]}")
+            return
+
+        # 7. Open the PR via the injectable opener.
+        try:
+            pr_url = await opener.open_pr(
+                repo_path=worktree_dir,
+                branch=branch,
+                base_branch=base_branch,
+                title=commit_title,
+                body=commit_body,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("belt: PR open failed for action %s", action.id, exc_info=True)
+            # The branch is pushed but no PR — record the partial so a human can
+            # open the PR by hand. This is NOT a clean success.
+            await store.mark_failed(
+                action.id,
+                f"branch '{branch}' pushed but PR open failed: {exc}. "
+                "Open the PR manually or re-propose.",
+            )
+            return
+
+        # 8. Mark executed with the structured outcome.
+        await store.mark_executed(
+            action.id,
+            f"PR opened: {pr_url} (branch '{branch}', {len(files_changed)} file(s) changed)",
+        )
+        logger.info(
+            "belt: applied code_change action %s → branch %s, %d file(s), PR %s",
+            action.id,
+            branch,
+            len(files_changed),
+            pr_url,
+        )
+    except Exception:  # noqa: BLE001 — never let an executor crash break approve
+        logger.warning(
+            "belt: code_change execution crashed for action %s", action.id, exc_info=True
+        )
+        with _suppress():
+            await store.mark_failed(action.id, "code-change executor crashed — re-propose")
+    finally:
+        # ALWAYS clean up — leave no half-state. Remove the temp diff file (if
+        # the apply path bailed before unlinking it) and the worktree.
+        if diff_file is not None:
+            with _suppress():
+                diff_file.unlink()
+        if worktree_created or worktree_dir.exists():
+            await _force_remove_worktree(repo_path, worktree_dir)
+
+
+async def _changed_files(worktree_dir: Path) -> list[str]:
+    """Return the staged file paths in the worktree (``git diff --cached
+    --name-only``). Empty list on any error — the caller treats empty as
+    'nothing to commit'."""
+    code, out, _err = await _run(
+        ["git", "diff", "--cached", "--name-only"], cwd=worktree_dir
+    )
+    if code != 0:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+async def _force_remove_worktree(repo_path: Path, worktree_dir: Path) -> None:
+    """Remove a worktree and prune the registration — best-effort, never
+    raises. Falls back to an ``rmtree`` if ``git worktree remove`` refuses."""
+    with _suppress():
+        await _run(
+            ["git", "worktree", "remove", "--force", str(worktree_dir)], cwd=repo_path
+        )
+    with _suppress():
+        await _run(["git", "worktree", "prune"], cwd=repo_path)
+    # If git left the directory behind (e.g. the add half-failed), nuke it.
+    if worktree_dir.exists():
+        with _suppress():
+            shutil.rmtree(worktree_dir, ignore_errors=True)
+
+
+def _commit_title(task: str, summary: str) -> str:
+    """Build a Conventional-Commits title from the task / summary.
+
+    Keeps it under ~72 chars and prefixes ``feat(belt):`` so the commit reads as
+    a Belt-applied change. The first sentence of the summary (falling back to
+    the task) becomes the subject. NO AI attribution anywhere."""
+    source = (summary or task or "apply code change").strip()
+    # First sentence / first line only.
+    first = source.replace("\n", " ").split(". ", 1)[0].strip().rstrip(".")
+    subject = first[:60].strip() or "apply code change"
+    return f"feat(belt): {subject}"
+
+
+class _suppress:
+    """Tiny context manager that swallows any exception — for best-effort
+    cleanup / mark_failed in the crash + finally paths where a second failure
+    must never mask the first."""
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return True
+
+
+__all__ = [
+    "GhCliPrOpener",
+    "PrOpener",
+    "execute_approved_change",
+]

--- a/ee/pocketpaw_ee/cloud/surface/domain.py
+++ b/ee/pocketpaw_ee/cloud/surface/domain.py
@@ -48,6 +48,12 @@
 # image + video) and ``CODE`` (/code — the agent edits + runs code). Both get
 # ``ripple_mode="off"`` profiles in ``service.py`` so the agent generates media /
 # edits code instead of defaulting to a ripple ui-spec dashboard.
+# Changes: 2026-06-10 (feat/belt-surface, BS-2 Belt & Pulley stations thin
+# slice) — added the ``BELT`` surface (/belt — the develop station). Its
+# ``ripple_mode="off"`` profile in ``service.py`` scopes the agent to the loom
+# orientation tools + the Instinct gate tool so it orients first, develops in a
+# station worktree, and proposes the diff through the gate — never applying to the
+# user's branches directly.
 
 from __future__ import annotations
 
@@ -87,6 +93,7 @@ class SurfaceKind(StrEnum):
     SITES = "sites"  # /sites — describe-to-create + manage published Paw Sites
     STUDIO = "studio"  # /studio — describe→generate media (image + video)
     CODE = "code"  # /code — agent edits + runs code in the workspace
+    BELT = "belt"  # /belt — the develop station (orient→develop→propose via gate)
     GENERIC = "generic"  # any unknown surface — agent still gets a usable preamble
 
 

--- a/ee/pocketpaw_ee/cloud/surface/handlers/belt.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/belt.py
@@ -1,0 +1,82 @@
+# belt.py — /belt surface preamble (the develop station).
+#
+# Created: 2026-06-10 (feat/belt-surface, BS-2 Belt & Pulley stations thin
+# slice) — Orients the chat agent when the user is on the /belt surface, the
+# develop station of the Belt & Pulley assembly line. The agent takes a coding
+# task, GROUNDS itself with loom's orient() first, implements in a station
+# worktree, and PROPOSES the resulting diff through the Instinct gate — it never
+# applies changes directly and never claims success unless the gate tool returned
+# ok. Without this preamble the surface falls back to GENERIC and the agent
+# builds a dashboard pocket instead of running the station loop.
+#
+# Mirrors handlers/code.py: an async ``build_preamble`` returning an XML-ish
+# ``<surface>`` + ``<orientation>`` + ``<procedure>`` block. The procedure
+# enforces the three-stage station loop:
+#   * ORIENT FIRST — call ``mcp__loom__orient`` with the task before reading any
+#     code; drill down with locate / why / what_depends_on as needed.
+#   * DEVELOP — implement in the station worktree with Bash/Read/Write/Edit/Glob/
+#     Grep; run targeted tests; keep the diff small (large changes → split).
+#   * PROPOSE VIA THE GATE — produce a clean unified diff and call
+#     ``mcp__pocketpaw_belt__belt_propose_change``; NEVER apply to the user's
+#     branches, NEVER push or merge; if the gate is unavailable/errors, say so —
+#     no phantom successes.
+#
+# The /belt SurfaceProfile sets ``ripple_mode="off"`` (so the agent doesn't
+# inherit the ~20k-char "default to ui-spec" ripple LAW and build a dashboard)
+# and scopes ``allow_mcp_tool_ids`` to the loom orientation tools + the gate
+# tool (see service.py).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+
+
+async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
+    """Render the /belt surface preamble — the develop station loop."""
+    route = meta.route_path or "/belt"
+    return (
+        f'<surface kind="belt" route="{route}" />\n'
+        "<belt-orientation>\n"
+        "The user is on the BELT surface, the develop station of the Belt & "
+        "Pulley assembly line. You take a coding task, GROUND yourself in the "
+        "codebase, implement the change in a station worktree, and PROPOSE the "
+        "resulting diff through the Instinct gate for a human to review. This is "
+        "NOT a dashboard — do not build widgets, charts, or a ui-spec, and do "
+        "not create a pocket. The deliverable is a PROPOSED CHANGE: a clean "
+        "unified diff handed to the gate, waiting in the Tray for human "
+        "approval. You NEVER apply changes to the user's branches directly, and "
+        "you NEVER claim the change was proposed unless the gate tool actually "
+        "returned ok. Talk about the work as 'the change', 'the diff', 'the "
+        "station', 'the gate', 'the Tray' — never as a 'pocket' or 'dashboard'.\n"
+        "</belt-orientation>\n"
+        "<belt-procedure>\n"
+        "Treat the user's message on this surface as a coding task and run the "
+        "station loop in three stages — in order.\n"
+        "1. ORIENT FIRST. Before reading any code, call `mcp__loom__orient` with "
+        "the user's task. Use the returned brief — scope, blast-radius, "
+        "entrypoints — to plan your approach. Drill down with `mcp__loom__locate` "
+        "(find where something lives), `mcp__loom__why` (understand a decision), "
+        "and `mcp__loom__what_depends_on` (find blast radius) as needed. Do NOT "
+        "start reading or editing code until you have oriented.\n"
+        "2. DEVELOP. Implement the change in the station worktree using the "
+        "built-in tools: `Bash` to run commands, `Read` to read files, `Write` / "
+        "`Edit` to change them, and `Glob` / `Grep` to find code. Run TARGETED "
+        "tests for what you touched. Keep the diff SMALL and focused — one task, "
+        "one change. If the task genuinely needs a large change, tell the user to "
+        "split it into smaller tasks rather than proposing a sprawling diff.\n"
+        "3. PROPOSE VIA THE GATE. Produce a clean unified diff of your change and "
+        "call `mcp__pocketpaw_belt__belt_propose_change` with `{repo, "
+        "base_branch, diff, summary, task}`. This is the ONLY way a change leaves "
+        "the station. NEVER apply your change to the user's branches directly, "
+        "NEVER `git push`, NEVER `git merge`. If the gate tool is unavailable or "
+        "returns an error, say so PLAINLY — do NOT claim the change was proposed "
+        "(no phantom successes). After the gate accepts the proposal, tell the "
+        "user the change is waiting in the Tray for review, and that on approve it "
+        "is applied in a worktree, branched, and opened as a PR.\n"
+        "The workspace is JAILED — stay inside the station worktree; do not reach "
+        "outside it. Destructive shell operations are blocked.\n"
+        "</belt-procedure>"
+    )
+
+
+__all__ = ["build_preamble"]

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -122,9 +122,7 @@ _SITES_SVELTE_CREATE_DENY: frozenset[str] = frozenset(
 # branch's ``ee/pocketpaw_ee/agent/mcp_servers/belt.py`` — not importable on this
 # base. When both PRs land, swap this literal for the imported constant (same
 # None-degrade path as the loom/media imports below). Do NOT drift the id.
-_BELT_GATE_TOOL_IDS: frozenset[str] = frozenset(
-    {"mcp__pocketpaw_belt__belt_propose_change"}
-)
+_BELT_GATE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_belt__belt_propose_change"})
 
 # Per-mode MCP-tool allow-lists keep a mode's agent context lean: only the
 # mode's SPECIALIZED tools are named here. The "general everywhere" set — ripple

--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -55,6 +55,17 @@
 # ``studio`` skill; CODE sets an ``allowed_sdk_tools`` allowlist (Bash/Read/Write/
 # Edit/Glob/Grep) and surfaces the ``code`` skill. Both are plain ``by_kind``
 # entries (not meta-aware like /sites).
+# Changes: 2026-06-10 (feat/belt-surface, BS-2 Belt & Pulley stations thin
+# slice) — registered the BELT surface (the develop station). Its handler
+# (``belt.build_preamble``) joins ``_load_handlers``, and ``_build_profiles``
+# gives it a ripple-OFF ``SurfaceProfile`` so the agent runs the station loop
+# instead of building a dashboard: ``allowed_sdk_tools`` = the coding built-ins
+# (Bash/Read/Write/Edit/Glob/Grep), ``skill_names`` = {"belt"}, and
+# ``allow_mcp_tool_ids`` = the loom orientation tools (``LOOM_TOOL_IDS``, loaded
+# in the existing try/except as a plain frozenset[str]) UNION the Instinct gate
+# tool (``_BELT_GATE_TOOL_IDS``). The gate tool id is a literal here because its
+# constant lives in a SIBLING branch's ``agent/mcp_servers/belt.py`` — the
+# import reconciles when both PRs land.
 
 from __future__ import annotations
 
@@ -105,6 +116,16 @@ _SITES_SVELTE_CREATE_DENY: frozenset[str] = frozenset(
     }
 )
 
+# The Instinct gate tool the /belt develop station proposes its diff through.
+# Spelled as a LITERAL because its canonical constant
+# (``BELT_PROPOSE_CHANGE_TOOL_ID`` / ``BELT_TOOL_IDS``) lives in a SIBLING
+# branch's ``ee/pocketpaw_ee/agent/mcp_servers/belt.py`` — not importable on this
+# base. When both PRs land, swap this literal for the imported constant (same
+# None-degrade path as the loom/media imports below). Do NOT drift the id.
+_BELT_GATE_TOOL_IDS: frozenset[str] = frozenset(
+    {"mcp__pocketpaw_belt__belt_propose_change"}
+)
+
 # Per-mode MCP-tool allow-lists keep a mode's agent context lean: only the
 # mode's SPECIALIZED tools are named here. The "general everywhere" set — ripple
 # widgets, the pocket lifecycle (read/create/edit/plan), and connectors
@@ -124,8 +145,10 @@ def _build_profiles() -> dict[str, Any]:
     foresight_allow: frozenset[str] | None
     sites_allow: frozenset[str] | None
     studio_allow: frozenset[str] | None
+    belt_allow: frozenset[str] | None
     try:
         from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
         from pocketpaw_ee.agent.mcp_servers.media import MEDIA_TOOL_IDS
         from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS
 
@@ -135,6 +158,12 @@ def _build_profiles() -> dict[str, Any]:
         # over from the EE mcp-server module as a plain frozenset[str] — never an
         # imported pocketpaw_ee symbol leaks into the OSS surface service.
         studio_allow = frozenset(MEDIA_TOOL_IDS)
+        # /belt (the develop station) scopes to the loom orientation tools (so
+        # the agent grounds itself before coding) UNION the Instinct gate tool
+        # (so it proposes the diff through the gate). LOOM_TOOL_IDS is importable
+        # on this base; the gate tool id is the literal _BELT_GATE_TOOL_IDS until
+        # its sibling-branch constant lands.
+        belt_allow = frozenset(LOOM_TOOL_IDS) | _BELT_GATE_TOOL_IDS
     except Exception:  # noqa: BLE001 — degrade to no restriction, never break chat
         logger.warning(
             "surface: could not load mcp tool ids; per-mode MCP scoping disabled",
@@ -144,6 +173,7 @@ def _build_profiles() -> dict[str, Any]:
         foresight_allow = None
         sites_allow = None
         studio_allow = None
+        belt_allow = None
 
     return {
         "by_kind": {
@@ -174,6 +204,18 @@ def _build_profiles() -> dict[str, Any]:
                 ripple_mode="off",
                 skill_names=frozenset({"code"}),
                 allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
+            ),
+            # Belt: the develop station (orient→develop→propose via gate). Ripple
+            # OFF so the agent runs the station loop instead of building a
+            # dashboard. SDK-tool allowlist scopes it to the coding built-ins; the
+            # `belt` skill carries the station playbook; the MCP allow-list is the
+            # loom orientation tools (ground first) UNION the Instinct gate tool
+            # (propose the diff). belt_allow is None when the import degraded.
+            SurfaceKind.BELT: SurfaceProfile(
+                ripple_mode="off",
+                skill_names=frozenset({"belt"}),
+                allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
+                allow_mcp_tool_ids=belt_allow,
             ),
         },
         # /sites is meta-aware (below). Both modes scope to the sites authoring
@@ -313,6 +355,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
     from pocketpaw_ee.cloud.surface.handlers import (
         activity,
         audit,
+        belt,
         calendar,
         code,
         files,
@@ -363,6 +406,7 @@ def _load_handlers() -> dict[SurfaceKind, Any]:
         SurfaceKind.SITES: sites.build_preamble,
         SurfaceKind.STUDIO: studio.build_preamble,
         SurfaceKind.CODE: code.build_preamble,
+        SurfaceKind.BELT: belt.build_preamble,
         SurfaceKind.GENERIC: generic.build_preamble,
     }
 

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -29,6 +29,17 @@ Updated: 2026-06-10 (feat/studio-code-migration) — added ``CloudMediaMcpProvid
 (``pocketpaw.mcp_servers`` entry ``media``) exposing the STUDIO image +
 video generation in-process server (``pocketpaw_media``) to the
 claude_agent_sdk cloud chat backend, mirroring ``CloudSitesMcpProvider``.
+
+Updated: 2026-06-10 (feat/belt-loom-mcp, BS-1) — added ``CloudLoomMcpProvider``
+(``pocketpaw.mcp_servers`` entry ``loom``) registering the external loom
+codebase-orientation binary as a STDIO MCP server (server name ``loom``;
+5 read tools: orient / locate / why / what_depends_on / boundaries) on the
+claude_agent_sdk cloud chat backend. Unlike the sibling providers this one
+returns a stdio config DICT (Path A), not an in-process SDK server object —
+the registration loop passes it through untouched. Ambient (not opt-in); the
+/belt surface scopes access via its profile allowlist. Returns None — and the
+loop skips it — when ``loom_model_path`` is unset or the binary is missing,
+so chat never breaks.
 """
 
 from __future__ import annotations
@@ -610,6 +621,35 @@ class CloudMediaMcpProvider:
         from pocketpaw_ee.agent.mcp_servers.media import MEDIA_TOOL_IDS
 
         return list(MEDIA_TOOL_IDS)
+
+
+class CloudLoomMcpProvider:
+    """`pocketpaw.mcp_servers` — the loom codebase-orientation MCP server.
+
+    Registers the external loom binary (``loom mcp -model <worldmodel.json>``)
+    as a STDIO MCP server — server name ``loom``, 5 read tools (orient /
+    locate / why / what_depends_on / boundaries). Unlike the sibling
+    providers, ``build_server`` returns a stdio CONFIG DICT, not an
+    in-process SDK server object (Path A): the claude_agent_sdk's
+    ``mcp_servers`` option accepts stdio configs natively and the pocketpaw
+    registration loop passes the dict through untouched.
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — the /belt surface scopes
+    access via its profile allowlist; surfaces whose allowlists don't name
+    the loom tool ids simply never see them. ``build_loom_server`` returns
+    None (loop skips it) when ``loom_model_path`` is unset or the binary is
+    missing, so chat keeps working with orientation simply absent.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        from pocketpaw_ee.agent.mcp_servers.loom import build_loom_server
+
+        return build_loom_server()
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
+
+        return list(LOOM_TOOL_IDS)
 
 
 class CloudAgentExtension:

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -40,6 +40,14 @@ the registration loop passes it through untouched. Ambient (not opt-in); the
 /belt surface scopes access via its profile allowlist. Returns None — and the
 loop skips it — when ``loom_model_path`` is unset or the binary is missing,
 so chat never breaks.
+
+Updated: 2026-06-10 (feat/belt-gate, BS-3) — added ``CloudBeltMcpProvider``
+(``pocketpaw.mcp_servers`` entry ``belt``) exposing the Belt & Pulley
+code-change gate in-process server (``pocketpaw_belt``; one tool
+``belt_propose_change``) to the claude_agent_sdk cloud chat backend, mirroring
+``CloudMediaMcpProvider``. The develop station proposes a diff through Instinct;
+the ee instinct router fires ``ee.cloud.belt.executor.execute_approved_change``
+on approval. Ambient (not opt-in).
 """
 
 from __future__ import annotations
@@ -650,6 +658,38 @@ class CloudLoomMcpProvider:
         from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
 
         return list(LOOM_TOOL_IDS)
+
+
+class CloudBeltMcpProvider:
+    """`pocketpaw.mcp_servers` — the Belt & Pulley code-change gate in-process
+    server (``pocketpaw_belt``). Hosts ``belt_propose_change`` only.
+
+    The develop station agent on the /belt surface produces a unified diff and
+    proposes it THROUGH Instinct (the human approve/reject layer) via this tool.
+    On approval the ee instinct router fires
+    ``ee.cloud.belt.executor.execute_approved_change`` to apply the diff in a
+    fresh worktree and open a PR — the captain still merges on GitHub.
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — the /belt surface scopes access
+    via its profile allowlist, the same regime the sibling loom / media / sites
+    servers use. ``build_belt_server`` returns None — and the loop skips it —
+    when the claude_agent_sdk isn't installed, so chat never breaks.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.belt import build_belt_server
+
+            return build_belt_server()
+        except ImportError:
+            # claude_agent_sdk not installed — the belt server is unavailable,
+            # same as the other in-process servers.
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.belt import BELT_TOOL_IDS
+
+        return list(BELT_TOOL_IDS)
 
 
 class CloudAgentExtension:

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -100,8 +100,29 @@
 #   ``_assert_pocket_write_workspace``) binds the Action to the approver's
 #   workspace on approve / reject / bulk paths. The executor applies the diff in
 #   a fresh worktree, commits, pushes, and opens a PR — it NEVER merges (the
-#   captain merges on GitHub; Instinct is the mid gate). The reject path needs
-#   no code-change-specific handling: ``store.reject`` round-trips any kind.
+#   captain merges on GitHub; Instinct is the mid gate).
+#
+# Updated: 2026-06-10 (feat/belt-trace, BS-4 — Belt Decision-Graph chain) —
+#   the Belt code-change path now lands in the Decision Graph as ONE chain per
+#   station run, mirroring the pocket-write chain. The propose path (belt.py)
+#   mints the ``correlation_id`` + emits ``agent.proposed``; this router emits
+#   the human-action + terminal events:
+#     * approve / bulk-approve — emit ``human.corrected(accepted|edited)`` for
+#       the ``_code_change`` blob, threading the ``agent.proposed`` event id
+#       (from the blob's ``proposed_event_id``) as causation, then pass the
+#       emitted ``human.corrected`` id into ``execute_approved_change(...,
+#       human_event_id=...)`` so the executor's terminal ``decision.completed``
+#       chains back to it. The executor owns the CLOSE on the approve path
+#       (success → landed, failure → failed) — the router does NOT emit a
+#       terminal here, so there is no double close.
+#     * reject / bulk-reject — emit ``human.corrected(rejected)`` THEN
+#       ``decision.completed(passed=False, action_outcome="rejected")`` here
+#       (the executor never runs on reject, so the router owns the close), each
+#       chaining causation to the prior event. The reason text rides as the
+#       rejection comment on the terminal payload.
+#   ``_code_change_proposed_event_id`` is the code-change peer of
+#   ``_parked_policy_event_id``. All emits are best-effort (the chain folds via
+#   ``correlation_id`` even if a causation_id is missing).
 #
 # Updated: 2026-05-26 (RFC 09 Slice 4 — approve-side policy.evaluated emit) —
 #   * Captain Decision 12 (chain symmetry) follow-up — ``approve_action``
@@ -309,6 +330,24 @@ def _parked_correlation_id(blob: dict[str, Any]) -> Any:
         return None
 
 
+def _code_change_proposed_event_id(blob: dict[str, Any]) -> Any:
+    """Pull the ``proposed_event_id`` UUID off a schema-2 ``_code_change``
+    blob, or ``None`` if missing / malformed. belt.py writes this back onto
+    the Action after the chain-opening ``agent.proposed`` event fires; using
+    it as the ``causation_id`` on the ``human.corrected`` event gives the
+    Belt chain a clean ``agent.proposed → human.corrected`` cause-arrow. The
+    code-change peer of ``_parked_policy_event_id``."""
+    from uuid import UUID
+
+    raw = blob.get("proposed_event_id")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return UUID(raw)
+    except ValueError:
+        return None
+
+
 def _emit_human_corrected(
     *,
     blob: dict[str, Any],
@@ -317,6 +356,7 @@ def _emit_human_corrected(
     workspace_id: str,
     disposition: str,
     note: str | None,
+    causation_override: Any | None = None,
 ) -> Any | None:
     """Best-effort ``human.corrected`` emit for an approve / reject /
     bulk-approve / bulk-reject item.
@@ -331,6 +371,13 @@ def _emit_human_corrected(
     a write without minting one). The Slice 4 reconciler / abandon
     sweeper will deal with the orphan.
 
+    ``causation_override`` (BS-4) — when provided, it is used as the
+    ``causation_id`` instead of the parked-policy-event lookup. The Belt
+    code-change path passes the ``agent.proposed`` event id here (a Belt
+    proposal has no parked ``policy.evaluated`` event to chain back to —
+    the proposal IS the chain origin). Pocket-write callers omit it and
+    fall back to ``_parked_policy_event_id``.
+
     Returns the emitted event id (``UUID``) on success, or ``None`` when
     the emit was skipped (missing correlation_id) or raised. Slice 4's
     approve-side ``policy.evaluated`` emit uses this as its
@@ -344,7 +391,11 @@ def _emit_human_corrected(
         return None
 
     pocket_id = str(getattr(action, "pocket_id", "") or "")
-    causation = _parked_policy_event_id(blob)
+    causation = (
+        causation_override
+        if causation_override is not None
+        else _parked_policy_event_id(blob)
+    )
     payload: dict[str, Any] = {
         "disposition": disposition,
         "action_id": str(getattr(action, "id", "") or ""),
@@ -381,6 +432,7 @@ def _emit_decision_completed_rejected(
     user_id: str,
     workspace_id: str,
     reason: str,
+    causation_override: Any | None = None,
 ) -> None:
     """Best-effort ``decision.completed(passed=False, action_outcome=
     "rejected")`` chain-close for a reject / bulk-reject item.
@@ -389,6 +441,12 @@ def _emit_decision_completed_rejected(
     ``_emit_human_corrected``. The reject path owns the close because
     the bridge is never invoked on rejection — for the approve path the
     bridge's ``_emit_bridge_chain_close`` owns the close instead.
+
+    ``causation_override`` (BS-4) — the Belt code-change reject path passes
+    the just-emitted ``human.corrected`` event id so the terminal chains its
+    causation back to the human rejection. Pocket-write callers omit it (their
+    terminal doesn't currently set a causation_id; the chain still folds via
+    ``correlation_id``).
     """
     from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
 
@@ -412,6 +470,7 @@ def _emit_decision_completed_rejected(
             ),
             scope=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
             payload=payload,
+            causation_id=causation_override,
         )
     except Exception:  # noqa: BLE001 — chain close is best-effort
         logger.warning(
@@ -765,16 +824,31 @@ async def bulk_approve_actions(
     # the bulk bar). The bridge owns the chain close on the approve
     # path so we do NOT emit ``decision.completed`` here.
     for action in approved:
-        # BS-3 — a Belt ``_code_change`` Action fires the apply-on-approve
-        # executor. It carries no parked-write chain (no correlation_id), so
-        # the Decision-Graph emits below are skipped for it; only the executor
-        # runs. Same best-effort shape as the pocket-write hook.
+        # BS-3/BS-4 — a Belt ``_code_change`` Action fires the apply-on-approve
+        # executor. BS-4: it now carries a Decision-Graph chain
+        # (``correlation_id`` minted at propose). Emit the per-item
+        # ``human.corrected(accepted)`` here (bulk-approve has no edit surface,
+        # so disposition is always ``accepted``), thread its event id into the
+        # executor so the terminal ``decision.completed`` chains its causation
+        # back to the human approval, then run the executor (which owns the
+        # chain close). Same best-effort shape as the pocket-write hook.
         code_change_blob = _code_change_blob(action)
         if code_change_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=code_change_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(code_change_blob),
+            )
             try:
                 from pocketpaw_ee.cloud.belt import executor as belt_executor
 
-                await belt_executor.execute_approved_change(action)
+                await belt_executor.execute_approved_change(
+                    action, human_event_id=human_event_id
+                )
             except Exception:
                 logger.exception(
                     "bulk-approve belt code-change execution failed for %s (non-fatal)",
@@ -862,30 +936,52 @@ async def bulk_reject_actions(
         list(req.ids), reason=req.reason, rejector=rejector_id
     )
 
-    # RFC 09 Slice 3 — per-item ``human.corrected`` + ``decision.
+    # RFC 09 Slice 3 / BS-4 — per-item ``human.corrected`` + ``decision.
     # completed(rejected)`` emit loop. The store's bulk_reject already
     # iterates per item internally for the audit log; this loop adds
-    # the chain emits. Non-pocket-write Actions (no blob) skip both
-    # emits — there's no chain to close.
+    # the chain emits. An item carries EITHER a ``_pocket_write`` blob OR
+    # a ``_code_change`` blob (BS-4) — both close their chain on reject
+    # here (the executor never runs on reject). An Action with neither
+    # blob has no chain to close and is skipped.
     for action in rejected:
         action_blob = _pocket_write_blob(action)
-        if action_blob is None:
+        if action_blob is not None:
+            _emit_human_corrected(
+                blob=action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+            )
+            _emit_decision_completed_rejected(
+                blob=action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+            )
             continue
-        _emit_human_corrected(
-            blob=action_blob,
-            action=action,
-            user_id=rejector_id,
-            workspace_id=workspace_id,
-            disposition="rejected",
-            note=req.reason or None,
-        )
-        _emit_decision_completed_rejected(
-            blob=action_blob,
-            action=action,
-            user_id=rejector_id,
-            workspace_id=workspace_id,
-            reason=req.reason,
-        )
+
+        code_change_blob = _code_change_blob(action)
+        if code_change_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=code_change_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(code_change_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=code_change_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
 
     return BulkActionResponse(bulk_id=bulk_id, affected=rejected, missing=missing)
 
@@ -1008,12 +1104,35 @@ async def approve_action(
     # hook above; the executor records success / failure on the Action itself.
     # A non-code-change Action skips this. The captain still merges on GitHub —
     # this opens the PR, it does NOT merge.
+    #
+    # BS-4 — this is part of the Belt Decision-Graph chain. Emit the
+    # ``human.corrected`` event for the code-change approval HERE (the router
+    # owns the human-action emit on every approve path), then thread its event
+    # id into the executor so the terminal ``decision.completed`` chains its
+    # causation back to the approval: ``agent.proposed → human.corrected →
+    # decision.completed`` under one correlation_id. The executor owns the
+    # chain CLOSE (success or failure) — the router does NOT emit
+    # ``decision.completed`` for code_change, mirroring how the pocket-write
+    # bridge owns the close on its approve path. No double terminal.
     code_change_blob = _code_change_blob(approved)
     if code_change_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=code_change_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(code_change_blob),
+        )
         try:
             from pocketpaw_ee.cloud.belt import executor as belt_executor
 
-            await belt_executor.execute_approved_change(approved)
+            await belt_executor.execute_approved_change(
+                approved, human_event_id=human_event_id
+            )
         except Exception:
             logger.exception("belt code-change execution after approval failed (non-fatal)")
 
@@ -1104,6 +1223,32 @@ async def reject_action(
             user_id=rejector_id,
             workspace_id=workspace_id,
             reason=reason,
+        )
+
+    # BS-4 — a rejected Belt ``_code_change`` Action closes its chain HERE
+    # (the executor never runs on reject). ``human.corrected(rejected)`` cites
+    # the ``agent.proposed`` event as causation; ``decision.completed(rejected,
+    # outcome=reason+comment)`` cites the human event so the chain reads
+    # ``agent.proposed → human.corrected → decision.completed`` cleanly. The
+    # reason text rides as the rejection comment on the terminal payload.
+    code_change_blob = _code_change_blob(action)
+    if code_change_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=code_change_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(code_change_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=code_change_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
         )
 
     return action

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -392,9 +392,7 @@ def _emit_human_corrected(
 
     pocket_id = str(getattr(action, "pocket_id", "") or "")
     causation = (
-        causation_override
-        if causation_override is not None
-        else _parked_policy_event_id(blob)
+        causation_override if causation_override is not None else _parked_policy_event_id(blob)
     )
     payload: dict[str, Any] = {
         "disposition": disposition,
@@ -846,9 +844,7 @@ async def bulk_approve_actions(
             try:
                 from pocketpaw_ee.cloud.belt import executor as belt_executor
 
-                await belt_executor.execute_approved_change(
-                    action, human_event_id=human_event_id
-                )
+                await belt_executor.execute_approved_change(action, human_event_id=human_event_id)
             except Exception:
                 logger.exception(
                     "bulk-approve belt code-change execution failed for %s (non-fatal)",
@@ -1130,9 +1126,7 @@ async def approve_action(
         try:
             from pocketpaw_ee.cloud.belt import executor as belt_executor
 
-            await belt_executor.execute_approved_change(
-                approved, human_event_id=human_event_id
-            )
+            await belt_executor.execute_approved_change(approved, human_event_id=human_event_id)
         except Exception:
             logger.exception("belt code-change execution after approval failed (non-fatal)")
 

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -88,6 +88,21 @@
 #     the per-item chain emits. No semantic change to the bulk-reject
 #     response shape (``BulkActionResponse`` with shared ``bulk_id``).
 #
+# Updated: 2026-06-10 (feat/belt-gate, BS-3 — Belt code-change dispatch) —
+#   ``approve_action`` / ``bulk_approve_actions`` now ALSO dispatch a Belt
+#   develop-station code change. When the approved Action carries a
+#   ``_code_change`` blob (the ``pocketpaw_belt`` MCP server stores it under
+#   ``Action.parameters._code_change``), the route lazy-imports
+#   ``ee.cloud.belt.executor`` and calls ``execute_approved_change`` — same
+#   best-effort / lazy-import / never-break-the-response shape as the
+#   pocket-write hook, keyed on a distinct parameters key so the two paths never
+#   cross. ``_assert_code_change_workspace`` (the code-change peer of
+#   ``_assert_pocket_write_workspace``) binds the Action to the approver's
+#   workspace on approve / reject / bulk paths. The executor applies the diff in
+#   a fresh worktree, commits, pushes, and opens a PR — it NEVER merges (the
+#   captain merges on GitHub; Instinct is the mid gate). The reject path needs
+#   no code-change-specific handling: ``store.reject`` round-trips any kind.
+#
 # Updated: 2026-05-26 (RFC 09 Slice 4 — approve-side policy.evaluated emit) —
 #   * Captain Decision 12 (chain symmetry) follow-up — ``approve_action``
 #     and ``bulk_approve_actions`` now emit a second
@@ -158,6 +173,46 @@ def _pocket_write_blob(action: Any) -> dict[str, Any] | None:
         return None
     blob = params.get("_pocket_write")
     return blob if isinstance(blob, dict) else None
+
+
+def _code_change_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_code_change`` blob on an Action, or ``None``.
+
+    The blob is the Belt develop-station payload the ``pocketpaw_belt`` MCP
+    server stores under ``Action.parameters._code_change`` (repo / base_branch /
+    diff / summary / task + the originating ``workspace_id``). This is the
+    code-change peer of ``_pocket_write_blob`` — the approve path dispatches the
+    apply-on-approve executor on its presence, exactly as it dispatches the
+    pocket-write bridge on ``_pocket_write``. Anything that is not a dict is
+    treated as "no code change".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_code_change")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_code_change_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving a Belt code change from another workspace.
+
+    Mirror of ``_assert_pocket_write_workspace`` for the ``_code_change`` blob.
+    ``require_action_any_workspace("instinct.approve")`` only proves the caller
+    holds the role SOMEWHERE; this binds the code-change Action to the caller's
+    active workspace. A code change carries no pocket the way a parked write
+    does, so its tenancy lives entirely on the blob's ``workspace_id``. A blob
+    whose ``workspace_id`` differs from the caller's active workspace → 403.
+    A non-code-change Action (no blob) is unaffected.
+    """
+    blob = _code_change_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This code change belongs to a different workspace",
+        )
 
 
 def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
@@ -692,6 +747,7 @@ async def bulk_approve_actions(
         action = await store.get_action(action_id)
         if action is not None:
             _assert_pocket_write_workspace(action, workspace_id)
+            _assert_code_change_workspace(action, workspace_id)
 
     approved, missing, bulk_id = await store.bulk_approve(
         list(req.ids), approver=approver_id, note=req.note
@@ -709,6 +765,23 @@ async def bulk_approve_actions(
     # the bulk bar). The bridge owns the chain close on the approve
     # path so we do NOT emit ``decision.completed`` here.
     for action in approved:
+        # BS-3 — a Belt ``_code_change`` Action fires the apply-on-approve
+        # executor. It carries no parked-write chain (no correlation_id), so
+        # the Decision-Graph emits below are skipped for it; only the executor
+        # runs. Same best-effort shape as the pocket-write hook.
+        code_change_blob = _code_change_blob(action)
+        if code_change_blob is not None:
+            try:
+                from pocketpaw_ee.cloud.belt import executor as belt_executor
+
+                await belt_executor.execute_approved_change(action)
+            except Exception:
+                logger.exception(
+                    "bulk-approve belt code-change execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
         action_blob = _pocket_write_blob(action)
         if action_blob is None:
             continue
@@ -783,6 +856,7 @@ async def bulk_reject_actions(
         action = await store.get_action(action_id)
         if action is not None:
             _assert_pocket_write_workspace(action, workspace_id)
+            _assert_code_change_workspace(action, workspace_id)
 
     rejected, missing, bulk_id = await store.bulk_reject(
         list(req.ids), reason=req.reason, rejector=rejector_id
@@ -849,6 +923,9 @@ async def approve_action(
     # caller holds ``instinct.approve`` somewhere; this binds the Action
     # to the caller's workspace.
     _assert_pocket_write_workspace(before, workspace_id)
+    # Same tenancy gate for a Belt code-change Action (BS-3) — its
+    # ``_code_change`` blob carries the workspace, not a pocket.
+    _assert_code_change_workspace(before, workspace_id)
 
     req = req or ApproveRequest()
     # SHOULD-FIX 1 — the audit actor is the authenticated identity, not
@@ -925,6 +1002,21 @@ async def approve_action(
         except Exception:
             logger.exception("pocket-write execution after approval failed (non-fatal)")
 
+    # BS-3 — when the approved Action carries a Belt ``_code_change`` blob,
+    # apply the diff in a fresh worktree and open a PR. Same best-effort,
+    # lazy-import, never-break-the-approve-response shape as the pocket-write
+    # hook above; the executor records success / failure on the Action itself.
+    # A non-code-change Action skips this. The captain still merges on GitHub —
+    # this opens the PR, it does NOT merge.
+    code_change_blob = _code_change_blob(approved)
+    if code_change_blob is not None:
+        try:
+            from pocketpaw_ee.cloud.belt import executor as belt_executor
+
+            await belt_executor.execute_approved_change(approved)
+        except Exception:
+            logger.exception("belt code-change execution after approval failed (non-fatal)")
+
     return ApproveResponse(action=approved, correction=correction)
 
 
@@ -984,6 +1076,7 @@ async def reject_action(
 
     # Touch-time security fix — same gate the approve path runs.
     _assert_pocket_write_workspace(before, workspace_id)
+    _assert_code_change_workspace(before, workspace_id)
 
     reason = req.reason if req else ""
     rejector_id = str(user.id)

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -177,6 +177,7 @@ meetings = "pocketpaw_ee.extensions:CloudMeetingsMcpProvider"
 sites = "pocketpaw_ee.extensions:CloudSitesMcpProvider"
 media = "pocketpaw_ee.extensions:CloudMediaMcpProvider"
 loom = "pocketpaw_ee.extensions:CloudLoomMcpProvider"
+belt = "pocketpaw_ee.extensions:CloudBeltMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]
 cloud = "pocketpaw_ee.extensions:CloudAgentExtension"

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -176,6 +176,7 @@ composio = "pocketpaw_ee.extensions:CloudComposioMcpProvider"
 meetings = "pocketpaw_ee.extensions:CloudMeetingsMcpProvider"
 sites = "pocketpaw_ee.extensions:CloudSitesMcpProvider"
 media = "pocketpaw_ee.extensions:CloudMediaMcpProvider"
+loom = "pocketpaw_ee.extensions:CloudLoomMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]
 cloud = "pocketpaw_ee.extensions:CloudAgentExtension"

--- a/src/pocketpaw/bundled_skills/_bundled/skills/belt/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/belt/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: belt
+description: |
+  Run the Belt & Pulley develop station: take a coding task, ORIENT in the
+  codebase first, develop the change in a station worktree, then PROPOSE the
+  diff through the Instinct gate for a human to review. Invoke when the user
+  asks to write, edit, fix, refactor, or implement code on the /belt surface:
+  "implement this", "fix this bug", "add this feature", "refactor...". You do
+  NOT build a dashboard or a ui-spec and you do NOT create a pocket. You NEVER
+  apply the change to the user's branches directly, NEVER push, NEVER merge —
+  every change leaves the station ONLY as a proposal through
+  mcp__pocketpaw_belt__belt_propose_change, and you NEVER claim success unless
+  the gate tool returned ok. The loop is orient → develop → propose. Loading
+  this skill keeps the chat agent's always-on system prompt small while still
+  delivering the full station playbook when a develop-station task is actually
+  requested.
+---
+
+# Belt — the develop station (orient → develop → propose)
+
+You're on **Belt**: the develop station of the Belt & Pulley assembly line.
+You take a coding task, ground yourself in the codebase, implement the change
+in a **station worktree**, and **propose** the resulting diff through the
+**Instinct gate** for a human to review. This is not a dashboard: no widgets,
+no ui-spec, no pocket. The deliverable is a **proposed change** — a clean
+unified diff waiting in the **Tray** for human approval.
+
+Two rules govern everything below:
+
+- **No direct apply.** You NEVER apply your change to the user's branches, you
+  NEVER `git push`, and you NEVER `git merge`. The gate is the only way out.
+- **No phantom success.** You NEVER claim the change was proposed unless
+  `mcp__pocketpaw_belt__belt_propose_change` actually returned ok. If the gate
+  is unavailable or errors, say so plainly.
+
+## The loop
+
+### 1. Orient first
+
+Before you read or edit any code, call **`mcp__loom__orient`** with the user's
+task. Use the brief it returns — scope, blast-radius, entrypoints — to plan
+your approach. Drill down as you need to:
+
+- **`mcp__loom__locate`** — find where something lives.
+- **`mcp__loom__why`** — understand why a decision was made.
+- **`mcp__loom__what_depends_on`** — find the blast radius of a change.
+
+Do not start reading code blindly. Orient, then plan.
+
+### 2. Develop
+
+Implement the change in the **station worktree** using the built-in tools:
+
+- **`Glob` / `Grep`** — find the files and code to change.
+- **`Read`** — read a file before editing it.
+- **`Edit`** — make a targeted change to an existing file.
+- **`Write`** — create a new file (or fully replace one you've read).
+- **`Bash`** — run commands and **targeted tests** for what you touched.
+
+Keep the diff **small and focused** — one task, one change. Don't gold-plate.
+If the task genuinely needs a large change, **tell the user to split it** into
+smaller tasks rather than proposing a sprawling diff.
+
+### 3. Propose via the gate
+
+Produce a **clean unified diff** of your change and call the gate tool. This is
+the only way a change leaves the station.
+
+```
+mcp__pocketpaw_belt__belt_propose_change({
+  "repo": "pocketpaw",
+  "base_branch": "dev",
+  "diff": "diff --git a/src/foo.py b/src/foo.py\n--- a/src/foo.py\n+++ b/src/foo.py\n@@ -10,6 +10,7 @@\n def handler():\n-    return None\n+    return compute()\n",
+  "summary": "Return the computed value from handler() instead of None",
+  "task": "Fix handler() returning None instead of the computed result"
+})
+```
+
+If the call returns ok, the proposal is queued. If it is unavailable or returns
+an error, **say so plainly** — do not pretend the change was proposed.
+
+## After proposing
+
+Tell the user the change is **waiting in the Tray** for review. On **approve**,
+the proposal is applied in a worktree, branched, and opened as a PR. You do not
+do any of that yourself — you only proposed it.
+
+## Safety — the workspace is jailed
+
+- Stay **inside the station worktree**. Do not reach outside it.
+- **Destructive shell is blocked** — don't delete or move large trees, format
+  disks, or run anything irreversible.
+- Never `git push`, `git merge`, or apply to the user's branches. The gate is
+  the only exit.

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,11 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-10: Added ``loom_bin`` + ``loom_model_path`` — the codebase
+    orientation (loom) MCP server settings. ``loom_model_path`` defaults
+    to None, which disables the loom MCP server; set it to a built
+    world-model JSON to enable orient / locate / why / what_depends_on /
+    boundaries for the cloud chat agent (BS-1, Belt & Pulley stations).
   - 2026-05-26: Added ``foresight_use_skill`` — env gate for the
     ``foresight-create-sim`` bundled skill (default OFF). The SKILL.md
     still auto-installs; this flag toggles the chat-surface affordance
@@ -818,6 +823,28 @@ class Settings(BaseSettings):
     video_model: str = Field(
         default="kwaivgi/kling-v2.0",
         description="Replicate video-generation model (owner/name slug)",
+    )
+
+    # Codebase orientation (loom) — the loom binary serves an MCP server over
+    # stdio that orients the cloud chat agent to a codebase (orient / locate /
+    # why / what_depends_on / boundaries). Wired into the claude_agent_sdk
+    # backend via CloudLoomMcpProvider. Env auto-derives POCKETPAW_LOOM_BIN /
+    # POCKETPAW_LOOM_MODEL_PATH.
+    loom_bin: str = Field(
+        default="loom",
+        description=(
+            "Path to the loom binary. Resolved as: this explicit setting → "
+            "PATH lookup → ~/go/bin/loom fallback. The default 'loom' relies on "
+            "PATH; set an absolute path to pin a specific build."
+        ),
+    )
+    loom_model_path: str | None = Field(
+        default=None,
+        description=(
+            "Path to a loom world-model JSON (built via `loom build`). When "
+            "unset, the loom MCP server is not registered — orientation is "
+            "disabled. The binary is served as `loom mcp -model <this path>`."
+        ),
     )
 
     # Security

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,10 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-10: Added ``belt_repo_allowlist`` — the security boundary for the
+    Belt & Pulley code-change gate (BS-3). A ``belt_propose_change`` proposal's
+    repo path must resolve inside one of these roots; empty defaults to the
+    cwd's parent. Env: POCKETPAW_BELT_REPO_ALLOWLIST (JSON list).
   - 2026-06-10: Added ``loom_bin`` + ``loom_model_path`` — the codebase
     orientation (loom) MCP server settings. ``loom_model_path`` defaults
     to None, which disables the loom MCP server; set it to a built
@@ -844,6 +848,24 @@ class Settings(BaseSettings):
             "Path to a loom world-model JSON (built via `loom build`). When "
             "unset, the loom MCP server is not registered — orientation is "
             "disabled. The binary is served as `loom mcp -model <this path>`."
+        ),
+    )
+
+    # Belt & Pulley — the develop station's code-change gate. The
+    # ``belt_propose_change`` MCP tool proposes a unified diff through Instinct
+    # (the human approve/reject layer); on approval the executor applies it in a
+    # fresh worktree and opens a PR. ``belt_repo_allowlist`` is the security
+    # boundary: a proposed ``repo`` path must resolve INSIDE one of these roots,
+    # so the agent can never move a diff into an arbitrary filesystem location.
+    # When empty, the allowlist defaults to the current working directory's
+    # parent (the workspace root that holds the project checkouts). Env auto-
+    # derives POCKETPAW_BELT_REPO_ALLOWLIST (JSON list).
+    belt_repo_allowlist: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Allowlisted root directories a Belt code-change proposal's repo "
+            "must live under. A repo path resolving outside every root is "
+            "refused. Empty → defaults to the cwd's parent (the workspace root)."
         ),
     )
 

--- a/tests/cloud/surface/test_belt_handler.py
+++ b/tests/cloud/surface/test_belt_handler.py
@@ -1,0 +1,111 @@
+# tests/cloud/surface/test_belt_handler.py — BELT surface handler + its
+# ripple-OFF, station-scoped SurfaceProfile.
+#
+# Created: 2026-06-10 (feat/belt-surface, BS-2 Belt & Pulley stations thin
+# slice) — Guards the /belt develop station:
+#   * the preamble orients to the station loop (not a dashboard), enforces
+#     ORIENT FIRST via loom, names the Instinct gate tool, and states the
+#     no-direct-apply / no-phantom-success rules;
+#   * the profile pins ripple_mode="off" (so it doesn't inherit the ripple
+#     "default to ui-spec" LAW), the exact coding SDK-tool allowlist, the `belt`
+#     skill, and an MCP allow-list that contains the 5 loom ids + the gate id;
+#   * the wire string "belt" resolves to SurfaceKind.BELT (not GENERIC).
+#
+# Mirrors test_studio_code_handlers.py. pytest-asyncio runs in auto mode (see
+# pyproject [tool.pytest] asyncio_mode), so async tests are detected
+# automatically — no module-level mark (it would wrongly tag the sync tests).
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface import SurfaceKind, SurfaceMeta, resolve_profile
+from pocketpaw_ee.cloud.surface.handlers import belt as belt_handler
+
+WORKSPACE = "ws-surface-belt"
+USER = "u-belt"
+
+# The Instinct gate tool id the station proposes its diff through. Literal here
+# (and in service.py) until the sibling-branch constant lands.
+GATE_TOOL_ID = "mcp__pocketpaw_belt__belt_propose_change"
+
+
+# --- /belt handler ---
+
+
+async def test_belt_handler_carries_station_orientation() -> None:
+    """The preamble orients to the develop station — and must NOT frame the
+    deliverable as a dashboard or a pocket."""
+    preamble = await belt_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/belt"))
+
+    assert '<surface kind="belt" ' in preamble
+    lower = preamble.lower()
+    assert "belt" in lower
+    assert "station" in lower
+    # The change is proposed through a gate, not applied directly.
+    assert "gate" in lower
+    assert "diff" in lower
+    # Not a dashboard / pocket build.
+    assert "build a pocket" not in lower
+    assert "ui-spec" not in lower or "not" in lower
+
+
+async def test_belt_handler_enforces_orient_first() -> None:
+    """The procedure makes the agent ORIENT FIRST via loom before touching code."""
+    preamble = await belt_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/belt"))
+
+    lower = preamble.lower()
+    assert "orient" in lower
+    # Names the loom orient tool by id so the agent calls it, not just "look around".
+    assert "mcp__loom__orient" in preamble
+
+
+async def test_belt_handler_names_gate_tool_and_forbids_direct_apply() -> None:
+    """The procedure names the Instinct gate tool and forbids applying / pushing /
+    merging directly — every change leaves the station ONLY as a proposal."""
+    preamble = await belt_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/belt"))
+
+    # The gate tool the agent must propose through.
+    assert GATE_TOOL_ID in preamble
+    lower = preamble.lower()
+    # The no-direct-apply rule.
+    assert "never apply" in lower
+    assert "directly" in lower
+    # And no phantom successes when the gate is unavailable.
+    assert "phantom" in lower or "do not claim" in lower
+
+
+async def test_belt_handler_names_builtin_dev_tools() -> None:
+    """The develop stage names the built-in coding tools used in the worktree."""
+    preamble = await belt_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/belt"))
+
+    for tool in ("Bash", "Read", "Write", "Edit", "Glob", "Grep"):
+        assert tool in preamble, f"preamble should name the {tool} tool"
+
+
+# --- Profile (ripple-OFF, station-scoped) ---
+
+
+def test_belt_profile_ripple_off_sdk_allowlist_skill_and_mcp_scope() -> None:
+    """The /belt profile turns ripple OFF, restricts SDK tools to the coding
+    built-ins, surfaces the `belt` skill, and scopes MCP to the loom orientation
+    tools + the Instinct gate tool."""
+    from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
+
+    profile = resolve_profile(SurfaceKind.BELT, SurfaceMeta())
+
+    assert profile.ripple_mode == "off"
+    assert "belt" in profile.skill_names
+    assert profile.allowed_sdk_tools == frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
+    # MCP allow-list: the 5 loom orientation tools + the gate tool.
+    assert profile.allow_mcp_tool_ids is not None
+    assert len(LOOM_TOOL_IDS) == 5
+    for loom_id in LOOM_TOOL_IDS:
+        assert loom_id in profile.allow_mcp_tool_ids
+    assert GATE_TOOL_ID in profile.allow_mcp_tool_ids
+
+
+def test_belt_kind_maps_from_wire_string() -> None:
+    """The wire ``surface`` string 'belt' resolves to SurfaceKind.BELT (not the
+    GENERIC fallback)."""
+    from pocketpaw_ee.cloud.surface.service import _resolve_kind
+
+    assert _resolve_kind("belt") is SurfaceKind.BELT

--- a/tests/cloud/test_belt_gate.py
+++ b/tests/cloud/test_belt_gate.py
@@ -1,0 +1,508 @@
+# tests/cloud/test_belt_gate.py — Belt & Pulley code-change gate (BS-3).
+#
+# Created: 2026-06-10 (feat/belt-gate, Belt & Pulley stations thin slice).
+#
+# What this pins — the WHOLE gate, driven through the REAL path with a local
+# git fixture (a bare repo as origin + a seeded working clone):
+#   * belt_propose_change (the real MCP handler) validates identity + inputs,
+#     files an Instinct Action carrying the ``_code_change`` blob, and returns
+#     {ok, action_id, tray_hint} — only after the store confirms the Action.
+#   * the apply-on-approve executor, on a REAL git repo: fresh worktree off
+#     origin/<base>, git apply --3way, branch feat/belt-<id>, Conventional-
+#     Commits commit (summary as body, NO AI attribution), push, PR via an
+#     INJECTED fake opener, mark_executed with {pr_url, branch, files_changed}.
+#     The branch + commit land in the BARE origin; the worktree is removed.
+#   * two actions run back-to-back with no cross-contamination (distinct
+#     branches, distinct PRs, distinct outcomes).
+#   * reject round-trips for a code_change Action (status REJECTED, recorded
+#     reason, NO worktree, NO PR).
+#   * apply conflict (doctored diff against a mutated base) → action FAILED,
+#     worktree cleaned, no branch pushed.
+#   * size-cap rejection (over the changed-line / byte budget).
+#   * identity-missing error (no workspace/user ContextVars).
+#   * repo-outside-allowlist refusal.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The handler reads
+# identity through ee.cloud.chat.agent_service ContextVars (set in-test via
+# attach_agent_identity) and the store through pocketpaw.stores.get_instinct_store
+# (patched to a tmp-file store so nothing touches ~/.pocketpaw/instinct.db).
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_PATH = os.environ.get("PATH", "/usr/bin:/bin")
+
+pytest.importorskip("pocketpaw_ee")
+
+import pocketpaw_ee.agent.mcp_servers.belt as belt  # noqa: E402
+from pocketpaw_ee.cloud.belt import executor as belt_executor  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers + fixtures
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    """Run git from an arg list (no shell), assert success, return stdout."""
+    res = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "Belt Test",
+            "GIT_AUTHOR_EMAIL": "belt@test.local",
+            "GIT_COMMITTER_NAME": "Belt Test",
+            "GIT_COMMITTER_EMAIL": "belt@test.local",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "PATH": _PATH,
+            "HOME": str(cwd),
+        },
+    )
+    return res.stdout
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A bare repo as origin + a seeded working clone.
+
+    Returns the WORKING CLONE path (the thing a proposal's ``repo`` points at).
+    The clone has ``origin`` pointing at the bare repo, a committed ``app.py`` on
+    ``main``, and ``main`` pushed to origin — so the executor can fetch
+    origin/main and branch off it.
+    """
+    bare = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", str(bare))
+
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", str(bare), str(work))
+    # Local identity on the clone so commits succeed regardless of global config.
+    _git(work, "config", "user.name", "Belt Test")
+    _git(work, "config", "user.email", "belt@test.local")
+
+    (work / "app.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
+    _git(work, "add", "app.py")
+    _git(work, "commit", "-m", "init")
+    # Ensure the default branch is named 'main' regardless of git's init default.
+    _git(work, "branch", "-M", "main")
+    _git(work, "push", "-u", "origin", "main")
+    return work
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired in everywhere the gate
+    reads it (the MCP handler + the executor both lazy-import
+    ``pocketpaw.stores.get_instinct_store``)."""
+    st = InstinctStore(tmp_path / "instinct_belt_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+@pytest.fixture
+def allowlist(repo: Path, monkeypatch) -> None:
+    """Point belt_repo_allowlist at the repo's parent so the real repo resolves
+    inside the boundary. Patches get_settings to carry the field."""
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+
+    class _S:
+        belt_repo_allowlist = [str(repo.parent)]
+
+        def __getattr__(self, name):  # delegate everything else to real settings
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+
+class _identity:
+    """Context manager that sets the workspace/user/session ContextVars the
+    handler reads, then resets them."""
+
+    def __init__(self, *, workspace="w1", user="u1", session="sess-1"):
+        self._ws, self._user, self._sess = workspace, user, session
+        self._tokens = None
+
+    def __enter__(self):
+        self._tokens = attach_agent_identity(
+            workspace_id=self._ws, user_id=self._user, session_mongo_id=self._sess
+        )
+        return self
+
+    def __exit__(self, *exc):
+        detach_agent_identity(self._tokens)
+        return False
+
+
+class FakePrOpener:
+    """An injectable PrOpener that records its call args and returns a fixed
+    URL — never touches GitHub."""
+
+    def __init__(self, url="https://github.com/acme/repo/pull/1"):
+        self.url = url
+        self.calls: list[dict] = []
+
+    async def open_pr(self, *, repo_path, branch, base_branch, title, body) -> str:
+        self.calls.append(
+            {
+                "repo_path": Path(repo_path),
+                "branch": branch,
+                "base_branch": base_branch,
+                "title": title,
+                "body": body,
+            }
+        )
+        return self.url
+
+
+async def _result_body(res: dict) -> dict:
+    """Parse the JSON body out of a success MCP response."""
+    assert res.get("is_error") is not True, res
+    return json.loads(res["content"][0]["text"])
+
+
+def _good_diff() -> str:
+    """A diff that applies cleanly to the seeded app.py — changes the return
+    value on line 2."""
+    return (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        " def hello():\n"
+        "-    return 'hi'\n"
+        "+    return 'hello world'\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# tool-id / provider contract pins
+# ---------------------------------------------------------------------------
+
+
+def test_tool_id_contract_pin() -> None:
+    """The server + tool id are the exact strings the sibling PR hardcodes."""
+    assert belt.SERVER_NAME == "pocketpaw_belt"
+    assert belt.PROPOSE_CHANGE_TOOL_ID == "mcp__pocketpaw_belt__belt_propose_change"
+    assert belt.BELT_TOOL_IDS == ("mcp__pocketpaw_belt__belt_propose_change",)
+    assert belt.CODE_CHANGE_KIND == "code_change"
+
+
+# ---------------------------------------------------------------------------
+# the REAL end-to-end path: propose → approve → apply → PR
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_then_approve_applies_and_opens_pr(repo, store, allowlist):
+    """Drive the whole gate: propose via the real handler, execute via the real
+    executor with a fake PR opener, assert the branch + commit land in the bare
+    origin, the opener gets the right args, and mark_executed carries the PR
+    url."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": _good_diff(),
+                "summary": "Return a friendlier greeting from hello().",
+                "task": "Make hello() return a greeting.",
+                "orient_ref": "loom: app.py is the entrypoint",
+            }
+        )
+    body = await _result_body(res)
+    assert body["ok"] is True
+    action_id = body["action_id"]
+    assert "tray_hint" in body
+
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+    blob = action.parameters["_code_change"]
+    assert blob["kind"] == "code_change"
+    assert blob["base_branch"] == "main"
+    assert blob["workspace_id"] == "w1"
+    assert blob["requested_by"] == "u1"
+    # The diff is stored verbatim — it's data.
+    assert "hello world" in blob["diff"]
+
+    # Approve via the real store, then run the real executor with a fake opener.
+    approved = await store.approve(action_id, approver="u1")
+    opener = FakePrOpener()
+    await belt_executor.execute_approved_change(approved, pr_opener=opener)
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+    outcome = final.outcome if isinstance(final.outcome, str) else str(final.outcome)
+    assert "github.com/acme/repo/pull/1" in outcome
+
+    # The fake opener was called with the belt branch + base.
+    assert len(opener.calls) == 1
+    call = opener.calls[0]
+    assert call["base_branch"] == "main"
+    assert call["branch"].startswith("feat/belt-")
+    # Conventional Commits title, NO AI attribution.
+    assert call["title"].startswith("feat(belt):")
+    assert "claude" not in (call["title"] + call["body"]).lower()
+    assert "co-authored-by" not in (call["title"] + call["body"]).lower()
+
+    # The branch + commit actually landed in the BARE origin.
+    bare = repo.parent / "origin.git"
+    branches = _git(bare, "branch", "--list", call["branch"])
+    assert call["branch"] in branches
+    log = _git(bare, "log", call["branch"], "--oneline", "-1")
+    assert "feat(belt)" in log
+    # The applied content is on that branch in origin.
+    blob_on_branch = _git(bare, "show", f"{call['branch']}:app.py")
+    assert "hello world" in blob_on_branch
+
+    # The worktree was cleaned up — nothing left under tmp/belt-actions for it.
+    leftover = (
+        list((repo / ".git" / "worktrees").glob("*"))
+        if (repo / ".git" / "worktrees").exists()
+        else []
+    )
+    # worktree registration is pruned
+    assert not any("act-" in p.name for p in leftover)
+
+
+async def test_two_actions_no_cross_contamination(repo, store, allowlist):
+    """Two proposals applied back-to-back land on DISTINCT branches with
+    DISTINCT PRs and DISTINCT outcomes — no shared worktree state leaks."""
+
+    async def _propose(summary: str, new_val: str) -> str:
+        diff = (
+            "--- a/app.py\n"
+            "+++ b/app.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            " def hello():\n"
+            "-    return 'hi'\n"
+            f"+    return '{new_val}'\n"
+        )
+        with _identity():
+            res = await belt._propose_change_handler(
+                {
+                    "repo": str(repo),
+                    "base_branch": "main",
+                    "diff": diff,
+                    "summary": summary,
+                    "task": "change greeting",
+                }
+            )
+        return (await _result_body(res))["action_id"]
+
+    id_a = await _propose("First greeting change.", "first")
+    id_b = await _propose("Second greeting change.", "second")
+
+    opener_a = FakePrOpener(url="https://github.com/acme/repo/pull/10")
+    opener_b = FakePrOpener(url="https://github.com/acme/repo/pull/11")
+
+    await belt_executor.execute_approved_change(
+        await store.approve(id_a, approver="u1"), pr_opener=opener_a
+    )
+    await belt_executor.execute_approved_change(
+        await store.approve(id_b, approver="u1"), pr_opener=opener_b
+    )
+
+    fa = await store.get_action(id_a)
+    fb = await store.get_action(id_b)
+    assert fa.status == ActionStatus.EXECUTED
+    assert fb.status == ActionStatus.EXECUTED
+    branch_a = opener_a.calls[0]["branch"]
+    branch_b = opener_b.calls[0]["branch"]
+    assert branch_a != branch_b
+
+    bare = repo.parent / "origin.git"
+    assert "first" in _git(bare, "show", f"{branch_a}:app.py")
+    assert "second" in _git(bare, "show", f"{branch_b}:app.py")
+    # The second branch must NOT carry the first's change (clean base each time).
+    assert "first" not in _git(bare, "show", f"{branch_b}:app.py")
+
+
+# ---------------------------------------------------------------------------
+# reject path
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_round_trips_for_code_change(repo, store, allowlist):
+    """A code_change Action rejects cleanly through the real store: status
+    REJECTED, reason recorded, no PR, no executor run."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": _good_diff(),
+                "summary": "A change to reject.",
+                "task": "change greeting",
+            }
+        )
+    action_id = (await _result_body(res))["action_id"]
+
+    rejected = await store.reject(action_id, reason="not now", rejector="u1")
+    assert rejected is not None
+    assert rejected.status == ActionStatus.REJECTED
+    assert rejected.rejected_reason == "not now"
+
+    # No branch was pushed to origin (the executor never ran).
+    bare = repo.parent / "origin.git"
+    branches = _git(bare, "branch", "--list", "feat/belt-*")
+    assert branches.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# apply-conflict path
+# ---------------------------------------------------------------------------
+
+
+async def test_apply_conflict_marks_failed_and_cleans_up(repo, store, allowlist):
+    """A diff that cannot apply (it edits a line the base no longer has) →
+    the Action is marked FAILED, no branch is pushed, the worktree is cleaned."""
+    # A diff that targets content NOT present in the seeded app.py — git apply
+    # --3way can't reconcile it, so it fails.
+    bad_diff = (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,3 +1,3 @@\n"
+        " def hello():\n"
+        "-    return 'NONEXISTENT LINE THAT IS NOT IN THE FILE'\n"
+        "+    return 'whatever'\n"
+        " trailing context that does not match\n"
+    )
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": bad_diff,
+                "summary": "A conflicting change.",
+                "task": "change greeting",
+            }
+        )
+    action_id = (await _result_body(res))["action_id"]
+
+    opener = FakePrOpener()
+    await belt_executor.execute_approved_change(
+        await store.approve(action_id, approver="u1"), pr_opener=opener
+    )
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.FAILED
+    assert opener.calls == []  # no PR opened
+    # Nothing pushed to origin.
+    bare = repo.parent / "origin.git"
+    assert _git(bare, "branch", "--list", "feat/belt-*").strip() == ""
+    # The worktree dir is gone.
+
+    leftover = Path(tempfile.gettempdir()) / "belt-actions"
+    if leftover.exists():
+        assert not any(p.is_dir() for p in leftover.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# input validation: size cap, identity, allowlist
+# ---------------------------------------------------------------------------
+
+
+async def test_size_cap_rejection(repo, store, allowlist):
+    """A diff over the changed-line budget is refused with a split-the-task
+    error — and no Action is filed."""
+    # Build a diff with > MAX_CHANGED_LINES added lines.
+    added = "\n".join(f"+line {i}" for i in range(belt.MAX_CHANGED_LINES + 5))
+    big_diff = "--- a/app.py\n+++ b/app.py\n@@ -1,1 +1,9999 @@\n" + added + "\n"
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": big_diff,
+                "summary": "Way too big.",
+                "task": "change greeting",
+            }
+        )
+    assert res.get("is_error") is True
+    assert "split the task" in res["content"][0]["text"].lower()
+    # No action filed.
+    assert await store.list_actions() == []
+
+
+async def test_identity_missing_errors(repo, store, allowlist):
+    """Called without workspace/user ContextVars → an explicit error, no
+    Action."""
+    res = await belt._propose_change_handler(
+        {
+            "repo": str(repo),
+            "base_branch": "main",
+            "diff": _good_diff(),
+            "summary": "No identity.",
+            "task": "change greeting",
+        }
+    )
+    assert res.get("is_error") is True
+    assert "workspace and user context" in res["content"][0]["text"]
+    assert await store.list_actions() == []
+
+
+async def test_repo_outside_allowlist_refused(repo, store, monkeypatch, tmp_path):
+    """A repo path outside the allowlist roots is refused — even if it's a real
+    git repo on disk."""
+    # Allowlist points somewhere ELSE, not the repo's parent.
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+    other_root = tmp_path / "elsewhere"
+    other_root.mkdir()
+
+    class _S:
+        belt_repo_allowlist = [str(other_root)]
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": _good_diff(),
+                "summary": "Out of bounds.",
+                "task": "change greeting",
+            }
+        )
+    assert res.get("is_error") is True
+    assert "outside the allowed roots" in res["content"][0]["text"]
+    assert await store.list_actions() == []
+
+
+async def test_empty_diff_refused(repo, store, allowlist):
+    """An empty / whitespace diff is refused before anything is stored."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": "   \n  ",
+                "summary": "Empty.",
+                "task": "change greeting",
+            }
+        )
+    assert res.get("is_error") is True
+    assert "non-empty unified `diff`" in res["content"][0]["text"]
+    assert await store.list_actions() == []

--- a/tests/cloud/test_belt_trace.py
+++ b/tests/cloud/test_belt_trace.py
@@ -1,0 +1,606 @@
+# tests/cloud/test_belt_trace.py — Belt & Pulley Decision-Graph chain (BS-4).
+#
+# Created: 2026-06-10 (feat/belt-trace, BS-4 — one station run = ONE Decision
+# chain).
+#
+# THE HARD GATE — this drives the REAL production path with NO stubs at the
+# seams between propose / approve / execute (the chain-doubling lesson,
+# 2026-05-26): the real ``belt.py`` propose handler (ContextVars set in-test),
+# the real Instinct store, the real Instinct router dispatch over a TestClient,
+# and the real ``ee.cloud.belt.executor`` against a LOCAL bare-repo git fixture
+# (reused from BS-3's ``test_belt_gate.py``). The ONLY fake is the PR opener —
+# that is the one genuine external boundary (``gh pr create``), allowed. The
+# Decision Graph journal + projection are the REAL singletons wired into the
+# lazy global lookups (same fixture shape as ``test_instinct_decision_events``).
+#
+# Expected chain shape (documented per the brief) — N = 3 events, ONE chain per
+# station run, sharing ONE correlation_id minted at propose:
+#
+#   EXECUTED (propose → approve → apply → PR):
+#     agent.proposed                                  (belt.py propose)
+#       → human.corrected(disposition=accepted)       (router approve)
+#       → decision.completed(passed=True,             (executor mark_executed)
+#                            action_outcome="landed",
+#                            pr_url=..., branch=..., files_changed=N)
+#
+#   REJECTED (propose → reject):
+#     agent.proposed                                  (belt.py propose)
+#       → human.corrected(disposition=rejected)       (router reject)
+#       → decision.completed(passed=False,            (router reject — executor
+#                            action_outcome="rejected", never runs)
+#                            reason=<comment>)
+#
+#   FAILED (propose → approve → apply conflict):
+#     agent.proposed → human.corrected(accepted)
+#       → decision.completed(passed=False, action_outcome="failed",
+#                            error_class="ApplyConflict", reason=...)
+#
+# Causation walk: agent.proposed (origin, causation_id=None) ←
+#   human.corrected (caused by agent.proposed) ← decision.completed (caused by
+#   human.corrected). Each event cites the prior via causation_id.
+#
+# The doubled-terminal trap is the thing under test: every assertion counts the
+# terminal events and proves EXACTLY ONE decision.completed lands per run, and a
+# SECOND full cycle produces a SECOND distinct, clean chain.
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+_PATH = os.environ.get("PATH", "/usr/bin:/bin")
+
+pytest.importorskip("pocketpaw_ee")
+
+from unittest.mock import AsyncMock  # noqa: E402
+
+import pocketpaw_ee.agent.mcp_servers.belt as belt  # noqa: E402
+import pocketpaw_ee.cloud.belt.executor as belt_executor_module  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# Workspace + user the in-test identity binds. The Belt action's pocket_id
+# carries the workspace (belt.py), so the chain scope is workspace-only.
+WS = "w1"
+USER = "u1"
+
+
+# ---------------------------------------------------------------------------
+# git bare-repo fixture (reused shape from test_belt_gate.py)
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    res = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "Belt Test",
+            "GIT_AUTHOR_EMAIL": "belt@test.local",
+            "GIT_COMMITTER_NAME": "Belt Test",
+            "GIT_COMMITTER_EMAIL": "belt@test.local",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "PATH": _PATH,
+            "HOME": str(cwd),
+        },
+    )
+    return res.stdout
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A bare repo as origin + a seeded working clone (returns the clone)."""
+    bare = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", str(bare))
+
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", str(bare), str(work))
+    _git(work, "config", "user.name", "Belt Test")
+    _git(work, "config", "user.email", "belt@test.local")
+
+    (work / "app.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
+    _git(work, "add", "app.py")
+    _git(work, "commit", "-m", "init")
+    _git(work, "branch", "-M", "main")
+    _git(work, "push", "-u", "origin", "main")
+    return work
+
+
+# ---------------------------------------------------------------------------
+# decision-graph + journal + store wiring (real singletons)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    """Fresh on-disk journal wired into the lazy ``get_journal`` lookup the
+    ``journal_writer`` helper resolves — production code and the test read the
+    same singleton."""
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    """Fresh DecisionGraph as the process-global singleton."""
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore wired everywhere the gate reads it (the MCP
+    handler, the router's ``_store``, and the executor all resolve through
+    ``pocketpaw.stores.get_instinct_store`` or the router indirection)."""
+    st = InstinctStore(tmp_path / "instinct.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    return st
+
+
+@pytest.fixture
+def allowlist(repo: Path, monkeypatch) -> None:
+    """Point belt_repo_allowlist at the repo's parent so the real repo resolves
+    inside the boundary."""
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+
+    class _S:
+        belt_repo_allowlist = [str(repo.parent)]
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+
+# ---------------------------------------------------------------------------
+# identity + router client + fake PR opener (the ONE allowed external fake)
+# ---------------------------------------------------------------------------
+
+
+class _identity:
+    """Sets the workspace/user/session ContextVars the belt handler reads."""
+
+    def __init__(self, *, workspace=WS, user=USER, session="sess-1"):
+        self._ws, self._user, self._sess = workspace, user, session
+        self._tokens = None
+
+    def __enter__(self):
+        self._tokens = attach_agent_identity(
+            workspace_id=self._ws, user_id=self._user, session_mongo_id=self._sess
+        )
+        return self
+
+    def __exit__(self, *exc):
+        detach_agent_identity(self._tokens)
+        return False
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = USER, workspace_id: str = WS) -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+
+        class _M:
+            def __init__(self, ws):
+                self.workspace = ws
+                self.role = "admin"
+
+        self.workspaces = [_M(workspace_id)]
+
+
+class FakePrOpener:
+    """Records its call args, returns a fixed URL — never touches GitHub. This
+    is the ONLY seam faked: the genuine external boundary (``gh pr create``)."""
+
+    instances: list[FakePrOpener] = []
+
+    def __init__(self, url: str = "https://github.com/acme/repo/pull/1"):
+        self.url = url
+        self.calls: list[dict] = []
+        FakePrOpener.instances.append(self)
+
+    async def open_pr(self, *, repo_path, branch, base_branch, title, body) -> str:
+        self.calls.append({"branch": branch, "base_branch": base_branch, "title": title})
+        return self.url
+
+
+def _make_client(store: InstinctStore, user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _patch_pr_opener(monkeypatch, url: str = "https://github.com/acme/repo/pull/1") -> None:
+    """Make the executor's DEFAULT opener (the one the router triggers, since
+    the router passes no ``pr_opener``) the fake. This keeps the router→executor
+    seam REAL — only the external ``gh`` boundary is replaced."""
+    monkeypatch.setattr(belt_executor_module, "GhCliPrOpener", lambda: FakePrOpener(url=url))
+
+
+def _good_diff() -> str:
+    return (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        " def hello():\n"
+        "-    return 'hi'\n"
+        "+    return 'hello world'\n"
+    )
+
+
+def _conflict_diff() -> str:
+    """A diff that cannot apply against the seeded app.py (line not present)."""
+    return (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,3 +1,3 @@\n"
+        " def hello():\n"
+        "-    return 'NONEXISTENT LINE THAT IS NOT IN THE FILE'\n"
+        "+    return 'whatever'\n"
+        " trailing context that does not match\n"
+    )
+
+
+async def _propose(repo: Path, diff: str, summary: str = "Friendlier greeting.") -> str:
+    """Drive the REAL belt propose handler and return the action id."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": diff,
+                "summary": summary,
+                "task": "Make hello() return a greeting.",
+            }
+        )
+    assert res.get("is_error") is not True, res
+    return json.loads(res["content"][0]["text"])["action_id"]
+
+
+def _events(journal, action: str) -> list:
+    return [e for e in journal.replay_from(0) if e.action == action]
+
+
+def _chain(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+async def _correlation_for(store: InstinctStore, action_id: str) -> UUID:
+    action = await store.get_action(action_id)
+    blob = action.parameters["_code_change"]
+    return UUID(blob["correlation_id"])
+
+
+# ---------------------------------------------------------------------------
+# EXECUTED path — propose → approve → apply → PR → ONE clean chain (N=3)
+# ---------------------------------------------------------------------------
+
+
+async def test_executed_run_is_one_clean_three_event_chain(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """The whole executed station run lands as ONE chain of EXACTLY three
+    events sharing one correlation_id minted at propose:
+    agent.proposed → human.corrected(accepted) → decision.completed(landed).
+    No doubled terminal. The Decision row is queryable via the graph."""
+    _patch_pr_opener(monkeypatch)
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+
+    action_id = await _propose(repo, _good_diff())
+    corr = await _correlation_for(store, action_id)
+
+    # agent.proposed fired at propose, before any approval.
+    proposed = _events(journal, "agent.proposed")
+    assert len(proposed) == 1
+    assert proposed[0].correlation_id == corr
+    assert proposed[0].causation_id is None  # chain origin
+    assert proposed[0].payload["action"] == "code_change"
+
+    # Approve over HTTP — the REAL router dispatch fires human.corrected then
+    # the REAL executor applies + closes the chain.
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+
+    # EXACTLY three events, one chain, in causal order.
+    chain = _chain(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+
+    proposed_e, human_e, completed_e = chain
+    # Causation walk: each event cites the prior.
+    assert proposed_e.causation_id is None
+    assert human_e.causation_id == proposed_e.id
+    assert completed_e.causation_id == human_e.id
+
+    # human.corrected — accepted, the human user is the actor.
+    assert human_e.payload["disposition"] == "accepted"
+    assert human_e.actor.kind == "user"
+    assert human_e.actor.id == f"user:{USER}"
+
+    # decision.completed — landed, carries the PR url + branch + file count.
+    assert completed_e.payload["passed"] is True
+    assert completed_e.payload["action_outcome"] == "landed"
+    assert "github.com/acme/repo/pull/1" in completed_e.payload["pr_url"]
+    assert completed_e.payload["branch"].startswith("feat/belt-")
+    assert completed_e.payload["files_changed"] == 1
+
+    # EXACTLY ONE terminal — the doubled-terminal trap.
+    assert len(_events(journal, "decision.completed")) == 1
+    assert len(_events(journal, "agent.proposed")) == 1
+    assert len(_events(journal, "human.corrected")) == 1
+
+    # The folded Decision row is queryable and not rejected.
+    assert graph.store.count() == 1
+    decisions = await graph.find()
+    assert len(decisions) == 1
+    d = decisions[0]
+    assert d.correlation_id == corr
+    assert d.action == "code_change"
+    assert len(d.approvers) == 1
+    assert d.approvers[0].actor.id == f"user:{USER}"
+    assert d.outcome is None or d.outcome.status != "rejected"
+
+
+# ---------------------------------------------------------------------------
+# TWO cycles — back-to-back runs form TWO distinct clean chains
+# ---------------------------------------------------------------------------
+
+
+async def test_two_cycles_form_two_distinct_clean_chains(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """A second full executed cycle produces a SECOND distinct chain — two
+    correlation_ids, each a clean 3-event chain, no cross-contamination and no
+    doubled terminals across the two runs."""
+    _patch_pr_opener(monkeypatch)
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+
+    # Cycle 1
+    id_a = await _propose(repo, _good_diff(), summary="First change.")
+    corr_a = await _correlation_for(store, id_a)
+    assert client.post(f"/instinct/actions/{id_a}/approve").status_code == 200
+
+    # Cycle 2 (a distinct diff value so the two branches differ)
+    diff_b = (
+        "--- a/app.py\n"
+        "+++ b/app.py\n"
+        "@@ -1,2 +1,2 @@\n"
+        " def hello():\n"
+        "-    return 'hi'\n"
+        "+    return 'second'\n"
+    )
+    id_b = await _propose(repo, diff_b, summary="Second change.")
+    corr_b = await _correlation_for(store, id_b)
+    assert client.post(f"/instinct/actions/{id_b}/approve").status_code == 200
+
+    assert corr_a != corr_b
+
+    # Each chain is its own clean 3-event walk.
+    for corr in (corr_a, corr_b):
+        actions = [e.action for e in _chain(journal, corr)]
+        assert actions == [
+            "agent.proposed",
+            "human.corrected",
+            "decision.completed",
+        ], (corr, actions)
+
+    # Two terminals total — one per run, none doubled.
+    assert len(_events(journal, "agent.proposed")) == 2
+    assert len(_events(journal, "human.corrected")) == 2
+    assert len(_events(journal, "decision.completed")) == 2
+
+    # Two distinct Decision rows.
+    assert graph.store.count() == 2
+    decisions = await graph.find()
+    corrs = {d.correlation_id for d in decisions}
+    assert corrs == {corr_a, corr_b}
+
+
+# ---------------------------------------------------------------------------
+# REJECT path — propose → reject → ONE clean chain (N=3), router owns close
+# ---------------------------------------------------------------------------
+
+
+async def test_rejected_run_is_one_clean_three_event_chain(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """A rejected station run lands as ONE clean chain:
+    agent.proposed → human.corrected(rejected) → decision.completed(rejected,
+    reason=<comment>). The executor never runs (no PR opener call), the router
+    owns the close, and there is exactly one terminal."""
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+    FakePrOpener.instances.clear()
+
+    action_id = await _propose(repo, _good_diff(), summary="A change to reject.")
+    corr = await _correlation_for(store, action_id)
+
+    resp = client.post(
+        f"/instinct/actions/{action_id}/reject",
+        json={"reason": "not now — out of scope"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED
+
+    chain = _chain(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+
+    proposed_e, human_e, completed_e = chain
+    assert human_e.causation_id == proposed_e.id
+    assert completed_e.causation_id == human_e.id
+
+    assert human_e.payload["disposition"] == "rejected"
+    assert human_e.payload["note"] == "not now — out of scope"
+
+    assert completed_e.payload["passed"] is False
+    assert completed_e.payload["action_outcome"] == "rejected"
+    assert completed_e.payload["reason"] == "not now — out of scope"
+
+    # Exactly one terminal; the executor never ran (no PR opener instantiated).
+    assert len(_events(journal, "decision.completed")) == 1
+    assert FakePrOpener.instances == []
+
+    # The folded Decision row is marked rejected.
+    decisions = await graph.find()
+    assert len(decisions) == 1
+    assert decisions[0].outcome is not None
+    assert decisions[0].outcome.status == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# FAILED path — propose → approve → apply conflict → ONE chain (failed terminal)
+# ---------------------------------------------------------------------------
+
+
+async def test_failed_apply_is_one_clean_three_event_chain(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """An approved run whose diff cannot apply closes the chain with a single
+    failed terminal: agent.proposed → human.corrected(accepted) →
+    decision.completed(passed=False, action_outcome="failed",
+    error_class="ApplyConflict"). No PR opened, no doubled terminal."""
+    _patch_pr_opener(monkeypatch)
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+    FakePrOpener.instances.clear()
+
+    action_id = await _propose(repo, _conflict_diff(), summary="A conflicting change.")
+    corr = await _correlation_for(store, action_id)
+
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.FAILED
+
+    chain = _chain(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+
+    proposed_e, human_e, completed_e = chain
+    assert human_e.causation_id == proposed_e.id
+    assert completed_e.causation_id == human_e.id
+
+    assert human_e.payload["disposition"] == "accepted"
+    assert completed_e.payload["passed"] is False
+    assert completed_e.payload["action_outcome"] == "failed"
+    assert completed_e.payload["error_class"] == "ApplyConflict"
+
+    # Exactly one terminal; the apply conflict means the PR opener was never
+    # reached (the executor bails before the push/PR step).
+    assert len(_events(journal, "decision.completed")) == 1
+    assert FakePrOpener.instances == [] or FakePrOpener.instances[0].calls == []
+
+
+# ---------------------------------------------------------------------------
+# bulk-approve — code_change item lands as one clean chain too
+# ---------------------------------------------------------------------------
+
+
+async def test_bulk_approve_code_change_is_one_clean_chain(
+    repo, store, allowlist, journal, graph, monkeypatch
+):
+    """A code_change Action approved via the BULK endpoint forms the same
+    clean 3-event chain — bulk-approve has no edit surface, so disposition is
+    accepted, and the executor still owns a single landed terminal."""
+    _patch_pr_opener(monkeypatch)
+    user = _FakeUser()
+    client = _make_client(store, user, monkeypatch)
+
+    action_id = await _propose(repo, _good_diff(), summary="Bulk change.")
+    corr = await _correlation_for(store, action_id)
+
+    resp = client.post(
+        "/instinct/actions/bulk-approve",
+        json={"ids": [action_id], "note": "ship it"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()["affected"]) == 1
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+
+    chain = _chain(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert chain[1].payload["disposition"] == "accepted"
+    assert chain[1].payload.get("note") == "ship it"
+    assert chain[2].payload["action_outcome"] == "landed"
+    assert len(_events(journal, "decision.completed")) == 1

--- a/tests/cloud/test_ee_instinct.py
+++ b/tests/cloud/test_ee_instinct.py
@@ -1,5 +1,15 @@
 # tests/test_ee_instinct.py — Comprehensive tests for ee/instinct (store + router).
 # Created: 2026-03-28 — Initial store tests.
+# Updated: 2026-06-10 (feat/belt-gate, BS-3) — added TestBeltCodeChangeRouterSeam:
+#   proves the approve/bulk-approve/reject routes dispatch the Belt
+#   apply-on-approve executor ONLY for a ``_code_change`` Action and NEVER for a
+#   plain (non-code-change) one — the kind-gated dispatch seam the spec security
+#   checklist requires ("the executor cannot be reached for non-code_change
+#   kinds"). The executor itself is patched (its real git behaviour is covered
+#   in test_belt_gate.py); these tests pin the router's routing decision, not
+#   the apply. The cross-workspace code-change 403 lives in
+#   test_instinct_approval_security.py beside its pocket-write peer (that app
+#   registers the CloudError → 403 handler).
 # Updated: 2026-05-21 (feat/instinct-outcome-verification) — issue #1162:
 #   added the outcome-verification e2e — an Action runs, the deterministic
 #   verifier checks the result against captured success_criteria, and the
@@ -1305,3 +1315,104 @@ class TestOutcomeVerificationE2E:
         assert "action_proposed" in events
         assert "action_approved" in events
         assert "action_executed" in events
+
+
+# ---------------------------------------------------------------------------
+# BS-3 — Belt code-change router dispatch seam
+# ---------------------------------------------------------------------------
+
+
+class TestBeltCodeChangeRouterSeam:
+    """The approve / reject routes must dispatch the Belt apply-on-approve
+    executor ONLY when the Action carries a ``_code_change`` blob — and never
+    for a plain Action. This pins the kind-gated seam the spec's security
+    checklist requires; the executor's real git work is covered end-to-end in
+    test_belt_gate.py, so here it is patched to a recorder."""
+
+    async def _seed(self, store: InstinctStore, *, parameters: dict) -> str:
+        action = await store.propose(
+            pocket_id="ws-test",  # the approver's active workspace (see _FakeUser)
+            title="seam test",
+            description="",
+            recommendation="",
+            trigger=make_trigger(),
+            parameters=parameters,
+        )
+        return action.id
+
+    @pytest.mark.asyncio
+    async def test_approve_code_change_dispatches_executor(
+        self, client: TestClient, router_store: InstinctStore
+    ) -> None:
+        """Approving a ``_code_change`` Action through the route fires
+        ``execute_approved_change`` exactly once with the approved Action."""
+        blob = {"kind": "code_change", "schema": 1, "workspace_id": "ws-test", "diff": "x"}
+        action_id = await self._seed(router_store, parameters={"_code_change": blob})
+
+        with patch(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+
+        assert resp.status_code == 200
+        assert mock_exec.await_count == 1
+        dispatched = mock_exec.await_args.args[0]
+        assert dispatched.id == action_id
+        assert dispatched.status == ActionStatus.APPROVED
+
+    @pytest.mark.asyncio
+    async def test_approve_plain_action_never_dispatches_executor(
+        self, client: TestClient, router_store: InstinctStore
+    ) -> None:
+        """A plain (non-code-change) Action must NEVER reach the Belt executor."""
+        action_id = await self._seed(router_store, parameters={"note": "ordinary action"})
+
+        with patch(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+
+        assert resp.status_code == 200
+        mock_exec.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bulk_approve_code_change_dispatches_executor(
+        self, client: TestClient, router_store: InstinctStore
+    ) -> None:
+        """Bulk-approve mirrors the single-approve seam: a ``_code_change`` item
+        fires the executor; a plain item in the same batch does not."""
+        blob = {"kind": "code_change", "schema": 1, "workspace_id": "ws-test", "diff": "x"}
+        code_id = await self._seed(router_store, parameters={"_code_change": blob})
+        plain_id = await self._seed(router_store, parameters={"note": "ordinary"})
+
+        with patch(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            resp = client.post("/instinct/actions/bulk-approve", json={"ids": [code_id, plain_id]})
+
+        assert resp.status_code == 200
+        # Exactly one dispatch — the code-change item, not the plain one.
+        assert mock_exec.await_count == 1
+        assert mock_exec.await_args.args[0].id == code_id
+
+    @pytest.mark.asyncio
+    async def test_reject_code_change_never_dispatches_executor(
+        self, client: TestClient, router_store: InstinctStore
+    ) -> None:
+        """Rejecting a ``_code_change`` Action round-trips to REJECTED without
+        ever reaching the executor — the reject path applies nothing."""
+        blob = {"kind": "code_change", "schema": 1, "workspace_id": "ws-test", "diff": "x"}
+        action_id = await self._seed(router_store, parameters={"_code_change": blob})
+
+        with patch(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
+
+        assert resp.status_code == 200
+        mock_exec.assert_not_awaited()
+        assert resp.json()["status"] == ActionStatus.REJECTED.value

--- a/tests/cloud/test_instinct_approval_security.py
+++ b/tests/cloud/test_instinct_approval_security.py
@@ -28,6 +28,15 @@
 #   403 with the same ``instinct.cross_workspace_approval`` code, and
 #   (b) same-workspace reject still succeeds + the rejected Action
 #   transitions to ``rejected``.
+#
+# Updated: 2026-06-10 (feat/belt-gate, BS-3) — added
+#   ``TestBeltCodeChangeCrossWorkspace``: the code-change peer of the
+#   pocket-write tenancy gate. ``_assert_code_change_workspace`` refuses a
+#   ``_code_change`` Action whose blob ``workspace_id`` differs from the
+#   approver's active workspace with the same 403 +
+#   ``instinct.cross_workspace_approval`` code on the approve / bulk-approve /
+#   reject paths, and a same-tenant approval passes the gate and dispatches the
+#   (here patched-off) Belt executor.
 
 from __future__ import annotations
 
@@ -106,6 +115,28 @@ def _pocket_write_params(workspace_id: str, outcome: str | None = "renewal_compl
             # ``parked_policy_event_id`` is populated by Slice 3.
             "correlation_id": None,
             "parked_policy_event_id": None,
+        }
+    }
+
+
+def _code_change_params(workspace_id: str) -> dict:
+    """An Action ``parameters`` payload carrying a Belt ``_code_change`` blob —
+    the shape ``belt._propose_change_handler`` stores. A code change carries no
+    pocket the way a parked write does, so its tenancy lives entirely on the
+    blob's ``workspace_id`` (BS-3). The schema/diff/branch are minimal — these
+    tests pin the cross-workspace gate, not the apply (covered in
+    test_belt_gate.py)."""
+    return {
+        "_code_change": {
+            "kind": "code_change",
+            "schema": 1,
+            "repo": "/tmp/belt-repo",
+            "base_branch": "main",
+            "diff": "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n",
+            "summary": "tenancy-gate fixture",
+            "task": "tenancy-gate fixture",
+            "workspace_id": workspace_id,
+            "requested_by": "requester-9",
         }
     }
 
@@ -499,3 +530,106 @@ async def test_count_outcomes_skips_foreign_workspace_rows(tmp_path: Path) -> No
         assert "leaked" not in counts.by_outcome
     finally:
         outcomes_service.set_ledger_dir("~/.pocketpaw/outcomes")
+
+
+# ---------------------------------------------------------------------------
+# BS-3 — Belt code-change cross-workspace tenancy gate
+# ---------------------------------------------------------------------------
+
+
+class TestBeltCodeChangeCrossWorkspace:
+    """``_assert_code_change_workspace`` is the code-change peer of
+    ``_assert_pocket_write_workspace``: a ``_code_change`` blob whose
+    ``workspace_id`` differs from the approver's active workspace must be
+    refused with the same 403 + ``instinct.cross_workspace_approval`` code on
+    the approve, bulk-approve, and reject paths. A code change carries no
+    pocket, so without this gate a ws-A admin could approve (and APPLY) a ws-B
+    diff. The executor is patched off so a same-tenant approval doesn't try to
+    drive real git."""
+
+    def test_single_approve_of_foreign_workspace_code_change_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B code change",
+                parameters=_code_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_bulk_approve_of_foreign_workspace_code_change_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A code change",
+                parameters=_code_change_params(workspace_id="ws-A"),
+            )
+            foreign = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B code change",
+                parameters=_code_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post(
+                "/instinct/actions/bulk-approve",
+                json={"ids": [own, foreign]},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            # The whole batch is rejected — nothing flipped.
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+    def test_single_reject_of_foreign_workspace_code_change_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-B",
+                title="ws-B code change",
+                parameters=_code_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post(
+                f"/instinct/actions/{action_id}/reject",
+                json={"reason": "nope"},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_single_approve_of_own_workspace_code_change_dispatches(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A same-tenant approval passes the gate and reaches the executor
+        (patched off here — the real apply is covered in test_belt_gate.py)."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+
+        async def _noop_execute(_action):
+            return None
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.belt.executor.execute_approved_change",
+            _noop_execute,
+        )
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-A",
+                title="ws-A code change",
+                parameters=_code_change_params(workspace_id="ws-A"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["action"]["status"] == "approved"

--- a/tests/cloud/test_loom_mcp.py
+++ b/tests/cloud/test_loom_mcp.py
@@ -1,0 +1,232 @@
+# tests/cloud/test_loom_mcp.py — loom codebase-orientation MCP server (BS-1).
+#
+# Created: 2026-06-10 (feat/belt-loom-mcp, Belt & Pulley stations thin slice).
+# Guards the loom MCP wiring for the cloud chat (claude_agent_sdk) backend:
+#   * LOOM_TOOL_IDS — the 5 namespaced tool ids (mcp__loom__orient etc.) the
+#     surface allow-list + the SDK allowlist machinery key on.
+#   * CloudLoomMcpProvider.build_server() — returns None when loom_model_path is
+#     unset, None when the binary can't be resolved, and the correct
+#     ("loom", <stdio config dict>) when both the model file and binary exist.
+#   * _resolve_loom_bin — explicit path → PATH → ~/go/bin/loom discovery order.
+#   * Path A registration: the stdio config dict the provider returns flows
+#     through the real ClaudeAgentSDK._get_mcp_servers registration loop with
+#     ``type: "stdio"`` intact (the spike verdict — no loop change needed).
+#
+# build_loom_server reads its config through pocketpaw.config.get_settings (a
+# cached singleton, the same pattern the sibling media / sites servers use), so
+# every test that needs loom enabled patches get_settings — not the SDK's
+# injected Settings instance.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pocketpaw_ee.agent.mcp_servers.loom as loom
+from pocketpaw_ee.extensions import CloudLoomMcpProvider
+
+from pocketpaw.agents.claude_sdk import OPT_IN_MCP_SERVERS, ClaudeAgentSDK
+from pocketpaw.config import Settings
+
+
+def _settings(*, model_path: str | None, loom_bin: str = "loom") -> MagicMock:
+    """A stand-in for get_settings() carrying only the loom fields the server
+    reads."""
+    return MagicMock(loom_model_path=model_path, loom_bin=loom_bin)
+
+
+# --- tool ids ---------------------------------------------------------------
+
+
+def test_loom_tool_ids_are_namespaced() -> None:
+    """The 5 tool ids use the ``mcp__<server>__<tool>`` form the Claude Code
+    allowlist machinery matches, under the binary's own server name ``loom``."""
+    assert loom.SERVER_NAME == "loom"
+    assert loom.ORIENT_TOOL_ID == "mcp__loom__orient"
+    assert loom.LOCATE_TOOL_ID == "mcp__loom__locate"
+    assert loom.WHY_TOOL_ID == "mcp__loom__why"
+    assert loom.WHAT_DEPENDS_ON_TOOL_ID == "mcp__loom__what_depends_on"
+    assert loom.BOUNDARIES_TOOL_ID == "mcp__loom__boundaries"
+    assert loom.LOOM_TOOL_IDS == (
+        loom.ORIENT_TOOL_ID,
+        loom.LOCATE_TOOL_ID,
+        loom.WHY_TOOL_ID,
+        loom.WHAT_DEPENDS_ON_TOOL_ID,
+        loom.BOUNDARIES_TOOL_ID,
+    )
+
+
+def test_provider_tool_ids_match_module() -> None:
+    """The provider surfaces exactly the module's tool ids for the allowlist."""
+    assert CloudLoomMcpProvider().tool_ids() == list(loom.LOOM_TOOL_IDS)
+
+
+# --- build_server: disabled / degraded paths -------------------------------
+
+
+def test_build_server_none_when_model_path_unset() -> None:
+    """loom_model_path unset → loom disabled → build returns None (chat keeps
+    working without orientation)."""
+    with patch("pocketpaw.config.get_settings", return_value=_settings(model_path=None)):
+        assert CloudLoomMcpProvider().build_server() is None
+        assert loom.build_loom_server() is None
+
+
+def test_build_server_none_when_model_file_missing(tmp_path) -> None:
+    """A configured world-model path that does not exist → None, not a crash."""
+    missing = str(tmp_path / "does-not-exist.json")
+    with patch("pocketpaw.config.get_settings", return_value=_settings(model_path=missing)):
+        assert loom.build_loom_server() is None
+
+
+def test_build_server_none_when_binary_missing(tmp_path) -> None:
+    """A real model file but an unresolvable binary → None (binary-missing
+    degrades gracefully)."""
+    model = tmp_path / "worldmodel.json"
+    model.write_text("{}")
+    # A bogus binary name that is neither an existing file, on PATH, nor at
+    # ~/go/bin. Also patch ~/go/bin discovery off via a HOME with no go/bin.
+    empty_home = tmp_path / "home"
+    empty_home.mkdir()
+    with (
+        patch(
+            "pocketpaw.config.get_settings",
+            return_value=_settings(model_path=str(model), loom_bin="loom-nonexistent-xyz"),
+        ),
+        patch("pocketpaw_ee.agent.mcp_servers.loom.Path.home", return_value=empty_home),
+    ):
+        assert loom.build_loom_server() is None
+
+
+# --- build_server: happy path ----------------------------------------------
+
+
+def test_build_server_returns_stdio_config_when_set(tmp_path) -> None:
+    """Model file + resolvable binary → ("loom", <McpStdioServerConfig dict>)
+    with the command resolved and the `mcp -model <path>` args."""
+    model = tmp_path / "worldmodel.json"
+    model.write_text("{}")
+    fake_bin = tmp_path / "loom"
+    fake_bin.write_text("#!/bin/sh\n")
+    fake_bin.chmod(0o755)
+
+    with patch(
+        "pocketpaw.config.get_settings",
+        return_value=_settings(model_path=str(model), loom_bin=str(fake_bin)),
+    ):
+        built = loom.build_loom_server()
+
+    assert built is not None
+    name, config = built
+    assert name == "loom"
+    assert config["type"] == "stdio"
+    assert config["command"] == str(fake_bin)
+    assert config["args"] == ["mcp", "-model", str(model)]
+
+
+# --- binary resolution order -----------------------------------------------
+
+
+def test_resolve_bin_prefers_explicit_path(tmp_path) -> None:
+    """An explicit executable path is returned verbatim (resolved)."""
+    explicit = tmp_path / "loom"
+    explicit.write_text("#!/bin/sh\n")
+    explicit.chmod(0o755)
+    assert loom._resolve_loom_bin(str(explicit)) == str(explicit)
+
+
+def test_resolve_bin_falls_back_to_path(tmp_path) -> None:
+    """A bare name not on disk resolves via PATH (shutil.which)."""
+    found = str(tmp_path / "loom-on-path")
+    with patch("pocketpaw_ee.agent.mcp_servers.loom.shutil.which", return_value=found):
+        assert loom._resolve_loom_bin("loom") == found
+
+
+def test_resolve_bin_falls_back_to_go_bin(tmp_path) -> None:
+    """Not an explicit file and not on PATH → ~/go/bin/loom fallback."""
+    home = tmp_path / "home"
+    (home / "go" / "bin").mkdir(parents=True)
+    go_loom = home / "go" / "bin" / "loom"
+    go_loom.write_text("#!/bin/sh\n")
+    go_loom.chmod(0o755)
+    with (
+        patch("pocketpaw_ee.agent.mcp_servers.loom.shutil.which", return_value=None),
+        patch("pocketpaw_ee.agent.mcp_servers.loom.Path.home", return_value=home),
+    ):
+        assert loom._resolve_loom_bin("loom") == str(go_loom)
+
+
+def test_resolve_bin_returns_none_when_nothing_found(tmp_path) -> None:
+    """Nothing on disk matches → None so the caller degrades to None."""
+    empty_home = tmp_path / "home"
+    empty_home.mkdir()
+    with (
+        patch("pocketpaw_ee.agent.mcp_servers.loom.shutil.which", return_value=None),
+        patch("pocketpaw_ee.agent.mcp_servers.loom.Path.home", return_value=empty_home),
+    ):
+        assert loom._resolve_loom_bin("loom-nope") is None
+
+
+# --- Path A: the registration loop accepts the stdio config shape ----------
+
+
+class TestLoomRegistrationLoop:
+    """The spike verdict, pinned as a test: the stdio CONFIG DICT the loom
+    provider returns flows through the real ``_get_mcp_servers`` loop untouched
+    (Path A — no loop change). The loop does ``servers[name] = cfg_entry`` with
+    no transformation, so a dict registers identically to an SDK server object.
+    """
+
+    def _make_sdk(self) -> ClaudeAgentSDK:
+        settings = Settings(anthropic_api_key="test-key", tool_profile="full")
+        with patch.object(ClaudeAgentSDK, "_initialize"):
+            sdk = ClaudeAgentSDK(settings)
+            sdk._sdk_available = False
+        return sdk
+
+    def test_loom_is_ambient_not_opt_in(self) -> None:
+        """loom is ambient — the /belt surface scopes it via its profile
+        allowlist, so it must NOT be in the opt-in set."""
+        assert loom.SERVER_NAME not in OPT_IN_MCP_SERVERS
+
+    def test_registration_accepts_stdio_config(self, tmp_path) -> None:
+        """When loom is enabled, the registration loop accepts the stdio config
+        dict and keeps ``type: "stdio"`` intact — proving Path A end to end."""
+        model = tmp_path / "worldmodel.json"
+        model.write_text("{}")
+        fake_bin = tmp_path / "loom"
+        fake_bin.write_text("#!/bin/sh\n")
+        fake_bin.chmod(0o755)
+
+        sdk = self._make_sdk()
+        loom_settings = _settings(model_path=str(model), loom_bin=str(fake_bin))
+        with (
+            patch("pocketpaw.mcp.config.load_mcp_config", return_value=[]),
+            patch("pocketpaw.config.get_settings", return_value=loom_settings),
+        ):
+            servers = sdk._get_mcp_servers()
+
+        assert loom.SERVER_NAME in servers
+        entry = servers[loom.SERVER_NAME]
+        assert entry["type"] == "stdio"
+        assert entry["command"] == str(fake_bin)
+        assert entry["args"] == ["mcp", "-model", str(model)]
+
+    def test_loom_absent_when_disabled(self, tmp_path) -> None:
+        """loom_model_path unset → loom not registered, other servers unaffected."""
+        sdk = self._make_sdk()
+        loom_settings = _settings(model_path=None)
+        with (
+            patch("pocketpaw.mcp.config.load_mcp_config", return_value=[]),
+            patch("pocketpaw.config.get_settings", return_value=loom_settings),
+        ):
+            servers = sdk._get_mcp_servers()
+        assert loom.SERVER_NAME not in servers
+
+    def test_loom_tool_ids_on_allowlist(self) -> None:
+        """The loom tool ids are on the in-process allowlist by default (ambient,
+        no opt-in) — the agent can call ``mcp__loom__orient`` once the surface
+        allowlist permits it."""
+        sdk = self._make_sdk()
+        ids = sdk._collect_mcp_tool_ids()
+        for tool_id in loom.LOOM_TOOL_IDS:
+            assert tool_id in ids

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -1,5 +1,10 @@
 """Tests for MCP + Claude Agent SDK integration — Sprint 17.
 
+Updated: 2026-06-10 (integration/belt-thin-slice) — ``_strip_builtin_servers``
+  now also drops ``pocketpaw_belt`` (the always-on Belt gate server:
+  belt_propose_change — the bundled `belt` skill calls it without an explicit
+  opt-in) and, defensively, ``loom`` (settings-gated, but a developer's
+  POCKETPAW_LOOM_MODEL_PATH env would leak into Settings and register it).
 Updated: 2026-06-10 (feat/studio-code-migration) — ``_strip_builtin_servers``
   now also drops ``pocketpaw_media`` (the new always-on STUDIO media-generation
   server: image_generate / video_generate), so the external-config assertions
@@ -44,9 +49,11 @@ All SDK imports are mocked.
 import logging
 from unittest.mock import patch
 
+from pocketpaw_ee.agent.mcp_servers.belt import SERVER_NAME as _BELT_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.connectors import SERVER_NAME as _CONNECTORS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.decisions import SERVER_NAME as _DECISIONS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.foresight import SERVER_NAME as _FORESIGHT_MCP_SERVER_NAME
+from pocketpaw_ee.agent.mcp_servers.loom import SERVER_NAME as _LOOM_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.media import SERVER_NAME as _MEDIA_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.meetings import SERVER_NAME as _MEETINGS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.planner import (
@@ -96,6 +103,13 @@ def _strip_builtin_servers(result: dict) -> dict:
     # ``pocketpaw_media`` is always-on too — the bundled `studio` skill calls
     # image_generate / video_generate without an explicit opt-in.
     out.pop(_MEDIA_MCP_SERVER_NAME, None)
+    # ``pocketpaw_belt`` is always-on too — the bundled `belt` skill calls
+    # belt_propose_change without an explicit opt-in. ``loom`` is settings-gated
+    # (loom_model_path unset -> not registered) but stripped defensively: a
+    # developer's POCKETPAW_LOOM_MODEL_PATH env leaks into Settings() and would
+    # otherwise register it in these tests.
+    out.pop(_BELT_MCP_SERVER_NAME, None)
+    out.pop(_LOOM_MCP_SERVER_NAME, None)
     return out
 
 


### PR DESCRIPTION
The full thin slice on one branch for a single smoke: loom wired into cloud chat over stdio MCP (#1407), the /belt develop-station surface (#1408), the Instinct code-change gate with apply-on-approve (#1409), and the per-run decision chain (#1410). Merge commits preserve each piece's history; the per-piece PRs stay open for focused review and get closed with pointers when this lands.

Verified on this branch: 179 tests across loom MCP, surface, gate, trace, and instinct seams. The live exit test already ran through this exact code — it produced #1411 (a real registry feature proposed, gated, applied, and PR'd by the line itself) with a clean three-event decision chain.

Post-merge smoke (2 min): set POCKETPAW_LOOM_MODEL_PATH, open /belt, hand it a task, approve in the Tray, watch the PR appear. Full steps in docs/design/drafts/2026-06-10-belt-stations-exit-test-record.md (workspace repo).