### PR TITLE
Belt: create new repositories and land changes without a remote

### DIFF
--- a/ee/pocketpaw_ee/cloud/belt/executor.py
+++ b/ee/pocketpaw_ee/cloud/belt/executor.py
@@ -1,6 +1,19 @@
 # executor.py — applies an approved Belt code-change Action and opens a PR.
 # Created: 2026-06-10 (feat/belt-gate, BS-3).
 #
+# Updated: 2026-06-11 (feat/belt-repo-init — local-only gate mode) — the executor
+#   now lands a change on a repo with NO ``origin`` remote WITHOUT pushing or
+#   opening a PR. ``_has_origin`` is checked once up front (step 0): with a remote
+#   the worktree bases on ``origin/<base>`` and the push + PR path runs as before;
+#   with no remote the worktree bases on the LOCAL ``<base>`` ref, the push + PR
+#   steps are SKIPPED, and ``_land_local_only`` records the executed outcome
+#   carrying the ``branch`` + ``commit_sha`` instead of a ``pr_url``. The branch is
+#   promoted into the real repo (``git branch <branch> <sha>``) so it survives the
+#   worktree teardown. ``_persist_run_result`` back-writes branch + commit_sha (and
+#   NOT pr_url) so the runs read model emits ``pr_url=None`` and the page renders a
+#   branch chip; ``belt_run_updated`` still fires (landed/done, no pr_url); the
+#   Decision-Graph chain still closes once. The with-remote path is unchanged.
+#
 # Updated: 2026-06-10 (feat/belt-console-backend, SC-2 — runs read model + SSE) —
 #   the executor now feeds the /belt console two things:
 #     * STRUCTURED outcome on the blob — on a SUCCESSFUL apply it back-writes
@@ -52,15 +65,20 @@
 #   2. RE-resolves the repo path against the allowlist (defense in depth — the
 #      allowlist may have tightened between propose and approve).
 #   3. Creates a FRESH git worktree (one per action id, under a tmp dir; NEVER
-#      the repo's live checkout) at ``origin/<base_branch>`` after a fetch.
+#      the repo's live checkout). WITH a remote: at ``origin/<base_branch>`` after
+#      a fetch. LOCAL-ONLY (no origin): DETACHED at the local ``<base_branch>``
+#      commit (never the branch name, which the live working tree holds).
 #   4. ``git apply --3way`` the diff (written to a temp FILE — never echoed/
 #      interpolated into a shell).
 #   5. Branches ``feat/belt-<action-id-short>``, commits (Conventional Commits;
-#      the agent's summary as the body; NO AI attribution), pushes.
-#   6. Opens a PR via an injectable opener (default shells ``gh pr create``;
-#      tests inject a fake).
-#   7. ``mark_executed`` with outcome ``{pr_url, branch, files_changed}``.
-#   8. ALWAYS removes the worktree — on success or any failure. On apply
+#      the agent's summary as the body; NO AI attribution).
+#   6a. WITH a remote — pushes, opens a PR via an injectable opener (default
+#       shells ``gh pr create``; tests inject a fake), ``mark_executed`` with
+#       outcome ``{pr_url, branch, files_changed}``.
+#   6b. LOCAL-ONLY (no origin) — NO push, NO PR. Promotes the belt branch into
+#       the real repo and ``mark_executed`` with outcome ``{branch, commit_sha,
+#       files_changed}`` (no pr_url). ``belt_run_updated`` still fires (landed).
+#   7. ALWAYS removes the worktree — on success or any failure. On apply
 #      conflict / any error → ``mark_failed`` with a clear outcome (the agent /
 #      user can re-propose); never leave half-state.
 #
@@ -265,6 +283,7 @@ def _emit_chain_close(
     causation_id: Any | None,
     pr_url: str | None = None,
     branch: str | None = None,
+    commit_sha: str | None = None,
     files_changed: int | None = None,
 ) -> None:
     """Emit the ``decision.completed`` chain-close for a Belt code-change run.
@@ -309,6 +328,8 @@ def _emit_chain_close(
         payload["pr_url"] = pr_url
     if branch:
         payload["branch"] = branch
+    if commit_sha:
+        payload["commit_sha"] = commit_sha
     if files_changed is not None:
         payload["files_changed"] = files_changed
 
@@ -364,18 +385,25 @@ async def _persist_run_result(
     *,
     store: Any,
     action_id: str,
-    pr_url: str,
     branch: str,
     files_changed: int,
+    pr_url: str | None = None,
+    commit_sha: str | None = None,
 ) -> None:
-    """Back-write the PR result onto the persisted ``_code_change`` blob.
+    """Back-write the apply result onto the persisted ``_code_change`` blob.
 
-    The runs read model reads ``pr_url`` / ``branch`` / ``files_changed`` off the
-    blob STRUCTURALLY rather than parsing the free-text ``mark_executed``
-    outcome. Direct SQL update — the same pattern belt.py's ``_persist_chain_ids``
-    uses for the propose-time chain ids. Best-effort: a write failure leaves the
-    run without the structured fields (the read model falls back to None) but
-    never breaks the approve response.
+    The runs read model reads ``pr_url`` / ``branch`` / ``commit_sha`` /
+    ``files_changed`` off the blob STRUCTURALLY rather than parsing the free-text
+    ``mark_executed`` outcome. Direct SQL update — the same pattern belt.py's
+    ``_persist_chain_ids`` uses for the propose-time chain ids. Best-effort: a
+    write failure leaves the run without the structured fields (the read model
+    falls back to None) but never breaks the approve response.
+
+    Two landing shapes share this writer:
+      * WITH-REMOTE — ``pr_url`` + ``branch`` are set; ``commit_sha`` is omitted.
+      * LOCAL-ONLY (no ``origin``) — ``branch`` + ``commit_sha`` are set; ``pr_url``
+        stays absent so the read model emits ``pr_url=None`` and the page renders
+        a branch chip instead of a PR link.
     """
     import json as _json
 
