### PR TITLE
Mirror Firestore collections into Fabric objects

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -5,6 +5,10 @@
   a declared credential, name set via auth.credential) and `header` (emits an
   arbitrary header named by auth.header — the escape hatch for keys that are
   not Bearer tokens). Both are additive; api_key/bearer/basic are unchanged.
+  Updated: 2026-06-11 (firestore-fabric-ingest) — added the "Firestore → Fabric
+  ingestion worker" section: the cloud background worker that mirrors selected
+  Firestore collections into Fabric objects per a per-workspace mapping config,
+  with a real high-water cursor, upsert-by-source, and tenant-stamped writes.
   Updated: 2026-06-08 (sense-mcp / Sense tier chunk 4) — added the Senses
   section: the "Sense" glossary entry, the sense-vs-connector distinction, and
   the two new agent tools (list_senses / sense_execute on the same
@@ -328,6 +332,77 @@ connector_execute("gmail", "gmail_search",
 connector_execute("gmail", "gmail_send", {...})
   → blocked: "needs approval (coming in v2). Not executed."
 ```
+
+## Firestore → Fabric ingestion worker
+
+The connectors above pull data on demand into a pocket's SQLite tables. A
+separate cloud background worker mirrors a different shape of source — a
+Firestore database — into **Fabric**, PocketPaw's ontology layer of typed
+objects and links. Use it when a deployment already runs on Firestore and wants
+those records to show up as Fabric objects that agents and pockets can query.
+
+The worker is **fully generic**. There are no collection names, field names, or
+object types in the code. A deployment describes its own mapping in a
+per-workspace `FabricIngestConfig`, and the worker walks it.
+
+### What it does
+
+On a schedule (every 5 minutes by default), for each workspace that has a config:
+
+1. Read each mapped Firestore collection. The first run is a full **backfill**;
+   later runs are **incremental** and read only documents newer than the stored
+   cursor.
+2. For each document, create or update a Fabric object of the mapped type. The
+   field map decides which Firestore fields become which object properties.
+3. Stamp every object with the workspace, `source_connector="firestore"`, and
+   `source_id` set to the full Firestore document path.
+4. Apply any link rules, wiring objects together by source path.
+
+### Upsert, not duplicate
+
+Each document maps to one object, keyed on its Firestore path. The worker rides
+the same connector→Fabric mapper the Google Calendar ingestion uses
+(`pocketpaw.connectors.fabric_ingest.ingest_records`): on a re-run it looks the
+object up by `(source_connector, source_id)` and updates it in place, so
+re-ingesting the same collection never piles up duplicates.
+
+### The cursor is a real high-water mark
+
+The incremental cursor is taken from the **document data** — the value of the
+mapping's `cursor_field` (typically an `updated_at` timestamp) on the
+newest-updated document seen, falling back to the Firestore snapshot's
+`update_time` when a document has no value for that field. It is **not** the
+run's wall clock. A document that arrives late but carries an older timestamp is
+still picked up on its own merits, and a re-run never re-scans a time window.
+
+### Configuring a mapping
+
+One `FabricIngestConfig` row per workspace holds a list of mappings:
+
+| Field | Meaning |
+|-------|---------|
+| `collection` | The Firestore collection path to mirror. |
+| `object_type_id` | The Fabric object type mirrored documents become. |
+| `field_map` | Firestore field name → Fabric property name. Unmapped fields are dropped. |
+| `cursor_field` | The document field used as the incremental high-water mark. |
+| `link_rules` | Optional. Each rule reads `via_field` off the document and links the new object to another mirrored object (`to_type`) found at that path, with `link_type`. |
+
+The mapping is validated at entry — a blank collection, a blank object type, or
+a link rule missing a field is rejected before any Firestore read, so a bad
+config fails loudly instead of mirroring nothing.
+
+### Operational notes
+
+- Gated by `POCKETPAW_CLOUD_SCHEDULER_ENABLED=true`, the same gate the other
+  cloud sweeps use, so tests never spawn a background loop. Override the cadence
+  with `POCKETPAW_FABRIC_INGEST_INTERVAL_SECONDS`.
+- The Firestore client is an **optional** dependency
+  (`pocketpaw-ee[firestore]`). A deployment that doesn't mirror Firestore never
+  installs it; the worker raises a clear install error if a config references
+  Firestore without the extra present.
+- Credentials resolve through Google Application Default Credentials — the
+  worker holds no secrets of its own.
+- Writes commit one object per row in v1. Batching is a known follow-up.
 
 ## Senses — provider-agnostic capabilities above connectors
 

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -714,6 +714,28 @@ def mount_cloud(app: FastAPI) -> None:
         async def _stop_member_ingest() -> None:
             await stop_member_ingest(app)
 
+    # Generic Firestore→Fabric ingest sweep. Every 5 minutes
+    # (POCKETPAW_FABRIC_INGEST_INTERVAL_SECONDS override) it mirrors each
+    # workspace's configured Firestore collections into Fabric objects (backfill
+    # on first sight of a source, incremental thereafter). The per-deployment
+    # mapping lives in FabricIngestConfig; nothing domain-specific is in code.
+    # Same scheduler gate as the cycle/decisions/member-ingest loops so pytest
+    # runs never spawn a background loop that outlives the test; production sets
+    # POCKETPAW_CLOUD_SCHEDULER_ENABLED=true.
+    if _os.environ.get("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "").lower() == "true":
+        from pocketpaw_ee.cloud.fabric_ingest.scheduler import (
+            start_fabric_ingest,
+            stop_fabric_ingest,
+        )
+
+        @app.on_event("startup")
+        async def _start_fabric_ingest() -> None:
+            await start_fabric_ingest(app)
+
+        @app.on_event("shutdown")
+        async def _stop_fabric_ingest() -> None:
+            await stop_fabric_ingest(app)
+
     # Mission Control activity buffer — per-workspace ring buffer fed by
     # agent.* bus events. Same constraint as the upload listeners: subscribe
     # AFTER init_realtime installed the singleton bus.

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -759,6 +759,15 @@ class MemberDataPurged(Event):
     EVENT_TYPE: ClassVar[str] = "member_ingest.purged"
 
 
+# Fabric ingest — generic Firestore→Fabric mirror worker. Fired when the
+# per-source ingest worker finishes mirroring one Firestore collection into
+# Fabric objects (backfill or incremental). data: workspace_id, source_id,
+# object_type_id, mode, status, objects_ingested, cursor.
+@dataclass
+class FabricIngestCompleted(Event):
+    EVENT_TYPE: ClassVar[str] = "fabric_ingest.completed"
+
+
 # Calls — call.notes_posted. The lifecycle events (call.started / call.ended)
 # are defined above with the rest of the LiveKit group-call types; this is the
 # post-call notes fan-out, audience = the group's members.

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/__init__.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/__init__.py
@@ -1,0 +1,56 @@
+# fabric_ingest — Generic Firestore→Fabric ingestion worker.
+# Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+# Updated: 2026-06-11 (rebase onto dev) — the upsert path now delegates to the
+#   canonical OSS connector→Fabric mapper (pocketpaw.connectors.fabric_ingest,
+#   landed in the Calendar ingestion PR #1418) instead of a private loop.
+"""Continuously mirror selected Firestore collections into Fabric objects.
+
+Fully generic: the per-deployment mapping (which collections, which Fabric
+object types, field maps, cursor fields, link rules) lives in a per-workspace
+``FabricIngestConfig`` document. NOTHING domain-specific lives in this package.
+
+Pieces
+------
+* ``service.ingest_collection`` — mirror ONE Firestore collection into Fabric
+  objects for one workspace. Reads the mapping from the workspace's config and
+  upserts each document through the canonical OSS connector→Fabric mapper
+  (``pocketpaw.connectors.fabric_ingest.ingest_records`` — the same loop the
+  Calendar connector ingestion uses), keyed on the doc's source path so a
+  re-run updates rather than duplicates. Every object is stamped with
+  ``workspace_id`` + ``source_connector="firestore"`` + ``source_id`` (the full
+  doc path); the worker advances a REAL high-water cursor taken from document
+  data and applies any link rules. Backfill on first run, incremental
+  thereafter.
+* ``service.run_ingest_sweep`` — fan ``ingest_collection`` out across every
+  configured (workspace, collection) pair under a bounded concurrency cap;
+  per-collection failures are isolated.
+* ``service.FirestoreReader`` — the narrow read Protocol the worker depends on,
+  so tests inject fakes with no google credentials.
+* ``firestore_reader.GoogleFirestoreReader`` — the concrete reader over the
+  optional ``google-cloud-firestore`` dependency (lazy import + clear install
+  error).
+* ``scheduler.FabricIngestScheduler`` — the periodic background sweep (every
+  5 min), gated on ``POCKETPAW_CLOUD_SCHEDULER_ENABLED`` and wired into
+  ``mount_cloud``.
+* ``models.fabric_ingest_state.FabricIngestState`` — per-(workspace, source)
+  sync status (status, backfill_done, last_sync_at, cursor, objects_ingested).
+* ``models.fabric_ingest_state.FabricIngestConfig`` — the per-workspace mapping.
+
+Cursor — the deliberate improvement over MemberIngestState
+----------------------------------------------------------
+The incremental cursor is a REAL high-water mark from document data — the
+mapping's configured ``cursor_field`` on the newest document seen (falling back
+to the snapshot ``update_time``). It is NOT the run's wall clock. A document
+that lands late but carries an older updated-at is still picked up, and a re-run
+never re-scans a wall-clock window. MemberIngestState's wall-clock cursor is a
+known flaw and is deliberately not copied here.
+
+Follow-ups (v1 ships a solid-but-bounded slice):
+* Batched writes. ``FabricStore.create_object`` commits per row today —
+  acceptable for v1, noted as a TODO; a batch-insert path would cut commits on
+  a large backfill.
+* A status/read router (``GET /api/v1/fabric-ingest/status``) for operator
+  visibility over ``FabricIngestState``.
+* A first-config-write trigger that kicks an immediate backfill instead of
+  waiting for the next sweep tick.
+"""

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/dto.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/dto.py
@@ -1,0 +1,111 @@
+# dto.py — Request/validation schemas for the Firestore→Fabric ingest worker.
+# Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+#
+# Per cloud rule §4 (request/response split) and §6 (validate at entry): the
+# service functions re-parse their inputs through these even when called by
+# internal callers (the sweep, the scheduler). The mapping config is validated
+# here too — a malformed mapping (blank collection, blank object type, a link
+# rule missing a field) is rejected before any Firestore read, so a bad
+# per-deployment config fails loudly at the entry point rather than silently
+# mirroring nothing or crashing mid-sweep.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class IngestCollectionRequest(BaseModel):
+    """Input to ``ingest_collection`` — the tenant + the source to mirror.
+
+    ``source_id`` is the Firestore collection path. Both are required and
+    non-blank: a blank workspace would un-scope the tenant filter and a blank
+    collection has nothing to read.
+    """
+
+    workspace_id: str = Field(min_length=1)
+    source_id: str = Field(min_length=1)
+
+    @field_validator("workspace_id", "source_id")
+    @classmethod
+    def _not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("must not be blank")
+        return v
+
+
+class SweepRequest(BaseModel):
+    """Input to ``run_ingest_sweep`` — the concurrency cap for the fan-out."""
+
+    concurrency: int = Field(default=4, ge=1, le=64)
+
+
+class LinkRuleSpec(BaseModel):
+    """Validation shape for one link rule on a mapping.
+
+    Mirrors ``models.fabric_ingest_state.FabricLinkRule`` but lives in the DTO
+    layer so the service can validate a raw config dict at entry without
+    importing the Beanie model into router/dto (cloud chokepoint rule).
+    """
+
+    to_type: str = Field(min_length=1)
+    link_type: str = Field(min_length=1)
+    via_field: str = Field(min_length=1)
+
+    @field_validator("to_type", "link_type", "via_field")
+    @classmethod
+    def _not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("must not be blank")
+        return v
+
+
+class FieldMappingSpec(BaseModel):
+    """Validation shape for one collection→object-type mapping.
+
+    A mapping with no ``field_map`` is allowed (the worker still stamps the
+    tenancy + provenance fields and can resolve links), but the collection and
+    object type are mandatory — without them there is nothing to mirror and
+    nowhere to put it.
+    """
+
+    collection: str = Field(min_length=1)
+    object_type_id: str = Field(min_length=1)
+    field_map: dict[str, str] = Field(default_factory=dict)
+    cursor_field: str = ""
+    link_rules: list[LinkRuleSpec] = Field(default_factory=list)
+
+    @field_validator("collection", "object_type_id")
+    @classmethod
+    def _not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("must not be blank")
+        return v
+
+    @field_validator("field_map")
+    @classmethod
+    def _no_blank_property_names(cls, v: dict[str, str]) -> dict[str, str]:
+        for src, prop in v.items():
+            if not str(src).strip() or not str(prop).strip():
+                raise ValueError("field_map keys and values must not be blank")
+        return v
+
+
+class IngestConfigRequest(BaseModel):
+    """Validation shape for a whole per-workspace ingest config.
+
+    Used at entry whenever a config is set or read back into the worker. A
+    config with an empty ``mappings`` list is structurally valid (the worker
+    just has nothing to do for that workspace); each present mapping is fully
+    validated by ``FieldMappingSpec``.
+    """
+
+    workspace_id: str = Field(min_length=1)
+    enabled: bool = True
+    mappings: list[FieldMappingSpec] = Field(default_factory=list)
+
+    @field_validator("workspace_id")
+    @classmethod
+    def _not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("workspace_id must not be blank")
+        return v

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/firestore_reader.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/firestore_reader.py
@@ -1,0 +1,109 @@
+# firestore_reader.py — Concrete FirestoreReader over google-cloud-firestore.
+# Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+#
+# Wraps the async google-cloud-firestore client behind the ``FirestoreReader``
+# Protocol the service depends on. Kept in its own module so the google import
+# is fully isolated: the service imports this lazily and only when no fake
+# reader was injected, so pure-unit tests never touch google and the dependency
+# stays OPTIONAL — ``google-cloud-firestore`` is an optional extra of the ee
+# package (``pocketpaw-ee[firestore]``). If it isn't installed, constructing
+# this reader raises a clear, actionable install error rather than an opaque
+# ImportError deep in the call path.
+#
+# Cursor semantics: ``read_collection`` orders ascending by the configured
+# ``cursor_field`` and returns only documents whose value is strictly greater
+# than the supplied cursor (everything when the cursor is empty — backfill).
+# Each document is shaped into the ``{path, data, update_time}`` dict the worker
+# expects, where ``update_time`` is the snapshot update time as RFC3339 — the
+# cursor fallback the service uses when a document has no ``cursor_field`` value.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_INSTALL_HINT = (
+    "google-cloud-firestore is not installed. The Firestore→Fabric ingest "
+    "worker needs it. Install the optional extra: `uv sync --group ee "
+    "--extra firestore` (or `pip install 'pocketpaw-ee[firestore]'`)."
+)
+
+
+def _require_firestore() -> Any:
+    """Import google-cloud-firestore's async client, or raise a clear error."""
+    try:
+        from google.cloud import firestore  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover — exercised only without the dep
+        raise RuntimeError(_INSTALL_HINT) from exc
+    return firestore
+
+
+class GoogleFirestoreReader:
+    """Async ``FirestoreReader`` backed by ``google.cloud.firestore``.
+
+    Credentials resolve through Application Default Credentials (the standard
+    GOOGLE_APPLICATION_CREDENTIALS / workload-identity path); this reader takes
+    no secrets of its own. ``project`` is optional — when omitted the client
+    picks it up from the ambient credentials/environment.
+    """
+
+    def __init__(self, project: str | None = None) -> None:
+        firestore = _require_firestore()
+        # AsyncClient is the async surface; the sync Client would block the loop.
+        self._client = firestore.AsyncClient(project=project)
+
+    async def read_collection(
+        self,
+        collection: str,
+        *,
+        cursor_field: str,
+        cursor: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        query = self._client.collection(collection)
+        # Order + lower-bound on the cursor field when one is configured. With
+        # no cursor_field we can't do an incremental window, so we read the page
+        # as-is (the service still de-dupes via upsert, so this is safe — it
+        # just re-reads each tick; configuring a cursor_field is recommended).
+        if cursor_field:
+            query = query.order_by(cursor_field)
+            if cursor:
+                query = query.start_after({cursor_field: cursor})
+        query = query.limit(limit)
+
+        docs: list[dict[str, Any]] = []
+        async for snapshot in query.stream():
+            update_time = getattr(snapshot, "update_time", None)
+            docs.append(
+                {
+                    "path": snapshot.reference.path,
+                    "data": snapshot.to_dict() or {},
+                    "update_time": _iso(update_time),
+                }
+            )
+        return docs
+
+
+def _iso(update_time: Any) -> str:
+    """Render a Firestore snapshot update_time as an RFC3339 string.
+
+    Firestore returns a ``DatetimeWithNanoseconds`` (a datetime subclass) or a
+    proto Timestamp depending on the client version; both expose ``isoformat``
+    or ``rfc3339``. Fall back to ``str`` so an unexpected shape never crashes
+    the read.
+    """
+    if update_time is None:
+        return ""
+    for attr in ("rfc3339", "isoformat"):
+        fn = getattr(update_time, attr, None)
+        if callable(fn):
+            try:
+                return str(fn())
+            except Exception:  # noqa: BLE001 — fall through to str()
+                pass
+    return str(update_time)
+
+
+__all__ = ["GoogleFirestoreReader"]

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/scheduler.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/scheduler.py
@@ -1,0 +1,177 @@
+# scheduler.py — Periodic background sweep for the Firestore→Fabric worker.
+# Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+#
+# Mirrors the MemberIngestScheduler / ChatRunDoc sweeper shape (the cloud's
+# established periodic-task pattern): a class with a testable ``tick()`` (one
+# sweep, no background task), a ``_run_loop()`` that wakes on a timeout OR a
+# stop event so ``stop()`` returns promptly, ``start()``/``stop()`` lifecycle,
+# and a module singleton wired onto ``app.state`` by ``mount_cloud`` under the
+# ``POCKETPAW_CLOUD_SCHEDULER_ENABLED`` gate (so pytest runs never spawn a loop
+# that outlives the test).
+#
+# Cadence: every 5 minutes by default. Each tick runs ``run_ingest_sweep``
+# across every configured (workspace, collection) pair — backfill on first
+# sight of a source, incremental thereafter. Override the interval via
+# POCKETPAW_FABRIC_INGEST_INTERVAL_SECONDS.
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from typing import Any
+
+from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+_TASK_KEY = "_fabric_ingest_scheduler"
+_DEFAULT_INTERVAL_SECONDS = 300  # 5 minutes — same cadence as the member sweep
+_ENV_INTERVAL = "POCKETPAW_FABRIC_INGEST_INTERVAL_SECONDS"
+
+
+def _interval_seconds() -> int:
+    """Read the sweep interval from env, default 300s (5 min)."""
+    raw = os.environ.get(_ENV_INTERVAL, "").strip()
+    if not raw:
+        return _DEFAULT_INTERVAL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an int — falling back to %d seconds",
+            _ENV_INTERVAL,
+            raw,
+            _DEFAULT_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_INTERVAL_SECONDS
+    return max(1, value)
+
+
+class FabricIngestScheduler:
+    """In-process periodic sweep for Firestore→Fabric mirroring.
+
+    Use:
+        scheduler = FabricIngestScheduler()
+        await scheduler.start()   # spawn the background loop
+        ...
+        await scheduler.stop()    # cancel + await cleanly
+
+    For unit tests:
+        scheduler = FabricIngestScheduler()
+        await scheduler.tick()    # one sweep, no background task
+    """
+
+    def __init__(self, interval_seconds: int | None = None) -> None:
+        self._interval = interval_seconds if interval_seconds is not None else _interval_seconds()
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event: asyncio.Event = asyncio.Event()
+
+    @property
+    def interval_seconds(self) -> int:
+        return self._interval
+
+    async def tick(self) -> dict[str, Any]:
+        """Run a single ingest sweep. Safe to call from tests without
+        ``start()``. Returns the sweep summary; never raises — a sweep failure
+        is logged and reported as an empty summary so the loop survives a
+        transient DB/Firestore hiccup."""
+        # Import inside so a test exercising ``tick()`` directly doesn't have to
+        # bootstrap the whole cloud module, and so a monkeypatch of
+        # ``service.run_ingest_sweep`` is observed (late binding).
+        from pocketpaw_ee.cloud.fabric_ingest import service as ingest_service
+
+        try:
+            summary = await ingest_service.run_ingest_sweep()
+            logger.info(
+                "fabric_ingest.scheduler: tick sources=%s ok=%s errors=%s",
+                summary.get("sources"),
+                summary.get("ok"),
+                summary.get("errors"),
+            )
+            return summary
+        except Exception:  # noqa: BLE001 — keep the loop alive across hiccups
+            logger.exception("fabric_ingest.scheduler: sweep tick raised")
+            return {"sources": 0, "ok": 0, "errors": 0}
+
+    async def _run_loop(self) -> None:
+        """Background loop body. Wakes on the interval OR the stop event."""
+        logger.info("fabric_ingest.scheduler: loop started (interval=%ds)", self._interval)
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self._interval)
+                # Reached here without TimeoutError → stop was signalled.
+                break
+            except TimeoutError:
+                pass
+            except asyncio.CancelledError:
+                logger.info("fabric_ingest.scheduler: loop cancelled — exiting")
+                raise
+            await self.tick()
+
+    async def start(self) -> None:
+        """Spawn the background loop. Idempotent."""
+        if self._task is not None and not self._task.done():
+            return
+        self._stop_event = asyncio.Event()
+        self._task = asyncio.create_task(self._run_loop(), name="fabric-ingest-scheduler")
+
+    async def stop(self) -> None:
+        """Cancel + await the loop. Safe to call multiple times."""
+        if self._task is None:
+            return
+        self._stop_event.set()
+        if not self._task.done():
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._task
+        self._task = None
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — mount_cloud installs one onto app.state.
+# ---------------------------------------------------------------------------
+
+
+_SCHEDULER: FabricIngestScheduler | None = None
+
+
+def get_scheduler() -> FabricIngestScheduler:
+    """Return the process singleton, constructing one lazily if needed."""
+    global _SCHEDULER
+    if _SCHEDULER is None:
+        _SCHEDULER = FabricIngestScheduler()
+    return _SCHEDULER
+
+
+def reset_scheduler_for_tests() -> None:
+    """Drop the singleton so each test gets a fresh instance."""
+    global _SCHEDULER
+    _SCHEDULER = None
+
+
+async def start_fabric_ingest(app: FastAPI) -> None:
+    """Wire the singleton onto ``app.state`` and spawn the loop.
+    Mirrors ``member_ingest.scheduler.start_member_ingest``."""
+    scheduler = get_scheduler()
+    setattr(app.state, _TASK_KEY, scheduler)
+    await scheduler.start()
+
+
+async def stop_fabric_ingest(app: FastAPI) -> None:
+    """Cancel + await the loop attached to ``app.state``."""
+    scheduler: FabricIngestScheduler | None = getattr(app.state, _TASK_KEY, None)
+    if scheduler is None:
+        return
+    await scheduler.stop()
+    setattr(app.state, _TASK_KEY, None)
+
+
+__all__ = [
+    "FabricIngestScheduler",
+    "get_scheduler",
+    "reset_scheduler_for_tests",
+    "start_fabric_ingest",
+    "stop_fabric_ingest",
+]

--- a/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
+++ b/ee/pocketpaw_ee/cloud/fabric_ingest/service.py
@@ -1,0 +1,536 @@
+# service.py — Generic Firestore→Fabric ingestion worker.
+# Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+# Updated: 2026-06-11 (rebase onto dev) — the per-document upsert now delegates
+#   to the OSS connector→Fabric mapper (pocketpaw.connectors.fabric_ingest
+#   .ingest_records, landed on dev in the Calendar ingestion PR #1418) instead
+#   of a private _upsert_object/_map_properties pair — one canonical
+#   upsert-by-source loop, not two parallel ones. Each Firestore doc becomes a
+#   connector record carrying its doc path under a sentinel key; the workspace
+#   config mapping translates into an OSS FabricMapping (field map inverted to
+#   the OSS {property: record_key} direction; the configured object_type_id
+#   pinned via the mapping's new optional type_id). Behavior note inherited
+#   from the canonical loop: a mapped field absent from a document projects as
+#   None (the mirror reflects the source) rather than being skipped.
+#
+# What this does
+# --------------
+# Continuously mirrors selected Firestore collections into Fabric objects for a
+# deployment. The per-deployment mapping (which collections, which object types,
+# field maps, cursor fields, link rules) lives entirely in a per-workspace
+# ``FabricIngestConfig`` document — there is NOTHING domain-specific in this
+# module. ``ingest_collection`` mirrors one collection for one workspace;
+# ``run_ingest_sweep`` fans that out across every configured (workspace,
+# collection) pair under a concurrency cap; the scheduler ticks the sweep.
+#
+# Cursor — a REAL high-water mark, not run wall-clock
+# ---------------------------------------------------
+# The incremental cursor stored in ``FabricIngestState.cursor`` is the value of
+# the mapping's configured ``cursor_field`` on the newest document seen (falling
+# back to the Firestore snapshot ``update_time`` when a document has no value
+# for the field). It is NOT the run's wall clock. MemberIngestState advances its
+# cursor to ``now`` on every run (service.py:188 there), which means a document
+# that lands late but carries an older updated-at is missed and a re-run
+# re-scans a time window. Here the worker passes the stored cursor as the
+# reader's lower bound and advances it only to the max cursor value it actually
+# observed, so re-runs don't re-ingest unchanged documents and late-but-older
+# documents are still picked up on their own merits.
+#
+# Write sink — the OSS FabricStore via the canonical connector mapper
+# --------------------------------------------------------------------
+# Every object is written through the OSS connector→Fabric mapper
+# (``pocketpaw.connectors.fabric_ingest.ingest_records``) into the OSS
+# ``FabricStore`` (the same store the Fabric router uses), stamped with the
+# caller's ``workspace_id`` (plain str — OSS must never import pocketpaw_ee),
+# ``source_connector="firestore"``, and ``source_id`` = the full Firestore
+# document path. The mapper upserts by ``(source_connector, source_id)`` via
+# ``FabricStore.get_object_by_source`` — a re-run UPDATEs instead of inserting
+# a duplicate. ``create_object`` commits per row — acceptable for v1; batching
+# is a TODO (see the follow-ups in __init__.py), not built here.
+#
+# Reader Protocol — testability
+# ------------------------------
+# All Firestore access goes through the ``FirestoreReader`` Protocol so tests
+# inject fakes with no google credentials. The concrete reader wrapping
+# ``google-cloud-firestore`` is constructed lazily and only when no fake was
+# passed, and the google import is deferred with a clear install error so the
+# dependency stays optional.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import FabricIngestCompleted
+from pocketpaw_ee.cloud.fabric_ingest.dto import (
+    IngestCollectionRequest,
+    IngestConfigRequest,
+    SweepRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+# Provenance stamp on every mirrored object (cloud rule: tenancy + source on
+# every write). ``source_connector`` is fixed; ``source_id`` is the doc path.
+_SOURCE_CONNECTOR = "firestore"
+# Sentinel record key carrying the Firestore doc path into the OSS mapper —
+# the doc path lives OUTSIDE the document's field dict, but ``ingest_records``
+# extracts the source id from a record key, so we graft it on under a name no
+# real Firestore field would use (and which would be overwritten if one did).
+_DOC_PATH_KEY = "__firestore_doc_path__"
+
+# Per-collection page cap so one huge collection can't wedge a sweep tick.
+_MAX_DOCS_PER_RUN = 1000
+# Default sweep fan-out cap so N collection-syncs don't swamp the box.
+_DEFAULT_SWEEP_CONCURRENCY = 4
+
+
+# --------------------------------------------------------------------------
+# Reader protocol — the worker depends on this narrow shape, not on the
+# concrete google-cloud-firestore client, so tests inject fakes with no creds.
+# --------------------------------------------------------------------------
+
+
+class FirestoreReader(Protocol):
+    async def read_collection(
+        self,
+        collection: str,
+        *,
+        cursor_field: str,
+        cursor: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Return documents from ``collection`` whose ``cursor_field`` value is
+        strictly greater than ``cursor`` (all documents when ``cursor`` is
+        empty — the backfill case), ordered ascending by that field, capped at
+        ``limit``.
+
+        Each returned dict carries:
+          * ``path``        — the full Firestore document path (becomes source_id)
+          * ``data``        — the document's field dict
+          * ``update_time`` — the snapshot update time as an RFC3339 string
+                              (the cursor fallback when a doc lacks cursor_field)
+        """
+        ...
+
+
+# ingest_fn(workspace_id, source_id, **kw) -> result dict. The per-collection
+# unit the sweep dispatches; defaults to ``ingest_collection`` but injectable.
+IngestFn = Callable[..., Awaitable[dict[str, Any]]]
+# A store with the create/update/link/get_object_by_source surface this worker
+# needs. Typed loosely so tests can pass a fake store without importing the OSS
+# FabricStore. The real default is ``pocketpaw.stores.get_fabric_store()``.
+StoreLike = Any
+
+
+# --------------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------------
+
+
+async def ingest_collection(
+    workspace_id: str,
+    source_id: str,
+    *,
+    reader: FirestoreReader | None = None,
+    store: StoreLike | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Mirror one Firestore collection (``source_id``) into Fabric objects for
+    one workspace.
+
+    The mapping (object type, field map, cursor field, link rules) is read from
+    the workspace's ``FabricIngestConfig``; if no mapping matches ``source_id``
+    the call is a no-op error. Backfill-vs-incremental is decided by the
+    persisted ``FabricIngestState.backfill_done`` flag. Returns a result dict
+    with ``status`` (``ok``/``error``), ``mode`` (``backfill``/``incremental``),
+    ``objects`` (count mirrored this run), ``cursor`` (the new high-water mark),
+    and any ``errors``.
+    """
+    # Validate at entry (cloud rule §6) — the sweep and scheduler get the same
+    # guard an HTTP body would.
+    body = IngestCollectionRequest.model_validate(
+        {"workspace_id": workspace_id, "source_id": source_id}
+    )
+    workspace_id, source_id = body.workspace_id, body.source_id
+    now = now or datetime.now(UTC)
+
+    mapping = await _load_mapping(workspace_id, source_id)
+    if mapping is None:
+        # No mapping for this collection — nothing to mirror. Report an error so
+        # a misconfigured sweep entry is visible, but never raise.
+        return {
+            "workspace_id": workspace_id,
+            "source_id": source_id,
+            "status": "error",
+            "mode": "none",
+            "objects": 0,
+            "cursor": "",
+            "errors": [f"no mapping for collection {source_id!r}"],
+        }
+
+    store = store or _default_store()
+    state = await _load_or_create_state(workspace_id, source_id)
+    mode = "backfill" if not state.backfill_done else "incremental"
+    state.status = "running"
+    await state.save()  # no-event: transient in-progress marker.
+
+    errors: list[str] = []
+    objects = 0
+    new_cursor = state.cursor
+
+    if reader is None:
+        reader = _default_reader()
+
+    try:
+        # Backfill reads from an empty cursor (everything); incremental reads
+        # only documents past the stored high-water mark.
+        lower_bound = "" if mode == "backfill" else state.cursor
+        docs = await reader.read_collection(
+            mapping.collection,
+            cursor_field=mapping.cursor_field,
+            cursor=lower_bound,
+            limit=_MAX_DOCS_PER_RUN,
+        )
+        # Advance the high-water mark to the MAX cursor value we actually saw
+        # across docs with a usable identity — a real watermark from document
+        # data, never run wall-clock. Persisted only on a clean run (below).
+        for doc in docs:
+            if not str(doc.get("path") or ""):
+                continue  # no stable identity — the mapper skips it too
+            doc_cursor = _doc_cursor(doc, mapping.cursor_field)
+            if doc_cursor and doc_cursor > new_cursor:
+                new_cursor = doc_cursor
+        # Upsert through the canonical OSS connector→Fabric loop.
+        objects = await _mirror_docs(store, workspace_id, docs, mapping)
+        # Link rules run after all objects exist so a link can target a
+        # document mirrored earlier in the same batch.
+        if mapping.link_rules:
+            await _apply_link_rules(store, workspace_id, docs, mapping)
+    except Exception as exc:  # noqa: BLE001 — isolate this collection so one bad
+        # source never crashes the sweep or the other collections.
+        logger.warning(
+            "fabric_ingest: read/write failed for ws=%s collection=%s: %s",
+            workspace_id,
+            source_id,
+            exc,
+        )
+        errors.append(f"{source_id}: {exc}")
+
+    # --- Persist outcome ---
+    status = "error" if errors else "ok"
+    state.status = status
+    state.last_error = "; ".join(errors)
+    state.objects_ingested += objects
+    if status == "ok":
+        # Only flip backfill_done + advance the cursor on a clean run — a failed
+        # backfill retries the wide read next time rather than skipping ahead.
+        state.backfill_done = True
+        state.last_sync_at = now
+        state.cursor = new_cursor
+    await state.save()  # no-event: domain event emitted explicitly below.
+
+    await emit(
+        FabricIngestCompleted(
+            data={
+                "workspace_id": workspace_id,
+                "source_id": source_id,
+                "object_type_id": mapping.object_type_id,
+                "mode": mode,
+                "status": status,
+                "objects_ingested": objects,
+                "cursor": state.cursor,
+            }
+        )
+    )
+
+    return {
+        "workspace_id": workspace_id,
+        "source_id": source_id,
+        "status": status,
+        "mode": mode,
+        "objects": objects,
+        "cursor": state.cursor,
+        "errors": errors,
+    }
+
+
+async def list_ingest_sources(workspace_id: str | None = None) -> list[dict[str, str]]:
+    """Enumerate (workspace, collection) pairs the worker should mirror.
+
+    One entry per mapping across every enabled ``FabricIngestConfig``. When
+    ``workspace_id`` is given the Beanie query pins it (tenant filter, cloud
+    rule §7); the global form (``None``) is the scheduler's cross-tenant sweep.
+    """
+    from pocketpaw_ee.cloud.models.fabric_ingest_state import FabricIngestConfig
+
+    query: dict[str, Any] = {"enabled": True}
+    if workspace_id:
+        query["workspace"] = workspace_id  # tenant filter
+    # else: global-read — the scheduler sweeps every configured tenant.
+
+    configs = await FabricIngestConfig.find(query).to_list()
+
+    sources: list[dict[str, str]] = []
+    for cfg in configs:
+        for mapping in cfg.mappings:
+            if not mapping.collection:
+                continue
+            sources.append({"workspace_id": cfg.workspace, "source_id": mapping.collection})
+    return sources
+
+
+async def run_ingest_sweep(
+    *,
+    workspace_id: str | None = None,
+    concurrency: int = _DEFAULT_SWEEP_CONCURRENCY,
+    ingest_fn: IngestFn | None = None,
+) -> dict[str, Any]:
+    """Mirror every configured collection, bounded by a concurrency cap.
+
+    One collection failing never aborts the others — each unit is isolated.
+    Returns ``{sources, ok, errors}``. ``ingest_fn`` defaults to
+    ``ingest_collection`` (real reader + real store); tests inject a fake.
+    """
+    body = SweepRequest.model_validate({"concurrency": concurrency})
+    concurrency = body.concurrency
+    fn = ingest_fn or ingest_collection
+
+    sources = await list_ingest_sources(workspace_id=workspace_id)
+    if not sources:
+        return {"sources": 0, "ok": 0, "errors": 0}
+
+    sem = asyncio.Semaphore(concurrency)
+    ok = 0
+    errors = 0
+
+    async def _one(entry: dict[str, str]) -> None:
+        nonlocal ok, errors
+        async with sem:
+            try:
+                result = await fn(entry["workspace_id"], entry["source_id"])
+            except Exception as exc:  # noqa: BLE001 — isolate per collection so a
+                # single bad source doesn't abort the whole sweep.
+                logger.warning(
+                    "fabric_ingest: sweep unit failed ws=%s source=%s: %s",
+                    entry["workspace_id"],
+                    entry["source_id"],
+                    exc,
+                )
+                errors += 1
+                return
+            if isinstance(result, dict) and result.get("status") == "error":
+                errors += 1
+            else:
+                ok += 1
+
+    await asyncio.gather(*(_one(s) for s in sources))
+    logger.info(
+        "fabric_ingest: sweep complete sources=%d ok=%d errors=%d (ws=%s)",
+        len(sources),
+        ok,
+        errors,
+        workspace_id or "ALL",
+    )
+    return {"sources": len(sources), "ok": ok, "errors": errors}
+
+
+# --------------------------------------------------------------------------
+# Mapping / state helpers
+# --------------------------------------------------------------------------
+
+
+async def _load_mapping(workspace_id: str, source_id: str):
+    """Return the mapping for ``source_id`` from the workspace's config, or None.
+
+    The config doc is validated through ``IngestConfigRequest`` at read (cloud
+    rule §6 — validate at entry even on the read path) so a malformed stored
+    config surfaces as a validation error rather than a silent half-mirror.
+    Tenant filter on the read (cloud rule §7): ``workspace`` pins the row.
+    """
+    from pocketpaw_ee.cloud.models.fabric_ingest_state import FabricIngestConfig
+
+    cfg = await FabricIngestConfig.find_one(
+        FabricIngestConfig.workspace == workspace_id,
+        FabricIngestConfig.enabled == True,  # noqa: E712 — Beanie needs ==, not `is`
+    )
+    if cfg is None:
+        return None
+
+    # Validate the stored config at entry. Raises on a malformed mapping.
+    IngestConfigRequest.model_validate(
+        {
+            "workspace_id": cfg.workspace,
+            "enabled": cfg.enabled,
+            "mappings": [m.model_dump() for m in cfg.mappings],
+        }
+    )
+
+    for mapping in cfg.mappings:
+        if mapping.collection == source_id:
+            return mapping
+    return None
+
+
+async def _load_or_create_state(workspace_id: str, source_id: str):
+    """Fetch the per-source ingest state, creating a fresh row on first run.
+
+    Tenant filter on the read (cloud rule §7): both ``workspace`` and
+    ``source_id`` pin the row so two sources never share state and no
+    cross-tenant row is ever touched.
+    """
+    from pocketpaw_ee.cloud.models.fabric_ingest_state import FabricIngestState
+
+    state = await FabricIngestState.find_one(
+        FabricIngestState.workspace == workspace_id,
+        FabricIngestState.source_id == source_id,
+    )
+    if state is None:
+        state = FabricIngestState(workspace=workspace_id, source_id=source_id)
+        await state.insert()
+    return state
+
+
+# --------------------------------------------------------------------------
+# Doc → object mapping + upsert
+# --------------------------------------------------------------------------
+
+
+def _doc_cursor(doc: dict[str, Any], cursor_field: str) -> str:
+    """The cursor value for a document: its ``cursor_field`` value, falling back
+    to the snapshot ``update_time`` when the field is absent/empty.
+
+    Returned as a string so the comparison stays uniform regardless of the
+    Firestore value type (timestamps serialize to RFC3339, which sorts
+    lexicographically the same as chronologically).
+    """
+    data = doc.get("data") or {}
+    raw = data.get(cursor_field) if cursor_field else None
+    if raw is None or raw == "":
+        raw = doc.get("update_time") or ""
+    return str(raw)
+
+
+async def _mirror_docs(
+    store: StoreLike,
+    workspace_id: str,
+    docs: list[dict[str, Any]],
+    mapping: Any,
+) -> int:
+    """Upsert the documents into Fabric via the canonical OSS connector mapper.
+
+    Delegates to ``pocketpaw.connectors.fabric_ingest.ingest_records`` (the
+    upsert-by-source loop the Calendar connector ingestion established) rather
+    than a parallel private implementation. The translation:
+
+    * each Firestore doc becomes a record of its field dict plus the doc path
+      grafted on under ``_DOC_PATH_KEY`` — the mapper extracts the source id
+      from a record key, and the path is the stable identity here;
+    * the workspace config's ``field_map`` ({firestore_field: property_name})
+      inverts into the OSS direction ({property_name: record_key}). If two
+      Firestore fields ever mapped to the same property, the last one wins;
+    * the configured ``object_type_id`` pins the ObjectType via the mapping's
+      ``type_id`` (no define-by-name — the type already exists per config);
+      ``type_name`` is only the reporting label on the result.
+
+    Every object lands stamped with ``workspace_id`` (a tenancy leak
+    otherwise — legacy NULL-workspace rows are globally visible),
+    ``source_connector="firestore"``, and ``source_id`` = the full doc path.
+    Returns the number of objects created + updated.
+    """
+    # Lazy import — keeps EE module import light and consistent with the other
+    # OSS imports in this module (_default_store).
+    from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
+
+    records = [
+        {**(doc.get("data") or {}), _DOC_PATH_KEY: str(doc.get("path") or "")} for doc in docs
+    ]
+    oss_mapping = FabricMapping(
+        type_name=mapping.object_type_id,  # label only; type_id pins the type
+        source_id_field=_DOC_PATH_KEY,
+        field_map={prop: fs_field for fs_field, prop in mapping.field_map.items()},
+        type_id=mapping.object_type_id,
+    )
+    summary = await ingest_records(
+        store,
+        _SOURCE_CONNECTOR,
+        records,
+        oss_mapping,
+        workspace_id=workspace_id,
+    )
+    return summary.total
+
+
+async def _apply_link_rules(
+    store: StoreLike,
+    workspace_id: str,
+    docs: list[dict[str, Any]],
+    mapping: Any,
+) -> None:
+    """Create links for every document per the mapping's link rules.
+
+    For each rule, read ``via_field`` off the source document; if it names the
+    source_id (full doc path) of an already-mirrored object of type ``to_type``
+    in this workspace, link the source object to it with ``link_type``. A rule
+    that can't resolve its target is skipped silently (the target may simply not
+    be mirrored yet) — links are best-effort enrichment, never a hard failure.
+    """
+    for doc in docs:
+        src_source_id = str(doc.get("path") or "")
+        src_obj = await store.get_object_by_source(
+            _SOURCE_CONNECTOR, src_source_id, workspace_id=workspace_id
+        )
+        if src_obj is None:
+            continue
+        data = doc.get("data") or {}
+        for rule in mapping.link_rules:
+            target_source_id = data.get(rule.via_field)
+            if not target_source_id:
+                continue
+            target = await store.get_object_by_source(
+                _SOURCE_CONNECTOR, str(target_source_id), workspace_id=workspace_id
+            )
+            if target is None or target.type_id != rule.to_type:
+                continue
+            await store.link(
+                src_obj.id,
+                target.id,
+                rule.link_type,
+                workspace_id=workspace_id,
+            )
+
+
+# --------------------------------------------------------------------------
+# Default reader + store (lazy — keep google + OSS imports out of unit tests)
+# --------------------------------------------------------------------------
+
+
+def _default_store() -> StoreLike:
+    """The process-wide OSS FabricStore singleton. Imported lazily so a unit
+    test passing a fake store never pulls the OSS store stack."""
+    from pocketpaw.stores import get_fabric_store
+
+    return get_fabric_store()
+
+
+def _default_reader() -> FirestoreReader:
+    """Construct the real google-cloud-firestore-backed reader.
+
+    Lazy-imports ``google.cloud.firestore`` and raises a clear, actionable
+    error if the optional dependency is not installed. Tests never reach here —
+    they inject a fake reader.
+    """
+    from pocketpaw_ee.cloud.fabric_ingest.firestore_reader import GoogleFirestoreReader
+
+    return GoogleFirestoreReader()
+
+
+__all__ = [
+    "FirestoreReader",
+    "ingest_collection",
+    "list_ingest_sources",
+    "run_ingest_sweep",
+]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -30,6 +30,12 @@ Updated: 2026-06-10 (feat/belt-console-backend, SC-1) — added
 to the imports, ``__all__``, and ``get_all_documents()`` so the console's
 add-repo route persistence is wired into ``init_beanie``. Only
 ``ee.cloud.belt.service`` imports the doc class directly.
+Updated: 2026-06-11 (feat/firestore-fabric-ingest) — added
+``FabricIngestConfig`` (the per-workspace Firestore→Fabric mapping) and
+``FabricIngestState`` (the per-(workspace, collection) sync bookkeeping) to the
+imports, ``__all__``, and ``get_all_documents()`` so the ingestion worker's
+collections are wired into ``init_beanie``. Only
+``ee.cloud.fabric_ingest.service`` imports the doc classes directly.
 """
 
 from __future__ import annotations
@@ -45,6 +51,10 @@ from pocketpaw_ee.cloud.models.comment import Comment, CommentAuthor, CommentTar
 from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
 from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
 from pocketpaw_ee.cloud.models.cycle import Cycle, CycleDailyPoint
+from pocketpaw_ee.cloud.models.fabric_ingest_state import (
+    FabricIngestConfig,
+    FabricIngestState,
+)
 from pocketpaw_ee.cloud.models.file import FileObj
 from pocketpaw_ee.cloud.models.foresight_backtest import ForesightBacktest
 from pocketpaw_ee.cloud.models.foresight_prediction_record import (
@@ -137,6 +147,8 @@ __all__ = [
     "ComposioConnection",
     "Cycle",
     "CycleDailyPoint",
+    "FabricIngestConfig",
+    "FabricIngestState",
     "FileFolder",
     "FileObj",
     "FileUpload",
@@ -223,6 +235,8 @@ def get_all_documents():
         MeetingProviderCredentials,
         MeetingsSettings,
         MemberIngestState,
+        FabricIngestConfig,
+        FabricIngestState,
         # Calendar — sibling enterprise package.
         _CalendarDoc,
         _EventDoc,

--- a/ee/pocketpaw_ee/cloud/models/fabric_ingest_state.py
+++ b/ee/pocketpaw_ee/cloud/models/fabric_ingest_state.py
@@ -1,0 +1,138 @@
+# FabricIngestState + FabricIngestConfig Beanie documents — Firestore→Fabric ingest.
+# Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+#
+# Two collections back the generic ingestion worker:
+#
+# * ``fabric_ingest_state`` (FabricIngestState) — one row per
+#   (workspace, source_id) where source_id is the Firestore collection path
+#   being mirrored. Tracks the worker's bookkeeping for that source: whether
+#   the first full backfill ran (``backfill_done`` drives backfill-vs-
+#   incremental), the high-water cursor, the last run status/error, and a
+#   running count of objects ingested. The cursor here is a REAL high-water
+#   mark taken from document data (the configured ``cursor_field``, falling
+#   back to the snapshot update_time) — NOT a run wall-clock. This is the
+#   deliberate improvement over MemberIngestState's wall-clock cursor: a
+#   document that arrives late but carries an older updated-at value is still
+#   picked up, and re-runs don't re-scan a wall-clock window.
+#
+# * ``fabric_ingest_config`` (FabricIngestConfig) — one row per workspace
+#   holding the per-deployment mapping: which Firestore collections to mirror,
+#   which Fabric object type each maps to, the field→property map, the cursor
+#   field, and optional link rules. Fully generic: no collection names, field
+#   names, or object types are hard-coded in code — they all live here, set
+#   per deployment.
+#
+# Tenancy: every row carries ``workspace`` (indexed); every service read
+# filters on it (cloud rule §7). The OSS FabricStore is stamped with this same
+# workspace_id on every object/link write so mirrored data is tenant-isolated.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+from pydantic import BaseModel, Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class FabricFieldMapping(BaseModel):
+    """One collection→object-type mapping inside a workspace's ingest config.
+
+    Generic by construction — the collection path, target object type, and
+    field map all come from the deployment, never from code.
+
+    * ``collection`` — the Firestore collection path to mirror.
+    * ``object_type_id`` — the Fabric ObjectType id mirrored documents become.
+    * ``field_map`` — Firestore field name → Fabric property name. Only the
+      mapped fields are copied onto the object's properties bag; unmapped
+      Firestore fields are ignored.
+    * ``cursor_field`` — the Firestore field used as the incremental high-water
+      mark (typically an ``updated_at`` / ``modified`` timestamp). When a
+      document has no value for it, the worker falls back to the document
+      snapshot's ``update_time``.
+    * ``link_rules`` — optional relationship rules; each links the mirrored
+      object to another object resolved by the value of ``via_field``.
+    """
+
+    collection: str = Field(min_length=1)
+    object_type_id: str = Field(min_length=1)
+    field_map: dict[str, str] = Field(default_factory=dict)
+    cursor_field: str = ""
+    link_rules: list[FabricLinkRule] = Field(default_factory=list)
+
+
+class FabricLinkRule(BaseModel):
+    """An optional link rule on a mapping.
+
+    After a document is mirrored into an object, the worker reads
+    ``via_field`` off the document; if it holds the ``source_id`` of another
+    already-mirrored object (its full Firestore doc path) of type ``to_type``,
+    a ``link_type`` link is created from the new object to that target.
+
+    * ``to_type`` — the object_type_id the target object should be.
+    * ``link_type`` — the Fabric link type string (e.g. ``belongs_to``).
+    * ``via_field`` — the Firestore field on the source document whose value
+      identifies the target document (its Firestore path / source_id).
+    """
+
+    to_type: str = Field(min_length=1)
+    link_type: str = Field(min_length=1)
+    via_field: str = Field(min_length=1)
+
+
+# Resolve the forward reference declared on FabricFieldMapping.link_rules.
+FabricFieldMapping.model_rebuild()
+
+
+class FabricIngestConfig(TimestampedDocument):
+    """Per-workspace Firestore→Fabric mapping config.
+
+    One row per workspace. ``mappings`` is the list of collection→object-type
+    rules the worker walks on each sweep. Nothing about the mapping is
+    hard-coded — a deployment writes its own collections, object types, field
+    maps, and link rules here.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    enabled: bool = True
+    mappings: list[FabricFieldMapping] = Field(default_factory=list)
+
+    class Settings(TimestampedDocument.Settings):
+        name = "fabric_ingest_config"
+
+
+class FabricIngestState(TimestampedDocument):
+    """Per-(workspace, source) ingest bookkeeping for the Fabric worker.
+
+    Tenancy: ``workspace`` is required and indexed; every read filters on it
+    (cloud rule §7). ``source_id`` is the Firestore collection path; paired
+    with ``workspace`` it is unique per mirrored source, enforced at the
+    service layer (upsert-on-write, no Mongo unique index so re-runs are
+    forgiving).
+
+    ``cursor`` holds the high-water mark of the newest document ingested from
+    this collection on the last successful run — the value of the mapping's
+    ``cursor_field`` (or the snapshot ``update_time`` fallback) of the
+    most-recently-updated document seen. The incremental pass reads only
+    documents with a cursor value strictly greater than this, so a re-run never
+    re-ingests an unchanged document and a late-but-older document is still
+    picked up on its own merits (the wall-clock flaw in MemberIngestState is
+    deliberately not copied).
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    source_id: str  # the Firestore collection path being mirrored
+    status: str = "never"  # "never" | "running" | "ok" | "error"
+    backfill_done: bool = False
+    last_sync_at: datetime | None = None
+    last_error: str = ""
+    # High-water mark (string-comparable, typically an RFC3339 timestamp) of
+    # the newest document ingested. Empty until the first successful run.
+    cursor: str = ""
+    # Running total — handy for an operator/status endpoint without a separate
+    # metrics store. Not load-bearing for correctness.
+    objects_ingested: int = 0
+
+    class Settings(TimestampedDocument.Settings):
+        name = "fabric_ingest_state"

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -127,6 +127,15 @@ extraction = [
     "python-docx>=1.1.0",
     "pytesseract>=0.3.10",
 ]
+# Firestore→Fabric ingest worker (ee/pocketpaw_ee/cloud/fabric_ingest). The
+# reader lazy-imports google-cloud-firestore behind a Protocol, so it stays
+# optional — a deployment that doesn't mirror Firestore never installs it, and
+# the worker raises a clear install error if a config references Firestore
+# without the extra present. Floor 2.27.0 (released 2026-04-13, well past the
+# workspace's 7-day supply-chain minimum-age rule).
+firestore = [
+    "google-cloud-firestore>=2.27.0",
+]
 
 [project.scripts]
 # Operator tool — mint / inspect enterprise license keys. Lives in EE
@@ -322,6 +331,17 @@ source_modules = [
     "pocketpaw_ee.cloud.notifications.domain",
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.notification"]
+
+[[tool.importlinter.contracts]]
+name = "FabricIngest — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.fabric_ingest.dto",
+    "pocketpaw_ee.cloud.fabric_ingest.scheduler",
+    "pocketpaw_ee.cloud.fabric_ingest.firestore_reader",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.fabric_ingest_state"]
 
 [[tool.importlinter.contracts]]
 name = "Sessions — Beanie writes only from service.py"

--- a/ee/uv.lock
+++ b/ee/uv.lock
@@ -1156,6 +1156,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
 ]
 
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
 [[package]]
 name = "google-api-python-client"
 version = "2.197.0"
@@ -1230,6 +1236,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-firestore"
+version = "2.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/83/bdfd4387fadc5f44de1d0f97b456c648b6f87ec0b1818a9f7f477e6e6eab/google_cloud_firestore-2.27.0.tar.gz", hash = "sha256:5633cb164ef56ca6c73a807822191a56a98f6f10e76978c4f2eb197ae03383d2", size = 649244, upload-time = "2026-04-13T22:55:43.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/db/fc72c4279887cc95011f16e70200d021030f0261e6391fa52e3adfaaea25/google_cloud_firestore-2.27.0-py3-none-any.whl", hash = "sha256:cc2ea78bc2d4dcc928016d56802deacfda3c9bbda0a7d691ee73b41a2f1a80d7", size = 429806, upload-time = "2026-04-13T22:55:41.726Z" },
 ]
 
 [[package]]
@@ -1403,6 +1426,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/3d/4f4a3450a1973568910c6909cb74abbf2126f68aefae5976962f9f7ad50d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa948712c8e5fa40ec250870bda14bc7578e1bb832a8912d9d2a0f720518edbe", size = 7846468, upload-time = "2026-06-01T05:56:14.536Z" },
     { url = "https://files.pythonhosted.org/packages/88/f4/5827fd248221ad3b44161c23ce9b5f4ee405b04fc6da5fd402a9aa87a84a/grpcio-1.81.0-cp314-cp314-win32.whl", hash = "sha256:fbbe81314a9d92156abce8b62c09364eb8bafc0ca2a19919a45ec64b5c6cb664", size = 4264427, upload-time = "2026-06-01T05:56:17.192Z" },
     { url = "https://files.pythonhosted.org/packages/0c/e8/127dc2b246096ad50ef7c8d9b7b31d757787aeb796368bcdd4454e4204c4/grpcio-1.81.0-cp314-cp314-win_amd64.whl", hash = "sha256:b93cee313cae4e113fbb3a0ce1ea5633db6f63cfde2b2dc1d817429026b2a50b", size = 5070848, upload-time = "2026-06-01T05:56:19.735Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.81.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/b6/cdc177114997d15c887fb09ccfd16705c8ceb8b4ca2487902b54a7bfd1af/grpcio_status-1.81.0.tar.gz", hash = "sha256:b6fe9788cfdd1f0f63c0528a1e0bfdb41e8ff0583e920d2d8e8888598c01bb69", size = 13900, upload-time = "2026-06-01T06:00:32.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/b7/5aa346bf1cdecd4ed64b86c10a4d5a089ce3da89145f8328caf0b22b240d/grpcio_status-1.81.0-py3-none-any.whl", hash = "sha256:10eb4c2309db902dc26c1873e80a821bf794be772c10dfd83030f7f59f165fab", size = 14634, upload-time = "2026-06-01T06:00:13.345Z" },
 ]
 
 [[package]]
@@ -3043,6 +3080,9 @@ extraction = [
     { name = "python-docx" },
     { name = "trafilatura" },
 ]
+firestore = [
+    { name = "google-cloud-firestore" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -3060,6 +3100,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.100.0" },
     { name = "google-auth", specifier = ">=2.25.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.0" },
+    { name = "google-cloud-firestore", marker = "extra == 'firestore'", specifier = ">=2.27.0" },
     { name = "google-cloud-storage", specifier = ">=2.14.0" },
     { name = "igraph", specifier = ">=0.11" },
     { name = "livekit-agents", extras = ["codecs"], specifier = ">=1.5.9" },
@@ -3077,7 +3118,7 @@ requires-dist = [
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "trafilatura", marker = "extra == 'extraction'" },
 ]
-provides-extras = ["extraction"]
+provides-extras = ["extraction", "firestore"]
 
 [[package]]
 name = "prometheus-client"

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -6,6 +6,12 @@
 #   create_object(). The store's update_object grew its own W4a tenancy guard, so
 #   an idempotent re-sync stays inside the caller's tenant on the write as well
 #   as the read.
+# Updated: 2026-06-11 (firestore-fabric-ingest) — FabricMapping gains an
+#   optional ``type_id``: when set, ensure_type() returns it directly instead
+#   of resolving/defining by name. Lets callers whose config references an
+#   existing ObjectType by id (the EE Firestore→Fabric worker's per-workspace
+#   mapping) ride this same canonical upsert loop instead of hand-rolling a
+#   parallel one. Additive; name-based callers are unchanged.
 #
 # WHY THIS EXISTS
 # ---------------
@@ -70,6 +76,12 @@ class FabricMapping:
     type_description: str = ""
     type_icon: str = "box"
     type_color: str = "#0A84FF"
+    # Optional: a concrete ObjectType id. When set, ``ensure_type`` returns it
+    # directly instead of resolving/defining by name — for callers whose config
+    # already references an existing type by id (the EE Firestore→Fabric
+    # worker's per-workspace mapping does). ``type_name`` then serves only as
+    # the reporting label on IngestResult.
+    type_id: str | None = None
 
     def extract_source_id(self, record: Mapping[str, Any]) -> str | None:
         """Pull the stable upstream id from a record, or None if absent/empty."""
@@ -108,11 +120,18 @@ class IngestResult:
 async def ensure_type(store: FabricStore, mapping: FabricMapping) -> str:
     """Ensure the mapping's ObjectType exists; return its ``type_id``.
 
-    Define-once-by-name: if a type with this name already exists (a prior sync,
-    a manually-defined ontology type, the EE fabric registry), reuse it rather
-    than creating a second type that would split the same logical objects across
-    two ``type_id``s. Name match is case-insensitive (see get_type_by_name).
+    When the mapping carries an explicit ``type_id`` (the caller's config
+    references an existing type by id), return it directly — no name lookup,
+    no implicit define.
+
+    Otherwise, define-once-by-name: if a type with this name already exists (a
+    prior sync, a manually-defined ontology type, the EE fabric registry),
+    reuse it rather than creating a second type that would split the same
+    logical objects across two ``type_id``s. Name match is case-insensitive
+    (see get_type_by_name).
     """
+    if mapping.type_id:
+        return mapping.type_id
     existing = await store.get_type_by_name(mapping.type_name)
     if existing is not None:
         return existing.id

--- a/tests/cloud/fabric_ingest/__init__.py
+++ b/tests/cloud/fabric_ingest/__init__.py
@@ -1,0 +1,2 @@
+# Test package for the generic Firestore→Fabric ingestion worker.
+# Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.

--- a/tests/cloud/fabric_ingest/test_fabric_ingest_service.py
+++ b/tests/cloud/fabric_ingest/test_fabric_ingest_service.py
@@ -1,0 +1,461 @@
+# tests/cloud/fabric_ingest/test_fabric_ingest_service.py
+# Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+#
+# Pins the per-collection Firestore→Fabric ingest contract. The worker is fully
+# generic: the mapping (collection, object type, field map, cursor field) comes
+# from a per-workspace FabricIngestConfig seeded in each test — no domain
+# specifics in the code under test. Coverage:
+#
+#   1. happy path — a fake reader's docs land as Fabric objects, stamped with
+#      workspace_id + source_connector="firestore" + source_id (doc path), and
+#      the field map projects the right properties.
+#   2. cursor advances to the MAX doc cursor-field value, NOT run wall-clock.
+#   3. re-run upserts, not duplicates — the same source_id updates in place.
+#   4. workspace_id is stamped on EVERY created object.
+#   5. config DTO validation rejects a bad mapping.
+#   6. (sweep file) one collection failing doesn't sink the others.
+#
+# Firestore access is a fake reader and the write sink is a real FabricStore on
+# a tmp SQLite file, so the suite runs with no google creds and no network.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.fabric_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.models.fabric_ingest_state import (  # noqa: E402
+    FabricFieldMapping,
+    FabricIngestConfig,
+    FabricIngestState,
+    FabricLinkRule,
+)
+
+from pocketpaw.fabric.models import PropertyDef  # noqa: E402
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+# --------------------------------------------------------------------------
+# Fakes + helpers.
+# --------------------------------------------------------------------------
+
+
+class FakeFirestoreReader:
+    """Stands in for the google-cloud-firestore client.
+
+    Records the (collection, cursor_field, cursor, limit) it was asked for so a
+    test can assert the backfill-vs-incremental window, and returns only the
+    documents whose cursor value is > the supplied cursor (mimicking the real
+    reader's start_after semantics)."""
+
+    def __init__(self, docs: list[dict] | None = None) -> None:
+        self._docs = docs or []
+        self.calls: list[tuple[str, str, str, int]] = []
+
+    async def read_collection(self, collection, *, cursor_field, cursor, limit):
+        self.calls.append((collection, cursor_field, cursor, limit))
+        out = []
+        for d in self._docs:
+            val = (d.get("data") or {}).get(cursor_field)
+            if val is None or val == "":
+                val = d.get("update_time") or ""
+            if cursor and str(val) <= cursor:
+                continue  # already past the high-water mark
+            out.append(d)
+        return out[:limit]
+
+
+def _doc(path: str, **fields) -> dict:
+    """A Firestore document in the worker's wire shape."""
+    update_time = fields.pop("_update_time", "2026-06-01T00:00:00Z")
+    return {"path": path, "data": dict(fields), "update_time": update_time}
+
+
+async def _make_store(tmp_path) -> FabricStore:
+    """A real FabricStore on a tmp SQLite file with one object type defined."""
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type("Customer", [PropertyDef(name="name")])
+    return store
+
+
+async def _seed_config(workspace_id: str, mappings: list[FabricFieldMapping]) -> None:
+    cfg = FabricIngestConfig(workspace=workspace_id, enabled=True, mappings=mappings)
+    await cfg.insert()
+
+
+# --------------------------------------------------------------------------
+# 1 — happy path: docs land as objects with tenancy + provenance + properties.
+# --------------------------------------------------------------------------
+
+
+async def test_ingest_happy_path_creates_stamped_objects(mongo_db, tmp_path):  # noqa: ARG001
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    mapping = FabricFieldMapping(
+        collection="customers",
+        object_type_id="ot-customer",
+        field_map={"display_name": "name", "tier": "tier"},
+        cursor_field="updated_at",
+    )
+    await _seed_config(ws, [mapping])
+
+    reader = FakeFirestoreReader(
+        [
+            _doc(
+                "customers/c1", display_name="Acme", tier="gold", updated_at="2026-06-02T10:00:00Z"
+            ),
+            _doc(
+                "customers/c2",
+                display_name="Globex",
+                tier="silver",
+                updated_at="2026-06-03T10:00:00Z",
+            ),
+        ]
+    )
+
+    result = await ingest_service.ingest_collection(ws, "customers", reader=reader, store=store)
+
+    assert result["status"] == "ok"
+    assert result["mode"] == "backfill"
+    assert result["objects"] == 2
+
+    # Both objects exist, scoped to the workspace, with the mapped properties.
+    obj1 = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    obj2 = await store.get_object_by_source("firestore", "customers/c2", workspace_id=ws)
+    assert obj1 is not None and obj2 is not None
+    assert obj1.source_connector == "firestore"
+    assert obj1.source_id == "customers/c1"
+    assert obj1.properties == {"name": "Acme", "tier": "gold"}
+    assert obj2.properties == {"name": "Globex", "tier": "silver"}
+
+
+# --------------------------------------------------------------------------
+# 2 — cursor advances to the MAX doc cursor-field value, not run wall-clock.
+# --------------------------------------------------------------------------
+
+
+async def test_cursor_advances_to_max_doc_cursor_field_not_wallclock(mongo_db, tmp_path):  # noqa: ARG001
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(
+        ws,
+        [
+            FabricFieldMapping(
+                collection="customers",
+                object_type_id="ot-customer",
+                field_map={"display_name": "name"},
+                cursor_field="updated_at",
+            )
+        ],
+    )
+    # Docs deliberately out of order; the newest cursor value is the middle doc.
+    reader = FakeFirestoreReader(
+        [
+            _doc("customers/c1", display_name="A", updated_at="2026-06-02T00:00:00Z"),
+            _doc("customers/c3", display_name="C", updated_at="2026-06-09T00:00:00Z"),
+            _doc("customers/c2", display_name="B", updated_at="2026-06-05T00:00:00Z"),
+        ]
+    )
+
+    result = await ingest_service.ingest_collection(ws, "customers", reader=reader, store=store)
+
+    # The cursor is the MAX cursor_field value seen — a real watermark from the
+    # document data — not a wall-clock "now" (which would be 2026-06-11+).
+    assert result["cursor"] == "2026-06-09T00:00:00Z"
+    state = await FabricIngestState.find_one(
+        FabricIngestState.workspace == ws,
+        FabricIngestState.source_id == "customers",
+    )
+    assert state.cursor == "2026-06-09T00:00:00Z"
+
+    # A second (incremental) run must read with that watermark as the lower
+    # bound, so an unchanged doc below it is never re-fetched.
+    reader2 = FakeFirestoreReader(
+        [
+            _doc("customers/c1", display_name="A", updated_at="2026-06-02T00:00:00Z"),  # stale
+            _doc("customers/c4", display_name="D", updated_at="2026-06-10T00:00:00Z"),  # new
+        ]
+    )
+    result2 = await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+    assert result2["mode"] == "incremental"
+    # The reader was called with the stored watermark as the cursor.
+    _coll, _field, used_cursor, _limit = reader2.calls[0]
+    assert used_cursor == "2026-06-09T00:00:00Z"
+    # Only the new doc came through; the stale one was filtered by the bound.
+    assert result2["objects"] == 1
+    assert result2["cursor"] == "2026-06-10T00:00:00Z"
+
+
+# --------------------------------------------------------------------------
+# 3 — re-run upserts (same source_id), no duplicates.
+# --------------------------------------------------------------------------
+
+
+async def test_rerun_upserts_same_source_id_no_duplicates(mongo_db, tmp_path):  # noqa: ARG001
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(
+        ws,
+        [
+            FabricFieldMapping(
+                collection="customers",
+                object_type_id="ot-customer",
+                field_map={"display_name": "name"},
+                cursor_field="updated_at",
+            )
+        ],
+    )
+
+    # First run mirrors c1.
+    reader1 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme", updated_at="2026-06-02T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader1, store=store)
+    obj_first = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+
+    # Backfill again from scratch (delete state) with an UPDATED c1 — same path.
+    state = await FabricIngestState.find_one(
+        FabricIngestState.workspace == ws, FabricIngestState.source_id == "customers"
+    )
+    await state.delete()  # force a fresh backfill so the same doc is re-read
+    reader2 = FakeFirestoreReader(
+        [_doc("customers/c1", display_name="Acme Renamed", updated_at="2026-06-04T00:00:00Z")]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader2, store=store)
+
+    # Still exactly ONE object for that source path — updated, not duplicated.
+    from pocketpaw.fabric.models import FabricQuery
+
+    res = await store.query(FabricQuery(type_id="ot-customer"), workspace_id=ws)
+    matching = [o for o in res.objects if o.source_id == "customers/c1"]
+    assert len(matching) == 1
+    # And it was updated in place (same object id, new property value).
+    obj_second = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    assert obj_second.id == obj_first.id
+    assert obj_second.properties["name"] == "Acme Renamed"
+
+
+# --------------------------------------------------------------------------
+# 4 — workspace_id stamped on EVERY created object (tenancy leak otherwise).
+# --------------------------------------------------------------------------
+
+
+async def test_workspace_id_stamped_on_every_object(mongo_db, tmp_path):  # noqa: ARG001
+    store = await _make_store(tmp_path)
+    ws = "w-tenant-a"
+    await _seed_config(
+        ws,
+        [
+            FabricFieldMapping(
+                collection="customers",
+                object_type_id="ot-customer",
+                field_map={"display_name": "name"},
+                cursor_field="updated_at",
+            )
+        ],
+    )
+    reader = FakeFirestoreReader(
+        [
+            _doc("customers/c1", display_name="A", updated_at="2026-06-02T00:00:00Z"),
+            _doc("customers/c2", display_name="B", updated_at="2026-06-03T00:00:00Z"),
+        ]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader, store=store)
+
+    # A read scoped to a DIFFERENT workspace must NOT see these objects (they
+    # carry ws-tenant-a, not NULL — so they don't leak to another tenant).
+    from pocketpaw.fabric.models import FabricQuery
+
+    other = await store.query(FabricQuery(type_id="ot-customer"), workspace_id="w-tenant-b")
+    leaked = [o for o in other.objects if o.source_id in {"customers/c1", "customers/c2"}]
+    assert leaked == []
+    # The owning tenant sees both.
+    owned = await store.query(FabricQuery(type_id="ot-customer"), workspace_id=ws)
+    assert {o.source_id for o in owned.objects} >= {"customers/c1", "customers/c2"}
+
+
+# --------------------------------------------------------------------------
+# 5 — config DTO validation rejects a bad mapping.
+# --------------------------------------------------------------------------
+
+
+async def test_config_dto_rejects_bad_mapping():
+    # Pure-validation test (no I/O); async only because the module is
+    # asyncio-marked, so pytest-asyncio runs it without a stray-mark warning.
+    from pocketpaw_ee.cloud.fabric_ingest.dto import IngestConfigRequest
+
+    # Blank object_type_id — there is nowhere to put the mirrored data.
+    with pytest.raises(Exception):
+        IngestConfigRequest.model_validate(
+            {
+                "workspace_id": "w1",
+                "mappings": [{"collection": "customers", "object_type_id": ""}],
+            }
+        )
+
+    # Blank collection — nothing to read.
+    with pytest.raises(Exception):
+        IngestConfigRequest.model_validate(
+            {
+                "workspace_id": "w1",
+                "mappings": [{"collection": "  ", "object_type_id": "ot-1"}],
+            }
+        )
+
+    # A link rule missing via_field is rejected.
+    with pytest.raises(Exception):
+        IngestConfigRequest.model_validate(
+            {
+                "workspace_id": "w1",
+                "mappings": [
+                    {
+                        "collection": "customers",
+                        "object_type_id": "ot-1",
+                        "link_rules": [{"to_type": "ot-2", "link_type": "belongs_to"}],
+                    }
+                ],
+            }
+        )
+
+    # Blank workspace_id is rejected.
+    with pytest.raises(Exception):
+        IngestConfigRequest.model_validate({"workspace_id": "  ", "mappings": []})
+
+    # A well-formed config validates cleanly.
+    ok = IngestConfigRequest.model_validate(
+        {
+            "workspace_id": "w1",
+            "mappings": [
+                {
+                    "collection": "customers",
+                    "object_type_id": "ot-1",
+                    "field_map": {"display_name": "name"},
+                    "cursor_field": "updated_at",
+                    "link_rules": [
+                        {"to_type": "ot-2", "link_type": "belongs_to", "via_field": "account_ref"}
+                    ],
+                }
+            ],
+        }
+    )
+    assert ok.mappings[0].collection == "customers"
+
+
+# --------------------------------------------------------------------------
+# Error isolation — a read failure marks error, writes nothing, doesn't crash.
+# --------------------------------------------------------------------------
+
+
+async def test_read_failure_marks_error_and_writes_nothing(mongo_db, tmp_path):  # noqa: ARG001
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    await _seed_config(
+        ws,
+        [
+            FabricFieldMapping(
+                collection="customers",
+                object_type_id="ot-customer",
+                field_map={"display_name": "name"},
+                cursor_field="updated_at",
+            )
+        ],
+    )
+
+    class BoomReader:
+        async def read_collection(self, *_a, **_k):
+            raise RuntimeError("firestore permission denied")
+
+    result = await ingest_service.ingest_collection(
+        ws, "customers", reader=BoomReader(), store=store
+    )
+
+    assert result["status"] == "error"
+    assert result["objects"] == 0
+    assert result["errors"]
+    # Nothing was written.
+    from pocketpaw.fabric.models import FabricQuery
+
+    res = await store.query(FabricQuery(type_id="ot-customer"), workspace_id=ws)
+    assert res.total == 0
+    # Backfill is NOT marked done on a failed run, so it retries the wide read.
+    state = await FabricIngestState.find_one(
+        FabricIngestState.workspace == ws, FabricIngestState.source_id == "customers"
+    )
+    assert state.status == "error"
+    assert state.backfill_done is False
+    assert state.cursor == ""
+
+
+async def test_unmapped_collection_is_error_not_crash(mongo_db, tmp_path):  # noqa: ARG001
+    store = await _make_store(tmp_path)
+    ws = "w1"
+    # Config has a mapping for "customers" only; ask for "orders".
+    await _seed_config(
+        ws,
+        [FabricFieldMapping(collection="customers", object_type_id="ot-customer")],
+    )
+    result = await ingest_service.ingest_collection(
+        ws, "orders", reader=FakeFirestoreReader([]), store=store
+    )
+    assert result["status"] == "error"
+    assert "no mapping" in result["errors"][0]
+
+
+# --------------------------------------------------------------------------
+# Bonus — link rules wire objects together by source path.
+# --------------------------------------------------------------------------
+
+
+async def test_link_rules_link_by_source_path(mongo_db, tmp_path):  # noqa: ARG001
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type("Account", [PropertyDef(name="name")])
+    await store.define_type("Customer", [PropertyDef(name="name")])
+    ws = "w1"
+
+    # Seed an Account object first (the link target).
+    await store.create_object(
+        type_id="ot-account",
+        properties={"name": "Acme Corp"},
+        source_connector="firestore",
+        source_id="accounts/a1",
+        workspace_id=ws,
+    )
+
+    await _seed_config(
+        ws,
+        [
+            FabricFieldMapping(
+                collection="customers",
+                object_type_id="ot-customer",
+                field_map={"display_name": "name"},
+                cursor_field="updated_at",
+                link_rules=[
+                    FabricLinkRule(
+                        to_type="ot-account", link_type="belongs_to", via_field="account_ref"
+                    )
+                ],
+            )
+        ],
+    )
+
+    reader = FakeFirestoreReader(
+        [
+            _doc(
+                "customers/c1",
+                display_name="Acme",
+                account_ref="accounts/a1",
+                updated_at="2026-06-02T00:00:00Z",
+            )
+        ]
+    )
+    await ingest_service.ingest_collection(ws, "customers", reader=reader, store=store)
+
+    cust = await store.get_object_by_source("firestore", "customers/c1", workspace_id=ws)
+    acct = await store.get_object_by_source("firestore", "accounts/a1", workspace_id=ws)
+    links, total = await store.list_links(from_id=cust.id, workspace_id=ws)
+    assert total == 1
+    assert links[0].to_object_id == acct.id
+    assert links[0].link_type == "belongs_to"

--- a/tests/cloud/fabric_ingest/test_fabric_ingest_sweep.py
+++ b/tests/cloud/fabric_ingest/test_fabric_ingest_sweep.py
@@ -1,0 +1,146 @@
+# tests/cloud/fabric_ingest/test_fabric_ingest_sweep.py
+# Created: 2026-06-11 — generic Firestore→Fabric ingestion worker.
+#
+# Pins the sweep fan-out: run_ingest_sweep enumerates every configured
+# (workspace, collection) pair across all enabled FabricIngestConfig rows and
+# ingests each under a concurrency cap. The load-bearing property is ISOLATION
+# — one collection raising must NOT abort the others. The scheduler's tick()
+# delegates to the sweep and never raises.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.fabric_ingest import service as ingest_service  # noqa: E402
+from pocketpaw_ee.cloud.models.fabric_ingest_state import (  # noqa: E402
+    FabricFieldMapping,
+    FabricIngestConfig,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed(workspace_id: str, collections: list[str]) -> None:
+    mappings = [
+        FabricFieldMapping(collection=c, object_type_id=f"ot-{c}", cursor_field="updated_at")
+        for c in collections
+    ]
+    cfg = FabricIngestConfig(workspace=workspace_id, enabled=True, mappings=mappings)
+    await cfg.insert()
+
+
+async def test_sweep_enumerates_all_configured_sources(mongo_db):  # noqa: ARG001
+    await _seed("w1", ["customers", "orders"])
+    await _seed("w2", ["leads"])
+
+    seen: list[tuple[str, str]] = []
+
+    async def fake_ingest(workspace_id, source_id):
+        seen.append((workspace_id, source_id))
+        return {"status": "ok"}
+
+    summary = await ingest_service.run_ingest_sweep(ingest_fn=fake_ingest)
+
+    assert summary["sources"] == 3
+    assert summary["ok"] == 3
+    assert summary["errors"] == 0
+    assert set(seen) == {("w1", "customers"), ("w1", "orders"), ("w2", "leads")}
+
+
+async def test_sweep_isolates_a_failing_collection(mongo_db):  # noqa: ARG001
+    await _seed("w1", ["good_a", "boom", "good_b"])
+
+    async def fake_ingest(workspace_id, source_id):
+        if source_id == "boom":
+            raise RuntimeError("firestore exploded for this collection")
+        return {"status": "ok"}
+
+    summary = await ingest_service.run_ingest_sweep(ingest_fn=fake_ingest)
+
+    # The one bad collection is counted as an error; the other two still ran.
+    assert summary["sources"] == 3
+    assert summary["ok"] == 2
+    assert summary["errors"] == 1
+
+
+async def test_sweep_counts_self_reported_error_status(mongo_db):  # noqa: ARG001
+    await _seed("w1", ["ok_one", "err_one"])
+
+    async def fake_ingest(workspace_id, source_id):
+        if source_id == "err_one":
+            return {"status": "error", "errors": ["no mapping"]}
+        return {"status": "ok"}
+
+    summary = await ingest_service.run_ingest_sweep(ingest_fn=fake_ingest)
+    assert summary["ok"] == 1
+    assert summary["errors"] == 1
+
+
+async def test_sweep_empty_when_no_configs(mongo_db):  # noqa: ARG001
+    summary = await ingest_service.run_ingest_sweep()
+    assert summary == {"sources": 0, "ok": 0, "errors": 0}
+
+
+async def test_sweep_respects_workspace_filter(mongo_db):  # noqa: ARG001
+    await _seed("w1", ["customers"])
+    await _seed("w2", ["leads"])
+
+    seen: list[tuple[str, str]] = []
+
+    async def fake_ingest(workspace_id, source_id):
+        seen.append((workspace_id, source_id))
+        return {"status": "ok"}
+
+    summary = await ingest_service.run_ingest_sweep(workspace_id="w1", ingest_fn=fake_ingest)
+    assert summary["sources"] == 1
+    assert seen == [("w1", "customers")]
+
+
+async def test_disabled_config_is_skipped(mongo_db):  # noqa: ARG001
+    # An enabled config and a disabled one; only the enabled one's sources sweep.
+    await _seed("w1", ["customers"])
+    disabled = FabricIngestConfig(
+        workspace="w2",
+        enabled=False,
+        mappings=[FabricFieldMapping(collection="leads", object_type_id="ot-leads")],
+    )
+    await disabled.insert()
+
+    sources = await ingest_service.list_ingest_sources()
+    assert {(s["workspace_id"], s["source_id"]) for s in sources} == {("w1", "customers")}
+
+
+# --------------------------------------------------------------------------
+# Scheduler tick — delegates to the sweep, never raises.
+# --------------------------------------------------------------------------
+
+
+async def test_scheduler_tick_runs_sweep(mongo_db, monkeypatch):  # noqa: ARG001
+    from pocketpaw_ee.cloud.fabric_ingest import scheduler as sched_mod
+
+    called = {}
+
+    async def fake_sweep():
+        called["ran"] = True
+        return {"sources": 2, "ok": 2, "errors": 0}
+
+    monkeypatch.setattr(ingest_service, "run_ingest_sweep", fake_sweep)
+    scheduler = sched_mod.FabricIngestScheduler(interval_seconds=999)
+    summary = await scheduler.tick()
+    assert called.get("ran") is True
+    assert summary == {"sources": 2, "ok": 2, "errors": 0}
+
+
+async def test_scheduler_tick_survives_sweep_failure(mongo_db, monkeypatch):  # noqa: ARG001
+    from pocketpaw_ee.cloud.fabric_ingest import scheduler as sched_mod
+
+    async def boom_sweep():
+        raise RuntimeError("db hiccup")
+
+    monkeypatch.setattr(ingest_service, "run_ingest_sweep", boom_sweep)
+    scheduler = sched_mod.FabricIngestScheduler(interval_seconds=999)
+    # tick() must swallow the failure and report an empty summary.
+    summary = await scheduler.tick()
+    assert summary == {"sources": 0, "ok": 0, "errors": 0}

--- a/uv.lock
+++ b/uv.lock
@@ -5088,6 +5088,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.100.0" },
     { name = "google-auth", specifier = ">=2.25.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.0" },
+    { name = "google-cloud-firestore", marker = "extra == 'firestore'", specifier = ">=2.27.0" },
     { name = "google-cloud-storage", specifier = ">=2.14.0" },
     { name = "igraph", specifier = ">=0.11" },
     { name = "livekit-agents", extras = ["codecs"], specifier = ">=1.5.9" },
@@ -5105,7 +5106,7 @@ requires-dist = [
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "trafilatura", marker = "extra == 'extraction'" },
 ]
-provides-extras = ["extraction"]
+provides-extras = ["extraction", "firestore"]
 
 [[package]]
 name = "portalocker"


### PR DESCRIPTION
## What this adds

A cloud background worker that mirrors selected Firestore collections into Fabric objects. A deployment running on Firestore can point this at its collections and get the records back as typed Fabric objects that agents and pockets can query.

The worker is generic. There are no collection names, field names, or object types in the code. Each workspace describes its own mapping in a `FabricIngestConfig` document, and the worker walks it.

## How it works

- `ingest_collection` mirrors one collection for one workspace. `run_ingest_sweep` fans that out across every configured `(workspace, collection)` pair under a concurrency cap. One collection failing never aborts the others.
- Writes ride the connector-to-Fabric mapper that #1418 established (`pocketpaw.connectors.fabric_ingest.ingest_records`) rather than a parallel private loop. Each document becomes a record carrying its doc path under a sentinel key, and the workspace mapping translates into a `FabricMapping`. Objects land stamped with the workspace plus `source_connector="firestore"` and `source_id` set to the full Firestore document path; a re-run finds the prior object via the store's `get_object_by_source` (also from #1418) and updates it in place, so nothing duplicates. `FabricMapping` gains an optional `type_id` so a caller whose config references an existing ObjectType by id skips the define-by-name path. Additive; the Calendar path is unchanged and its tests pass as-is.
- The incremental cursor is a real high-water mark taken from the document data (the mapped `cursor_field`, falling back to the snapshot `update_time`), not the run's wall clock. A document that lands late but carries an older timestamp is still picked up, and a re-run never re-scans a time window. This is the deliberate fix for the wall-clock cursor in the member-ingest worker.
- The scheduler mirrors the member-ingest one and is gated by `POCKETPAW_CLOUD_SCHEDULER_ENABLED`, so tests never spawn a background loop. Cadence overrides via `POCKETPAW_FABRIC_INGEST_INTERVAL_SECONDS`.

## Tenancy and the OSS boundary

Every object carries the workspace id (a plain string crossing from the cloud worker). An unstamped object would land with a NULL workspace, which is globally visible on a shared deployment, so the stamp is load-bearing. The OSS store never imports the cloud package; the workspace id crosses as a value.

## Optional dependency

The Firestore client is an optional ee extra (`pocketpaw-ee[firestore]`, `google-cloud-firestore>=2.27.0`), lazy-imported behind a `FirestoreReader` Protocol. Tests inject fakes and need no Google credentials. A deployment that doesn't mirror Firestore never installs it, and the worker raises a clear install error if a config references Firestore without the extra present.

## Config shape

One `FabricIngestConfig` per workspace, holding a list of mappings: `collection`, `object_type_id`, `field_map` (Firestore field to property name), `cursor_field`, and optional `link_rules` (`to_type`, `link_type`, `via_field`). The mapping is validated at entry, so a blank collection, a blank object type, or a link rule missing a field is rejected before any read.

## Tests

`tests/cloud/fabric_ingest/` covers:

- happy path: fake-reader documents land as objects with the mapped properties
- the cursor advances to the max document cursor-field value, not wall clock, and the next run reads from that bound
- a re-run upserts the same source path instead of duplicating
- the workspace id is stamped on every object (a read scoped to another tenant sees nothing)
- the sweep isolates a failing collection from the rest
- config validation rejects a bad mapping
- link rules wire objects together by source path

46 targeted tests pass: the new fabric_ingest suite, the existing member-ingest suite, and #1418's gcalendar fabric-ingest and e2e connector-to-fabric suites as regression checks both ways. All 23 ee import-linter contracts stay green (a new "FabricIngest — Beanie writes only from service.py" contract is added), and the OSS-may-not-import-EE contract holds.

## Docs

A "Firestore to Fabric ingestion worker" section in `docs/CONNECTORS.md` covering the mapping config, the cursor semantics, upsert, and the operational gates.

## Not in this PR

- Batched writes. `create_object` commits per row today. Noted as a follow-up, not built here.
- A status read endpoint over `FabricIngestState`.
- A first-config-write trigger that kicks an immediate backfill instead of waiting for the next tick.
