### PR TITLE
Fix the ruff format break in paw-print decision_loop

### DIFF
--- a/ee/pocketpaw_ee/paw_print/decision_loop.py
+++ b/ee/pocketpaw_ee/paw_print/decision_loop.py
@@ -94,10 +94,7 @@ def _default_reply(event_type: str) -> str:
     flows through the existing Instinct correction path (the edit is captured as
     a Correction and the edited recommendation is what gets delivered).
     """
-    return (
-        f"Thanks for your '{event_type}' request — we've received it and "
-        "will follow up shortly."
-    )
+    return f"Thanks for your '{event_type}' request — we've received it and will follow up shortly."
 
 
 async def propose_customer_decision(


### PR DESCRIPTION
dev's Lint job has been failing since #1419 merged: `ee/pocketpaw_ee/paw_print/decision_loop.py` missed a format pass, and every open PR now inherits the red check. This runs `ruff format` on that one file. 5 lines, formatting only, no behavior change.