### PR TITLE
Housekeeping: gap-slice review follow-ups (tenancy guards, migration safety, validators)

### DIFF
--- a/ee/pocketpaw_ee/cloud/outcomes/service.py
+++ b/ee/pocketpaw_ee/cloud/outcomes/service.py
@@ -42,6 +42,13 @@
 #   scoped with the same defense-in-depth tenant filter as `count_outcomes`.
 #   Deferred (NOT here): invoicing, payment, currency, pricing-rules engine,
 #   disputes/clawback (outcome-spec.md Decisions 4/5/7).
+# Updated: 2026-06-11 (gap-housekeeping) — `meter_outcomes` no longer compares
+#   the period window lexicographically on raw ISO strings. The new `_parse_ts`
+#   helper normalizes the stored `occurred_at` AND the since/until bounds to
+#   UTC-aware datetimes before comparing, so the same instant written as `...Z`,
+#   `...+00:00`, or an offset (`...-04:00`) sorts correctly into the window. The
+#   since-inclusive / until-exclusive contract is unchanged; a torn/unparseable
+#   timestamp falls back to the old byte-wise compare rather than crashing.
 from __future__ import annotations
 
 import json
@@ -73,6 +80,40 @@ def set_ledger_dir(path: str | Path) -> None:
     """Override the outcomes ledger directory (test seam)."""
     global _LEDGER_DIR
     _LEDGER_DIR = Path(path)
