### PR TITLE
Customer decision loop: widget event → Instinct approval → decision delivered

### DIFF
--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -913,6 +913,23 @@ async def approve_action(
         except Exception:
             logger.exception("belt code-change execution after approval failed (non-fatal)")
 
+    # gap2 — when the approved Action carries a ``_customer_reply`` blob (a
+    # paw-print customer event awaiting a decision), deliver the owner's reply
+    # back to the customer surface. Same best-effort, lazy-import,
+    # never-break-the-approve-response shape as the hooks above. The operator's
+    # (possibly edited) recommendation is the wording the customer reads, so the
+    # edit path above feeds straight into the delivery.
+    try:
+        from pocketpaw_ee.paw_print.decision_loop import (
+            customer_reply_blob,
+            deliver_customer_decision,
+        )
+
+        if customer_reply_blob(approved) is not None:
+            await deliver_customer_decision(approved, declined=False)
+    except Exception:
+        logger.exception("customer-decision delivery after approval failed (non-fatal)")
+
     return ApproveResponse(action=approved, correction=correction)
 
 
@@ -1027,6 +1044,21 @@ async def reject_action(
             reason=reason,
             causation_override=human_event_id,
         )
+
+    # gap2 — a rejected ``_customer_reply`` Action delivers a DECLINED decision
+    # (carrying the rejection reason) back to the customer surface. Same
+    # best-effort, lazy-import shape as the approve hook. The loop closes either
+    # way: the customer always gets an answer, approve or reject.
+    try:
+        from pocketpaw_ee.paw_print.decision_loop import (
+            customer_reply_blob,
+            deliver_customer_decision,
+        )
+
+        if customer_reply_blob(action) is not None:
+            await deliver_customer_decision(action, declined=True)
+    except Exception:
+        logger.exception("customer-decision delivery after rejection failed (non-fatal)")
 
     return action
 

--- a/ee/pocketpaw_ee/paw_print/decision_loop.py
+++ b/ee/pocketpaw_ee/paw_print/decision_loop.py
@@ -1,0 +1,318 @@
+# ee/paw_print/decision_loop.py — Close the customer decision loop via Instinct.
+# Created: 2026-06-11 (gap2) — The missing back-half of the Paw Print loop.
+#   Before this module, an inbound widget/site event became a Fabric object and
+#   STOPPED: no proposal, no human approval, no decision delivered back to the
+#   customer. This module wires the closed loop:
+#
+#     customer event → propose_customer_decision()  (raise an Instinct proposal
+#       carrying the event context + a default reply + a parked PENDING
+#       DecisionStatus row)
+#         → the proposal lands in the workspace-scoped pending list / The Tray
+#           (existing Instinct surface — no new UI needed)
+#         → a human APPROVES (or rejects) via the existing instinct router
+#           → deliver_customer_decision()  (flip the parked DecisionStatus to
+#             delivered/declined with the human's reply)
+#         → the customer surface polls get_latest_decision and reads the answer.
+#
+# Why a separate module (mirrors cloud/pockets/instinct_bridge.py): the
+#   proposal/deliver functions sit between the OSS PawPrintStore and the OSS
+#   InstinctStore. They are allowed to be impure (they call both stores), and
+#   keeping them out of the HTTP router lets the instinct router import the
+#   deliver hook directly without dragging in FastAPI.
+#
+# Tenancy: the proposal's ``_customer_reply`` blob carries ``workspace_id`` so
+#   the Instinct Action is workspace-scoped exactly like a parked pocket write.
+#   paw_print's widget model predates per-row tenancy and has no workspace_id
+#   column, so the workspace is resolved from the widget OWNER (the freelancer /
+#   operator who owns the widget IS the tenant boundary here). This is the same
+#   scoping key the paw_print store already indexes on. When the widget model
+#   grows a real workspace_id this resolver is the one line to change.
+#
+# Security: the blob carries NO secret — only the widget id, customer_ref,
+#   event type/payload-summary, workspace, and the default reply text. The
+#   delivery hook re-resolves the parked row by Instinct action id (the stable
+#   join key) so a tampered blob cannot redirect a decision to another
+#   customer's row.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Schema version stamped onto the ``_customer_reply`` blob. Bump when the blob
+# shape changes so a stale pending Action approved after a deploy is handled
+# loudly rather than misinterpreted. (Mirrors instinct_bridge._POCKET_WRITE_SCHEMA.)
+_CUSTOMER_REPLY_SCHEMA = 1
+
+# The blob key the Instinct Action carries under ``parameters``. The instinct
+# router dispatches the delivery hook on this key's presence, exactly as it
+# dispatches the pocket-write bridge on ``_pocket_write``.
+CUSTOMER_REPLY_KEY = "_customer_reply"
+
+_MAX_SUMMARY_CHARS = 280
+
+
+def resolve_workspace_id(widget: Any) -> str:
+    """Resolve the owning workspace for a Paw Print widget.
+
+    The widget model predates per-row tenancy and has no ``workspace_id``; the
+    OWNER (the operator who created the widget) is the tenant boundary, and it is
+    the column the paw_print store already scopes on. A widget with a
+    colon-qualified owner (``user:maya``) keeps the full string — the instinct
+    workspace assertion compares the blob's ``workspace_id`` to the caller's
+    active workspace as an opaque string, so consistency, not format, is what
+    matters here.
+    """
+    return str(getattr(widget, "owner", "") or "")
+
+
+def _summarize_payload(payload: dict[str, Any]) -> str:
+    """One-line, length-capped human summary of an event payload for the proposal.
+
+    The proposal title/recommendation shows the operator WHAT the customer asked
+    without dumping an arbitrarily large payload into the Action. Truncated hard
+    at ``_MAX_SUMMARY_CHARS`` so a large (already size-capped at ingest) payload
+    can't bloat the Action row.
+    """
+    import json as _json
+
+    try:
+        text = _json.dumps(payload, default=str, sort_keys=True)
+    except Exception:  # noqa: BLE001 — summary must never raise into ingest
+        text = str(payload)
+    if len(text) > _MAX_SUMMARY_CHARS:
+        return text[: _MAX_SUMMARY_CHARS - 1] + "…"
+    return text
+
+
+def _default_reply(event_type: str) -> str:
+    """The pre-filled reply the operator can accept as-is or edit on approval.
+
+    Kept deliberately generic — the operator owns the final wording. Editing it
+    flows through the existing Instinct correction path (the edit is captured as
+    a Correction and the edited recommendation is what gets delivered).
+    """
+    return (
+        f"Thanks for your '{event_type}' request — we've received it and "
+        "will follow up shortly."
+    )
+
+
+async def propose_customer_decision(
+    *,
+    widget: Any,
+    event: Any,
+    paw_print_store: Any,
+    requested_by: str = "paw_print",
+) -> str | None:
+    """Raise an Instinct proposal for one inbound customer event + park a row.
+
+    ``widget`` is the :class:`PawPrintWidget`; ``event`` is the accepted
+    :class:`PawPrintEvent`. Creates:
+
+      1. An Instinct ``Action`` (category EXTERNAL) carrying a ``_customer_reply``
+         blob with the event context + a default reply + the workspace scope. The
+         Action lands in the owner's workspace-scoped pending list / The Tray.
+      2. A PENDING :class:`DecisionStatus` row keyed to that Action id, so the
+         customer surface immediately polls "we're looking into it" and the
+         approve hook has a stable row to flip.
+
+    Returns the proposed Action id, or ``None`` if the proposal could not be
+    raised (best-effort — a decision-loop failure must NEVER fail the ingest
+    response; the event + Fabric object already persisted).
+    """
+    try:
+        from pocketpaw.instinct.models import ActionCategory, ActionTrigger
+        from pocketpaw.paw_print.models import DecisionState, DecisionStatus
+        from pocketpaw.stores import get_instinct_store
+
+        widget_id = str(getattr(widget, "id", "") or "")
+        pocket_id = str(getattr(widget, "pocket_id", "") or "")
+        workspace_id = resolve_workspace_id(widget)
+        customer_ref = str(getattr(event, "customer_ref", "") or "")
+        event_type = str(getattr(event, "type", "") or "")
+        payload = getattr(event, "payload", None) or {}
+
+        widget_name = str(getattr(widget, "name", "") or "") or widget_id
+        summary = _summarize_payload(payload)
+        default_reply = _default_reply(event_type)
+
+        title = f"Customer request on {widget_name}: {event_type}".strip()
+        recommendation = (
+            f"A customer ({customer_ref}) sent a '{event_type}' request via the "
+            f"'{widget_name}' widget. Suggested reply: {default_reply}"
+        )
+        description = f"Request payload: {summary}"
+
+        trigger = ActionTrigger(
+            type="connector",
+            source=f"paw_print:{widget_id}",
+            reason=f"customer '{event_type}' event awaiting a human decision",
+        )
+
+        # The blob carries NO secret — only routing + context + the editable
+        # reply. ``reply`` is the default; if the operator edits the Action's
+        # recommendation on approval, the delivery hook reads the (edited)
+        # recommendation off the approved Action, so the customer gets the
+        # operator's final wording.
+        blob = {
+            "schema": _CUSTOMER_REPLY_SCHEMA,
+            "widget_id": widget_id,
+            "pocket_id": pocket_id,
+            "customer_ref": customer_ref,
+            "event_type": event_type,
+            "workspace_id": workspace_id,
+            "default_reply": default_reply,
+            "payload_summary": summary,
+        }
+
+        store = get_instinct_store()
+        action = await store.propose(
+            pocket_id=pocket_id or widget_id,
+            title=title,
+            description=description,
+            recommendation=recommendation,
+            trigger=trigger,
+            category=ActionCategory.EXTERNAL,
+            parameters={CUSTOMER_REPLY_KEY: blob},
+            # Workspace-scope the Action so it appears only in the owning
+            # tenant's pending list (deny-by-default Instinct tenancy — W4a).
+            workspace_id=workspace_id or None,
+            # Route the approval to the widget owner — the operator who owns the
+            # customer relationship is the human in the loop.
+            assignee=workspace_id or None,
+        )
+
+        # Park the PENDING decision row so the customer surface has something to
+        # poll immediately and the approve hook has a row to flip by action id.
+        decision = DecisionStatus(
+            widget_id=widget_id,
+            customer_ref=customer_ref,
+            event_type=event_type,
+            instinct_action_id=str(action.id),
+            workspace_id=workspace_id,
+            state=DecisionState.PENDING,
+            reply="",
+        )
+        await paw_print_store.create_decision(decision)
+
+        logger.info(
+            "paw-print event on widget %s (customer %s) → Instinct proposal %s "
+            "(workspace=%s) + parked PENDING decision",
+            widget_id,
+            customer_ref,
+            action.id,
+            workspace_id or "<owner-unset>",
+        )
+        return str(action.id)
+    except Exception:  # noqa: BLE001 — the loop is best-effort over ingest
+        logger.warning(
+            "failed to raise customer-decision proposal for widget %s — the "
+            "event + Fabric object already persisted; the loop just didn't open",
+            getattr(widget, "id", "<unknown>"),
+            exc_info=True,
+        )
+        return None
+
+
+def customer_reply_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_customer_reply`` blob on an Action, or ``None``.
+
+    Mirror of ``instinct_bridge`` / ``_code_change_blob`` — the instinct router
+    dispatches the delivery hook on this blob's presence. Anything that is not a
+    dict is treated as "no customer reply".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get(CUSTOMER_REPLY_KEY)
+    return blob if isinstance(blob, dict) else None
+
+
+async def deliver_customer_decision(action: Any, *, declined: bool = False) -> None:
+    """Deliver the human's decision back to the customer surface.
+
+    Called best-effort from the instinct router's approve / reject handlers
+    after the Action status flips. Flips the parked :class:`DecisionStatus` row
+    (resolved by Instinct action id — the stable join key) to:
+
+      * DELIVERED with the operator's reply, on approve. The reply is taken from
+        the approved Action's ``recommendation`` if the operator edited it (the
+        edited wording is what the customer should read), else the blob's
+        ``default_reply``.
+      * DECLINED with the rejection reason, on reject.
+
+    Never raises — a delivery failure must not break the approve/reject response.
+    The row simply stays PENDING and a retry / sweep can re-resolve it later.
+    """
+    try:
+        from pocketpaw.paw_print.models import DecisionState
+        from pocketpaw.stores import get_paw_print_store
+
+        blob = customer_reply_blob(action)
+        if blob is None:
+            return
+        if blob.get("schema") != _CUSTOMER_REPLY_SCHEMA:
+            logger.warning(
+                "customer-reply blob on action %s is from an incompatible build "
+                "(schema=%s) — not delivering",
+                getattr(action, "id", "<unknown>"),
+                blob.get("schema"),
+            )
+            return
+
+        action_id = str(getattr(action, "id", "") or "")
+        decided_by = str(getattr(action, "approved_by", "") or "") or "system"
+
+        if declined:
+            state = DecisionState.DECLINED
+            reply = str(getattr(action, "rejected_reason", "") or "") or (
+                "We're unable to action this request right now."
+            )
+        else:
+            state = DecisionState.DELIVERED
+            # Prefer the operator's (possibly edited) recommendation — that is
+            # the human's final wording. Fall back to the default reply.
+            reply = str(getattr(action, "recommendation", "") or "") or str(
+                blob.get("default_reply") or ""
+            )
+
+        store = get_paw_print_store()
+        updated = await store.set_decision(
+            action_id,
+            state=state,
+            reply=reply,
+            decided_by=decided_by,
+        )
+        if updated is None:
+            logger.info(
+                "no parked decision row for action %s — nothing to deliver "
+                "(proposal may predate the decision-loop slice)",
+                action_id,
+            )
+            return
+        logger.info(
+            "delivered customer decision for action %s → %s (widget %s, customer %s)",
+            action_id,
+            state.value,
+            updated.widget_id,
+            updated.customer_ref,
+        )
+    except Exception:  # noqa: BLE001 — delivery is best-effort over approve/reject
+        logger.warning(
+            "failed to deliver customer decision for action %s — the parked row "
+            "stays pending; a later approve replay or sweep re-resolves it",
+            getattr(action, "id", "<unknown>"),
+            exc_info=True,
+        )
+
+
+__all__ = [
+    "CUSTOMER_REPLY_KEY",
+    "customer_reply_blob",
+    "deliver_customer_decision",
+    "propose_customer_decision",
+    "resolve_workspace_id",
+]

--- a/ee/pocketpaw_ee/paw_print/router.py
+++ b/ee/pocketpaw_ee/paw_print/router.py
@@ -22,6 +22,15 @@
 # authenticated create + rotate-token paths so an owner can capture it once.
 # The public spec-serving and event-ingest endpoints stay unauthenticated by
 # design (origin/CORS-gated for the embedded widget bundle).
+# Updated: 2026-06-11 (gap2 — close the customer decision loop) — An accepted,
+# mapped customer event no longer dead-ends at a Fabric object: ingest now also
+# raises an Instinct proposal via decision_loop.propose_customer_decision and
+# parks a PENDING DecisionStatus row (best-effort — a loop failure never fails
+# the ingest response). Added a public, CORS-gated poll endpoint
+# (GET /paw-print/events/{widget_id}/decision/{customer_ref}) so the rendered
+# widget can read the owner's decision back out — the back-half of the loop. The
+# approve/reject delivery hook lives in the instinct router (it owns the human
+# decision); see decision_loop.deliver_customer_decision.
 
 from __future__ import annotations
 
@@ -108,7 +117,26 @@ class EventIngestResponse(BaseModel):
     accepted: bool
     event: PawPrintEvent | None = None
     fabric_object_id: str | None = None
+    # gap2 — the Instinct proposal raised for this event (when the widget maps
+    # the event type). The customer surface can poll the decision endpoint to
+    # read the owner's eventual decision; None when no proposal was raised.
+    instinct_action_id: str | None = None
     reason: str | None = None
+
+
+class DecisionStatusResponse(BaseModel):
+    """The customer-facing view of a decision (gap2).
+
+    Deliberately omits internal-only fields (the Instinct action id, the
+    workspace) — the customer surface only needs the state + the reply.
+    ``found`` is False when no decision exists yet for this (widget, customer).
+    """
+
+    found: bool
+    state: str | None = None
+    reply: str | None = None
+    decided_by: str | None = None
+    updated_at: str | None = None
 
 
 class EventsListResponse(BaseModel):
@@ -318,6 +346,12 @@ async def ingest_event(
        (degrades cleanly to accept when the security stack is absent).
     After that, the event is persisted and — if the widget has a matching
     `event_mapping` — a Fabric object is created.
+
+    gap2 — when the event maps to a Fabric object, ingest ALSO raises an
+    Instinct proposal carrying the event context (best-effort) so a human can
+    decide and the decision is delivered back via the poll endpoint. This is the
+    open-the-loop half; the human decides on the existing Instinct surface and
+    deliver_customer_decision closes it.
     """
     store = _store()
     widget = await store.get_widget(widget_id)
@@ -353,11 +387,72 @@ async def ingest_event(
     await store.record_event(event)
     fabric_object_id = await _apply_event_mapping(widget, event)
 
+    # gap2 — open the customer decision loop. Only events the widget actually
+    # maps (a real, recognized customer request, not arbitrary telemetry) raise
+    # a proposal, so we don't flood The Tray with noise. Best-effort: a loop
+    # failure never fails this ingest response — the event + Fabric object have
+    # already persisted.
+    instinct_action_id: str | None = None
+    if widget.event_mapping.get(event.type) is not None:
+        instinct_action_id = await _open_decision_loop(widget, event, store)
+
     return EventIngestResponse(
         accepted=True,
         event=event,
         fabric_object_id=fabric_object_id,
+        instinct_action_id=instinct_action_id,
     )
+
+
+# ---------------------------------------------------------------------------
+# Customer decision poll (public, CORS-enforced) — the back-half of the loop
+# ---------------------------------------------------------------------------
+
+
+@router.get("/paw-print/events/{widget_id}/decision/{customer_ref}")
+async def get_decision(
+    widget_id: str,
+    customer_ref: str,
+    request: Request,
+) -> JSONResponse:
+    """Public endpoint the rendered widget polls to read the owner's decision.
+
+    The widget posted an event (which may have raised an Instinct proposal);
+    this returns the latest decision for ``(widget_id, customer_ref)``:
+    ``pending`` while a human hasn't decided, then ``delivered`` (with the reply)
+    on approval or ``declined`` on rejection.
+
+    Auth model matches the public spec/ingest endpoints: no owner credential —
+    the row is scoped to the customer's own ``customer_ref`` on a specific
+    widget, which is all the embedded widget knows. CORS is enforced per-widget
+    exactly as on the spec endpoint so only allowlisted origins can read it.
+    """
+    store = _store()
+    widget = await store.get_widget(widget_id)
+    if widget is None:
+        raise HTTPException(404, "Widget not found")
+
+    origin = request.headers.get("origin")
+    if not _origin_allowed(widget, origin):
+        raise HTTPException(403, "Origin not allowed for this widget")
+
+    decision = await store.get_latest_decision(widget_id, customer_ref)
+    headers: dict[str, str] = {}
+    if origin:
+        headers["Access-Control-Allow-Origin"] = origin
+        headers["Vary"] = "Origin"
+
+    if decision is None:
+        body = DecisionStatusResponse(found=False)
+    else:
+        body = DecisionStatusResponse(
+            found=True,
+            state=decision.state.value,
+            reply=decision.reply,
+            decided_by=decision.decided_by,
+            updated_at=decision.updated_at.isoformat(),
+        )
+    return JSONResponse(body.model_dump(), headers=headers)
 
 
 # ---------------------------------------------------------------------------
@@ -408,6 +503,36 @@ async def _screen_event_for_injection(event: PawPrintEvent) -> bool:
         )
         return False
     return True
+
+
+async def _open_decision_loop(
+    widget: PawPrintWidget,
+    event: PawPrintEvent,
+    store: Any,
+) -> str | None:
+    """Raise an Instinct proposal for a mapped customer event (gap2).
+
+    Thin wrapper over ``decision_loop.propose_customer_decision`` — keeps the
+    import lazy (the OSS paw_print store never reaches into the EE decision-loop
+    module) and the failure best-effort: any error is swallowed by the called
+    function, and a defensive guard here ensures even an import failure can't
+    break the ingest response. Returns the proposed Instinct action id, or None.
+    """
+    try:
+        from pocketpaw_ee.paw_print.decision_loop import propose_customer_decision
+
+        return await propose_customer_decision(
+            widget=widget,
+            event=event,
+            paw_print_store=store,
+        )
+    except Exception:
+        logger.warning(
+            "decision-loop proposal failed for widget %s (non-fatal)",
+            widget.id,
+            exc_info=True,
+        )
+        return None
 
 
 async def _apply_event_mapping(widget: PawPrintWidget, event: PawPrintEvent) -> str | None:

--- a/src/pocketpaw/paw_print/__init__.py
+++ b/src/pocketpaw/paw_print/__init__.py
@@ -5,8 +5,13 @@
 # back to the widget. This module is the backend side of that loop.
 # Updated: 2026-06-10 (W0b security fix) — Export PawPrintWidgetPublic, the
 # token-free response projection used by the list/read endpoints.
+# Updated: 2026-06-11 (gap2 — close the customer decision loop) — Export
+# DecisionStatus + DecisionState, the deliverable that carries the owner's
+# decision back out to the customer surface (the back-half of the loop).
 
 from pocketpaw.paw_print.models import (
+    DecisionState,
+    DecisionStatus,
     PawPrintBlock,
     PawPrintEvent,
     PawPrintEventMapping,
@@ -17,6 +22,8 @@ from pocketpaw.paw_print.models import (
 from pocketpaw.paw_print.store import PawPrintStore
 
 __all__ = [
+    "DecisionState",
+    "DecisionStatus",
     "PawPrintBlock",
     "PawPrintEvent",
     "PawPrintEventMapping",

--- a/src/pocketpaw/paw_print/models.py
+++ b/src/pocketpaw/paw_print/models.py
@@ -8,11 +8,21 @@
 # list/read endpoints so the per-widget access_token never leaves the server
 # in those payloads. The token is now only returned by the explicit,
 # authenticated create + rotate-token paths.
+# Updated: 2026-06-11 (gap2 — close the customer decision loop) — Added
+# DecisionStatus + DecisionState. An inbound customer event no longer dead-ends
+# at a Fabric object: it can raise an Instinct proposal, and the human's
+# decision (reply text + state) is recorded here as the deliverable the
+# customer surface polls back. DecisionStatus is keyed by (widget_id,
+# customer_ref) so a rendered widget can fetch "what did the owner decide about
+# my request?" without any owner credential. State machine: pending → delivered
+# (approved) | declined (rejected). This is the back-half of the loop the
+# module docstring promised since 2026-04-13 but never wired.
 
 from __future__ import annotations
 
 import secrets
 from datetime import datetime
+from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -219,6 +229,50 @@ class PawPrintEvent(BaseModel):
         if not value.strip():
             raise ValueError("event type is required")
         return value.strip()
+
+
+# ---------------------------------------------------------------------------
+# Decision delivery — the back-half of the customer decision loop (gap2)
+# ---------------------------------------------------------------------------
+
+
+class DecisionState(StrEnum):
+    """Where a customer's request sits in the decision loop.
+
+    ``PENDING``   — the event raised an Instinct proposal; a human has not yet
+                    decided. The customer surface shows "we're looking into it".
+    ``DELIVERED`` — the human approved; ``reply`` carries the answer the
+                    customer can read.
+    ``DECLINED``  — the human rejected; ``reply`` carries the (optional) reason.
+    """
+
+    PENDING = "pending"
+    DELIVERED = "delivered"
+    DECLINED = "declined"
+
+
+class DecisionStatus(BaseModel):
+    """A decision made (or pending) for one inbound customer event.
+
+    This is the deliverable the customer surface polls back: the widget posted
+    an event, a human decided, and the answer lands here keyed by
+    ``(widget_id, customer_ref)`` so the rendered widget can retrieve it with no
+    owner credential. ``instinct_action_id`` ties the row to the Instinct
+    proposal that drove the decision, so the audit trail is reconstructable.
+    ``workspace_id`` scopes the row to the owning tenant.
+    """
+
+    id: str = Field(default_factory=lambda: _gen_id("ppd"))
+    widget_id: str
+    customer_ref: str
+    event_type: str = ""
+    instinct_action_id: str = ""
+    workspace_id: str = ""
+    state: DecisionState = DecisionState.PENDING
+    reply: str = ""
+    decided_by: str = ""
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pocketpaw/paw_print/store.py
+++ b/src/pocketpaw/paw_print/store.py
@@ -2,6 +2,13 @@
 # Created: 2026-04-13 (Move 3 PR-A) — CRUD for PawPrintWidget + append-only
 # PawPrintEvent log. Token rotation invalidates any cached copies. Event ingest
 # + rate-limit logic lives in PR-B; this module only handles persistence.
+# Updated: 2026-06-11 (gap2 — close the customer decision loop) — Added the
+# paw_print_decisions table + upsert_decision / set_decision /
+# get_latest_decision. This is the delivery sink for the back-half of the loop:
+# an inbound event raises an Instinct proposal and parks a PENDING DecisionStatus
+# here; on human approval/rejection the EE approve hook flips it to
+# delivered/declined; the customer surface polls get_latest_decision by
+# (widget_id, customer_ref). Pure SQLite — no EE import, OSS-boundary clean.
 
 from __future__ import annotations
 
@@ -12,7 +19,14 @@ from typing import Any
 
 import aiosqlite
 
-from pocketpaw.paw_print.models import PawPrintEvent, PawPrintSpec, PawPrintWidget, _gen_token
+from pocketpaw.paw_print.models import (
+    DecisionState,
+    DecisionStatus,
+    PawPrintEvent,
+    PawPrintSpec,
+    PawPrintWidget,
+    _gen_token,
+)
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS paw_print_widgets (
@@ -39,12 +53,33 @@ CREATE TABLE IF NOT EXISTS paw_print_events (
     timestamp TEXT NOT NULL
 );
 
+-- gap2: the customer-decision delivery sink. One row per inbound event that
+-- raised an Instinct proposal; the customer surface polls the latest row for
+-- (widget_id, customer_ref) to read the owner's decision.
+CREATE TABLE IF NOT EXISTS paw_print_decisions (
+    id TEXT PRIMARY KEY,
+    widget_id TEXT NOT NULL,
+    customer_ref TEXT NOT NULL,
+    event_type TEXT DEFAULT '',
+    instinct_action_id TEXT DEFAULT '',
+    workspace_id TEXT DEFAULT '',
+    state TEXT DEFAULT 'pending',
+    reply TEXT DEFAULT '',
+    decided_by TEXT DEFAULT '',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_pocket ON paw_print_widgets(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_owner ON paw_print_widgets(owner);
 CREATE INDEX IF NOT EXISTS idx_pp_events_widget_ts
     ON paw_print_events(widget_id, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_pp_events_customer
     ON paw_print_events(widget_id, customer_ref);
+CREATE INDEX IF NOT EXISTS idx_pp_decisions_customer
+    ON paw_print_decisions(widget_id, customer_ref, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_pp_decisions_action
+    ON paw_print_decisions(instinct_action_id);
 """
 
 
@@ -242,6 +277,112 @@ class PawPrintStore:
         )
         return per_customer < per_customer_per_min
 
+    # ---------------- Decisions (gap2 — the back-half of the loop) ----------------
+
+    async def create_decision(self, decision: DecisionStatus) -> DecisionStatus:
+        """Insert a PENDING (or any pre-built) decision row.
+
+        Called from the ingest path right after an Instinct proposal is raised:
+        the customer's request is now "we're looking into it" until a human
+        decides. One row per inbound event — the latest row for
+        ``(widget_id, customer_ref)`` is what the customer surface reads back.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO paw_print_decisions"
+                " (id, widget_id, customer_ref, event_type, instinct_action_id,"
+                " workspace_id, state, reply, decided_by, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    decision.id,
+                    decision.widget_id,
+                    decision.customer_ref,
+                    decision.event_type,
+                    decision.instinct_action_id,
+                    decision.workspace_id,
+                    decision.state.value,
+                    decision.reply,
+                    decision.decided_by,
+                    decision.created_at.isoformat(),
+                    decision.updated_at.isoformat(),
+                ),
+            )
+            await db.commit()
+        return decision
+
+    async def get_decision_by_action(self, instinct_action_id: str) -> DecisionStatus | None:
+        """Fetch the decision row tied to an Instinct action id.
+
+        The approve/reject delivery hook resolves the parked row this way: the
+        Instinct Action's ``_customer_reply`` blob carries no DB handle, only the
+        action id, which is the stable join key back to the parked row.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM paw_print_decisions WHERE instinct_action_id = ? LIMIT 1",
+                (instinct_action_id,),
+            ) as cur:
+                row = await cur.fetchone()
+                return self._row_to_decision(row) if row else None
+
+    async def set_decision(
+        self,
+        instinct_action_id: str,
+        *,
+        state: DecisionState,
+        reply: str,
+        decided_by: str,
+    ) -> DecisionStatus | None:
+        """Flip a parked decision to delivered/declined and record the answer.
+
+        Idempotent on the action id. Returns the updated row, or ``None`` when no
+        parked row matches (e.g. the proposal was raised before this slice
+        shipped, or the row was never created — the approve hook degrades
+        cleanly in that case).
+        """
+        existing = await self.get_decision_by_action(instinct_action_id)
+        if existing is None:
+            return None
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "UPDATE paw_print_decisions"
+                " SET state = ?, reply = ?, decided_by = ?, updated_at = ?"
+                " WHERE instinct_action_id = ?",
+                (
+                    state.value,
+                    reply,
+                    decided_by,
+                    datetime.now().isoformat(),
+                    instinct_action_id,
+                ),
+            )
+            await db.commit()
+        return await self.get_decision_by_action(instinct_action_id)
+
+    async def get_latest_decision(self, widget_id: str, customer_ref: str) -> DecisionStatus | None:
+        """Return the most-recent decision for a (widget, customer) pair.
+
+        This is the customer-surface poll: the rendered widget posted an event,
+        then polls here to read "what did the owner decide about my request?".
+        No owner credential is required — the row is scoped to the customer's own
+        ``customer_ref`` on a specific widget, which is all the widget knows.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM paw_print_decisions"
+                " WHERE widget_id = ? AND customer_ref = ?"
+                " ORDER BY created_at DESC LIMIT 1",
+                (widget_id, customer_ref),
+            ) as cur:
+                row = await cur.fetchone()
+                return self._row_to_decision(row) if row else None
+
     # ---------------- Helpers ----------------
 
     def _row_to_widget(self, row: Any) -> PawPrintWidget:
@@ -273,4 +414,19 @@ class PawPrintStore:
             payload=json.loads(row["payload"]) if row["payload"] else {},
             customer_ref=row["customer_ref"],
             timestamp=datetime.fromisoformat(row["timestamp"]),
+        )
+
+    def _row_to_decision(self, row: Any) -> DecisionStatus:
+        return DecisionStatus(
+            id=row["id"],
+            widget_id=row["widget_id"],
+            customer_ref=row["customer_ref"],
+            event_type=row["event_type"] or "",
+            instinct_action_id=row["instinct_action_id"] or "",
+            workspace_id=row["workspace_id"] or "",
+            state=DecisionState(row["state"]),
+            reply=row["reply"] or "",
+            decided_by=row["decided_by"] or "",
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
         )

--- a/tests/cloud/test_paw_print_decision_loop.py
+++ b/tests/cloud/test_paw_print_decision_loop.py
@@ -1,0 +1,322 @@
+# tests/cloud/test_paw_print_decision_loop.py — gap2: the closed customer
+# decision loop, end to end.
+# Created: 2026-06-11 (gap2) — Proves the loop the module promised but never
+# wired: a customer event raises a PENDING Instinct proposal + parked decision;
+# approving it delivers the reply back, retrievable for that (widget, customer);
+# rejecting it declines with the reason. Also covers tenancy (the proposal is
+# workspace-scoped to the widget owner), the public poll endpoint (CORS-gated),
+# and the best-effort guarantee (a loop failure never fails ingest).
+#
+# asyncio_mode = "auto" (see pyproject) → every ``async def test_*`` is run by
+# pytest-asyncio without a per-test marker. The TestClient calls are synchronous
+# (Starlette spins its own loop), so mixing sync HTTP calls with awaited store
+# reads inside one async test is fine and matches the repo's existing pattern.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.paw_print.decision_loop import (
+    deliver_customer_decision,
+    propose_customer_decision,
+)
+from pocketpaw_ee.paw_print.router import router
+
+from pocketpaw.instinct.store import InstinctStore
+from pocketpaw.paw_print.models import (
+    PawPrintBlock,
+    PawPrintEvent,
+    PawPrintSpec,
+    PawPrintWidget,
+)
+from pocketpaw.paw_print.store import PawPrintStore
+
+
+def _spec(widget_id: str = "pp_test", pocket_id: str = "pocket-1") -> PawPrintSpec:
+    return PawPrintSpec(
+        widget_id=widget_id,
+        pocket_id=pocket_id,
+        blocks=[PawPrintBlock(type="text", content="Bright Smile Dental")],
+    )
+
+
+def _widget_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "pocket_id": "pocket-1",
+        "owner": "ws:bright-smile",
+        "name": "Appointment Widget",
+        "spec": _spec().model_dump(),
+        "allowed_domains": ["brightsmiledental.com"],
+        "rate_limit_per_min": 20,
+        "per_customer_limit_per_min": 10,
+        "event_mapping": {
+            "appointment_request": {
+                "creates": "AppointmentRequest",
+                "fields": {"when": "{{ payload.when }}", "patient": "{{ customer_ref }}"},
+            },
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    """Wire isolated Instinct + PawPrint stores and patch the singletons.
+
+    The decision_loop functions lazy-import ``get_instinct_store`` /
+    ``get_paw_print_store`` from ``pocketpaw.stores``, so patching there reaches
+    both the ingest (propose) and the approve (deliver) sides.
+    """
+    pp_store = PawPrintStore(tmp_path / "paw_print_loop.db")
+    instinct_store = InstinctStore(tmp_path / "instinct_loop.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: instinct_store)
+    monkeypatch.setattr("pocketpaw.stores.get_paw_print_store", lambda: pp_store)
+    return pp_store, instinct_store
+
+
+@pytest.fixture
+def client(stores, monkeypatch):
+    pp_store, _ = stores
+    app = FastAPI()
+    app.include_router(router)
+    monkeypatch.setattr("pocketpaw_ee.paw_print.router._store", lambda: pp_store)
+    return TestClient(app)
+
+
+def _create_widget(client: TestClient, **overrides: Any) -> dict[str, Any]:
+    res = client.post("/paw-print/widgets", json=_widget_payload(**overrides))
+    assert res.status_code == 201, res.text
+    return res.json()
+
+
+def _ingest(client: TestClient, widget_id: str, customer_ref: str = "patient_42") -> dict[str, Any]:
+    res = client.post(
+        f"/paw-print/events/{widget_id}",
+        json={
+            "type": "appointment_request",
+            "payload": {"when": "Tuesday 3pm"},
+            "customer_ref": customer_ref,
+        },
+        headers={"Origin": "https://brightsmiledental.com"},
+    )
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+def _poll(client: TestClient, widget_id: str, customer_ref: str = "patient_42"):
+    return client.get(
+        f"/paw-print/events/{widget_id}/decision/{customer_ref}",
+        headers={"Origin": "https://brightsmiledental.com"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Open-the-loop: a mapped event raises a proposal + parks a PENDING decision
+# ---------------------------------------------------------------------------
+
+
+class TestOpenLoop:
+    async def test_mapped_event_raises_instinct_proposal(self, client, stores) -> None:
+        _, instinct_store = stores
+        created = _create_widget(client)
+        body = _ingest(client, created["id"])
+
+        action_id = body["instinct_action_id"]
+        assert action_id, "ingest of a mapped event must raise an Instinct proposal"
+
+        # The proposal lands in the OWNER's workspace-scoped pending list.
+        pending = await instinct_store.pending(workspace_id="ws:bright-smile")
+        assert len(pending) == 1
+        assert pending[0].id == action_id
+        blob = pending[0].parameters["_customer_reply"]
+        assert blob["widget_id"] == created["id"]
+        assert blob["customer_ref"] == "patient_42"
+        assert blob["event_type"] == "appointment_request"
+        assert blob["workspace_id"] == "ws:bright-smile"
+
+    async def test_proposal_is_workspace_scoped(self, client, stores) -> None:
+        """A different tenant must NOT see this proposal (deny-by-default)."""
+        _, instinct_store = stores
+        created = _create_widget(client)
+        _ingest(client, created["id"])
+
+        other = await instinct_store.pending(workspace_id="ws:someone-else")
+        assert other == []
+
+    async def test_decision_parked_pending_after_ingest(self, client) -> None:
+        created = _create_widget(client)
+        _ingest(client, created["id"])
+
+        # The customer surface polls and sees "we're looking into it".
+        res = _poll(client, created["id"])
+        assert res.status_code == 200
+        body = res.json()
+        assert body["found"] is True
+        assert body["state"] == "pending"
+        assert body["reply"] == ""
+
+    async def test_unmapped_event_does_not_raise_proposal(self, client, stores) -> None:
+        """Only mapped events open the loop — telemetry must not flood The Tray."""
+        _, instinct_store = stores
+        created = _create_widget(client)
+        res = client.post(
+            f"/paw-print/events/{created['id']}",
+            json={"type": "page_view", "payload": {}, "customer_ref": "patient_42"},
+            headers={"Origin": "https://brightsmiledental.com"},
+        )
+        assert res.status_code == 200
+        assert res.json()["instinct_action_id"] is None
+        assert await instinct_store.pending(workspace_id="ws:bright-smile") == []
+
+
+# ---------------------------------------------------------------------------
+# Close-the-loop: approving delivers the reply; rejecting declines
+# ---------------------------------------------------------------------------
+
+
+class TestCloseLoop:
+    async def test_approval_delivers_decision_back(self, client, stores) -> None:
+        _, instinct_store = stores
+        created = _create_widget(client)
+        body = _ingest(client, created["id"])
+        action_id = body["instinct_action_id"]
+
+        # The human approves on the Instinct surface (store-level approve, then
+        # the delivery hook the router calls).
+        approved = await instinct_store.approve(action_id, approver="user:dr_jones")
+        assert approved is not None
+        await deliver_customer_decision(approved, declined=False)
+
+        # The customer polls and now reads the DELIVERED reply.
+        res = _poll(client, created["id"])
+        assert res.status_code == 200
+        out = res.json()
+        assert out["found"] is True
+        assert out["state"] == "delivered"
+        assert out["reply"]  # non-empty operator reply
+        assert out["decided_by"] == "user:dr_jones"
+
+    async def test_edited_reply_is_what_customer_reads(self, client, stores) -> None:
+        """If the operator edits the recommendation, that wording is delivered."""
+        import aiosqlite
+
+        _, instinct_store = stores
+        created = _create_widget(client)
+        body = _ingest(client, created["id"])
+        action_id = body["instinct_action_id"]
+
+        # Operator edits the recommendation before approving (the delivery hook
+        # prefers the approved Action's recommendation as the customer reply).
+        edited = "Confirmed for Tuesday 3pm — see you then!"
+        async with aiosqlite.connect(instinct_store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET recommendation = ? WHERE id = ?",
+                (edited, action_id),
+            )
+            await db.commit()
+
+        approved = await instinct_store.approve(action_id, approver="user:dr_jones")
+        await deliver_customer_decision(approved, declined=False)
+
+        res = _poll(client, created["id"])
+        assert res.json()["reply"] == edited
+
+    async def test_rejection_declines_with_reason(self, client, stores) -> None:
+        _, instinct_store = stores
+        created = _create_widget(client)
+        body = _ingest(client, created["id"])
+        action_id = body["instinct_action_id"]
+
+        rejected = await instinct_store.reject(
+            action_id,
+            reason="No slots Tuesday — please pick another day",
+            rejector="user:dr_jones",
+        )
+        assert rejected is not None
+        await deliver_customer_decision(rejected, declined=True)
+
+        res = _poll(client, created["id"])
+        out = res.json()
+        assert out["state"] == "declined"
+        assert "No slots Tuesday" in out["reply"]
+
+
+# ---------------------------------------------------------------------------
+# Robustness: best-effort + CORS on the poll endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestRobustness:
+    async def test_poll_unknown_customer_returns_not_found(self, client) -> None:
+        created = _create_widget(client)
+        res = _poll(client, created["id"], customer_ref="never_seen")
+        assert res.status_code == 200
+        assert res.json()["found"] is False
+
+    async def test_poll_disallowed_origin_rejected(self, client) -> None:
+        created = _create_widget(client)
+        _ingest(client, created["id"])
+        res = client.get(
+            f"/paw-print/events/{created['id']}/decision/patient_42",
+            headers={"Origin": "https://evil.example"},
+        )
+        assert res.status_code == 403
+
+    async def test_proposal_failure_does_not_break_ingest(self, stores, monkeypatch) -> None:
+        """If the Instinct store explodes, the loop swallows it — the ingest
+        response is never broken by a decision-loop failure."""
+        pp_store, _ = stores
+        widget = PawPrintWidget(
+            pocket_id="pocket-1",
+            owner="ws:bright-smile",
+            name="W",
+            spec=_spec(),
+            event_mapping={},
+        )
+        event = PawPrintEvent(
+            widget_id=widget.id,
+            type="appointment_request",
+            payload={},
+            customer_ref="p1",
+        )
+
+        def _boom():
+            raise RuntimeError("instinct store down")
+
+        monkeypatch.setattr("pocketpaw.stores.get_instinct_store", _boom)
+        result = await propose_customer_decision(
+            widget=widget, event=event, paw_print_store=pp_store
+        )
+        assert result is None
+
+    async def test_deliver_no_parked_row_is_noop(self, stores) -> None:
+        """Delivering for an action with no parked decision row degrades cleanly."""
+        from pocketpaw.instinct.models import ActionCategory, ActionTrigger
+
+        _, instinct_store = stores
+        action = await instinct_store.propose(
+            pocket_id="pocket-1",
+            title="orphan",
+            description="",
+            recommendation="hi",
+            trigger=ActionTrigger(type="connector", source="x", reason="y"),
+            category=ActionCategory.EXTERNAL,
+            parameters={
+                "_customer_reply": {
+                    "schema": 1,
+                    "widget_id": "pp_x",
+                    "customer_ref": "c1",
+                    "event_type": "t",
+                    "workspace_id": "ws:bright-smile",
+                    "default_reply": "ok",
+                }
+            },
+        )
+        approved = await instinct_store.approve(action.id, approver="u")
+        # No create_decision was called → set_decision returns None → no raise.
+        await deliver_customer_decision(approved, declined=False)


### PR DESCRIPTION
The customer-facing decision loop — the full-stack "decision back to the end customer" that's the differentiator vs Palantir, and that today doesn't exist (an inbound widget/site event becomes a Fabric object or Lead and stops, with zero Instinct involvement).

Thin vertical slice: the loop is wired and tested in code. Draft for review — expand and close later.

**The loop:** a mapped widget/site event raises an Instinct proposal (carrying widget/customer/event context + a default reply) and parks a PENDING decision row, workspace-scoped. It lands in the owner's pending list / The Tray on the existing surface. A human approves (optionally editing the reply) or rejects with a reason, which flips the parked row to DELIVERED/DECLINED. The customer surface polls `GET /paw-print/events/{widget}/decision/{ref}` and reads back `{state, reply, decided_by}`. Event in → human decides → decision out. It's best-effort on the propose side, so Instinct being down never breaks event ingest.

**Tested:** 11 loop tests (proposal parked + workspace-isolated, unmapped events don't flood the Tray, approve→delivered, edited reply is what the customer reads, reject→declined-with-reason, CORS on the poll, clean degrade) + 295 paw_print/instinct regression. Both import boundaries clean.

**Honestly deferred:** real-time push (the customer polls; no WebSocket yet); widget tenancy — the widget model has no `workspace_id` column, so the owner string is the tenant key for now (one line in `resolve_workspace_id` when the model grows real tenancy); widget infra redeploy (NXDOMAIN, an ops problem); Decision-Graph chain emits for the customer-reply blob (the loop is audited via the Instinct action lifecycle, but chain-graph parity with the pocket-write/Belt blobs is a follow-up).

Note: touches `ee/pocketpaw_ee/instinct/router.py` (approve/reject delivery hooks) — may need a trivial conflict resolution if merged alongside the outcome-metering PR.
