### PR TITLE
Add a gated external-action proposal type to Instinct

### DIFF
--- a/ee/pocketpaw_ee/cloud/external_actions/README.md
+++ b/ee/pocketpaw_ee/cloud/external_actions/README.md
@@ -1,0 +1,93 @@
+<!--
+README.md — the gated external-action Instinct proposal type.
+Created: 2026-06-11 (feat/external-action-proposal).
+Documents the third gated proposal kind (alongside `_pocket_write` and
+`_code_change`): its blob contract, the propose/execute split, the
+exactly-one-terminal Decision-Graph discipline, and the router wiring.
+-->
+
+# Gated external actions
+
+A **gated external action** is a proposed call to an external system through a
+**bound connector** — for example "call action `approveApplication` on connector
+`crm` with params `{...}`". It is the **third gated Instinct proposal type**,
+sitting alongside the two that shipped before it:
+
+| Kind | Parameters key | Propose | Execute-on-approve |
+|------|----------------|---------|--------------------|
+| Pocket write | `_pocket_write` | `pockets/instinct_bridge.propose_pocket_write` | `pockets/instinct_bridge.execute_approved_write` |
+| Code change (Belt) | `_code_change` | `agent/mcp_servers/belt.py` | `cloud/belt/executor.execute_approved_change` |
+| **External action** | **`_external_action`** | **`external_actions.propose.propose_external_action`** | **`external_actions.executor.execute_approved_external_action`** |
+
+Instinct is the approval gate: an agent **proposes**, a human **approves or
+rejects** in The Tray, and every decision is audit-trailed as a Decision-Graph
+chain. On approve the executor performs the connector call; on reject nothing
+fires. The kind is **fully generic** — no domain-specific logic, no client
+names.
+
+## The blob (`Action.parameters._external_action`, schema 1)
+
+The propose helper files an Instinct `Action` carrying this blob. No connector
+secret is ever written — only the connector *name* + scope; the credential is
+resolved fresh at execution from the workspace's saved connector config.
+
+| Field | Meaning |
+|-------|---------|
+| `schema` / `kind` | version (`1`) + discriminator (`"external_action"`) |
+| `workspace_id` | originating tenant — the executor's tenancy gate reads it here (an external action isn't bound to a pocket) |
+| `connector_name` / `scope` / `pocket_id` | which bound connector, at which scope |
+| `action` | the named connector action to call |
+| `params` | the proposed call params (DATA — passed verbatim to the adapter) |
+| `params_hash` | stable SHA-256 of `action` + `params`; re-checked at execute so a post-propose edit is refused |
+| `idempotency_key` | so the executor never double-fires the call on re-invocation |
+| `correlation_id` / `proposed_event_id` | Decision-Graph chain ids minted at propose time |
+| `summary` | human-readable one-liner for the gate UI |
+| `outcome` | `{status, response_summary, executed_at}` back-written by the executor after the call |
+
+## Execute-on-approve contract
+
+`execute_approved_external_action(action, *, human_event_id=None)` is fired
+best-effort from the instinct router's approve / bulk-approve handlers. It:
+
+1. Re-validates the **schema version** (fail loud on mismatch — a stale blob
+   from an incompatible build never fires).
+2. Re-validates the **params hash** (a human approved a *specific* call; a
+   params edit between propose and approve is refused).
+3. **Idempotency guard** — never re-fires the call if the Action already
+   executed / failed or already carries a back-written outcome.
+4. Resolves the connector and calls the named action with the proposed params
+   through the **cloud connector path** (`connectors.service.execute`).
+5. Back-writes the structured `outcome` via the direct-SQL pattern (the same one
+   belt's `_persist_run_result` and the pocket-write bridge's
+   `_persist_parked_policy_event_id` use).
+6. Records the result on the Action (`mark_executed` / `mark_failed`) and closes
+   the Decision-Graph chain.
+
+It **never raises** into the router — a connector error (reported failure or a
+raised exception) is captured as `status=failed` with a `failed` terminal, best
+effort.
+
+## Exactly-one-terminal discipline (Decision Graph)
+
+The chain folds into **one** Decision per call:
+`agent.proposed → human.corrected → decision.completed`.
+
+- **On approve**, the **executor owns** the `decision.completed` close (success →
+  `landed`, failure → `failed`). The router emits `human.corrected` only — it
+  does **not** close, so the chain never double-closes.
+- **On reject**, the **router owns** the close (`human.corrected` then
+  `decision.completed(rejected)`); the executor never runs.
+
+This mirrors the pocket-write bridge and the Belt executor exactly. Getting it
+wrong double-closes the chain — the production-path integration test in
+`tests/cloud/test_external_action_gate.py` walks the chain and asserts exactly
+one terminal on both the approve and reject paths.
+
+## Router wiring
+
+`ee/instinct/router.py` dispatches on the `_external_action` blob in all four
+handlers — `approve_action`, `bulk_approve_actions`, `reject_action`,
+`bulk_reject_actions` — with the up-front `_assert_external_action_workspace`
+tenancy gate in each. The blob branches are matched in priority order against
+the `_pocket_write` / `_code_change` branches (mutually exclusive — an Action
+carries exactly one kind).

--- a/ee/pocketpaw_ee/cloud/external_actions/__init__.py
+++ b/ee/pocketpaw_ee/cloud/external_actions/__init__.py
@@ -1,0 +1,33 @@
+# ee/cloud/external_actions/__init__.py — the generic gated external-action
+# Instinct proposal type (the third gated kind, alongside ``_pocket_write`` and
+# ``_code_change``).
+# Created: 2026-06-11 (feat/external-action-proposal) — a proposed call to an
+#   external system through a bound connector. An agent proposes "run action
+#   ``approveApplication`` on connector ``X`` with params ``Y``"; a human
+#   approves or rejects in The Tray; on approve the executor performs the
+#   connector call through the cloud connector path. Fully generic — no
+#   domain-specific logic.
+#
+# Re-exports the propose helper + the apply-on-approve executor so callers
+# (the agent MCP surface, the instinct router) import from the package root,
+# mirroring how the pocket-write bridge and belt executor are imported.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.external_actions.executor import execute_approved_external_action
+from pocketpaw_ee.cloud.external_actions.propose import (
+    EXTERNAL_ACTION_KIND,
+    EXTERNAL_ACTION_PARAM_KEY,
+    EXTERNAL_ACTION_SCHEMA,
+    compute_params_hash,
+    propose_external_action,
+)
+
+__all__ = [
+    "EXTERNAL_ACTION_KIND",
+    "EXTERNAL_ACTION_PARAM_KEY",
+    "EXTERNAL_ACTION_SCHEMA",
+    "compute_params_hash",
+    "execute_approved_external_action",
+    "propose_external_action",
+]

