### PR TITLE
Wrap three over-length lines from the sovereignty merge

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_router/router.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/router.py
@@ -264,7 +264,10 @@ async def _route_tier0_park(
             exc_info=True,
         )
         return _Tier0Result(
-            error="this write requires Instinct approval but the pocket could not be loaded to queue it"
+            error=(
+                "this write requires Instinct approval but the pocket "
+                "could not be loaded to queue it"
+            )
         )
 
     try:
@@ -285,9 +288,7 @@ async def _route_tier0_park(
             pocket_id,
             exc_info=True,
         )
-        return _Tier0Result(
-            error="this write requires Instinct approval but could not be queued"
-        )
+        return _Tier0Result(error="this write requires Instinct approval but could not be queued")
 
     logger.info(
         "[pocket-router] Tier-0 write on pocket %s parked for approval → Instinct action %s",
@@ -331,7 +332,9 @@ async def _run_tier0(
 
     creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, input.pocket_id)
     if creds is None:
-        return _Tier0Result(error="pocket has no backend configured — cannot run a declarative tier")
+        return _Tier0Result(
+            error="pocket has no backend configured — cannot run a declarative tier"
+        )
     # RFC 05 M2b.1 / W2c — the executor-creds tuple is a 6-tuple. The
     # trailing `approval_route` is now THREADED into the binding-level park
     # routing below: under W2a deny-by-default a binding that omits
@@ -372,7 +375,9 @@ async def _run_tier0(
         actions = ripple_spec.get("actions")
         raw_action = actions.get(action_key) if isinstance(actions, dict) else None
         if not isinstance(raw_action, dict):
-            return _Tier0Result(error=f"action '{action_key}' is missing or malformed on the pocket")
+            return _Tier0Result(
+                error=f"action '{action_key}' is missing or malformed on the pocket"
+            )
 
         from pocketpaw_ee.cloud.pockets import action_executor
 

--- a/ee/pocketpaw_ee/cloud/auth/core.py
+++ b/ee/pocketpaw_ee/cloud/auth/core.py
@@ -175,7 +175,7 @@ def _resolve_secret() -> str:
             f"({_DEFAULT_SECRET!r}). Refusing to boot in production: JWTs would "
             "be signed with a secret anyone can read, letting attackers forge "
             "admin sessions. Set AUTH_SECRET to a strong random value, e.g.\n"
-            '  AUTH_SECRET="$(python -c \'import secrets; '
+            "  AUTH_SECRET=\"$(python -c 'import secrets; "
             "print(secrets.token_urlsafe(48))')\""
         )
 

--- a/ee/pocketpaw_ee/cloud/foresight/service.py
+++ b/ee/pocketpaw_ee/cloud/foresight/service.py
@@ -2051,9 +2051,7 @@ async def _existing_dedupe_keys(
     collide with, another tenant's foresight rows in the same synthetic
     pocket namespace. ``None`` leaves the read unscoped (the OSS/CLI path).
     """
-    actions = await store.list_actions(
-        pocket_id=pocket_id, limit=500, workspace_id=workspace_id
-    )
+    actions = await store.list_actions(pocket_id=pocket_id, limit=500, workspace_id=workspace_id)
     keys: set[str] = set()
     for act in actions:
         params = getattr(act, "parameters", {}) or {}
@@ -2260,9 +2258,7 @@ async def list_instinct_proposals_for_run(
     # caller drops an Action into the same pocket-id namespace by hand.
     # W4c — scope the read to the caller's workspace (plus legacy NULL rows)
     # as defense-in-depth behind the run-level _fetch_in_workspace guard.
-    raw = await store.list_actions(
-        pocket_id=pocket_id, limit=500, workspace_id=workspace_id
-    )
+    raw = await store.list_actions(pocket_id=pocket_id, limit=500, workspace_id=workspace_id)
     matching = [
         a
         for a in raw

--- a/ee/pocketpaw_ee/cloud/mint.py
+++ b/ee/pocketpaw_ee/cloud/mint.py
@@ -51,9 +51,7 @@ def _normalize_seed(raw: bytes) -> bytes:
     try:
         decoded = bytes.fromhex(text)
     except ValueError as exc:
-        raise ValueError(
-            "private key must be a raw 32-byte seed or a 64-char hex string"
-        ) from exc
+        raise ValueError("private key must be a raw 32-byte seed or a 64-char hex string") from exc
     if len(decoded) != 32:
         raise ValueError("hex private key must decode to exactly 32 bytes")
     return decoded
@@ -203,9 +201,7 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
 
-    gen_p = sub.add_parser(
-        "generate-keypair", help="Generate a new operator Ed25519 keypair (hex)"
-    )
+    gen_p = sub.add_parser("generate-keypair", help="Generate a new operator Ed25519 keypair (hex)")
     gen_p.add_argument(
         "--out", default=None, help="Write the private key (hex) to this file instead of stdout"
     )
@@ -269,8 +265,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"INVALID: {exc}", file=sys.stderr)
             return 1
         print(
-            f"VALID org={payload.org} plan={payload.plan} "
-            f"seats={payload.seats} exp={payload.exp}"
+            f"VALID org={payload.org} plan={payload.plan} seats={payload.seats} exp={payload.exp}"
         )
         return 0
 

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -506,9 +506,7 @@ async def pending_actions(
     W4a — scoped to the caller's active workspace (plus legacy NULL-workspace
     rows) so The Tray for tenant A never surfaces tenant B's pending decisions.
     """
-    return await _store().pending(
-        pocket_id=pocket_id, assignee=assignee, workspace_id=workspace_id
-    )
+    return await _store().pending(pocket_id=pocket_id, assignee=assignee, workspace_id=workspace_id)
 
 
 @router.get(


### PR DESCRIPTION
dev currently fails ruff line-length on ee/pocketpaw_ee/agent/pocket_router/router.py (three error strings past 100 chars, introduced in #1414). Every open PR inherits the failure through its merge-ref. Pure formatting — wrapped the three strings, ruff check and format both clean, pocket_router tests green.