### PR TITLE
Connector→Fabric: typed ingestion pattern (Google Calendar first adopter)

### DIFF
--- a/src/pocketpaw/connectors/__init__.py
+++ b/src/pocketpaw/connectors/__init__.py
@@ -1,7 +1,16 @@
 # Connectors — data integration layer for Paw OS.
 # Created: 2026-03-27 — Multi-adapter facade for external data sources.
 # DirectREST (YAML-defined) is the primary adapter. Composio/MCP are fallbacks.
+# Updated: 2026-06-11 (gap1-connfabric slice) — re-export the connector->Fabric
+#   ingestion primitives (FabricMapping / IngestResult / ingest_records) so the
+#   reusable "connector record -> typed Fabric object with provenance" pattern is
+#   discoverable from the package root, not buried in the submodule.
 
+from pocketpaw.connectors.fabric_ingest import (
+    FabricMapping,
+    IngestResult,
+    ingest_records,
+)
 from pocketpaw.connectors.protocol import (
     ActionResult,
     ActionSchema,
@@ -22,4 +31,7 @@ __all__ = [
     "IngestAdapter",
     "SyncResult",
     "ConnectorRegistry",
+    "FabricMapping",
+    "IngestResult",
+    "ingest_records",
 ]

--- a/src/pocketpaw/connectors/adapters/gcalendar.py
+++ b/src/pocketpaw/connectors/adapters/gcalendar.py
@@ -7,6 +7,18 @@
 # Action surface mirrors the 3 hand-written tools in
 # src/pocketpaw/tools/builtin/calendar.py + adds calendar_summary
 # for the home widget aggregator.
+#
+# Updated: 2026-06-11 (gap1-connfabric slice) — this is the FIRST connector to
+#   land typed Fabric objects instead of a sync() stub. Added:
+#     * CALENDAR_EVENT_MAPPING — the declared FabricMapping (CalendarEvent type +
+#       field projection + event-id provenance), the reusable pattern other
+#       connectors copy.
+#     * ingest_to_fabric(store, ...) — pulls events via the client and maps them
+#       into typed, provenanced, idempotent Fabric objects through the shared
+#       connectors.fabric_ingest.ingest_records().
+#   sync() still returns records_synced=0 (it has no FabricStore handle in the
+#   adapter contract); ingest_to_fabric() is the real path a caller with a store
+#   drives. Migrating the sync()/EE service wiring is deferred (see slice notes).
 
 from __future__ import annotations
 
@@ -15,6 +27,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from pocketpaw.connectors.fabric_ingest import FabricMapping, IngestResult, ingest_records
 from pocketpaw.connectors.protocol import (
     ActionResult,
     ActionSchema,
@@ -27,8 +40,44 @@ from pocketpaw.connectors.protocol import (
     TrustLevel,
     WidgetRecipe,
 )
+from pocketpaw.fabric.models import PropertyDef
+from pocketpaw.fabric.store import FabricStore
 
 logger = logging.getLogger(__name__)
+
+
+# The connector->Fabric contract for calendar events. A Google Calendar event id
+# is stable across syncs, so it is the idempotency key (source_id). attendees is
+# projected as a count for queryability ("meetings with >3 attendees") while the
+# raw list is preserved alongside it. This declaration is the pattern other
+# connectors replicate: declare a type + field projection + the source-id field,
+# then hand records to ingest_records().
+CALENDAR_EVENT_MAPPING = FabricMapping(
+    type_name="CalendarEvent",
+    type_description="A calendar event ingested from Google Calendar.",
+    type_icon="calendar",
+    source_id_field="id",
+    properties=[
+        PropertyDef(name="summary", type="string", description="Event title"),
+        PropertyDef(name="start", type="date", description="Start time (RFC 3339 or date)"),
+        PropertyDef(name="end", type="date", description="End time (RFC 3339 or date)"),
+        PropertyDef(name="location", type="string", description="Event location"),
+        PropertyDef(name="description", type="string", description="Event description"),
+        PropertyDef(name="attendees", type="string", description="Attendee emails (list)"),
+        PropertyDef(name="attendee_count", type="number", description="Number of attendees"),
+        PropertyDef(name="html_link", type="string", description="Link to the event"),
+    ],
+    field_map={
+        "summary": "summary",
+        "start": "start",
+        "end": "end",
+        "location": "location",
+        "description": "description",
+        "attendees": lambda r: r.get("attendees", []),
+        "attendee_count": lambda r: len(r.get("attendees", []) or []),
+        "html_link": "htmlLink",
+    },
+)
 
 
 class GoogleCalendarConnector:
@@ -216,7 +265,56 @@ class GoogleCalendarConnector:
             return ActionResult(success=False, error=f"Calendar {action} failed: {exc}")
 
     async def sync(self, pocket_id: str) -> SyncResult:
+        # sync() keeps the stub contract: the adapter has no FabricStore handle
+        # in the ConnectorProtocol signature. Real typed ingestion is
+        # ingest_to_fabric() below, which a caller drives with a store. Wiring
+        # the EE connector service's sync path to call ingest_to_fabric is the
+        # next slice (see module header).
         return SyncResult(success=True, connector_name=self.name, records_synced=0)
+
+    async def ingest_to_fabric(
+        self,
+        store: FabricStore,
+        days_ahead: int = 30,
+        max_results: int = 50,
+        workspace_id: str | None = None,
+        user_id: str | None = None,
+    ) -> IngestResult:
+        """Pull calendar events and land them as typed Fabric objects.
+
+        This is the connector's half of the connector->Fabric contract: it
+        fetches records via the existing CalendarClient, then hands them to the
+        shared ``ingest_records`` ingester with this connector's declared
+        ``CALENDAR_EVENT_MAPPING``. Events become ``CalendarEvent`` Fabric
+        objects with ``source_connector="gcalendar"`` and ``source_id`` = the
+        Google event id, so a re-sync UPDATES rather than duplicates.
+
+        Args:
+            store: the FabricStore to persist into.
+            days_ahead: how far forward to pull events (default 30 days).
+            max_results: cap on events fetched (default 50).
+            workspace_id: W4a tenancy scope for the landed objects.
+            user_id: optional per-user calendar token (VIP onboarding Phase B).
+
+        Returns:
+            IngestResult with created / updated / skipped counts.
+        """
+        from pocketpaw.clients.gcalendar import CalendarClient
+
+        client = CalendarClient(user_id=user_id)
+        now = datetime.now(UTC)
+        events = await client.list_events(
+            time_min=now,
+            time_max=now + timedelta(days=max(int(days_ahead), 1)),
+            max_results=min(int(max_results), 250),
+        )
+        return await ingest_records(
+            store=store,
+            connector=self.name,
+            records=events,
+            mapping=CALENDAR_EVENT_MAPPING,
+            workspace_id=workspace_id,
+        )
 
     async def schema(self) -> dict[str, Any]:
         return {"table": "calendar_events", "mapping": {}, "schedule": "manual"}

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -1,0 +1,180 @@
+# Connector -> Fabric ingestion — the reusable record-to-typed-object mapper.
+# Created: 2026-06-11 (gap1-connfabric slice).
+#
+# WHY THIS EXISTS
+# ---------------
+# Until now the "connector data lands as typed Fabric objects with provenance"
+# claim was hollow: connector ``sync()`` methods returned ``records_synced=0``
+# stubs, and the only connector->Fabric mapping in the tree lived *inside a test*
+# (tests/cloud/test_e2e_connector_to_fabric.py hand-rolls the loop). Connector
+# data otherwise reached the brain only as BM25 text in kb-go, never as queryable
+# typed objects.
+#
+# THE PATTERN (what other connectors copy)
+# ----------------------------------------
+# A connector declares ONE ``FabricMapping`` describing how its records become a
+# typed Fabric object:
+#
+#   * ``type_name`` / ``type_description`` / ``properties`` — the Fabric ObjectType
+#     to ensure-exists (idempotent: defined once, reused thereafter).
+#   * ``source_id_field`` — the record key holding the stable upstream id
+#     (a calendar event id, a Stripe invoice id). This is the idempotency key.
+#   * ``field_map`` — {fabric_property: record_key} projection. A callable value
+#     is allowed for derived/normalized fields.
+#
+# Then it calls ``ingest_records(store, connector, records, mapping, workspace_id)``.
+# For each record the ingester:
+#   1. ensures the ObjectType exists (define-once, by name),
+#   2. extracts ``source_id`` and projects the record through ``field_map``,
+#   3. UPSERTS by ``(source_connector, source_id)`` — update if the object already
+#      exists (re-sync refreshes properties), else create with provenance stamped
+#      (``source_connector`` + ``source_id``). Re-ingest is therefore idempotent:
+#      N re-syncs of the same records = N stable objects, not N*records.
+#
+# SCOPE: pure OSS — depends only on the OSS FabricStore. The EE connector service
+# can call this from its sync path later; nothing here imports pocketpaw_ee, so
+# the EE/OSS import boundary is preserved.
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from pocketpaw.fabric.models import PropertyDef
+from pocketpaw.fabric.store import FabricStore
+
+# A field projection value is either a record key (str) or a callable that
+# derives the value from the whole record (for normalization / joins).
+FieldSource = str | Callable[[Mapping[str, Any]], Any]
+
+
+@dataclass(frozen=True)
+class FabricMapping:
+    """Declares how one connector's records map to a typed Fabric object.
+
+    This is the unit other connectors reuse. Keep it data-only: no I/O, no
+    connector-specific imports, so it round-trips cleanly and is trivial to test.
+    """
+
+    type_name: str
+    source_id_field: str
+    field_map: dict[str, FieldSource]
+    properties: list[PropertyDef] = field(default_factory=list)
+    type_description: str = ""
+    type_icon: str = "box"
+    type_color: str = "#0A84FF"
+
+    def extract_source_id(self, record: Mapping[str, Any]) -> str | None:
+        """Pull the stable upstream id from a record, or None if absent/empty."""
+        raw = record.get(self.source_id_field)
+        if raw is None:
+            return None
+        sid = str(raw).strip()
+        return sid or None
+
+    def project(self, record: Mapping[str, Any]) -> dict[str, Any]:
+        """Project a raw connector record into Fabric object properties."""
+        out: dict[str, Any] = {}
+        for prop, src in self.field_map.items():
+            if callable(src):
+                out[prop] = src(record)
+            else:
+                out[prop] = record.get(src)
+        return out
+
+
+@dataclass
+class IngestResult:
+    """Summary of an ingest run — what landed in Fabric and how."""
+
+    type_name: str
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0  # records with no usable source_id
+    object_ids: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return self.created + self.updated
+
+
+async def ensure_type(store: FabricStore, mapping: FabricMapping) -> str:
+    """Ensure the mapping's ObjectType exists; return its ``type_id``.
+
+    Define-once-by-name: if a type with this name already exists (a prior sync,
+    a manually-defined ontology type, the EE fabric registry), reuse it rather
+    than creating a second type that would split the same logical objects across
+    two ``type_id``s. Name match is case-insensitive (see get_type_by_name).
+    """
+    existing = await store.get_type_by_name(mapping.type_name)
+    if existing is not None:
+        return existing.id
+    created = await store.define_type(
+        name=mapping.type_name,
+        properties=mapping.properties,
+        description=mapping.type_description,
+        icon=mapping.type_icon,
+        color=mapping.type_color,
+    )
+    return created.id
+
+
+async def ingest_records(
+    store: FabricStore,
+    connector: str,
+    records: Iterable[Mapping[str, Any]],
+    mapping: FabricMapping,
+    workspace_id: str | None = None,
+) -> IngestResult:
+    """Map connector records into typed Fabric objects with provenance (idempotent).
+
+    Args:
+        store: the OSS FabricStore to persist into.
+        connector: the connector name, stamped as ``source_connector`` provenance.
+        records: raw connector records (e.g. Calendar event dicts).
+        mapping: the FabricMapping declaring type + field projection + id field.
+        workspace_id: W4a tenancy scope; threaded into both the dedup read and
+            the create write so an ingest stays inside its tenant. ``None`` for
+            single-tenant / OSS callers.
+
+    Returns:
+        IngestResult with created / updated / skipped counts and the object ids.
+
+    Idempotency: keyed on ``(connector, source_id)``. A record whose source_id
+    already has an object UPDATES that object (properties refreshed via the
+    store's merge-update); a new source_id CREATES one with provenance. Records
+    lacking a usable source_id are skipped (counted) — without a stable key they
+    cannot be deduplicated and would silently duplicate on every sync.
+    """
+    type_id = await ensure_type(store, mapping)
+    result = IngestResult(type_name=mapping.type_name)
+
+    for record in records:
+        source_id = mapping.extract_source_id(record)
+        if source_id is None:
+            result.skipped += 1
+            continue
+        properties = mapping.project(record)
+
+        existing = await store.get_object_by_source(
+            source_connector=connector,
+            source_id=source_id,
+            workspace_id=workspace_id,
+        )
+        if existing is not None:
+            updated = await store.update_object(existing.id, properties)
+            result.updated += 1
+            result.object_ids.append((updated or existing).id)
+        else:
+            created = await store.create_object(
+                type_id=type_id,
+                properties=properties,
+                source_connector=connector,
+                source_id=source_id,
+                workspace_id=workspace_id,
+            )
+            result.created += 1
+            result.object_ids.append(created.id)
+
+    return result

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -38,6 +38,15 @@
 #   reads ``$.a-b`` as a literal key) but were unnecessarily permissive and made
 #   ``$.a-b`` ambiguous in a SQL trace. No object type uses hyphenated property
 #   names, so this loses nothing. W0d filter tests unchanged and still pass.
+# Updated: 2026-06-11 (gap1-connfabric — connector→Fabric ingestion slice) — added
+#   get_object_by_source(): looks up a single object by its
+#   (source_connector, source_id) provenance pair via the existing
+#   idx_objects_source index. This is the idempotency primitive the new
+#   connector ingest path (connectors/fabric_ingest.py) needs to upsert instead
+#   of duplicate — until now Fabric had no source-keyed read, so a re-sync
+#   always created a second object (documented in
+#   tests/cloud/test_e2e_connector_to_fabric.py::test_fabric_source_deduplication).
+#   Read-only and additive; honors the W4a workspace scope like get_object().
 
 from __future__ import annotations
 
@@ -384,6 +393,42 @@ class FabricStore:
         if ws_cond:
             sql += f" AND {ws_cond}"
             params.extend(ws_params)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, params) as cur:
+                row = await cur.fetchone()
+                if not row:
+                    return None
+                return self._row_to_object(row)
+
+    async def get_object_by_source(
+        self,
+        source_connector: str,
+        source_id: str,
+        workspace_id: str | None = None,
+    ) -> FabricObject | None:
+        """Fetch the object that originated from ``(source_connector, source_id)``.
+
+        This is the idempotency lookup for connector ingestion: a connector
+        record carries a stable upstream id (a Google Calendar event id, a
+        Stripe invoice id), so re-syncing should find the prior object and
+        update it rather than create a duplicate. Backed by the existing
+        ``idx_objects_source`` index.
+
+        Returns the most recently created match (defensive — provenance pairs
+        are expected to be unique, but nothing enforces a DB-level constraint
+        yet, so a duplicate from before this path existed resolves to the
+        newest row). ``workspace_id`` applies the same W4a tenancy scope as
+        :meth:`get_object`; ``None`` leaves the read unscoped.
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_objects WHERE source_connector = ? AND source_id = ?"
+        params: list[Any] = [source_connector, source_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        sql += " ORDER BY created_at DESC LIMIT 1"
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row

--- a/tests/connectors/test_gcalendar_fabric_ingest.py
+++ b/tests/connectors/test_gcalendar_fabric_ingest.py
@@ -1,0 +1,223 @@
+# test_gcalendar_fabric_ingest.py
+# Created: 2026-06-11 (gap1-connfabric slice).
+#
+# Proves the connector->Fabric ingestion slice end to end:
+#   GoogleCalendarConnector.ingest_to_fabric() pulls (mocked) calendar events
+#   and lands them as typed `CalendarEvent` Fabric objects in a real FabricStore
+#   with `source_connector`/`source_id` provenance — and a re-ingest UPDATES the
+#   same objects rather than duplicating (idempotency via source_id).
+#
+# Also exercises the reusable mapper (FabricMapping / ingest_records) directly,
+# independent of the calendar connector, since that is the pattern other
+# connectors copy. No real HTTP / OAuth — CalendarClient.list_events is patched.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from pocketpaw.connectors.adapters.gcalendar import (
+    CALENDAR_EVENT_MAPPING,
+    GoogleCalendarConnector,
+)
+from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
+from pocketpaw.fabric.models import FabricQuery, PropertyDef
+from pocketpaw.fabric.store import FabricStore
+
+_CLIENT_LIST = "pocketpaw.clients.gcalendar.CalendarClient.list_events"
+
+
+def _events(*ids_and_summaries: tuple[str, str]) -> list[dict]:
+    """Build calendar-event records shaped like CalendarClient.list_events output."""
+    out = []
+    for ev_id, summary in ids_and_summaries:
+        out.append(
+            {
+                "id": ev_id,
+                "summary": summary,
+                "start": "2026-06-12T10:00:00Z",
+                "end": "2026-06-12T11:00:00Z",
+                "location": "Room 1",
+                "description": "",
+                "attendees": ["a@x.com", "b@x.com"],
+                "htmlLink": f"https://cal/{ev_id}",
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The connector slice: gcalendar -> typed Fabric objects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingest_lands_typed_objects_with_provenance(tmp_path: Path) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    connector = GoogleCalendarConnector()
+
+    events = _events(("evt_1", "Standup"), ("evt_2", "Q2 Review"))
+    with patch(_CLIENT_LIST, new=AsyncMock(return_value=events)):
+        result = await connector.ingest_to_fabric(store)
+
+    # Ingest summary
+    assert result.created == 2
+    assert result.updated == 0
+    assert result.skipped == 0
+    assert result.type_name == "CalendarEvent"
+
+    # A typed CalendarEvent ObjectType was defined
+    obj_type = await store.get_type_by_name("CalendarEvent")
+    assert obj_type is not None
+
+    # Two typed objects landed, queryable by type
+    q = await store.query(FabricQuery(type_name="CalendarEvent"))
+    assert q.total == 2
+
+    by_source = {o.source_id: o for o in q.objects}
+    assert set(by_source) == {"evt_1", "evt_2"}
+
+    standup = by_source["evt_1"]
+    assert standup.type_id == obj_type.id
+    assert standup.type_name == "CalendarEvent"
+    # Provenance stamped
+    assert standup.source_connector == "gcalendar"
+    assert standup.source_id == "evt_1"
+    # Field projection: declared properties present + derived attendee_count
+    assert standup.properties["summary"] == "Standup"
+    assert standup.properties["location"] == "Room 1"
+    assert standup.properties["attendee_count"] == 2
+    assert standup.properties["attendees"] == ["a@x.com", "b@x.com"]
+    assert standup.properties["html_link"] == "https://cal/evt_1"
+
+
+@pytest.mark.asyncio
+async def test_reingest_is_idempotent_and_updates(tmp_path: Path) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    connector = GoogleCalendarConnector()
+
+    first = _events(("evt_1", "Standup"), ("evt_2", "Q2 Review"))
+    with patch(_CLIENT_LIST, new=AsyncMock(return_value=first)):
+        r1 = await connector.ingest_to_fabric(store)
+    assert r1.created == 2
+
+    # Re-sync: evt_1 retitled, evt_2 unchanged. Same source ids.
+    second = _events(("evt_1", "Standup (moved)"), ("evt_2", "Q2 Review"))
+    with patch(_CLIENT_LIST, new=AsyncMock(return_value=second)):
+        r2 = await connector.ingest_to_fabric(store)
+
+    # No duplicates: both records resolved to existing objects -> updates only
+    assert r2.created == 0
+    assert r2.updated == 2
+
+    q = await store.query(FabricQuery(type_name="CalendarEvent"))
+    assert q.total == 2  # still 2 objects, not 4
+
+    # Object ids stable across syncs
+    assert set(r1.object_ids) == set(r2.object_ids)
+
+    # The updated property is reflected
+    evt1 = await store.get_object_by_source("gcalendar", "evt_1")
+    assert evt1 is not None
+    assert evt1.properties["summary"] == "Standup (moved)"
+
+    # Exactly one type was defined despite two syncs
+    types = await store.list_types()
+    assert sum(1 for t in types if t.name == "CalendarEvent") == 1
+
+
+@pytest.mark.asyncio
+async def test_records_without_source_id_are_skipped(tmp_path: Path) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    connector = GoogleCalendarConnector()
+
+    events = _events(("evt_1", "Standup"))
+    events.append({"id": "", "summary": "no-id event", "attendees": []})  # blank id -> skip
+    with patch(_CLIENT_LIST, new=AsyncMock(return_value=events)):
+        result = await connector.ingest_to_fabric(store)
+
+    assert result.created == 1
+    assert result.skipped == 1
+    q = await store.query(FabricQuery(type_name="CalendarEvent"))
+    assert q.total == 1
+
+
+# ---------------------------------------------------------------------------
+# The reusable mapper, independent of any one connector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingest_records_pattern_is_connector_agnostic(tmp_path: Path) -> None:
+    """ingest_records works for any connector that declares a FabricMapping."""
+    store = FabricStore(tmp_path / "fabric.db")
+
+    mapping = FabricMapping(
+        type_name="Ticket",
+        source_id_field="ticket_id",
+        properties=[
+            PropertyDef(name="title", type="string"),
+            PropertyDef(name="priority", type="number"),
+        ],
+        field_map={
+            "title": "subject",
+            "priority": lambda r: int(r.get("priority", 0)),
+        },
+    )
+    records = [
+        {"ticket_id": "T-1", "subject": "Login broken", "priority": "3"},
+        {"ticket_id": "T-2", "subject": "Typo", "priority": "1"},
+    ]
+
+    result = await ingest_records(store, connector="helpdesk", records=records, mapping=mapping)
+    assert result.created == 2
+
+    obj = await store.get_object_by_source("helpdesk", "T-1")
+    assert obj is not None
+    assert obj.source_connector == "helpdesk"
+    assert obj.type_name == "Ticket"
+    assert obj.properties["title"] == "Login broken"
+    assert obj.properties["priority"] == 3  # derived/normalized via callable
+
+    # Re-ingest with a changed value -> update, no duplicate
+    records[0]["subject"] = "Login broken (P1)"
+    again = await ingest_records(store, connector="helpdesk", records=records, mapping=mapping)
+    assert again.updated == 2
+    assert again.created == 0
+    refreshed = await store.get_object_by_source("helpdesk", "T-1")
+    assert refreshed is not None
+    assert refreshed.properties["title"] == "Login broken (P1)"
+
+
+@pytest.mark.asyncio
+async def test_existing_type_is_reused_not_duplicated(tmp_path: Path) -> None:
+    """If the ObjectType already exists, ingest reuses it (define-once-by-name)."""
+    store = FabricStore(tmp_path / "fabric.db")
+    # Pre-define the type the calendar mapping wants.
+    predefined = await store.define_type(name="CalendarEvent", properties=[])
+
+    events = _events(("evt_1", "Standup"))
+    connector = GoogleCalendarConnector()
+    with patch(_CLIENT_LIST, new=AsyncMock(return_value=events)):
+        await connector.ingest_to_fabric(store)
+
+    obj = await store.get_object_by_source("gcalendar", "evt_1")
+    assert obj is not None
+    # Object bound to the pre-existing type id, not a freshly-created duplicate
+    assert obj.type_id == predefined.id
+    types = [t for t in await store.list_types() if t.name == "CalendarEvent"]
+    assert len(types) == 1
+
+
+def test_calendar_mapping_declares_event_id_as_source() -> None:
+    """The declared mapping pins the idempotency key + type name (snapshot)."""
+    assert CALENDAR_EVENT_MAPPING.type_name == "CalendarEvent"
+    assert CALENDAR_EVENT_MAPPING.source_id_field == "id"
+    # source-id extraction + projection behave as the ingester expects
+    rec = {"id": "  evt_x  ", "summary": "Hi", "attendees": ["a@x.com"]}
+    assert CALENDAR_EVENT_MAPPING.extract_source_id(rec) == "evt_x"
+    props = CALENDAR_EVENT_MAPPING.project(rec)
+    assert props["summary"] == "Hi"
+    assert props["attendee_count"] == 1


### PR DESCRIPTION
First real path from a connector into the Fabric ontology — closing the gap where connector data only ever landed as BM25 text in kb-go, never as typed, queryable Fabric objects with provenance.

This is a thin vertical slice, not the whole subsystem: one connector wired (Google Calendar) on a reusable pattern the others copy. Draft for review — the plan is to expand it (thread the rest of the connectors) and close later.

**The pattern.** A connector declares a single data-only `FabricMapping`: the Fabric type to ensure-exists, the record field holding the stable upstream id (the idempotency key), and a field projection (a callable can derive a value, e.g. attendee_count from attendees). `ingest_records()` then upserts each record by `(source_connector, source_id)` — updates in place if that provenance pair already has an object, else creates one with provenance stamped. Re-syncing the same records updates them rather than duplicating, so N syncs leave N stable objects. Records with no usable id are skipped and counted. The whole path is pure OSS (depends only on the OSS FabricStore), so the EE connector service can call it without crossing the import boundary.

**What's wired:** `connectors/fabric_ingest.py` (the pattern), `fabric/store.py` `get_object_by_source` (tenancy-aware idempotency lookup over the existing source index), and the Google Calendar adapter as first adopter (events land as typed CalendarEvent objects). 6 ingest tests + 33 fabric/connector regression tests pass; import boundary clean.

**Honestly deferred** (the "close later" work): `sync()` itself still returns 0 — the `ConnectorProtocol.sync()` signature has no FabricStore handle, so threading the EE connector sync path to call `ingest_to_fabric` is the next slice; every other connector still stubs Fabric ingestion (Gmail, Drive, Postgres, etc. follow the pattern); no DB uniqueness constraint on the provenance pair yet; no Fabric links (flat objects only).