--- a/ee/pocketpaw_ee/cloud/external_actions/executor.py
+++ b/ee/pocketpaw_ee/cloud/external_actions/executor.py
@@ -1,0 +1,493 @@
+# ee/cloud/external_actions/executor.py — apply an approved external-action call.
+# Created: 2026-06-11 (feat/external-action-proposal).
+#
+# What this module does (the apply-on-approve half of the external-action gate):
+# the propose helper (``external_actions.propose.propose_external_action``) files
+# an Instinct Action carrying an ``_external_action`` blob THROUGH Instinct (the
+# human approve/reject layer). After a human approves the Action, the ee instinct
+# router's ``approve_action`` fires ``execute_approved_external_action`` here —
+# exactly mirroring how ``instinct_bridge.execute_approved_write`` is fired for a
+# parked pocket write and ``belt.executor.execute_approved_change`` for a code
+# change. This function:
+#
+#   1. Reads the ``_external_action`` blob from ``action.parameters``. A missing
+#      blob → return (no chain was opened, nothing to close). A schema-mismatched
+#      blob → mark_failed + close the chain, return.
+#   2. Re-validates the params hash off the persisted blob — a params edit
+#      between propose and approve → mark_failed + close, no call fires (a human
+#      approved a SPECIFIC call).
+#   3. Idempotency guard — if the blob's ``idempotency_key`` was already recorded
+#      as executed (the Action is already in a terminal state, or a prior run
+#      back-wrote an outcome), the call is NOT re-fired. Bulk re-approve / retry
+#      can never double-fire the external call.
+#   4. Resolves the connector + calls the named action with the proposed params
+#      through the CLOUD connector path (``connectors.service.execute``), which
+#      loads the workspace's saved connector config fresh — NO secret is read off
+#      the blob.
+#   5. Back-writes the outcome ``{status, response_summary, executed_at}`` onto
+#      the persisted blob via the direct-SQL pattern (the same one belt's
+#      ``_persist_run_result`` and the pocket-write bridge's
+#      ``_persist_parked_policy_event_id`` use).
+#   6. Records the result on the Action (``mark_executed`` / ``mark_failed``) and
+#      CLOSES the Decision-Graph chain exactly once.
+#
+# EXACTLY-ONE-TERMINAL discipline (critical): on APPROVE the EXECUTOR owns the
+# ``decision.completed`` chain close — the router does NOT emit it (mirrors the
+# pocket-write bridge + belt executor). On REJECT the ROUTER owns the close and
+# the executor never runs. Get this wrong and chains double-close. Every terminal
+# path here goes through the single ``_fail`` chokepoint (failure) or the one
+# success emit at the end — never both.
+#
+# Never raises — a failure here must not break the approve response. The router
+# wraps the call too; this is belt-and-braces. A connector error is captured as
+# ``status=failed`` with a ``failed`` terminal, NOT re-raised.
+#
+# Security (this code fires an external call on approval):
+#   * NO connector secret is read off the blob — the cloud connector service
+#     loads the workspace's saved config fresh at execution.
+#   * the params hash is re-validated — a tampered blob is refused, not fired.
+#   * tenancy: the connector service is scoped by the blob's ``workspace_id``;
+#     an empty workspace_id is refused (unexecutable). The router's
+#     ``_assert_external_action_workspace`` is the primary gate; this is
+#     belt-and-braces.
+#   * NO secrets in logs — only action ids, connector names, and outcome status.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.external_actions.propose import (
+    EXTERNAL_ACTION_PARAM_KEY,
+    EXTERNAL_ACTION_SCHEMA,
+    compute_params_hash,
+)
+
+logger = logging.getLogger(__name__)
+
+# Max length of the response summary persisted onto the blob / surfaced in the
+# outcome. The full connector response is not stored — only a bounded summary so
+# a large payload never bloats the Instinct DB or leaks a secret into the audit
+# trail.
+_RESPONSE_SUMMARY_MAX = 500
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _summarize_response(data: Any, error: str | None) -> str:
+    """Build a short, bounded, secret-free response summary for the outcome.
+
+    Prefers the error text on a failure; otherwise a compact repr of the data,
+    truncated to ``_RESPONSE_SUMMARY_MAX``. Never includes auth headers / tokens
+    — the connector service returns only the action's response body, but we still
+    bound + truncate so an over-large or sensitive payload can't ride into the
+    audit trail in full.
+    """
+    if error:
+        text = str(error)
+    elif data is None:
+        text = "ok"
+    else:
+        text = repr(data)
+    text = text.replace("\n", " ").strip()
+    if len(text) > _RESPONSE_SUMMARY_MAX:
+        text = text[:_RESPONSE_SUMMARY_MAX] + "…"
+    return text
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    response_summary: str,
+    executed_at: str,
+) -> None:
+    """Back-write the call outcome onto the persisted ``_external_action`` blob.
+
+    Direct SQL update — the same pattern belt's ``_persist_run_result`` and the
+    pocket-write bridge's ``_persist_parked_policy_event_id`` use. The blob's
+    ``outcome`` carries ``{status, response_summary, executed_at}`` so a reader
+    (audit, a runs read model, a re-invocation idempotency check) sees the result
+    structurally. Best-effort: a write failure leaves the blob without the
+    structured outcome but the free-text ``mark_executed`` / ``mark_failed``
+    outcome still records it.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(EXTERNAL_ACTION_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {
+            "status": status,
+            "response_summary": response_summary,
+            "executed_at": executed_at,
+        }
+        params[EXTERNAL_ACTION_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "external_action: failed to persist outcome onto action %s — the "
+            "structured outcome is unavailable (free-text outcome still recorded)",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    response_summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for an external-action call.
+
+    Mirrors ``instinct_bridge._emit_bridge_chain_close`` and belt's
+    ``_emit_chain_close`` — the executor owns the chain close on the approve
+    path, exactly as the pocket-write bridge / belt executor own it on theirs.
+    ``correlation_id`` is read off the blob; ``causation_id`` is the
+    ``human.corrected`` event the router emitted just before approval so the
+    terminal chains back to the human approval.
+
+    Returns early when ``correlation_id`` is None (a blob with a malformed /
+    missing id): there is no chain to close. Best-effort: a Decision-Graph wiring
+    failure must never break the approve response — the journal write is the
+    source of truth; the Slice 4 reconciler is the safety net.
+    """
+    if correlation_id is None:
+        return
+
+    # Late imports — keep the executor's import surface small and avoid a
+    # circular import with the decisions package.
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if response_summary:
+        payload["response_summary"] = response_summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "external_action decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+async def _run_connector_call(
+    *,
+    workspace_id: str,
+    connector_name: str,
+    connector_action: str,
+    params: dict[str, Any],
+    scope: str,
+    pocket_id: str | None,
+    user_id: str,
+) -> tuple[bool, Any, str | None]:
+    """Resolve the connector + call the named action through the CLOUD path.
+
+    Returns ``(success, data, error)``. Routes through
+    ``connectors.service.execute`` — the canonical cloud connector surface, which
+    loads the workspace's saved connector config fresh (no secret off the blob),
+    dispatches by execution mode (cloud / local / sandbox), and returns an
+    ``ExecuteActionResponse``. A raised exception (connector unknown, action
+    unknown, local-agent unavailable, adapter crash) is caught by the caller and
+    turned into a ``failed`` outcome — this helper lets it propagate so the
+    caller has the exception class for the error_class on the terminal.
+    """
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+
+    body = ExecuteActionRequest(
+        action=connector_action,
+        params=dict(params or {}),
+        scope=scope if scope in ("pocket", "workspace", "user") else "workspace",
+        pocket_id=pocket_id,
+        user_id=user_id or None,
+    )
+    result = await connectors_service.execute(
+        workspace_id,
+        connector_name,
+        body,
+        user_id=user_id or None,
+    )
+    return bool(result.success), result.data, result.error
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this external call already fired.
+
+    Two signals, either is sufficient:
+      * the blob already carries an ``outcome`` (a prior run back-wrote it), or
+      * the Action is already in a terminal state (executed / failed).
+
+    Re-invocation (bulk re-approve, retry) must never double-fire the HTTP call.
+    The Action's ``status`` is the authoritative gate (the router only fires the
+    executor on a fresh approve, but defense in depth), and the back-written
+    outcome is the belt-and-braces signal in case status reads are stale.
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+async def execute_approved_external_action(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """Execute the external-action call carried by a freshly-approved Action.
+
+    Called best-effort from the instinct router's ``approve_action`` /
+    ``bulk_approve_actions`` after ``store.approve()`` succeeds — the same hook
+    shape the pocket-write bridge and belt executor use. ``action`` is the
+    approved Action.
+
+    ``human_event_id`` is the id of the ``human.corrected`` event the router
+    emitted just before calling this — threaded through so the terminal
+    ``decision.completed`` event can chain its ``causation_id`` back to the
+    approval, completing the causal walk ``agent.proposed → human.corrected →
+    decision.completed``. ``None`` is tolerated (the chain still folds via the
+    shared ``correlation_id``).
+
+    Never raises — a failure here must not break the approve response. The router
+    wraps the call too; this is belt-and-braces. The Action is marked executed on
+    a successful connector call or failed with a clear outcome on any error, and
+    the Decision-Graph chain is closed exactly once (success → completed/landed,
+    failure → completed/failed).
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(EXTERNAL_ACTION_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not an external-action Action at all — no chain was opened for it, so
+        # there is nothing to close. Return without a terminal emit.
+        logger.warning("approved action %s carries no _external_action blob", action.id)
+        return
+
+    # Read the chain ids off the blob up front so EVERY terminal path can close
+    # the chain it opened. A malformed / missing id → None and the close no-ops
+    # (the Slice 4 abandon-sweeper closes any chain left open).
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    requested_by = str(blob.get("requested_by") or "")
+    approver = str(getattr(action, "approved_by", "") or "") or requested_by or "system"
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str, response_summary: str | None = None) -> None:
+        """Mark the Action failed AND close the chain with one terminal — the
+        single failure-path chokepoint so a path can never both fail and
+        double-fire the terminal. Best-effort back-write of the structured
+        failed outcome too."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            response_summary=response_summary or reason,
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=approver,
+            causation_id=causation,
+            response_summary=response_summary,
+        )
+
+    # Schema guard — a stale blob from an incompatible build fails loud rather
+    # than firing a misinterpreted external call.
+    if blob.get("schema") != EXTERNAL_ACTION_SCHEMA:
+        await _fail(
+            "external-action schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    # Tenancy — an external action with no workspace is unexecutable. The
+    # connector service is scoped by workspace_id; an empty one would never
+    # resolve a connector config anyway, but fail loud so a malformed blob is
+    # recorded, not silently dropped.
+    if not workspace_id:
+        await _fail(
+            "external-action blob carries no workspace_id — cannot scope the call",
+            error_class="MissingWorkspace",
+        )
+        return
+
+    connector_name = str(blob.get("connector_name") or "")
+    connector_action = str(blob.get("action") or "")
+    call_params = blob.get("params")
+    if not connector_name or not connector_action or not isinstance(call_params, dict):
+        await _fail(
+            "external-action blob is missing connector_name, action, or params",
+            error_class="MalformedBlob",
+        )
+        return
+
+    # Hash guard — a human approved a SPECIFIC call. If the params were edited
+    # between propose and approve, the recomputed hash won't match the stored
+    # one; refuse rather than fire a different call than the one approved.
+    stored_hash = str(blob.get("params_hash") or "")
+    recomputed = compute_params_hash(connector_action, call_params)
+    if stored_hash and stored_hash != recomputed:
+        await _fail(
+            "external-action params hash mismatch — the call params changed after "
+            "the proposal was approved; refusing to fire a different call",
+            error_class="ParamsHashMismatch",
+        )
+        return
+
+    # Idempotency — never double-fire the external call on a re-invocation.
+    if _already_executed(action, blob):
+        logger.info(
+            "external_action: action %s already executed (idempotency guard) — "
+            "skipping the connector call",
+            action.id,
+        )
+        return
+
+    scope = str(blob.get("scope") or "workspace")
+    pocket_id = blob.get("pocket_id")
+    pocket_id = str(pocket_id) if pocket_id else None
+
+    # Fire the connector call. Any failure (connector unknown, action unknown,
+    # local-agent unavailable, adapter crash) is captured as a failed outcome —
+    # NEVER re-raised into the router.
+    try:
+        success, data, error = await _run_connector_call(
+            workspace_id=workspace_id,
+            connector_name=connector_name,
+            connector_action=connector_action,
+            params=call_params,
+            scope=scope,
+            pocket_id=pocket_id,
+            user_id=approver,
+        )
+    except Exception as exc:  # noqa: BLE001 — never let a connector crash break approve
+        logger.warning(
+            "external_action: connector call crashed for action %s (connector=%s)",
+            action.id,
+            connector_name,
+            exc_info=True,
+        )
+        await _fail(
+            f"connector call failed: {exc}",
+            error_class=type(exc).__name__,
+            response_summary=str(exc),
+        )
+        return
+
+    response_summary = _summarize_response(data, error)
+
+    if not success:
+        # The connector reported a failure (e.g. a 4xx / business error). Record
+        # it as a failed outcome — NOT a phantom success.
+        await _fail(
+            f"connector '{connector_name}' action '{connector_action}' failed: {error or 'error'}",
+            error_class="ConnectorError",
+            response_summary=response_summary,
+        )
+        return
+
+    # Success — mark executed, back-write the structured outcome, close the chain.
+    await store.mark_executed(
+        action.id,
+        f"external action '{connector_action}' on connector '{connector_name}' "
+        f"executed: {response_summary}",
+    )
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        response_summary=response_summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    # Close the chain on the SUCCESS path. This is the ONLY terminal on the happy
+    # path (every failure path above closed via ``_fail`` and returned), so
+    # exactly one ``decision.completed`` lands per call.
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=approver,
+        causation_id=causation,
+        response_summary=response_summary,
+    )
+    logger.info(
+        "external_action: executed action %s → connector %s action %s (ok)",
+        action.id,
+        connector_name,
+        connector_action,
+    )
+
+
+__all__ = ["execute_approved_external_action"]