+
+
+def _parse_ts(raw: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp to a timezone-aware UTC ``datetime``.
+
+    The stored ``occurred_at`` and the ``since`` / ``until`` bounds can each
+    arrive in a DIFFERENT textual form for the SAME instant — ``...Z``,
+    ``...+00:00``, or an offset like ``...-04:00``. A lexicographic string
+    compare sorts those wrong (``"...Z" > "...+00:00"`` byte-wise even though
+    they are equal instants, and an offset timestamp sorts on its local digits,
+    not its UTC instant). Parsing to a UTC-normalized ``datetime`` makes the
+    window comparison correct regardless of representation.
+
+    ``Z`` is rewritten to ``+00:00`` for ``fromisoformat`` (Python < 3.11 does
+    not accept ``Z``). A naive timestamp (no offset) is assumed UTC — the
+    producer stamps ``datetime.now(UTC)``, so a stored value is always
+    UTC-aware, and a hand-edited naive value is most safely read as UTC.
+    Returns ``None`` when the value is empty or unparseable, so the caller can
+    fall back to the byte-wise compare rather than crash on a torn row.
+    """
+    if not raw:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
 
 
 def _coerce_value(raw: object) -> float | None:
@@ -414,6 +455,13 @@ async def meter_outcomes(
     # Accumulate (count, summed_value) per unit before building the DTOs.
     unit_count: dict[str, int] = {}
     unit_value: dict[str, float] = {}
+    # Parse the window bounds ONCE to UTC-normalized datetimes so the per-row
+    # comparison is on instants, not raw ISO strings — a `Z`-vs-`+00:00`-vs-
+    # offset representation of the same instant compares correctly. When a bound
+    # is present but unparseable we keep its raw string for a defensive
+    # lexicographic fallback rather than dropping the bound entirely.
+    since_dt = _parse_ts(body.since) if body.since is not None else None
+    until_dt = _parse_ts(body.until) if body.until is not None else None
     try:
         with path.open("r", encoding="utf-8") as fh:
             for line in fh:
@@ -432,12 +480,28 @@ async def meter_outcomes(
                 if body.pocket_id is not None and row.get("pocket_id") != body.pocket_id:
                     continue
                 occurred = str(row.get("occurred_at") or "")
-                if body.since is not None and occurred < body.since:
-                    continue
-                # `until` is an EXCLUSIVE upper bound so back-to-back
-                # periods never double-count a boundary outcome.
-                if body.until is not None and occurred >= body.until:
-                    continue
+                occurred_dt = _parse_ts(occurred)
+                # `since` is INCLUSIVE, `until` EXCLUSIVE so back-to-back periods
+                # never double-count a boundary outcome. Compare as datetimes
+                # when BOTH sides parsed; otherwise fall back to the byte-wise
+                # string compare (a torn/hand-edited timestamp) so the row is
+                # still filtered rather than crashing the meter.
+                if body.since is not None:
+                    in_window = (
+                        occurred_dt >= since_dt
+                        if (occurred_dt is not None and since_dt is not None)
+                        else occurred >= body.since
+                    )
+                    if not in_window:
+                        continue
+                if body.until is not None:
+                    before_until = (
+                        occurred_dt < until_dt
+                        if (occurred_dt is not None and until_dt is not None)
+                        else occurred < body.until
+                    )
+                    if not before_until:
+                        continue
 
                 total_outcomes += 1
 

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -1,4 +1,11 @@
 # action_executor.py — Server-side executor for pocket WRITE actions.
+# Updated: 2026-06-11 (gap-housekeeping) — the
+#   `_outcome_value_pairs_with_unit` model_validator now also rejects a
+#   NEGATIVE `outcome_value`. The aggregation sums value by unit into a
+#   billable total, so a negative figure would silently subtract from a
+#   tenant's metered total (a credit/clawback the pricing layer owns, not an
+#   author-time binding). Zero is still allowed (a free but named+metered
+#   outcome). Caught at parse time so the ledger never sees it.
 # Updated: 2026-06-11 (gap-3 outcome VALUE metering) — `ActionBinding` now
 #   declares `outcome_value: float | None` and `outcome_unit: str | None`,
 #   the author-time billable-value pair that turns the count-only outcome
@@ -349,6 +356,19 @@ class ActionBinding(BaseModel):
             raise ValueError(
                 "outcome_value is set but no `outcome` name is declared — "
                 "a billable value needs a named outcome to attach to"
+            )
+        # gap-housekeeping — a billable figure cannot be negative. The
+        # aggregation SUMS outcome_value by unit into a "pay for governed
+        # outcomes" total; a negative value would silently subtract from a
+        # tenant's billable figure (a credit/clawback the pricing layer owns,
+        # not an author-time binding). Reject it at parse time so a negative
+        # value never reaches the ledger. Zero is allowed (a free, but still
+        # named+metered, outcome).
+        if has_value and self.outcome_value < 0:
+            raise ValueError(
+                "outcome_value must not be negative — a billable figure cannot "
+                "be negative (credits/clawbacks are a pricing-layer concern, not "
+                "an action binding)"
             )
         return self
 

--- a/ee/pocketpaw_ee/paw_print/decision_loop.py
+++ b/ee/pocketpaw_ee/paw_print/decision_loop.py
@@ -33,6 +33,15 @@
 #   delivery hook re-resolves the parked row by Instinct action id (the stable
 #   join key) so a tampered blob cannot redirect a decision to another
 #   customer's row.
+#
+# Updated: 2026-06-11 (gap-housekeeping) — propose_customer_decision now SKIPS
+#   the loop when the widget resolves to an EMPTY workspace (owner unset). A
+#   NULL-scoped Instinct proposal would surface in every tenant's pending list,
+#   so an owner-less widget logs a warning and raises NO proposal rather than an
+#   all-tenant-visible one. The event + Fabric object still persist; the loop
+#   simply doesn't open until the owner is set. Chose the guard over a hard
+#   PawPrintWidget.owner field-validator because the owner may legitimately be
+#   assigned after the widget is created.
 
 from __future__ import annotations
 
@@ -131,6 +140,25 @@ async def propose_customer_decision(
         widget_id = str(getattr(widget, "id", "") or "")
         pocket_id = str(getattr(widget, "pocket_id", "") or "")
         workspace_id = resolve_workspace_id(widget)
+        # Tenancy guard: an owner-less widget resolves to an EMPTY workspace. A
+        # proposal raised with no workspace scope is NULL-scoped in Instinct, so
+        # it would appear in EVERY tenant's pending list / The Tray — a
+        # cross-tenant leak that also lets any operator approve another's
+        # customer request. Skip the loop entirely rather than open it
+        # mis-scoped: log a warning and leave the event + Fabric object (already
+        # persisted) as the only record. The owner can be set later and a re-sent
+        # event will then open the loop correctly. This is deliberately the
+        # less-invasive of the two options in the review note — a hard
+        # field-validator on PawPrintWidget.owner would reject a widget whose
+        # owner is legitimately assigned after creation.
+        if not workspace_id.strip():
+            logger.warning(
+                "paw-print widget %s has no owner/workspace — SKIPPING the "
+                "decision proposal so it is not raised NULL-scoped and visible "
+                "to every tenant. Set the widget owner to open the loop.",
+                widget_id or "<unknown>",
+            )
+            return None
         customer_ref = str(getattr(event, "customer_ref", "") or "")
         event_type = str(getattr(event, "type", "") or "")
         payload = getattr(event, "payload", None) or {}
@@ -279,12 +307,18 @@ async def deliver_customer_decision(action: Any, *, declined: bool = False) -> N
                 blob.get("default_reply") or ""
             )
 
+        # The blob carries the owning workspace; thread it so set_decision flips
+        # only a row inside that tenant. An empty blob workspace passes None
+        # (unscoped) — matching how the proposal would have been raised.
+        blob_workspace = str(blob.get("workspace_id") or "") or None
+
         store = get_paw_print_store()
         updated = await store.set_decision(
             action_id,
             state=state,
             reply=reply,
             decided_by=decided_by,
+            workspace_id=blob_workspace,
         )
         if updated is None:
             logger.info(

--- a/src/pocketpaw/connectors/adapters/gcalendar.py
+++ b/src/pocketpaw/connectors/adapters/gcalendar.py
@@ -19,6 +19,11 @@
 #   sync() still returns records_synced=0 (it has no FabricStore handle in the
 #   adapter contract); ingest_to_fabric() is the real path a caller with a store
 #   drives. Migrating the sync()/EE service wiring is deferred (see slice notes).
+# Updated: 2026-06-11 (gap-housekeeping) — the `attendees` PropertyDef in
+#   CALENDAR_EVENT_MAPPING now declares type="array" (was "string"); the field
+#   projects a list (the raw attendee-email list), so "string" mislabelled the
+#   property's true type. "array" matches the calendar_create action schema's
+#   `attendees` param, which already uses type="array".
 
 from __future__ import annotations
 
@@ -63,7 +68,7 @@ CALENDAR_EVENT_MAPPING = FabricMapping(
         PropertyDef(name="end", type="date", description="End time (RFC 3339 or date)"),
         PropertyDef(name="location", type="string", description="Event location"),
         PropertyDef(name="description", type="string", description="Event description"),
-        PropertyDef(name="attendees", type="string", description="Attendee emails (list)"),
+        PropertyDef(name="attendees", type="array", description="Attendee emails (list)"),
         PropertyDef(name="attendee_count", type="number", description="Number of attendees"),
         PropertyDef(name="html_link", type="string", description="Link to the event"),
     ],

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -1,5 +1,11 @@
 # Connector -> Fabric ingestion — the reusable record-to-typed-object mapper.
 # Created: 2026-06-11 (gap1-connfabric slice).
+# Updated: 2026-06-11 (gap-housekeeping) — ingest_records now threads
+#   ``workspace_id`` into the update_object() call on the re-ingest (UPDATE)
+#   path, matching the workspace it already passes to get_object_by_source() and
+#   create_object(). The store's update_object grew its own W4a tenancy guard, so
+#   an idempotent re-sync stays inside the caller's tenant on the write as well
+#   as the read.
 #
 # WHY THIS EXISTS
 # ---------------
@@ -163,7 +169,7 @@ async def ingest_records(
             workspace_id=workspace_id,
         )
         if existing is not None:
-            updated = await store.update_object(existing.id, properties)
+            updated = await store.update_object(existing.id, properties, workspace_id=workspace_id)
             result.updated += 1
             result.object_ids.append((updated or existing).id)
         else:

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -47,10 +47,27 @@
 #   always created a second object (documented in
 #   tests/cloud/test_e2e_connector_to_fabric.py::test_fabric_source_deduplication).
 #   Read-only and additive; honors the W4a workspace scope like get_object().
+# Updated: 2026-06-11 (gap-housekeeping) — three small hardening fixes:
+#   (1) fabric_object_types.name gets a UNIQUE index so a concurrent ensure_type
+#       race can't define the same type twice with different ids. Created AFTER
+#       SCHEMA_SQL (mirrors the _WORKSPACE_INDEX_SQL pattern), NOT inside the
+#       executescript — a pre-W4a / pre-this-change DB may already hold duplicate
+#       name rows, so _ensure_schema de-dups defensively first (keeps the lowest
+#       rowid per case-folded name, re-points objects of the losing types at the
+#       survivor, then drops the loser rows) and wraps the index creation in
+#       try/except so a residual dup can never crash _ensure_schema — it logs a
+#       warning and leaves the unique index uncreated instead.
+#   (2) update_object() now threads an optional workspace_id and applies the same
+#       `workspace_id = ? OR workspace_id IS NULL` scope as get_object /
+#       get_object_by_source, so the write has its OWN tenancy guard rather than
+#       trusting the caller to have scoped the prior read. connectors.fabric_ingest
+#       passes workspace_id through.
+
 
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -64,6 +81,8 @@ from pocketpaw.fabric.models import (
     ObjectType,
     PropertyDef,
 )
+
+logger = logging.getLogger(__name__)
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS fabric_object_types (
@@ -119,6 +138,19 @@ CREATE INDEX IF NOT EXISTS idx_links_type ON fabric_links(link_type);
 _WORKSPACE_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_objects_workspace ON fabric_objects(workspace_id)",
     "CREATE INDEX IF NOT EXISTS idx_links_workspace ON fabric_links(workspace_id)",
+)
+
+# A UNIQUE index on the (case-folded) type name closes a concurrent
+# ``ensure_type`` race: two callers both miss ``get_type_by_name`` and both run
+# ``define_type``, leaving two type rows with the SAME name but different ids —
+# objects of "the same logical type" then split across two ``type_id``s. Created
+# AFTER SCHEMA_SQL (same reason as _WORKSPACE_INDEX_SQL): a pre-existing DB may
+# already hold duplicate-name rows, so _ensure_schema de-dups defensively before
+# creating the index. ``get_type_by_name`` matches case-insensitively, so the
+# uniqueness key is LOWER(name) to match.
+_TYPE_NAME_UNIQUE_INDEX_SQL = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_object_types_name_unique"
+    " ON fabric_object_types(LOWER(name))"
 )
 
 # Whitelist of filter operators -> SQL operator. User input never reaches the
@@ -253,8 +285,74 @@ class FabricStore:
             # above). Doing this inside SCHEMA_SQL would fail on a pre-W4a DB.
             for _idx in _WORKSPACE_INDEX_SQL:
                 await db.execute(_idx)
+            # Unique-name index on fabric_object_types. A pre-existing DB may
+            # already hold duplicate-name rows (the ensure_type race this index
+            # prevents could have fired before this code shipped), so de-dup
+            # FIRST, then create the index. Both steps are wrapped so a residual
+            # duplicate can never crash _ensure_schema — a metering/ontology
+            # nicety must not take the store down on boot.
+            await self._dedup_object_types(db)
+            try:
+                await db.execute(_TYPE_NAME_UNIQUE_INDEX_SQL)
+            except aiosqlite.OperationalError:
+                # The only realistic cause is a residual duplicate the de-dup
+                # pass could not resolve (e.g. an exotic collation). Log and
+                # carry on uncreated rather than crashing the boot — the index
+                # is a race guard, not a correctness invariant the store needs
+                # to function.
+                logger.warning(
+                    "could not create unique index on fabric_object_types(name) — "
+                    "duplicate type names may remain; ensure_type race guard is off",
+                    exc_info=True,
+                )
             await db.commit()
         self._initialized = True
+
+    @staticmethod
+    async def _dedup_object_types(db: aiosqlite.Connection) -> None:
+        """Collapse duplicate-name object types before the UNIQUE index is built.
+
+        Two type rows can share a name (case-insensitively) only on a DB that
+        predates the unique index — the concurrent ``ensure_type`` race. Keep the
+        LOWEST rowid per case-folded name (the first-defined survivor), re-point
+        any objects bound to a losing type id at the survivor's id so no object is
+        orphaned, then delete the loser type rows. Best-effort: a failure here is
+        swallowed (logged) so it can never crash ``_ensure_schema``; the index
+        creation that follows is itself try/except-guarded as the final backstop.
+        """
+        try:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT rowid, id, name FROM fabric_object_types ORDER BY rowid ASC"
+            ) as cur:
+                rows = await cur.fetchall()
+            survivor_by_name: dict[str, str] = {}
+            for row in rows:
+                key = (row["name"] or "").strip().lower()
+                survivor_id = survivor_by_name.get(key)
+                if survivor_id is None:
+                    survivor_by_name[key] = row["id"]
+                    continue
+                loser_id = row["id"]
+                if loser_id == survivor_id:
+                    continue
+                # Re-home objects from the loser type onto the survivor, then
+                # drop the duplicate type row.
+                await db.execute(
+                    "UPDATE fabric_objects SET type_id = ? WHERE type_id = ?",
+                    (survivor_id, loser_id),
+                )
+                await db.execute(
+                    "DELETE FROM fabric_object_types WHERE id = ?",
+                    (loser_id,),
+                )
+        except aiosqlite.Error:
+            logger.warning(
+                "fabric_object_types de-dup pass failed — leaving rows as-is",
+                exc_info=True,
+            )
+        finally:
+            db.row_factory = None
 
     def _conn(self) -> aiosqlite.Connection:
         """Return a new connection context manager. Use with `async with`."""
@@ -438,21 +536,37 @@ class FabricStore:
                     return None
                 return self._row_to_object(row)
 
-    async def update_object(self, obj_id: str, properties: dict[str, Any]) -> FabricObject | None:
-        existing = await self.get_object(obj_id)
+    async def update_object(
+        self,
+        obj_id: str,
+        properties: dict[str, Any],
+        workspace_id: str | None = None,
+    ) -> FabricObject | None:
+        """Merge-update one object's properties, optionally scoped to a tenant (W4a).
+
+        ``workspace_id`` gives the WRITE its own tenancy guard rather than relying
+        on the caller to have scoped the prior read: the same
+        ``workspace_id = ? OR workspace_id IS NULL`` scope as :meth:`get_object`
+        and :meth:`get_object_by_source` is applied to BOTH the read-before-merge
+        and the UPDATE. A cross-tenant ``obj_id`` returns ``None`` and writes
+        nothing. ``None`` leaves the update unscoped (OSS / agent-tool callers),
+        exactly as before.
+        """
+        existing = await self.get_object(obj_id, workspace_id=workspace_id)
         if not existing:
             return None
         merged = {**existing.properties, **properties}
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "UPDATE fabric_objects SET properties = ?, updated_at = datetime('now') WHERE id = ?"
+        params: list[Any] = [json.dumps(merged), obj_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
         await self._ensure_schema()
         async with self._conn() as db:
-            await db.execute(
-                "UPDATE fabric_objects"
-                " SET properties = ?, updated_at = datetime('now')"
-                " WHERE id = ?",
-                (json.dumps(merged), obj_id),
-            )
+            await db.execute(sql, params)
             await db.commit()
-        return await self.get_object(obj_id)
+        return await self.get_object(obj_id, workspace_id=workspace_id)
 
     async def remove_object(self, obj_id: str) -> None:
         await self._ensure_schema()

--- a/src/pocketpaw/paw_print/store.py
+++ b/src/pocketpaw/paw_print/store.py
@@ -9,6 +9,14 @@
 # here; on human approval/rejection the EE approve hook flips it to
 # delivered/declined; the customer surface polls get_latest_decision by
 # (widget_id, customer_ref). Pure SQLite — no EE import, OSS-boundary clean.
+# Updated: 2026-06-11 (gap-housekeeping) — get_decision_by_action /
+# set_decision now take an optional workspace_id and scope the lookup +
+# UPDATE to that tenant (via the new _decision_workspace_scope helper, which
+# also matches the empty-string/NULL legacy rows). The EE delivery hook threads
+# the workspace off the approved Action's blob so a cross-tenant action id flips
+# nothing. The hot-lookup indexes the decision-loop needs already ship in
+# SCHEMA_SQL: idx_pp_decisions_action covers the instinct_action_id lookup and
+# idx_pp_decisions_customer covers the (widget_id, customer_ref) poll.
 
 from __future__ import annotations
 
@@ -81,6 +89,20 @@ CREATE INDEX IF NOT EXISTS idx_pp_decisions_customer
 CREATE INDEX IF NOT EXISTS idx_pp_decisions_action
     ON paw_print_decisions(instinct_action_id);
 """
+
+
+def _decision_workspace_scope(workspace_id: str | None) -> tuple[str | None, list[Any]]:
+    """Build the tenancy WHERE fragment + bound params for a scoped decision read.
+
+    Mirrors the Fabric store's ``_workspace_scope`` helper, but decision rows
+    store ``workspace_id`` as an EMPTY STRING (the model default) rather than
+    SQL NULL when no workspace was set, so a legacy/global row is matched on
+    ``= ''`` as well as ``IS NULL``. Returns ``(None, [])`` when ``workspace_id``
+    is ``None`` — no scoping, fully backward-compatible.
+    """
+    if workspace_id is None:
+        return None, []
+    return "(workspace_id = ? OR workspace_id = '' OR workspace_id IS NULL)", [workspace_id]
 
 
 class PawPrintStore:
@@ -311,20 +333,34 @@ class PawPrintStore:
             await db.commit()
         return decision
 
-    async def get_decision_by_action(self, instinct_action_id: str) -> DecisionStatus | None:
+    async def get_decision_by_action(
+        self, instinct_action_id: str, workspace_id: str | None = None
+    ) -> DecisionStatus | None:
         """Fetch the decision row tied to an Instinct action id.
 
         The approve/reject delivery hook resolves the parked row this way: the
         Instinct Action's ``_customer_reply`` blob carries no DB handle, only the
         action id, which is the stable join key back to the parked row.
+
+        ``workspace_id`` gives the lookup its own tenancy guard: when supplied,
+        only a row in that workspace (or a legacy NULL/empty-workspace row that
+        predates per-row tenancy) resolves — a row owned by another tenant
+        returns ``None``. The decision row stores ``workspace_id`` as an empty
+        string for rows created without one, so the scope matches
+        ``workspace_id = ? OR workspace_id = '' OR workspace_id IS NULL``.
+        ``None`` leaves the lookup unscoped (backward-compatible).
         """
+        ws_cond, ws_params = _decision_workspace_scope(workspace_id)
+        sql = "SELECT * FROM paw_print_decisions WHERE instinct_action_id = ?"
+        params: list[Any] = [instinct_action_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        sql += " LIMIT 1"
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM paw_print_decisions WHERE instinct_action_id = ? LIMIT 1",
-                (instinct_action_id,),
-            ) as cur:
+            async with db.execute(sql, params) as cur:
                 row = await cur.fetchone()
                 return self._row_to_decision(row) if row else None
 
@@ -335,6 +371,7 @@ class PawPrintStore:
         state: DecisionState,
         reply: str,
         decided_by: str,
+        workspace_id: str | None = None,
     ) -> DecisionStatus | None:
         """Flip a parked decision to delivered/declined and record the answer.
 
@@ -342,26 +379,35 @@ class PawPrintStore:
         parked row matches (e.g. the proposal was raised before this slice
         shipped, or the row was never created — the approve hook degrades
         cleanly in that case).
+
+        ``workspace_id``, when supplied, scopes BOTH the resolve and the UPDATE
+        to the caller's tenant so a cross-tenant action id flips nothing — the
+        delivery hook threads the workspace off the approved Action's blob.
         """
