### PR TITLE
Belt mandates: charter, patrols, foreman judgment, and the plan gate

### DIFF
--- a/docs/internal/2026-06-belt-mandates.md
+++ b/docs/internal/2026-06-belt-mandates.md
@@ -111,6 +111,13 @@ still closes exactly once.
 proposal}`), mirroring `belt_run_updated`'s audience fan-out; the mandates page
 subscribes to that topic.
 
+## Plan-feature gating posture
+
+The mandates router intentionally matches the belt console's posture: routes
+are gated by license + RBAC (`belt.read` / `belt.manage`) but carry **no**
+`require_plan_feature` tier gate at demo bar (the belt console router doesn't
+either). Tighten both surfaces together before GA.
+
 ## Storage
 
 4-file entity at `ee/pocketpaw_ee/cloud/mandates/` (+ `patrols.py`,

--- a/docs/internal/2026-06-belt-mandates.md
+++ b/docs/internal/2026-06-belt-mandates.md
@@ -1,0 +1,157 @@
+<!-- docs/internal/2026-06-belt-mandates.md
+     Created: 2026-06-11 (feat/belt-mandates) — anatomy, endpoints, and
+     demo-bar concessions for the MANDATE primitive.
+     Updated: 2026-06-11 (UI contract sync) — response envelopes, dual-shape
+     feedback, pawprint item shape, `patrols` toggles, POST .../plan/resolve,
+     and the `belt_plan` realtime topic. -->
+
+# Belt Mandates — the standing JOB primitive
+
+A **mandate** is a standing job the Belt holds over time — the FDE-retainer
+counterpart to the Belt's one-shot develop-station runs. Instead of a human
+handing the station a task, the mandate **senses** its surface, **judges** what
+(if anything) is worth doing, routes that judgment through a **human gate**,
+and only then dispatches work.
+
+Validated in simulation (5/5 scenarios) before this implementation;
+productionized here at **demo bar** (manual shift trigger, stubbed advisory
+data, synthetic dispatch).
+
+## Anatomy
+
+```
+MANDATE  (charter: goal, KPIs, says_no, boundaries, budget, cadence; surface: repo)
+   │
+   ├── PATROLS sense the surface (scoped by the
+   │   mandate's `patrols` toggles) ───────────► SIGHTINGS
+   │     • deps      — manifest scan (pyproject/package.json) vs advisory table
+   │     • feedback  — human intake (POST .../feedback)
+   │
+   └── SHIFT (manual trigger, one per cycle)
+         1. sense   — run patrols, persist new sightings (deduped)
+         2. judge   — the FOREMAN makes ONE LLM call over:
+                      charter (verbatim, BOUNDARIES first) + sighting digest
+                      since last shift + last 3 shifts' outcomes + soul recall
+         3. validate — machine checks on ACTION fields ONLY
+                      (budget cap, evidence refs, boundary phrases in
+                      title/expected_outcome — the `why` narration is NEVER
+                      scanned: a good foreman names forbidden things when
+                      refusing them)
+         4. gate    — PlanProposal lands as an Instinct `belt_plan` Action
+                      (the third blob peer of `_pocket_write`/`_code_change`)
+            ── or ── stood_down: empty plan, a SUCCESS state; the chain opens
+                      and closes in the trigger, no human gate for a no-op
+         5. dispatch — on human APPROVE, the plan executor re-validates
+                      (mandate active, budget unchanged) and dispatches each
+                      task as a Belt run; on REJECT the router closes the
+                      chain and the shift records the reason
+```
+
+### Decision chains (RFC 09)
+
+One shift = one chain, **exactly one `decision.completed`** per chain:
+
+| Path        | Chain |
+|-------------|-------|
+| dispatched  | `agent.proposed → human.corrected(accepted\|edited) → decision.completed(passed=True, action_outcome="dispatched", task_count, run_refs)` |
+| rejected    | `agent.proposed → human.corrected(rejected) → decision.completed(passed=False, action_outcome="rejected")` (router owns the close) |
+| stood_down  | `agent.proposed → decision.completed(passed=True, action_outcome="stood_down")` (trigger owns both; no human event) |
+| gate failure| `agent.proposed → human.corrected → decision.completed(passed=False, action_outcome="failed", error_class=…)` (executor `_fail` chokepoint) |
+
+The executor mirrors `ee.cloud.belt.executor` exactly: a single `_fail`
+chokepoint per failure path, success emits once at the end, chain emits are
+best-effort and never break the approve response.
+
+### The foreman
+
+`ee/pocketpaw_ee/cloud/mandates/foreman.py`. One judgment call per shift
+through a pluggable `PlanLlm` protocol, selected by `POCKETPAW_MANDATE_LLM`:
+
+- `claude` (default) — shells `claude -p <prompt> --output-format json`,
+  parses the envelope's `result`, tolerates fenced JSON.
+- `mock` — deterministic (one task per sighting, severity-ranked, budget-capped;
+  `no_action` on a quiet digest). Tests script it via `foreman.set_mock_plan`.
+
+The prompt encodes every sim-validated rule: charter verbatim with BOUNDARIES
+prominent; at most `budget.max_tasks_per_shift` tasks; every task cites
+sighting ids and names an expected KPI direction; an empty plan with a reason
+is correct and respected; boundaries override KPI opportunities; never repeat
+a failed approach without stating what changed; strict JSON only.
+
+## Endpoints (`/api/v1/belt/mandates`, RBAC mirrors the belt console)
+
+| Method | Path | Gate | What |
+|--------|------|------|------|
+| POST | `/belt/mandates` | `belt.manage` | Create (charter body + `patrols` senses toggles) → `{mandate}` |
+| GET | `/belt/mandates` | `belt.read` | `{mandates}` + health (last shift state, open gate count, sighting count) |
+| GET | `/belt/mandates/{id}` | `belt.read` | Bare detail: charter, patrols, recent shifts, sightings-by-patrol |
+| POST | `/belt/mandates/{id}/feedback` | `belt.manage` | Intake patrol → Sighting. TWO shapes, discriminated on `kind`: general `{text, severity?, source}` → sighting dict (autopilot keeps using this); teaching `{kind: reject\|edit\|plan, reason, shift_no?, task_title?}` → `{ok: true}` (the gate UI's channel) |
+| GET | `/belt/mandates/{id}/sightings` | `belt.read` | `{sightings}`, newest-first |
+| POST | `/belt/mandates/{id}/shift` | `belt.manage` | Run a shift (manual trigger) → `{shift: {shift_id, no, state, plan_action_id, task_count, no_action_reason}}` |
+| POST | `/belt/mandates/{id}/plan/resolve` | `belt.manage` | The console's gate action: `{shift_no, decisions: [{index (0-based), decision: approve\|reject\|edit, edited_title?, reason?}]}` → `{shift}`. Every task needs exactly one decision. |
+| GET | `/belt/mandates/{id}/pawprints` | `belt.read` | `{pawprints}` past-tense feed; item shape `{id, mandate_id, shift_no, kind, summary, evidence_refs, ts}` |
+
+Pawprint `kind`s: the UI consumes `executed` / `rejected` / `edited` /
+`stood_down`; the feed also emits `proposed` / `approved` / `failed` /
+`planning` (a documented superset, same item shape). `edited` fires when the
+approval carried human edits (Corrections exist on the plan Action).
+
+**The Instinct gate stays the single chain authority.** `plan/resolve` maps the
+console's per-task verdicts onto the REAL instinct paths: any approved/edited
+subset becomes an approve-WITH-EDITS (the blob's task list filtered/retitled —
+the standard Corrections machinery; the executor dispatches the kept tasks),
+and an all-reject becomes a plain reject (the router closes the chain).
+Rejected tasks are recorded as teaching sightings. Direct
+`POST /instinct/actions/{id}/approve|reject` (the Tray, MCP, bulk endpoints)
+keeps working unchanged — both surfaces hit the same transition, so the chain
+still closes exactly once.
+
+**Realtime:** when a plan proposal lands at the gate, the service emits a
+`belt_plan` event on the workspace bus (payload `{workspace_id, mandate_id,
+proposal}`), mirroring `belt_run_updated`'s audience fan-out; the mandates page
+subscribes to that topic.
+
+## Storage
+
+4-file entity at `ee/pocketpaw_ee/cloud/mandates/` (+ `patrols.py`,
+`foreman.py`, `executor.py`, `soul_link.py`, `events.py` supporting modules —
+the same beyond-four shape the belt console uses). Beanie docs (`MandateDoc`,
+`ShiftDoc`, `SightingDoc`; all workspace-keyed) live in `mandates/domain.py`,
+imported ONLY by `mandates/service.py`, and register into `init_beanie` via a
+lazy import in `cloud/models/__init__.py` (the calendar-doc pattern).
+
+## Soul wiring (demo bar)
+
+When a mandate binds `soul_path`, `soul_link.py` recalls up to 5 memories
+before planning and appends an episodic shift summary after every terminal
+(dispatched / rejected / stood_down) via the real soul-protocol API
+(`Soul.awaken → recall/remember → save_local`). Best-effort throughout — a
+soul failure never wedges a shift.
+
+## Demo-bar concessions (each marked in code)
+
+1. **Manual shift trigger only.** `cadence: "weekly"` is stored but not
+   scheduled; the autopilot PR wires the scheduler (and Foresight — explicitly
+   NOT integrated here).
+2. **Deps patrol advisory data is a hardcoded table** (`patrols.KNOWN_STALE`).
+   The manifest parsing + sighting plumbing are production-shaped; only the
+   data source is stubbed.
+3. **Task dispatch announces, it does not run.** `BusTaskDispatcher` emits
+   `belt_run_updated(status="dispatched", stage="station")` through the
+   existing belt service under a synthetic run id (`<plan_action_id>:t<n>`).
+   Wiring an autonomous develop-station runner that picks the task up is the
+   autopilot PR's job. The `TaskDispatcher` protocol is the swap point.
+4. **LLM transport is the `claude` CLI shell-out** behind the `PlanLlm`
+   protocol; an SDK transport can replace it without touching the foreman.
+5. **Pawprints read the store, not the journal.** The feed derives from
+   ShiftDoc states + the plan Action's status/blob — the same facts the chain
+   folded from; a journal-walking narrator can replace it later.
+
+## Tests
+
+`tests/cloud/test_belt_mandates.py`. The hard gate
+(`test_full_shift_gate_one_clean_chain`) drives create → feedback → shift →
+real-instinct-router approve → dispatch and asserts EXACTLY ONE
+`decision.completed` (this repo's documented chain-doubling seam). Also pinned:
+stood_down, budget cap, boundary-check-ignores-`why`, patrol intake, deps
+patrol + dedup, tenant isolation, reject-closes-once.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -324,6 +324,15 @@ def mount_cloud(app: FastAPI) -> None:
 
     app.include_router(belt_console_router, prefix="/api/v1")
 
+    # Belt MANDATES — the standing-JOB primitive (feat/belt-mandates). The
+    # /belt/mandates surface: charter CRUD, patrol intake (feedback), sightings
+    # read, manual shift trigger (foreman → plan gate), and the pawprints feed.
+    # The plan-gate apply-on-approve executor lives in ee.cloud.mandates.executor
+    # and is fired from the Instinct router's approve path on a ``belt_plan`` blob.
+    from pocketpaw_ee.cloud.mandates.router import router as belt_mandates_router
+
+    app.include_router(belt_mandates_router, prefix="/api/v1")
+
     # Files Tab v2 — /api/v1/files/tree + /api/v1/files/browse. Mounted
     # inline (instead of via build_router's ctx_factory) so the routes can
     # use the canonical `Depends(current_active_user)` auth chain without

--- a/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
@@ -304,6 +304,16 @@ class AudienceResolver:
                 return await self._workspace(wid)
             return []
 
+        # --- Belt mandates (shift plan proposals) --------------------------------
+        # Workspace-scoped, same rationale as belt_run_updated: a plan lands at
+        # the gate asynchronously and must reach every member with the mandates
+        # page open. The UI subscribes to the ``belt_plan`` topic and reads
+        # {mandate_id, proposal} off the payload.
+        if t == "belt_plan":
+            if wid := d.get("workspace_id"):
+                return await self._workspace(wid)
+            return []
+
         # --- Composio (per-user OAuth identity probes) --------------------------
         if t in {"composio.connection.verified", "composio.connection.mismatch"}:
             if uid := d.get("user_id"):

--- a/ee/pocketpaw_ee/cloud/mandates/__init__.py
+++ b/ee/pocketpaw_ee/cloud/mandates/__init__.py
@@ -1,0 +1,9 @@
+# ee/pocketpaw_ee/cloud/mandates/__init__.py — the Belt MANDATE primitive.
+# Created: 2026-06-11 (feat/belt-mandates).
+#
+# A MANDATE is a standing JOB the Belt holds over time (an FDE retainer): it
+# senses its surface via PATROLS, plans a FEW tasks per SHIFT via a FOREMAN
+# (LLM judgment), routes the plan through a PLAN GATE (Instinct ``belt_plan``
+# proposal), and dispatches approved tasks as normal Belt runs. 4-file entity:
+# domain.py (models + value objects) / dto.py / service.py / router.py.
+from pocketpaw_ee.cloud.mandates.router import router  # noqa: F401

--- a/ee/pocketpaw_ee/cloud/mandates/domain.py
+++ b/ee/pocketpaw_ee/cloud/mandates/domain.py
@@ -114,6 +114,10 @@ class MandateDoc(TimestampedDocument):
     charter: Charter
     status: MandateStatus = "active"
     soul_path: str | None = None
+    # UI contract — the charter composer's senses toggles. Scopes which SENSE
+    # patrols run on a shift trigger ("feedback" intake stays open as a human
+    # channel regardless; the list gates the automated sense loop).
+    patrols: list[str] = Field(default_factory=lambda: ["deps", "feedback"])
 
     class Settings:
         name = "mandates"

--- a/ee/pocketpaw_ee/cloud/mandates/domain.py
+++ b/ee/pocketpaw_ee/cloud/mandates/domain.py
@@ -1,0 +1,227 @@
+# ee/pocketpaw_ee/cloud/mandates/domain.py
+# Created: 2026-06-11 (feat/belt-mandates, slice 1 — models + CRUD).
+#
+# The MANDATE primitive's persistence + value objects. A MANDATE is a standing
+# JOB the Belt holds over time (an FDE retainer): it senses its surface via
+# PATROLS, plans a FEW tasks per SHIFT via a FOREMAN (LLM judgment), routes the
+# plan through a PLAN GATE (Instinct ``belt_plan`` proposal), and dispatches
+# approved tasks as normal Belt runs.
+#
+# This module holds BOTH the Beanie documents (MandateDoc / ShiftDoc /
+# SightingDoc) AND the frozen domain/charter value objects. Per the 4-file
+# entity rule, ONLY ``mandates/service.py`` imports the Beanie doc classes; the
+# router/dto layers see only the frozen domain objects the service maps to.
+#
+# The docs live here (not in cloud/models/) so the entity is self-contained;
+# they are registered into ``init_beanie`` via a lazy import in
+# ``cloud/models/__init__.get_all_documents`` (same out-of-models pattern the
+# calendar docs use). Every doc carries the ``workspace`` tenancy key, indexed.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Literal
+
+from beanie import Indexed
+from pydantic import BaseModel, Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+# ---------------------------------------------------------------------------
+# Literals shared across charter + docs
+# ---------------------------------------------------------------------------
+
+KpiDirection = Literal["up", "down"]
+Cadence = Literal["weekly", "manual"]
+MandateStatus = Literal["active", "paused"]
+ShiftState = Literal["planning", "in_gate", "executing", "done", "stood_down"]
+
+
+# ---------------------------------------------------------------------------
+# Charter sub-objects — persisted as embedded subdocs on MandateDoc and mirrored
+# as frozen value objects on the read path.
+# ---------------------------------------------------------------------------
+
+
+class Kpi(BaseModel):
+    """A single tracked KPI on a mandate charter.
+
+    ``direction`` says which way is GOOD — ``"up"`` (e.g. coverage) or
+    ``"down"`` (e.g. open CVE count). The foreman names an expected KPI
+    direction on every task it plans.
+    """
+
+    name: str
+    target: float
+    direction: KpiDirection
+
+
+class Budget(BaseModel):
+    """Per-shift + per-week budget caps on a mandate charter.
+
+    ``max_tasks_per_shift`` is the hard cap the foreman MUST respect and the
+    plan-gate executor RE-validates at approval time. ``gate_minutes_per_week``
+    is the human-review time budget the mandate is allowed to consume (advisory
+    at demo bar).
+    """
+
+    max_tasks_per_shift: int = 3
+    gate_minutes_per_week: int = 15
+
+
+class Charter(BaseModel):
+    """The standing instruction set for a mandate — the FDE retainer's brief.
+
+    ``goal`` is the one-line job. ``kpis`` are the tracked outcomes.
+    ``says_no`` + ``boundaries`` are hard constraints the foreman must honor
+    (a boundary OVERRIDES a KPI opportunity). ``budget`` caps the per-shift
+    task count + weekly gate minutes. ``cadence`` is ``"weekly"`` or
+    ``"manual"`` (demo bar triggers shifts manually).
+    """
+
+    goal: str
+    kpis: list[Kpi] = Field(default_factory=list)
+    says_no: list[str] = Field(default_factory=list)
+    boundaries: list[str] = Field(default_factory=list)
+    budget: Budget = Field(default_factory=Budget)
+    cadence: Cadence = "weekly"
+
+
+class Surface(BaseModel):
+    """What a mandate senses + acts on. v1 binds one repo (``repo_id``)."""
+
+    repo_id: str
+
+
+# ---------------------------------------------------------------------------
+# Beanie documents — service.py is the SOLE importer.
+# ---------------------------------------------------------------------------
+
+
+class MandateDoc(TimestampedDocument):
+    """A standing Belt mandate. One row per mandate; ``workspace`` tenancy key.
+
+    The charter + surface ride as embedded subdocs. ``status`` gates whether
+    shifts may run (``paused`` mandates are inert). ``soul_path`` optionally
+    binds a soul file the foreman recalls before planning + appends a shift
+    summary to after.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    name: str
+    surface: Surface
+    charter: Charter
+    status: MandateStatus = "active"
+    soul_path: str | None = None
+
+    class Settings:
+        name = "mandates"
+
+
+class ShiftDoc(TimestampedDocument):
+    """One SHIFT of a mandate — a single plan→gate→dispatch cycle.
+
+    ``no`` is the monotonic shift number within a mandate (1-based). ``state``
+    walks ``planning → in_gate → executing → done`` on the happy path, or lands
+    on ``stood_down`` when the foreman returned an empty plan (a SUCCESS state,
+    not an error). ``plan_action_id`` is the Instinct ``belt_plan`` Action id the
+    plan was proposed through (None until the gate proposal lands).
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    mandate_id: Indexed(str)  # type: ignore[valid-type]
+    no: int
+    state: ShiftState = "planning"
+    plan_action_id: str | None = None
+
+    class Settings:
+        name = "mandate_shifts"
+
+
+class SightingDoc(TimestampedDocument):
+    """One SIGHTING — a thing a PATROL (or human feedback) flagged on a surface.
+
+    ``patrol`` is the producing patrol name (``"deps"`` / ``"feedback"``).
+    ``severity`` is 1-5 (5 = most urgent). ``summary`` is the one-line headline;
+    ``evidence`` carries patrol-specific detail (package name, CVE id, feedback
+    source). Sightings are the foreman's input signal between shifts.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    mandate_id: Indexed(str)  # type: ignore[valid-type]
+    patrol: str
+    severity: int
+    summary: str
+    evidence: dict = Field(default_factory=dict)
+    ts: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "mandate_sightings"
+
+
+# ---------------------------------------------------------------------------
+# Frozen read-path value objects — what consumers outside the service see.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MandateView:
+    """Read-path view of a mandate. ``workspace`` + ``id`` are required tenancy
+    / identity fields."""
+
+    id: str
+    workspace: str
+    name: str
+    surface: Surface
+    charter: Charter
+    status: MandateStatus
+    soul_path: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class ShiftView:
+    """Read-path view of a shift."""
+
+    id: str
+    workspace: str
+    mandate_id: str
+    no: int
+    state: ShiftState
+    plan_action_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class SightingView:
+    """Read-path view of a sighting."""
+
+    id: str
+    workspace: str
+    mandate_id: str
+    patrol: str
+    severity: int
+    summary: str
+    evidence: dict = field(default_factory=dict)
+    ts: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+__all__ = [
+    "Budget",
+    "Cadence",
+    "Charter",
+    "Kpi",
+    "KpiDirection",
+    "MandateDoc",
+    "MandateStatus",
+    "MandateView",
+    "ShiftDoc",
+    "ShiftState",
+    "ShiftView",
+    "SightingDoc",
+    "SightingView",
+    "Surface",
+]

--- a/ee/pocketpaw_ee/cloud/mandates/domain.py
+++ b/ee/pocketpaw_ee/cloud/mandates/domain.py
@@ -126,7 +126,9 @@ class ShiftDoc(TimestampedDocument):
     walks ``planning → in_gate → executing → done`` on the happy path, or lands
     on ``stood_down`` when the foreman returned an empty plan (a SUCCESS state,
     not an error). ``plan_action_id`` is the Instinct ``belt_plan`` Action id the
-    plan was proposed through (None until the gate proposal lands).
+    plan was proposed through (None until the gate proposal lands). ``outcome``
+    is the free-text result of the shift (what landed / was rejected / why the
+    foreman stood down) — the foreman's history context reads the last 3.
     """
 
     workspace: Indexed(str)  # type: ignore[valid-type]
@@ -134,6 +136,7 @@ class ShiftDoc(TimestampedDocument):
     no: int
     state: ShiftState = "planning"
     plan_action_id: str | None = None
+    outcome: str | None = None
 
     class Settings:
         name = "mandate_shifts"

--- a/ee/pocketpaw_ee/cloud/mandates/dto.py
+++ b/ee/pocketpaw_ee/cloud/mandates/dto.py
@@ -117,6 +117,7 @@ class MandateDetailResponse(BaseModel):
     surface: SurfaceRequest
     charter: CharterRequest
     soul_path: str | None = None
+    patrols: list[str] = Field(default_factory=lambda: ["deps", "feedback"])
     recent_shifts: list[ShiftSummaryResponse] = Field(default_factory=list)
     sightings_by_patrol: dict[str, int] = Field(default_factory=dict)
     created_at: datetime

--- a/ee/pocketpaw_ee/cloud/mandates/dto.py
+++ b/ee/pocketpaw_ee/cloud/mandates/dto.py
@@ -1,0 +1,218 @@
+# ee/pocketpaw_ee/cloud/mandates/dto.py
+# Created: 2026-06-11 (feat/belt-mandates, slice 1 — models + CRUD).
+#
+# Request/Response schemas for the MANDATE primitive. Separate Request and
+# Response models per the cloud entity rule (never reuse one model for both
+# directions). The Request models are the ``body`` the service ``model_validate``s
+# at entry; the Response models are the wire dicts the service returns.
+#
+# Updated: 2026-06-11 (slice 2 — patrols) — added FeedbackRequest /
+# SightingResponse / SightingsListResponse for the feedback-intake patrol and
+# the sightings read.
+# Updated: 2026-06-11 (slice 4 — plan gate) — added ShiftResponse for the
+# manual-shift trigger.
+# Updated: 2026-06-11 (slice 5 — pawprints) — added PawprintResponse /
+# PawprintsListResponse for the past-tense event feed.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from pocketpaw_ee.cloud.mandates.domain import (
+    Cadence,
+    KpiDirection,
+    MandateStatus,
+    ShiftState,
+)
+
+# ---------------------------------------------------------------------------
+# Charter request sub-schemas
+# ---------------------------------------------------------------------------
+
+
+class KpiRequest(BaseModel):
+    name: str = Field(min_length=1)
+    target: float
+    direction: KpiDirection
+
+
+class BudgetRequest(BaseModel):
+    max_tasks_per_shift: int = Field(default=3, ge=1, le=20)
+    gate_minutes_per_week: int = Field(default=15, ge=0)
+
+
+class SurfaceRequest(BaseModel):
+    repo_id: str = Field(min_length=1)
+
+
+class CharterRequest(BaseModel):
+    goal: str = Field(min_length=1)
+    kpis: list[KpiRequest] = Field(default_factory=list)
+    says_no: list[str] = Field(default_factory=list)
+    boundaries: list[str] = Field(default_factory=list)
+    budget: BudgetRequest = Field(default_factory=BudgetRequest)
+    cadence: Cadence = "weekly"
+
+
+# ---------------------------------------------------------------------------
+# Mandate create + read
+# ---------------------------------------------------------------------------
+
+
+class CreateMandateRequest(BaseModel):
+    """Body for ``POST /belt/mandates``. The charter is the standing brief."""
+
+    name: str = Field(min_length=1)
+    surface: SurfaceRequest
+    charter: CharterRequest
+    soul_path: str | None = None
+
+
+class MandateHealth(BaseModel):
+    """The health summary on the list view — last shift state, open gate count,
+    sighting count."""
+
+    last_shift_state: ShiftState | None = None
+    open_gate_count: int = 0
+    sighting_count: int = 0
+
+
+class MandateSummaryResponse(BaseModel):
+    """One mandate on the list view (charter omitted; health summarized)."""
+
+    id: str
+    name: str
+    status: MandateStatus
+    repo_id: str
+    cadence: Cadence
+    health: MandateHealth
+    created_at: datetime
+
+
+class MandateListResponse(BaseModel):
+    mandates: list[MandateSummaryResponse] = Field(default_factory=list)
+
+
+class ShiftSummaryResponse(BaseModel):
+    """A recent shift on the mandate detail view."""
+
+    id: str
+    no: int
+    state: ShiftState
+    plan_action_id: str | None = None
+    created_at: datetime
+
+
+class MandateDetailResponse(BaseModel):
+    """Full mandate detail — charter, recent shifts, sightings-count-by-patrol."""
+
+    id: str
+    name: str
+    status: MandateStatus
+    surface: SurfaceRequest
+    charter: CharterRequest
+    soul_path: str | None = None
+    recent_shifts: list[ShiftSummaryResponse] = Field(default_factory=list)
+    sightings_by_patrol: dict[str, int] = Field(default_factory=dict)
+    created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Patrols (slice 2) — feedback intake + sightings read
+# ---------------------------------------------------------------------------
+
+
+class FeedbackRequest(BaseModel):
+    """Body for ``POST /belt/mandates/{id}/feedback`` — a human-filed signal.
+
+    ``text`` is the feedback. ``severity`` defaults to 3 (mid) when omitted.
+    ``source`` names where it came from (e.g. ``"slack"``, ``"support"``)."""
+
+    text: str = Field(min_length=1)
+    severity: int | None = Field(default=None, ge=1, le=5)
+    source: str = Field(min_length=1)
+
+
+class SightingResponse(BaseModel):
+    id: str
+    mandate_id: str
+    patrol: str
+    severity: int
+    summary: str
+    evidence: dict = Field(default_factory=dict)
+    ts: datetime
+
+
+class SightingsListResponse(BaseModel):
+    sightings: list[SightingResponse] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Shift trigger (slice 4)
+# ---------------------------------------------------------------------------
+
+
+class ShiftResponse(BaseModel):
+    """Response from ``POST /belt/mandates/{id}/shift`` — the shift the foreman
+    planned + how the plan gate resolved.
+
+    ``state`` is the shift state after planning: ``in_gate`` when the foreman
+    proposed tasks (awaiting human approval), ``stood_down`` when the foreman
+    returned an empty plan (a SUCCESS — quiet surface, healthy KPIs).
+    ``plan_action_id`` is the Instinct ``belt_plan`` Action id (None for a
+    stood-down shift). ``task_count`` is how many tasks the plan proposed."""
+
+    shift_id: str
+    no: int
+    state: ShiftState
+    plan_action_id: str | None = None
+    task_count: int = 0
+    no_action_reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Pawprints (slice 5) — past-tense event feed
+# ---------------------------------------------------------------------------
+
+
+class PawprintResponse(BaseModel):
+    """One past-tense event in a mandate's history.
+
+    ``kind`` is the event class (``proposed`` / ``approved`` / ``rejected`` /
+    ``executed`` / ``stood_down``). ``text`` is the human-readable past-tense
+    line. ``shift_no`` ties it to a shift; ``evidence_refs`` lists the sighting
+    ids the underlying task cited."""
+
+    shift_no: int | None = None
+    kind: str
+    text: str
+    evidence_refs: list[str] = Field(default_factory=list)
+    ts: datetime | None = None
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+class PawprintsListResponse(BaseModel):
+    pawprints: list[PawprintResponse] = Field(default_factory=list)
+
+
+__all__ = [
+    "BudgetRequest",
+    "CharterRequest",
+    "CreateMandateRequest",
+    "FeedbackRequest",
+    "KpiRequest",
+    "MandateDetailResponse",
+    "MandateHealth",
+    "MandateListResponse",
+    "MandateSummaryResponse",
+    "PawprintResponse",
+    "PawprintsListResponse",
+    "ShiftResponse",
+    "ShiftSummaryResponse",
+    "SightingResponse",
+    "SightingsListResponse",
+    "SurfaceRequest",
+]

--- a/ee/pocketpaw_ee/cloud/mandates/dto.py
+++ b/ee/pocketpaw_ee/cloud/mandates/dto.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -63,12 +62,15 @@ class CharterRequest(BaseModel):
 
 
 class CreateMandateRequest(BaseModel):
-    """Body for ``POST /belt/mandates``. The charter is the standing brief."""
+    """Body for ``POST /belt/mandates``. The charter is the standing brief.
+    ``patrols`` (UI contract) is the charter composer's senses toggles — which
+    patrols sense this mandate's surface."""
 
     name: str = Field(min_length=1)
     surface: SurfaceRequest
     charter: CharterRequest
     soul_path: str | None = None
+    patrols: list[str] = Field(default_factory=lambda: ["deps", "feedback"])
 
 
 class MandateHealth(BaseModel):
@@ -126,7 +128,8 @@ class MandateDetailResponse(BaseModel):
 
 
 class FeedbackRequest(BaseModel):
-    """Body for ``POST /belt/mandates/{id}/feedback`` — a human-filed signal.
+    """Body for ``POST /belt/mandates/{id}/feedback`` — a human-filed signal
+    (the GENERAL shape; autopilot and integrations use this).
 
     ``text`` is the feedback. ``severity`` defaults to 3 (mid) when omitted.
     ``source`` names where it came from (e.g. ``"slack"``, ``"support"``)."""
@@ -134,6 +137,21 @@ class FeedbackRequest(BaseModel):
     text: str = Field(min_length=1)
     severity: int | None = Field(default=None, ge=1, le=5)
     source: str = Field(min_length=1)
+
+
+class TeachingFeedbackRequest(BaseModel):
+    """The TEACHING shape of ``POST /belt/mandates/{id}/feedback`` — the human
+    teaching channel the gate UI files from rejections/edits. Discriminated
+    from :class:`FeedbackRequest` by the presence of ``kind``.
+
+    ``kind`` names the gate action (``reject``/``edit``/``plan``); ``reason``
+    is the human's explanation; ``shift_no``/``task_title`` tie it to the plan
+    item it teaches about. Returns ``{"ok": true}`` on the wire."""
+
+    kind: str = Field(pattern="^(reject|edit|plan)$")
+    reason: str = Field(min_length=1)
+    shift_no: int | None = None
+    task_title: str | None = None
 
 
 class SightingResponse(BaseModel):
@@ -174,24 +192,54 @@ class ShiftResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Plan resolve (UI contract) — the console's authoritative gate action
+# ---------------------------------------------------------------------------
+
+
+class PlanDecision(BaseModel):
+    """One per-task verdict in a plan resolution.
+
+    ``index`` is the 0-BASED position in the proposed plan's ``tasks`` array
+    (the order the UI rendered). ``edit`` applies ``edited_title`` and keeps
+    the task; ``reject`` drops it and records ``reason`` as teaching feedback."""
+
+    index: int = Field(ge=0)
+    decision: str = Field(pattern="^(approve|reject|edit)$")
+    edited_title: str | None = None
+    reason: str | None = None
+
+
+class ResolvePlanRequest(BaseModel):
+    """Body for ``POST /belt/mandates/{id}/plan/resolve`` — the console's gate
+    action. Every task in the shift's plan must carry exactly one decision
+    (explicit beats implicit at a human gate)."""
+
+    shift_no: int
+    decisions: list[PlanDecision] = Field(min_length=1)
+
+
+# ---------------------------------------------------------------------------
 # Pawprints (slice 5) — past-tense event feed
 # ---------------------------------------------------------------------------
 
 
 class PawprintResponse(BaseModel):
-    """One past-tense event in a mandate's history.
+    """One past-tense event in a mandate's history (UI contract shape).
 
-    ``kind`` is the event class (``proposed`` / ``approved`` / ``rejected`` /
-    ``executed`` / ``stood_down``). ``text`` is the human-readable past-tense
-    line. ``shift_no`` ties it to a shift; ``evidence_refs`` lists the sighting
-    ids the underlying task cited."""
+    ``kind`` is the event class — the UI consumes ``executed`` / ``rejected`` /
+    ``edited`` / ``stood_down``; the feed also emits ``proposed`` / ``approved``
+    / ``failed`` / ``planning`` (a superset, same shape). ``summary`` is the
+    human-readable past-tense line. ``id`` is a stable per-item key
+    (``<shift_id>:<kind>``); ``evidence_refs`` lists the sighting ids the
+    underlying plan cited."""
 
+    id: str
+    mandate_id: str
     shift_no: int | None = None
     kind: str
-    text: str
+    summary: str
     evidence_refs: list[str] = Field(default_factory=list)
     ts: datetime | None = None
-    extra: dict[str, Any] = Field(default_factory=dict)
 
 
 class PawprintsListResponse(BaseModel):
@@ -208,11 +256,14 @@ __all__ = [
     "MandateHealth",
     "MandateListResponse",
     "MandateSummaryResponse",
+    "PlanDecision",
     "PawprintResponse",
     "PawprintsListResponse",
+    "ResolvePlanRequest",
     "ShiftResponse",
     "ShiftSummaryResponse",
     "SightingResponse",
     "SightingsListResponse",
     "SurfaceRequest",
+    "TeachingFeedbackRequest",
 ]

--- a/ee/pocketpaw_ee/cloud/mandates/events.py
+++ b/ee/pocketpaw_ee/cloud/mandates/events.py
@@ -1,0 +1,43 @@
+# ee/pocketpaw_ee/cloud/mandates/events.py
+# Created: 2026-06-11 (feat/belt-mandates, slice 1 — models + CRUD).
+#
+# Realtime events the mandates service emits on writes (cloud entity rule:
+# emit an event on every write, or annotate ``# no-event``). Thin Event
+# subclasses keyed by an ``EVENT_TYPE`` discriminator, mirroring the workspace
+# / foresight event shapes. Carried on the workspace realtime bus so a teammate
+# with a mandate console open sees a new mandate / shift / sighting land live.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pocketpaw_ee.cloud._core.realtime.events import Event
+
+
+@dataclass
+class MandateCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "mandate.created"
+
+
+@dataclass
+class MandateSightingAdded(Event):
+    EVENT_TYPE: ClassVar[str] = "mandate.sighting_added"
+
+
+@dataclass
+class MandateShiftStarted(Event):
+    EVENT_TYPE: ClassVar[str] = "mandate.shift_started"
+
+
+@dataclass
+class MandateShiftUpdated(Event):
+    EVENT_TYPE: ClassVar[str] = "mandate.shift_updated"
+
+
+__all__ = [
+    "MandateCreated",
+    "MandateShiftStarted",
+    "MandateShiftUpdated",
+    "MandateSightingAdded",
+]

--- a/ee/pocketpaw_ee/cloud/mandates/events.py
+++ b/ee/pocketpaw_ee/cloud/mandates/events.py
@@ -35,7 +35,18 @@ class MandateShiftUpdated(Event):
     EVENT_TYPE: ClassVar[str] = "mandate.shift_updated"
 
 
+# UI contract — fired when a shift's PlanProposal lands as a pending Instinct
+# ``belt_plan`` Action. Payload: {workspace_id, mandate_id, proposal} —
+# ``workspace_id`` drives the audience resolver's workspace fan-out (the same
+# branch shape as ``belt_run_updated``); the /belt mandates page subscribes to
+# exactly the ``belt_plan`` topic and reads {mandate_id, proposal}.
+@dataclass
+class BeltPlanProposed(Event):
+    EVENT_TYPE: ClassVar[str] = "belt_plan"
+
+
 __all__ = [
+    "BeltPlanProposed",
     "MandateCreated",
     "MandateShiftStarted",
     "MandateShiftUpdated",

--- a/ee/pocketpaw_ee/cloud/mandates/executor.py
+++ b/ee/pocketpaw_ee/cloud/mandates/executor.py
@@ -27,6 +27,12 @@
 #      failure path returns right after its single ``_fail`` emit; the success
 #      path emits once at the end.
 #
+# Vocabulary pin (review M1): the chain's SUCCESS terminal is
+# ``action_outcome="dispatched"`` — everywhere. The strings "executed" /
+# ``mark_executed`` / ``ActionStatus.EXECUTED`` that appear nearby are the
+# Instinct STORE's status vocabulary for the Action row, not the chain
+# outcome; do not conflate the two.
+#
 # Reject path: the instinct router owns the chain close on reject (mirroring
 # code_change); it calls ``mark_plan_rejected`` here best-effort so the shift
 # record reflects the rejection.

--- a/ee/pocketpaw_ee/cloud/mandates/executor.py
+++ b/ee/pocketpaw_ee/cloud/mandates/executor.py
@@ -1,0 +1,417 @@
+# ee/pocketpaw_ee/cloud/mandates/executor.py
+# Created: 2026-06-11 (feat/belt-mandates, slice 4 — plan gate + executor).
+#
+# The apply-on-approve half of the MANDATE plan gate. ``service.trigger_shift``
+# proposes the foreman's PlanProposal THROUGH Instinct as a ``belt_plan``
+# Action (blob under ``Action.parameters._belt_plan``); after a human approves
+# it in The Tray, the ee instinct router fires ``execute_approved_plan`` here —
+# EXACTLY mirroring how ``ee.cloud.belt.executor.execute_approved_change`` is
+# fired for a ``_code_change`` Action. This function:
+#
+#   1. Reads the ``_belt_plan`` blob; a missing/schema-mismatched blob fails loud.
+#   2. RE-validates at approve time (defense in depth): the mandate still
+#      exists, is still ACTIVE, and the charter budget is UNCHANGED since the
+#      plan was proposed (a tightened budget refuses a now-over-budget plan).
+#   3. Dispatches each approved task as a normal Belt run via the injectable
+#      ``TaskDispatcher``. The default ``BusTaskDispatcher`` routes through the
+#      EXISTING belt service (``emit_belt_run_updated``) — the genuine external
+#      boundary here is the develop-station agent session, exactly as ``gh pr
+#      create`` was for the code-change executor, so tests inject a recorder.
+#      >>> DEMO-BAR CONCESSION: dispatch announces the run on the belt bus and
+#      records the task; wiring an autonomous develop-station runner is the
+#      autopilot PR's job. <<<
+#   4. Marks the shift ``executing`` → ``done`` (via the mandates service — the
+#      sole Beanie importer), appends the shift summary to the mandate's soul
+#      (best-effort), and closes the Decision-Graph chain with EXACTLY ONE
+#      ``decision.completed`` (the documented chain-doubling trap): every
+#      failure path returns right after its single ``_fail`` emit; the success
+#      path emits once at the end.
+#
+# Reject path: the instinct router owns the chain close on reject (mirroring
+# code_change); it calls ``mark_plan_rejected`` here best-effort so the shift
+# record reflects the rejection.
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Schema version stamped on the ``_belt_plan`` blob. Bump when the blob shape
+# changes so a stale pending plan approved post-deploy fails loud (same
+# discipline as the code-change executor's ``_CODE_CHANGE_SCHEMA``).
+BELT_PLAN_SCHEMA = 1
+
+# The parameters key the plan blob rides under. The instinct router dispatches
+# the approve/reject hooks on this key's presence — the ``belt_plan`` peer of
+# ``_code_change`` / ``_pocket_write``.
+BELT_PLAN_PARAM_KEY = "_belt_plan"
+
+
+class TaskDispatcher(Protocol):
+    """Injectable dispatch seam — one call per approved task.
+
+    Returns a run reference string (an id the pawprints feed can show). Tests
+    inject a recorder; production gets ``BusTaskDispatcher``."""
+
+    async def dispatch(
+        self,
+        *,
+        workspace_id: str,
+        mandate_id: str,
+        shift_no: int,
+        plan_action_id: str,
+        index: int,
+        task: dict[str, Any],
+    ) -> str: ...
+
+
+class BusTaskDispatcher:
+    """Default ``TaskDispatcher`` — announces the run via the EXISTING belt
+    service (``emit_belt_run_updated`` on the workspace realtime bus) under a
+    synthetic per-task run id ``<plan_action_id>:t<index>``."""
+
+    async def dispatch(
+        self,
+        *,
+        workspace_id: str,
+        mandate_id: str,
+        shift_no: int,
+        plan_action_id: str,
+        index: int,
+        task: dict[str, Any],
+    ) -> str:
+        from pocketpaw_ee.cloud.belt import service as belt_service
+
+        run_ref = f"{plan_action_id}:t{index}"
+        await belt_service.emit_belt_run_updated(
+            workspace_id=workspace_id,
+            action_id=run_ref,
+            status="dispatched",
+            stage="station",
+        )
+        logger.info(
+            "mandate: dispatched task %d of shift %s (mandate=%s) as belt run %s: %s",
+            index,
+            shift_no,
+            mandate_id,
+            run_ref,
+            str(task.get("title", ""))[:80],
+        )
+        return run_ref
+
+
+def _coerce_uuid(raw: Any) -> Any | None:
+    """Coerce to UUID or None (mirrors the belt executor helper)."""
+    from uuid import UUID
+
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: Any | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: Any | None,
+    task_count: int | None = None,
+    run_refs: list[str] | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a belt_plan run.
+
+    Mirrors the code-change executor's helper. No-ops on a missing
+    correlation_id (the abandon-sweeper closes orphans). Best-effort: a
+    Decision-Graph wiring failure never breaks the approve response."""
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {"passed": passed, "action_outcome": action_outcome}
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if task_count is not None:
+        payload["task_count"] = task_count
+    if run_refs:
+        payload["run_refs"] = list(run_refs)
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "belt_plan decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+async def _mark_shift_safe(
+    *,
+    workspace_id: str,
+    shift_id: str,
+    state: str,
+    outcome: str | None = None,
+) -> None:
+    """Best-effort shift-state transition through the mandates service (the
+    sole Beanie importer). A Mongo failure must never break the approve path —
+    the Instinct outcome is the source of truth."""
+    try:
+        from pocketpaw_ee.cloud.mandates import service as mandate_service
+
+        await mandate_service.mark_shift(
+            workspace_id=workspace_id, shift_id=shift_id, state=state, outcome=outcome
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "mandate: shift %s state write (%s) failed — instinct outcome remains "
+            "the source of truth",
+            shift_id,
+            state,
+            exc_info=True,
+        )
+
+
+async def execute_approved_plan(
+    action: Any,
+    *,
+    dispatcher: TaskDispatcher | None = None,
+    human_event_id: Any | None = None,
+) -> None:
+    """Dispatch the shift plan carried by a freshly-approved ``belt_plan``
+    Action. Called best-effort from the instinct router's approve paths.
+
+    Never raises. Every terminal path (success or any failure) closes the
+    Decision-Graph chain EXACTLY ONCE: failures via the single ``_fail``
+    chokepoint (emit + return), success via the single close at the end."""
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    dispatch: TaskDispatcher = dispatcher or BusTaskDispatcher()
+
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(BELT_PLAN_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not a belt_plan Action — no chain was opened for it here.
+        logger.warning("approved action %s carries no _belt_plan blob", action.id)
+        return
+
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    requested_by = str(blob.get("requested_by") or "")
+    mandate_id = str(blob.get("mandate_id") or "")
+    shift_id = str(blob.get("shift_id") or "")
+    shift_no = int(blob.get("shift_no") or 0)
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Single failure chokepoint — one mark_failed + ONE chain close, then
+        the caller returns. A path can never double-fire the terminal."""
+        await store.mark_failed(action.id, reason)
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=requested_by,
+            causation_id=causation,
+        )
+        await _mark_shift_safe(
+            workspace_id=workspace_id,
+            shift_id=shift_id,
+            state="done",
+            outcome=f"plan failed at the gate: {reason}",
+        )
+
+    try:
+        if blob.get("schema") != BELT_PLAN_SCHEMA:
+            await _fail(
+                "belt_plan schema mismatch — the plan blob is from an incompatible "
+                "build and cannot be dispatched",
+                error_class="SchemaMismatch",
+            )
+            return
+
+        plan = blob.get("plan")
+        if not isinstance(plan, dict) or not mandate_id or not shift_id:
+            await _fail(
+                "belt_plan blob is missing plan/mandate_id/shift_id",
+                error_class="MalformedBlob",
+            )
+            return
+        tasks = plan.get("tasks") or []
+
+        # 2. RE-validate at approve time (defense in depth) — the mandate must
+        #    still exist, still be ACTIVE, and the budget must be UNCHANGED.
+        from pocketpaw_ee.cloud.mandates import service as mandate_service
+
+        try:
+            current = await mandate_service.executor_revalidate(workspace_id, mandate_id)
+        except Exception:  # noqa: BLE001 — a read failure refuses the dispatch
+            await _fail(
+                "mandate could not be re-validated at approval time",
+                error_class="RevalidateFailed",
+            )
+            return
+        if not current["exists"]:
+            await _fail("mandate no longer exists", error_class="MandateGone")
+            return
+        if not current["active"]:
+            await _fail(
+                "mandate is paused — plan refused at approval time",
+                error_class="MandatePaused",
+            )
+            return
+        budget_now = int(current["budget_max_tasks"])
+        budget_at_propose = int(blob.get("budget_max_tasks") or 0)
+        if budget_now != budget_at_propose or len(tasks) > budget_now:
+            await _fail(
+                f"charter budget changed since the plan was proposed "
+                f"({budget_at_propose} → {budget_now}; plan carries {len(tasks)} "
+                "task(s)) — re-run the shift",
+                error_class="BudgetChanged",
+            )
+            return
+
+        # 3. Dispatch each approved task as a normal Belt run.
+        await _mark_shift_safe(workspace_id=workspace_id, shift_id=shift_id, state="executing")
+        run_refs: list[str] = []
+        for i, task in enumerate(tasks, start=1):
+            try:
+                ref = await dispatch.dispatch(
+                    workspace_id=workspace_id,
+                    mandate_id=mandate_id,
+                    shift_no=shift_no,
+                    plan_action_id=str(action.id),
+                    index=i,
+                    task=dict(task) if isinstance(task, dict) else {},
+                )
+            except Exception as exc:  # noqa: BLE001
+                await _fail(
+                    f"task {i} dispatch failed: {exc}",
+                    error_class="DispatchFailed",
+                )
+                return
+            run_refs.append(ref)
+
+        # 4. Success terminal — one mark_executed, one shift transition, one
+        #    soul append, ONE chain close.
+        outcome_text = (
+            f"Shift {shift_no}: dispatched {len(run_refs)} task(s) as belt runs "
+            f"({', '.join(run_refs)})"
+        )
+        await store.mark_executed(action.id, outcome_text)
+        await _mark_shift_safe(
+            workspace_id=workspace_id,
+            shift_id=shift_id,
+            state="done",
+            outcome=outcome_text,
+        )
+        try:
+            from pocketpaw_ee.cloud.mandates import soul_link
+
+            await soul_link.remember_shift(
+                str(blob.get("soul_path") or "") or None,
+                f"Mandate shift {shift_no}: plan approved; {outcome_text}",
+            )
+        except Exception:  # noqa: BLE001 — soul append is best-effort
+            logger.debug("mandate: soul append failed (non-fatal)", exc_info=True)
+
+        _emit_chain_close(
+            passed=True,
+            action_outcome="dispatched",
+            error_class=None,
+            reason=None,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=requested_by,
+            causation_id=causation,
+            task_count=len(run_refs),
+            run_refs=run_refs,
+        )
+        logger.info(
+            "mandate: dispatched belt_plan action %s (mandate=%s, shift=%s, %d task(s))",
+            action.id,
+            mandate_id,
+            shift_no,
+            len(run_refs),
+        )
+    except Exception:  # noqa: BLE001 — never let the executor break approve
+        logger.warning(
+            "mandate: belt_plan execution crashed for action %s", action.id, exc_info=True
+        )
+        try:
+            await _fail(
+                "belt_plan executor crashed — re-run the shift", error_class="ExecutorCrash"
+            )
+        except Exception:  # noqa: BLE001 — a second failure must never mask the first
+            logger.debug("mandate: crash-path _fail itself failed", exc_info=True)
+
+
+async def mark_plan_rejected(action: Any, reason: str) -> None:
+    """Reflect a gate REJECTION onto the shift record (state=done, outcome
+    carries the reason) + soul append. The instinct ROUTER owns the chain close
+    on reject (mirroring code_change) — this only updates the read model.
+    Best-effort, never raises."""
+    try:
+        params = getattr(action, "parameters", None) or {}
+        blob = params.get(BELT_PLAN_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        shift_no = int(blob.get("shift_no") or 0)
+        outcome = f"Shift {shift_no}: plan rejected at the gate" + (
+            f" — {reason}" if reason else ""
+        )
+        await _mark_shift_safe(
+            workspace_id=str(blob.get("workspace_id") or ""),
+            shift_id=str(blob.get("shift_id") or ""),
+            state="done",
+            outcome=outcome,
+        )
+        from pocketpaw_ee.cloud.mandates import soul_link
+
+        await soul_link.remember_shift(
+            str(blob.get("soul_path") or "") or None, f"Mandate {outcome}"
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("mandate: mark_plan_rejected failed (non-fatal)", exc_info=True)
+
+
+__all__ = [
+    "BELT_PLAN_PARAM_KEY",
+    "BELT_PLAN_SCHEMA",
+    "BusTaskDispatcher",
+    "TaskDispatcher",
+    "execute_approved_plan",
+    "mark_plan_rejected",
+]

--- a/ee/pocketpaw_ee/cloud/mandates/foreman.py
+++ b/ee/pocketpaw_ee/cloud/mandates/foreman.py
@@ -1,0 +1,401 @@
+# ee/pocketpaw_ee/cloud/mandates/foreman.py
+# Created: 2026-06-11 (feat/belt-mandates, slice 3 — foreman).
+#
+# The FOREMAN — the LLM judgment seat of a mandate. Once per SHIFT it reads the
+# charter, the sighting digest since the last shift, the last 3 shifts'
+# outcomes, and (when a soul is bound) the soul recall, then makes EXACTLY ONE
+# LLM call that returns a strict-JSON PlanProposal: a FEW tasks (≤ the
+# charter's budget) or an explicit empty plan with a reason.
+#
+# Pluggable LLM layer (env ``POCKETPAW_MANDATE_LLM=claude|mock``):
+#   * ``claude`` (default) — shells the ``claude`` CLI:
+#       ``claude -p <prompt> --output-format json``
+#     and reads the ``result`` field off the JSON envelope. DEMO-BAR: the CLI
+#     shell-out is the LLM transport; a later PR can swap an SDK transport in
+#     behind the same ``PlanLlm`` protocol. The prompt is passed as ONE argv
+#     element — never interpolated into a shell string.
+#   * ``mock`` — deterministic: plans one task per sighting (highest severity
+#     first) up to the budget, or a no_action plan when the digest is empty.
+#     Tests can override the scripted response via ``set_mock_plan()``.
+#
+# Validation discipline (proven in sim — encoded here, do not weaken):
+#   * machine validation runs on ACTION fields (title, expected_outcome) and
+#     structural fields (task count vs budget, evidence_refs non-empty) ONLY.
+#   * the ``why`` narration is NEVER scanned — a well-behaved foreman names
+#     forbidden things precisely when REFUSING them; scanning why would punish
+#     the refusal.
+#
+# Prompt requirements (all sim-validated — keep them in ``build_prompt``):
+#   charter verbatim with BOUNDARIES prominent; ≤ budget tasks; every task
+#   cites sighting ids + names an expected KPI direction; an EMPTY plan with a
+#   reason is correct when signals are quiet and KPIs healthy; boundaries
+#   override KPI opportunities; never repeat a failed approach without stating
+#   what changed; output strict JSON only.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# Subprocess timeout for the claude CLI call (seconds). A hung CLI must not
+# wedge the shift trigger forever.
+_CLI_TIMEOUT = 180.0
+
+
+# ---------------------------------------------------------------------------
+# The strict plan schema the LLM must return
+# ---------------------------------------------------------------------------
+
+
+class PlannedTask(BaseModel):
+    """One task the foreman proposes for the shift."""
+
+    title: str
+    why: str
+    evidence_refs: list[str] = Field(default_factory=list)
+    expected_outcome: str
+    est_cost_hours: float = 1.0
+
+
+class PlanProposal(BaseModel):
+    """The foreman's whole-shift output — strict JSON, nothing else."""
+
+    shift_no: int
+    no_action: bool = False
+    no_action_reason: str | None = None
+    tasks: list[PlannedTask] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Judgment context — everything the foreman sees
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ForemanContext:
+    """The assembled judgment context for one shift."""
+
+    shift_no: int
+    charter: dict[str, Any]
+    # Each digest entry: {id, patrol, severity, summary}
+    sightings: list[dict[str, Any]] = field(default_factory=list)
+    # Last 3 shifts, oldest-first: {no, state, outcome} — outcome is the
+    # free-text result of the shift (what landed / failed / stood down).
+    history: list[dict[str, Any]] = field(default_factory=list)
+    # Soul recall lines (empty when no soul bound).
+    soul_context: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Pluggable LLM layer
+# ---------------------------------------------------------------------------
+
+
+class PlanLlm(Protocol):
+    """One judgment call: prompt in, raw model text out.
+
+    ``context`` rides along so a deterministic mock can answer without parsing
+    prose; real transports ignore it and send only the prompt."""
+
+    async def plan(self, *, prompt: str, context: ForemanContext) -> str: ...
+
+
+class ClaudeCliLlm:
+    """Default transport — shells the ``claude`` CLI (demo bar).
+
+    ``claude -p <prompt> --output-format json`` prints a JSON envelope whose
+    ``result`` field carries the model's text. The prompt is a single argv
+    element (the CLI does its own auth); nothing is shell-interpolated."""
+
+    async def plan(self, *, prompt: str, context: ForemanContext) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            "claude",
+            "-p",
+            prompt,
+            "--output-format",
+            "json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=_CLI_TIMEOUT)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise RuntimeError(f"claude CLI timed out after {_CLI_TIMEOUT}s") from None
+        out = out_b.decode("utf-8", "replace")
+        if proc.returncode != 0:
+            err = err_b.decode("utf-8", "replace")
+            raise RuntimeError(
+                f"claude CLI failed (exit {proc.returncode}): {err.strip()[:300]}"
+            )
+        # The envelope is JSON with a ``result`` field; tolerate a bare-text
+        # response (older CLI / plain output) by falling back to stdout.
+        try:
+            envelope = json.loads(out)
+        except json.JSONDecodeError:
+            return out
+        if isinstance(envelope, dict) and isinstance(envelope.get("result"), str):
+            return envelope["result"]
+        return out
+
+
+# Test hook — when set, MockLlm returns this verbatim (a dict is dumped to
+# JSON). Reset with ``set_mock_plan(None)``.
+_MOCK_PLAN: dict[str, Any] | str | None = None
+
+
+def set_mock_plan(plan: dict[str, Any] | str | None) -> None:
+    """Override the MockLlm's next responses (tests). ``None`` restores the
+    deterministic default."""
+    global _MOCK_PLAN
+    _MOCK_PLAN = plan
+
+
+class MockLlm:
+    """Deterministic foreman for tests + offline demos.
+
+    Default behavior: one task per sighting (highest severity first) capped at
+    the charter budget; an explicit no_action plan when the digest is empty.
+    ``set_mock_plan`` overrides the response entirely."""
+
+    async def plan(self, *, prompt: str, context: ForemanContext) -> str:
+        if _MOCK_PLAN is not None:
+            return _MOCK_PLAN if isinstance(_MOCK_PLAN, str) else json.dumps(_MOCK_PLAN)
+
+        budget = int(
+            (context.charter.get("budget") or {}).get("max_tasks_per_shift") or 3
+        )
+        kpis = context.charter.get("kpis") or []
+        kpi_hint = (
+            f"{kpis[0]['name']} {kpis[0]['direction']}" if kpis else "surface health up"
+        )
+        ranked = sorted(
+            context.sightings, key=lambda s: int(s.get("severity") or 0), reverse=True
+        )
+        if not ranked:
+            return json.dumps(
+                {
+                    "shift_no": context.shift_no,
+                    "no_action": True,
+                    "no_action_reason": "Signals are quiet and KPIs are healthy — standing down.",
+                    "tasks": [],
+                }
+            )
+        tasks = [
+            {
+                "title": f"Address: {s.get('summary', 'sighting')[:80]}",
+                "why": f"Sighting {s.get('id')} (severity {s.get('severity')}) from the "
+                f"{s.get('patrol')} patrol warrants action this shift.",
+                "evidence_refs": [str(s.get("id"))],
+                "expected_outcome": f"KPI {kpi_hint}; sighting resolved.",
+                "est_cost_hours": 1.0,
+            }
+            for s in ranked[:budget]
+        ]
+        return json.dumps(
+            {
+                "shift_no": context.shift_no,
+                "no_action": False,
+                "no_action_reason": None,
+                "tasks": tasks,
+            }
+        )
+
+
+def resolve_llm() -> PlanLlm:
+    """Pick the transport from ``POCKETPAW_MANDATE_LLM`` (``claude`` default)."""
+    choice = (os.environ.get("POCKETPAW_MANDATE_LLM") or "claude").strip().lower()
+    if choice == "mock":
+        return MockLlm()
+    return ClaudeCliLlm()
+
+
+# ---------------------------------------------------------------------------
+# Prompt — every sim-validated rule lives here
+# ---------------------------------------------------------------------------
+
+
+def build_prompt(context: ForemanContext) -> str:
+    """Assemble the single judgment prompt. Charter rides VERBATIM (as JSON)
+    with the BOUNDARIES block pulled out and stated first — boundaries override
+    every KPI opportunity."""
+    charter = context.charter
+    boundaries = list(charter.get("boundaries") or [])
+    says_no = list(charter.get("says_no") or [])
+    budget = (charter.get("budget") or {}).get("max_tasks_per_shift", 3)
+
+    sighting_lines = (
+        "\n".join(
+            f"- id={s['id']} patrol={s.get('patrol')} severity={s.get('severity')}: "
+            f"{s.get('summary')}"
+            for s in context.sightings
+        )
+        or "(none — the surface has been quiet since the last shift)"
+    )
+    history_lines = (
+        "\n".join(
+            f"- shift {h.get('no')}: state={h.get('state')} outcome={h.get('outcome') or 'n/a'}"
+            for h in context.history
+        )
+        or "(no prior shifts)"
+    )
+    soul_lines = "\n".join(f"- {line}" for line in context.soul_context) or "(none)"
+
+    return f"""You are the FOREMAN of a standing engineering mandate. Once per shift you decide \
+what FEW tasks (if any) the crew should run. You are judged on judgment, not output volume.
+
+== BOUNDARIES (ABSOLUTE — these override every KPI opportunity) ==
+{json.dumps(boundaries, indent=2)}
+The mandate also SAYS NO to:
+{json.dumps(says_no, indent=2)}
+If a tempting task would cross a boundary, you refuse it. When refusing, you may name the \
+forbidden thing in your reasoning — that is correct behavior.
+
+== CHARTER (verbatim) ==
+{json.dumps(charter, indent=2)}
+
+== SIGHTINGS since the last shift ==
+{sighting_lines}
+
+== LAST SHIFTS' OUTCOMES (oldest first) ==
+{history_lines}
+Never repeat an approach that already failed above without explicitly stating in the task's \
+"why" what is different this time.
+
+== SOUL CONTEXT (long-lived memory of this mandate) ==
+{soul_lines}
+
+== YOUR RULES ==
+1. Plan AT MOST {budget} task(s) this shift. Fewer is better. Pick only what moves a KPI.
+2. Every task MUST cite at least one sighting id in "evidence_refs" and MUST name an \
+expected KPI and its direction in "expected_outcome" (e.g. "open_cves down").
+3. An EMPTY plan is a correct, respected outcome: if the signals are quiet and the KPIs are \
+healthy, set "no_action": true with a short "no_action_reason" and an empty "tasks" list. \
+Do not invent work.
+4. Boundaries override KPI opportunities — a boundary-crossing task is never worth it.
+5. This is shift number {context.shift_no}; set "shift_no" to exactly {context.shift_no}.
+
+== OUTPUT (STRICT) ==
+Reply with STRICT JSON only — no prose, no markdown fences, no commentary:
+{{"shift_no": {context.shift_no}, "no_action": false, "no_action_reason": null, "tasks": \
+[{{"title": "...", "why": "...", "evidence_refs": ["<sighting id>"], "expected_outcome": \
+"<kpi> <up|down>; ...", "est_cost_hours": 1.0}}]}}"""
+
+
+# ---------------------------------------------------------------------------
+# Output parsing + machine validation
+# ---------------------------------------------------------------------------
+
+_FENCE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.DOTALL)
+
+
+def parse_plan(raw: str) -> PlanProposal:
+    """Parse the model's text into a PlanProposal — tolerating a fenced JSON
+    block or stray text around a single top-level JSON object."""
+    text = raw.strip()
+    m = _FENCE.match(text)
+    if m:
+        text = m.group(1).strip()
+    try:
+        return PlanProposal.model_validate(json.loads(text))
+    except (json.JSONDecodeError, ValueError):
+        # Last resort: find the outermost {...} span.
+        start, end = text.find("{"), text.rfind("}")
+        if start >= 0 and end > start:
+            return PlanProposal.model_validate(json.loads(text[start : end + 1]))
+        raise
+
+
+def validate_plan(plan: PlanProposal, charter: dict[str, Any]) -> list[str]:
+    """Machine validation of a PlanProposal. Returns a list of violation
+    strings (empty = valid).
+
+    CRITICAL (sim-proven): checks run on ACTION fields — ``title`` and
+    ``expected_outcome`` — plus structural fields (task count vs budget,
+    evidence_refs non-empty). The ``why`` narration is NEVER scanned: a
+    well-behaved foreman names forbidden things when REFUSING them."""
+    violations: list[str] = []
+    budget = int((charter.get("budget") or {}).get("max_tasks_per_shift") or 3)
+
+    if plan.no_action:
+        if plan.tasks:
+            violations.append("no_action plan must carry zero tasks")
+        if not (plan.no_action_reason or "").strip():
+            violations.append("no_action plan must carry a no_action_reason")
+        return violations
+
+    if len(plan.tasks) > budget:
+        violations.append(
+            f"plan proposes {len(plan.tasks)} tasks but the charter budget caps a "
+            f"shift at {budget}"
+        )
+
+    forbidden = [
+        p.strip().lower()
+        for p in [*(charter.get("says_no") or []), *(charter.get("boundaries") or [])]
+        if isinstance(p, str) and p.strip()
+    ]
+    for i, task in enumerate(plan.tasks):
+        if not task.evidence_refs:
+            violations.append(f"task {i + 1} ({task.title[:40]!r}) cites no sighting ids")
+        action_text = f"{task.title} {task.expected_outcome}".lower()
+        for phrase in forbidden:
+            if phrase in action_text:
+                violations.append(
+                    f"task {i + 1} ({task.title[:40]!r}) crosses a charter boundary: "
+                    f"{phrase!r} appears in its action fields"
+                )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# The one judgment call
+# ---------------------------------------------------------------------------
+
+
+async def plan_shift(context: ForemanContext, llm: PlanLlm | None = None) -> PlanProposal:
+    """Build the prompt, make ONE LLM call, parse the strict-JSON plan.
+
+    Raises on transport failure or unparseable output — the caller (service)
+    decides how a failed judgment surfaces. Validation is the caller's step
+    (``validate_plan``) so the service can map violations to CloudErrors."""
+    llm = llm or resolve_llm()
+    prompt = build_prompt(context)
+    raw = await llm.plan(prompt=prompt, context=context)
+    plan = parse_plan(raw)
+    # The model is told to echo the shift number; normalize drift rather than
+    # failing the shift on an off-by-one echo.
+    if plan.shift_no != context.shift_no:
+        logger.warning(
+            "foreman echoed shift_no=%s for shift %s — normalizing",
+            plan.shift_no,
+            context.shift_no,
+        )
+        plan = plan.model_copy(update={"shift_no": context.shift_no})
+    return plan
+
+
+__all__ = [
+    "ClaudeCliLlm",
+    "ForemanContext",
+    "MockLlm",
+    "PlanLlm",
+    "PlanProposal",
+    "PlannedTask",
+    "build_prompt",
+    "parse_plan",
+    "plan_shift",
+    "resolve_llm",
+    "set_mock_plan",
+    "validate_plan",
+]

--- a/ee/pocketpaw_ee/cloud/mandates/foreman.py
+++ b/ee/pocketpaw_ee/cloud/mandates/foreman.py
@@ -135,9 +135,7 @@ class ClaudeCliLlm:
         out = out_b.decode("utf-8", "replace")
         if proc.returncode != 0:
             err = err_b.decode("utf-8", "replace")
-            raise RuntimeError(
-                f"claude CLI failed (exit {proc.returncode}): {err.strip()[:300]}"
-            )
+            raise RuntimeError(f"claude CLI failed (exit {proc.returncode}): {err.strip()[:300]}")
         # The envelope is JSON with a ``result`` field; tolerate a bare-text
         # response (older CLI / plain output) by falling back to stdout.
         try:
@@ -172,16 +170,10 @@ class MockLlm:
         if _MOCK_PLAN is not None:
             return _MOCK_PLAN if isinstance(_MOCK_PLAN, str) else json.dumps(_MOCK_PLAN)
 
-        budget = int(
-            (context.charter.get("budget") or {}).get("max_tasks_per_shift") or 3
-        )
+        budget = int((context.charter.get("budget") or {}).get("max_tasks_per_shift") or 3)
         kpis = context.charter.get("kpis") or []
-        kpi_hint = (
-            f"{kpis[0]['name']} {kpis[0]['direction']}" if kpis else "surface health up"
-        )
-        ranked = sorted(
-            context.sightings, key=lambda s: int(s.get("severity") or 0), reverse=True
-        )
+        kpi_hint = f"{kpis[0]['name']} {kpis[0]['direction']}" if kpis else "surface health up"
+        ranked = sorted(context.sightings, key=lambda s: int(s.get("severity") or 0), reverse=True)
         if not ranked:
             return json.dumps(
                 {
@@ -336,8 +328,7 @@ def validate_plan(plan: PlanProposal, charter: dict[str, Any]) -> list[str]:
 
     if len(plan.tasks) > budget:
         violations.append(
-            f"plan proposes {len(plan.tasks)} tasks but the charter budget caps a "
-            f"shift at {budget}"
+            f"plan proposes {len(plan.tasks)} tasks but the charter budget caps a shift at {budget}"
         )
 
     forbidden = [

--- a/ee/pocketpaw_ee/cloud/mandates/patrols.py
+++ b/ee/pocketpaw_ee/cloud/mandates/patrols.py
@@ -28,8 +28,9 @@ import json
 import logging
 import re
 import tomllib
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any, Awaitable, Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/ee/pocketpaw_ee/cloud/mandates/patrols.py
+++ b/ee/pocketpaw_ee/cloud/mandates/patrols.py
@@ -1,0 +1,158 @@
+# ee/pocketpaw_ee/cloud/mandates/patrols.py
+# Created: 2026-06-11 (feat/belt-mandates, slice 2 — patrols).
+#
+# The PATROL framework — a patrol is an async callable that senses a mandate's
+# surface and produces Sighting DRAFTS (plain dicts; the service persists them
+# as SightingDoc rows — patrols never touch the store, keeping service.py the
+# sole Beanie importer).
+#
+# Two patrols ship in v1:
+#   * ``deps``    — parses the bound repo's manifest (pyproject.toml /
+#                   package.json) and flags entries found in a DETERMINISTIC
+#                   STUB TABLE of known-stale / CVE-carrying packages.
+#                   >>> DEMO-BAR CONCESSION: the stale/CVE data is a hardcoded
+#                   table, not a live advisory feed. The patrol's parse +
+#                   sighting plumbing is production-shaped; only the data
+#                   source is stubbed. <<<
+#   * ``feedback`` — intake-only (no sense loop); humans file sightings via
+#                   ``POST /belt/mandates/{id}/feedback`` (service.file_feedback).
+#                   It has no callable here on purpose.
+#
+# Security: the repo manifest is DATA — parsed with tomllib/json, never
+# executed or shell-interpolated. A repo path that doesn't resolve or parse
+# yields zero sightings (the patrol never raises into the shift trigger).
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import tomllib
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+# A sighting draft — what a patrol hands the service for persistence.
+SightingDraft = dict[str, Any]
+# A patrol: async (repo_path) -> drafts. Kept narrow on purpose; future patrols
+# that need more surface context can grow the signature behind the registry.
+PatrolFn = Callable[[str], Awaitable[list[SightingDraft]]]
+
+
+# ---------------------------------------------------------------------------
+# DEMO-BAR STUB TABLE — known-stale / CVE-carrying packages. Deterministic on
+# purpose: the demo needs reproducible sightings, not a live advisory feed.
+# Key = normalized package name; value = the advisory the patrol reports.
+# ---------------------------------------------------------------------------
+
+KNOWN_STALE: dict[str, dict[str, Any]] = {
+    # Python
+    "requests": {"latest": "2.32.3", "cve": "CVE-2024-35195", "severity": 3},
+    "urllib3": {"latest": "2.2.2", "cve": "CVE-2024-37891", "severity": 3},
+    "pyyaml": {"latest": "6.0.2", "cve": "CVE-2020-14343", "severity": 4},
+    "jinja2": {"latest": "3.1.4", "cve": "CVE-2024-34064", "severity": 3},
+    "cryptography": {"latest": "43.0.0", "cve": "CVE-2024-26130", "severity": 4},
+    "pillow": {"latest": "10.4.0", "cve": "CVE-2023-50447", "severity": 5},
+    # JavaScript
+    "lodash": {"latest": "4.17.21", "cve": "CVE-2021-23337", "severity": 4},
+    "axios": {"latest": "1.7.4", "cve": "CVE-2024-39338", "severity": 4},
+    "minimist": {"latest": "1.2.8", "cve": "CVE-2021-44906", "severity": 5},
+    "node-fetch": {"latest": "3.3.2", "cve": "CVE-2022-0235", "severity": 3},
+    "express": {"latest": "4.19.2", "cve": "CVE-2024-29041", "severity": 3},
+}
+
+# PEP 508-ish dependency string → bare name ("requests>=2.0; extra" → "requests").
+_PY_DEP_NAME = re.compile(r"^\s*([A-Za-z0-9_.-]+)")
+
+
+def _normalize(name: str) -> str:
+    return name.strip().lower().replace("_", "-")
+
+
+def _python_deps(repo: Path) -> list[str]:
+    """Dependency names from pyproject.toml ([project].dependencies +
+    [dependency-groups]). Empty list on a missing / unparseable file."""
+    manifest = repo / "pyproject.toml"
+    if not manifest.is_file():
+        return []
+    try:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        logger.debug("deps patrol: unparseable pyproject.toml at %s", repo, exc_info=True)
+        return []
+    raw: list[str] = list(data.get("project", {}).get("dependencies", []) or [])
+    for group in (data.get("dependency-groups") or {}).values():
+        raw.extend(d for d in group if isinstance(d, str))
+    names: list[str] = []
+    for dep in raw:
+        m = _PY_DEP_NAME.match(dep)
+        if m:
+            names.append(_normalize(m.group(1)))
+    return names
+
+
+def _js_deps(repo: Path) -> list[str]:
+    """Dependency names from package.json (dependencies + devDependencies).
+    Empty list on a missing / unparseable file."""
+    manifest = repo / "package.json"
+    if not manifest.is_file():
+        return []
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.debug("deps patrol: unparseable package.json at %s", repo, exc_info=True)
+        return []
+    names: list[str] = []
+    for key in ("dependencies", "devDependencies"):
+        block = data.get(key)
+        if isinstance(block, dict):
+            names.extend(_normalize(n) for n in block)
+    return names
+
+
+async def deps_patrol(repo_id: str) -> list[SightingDraft]:
+    """The ``deps`` patrol — flag manifest entries present in KNOWN_STALE.
+
+    ``repo_id`` is the mandate surface's repo path. A path that doesn't resolve
+    to a directory yields zero sightings (never raises — a broken surface must
+    not wedge the shift trigger)."""
+    repo = Path(repo_id).expanduser()
+    if not repo.is_dir():
+        logger.warning("deps patrol: repo %r not found — zero sightings", repo_id)
+        return []
+
+    seen: set[str] = set()
+    drafts: list[SightingDraft] = []
+    for name in [*_python_deps(repo), *_js_deps(repo)]:
+        if name in seen or name not in KNOWN_STALE:
+            continue
+        seen.add(name)
+        advisory = KNOWN_STALE[name]
+        drafts.append(
+            {
+                "patrol": "deps",
+                "severity": int(advisory["severity"]),
+                "summary": (
+                    f"{name} is stale/vulnerable ({advisory['cve']}) — "
+                    f"latest is {advisory['latest']}"
+                ),
+                "evidence": {
+                    "package": name,
+                    "latest": advisory["latest"],
+                    "cve": advisory["cve"],
+                    "source": "demo-stub-table",
+                },
+            }
+        )
+    return drafts
+
+
+# Patrol registry — the service iterates this on a shift trigger. ``feedback``
+# is intake-only (service.file_feedback), so it doesn't appear here.
+PATROLS: dict[str, PatrolFn] = {
+    "deps": deps_patrol,
+}
+
+
+__all__ = ["KNOWN_STALE", "PATROLS", "PatrolFn", "SightingDraft", "deps_patrol"]

--- a/ee/pocketpaw_ee/cloud/mandates/router.py
+++ b/ee/pocketpaw_ee/cloud/mandates/router.py
@@ -1,0 +1,123 @@
+# ee/pocketpaw_ee/cloud/mandates/router.py
+# Created: 2026-06-11 (feat/belt-mandates, slice 1 — models + CRUD).
+#
+# FastAPI router for the MANDATE primitive — the standing Belt JOB. Routes ride
+# the ``/belt/mandates`` prefix (the spec pins them under the belt surface). The
+# routes are THIN: they read identity (workspace + user) from the cloud deps,
+# delegate to ``ee.cloud.mandates.service``, and return the wire dict the service
+# built. RBAC mirrors the belt console — ``belt.read`` (MEMBER) on reads,
+# ``belt.manage`` (ADMIN) on mutations (create / shift trigger / feedback intake).
+# Errors propagate via ``CloudError`` so the central handler maps them; the
+# router never raises ``HTTPException``.
+#
+# Updated: 2026-06-11 (slice 2 — patrols) — added feedback intake +
+# sightings read.
+# Updated: 2026-06-11 (slice 4 — plan gate) — added POST .../shift.
+# Updated: 2026-06-11 (slice 5 — pawprints) — added GET .../pawprints.
+
+"""FastAPI router for Belt mandates (standing jobs)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.mandates import service as mandate_service
+from pocketpaw_ee.cloud.mandates.dto import (
+    CreateMandateRequest,
+    FeedbackRequest,
+)
+
+router = APIRouter(
+    prefix="/belt/mandates", tags=["Belt Mandates"], dependencies=[Depends(require_license)]
+)
+
+
+@router.post("")
+async def create_mandate(
+    body: CreateMandateRequest,
+    _user: Any = Depends(require_action_any_workspace("belt.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Create a standing mandate (admin-gated). Returns the mandate detail."""
+    return await mandate_service.create_mandate(workspace_id, user_id, body.model_dump())
+
+
+@router.get("")
+async def list_mandates(
+    _user: Any = Depends(require_action_any_workspace("belt.read")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """List the workspace's mandates with a per-mandate health summary."""
+    return await mandate_service.list_mandates(workspace_id, user_id)
+
+
+@router.get("/{mandate_id}")
+async def get_mandate(
+    mandate_id: str,
+    _user: Any = Depends(require_action_any_workspace("belt.read")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Return one mandate's detail (charter, recent shifts, sightings-by-patrol).
+    A mandate in another workspace is a 404."""
+    return await mandate_service.get_mandate(workspace_id, user_id, mandate_id)
+
+
+@router.post("/{mandate_id}/feedback")
+async def file_feedback(
+    mandate_id: str,
+    body: FeedbackRequest,
+    _user: Any = Depends(require_action_any_workspace("belt.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Intake patrol — file human feedback as a Sighting on the mandate."""
+    return await mandate_service.file_feedback(workspace_id, user_id, mandate_id, body.model_dump())
+
+
+@router.get("/{mandate_id}/sightings")
+async def list_sightings(
+    mandate_id: str,
+    _user: Any = Depends(require_action_any_workspace("belt.read")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """List a mandate's sightings, newest-first."""
+    return await mandate_service.list_sightings(workspace_id, user_id, mandate_id)
+
+
+@router.post("/{mandate_id}/shift")
+async def trigger_shift(
+    mandate_id: str,
+    _user: Any = Depends(require_action_any_workspace("belt.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Run a SHIFT — the foreman plans a few tasks; the plan routes through the
+    Instinct plan gate. Demo-bar manual trigger (admin-gated)."""
+    return await mandate_service.trigger_shift(workspace_id, user_id, mandate_id)
+
+
+@router.get("/{mandate_id}/pawprints")
+async def get_pawprints(
+    mandate_id: str,
+    _user: Any = Depends(require_action_any_workspace("belt.read")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Return the mandate's past-tense event feed (shift n: proposed / approved /
+    rejected / executed / stood_down, with evidence refs)."""
+    return await mandate_service.get_pawprints(workspace_id, user_id, mandate_id)
+
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/mandates/router.py
+++ b/ee/pocketpaw_ee/cloud/mandates/router.py
@@ -14,6 +14,13 @@
 # sightings read.
 # Updated: 2026-06-11 (slice 4 — plan gate) — added POST .../shift.
 # Updated: 2026-06-11 (slice 5 — pawprints) — added GET .../pawprints.
+# Updated: 2026-06-11 (UI contract sync 2) — added POST .../plan/resolve (the
+# console's per-task gate action, mapped onto the real instinct approve-with-
+# edits / reject paths) and the `patrols` senses toggles on create.
+# Updated: 2026-06-11 (UI contract sync) — POST create returns {"mandate"},
+# POST shift returns {"shift"}; the feedback route accepts BOTH the general
+# {text, severity?, source} shape and the teaching {kind, reason, shift_no?,
+# task_title?} shape (discriminated in the service on `kind`).
 
 """FastAPI router for Belt mandates (standing jobs)."""
 
@@ -32,7 +39,6 @@ from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.mandates import service as mandate_service
 from pocketpaw_ee.cloud.mandates.dto import (
     CreateMandateRequest,
-    FeedbackRequest,
 )
 
 router = APIRouter(
@@ -47,7 +53,8 @@ async def create_mandate(
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> dict[str, Any]:
-    """Create a standing mandate (admin-gated). Returns the mandate detail."""
+    """Create a standing mandate (admin-gated). Returns ``{"mandate": <detail>}``
+    (UI contract envelope; the GET detail route stays unwrapped)."""
     return await mandate_service.create_mandate(workspace_id, user_id, body.model_dump())
 
 
@@ -76,13 +83,22 @@ async def get_mandate(
 @router.post("/{mandate_id}/feedback")
 async def file_feedback(
     mandate_id: str,
-    body: FeedbackRequest,
+    body: dict[str, Any],
     _user: Any = Depends(require_action_any_workspace("belt.manage")),
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> dict[str, Any]:
-    """Intake patrol — file human feedback as a Sighting on the mandate."""
-    return await mandate_service.file_feedback(workspace_id, user_id, mandate_id, body.model_dump())
+    """Intake patrol — file human feedback as a Sighting on the mandate.
+
+    Two body shapes (UI contract), discriminated on the presence of ``kind``;
+    the SERVICE validates the raw dict against the matching schema at entry
+    (the validate-at-entry rule holds — discrimination just happens first):
+
+    * GENERAL  — ``{text, severity?, source}`` → the sighting wire dict
+      (autopilot and integrations keep using this).
+    * TEACHING — ``{kind: reject|edit|plan, reason, shift_no?, task_title?}``
+      → ``{"ok": true}`` (the gate UI's teaching channel)."""
+    return await mandate_service.file_feedback(workspace_id, user_id, mandate_id, body)
 
 
 @router.get("/{mandate_id}/sightings")
@@ -104,8 +120,64 @@ async def trigger_shift(
     user_id: str = Depends(current_user_id),
 ) -> dict[str, Any]:
     """Run a SHIFT — the foreman plans a few tasks; the plan routes through the
-    Instinct plan gate. Demo-bar manual trigger (admin-gated)."""
+    Instinct plan gate. Demo-bar manual trigger (admin-gated). Returns
+    ``{"shift": {...}}`` (UI contract envelope)."""
     return await mandate_service.trigger_shift(workspace_id, user_id, mandate_id)
+
+
+@router.post("/{mandate_id}/plan/resolve")
+async def resolve_plan(
+    mandate_id: str,
+    body: dict[str, Any],
+    user: Any = Depends(require_action_any_workspace("belt.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """The console's authoritative gate action (UI contract): per-task verdicts
+    for an in_gate shift plan → ``{"shift": {...}}``.
+
+    The verdicts are MAPPED ONTO THE REAL INSTINCT PATH — the single chain
+    authority — so the decision chain still closes exactly once in the same
+    code the Tray uses:
+
+    * any approved/edited subset → ``approve_action`` WITH EDITS (the blob's
+      task list filtered + retitled; Corrections recorded; the plan executor
+      dispatches the kept tasks as belt runs).
+    * all tasks rejected → ``reject_action`` (router closes the chain; the
+      shift records the rejection).
+
+    Rejected tasks are recorded as teaching sightings (reason + task title) so
+    the foreman's next digest learns. Decision ``index`` is 0-based into the
+    plan's tasks array, and every task must carry exactly one decision."""
+    orders = await mandate_service.prepare_plan_resolution(workspace_id, user_id, mandate_id, body)
+
+    # Lazy import — the mandates router must not put a module-top dependency on
+    # the instinct package (mirrors how the instinct router lazy-imports the
+    # mandates executor on its approve path).
+    from pocketpaw_ee.instinct.router import (
+        ApproveRequest,
+        RejectRequest,
+        approve_action,
+        reject_action,
+    )
+
+    if orders["mode"] == "reject":
+        await reject_action(
+            orders["action_id"],
+            req=RejectRequest(reason=str(orders.get("reject_reason") or "")),
+            user=user,
+            workspace_id=workspace_id,
+        )
+    else:
+        req = ApproveRequest(parameters=orders["parameters"]) if orders["edited"] else None
+        await approve_action(
+            orders["action_id"],
+            req=req,
+            user=user,
+            workspace_id=workspace_id,
+        )
+
+    return {"shift": await mandate_service.shift_wire(workspace_id, orders["shift_id"])}
 
 
 @router.get("/{mandate_id}/pawprints")

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -64,7 +64,9 @@ def _charter_from_request(req: CreateMandateRequest) -> Charter:
 def _charter_to_wire(charter: Charter) -> dict[str, Any]:
     return {
         "goal": charter.goal,
-        "kpis": [{"name": k.name, "target": k.target, "direction": k.direction} for k in charter.kpis],
+        "kpis": [
+            {"name": k.name, "target": k.target, "direction": k.direction} for k in charter.kpis
+        ],
         "says_no": list(charter.says_no),
         "boundaries": list(charter.boundaries),
         "budget": {
@@ -132,7 +134,9 @@ async def create_mandate(workspace_id: str, user_id: str, body: Any) -> dict[str
             }
         )
     )
-    logger.info("mandate: created %s (workspace=%s, repo=%s)", doc.id, workspace_id, body.surface.repo_id)
+    logger.info(
+        "mandate: created %s (workspace=%s, repo=%s)", doc.id, workspace_id, body.surface.repo_id
+    )
     return await _mandate_detail_wire(doc)
 
 
@@ -142,11 +146,7 @@ async def list_mandates(workspace_id: str, user_id: str, body: Any = None) -> di
     Health = last shift state, open gate count (shifts awaiting approval), and
     total sighting count. ``body`` is unused (read path)."""
     # no-event: read-only path; emit only on writes.
-    docs = (
-        await MandateDoc.find(MandateDoc.workspace == workspace_id)
-        .sort("-createdAt")
-        .to_list()
-    )
+    docs = await MandateDoc.find(MandateDoc.workspace == workspace_id).sort("-createdAt").to_list()
     out: list[dict[str, Any]] = []
     for doc in docs:
         mandate_id = str(doc.id)
@@ -198,9 +198,7 @@ async def _mandate_detail_wire(doc: MandateDoc) -> dict[str, Any]:
     mandate_id = str(doc.id)
     workspace_id = doc.workspace
     recent_shifts = (
-        await ShiftDoc.find(
-            ShiftDoc.workspace == workspace_id, ShiftDoc.mandate_id == mandate_id
-        )
+        await ShiftDoc.find(ShiftDoc.workspace == workspace_id, ShiftDoc.mandate_id == mandate_id)
         .sort("-no")
         .limit(10)
         .to_list()
@@ -239,7 +237,9 @@ async def _mandate_detail_wire(doc: MandateDoc) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-async def file_feedback(workspace_id: str, user_id: str, mandate_id: str, body: Any) -> dict[str, Any]:
+async def file_feedback(
+    workspace_id: str, user_id: str, mandate_id: str, body: Any
+) -> dict[str, Any]:
     """Intake patrol — turn a human's feedback into a Sighting.
 
     Severity defaults to 3 (mid) when omitted. The sighting's ``patrol`` is
@@ -302,9 +302,7 @@ async def run_patrols(workspace_id: str, user_id: str, mandate_id: str) -> dict[
     existing = await SightingDoc.find(
         SightingDoc.workspace == workspace_id, SightingDoc.mandate_id == mandate_id
     ).to_list()
-    seen_keys = {
-        (s.patrol, str((s.evidence or {}).get("package") or s.summary)) for s in existing
-    }
+    seen_keys = {(s.patrol, str((s.evidence or {}).get("package") or s.summary)) for s in existing}
 
     created: list[SightingDoc] = []
     for patrol_name, patrol in PATROLS.items():
@@ -359,15 +357,634 @@ def _sighting_to_wire(s: SightingDoc) -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Shift trigger — foreman → plan gate (slice 4)
+# ---------------------------------------------------------------------------
+
+
+async def trigger_shift(workspace_id: str, user_id: str, mandate_id: str) -> dict[str, Any]:
+    """Run one SHIFT: sense (patrols) → judge (foreman, ONE LLM call) →
+    machine-validate → route the plan through the Instinct PLAN GATE as a
+    ``belt_plan`` proposal, or stand the shift down on an empty plan.
+
+    DEMO BAR: manual trigger only (``cadence`` scheduling is a later PR).
+
+    Terminal shapes:
+      * tasks planned   → ShiftDoc(state="in_gate", plan_action_id=...) and a
+        pending Instinct Action; the chain opened with ``agent.proposed`` —
+        the approve/reject paths close it (executor / router).
+      * empty plan      → ShiftDoc(state="stood_down") — a SUCCESS state. The
+        chain opens AND closes here (``agent.proposed`` →
+        ``decision.completed(passed=True, action_outcome="stood_down")``) —
+        exactly ONE terminal; no human gate for a no-op.
+      * validation fail → ValidationError (422); the shift stays ``planning``
+        with the violations recorded on its outcome. # no-event on the raise
+        path beyond the shift-started emit: the shift row carries the state.
+    """
+    from uuid import uuid4
+
+    from pocketpaw_ee.cloud.mandates import foreman as foreman_mod
+    from pocketpaw_ee.cloud.mandates import soul_link
+
+    doc = await _fetch_mandate(workspace_id, mandate_id)
+    if doc.status != "active":
+        raise ValidationError(
+            "mandate.paused", "This mandate is paused — resume it before running a shift"
+        )
+
+    # 1. SENSE — run the patrols so the foreman sees fresh signals.
+    await run_patrols(workspace_id, user_id, mandate_id)
+
+    # 2. Open the shift row (state=planning) — the durable record that a
+    #    judgment was attempted, even if the foreman fails.
+    last = (
+        await ShiftDoc.find(ShiftDoc.workspace == workspace_id, ShiftDoc.mandate_id == mandate_id)
+        .sort("-no")
+        .first_or_none()
+    )
+    shift_no = (last.no if last else 0) + 1
+    shift = ShiftDoc(workspace=workspace_id, mandate_id=mandate_id, no=shift_no, state="planning")
+    await shift.insert()
+    await emit(
+        mandate_events.MandateShiftStarted(
+            data={
+                "workspace_id": workspace_id,
+                "mandate_id": mandate_id,
+                "shift_id": str(shift.id),
+                "no": shift_no,
+            }
+        )
+    )
+
+    # 3. JUDGE — assemble the context and make the ONE foreman call.
+    charter_wire = _charter_to_wire(doc.charter)
+    since = last.createdAt if last else None
+    all_sightings = (
+        await SightingDoc.find(
+            SightingDoc.workspace == workspace_id, SightingDoc.mandate_id == mandate_id
+        )
+        .sort("-ts")
+        .to_list()
+    )
+    digest = [
+        {"id": str(s.id), "patrol": s.patrol, "severity": s.severity, "summary": s.summary}
+        for s in all_sightings
+        if since is None or _aware(s.ts) > _aware(since)
+    ]
+    history_docs = (
+        await ShiftDoc.find(
+            ShiftDoc.workspace == workspace_id,
+            ShiftDoc.mandate_id == mandate_id,
+            ShiftDoc.no < shift_no,
+        )
+        .sort("-no")
+        .limit(3)
+        .to_list()
+    )
+    history = [{"no": h.no, "state": h.state, "outcome": h.outcome} for h in reversed(history_docs)]
+    soul_context = await soul_link.recall_for_planning(
+        doc.soul_path, f"{doc.name} {doc.charter.goal}"
+    )
+
+    context = foreman_mod.ForemanContext(
+        shift_no=shift_no,
+        charter=charter_wire,
+        sightings=digest,
+        history=history,
+        soul_context=soul_context,
+    )
+    try:
+        plan = await foreman_mod.plan_shift(context)
+    except Exception as exc:  # noqa: BLE001 — surface a clean upstream failure
+        from pocketpaw_ee.cloud._core.errors import CloudError
+
+        await mark_shift(
+            workspace_id=workspace_id,
+            shift_id=str(shift.id),
+            state="planning",
+            outcome=f"foreman call failed: {exc}",
+        )
+        raise CloudError(
+            502, "mandate.foreman_failed", f"The foreman's judgment call failed: {exc}"
+        ) from exc
+
+    # 4. MACHINE VALIDATION — action fields + structure ONLY (never ``why``).
+    violations = foreman_mod.validate_plan(plan, charter_wire)
+    if violations:
+        await mark_shift(
+            workspace_id=workspace_id,
+            shift_id=str(shift.id),
+            state="planning",
+            outcome="plan refused by machine validation: " + "; ".join(violations),
+        )
+        raise ValidationError("mandate.plan_invalid", "; ".join(violations))
+
+    # 5a. EMPTY PLAN — stand the shift down. A success, not an error: the
+    #     chain opens and closes here with exactly ONE terminal.
+    if plan.no_action:
+        correlation_id = uuid4()
+        proposed_event_id = _emit_agent_proposed_plan(
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            mandate_name=doc.name,
+            shift_no=shift_no,
+            task_count=0,
+            no_action=True,
+        )
+        _emit_stood_down_close(
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            reason=plan.no_action_reason or "",
+            causation_id=proposed_event_id,
+        )
+        outcome = f"stood down: {plan.no_action_reason or 'no action needed'}"
+        await mark_shift(
+            workspace_id=workspace_id,
+            shift_id=str(shift.id),
+            state="stood_down",
+            outcome=outcome,
+        )
+        await soul_link.remember_shift(
+            doc.soul_path, f"Mandate '{doc.name}' shift {shift_no} {outcome}"
+        )
+        return {
+            "shift_id": str(shift.id),
+            "no": shift_no,
+            "state": "stood_down",
+            "plan_action_id": None,
+            "task_count": 0,
+            "no_action_reason": plan.no_action_reason,
+        }
+
+    # 5b. TASK PLAN — propose through the Instinct PLAN GATE as a ``belt_plan``
+    #     Action. Mirrors the belt MCP propose: mint the chain correlation_id
+    #     BEFORE building the blob; confirm the Action is durable; THEN open the
+    #     chain and back-write the proposed event id.
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+    from pocketpaw_ee.cloud.mandates.executor import BELT_PLAN_PARAM_KEY, BELT_PLAN_SCHEMA
+
+    correlation_id = uuid4()
+    blob: dict[str, Any] = {
+        "kind": "belt_plan",
+        "schema": BELT_PLAN_SCHEMA,
+        "mandate_id": mandate_id,
+        "shift_id": str(shift.id),
+        "shift_no": shift_no,
+        "plan": plan.model_dump(),
+        # Budget snapshot — the executor re-validates it is UNCHANGED at
+        # approval time.
+        "budget_max_tasks": doc.charter.budget.max_tasks_per_shift,
+        "soul_path": doc.soul_path,
+        "workspace_id": workspace_id,
+        "requested_by": user_id,
+        "correlation_id": str(correlation_id),
+        "proposed_event_id": None,
+    }
+
+    titles = "; ".join(t.title for t in plan.tasks)
+    title = f"Shift plan — {doc.name} (shift {shift_no})"
+    recommendation = (
+        f"Approve to dispatch {len(plan.tasks)} task(s) as Belt runs for mandate "
+        f"'{doc.name}': {titles[:400]}"
+    )
+    trigger = ActionTrigger(
+        type="agent",
+        source="belt:mandate-foreman",
+        reason="shift plan proposed by the mandate foreman — requires human approval",
+    )
+    store = get_instinct_store()
+    try:
+        action = await store.propose(
+            pocket_id=workspace_id,
+            title=title,
+            description=recommendation,
+            recommendation=recommendation,
+            trigger=trigger,
+            category=ActionCategory.EXTERNAL,
+            priority=ActionPriority.HIGH,
+            parameters={BELT_PLAN_PARAM_KEY: blob},
+            assignee=user_id,
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        from pocketpaw_ee.cloud._core.errors import CloudError
+
+        await mark_shift(
+            workspace_id=workspace_id,
+            shift_id=str(shift.id),
+            state="planning",
+            outcome=f"gate proposal failed: {exc}",
+        )
+        raise CloudError(
+            502, "mandate.gate_propose_failed", f"could not propose the plan: {exc}"
+        ) from exc
+
+    # NO phantom success — confirm the Action is durably readable.
+    stored = await store.get_action(action.id)
+    if stored is None:
+        from pocketpaw_ee.cloud._core.errors import CloudError
+
+        raise CloudError(502, "mandate.gate_propose_failed", "the plan was not stored — retry")
+
+    proposed_event_id = _emit_agent_proposed_plan(
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        mandate_name=doc.name,
+        shift_no=shift_no,
+        task_count=len(plan.tasks),
+        no_action=False,
+        action_id=str(action.id),
+    )
+    if proposed_event_id is not None:
+        await _persist_plan_chain_ids(
+            store=store,
+            action_id=str(action.id),
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    await mark_shift(
+        workspace_id=workspace_id,
+        shift_id=str(shift.id),
+        state="in_gate",
+        plan_action_id=str(action.id),
+    )
+    logger.info(
+        "mandate: shift %s of %s proposed %d task(s) via belt_plan action %s (correlation_id=%s)",
+        shift_no,
+        mandate_id,
+        len(plan.tasks),
+        action.id,
+        correlation_id,
+    )
+    return {
+        "shift_id": str(shift.id),
+        "no": shift_no,
+        "state": "in_gate",
+        "plan_action_id": str(action.id),
+        "task_count": len(plan.tasks),
+        "no_action_reason": None,
+    }
+
+
+def _aware(ts: datetime) -> datetime:
+    """Normalize a possibly-naive datetime to UTC-aware for comparisons
+    (mongomock round-trips naive datetimes)."""
+    return ts if ts.tzinfo is not None else ts.replace(tzinfo=UTC)
+
+
+def _emit_agent_proposed_plan(
+    *,
+    correlation_id: Any,
+    workspace_id: str,
+    user_id: str,
+    mandate_name: str,
+    shift_no: int,
+    task_count: int,
+    no_action: bool,
+    action_id: str | None = None,
+) -> Any | None:
+    """Open the Decision-Graph chain for a shift plan (``agent.proposed``).
+
+    Returns the emitted event id for causation chaining, or None when the emit
+    raised — best-effort per RFC 09 (the reconciler picks up orphans)."""
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"shift {shift_no} of mandate '{mandate_name}' — " + (
+        "stand down (no action)" if no_action else f"plan {task_count} task(s)"
+    )
+    payload: dict[str, Any] = {
+        "intent": intent,
+        "action": "belt_plan",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        "proposal_kind": "belt_plan",
+        "shift_no": shift_no,
+        "task_count": task_count,
+        "no_action": no_action,
+    }
+    if action_id:
+        payload["action_id"] = action_id
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "mandate agent.proposed emit failed for correlation_id=%s — reconciler will catch up",
+            correlation_id,
+            exc_info=True,
+        )
+        return None
+
+
+def _emit_stood_down_close(
+    *,
+    correlation_id: Any,
+    workspace_id: str,
+    user_id: str,
+    reason: str,
+    causation_id: Any | None,
+) -> None:
+    """Close a stood-down shift's chain with its ONE terminal —
+    ``decision.completed(passed=True, action_outcome="stood_down")``. A
+    stood-down shift is a SUCCESS (the foreman judged no action was needed)."""
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": True,
+        "action_outcome": "stood_down",
+        "task_count": 0,
+    }
+    if reason:
+        payload["reason"] = reason
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "mandate stood_down chain close failed for correlation_id=%s — "
+            "reconciler will catch up",
+            correlation_id,
+            exc_info=True,
+        )
+
+
+async def _persist_plan_chain_ids(*, store: Any, action_id: str, proposed_event_id: str) -> None:
+    """Back-write ``proposed_event_id`` onto the persisted ``_belt_plan`` blob
+    (the correlation_id was minted before the blob was built, so it's already
+    correct). Direct SQL update — the same pattern the belt MCP propose uses.
+    Best-effort."""
+    import json as _json
+
+    import aiosqlite
+
+    from pocketpaw_ee.cloud.mandates.executor import BELT_PLAN_PARAM_KEY
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(BELT_PLAN_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["proposed_event_id"] = proposed_event_id
+        params[BELT_PLAN_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "mandate: failed to persist chain ids onto action %s — human.corrected "
+            "will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pawprints — the past-tense event feed (slice 5)
+# ---------------------------------------------------------------------------
+
+
+async def get_pawprints(workspace_id: str, user_id: str, mandate_id: str) -> dict[str, Any]:
+    """Walk the mandate's shift history + decision chains into a past-tense
+    event feed: shift n proposed / approved / rejected / executed / failed /
+    stood_down, with the evidence (sighting) refs the plan cited.
+
+    Sources: the ShiftDoc rows (state + outcome) and each shift's ``belt_plan``
+    Instinct Action (status + the plan blob's evidence refs) — the same records
+    the decision chain folded from, read through the store instead of replaying
+    the journal at demo bar."""
+    # no-event: read-only path; emit only on writes.
+    await _fetch_mandate(workspace_id, mandate_id)
+    shifts = (
+        await ShiftDoc.find(ShiftDoc.workspace == workspace_id, ShiftDoc.mandate_id == mandate_id)
+        .sort("+no")
+        .to_list()
+    )
+
+    from pocketpaw.stores import get_instinct_store
+    from pocketpaw_ee.cloud.mandates.executor import BELT_PLAN_PARAM_KEY
+
+    store = get_instinct_store()
+    prints: list[dict[str, Any]] = []
+    for shift in shifts:
+        if shift.state == "stood_down":
+            prints.append(
+                {
+                    "shift_no": shift.no,
+                    "kind": "stood_down",
+                    "text": f"Shift {shift.no}: the foreman stood down — "
+                    f"{(shift.outcome or 'no action needed').removeprefix('stood down: ')}",
+                    "evidence_refs": [],
+                    "ts": shift.updatedAt,
+                    "extra": {},
+                }
+            )
+            continue
+        if shift.state == "planning":
+            text = f"Shift {shift.no}: planning"
+            if shift.outcome:
+                text = f"Shift {shift.no}: plan did not reach the gate — {shift.outcome}"
+            prints.append(
+                {
+                    "shift_no": shift.no,
+                    "kind": "planning",
+                    "text": text,
+                    "evidence_refs": [],
+                    "ts": shift.updatedAt,
+                    "extra": {},
+                }
+            )
+            continue
+
+        # in_gate / executing / done — read the plan Action for status + refs.
+        action = None
+        if shift.plan_action_id:
+            try:
+                action = await store.get_action(shift.plan_action_id)
+            except Exception:  # noqa: BLE001 — a store hiccup degrades the feed
+                logger.debug("mandate: pawprints action read failed", exc_info=True)
+        blob = (
+            (getattr(action, "parameters", None) or {}).get(BELT_PLAN_PARAM_KEY) if action else None
+        )
+        tasks = (blob or {}).get("plan", {}).get("tasks", []) if isinstance(blob, dict) else []
+        refs = sorted({r for t in tasks for r in (t.get("evidence_refs") or [])})
+        task_count = len(tasks)
+
+        prints.append(
+            {
+                "shift_no": shift.no,
+                "kind": "proposed",
+                "text": f"Shift {shift.no}: the foreman proposed {task_count} task(s) "
+                "through the plan gate",
+                "evidence_refs": refs,
+                "ts": shift.createdAt,
+                "extra": {"plan_action_id": shift.plan_action_id},
+            }
+        )
+        status = str(getattr(getattr(action, "status", None), "value", "") or "")
+        if status in ("approved", "executed", "failed"):
+            prints.append(
+                {
+                    "shift_no": shift.no,
+                    "kind": "approved",
+                    "text": f"Shift {shift.no}: a human approved the plan at the gate",
+                    "evidence_refs": refs,
+                    "ts": shift.updatedAt,
+                    "extra": {},
+                }
+            )
+        if status == "rejected":
+            prints.append(
+                {
+                    "shift_no": shift.no,
+                    "kind": "rejected",
+                    "text": f"Shift {shift.no}: a human rejected the plan at the gate"
+                    + (f" — {shift.outcome}" if shift.outcome else ""),
+                    "evidence_refs": refs,
+                    "ts": shift.updatedAt,
+                    "extra": {},
+                }
+            )
+        elif status == "executed":
+            prints.append(
+                {
+                    "shift_no": shift.no,
+                    "kind": "executed",
+                    "text": f"Shift {shift.no}: "
+                    + (shift.outcome or f"dispatched {task_count} task(s) as belt runs"),
+                    "evidence_refs": refs,
+                    "ts": shift.updatedAt,
+                    "extra": {"outcome": getattr(action, "outcome", None)},
+                }
+            )
+        elif status == "failed":
+            prints.append(
+                {
+                    "shift_no": shift.no,
+                    "kind": "failed",
+                    "text": f"Shift {shift.no}: the approved plan failed to dispatch"
+                    + (f" — {shift.outcome}" if shift.outcome else ""),
+                    "evidence_refs": refs,
+                    "ts": shift.updatedAt,
+                    "extra": {},
+                }
+            )
+    return {"pawprints": prints}
+
+
+# ---------------------------------------------------------------------------
+# Executor-facing helpers (the executor never imports Beanie models)
+# ---------------------------------------------------------------------------
+
+
+async def executor_revalidate(workspace_id: str, mandate_id: str) -> dict[str, Any]:
+    """Approve-time re-validation read for the plan executor: does the mandate
+    still exist, is it active, what is the CURRENT budget."""
+    # no-event: read-only path; emit only on writes.
+    try:
+        doc = await MandateDoc.find_one(
+            MandateDoc.workspace == workspace_id, MandateDoc.id == _as_object_id(mandate_id)
+        )
+    except Exception:  # noqa: BLE001 — malformed id == gone
+        doc = None
+    if doc is None:
+        return {"exists": False, "active": False, "budget_max_tasks": 0}
+    return {
+        "exists": True,
+        "active": doc.status == "active",
+        "budget_max_tasks": doc.charter.budget.max_tasks_per_shift,
+    }
+
+
+async def mark_shift(
+    *,
+    workspace_id: str,
+    shift_id: str,
+    state: str,
+    outcome: str | None = None,
+    plan_action_id: str | None = None,
+) -> None:
+    """State-transition a shift row (tenant-scoped). Used by the trigger path
+    and (via a best-effort wrapper) the plan executor + the router's reject
+    hook. Unknown shift ids are a logged no-op — the Instinct outcome stays the
+    source of truth."""
+    try:
+        doc = await ShiftDoc.find_one(
+            ShiftDoc.workspace == workspace_id, ShiftDoc.id == _as_object_id(shift_id)
+        )
+    except Exception:  # noqa: BLE001
+        doc = None
+    if doc is None:
+        logger.warning("mandate: shift %s not found for state write %s", shift_id, state)
+        return
+    doc.state = state  # type: ignore[assignment]
+    if outcome is not None:
+        doc.outcome = outcome
+    if plan_action_id is not None:
+        doc.plan_action_id = plan_action_id
+    await doc.save()
+    await emit(
+        mandate_events.MandateShiftUpdated(
+            data={
+                "workspace_id": workspace_id,
+                "mandate_id": doc.mandate_id,
+                "shift_id": shift_id,
+                "no": doc.no,
+                "state": state,
+            }
+        )
+    )
+
+
 def _utcnow() -> datetime:
     return datetime.now(UTC)
 
 
 __all__ = [
     "create_mandate",
+    "executor_revalidate",
     "file_feedback",
     "get_mandate",
+    "get_pawprints",
     "list_mandates",
     "list_sightings",
+    "mark_shift",
     "run_patrols",
+    "trigger_shift",
 ]

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -512,6 +512,8 @@ async def trigger_shift(workspace_id: str, user_id: str, mandate_id: str) -> dic
     except Exception as exc:  # noqa: BLE001 — surface a clean upstream failure
         from pocketpaw_ee.cloud._core.errors import CloudError
 
+        # Failure path keeps the state UNCHANGED ("planning") and only records
+        # the failure on ``outcome`` — the shift never advances on a bad call.
         await mark_shift(
             workspace_id=workspace_id,
             shift_id=str(shift.id),
@@ -992,7 +994,14 @@ async def prepare_plan_resolution(
 
 
 async def shift_wire(workspace_id: str, shift_id: str) -> dict[str, Any]:
-    """Refresh one shift's wire dict (the resolve response's ``shift``)."""
+    """Refresh one shift's wire dict (the resolve response's ``shift``).
+
+    Shape-matched to ``trigger_shift``'s ``shift`` payload (shift_id, no,
+    state, plan_action_id, task_count, no_action_reason) so POST /shift and
+    POST /plan/resolve return the same shape; ``outcome`` rides along as a
+    resolve-path extra (the dispatch/rejection text the console can show).
+    ``task_count`` reads the plan Action's CURRENT task list, so a resolve
+    that dropped tasks reports the kept count."""
     # no-event: read-only path; emit only on writes.
     try:
         doc = await ShiftDoc.find_one(
@@ -1002,11 +1011,31 @@ async def shift_wire(workspace_id: str, shift_id: str) -> dict[str, Any]:
         doc = None
     if doc is None:
         raise NotFound("shift", shift_id)
+
+    task_count = 0
+    if doc.plan_action_id:
+        from pocketpaw.stores import get_instinct_store
+        from pocketpaw_ee.cloud.mandates.executor import BELT_PLAN_PARAM_KEY
+
+        try:
+            action = await get_instinct_store().get_action(doc.plan_action_id)
+            blob = (getattr(action, "parameters", None) or {}).get(BELT_PLAN_PARAM_KEY)
+            if isinstance(blob, dict):
+                task_count = len((blob.get("plan") or {}).get("tasks") or [])
+        except Exception:  # noqa: BLE001 — count degrades to 0, never breaks the read
+            logger.debug("mandate: shift_wire task count read failed", exc_info=True)
+
+    no_action_reason = None
+    if doc.state == "stood_down" and doc.outcome:
+        no_action_reason = doc.outcome.removeprefix("stood down: ")
+
     return {
         "shift_id": str(doc.id),
         "no": doc.no,
         "state": doc.state,
         "plan_action_id": doc.plan_action_id,
+        "task_count": task_count,
+        "no_action_reason": no_action_reason,
         "outcome": doc.outcome,
     }
 

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -37,6 +37,7 @@ from pocketpaw_ee.cloud.mandates.domain import (
 from pocketpaw_ee.cloud.mandates.dto import (
     CreateMandateRequest,
     FeedbackRequest,
+    TeachingFeedbackRequest,
 )
 
 logger = logging.getLogger(__name__)
@@ -122,6 +123,7 @@ async def create_mandate(workspace_id: str, user_id: str, body: Any) -> dict[str
         charter=_charter_from_request(body),
         status="active",
         soul_path=body.soul_path,
+        patrols=list(body.patrols),
     )
     await doc.insert()
 
@@ -137,7 +139,9 @@ async def create_mandate(workspace_id: str, user_id: str, body: Any) -> dict[str
     logger.info(
         "mandate: created %s (workspace=%s, repo=%s)", doc.id, workspace_id, body.surface.repo_id
     )
-    return await _mandate_detail_wire(doc)
+    # UI contract — the create response wraps the detail in a ``mandate``
+    # envelope; GET /belt/mandates/{id} stays bare.
+    return {"mandate": await _mandate_detail_wire(doc)}
 
 
 async def list_mandates(workspace_id: str, user_id: str, body: Any = None) -> dict[str, Any]:
@@ -217,6 +221,7 @@ async def _mandate_detail_wire(doc: MandateDoc) -> dict[str, Any]:
         "surface": {"repo_id": doc.surface.repo_id},
         "charter": _charter_to_wire(doc.charter),
         "soul_path": doc.soul_path,
+        "patrols": list(doc.patrols),
         "recent_shifts": [
             {
                 "id": str(s.id),
@@ -242,10 +247,53 @@ async def file_feedback(
 ) -> dict[str, Any]:
     """Intake patrol — turn a human's feedback into a Sighting.
 
-    Severity defaults to 3 (mid) when omitted. The sighting's ``patrol`` is
-    ``"feedback"`` and the ``source`` rides on the evidence so the foreman can
-    weight it."""
-    body = FeedbackRequest.model_validate(body)
+    Two body shapes (UI contract), discriminated on the presence of ``kind``:
+
+    * GENERAL — ``{text, severity?, source}`` (autopilot / integrations).
+      Severity defaults to 3 (mid). Returns the sighting wire dict.
+    * TEACHING — ``{kind: reject|edit|plan, reason, shift_no?, task_title?}``
+      (the gate UI's human-teaching channel from rejections/edits). Returns
+      ``{"ok": true}``.
+
+    Both shapes persist a ``patrol="feedback"`` Sighting so the foreman's next
+    digest sees the signal; teaching items carry the gate context on the
+    evidence."""
+    raw = dict(body or {})
+    if "kind" in raw:
+        teaching = TeachingFeedbackRequest.model_validate(raw)
+        # Tenant gate — a mandate in another workspace is a 404.
+        await _fetch_mandate(workspace_id, mandate_id)
+        summary = f"[gate {teaching.kind}] {teaching.reason.strip()}"[:280]
+        sighting = SightingDoc(
+            workspace=workspace_id,
+            mandate_id=mandate_id,
+            patrol="feedback",
+            severity=3,
+            summary=summary,
+            evidence={
+                "source": "gate",
+                "kind": teaching.kind,
+                "filed_by": user_id,
+                "reason": teaching.reason.strip(),
+                "shift_no": teaching.shift_no,
+                "task_title": teaching.task_title,
+            },
+        )
+        await sighting.insert()
+        await emit(
+            mandate_events.MandateSightingAdded(
+                data={
+                    "workspace_id": workspace_id,
+                    "mandate_id": mandate_id,
+                    "sighting_id": str(sighting.id),
+                    "patrol": "feedback",
+                    "severity": 3,
+                }
+            )
+        )
+        return {"ok": True}
+
+    body = FeedbackRequest.model_validate(raw)
     # Tenant gate — a mandate in another workspace is a 404.
     await _fetch_mandate(workspace_id, mandate_id)
 
@@ -305,7 +353,13 @@ async def run_patrols(workspace_id: str, user_id: str, mandate_id: str) -> dict[
     seen_keys = {(s.patrol, str((s.evidence or {}).get("package") or s.summary)) for s in existing}
 
     created: list[SightingDoc] = []
+    enabled = set(doc.patrols or [])
     for patrol_name, patrol in PATROLS.items():
+        # UI contract — the mandate's ``patrols`` toggles scope the sense loop;
+        # an un-toggled patrol never runs. (The "feedback" intake endpoint is a
+        # human channel and stays open regardless — it has no sense callable.)
+        if patrol_name not in enabled:
+            continue
         try:
             drafts = await patrol(doc.surface.repo_id)
         except Exception:  # noqa: BLE001 — a broken patrol must not wedge the shift
@@ -509,13 +563,16 @@ async def trigger_shift(workspace_id: str, user_id: str, mandate_id: str) -> dic
         await soul_link.remember_shift(
             doc.soul_path, f"Mandate '{doc.name}' shift {shift_no} {outcome}"
         )
+        # UI contract — the shift response rides a ``shift`` envelope.
         return {
-            "shift_id": str(shift.id),
-            "no": shift_no,
-            "state": "stood_down",
-            "plan_action_id": None,
-            "task_count": 0,
-            "no_action_reason": plan.no_action_reason,
+            "shift": {
+                "shift_id": str(shift.id),
+                "no": shift_no,
+                "state": "stood_down",
+                "plan_action_id": None,
+                "task_count": 0,
+                "no_action_reason": plan.no_action_reason,
+            }
         }
 
     # 5b. TASK PLAN — propose through the Instinct PLAN GATE as a ``belt_plan``
@@ -612,6 +669,23 @@ async def trigger_shift(workspace_id: str, user_id: str, mandate_id: str) -> dic
         state="in_gate",
         plan_action_id=str(action.id),
     )
+    # UI contract — announce the new plan proposal on the ``belt_plan`` topic
+    # (workspace fan-out, mirroring how belt_run_updated rides the bus). The
+    # page subscribing to this topic reads {mandate_id, proposal}.
+    await emit(
+        mandate_events.BeltPlanProposed(
+            data={
+                "workspace_id": workspace_id,
+                "mandate_id": mandate_id,
+                "proposal": {
+                    "plan_action_id": str(action.id),
+                    "shift_id": str(shift.id),
+                    "shift_no": shift_no,
+                    **plan.model_dump(),
+                },
+            }
+        )
+    )
     logger.info(
         "mandate: shift %s of %s proposed %d task(s) via belt_plan action %s (correlation_id=%s)",
         shift_no,
@@ -620,13 +694,16 @@ async def trigger_shift(workspace_id: str, user_id: str, mandate_id: str) -> dic
         action.id,
         correlation_id,
     )
+    # UI contract — the shift response rides a ``shift`` envelope.
     return {
-        "shift_id": str(shift.id),
-        "no": shift_no,
-        "state": "in_gate",
-        "plan_action_id": str(action.id),
-        "task_count": len(plan.tasks),
-        "no_action_reason": None,
+        "shift": {
+            "shift_id": str(shift.id),
+            "no": shift_no,
+            "state": "in_gate",
+            "plan_action_id": str(action.id),
+            "task_count": len(plan.tasks),
+            "no_action_reason": None,
+        }
     }
 
 
@@ -776,14 +853,179 @@ async def _persist_plan_chain_ids(*, store: Any, action_id: str, proposed_event_
 
 
 # ---------------------------------------------------------------------------
+# Plan resolve (UI contract) — map per-task gate verdicts onto the Instinct path
+# ---------------------------------------------------------------------------
+
+
+async def prepare_plan_resolution(
+    workspace_id: str, user_id: str, mandate_id: str, body: Any
+) -> dict[str, Any]:
+    """Validate a console plan-resolution and translate it into ONE Instinct
+    transition the router then performs through the REAL approve/reject path.
+
+    The instinct gate stays the single authority: an approved/edited subset
+    becomes an APPROVE-WITH-EDITS (the blob's task list filtered + retitled —
+    the same Corrections machinery every instinct edit uses), and an all-reject
+    becomes a plain REJECT. The chain therefore closes exactly once, in the
+    same code paths the Tray uses. Rejected tasks are recorded as teaching
+    sightings (the feedback patrol) so the foreman's next digest learns.
+
+    Rules: the shift must be ``in_gate`` with a plan Action still PENDING;
+    decision ``index`` is 0-BASED into the plan's tasks array; EVERY task must
+    carry exactly one decision (explicit beats implicit at a human gate).
+
+    Returns the router's marching orders:
+    ``{action_id, shift_id, mode: "approve"|"reject", parameters?, edited,
+    reject_reason?}`` — ``parameters`` (approve mode) is the full edited
+    parameters dict for ``ApproveRequest``; ``edited`` says whether any task
+    was edited/dropped (drives the corrections path)."""
+    from pocketpaw.stores import get_instinct_store
+    from pocketpaw_ee.cloud.mandates.dto import ResolvePlanRequest
+    from pocketpaw_ee.cloud.mandates.executor import BELT_PLAN_PARAM_KEY
+
+    body = ResolvePlanRequest.model_validate(body)
+    await _fetch_mandate(workspace_id, mandate_id)
+
+    shift = await ShiftDoc.find_one(
+        ShiftDoc.workspace == workspace_id,
+        ShiftDoc.mandate_id == mandate_id,
+        ShiftDoc.no == body.shift_no,
+    )
+    if shift is None:
+        raise NotFound("shift", str(body.shift_no))
+    if shift.state != "in_gate" or not shift.plan_action_id:
+        raise ValidationError(
+            "mandate.shift_not_in_gate",
+            f"shift {body.shift_no} is {shift.state!r} — only an in_gate shift can be resolved",
+        )
+
+    store = get_instinct_store()
+    action = await store.get_action(shift.plan_action_id)
+    params = dict(getattr(action, "parameters", None) or {}) if action else {}
+    blob = params.get(BELT_PLAN_PARAM_KEY)
+    if action is None or not isinstance(blob, dict):
+        raise ValidationError(
+            "mandate.plan_missing", "the shift's plan Action is missing or malformed"
+        )
+    status = str(getattr(getattr(action, "status", None), "value", "") or "")
+    if status != "pending":
+        raise ValidationError("mandate.plan_already_resolved", f"the plan is already {status}")
+
+    tasks = list((blob.get("plan") or {}).get("tasks") or [])
+    by_index: dict[int, Any] = {}
+    for d in body.decisions:
+        if d.index >= len(tasks):
+            raise ValidationError(
+                "mandate.bad_decision_index",
+                f"decision index {d.index} is out of range (plan has {len(tasks)} tasks; "
+                "indices are 0-based)",
+            )
+        if d.index in by_index:
+            raise ValidationError(
+                "mandate.duplicate_decision", f"task index {d.index} has two decisions"
+            )
+        if d.decision == "edit" and not (d.edited_title or "").strip():
+            raise ValidationError(
+                "mandate.edit_without_title", f"edit decision on task {d.index} needs edited_title"
+            )
+        by_index[d.index] = d
+    missing = [i for i in range(len(tasks)) if i not in by_index]
+    if missing:
+        raise ValidationError(
+            "mandate.incomplete_decisions",
+            f"every task needs a decision; missing indices {missing} (0-based)",
+        )
+
+    kept: list[dict[str, Any]] = []
+    edited = False
+    rejected: list[tuple[int, Any]] = []
+    for i, task in enumerate(tasks):
+        d = by_index[i]
+        if d.decision == "reject":
+            rejected.append((i, d))
+            edited = True
+            continue
+        t = dict(task)
+        if d.decision == "edit":
+            t["title"] = d.edited_title.strip()
+            edited = True
+        kept.append(t)
+
+    # Rejected tasks become teaching sightings — the foreman's next digest
+    # reads the human's reasons. (Each insert emits MandateSightingAdded.)
+    for i, d in rejected:
+        await file_feedback(
+            workspace_id,
+            user_id,
+            mandate_id,
+            {
+                "kind": "reject",
+                "reason": (d.reason or "rejected at the gate").strip(),
+                "shift_no": body.shift_no,
+                "task_title": str(tasks[i].get("title") or ""),
+            },
+        )
+
+    if not kept:
+        reasons = "; ".join((d.reason or "").strip() for _, d in rejected if d.reason)
+        return {
+            "action_id": str(shift.plan_action_id),
+            "shift_id": str(shift.id),
+            "mode": "reject",
+            "edited": True,
+            "reject_reason": reasons or "all tasks rejected at the gate",
+        }
+
+    new_blob = dict(blob)
+    new_plan = dict(blob.get("plan") or {})
+    new_plan["tasks"] = kept
+    new_blob["plan"] = new_plan
+    new_params = dict(params)
+    new_params[BELT_PLAN_PARAM_KEY] = new_blob
+    return {
+        "action_id": str(shift.plan_action_id),
+        "shift_id": str(shift.id),
+        "mode": "approve",
+        "edited": edited,
+        "parameters": new_params,
+    }
+
+
+async def shift_wire(workspace_id: str, shift_id: str) -> dict[str, Any]:
+    """Refresh one shift's wire dict (the resolve response's ``shift``)."""
+    # no-event: read-only path; emit only on writes.
+    try:
+        doc = await ShiftDoc.find_one(
+            ShiftDoc.workspace == workspace_id, ShiftDoc.id == _as_object_id(shift_id)
+        )
+    except Exception:  # noqa: BLE001 — malformed id == 404
+        doc = None
+    if doc is None:
+        raise NotFound("shift", shift_id)
+    return {
+        "shift_id": str(doc.id),
+        "no": doc.no,
+        "state": doc.state,
+        "plan_action_id": doc.plan_action_id,
+        "outcome": doc.outcome,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Pawprints — the past-tense event feed (slice 5)
 # ---------------------------------------------------------------------------
 
 
 async def get_pawprints(workspace_id: str, user_id: str, mandate_id: str) -> dict[str, Any]:
     """Walk the mandate's shift history + decision chains into a past-tense
-    event feed: shift n proposed / approved / rejected / executed / failed /
-    stood_down, with the evidence (sighting) refs the plan cited.
+    event feed (UI contract item shape: ``{id, mandate_id, shift_no, kind,
+    summary, evidence_refs, ts}``).
+
+    Kinds: the UI consumes ``executed`` / ``rejected`` / ``edited`` /
+    ``stood_down``; the feed also emits ``proposed`` / ``approved`` /
+    ``failed`` / ``planning`` with the same shape (a documented superset).
+    ``edited`` fires instead of ``approved`` when the approval carried human
+    edits (the action has Corrections recorded).
 
     Sources: the ShiftDoc rows (state + outcome) and each shift's ``belt_plan``
     Instinct Action (status + the plan blob's evidence refs) — the same records
@@ -802,34 +1044,36 @@ async def get_pawprints(workspace_id: str, user_id: str, mandate_id: str) -> dic
 
     store = get_instinct_store()
     prints: list[dict[str, Any]] = []
+
+    def _item(shift: Any, kind: str, summary: str, refs: list[str], ts: Any) -> dict[str, Any]:
+        return {
+            "id": f"{shift.id}:{kind}",
+            "mandate_id": mandate_id,
+            "shift_no": shift.no,
+            "kind": kind,
+            "summary": summary,
+            "evidence_refs": refs,
+            "ts": ts,
+        }
+
     for shift in shifts:
         if shift.state == "stood_down":
+            reason = (shift.outcome or "no action needed").removeprefix("stood down: ")
             prints.append(
-                {
-                    "shift_no": shift.no,
-                    "kind": "stood_down",
-                    "text": f"Shift {shift.no}: the foreman stood down — "
-                    f"{(shift.outcome or 'no action needed').removeprefix('stood down: ')}",
-                    "evidence_refs": [],
-                    "ts": shift.updatedAt,
-                    "extra": {},
-                }
+                _item(
+                    shift,
+                    "stood_down",
+                    f"Shift {shift.no}: the foreman stood down — {reason}",
+                    [],
+                    shift.updatedAt,
+                )
             )
             continue
         if shift.state == "planning":
-            text = f"Shift {shift.no}: planning"
+            summary = f"Shift {shift.no}: planning"
             if shift.outcome:
-                text = f"Shift {shift.no}: plan did not reach the gate — {shift.outcome}"
-            prints.append(
-                {
-                    "shift_no": shift.no,
-                    "kind": "planning",
-                    "text": text,
-                    "evidence_refs": [],
-                    "ts": shift.updatedAt,
-                    "extra": {},
-                }
-            )
+                summary = f"Shift {shift.no}: plan did not reach the gate — {shift.outcome}"
+            prints.append(_item(shift, "planning", summary, [], shift.updatedAt))
             continue
 
         # in_gate / executing / done — read the plan Action for status + refs.
@@ -847,63 +1091,69 @@ async def get_pawprints(workspace_id: str, user_id: str, mandate_id: str) -> dic
         task_count = len(tasks)
 
         prints.append(
-            {
-                "shift_no": shift.no,
-                "kind": "proposed",
-                "text": f"Shift {shift.no}: the foreman proposed {task_count} task(s) "
+            _item(
+                shift,
+                "proposed",
+                f"Shift {shift.no}: the foreman proposed {task_count} task(s) "
                 "through the plan gate",
-                "evidence_refs": refs,
-                "ts": shift.createdAt,
-                "extra": {"plan_action_id": shift.plan_action_id},
-            }
+                refs,
+                shift.createdAt,
+            )
         )
         status = str(getattr(getattr(action, "status", None), "value", "") or "")
         if status in ("approved", "executed", "failed"):
+            # ``edited`` when the human approved WITH edits (Corrections exist
+            # on the action); plain ``approved`` otherwise.
+            approve_kind = "approved"
+            try:
+                if shift.plan_action_id and await store.get_corrections_for_action(
+                    shift.plan_action_id
+                ):
+                    approve_kind = "edited"
+            except Exception:  # noqa: BLE001 — corrections lookup degrades to approved
+                logger.debug("mandate: pawprints corrections read failed", exc_info=True)
+            verb = "approved" if approve_kind == "approved" else "approved with edits"
             prints.append(
-                {
-                    "shift_no": shift.no,
-                    "kind": "approved",
-                    "text": f"Shift {shift.no}: a human approved the plan at the gate",
-                    "evidence_refs": refs,
-                    "ts": shift.updatedAt,
-                    "extra": {},
-                }
+                _item(
+                    shift,
+                    approve_kind,
+                    f"Shift {shift.no}: a human {verb} the plan at the gate",
+                    refs,
+                    shift.updatedAt,
+                )
             )
         if status == "rejected":
             prints.append(
-                {
-                    "shift_no": shift.no,
-                    "kind": "rejected",
-                    "text": f"Shift {shift.no}: a human rejected the plan at the gate"
+                _item(
+                    shift,
+                    "rejected",
+                    f"Shift {shift.no}: a human rejected the plan at the gate"
                     + (f" — {shift.outcome}" if shift.outcome else ""),
-                    "evidence_refs": refs,
-                    "ts": shift.updatedAt,
-                    "extra": {},
-                }
+                    refs,
+                    shift.updatedAt,
+                )
             )
         elif status == "executed":
             prints.append(
-                {
-                    "shift_no": shift.no,
-                    "kind": "executed",
-                    "text": f"Shift {shift.no}: "
+                _item(
+                    shift,
+                    "executed",
+                    f"Shift {shift.no}: "
                     + (shift.outcome or f"dispatched {task_count} task(s) as belt runs"),
-                    "evidence_refs": refs,
-                    "ts": shift.updatedAt,
-                    "extra": {"outcome": getattr(action, "outcome", None)},
-                }
+                    refs,
+                    shift.updatedAt,
+                )
             )
         elif status == "failed":
             prints.append(
-                {
-                    "shift_no": shift.no,
-                    "kind": "failed",
-                    "text": f"Shift {shift.no}: the approved plan failed to dispatch"
+                _item(
+                    shift,
+                    "failed",
+                    f"Shift {shift.no}: the approved plan failed to dispatch"
                     + (f" — {shift.outcome}" if shift.outcome else ""),
-                    "evidence_refs": refs,
-                    "ts": shift.updatedAt,
-                    "extra": {},
-                }
+                    refs,
+                    shift.updatedAt,
+                )
             )
     return {"pawprints": prints}
 
@@ -985,6 +1235,8 @@ __all__ = [
     "list_mandates",
     "list_sightings",
     "mark_shift",
+    "prepare_plan_resolution",
     "run_patrols",
+    "shift_wire",
     "trigger_shift",
 ]

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -1,0 +1,313 @@
+# ee/pocketpaw_ee/cloud/mandates/service.py
+# Created: 2026-06-11 (feat/belt-mandates, slice 1 — models + CRUD).
+#
+# Business logic for the MANDATE primitive — the standing Belt JOB. Sole owner
+# of writes to MandateDoc / ShiftDoc / SightingDoc (the only module that imports
+# those Beanie classes, per the 4-file entity rule).
+#
+# Public API (module-level ``async def op(workspace_id, user_id, body) -> dict``):
+#   slice 1: create_mandate, list_mandates, get_mandate
+#   slice 2: file_feedback, list_sightings, run_patrols (deps patrol)
+#   slice 4: trigger_shift (foreman → plan gate)
+#   slice 5: get_pawprints
+#
+# Conventions (cloud entity rules): validate body at entry
+# (``Schema.model_validate(body)``); tenant filter ``workspace=...`` on EVERY
+# find; emit an event on every write (or ``# no-event: <reason>``); errors via
+# ``_core.errors`` CloudError subclasses (never HTTPException).
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud.mandates import events as mandate_events
+from pocketpaw_ee.cloud.mandates.domain import (
+    Budget,
+    Charter,
+    Kpi,
+    MandateDoc,
+    ShiftDoc,
+    SightingDoc,
+    Surface,
+)
+from pocketpaw_ee.cloud.mandates.dto import (
+    CreateMandateRequest,
+    FeedbackRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers — DTO charter ↔ domain charter; doc → wire dict
+# ---------------------------------------------------------------------------
+
+
+def _charter_from_request(req: CreateMandateRequest) -> Charter:
+    return Charter(
+        goal=req.charter.goal,
+        kpis=[Kpi(name=k.name, target=k.target, direction=k.direction) for k in req.charter.kpis],
+        says_no=list(req.charter.says_no),
+        boundaries=list(req.charter.boundaries),
+        budget=Budget(
+            max_tasks_per_shift=req.charter.budget.max_tasks_per_shift,
+            gate_minutes_per_week=req.charter.budget.gate_minutes_per_week,
+        ),
+        cadence=req.charter.cadence,
+    )
+
+
+def _charter_to_wire(charter: Charter) -> dict[str, Any]:
+    return {
+        "goal": charter.goal,
+        "kpis": [{"name": k.name, "target": k.target, "direction": k.direction} for k in charter.kpis],
+        "says_no": list(charter.says_no),
+        "boundaries": list(charter.boundaries),
+        "budget": {
+            "max_tasks_per_shift": charter.budget.max_tasks_per_shift,
+            "gate_minutes_per_week": charter.budget.gate_minutes_per_week,
+        },
+        "cadence": charter.cadence,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal fetch helpers — tenant-scoped, raise NotFound on a miss / cross-tenant
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_mandate(workspace_id: str, mandate_id: str) -> MandateDoc:
+    """Load a mandate in the caller's workspace, or 404.
+
+    The ``workspace=`` filter is part of the query so a cross-tenant id is a
+    clean 404 (we never confirm a foreign mandate exists)."""
+    try:
+        doc = await MandateDoc.find_one(
+            MandateDoc.workspace == workspace_id, MandateDoc.id == _as_object_id(mandate_id)
+        )
+    except Exception:  # noqa: BLE001 — a malformed id is a 404, not a 500
+        doc = None
+    if doc is None:
+        raise NotFound("mandate", mandate_id)
+    return doc
+
+
+def _as_object_id(raw: str) -> Any:
+    """Coerce a string id to a Beanie/Mongo ObjectId. A malformed id raises,
+    which the callers translate to a 404."""
+    from bson import ObjectId
+
+    return ObjectId(raw)
+
+
+# ---------------------------------------------------------------------------
+# CRUD (slice 1)
+# ---------------------------------------------------------------------------
+
+
+async def create_mandate(workspace_id: str, user_id: str, body: Any) -> dict[str, Any]:
+    """Create a new standing mandate. Charter body validated at entry."""
+    body = CreateMandateRequest.model_validate(body)
+
+    doc = MandateDoc(
+        workspace=workspace_id,
+        name=body.name,
+        surface=Surface(repo_id=body.surface.repo_id),
+        charter=_charter_from_request(body),
+        status="active",
+        soul_path=body.soul_path,
+    )
+    await doc.insert()
+
+    await emit(
+        mandate_events.MandateCreated(
+            data={
+                "workspace_id": workspace_id,
+                "mandate_id": str(doc.id),
+                "name": doc.name,
+            }
+        )
+    )
+    logger.info("mandate: created %s (workspace=%s, repo=%s)", doc.id, workspace_id, body.surface.repo_id)
+    return await _mandate_detail_wire(doc)
+
+
+async def list_mandates(workspace_id: str, user_id: str, body: Any = None) -> dict[str, Any]:
+    """List the workspace's mandates with a per-mandate health summary.
+
+    Health = last shift state, open gate count (shifts awaiting approval), and
+    total sighting count. ``body`` is unused (read path)."""
+    # no-event: read-only path; emit only on writes.
+    docs = (
+        await MandateDoc.find(MandateDoc.workspace == workspace_id)
+        .sort("-createdAt")
+        .to_list()
+    )
+    out: list[dict[str, Any]] = []
+    for doc in docs:
+        mandate_id = str(doc.id)
+        last_shift = (
+            await ShiftDoc.find(
+                ShiftDoc.workspace == workspace_id, ShiftDoc.mandate_id == mandate_id
+            )
+            .sort("-no")
+            .first_or_none()
+        )
+        open_gate_count = await ShiftDoc.find(
+            ShiftDoc.workspace == workspace_id,
+            ShiftDoc.mandate_id == mandate_id,
+            ShiftDoc.state == "in_gate",
+        ).count()
+        sighting_count = await SightingDoc.find(
+            SightingDoc.workspace == workspace_id, SightingDoc.mandate_id == mandate_id
+        ).count()
+        out.append(
+            {
+                "id": mandate_id,
+                "name": doc.name,
+                "status": doc.status,
+                "repo_id": doc.surface.repo_id,
+                "cadence": doc.charter.cadence,
+                "health": {
+                    "last_shift_state": last_shift.state if last_shift else None,
+                    "open_gate_count": open_gate_count,
+                    "sighting_count": sighting_count,
+                },
+                "created_at": doc.createdAt,
+            }
+        )
+    return {"mandates": out}
+
+
+async def get_mandate(workspace_id: str, user_id: str, mandate_id: str) -> dict[str, Any]:
+    """Return one mandate's detail — charter, recent shifts, sightings-by-patrol.
+
+    A mandate in another workspace is a 404."""
+    # no-event: read-only path; emit only on writes.
+    doc = await _fetch_mandate(workspace_id, mandate_id)
+    return await _mandate_detail_wire(doc)
+
+
+async def _mandate_detail_wire(doc: MandateDoc) -> dict[str, Any]:
+    """Build the detail wire dict for a mandate doc — recent shifts + sightings
+    grouped by patrol."""
+    mandate_id = str(doc.id)
+    workspace_id = doc.workspace
+    recent_shifts = (
+        await ShiftDoc.find(
+            ShiftDoc.workspace == workspace_id, ShiftDoc.mandate_id == mandate_id
+        )
+        .sort("-no")
+        .limit(10)
+        .to_list()
+    )
+    sightings = await SightingDoc.find(
+        SightingDoc.workspace == workspace_id, SightingDoc.mandate_id == mandate_id
+    ).to_list()
+    by_patrol: dict[str, int] = {}
+    for s in sightings:
+        by_patrol[s.patrol] = by_patrol.get(s.patrol, 0) + 1
+
+    return {
+        "id": mandate_id,
+        "name": doc.name,
+        "status": doc.status,
+        "surface": {"repo_id": doc.surface.repo_id},
+        "charter": _charter_to_wire(doc.charter),
+        "soul_path": doc.soul_path,
+        "recent_shifts": [
+            {
+                "id": str(s.id),
+                "no": s.no,
+                "state": s.state,
+                "plan_action_id": s.plan_action_id,
+                "created_at": s.createdAt,
+            }
+            for s in recent_shifts
+        ],
+        "sightings_by_patrol": by_patrol,
+        "created_at": doc.createdAt,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Patrols + sightings (slice 2)
+# ---------------------------------------------------------------------------
+
+
+async def file_feedback(workspace_id: str, user_id: str, mandate_id: str, body: Any) -> dict[str, Any]:
+    """Intake patrol — turn a human's feedback into a Sighting.
+
+    Severity defaults to 3 (mid) when omitted. The sighting's ``patrol`` is
+    ``"feedback"`` and the ``source`` rides on the evidence so the foreman can
+    weight it."""
+    body = FeedbackRequest.model_validate(body)
+    # Tenant gate — a mandate in another workspace is a 404.
+    await _fetch_mandate(workspace_id, mandate_id)
+
+    severity = body.severity if body.severity is not None else 3
+    sighting = SightingDoc(
+        workspace=workspace_id,
+        mandate_id=mandate_id,
+        patrol="feedback",
+        severity=severity,
+        summary=body.text.strip()[:280],
+        evidence={"source": body.source, "filed_by": user_id, "text": body.text.strip()},
+    )
+    await sighting.insert()
+
+    await emit(
+        mandate_events.MandateSightingAdded(
+            data={
+                "workspace_id": workspace_id,
+                "mandate_id": mandate_id,
+                "sighting_id": str(sighting.id),
+                "patrol": "feedback",
+                "severity": severity,
+            }
+        )
+    )
+    return _sighting_to_wire(sighting)
+
+
+async def list_sightings(workspace_id: str, user_id: str, mandate_id: str) -> dict[str, Any]:
+    """List a mandate's sightings, newest-first. Cross-tenant mandate → 404."""
+    # no-event: read-only path; emit only on writes.
+    await _fetch_mandate(workspace_id, mandate_id)
+    docs = (
+        await SightingDoc.find(
+            SightingDoc.workspace == workspace_id, SightingDoc.mandate_id == mandate_id
+        )
+        .sort("-ts")
+        .to_list()
+    )
+    return {"sightings": [_sighting_to_wire(s) for s in docs]}
+
+
+def _sighting_to_wire(s: SightingDoc) -> dict[str, Any]:
+    return {
+        "id": str(s.id),
+        "mandate_id": s.mandate_id,
+        "patrol": s.patrol,
+        "severity": s.severity,
+        "summary": s.summary,
+        "evidence": dict(s.evidence or {}),
+        "ts": s.ts,
+    }
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+__all__ = [
+    "create_mandate",
+    "file_feedback",
+    "get_mandate",
+    "list_mandates",
+    "list_sightings",
+]

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -288,6 +288,65 @@ async def list_sightings(workspace_id: str, user_id: str, mandate_id: str) -> di
     return {"sightings": [_sighting_to_wire(s) for s in docs]}
 
 
+async def run_patrols(workspace_id: str, user_id: str, mandate_id: str) -> dict[str, Any]:
+    """Run every registered patrol over the mandate's surface and persist the
+    resulting Sightings.
+
+    Dedup: a draft whose ``evidence.package`` already has a sighting from the
+    same patrol on this mandate is skipped — repeated shift triggers must not
+    spam the foreman with identical signals. Returns the NEW sightings only."""
+    from pocketpaw_ee.cloud.mandates.patrols import PATROLS
+
+    doc = await _fetch_mandate(workspace_id, mandate_id)
+
+    existing = await SightingDoc.find(
+        SightingDoc.workspace == workspace_id, SightingDoc.mandate_id == mandate_id
+    ).to_list()
+    seen_keys = {
+        (s.patrol, str((s.evidence or {}).get("package") or s.summary)) for s in existing
+    }
+
+    created: list[SightingDoc] = []
+    for patrol_name, patrol in PATROLS.items():
+        try:
+            drafts = await patrol(doc.surface.repo_id)
+        except Exception:  # noqa: BLE001 — a broken patrol must not wedge the shift
+            logger.warning("mandate: patrol %r raised — skipping", patrol_name, exc_info=True)
+            continue
+        for draft in drafts:
+            key = (
+                str(draft.get("patrol") or patrol_name),
+                str((draft.get("evidence") or {}).get("package") or draft.get("summary") or ""),
+            )
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            sighting = SightingDoc(
+                workspace=workspace_id,
+                mandate_id=mandate_id,
+                patrol=str(draft.get("patrol") or patrol_name),
+                severity=int(draft.get("severity") or 3),
+                summary=str(draft.get("summary") or "")[:280],
+                evidence=dict(draft.get("evidence") or {}),
+            )
+            await sighting.insert()
+            created.append(sighting)
+
+    for sighting in created:
+        await emit(
+            mandate_events.MandateSightingAdded(
+                data={
+                    "workspace_id": workspace_id,
+                    "mandate_id": mandate_id,
+                    "sighting_id": str(sighting.id),
+                    "patrol": sighting.patrol,
+                    "severity": sighting.severity,
+                }
+            )
+        )
+    return {"sightings": [_sighting_to_wire(s) for s in created]}
+
+
 def _sighting_to_wire(s: SightingDoc) -> dict[str, Any]:
     return {
         "id": str(s.id),
@@ -310,4 +369,5 @@ __all__ = [
     "get_mandate",
     "list_mandates",
     "list_sightings",
+    "run_patrols",
 ]

--- a/ee/pocketpaw_ee/cloud/mandates/soul_link.py
+++ b/ee/pocketpaw_ee/cloud/mandates/soul_link.py
@@ -1,0 +1,71 @@
+# ee/pocketpaw_ee/cloud/mandates/soul_link.py
+# Created: 2026-06-11 (feat/belt-mandates, slice 6 — soul wiring, demo bar).
+#
+# The mandate ↔ soul bridge. When a mandate binds a ``soul_path`` (a .soul
+# file), the foreman RECALLS context from it before planning, and every
+# finished shift APPENDS an episodic summary to it — the mandate accumulates
+# long-lived judgment context across shifts.
+#
+# Clean, narrow interface (two functions) so the transport can be swapped
+# without touching the foreman/service:
+#   * ``recall_for_planning(soul_path, query)``  -> list[str]
+#   * ``remember_shift(soul_path, summary)``     -> bool
+#
+# Implementation rides the real soul-protocol API (``Soul.awaken`` →
+# ``recall``/``remember`` → ``save_local``). EVERYTHING is best-effort: a
+# missing file, a corrupt soul, or a protocol error logs and degrades to an
+# empty recall / no-op remember — a soul failure must never wedge a shift.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# How many memories a planning recall pulls.
+_RECALL_LIMIT = 5
+
+
+async def recall_for_planning(soul_path: str | None, query: str) -> list[str]:
+    """Recall up to ``_RECALL_LIMIT`` memory lines relevant to ``query`` from
+    the mandate's soul. Empty list when no soul is bound or anything fails."""
+    if not soul_path:
+        return []
+    path = Path(soul_path).expanduser()
+    if not path.exists():
+        logger.warning("mandate soul: %s does not exist — empty recall", soul_path)
+        return []
+    try:
+        from soul_protocol import Soul
+
+        soul = await Soul.awaken(path)
+        entries = await soul.recall(query, limit=_RECALL_LIMIT)
+        return [str(e.content) for e in entries]
+    except Exception:  # noqa: BLE001 — soul failures must never wedge a shift
+        logger.warning("mandate soul: recall failed for %s", soul_path, exc_info=True)
+        return []
+
+
+async def remember_shift(soul_path: str | None, summary: str) -> bool:
+    """Append an episodic shift summary to the mandate's soul and save it
+    back in place. Returns True on success; False (logged) on any failure."""
+    if not soul_path or not summary.strip():
+        return False
+    path = Path(soul_path).expanduser()
+    if not path.exists():
+        logger.warning("mandate soul: %s does not exist — remember skipped", soul_path)
+        return False
+    try:
+        from soul_protocol import MemoryType, Soul
+
+        soul = await Soul.awaken(path)
+        await soul.remember(summary.strip(), type=MemoryType.EPISODIC, importance=7)
+        await soul.save_local(path)
+        return True
+    except Exception:  # noqa: BLE001 — soul failures must never wedge a shift
+        logger.warning("mandate soul: remember failed for %s", soul_path, exc_info=True)
+        return False
+
+
+__all__ = ["recall_for_planning", "remember_shift"]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -94,6 +94,13 @@ FileUpload: type = None  # type: ignore[assignment]
 FileFolder: type = None  # type: ignore[assignment]
 _CalendarDoc: type = None  # type: ignore[assignment]
 _EventDoc: type = None  # type: ignore[assignment]
+# The Belt MANDATE docs live in ee.cloud.mandates.domain (4-file entity, sole
+# importer = its own service). Lazy-loaded here so init_beanie registers them
+# without ee.cloud.models taking a hard import on the mandates package (same
+# out-of-models discipline the calendar docs use).
+_MandateDoc: type = None  # type: ignore[assignment]
+_ShiftDoc: type = None  # type: ignore[assignment]
+_SightingDoc: type = None  # type: ignore[assignment]
 
 
 def _ensure_file_upload():
@@ -119,6 +126,22 @@ def _ensure_calendar_docs():
         _CalendarDoc = _CD
         _EventDoc = _ED
     return _CalendarDoc, _EventDoc
+
+
+def _ensure_mandate_docs():
+    # Why: the mandates package's __init__ imports its router (→ deps → auth),
+    # so registering the docs via the package would pull the auth chain in
+    # during cloud.models init. Import the doc module directly + deferred.
+    global _MandateDoc, _ShiftDoc, _SightingDoc
+    if _MandateDoc is None:
+        from pocketpaw_ee.cloud.mandates.domain import MandateDoc as _MD
+        from pocketpaw_ee.cloud.mandates.domain import ShiftDoc as _SD
+        from pocketpaw_ee.cloud.mandates.domain import SightingDoc as _SG
+
+        _MandateDoc = _MD
+        _ShiftDoc = _SD
+        _SightingDoc = _SG
+    return _MandateDoc, _ShiftDoc, _SightingDoc
 
 
 __all__ = [
@@ -193,6 +216,7 @@ def get_all_documents():
     """Get all Beanie documents, with lazy FileUpload loading."""
     _ensure_file_upload()
     cal_doc, evt_doc = _ensure_calendar_docs()
+    mandate_doc, shift_doc, sighting_doc = _ensure_mandate_docs()
     return [
         User,
         Agent,
@@ -245,6 +269,9 @@ def get_all_documents():
         TaskEvent,
         cal_doc,
         evt_doc,
+        mandate_doc,
+        shift_doc,
+        sighting_doc,
     ]
 
 

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -250,6 +250,62 @@ def _code_change_blob(action: Any) -> dict[str, Any] | None:
     return blob if isinstance(blob, dict) else None
 
 
+def _belt_plan_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_belt_plan`` blob on an Action, or ``None``.
+
+    The blob is the mandate FOREMAN's shift-plan payload
+    (``ee.cloud.mandates.service.trigger_shift`` stores it under
+    ``Action.parameters._belt_plan``: the PlanProposal + mandate/shift ids +
+    budget snapshot + chain correlation fields). The third peer of
+    ``_pocket_write`` / ``_code_change`` — the approve path dispatches the
+    plan executor on its presence; reject closes the chain here in the router.
+    Anything that is not a dict is treated as "no plan".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_belt_plan")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_belt_plan_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving/rejecting a mandate shift plan from another workspace.
+
+    Mirror of ``_assert_code_change_workspace`` for the ``_belt_plan`` blob —
+    its tenancy lives entirely on the blob's ``workspace_id``.
+    """
+    blob = _belt_plan_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This shift plan belongs to a different workspace",
+        )
+
+
+def _belt_plan_proposed_event_id(blob: dict[str, Any]) -> Any:
+    """Pull the ``proposed_event_id`` off a ``_belt_plan`` blob (same field
+    contract as the code-change blob) for ``human.corrected`` causation."""
+    return _code_change_proposed_event_id(blob)
+
+
+async def _mark_plan_rejected_safe(action: Any, reason: str) -> None:
+    """Best-effort shift-record update for a rejected ``belt_plan`` Action.
+
+    The router owns the CHAIN close on reject (the executor never runs); this
+    lazy-imported hook only reflects the rejection onto the mandate's ShiftDoc
+    (state=done, outcome carries the reason) so the pawprints feed reads it.
+    Never breaks the reject response."""
+    try:
+        from pocketpaw_ee.cloud.mandates import executor as mandate_executor
+
+        await mandate_executor.mark_plan_rejected(action, reason)
+    except Exception:  # noqa: BLE001 — read-model nudge must never break reject
+        logger.debug("mandate: mark_plan_rejected hook failed (non-fatal)", exc_info=True)
+
+
 async def _emit_belt_run_updated_safe(
     *, workspace_id: str, action_id: str, status: str, stage: str
 ) -> None:
@@ -609,6 +665,7 @@ async def bulk_approve_actions(
         if action is not None:
             _assert_pocket_write_workspace(action, workspace_id)
             _assert_code_change_workspace(action, workspace_id)
+            _assert_belt_plan_workspace(action, workspace_id)
 
     approved, missing, bulk_id = await store.bulk_approve(
         list(req.ids), approver=approver_id, note=req.note
@@ -660,6 +717,34 @@ async def bulk_approve_actions(
             except Exception:
                 logger.exception(
                     "bulk-approve belt code-change execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
+        # MANDATES — a bulk-approved ``_belt_plan`` Action fires the plan
+        # executor, exactly like the single-approve hook (disposition is always
+        # ``accepted`` — bulk-approve has no edit surface). The executor owns
+        # the chain close.
+        belt_plan_blob = _belt_plan_blob(action)
+        if belt_plan_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=belt_plan_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_belt_plan_proposed_event_id(belt_plan_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.mandates import executor as mandate_executor
+
+                await mandate_executor.execute_approved_plan(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve belt_plan execution failed for %s (non-fatal)",
                     action.id,
                 )
             continue
@@ -739,6 +824,7 @@ async def bulk_reject_actions(
         if action is not None:
             _assert_pocket_write_workspace(action, workspace_id)
             _assert_code_change_workspace(action, workspace_id)
+            _assert_belt_plan_workspace(action, workspace_id)
 
     rejected, missing, bulk_id = await store.bulk_reject(
         list(req.ids), reason=req.reason, rejector=rejector_id
@@ -797,6 +883,31 @@ async def bulk_reject_actions(
                 status="rejected",
                 stage="done",
             )
+            continue
+
+        # MANDATES — a bulk-rejected ``_belt_plan`` Action closes its chain
+        # here (the plan executor never runs on reject), mirroring the
+        # code-change branch above.
+        belt_plan_blob = _belt_plan_blob(action)
+        if belt_plan_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=belt_plan_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_belt_plan_proposed_event_id(belt_plan_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=belt_plan_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            await _mark_plan_rejected_safe(action, req.reason)
 
     return BulkActionResponse(bulk_id=bulk_id, affected=rejected, missing=missing)
 
@@ -837,6 +948,9 @@ async def approve_action(
     # Same tenancy gate for a Belt code-change Action (BS-3) — its
     # ``_code_change`` blob carries the workspace, not a pocket.
     _assert_code_change_workspace(before, workspace_id)
+    # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
+    # ``_belt_plan`` blob carries the workspace.
+    _assert_belt_plan_workspace(before, workspace_id)
 
     req = req or ApproveRequest()
     # SHOULD-FIX 1 — the audit actor is the authenticated identity, not
@@ -956,6 +1070,32 @@ async def approve_action(
         except Exception:
             logger.exception("belt code-change execution after approval failed (non-fatal)")
 
+    # MANDATES — when the approved Action carries a ``_belt_plan`` blob (the
+    # mandate foreman's shift plan), dispatch the plan executor. Same shape as
+    # the code-change hook: the router owns the ``human.corrected`` emit, the
+    # EXECUTOR owns the chain close (success or failure) — the router never
+    # emits ``decision.completed`` for belt_plan. Best-effort, lazy import,
+    # never breaks the approve response.
+    belt_plan_blob = _belt_plan_blob(approved)
+    if belt_plan_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=belt_plan_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_belt_plan_proposed_event_id(belt_plan_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.mandates import executor as mandate_executor
+
+            await mandate_executor.execute_approved_plan(approved, human_event_id=human_event_id)
+        except Exception:
+            logger.exception("belt_plan execution after approval failed (non-fatal)")
+
     return ApproveResponse(action=approved, correction=correction)
 
 
@@ -1016,6 +1156,9 @@ async def reject_action(
     # Touch-time security fix — same gate the approve path runs.
     _assert_pocket_write_workspace(before, workspace_id)
     _assert_code_change_workspace(before, workspace_id)
+    # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
+    # ``_belt_plan`` blob carries the workspace.
+    _assert_belt_plan_workspace(before, workspace_id)
 
     reason = req.reason if req else ""
     rejector_id = str(user.id)
@@ -1077,6 +1220,31 @@ async def reject_action(
         await _emit_belt_run_updated_safe(
             workspace_id=workspace_id, action_id=str(action.id), status="rejected", stage="done"
         )
+
+    # MANDATES — a rejected ``_belt_plan`` Action closes its chain HERE (the
+    # plan executor never runs on reject), mirroring the code-change shape:
+    # ``human.corrected(rejected)`` cites ``agent.proposed``; the terminal
+    # cites the human event. The shift record is updated best-effort.
+    belt_plan_blob = _belt_plan_blob(action)
+    if belt_plan_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=belt_plan_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_belt_plan_proposed_event_id(belt_plan_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=belt_plan_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
+        await _mark_plan_rejected_safe(action, reason)
 
     return action
 

--- a/tests/cloud/test_belt_mandates.py
+++ b/tests/cloud/test_belt_mandates.py
@@ -203,7 +203,7 @@ def _create_mandate(client: TestClient, repo_dir: Path, *, budget: int = 3, **ch
         },
     )
     assert res.status_code == 200, res.text
-    return res.json()["id"]
+    return res.json()["mandate"]["id"]
 
 
 def _events(journal, action: str) -> list:
@@ -221,7 +221,7 @@ def _chain(journal, correlation_id: UUID) -> list:
 
 
 async def test_full_shift_gate_one_clean_chain(
-    tmp_path, mongo_db, store, journal, graph, dispatcher, monkeypatch
+    tmp_path, mongo_db, store, journal, graph, dispatcher, monkeypatch, recording_bus
 ):
     """Create mandate → seed 2 feedback sightings → trigger shift (mock LLM
     plans 2 tasks) → the plan lands as a pending ``belt_plan`` Instinct Action →
@@ -245,7 +245,7 @@ async def test_full_shift_gate_one_clean_chain(
     # Trigger the shift — the mock foreman plans one task per sighting (2).
     res = client.post(f"/belt/mandates/{mandate_id}/shift")
     assert res.status_code == 200, res.text
-    shift = res.json()
+    shift = res.json()["shift"]
     assert shift["state"] == "in_gate"
     assert shift["task_count"] == 2
     plan_action_id = shift["plan_action_id"]
@@ -315,6 +315,31 @@ async def test_full_shift_gate_one_clean_chain(
     kinds = [p["kind"] for p in prints]
     assert kinds == ["proposed", "approved", "executed"], kinds
     assert prints[0]["evidence_refs"]  # the cited sighting ids surface
+    # UI contract item shape: {id, mandate_id, shift_no, kind, summary,
+    # evidence_refs, ts}.
+    for item in prints:
+        assert set(item) == {
+            "id",
+            "mandate_id",
+            "shift_no",
+            "kind",
+            "summary",
+            "evidence_refs",
+            "ts",
+        }, item
+        assert item["mandate_id"] == mandate_id
+        assert item["summary"].startswith("Shift 1:")
+
+    # UI contract — the plan proposal rode the realtime bus on the
+    # ``belt_plan`` topic with {mandate_id, proposal} (workspace_id rides
+    # along for the audience fan-out).
+    plan_events = [e for e in recording_bus.events if e.type == "belt_plan"]
+    assert len(plan_events) == 1
+    payload = plan_events[0].data
+    assert payload["mandate_id"] == mandate_id
+    assert payload["workspace_id"] == WS
+    assert payload["proposal"]["plan_action_id"] == plan_action_id
+    assert len(payload["proposal"]["tasks"]) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -334,7 +359,7 @@ async def test_no_action_stands_down(tmp_path, mongo_db, store, journal, graph, 
     mandate_id = _create_mandate(client, repo)
     res = client.post(f"/belt/mandates/{mandate_id}/shift")
     assert res.status_code == 200, res.text
-    shift = res.json()
+    shift = res.json()["shift"]
     assert shift["state"] == "stood_down"
     assert shift["plan_action_id"] is None
     assert shift["task_count"] == 0
@@ -444,7 +469,7 @@ async def test_boundary_check_ignores_why(tmp_path, mongo_db, store, journal, gr
     )
     res = client.post(f"/belt/mandates/{mandate_id}/shift")
     assert res.status_code == 200, res.text
-    assert res.json()["state"] == "in_gate"
+    assert res.json()["shift"]["state"] == "in_gate"
 
     # FAIL — the same phrase in the TITLE (an action field) is refused.
     foreman.set_mock_plan(
@@ -481,6 +506,45 @@ async def test_feedback_intake_creates_sighting(tmp_path, mongo_db, store, monke
     assert listed[0]["evidence"]["source"] == "slack"
 
 
+async def test_teaching_feedback_shape(tmp_path, mongo_db, store, monkeypatch):
+    """The gate UI's teaching shape ({kind, reason, shift_no?, task_title?})
+    returns {ok: true} and still lands as a feedback Sighting the foreman's
+    next digest will see — discriminated from the general shape on ``kind``."""
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client, repo)
+
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/feedback",
+        json={
+            "kind": "reject",
+            "reason": "too risky during the release freeze",
+            "shift_no": 1,
+            "task_title": "bump lodash",
+        },
+    )
+    assert res.status_code == 200, res.text
+    assert res.json() == {"ok": True}
+
+    listed = client.get(f"/belt/mandates/{mandate_id}/sightings").json()["sightings"]
+    assert len(listed) == 1
+    s = listed[0]
+    assert s["patrol"] == "feedback"
+    assert s["evidence"]["kind"] == "reject"
+    assert s["evidence"]["source"] == "gate"
+    assert s["evidence"]["task_title"] == "bump lodash"
+    assert "too risky" in s["summary"]
+
+    # The general shape keeps working side by side.
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/feedback",
+        json={"text": "autopilot ping", "source": "autopilot"},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["patrol"] == "feedback"
+
+
 async def test_deps_patrol_flags_known_stale_manifest_entries(tmp_path, mongo_db, store):
     """The deps patrol parses a REAL pyproject.toml and files sightings for
     entries in the (demo-bar) stub advisory table — deduped on re-run."""
@@ -496,7 +560,7 @@ async def test_deps_patrol_flags_known_stale_manifest_entries(tmp_path, mongo_db
         USER,
         {"name": "m", "surface": {"repo_id": str(repo)}, "charter": _charter()},
     )
-    mandate_id = created["id"]
+    mandate_id = created["mandate"]["id"]
 
     out = await mandate_service.run_patrols(WS, USER, mandate_id)
     assert len(out["sightings"]) == 1
@@ -508,6 +572,30 @@ async def test_deps_patrol_flags_known_stale_manifest_entries(tmp_path, mongo_db
     # Re-running the patrol does not duplicate the sighting.
     again = await mandate_service.run_patrols(WS, USER, mandate_id)
     assert again["sightings"] == []
+
+
+async def test_patrols_toggles_scope_the_sense_loop(tmp_path, mongo_db, store):
+    """UI contract — a mandate created with ``patrols: ["feedback"]`` never
+    runs the deps patrol, even against a manifest full of stale entries."""
+    repo = tmp_path / "pyrepo2"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "x"\nversion = "0.1.0"\ndependencies = ["requests>=2.28"]\n',
+        encoding="utf-8",
+    )
+    created = await mandate_service.create_mandate(
+        WS,
+        USER,
+        {
+            "name": "m2",
+            "surface": {"repo_id": str(repo)},
+            "charter": _charter(),
+            "patrols": ["feedback"],
+        },
+    )
+    assert created["mandate"]["patrols"] == ["feedback"]
+    out = await mandate_service.run_patrols(WS, USER, created["mandate"]["id"])
+    assert out["sightings"] == []  # deps patrol toggled off
 
 
 # ---------------------------------------------------------------------------
@@ -552,7 +640,7 @@ async def test_reject_closes_chain_once(
         f"/belt/mandates/{mandate_id}/feedback",
         json={"text": "minor papercut", "source": "support"},
     )
-    shift = client.post(f"/belt/mandates/{mandate_id}/shift").json()
+    shift = client.post(f"/belt/mandates/{mandate_id}/shift").json()["shift"]
     plan_action_id = shift["plan_action_id"]
 
     res = client.post(
@@ -579,3 +667,147 @@ async def test_reject_closes_chain_once(
     # The shift record reflects the rejection and pawprints read it.
     prints = client.get(f"/belt/mandates/{mandate_id}/pawprints").json()["pawprints"]
     assert [p["kind"] for p in prints] == ["proposed", "rejected"]
+
+
+# ---------------------------------------------------------------------------
+# plan/resolve — the console gate action, mapped onto the real instinct path
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_mixed_verdicts_dispatches_kept_tasks_one_terminal(
+    tmp_path, mongo_db, store, journal, graph, dispatcher, monkeypatch
+):
+    """approve + reject + edit on a 3-task plan: the kept two tasks (one with
+    the edited title) dispatch as belt runs through the REAL approve-with-edits
+    path; the rejected task lands as a teaching sighting; the chain closes with
+    EXACTLY ONE decision.completed; pawprints read kind=edited."""
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client, repo)
+
+    for text in ("signal one", "signal two", "signal three"):
+        client.post(
+            f"/belt/mandates/{mandate_id}/feedback",
+            json={"text": text, "severity": 3, "source": "support"},
+        )
+    shift = client.post(f"/belt/mandates/{mandate_id}/shift").json()["shift"]
+    assert shift["task_count"] == 3
+    plan_action_id = shift["plan_action_id"]
+    action = await store.get_action(plan_action_id)
+    corr = UUID(action.parameters["_belt_plan"]["correlation_id"])
+
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/plan/resolve",
+        json={
+            "shift_no": shift["no"],
+            "decisions": [
+                {"index": 0, "decision": "approve"},
+                {"index": 1, "decision": "reject", "reason": "not worth the risk"},
+                {"index": 2, "decision": "edit", "edited_title": "tighter scoped fix"},
+            ],
+        },
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["shift"]["state"] == "done"
+
+    final = await store.get_action(plan_action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+
+    # Two kept tasks dispatched; the edited one carries the new title.
+    calls = RecorderDispatcher.instances[0].calls
+    assert len(calls) == 2
+    titles = [c["task"]["title"] for c in calls]
+    assert "tighter scoped fix" in titles
+
+    # The chain closed EXACTLY once, through the real instinct edit path.
+    chain = _chain(journal, corr)
+    assert [e.action for e in chain] == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ]
+    assert chain[1].payload["disposition"] == "edited"
+    assert chain[2].payload["passed"] is True
+    assert chain[2].payload["action_outcome"] == "dispatched"
+    assert chain[2].payload["task_count"] == 2
+    assert len(_events(journal, "decision.completed")) == 1
+
+    # The rejected task became a teaching sighting with the human's reason.
+    sightings = client.get(f"/belt/mandates/{mandate_id}/sightings").json()["sightings"]
+    teaching = [s for s in sightings if s["evidence"].get("kind") == "reject"]
+    assert len(teaching) == 1
+    assert "not worth the risk" in teaching[0]["summary"]
+    assert teaching[0]["evidence"]["shift_no"] == shift["no"]
+
+    # Pawprints read the edited approval.
+    prints = client.get(f"/belt/mandates/{mandate_id}/pawprints").json()["pawprints"]
+    assert [p["kind"] for p in prints] == ["proposed", "edited", "executed"]
+
+
+async def test_resolve_all_reject_closes_chain_once(
+    tmp_path, mongo_db, store, journal, graph, dispatcher, monkeypatch
+):
+    """All tasks rejected → the REAL reject path closes the chain once; zero
+    dispatches; the reasons land as teaching sightings."""
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client, repo)
+    client.post(
+        f"/belt/mandates/{mandate_id}/feedback",
+        json={"text": "one thing", "source": "support"},
+    )
+    shift = client.post(f"/belt/mandates/{mandate_id}/shift").json()["shift"]
+
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/plan/resolve",
+        json={
+            "shift_no": shift["no"],
+            "decisions": [{"index": 0, "decision": "reject", "reason": "freeze week"}],
+        },
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["shift"]["state"] == "done"
+
+    final = await store.get_action(shift["plan_action_id"])
+    assert final.status == ActionStatus.REJECTED
+
+    completed = _events(journal, "decision.completed")
+    assert len(completed) == 1
+    assert completed[0].payload["action_outcome"] == "rejected"
+    assert all(not inst.calls for inst in RecorderDispatcher.instances)
+
+    teaching = [
+        s
+        for s in client.get(f"/belt/mandates/{mandate_id}/sightings").json()["sightings"]
+        if s["evidence"].get("kind") == "reject"
+    ]
+    assert len(teaching) == 1 and "freeze week" in teaching[0]["summary"]
+
+
+async def test_resolve_requires_complete_decisions(
+    tmp_path, mongo_db, store, journal, graph, monkeypatch
+):
+    """Every task needs exactly one decision; a partial verdict set is a 422
+    and the plan stays pending at the gate."""
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client, repo)
+    for text in ("a", "b"):
+        client.post(
+            f"/belt/mandates/{mandate_id}/feedback",
+            json={"text": text, "source": "support"},
+        )
+    shift = client.post(f"/belt/mandates/{mandate_id}/shift").json()["shift"]
+    assert shift["task_count"] == 2
+
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/plan/resolve",
+        json={"shift_no": shift["no"], "decisions": [{"index": 0, "decision": "approve"}]},
+    )
+    assert res.status_code == 422, res.text
+    assert "missing indices" in res.json()["error"]["message"]
+    final = await store.get_action(shift["plan_action_id"])
+    assert final.status == ActionStatus.PENDING

--- a/tests/cloud/test_belt_mandates.py
+++ b/tests/cloud/test_belt_mandates.py
@@ -1,0 +1,581 @@
+# tests/cloud/test_belt_mandates.py — the Belt MANDATE primitive (feat/belt-mandates).
+#
+# Created: 2026-06-11.
+#
+# THE HARD GATE — ``test_full_shift_gate_one_clean_chain`` drives the REAL
+# production path with NO stubs at the propose/execute seam (the documented
+# chain-doubling lesson): the real mandates router (TestClient), the real
+# foreman pipeline (mock LLM transport selected via POCKETPAW_MANDATE_LLM —
+# the one genuine external boundary), the real Instinct store, the real
+# instinct-router approve dispatch over HTTP, and the real plan executor. The
+# ONLY other fake is the TaskDispatcher default (the develop-station agent
+# session — the second genuine external boundary), patched the same way
+# test_belt_trace patches GhCliPrOpener. The Decision-Graph journal +
+# projection are the REAL singletons.
+#
+# Expected chain shape for a dispatched shift — ONE chain, ONE terminal:
+#   agent.proposed                              (service.trigger_shift)
+#     → human.corrected(disposition=accepted)   (instinct router approve)
+#     → decision.completed(passed=True,         (plan executor)
+#                          action_outcome="dispatched", task_count=N)
+#
+# Stood-down shift — ONE chain that opens AND closes in the trigger:
+#   agent.proposed → decision.completed(passed=True, action_outcome="stood_down")
+#
+# Also pinned: budget cap enforced (422, nothing reaches the gate); the
+# boundary check reads ACTION fields only (a ``why`` that names the forbidden
+# thing passes — that's a refusal, not a violation); patrol intake → sighting;
+# deps patrol against a real manifest; tenant isolation on every read.
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+pytest.importorskip("mongomock_motor")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.mandates import executor as mandate_executor  # noqa: E402
+from pocketpaw_ee.cloud.mandates import foreman  # noqa: E402
+from pocketpaw_ee.cloud.mandates import service as mandate_service  # noqa: E402
+from pocketpaw_ee.cloud.mandates.router import router as mandates_router  # noqa: E402
+from pocketpaw_ee.instinct.router import router as instinct_router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+WS = "w1"
+USER = "u1"
+
+
+# ---------------------------------------------------------------------------
+# fixtures — journal / graph / store / mock-LLM / dispatcher recorder / client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    """Fresh on-disk journal wired into the lazy ``get_journal`` lookup —
+    production code and the test read the same singleton."""
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    """Fresh DecisionGraph as the process-global singleton."""
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore wired everywhere the gate reads it (the mandates
+    service, the instinct router, and the plan executor all resolve through
+    ``pocketpaw.stores.get_instinct_store`` or the router indirection)."""
+    st = InstinctStore(tmp_path / "instinct_mandates.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    return st
+
+
+@pytest.fixture(autouse=True)
+def mock_llm(monkeypatch):
+    """Every test in this module runs the deterministic mock foreman. The
+    scripted override is reset after each test."""
+    monkeypatch.setenv("POCKETPAW_MANDATE_LLM", "mock")
+    foreman.set_mock_plan(None)
+    yield
+    foreman.set_mock_plan(None)
+
+
+class RecorderDispatcher:
+    """Records dispatch calls — the develop-station boundary, the analogue of
+    test_belt_trace's FakePrOpener. The router→executor seam stays REAL."""
+
+    instances: list[RecorderDispatcher] = []
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        RecorderDispatcher.instances.append(self)
+
+    async def dispatch(
+        self, *, workspace_id, mandate_id, shift_no, plan_action_id, index, task
+    ) -> str:
+        self.calls.append(
+            {
+                "workspace_id": workspace_id,
+                "mandate_id": mandate_id,
+                "shift_no": shift_no,
+                "plan_action_id": plan_action_id,
+                "index": index,
+                "task": task,
+            }
+        )
+        return f"{plan_action_id}:t{index}"
+
+
+@pytest.fixture
+def dispatcher(monkeypatch) -> type[RecorderDispatcher]:
+    """Make the executor's DEFAULT dispatcher the recorder, keeping the
+    router→executor seam real — only the station boundary is replaced."""
+    RecorderDispatcher.instances = []
+    monkeypatch.setattr(mandate_executor, "BusTaskDispatcher", RecorderDispatcher)
+    return RecorderDispatcher
+
+
+def _make_client(monkeypatch, *, workspace_id: str = WS, user_id: str = USER) -> TestClient:
+    """One app holding BOTH routers (mandates + instinct) with the real RBAC
+    guard, an admin user, license bypassed, enterprise plan."""
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(mandates_router)
+    app.include_router(instinct_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    user = SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role="admin")],
+    )
+
+    async def _fake_user_dep():
+        return user
+
+    app.dependency_overrides[current_active_user] = _fake_user_dep
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    return TestClient(app)
+
+
+def _charter(budget: int = 3, says_no=None, boundaries=None) -> dict:
+    return {
+        "goal": "keep dependencies fresh and CVE-free",
+        "kpis": [{"name": "open_cves", "target": 0, "direction": "down"}],
+        "says_no": says_no if says_no is not None else ["major version bumps"],
+        "boundaries": boundaries if boundaries is not None else ["never touch auth code"],
+        "budget": {"max_tasks_per_shift": budget, "gate_minutes_per_week": 15},
+        "cadence": "manual",
+    }
+
+
+def _create_mandate(client: TestClient, repo_dir: Path, *, budget: int = 3, **charter_kw) -> str:
+    res = client.post(
+        "/belt/mandates",
+        json={
+            "name": "deps freshness",
+            "surface": {"repo_id": str(repo_dir)},
+            "charter": _charter(budget=budget, **charter_kw),
+        },
+    )
+    assert res.status_code == 200, res.text
+    return res.json()["id"]
+
+
+def _events(journal, action: str) -> list:
+    return [e for e in journal.replay_from(0) if e.action == action]
+
+
+def _chain(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+# ---------------------------------------------------------------------------
+# THE PRODUCTION-PATH GATE TEST — create → feedback → shift → approve →
+# dispatch → EXACTLY ONE decision.completed
+# ---------------------------------------------------------------------------
+
+
+async def test_full_shift_gate_one_clean_chain(
+    tmp_path, mongo_db, store, journal, graph, dispatcher, monkeypatch
+):
+    """Create mandate → seed 2 feedback sightings → trigger shift (mock LLM
+    plans 2 tasks) → the plan lands as a pending ``belt_plan`` Instinct Action →
+    approve over the REAL instinct router HTTP path → the REAL plan executor
+    dispatches both tasks as belt runs → the chain holds EXACTLY ONE
+    decision.completed (the chain-doubling trap)."""
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "surface-repo"
+    repo.mkdir()  # empty repo dir — the deps patrol stays quiet on purpose
+
+    mandate_id = _create_mandate(client, repo)
+
+    # Seed two feedback sightings through the intake patrol.
+    for text in ("builds got slower after the last release", "lodash CVE flagged by a customer"):
+        res = client.post(
+            f"/belt/mandates/{mandate_id}/feedback",
+            json={"text": text, "severity": 4, "source": "support"},
+        )
+        assert res.status_code == 200, res.text
+
+    # Trigger the shift — the mock foreman plans one task per sighting (2).
+    res = client.post(f"/belt/mandates/{mandate_id}/shift")
+    assert res.status_code == 200, res.text
+    shift = res.json()
+    assert shift["state"] == "in_gate"
+    assert shift["task_count"] == 2
+    plan_action_id = shift["plan_action_id"]
+    assert plan_action_id
+
+    # The plan landed as a PENDING belt_plan Instinct Action with the blob.
+    action = await store.get_action(plan_action_id)
+    assert action is not None and action.status == ActionStatus.PENDING
+    blob = action.parameters["_belt_plan"]
+    assert blob["kind"] == "belt_plan"
+    assert blob["workspace_id"] == WS
+    assert blob["budget_max_tasks"] == 3
+    assert len(blob["plan"]["tasks"]) == 2
+    # Every task cites a sighting id.
+    for task in blob["plan"]["tasks"]:
+        assert task["evidence_refs"], task
+    corr = UUID(blob["correlation_id"])
+
+    # agent.proposed fired at the trigger, before any approval.
+    proposed = _events(journal, "agent.proposed")
+    assert len(proposed) == 1
+    assert proposed[0].correlation_id == corr
+    assert proposed[0].causation_id is None
+    assert proposed[0].payload["action"] == "belt_plan"
+
+    # Approve over HTTP — the REAL router dispatch fires human.corrected then
+    # the REAL plan executor re-validates, dispatches, and closes the chain.
+    res = client.post(f"/instinct/actions/{plan_action_id}/approve")
+    assert res.status_code == 200, res.text
+
+    final = await store.get_action(plan_action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+
+    # Belt runs dispatched — one dispatcher call per approved task.
+    assert len(RecorderDispatcher.instances) == 1
+    calls = RecorderDispatcher.instances[0].calls
+    assert len(calls) == 2
+    assert {c["index"] for c in calls} == {1, 2}
+    assert all(c["mandate_id"] == mandate_id and c["workspace_id"] == WS for c in calls)
+
+    # EXACTLY three events, one chain, causal order intact.
+    chain = _chain(journal, corr)
+    assert [e.action for e in chain] == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], [e.action for e in chain]
+    proposed_e, human_e, completed_e = chain
+    assert human_e.causation_id == proposed_e.id
+    assert completed_e.causation_id == human_e.id
+    assert human_e.payload["disposition"] == "accepted"
+    assert completed_e.payload["passed"] is True
+    assert completed_e.payload["action_outcome"] == "dispatched"
+    assert completed_e.payload["task_count"] == 2
+
+    # THE TRAP — exactly ONE terminal in the whole journal.
+    assert len(_events(journal, "decision.completed")) == 1
+    assert len(_events(journal, "agent.proposed")) == 1
+    assert len(_events(journal, "human.corrected")) == 1
+
+    # The shift record reflects the dispatch.
+    detail = client.get(f"/belt/mandates/{mandate_id}").json()
+    assert detail["recent_shifts"][0]["state"] == "done"
+
+    # Pawprints read past-tense: proposed → approved → executed.
+    prints = client.get(f"/belt/mandates/{mandate_id}/pawprints").json()["pawprints"]
+    kinds = [p["kind"] for p in prints]
+    assert kinds == ["proposed", "approved", "executed"], kinds
+    assert prints[0]["evidence_refs"]  # the cited sighting ids surface
+
+
+# ---------------------------------------------------------------------------
+# no_action → stood_down (a SUCCESS state, one clean 2-event chain)
+# ---------------------------------------------------------------------------
+
+
+async def test_no_action_stands_down(tmp_path, mongo_db, store, journal, graph, monkeypatch):
+    """A quiet surface (no sightings) makes the mock foreman return an empty
+    plan: the shift stands down as a SUCCESS — chain opens AND closes in the
+    trigger with exactly one decision.completed(stood_down); nothing reaches
+    the Instinct gate."""
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "quiet-repo"
+    repo.mkdir()
+
+    mandate_id = _create_mandate(client, repo)
+    res = client.post(f"/belt/mandates/{mandate_id}/shift")
+    assert res.status_code == 200, res.text
+    shift = res.json()
+    assert shift["state"] == "stood_down"
+    assert shift["plan_action_id"] is None
+    assert shift["task_count"] == 0
+    assert shift["no_action_reason"]
+
+    # One 2-event chain: agent.proposed → decision.completed(stood_down).
+    proposed = _events(journal, "agent.proposed")
+    completed = _events(journal, "decision.completed")
+    assert len(proposed) == 1 and len(completed) == 1
+    assert completed[0].correlation_id == proposed[0].correlation_id
+    assert completed[0].causation_id == proposed[0].id
+    assert completed[0].payload["passed"] is True
+    assert completed[0].payload["action_outcome"] == "stood_down"
+
+    # Nothing reached the gate.
+    assert await store.pending() == []
+
+    # The pawprints feed reads the stand-down.
+    prints = client.get(f"/belt/mandates/{mandate_id}/pawprints").json()["pawprints"]
+    assert [p["kind"] for p in prints] == ["stood_down"]
+
+
+# ---------------------------------------------------------------------------
+# budget cap enforced — an over-budget plan never reaches the gate
+# ---------------------------------------------------------------------------
+
+
+async def test_budget_cap_enforced(tmp_path, mongo_db, store, journal, graph, monkeypatch):
+    """A misbehaving foreman returning more tasks than the charter budget is
+    refused by machine validation (422) — no Instinct Action is created."""
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client, repo, budget=1)
+
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/feedback",
+        json={"text": "two things broke", "source": "support"},
+    )
+    sighting_id = res.json()["id"]
+
+    foreman.set_mock_plan(
+        {
+            "shift_no": 1,
+            "no_action": False,
+            "no_action_reason": None,
+            "tasks": [
+                {
+                    "title": f"task {i}",
+                    "why": "needed",
+                    "evidence_refs": [sighting_id],
+                    "expected_outcome": "open_cves down",
+                    "est_cost_hours": 1.0,
+                }
+                for i in (1, 2)
+            ],
+        }
+    )
+    res = client.post(f"/belt/mandates/{mandate_id}/shift")
+    assert res.status_code == 422, res.text
+    assert "budget" in res.json()["error"]["message"]
+    assert await store.pending() == []  # nothing reached the gate
+
+
+# ---------------------------------------------------------------------------
+# boundary check — ACTION fields only; the why narration is never scanned
+# ---------------------------------------------------------------------------
+
+
+async def test_boundary_check_ignores_why(tmp_path, mongo_db, store, journal, graph, monkeypatch):
+    """A task whose ``why`` names the forbidden phrase (a refusal explanation)
+    PASSES; the same phrase in the ``title`` (an action field) is refused."""
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client, repo, says_no=["major version bumps"])
+
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/feedback",
+        json={"text": "lodash is stale", "source": "support"},
+    )
+    sighting_id = res.json()["id"]
+
+    def _plan(title: str, why: str) -> dict:
+        return {
+            "shift_no": 1,
+            "no_action": False,
+            "no_action_reason": None,
+            "tasks": [
+                {
+                    "title": title,
+                    "why": why,
+                    "evidence_refs": [sighting_id],
+                    "expected_outcome": "open_cves down; sighting resolved",
+                    "est_cost_hours": 1.0,
+                }
+            ],
+        }
+
+    # PASS — the why names the forbidden phrase while refusing it.
+    foreman.set_mock_plan(
+        _plan(
+            "bump lodash to the latest 4.x patch release",
+            "We deliberately avoid major version bumps per the charter, so this "
+            "stays on 4.x — patch upgrade only.",
+        )
+    )
+    res = client.post(f"/belt/mandates/{mandate_id}/shift")
+    assert res.status_code == 200, res.text
+    assert res.json()["state"] == "in_gate"
+
+    # FAIL — the same phrase in the TITLE (an action field) is refused.
+    foreman.set_mock_plan(
+        _plan("do major version bumps across the repo", "the fastest route to zero CVEs")
+    )
+    res = client.post(f"/belt/mandates/{mandate_id}/shift")
+    assert res.status_code == 422, res.text
+    assert "boundary" in res.json()["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# patrol intake → sighting; deps patrol against a real manifest
+# ---------------------------------------------------------------------------
+
+
+async def test_feedback_intake_creates_sighting(tmp_path, mongo_db, store, monkeypatch):
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client, repo)
+
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/feedback",
+        json={"text": "checkout flow feels slow", "source": "slack"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["patrol"] == "feedback"
+    assert body["severity"] == 3  # default when omitted
+
+    listed = client.get(f"/belt/mandates/{mandate_id}/sightings").json()["sightings"]
+    assert len(listed) == 1
+    assert listed[0]["summary"] == "checkout flow feels slow"
+    assert listed[0]["evidence"]["source"] == "slack"
+
+
+async def test_deps_patrol_flags_known_stale_manifest_entries(tmp_path, mongo_db, store):
+    """The deps patrol parses a REAL pyproject.toml and files sightings for
+    entries in the (demo-bar) stub advisory table — deduped on re-run."""
+    repo = tmp_path / "pyrepo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "x"\nversion = "0.1.0"\n'
+        'dependencies = ["requests>=2.28", "totally-fine-pkg==1.0"]\n',
+        encoding="utf-8",
+    )
+    created = await mandate_service.create_mandate(
+        WS,
+        USER,
+        {"name": "m", "surface": {"repo_id": str(repo)}, "charter": _charter()},
+    )
+    mandate_id = created["id"]
+
+    out = await mandate_service.run_patrols(WS, USER, mandate_id)
+    assert len(out["sightings"]) == 1
+    s = out["sightings"][0]
+    assert s["patrol"] == "deps"
+    assert s["evidence"]["package"] == "requests"
+    assert s["evidence"]["cve"].startswith("CVE-")
+
+    # Re-running the patrol does not duplicate the sighting.
+    again = await mandate_service.run_patrols(WS, USER, mandate_id)
+    assert again["sightings"] == []
+
+
+# ---------------------------------------------------------------------------
+# tenant isolation — reads never confirm a foreign mandate exists
+# ---------------------------------------------------------------------------
+
+
+async def test_tenant_isolation_on_reads(tmp_path, mongo_db, store, monkeypatch):
+    client_w1 = _make_client(monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client_w1, repo)
+
+    client_w2 = _make_client(monkeypatch, workspace_id="w2", user_id="u2")
+    # Detail, sightings, pawprints, feedback: all 404 — never confirm existence.
+    assert client_w2.get(f"/belt/mandates/{mandate_id}").status_code == 404
+    assert client_w2.get(f"/belt/mandates/{mandate_id}/sightings").status_code == 404
+    assert client_w2.get(f"/belt/mandates/{mandate_id}/pawprints").status_code == 404
+    res = client_w2.post(f"/belt/mandates/{mandate_id}/feedback", json={"text": "x", "source": "s"})
+    assert res.status_code == 404
+    # The list is workspace-scoped.
+    assert client_w2.get("/belt/mandates").json()["mandates"] == []
+    assert len(client_w1.get("/belt/mandates").json()["mandates"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# reject path — the router closes the chain; the shift records the rejection
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_closes_chain_once(
+    tmp_path, mongo_db, store, journal, graph, dispatcher, monkeypatch
+):
+    """Rejecting the plan at the gate closes the chain in the ROUTER (the plan
+    executor never runs): agent.proposed → human.corrected(rejected) →
+    decision.completed(rejected) — exactly one terminal, zero dispatches."""
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client, repo)
+    client.post(
+        f"/belt/mandates/{mandate_id}/feedback",
+        json={"text": "minor papercut", "source": "support"},
+    )
+    shift = client.post(f"/belt/mandates/{mandate_id}/shift").json()
+    plan_action_id = shift["plan_action_id"]
+
+    res = client.post(
+        f"/instinct/actions/{plan_action_id}/reject",
+        json={"reason": "not this week — freeze is on"},
+    )
+    assert res.status_code == 200, res.text
+
+    final = await store.get_action(plan_action_id)
+    assert final.status == ActionStatus.REJECTED
+
+    completed = _events(journal, "decision.completed")
+    assert len(completed) == 1
+    assert completed[0].payload["passed"] is False
+    assert completed[0].payload["action_outcome"] == "rejected"
+    human = _events(journal, "human.corrected")
+    assert len(human) == 1
+    assert human[0].payload["disposition"] == "rejected"
+    assert completed[0].causation_id == human[0].id
+
+    # No dispatches happened.
+    assert all(not inst.calls for inst in RecorderDispatcher.instances)
+
+    # The shift record reflects the rejection and pawprints read it.
+    prints = client.get(f"/belt/mandates/{mandate_id}/pawprints").json()["pawprints"]
+    assert [p["kind"] for p in prints] == ["proposed", "rejected"]


### PR DESCRIPTION
## What this adds

The MANDATE primitive: a standing job the belt holds over time. A charter (goal, KPIs, boundaries, budget, says-no gates) defines the job; patrols produce sightings; a Foreman plans a few evidenced tasks per shift; the plan rides the Instinct gate as a new `belt_plan` proposal type; approved tasks dispatch as belt runs; everything lands in a pawprints feed. Validated first in simulation (paw-workspace `experiments/mandate-sim`, 5/5 scenarios) before this productionization.

Stacked on #1421 (`feat/belt-repo-init`) — review the last 7 commits.

## Surface

`/api/v1/belt/mandates`: create/list/detail, feedback intake (dual shape: general text → sighting, gate teaching → ok), sightings, `POST /shift` (run judgment now), `POST /plan/resolve` (per-task approve/edit/reject from the console), pawprints. New realtime topic `belt_plan`. The instinct router gains `_belt_plan` as a third blob peer — purely additive, zero behavior change to the existing pocket-write and code-diff paths.

## Design rules carried from the sim

- An empty plan with a reason is a respected outcome (`stood_down` is a success state) — a mandate with quiet senses must not invent busywork.
- Plan validation runs on action fields (title, expected_outcome) only, never the `why` narration — a well-behaved Foreman names a forbidden opportunity precisely when refusing it.
- Budget is enforced server-side before anything reaches the gate.
- Exactly one `decision.completed` per chain, proven by a production-path test through the real instinct router (no stubs at the propose/execute seam).

## Demo-bar concessions (explicit, in docs/internal/2026-06-belt-mandates.md)

- Task dispatch is announce-only behind an injectable `TaskDispatcher` — the autopilot PR swaps in the real runner.
- Deps patrol uses a deterministic stale-package table; shift trigger is manual (cron later).
- No `require_plan_feature` on the router, matching the belt console's current posture — tighten both together before GA.
- `POST /autopilot` is intentionally absent here; it ships with the Foresight bridge PR.

## Tests

54 passed (mandates suite + the existing belt gate/trace/console suites): full shift→gate→approve→dispatch chain, stood-down path, budget cap 422, boundary-check-ignores-why, patrol intake + dedup, tenant isolation, reject-closes-once, resolve with mixed decisions.