### PR TITLE
Outcome metering: governed-outcome value + billable aggregation surface

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,6 +23,13 @@ the authoring agent stops hallucinating endpoints.
 Updated: 2026-05-22 (feat/catalog-allowlist, Increment 5) — documented
 the catalog-as-allowlist ingest gate, the two escape-hatch widgets
 (`model-viewer` + `embed`), and the `embed` URL/host policy.
+
+Updated: 2026-06-11 (gap-3 outcome VALUE metering) — documented the
+Outcome Metering section: the binding-level `outcome` / `outcome_value` /
+`outcome_unit` declaration, the existing `GET /outcomes` count surface,
+and the new `GET /outcomes/meter` aggregation surface that sums billable
+value by unit per workspace over a since/until window. Invoicing /
+payment / pricing-rules / clawback remain deferred.
 -->
 
 # Cloud REST API Reference
@@ -556,3 +563,70 @@ enforces:
 Every ingested spec that contains an `embed` node is audit-logged
 (category `pocket_embed`) with the embed count and URLs — never the
 iframe contents.
+
+## Outcome Metering
+
+RFC 05 M2b.2 + gap-3. When a governed write action succeeds, the pocket's
+binding can declare a named `outcome` and an optional billable value/unit.
+Each one appends a row to a workspace-scoped, append-only JSONL ledger.
+Two read surfaces sit over the ledger; both take tenancy from the auth
+context and **reject** a `workspace_id` query param (a caller cannot read
+another workspace's ledger).
+
+### Declaring an outcome on a binding
+
+A write binding in `rippleSpec.actions` declares the metering fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `outcome` | string \| null | The named business event (`meeting_booked`, `ticket_resolved`, …). `null` → the write is not metered. |
+| `outcome_value` | number \| null | The billable value the operator assigns this outcome. Requires `outcome_unit` AND a non-null `outcome` — a half-declared pair is rejected at parse time. |
+| `outcome_unit` | string \| null | The unit the value is denominated in (`usd`, `ticket_resolved`, …). Requires `outcome_value`. |
+
+Declaring `outcome` with no value/unit is the **count-only** binding (the
+prior behaviour). Declaring all three turns the count into a billable
+figure.
+
+### `GET /outcomes`
+
+Count this workspace's recorded outcomes, grouped by name and pocket.
+Requires the `outcomes.read` action.
+
+Query params: `pocket_id` (narrow to one pocket), `since` (inclusive
+ISO-8601 lower bound on `occurred_at`). Both optional.
+
+Response `200`:
+
+```json
+{ "total": 12, "by_outcome": { "ticket_resolved": 9, "meeting_booked": 3 },
+  "by_pocket": { "p_support": 9, "p_sales": 3 } }
+```
+
+### `GET /outcomes/meter`
+
+Aggregate this workspace's **billable** outcomes into a queryable figure —
+the "pay for governed outcomes" read primitive. Requires the
+`outcomes.read` action.
+
+Query params: `pocket_id`, `since` (inclusive lower bound), `until`
+(**exclusive** upper bound, so adjacent periods never double-count a
+boundary outcome). All optional.
+
+Response `200`:
+
+```json
+{ "total_outcomes": 12, "metered_count": 9,
+  "by_unit": {
+    "usd": { "unit": "usd", "count": 6, "total_value": 7200.0 },
+    "ticket_resolved": { "unit": "ticket_resolved", "count": 3, "total_value": 3.0 }
+  } }
+```
+
+`total_outcomes` counts every matching row (including count-only ones);
+`metered_count` counts only the rows carrying a whole value/unit pair;
+`by_unit` sums `outcome_value` per unit over the window.
+
+**Deferred (not in this surface):** invoicing, payment, currency
+conversion, a pricing-rules engine, and disputes / clawback. This endpoint
+returns a raw sum of declared values — the queryable figure those layers
+will build on later (see `outcome-spec.md`).

--- a/ee/pocketpaw_ee/cloud/outcomes/__init__.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/__init__.py
@@ -9,3 +9,12 @@
 #   is reserved: the event carries both fields as `null` and this entity
 #   never sets them. The meter exists so an operator can SEE how many
 #   business outcomes a pocket produced before any pricing is wired.
+#
+# Updated: 2026-06-11 (gap-3 outcome VALUE metering) — Layer 4 is now
+#   partially wired: `outcome_value` / `outcome_unit` carry the author-time
+#   billable pair declared on the `ActionBinding`, persisted on the ledger
+#   row, and `GET /api/v1/outcomes/meter` aggregates them into a billable
+#   figure per workspace per period (count + total value by unit). This is
+#   the "pay for governed outcomes" READ primitive. Still DEFERRED:
+#   invoicing, payment, currency, a pricing-rules engine, and
+#   disputes/clawback — turning the queryable figure into money.

--- a/ee/pocketpaw_ee/cloud/outcomes/domain.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/domain.py
@@ -13,6 +13,12 @@
 #   `_apply_outcome_attached` handler mutates the Decision in place.
 #   Optional — pre-Slice-2 writers pass None and the back-reference is
 #   simply absent from the ledger row.
+# Updated: 2026-06-11 (gap-3 outcome VALUE metering) — `outcome_value` /
+#   `outcome_unit` are no longer the always-`None` reserved slots. They
+#   now carry the binding's author-time billable value/unit, persisted on
+#   the ledger row so `meter_outcomes` can sum value by unit per workspace.
+#   The fields and their defaults are unchanged; only the meaning is — a
+#   pre-gap-3 ledger row (both `None`) reads back as a count-only outcome.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -24,8 +30,10 @@ class OutcomeRecord:
 
     Built from a ``PocketOutcomeEvent`` and appended verbatim to the
     workspace JSONL ledger. ``outcome_value`` / ``outcome_unit`` are the
-    Layer-4 billing slots — always ``None`` in this build, kept on the
-    record so the ledger format is forward-stable when pricing lands.
+    billable-value pair (gap-3): a real figure when the binding declared
+    one, ``None``/``None`` for a count-only outcome. They are always a WHOLE
+    pair or both ``None`` — ``record_outcome`` drops a torn half-pair to
+    count-only so the aggregation can sum value strictly by unit.
     ``decision_id`` is the optional back-reference to the Decision in
     the RFC 07 decision graph that this outcome resolved — None for
     outcomes emitted by writers that don't know their Decision.

--- a/ee/pocketpaw_ee/cloud/outcomes/dto.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/dto.py
@@ -10,6 +10,14 @@
 #   returns a list of rows yet; the DTO is shipped now so future
 #   `GET /api/v1/outcomes?detail=rows` lookups have a stable wire
 #   contract and the back-reference is visible on the lint surface.
+# Updated: 2026-06-11 (gap-3 outcome VALUE metering) — added the
+#   aggregation surface DTOs: `MeterOutcomesRequest` (the `since`/`until`
+#   period window for `GET /api/v1/outcomes/meter`), `UnitMeter` (one
+#   billable unit's count + summed value), and `MeterOutcomesResponse`
+#   (the workspace's metered total: count of value-bearing outcomes plus a
+#   per-unit rollup). This is the "pay for governed outcomes" read
+#   primitive — a queryable billable figure per workspace per period. It
+#   is NOT invoicing/payment (deferred).
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -65,4 +73,63 @@ class OutcomeResponse(BaseModel):
     decision_id: str | None = None
 
 
-__all__ = ["CountOutcomesRequest", "OutcomeCountResponse", "OutcomeResponse"]
+class MeterOutcomesRequest(BaseModel):
+    """Validated period window for ``GET /api/v1/outcomes/meter``.
+
+    ``workspace_id`` is taken from the auth context, never the query — the
+    router rejects a ``workspace_id`` query param. ``pocket_id`` narrows to
+    one pocket. ``since`` / ``until`` are ISO-8601 bounds on
+    ``occurred_at``: ``since`` is an inclusive lower bound, ``until`` an
+    EXCLUSIVE upper bound so adjacent periods (e.g. month boundaries) don't
+    double-count the same outcome. All optional — an unbounded meter sums
+    the whole ledger.
+    """
+
+    pocket_id: str | None = None
+    since: str | None = None
+    until: str | None = None
+
+
+class UnitMeter(BaseModel):
+    """One billable unit's rollup — how many outcomes and their total value.
+
+    ``count`` is the number of value-bearing outcomes carrying this unit;
+    ``total_value`` is their summed ``outcome_value``. A unit only appears
+    in the meter when at least one outcome declared it (count-only outcomes
+    — no value/unit — are excluded from the per-unit rollup entirely).
+    """
+
+    unit: str
+    count: int
+    total_value: float
+
+
+class MeterOutcomesResponse(BaseModel):
+    """The metered (billable) view of a workspace's governed outcomes.
+
+    ``metered_count`` is the number of outcomes that carried a real
+    value/unit pair in the window — the count-only outcomes are NOT
+    included here (they have no billable figure). ``by_unit`` is the
+    per-unit rollup (count + summed value) keyed by unit name.
+    ``total_outcomes`` is every matching ledger row including count-only
+    ones, so an operator can see metered vs total coverage.
+
+    This is the queryable "pay for governed outcomes" figure. It is a READ
+    surface only — turning ``total_value`` into an invoice, a charge, or a
+    rev-share split is deferred (outcome-spec.md Decisions 5/7 — pricing
+    rules, clawback, disputes).
+    """
+
+    total_outcomes: int
+    metered_count: int
+    by_unit: dict[str, UnitMeter] = Field(default_factory=dict)
+
+
+__all__ = [
+    "CountOutcomesRequest",
+    "OutcomeCountResponse",
+    "OutcomeResponse",
+    "MeterOutcomesRequest",
+    "UnitMeter",
+    "MeterOutcomesResponse",
+]

--- a/ee/pocketpaw_ee/cloud/outcomes/router.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/router.py
@@ -3,6 +3,13 @@
 #   count surface over the workspace outcome ledger. Thin: parses the
 #   query, delegates to `outcomes_service.count_outcomes`. Never raises
 #   HTTPException — CloudError → JSON via `_core.http`.
+# Updated: 2026-06-11 (gap-3 outcome VALUE metering) — added
+#   `GET /api/v1/outcomes/meter`, the aggregation read surface. Same
+#   tenancy posture as the count endpoint (workspace_id from auth context,
+#   a query param is rejected); delegates to `outcomes_service.
+#   meter_outcomes`, which sums billable value BY unit over a since/until
+#   window. Behind the same `outcomes.read` RBAC action — reading the
+#   metered figure is the same right as reading the count.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -11,7 +18,12 @@ from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import CloudError
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.outcomes import service as outcomes_service
-from pocketpaw_ee.cloud.outcomes.dto import CountOutcomesRequest, OutcomeCountResponse
+from pocketpaw_ee.cloud.outcomes.dto import (
+    CountOutcomesRequest,
+    MeterOutcomesRequest,
+    MeterOutcomesResponse,
+    OutcomeCountResponse,
+)
 from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
 
 router = APIRouter(
@@ -45,3 +57,34 @@ async def count_outcomes(
         )
     body = CountOutcomesRequest(pocket_id=pocket_id, since=since)
     return await outcomes_service.count_outcomes(ctx.workspace_id or "", body)
+
+
+@router.get(
+    "/meter",
+    response_model=MeterOutcomesResponse,
+    dependencies=[Depends(require_action_any_workspace("outcomes.read"))],
+)
+async def meter_outcomes(
+    request: Request,
+    pocket_id: str | None = Query(default=None),
+    since: str | None = Query(default=None, description="ISO-8601 inclusive lower bound"),
+    until: str | None = Query(default=None, description="ISO-8601 exclusive upper bound"),
+    ctx: RequestContext = Depends(request_context),
+) -> MeterOutcomesResponse:
+    """Aggregate the caller's governed outcomes into a billable figure.
+
+    Sums ``outcome_value`` BY ``outcome_unit`` over the optional
+    ``pocket_id`` / ``since`` / ``until`` window — the "pay for governed
+    outcomes" read primitive. Tenancy comes from the auth context; a
+    ``workspace_id`` query param is rejected so a caller cannot meter
+    another workspace's ledger. This is a READ surface — no invoice, no
+    charge fires (deferred).
+    """
+    if "workspace_id" in request.query_params:
+        raise CloudError(
+            400,
+            "outcomes.workspace_id_forbidden",
+            "workspace_id is taken from auth context, not query",
+        )
+    body = MeterOutcomesRequest(pocket_id=pocket_id, since=since, until=until)
+    return await outcomes_service.meter_outcomes(ctx.workspace_id or "", body)

--- a/ee/pocketpaw_ee/cloud/outcomes/service.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/service.py
@@ -30,6 +30,18 @@
 #   listener so the test suite can pin the contract.
 #   `"decision.outcome_attached"` is used as a STRING LITERAL (the
 #   namespace registration in soul-protocol is parallel work — Slice 0).
+# Updated: 2026-06-11 (gap-3 outcome VALUE metering) — Layer 4 is no longer
+#   hardcoded `None`. `emit_pocket_outcome` now accepts `outcome_value` /
+#   `outcome_unit` (the author-time billable pair declared on the binding)
+#   and `record_outcome` persists them on the ledger row (via the defensive
+#   `_coerce_value` + whole-pair guard, so a torn half-pair degrades to a
+#   count-only row rather than corrupting the total). New `meter_outcomes`
+#   is the aggregation READ surface: it sums value BY unit over a
+#   since/until window per workspace and returns count + total_value per
+#   unit — the queryable "pay for governed outcomes" figure. Workspace-
+#   scoped with the same defense-in-depth tenant filter as `count_outcomes`.
+#   Deferred (NOT here): invoicing, payment, currency, pricing-rules engine,
+#   disputes/clawback (outcome-spec.md Decisions 4/5/7).
 from __future__ import annotations
 
 import json
@@ -42,7 +54,13 @@ from uuid import UUID, uuid4
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import PocketOutcomeEvent
 from pocketpaw_ee.cloud.outcomes.domain import OutcomeRecord
-from pocketpaw_ee.cloud.outcomes.dto import CountOutcomesRequest, OutcomeCountResponse
+from pocketpaw_ee.cloud.outcomes.dto import (
+    CountOutcomesRequest,
+    MeterOutcomesRequest,
+    MeterOutcomesResponse,
+    OutcomeCountResponse,
+    UnitMeter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +73,24 @@ def set_ledger_dir(path: str | Path) -> None:
     """Override the outcomes ledger directory (test seam)."""
     global _LEDGER_DIR
     _LEDGER_DIR = Path(path)
+
+
+def _coerce_value(raw: object) -> float | None:
+    """Coerce a raw outcome value to ``float``, or ``None`` if it can't be.
+
+    The value arrives off a bus event payload (or, on count, off a JSON
+    ledger row), so it may be ``int``, ``float``, a numeric string, or
+    junk. A bool is rejected explicitly — ``bool`` is an ``int`` subclass
+    in Python and ``True`` would silently become ``1.0``. Anything that
+    does not parse drops the row to count-only rather than corrupting the
+    billable total.
+    """
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        return float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
 
 
 def _ledger_path(workspace_id: str) -> Path:
@@ -78,6 +114,8 @@ async def emit_pocket_outcome(
     via_instinct: bool,
     instinct_action_id: str | None = None,
     decision_id: str | None = None,
+    outcome_value: float | None = None,
+    outcome_unit: str | None = None,
 ) -> None:
     """Emit a ``pocket.outcome`` event for a successful write action.
 
@@ -90,8 +128,14 @@ async def emit_pocket_outcome(
     event. ``emit`` itself never raises, so a bus failure here can never
     break the write that already succeeded.
 
-    ``outcome_value`` / ``outcome_unit`` are emitted as ``None`` — Layer 4
-    (billing) is reserved and this build never assigns a monetary value.
+    ``outcome_value`` / ``outcome_unit`` are the gap-3 billable-value pair.
+    A producer that resolved a per-action value (from the binding's
+    author-time declaration) passes them here; they ride the event onto the
+    ledger row so the aggregation surface can sum value BY unit per
+    workspace. Both default to ``None`` — a count-only outcome (no monetary
+    value) leaves the meter exactly as it was before pricing. The binding
+    validator guarantees the pair is whole (both set or both ``None``) by
+    the time it reaches here, so the meter never sees a value with no unit.
 
     ``decision_id`` is the RFC 07 Slice 2 back-reference — pass the id
     of the Decision in the decision graph that this outcome resolved,
@@ -114,9 +158,11 @@ async def emit_pocket_outcome(
                 "via_instinct": via_instinct,
                 "instinct_action_id": instinct_action_id,
                 "occurred_at": datetime.now(UTC).isoformat(),
-                # Layer 4 reserved — billing is not wired in this build.
-                "outcome_value": None,
-                "outcome_unit": None,
+                # gap-3 — the billable value/unit. `None`/`None` for a
+                # count-only outcome; a real figure when the binding
+                # declared one. The aggregation surface sums value by unit.
+                "outcome_value": outcome_value,
+                "outcome_unit": outcome_unit,
                 # RFC 07 Slice 2 — back-reference to the decision graph.
                 "decision_id": decision_id,
             }
@@ -148,6 +194,21 @@ async def record_outcome(event) -> None:  # type: ignore[no-untyped-def]
     decision_id_raw = data.get("decision_id")
     decision_id = str(decision_id_raw) if decision_id_raw else None
 
+    # gap-3 — the billable value/unit. The pair is whole or absent (the
+    # binding validator enforced it upstream), but `record_outcome` is the
+    # ledger's last gate and also runs on hand-published bus events, so be
+    # defensive: a value that does not coerce to float, or a value with no
+    # unit, is dropped to a count-only row rather than persisting a figure
+    # the aggregation cannot total.
+    outcome_value = _coerce_value(data.get("outcome_value"))
+    unit_raw = data.get("outcome_unit")
+    outcome_unit = str(unit_raw) if unit_raw else None
+    if outcome_value is None or outcome_unit is None:
+        # Half a pair (or none) → count-only row. Never persist a lone
+        # value or a lone unit; the rollup sums value strictly by unit.
+        outcome_value = None
+        outcome_unit = None
+
     record = OutcomeRecord(
         outcome=str(outcome),
         pocket_id=str(data.get("pocket_id") or ""),
@@ -157,9 +218,10 @@ async def record_outcome(event) -> None:  # type: ignore[no-untyped-def]
         via_instinct=bool(data.get("via_instinct")),
         instinct_action_id=data.get("instinct_action_id"),
         occurred_at=str(data.get("occurred_at") or ""),
-        # Layer 4 reserved — never set here.
-        outcome_value=None,
-        outcome_unit=None,
+        # gap-3 — persist the billable value/unit (replaces the hardcoded
+        # `None`). A count-only outcome leaves both `None`, the prior shape.
+        outcome_value=outcome_value,
+        outcome_unit=outcome_unit,
         # RFC 07 Slice 2 — back-reference into the decision graph.
         decision_id=decision_id,
     )
@@ -319,9 +381,95 @@ async def count_outcomes(
     return OutcomeCountResponse(total=total, by_outcome=by_outcome, by_pocket=by_pocket)
 
 
+async def meter_outcomes(
+    workspace_id: str,
+    body: MeterOutcomesRequest | dict | None = None,
+) -> MeterOutcomesResponse:
+    """Aggregate a workspace's governed outcomes into a billable figure.
+
+    This is the gap-3 "pay for governed outcomes" READ surface. It reads
+    the workspace JSONL ledger over the optional ``pocket_id`` /
+    ``since`` (inclusive) / ``until`` (EXCLUSIVE) window, then rolls the
+    value-bearing rows up BY unit: per unit it returns the count of
+    outcomes and the SUM of their ``outcome_value``. Count-only rows (no
+    value/unit) are tallied into ``total_outcomes`` but excluded from the
+    per-unit billable rollup — there is nothing to bill.
+
+    Workspace-scoped exactly like ``count_outcomes``: the file is keyed by
+    workspace, and a defense-in-depth filter drops any row whose
+    ``workspace_id`` does not match the caller's. A workspace with no
+    ledger returns a zeroed meter, not an error.
+
+    Deliberately NOT here: pricing rules, currency, invoicing, payment,
+    disputes/clawback. ``total_value`` is a raw sum of declared values, the
+    queryable primitive those layers will build on later.
+    """
+    body = MeterOutcomesRequest.model_validate(body or {})
+    path = _ledger_path(workspace_id)
+    if not workspace_id or not path.exists():
+        return MeterOutcomesResponse(total_outcomes=0, metered_count=0)
+
+    total_outcomes = 0
+    metered_count = 0
+    # Accumulate (count, summed_value) per unit before building the DTOs.
+    unit_count: dict[str, int] = {}
+    unit_value: dict[str, float] = {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                # Defense-in-depth tenant filter — same as count_outcomes.
+                if str(row.get("workspace_id") or "") != workspace_id:
+                    continue
+                if body.pocket_id is not None and row.get("pocket_id") != body.pocket_id:
+                    continue
+                occurred = str(row.get("occurred_at") or "")
+                if body.since is not None and occurred < body.since:
+                    continue
+                # `until` is an EXCLUSIVE upper bound so back-to-back
+                # periods never double-count a boundary outcome.
+                if body.until is not None and occurred >= body.until:
+                    continue
+
+                total_outcomes += 1
+
+                value = _coerce_value(row.get("outcome_value"))
+                unit_raw = row.get("outcome_unit")
+                unit = str(unit_raw) if unit_raw else None
+                # Only a WHOLE value/unit pair is billable. A count-only row
+                # (or a torn half-pair) contributes to total_outcomes only.
+                if value is None or unit is None:
+                    continue
+                metered_count += 1
+                unit_count[unit] = unit_count.get(unit, 0) + 1
+                unit_value[unit] = unit_value.get(unit, 0.0) + value
+    except OSError:
+        logger.warning("failed to read outcomes ledger %s", path, exc_info=True)
+        return MeterOutcomesResponse(total_outcomes=0, metered_count=0)
+
+    by_unit = {
+        unit: UnitMeter(unit=unit, count=count, total_value=unit_value[unit])
+        for unit, count in unit_count.items()
+    }
+    return MeterOutcomesResponse(
+        total_outcomes=total_outcomes,
+        metered_count=metered_count,
+        by_unit=by_unit,
+    )
+
+
 __all__ = [
     "emit_pocket_outcome",
     "record_outcome",
     "count_outcomes",
+    "meter_outcomes",
     "set_ledger_dir",
 ]

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -1,4 +1,14 @@
 # action_executor.py — Server-side executor for pocket WRITE actions.
+# Updated: 2026-06-11 (gap-3 outcome VALUE metering) — `ActionBinding` now
+#   declares `outcome_value: float | None` and `outcome_unit: str | None`,
+#   the author-time billable-value pair that turns the count-only outcome
+#   meter into the "pay for governed outcomes" pricing primitive. A
+#   `model_validator` (`_outcome_value_pairs_with_unit`) rejects a half-
+#   declared pair (value without unit / unit without value) and a value
+#   with no `outcome` name, so a ledger row the aggregation can never total
+#   never gets persisted. Both fields ride the same path `outcome` already
+#   travels — the gate `park`, the `_park` sentinel, and the direct success
+#   result — so the producers can thread them to `emit_pocket_outcome`.
 # Updated: 2026-06-10 (W2a — deny-by-default Instinct governance) —
 #   `ActionBinding.requires_instinct` now DEFAULTS to True. Every write
 #   binding routes through the Instinct approval gate (parks at gate 7)
@@ -260,6 +270,21 @@ class ActionBinding(BaseModel):
     requires_instinct: bool = True
     instinct_policy: Literal["approve_per_row", "approve_batch"] | None = None
     outcome: str | None = None
+    # --- gap-3 outcome VALUE metering (the "pay for governed outcomes"
+    # pricing primitive) -------------------------------------------------
+    # A named `outcome` is the COUNT; `outcome_value` + `outcome_unit` turn
+    # the count into a billable FIGURE. They are author-time declarations on
+    # the binding (the per-action-type rule from outcome-spec.md Decision 6
+    # / Decision 7: the operator declares what the work is worth). When set
+    # they ride the same end-to-end path `outcome` already travels — park →
+    # propose → execute → emit → ledger row — and persist on the outcome
+    # record (replacing the hardcoded `None` Layer-4 slots). When absent the
+    # record's value/unit stay `None` and the meter is count-only, exactly
+    # as before. `_outcome_value_pairs_with_unit` keeps the ledger clean: a
+    # value without a unit (or vice versa) is uncountable in the aggregation
+    # rollup, so reject the half-declared shape at parse time.
+    outcome_value: float | None = None
+    outcome_unit: str | None = None
     # W2a: explicit, auditable exemption. A binding the author deliberately
     # allows to fire WITHOUT the gate sets this True in the persisted spec.
     instinct_exempt: bool = False
@@ -296,6 +321,34 @@ class ActionBinding(BaseModel):
             raise ValueError(
                 "instinct_exempt is true but instinct_policy is set — an "
                 "exempt binding has no gate for a policy to apply to"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _outcome_value_pairs_with_unit(self) -> ActionBinding:
+        """A billable value needs a unit, and a unit needs a value (gap-3).
+
+        ``outcome_value`` / ``outcome_unit`` are the metering pair: the
+        aggregation rollup sums value BY unit, so a value with no unit
+        (or a unit with no value) is uncountable. Reject the half-declared
+        shape at parse time rather than persisting a ledger row the meter
+        can never total. Declaring NEITHER is fine — that's the count-only
+        binding (``outcome`` set, no monetary value), the prior behaviour.
+        A value also requires a named ``outcome``: there is no business
+        event to attach the value to without one.
+        """
+        has_value = self.outcome_value is not None
+        has_unit = self.outcome_unit is not None
+        if has_value != has_unit:
+            raise ValueError(
+                "outcome_value and outcome_unit must be declared together — "
+                "a value with no unit (or a unit with no value) cannot be "
+                "summed by the outcome aggregation"
+            )
+        if has_value and not self.outcome:
+            raise ValueError(
+                "outcome_value is set but no `outcome` name is declared — "
+                "a billable value needs a named outcome to attach to"
             )
         return self
 
@@ -666,6 +719,10 @@ async def run_action(
             "params": params,
             "idempotency_key": idempotency_key,
             "outcome": binding.outcome,
+            # gap-3 — the billable value/unit ride alongside `outcome` so
+            # the post-approval emit carries them to the ledger row.
+            "outcome_value": binding.outcome_value,
+            "outcome_unit": binding.outcome_unit,
         }
         gate = await instinct_dispatch.gate_action(
             workspace_id=workspace_id,
@@ -919,6 +976,11 @@ async def run_action(
                 "params": params,
                 "idempotency_key": idempotency_key,
                 "outcome": binding.outcome,
+                # gap-3 — billable value/unit ride on _park so the bridge
+                # stashes them on the persisted parked-write blob and the
+                # post-approval emit threads them to the ledger row.
+                "outcome_value": binding.outcome_value,
+                "outcome_unit": binding.outcome_unit,
                 # RFC 09 Slice 2 — correlation_id rides on _park so the
                 # bridge can stash it on the parked Action's schema-2
                 # _pocket_write blob. The Instinct router reads it back
@@ -1126,6 +1188,11 @@ async def run_action(
         # `pocket.outcome` event. `None` when the binding declares none;
         # the emit helper treats `None` as a no-op.
         "outcome": binding.outcome,
+        # gap-3 — the billable value/unit for the direct (non-gated) path.
+        # `None`/`None` when the binding declares no monetary value, leaving
+        # the meter count-only as before.
+        "outcome_value": binding.outcome_value,
+        "outcome_unit": binding.outcome_unit,
         "on_success": binding.on_success,
         "on_error": on_error,
     }

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
@@ -208,6 +208,11 @@ async def propose_pocket_write(
         "params": parked_write.get("params") or {},
         "idempotency_key": parked_write.get("idempotency_key"),
         "outcome": parked_write.get("outcome"),
+        # gap-3 — the billable value/unit declared on the binding. Persisted
+        # on the parked blob so `execute_approved_write` can thread them to
+        # the outcome ledger row after the human-approved write succeeds.
+        "outcome_value": parked_write.get("outcome_value"),
+        "outcome_unit": parked_write.get("outcome_unit"),
         "workspace_id": workspace_id,
         "requested_by": requested_by,
         # RFC 09 Slice 2 — schema-2 chain-correlation fields
@@ -622,6 +627,11 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
             actor=approver,
             via_instinct=True,
             instinct_action_id=str(action.id),
+            # gap-3 — the billable value/unit declared on the binding at
+            # author time, persisted on the parked blob and threaded here so
+            # the GOVERNED (human-approved) outcome carries a real figure.
+            outcome_value=blob.get("outcome_value"),
+            outcome_unit=blob.get("outcome_unit"),
         )
     except Exception:  # noqa: BLE001 — emit is best-effort; the write already succeeded
         logger.warning(

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -1114,6 +1114,9 @@ async def run_pocket_action(
             actor=user_id,
             via_instinct=False,
             instinct_action_id=None,
+            # gap-3 — billable value/unit for the direct (non-gated) write.
+            outcome_value=result.get("outcome_value"),
+            outcome_unit=result.get("outcome_unit"),
         )
 
     # Strip executor-internal keys (`_park`, `outcome`) the wire model
@@ -1123,7 +1126,15 @@ async def run_pocket_action(
     # assertion below catches a strip that drifts out of sync with the
     # executor's result keys; `RunActionResponse` is also `extra="forbid"`
     # so a missed key fails construction rather than leaking.
-    wire = {k: v for k, v in result.items() if k not in ("_park", "outcome")}
+    wire = {
+        k: v
+        for k, v in result.items()
+        # gap-3 — strip the metering keys too: `outcome_value`/`outcome_unit`
+        # join `outcome` as executor-internal fields the wire model
+        # (`extra="forbid"`) does not carry. They were already consumed by
+        # the `emit_pocket_outcome` call above.
+        if k not in ("_park", "outcome", "outcome_value", "outcome_unit")
+    }
     assert "_park" not in wire, "executor `_park` blob must be stripped before the wire response"
     return RunActionResponse(**wire)
 

--- a/tests/cloud/test_outcome_value_metering.py
+++ b/tests/cloud/test_outcome_value_metering.py
@@ -1,0 +1,294 @@
+# tests/cloud/test_outcome_value_metering.py — gap-3 outcome VALUE metering.
+# Created: 2026-06-11 — coverage for the "pay for governed outcomes"
+# pricing primitive: a governed outcome carrying a real billable
+# value/unit, persisted on the ledger row (replacing the hardcoded
+# Layer-4 `None`), and the `meter_outcomes` aggregation surface that sums
+# value BY unit per workspace over a period.
+#
+# What this pins:
+#   - emit_pocket_outcome threads outcome_value/outcome_unit onto the event.
+#   - record_outcome persists a WHOLE value/unit pair on the ledger row,
+#     and drops a torn half-pair (value-no-unit / unit-no-value) to a
+#     count-only row so the aggregation can never total a lone value.
+#   - meter_outcomes sums value by unit, counts metered vs total outcomes,
+#     honours the pocket_id / since / until window (until is EXCLUSIVE),
+#     and is WORKSPACE-ISOLATED.
+#   - the ActionBinding validator rejects a half-declared value/unit pair
+#     and a value with no `outcome` name, so a row the meter can't total
+#     never gets authored.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.realtime.events import PocketOutcomeEvent  # noqa: E402
+from pocketpaw_ee.cloud.outcomes import service as outcomes_service  # noqa: E402
+from pocketpaw_ee.cloud.outcomes.dto import MeterOutcomesRequest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _tmp_ledger(tmp_path):
+    """Point the outcomes ledger at a tmp dir so tests never touch ~/.pocketpaw."""
+    outcomes_service.set_ledger_dir(tmp_path / "outcomes")
+    yield
+    outcomes_service.set_ledger_dir("~/.pocketpaw/outcomes")
+
+
+def _valued_event(
+    *,
+    outcome: str = "renewal_completed",
+    workspace_id: str = "w1",
+    pocket_id: str = "p1",
+    action: str = "mark_renewed",
+    outcome_value: float | None = 1200.0,
+    outcome_unit: str | None = "usd",
+    occurred_at: str = "2026-06-01T10:00:00+00:00",
+) -> PocketOutcomeEvent:
+    return PocketOutcomeEvent(
+        data={
+            "outcome": outcome,
+            "pocket_id": pocket_id,
+            "workspace_id": workspace_id,
+            "action": action,
+            "actor": "u1",
+            "via_instinct": True,
+            "instinct_action_id": "a1",
+            "occurred_at": occurred_at,
+            "outcome_value": outcome_value,
+            "outcome_unit": outcome_unit,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# emit_pocket_outcome — value/unit ride the event
+# ---------------------------------------------------------------------------
+
+
+async def test_emit_threads_value_and_unit(monkeypatch):
+    emitted = []
+
+    async def _emit(event):
+        emitted.append(event)
+
+    monkeypatch.setattr(outcomes_service, "emit", _emit)
+    await outcomes_service.emit_pocket_outcome(
+        outcome="ticket_resolved",
+        pocket_id="p1",
+        workspace_id="w1",
+        action="close_ticket",
+        actor="u1",
+        via_instinct=True,
+        outcome_value=42.5,
+        outcome_unit="usd",
+    )
+    assert len(emitted) == 1
+    assert emitted[0].data["outcome_value"] == 42.5
+    assert emitted[0].data["outcome_unit"] == "usd"
+
+
+async def test_emit_defaults_value_unit_to_none(monkeypatch):
+    """A count-only outcome (no value/unit passed) emits null Layer-4 slots."""
+    emitted = []
+
+    async def _emit(event):
+        emitted.append(event)
+
+    monkeypatch.setattr(outcomes_service, "emit", _emit)
+    await outcomes_service.emit_pocket_outcome(
+        outcome="email_sent",
+        pocket_id="p1",
+        workspace_id="w1",
+        action="send",
+        actor="u1",
+        via_instinct=False,
+    )
+    assert emitted[0].data["outcome_value"] is None
+    assert emitted[0].data["outcome_unit"] is None
+
+
+# ---------------------------------------------------------------------------
+# record_outcome — persists a whole pair, drops a torn half-pair
+# ---------------------------------------------------------------------------
+
+
+async def test_record_persists_value_and_unit():
+    await outcomes_service.record_outcome(_valued_event(outcome_value=1200.0, outcome_unit="usd"))
+    meter = await outcomes_service.meter_outcomes("w1")
+    assert meter.metered_count == 1
+    assert meter.by_unit["usd"].total_value == 1200.0
+    assert meter.by_unit["usd"].count == 1
+
+
+async def test_record_drops_value_with_no_unit():
+    """A value with no unit cannot be summed — persisted as count-only."""
+    await outcomes_service.record_outcome(_valued_event(outcome_value=999.0, outcome_unit=None))
+    meter = await outcomes_service.meter_outcomes("w1")
+    # The outcome counts, but contributes no billable figure.
+    assert meter.total_outcomes == 1
+    assert meter.metered_count == 0
+    assert meter.by_unit == {}
+
+
+async def test_record_drops_unit_with_no_value():
+    """A unit with no value is likewise count-only."""
+    await outcomes_service.record_outcome(_valued_event(outcome_value=None, outcome_unit="usd"))
+    meter = await outcomes_service.meter_outcomes("w1")
+    assert meter.total_outcomes == 1
+    assert meter.metered_count == 0
+    assert meter.by_unit == {}
+
+
+async def test_record_rejects_bool_value():
+    """A bool value (int subclass) must not silently become 1.0."""
+    await outcomes_service.record_outcome(
+        _valued_event(outcome_value=True, outcome_unit="usd")  # type: ignore[arg-type]
+    )
+    meter = await outcomes_service.meter_outcomes("w1")
+    assert meter.metered_count == 0
+
+
+# ---------------------------------------------------------------------------
+# meter_outcomes — the aggregation surface
+# ---------------------------------------------------------------------------
+
+
+async def test_meter_sums_value_by_unit():
+    await outcomes_service.record_outcome(
+        _valued_event(outcome="renewal", outcome_value=1000.0, outcome_unit="usd")
+    )
+    await outcomes_service.record_outcome(
+        _valued_event(outcome="renewal", outcome_value=500.0, outcome_unit="usd")
+    )
+    await outcomes_service.record_outcome(
+        _valued_event(outcome="tickets", outcome_value=3.0, outcome_unit="ticket_resolved")
+    )
+    meter = await outcomes_service.meter_outcomes("w1")
+    assert meter.total_outcomes == 3
+    assert meter.metered_count == 3
+    assert meter.by_unit["usd"].count == 2
+    assert meter.by_unit["usd"].total_value == 1500.0
+    assert meter.by_unit["ticket_resolved"].count == 1
+    assert meter.by_unit["ticket_resolved"].total_value == 3.0
+
+
+async def test_meter_excludes_count_only_outcomes_from_rollup():
+    """Count-only outcomes raise total_outcomes but not metered_count/by_unit."""
+    await outcomes_service.record_outcome(_valued_event(outcome_value=200.0, outcome_unit="usd"))
+    await outcomes_service.record_outcome(
+        _valued_event(outcome="count_only", outcome_value=None, outcome_unit=None)
+    )
+    meter = await outcomes_service.meter_outcomes("w1")
+    assert meter.total_outcomes == 2
+    assert meter.metered_count == 1
+    assert meter.by_unit["usd"].total_value == 200.0
+
+
+async def test_meter_is_workspace_isolated():
+    """One workspace's value never leaks into another's billable figure."""
+    await outcomes_service.record_outcome(
+        _valued_event(workspace_id="w1", outcome_value=1000.0, outcome_unit="usd")
+    )
+    await outcomes_service.record_outcome(
+        _valued_event(workspace_id="w2", outcome_value=9999.0, outcome_unit="usd")
+    )
+    w1 = await outcomes_service.meter_outcomes("w1")
+    w2 = await outcomes_service.meter_outcomes("w2")
+    assert w1.by_unit["usd"].total_value == 1000.0
+    assert w2.by_unit["usd"].total_value == 9999.0
+
+
+async def test_meter_period_window_until_is_exclusive():
+    """`until` is an EXCLUSIVE upper bound; `since` an inclusive lower bound."""
+    await outcomes_service.record_outcome(
+        _valued_event(
+            outcome_value=10.0, outcome_unit="usd", occurred_at="2026-05-31T23:59:00+00:00"
+        )
+    )
+    await outcomes_service.record_outcome(
+        _valued_event(
+            outcome_value=20.0, outcome_unit="usd", occurred_at="2026-06-01T00:00:00+00:00"
+        )
+    )
+    await outcomes_service.record_outcome(
+        _valued_event(
+            outcome_value=40.0, outcome_unit="usd", occurred_at="2026-07-01T00:00:00+00:00"
+        )
+    )
+    # June only: since inclusive 06-01, until exclusive 07-01.
+    june = await outcomes_service.meter_outcomes(
+        "w1",
+        MeterOutcomesRequest(since="2026-06-01T00:00:00+00:00", until="2026-07-01T00:00:00+00:00"),
+    )
+    assert june.metered_count == 1
+    assert june.by_unit["usd"].total_value == 20.0
+
+
+async def test_meter_pocket_filter():
+    await outcomes_service.record_outcome(
+        _valued_event(pocket_id="p1", outcome_value=100.0, outcome_unit="usd")
+    )
+    await outcomes_service.record_outcome(
+        _valued_event(pocket_id="p2", outcome_value=300.0, outcome_unit="usd")
+    )
+    p1 = await outcomes_service.meter_outcomes("w1", MeterOutcomesRequest(pocket_id="p1"))
+    assert p1.by_unit["usd"].total_value == 100.0
+    assert p1.metered_count == 1
+
+
+async def test_meter_empty_ledger_is_zero():
+    meter = await outcomes_service.meter_outcomes("never-seen")
+    assert meter.total_outcomes == 0
+    assert meter.metered_count == 0
+    assert meter.by_unit == {}
+
+
+# ---------------------------------------------------------------------------
+# ActionBinding validator — a half-declared pair never gets authored
+# ---------------------------------------------------------------------------
+
+
+def _make_binding(**kw):
+    from pocketpaw_ee.cloud.pockets.action_executor import ActionBinding
+
+    base = {"method": "POST", "path": "/x"}
+    base.update(kw)
+    return ActionBinding(**base)
+
+
+def test_binding_accepts_whole_value_unit_pair():
+    b = _make_binding(outcome="renewal", outcome_value=1200.0, outcome_unit="usd")
+    assert b.outcome_value == 1200.0
+    assert b.outcome_unit == "usd"
+
+
+def test_binding_accepts_count_only():
+    """outcome with no value/unit is the count-only binding — still valid."""
+    b = _make_binding(outcome="email_sent")
+    assert b.outcome_value is None
+    assert b.outcome_unit is None
+
+
+def test_binding_rejects_value_without_unit():
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="declared together"):
+        _make_binding(outcome="renewal", outcome_value=1200.0)
+
+
+def test_binding_rejects_unit_without_value():
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="declared together"):
+        _make_binding(outcome="renewal", outcome_unit="usd")
+
+
+def test_binding_rejects_value_without_outcome_name():
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="named outcome"):
+        _make_binding(outcome_value=1200.0, outcome_unit="usd")


### PR DESCRIPTION
Makes "pay for governed outcomes" a real, queryable primitive instead of a slogan. Today the meter is count-only — `outcome_value`/`outcome_unit` were hardcoded None ("Layer 4 reserved") and there's no billable surface. (Token-usage metering went in separately; this is business-OUTCOME metering, the commercial anchor of the pricing thesis.)

Thin vertical slice. Draft for review — invoicing/payments/pricing-engine are deliberately later.

**Value source = the binding declaration.** An `ActionBinding` (the persisted author-time write spec) now declares `outcome_value` + `outcome_unit`. That pair rides the exact path the outcome name already travels — gate-park → propose → human-approved execute → record_outcome ledger row — so a metered value only ever exists for a *governed* outcome. A validator rejects a half-declared pair (value-no-unit, unit-no-value) or a value with no outcome name, and `record_outcome` defensively drops a torn pair to a count-only row, so the rollup never sums a lone value.

**Billable aggregation:** new `GET /api/v1/outcomes/meter` (+ `meter_outcomes` service) sums value by unit per workspace over a since/until window, returning total_outcomes, metered_count, and by_unit (count + total_value). Same tenant filter + workspace_id-query rejection as the existing count endpoint. Docs added to api-reference.md.

**Tested:** 17 metering tests (value/unit threading + persistence, whole-pair-or-drop, sum-by-unit, count-only excluded, workspace isolation, until-exclusive window, pocket filter) + 48 producer regression (executor/bridge/dispatch). Import boundary intact.

**Honestly deferred:** invoicing, payment, currency conversion, a pricing-rules engine, disputes/clawback, a value catalog with per-unit price validation, anti-spam rate-limiting. `total_value` is the raw declared sum those layers build on.

Note: two `test_pocket_outcomes.py` route tests (`test_get_outcomes_counts`, `..._rejects_workspace_id_query`) fail on this branch — verified they fail **identically on clean dev** (a pre-existing 401 auth-fixture limitation, not this change). Metering logic is covered at the service + binding-model layer, which exercises the real producer signature.