-        existing = await self.get_decision_by_action(instinct_action_id)
+        existing = await self.get_decision_by_action(instinct_action_id, workspace_id=workspace_id)
         if existing is None:
             return None
+        ws_cond, ws_params = _decision_workspace_scope(workspace_id)
+        sql = (
+            "UPDATE paw_print_decisions"
+            " SET state = ?, reply = ?, decided_by = ?, updated_at = ?"
+            " WHERE instinct_action_id = ?"
+        )
+        params: list[Any] = [
+            state.value,
+            reply,
+            decided_by,
+            datetime.now().isoformat(),
+            instinct_action_id,
+        ]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
         await self._ensure_schema()
         async with self._conn() as db:
-            await db.execute(
-                "UPDATE paw_print_decisions"
-                " SET state = ?, reply = ?, decided_by = ?, updated_at = ?"
-                " WHERE instinct_action_id = ?",
-                (
-                    state.value,
-                    reply,
-                    decided_by,
-                    datetime.now().isoformat(),
-                    instinct_action_id,
-                ),
-            )
+            await db.execute(sql, params)
             await db.commit()
-        return await self.get_decision_by_action(instinct_action_id)
+        return await self.get_decision_by_action(instinct_action_id, workspace_id=workspace_id)
 
     async def get_latest_decision(self, widget_id: str, customer_ref: str) -> DecisionStatus | None:
         """Return the most-recent decision for a (widget, customer) pair.

--- a/tests/cloud/test_ee_fabric.py
+++ b/tests/cloud/test_ee_fabric.py
@@ -14,11 +14,18 @@
 #   combined type+property filters, and the property-name / operator validation
 #   guards. These would all have silently passed (returning every object) before
 #   store.query() learned to honor filters.
+# Updated: 2026-06-11 (gap-housekeeping) — Added TestTypeNameUniqueIndex (a
+#   concurrent ensure_type race can't leave two type rows with the same name; the
+#   unique index exists and a pre-existing duplicate-name DB is de-duped on first
+#   _ensure_schema) and TestUpdateObjectWorkspaceScope (update_object honours its
+#   own W4a tenancy guard — a cross-tenant id writes nothing and returns None).
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
+import aiosqlite
 import pytest
 
 from pocketpaw.fabric.models import FabricQuery, PropertyDef
@@ -382,3 +389,118 @@ class TestWorkspaceScoping:
 
         result = await store.query(FabricQuery(type_name="Item"))
         assert result.total == 3
+
+
+class TestTypeNameUniqueIndex:
+    """A UNIQUE index on fabric_object_types(name) closes the ensure_type race."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_name_defines_one_type(self, store: FabricStore) -> None:
+        # Two concurrent define_type calls for the same name must not leave two
+        # type rows. The UNIQUE index makes the second INSERT fail rather than
+        # silently splitting the same logical type across two ids.
+        results = await asyncio.gather(
+            store.define_type(name="Customer", properties=[]),
+            store.define_type(name="Customer", properties=[]),
+            return_exceptions=True,
+        )
+        # At least one succeeded; any second one either errored or was rejected.
+        ok = [r for r in results if not isinstance(r, Exception)]
+        assert ok, "at least one define_type must succeed"
+
+        types = [t for t in await store.list_types() if t.name == "Customer"]
+        assert len(types) == 1, "the unique index must prevent a duplicate type row"
+
+    @pytest.mark.asyncio
+    async def test_unique_index_exists(self, store: FabricStore) -> None:
+        await store.define_type(name="Anything", properties=[])  # forces _ensure_schema
+        async with aiosqlite.connect(store._db_path) as db:  # noqa: SLF001
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+                " AND tbl_name='fabric_object_types'"
+            ) as cur:
+                names = {row["name"] async for row in cur}
+        assert "idx_object_types_name_unique" in names
+
+    @pytest.mark.asyncio
+    async def test_preexisting_duplicate_names_are_deduped(self, tmp_path: Path) -> None:
+        # Simulate a pre-this-change DB that already holds duplicate-name type
+        # rows (the race could fire before the unique index existed). _ensure_schema
+        # must de-dup defensively and STILL create the index — never crash.
+        db_path = tmp_path / "dup.db"
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                "CREATE TABLE fabric_object_types ("
+                " id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT DEFAULT '',"
+                " icon TEXT DEFAULT 'box', color TEXT DEFAULT '#0A84FF',"
+                " properties_schema TEXT DEFAULT '[]',"
+                " created_at TEXT DEFAULT (datetime('now')),"
+                " updated_at TEXT DEFAULT (datetime('now')))"
+            )
+            await db.execute(
+                "CREATE TABLE fabric_objects ("
+                " id TEXT PRIMARY KEY, type_id TEXT NOT NULL, type_name TEXT DEFAULT '',"
+                " properties TEXT NOT NULL DEFAULT '{}', source_connector TEXT, source_id TEXT,"
+                " created_at TEXT DEFAULT (datetime('now')),"
+                " updated_at TEXT DEFAULT (datetime('now')))"
+            )
+            # Two type rows with the same name; an object bound to the LOSER id.
+            await db.execute(
+                "INSERT INTO fabric_object_types (id, name) VALUES ('ot-keep', 'Customer')"
+            )
+            await db.execute(
+                "INSERT INTO fabric_object_types (id, name) VALUES ('ot-dup', 'Customer')"
+            )
+            await db.execute(
+                "INSERT INTO fabric_objects (id, type_id, properties)"
+                " VALUES ('obj-1', 'ot-dup', '{}')"
+            )
+            await db.commit()
+
+        store = FabricStore(db_path)
+        # First read triggers _ensure_schema → de-dup + index creation.
+        types = [t for t in await store.list_types() if t.name == "Customer"]
+        assert len(types) == 1, "duplicate type rows must be collapsed to one survivor"
+        assert types[0].id == "ot-keep", "the lowest-rowid survivor is kept"
+
+        # The orphan object was re-homed onto the survivor, not dropped.
+        obj = await store.get_object("obj-1")
+        assert obj is not None
+        assert obj.type_id == "ot-keep"
+
+
+class TestUpdateObjectWorkspaceScope:
+    """update_object carries its own W4a tenancy guard (gap-housekeeping)."""
+
+    @pytest.mark.asyncio
+    async def test_update_is_workspace_scoped(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Lease", properties=[])
+        b_obj = await store.create_object(t.id, {"rent": 100}, workspace_id="ws-b")
+
+        # Workspace A cannot update B's object — returns None and writes nothing.
+        result = await store.update_object(b_obj.id, {"rent": 999}, workspace_id="ws-a")
+        assert result is None
+        unchanged = await store.get_object(b_obj.id, workspace_id="ws-b")
+        assert unchanged is not None
+        assert unchanged.properties["rent"] == 100
+
+    @pytest.mark.asyncio
+    async def test_owner_can_update_in_scope(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Lease", properties=[])
+        b_obj = await store.create_object(t.id, {"rent": 100}, workspace_id="ws-b")
+        updated = await store.update_object(b_obj.id, {"rent": 250}, workspace_id="ws-b")
+        assert updated is not None
+        assert updated.properties["rent"] == 250
+
+    @pytest.mark.asyncio
+    async def test_legacy_null_workspace_updatable_by_scoped_caller(
+        self, store: FabricStore
+    ) -> None:
+        # A legacy NULL-workspace row stays writable by any scoped caller, matching
+        # the read-side `workspace_id = ? OR workspace_id IS NULL` semantics.
+        t = await store.define_type(name="Lease", properties=[])
+        legacy = await store.create_object(t.id, {"rent": 100})  # NULL workspace
+        updated = await store.update_object(legacy.id, {"rent": 175}, workspace_id="ws-a")
+        assert updated is not None
+        assert updated.properties["rent"] == 175

--- a/tests/cloud/test_outcome_value_metering.py
+++ b/tests/cloud/test_outcome_value_metering.py
@@ -292,3 +292,86 @@ def test_binding_rejects_value_without_outcome_name():
 
     with pytest.raises(pydantic.ValidationError, match="named outcome"):
         _make_binding(outcome_value=1200.0, outcome_unit="usd")
+
+
+def test_binding_rejects_negative_value():
+    """A billable figure cannot be negative (gap-housekeeping)."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="must not be negative"):
+        _make_binding(outcome="refund", outcome_value=-50.0, outcome_unit="usd")
+
+
+def test_binding_accepts_zero_value():
+    """Zero is a valid (free but named+metered) outcome — only negative is rejected."""
+    b = _make_binding(outcome="free_trial", outcome_value=0.0, outcome_unit="usd")
+    assert b.outcome_value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# meter_outcomes — window comparison is on instants, not raw ISO strings
+# ---------------------------------------------------------------------------
+
+
+async def test_meter_window_normalizes_timezone_representations():
+    """A row stamped `...Z` and a bound stamped `...+00:00` are the same instant
+    and must compare correctly — a lexicographic string compare gets this wrong
+    (gap-housekeeping). The `Z` row sits AT the inclusive `since` boundary, so it
+    must be counted; byte-wise, "...Z" > "...+00:00" would exclude it."""
+    # Same instant, different textual forms.
+    await outcomes_service.record_outcome(
+        _valued_event(outcome_value=100.0, outcome_unit="usd", occurred_at="2026-06-01T00:00:00Z")
+    )
+    # since == that instant in +00:00 form (inclusive lower bound).
+    meter = await outcomes_service.meter_outcomes(
+        "w1",
+        MeterOutcomesRequest(since="2026-06-01T00:00:00+00:00"),
+    )
+    assert meter.metered_count == 1
+    assert meter.by_unit["usd"].total_value == 100.0
+
+
+async def test_meter_until_exclusive_across_timezone_forms():
+    """`until` stays EXCLUSIVE even when the row uses `Z` and the bound uses an
+    offset for the SAME instant: the boundary row is excluded, the earlier one in."""
+    await outcomes_service.record_outcome(
+        _valued_event(
+            outcome="early",
+            outcome_value=10.0,
+            outcome_unit="usd",
+            occurred_at="2026-06-30T23:00:00Z",
+        )
+    )
+    # This row is AT the exclusive `until` instant (Z form) — must be excluded.
+    await outcomes_service.record_outcome(
+        _valued_event(
+            outcome="boundary",
+            outcome_value=20.0,
+            outcome_unit="usd",
+            occurred_at="2026-07-01T00:00:00Z",
+        )
+    )
+    meter = await outcomes_service.meter_outcomes(
+        "w1",
+        MeterOutcomesRequest(until="2026-07-01T00:00:00+00:00"),
+    )
+    assert meter.metered_count == 1
+    assert meter.by_unit["usd"].total_value == 10.0
+
+
+async def test_meter_window_handles_offset_timestamps():
+    """An offset timestamp (`-04:00`) is compared on its UTC instant, not its
+    local digits. 20:00-04:00 == 00:00Z next day, so it falls in July, not June."""
+    await outcomes_service.record_outcome(
+        _valued_event(
+            outcome_value=77.0,
+            outcome_unit="usd",
+            occurred_at="2026-06-30T20:00:00-04:00",  # == 2026-07-01T00:00:00Z
+        )
+    )
+    june = await outcomes_service.meter_outcomes(
+        "w1",
+        MeterOutcomesRequest(since="2026-06-01T00:00:00Z", until="2026-07-01T00:00:00Z"),
+    )
+    # Excluded from June: its UTC instant is the July boundary (exclusive until).
+    assert june.metered_count == 0

--- a/tests/cloud/test_paw_print_decision_loop.py
+++ b/tests/cloud/test_paw_print_decision_loop.py
@@ -320,3 +320,106 @@ class TestRobustness:
         approved = await instinct_store.approve(action.id, approver="u")
         # No create_decision was called → set_decision returns None → no raise.
         await deliver_customer_decision(approved, declined=False)
+
+
+# ---------------------------------------------------------------------------
+# Tenancy: an owner-less widget must NOT raise an all-tenant-visible proposal
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerlessWidgetGuard:
+    async def test_ownerless_widget_does_not_propose(self, stores) -> None:
+        """A widget with no owner resolves to an EMPTY workspace. Raising a
+        proposal there would NULL-scope it into every tenant's pending list, so
+        the loop is skipped entirely — no proposal, no parked row."""
+        pp_store, instinct_store = stores
+        widget = PawPrintWidget(
+            pocket_id="pocket-1",
+            owner="",  # no owner → empty workspace
+            name="W",
+            spec=_spec(),
+            event_mapping={},
+        )
+        event = PawPrintEvent(
+            widget_id=widget.id,
+            type="appointment_request",
+            payload={"when": "Tuesday 3pm"},
+            customer_ref="patient_42",
+        )
+
+        action_id = await propose_customer_decision(
+            widget=widget, event=event, paw_print_store=pp_store
+        )
+        assert action_id is None, "an owner-less widget must not open the loop"
+
+        # No proposal landed in ANY workspace — not even the unscoped global list.
+        assert await instinct_store.pending(workspace_id="ws:bright-smile") == []
+        assert await instinct_store.pending() == []
+        # No parked decision row either.
+        assert await pp_store.get_latest_decision(widget.id, "patient_42") is None
+
+
+# ---------------------------------------------------------------------------
+# Decision store — get_decision_by_action / set_decision are workspace-scoped
+# ---------------------------------------------------------------------------
+
+
+class TestDecisionLookupScope:
+    async def test_get_decision_by_action_is_scoped(self, stores) -> None:
+        from pocketpaw.paw_print.models import DecisionState, DecisionStatus
+
+        pp_store, _ = stores
+        await pp_store.create_decision(
+            DecisionStatus(
+                widget_id="pp_a",
+                customer_ref="c1",
+                instinct_action_id="act-1",
+                workspace_id="ws-a",
+                state=DecisionState.PENDING,
+            )
+        )
+
+        # The owning tenant resolves the row; another tenant gets None.
+        assert await pp_store.get_decision_by_action("act-1", workspace_id="ws-a") is not None
+        assert await pp_store.get_decision_by_action("act-1", workspace_id="ws-b") is None
+        # Unscoped lookup still finds it (backward-compatible).
+        assert await pp_store.get_decision_by_action("act-1") is not None
+
+    async def test_set_decision_is_scoped(self, stores) -> None:
+        from pocketpaw.paw_print.models import DecisionState, DecisionStatus
+
+        pp_store, _ = stores
+        await pp_store.create_decision(
+            DecisionStatus(
+                widget_id="pp_a",
+                customer_ref="c1",
+                instinct_action_id="act-2",
+                workspace_id="ws-a",
+                state=DecisionState.PENDING,
+            )
+        )
+
+        # A cross-tenant flip changes nothing and returns None.
+        cross = await pp_store.set_decision(
+            "act-2",
+            state=DecisionState.DELIVERED,
+            reply="nope",
+            decided_by="attacker",
+            workspace_id="ws-b",
+        )
+        assert cross is None
+        still_pending = await pp_store.get_decision_by_action("act-2", workspace_id="ws-a")
+        assert still_pending is not None
+        assert still_pending.state == DecisionState.PENDING
+
+        # The owning tenant flips it.
+        ok = await pp_store.set_decision(
+            "act-2",
+            state=DecisionState.DELIVERED,
+            reply="confirmed",
+            decided_by="user:owner",
+            workspace_id="ws-a",
+        )
+        assert ok is not None
+        assert ok.state == DecisionState.DELIVERED
+        assert ok.reply == "confirmed"

--- a/tests/connectors/test_gcalendar_fabric_ingest.py
+++ b/tests/connectors/test_gcalendar_fabric_ingest.py
@@ -221,3 +221,13 @@ def test_calendar_mapping_declares_event_id_as_source() -> None:
     props = CALENDAR_EVENT_MAPPING.project(rec)
     assert props["summary"] == "Hi"
     assert props["attendee_count"] == 1
+
+
+def test_attendees_property_is_typed_array() -> None:
+    """`attendees` stores a list, so its PropertyDef must declare type='array'
+    (gap-housekeeping) — it was mislabelled type='string'."""
+    by_name = {p.name: p for p in CALENDAR_EVENT_MAPPING.properties}
+    assert by_name["attendees"].type == "array"
+    # The projection genuinely yields a list, confirming the type label matches.
+    props = CALENDAR_EVENT_MAPPING.project({"id": "e", "attendees": ["a@x.com", "b@x.com"]})
+    assert isinstance(props["attendees"], list)


### PR DESCRIPTION
Non-blocking follow-ups from the review of the three gap-foundation PRs (#1418/#1419/#1420). Eight small fixes, each with a test, across the three areas.

**Fabric / connectors:** a unique index on `fabric_object_types(LOWER(name))` closes the concurrent `ensure_type` race (two callers could define the same type with different ids). It ships as a safe migration — it de-dups any pre-existing same-name rows first (keeps the lowest rowid, re-homes orphaned objects onto the survivor) and wraps the index creation in a fail-soft warning so it can never crash `_ensure_schema`. `update_object` now takes a `workspace_id` and scopes the read+write itself instead of relying on the caller. The gcalendar `attendees` mapping is typed `array`, not `string`.

**paw_print decision loop:** an owner-less widget no longer creates a NULL-workspace proposal that would be visible to every tenant — `propose_customer_decision` logs and skips when the workspace is blank. `get_decision_by_action`/`set_decision` take a `workspace_id` and scope the lookup themselves. (The hot-path indexes were already in the schema — verified, no change needed.)

**Outcome metering:** `ActionBinding` rejects a negative `outcome_value` at parse time (a billable figure can't be negative; zero stays valid). The meter's `since`/`until` window now parses timestamps to UTC-aware datetimes before comparing, so `Z` vs `+00:00` vs offset forms can't sort wrong (since-inclusive / until-exclusive preserved).

Deliberately skipped: Decimal-based billing accumulation — that belongs with the pricing layer, not housekeeping.

219 targeted tests pass (incl. a synthetic pre-existing-duplicate DB for the migration); both import boundaries clean. The two pre-existing `test_pocket_outcomes` route failures (401 auth-fixture) are unchanged and unrelated.