--- a/ee/pocketpaw_ee/cloud/external_actions/propose.py
+++ b/ee/pocketpaw_ee/cloud/external_actions/propose.py
@@ -1,0 +1,386 @@
+# ee/cloud/external_actions/propose.py — propose a gated external-action call.
+# Created: 2026-06-11 (feat/external-action-proposal).
+#
+# What this module does (the propose half of the external-action gate): an
+# agent (or any caller) proposes a call to an external system through a bound
+# connector — "run action ``approveApplication`` on connector ``crm`` with
+# params ``{...}``". This files an Instinct ``Action`` carrying an
+# ``_external_action`` blob (schema 1) under ``Action.parameters``. A human
+# approves it in The Tray; the apply-on-approve executor
+# (``external_actions.executor.execute_approved_external_action``) then makes
+# the connector call. This module does NOT call the connector — it only gates.
+#
+# The blob is the third gated proposal kind, sitting alongside the pocket-write
+# bridge's ``_pocket_write`` and the Belt develop-station's ``_code_change``.
+# The router + executor dispatch on the presence of the ``_external_action``
+# parameters key (the Action model has no literal ``kind`` column; the blob
+# also carries ``kind="external_action"`` for readers that introspect it).
+#
+# Schema 1 (this is the first version — the schema-version pattern is replicated
+# from ``instinct_bridge._POCKET_WRITE_SCHEMA`` / belt's ``CODE_CHANGE_SCHEMA``,
+# starting at 1). The blob carries:
+#   * ``schema`` / ``kind`` — version + discriminator;
+#   * ``workspace_id`` — the originating tenant (the executor's tenancy gate
+#     reads it HERE; an external action isn't bound to a pocket the way a parked
+#     write is, so tenancy lives entirely on the blob);
+#   * ``connector_name`` / ``scope`` / ``pocket_id`` — the connector reference
+#     (which bound connector, at which scope) the executor resolves;
+#   * ``action`` — the named connector action to call;
+#   * ``params`` — the proposed call params (DATA — never interpolated into a
+#     shell; passed verbatim to the connector adapter);
+#   * ``params_hash`` — a stable hash of ``action`` + ``params`` so the executor
+#     can refuse if the params were tampered with between propose and approve;
+#   * ``idempotency_key`` — so the executor never double-fires the HTTP call if
+#     re-invoked (bulk re-approve, retry, etc.);
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids,
+#     minted here at propose time (``agent.proposed`` opens the chain). The
+#     router's approve / reject paths and the executor close the SAME chain.
+#   * ``summary`` — a human-readable one-liner for the gate UI (The Tray).
+#
+# Security:
+#   * NO connector secret reaches the Instinct DB. The blob carries the
+#     connector NAME + scope only; the credential is resolved fresh at execution
+#     by the cloud connector service from the workspace's saved config.
+#   * The params hash is re-checked at execution — a params edit between propose
+#     and approve refuses the call (the human approved a specific call, not an
+#     arbitrary one).
+#   * Tenancy is bound on the router's approve / reject paths via
+#     ``_assert_external_action_workspace`` and re-validated at execution (the
+#     connector service is scoped by the blob's ``workspace_id``).
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator for an external-action proposal. The
+# router + executor dispatch on the presence of the parameters key below; the
+# blob also carries ``kind="external_action"`` for readers that introspect it.
+EXTERNAL_ACTION_KIND = "external_action"
+
+# The parameters key under which the external-action blob rides — peer of the
+# pocket-write bridge's ``_pocket_write`` and belt's ``_code_change``. The
+# router + executor dispatch on this key being present.
+EXTERNAL_ACTION_PARAM_KEY = "_external_action"
+
+# Schema version stamped on the ``_external_action`` blob. Bump when the blob
+# shape changes so a stale pending Action approved after a deploy fails loud
+# instead of firing a misinterpreted external call (same discipline as the
+# pocket-write bridge's ``_POCKET_WRITE_SCHEMA`` and belt's
+# ``CODE_CHANGE_SCHEMA``). Starts at 1 — this is the first version.
+EXTERNAL_ACTION_SCHEMA = 1
+
+
+def compute_params_hash(action: str, params: dict[str, Any]) -> str:
+    """Return a stable SHA-256 hex digest of ``action`` + ``params``.
+
+    Canonical JSON (sorted keys, no whitespace) so the same logical call hashes
+    identically regardless of dict ordering. The executor recomputes this off
+    the persisted blob and refuses the call if it no longer matches — a human
+    approved a SPECIFIC call, and a params edit between propose and approve must
+    not silently fire a different one.
+    """
+    canonical = json.dumps(
+        {"action": action, "params": params or {}},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    connector_name: str,
+    connector_action: str,
+    workspace_id: str,
+    user_id: str,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for an external action.
+
+    Mirrors belt.py's ``_emit_agent_proposed``: the proposing caller is the
+    actor (``kind="agent"`` with the requesting user on its id, the workspace on
+    its scope_context). An external action isn't bound to a pocket — its tenancy
+    is the workspace — so ``pocket_id`` on the chain carries the workspace id
+    (matching how the Action's ``pocket_id`` field carries the workspace).
+
+    Returns the emitted event id so the caller can persist it on the blob's
+    ``proposed_event_id`` field for the ``human.corrected`` causation chain, or
+    ``None`` when the emit raised — best-effort per RFC 09; the Slice 4
+    reconciler picks up any orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"external action '{connector_action}' on connector '{connector_name}'"
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "external_action",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator.
+        "proposal_kind": "external_action",
+        "proposal": {
+            "connector": connector_name,
+            "connector_action": connector_action,
+        },
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "external_action agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._external_action`` blob after ``agent.proposed`` fired.
+
+    The blob is built with ``correlation_id`` already set (minted before build);
+    ``proposed_event_id`` is the field this back-write fills in. Direct SQL
+    update — the same pattern belt.py's ``_persist_chain_ids`` and the
+    pocket-write bridge's ``_persist_parked_policy_event_id`` use. Best-effort:
+    a write failure leaves ``proposed_event_id`` None and the eventual
+    ``human.corrected`` emits without a causation_id (the chain still folds;
+    causation_id is optional on EventEntry).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(EXTERNAL_ACTION_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[EXTERNAL_ACTION_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "external_action: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+async def propose_external_action(
+    *,
+    workspace_id: str,
+    connector_name: str,
+    action: str,
+    params: dict[str, Any] | None = None,
+    requested_by: str,
+    scope: str = "workspace",
+    pocket_id: str | None = None,
+    idempotency_key: str | None = None,
+    summary: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+) -> str:
+    """Build + store an Instinct ``Action`` for a gated external-action call.
+
+    Files an Action carrying the ``_external_action`` blob (schema 1) and opens
+    the Decision-Graph chain (``agent.proposed``). Returns the proposed Action
+    id. NO connector secret is written — the blob carries the connector NAME +
+    scope only; the credential is resolved fresh at execution.
+
+    Args:
+        workspace_id: the originating tenant. Bound on the router's approve /
+            reject paths and re-validated at execution. Required — an external
+            action with no tenant to scope it to is unexecutable.
+        connector_name: the bound connector to call (e.g. ``"crm"``).
+        action: the named connector action to call (e.g. ``"approveApplication"``).
+        params: the proposed call params, passed verbatim to the connector
+            adapter at execution. Hashed into ``params_hash`` so the executor
+            can refuse a post-propose params edit.
+        requested_by: the user id that proposed the call (chain actor + audit).
+        scope: connector scope — one of ``pocket`` / ``workspace`` / ``user``.
+            Defaults to ``workspace``.
+        pocket_id: the pocket the connector is bound to, when ``scope="pocket"``.
+        idempotency_key: caller-supplied key so the executor never double-fires
+            the call. Defaults to a deterministic value derived from the params
+            hash when omitted, so an identical re-propose dedupes naturally.
+        summary: a human-readable one-liner for the gate UI. A sensible default
+            is built from the connector + action when omitted.
+        correlation_id: an optional pre-minted chain id. When omitted a fresh one
+            is minted here (the common case).
+        assignee: the workspace member who should approve. Defaults to
+            ``requested_by`` so the proposer's queue carries it.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_external_action requires a non-empty workspace_id")
+    connector_name = str(connector_name or "")
+    if not connector_name:
+        raise ValueError("propose_external_action requires a non-empty connector_name")
+    action = str(action or "")
+    if not action:
+        raise ValueError("propose_external_action requires a non-empty action")
+
+    call_params = dict(params or {})
+    params_hash = compute_params_hash(action, call_params)
+    # A deterministic idempotency key when the caller doesn't supply one — keyed
+    # on the workspace + connector + params hash so an identical re-propose
+    # dedupes at the executor (the executor never double-fires a key it already
+    # recorded as executed).
+    idem = idempotency_key or f"{workspace_id}:{connector_name}:{action}:{params_hash[:16]}"
+
+    # Mint the chain correlation_id BEFORE building the blob so the stored Action
+    # carries it from the first write. The same id threads through approve /
+    # reject (router) and execute (executor) so the whole call folds into ONE
+    # Decision chain.
+    corr = correlation_id or str(uuid4())
+
+    human_summary = summary or (
+        f"Call '{action}' on connector '{connector_name}' (scope: {scope})."
+    )
+
+    blob: dict[str, Any] = {
+        "kind": EXTERNAL_ACTION_KIND,
+        "schema": EXTERNAL_ACTION_SCHEMA,
+        "workspace_id": workspace_id,
+        "connector_name": connector_name,
+        "scope": scope,
+        "pocket_id": pocket_id,
+        "action": action,
+        "params": call_params,
+        "params_hash": params_hash,
+        "idempotency_key": idem,
+        "requested_by": requested_by,
+        "summary": human_summary,
+        # RFC 09 chain-correlation fields (schema 1 carries them from the start).
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    title = f"External action — {connector_action_label(connector_name, action)}"
+    recommendation = (
+        f"Approve to call '{action}' on connector '{connector_name}' "
+        f"(scope: {scope}). {human_summary}"
+    )
+    trigger = ActionTrigger(
+        type="agent",
+        source=requested_by or "external_action",
+        reason=f"external action '{action}' on connector '{connector_name}' requires approval",
+    )
+
+    store = get_instinct_store()
+    action_obj = await store.propose(
+        # ``pocket_id`` carries the workspace for external actions — they aren't
+        # bound to a pocket the way Mission Control items are (mirrors belt.py).
+        # The workspace also rides on the blob (the executor's tenancy gate reads
+        # it there); pocket_id mirrors it so the existing per-pocket queries
+        # still surface the row.
+        pocket_id=workspace_id,
+        title=title,
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.EXTERNAL,
+        priority=ActionPriority.HIGH,
+        parameters={EXTERNAL_ACTION_PARAM_KEY: blob},
+        assignee=assignee or requested_by or None,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "external_action: proposed call '%s' on connector '%s' → Instinct action %s "
+        "(workspace=%s, correlation_id=%s)",
+        action,
+        connector_name,
+        action_obj.id,
+        workspace_id,
+        corr,
+    )
+
+    # Open the Decision-Graph chain now that the Action is stored. ``agent.
+    # proposed`` is the chain origin; its event id is back-written onto the blob
+    # so the router's ``human.corrected`` can cite it as causation. Best-effort:
+    # a Decision-Graph wiring failure must NOT fail the propose response.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        connector_name=connector_name,
+        connector_action=action,
+        workspace_id=workspace_id,
+        user_id=requested_by,
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+def connector_action_label(connector_name: str, action: str) -> str:
+    """Build a short, content-free label for the Action title.
+
+    Just ``connector.action`` — no params (a param can carry resolved values an
+    operator doesn't need in a title, and a stable label keeps the title the
+    same for the same call kind).
+    """
+    return f"{connector_name}.{action}"
+
+
+__all__ = [
+    "EXTERNAL_ACTION_KIND",
+    "EXTERNAL_ACTION_PARAM_KEY",
+    "EXTERNAL_ACTION_SCHEMA",
+    "compute_params_hash",
+    "connector_action_label",
+    "propose_external_action",
+]

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,24 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-11 (feat/external-action-proposal) — added the THIRD gated
+#   proposal kind: a gated external-action connector call. ``_external_action_blob``
+#   + ``_assert_external_action_workspace`` are the peers of the ``_code_change``
+#   / ``_pocket_write`` blob accessor + tenancy guard. The four dispatch handlers
+#   (approve_action / bulk_approve_actions / reject_action / bulk_reject_actions)
+#   now also branch on an ``_external_action`` blob: on APPROVE the router emits
+#   ``human.corrected`` then fires ``external_actions.executor.
+#   execute_approved_external_action`` (which OWNS the chain close); on REJECT the
+#   router emits ``human.corrected`` + ``decision.completed(rejected)`` itself
+#   (the executor never runs on reject). The up-front tenancy assertion runs in
+#   all four locations. Same exactly-one-terminal discipline as the pocket-write
+#   bridge + belt executor — no double chain close. The blob's
+#   ``proposed_event_id`` (the chain-opening ``agent.proposed`` id) is the
+#   causation source, resolved via the generic ``_code_change_proposed_event_id``
+#   helper (it reads ``blob["proposed_event_id"]``, shared across the two kinds).
+#   Rebased over the paw-print ``_customer_reply`` delivery hooks (gap2) — the
+#   external-action branches sit BEFORE the customer-reply hooks in approve /
+#   reject (all blob kinds are mutually exclusive; customer-reply keeps its
+#   last-before-return placement and its no-bulk / no-assert design unchanged).
 # Updated: 2026-06-11 (merge origin/dev into integration/sovereignty-waves —
 #   Belt code-change union) — reconciled the sovereignty extraction with dev's
 #   Belt feature. The chain-emit helpers (``_emit_human_corrected`` /
@@ -250,6 +269,26 @@ def _code_change_blob(action: Any) -> dict[str, Any] | None:
     return blob if isinstance(blob, dict) else None
 
 
+def _external_action_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_external_action`` blob on an Action, or ``None``.
+
+    The blob is the gated external-action payload
+    ``ee.cloud.external_actions.propose`` stores under
+    ``Action.parameters._external_action`` (connector_name / scope / action /
+    params / params_hash / idempotency_key + the originating ``workspace_id``).
+    This is the third gated proposal kind — the approve path dispatches the
+    apply-on-approve executor on its presence, exactly as it dispatches the
+    pocket-write bridge on ``_pocket_write`` and the belt executor on
+    ``_code_change``. Anything that is not a dict is treated as "no external
+    action".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_external_action")
+    return blob if isinstance(blob, dict) else None
+
+
 async def _emit_belt_run_updated_safe(
     *, workspace_id: str, action_id: str, status: str, stage: str
 ) -> None:
@@ -292,6 +331,28 @@ def _assert_code_change_workspace(action: Any, current_workspace: str) -> None:
         raise Forbidden(
             "instinct.cross_workspace_approval",
             "This code change belongs to a different workspace",
+        )
+
+
+def _assert_external_action_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting an external action from another workspace.
+
+    Mirror of ``_assert_code_change_workspace`` for the ``_external_action``
+    blob. ``require_action_any_workspace("instinct.approve")`` only proves the
+    caller holds the role SOMEWHERE; this binds the external-action Action to the
+    caller's active workspace. An external action carries no pocket the way a
+    parked write does, so its tenancy lives entirely on the blob's
+    ``workspace_id``. A blob whose ``workspace_id`` differs from the caller's
+    active workspace → 403. A non-external-action Action (no blob) is unaffected.
+    """
+    blob = _external_action_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This external action belongs to a different workspace",
         )
 
 
@@ -609,6 +670,7 @@ async def bulk_approve_actions(
         if action is not None:
             _assert_pocket_write_workspace(action, workspace_id)
             _assert_code_change_workspace(action, workspace_id)
+            _assert_external_action_workspace(action, workspace_id)
 
     approved, missing, bulk_id = await store.bulk_approve(
         list(req.ids), approver=approver_id, note=req.note
@@ -660,6 +722,39 @@ async def bulk_approve_actions(
             except Exception:
                 logger.exception(
                     "bulk-approve belt code-change execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
+        # A gated ``_external_action`` Action fires the apply-on-approve
+        # connector executor. Mirrors the code-change branch above: per-item
+        # ``human.corrected(accepted)`` (bulk-approve has no edit surface), the
+        # ``agent.proposed`` event id (off the blob's ``proposed_event_id``) as
+        # causation, then the executor (which owns the chain close). Same
+        # best-effort shape; matched BEFORE the pocket-write branch and
+        # ``continue``d so the two never cross.
+        external_action_blob = _external_action_blob(action)
+        if external_action_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=external_action_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(external_action_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.external_actions import (
+                    executor as external_action_executor,
+                )
+
+                await external_action_executor.execute_approved_external_action(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve external-action execution failed for %s (non-fatal)",
                     action.id,
                 )
             continue
@@ -739,6 +834,7 @@ async def bulk_reject_actions(
         if action is not None:
             _assert_pocket_write_workspace(action, workspace_id)
             _assert_code_change_workspace(action, workspace_id)
+            _assert_external_action_workspace(action, workspace_id)
 
     rejected, missing, bulk_id = await store.bulk_reject(
         list(req.ids), reason=req.reason, rejector=rejector_id
@@ -797,6 +893,32 @@ async def bulk_reject_actions(
                 status="rejected",
                 stage="done",
             )
+            continue
+
+        # A bulk-rejected gated ``_external_action`` Action closes its chain
+        # HERE (the executor never runs on reject — the router owns the close).
+        # Mirrors the code-change reject branch. Matched AFTER pocket-write +
+        # code-change and ``continue``d so the three never cross.
+        external_action_blob = _external_action_blob(action)
+        if external_action_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=external_action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(external_action_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=external_action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            continue
 
     return BulkActionResponse(bulk_id=bulk_id, affected=rejected, missing=missing)
 
@@ -837,6 +959,9 @@ async def approve_action(
     # Same tenancy gate for a Belt code-change Action (BS-3) — its
     # ``_code_change`` blob carries the workspace, not a pocket.
     _assert_code_change_workspace(before, workspace_id)
+    # Same tenancy gate for a gated external-action Action — its
+    # ``_external_action`` blob carries the workspace, not a pocket.
+    _assert_external_action_workspace(before, workspace_id)
 
     req = req or ApproveRequest()
     # SHOULD-FIX 1 — the audit actor is the authenticated identity, not
@@ -956,6 +1081,46 @@ async def approve_action(
         except Exception:
             logger.exception("belt code-change execution after approval failed (non-fatal)")
 
+    # When the approved Action carries a gated ``_external_action`` blob, fire
+    # the connector call. Same best-effort, lazy-import, never-break-the-approve-
+    # response shape as the pocket-write + code-change hooks above; the executor
+    # records success / failure on the Action itself. A non-external-action
+    # Action skips this.
+    #
+    # The external action is part of its own Decision-Graph chain (the propose
+    # helper minted the ``correlation_id`` + emitted ``agent.proposed``). Emit
+    # the ``human.corrected`` event for the approval HERE (the router owns the
+    # human-action emit on every approve path), citing the ``agent.proposed``
+    # event id (stored on the blob as ``proposed_event_id`` — the same field the
+    # code-change path reads, so ``_code_change_proposed_event_id`` resolves it)
+    # as causation, then thread its event id into the executor so the terminal
+    # ``decision.completed`` chains back to the approval:
+    # ``agent.proposed → human.corrected → decision.completed`` under one
+    # correlation_id. The executor owns the chain CLOSE (success or failure) —
+    # the router does NOT emit ``decision.completed`` here, mirroring the
+    # pocket-write bridge + belt executor. No double terminal.
+    external_action_blob = _external_action_blob(approved)
+    if external_action_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=external_action_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(external_action_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.external_actions import executor as external_action_executor
+
+            await external_action_executor.execute_approved_external_action(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("external-action execution after approval failed (non-fatal)")
+
     # gap2 — when the approved Action carries a ``_customer_reply`` blob (a
     # paw-print customer event awaiting a decision), deliver the owner's reply
     # back to the customer surface. Same best-effort, lazy-import,
@@ -1033,6 +1198,7 @@ async def reject_action(
     # Touch-time security fix — same gate the approve path runs.
     _assert_pocket_write_workspace(before, workspace_id)
     _assert_code_change_workspace(before, workspace_id)
+    _assert_external_action_workspace(before, workspace_id)
 
     reason = req.reason if req else ""
     rejector_id = str(user.id)
@@ -1093,6 +1259,32 @@ async def reject_action(
         # run.
         await _emit_belt_run_updated_safe(
             workspace_id=workspace_id, action_id=str(action.id), status="rejected", stage="done"
+        )
+
+    # A rejected gated ``_external_action`` Action closes its chain HERE (the
+    # executor never runs on reject — the router owns the close, mirroring the
+    # code-change reject path). ``human.corrected(rejected)`` cites the
+    # ``agent.proposed`` event (off the blob's ``proposed_event_id``);
+    # ``decision.completed(rejected)`` cites the human event so the chain reads
+    # ``agent.proposed → human.corrected → decision.completed``.
+    external_action_blob = _external_action_blob(action)
+    if external_action_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=external_action_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(external_action_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=external_action_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
         )
 
     # gap2 — a rejected ``_customer_reply`` Action delivers a DECLINED decision

--- a/tests/cloud/test_external_action_gate.py
+++ b/tests/cloud/test_external_action_gate.py
@@ -1,0 +1,548 @@
+# tests/cloud/test_external_action_gate.py — the gated external-action proposal
+# type (the third gated Instinct kind, alongside _pocket_write + _code_change).
+#
+# Created: 2026-06-11 (feat/external-action-proposal).
+#
+# What this pins:
+#   * propose_external_action — blob shape (schema 1, connector ref, action,
+#     params, params_hash, idempotency_key, correlation_id, summary), tenancy
+#     (workspace required), and that NO connector secret is written.
+#   * execute_approved_external_action with a FAKE connector service:
+#       - happy path: connector called with the proposed params, action marked
+#         EXECUTED, structured outcome back-written.
+#       - idempotency: a second invocation does NOT re-fire the connector call.
+#       - hash mismatch: a params edit between propose and approve → FAILED, no
+#         call fired.
+#       - schema mismatch: a stale schema blob → FAILED, no call fired.
+#       - connector failure (success=False) → FAILED status, NOT an exception.
+#       - connector crash (raise) → FAILED status, NOT an exception.
+#   * the MANDATORY production-path integration test: propose → approve via the
+#     REAL router handler → executor runs (fake connector) → walk the decision
+#     chain and assert EXACTLY the expected events (agent.proposed →
+#     human.corrected → decision.completed), no double terminal.
+#   * reject path: the router emits human.corrected + decision.completed
+#     (rejected); the executor is NEVER called.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The store is patched
+# to a tmp-file InstinctStore; the connector service's `execute` is monkeypatched
+# to a fake so nothing touches a real connector. The integration test wires a
+# fresh on-disk journal + DecisionGraph (same fixture shape as
+# tests/ee/test_instinct_decision_events.py) and drives the router over a
+# TestClient with stubbed auth deps.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.external_actions import executor as ea_executor  # noqa: E402
+from pocketpaw_ee.cloud.external_actions import propose as ea_propose  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fakes + fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeExecuteResponse:
+    """Duck-typed ExecuteActionResponse the executor reads (.success / .data /
+    .error)."""
+
+    def __init__(self, *, success: bool, data: Any = None, error: str | None = None):
+        self.success = success
+        self.data = data
+        self.error = error
+        self.records_affected = 0
+        self.execution_mode = "cloud"
+
+
+class FakeConnectorService:
+    """Records connector calls + returns a scripted response. Never touches a
+    real connector. Injected by monkeypatching
+    ``connectors.service.execute``."""
+
+    def __init__(
+        self, *, response: _FakeExecuteResponse | None = None, raises: Exception | None = None
+    ):
+        self.calls: list[dict[str, Any]] = []
+        self._response = response or _FakeExecuteResponse(success=True, data={"ok": True})
+        self._raises = raises
+
+    async def execute(self, workspace_id, name, body, *, user_id=None):
+        self.calls.append(
+            {
+                "workspace_id": workspace_id,
+                "name": name,
+                "action": body.action,
+                "params": dict(body.params),
+                "scope": body.scope,
+                "pocket_id": body.pocket_id,
+                "user_id": user_id,
+            }
+        )
+        if self._raises is not None:
+            raise self._raises
+        return self._response
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired everywhere the gate reads it
+    (the propose helper + the executor both lazy-import
+    ``pocketpaw.stores.get_instinct_store``)."""
+    st = InstinctStore(tmp_path / "instinct_external_action_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+def _patch_connector(monkeypatch, fake: FakeConnectorService) -> None:
+    """Patch the cloud connector service's ``execute`` to the fake."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.connectors.service.execute",
+        fake.execute,
+    )
+
+
+# ---------------------------------------------------------------------------
+# propose — blob shape + tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_builds_external_action_blob(store):
+    """propose_external_action files an Action carrying a well-formed schema-1
+    ``_external_action`` blob — connector ref, action, params, params_hash,
+    idempotency_key, summary — and NO connector secret."""
+    action_id = await ea_propose.propose_external_action(
+        workspace_id="w1",
+        connector_name="crm",
+        action="approveApplication",
+        params={"application_id": "app-7", "note": "ok"},
+        requested_by="u1",
+        scope="workspace",
+    )
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+
+    blob = action.parameters["_external_action"]
+    assert blob["kind"] == "external_action"
+    assert blob["schema"] == 1
+    assert blob["workspace_id"] == "w1"
+    assert blob["connector_name"] == "crm"
+    assert blob["action"] == "approveApplication"
+    assert blob["params"] == {"application_id": "app-7", "note": "ok"}
+    assert blob["requested_by"] == "u1"
+    # params_hash is the canonical hash of action + params.
+    assert blob["params_hash"] == ea_propose.compute_params_hash(
+        "approveApplication", {"application_id": "app-7", "note": "ok"}
+    )
+    # idempotency key present; correlation_id minted.
+    assert blob["idempotency_key"]
+    assert blob["correlation_id"]
+    assert blob["summary"]
+    # NO secret/token anywhere on the blob.
+    flat = str(blob).lower()
+    assert "token" not in flat
+    assert "secret" not in flat
+    assert "authorization" not in flat
+
+
+async def test_propose_requires_workspace(store):
+    """A propose with no workspace_id is rejected up front — an external action
+    with no tenant to scope it to is unexecutable."""
+    with pytest.raises(ValueError, match="workspace_id"):
+        await ea_propose.propose_external_action(
+            workspace_id="",
+            connector_name="crm",
+            action="approveApplication",
+            params={},
+            requested_by="u1",
+        )
+
+
+async def test_propose_custom_idempotency_and_summary(store):
+    """A caller-supplied idempotency_key + summary round-trip onto the blob."""
+    action_id = await ea_propose.propose_external_action(
+        workspace_id="w1",
+        connector_name="crm",
+        action="sendInvoice",
+        params={"id": 5},
+        requested_by="u1",
+        idempotency_key="my-key-1",
+        summary="Send invoice #5 to the customer.",
+    )
+    blob = (await store.get_action(action_id)).parameters["_external_action"]
+    assert blob["idempotency_key"] == "my-key-1"
+    assert blob["summary"] == "Send invoice #5 to the customer."
+
+
+# ---------------------------------------------------------------------------
+# executor — happy path, idempotency, hash, schema, failure
+# ---------------------------------------------------------------------------
+
+
+async def _propose_and_approve(store, **kwargs) -> Any:
+    """Propose then approve via the store, returning the approved Action."""
+    action_id = await ea_propose.propose_external_action(
+        workspace_id="w1",
+        connector_name="crm",
+        action="approveApplication",
+        params={"application_id": "app-7"},
+        requested_by="u1",
+        **kwargs,
+    )
+    return await store.approve(action_id, approver="u1")
+
+
+async def test_executor_happy_path_calls_connector(store, monkeypatch):
+    """On approve the executor resolves the connector, calls the named action
+    with the proposed params, marks EXECUTED, and back-writes the structured
+    outcome {status, response_summary, executed_at}."""
+    fake = FakeConnectorService(
+        response=_FakeExecuteResponse(success=True, data={"decision": "approved"})
+    )
+    _patch_connector(monkeypatch, fake)
+
+    approved = await _propose_and_approve(store)
+    await ea_executor.execute_approved_external_action(approved)
+
+    # The connector was called once with the proposed action + params.
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["workspace_id"] == "w1"
+    assert call["name"] == "crm"
+    assert call["action"] == "approveApplication"
+    assert call["params"] == {"application_id": "app-7"}
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED
+    blob = final.parameters["_external_action"]
+    assert blob["outcome"]["status"] == "executed"
+    assert "executed_at" in blob["outcome"]
+    assert blob["outcome"]["response_summary"]
+
+
+async def test_executor_idempotent_never_double_fires(store, monkeypatch):
+    """Re-invoking the executor on an already-executed Action does NOT call the
+    connector a second time."""
+    fake = FakeConnectorService()
+    _patch_connector(monkeypatch, fake)
+
+    approved = await _propose_and_approve(store)
+    await ea_executor.execute_approved_external_action(approved)
+    assert len(fake.calls) == 1
+
+    # Re-fetch the (now executed) Action and re-invoke — the idempotency guard
+    # short-circuits before the connector call.
+    reloaded = await store.get_action(approved.id)
+    await ea_executor.execute_approved_external_action(reloaded)
+    assert len(fake.calls) == 1  # still ONE
+
+
+async def test_executor_hash_mismatch_refuses(store, monkeypatch):
+    """A params edit between propose and approve (the stored hash no longer
+    matches the params) → FAILED, no connector call."""
+    fake = FakeConnectorService()
+    _patch_connector(monkeypatch, fake)
+
+    approved = await _propose_and_approve(store)
+    # Tamper with the params on the in-memory Action AFTER approval — the stored
+    # params_hash no longer matches.
+    approved.parameters["_external_action"]["params"] = {"application_id": "DIFFERENT"}
+
+    await ea_executor.execute_approved_external_action(approved)
+
+    assert fake.calls == []  # nothing fired
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "hash" in str(final.error).lower()
+    assert final.parameters["_external_action"]["outcome"]["status"] == "failed"
+
+
+async def test_executor_schema_mismatch_refuses(store, monkeypatch):
+    """A stale blob with an incompatible schema version → FAILED, no call."""
+    fake = FakeConnectorService()
+    _patch_connector(monkeypatch, fake)
+
+    approved = await _propose_and_approve(store)
+    approved.parameters["_external_action"]["schema"] = 999  # incompatible
+
+    await ea_executor.execute_approved_external_action(approved)
+
+    assert fake.calls == []
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "schema" in str(final.error).lower()
+
+
+async def test_executor_connector_failure_marks_failed_not_exception(store, monkeypatch):
+    """A connector that reports success=False → the Action is FAILED (not a
+    phantom success), and the executor does NOT raise."""
+    fake = FakeConnectorService(
+        response=_FakeExecuteResponse(success=False, error="upstream 422 invalid application")
+    )
+    _patch_connector(monkeypatch, fake)
+
+    approved = await _propose_and_approve(store)
+    # Must NOT raise.
+    await ea_executor.execute_approved_external_action(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "422" in str(final.error)
+    blob = final.parameters["_external_action"]
+    assert blob["outcome"]["status"] == "failed"
+    assert "422" in blob["outcome"]["response_summary"]
+
+
+async def test_executor_connector_crash_marks_failed_not_exception(store, monkeypatch):
+    """A connector adapter that RAISES → the Action is FAILED, the executor
+    swallows the exception (best-effort, never breaks the approve response)."""
+    fake = FakeConnectorService(raises=RuntimeError("connector blew up"))
+    _patch_connector(monkeypatch, fake)
+
+    approved = await _propose_and_approve(store)
+    await ea_executor.execute_approved_external_action(approved)  # must not raise
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "blew up" in str(final.error)
+    assert final.parameters["_external_action"]["outcome"]["status"] == "failed"
+
+
+async def test_executor_no_blob_is_noop(store, monkeypatch):
+    """An Action with no ``_external_action`` blob is a clean no-op (no chain was
+    ever opened)."""
+    fake = FakeConnectorService()
+    _patch_connector(monkeypatch, fake)
+
+    from pocketpaw.instinct.models import ActionTrigger
+
+    action = await store.propose(
+        pocket_id="w1",
+        title="not external",
+        description="",
+        recommendation="",
+        trigger=ActionTrigger(type="agent", source="x", reason="y"),
+    )
+    approved = await store.approve(action.id, approver="u1")
+    await ea_executor.execute_approved_external_action(approved)
+    assert fake.calls == []
+
+
+# ---------------------------------------------------------------------------
+# MANDATORY production-path integration test — propose → approve via the REAL
+# router → executor runs → walk the chain, assert EXACTLY one terminal.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    """Fresh on-disk journal wired into the lazy
+    ``pocketpaw.journal_dep.get_journal`` lookup (same shape as the Slice 3
+    tests). ``journal_writer.record_decision_event`` resolves the journal
+    through that dep so production code + tests share the singleton."""
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    """Fresh DecisionGraph + decisions.db as the process-global singleton."""
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "u1", workspace_id: str = "w1") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _make_client(user: _FakeUser, monkeypatch) -> TestClient:
+    """Build a TestClient over the Instinct router with auth deps stubbed and a
+    CloudError handler so a Forbidden maps to 403."""
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _events_by_correlation(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+async def test_production_path_approve_runs_executor_one_terminal(
+    store, journal, graph, monkeypatch
+):
+    """THE mandatory chain-doubling guard: propose → approve through the REAL
+    router handler → the executor fires the connector → walk the decision chain
+    and assert EXACTLY agent.proposed → human.corrected → decision.completed.
+    No second terminal (the router must NOT also close on approve)."""
+    fake = FakeConnectorService(
+        response=_FakeExecuteResponse(success=True, data={"decision": "approved"})
+    )
+    _patch_connector(monkeypatch, fake)
+
+    # Propose through the real helper (mints correlation_id + agent.proposed).
+    action_id = await ea_propose.propose_external_action(
+        workspace_id="w1",
+        connector_name="crm",
+        action="approveApplication",
+        params={"application_id": "app-7"},
+        requested_by="u1",
+    )
+    blob = (await store.get_action(action_id)).parameters["_external_action"]
+    corr = UUID(blob["correlation_id"])
+
+    # Approve via the REAL router handler (the production path that fires the
+    # executor). The router's _store indirection points at our tmp store.
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    # The executor fired the connector exactly once.
+    assert len(fake.calls) == 1
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED
+
+    # Walk the chain — EXACTLY the three expected events, in order, ONE terminal.
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    # Exactly one decision.completed (no double close).
+    assert actions.count("decision.completed") == 1
+    # The terminal is the executor's success close.
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is True
+    assert (terminal.payload or {})["action_outcome"] == "landed"
+    # human.corrected → decision.completed causation chain.
+    hc = chain[1]
+    assert terminal.causation_id == hc.id
+
+
+async def test_production_path_reject_router_closes_executor_never_called(
+    store, journal, graph, monkeypatch
+):
+    """Reject path: the ROUTER emits human.corrected + decision.completed
+    (rejected); the executor is NEVER called (no connector call)."""
+    fake = FakeConnectorService()
+    _patch_connector(monkeypatch, fake)
+
+    action_id = await ea_propose.propose_external_action(
+        workspace_id="w1",
+        connector_name="crm",
+        action="approveApplication",
+        params={"application_id": "app-7"},
+        requested_by="u1",
+    )
+    blob = (await store.get_action(action_id)).parameters["_external_action"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
+    assert resp.status_code == 200, resp.text
+
+    # The executor never ran — no connector call.
+    assert fake.calls == []
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED
+
+    # The router owns the close on reject: agent.proposed → human.corrected →
+    # decision.completed(rejected). Exactly one terminal.
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is False
+    assert (terminal.payload or {})["action_outcome"] == "rejected"
+
+
+async def test_router_cross_workspace_approval_forbidden(store, journal, graph, monkeypatch):
+    """A caller whose active workspace differs from the blob's workspace_id
+    gets 403 on approve — the tenancy gate binds the Action to the caller's
+    workspace."""
+    fake = FakeConnectorService()
+    _patch_connector(monkeypatch, fake)
+
+    action_id = await ea_propose.propose_external_action(
+        workspace_id="w-OTHER",
+        connector_name="crm",
+        action="approveApplication",
+        params={"application_id": "app-7"},
+        requested_by="u1",
+    )
+
+    # Caller is in w1 but the action belongs to w-OTHER.
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 403, resp.text
+    # Nothing fired.
+    assert fake.calls == []
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING


### PR DESCRIPTION
## What

Instinct already gates two kinds of agent proposals behind human approval: pocket writes (`_pocket_write`) and code diffs (`_code_change`). This adds the third — `_external_action` — a proposed call to an external system through a bound connector. An agent proposes "run action `X` on connector `Y` with params `Z`", a human approves or rejects it in The Tray, and on approve the executor makes the connector call. Everything stays generic; there's no domain-specific logic baked in.

## How

New package `ee/cloud/external_actions`, modelled on the pocket-write bridge and the Belt executor so the propose/execute shapes match what's already there:

- **`propose.propose_external_action`** files an Action carrying an `_external_action` blob (schema 1): workspace, connector reference, action name, params, a params hash, an idempotency key, the Decision-Graph correlation id, and a human-readable summary for the gate UI. It opens the chain with `agent.proposed`. No connector secret is written — the blob carries only the connector name; the credential is resolved fresh at execution from the workspace's saved config.
- **`executor.execute_approved_external_action`** re-validates the schema version and the params hash (a human approved a *specific* call, so a params edit between propose and approve is refused), guards against double-firing on re-invocation, resolves the connector through the cloud connector path, calls the action, back-writes `{status, response_summary, executed_at}` onto the blob, and closes the chain. It never raises into the router — a reported connector failure or a raised exception both land as `status=failed` with a failed terminal.

Router wiring adds the `_external_action` blob accessor and tenancy guard (peers of the code-change ones) plus dispatch branches in all four handlers — approve, bulk-approve, reject, bulk-reject — each with the up-front workspace assertion.

## The terminal discipline

The chain folds into one Decision per call: `agent.proposed → human.corrected → decision.completed`. On approve the **executor** owns the `decision.completed` close (the router emits only `human.corrected`); on reject the **router** owns it and the executor never runs. That's the same split the pocket-write bridge and the Belt executor use, and it's the thing that prevents the known chain-doubling bug.

## Tests

`tests/cloud/test_external_action_gate.py` covers the propose blob shape and tenancy, and the executor against a fake connector: idempotency, hash mismatch refusal, schema mismatch refusal, and a connector failure landing as `failed` rather than an exception. The mandatory production-path test drives propose → approve through the real router handler, lets the executor fire the fake connector, then walks the decision chain and asserts exactly one terminal — plus the reject path, where the router closes the chain and the executor is never called.

215 tests pass across the new suite and the existing instinct router / bridge / belt / decision-event suites (no regressions). Ruff and all 22 ee import-linter contracts are clean.

## Docs

`ee/cloud/external_actions/README.md` documents the blob contract, the propose/execute split, the one-terminal discipline, and the router wiring — there was no single existing doc enumerating the gated proposal kinds.