@@ -390,9 +418,15 @@ async def _persist_run_result(
         if not isinstance(blob, dict):
             return
         blob = dict(blob)
-        blob["pr_url"] = pr_url
         blob["branch"] = branch
         blob["files_changed"] = files_changed
+        # Only set the fields that apply to THIS landing shape — never write a
+        # null pr_url over a real one (and vice-versa). The read model treats an
+        # absent key the same as None.
+        if pr_url is not None:
+            blob["pr_url"] = pr_url
+        if commit_sha is not None:
+            blob["commit_sha"] = commit_sha
         params[_CODE_CHANGE_PARAM_KEY] = blob
 
         async with aiosqlite.connect(store._db_path) as db:
@@ -524,21 +558,48 @@ async def execute_approved_change(
     worktree_created = False
 
     try:
-        # 1. Fetch the latest base so we branch off the freshest origin tip.
-        code, _out, err = await _run(["git", "fetch", "origin", base_branch], cwd=repo_path)
-        if code != 0:
-            await _fail(
-                f"git fetch origin {base_branch} failed: {err.strip()[:300]}",
-                error_class="GitFetchFailed",
-            )
-            return
+        # 0. LOCAL-ONLY DETECTION — does the repo have an ``origin`` remote? A
+        #    repo with no origin is a local-only landing: we branch off the LOCAL
+        #    base ref (never ``origin/<base>``, which doesn't exist) and skip the
+        #    push + PR entirely (handled after the commit, step 6).
+        has_origin = await _has_origin(repo_path)
 
-        # 2. Fresh worktree at origin/<base_branch>. If the dir somehow exists
-        #    from a prior crash, remove it first so add doesn't refuse.
+        # 1. With a remote: fetch the latest base so we branch off the freshest
+        #    origin tip, then base the worktree on ``origin/<base>`` (a remote-
+        #    tracking ref — ``worktree add`` checks it out DETACHED, never as a
+        #    local branch). Local-only: no fetch, resolve the LOCAL ``<base>``
+        #    branch to its commit sha so the worktree can check it out DETACHED —
+        #    we MUST NOT ``worktree add`` a local branch name that is already
+        #    checked out in the repo's live working tree (git refuses it).
+        if has_origin:
+            code, _out, err = await _run(["git", "fetch", "origin", base_branch], cwd=repo_path)
+            if code != 0:
+                await _fail(
+                    f"git fetch origin {base_branch} failed: {err.strip()[:300]}",
+                    error_class="GitFetchFailed",
+                )
+                return
+            worktree_base = f"origin/{base_branch}"
+        else:
+            code, out, err = await _run(
+                ["git", "rev-parse", "--verify", base_branch], cwd=repo_path
+            )
+            if code != 0:
+                await _fail(
+                    f"local base branch {base_branch!r} not found: {err.strip()[:300]}",
+                    error_class="BaseBranchNotFound",
+                )
+                return
+            worktree_base = out.strip()
+
+        # 2. Fresh worktree DETACHED at the base ref. If the dir somehow exists
+        #    from a prior crash, remove it first so add doesn't refuse. ``--detach``
+        #    keeps it a detached HEAD so step 3 can create the belt branch without
+        #    colliding with a branch already checked out in the live working tree.
         if worktree_dir.exists():
             await _force_remove_worktree(repo_path, worktree_dir)
         code, _out, err = await _run(
-            ["git", "worktree", "add", str(worktree_dir), f"origin/{base_branch}"],
+            ["git", "worktree", "add", "--detach", str(worktree_dir), worktree_base],
             cwd=repo_path,
         )
         if code != 0:
@@ -603,13 +664,37 @@ async def execute_approved_change(
             await _fail(f"git commit failed: {err.strip()[:300]}", error_class="GitCommitFailed")
             return
 
-        # 6. Push the branch.
+        commit_sha = await _head_sha(worktree_dir)
+
+        # 6. LOCAL-ONLY GATE MODE — a repo with NO ``origin`` remote can't be
+        #    pushed and has no PR target. Approve = apply + commit on the belt
+        #    branch LOCALLY. We detected the missing remote BEFORE the push step
+        #    (step 0) so the push / PR path is skipped entirely (never attempted).
+        #    The outcome carries the branch + commit sha instead of a pr_url; the
+        #    run still lands as executed and ``belt_run_updated`` still fires.
+        if not has_origin:
+            await _land_local_only(
+                store=store,
+                action=action,
+                worktree_dir=worktree_dir,
+                repo_path=repo_path,
+                branch=branch,
+                commit_sha=commit_sha,
+                files_changed=files_changed,
+                workspace_id=workspace_id,
+                requested_by=requested_by,
+                correlation_id=correlation_id,
+                causation=causation,
+            )
+            return
+
+        # 7. Push the branch.
         code, _out, err = await _run(["git", "push", "-u", "origin", branch], cwd=worktree_dir)
         if code != 0:
             await _fail(f"git push failed: {err.strip()[:300]}", error_class="GitPushFailed")
             return
 
-        # 7. Open the PR via the injectable opener.
+        # 8. Open the PR via the injectable opener.
         try:
             pr_url = await opener.open_pr(
                 repo_path=worktree_dir,
@@ -629,7 +714,7 @@ async def execute_approved_change(
             )
             return
 
-        # 8. Mark executed with the structured outcome.
+        # 9. Mark executed with the structured outcome.
         await store.mark_executed(
             action.id,
             f"PR opened: {pr_url} (branch '{branch}', {len(files_changed)} file(s) changed)",
@@ -641,9 +726,9 @@ async def execute_approved_change(
         await _persist_run_result(
             store=store,
             action_id=str(action.id),
-            pr_url=pr_url,
             branch=branch,
             files_changed=len(files_changed),
+            pr_url=pr_url,
         )
         # SC-2 — publish ``belt_run_updated`` (status=landed, stage=done) on the
         # workspace bus so the /belt page reflects the landed PR live. Best-effort.
@@ -703,6 +788,124 @@ async def _changed_files(worktree_dir: Path) -> list[str]:
     if code != 0:
         return []
     return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+async def _has_origin(cwd: Path) -> bool:
+    """True when the repo has an ``origin`` remote (``git remote get-url origin``
+    exits 0). A repo with no origin is a LOCAL-ONLY landing — the executor skips
+    the push + PR and lands the change on the belt branch locally. Checked once
+    up front against the repo (the worktree shares the repo's remotes)."""
+    code, _out, _err = await _run(["git", "remote", "get-url", "origin"], cwd=cwd)
+    return code == 0
+
+
+async def _head_sha(worktree_dir: Path) -> str:
+    """Resolve the worktree's current HEAD commit sha (``git rev-parse HEAD``).
+    Returns the full sha, or ``""`` on any error — the local-only outcome still
+    records the branch even if the sha read fails."""
+    code, out, _err = await _run(["git", "rev-parse", "HEAD"], cwd=worktree_dir)
+    if code != 0:
+        return ""
+    return out.strip()
+
+
+async def _land_local_only(
+    *,
+    store: Any,
+    action: Any,
+    worktree_dir: Path,
+    repo_path: Path,
+    branch: str,
+    commit_sha: str,
+    files_changed: list[str],
+    workspace_id: str,
+    requested_by: str,
+    correlation_id: Any | None,
+    causation: Any | None,
+) -> None:
+    """Land a local-only (no-origin) Belt code change.
+
+    The change is already committed on ``branch`` in the throwaway worktree. A
+    local-only repo has no push target and no PR, so we promote the branch into
+    the REAL repo (``git branch <branch> <sha>`` run in ``repo_path``) so the
+    landed branch survives the worktree teardown, then record the executed
+    outcome carrying the branch + commit sha INSTEAD of a pr_url:
+
+      * ``mark_executed`` free-text outcome names the branch + sha (The Tray).
+      * ``_persist_run_result`` back-writes ``branch`` + ``commit_sha`` (and NOT
+        ``pr_url``) onto the blob so the runs read model surfaces them
+        structurally and emits ``pr_url=None`` — the page renders a branch chip.
+      * ``belt_run_updated`` fires (status=landed, stage=done) with NO pr_url.
+      * the Decision-Graph chain closes once (``action_outcome="landed"``) with
+        the branch + sha on the payload (no pr_url).
+
+    Mirrors the with-remote success terminal exactly (one mark_executed, one
+    persist, one emit, one chain-close) so the runs read model and the Tray stay
+    consistent across both landing shapes.
+    """
+    n_files = len(files_changed)
+
+    # Promote the worktree branch into the real repo so it outlives the worktree
+    # teardown in the finally block. ``git worktree remove`` would otherwise drop
+    # the only ref to the commit. Best-effort: a failure here still records the
+    # outcome (the commit object survives, reachable by sha) but logs the gap.
+    if commit_sha:
+        code, _out, err = await _run(["git", "branch", branch, commit_sha], cwd=repo_path)
+        if code != 0:
+            logger.warning(
+                "belt: could not promote local-only branch %s in repo %s: %s",
+                branch,
+                repo_path,
+                err.strip()[:200],
+            )
+
+    await store.mark_executed(
+        action.id,
+        (
+            f"Committed locally on branch '{branch}' "
+            f"({commit_sha[:12] or 'unknown'}, {n_files} file(s) changed). "
+            "No origin remote — not pushed, no PR opened."
+        ),
+    )
+    # Back-write branch + commit_sha (NOT pr_url) so the runs read model reads
+    # them structurally and surfaces pr_url=None for the page's branch chip.
+    await _persist_run_result(
+        store=store,
+        action_id=str(action.id),
+        branch=branch,
+        files_changed=n_files,
+        commit_sha=commit_sha,
+    )
+    # Publish belt_run_updated (status=landed, stage=done) — NO pr_url for a
+    # local-only landing. Best-effort.
+    await _emit_run_updated(
+        workspace_id=workspace_id,
+        action_id=str(action.id),
+        status="landed",
+        stage="done",
+    )
+    # Close the Decision-Graph chain once on the success path — branch + sha
+    # ride the payload (no pr_url) for the explain narrator.
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=requested_by,
+        causation_id=causation,
+        branch=branch,
+        commit_sha=commit_sha,
+        files_changed=n_files,
+    )
+    logger.info(
+        "belt: applied local-only code_change action %s → branch %s, %d file(s), sha %s",
+        action.id,
+        branch,
+        n_files,
+        commit_sha[:12] or "unknown",
+    )
 
 
 async def _force_remove_worktree(repo_path: Path, worktree_dir: Path) -> None:

--- a/ee/pocketpaw_ee/cloud/belt/router.py
+++ b/ee/pocketpaw_ee/cloud/belt/router.py
@@ -4,8 +4,16 @@
 # endpoints (a sibling frontend PR pins the contract):
 #   * GET  /belt/repos          — discover git repos under the allowlist roots
 #   * POST /belt/repos {path}   — add a new repo root (admin/owner-gated)
+#   * POST /belt/repos/init     — CREATE a new git repo under an allowlist root
+#                                 (admin-gated); optional GitHub remote
 #   * GET  /belt/runs           — list this workspace's station runs (newest-first)
 #   * GET  /belt/runs/{action_id} — one run + its proposed diff (capped ~200 KB)
+#
+# Updated: 2026-06-11 (feat/belt-repo-init) — added ``POST /belt/repos/init``.
+# Same ADMIN gate as the add-repo mutation (``belt.manage``) and the same
+# realpath discipline (the service validates the name + location_root). The
+# ``RepoCreator`` is injected via a dependency so tests can fake the ``gh repo
+# create`` shell-out; production gets the default ``GhCliRepoCreator``.
 #
 # Routes are THIN: they read identity (workspace + user) from the cloud deps,
 # delegate to ``ee.cloud.belt.service``, and return the wire dict the service
@@ -50,6 +58,32 @@ class AddRepoRequest(BaseModel):
     path: str = Field(min_length=1)
 
 
+class InitRepoRequest(BaseModel):
+    """Body for ``POST /belt/repos/init`` — create a brand-new git repository.
+
+    * ``name`` — the new repo's directory name. Must be a safe single segment
+      (``[a-z0-9._-]``, no path separators); the service validates it.
+    * ``location_root`` — an existing directory UNDER an allowlist root the new
+      repo dir is created in. The service realpath-resolves it and requires
+      containment.
+    * ``create_remote`` — when true, also create + push a private GitHub remote
+      via ``gh repo create``. A remote failure keeps the local repo and returns
+      a ``remote_error`` message; the local init is never rolled back.
+    """
+
+    name: str = Field(min_length=1)
+    location_root: str = Field(min_length=1)
+    create_remote: bool = False
+
+
+def repo_creator_dep() -> belt_service.RepoCreator | None:
+    """Provide the ``RepoCreator`` for the init route. Production returns ``None``
+    so the service uses its default ``GhCliRepoCreator``; tests override this
+    dependency to inject a fake that records the ``gh repo create`` args without
+    touching GitHub (mirrors how the executor's ``PrOpener`` is faked)."""
+    return None
+
+
 def _to_cloud_error(exc: belt_service.BeltConsoleError) -> CloudError:
     """Map a service ``BeltConsoleError`` to the cloud error envelope.
 
@@ -91,6 +125,45 @@ async def add_repo(
     """
     try:
         return await belt_service.add_repo(workspace_id, body.path)
+    except belt_service.BeltConsoleError as exc:
+        raise _to_cloud_error(exc) from exc
+
+
+@router.post("/repos/init")
+async def init_repo(
+    body: InitRepoRequest,
+    _user: Any = Depends(require_action_any_workspace("belt.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+    repo_creator: belt_service.RepoCreator | None = Depends(repo_creator_dep),
+) -> dict[str, Any]:
+    """Create a brand-new git repository under an allowlist root (admin/owner-
+    gated, ``belt.manage``).
+
+    Validates ``name`` is a safe directory segment and ``location_root`` resolves
+    UNDER an authorized allowlist root, refuses an already-existing target,
+    ``git init`` + seeds a README + initial commit (so the repo has a HEAD and a
+    default branch), and registers the new repo via the same persistence the
+    add-repo route uses. Returns ``{"repo": {path, name, current_branch,
+    branches}}`` — the same repo shape the registry returns.
+
+    With ``create_remote=true`` the route also creates + pushes a private GitHub
+    remote via ``gh repo create``. IMPORTANT: a remote-creation failure does NOT
+    roll back the local repo — it returns 200 with the repo plus a top-level
+    ``remote_error`` message (the frontend shows it inline) so the local work is
+    never lost.
+
+    4xx with a clear, path-free message on: an invalid name (not a safe
+    dirname), a ``location_root`` outside the allowlist, an already-existing
+    target dir, or a git-init / commit failure.
+    """
+    try:
+        return await belt_service.init_repo(
+            workspace_id,
+            name=body.name,
+            location_root=body.location_root,
+            create_remote=body.create_remote,
+            repo_creator=repo_creator,
+        )
     except belt_service.BeltConsoleError as exc:
         raise _to_cloud_error(exc) from exc
 

--- a/ee/pocketpaw_ee/cloud/belt/service.py
+++ b/ee/pocketpaw_ee/cloud/belt/service.py
@@ -5,6 +5,17 @@
 # instead of the agent asking, (2) ADD a new repo root durably (admin-gated),
 # (3) read STATION RUNS + a run's diff so the page can show status/output.
 #
+# Updated: 2026-06-11 (feat/belt-repo-init) — added ``init_repo``: create a
+# brand-new git REPOSITORY under an allowlisted root (admin-gated, same RBAC +
+# realpath discipline as add_repo), seed a README + initial commit so it has a
+# HEAD and a default branch, register it via the same persistence add_repo uses,
+# and (optionally) create the GitHub remote via the injectable ``RepoCreator``
+# (default ``GhCliRepoCreator`` shells ``gh repo create --private --source --push``,
+# mirroring the executor's ``GhCliPrOpener`` injectable). A remote-creation
+# failure KEEPS the local repo and returns a ``remote_error`` message — the local
+# init is never rolled back. The runs read model (_run_summary) now also surfaces
+# ``commit_sha`` for local-only (no-origin) landings, where ``pr_url`` is None.
+#
 # What lives here:
 #   * ``resolve_allowlist_roots(workspace_id)`` — the union of
 #     ``settings.belt_repo_allowlist`` and the per-workspace persisted extension
@@ -45,8 +56,9 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +73,16 @@ MAX_BRANCHES = 20
 # here so the console service has no import dependency on the agent-side MCP
 # module (the OSS-EE boundary keeps the agent layer out of the cloud read path).
 _CODE_CHANGE_PARAM_KEY = "_code_change"
+
+# A repo name must be a SINGLE safe directory segment — lowercase alphanumerics
+# plus ``. _ -``, no path separators, no leading dot. This is the security
+# contract for the init route: the name is joined onto an allowlisted
+# ``location_root`` to form the target dir, so it must NOT be able to traverse
+# (``..``), absolutize (``/foo``), or smuggle a separator. The realpath +
+# containment check after the join is the second line of defense.
+_REPO_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+# A repo name capped well under any filesystem limit; keeps the dir name sane.
+_MAX_REPO_NAME = 100
 
 
 async def emit_belt_run_updated(
@@ -358,6 +380,244 @@ async def _persist_root(workspace_id: str, resolved_path: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# init_repo — create a brand-new git repo under an allowlisted root, register it
+# ---------------------------------------------------------------------------
+
+
+class RepoCreator(Protocol):
+    """Injectable remote-repo creator (mirrors the executor's ``PrOpener``).
+
+    The default implementation shells ``gh repo create`` from the new repo dir;
+    tests inject a fake to assert the call args without touching GitHub. Raises
+    on any failure so the init route can record a ``remote_error`` while keeping
+    the local repo. ``gh`` reads the authenticated token from the environment —
+    no secret is ever passed on the command line."""
+
+    async def create_remote(self, *, repo_path: Path, name: str) -> None: ...
+
+
+class GhCliRepoCreator:
+    """Default ``RepoCreator`` — shells ``gh repo create --private --source
+    <path> --push`` from the new repo dir.
+
+    Mirrors the executor's ``GhCliPrOpener``: argv-only (never ``shell=True``,
+    never string interpolation), the name + path are literal argv elements, and
+    ``gh`` reads its token from the environment. Raises ``RuntimeError`` on a
+    non-zero exit so the caller records the remote failure without rolling back
+    the local repo."""
+
+    async def create_remote(self, *, repo_path: Path, name: str) -> None:
+        from pocketpaw_ee.cloud.belt.executor import _run
+
+        code, out, err = await _run(
+            [
+                "gh",
+                "repo",
+                "create",
+                name,
+                "--private",
+                "--source",
+                str(repo_path),
+                "--push",
+            ],
+            cwd=repo_path,
+        )
+        if code != 0:
+            raise RuntimeError(f"gh repo create failed (exit {code}): {err.strip() or out.strip()}")
+
+
+def _validate_repo_name(name: str) -> str:
+    """Validate ``name`` is a safe single directory segment, return it stripped.
+
+    Rejects (with a clear, path-free message) an empty name, a name with a path
+    separator, a name that starts with a dot or hyphen, a too-long name, or any
+    character outside ``[a-z0-9._-]``. This is the first security gate on the
+    init route — the validated name is joined onto an allowlisted root to form
+    the target dir, so it must never traverse or absolutize."""
+    if not isinstance(name, str) or not name.strip():
+        raise BeltConsoleError(400, "A repository name is required.")
+    candidate = name.strip()
+    if len(candidate) > _MAX_REPO_NAME:
+        raise BeltConsoleError(
+            400, f"Repository name must be {_MAX_REPO_NAME} characters or fewer."
+        )
+    if "/" in candidate or "\\" in candidate or candidate in (".", ".."):
+        raise BeltConsoleError(
+            400, "Repository name cannot contain path separators or be '.' / '..'."
+        )
+    if not _REPO_NAME_RE.match(candidate):
+        raise BeltConsoleError(
+            400,
+            "Repository name must start with a letter or digit and use only "
+            "lowercase letters, digits, '.', '_', or '-'.",
+        )
+    return candidate
+
+
+async def _resolve_location_root(workspace_id: str, raw_root: str) -> Path:
+    """Resolve ``raw_root`` and require it to be an existing dir INSIDE one of
+    the workspace's allowlist roots. Returns the resolved root.
+
+    The containment check runs on the REALPATH so a ``..`` in the submission
+    can't escape the boundary. A root outside every allowlist root, or one that
+    doesn't exist, is refused with a path-free 400 (we never confirm whether an
+    out-of-bounds path exists)."""
+    if not isinstance(raw_root, str) or not raw_root.strip():
+        raise BeltConsoleError(400, "A location is required.")
+    try:
+        resolved = Path(raw_root).expanduser().resolve()
+    except (OSError, RuntimeError):
+        logger.warning("belt: init_repo rejected an unresolvable location root for workspace")
+        raise BeltConsoleError(400, "That location could not be resolved.") from None
+
+    roots = await resolve_allowlist_roots(workspace_id)
+    if not _is_within_roots(resolved, roots):
+        # Don't leak whether the out-of-bounds path exists — same message either way.
+        raise BeltConsoleError(400, "That location is not under an authorized root.")
+    if not resolved.is_dir():
+        raise BeltConsoleError(400, "That location does not exist or is not a directory.")
+    return resolved
+
+
+def _is_within_roots(path: Path, roots: list[Path]) -> bool:
+    """True when ``path`` is inside (or equal to) one of the allowlist ``roots``.
+    ``path`` MUST already be resolved by the caller. Mirrors the MCP resolver's
+    ``_is_within_allowlist``."""
+    for root in roots:
+        try:
+            path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+async def init_repo(
+    workspace_id: str,
+    *,
+    name: str,
+    location_root: str,
+    create_remote: bool,
+    repo_creator: RepoCreator | None = None,
+) -> dict[str, Any]:
+    """Create a brand-new git repo under an allowlisted root and register it.
+
+    Steps (each failure raises a path-free ``BeltConsoleError`` BEFORE any
+    filesystem mutation it would have to roll back):
+      1. validate ``name`` is a safe single dir segment (no separators / ``..``).
+      2. resolve ``location_root`` and require it under the workspace allowlist.
+      3. refuse if ``<location_root>/<name>`` already exists.
+      4. ``git init`` (argv-only subprocess — never ``shell=True``).
+      5. seed a minimal ``README.md`` (the repo name) and commit it so the repo
+         has a HEAD + a default branch.
+      6. register the new repo path via the same persistence ``add_repo`` uses
+         (``_persist_root``) so discovery + the code-change boundary pick it up.
+      7. if ``create_remote`` — shell ``gh repo create ... --push`` via the
+         injectable ``RepoCreator``. On remote FAILURE the LOCAL repo is KEPT and
+         the response carries a ``remote_error`` message (the frontend shows it
+         inline); the local init is NEVER rolled back.
+
+    Returns ``{"repo": {path, name, current_branch, branches}}`` (the standard
+    repo shape the registry returns) plus an optional top-level ``remote_error``
+    string when a requested remote creation failed.
+    """
+    safe_name = _validate_repo_name(name)
+    root = await _resolve_location_root(workspace_id, location_root)
+    target = root / safe_name
+
+    if target.exists():
+        raise BeltConsoleError(400, f"A directory named '{safe_name}' already exists there.")
+
+    from pocketpaw_ee.cloud.belt.executor import _run
+
+    # 4. Create the dir + git init. We make the dir ourselves so a partial init
+    #    leaves an obvious, removable artifact (no surprise reuse of an existing
+    #    path — we already refused an existing target above).
+    try:
+        target.mkdir(parents=False, exist_ok=False)
+    except OSError:
+        logger.warning("belt: init_repo could not create the target dir for workspace")
+        raise BeltConsoleError(400, "Could not create the repository directory.") from None
+
+    code, _out, err = await _run(["git", "init"], cwd=target)
+    if code != 0:
+        # Clean up the empty dir we just made so a retry isn't blocked.
+        _safe_rmdir(target)
+        raise BeltConsoleError(400, f"git init failed: {err.strip()[:200]}")
+
+    # 5. Seed README.md and make the initial commit so the repo has a HEAD and a
+    #    default branch (an empty repo has neither, which breaks discovery's
+    #    branch read and a later code-change base).
+    try:
+        (target / "README.md").write_text(f"# {safe_name}\n", encoding="utf-8")
+    except OSError:
+        _safe_rmdir(target)
+        raise BeltConsoleError(400, "Could not seed the repository README.") from None
+
+    code, _out, err = await _run(["git", "add", "README.md"], cwd=target)
+    if code != 0:
+        _safe_rmdir(target)
+        raise BeltConsoleError(400, f"git add failed: {err.strip()[:200]}")
+    # Stamp a deterministic committer identity via ``-c`` flags so the seed commit
+    # lands even when the host has no global git ``user.name`` / ``user.email``
+    # (a bare server / CI). argv-only — the identity is literal argv, never a
+    # shell string.
+    code, _out, err = await _run(
+        [
+            "git",
+            "-c",
+            "user.name=PocketPaw Belt",
+            "-c",
+            "user.email=belt@pocketpaw.local",
+            "commit",
+            "-m",
+            "Initial commit",
+        ],
+        cwd=target,
+    )
+    if code != 0:
+        _safe_rmdir(target)
+        raise BeltConsoleError(400, f"git commit failed: {err.strip()[:200]}")
+
+    resolved_target = target.resolve()
+
+    # 6. Register the new repo so discovery + the code-change boundary see it.
+    await _persist_root(workspace_id, str(resolved_target))
+
+    result: dict[str, Any] = {"repo": await _repo_view(resolved_target)}
+
+    # 7. Optional remote creation. A failure NEVER rolls back the local repo —
+    #    the local init already succeeded and is registered; we surface the
+    #    remote failure inline so the user can retry the remote half by hand.
+    if create_remote:
+        creator: RepoCreator = repo_creator or GhCliRepoCreator()
+        try:
+            await creator.create_remote(repo_path=resolved_target, name=safe_name)
+            # Refresh the view so a new ``origin``/branch state is reflected.
+            result["repo"] = await _repo_view(resolved_target)
+        except Exception as exc:  # noqa: BLE001 — keep the local repo, report the remote gap
+            logger.warning("belt: init_repo remote creation failed for workspace", exc_info=True)
+            result["remote_error"] = (
+                f"The local repository was created, but the GitHub remote could "
+                f"not be created: {exc}. Create it manually or retry."
+            )
+
+    return result
+
+
+def _safe_rmdir(path: Path) -> None:
+    """Best-effort removal of a half-initialized target dir — never raises.
+    Used to clean up after a git-init / seed-commit failure so a retry isn't
+    blocked by a stale empty dir."""
+    import shutil
+
+    try:
+        shutil.rmtree(path, ignore_errors=True)
+    except Exception:  # noqa: BLE001 — cleanup is best-effort
+        logger.debug("belt: init_repo cleanup failed (non-fatal)", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
 # runs read model — over the belt code_change Instinct Actions
 # ---------------------------------------------------------------------------
 
@@ -397,9 +657,18 @@ def _derive_status_stage(action: Any) -> tuple[str, str]:
 def _run_summary(action: Any, blob: dict[str, Any]) -> dict[str, Any]:
     """Build the runs-list row for one belt Action (no diff — that's detail-only).
 
-    Reads task/summary/repo/base_branch/correlation_id off the blob, pr_url +
-    branch STRUCTURALLY off the blob (the executor back-writes them on success),
-    and status/stage from the Action lifecycle. ``created_at`` is ISO-8601.
+    Reads task/summary/repo/base_branch/correlation_id off the blob, and the
+    landing fields — ``branch`` / ``pr_url`` / ``commit_sha`` — STRUCTURALLY off
+    the blob (the executor back-writes them on success), and status/stage from the
+    Action lifecycle. ``created_at`` is ISO-8601.
+
+    Two landing shapes feed this row:
+      * WITH-REMOTE — ``pr_url`` + ``branch`` are present; the page renders a PR
+        link.
+      * LOCAL-ONLY (no origin) — ``branch`` + ``commit_sha`` are present and
+        ``pr_url`` is None; the page renders a branch chip. We emit ``pr_url:
+        None`` cleanly (key present, value null) so the frontend's
+        ``pr_url ? <link> : <chip>`` switch is unambiguous.
     """
     status, stage = _derive_status_stage(action)
     created = getattr(action, "created_at", None)
@@ -415,6 +684,7 @@ def _run_summary(action: Any, blob: dict[str, Any]) -> dict[str, Any]:
         "base_branch": str(blob.get("base_branch") or ""),
         "branch": blob.get("branch") or None,
         "pr_url": blob.get("pr_url") or None,
+        "commit_sha": blob.get("commit_sha") or None,
         "created_at": created.isoformat() if hasattr(created, "isoformat") else None,
         "correlation_id": str(blob.get("correlation_id") or "") or None,
     }
@@ -476,12 +746,15 @@ async def get_run(workspace_id: str, action_id: str) -> dict[str, Any]:
 
 __all__ = [
     "BeltConsoleError",
+    "GhCliRepoCreator",
     "MAX_BRANCHES",
     "MAX_DIFF_BYTES",
+    "RepoCreator",
     "add_repo",
     "discover_repos",
     "emit_belt_run_updated",
     "get_run",
+    "init_repo",
     "list_runs",
     "resolve_allowlist_roots",
 ]

--- a/tests/cloud/test_belt_console.py
+++ b/tests/cloud/test_belt_console.py
@@ -8,6 +8,13 @@
 #   * POST /belt/repos — validates the path is an existing git repo, realpaths
 #     it, persists it to the per-workspace allowlist extension. 4xx on
 #     non-existent / non-git path; 403 for a non-admin caller.
+#
+# Updated: 2026-06-11 (feat/belt-repo-init) — added POST /belt/repos/init tests:
+#   creates the dir + git repo + initial commit + registers it + returns the
+#   standard repo shape; name validation rejects unsafe names; a location_root
+#   outside the allowlist rejects; an existing target rejects; 403 for a
+#   non-admin. create_remote: the fake gh-runner is called with the right args;
+#   a remote failure → 200 + remote_error with the local repo intact.
 #   * GET /belt/runs — runs read model over the belt code_change Instinct
 #     Actions, newest-first, status/stage derived from the Action lifecycle.
 #   * GET /belt/runs/{id} — run + diff, diff capped at MAX_DIFF_BYTES, 404 for a
@@ -123,16 +130,24 @@ def store(tmp_path: Path, monkeypatch) -> InstinctStore:
 # ---------------------------------------------------------------------------
 
 
-def _build_app(*, role: str = "admin", workspace_id: str = "w1", user_id: str = "u1") -> FastAPI:
+def _build_app(
+    *,
+    role: str = "admin",
+    workspace_id: str = "w1",
+    user_id: str = "u1",
+    repo_creator=None,
+) -> FastAPI:
     """A TestClient app over the belt console router with the REAL RBAC guard.
 
     The user's workspace role drives ``require_action_any_workspace`` — a
-    ``member`` is rejected on the ADMIN-gated add-repo route (403) but passes the
-    MEMBER-gated reads. License is bypassed.
+    ``member`` is rejected on the ADMIN-gated add-repo / init routes (403) but
+    passes the MEMBER-gated reads. License is bypassed. ``repo_creator`` (when
+    given) overrides the init route's ``RepoCreator`` so the ``gh repo create``
+    shell-out is faked.
     """
     from pocketpaw_ee.cloud._core.http import add_error_handler
     from pocketpaw_ee.cloud.auth import current_active_user
-    from pocketpaw_ee.cloud.belt.router import router
+    from pocketpaw_ee.cloud.belt.router import repo_creator_dep, router
     from pocketpaw_ee.cloud.license import require_license
 
     app = FastAPI()
@@ -150,6 +165,8 @@ def _build_app(*, role: str = "admin", workspace_id: str = "w1", user_id: str = 
         return user
 
     app.dependency_overrides[current_active_user] = _fake_user_dep
+    if repo_creator is not None:
+        app.dependency_overrides[repo_creator_dep] = lambda: repo_creator
     return app
 
 
@@ -247,6 +264,162 @@ async def test_add_repo_forbidden_for_non_admin(settings_allowlist, store, mongo
     with TestClient(_build_app(role="member")) as client:
         res = client.post("/api/v1/belt/repos", json={"path": str(roots / "acme-api")})
     assert res.status_code == 403, res.text
+
+
+# ---------------------------------------------------------------------------
+# POST /belt/repos/init — create a brand-new repo + validation + RBAC + remote
+# ---------------------------------------------------------------------------
+
+
+class _FakeRepoCreator:
+    """A fake RepoCreator that records its call args and never touches GitHub."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.calls: list[dict] = []
+
+    async def create_remote(self, *, repo_path, name) -> None:
+        self.calls.append({"repo_path": Path(repo_path), "name": name})
+        if self.fail:
+            raise RuntimeError("gh repo create failed (exit 1): not authenticated")
+
+
+async def test_init_repo_creates_dir_git_commit_and_registers(
+    settings_allowlist, store, mongo_db, tmp_path
+):
+    """A valid init creates the dir + a git repo with an initial commit, registers
+    the repo under the workspace allowlist, and returns the standard repo shape."""
+    location = tmp_path / "checkouts"  # the settings_allowlist root
+    with TestClient(_build_app(role="admin")) as client:
+        res = client.post(
+            "/api/v1/belt/repos/init",
+            json={"name": "fresh-svc", "location_root": str(location), "create_remote": False},
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert "remote_error" not in body
+        repo = body["repo"]
+        assert repo["name"] == "fresh-svc"
+        assert set(repo.keys()) == {"path", "name", "current_branch", "branches"}
+        # The repo has a HEAD + default branch (seed commit landed).
+        assert repo["current_branch"] != ""
+
+        target = location / "fresh-svc"
+        assert (target / ".git").is_dir()
+        assert (target / "README.md").read_text(encoding="utf-8") == "# fresh-svc\n"
+        # One commit on the default branch.
+        log = _git(target, "log", "--oneline")
+        assert log.strip()
+
+        # Registered: the workspace extension now carries the resolved repo path.
+        from pocketpaw_ee.cloud.models.belt_workspace_config import BeltWorkspaceConfig
+
+        doc = await BeltWorkspaceConfig.find_one(BeltWorkspaceConfig.workspace == "w1")
+        assert doc is not None
+        assert str(target.resolve()) in doc.allowlist_roots
+
+
+async def test_init_repo_rejects_unsafe_name(settings_allowlist, store, mongo_db, tmp_path):
+    """A name with a path separator (or traversal) is refused before any FS write."""
+    location = tmp_path / "checkouts"
+    with TestClient(_build_app(role="admin")) as client:
+        for bad in ("../escape", "a/b", "Has Space", "UPPER", ".hidden"):
+            res = client.post(
+                "/api/v1/belt/repos/init",
+                json={"name": bad, "location_root": str(location)},
+            )
+            assert res.status_code == 400, f"{bad!r}: {res.text}"
+            assert "error" in res.json()
+    # Nothing was created.
+    assert not (location / "escape").exists()
+
+
+async def test_init_repo_rejects_root_outside_allowlist(
+    settings_allowlist, store, mongo_db, tmp_path
+):
+    """A location_root outside every allowlist root is refused (path-free 400)."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    with TestClient(_build_app(role="admin")) as client:
+        res = client.post(
+            "/api/v1/belt/repos/init",
+            json={"name": "x", "location_root": str(outside)},
+        )
+    assert res.status_code == 400, res.text
+    assert "authorized" in res.json()["error"]["message"].lower()
+    assert not (outside / "x").exists()
+
+
+async def test_init_repo_rejects_existing_target(settings_allowlist, store, mongo_db, tmp_path):
+    """An init at a path that already exists is refused — no clobber."""
+    location = tmp_path / "checkouts"
+    (location / "taken").mkdir()
+    with TestClient(_build_app(role="admin")) as client:
+        res = client.post(
+            "/api/v1/belt/repos/init",
+            json={"name": "taken", "location_root": str(location)},
+        )
+    assert res.status_code == 400, res.text
+    assert "already exists" in res.json()["error"]["message"].lower()
+
+
+async def test_init_repo_forbidden_for_non_admin(settings_allowlist, store, mongo_db, tmp_path):
+    """A workspace MEMBER cannot init a repo — belt.manage is ADMIN-gated."""
+    location = tmp_path / "checkouts"
+    with TestClient(_build_app(role="member")) as client:
+        res = client.post(
+            "/api/v1/belt/repos/init",
+            json={"name": "nope", "location_root": str(location)},
+        )
+    assert res.status_code == 403, res.text
+    assert not (location / "nope").exists()
+
+
+async def test_init_repo_with_remote_calls_creator_with_right_args(
+    settings_allowlist, store, mongo_db, tmp_path
+):
+    """create_remote=true → the fake gh-runner is called with the new repo path
+    and name; the response has no remote_error."""
+    location = tmp_path / "checkouts"
+    creator = _FakeRepoCreator()
+    with TestClient(_build_app(role="admin", repo_creator=creator)) as client:
+        res = client.post(
+            "/api/v1/belt/repos/init",
+            json={"name": "remote-svc", "location_root": str(location), "create_remote": True},
+        )
+    assert res.status_code == 200, res.text
+    assert "remote_error" not in res.json()
+    assert len(creator.calls) == 1
+    call = creator.calls[0]
+    assert call["name"] == "remote-svc"
+    assert call["repo_path"] == (location / "remote-svc").resolve()
+
+
+async def test_init_repo_remote_failure_keeps_local_repo(
+    settings_allowlist, store, mongo_db, tmp_path
+):
+    """A remote-creation failure → 200 with remote_error; the local repo is intact
+    and registered (never rolled back)."""
+    location = tmp_path / "checkouts"
+    creator = _FakeRepoCreator(fail=True)
+    with TestClient(_build_app(role="admin", repo_creator=creator)) as client:
+        res = client.post(
+            "/api/v1/belt/repos/init",
+            json={"name": "half-svc", "location_root": str(location), "create_remote": True},
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert "remote_error" in body
+        assert "local repository was created" in body["remote_error"].lower()
+        # Local repo is intact.
+        target = location / "half-svc"
+        assert (target / ".git").is_dir()
+        assert (target / "README.md").exists()
+        # And registered despite the remote failure.
+        from pocketpaw_ee.cloud.models.belt_workspace_config import BeltWorkspaceConfig
+
+        doc = await BeltWorkspaceConfig.find_one(BeltWorkspaceConfig.workspace == "w1")
+        assert str(target.resolve()) in doc.allowlist_roots
 
 
 # ---------------------------------------------------------------------------
@@ -579,6 +752,79 @@ async def test_executor_emits_landed_and_persists_pr_result(
     blob = refreshed.parameters["_code_change"]
     assert blob["pr_url"] == "https://github.com/acme/repo/pull/7"
     assert blob["branch"].startswith("feat/belt-")
+    assert blob["files_changed"] == 1
+
+
+async def test_executor_local_only_emits_landed_without_pr_url(
+    monkeypatch, recording_bus, sse, tmp_path
+):
+    """A NO-ORIGIN repo: the executor publishes belt_run_updated(landed, done) on
+    the bus WITHOUT a pr_url, and back-writes branch + commit_sha (not pr_url)."""
+    # A plain repo with NO remote at all.
+    work = tmp_path / "local"
+    work.mkdir()
+    _git(work, "init")
+    _git(work, "config", "user.name", "Belt Test")
+    _git(work, "config", "user.email", "belt@test.local")
+    (work / "app.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
+    _git(work, "add", "app.py")
+    _git(work, "commit", "-m", "init")
+    _git(work, "branch", "-M", "main")
+
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+
+    class _S:
+        belt_repo_allowlist = [str(tmp_path)]
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+    st = InstinctStore(tmp_path / "exec_local.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+
+    action = await _propose_run(
+        st,
+        repo=str(work),
+        base_branch="main",
+        diff=(
+            "--- a/app.py\n+++ b/app.py\n@@ -1,2 +1,2 @@\n"
+            " def hello():\n-    return 'hi'\n+    return 'hello world'\n"
+        ),
+    )
+    await st.approve(action.id)
+
+    from pocketpaw_ee.cloud.belt import executor as belt_executor
+
+    class _FakeOpener:
+        def __init__(self) -> None:
+            self.called = False
+
+        async def open_pr(self, *, repo_path, branch, base_branch, title, body) -> str:
+            self.called = True
+            return "https://should-not-be-used"
+
+    opener = _FakeOpener()
+    await belt_executor.execute_approved_change(action, pr_opener=opener)
+
+    # No PR opener was invoked (no remote → no push, no PR).
+    assert opener.called is False
+
+    # Bus: a landed/done terminal with NO pr_url key.
+    landed = [e for e in _bus_belt_events(recording_bus) if e["status"] == "landed"]
+    assert landed and landed[0]["stage"] == "done"
+    assert "pr_url" not in landed[0]
+    assert landed[0]["workspace_id"] == "w1"
+
+    # Blob: branch + commit_sha back-written, NO pr_url.
+    refreshed = await st.get_action(action.id)
+    blob = refreshed.parameters["_code_change"]
+    assert blob["branch"].startswith("feat/belt-")
+    assert blob["commit_sha"]
+    assert "pr_url" not in blob or blob["pr_url"] is None
     assert blob["files_changed"] == 1
 
 

--- a/tests/cloud/test_belt_gate.py
+++ b/tests/cloud/test_belt_gate.py
@@ -2,6 +2,14 @@
 #
 # Created: 2026-06-10 (feat/belt-gate, Belt & Pulley stations thin slice).
 #
+# Updated: 2026-06-11 (feat/belt-repo-init — local-only gate mode) — added the
+# NO-ORIGIN landing path: a propose→approve cycle against a repo with no
+# ``origin`` remote applies + commits on ``feat/belt-<id>`` LOCALLY, NEVER pushes
+# and NEVER opens a PR (a fake opener proves it's untouched), the branch + commit
+# survive in the repo, and the executed outcome carries the branch + commit sha
+# (and the blob carries branch + commit_sha, NOT pr_url) so the runs read model
+# surfaces a branch chip with pr_url=None.
+#
 # What this pins — the WHOLE gate, driven through the REAL path with a local
 # git fixture (a bare repo as origin + a seeded working clone):
 #   * belt_propose_change (the real MCP handler) validates identity + inputs,
@@ -102,6 +110,29 @@ def repo(tmp_path: Path) -> Path:
     # Ensure the default branch is named 'main' regardless of git's init default.
     _git(work, "branch", "-M", "main")
     _git(work, "push", "-u", "origin", "main")
+    return work
+
+
+@pytest.fixture
+def local_repo(tmp_path: Path) -> Path:
+    """A git repo with NO ``origin`` remote — the local-only landing fixture.
+
+    A committed ``app.py`` on ``main``, identity configured locally so commits
+    succeed, but no remote at all. The executor must apply + commit on the belt
+    branch WITHOUT pushing or opening a PR.
+    """
+    work = tmp_path / "local-work"
+    work.mkdir()
+    _git(work, "init")
+    _git(work, "config", "user.name", "Belt Test")
+    _git(work, "config", "user.email", "belt@test.local")
+    (work / "app.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
+    _git(work, "add", "app.py")
+    _git(work, "commit", "-m", "init")
+    _git(work, "branch", "-M", "main")
+    # Sanity: there is no origin remote.
+    remotes = _git(work, "remote")
+    assert remotes.strip() == ""
     return work
 
 
@@ -506,3 +537,117 @@ async def test_empty_diff_refused(repo, store, allowlist):
     assert res.get("is_error") is True
     assert "non-empty unified `diff`" in res["content"][0]["text"]
     assert await store.list_actions() == []
+
+
+# ---------------------------------------------------------------------------
+# LOCAL-ONLY gate mode — a repo with NO origin: apply + commit locally, NO push,
+# NO PR; the outcome carries branch + commit sha instead of pr_url.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def local_allowlist(local_repo: Path, monkeypatch) -> None:
+    """Allowlist the no-remote repo's parent so the real repo resolves inside."""
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+
+    class _S:
+        belt_repo_allowlist = [str(local_repo.parent)]
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+
+async def test_local_only_landing_commits_locally_no_push_no_pr(local_repo, store, local_allowlist):
+    """propose→approve against a NO-ORIGIN repo: the change applies + commits on
+    feat/belt-<id> LOCALLY, the PR opener is NEVER called (no push, no PR), the
+    branch + commit survive in the repo, and the outcome / blob carry branch +
+    commit_sha with NO pr_url."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(local_repo),
+                "base_branch": "main",
+                "diff": _good_diff(),
+                "summary": "Friendlier greeting, landed locally.",
+                "task": "Make hello() friendlier.",
+            }
+        )
+    action_id = (await _result_body(res))["action_id"]
+
+    approved = await store.approve(action_id, approver="u1")
+    opener = FakePrOpener()
+    await belt_executor.execute_approved_change(approved, pr_opener=opener)
+
+    # The PR opener was NEVER called — no remote, so no push and no PR.
+    assert opener.calls == []
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+
+    # The structured blob carries branch + commit_sha, NOT pr_url.
+    blob = final.parameters["_code_change"]
+    assert blob["branch"].startswith("feat/belt-")
+    assert blob.get("commit_sha"), "local-only landing must record the commit sha"
+    assert "pr_url" not in blob or blob["pr_url"] is None
+    assert blob["files_changed"] == 1
+
+    branch = blob["branch"]
+    commit_sha = blob["commit_sha"]
+
+    # The free-text outcome names the branch + sha, and mentions no PR.
+    outcome = final.outcome if isinstance(final.outcome, str) else str(final.outcome)
+    assert branch in outcome
+    assert commit_sha[:12] in outcome
+    assert "no pr" in outcome.lower() or "no origin" in outcome.lower()
+
+    # The branch + commit actually landed in the LOCAL repo (promoted off the
+    # throwaway worktree). The change is on that branch.
+    branches = _git(local_repo, "branch", "--list", branch)
+    assert branch in branches
+    content = _git(local_repo, "show", f"{branch}:app.py")
+    assert "hello world" in content
+    # The branch points at the recorded commit sha.
+    head = _git(local_repo, "rev-parse", branch).strip()
+    assert head == commit_sha
+
+    # Still no origin remote was added.
+    assert _git(local_repo, "remote").strip() == ""
+
+
+async def test_local_only_runs_read_model_branch_chip_no_pr(
+    local_repo, store, local_allowlist, monkeypatch
+):
+    """After a local-only landing, the runs read model returns the run with the
+    branch (+ commit_sha) and pr_url=None — so the page renders a branch chip."""
+    with _identity():
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(local_repo),
+                "base_branch": "main",
+                "diff": _good_diff(),
+                "summary": "Local-only run for the read model.",
+                "task": "tweak greeting",
+            }
+        )
+    action_id = (await _result_body(res))["action_id"]
+    approved = await store.approve(action_id, approver="u1")
+    await belt_executor.execute_approved_change(approved, pr_opener=FakePrOpener())
+
+    from pocketpaw_ee.cloud.belt import service as belt_service
+
+    detail = await belt_service.get_run("w1", action_id)
+    assert detail["status"] == "landed"
+    assert detail["stage"] == "done"
+    assert detail["branch"].startswith("feat/belt-")
+    assert detail["commit_sha"]
+    assert detail["pr_url"] is None  # branch chip, not a PR link
+
+    listed = await belt_service.list_runs("w1")
+    row = next(r for r in listed["runs"] if r["action_id"] == action_id)
+    assert row["branch"].startswith("feat/belt-")
+    assert row["pr_url"] is None
+    assert row["commit_sha"]


### PR DESCRIPTION
## What this does

Two things, both behind the existing Belt console:

**`POST /api/v1/belt/repos/init`** — create a brand-new git repository under an allowlisted root, so an admin can start a repo from the Belt page instead of cloning or `git init`-ing one by hand first.

- Body: `{name, location_root, create_remote: boolean}`
- Returns 200 `{repo: {path, name, current_branch, branches}}` — the same repo shape the registry returns.
- Validates the name is a safe directory segment, requires `location_root` under an authorized root, refuses an existing target, runs `git init`, seeds a `README.md` + initial commit (so the repo has a HEAD and a default branch), and registers the repo through the same persistence the add-repo route uses.
- `create_remote=true` also creates and pushes a private GitHub remote via `gh repo create`. If that fails, the local repo is kept and the response carries a top-level `remote_error` message — the local init is never rolled back.

**Local-only gate mode in the apply-on-approve executor** — when a bound repo has no `origin` remote, approve applies and commits on `feat/belt-<action-id>` locally without pushing or opening a PR.

- The outcome carries the branch + commit sha instead of a `pr_url`; the run still lands as executed and `belt_run_updated` still fires.
- The runs read model (`GET /belt/runs`, `/runs/{id}`) surfaces `branch` + `commit_sha` with `pr_url: null`, so the frontend renders a branch chip.

## Contract

Matches the pinned contract (frontend PR qbtrix/paw-enterprise#406):

- 4xx with clear, path-free messages: invalid name, location outside the allowlist, target already exists, git init / commit failure.
- `remote_error` returned inline on remote-creation failure (200, local repo intact).
- Local-only landings encode `branch` + `commit_sha` on the `_code_change` blob; `pr_url` stays absent.

No contract deviations.

## Security

- Subprocess calls stay arg-list only — no `shell=True`, no string interpolation of user input. The repo name, location, and `gh` args are all literal argv elements.
- The init route keeps the same ADMIN gate as add-repo (`belt.manage`) and the same realpath + containment discipline: the name is validated as a single safe segment and the resolved `location_root` must sit under an authorized root, so the join can't traverse or absolutize.
- Remote creation mirrors the executor's injectable PR-opener (`RepoCreator` / `GhCliRepoCreator`) so tests fake the `gh` shell-out; `gh` reads its token from the environment, never the command line.
- Error messages are path-free so a probe can't learn whether an out-of-bounds path exists.

## How local-only encodes branch/sha

`_persist_run_result` back-writes `branch` + `commit_sha` (and not `pr_url`) onto the `_code_change` blob. The runs read model reads them structurally and emits `pr_url: null`. The free-text `mark_executed` outcome names the branch + short sha and notes there's no PR. The branch is promoted into the real repo (`git branch <branch> <sha>`) so it survives the throwaway worktree teardown.

## Test evidence

```
tests/cloud/test_belt_console.py tests/cloud/test_belt_gate.py
tests/cloud/test_ee_instinct.py tests/ee/test_mcp_claude_sdk.py
168 passed in 10.55s
```

`uv run ruff check .` — All checks passed. `uv run ruff format --check .` — clean.

New tests cover: init creates dir + git repo + initial commit + registration + response shape; name validation; outside-allowlist root; existing-dir; non-admin 403; create_remote calls the fake runner with the right args; remote failure → 200 + remote_error with the local repo intact; the full propose→approve cycle against a no-remote repo (branch + commit land locally, PR opener never called, outcome + blob carry branch + sha and no pr_url, runs read model returns the branch chip, `belt_run_updated` fired). The with-remote push + PR path regression tests stay green.
