### PR TITLE
Cookie/session auth and a reused HTTP client for YAML connectors

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,10 @@
 <!--
   Connectors documentation.
+  Updated: 2026-06-11 (connector cookie/session auth) — documented two new
+  auth methods on the DirectREST engine: `cookie` (emits a Cookie: header from
+  a declared credential, name set via auth.credential) and `header` (emits an
+  arbitrary header named by auth.header — the escape hatch for keys that are
+  not Bearer tokens). Both are additive; api_key/bearer/basic are unchanged.
   Updated: 2026-06-08 (sense-mcp / Sense tier chunk 4) — added the Senses
   section: the "Sense" glossary entry, the sense-vs-connector distinction, and
   the two new agent tools (list_senses / sense_execute on the same
@@ -61,7 +66,7 @@ type: payment                     # category for grouping
 icon: credit-card                 # lucide icon name
 
 auth:
-  method: api_key                 # api_key | oauth | basic | bearer | none
+  method: api_key                 # api_key | bearer | basic | header | cookie | oauth | none
   credentials:
     - name: MY_API_KEY
       description: API key from My Service dashboard
@@ -108,11 +113,55 @@ exactly as before. See [Connector → Skill / Tool auto-authoring](#connector--s
 
 | Method | When to Use | Example |
 |--------|-------------|---------|
-| `api_key` | Service provides a static API key | Stripe, Tavily |
+| `api_key` | Service provides a static API key sent as `Authorization: Bearer …` | Stripe, Tavily |
 | `oauth` | Service uses OAuth 2.0 flow | Google, Spotify |
-| `bearer` | Token-based auth (API key in Authorization header) | Generic REST APIs |
+| `bearer` | Token-based auth (token in the `Authorization` header) | Generic REST APIs |
 | `basic` | Username + password auth | Legacy APIs |
+| `header` | Key goes in a custom header (not a Bearer token) | APIs using `X-API-Key`, `Api-Token`, … |
+| `cookie` | Session/cookie auth — a stored value sent as the `Cookie` header | Login-session APIs, internal tools |
 | `none` | Public API, no auth needed | Reddit (read-only) |
+
+### `header` — custom-header auth
+
+Use when the credential is sent in a named header that is **not** an
+`Authorization: Bearer` token. Set `header` to the header name and `credential`
+to the credential the value comes from. The value is sent verbatim — no `Bearer`
+prefix — so this is the escape hatch for the `api_key` method's
+always-`Bearer` behavior.
+
+```yaml
+auth:
+  method: header
+  header: X-API-Key             # the header to emit
+  credential: SERVICE_KEY       # which credential holds the value
+  credentials:
+    - name: SERVICE_KEY
+      description: API key sent in the X-API-Key header
+      required: true
+```
+
+### `cookie` — session / cookie auth
+
+Use for services authenticated by a session cookie (or any value that belongs in
+the `Cookie` header). `credential` names the credential whose value is emitted
+as the `Cookie` header; it defaults to the first declared credential when
+omitted. The value is sent as-is (e.g. `sessionid=abc123` or a raw token), so
+store the full cookie string in the credential.
+
+```yaml
+auth:
+  method: cookie
+  credential: SESSION_COOKIE    # which credential holds the cookie value
+  credentials:
+    - name: SESSION_COOKIE
+      description: Session cookie string, e.g. "sessionid=abc123"
+      required: true
+```
+
+The DirectREST engine keeps one HTTP client per connected adapter, so any
+`Set-Cookie` the service returns is retained in the client's cookie jar and sent
+on the next call within the same connection — and connections are pooled across
+actions.
 
 ## Trust Levels
 

--- a/src/pocketpaw/connectors/yaml_engine.py
+++ b/src/pocketpaw/connectors/yaml_engine.py
@@ -9,6 +9,15 @@
 # Updated: 2026-06-08 — Added `senses: list[str]` to ConnectorDef + parse-time
 #   validation via senses.validate_sense_id (Sense tier chunk 1). Unknown paw.*
 #   ids fail loudly; missing `senses:` key is backward compatible ([]).
+# Updated: 2026-06-11 — Cookie/session auth + a persistent HTTP client.
+#   _build_auth_headers gains two additive methods: `cookie` (emits a Cookie:
+#   header from a declared credential, name set via auth.credential) and
+#   `header` (emits an arbitrary header named by auth.header from a credential —
+#   the escape hatch for APIs whose key is not a Bearer token, fixing the
+#   api_key-always-Bearer trap without touching api_key). execute() now reuses a
+#   lazily-built httpx.AsyncClient per adapter instance (connection pooling +
+#   cookie jar) instead of opening a fresh client per call; disconnect() closes
+#   it. Existing auth methods, timeouts, and error mapping are unchanged.
 
 from __future__ import annotations
 
@@ -137,6 +146,19 @@ class DirectRESTAdapter:
         self._def = definition
         self._credentials: dict[str, str] = {}
         self._connected = False
+        # Persistent HTTP client — built lazily on first execute() and reused
+        # across calls so connections pool and any Set-Cookie response is kept
+        # in the client's cookie jar for the next request. ``Any`` avoids a
+        # module-level httpx import (it stays inside execute()/_get_client).
+        self._client: Any | None = None
+
+    async def _get_client(self) -> Any:
+        """Return the per-adapter httpx.AsyncClient, building it on first use."""
+        if self._client is None:
+            import httpx
+
+            self._client = httpx.AsyncClient(timeout=30.0)
+        return self._client
 
     @property
     def name(self) -> str:
@@ -177,6 +199,10 @@ class DirectRESTAdapter:
     async def disconnect(self, pocket_id: str) -> bool:
         self._credentials.clear()
         self._connected = False
+        # Close the pooled HTTP client (and drop the cookie jar) on disconnect.
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
         return True
 
     async def actions(self) -> list[ActionSchema]:
@@ -285,57 +311,59 @@ class DirectRESTAdapter:
             content_type = act_def.get("content_type", "")
             use_form = content_type == "form" or "stripe.com" in url
 
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                if method == "GET":
-                    resp = await client.get(url, params=query_params, headers=headers)
-                elif method == "POST":
-                    if use_form:
-                        resp = await client.post(
-                            url, data=body_data, params=query_params, headers=headers
-                        )
-                    else:
-                        resp = await client.post(
-                            url, json=body_data, params=query_params, headers=headers
-                        )
-                elif method == "PUT":
-                    if use_form:
-                        resp = await client.put(
-                            url, data=body_data, params=query_params, headers=headers
-                        )
-                    else:
-                        resp = await client.put(
-                            url, json=body_data, params=query_params, headers=headers
-                        )
-                elif method == "PATCH":
-                    if use_form:
-                        resp = await client.patch(
-                            url, data=body_data, params=query_params, headers=headers
-                        )
-                    else:
-                        resp = await client.patch(
-                            url, json=body_data, params=query_params, headers=headers
-                        )
-                elif method == "DELETE":
-                    resp = await client.delete(url, params=query_params, headers=headers)
+            # Reuse the per-adapter client: pooled connections + persistent
+            # cookie jar across calls. Closed in disconnect().
+            client = await self._get_client()
+            if method == "GET":
+                resp = await client.get(url, params=query_params, headers=headers)
+            elif method == "POST":
+                if use_form:
+                    resp = await client.post(
+                        url, data=body_data, params=query_params, headers=headers
+                    )
                 else:
-                    return ActionResult(success=False, error=f"Unsupported method: {method}")
-
-                resp.raise_for_status()
-                data = (
-                    resp.json()
-                    if resp.headers.get("content-type", "").startswith("application/json")
-                    else resp.text
-                )
-
-                # Count records — handle wrapped responses (Stripe: {data: [...]})
-                if isinstance(data, list):
-                    records = len(data)
-                elif isinstance(data, dict) and isinstance(data.get("data"), list):
-                    records = len(data["data"])
+                    resp = await client.post(
+                        url, json=body_data, params=query_params, headers=headers
+                    )
+            elif method == "PUT":
+                if use_form:
+                    resp = await client.put(
+                        url, data=body_data, params=query_params, headers=headers
+                    )
                 else:
-                    records = 1
+                    resp = await client.put(
+                        url, json=body_data, params=query_params, headers=headers
+                    )
+            elif method == "PATCH":
+                if use_form:
+                    resp = await client.patch(
+                        url, data=body_data, params=query_params, headers=headers
+                    )
+                else:
+                    resp = await client.patch(
+                        url, json=body_data, params=query_params, headers=headers
+                    )
+            elif method == "DELETE":
+                resp = await client.delete(url, params=query_params, headers=headers)
+            else:
+                return ActionResult(success=False, error=f"Unsupported method: {method}")
 
-                return ActionResult(success=True, data=data, records_affected=records)
+            resp.raise_for_status()
+            data = (
+                resp.json()
+                if resp.headers.get("content-type", "").startswith("application/json")
+                else resp.text
+            )
+
+            # Count records — handle wrapped responses (Stripe: {data: [...]})
+            if isinstance(data, list):
+                records = len(data)
+            elif isinstance(data, dict) and isinstance(data.get("data"), list):
+                records = len(data["data"])
+            else:
+                records = 1
+
+            return ActionResult(success=True, data=data, records_affected=records)
 
         except httpx.HTTPStatusError as e:
             return ActionResult(
@@ -373,6 +401,33 @@ class DirectRESTAdapter:
             password = self._credentials.get("password", "")
             encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
             headers["Authorization"] = f"Basic {encoded}"
+        elif auth_method == "cookie":
+            # Session/cookie auth — emit a `Cookie:` header from a declared
+            # credential. The credential name comes from `auth.credential`,
+            # falling back to the first declared credential. The stored value
+            # is sent verbatim (e.g. "sessionid=abc" or a raw token).
+            cred_name = self._def.auth.get("credential")
+            if not cred_name:
+                creds = self._def.auth.get("credentials", [])
+                cred_name = creds[0]["name"] if creds else None
+            if cred_name:
+                value = self._credentials.get(cred_name, "")
+                if value:
+                    headers["Cookie"] = value
+        elif auth_method == "header":
+            # Custom-header auth — emit an arbitrary header (name from
+            # `auth.header`, value from the declared credential). This is the
+            # escape hatch for APIs whose key is NOT a Bearer token, so it
+            # avoids the api_key-always-Bearer trap without changing api_key.
+            header_name = self._def.auth.get("header")
+            cred_name = self._def.auth.get("credential")
+            if not cred_name:
+                creds = self._def.auth.get("credentials", [])
+                cred_name = creds[0]["name"] if creds else None
+            if header_name and cred_name:
+                value = self._credentials.get(cred_name, "")
+                if value:
+                    headers[header_name] = value
 
         return headers
 

--- a/tests/cloud/test_connectors.py
+++ b/tests/cloud/test_connectors.py
@@ -1,5 +1,9 @@
 # Tests for ConnectorProtocol — YAML parsing, registry, adapter lifecycle.
 # Created: 2026-03-27
+# Updated: 2026-06-11 — Added TestDirectRESTAuthAndClient: covers the new
+#   `cookie` and `header` auth methods, the persistent per-adapter
+#   httpx.AsyncClient (reused across execute calls, closed on disconnect),
+#   and pins that the existing api_key/bearer/basic methods are unchanged.
 
 from __future__ import annotations
 
@@ -9,7 +13,11 @@ import pytest
 
 from pocketpaw.connectors.protocol import ConnectorStatus, TrustLevel
 from pocketpaw.connectors.registry import ConnectorRegistry
-from pocketpaw.connectors.yaml_engine import DirectRESTAdapter, parse_connector_yaml
+from pocketpaw.connectors.yaml_engine import (
+    ConnectorDef,
+    DirectRESTAdapter,
+    parse_connector_yaml,
+)
 
 CONNECTORS_DIR = Path(__file__).parent.parent.parent / "connectors"
 
@@ -136,6 +144,168 @@ class TestDirectRESTAdapter:
         schema = await stripe_adapter.schema()
         assert schema["table"] == "stripe_invoices"
         assert schema["schedule"] == "every_15m"
+
+
+def _adapter_with_auth(auth: dict) -> DirectRESTAdapter:
+    """Build a DirectRESTAdapter over a minimal in-memory ConnectorDef.
+
+    Gives one GET action at a fixed URL so the auth-header and client tests
+    don't depend on any shipped YAML's exact shape.
+    """
+    defn = ConnectorDef(
+        name="probe",
+        display_name="Probe",
+        auth=auth,
+        actions=[
+            {
+                "name": "ping",
+                "method": "GET",
+                "url": "https://api.example.com/ping",
+            }
+        ],
+    )
+    return DirectRESTAdapter(defn)
+
+
+class TestDirectRESTAuthAndClient:
+    """Cookie/header auth methods + the persistent per-adapter HTTP client."""
+
+    @pytest.mark.asyncio
+    async def test_cookie_auth_emits_cookie_header(self) -> None:
+        """`method: cookie` sends the credential value as a Cookie: header."""
+        adapter = _adapter_with_auth(
+            {
+                "method": "cookie",
+                "credential": "SESSION_COOKIE",
+                "credentials": [{"name": "SESSION_COOKIE", "required": True}],
+            }
+        )
+        await adapter.connect("pocket-1", {"SESSION_COOKIE": "sessionid=abc123"})
+        headers = adapter._build_auth_headers()
+        assert headers["Cookie"] == "sessionid=abc123"
+        assert "Authorization" not in headers
+
+    @pytest.mark.asyncio
+    async def test_cookie_auth_falls_back_to_first_credential(self) -> None:
+        """With no explicit `credential`, cookie auth uses the first one."""
+        adapter = _adapter_with_auth(
+            {
+                "method": "cookie",
+                "credentials": [{"name": "SID", "required": True}],
+            }
+        )
+        await adapter.connect("pocket-1", {"SID": "sid=xyz"})
+        assert adapter._build_auth_headers()["Cookie"] == "sid=xyz"
+
+    @pytest.mark.asyncio
+    async def test_header_auth_emits_named_custom_header(self) -> None:
+        """`method: header` emits an arbitrary header — not a Bearer token."""
+        adapter = _adapter_with_auth(
+            {
+                "method": "header",
+                "header": "X-API-Key",
+                "credential": "SERVICE_KEY",
+                "credentials": [{"name": "SERVICE_KEY", "required": True}],
+            }
+        )
+        await adapter.connect("pocket-1", {"SERVICE_KEY": "raw-key-value"})
+        headers = adapter._build_auth_headers()
+        assert headers["X-API-Key"] == "raw-key-value"
+        # The custom-header method must NOT add a Bearer Authorization header.
+        assert "Authorization" not in headers
+
+    @pytest.mark.asyncio
+    async def test_api_key_still_emits_bearer(self) -> None:
+        """Existing api_key behavior is unchanged — still a Bearer token."""
+        adapter = _adapter_with_auth(
+            {
+                "method": "api_key",
+                "credentials": [{"name": "MY_API_KEY", "required": True}],
+            }
+        )
+        await adapter.connect("pocket-1", {"MY_API_KEY": "sk_test_1"})
+        assert adapter._build_auth_headers()["Authorization"] == "Bearer sk_test_1"
+
+    @pytest.mark.asyncio
+    async def test_bearer_and_basic_unchanged(self) -> None:
+        """bearer + basic still produce the same Authorization headers."""
+        import base64
+
+        bearer = _adapter_with_auth(
+            {
+                "method": "bearer",
+                "credentials": [{"name": "API_TOKEN", "required": True}],
+            }
+        )
+        await bearer.connect("pocket-1", {"API_TOKEN": "tok_1"})
+        assert bearer._build_auth_headers()["Authorization"] == "Bearer tok_1"
+
+        basic = _adapter_with_auth(
+            {
+                "method": "basic",
+                "credentials": [
+                    {"name": "username", "required": True},
+                    {"name": "password", "required": True},
+                ],
+            }
+        )
+        await basic.connect("pocket-1", {"username": "u", "password": "p"})
+        expected = "Basic " + base64.b64encode(b"u:p").decode()
+        assert basic._build_auth_headers()["Authorization"] == expected
+
+    @pytest.mark.asyncio
+    async def test_client_reused_across_two_executes(self) -> None:
+        """Two execute() calls share one httpx.AsyncClient instance."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        adapter = _adapter_with_auth({"method": "none"})
+        await adapter.connect("pocket-1", {})
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = {"ok": True}
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=mock_client) as factory:
+            await adapter.execute("ping", {})
+            first = adapter._client
+            await adapter.execute("ping", {})
+            second = adapter._client
+
+        # Same instance both calls, and the factory was only built once.
+        assert first is second
+        assert factory.call_count == 1
+        assert mock_client.get.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_client_closed_on_disconnect(self) -> None:
+        """disconnect() closes the pooled client and clears the reference."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        adapter = _adapter_with_auth({"method": "none"})
+        await adapter.connect("pocket-1", {})
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = {"ok": True}
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        mock_client.aclose = AsyncMock()
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await adapter.execute("ping", {})
+
+        assert adapter._client is mock_client
+        await adapter.disconnect("pocket-1")
+        mock_client.aclose.assert_awaited_once()
+        assert adapter._client is None
 
 
 class TestConnectorRegistry:


### PR DESCRIPTION
## What this does

The DirectREST YAML connector engine couldn't authenticate with a session cookie, and it opened a brand-new `httpx.AsyncClient` on every action call — so connections never pooled and cookies never persisted between calls. This adds the missing auth methods and reuses one client per adapter.

### Two new auth methods (both additive)

- **`cookie`** — sends a stored credential as the `Cookie` header. The credential name comes from `auth.credential`, falling back to the first declared credential. The value is sent verbatim, so you store the full cookie string (e.g. `sessionid=abc123`).
- **`header`** — sends a credential as an arbitrary named header (`auth.header`), value passed through as-is. This is the escape hatch for APIs whose key isn't a Bearer token, so they no longer have to misuse the `api_key` method (which always emits `Authorization: Bearer …`).

`api_key`, `bearer`, and `basic` are unchanged.

### Persistent HTTP client

`execute()` now builds the `httpx.AsyncClient` lazily on first use and reuses it across calls — connections pool and any `Set-Cookie` the service returns stays in the client's cookie jar for the next request. `disconnect()` closes it (the registry already calls `adapter.disconnect()` on its cleanup path, so no registry change was needed). Timeouts and error mapping are untouched.

## Example

```yaml
auth:
  method: cookie
  credential: SESSION_COOKIE
  credentials:
    - name: SESSION_COOKIE
      required: true
```

```yaml
auth:
  method: header
  header: X-API-Key
  credential: SERVICE_KEY
  credentials:
    - name: SERVICE_KEY
      required: true
```

## Tests

Added `TestDirectRESTAuthAndClient` in `tests/cloud/test_connectors.py`:

- cookie header emitted from the named credential, and from the first credential when `auth.credential` is omitted
- custom header emitted, with no stray `Authorization` header
- `api_key`/`bearer`/`basic` still produce the same headers as before
- the client is the same instance across two `execute()` calls (built once, two requests)
- `disconnect()` closes the client and clears the reference

All 31 tests in `test_connectors.py` + `test_surface_profile_yaml.py` pass. Lint clean.

Six failures in `test_connectors_execute.py` are pre-existing (401 from EE HTTP-route auth/license fixtures not wired in this environment) — verified they fail identically on the base commit with these changes stashed.

## Docs

`docs/CONNECTORS.md` gains both methods in the auth table plus a YAML example and a note about the pooled client / cookie jar.