### PR TITLE
feat(mission-control): add revert endpoint to flip terminal tasks back to in-progress

### DIFF
--- a/ee/pocketpaw_ee/cloud/cycles/router.py
+++ b/ee/pocketpaw_ee/cloud/cycles/router.py
@@ -66,6 +66,20 @@ async def close_cycle(
     return await cycles_service.agent_close_cycle(ctx, cycle_id)
 
 
+@router.delete("/{cycle_id}")
+async def delete_cycle(
+    cycle_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> dict[str, str]:
+    """Delete a completed cycle permanently.
+
+    Only completed cycles can be deleted. The cycle document is removed
+    from the database and any remaining task references to this cycle are
+    detached.
+    """
+    return await cycles_service.agent_delete_cycle(ctx, cycle_id)
+
+
 @router.get("/{cycle_id}/items")
 async def list_cycle_items(
     cycle_id: str,

--- a/ee/pocketpaw_ee/cloud/cycles/service.py
+++ b/ee/pocketpaw_ee/cloud/cycles/service.py
@@ -443,6 +443,47 @@ async def agent_close_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse
     return response
 
 
+async def agent_delete_cycle(ctx: RequestContext, cycle_id: str) -> dict[str, Any]:
+    """Delete a completed cycle permanently.
+
+    Only completed cycles can be deleted — active or upcoming cycles must
+    be closed first. This is a destructive operation: the cycle document
+    is removed from the database. Incomplete tasks attached to the cycle
+    have their ``cycle_id`` cleared so they don't orphan.
+
+    Raises:
+        Forbidden: If the cycle is not completed.
+        NotFound: If the cycle does not exist in the caller's workspace.
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, cycle_id)
+
+    if doc.status != "completed":
+        raise Forbidden(
+            "cycle.not_completed",
+            "Only completed cycles can be deleted. Close the cycle first.",
+        )
+
+    # Detach any tasks still pointing at this cycle
+    try:
+        from pocketpaw_ee.cloud.tasks import service as tasks_service
+    except ImportError:
+        pass
+    else:
+        tasks = await _tasks_for_cycle(ctx, cycle_id)
+        if tasks:
+            for t in tasks:
+                try:
+                    await tasks_service.agent_set_task_cycle(ctx, str(t.id), None)
+                except Exception:
+                    logger.info("agent_delete_cycle: failed to detach task %s", t.id, exc_info=True)
+
+    await doc.delete()
+
+    logger.info("Cycle %s deleted by user %s", cycle_id, ctx.user_id)
+    return {"deleted": cycle_id}
+
+
 async def _roll_incomplete_tasks(ctx: RequestContext, doc: _CycleDoc) -> int:
     """Reassign incomplete tasks attached to this cycle to the next active
     cycle on the same pocket (or clear ``cycle_id`` if none exists).
@@ -683,6 +724,7 @@ async def list_active_workspace_ids() -> list[str]:
 __all__ = [
     "agent_close_cycle",
     "agent_create_cycle",
+    "agent_delete_cycle",
     "agent_get_cycle",
     "agent_list_cycle_items",
     "agent_list_cycles",

--- a/ee/pocketpaw_ee/cloud/mission_control/dto.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/dto.py
@@ -133,6 +133,17 @@ class BulkSnoozeRequest(BaseModel):
     until_iso: str = Field(description="ISO-8601 timestamp to snooze until")
 
 
+class BulkRevertRequest(BaseModel):
+    """Body for ``POST /mission-control/items/bulk-revert``.
+
+    Reverts N Tasks from a terminal status (done, reverted, failed) back
+    to ``in_progress`` via ``tasks.service.agent_update_task``. Ids that
+    aren't Tasks come back in ``skipped``.
+    """
+
+    ids: list[str] = Field(min_length=1)
+
+
 class OutcomesQueryRequest(BaseModel):
     """Query filters for ``GET /mission-control/outcomes``."""
 
@@ -410,6 +421,7 @@ __all__ = [
     "AnalyticsResponse",
     "BulkActionRequest",
     "BulkReassignRequest",
+    "BulkRevertRequest",
     "BulkSnoozeRequest",
     "CreateCycleRequest",
     "ListActivityRequest",

--- a/ee/pocketpaw_ee/cloud/mission_control/router.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/router.py
@@ -53,6 +53,7 @@ from pocketpaw_ee.cloud.mission_control.dto import (
     AttachCycleItemsResponse,
     BulkActionRequest,
     BulkReassignRequest,
+    BulkRevertRequest,
     BulkSnoozeRequest,
     CreateCycleRequest,
     ListActivityRequest,
@@ -150,6 +151,20 @@ async def bulk_snooze(
     ``mission_control.invalid_until_iso``.
     """
     return await mc_service.agent_bulk_snooze(ctx, body)
+
+
+@router.post("/items/bulk-revert")
+async def bulk_revert(
+    body: BulkRevertRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> dict:
+    """Revert N Tasks from a terminal status back to in_progress.
+
+    Flips task status from ``done``, ``reverted``, or ``failed`` back to
+    ``in_progress`` so the operator can resume work. Ids that aren't
+    Tasks land in ``skipped``.
+    """
+    return await mc_service.agent_bulk_revert(ctx, body)
 
 
 @router.get("/outcomes", response_model=OutcomeSummaryResponse)

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -87,6 +87,7 @@ from pocketpaw_ee.cloud.mission_control.dto import (
     AttachCycleItemsResponse,
     BulkActionRequest,
     BulkReassignRequest,
+    BulkRevertRequest,
     BulkSnoozeRequest,
     CreateCycleRequest,
     ListActivityRequest,
@@ -737,6 +738,49 @@ async def agent_bulk_snooze(
     return {"bulk_id": bulk_id, "affected": affected, "skipped": skipped}
 
 
+async def agent_bulk_revert(
+    ctx: RequestContext, body: BulkRevertRequest | dict[str, Any]
+) -> dict[str, Any]:
+    """Revert N Tasks from a terminal status back to in_progress.
+
+    Fans out per-id to ``tasks.service.agent_revert_task`` to flip the
+    task status from ``done``, ``reverted``, or ``failed`` back to
+    ``in_progress``. Ids that aren't Tasks land in ``skipped``.
+
+    This differs from ``agent_bulk_reject`` (which rejects pending
+    Nudges) — revert acts on *already-finished* work to un-mark it
+    as complete so the operator can resume work.
+    """
+    body = BulkRevertRequest.model_validate(body)
+    _require_workspace(ctx)
+
+    from uuid import uuid4
+
+    from pocketpaw_ee.cloud.tasks import service as tasks_service
+
+    bulk_id = uuid4().hex
+    affected: list[str] = []
+    skipped: list[str] = []
+
+    for raw_id in body.ids:
+        task_id = _classify_task_id(raw_id)
+        if task_id is None:
+            skipped.append(raw_id)
+            continue
+        try:
+            await tasks_service.agent_revert_task(ctx, task_id)
+            affected.append(raw_id)
+        except Exception:
+            logger.info(
+                "mission_control.bulk_revert: skipped id %s",
+                raw_id,
+                exc_info=True,
+            )
+            skipped.append(raw_id)
+
+    return {"bulk_id": bulk_id, "affected": affected, "skipped": skipped}
+
+
 # ---------------------------------------------------------------------------
 # Plan sessions — drafts list for the Mission Control Plan tab
 # ---------------------------------------------------------------------------
@@ -1109,6 +1153,7 @@ __all__ = [
     "agent_bulk_approve",
     "agent_bulk_reassign",
     "agent_bulk_reject",
+    "agent_bulk_revert",
     "agent_bulk_snooze",
     "agent_create_cycle",
     "agent_list_activity",

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -508,6 +508,34 @@ async def agent_block_task(
     return task_to_dto(task)
 
 
+async def agent_revert_task(ctx: RequestContext, task_id: str) -> TaskResponse:
+    """Revert a task from a terminal status back to in_progress.
+
+    Moves a task from ``done``, ``reverted``, or ``failed`` back to
+    ``in_progress`` so work can resume. This is the inverse of
+    ``agent_complete_task`` — it un-marks finished work.
+
+    Raises:
+        ValidationError: If the task is not in a revertable state.
+        NotFound: If the task does not exist in the caller's workspace.
+        Forbidden: If the caller is not authorized.
+    """
+    doc = await _fetch_task(ctx, task_id)
+
+    if doc.status not in ("done", "reverted", "failed"):
+        raise ValidationError(
+            "task.not_revertable",
+            f"Cannot revert task with status {doc.status!r}. "
+            "Only done, reverted, or failed tasks can be reverted.",
+        )
+
+    doc.status = "in_progress"
+    await doc.save()
+    task = _to_domain(doc)
+    await emit(TaskUpdated(data=_event_payload(doc, task)))
+    return task_to_dto(task)
+
+
 async def agent_reassign_task(
     ctx: RequestContext, task_id: str, body: ReassignTaskRequest
 ) -> TaskResponse:
@@ -802,6 +830,7 @@ __all__ = [
     "agent_list_tasks",
     "agent_reassign_task",
     "agent_reassign_task_cycle",
+    "agent_revert_task",
     "agent_set_task_cycle",
     "agent_update_task",
     "list_for_agent_runtime",


### PR DESCRIPTION
## Summary

Adds two features to Mission Control:

1. **Revert tasks** from terminal statuses (done/reverted/failed) back to `in_progress` so work can resume.
2. **Delete completed cycles** permanently.

## Changes — Revert Tasks

**`ee/pocketpaw_ee/cloud/mission_control/dto.py`** — Added `BulkRevertRequest` with an `ids` field.

**`ee/pocketpaw_ee/cloud/mission_control/service.py`** — Added `agent_bulk_revert` that fans out per-task via `tasks.service.agent_revert_task`. Non-task IDs land in `skipped`.

**`ee/pocketpaw_ee/cloud/mission_control/router.py`** — Added `POST /mission-control/items/bulk-revert` endpoint.

**`ee/pocketpaw_ee/cloud/tasks/service.py`** — Added `agent_revert_task` that validates the task is in a revertable state (`done`, `reverted`, or `failed`) before flipping to `in_progress`. Raises `ValidationError` for non-revertable states.

## Changes — Delete Completed Cycles

**`ee/pocketpaw_ee/cloud/cycles/service.py`** — Added `agent_delete_cycle` that:
- Verifies the cycle is `completed` (raises `Forbidden` otherwise)
- Detaches any remaining task references to the cycle
- Permanently removes the cycle document
- Returns `{"deleted": cycle_id}`

**`ee/pocketpaw_ee/cloud/cycles/router.py`** — Added `DELETE /{cycle_id}` endpoint. Only completed cycles can be deleted.

## Testing

- `ruff check` and `ruff format` all clean
- Existing tests pass