### PR TITLE
Belt mandates: autopilot sim users and real run dispatch

### DIFF
--- a/docs/internal/2026-06-belt-mandates.md
+++ b/docs/internal/2026-06-belt-mandates.md
@@ -177,9 +177,21 @@ scenario runner in behind `UserSim` with no caller change.
 every feedback POST, and every cycle is wrapped — a failure is logged and
 swallowed per-cycle; the loop sleeps and retries next interval. The persisted
 `MandateDoc.autopilot = {on, users}` is the source of truth for whether
-autopilot *should* run; the live task is process-local (a restart re-derives it
-from the persisted `on` flag). State rides the detail + list wire + the
-`MandateAutopilotChanged` event (`{workspace_id, mandate_id, on, users}`).
+autopilot *should* run; the live task is process-local. State rides the detail +
+list wire + the `MandateAutopilotChanged` event
+(`{workspace_id, mandate_id, on, users}`).
+
+**Lifespan wiring.** A restart re-derives the loops from the persisted flags:
+`reconcile_autopilot_tasks` (lifespan startup) queries every ACTIVE mandate with
+`autopilot.on=True` (via `service.list_autopilot_enabled` — a deliberate
+cross-workspace system read, the stale-run-sweeper posture; paused mandates are
+skipped) and restarts each loop with `run_immediate=False`, so a boot never
+storms a cycle per mandate — the first cycle lands after the normal interval.
+`shutdown_all_autopilot_tasks` (lifespan shutdown) cancels + awaits every
+registered loop so the process exits without orphaned tasks. Both hooks are
+registered in `cloud/__init__.mount_cloud` under the same
+`POCKETPAW_CLOUD_SCHEDULER_ENABLED=true` gate as the decisions reconciler / run
+sweeper, so pytest runs never spawn background loops that outlive the test.
 
 ## Dispatcher reality — REAL station runs vs. announce-only (feat/belt-autopilot)
 
@@ -254,6 +266,8 @@ loop, so it can't observe the task); a full loop autopilot → shift (the mock
 foreman cites the autopilot sightings) → resolve-approve → the **real**
 `StationTaskDispatcher` files one queued `code_change` station run per task
 (`status=queued`, `station_pending=True`, repo pre-bound); the dispatcher env
-selection (`station`/`bus`); the `bus` path's announce-only behaviour; and
-tenant isolation on the autopilot endpoint. All run the deterministic mock
+selection (`station`/`bus`); the `bus` path's announce-only behaviour; the
+startup reconciler (restarts exactly the ACTIVE autopilot-on mandates after a
+simulated restart, skips off/paused, and the shutdown drain cancels every loop);
+and tenant isolation on the autopilot endpoint. All run the deterministic mock
 LLM/UserSim.

--- a/docs/internal/2026-06-belt-mandates.md
+++ b/docs/internal/2026-06-belt-mandates.md
@@ -89,6 +89,7 @@ a failed approach without stating what changed; strict JSON only.
 | GET | `/belt/mandates/{id}/sightings` | `belt.read` | `{sightings}`, newest-first |
 | POST | `/belt/mandates/{id}/shift` | `belt.manage` | Run a shift (manual trigger) → `{shift: {shift_id, no, state, plan_action_id, task_count, no_action_reason}}` |
 | POST | `/belt/mandates/{id}/plan/resolve` | `belt.manage` | The console's gate action: `{shift_no, decisions: [{index (0-based), decision: approve\|reject\|edit, edited_title?, reason?}]}` → `{shift}`. Every task needs exactly one decision. |
+| POST | `/belt/mandates/{id}/autopilot` | `belt.manage` | Start/stop Foresight-seeded simulated users feeding the feedback patrol: `{action: start\|stop, users?: int (default 3, max 10)}` → `{mandate}`. START persists `autopilot={on, users}`, runs ONE cycle immediately, spawns the background loop; STOP cancels it. |
 | GET | `/belt/mandates/{id}/pawprints` | `belt.read` | `{pawprints}` past-tense feed; item shape `{id, mandate_id, shift_no, kind, summary, evidence_refs, ts}` |
 
 Pawprint `kind`s: the UI consumes `executed` / `rejected` / `edited` /
@@ -135,21 +136,103 @@ before planning and appends an episodic shift summary after every terminal
 (`Soul.awaken → recall/remember → save_local`). Best-effort throughout — a
 soul failure never wedges a shift.
 
+## Autopilot — Foresight-seeded simulated users (feat/belt-autopilot)
+
+`POST /belt/mandates/{id}/autopilot {action, users?}` turns a mandate's feedback
+patrol into a self-feeding loop. When ON, a per-mandate background asyncio task
+(`autopilot.start_autopilot`, registered in the module's process-local `_TASKS`
+registry keyed by mandate id — the same create-task + cancel-and-await shape as
+`decisions._action_sweeper`, but per-mandate so STOP cancels exactly one) runs a
+cycle every `POCKETPAW_MANDATE_AUTOPILOT_INTERVAL` seconds (default 300); START
+also runs ONE cycle immediately (synchronously, inside the request, so START's
+response already reflects the first cycle's sightings).
+
+Each cycle:
+
+1. Reads the bound repo's surface — the README's first ~800 chars + up to 10
+   recent commit titles (`git log`, argv-only subprocess).
+2. Builds N personas (1-10, default 3) from a deterministic palette, each seeded
+   with a **Foresight `OceanDrift`** temperament (`ee.foresight.persona.OceanDrift`
+   — the genuine bridge to the sim module).
+3. Each persona emits 1-3 structured `{text, severity 1-5}` feedback items
+   through a pluggable `UserSim` interface, POSTed through the EXISTING
+   `service.file_feedback` path (NOT raw HTTP) with `source="autopilot:<persona>"`
+   — so they become feedback Sightings the next shift's foreman cites.
+
+**Which Foresight path + why.** The brief allows a lighter persona LLM call when
+foresight's scenario runner is too heavyweight per-cycle. We took the **lighter
+path**: foresight's `run_scenario` / OASIS substrate is a tick-based *world*
+simulation (CAMEL + OASIS + a YAML scenario config, anchors, prediction records)
+built to rehearse a *decision across a population*, not "use a product and emit
+free-text feedback" — spinning it up per cycle would pull in torch/igraph/pandas
+and a multi-tick loop, and its action vocabulary (`action/rationale/put`) is the
+wrong shape. Instead the persona transport reuses the **foreman's proven
+pluggable pattern** (`POCKETPAW_MANDATE_LLM=claude|mock` — the SAME env) behind
+the `UserSim` interface, and bridges foresight's `OceanDrift` value object for
+the persona seed. Mock mode is deterministic + seeded (a per-persona RNG seeded
+on the persona name) so tests get stable sightings. A later PR can swap the full
+scenario runner in behind `UserSim` with no caller change.
+
+**Resilience.** Autopilot never crashes a shift or the app: every persona call,
+every feedback POST, and every cycle is wrapped — a failure is logged and
+swallowed per-cycle; the loop sleeps and retries next interval. The persisted
+`MandateDoc.autopilot = {on, users}` is the source of truth for whether
+autopilot *should* run; the live task is process-local (a restart re-derives it
+from the persisted `on` flag). State rides the detail + list wire + the
+`MandateAutopilotChanged` event (`{workspace_id, mandate_id, on, users}`).
+
+## Dispatcher reality — REAL station runs vs. announce-only (feat/belt-autopilot)
+
+`POCKETPAW_MANDATE_DISPATCHER=station|bus` selects the `TaskDispatcher`
+(default `station` when the belt plumbing imports, else a clean fall-back to
+`bus`):
+
+- **`station` (`StationTaskDispatcher`, the real one).** Each approved plan task
+  becomes a **real Belt run** in the console Runs tab.
+- **`bus` (`BusTaskDispatcher`, the prior default).** Announce-only —
+  `belt_run_updated(status="dispatched", stage="station")` under a synthetic run
+  id (`<plan_action_id>:t<n>`); no run record is created.
+
+**HONESTY — is a genuinely headless station run reachable? NO.** The Belt
+*develop station* is an **interactive chat-agent loop**: the `/belt` surface
+preamble (`cloud/surface/handlers/belt.py`) drives a Claude chat session that
+ORIENTs, DEVELOPs, and produces a unified diff, which the
+`mcp__pocketpaw_belt__belt_propose_change` tool then files as a `code_change`
+Instinct Action. There is **no programmatic "task → diff" runner** to call from
+a dispatcher — the diff is the *output* of an LLM chat session, not a function.
+
+So `StationTaskDispatcher` does the **closest real thing**: it files a real
+`code_change` Instinct Action per task (the SAME row type the console Runs tab
+reads and the belt gate executes) carrying the task text, in a **queued** state
+(`station_pending=True`, no diff yet, repo pre-bound to the mandate's surface).
+The runs read model surfaces it as `status=queued / stage=station`; a human opens
+the `/belt` station for that queued run (one click) and drives it to a diff,
+which rides the existing belt gate as normal. This is a genuine run record, not a
+bus echo — the tests assert the persisted `code_change` Action + its
+`station_pending` queued state, not a bus message. Because a queued run carries
+no diff it is **not auto-applyable**: the belt executor refuses a
+`station_pending` blob loud (`error_class="StationPending"`) if it is ever
+(mistakenly) approved. When a real headless station runner lands, swap its call
+into `StationTaskDispatcher` behind the same `TaskDispatcher` protocol — no
+caller change.
+
 ## Demo-bar concessions (each marked in code)
 
 1. **Manual shift trigger only.** `cadence: "weekly"` is stored but not
-   scheduled; the autopilot PR wires the scheduler (and Foresight — explicitly
-   NOT integrated here).
+   scheduled (autopilot seeds *sightings*, not shift triggers — wiring the
+   cadence scheduler is still a later PR).
 2. **Deps patrol advisory data is a hardcoded table** (`patrols.KNOWN_STALE`).
    The manifest parsing + sighting plumbing are production-shaped; only the
    data source is stubbed.
-3. **Task dispatch announces, it does not run.** `BusTaskDispatcher` emits
-   `belt_run_updated(status="dispatched", stage="station")` through the
-   existing belt service under a synthetic run id (`<plan_action_id>:t<n>`).
-   Wiring an autonomous develop-station runner that picks the task up is the
-   autopilot PR's job. The `TaskDispatcher` protocol is the swap point.
-4. **LLM transport is the `claude` CLI shell-out** behind the `PlanLlm`
-   protocol; an SDK transport can replace it without touching the foreman.
+3. **Station dispatch QUEUES a real run; it does not auto-produce the diff.**
+   `StationTaskDispatcher` (default) files a real queued `code_change` run a
+   human starts in the console — see *Dispatcher reality* above for why a fully
+   headless diff-producing run is not reachable. `bus` mode keeps the prior
+   announce-only behaviour. The `TaskDispatcher` protocol is the swap point for a
+   future headless runner.
+4. **LLM transport is the `claude` CLI shell-out** behind the `PlanLlm` (foreman)
+   and `UserSim` (autopilot) protocols; an SDK transport can replace either
+   without touching the caller.
 5. **Pawprints read the store, not the journal.** The feed derives from
    ShiftDoc states + the plan Action's status/blob — the same facts the chain
    folded from; a journal-walking narrator can replace it later.
@@ -162,3 +245,15 @@ real-instinct-router approve → dispatch and asserts EXACTLY ONE
 `decision.completed` (this repo's documented chain-doubling seam). Also pinned:
 stood_down, budget cap, boundary-check-ignores-`why`, patrol intake, deps
 patrol + dedup, tenant isolation, reject-closes-once.
+
+`tests/cloud/test_belt_autopilot.py` (feat/belt-autopilot) pins both new pieces:
+autopilot start persists state + runs an immediate cycle whose sightings carry
+`source="autopilot:*"`; the background task start/stop lifecycle (asserted
+directly against the module — a TestClient request runs on its own short-lived
+loop, so it can't observe the task); a full loop autopilot → shift (the mock
+foreman cites the autopilot sightings) → resolve-approve → the **real**
+`StationTaskDispatcher` files one queued `code_change` station run per task
+(`status=queued`, `station_pending=True`, repo pre-bound); the dispatcher env
+selection (`station`/`bus`); the `bus` path's announce-only behaviour; and
+tenant isolation on the autopilot endpoint. All run the deterministic mock
+LLM/UserSim.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,11 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-06-11 (feat/belt-autopilot) — Registers the mandate-autopilot
+    lifespan pair under the POCKETPAW_CLOUD_SCHEDULER_ENABLED gate:
+    ``reconcile_autopilot_tasks`` at startup (re-derives per-mandate autopilot
+    loops from the persisted ``MandateDoc.autopilot.on`` flags,
+    run_immediate=False) and ``shutdown_all_autopilot_tasks`` at shutdown
+    (cancels + awaits every registered loop).
 Modified: 2026-06-10 (W4b — privilege-escalation fix) — Updated the inline
     note on the EEAuthBridge middleware: the bridge now grants OSS
     ``full_access`` only to genuine platform admins (``is_superuser``), not
@@ -744,6 +750,29 @@ def mount_cloud(app: FastAPI) -> None:
         @app.on_event("shutdown")
         async def _stop_fabric_ingest() -> None:
             await stop_fabric_ingest(app)
+
+    # Mandate autopilot reconciler (feat/belt-autopilot). The persisted
+    # ``MandateDoc.autopilot.on`` flag is the source of truth for whether a
+    # mandate's autopilot SHOULD run; the background loop itself is
+    # process-local. At startup the reconciler re-derives the loops from the
+    # persisted flags (run_immediate=False — a boot never storms a cycle per
+    # mandate; the first cycle lands after the normal interval). At shutdown
+    # every registered loop is cancelled + awaited so the process exits without
+    # orphaned tasks. Same scheduler gate as the cycle/decisions loops so pytest
+    # runs never spawn a background loop that outlives the test.
+    if _os.environ.get("POCKETPAW_CLOUD_SCHEDULER_ENABLED", "").lower() == "true":
+        from pocketpaw_ee.cloud.mandates.autopilot import (
+            reconcile_autopilot_tasks,
+            shutdown_all_autopilot_tasks,
+        )
+
+        @app.on_event("startup")
+        async def _start_mandate_autopilot() -> None:
+            await reconcile_autopilot_tasks()
+
+        @app.on_event("shutdown")
+        async def _stop_mandate_autopilot() -> None:
+            await shutdown_all_autopilot_tasks()
 
     # Mission Control activity buffer — per-workspace ring buffer fed by
     # agent.* bus events. Same constraint as the upload listeners: subscribe

--- a/ee/pocketpaw_ee/cloud/belt/executor.py
+++ b/ee/pocketpaw_ee/cloud/belt/executor.py
@@ -1,6 +1,13 @@
 # executor.py — applies an approved Belt code-change Action and opens a PR.
 # Created: 2026-06-10 (feat/belt-gate, BS-3).
 #
+# Updated: 2026-06-11 (feat/belt-autopilot) — refuses a QUEUED station run loud.
+#   A ``code_change`` blob carrying ``station_pending=True`` (filed by the
+#   mandate ``StationTaskDispatcher`` with the task text but NO diff) is a
+#   placeholder run waiting for a human to drive the develop station to a diff —
+#   it is never auto-applyable. The executor fails it with error_class
+#   ``StationPending`` if it is ever (mistakenly) approved.
+#
 # Updated: 2026-06-11 (feat/belt-repo-init — local-only gate mode) — the executor
 #   now lands a change on a repo with NO ``origin`` remote WITHOUT pushing or
 #   opening a PR. ``_has_origin`` is checked once up front (step 0): with a remote
@@ -522,6 +529,19 @@ async def execute_approved_change(
             "code-change schema mismatch — the change blob is from an "
             "incompatible build and cannot be applied",
             error_class="SchemaMismatch",
+        )
+        return
+
+    # A QUEUED STATION RUN (filed by the mandate StationTaskDispatcher) carries
+    # the task text but NO diff — it is waiting for a human to drive the develop
+    # station to a diff, which files a FRESH applyable code_change Action. It must
+    # never auto-apply (there is nothing to apply). The normal flow never approves
+    # a queued run, but a stray bulk-approve would land here — refuse it loud.
+    if blob.get("station_pending"):
+        await _fail(
+            "this is a QUEUED station run, not an applyable change — open the "
+            "develop station to produce a diff first, then approve that proposal",
+            error_class="StationPending",
         )
         return
 

--- a/ee/pocketpaw_ee/cloud/belt/service.py
+++ b/ee/pocketpaw_ee/cloud/belt/service.py
@@ -1,4 +1,11 @@
 # ee/pocketpaw_ee/cloud/belt/service.py
+# Updated: 2026-06-11 (feat/belt-autopilot) — the runs read model now renders a
+#   QUEUED STATION RUN. A pending ``code_change`` Action whose blob carries
+#   ``station_pending=True`` (filed by the mandate ``StationTaskDispatcher`` with
+#   the task text but no diff yet) derives status ``queued`` / stage ``station``
+#   instead of ``proposed`` / ``gate``, so the console shows it as waiting for a
+#   human to open the develop station (one click) rather than sitting at the
+#   approve gate.
 # Created: 2026-06-10 (feat/belt-console-backend, SC-1 + SC-2) — the Belt &
 # Pulley console read/write service. Powers the /belt page's three needs the
 # first live runs exposed: (1) DISCOVER repos so the user can bind one up front
@@ -645,9 +652,22 @@ _STATUS_MAP: dict[str, tuple[str, str]] = {
 }
 
 
-def _derive_status_stage(action: Any) -> tuple[str, str]:
+def _derive_status_stage(action: Any, blob: dict[str, Any] | None = None) -> tuple[str, str]:
     """Map an Action's status to the console (status, stage) pair. An unknown
-    status (forward-compat) falls back to (the raw value, 'gate')."""
+    status (forward-compat) falls back to (the raw value, 'gate').
+
+    A QUEUED STATION RUN — a pending ``code_change`` Action whose blob carries
+    ``station_pending=True`` (filed by the mandate ``StationTaskDispatcher`` with
+    no diff yet) — reads as ``("queued", "station")`` so the console shows it as
+    waiting for a human to open the develop station, not sitting at the gate."""
+    if blob is not None and blob.get("station_pending"):
+        raw = getattr(getattr(action, "status", None), "value", None) or str(
+            getattr(action, "status", "")
+        )
+        # Only a still-pending queued run reads as "queued"; once the human drives
+        # the station and a diff is proposed, a fresh non-pending row supersedes it.
+        if raw == "pending":
+            return ("queued", "station")
     raw = getattr(getattr(action, "status", None), "value", None) or str(
         getattr(action, "status", "")
     )
@@ -670,7 +690,7 @@ def _run_summary(action: Any, blob: dict[str, Any]) -> dict[str, Any]:
         None`` cleanly (key present, value null) so the frontend's
         ``pr_url ? <link> : <chip>`` switch is unambiguous.
     """
-    status, stage = _derive_status_stage(action)
+    status, stage = _derive_status_stage(action, blob)
     created = getattr(action, "created_at", None)
     repo_path = str(blob.get("repo") or "")
     return {

--- a/ee/pocketpaw_ee/cloud/mandates/autopilot.py
+++ b/ee/pocketpaw_ee/cloud/mandates/autopilot.py
@@ -1,0 +1,572 @@
+# ee/pocketpaw_ee/cloud/mandates/autopilot.py
+# Created: 2026-06-11 (feat/belt-autopilot).
+#
+# AUTOPILOT — Foresight-seeded simulated users that exercise a mandate's surface
+# and feed the FEEDBACK PATROL. When autopilot is ON, a per-mandate background
+# cycle runs every ``POCKETPAW_MANDATE_AUTOPILOT_INTERVAL`` seconds (default 300;
+# one cycle also fires IMMEDIATELY on start). Each cycle:
+#
+#   1. Reads the bound repo's surface context — the README's first lines + the
+#      recent commit titles (``git log``) — so the personas "use" something real.
+#   2. Builds N personas (1-10, default 3) via the FORESIGHT module's persona
+#      seeding (``ee.foresight.persona.OceanDrift`` — a genuine bridge to the sim
+#      module; the seeded drift shapes each persona's temperament).
+#   3. Each persona emits 1-3 STRUCTURED feedback items {text, severity 1-5,
+#      source: "autopilot:<persona>"} through a pluggable ``UserSim`` interface,
+#      POSTed through the EXISTING feedback service path
+#      (``service.file_feedback`` — NOT raw HTTP) so they become Sightings the
+#      next shift's foreman cites.
+#
+# WHICH PATH + WHY (the honesty note the brief asks for): the brief allows a
+# lighter persona LLM call when foresight's full scenario runner is too heavy
+# for a per-cycle call. We took the LIGHTER path:
+#
+#   * Foresight's ``run_scenario`` / OASIS substrate is a TICK-BASED world
+#     simulation (CAMEL + OASIS + a YAML scenario config, anchors, prediction
+#     records) geared to "rehearse a decision across a population of personas",
+#     NOT "use a product and emit free-text feedback". Spinning it up per cycle
+#     would pull in torch/igraph/pandas and a multi-tick world loop for what is a
+#     one-shot "react to this surface" call — far too heavyweight, and its
+#     action vocabulary (``action/rationale/put``) is the wrong shape.
+#   * Instead we reuse the FOREMAN's proven pluggable transport pattern
+#     (``POCKETPAW_MANDATE_LLM=claude|mock`` — the SAME env the foreman reads) and
+#     the foresight ``OceanDrift`` persona-seed value object. The persona LLM
+#     call lives behind the ``UserSim`` interface so a later PR can swap the full
+#     foresight scenario runner in with no caller change. Mock mode is
+#     deterministic + seeded so tests get stable sightings.
+#
+# RESILIENCE: autopilot must NEVER crash a shift or the app. Every persona call,
+# every feedback POST, and every cycle is wrapped — a failure is logged and
+# swallowed per-cycle; the loop sleeps and tries again next interval.
+#
+# BACKGROUND TASK: each mandate's loop is an asyncio task in the process-local
+# ``_TASKS`` registry keyed by mandate id (mirrors
+# ``decisions._action_sweeper``'s create-task + cancel-and-await shape, but
+# per-mandate so STOP can cancel exactly one). The persisted
+# ``MandateDoc.autopilot.on`` flag is the source of truth for whether autopilot
+# SHOULD be running; the task is process-local and is re-derivable from that flag.
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import random
+import re
+from pathlib import Path
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Default cycle interval (seconds) — env ``POCKETPAW_MANDATE_AUTOPILOT_INTERVAL``.
+_DEFAULT_INTERVAL_SECONDS = 300
+# Persona-count bounds (mirrors the DTO's clamp).
+_MIN_USERS = 1
+_MAX_USERS = 10
+# Per-persona feedback-item bounds.
+_MIN_ITEMS = 1
+_MAX_ITEMS = 3
+# Subprocess timeout for the per-persona claude CLI call (seconds).
+_CLI_TIMEOUT = 120.0
+# How much surface context to feed a persona (chars of README / count of commits).
+_README_CHARS = 800
+_COMMIT_COUNT = 10
+
+# Process-local registry of running autopilot loops, keyed by mandate id.
+_TASKS: dict[str, asyncio.Task] = {}
+
+
+# ---------------------------------------------------------------------------
+# Persona seeding — bridges the FORESIGHT module's OceanDrift value object.
+# ---------------------------------------------------------------------------
+
+
+def _ocean_drift_cls() -> Any:
+    """Resolve foresight's ``OceanDrift`` value object, or ``None`` if the
+    foresight module can't be imported (a partial install). The bridge is
+    genuine but optional — without it we still build personas with a name +
+    a neutral temperament string."""
+    try:
+        from pocketpaw_ee.foresight.persona import OceanDrift
+
+        return OceanDrift
+    except Exception:  # noqa: BLE001 — foresight is optional here
+        logger.debug("autopilot: foresight OceanDrift unavailable", exc_info=True)
+        return None
+
+
+# A small deterministic persona palette — name + drift seed. In mock mode the
+# personas are picked from the head of this list so tests are stable; the
+# claude transport uses the same names + drift to shape the prompt.
+_PERSONA_PALETTE: list[dict[str, Any]] = [
+    {"name": "power-user", "drift": {"conscientiousness": 1.5, "openness": 0.5}},
+    {"name": "skeptic", "drift": {"agreeableness": -1.0, "neuroticism": 0.8}},
+    {"name": "newcomer", "drift": {"openness": 1.0, "conscientiousness": -0.5}},
+    {"name": "ops-lead", "drift": {"conscientiousness": 2.0, "neuroticism": 0.5}},
+    {"name": "casual", "drift": {"extraversion": 1.0, "conscientiousness": -1.0}},
+    {"name": "security-minded", "drift": {"neuroticism": 1.2, "conscientiousness": 1.0}},
+    {"name": "designer", "drift": {"openness": 1.8, "agreeableness": 0.5}},
+    {"name": "integrator", "drift": {"conscientiousness": 0.8, "openness": 0.8}},
+    {"name": "manager", "drift": {"extraversion": 1.2, "agreeableness": 0.8}},
+    {"name": "tester", "drift": {"conscientiousness": 1.6, "neuroticism": 1.0}},
+]
+
+
+class Persona:
+    """One autopilot simulated user — a name + a temperament block.
+
+    The temperament block is rendered from foresight's ``OceanDrift`` when the
+    foresight module is available (the genuine bridge), else a neutral string."""
+
+    def __init__(self, name: str, drift_kwargs: dict[str, float]) -> None:
+        self.name = name
+        drift_cls = _ocean_drift_cls()
+        if drift_cls is not None:
+            try:
+                self._drift = drift_cls(**drift_kwargs)
+                self.temperament = self._drift.as_prompt_block()
+            except Exception:  # noqa: BLE001 — drift construction must never break a persona
+                self._drift = None
+                self.temperament = "baseline temperament"
+        else:
+            self._drift = None
+            self.temperament = "baseline temperament"
+
+
+def build_personas(users: int) -> list[Persona]:
+    """Build ``users`` personas (clamped 1-10) from the deterministic palette.
+
+    Deterministic + seeded: the first ``users`` entries of the palette are taken
+    in order, so the same ``users`` value always yields the same personas — the
+    test seeding the brief requires. Personas beyond the palette length wrap with
+    an index suffix so a request for the max (10) is always satisfiable."""
+    n = max(_MIN_USERS, min(_MAX_USERS, int(users)))
+    personas: list[Persona] = []
+    for i in range(n):
+        spec = _PERSONA_PALETTE[i % len(_PERSONA_PALETTE)]
+        name = spec["name"] if i < len(_PERSONA_PALETTE) else f"{spec['name']}-{i}"
+        personas.append(Persona(name=name, drift_kwargs=dict(spec["drift"])))
+    return personas
+
+
+# ---------------------------------------------------------------------------
+# Surface context — what the personas "use" (README + recent commit titles).
+# ---------------------------------------------------------------------------
+
+
+async def _read_surface(repo_id: str) -> dict[str, Any]:
+    """Read the bound repo's surface context for the personas.
+
+    Returns ``{"name", "readme", "commits"}`` — the repo dir name, the first
+    ~800 chars of the README (any-case ``README*``), and up to 10 recent commit
+    titles (``git log --format=%s``). A missing repo / README / git history
+    degrades to empty values — autopilot never raises on a thin surface."""
+    repo = Path(repo_id).expanduser()
+    out: dict[str, Any] = {"name": repo.name, "readme": "", "commits": []}
+    if not repo.is_dir():
+        return out
+
+    # README — first matching README* file, first ~800 chars.
+    try:
+        for child in sorted(repo.iterdir()):
+            if child.is_file() and child.name.lower().startswith("readme"):
+                out["readme"] = child.read_text(encoding="utf-8", errors="replace")[:_README_CHARS]
+                break
+    except OSError:
+        logger.debug("autopilot: README read failed for %s", repo_id, exc_info=True)
+
+    # Recent commit titles — git log, argv-only subprocess (no shell).
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "log",
+            f"-{_COMMIT_COUNT}",
+            "--format=%s",
+            cwd=str(repo),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, _stderr = await asyncio.wait_for(proc.communicate(), timeout=30.0)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            stdout = b""
+        titles = [
+            line.strip() for line in stdout.decode("utf-8", "replace").splitlines() if line.strip()
+        ]
+        out["commits"] = titles[:_COMMIT_COUNT]
+    except Exception:  # noqa: BLE001 — git history is optional context
+        logger.debug("autopilot: git log failed for %s", repo_id, exc_info=True)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# UserSim — the pluggable persona transport (mirrors the foreman's PlanLlm).
+# ---------------------------------------------------------------------------
+
+
+class UserSim(Protocol):
+    """One persona's reaction: surface context + persona in, feedback items out.
+
+    Returns a list of 1-3 ``{text, severity}`` dicts (the ``source`` is stamped
+    by the caller as ``autopilot:<persona>``). Selected by
+    ``POCKETPAW_MANDATE_LLM`` — the SAME env the foreman's transport reads."""
+
+    async def react(self, *, persona: Persona, surface: dict[str, Any]) -> list[dict[str, Any]]: ...
+
+
+class MockUserSim:
+    """Deterministic, SEEDED persona transport for tests + offline demos.
+
+    Each persona emits 1-3 feedback items derived from the surface context +
+    the persona name, with a per-persona RNG SEEDED on the persona name so the
+    same persona + same surface always yields the same items (the brief's
+    deterministic-in-mock-mode requirement)."""
+
+    async def react(self, *, persona: Persona, surface: dict[str, Any]) -> list[dict[str, Any]]:
+        rng = random.Random(persona.name)  # seeded on the persona — stable
+        name = surface.get("name") or "the product"
+        commits = list(surface.get("commits") or [])
+        readme = (surface.get("readme") or "").strip()
+
+        # A small templated bank — the persona picks a deterministic subset.
+        templates = [
+            f"As a {persona.name}, the onboarding for {name} felt unclear.",
+            f"As a {persona.name}, I hit friction using {name} today.",
+            f"As a {persona.name}, I'd want clearer docs for {name}.",
+        ]
+        if commits:
+            templates.append(
+                f"As a {persona.name}, the recent change '{commits[0][:60]}' needs a follow-up."
+            )
+        if readme:
+            templates.append(
+                f"As a {persona.name}, the README pitch for {name} oversells vs. reality."
+            )
+
+        count = rng.randint(_MIN_ITEMS, min(_MAX_ITEMS, len(templates)))
+        chosen = rng.sample(templates, count)
+        return [{"text": text, "severity": rng.randint(2, 5)} for text in chosen]
+
+
+class ClaudeCliUserSim:
+    """Real persona transport — shells the ``claude`` CLI (demo bar).
+
+    Mirrors the foreman's ``ClaudeCliLlm``: ``claude -p <prompt> --output-format
+    json``; the prompt is a single argv element (the CLI does its own auth). The
+    model is asked for STRICT JSON: a list of ``{text, severity}`` feedback items.
+    A transport / parse failure returns an empty list — the caller logs + skips
+    that persona; autopilot never raises out of a cycle."""
+
+    async def react(self, *, persona: Persona, surface: dict[str, Any]) -> list[dict[str, Any]]:
+        prompt = _build_persona_prompt(persona, surface)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "claude",
+                "-p",
+                prompt,
+                "--output-format",
+                "json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                out_b, err_b = await asyncio.wait_for(proc.communicate(), timeout=_CLI_TIMEOUT)
+            except TimeoutError:
+                proc.kill()
+                await proc.wait()
+                logger.warning("autopilot: persona %s CLI timed out", persona.name)
+                return []
+            if proc.returncode != 0:
+                logger.warning(
+                    "autopilot: persona %s CLI failed (exit %s): %s",
+                    persona.name,
+                    proc.returncode,
+                    err_b.decode("utf-8", "replace").strip()[:200],
+                )
+                return []
+            text = _unwrap_cli_result(out_b.decode("utf-8", "replace"))
+            return _parse_items(text)
+        except Exception:  # noqa: BLE001 — a transport failure skips this persona
+            logger.warning("autopilot: persona %s react crashed", persona.name, exc_info=True)
+            return []
+
+
+def _build_persona_prompt(persona: Persona, surface: dict[str, Any]) -> str:
+    """Assemble the persona prompt for the claude transport."""
+    commit_titles = (surface.get("commits") or [])[:_COMMIT_COUNT]
+    commits = "\n".join(f"- {c}" for c in commit_titles) or "(none)"
+    readme = (surface.get("readme") or "(no README)").strip()[:_README_CHARS]
+    return f"""You are a simulated user of the product "{surface.get("name")}".
+Persona: {persona.name}. Temperament: {persona.temperament}.
+
+== PRODUCT README (excerpt) ==
+{readme}
+
+== RECENT CHANGES (commit titles) ==
+{commits}
+
+You just used this product as the persona above. Report 1-3 pieces of concrete,
+specific feedback — friction, confusion, a bug you'd hit, a missing capability —
+in the voice of the persona. Each item has a severity 1 (minor) to 5 (blocking).
+
+Reply with STRICT JSON only — no prose, no markdown fences:
+[{{"text": "<one concrete piece of feedback>", "severity": 3}}]"""
+
+
+def _unwrap_cli_result(out: str) -> str:
+    """Pull the ``result`` field off the claude CLI JSON envelope, tolerating a
+    bare-text response (mirrors the foreman's ClaudeCliLlm)."""
+    try:
+        envelope = json.loads(out)
+    except json.JSONDecodeError:
+        return out
+    if isinstance(envelope, dict) and isinstance(envelope.get("result"), str):
+        return envelope["result"]
+    return out
+
+
+_FENCE = re.compile(r"^\s*```(?:json)?\s*(.*?)\s*```\s*$", re.DOTALL)
+
+
+def _parse_items(raw: str) -> list[dict[str, Any]]:
+    """Parse the model's text into a list of ``{text, severity}`` items.
+
+    Tolerates a fenced JSON block or stray text around a top-level JSON array.
+    Each item is normalized: ``text`` is required (non-empty), ``severity`` is
+    clamped to 1-5 (default 3). Returns at most 3 items. An unparseable response
+    yields an empty list — the caller skips that persona."""
+    text = raw.strip()
+    m = _FENCE.match(text)
+    if m:
+        text = m.group(1).strip()
+    data: Any = None
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        start, end = text.find("["), text.rfind("]")
+        if start >= 0 and end > start:
+            with contextlib.suppress(json.JSONDecodeError, ValueError):
+                data = json.loads(text[start : end + 1])
+    if not isinstance(data, list):
+        return []
+    items: list[dict[str, Any]] = []
+    for entry in data[:_MAX_ITEMS]:
+        if not isinstance(entry, dict):
+            continue
+        body = str(entry.get("text") or "").strip()
+        if not body:
+            continue
+        try:
+            sev = int(entry.get("severity") or 3)
+        except (TypeError, ValueError):
+            sev = 3
+        sev = max(1, min(5, sev))
+        items.append({"text": body, "severity": sev})
+    return items
+
+
+def resolve_user_sim() -> UserSim:
+    """Pick the persona transport from ``POCKETPAW_MANDATE_LLM`` (the SAME env the
+    foreman reads). ``mock`` → deterministic seeded sim; anything else → claude."""
+    choice = (os.environ.get("POCKETPAW_MANDATE_LLM") or "claude").strip().lower()
+    if choice == "mock":
+        return MockUserSim()
+    return ClaudeCliUserSim()
+
+
+# ---------------------------------------------------------------------------
+# One cycle — the unit the loop runs (and the unit run immediately on start).
+# ---------------------------------------------------------------------------
+
+
+async def run_autopilot_cycle(
+    workspace_id: str,
+    mandate_id: str,
+    *,
+    users: int,
+    user_sim: UserSim | None = None,
+) -> int:
+    """Run ONE autopilot cycle: build personas, read the surface, file feedback.
+
+    Returns the number of feedback sightings filed. NEVER raises — every persona
+    and every feedback POST is wrapped; a failure is logged and swallowed so a
+    bad cycle can't crash the loop, a shift, or the app. The feedback goes
+    through the EXISTING ``service.file_feedback`` path (not raw HTTP), so each
+    item becomes a Sighting the next shift's foreman cites, with
+    ``source="autopilot:<persona>"``."""
+    from pocketpaw_ee.cloud.mandates import service as mandate_service
+
+    sim: UserSim = user_sim or resolve_user_sim()
+
+    # Resolve the bound repo for the surface context. A read failure degrades to
+    # an empty surface (the personas still emit generic feedback).
+    try:
+        repo_id = await mandate_service.repo_for_mandate(workspace_id, mandate_id)
+    except Exception:  # noqa: BLE001 — a repo read must never break the cycle
+        logger.debug("autopilot: repo lookup failed for %s", mandate_id, exc_info=True)
+        repo_id = None
+    surface = await _read_surface(repo_id) if repo_id else {"name": "", "readme": "", "commits": []}
+
+    personas = build_personas(users)
+    filed = 0
+    for persona in personas:
+        try:
+            items = await sim.react(persona=persona, surface=surface)
+        except Exception:  # noqa: BLE001 — one bad persona never sinks the cycle
+            logger.warning(
+                "autopilot: persona %s reaction failed for mandate %s",
+                persona.name,
+                mandate_id,
+                exc_info=True,
+            )
+            continue
+        for item in items[:_MAX_ITEMS]:
+            text = str(item.get("text") or "").strip()
+            if not text:
+                continue
+            severity = item.get("severity")
+            try:
+                # File through the EXISTING feedback service path — the general
+                # {text, severity, source} shape becomes a feedback Sighting.
+                await mandate_service.file_feedback(
+                    workspace_id,
+                    f"autopilot:{persona.name}",
+                    mandate_id,
+                    {
+                        "text": text,
+                        "severity": severity,
+                        "source": f"autopilot:{persona.name}",
+                    },
+                )
+                filed += 1
+            except Exception:  # noqa: BLE001 — a feedback failure skips this item
+                logger.warning(
+                    "autopilot: feedback file failed for mandate %s (persona %s)",
+                    mandate_id,
+                    persona.name,
+                    exc_info=True,
+                )
+    logger.info(
+        "autopilot: cycle for mandate %s filed %d feedback sighting(s) from %d persona(s)",
+        mandate_id,
+        filed,
+        len(personas),
+    )
+    return filed
+
+
+# ---------------------------------------------------------------------------
+# The background loop + the per-mandate task registry (start / stop).
+# ---------------------------------------------------------------------------
+
+
+def _interval_seconds() -> int:
+    """Read the cycle interval from env, default 300s. A non-int / non-positive
+    value falls back to the default."""
+    raw = os.environ.get("POCKETPAW_MANDATE_AUTOPILOT_INTERVAL", "").strip()
+    if not raw:
+        return _DEFAULT_INTERVAL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "POCKETPAW_MANDATE_AUTOPILOT_INTERVAL=%r is not an int — using %d",
+            raw,
+            _DEFAULT_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_INTERVAL_SECONDS
+    return value if value > 0 else _DEFAULT_INTERVAL_SECONDS
+
+
+async def _autopilot_loop(
+    workspace_id: str, mandate_id: str, users: int, *, run_immediate: bool = True
+) -> None:
+    """The per-mandate background loop body. Runs ONE cycle immediately (unless
+    ``run_immediate`` is False — the service already ran it synchronously), then
+    a cycle every interval. Per-cycle failures are caught inside
+    ``run_autopilot_cycle`` already, but the loop also guards the sleep +
+    catch-all so nothing escapes. ``CancelledError`` propagates so STOP can
+    cancel-and-await cleanly."""
+    interval = _interval_seconds()
+    logger.info(
+        "autopilot: loop started for mandate %s (users=%d, interval=%ds)",
+        mandate_id,
+        users,
+        interval,
+    )
+    # One cycle IMMEDIATELY on start (the brief's "also run ONE cycle immediately")
+    # — skipped only when the caller already ran it synchronously (the endpoint
+    # path, so START's response already reflects the first cycle's sightings).
+    if run_immediate:
+        with contextlib.suppress(asyncio.CancelledError):
+            try:
+                await run_autopilot_cycle(workspace_id, mandate_id, users=users)
+            except Exception:  # noqa: BLE001 — already swallowed inside; belt-and-braces
+                logger.warning(
+                    "autopilot: immediate cycle failed for %s", mandate_id, exc_info=True
+                )
+
+    while True:
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("autopilot: loop for mandate %s cancelled — exiting", mandate_id)
+            raise
+        try:
+            await run_autopilot_cycle(workspace_id, mandate_id, users=users)
+        except Exception:  # noqa: BLE001 — a bad cycle never sinks the loop
+            logger.warning("autopilot: cycle failed for mandate %s", mandate_id, exc_info=True)
+
+
+async def start_autopilot(
+    workspace_id: str, mandate_id: str, users: int, *, run_immediate: bool = True
+) -> None:
+    """Start (or restart) the background autopilot loop for a mandate.
+
+    Idempotent on restart: an existing live task for this mandate is cancelled
+    first (a ``users`` change takes effect on restart), then a fresh task is
+    created and registered. ``run_immediate=False`` tells the loop the caller
+    already ran the first cycle synchronously (the endpoint path), so the loop's
+    next action is the first interval sleep — no double-fire."""
+    await stop_autopilot(mandate_id)
+    n = max(_MIN_USERS, min(_MAX_USERS, int(users)))
+    task = asyncio.create_task(
+        _autopilot_loop(workspace_id, mandate_id, n, run_immediate=run_immediate),
+        name=f"autopilot-{mandate_id}",
+    )
+    _TASKS[mandate_id] = task
+
+
+async def stop_autopilot(mandate_id: str) -> None:
+    """Cancel + await the mandate's background loop. Safe to call when no task is
+    running (a no-op). Idempotent."""
+    task = _TASKS.pop(mandate_id, None)
+    if task is None or task.done():
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+
+
+def is_running(mandate_id: str) -> bool:
+    """True when a live autopilot loop is registered for the mandate."""
+    task = _TASKS.get(mandate_id)
+    return task is not None and not task.done()
+
+
+__all__ = [
+    "ClaudeCliUserSim",
+    "MockUserSim",
+    "Persona",
+    "UserSim",
+    "build_personas",
+    "is_running",
+    "resolve_user_sim",
+    "run_autopilot_cycle",
+    "start_autopilot",
+    "stop_autopilot",
+]

--- a/ee/pocketpaw_ee/cloud/mandates/autopilot.py
+++ b/ee/pocketpaw_ee/cloud/mandates/autopilot.py
@@ -44,7 +44,12 @@
 # ``decisions._action_sweeper``'s create-task + cancel-and-await shape, but
 # per-mandate so STOP can cancel exactly one). The persisted
 # ``MandateDoc.autopilot.on`` flag is the source of truth for whether autopilot
-# SHOULD be running; the task is process-local and is re-derivable from that flag.
+# SHOULD be running; the task is process-local and is re-derived from that flag
+# at boot by ``reconcile_autopilot_tasks`` (lifespan startup, run_immediate=False
+# so a boot never storms cycles); ``shutdown_all_autopilot_tasks`` drains every
+# loop at lifespan shutdown. Both are registered in ``cloud/__init__.mount_cloud``
+# under the same POCKETPAW_CLOUD_SCHEDULER_ENABLED gate the decisions
+# reconciler / run sweeper use.
 
 from __future__ import annotations
 
@@ -558,6 +563,62 @@ def is_running(mandate_id: str) -> bool:
     return task is not None and not task.done()
 
 
+# ---------------------------------------------------------------------------
+# Lifespan wiring — the startup reconciler + the shutdown drain. Registered in
+# ``cloud/__init__.mount_cloud`` under the same POCKETPAW_CLOUD_SCHEDULER_ENABLED
+# gate the decisions reconciler / run sweeper use (so pytest runs never spawn
+# background loops that outlive the test).
+# ---------------------------------------------------------------------------
+
+
+async def reconcile_autopilot_tasks() -> int:
+    """STARTUP RECONCILER — re-derive the process-local background loops from
+    the persisted ``MandateDoc.autopilot.on`` flags (the source of truth).
+
+    Called once at lifespan startup. For every ACTIVE mandate with autopilot on,
+    start its loop with ``run_immediate=False`` — a boot must NOT storm a cycle
+    per mandate; the first cycle lands after the normal interval. Paused /
+    autopilot-off mandates are ignored (the service read excludes them). Never
+    raises — a reconcile failure logs and returns 0 so app startup is never
+    blocked. Returns the number of loops started."""
+    try:
+        from pocketpaw_ee.cloud.mandates import service as mandate_service
+
+        rows = await mandate_service.list_autopilot_enabled()
+    except Exception:  # noqa: BLE001 — a reconcile read failure must not block startup
+        logger.warning("autopilot: startup reconcile read failed", exc_info=True)
+        return 0
+
+    started = 0
+    for row in rows:
+        try:
+            await start_autopilot(
+                str(row["workspace_id"]),
+                str(row["mandate_id"]),
+                int(row["users"]),
+                run_immediate=False,
+            )
+            started += 1
+        except Exception:  # noqa: BLE001 — one bad mandate never blocks the rest
+            logger.warning(
+                "autopilot: reconcile could not start loop for mandate %s",
+                row.get("mandate_id"),
+                exc_info=True,
+            )
+    logger.info("autopilot: startup reconciler started %d loop(s)", started)
+    return started
+
+
+async def shutdown_all_autopilot_tasks() -> None:
+    """SHUTDOWN DRAIN — cancel + await every registered autopilot loop.
+
+    Called once at lifespan shutdown so the process exits without orphaned
+    tasks. Each stop is the same cancel-and-await ``stop_autopilot`` uses;
+    idempotent and never raises."""
+    for mandate_id in list(_TASKS):
+        await stop_autopilot(mandate_id)
+
+
 __all__ = [
     "ClaudeCliUserSim",
     "MockUserSim",
@@ -565,8 +626,10 @@ __all__ = [
     "UserSim",
     "build_personas",
     "is_running",
+    "reconcile_autopilot_tasks",
     "resolve_user_sim",
     "run_autopilot_cycle",
+    "shutdown_all_autopilot_tasks",
     "start_autopilot",
     "stop_autopilot",
 ]

--- a/ee/pocketpaw_ee/cloud/mandates/domain.py
+++ b/ee/pocketpaw_ee/cloud/mandates/domain.py
@@ -1,6 +1,13 @@
 # ee/pocketpaw_ee/cloud/mandates/domain.py
 # Created: 2026-06-11 (feat/belt-mandates, slice 1 — models + CRUD).
 #
+# Updated: 2026-06-11 (feat/belt-autopilot) — added the ``Autopilot`` embedded
+# value object + the ``autopilot`` field on ``MandateDoc``. Autopilot runs
+# Foresight-seeded simulated users against the mandate's surface on a background
+# cycle, emitting structured feedback sightings the next shift's foreman cites.
+# The persisted state is ``{on: bool, users: int}``; the background asyncio task
+# itself is process-local (the ``autopilot`` module's registry), never persisted.
+#
 # The MANDATE primitive's persistence + value objects. A MANDATE is a standing
 # JOB the Belt holds over time (an FDE retainer): it senses its surface via
 # PATROLS, plans a FEW tasks per SHIFT via a FOREMAN (LLM judgment), routes the
@@ -94,6 +101,20 @@ class Surface(BaseModel):
     repo_id: str
 
 
+class Autopilot(BaseModel):
+    """Autopilot state on a mandate — Foresight-seeded simulated users.
+
+    ``on`` is whether a background autopilot cycle is running; ``users`` is how
+    many personas each cycle builds (1-10). The persisted state is the
+    SOURCE OF TRUTH for whether autopilot SHOULD be running; the live asyncio
+    task lives in the ``autopilot`` module's process-local registry (a process
+    restart re-derives the task from this persisted ``on`` flag — see the
+    autopilot module). DEFAULT off."""
+
+    on: bool = False
+    users: int = 3
+
+
 # ---------------------------------------------------------------------------
 # Beanie documents — service.py is the SOLE importer.
 # ---------------------------------------------------------------------------
@@ -118,6 +139,9 @@ class MandateDoc(TimestampedDocument):
     # patrols run on a shift trigger ("feedback" intake stays open as a human
     # channel regardless; the list gates the automated sense loop).
     patrols: list[str] = Field(default_factory=lambda: ["deps", "feedback"])
+    # Autopilot — Foresight-seeded simulated users feeding the feedback patrol.
+    # Persisted so a restart re-derives the running task; default off.
+    autopilot: Autopilot = Field(default_factory=Autopilot)
 
     class Settings:
         name = "mandates"
@@ -217,6 +241,7 @@ class SightingView:
 
 
 __all__ = [
+    "Autopilot",
     "Budget",
     "Cadence",
     "Charter",

--- a/ee/pocketpaw_ee/cloud/mandates/dto.py
+++ b/ee/pocketpaw_ee/cloud/mandates/dto.py
@@ -13,6 +13,9 @@
 # manual-shift trigger.
 # Updated: 2026-06-11 (slice 5 — pawprints) — added PawprintResponse /
 # PawprintsListResponse for the past-tense event feed.
+# Updated: 2026-06-11 (feat/belt-autopilot) — added AutopilotRequest (the
+# start/stop body) + AutopilotState (the persisted on/users wire object) and
+# wired ``autopilot`` onto the detail + summary responses.
 
 from __future__ import annotations
 
@@ -73,6 +76,27 @@ class CreateMandateRequest(BaseModel):
     patrols: list[str] = Field(default_factory=lambda: ["deps", "feedback"])
 
 
+class AutopilotState(BaseModel):
+    """The persisted autopilot state on a mandate — Foresight-seeded sim users.
+
+    ``on`` is whether the background autopilot cycle is running; ``users`` is the
+    persona count per cycle (1-10). Rides on the mandate detail + list + the
+    autopilot endpoint's response so the console can render the toggle."""
+
+    on: bool = False
+    users: int = Field(default=3, ge=1, le=10)
+
+
+class AutopilotRequest(BaseModel):
+    """Body for ``POST /belt/mandates/{id}/autopilot``.
+
+    ``action`` starts or stops the background autopilot cycle. ``users`` (start
+    only; clamped 1-10, default 3) is the persona count per cycle."""
+
+    action: str = Field(pattern="^(start|stop)$")
+    users: int = Field(default=3, ge=1, le=10)
+
+
 class MandateHealth(BaseModel):
     """The health summary on the list view — last shift state, open gate count,
     sighting count."""
@@ -91,6 +115,7 @@ class MandateSummaryResponse(BaseModel):
     repo_id: str
     cadence: Cadence
     health: MandateHealth
+    autopilot: AutopilotState = Field(default_factory=AutopilotState)
     created_at: datetime
 
 
@@ -118,6 +143,7 @@ class MandateDetailResponse(BaseModel):
     charter: CharterRequest
     soul_path: str | None = None
     patrols: list[str] = Field(default_factory=lambda: ["deps", "feedback"])
+    autopilot: AutopilotState = Field(default_factory=AutopilotState)
     recent_shifts: list[ShiftSummaryResponse] = Field(default_factory=list)
     sightings_by_patrol: dict[str, int] = Field(default_factory=dict)
     created_at: datetime
@@ -248,6 +274,8 @@ class PawprintsListResponse(BaseModel):
 
 
 __all__ = [
+    "AutopilotRequest",
+    "AutopilotState",
     "BudgetRequest",
     "CharterRequest",
     "CreateMandateRequest",

--- a/ee/pocketpaw_ee/cloud/mandates/events.py
+++ b/ee/pocketpaw_ee/cloud/mandates/events.py
@@ -35,6 +35,15 @@ class MandateShiftUpdated(Event):
     EVENT_TYPE: ClassVar[str] = "mandate.shift_updated"
 
 
+# Fired when autopilot is started / stopped on a mandate (feat/belt-autopilot).
+# Payload: {workspace_id, mandate_id, on, users}. ``workspace_id`` drives the
+# audience resolver's workspace fan-out so a teammate with the mandate console
+# open sees the autopilot toggle flip live.
+@dataclass
+class MandateAutopilotChanged(Event):
+    EVENT_TYPE: ClassVar[str] = "mandate.autopilot_changed"
+
+
 # UI contract — fired when a shift's PlanProposal lands as a pending Instinct
 # ``belt_plan`` Action. Payload: {workspace_id, mandate_id, proposal} —
 # ``workspace_id`` drives the audience resolver's workspace fan-out (the same
@@ -47,6 +56,7 @@ class BeltPlanProposed(Event):
 
 __all__ = [
     "BeltPlanProposed",
+    "MandateAutopilotChanged",
     "MandateCreated",
     "MandateShiftStarted",
     "MandateShiftUpdated",

--- a/ee/pocketpaw_ee/cloud/mandates/executor.py
+++ b/ee/pocketpaw_ee/cloud/mandates/executor.py
@@ -1,6 +1,33 @@
 # ee/pocketpaw_ee/cloud/mandates/executor.py
 # Created: 2026-06-11 (feat/belt-mandates, slice 4 — plan gate + executor).
 #
+# Updated: 2026-06-11 (feat/belt-autopilot — REAL task dispatcher) — added the
+#   ``StationTaskDispatcher`` and ``resolve_dispatcher()`` so an approved plan
+#   task starts a REAL Belt station run instead of a bus-only echo. The
+#   dispatcher selection is env-driven (``POCKETPAW_MANDATE_DISPATCHER=
+#   station|bus``; default ``station`` when the belt plumbing imports cleanly,
+#   else a clean fall-back to ``bus``).
+#
+#   HONESTY (the dispatcher-reality verdict): a genuinely HEADLESS belt station
+#   run is NOT reachable with the existing machinery. The belt "develop station"
+#   is an INTERACTIVE chat-agent loop — the ``/belt`` surface preamble
+#   (``cloud/surface/handlers/belt.py``) drives a Claude chat session that
+#   ORIENTs, DEVELOPs, and produces a unified diff, which the
+#   ``mcp__pocketpaw_belt__belt_propose_change`` tool then files as a
+#   ``code_change`` Instinct Action. There is NO programmatic "task → diff"
+#   runner to call from here; the diff is the OUTPUT of an LLM chat session.
+#   So ``StationTaskDispatcher`` does the CLOSEST REAL thing: it files a real
+#   ``code_change`` Instinct Action (the SAME row type the console Runs tab reads
+#   and the belt gate executes) carrying the task text, in a QUEUED state
+#   (``station_pending=True``, no diff yet), and fires the real
+#   ``belt_run_updated`` event so the run shows up live in the console. A human
+#   opens the ``/belt`` station for that queued run (one click) to drive it to a
+#   diff, which rides the existing gate as normal. This is a genuine run record,
+#   not a bus echo — the tests assert the persisted ``code_change`` Action and
+#   its ``station_pending`` queued state, not a bus message. If a later PR lands
+#   a real headless station runner, swap its call into ``StationTaskDispatcher``
+#   behind this same ``TaskDispatcher`` protocol with no caller change.
+#
 # The apply-on-approve half of the MANDATE plan gate. ``service.trigger_shift``
 # proposes the foreman's PlanProposal THROUGH Instinct as a ``belt_plan``
 # Action (blob under ``Action.parameters._belt_plan``); after a human approves
@@ -106,6 +133,168 @@ class BusTaskDispatcher:
             str(task.get("title", ""))[:80],
         )
         return run_ref
+
+
+# The blob key + kind a Belt station run rides under — kept in sync with the
+# agent-side MCP server's ``CODE_CHANGE_PARAM_KEY`` / ``CODE_CHANGE_KIND`` /
+# ``CODE_CHANGE_SCHEMA`` literals. Duplicated here (not imported) so the
+# dispatcher has no hard dependency on the agent MCP module — same OSS/EE
+# discipline the belt console service uses for the same literals.
+_CODE_CHANGE_PARAM_KEY = "_code_change"
+_CODE_CHANGE_KIND = "code_change"
+_CODE_CHANGE_SCHEMA = 2
+
+
+class StationTaskDispatcher:
+    """REAL ``TaskDispatcher`` — starts a Belt STATION RUN for each approved task.
+
+    HONESTY (see the module header): a headless station run that PRODUCES a diff
+    is not reachable — the belt develop station is an interactive chat-agent
+    loop (the ``/belt`` surface), and the diff is the OUTPUT of that LLM session,
+    not a function we can call. So this dispatcher does the closest REAL thing:
+    it files a real ``code_change`` Instinct Action (the SAME row the console
+    Runs tab reads and the belt gate executes) carrying the task text in a
+    QUEUED state — ``station_pending=True``, no diff yet — and fires the real
+    ``belt_run_updated`` event so the run shows up live in the console. A human
+    opens the ``/belt`` station for that queued run (one click) and drives it to
+    a diff, which rides the existing belt gate as normal.
+
+    This is NOT a bus echo: the run is a durable Instinct Action the tests assert
+    against. Because the blob carries no diff, the run is NOT auto-executable —
+    the belt executor refuses a ``station_pending`` blob loud (defense in depth),
+    but the normal flow never approves a queued run; a human re-proposes the diff
+    through the station, which files a fresh, applyable ``code_change`` Action.
+    """
+
+    async def dispatch(
+        self,
+        *,
+        workspace_id: str,
+        mandate_id: str,
+        shift_no: int,
+        plan_action_id: str,
+        index: int,
+        task: dict[str, Any],
+    ) -> str:
+        from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+        from pocketpaw.stores import get_instinct_store
+        from pocketpaw_ee.cloud.belt import service as belt_service
+
+        store = get_instinct_store()
+
+        title = str(task.get("title") or "Belt station task")
+        why = str(task.get("why") or "")
+        expected = str(task.get("expected_outcome") or "")
+        repo = await _repo_for_mandate(workspace_id, mandate_id)
+
+        # The QUEUED-run blob: the SAME ``_code_change`` shape the console reads,
+        # but with ``station_pending=True`` and NO diff. ``task`` carries the
+        # human-readable text the station agent picks up; ``repo`` lets the
+        # ``/belt`` page pre-bind the surface so the human doesn't re-pick it.
+        blob: dict[str, Any] = {
+            "kind": _CODE_CHANGE_KIND,
+            "schema": _CODE_CHANGE_SCHEMA,
+            # A station-queued run carries the task text instead of a diff.
+            "station_pending": True,
+            "repo": repo or "",
+            "base_branch": "",
+            "diff": "",
+            "task": f"{title}\n\n{why}".strip(),
+            "summary": expected or title,
+            "workspace_id": workspace_id,
+            "requested_by": str(task.get("requested_by") or ""),
+            # Provenance — tie the queued run back to the mandate shift + plan.
+            "mandate_id": mandate_id,
+            "shift_no": shift_no,
+            "plan_action_id": plan_action_id,
+            "task_index": index,
+        }
+
+        trigger = ActionTrigger(
+            type="agent",
+            source="belt:mandate-dispatch",
+            reason="approved mandate shift task queued for the develop station",
+        )
+        action = await store.propose(
+            pocket_id=workspace_id,
+            title=f"Station task — {title[:60]}",
+            description=f"Queued from mandate shift {shift_no}. {expected}".strip(),
+            recommendation=(
+                f"Open the develop station to work this task: {title}. "
+                "It was approved on a mandate shift and is waiting for the station."
+            ),
+            trigger=trigger,
+            category=ActionCategory.EXTERNAL,
+            priority=ActionPriority.HIGH,
+            parameters={_CODE_CHANGE_PARAM_KEY: blob},
+            assignee=blob["requested_by"] or None,
+            workspace_id=workspace_id,
+        )
+
+        run_ref = str(action.id)
+        # Fire the REAL run feed event so the console Runs tab shows the queued
+        # station run live (status=queued, stage=station). Best-effort.
+        await belt_service.emit_belt_run_updated(
+            workspace_id=workspace_id,
+            action_id=run_ref,
+            status="queued",
+            stage="station",
+        )
+        logger.info(
+            "mandate: queued station run %s for task %d of shift %s (mandate=%s): %s",
+            run_ref,
+            index,
+            shift_no,
+            mandate_id,
+            title[:80],
+        )
+        return run_ref
+
+
+async def _repo_for_mandate(workspace_id: str, mandate_id: str) -> str | None:
+    """Best-effort read of a mandate's bound repo path (the surface ``repo_id``).
+
+    Used by ``StationTaskDispatcher`` to pre-bind the ``/belt`` station to the
+    mandate's repo on the queued run. Goes through the mandates service (the sole
+    Beanie importer); a read failure degrades to ``None`` (the station then asks
+    for the repo) — it never breaks the dispatch."""
+    try:
+        from pocketpaw_ee.cloud.mandates import service as mandate_service
+
+        return await mandate_service.repo_for_mandate(workspace_id, mandate_id)
+    except Exception:  # noqa: BLE001 — a repo read must never break dispatch
+        logger.debug("mandate: repo lookup for station run failed (non-fatal)", exc_info=True)
+        return None
+
+
+def resolve_dispatcher() -> TaskDispatcher:
+    """Pick the dispatcher from ``POCKETPAW_MANDATE_DISPATCHER``.
+
+    * ``station`` (default) — the REAL ``StationTaskDispatcher``: each approved
+      task becomes a queued belt station run (a real ``code_change`` Instinct
+      Action) that shows in the console Runs tab. Falls back to ``bus`` if the
+      belt plumbing can't be imported (an OSS-only / partial install).
+    * ``bus`` — the announce-only ``BusTaskDispatcher`` (the prior default).
+
+    An unrecognized value falls back to the station default.
+    """
+    import os
+
+    choice = (os.environ.get("POCKETPAW_MANDATE_DISPATCHER") or "station").strip().lower()
+    if choice == "bus":
+        return BusTaskDispatcher()
+    # Default / "station": prefer the real station dispatcher, but degrade to the
+    # bus dispatcher cleanly if the belt service can't be imported.
+    try:
+        import pocketpaw_ee.cloud.belt.service  # noqa: F401
+        from pocketpaw.stores import get_instinct_store  # noqa: F401
+    except Exception:  # noqa: BLE001 — a partial install falls back to bus
+        logger.warning(
+            "mandate: belt plumbing unavailable — falling back to the bus dispatcher",
+            exc_info=True,
+        )
+        return BusTaskDispatcher()
+    return StationTaskDispatcher()
 
 
 def _coerce_uuid(raw: Any) -> Any | None:
@@ -221,7 +410,7 @@ async def execute_approved_plan(
     from pocketpaw.stores import get_instinct_store
 
     store = get_instinct_store()
-    dispatch: TaskDispatcher = dispatcher or BusTaskDispatcher()
+    dispatch: TaskDispatcher = dispatcher or resolve_dispatcher()
 
     params = getattr(action, "parameters", None) or {}
     blob = params.get(BELT_PLAN_PARAM_KEY)
@@ -417,7 +606,9 @@ __all__ = [
     "BELT_PLAN_PARAM_KEY",
     "BELT_PLAN_SCHEMA",
     "BusTaskDispatcher",
+    "StationTaskDispatcher",
     "TaskDispatcher",
     "execute_approved_plan",
     "mark_plan_rejected",
+    "resolve_dispatcher",
 ]

--- a/ee/pocketpaw_ee/cloud/mandates/router.py
+++ b/ee/pocketpaw_ee/cloud/mandates/router.py
@@ -14,6 +14,8 @@
 # sightings read.
 # Updated: 2026-06-11 (slice 4 — plan gate) — added POST .../shift.
 # Updated: 2026-06-11 (slice 5 — pawprints) — added GET .../pawprints.
+# Updated: 2026-06-11 (feat/belt-autopilot) — added POST .../autopilot
+# (start/stop Foresight-seeded simulated users; admin-gated).
 # Updated: 2026-06-11 (UI contract sync 2) — added POST .../plan/resolve (the
 # console's per-task gate action, mapped onto the real instinct approve-with-
 # edits / reject paths) and the `patrols` senses toggles on create.
@@ -178,6 +180,25 @@ async def resolve_plan(
         )
 
     return {"shift": await mandate_service.shift_wire(workspace_id, orders["shift_id"])}
+
+
+@router.post("/{mandate_id}/autopilot")
+async def set_autopilot(
+    mandate_id: str,
+    body: dict[str, Any],
+    _user: Any = Depends(require_action_any_workspace("belt.manage")),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict[str, Any]:
+    """Start or stop AUTOPILOT — Foresight-seeded simulated users that exercise
+    the mandate's surface and feed the feedback patrol (admin-gated).
+
+    Body: ``{action: "start"|"stop", users?: int (default 3, max 10)}``. START
+    persists ``autopilot={on, users}``, runs ONE cycle immediately (so the
+    response already reflects its sightings), and spawns the background cycle.
+    STOP cancels the background task and persists the off state. Returns
+    ``{"mandate": <detail>}`` (UI contract envelope)."""
+    return await mandate_service.set_autopilot(workspace_id, user_id, mandate_id, body)
 
 
 @router.get("/{mandate_id}/pawprints")

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -1300,6 +1300,33 @@ async def repo_for_mandate(workspace_id: str, mandate_id: str) -> str | None:
     return doc.surface.repo_id if doc is not None else None
 
 
+async def list_autopilot_enabled() -> list[dict[str, Any]]:
+    """All ACTIVE mandates whose persisted ``autopilot.on`` is True — the
+    startup reconciler's read (``autopilot.reconcile_autopilot_tasks``).
+
+    DELIBERATELY cross-workspace: this is a SYSTEM boot read that re-derives the
+    process-local background loops from the persisted flags, the same posture as
+    the stale-run sweeper's all-workspace scan — not a user-facing query (the
+    tenant-filter rule applies to request-path finds). Paused mandates are
+    excluded: a paused mandate is inert, so its loop is not restarted (it
+    resumes when autopilot is started again via the endpoint).
+
+    Returns ``[{workspace_id, mandate_id, users}]``."""
+    # no-event: read-only path; emit only on writes.
+    docs = await MandateDoc.find(
+        MandateDoc.autopilot.on == True,  # noqa: E712 — Beanie expression syntax
+        MandateDoc.status == "active",
+    ).to_list()
+    return [
+        {
+            "workspace_id": d.workspace,
+            "mandate_id": str(d.id),
+            "users": int(d.autopilot.users) if d.autopilot else 3,
+        }
+        for d in docs
+    ]
+
+
 async def executor_revalidate(workspace_id: str, mandate_id: str) -> dict[str, Any]:
     """Approve-time re-validation read for the plan executor: does the mandate
     still exist, is it active, what is the CURRENT budget."""
@@ -1369,6 +1396,7 @@ __all__ = [
     "file_feedback",
     "get_mandate",
     "get_pawprints",
+    "list_autopilot_enabled",
     "list_mandates",
     "list_sightings",
     "mark_shift",

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -10,6 +10,9 @@
 #   slice 2: file_feedback, list_sightings, run_patrols (deps patrol)
 #   slice 4: trigger_shift (foreman → plan gate)
 #   slice 5: get_pawprints
+#   autopilot (feat/belt-autopilot): set_autopilot (start/stop Foresight-seeded
+#     simulated users feeding the feedback patrol) + repo_for_mandate (the
+#     dispatcher/autopilot surface read).
 #
 # Conventions (cloud entity rules): validate body at entry
 # (``Schema.model_validate(body)``); tenant filter ``workspace=...`` on EVERY
@@ -107,6 +110,17 @@ def _as_object_id(raw: str) -> Any:
     return ObjectId(raw)
 
 
+def _first_pydantic_msg(exc: Any) -> str:
+    """Render the first error off a Pydantic ``ValidationError`` as a single
+    user-facing message ``"<field>: <reason>"`` for a 422 CloudError."""
+    try:
+        err = exc.errors()[0]
+        loc = ".".join(str(p) for p in err.get("loc", ())) or "body"
+        return f"{loc}: {err.get('msg', 'invalid value')}"
+    except Exception:  # noqa: BLE001 — fall back to the str form
+        return str(exc)
+
+
 # ---------------------------------------------------------------------------
 # CRUD (slice 1)
 # ---------------------------------------------------------------------------
@@ -181,10 +195,18 @@ async def list_mandates(workspace_id: str, user_id: str, body: Any = None) -> di
                     "open_gate_count": open_gate_count,
                     "sighting_count": sighting_count,
                 },
+                "autopilot": _autopilot_to_wire(doc),
                 "created_at": doc.createdAt,
             }
         )
     return {"mandates": out}
+
+
+def _autopilot_to_wire(doc: MandateDoc) -> dict[str, Any]:
+    """Render a mandate's persisted autopilot state for the wire ({on, users}).
+    A mandate predating the autopilot field reads as off/3 (the doc default)."""
+    ap = doc.autopilot
+    return {"on": bool(ap.on), "users": int(ap.users)} if ap else {"on": False, "users": 3}
 
 
 async def get_mandate(workspace_id: str, user_id: str, mandate_id: str) -> dict[str, Any]:
@@ -222,6 +244,7 @@ async def _mandate_detail_wire(doc: MandateDoc) -> dict[str, Any]:
         "charter": _charter_to_wire(doc.charter),
         "soul_path": doc.soul_path,
         "patrols": list(doc.patrols),
+        "autopilot": _autopilot_to_wire(doc),
         "recent_shifts": [
             {
                 "id": str(s.id),
@@ -397,6 +420,75 @@ async def run_patrols(workspace_id: str, user_id: str, mandate_id: str) -> dict[
             )
         )
     return {"sightings": [_sighting_to_wire(s) for s in created]}
+
+
+async def set_autopilot(
+    workspace_id: str, user_id: str, mandate_id: str, body: Any
+) -> dict[str, Any]:
+    """Start or stop AUTOPILOT on a mandate — Foresight-seeded simulated users
+    feeding the feedback patrol. Body: ``{action: "start"|"stop", users?: int}``.
+
+    START: persist ``autopilot={on: True, users: N}``, run ONE cycle SYNCHRONOUSLY
+    (so this response already reflects the first cycle's sightings — the brief's
+    "run ONE cycle immediately on start"), then spawn the background loop for the
+    subsequent every-interval cycles. STOP: cancel the background task, persist
+    ``autopilot.on=False``. Either way, emit ``MandateAutopilotChanged`` and
+    return the mandate detail wire dict (envelope-free, matching GET detail).
+
+    A cross-tenant mandate is a 404. Autopilot must never crash a shift or the
+    app — the immediate cycle is failure-swallowing by construction
+    (``autopilot.run_autopilot_cycle`` never raises)."""
+    from pydantic import ValidationError as PydanticValidationError
+
+    from pocketpaw_ee.cloud.mandates import autopilot as autopilot_mod
+    from pocketpaw_ee.cloud.mandates.domain import Autopilot
+    from pocketpaw_ee.cloud.mandates.dto import AutopilotRequest
+
+    # Validate at entry — a bad body (unknown action / out-of-range users) is a
+    # 422 ``ValidationError`` CloudError, not a 500 (the cloud error handler only
+    # maps CloudError; a raw Pydantic error would escape as a 500).
+    try:
+        req = AutopilotRequest.model_validate(body)
+    except PydanticValidationError as exc:
+        raise ValidationError("mandate.autopilot_invalid", _first_pydantic_msg(exc)) from exc
+
+    doc = await _fetch_mandate(workspace_id, mandate_id)
+
+    if req.action == "start":
+        users = max(1, min(10, req.users))
+        doc.autopilot = Autopilot(on=True, users=users)
+        await doc.save()
+        # Run the first cycle SYNCHRONOUSLY so the response/assertions see its
+        # sightings, THEN start the loop (which skips its own immediate cycle so
+        # the first cycle isn't double-filed). The cycle never raises.
+        await autopilot_mod.run_autopilot_cycle(workspace_id, mandate_id, users=users)
+        await autopilot_mod.start_autopilot(workspace_id, mandate_id, users, run_immediate=False)
+    else:  # stop
+        await autopilot_mod.stop_autopilot(mandate_id)
+        users = doc.autopilot.users if doc.autopilot else 3
+        doc.autopilot = Autopilot(on=False, users=users)
+        await doc.save()
+
+    await emit(
+        mandate_events.MandateAutopilotChanged(
+            data={
+                "workspace_id": workspace_id,
+                "mandate_id": mandate_id,
+                "on": doc.autopilot.on,
+                "users": doc.autopilot.users,
+            }
+        )
+    )
+    logger.info(
+        "mandate: autopilot %s for %s (workspace=%s, users=%d)",
+        "started" if doc.autopilot.on else "stopped",
+        mandate_id,
+        workspace_id,
+        doc.autopilot.users,
+    )
+    # UI contract — the autopilot response wraps the detail in a ``mandate``
+    # envelope (same shape as create), so the console can re-render the row.
+    return {"mandate": await _mandate_detail_wire(doc)}
 
 
 def _sighting_to_wire(s: SightingDoc) -> dict[str, Any]:
@@ -1192,6 +1284,22 @@ async def get_pawprints(workspace_id: str, user_id: str, mandate_id: str) -> dic
 # ---------------------------------------------------------------------------
 
 
+async def repo_for_mandate(workspace_id: str, mandate_id: str) -> str | None:
+    """Read a mandate's bound repo path (the surface ``repo_id``), tenant-scoped.
+
+    Used by the ``StationTaskDispatcher`` to pre-bind the ``/belt`` station to
+    the mandate's repo on a queued station run. Returns ``None`` on a miss /
+    cross-tenant id (a malformed id is a clean miss, not a 500)."""
+    # no-event: read-only path; emit only on writes.
+    try:
+        doc = await MandateDoc.find_one(
+            MandateDoc.workspace == workspace_id, MandateDoc.id == _as_object_id(mandate_id)
+        )
+    except Exception:  # noqa: BLE001 — malformed id == miss
+        doc = None
+    return doc.surface.repo_id if doc is not None else None
+
+
 async def executor_revalidate(workspace_id: str, mandate_id: str) -> dict[str, Any]:
     """Approve-time re-validation read for the plan executor: does the mandate
     still exist, is it active, what is the CURRENT budget."""
@@ -1265,7 +1373,9 @@ __all__ = [
     "list_sightings",
     "mark_shift",
     "prepare_plan_resolution",
+    "repo_for_mandate",
     "run_patrols",
+    "set_autopilot",
     "shift_wire",
     "trigger_shift",
 ]

--- a/tests/cloud/test_belt_autopilot.py
+++ b/tests/cloud/test_belt_autopilot.py
@@ -1,0 +1,478 @@
+# tests/cloud/test_belt_autopilot.py — the Belt MANDATE autopilot + the REAL
+# station task dispatcher (feat/belt-autopilot).
+#
+# Created: 2026-06-11.
+#
+# Two pieces under test:
+#
+#   PIECE 1 — the StationTaskDispatcher. When an approved plan dispatches, the
+#     REAL station dispatcher (selected by POCKETPAW_MANDATE_DISPATCHER=station,
+#     the default) files a real ``code_change`` Instinct Action per task in a
+#     QUEUED state (station_pending=True, no diff). The console Runs read model
+#     surfaces it as status=queued / stage=station. This is the closest REAL
+#     thing to a headless station run: a genuinely headless diff-producing run
+#     is NOT reachable (the belt develop station is an interactive chat-agent
+#     loop), so we assert the persisted run record + its queued state, NOT a bus
+#     echo. The ``bus`` env value restores the announce-only default — the
+#     existing test_belt_mandates suite already proves that path with its
+#     RecorderDispatcher patch.
+#
+#   PIECE 2 — autopilot. POST .../autopilot {action:start} persists
+#     autopilot={on, users}, runs ONE cycle immediately (Foresight-seeded sim
+#     personas → structured feedback through the EXISTING feedback service path),
+#     and spawns a background loop; {action:stop} cancels it. The mock UserSim is
+#     deterministic + seeded so the sightings are stable. A full loop test chains
+#     autopilot → shift (mock foreman cites the autopilot sightings) → resolve
+#     approve → the StationTaskDispatcher path.
+#
+# All tests run the deterministic mock LLM/UserSim (POCKETPAW_MANDATE_LLM=mock).
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+pytest.importorskip("mongomock_motor")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.belt import service as belt_service  # noqa: E402
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.mandates import autopilot as autopilot_mod  # noqa: E402
+from pocketpaw_ee.cloud.mandates import executor as mandate_executor  # noqa: E402
+from pocketpaw_ee.cloud.mandates import foreman  # noqa: E402
+from pocketpaw_ee.cloud.mandates import service as mandate_service  # noqa: E402
+from pocketpaw_ee.cloud.mandates.router import router as mandates_router  # noqa: E402
+from pocketpaw_ee.instinct.router import router as instinct_router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+WS = "w1"
+USER = "u1"
+
+
+# ---------------------------------------------------------------------------
+# fixtures — journal / graph / store / mock LLM + UserSim / dispatcher / client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    st = InstinctStore(tmp_path / "instinct_autopilot.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: st)
+    return st
+
+
+@pytest.fixture(autouse=True)
+def mock_llm(monkeypatch):
+    """Deterministic mock foreman AND mock UserSim (both read
+    POCKETPAW_MANDATE_LLM); the station dispatcher is the default. Reset after."""
+    monkeypatch.setenv("POCKETPAW_MANDATE_LLM", "mock")
+    monkeypatch.delenv("POCKETPAW_MANDATE_DISPATCHER", raising=False)
+    foreman.set_mock_plan(None)
+    yield
+    foreman.set_mock_plan(None)
+
+
+@pytest.fixture(autouse=True)
+def _drain_autopilot_tasks():
+    """Cancel any autopilot background tasks a test left running, so a leaked
+    loop never bleeds into the next test (the registry is process-local)."""
+    yield
+    autopilot_mod._TASKS.clear()
+
+
+def _make_client(monkeypatch, *, workspace_id: str = WS, user_id: str = USER) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(mandates_router)
+    app.include_router(instinct_router)
+    app.dependency_overrides[require_license] = lambda: None
+
+    user = SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role="admin")],
+    )
+
+    async def _fake_user_dep():
+        return user
+
+    app.dependency_overrides[current_active_user] = _fake_user_dep
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    return TestClient(app)
+
+
+def _charter(budget: int = 3, says_no=None, boundaries=None) -> dict:
+    return {
+        "goal": "keep the surface healthy",
+        "kpis": [{"name": "open_cves", "target": 0, "direction": "down"}],
+        "says_no": says_no if says_no is not None else ["major version bumps"],
+        "boundaries": boundaries if boundaries is not None else ["never touch auth code"],
+        "budget": {"max_tasks_per_shift": budget, "gate_minutes_per_week": 15},
+        "cadence": "manual",
+    }
+
+
+def _seed_repo(tmp_path: Path, name: str) -> Path:
+    """A real git repo with a README + a couple of commits so the autopilot
+    surface read has something to chew on (README + commit titles)."""
+    import subprocess
+
+    repo = tmp_path / name
+    repo.mkdir()
+    (repo / "README.md").write_text("# Demo\nA demo product for autopilot.\n", encoding="utf-8")
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    import os
+
+    full_env = {**os.environ, **env}
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=full_env)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=full_env)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "feat: initial demo"], cwd=repo, check=True, env=full_env
+    )
+    (repo / "CHANGELOG.md").write_text("changes\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=full_env)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "docs: add changelog"], cwd=repo, check=True, env=full_env
+    )
+    return repo
+
+
+def _create_mandate(client: TestClient, repo_dir: Path, *, budget: int = 3, **charter_kw) -> str:
+    res = client.post(
+        "/belt/mandates",
+        json={
+            "name": "surface health",
+            "surface": {"repo_id": str(repo_dir)},
+            "charter": _charter(budget=budget, **charter_kw),
+        },
+    )
+    assert res.status_code == 200, res.text
+    return res.json()["mandate"]["id"]
+
+
+# ---------------------------------------------------------------------------
+# PIECE 2 — autopilot start persists state + runs ONE cycle → sightings exist
+# with source autopilot:*; stop cancels the background task.
+# ---------------------------------------------------------------------------
+
+
+async def test_autopilot_start_seeds_sightings_then_stop_cancels(
+    tmp_path, mongo_db, store, monkeypatch, recording_bus
+):
+    client = _make_client(monkeypatch)
+    repo = _seed_repo(tmp_path, "ap-repo")
+    mandate_id = _create_mandate(client, repo)
+
+    # START with 3 users — the response carries the persisted state AND the
+    # immediate cycle's sightings already exist.
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/autopilot", json={"action": "start", "users": 3}
+    )
+    assert res.status_code == 200, res.text
+    detail = res.json()["mandate"]
+    assert detail["autopilot"] == {"on": True, "users": 3}
+
+    # The persisted state survives a re-read.
+    again = client.get(f"/belt/mandates/{mandate_id}").json()
+    assert again["autopilot"] == {"on": True, "users": 3}
+
+    # The immediate cycle filed feedback sightings with source "autopilot:*".
+    sightings = client.get(f"/belt/mandates/{mandate_id}/sightings").json()["sightings"]
+    autop = [s for s in sightings if str(s["evidence"].get("source", "")).startswith("autopilot:")]
+    assert autop, sightings
+    # Severity is in range and the source names a persona.
+    for s in autop:
+        assert s["patrol"] == "feedback"
+        assert 1 <= s["severity"] <= 5
+        assert s["evidence"]["source"].startswith("autopilot:")
+
+    # The autopilot-changed event rode the bus.
+    changed = [e for e in recording_bus.events if e.type == "mandate.autopilot_changed"]
+    assert changed and changed[-1].data == {
+        "workspace_id": WS,
+        "mandate_id": mandate_id,
+        "on": True,
+        "users": 3,
+    }
+
+    # STOP persists the off state (and cancels the background task — the task
+    # lifecycle itself is asserted directly against the module below, since the
+    # TestClient runs each request on its own short-lived event loop).
+    res = client.post(f"/belt/mandates/{mandate_id}/autopilot", json={"action": "stop"})
+    assert res.status_code == 200, res.text
+    assert res.json()["mandate"]["autopilot"]["on"] is False
+    assert client.get(f"/belt/mandates/{mandate_id}").json()["autopilot"]["on"] is False
+
+
+async def test_autopilot_background_task_lifecycle(tmp_path, mongo_db, store, monkeypatch):
+    """The background loop's start/stop lifecycle, asserted directly against the
+    autopilot module (the TestClient path can't observe the task because each
+    HTTP request runs on its own short-lived event loop). START registers a live
+    task; STOP cancels + de-registers it."""
+    repo = _seed_repo(tmp_path, "lifecycle-repo")
+    created = await mandate_service.create_mandate(
+        WS, USER, {"name": "m", "surface": {"repo_id": str(repo)}, "charter": _charter()}
+    )
+    mandate_id = created["mandate"]["id"]
+
+    assert not autopilot_mod.is_running(mandate_id)
+    # run_immediate=False so the long interval sleep keeps the task alive to observe.
+    await autopilot_mod.start_autopilot(WS, mandate_id, 2, run_immediate=False)
+    assert autopilot_mod.is_running(mandate_id)
+
+    await autopilot_mod.stop_autopilot(mandate_id)
+    assert not autopilot_mod.is_running(mandate_id)
+    # Idempotent — a second stop is a no-op.
+    await autopilot_mod.stop_autopilot(mandate_id)
+
+
+async def test_autopilot_users_clamped_and_deterministic(tmp_path, mongo_db, store, monkeypatch):
+    """``users`` is clamped to 1-10 by the DTO (an over-max request is a 422),
+    and the mock personas are deterministic + seeded."""
+    client = _make_client(monkeypatch)
+    repo = _seed_repo(tmp_path, "clamp-repo")
+    mandate_id = _create_mandate(client, repo)
+
+    # Over the cap → 422 (DTO clamp), nothing started.
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/autopilot", json={"action": "start", "users": 99}
+    )
+    assert res.status_code == 422, res.text
+    assert not autopilot_mod.is_running(mandate_id)
+
+    # The mock personas are deterministic for the same count.
+    a = [p.name for p in autopilot_mod.build_personas(4)]
+    b = [p.name for p in autopilot_mod.build_personas(4)]
+    assert a == b and len(a) == 4
+
+
+async def test_autopilot_default_users_is_three(tmp_path, mongo_db, store, monkeypatch):
+    """Omitting ``users`` defaults to 3 (the brief's default)."""
+    client = _make_client(monkeypatch)
+    repo = _seed_repo(tmp_path, "default-repo")
+    mandate_id = _create_mandate(client, repo)
+    res = client.post(f"/belt/mandates/{mandate_id}/autopilot", json={"action": "start"})
+    assert res.status_code == 200, res.text
+    assert res.json()["mandate"]["autopilot"]["users"] == 3
+
+
+# ---------------------------------------------------------------------------
+# PIECE 1 + 2 full loop — autopilot seeds sightings → shift (foreman cites them)
+# → resolve approve → the StationTaskDispatcher files queued station runs.
+# ---------------------------------------------------------------------------
+
+
+async def test_full_loop_autopilot_to_station_runs(
+    tmp_path, mongo_db, store, journal, graph, monkeypatch, recording_bus
+):
+    """The end-to-end mandate loop with the REAL station dispatcher (default):
+    autopilot cycle seeds feedback sightings → trigger shift (the mock foreman
+    plans tasks citing those sightings) → resolve-approve → the REAL
+    StationTaskDispatcher files a queued ``code_change`` station run per task that
+    the console Runs read model surfaces as status=queued / stage=station."""
+    client = _make_client(monkeypatch)
+    repo = _seed_repo(tmp_path, "loop-repo")
+    mandate_id = _create_mandate(client, repo, budget=3)
+
+    # 1. Autopilot one cycle → feedback sightings from sim personas.
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/autopilot", json={"action": "start", "users": 2}
+    )
+    assert res.status_code == 200, res.text
+    sightings = client.get(f"/belt/mandates/{mandate_id}/sightings").json()["sightings"]
+    autop = [s for s in sightings if str(s["evidence"].get("source", "")).startswith("autopilot:")]
+    assert autop, "autopilot must have seeded feedback sightings"
+
+    # Stop autopilot so its background loop doesn't seed mid-shift.
+    client.post(f"/belt/mandates/{mandate_id}/autopilot", json={"action": "stop"})
+
+    # 2. Trigger the shift — the mock foreman plans one task per sighting,
+    #    citing the autopilot sighting ids.
+    shift = client.post(f"/belt/mandates/{mandate_id}/shift").json()["shift"]
+    assert shift["state"] == "in_gate"
+    assert shift["task_count"] >= 1
+    plan_action_id = shift["plan_action_id"]
+
+    # The plan cites the autopilot sightings (evidence_refs are sighting ids).
+    action = await store.get_action(plan_action_id)
+    blob = action.parameters["_belt_plan"]
+    cited = {ref for t in blob["plan"]["tasks"] for ref in t["evidence_refs"]}
+    autop_ids = {s["id"] for s in autop}
+    assert cited & autop_ids, "the foreman must cite at least one autopilot sighting"
+
+    n_tasks = len(blob["plan"]["tasks"])
+
+    # 3. Resolve-approve every task → the REAL StationTaskDispatcher runs (no
+    #    recorder patch — this is the genuine station path).
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/plan/resolve",
+        json={
+            "shift_no": shift["no"],
+            "decisions": [{"index": i, "decision": "approve"} for i in range(n_tasks)],
+        },
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["shift"]["state"] == "done"
+
+    final = await store.get_action(plan_action_id)
+    assert final.status == ActionStatus.EXECUTED, final.outcome
+
+    # 4. The station dispatcher filed a REAL code_change run per approved task,
+    #    in a QUEUED state — assert the persisted run record, NOT a bus echo.
+    runs = await belt_service.list_runs(WS)
+    station_runs = [r for r in runs["runs"] if r["status"] == "queued"]
+    assert len(station_runs) == n_tasks, station_runs
+    for r in station_runs:
+        assert r["stage"] == "station"
+        assert r["repo"] == str(repo)  # the station is pre-bound to the mandate repo
+        assert r["task"]  # the task text rides on the run
+
+    # The underlying Instinct Action is a real pending code_change with the
+    # station_pending marker (the queued station run, not a diff).
+    sample = await store.get_action(station_runs[0]["action_id"])
+    assert sample.status == ActionStatus.PENDING
+    cc = sample.parameters["_code_change"]
+    assert cc["kind"] == "code_change"
+    assert cc["station_pending"] is True
+    assert cc["mandate_id"] == mandate_id
+
+    # A queued station run is NOT applyable — a stray approve fails loud
+    # (StationPending) rather than applying a non-existent diff.
+    from pocketpaw_ee.cloud.belt.executor import execute_approved_change
+
+    await store.approve(sample.id)
+    approved = await store.get_action(sample.id)
+    await execute_approved_change(approved)
+    after = await store.get_action(sample.id)
+    assert after.status == ActionStatus.FAILED
+    assert "station" in (after.error or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# PIECE 1 — dispatcher selection: env=bus restores the announce-only default.
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_selection_env(monkeypatch):
+    """POCKETPAW_MANDATE_DISPATCHER selects the dispatcher: default + 'station'
+    → the REAL StationTaskDispatcher; 'bus' → the announce-only BusTaskDispatcher
+    (the prior default, still proven by test_belt_mandates' RecorderDispatcher)."""
+    monkeypatch.delenv("POCKETPAW_MANDATE_DISPATCHER", raising=False)
+    assert isinstance(mandate_executor.resolve_dispatcher(), mandate_executor.StationTaskDispatcher)
+
+    monkeypatch.setenv("POCKETPAW_MANDATE_DISPATCHER", "station")
+    assert isinstance(mandate_executor.resolve_dispatcher(), mandate_executor.StationTaskDispatcher)
+
+    monkeypatch.setenv("POCKETPAW_MANDATE_DISPATCHER", "bus")
+    assert isinstance(mandate_executor.resolve_dispatcher(), mandate_executor.BusTaskDispatcher)
+
+    # An unrecognized value falls back to the station default.
+    monkeypatch.setenv("POCKETPAW_MANDATE_DISPATCHER", "nonsense")
+    assert isinstance(mandate_executor.resolve_dispatcher(), mandate_executor.StationTaskDispatcher)
+
+
+async def test_bus_dispatcher_announces_only(tmp_path, mongo_db, store, monkeypatch, recording_bus):
+    """With env=bus the approved plan dispatches via the announce-only path: a
+    ``belt_run_updated`` event fires per task and NO code_change station run is
+    created (the prior behavior the existing suite relies on)."""
+    monkeypatch.setenv("POCKETPAW_MANDATE_DISPATCHER", "bus")
+    client = _make_client(monkeypatch)
+    repo = tmp_path / "bus-repo"
+    repo.mkdir()
+    mandate_id = _create_mandate(client, repo)
+
+    client.post(
+        f"/belt/mandates/{mandate_id}/feedback",
+        json={"text": "one signal", "severity": 4, "source": "support"},
+    )
+    shift = client.post(f"/belt/mandates/{mandate_id}/shift").json()["shift"]
+    res = client.post(
+        f"/belt/mandates/{mandate_id}/plan/resolve",
+        json={"shift_no": shift["no"], "decisions": [{"index": 0, "decision": "approve"}]},
+    )
+    assert res.status_code == 200, res.text
+
+    # No code_change station runs were created (bus path only announces).
+    runs = await belt_service.list_runs(WS)
+    assert runs["runs"] == []
+    # The announce event fired (status=dispatched, stage=station).
+    announces = [e for e in recording_bus.events if e.type == "belt_run_updated"]
+    assert announces and any(e.data.get("status") == "dispatched" for e in announces)
+
+
+# ---------------------------------------------------------------------------
+# tenant isolation — autopilot endpoint never confirms a foreign mandate exists.
+# ---------------------------------------------------------------------------
+
+
+async def test_autopilot_tenant_isolation(tmp_path, mongo_db, store, monkeypatch):
+    client_w1 = _make_client(monkeypatch)
+    repo = _seed_repo(tmp_path, "iso-repo")
+    mandate_id = _create_mandate(client_w1, repo)
+
+    client_w2 = _make_client(monkeypatch, workspace_id="w2", user_id="u2")
+    # A foreign workspace can't start autopilot on w1's mandate — 404, never a
+    # confirmation that the mandate exists, and no task is registered.
+    res = client_w2.post(f"/belt/mandates/{mandate_id}/autopilot", json={"action": "start"})
+    assert res.status_code == 404, res.text
+    assert not autopilot_mod.is_running(mandate_id)
+
+    res = client_w2.post(f"/belt/mandates/{mandate_id}/autopilot", json={"action": "stop"})
+    assert res.status_code == 404, res.text
+
+    # w1 still owns it.
+    res = client_w1.post(f"/belt/mandates/{mandate_id}/autopilot", json={"action": "start"})
+    assert res.status_code == 200, res.text

--- a/tests/cloud/test_belt_autopilot.py
+++ b/tests/cloud/test_belt_autopilot.py
@@ -29,6 +29,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -117,10 +119,17 @@ def mock_llm(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _drain_autopilot_tasks():
-    """Cancel any autopilot background tasks a test left running, so a leaked
-    loop never bleeds into the next test (the registry is process-local)."""
+async def _drain_autopilot_tasks():
+    """Cancel + AWAIT any autopilot background tasks a test left running before
+    clearing the registry, so a leaked loop never bleeds into the next test.
+    Tasks spawned inside a TestClient request live on that request's (now
+    closed) portal loop — the suppress swallows the cross-loop errors those
+    raise on cancel/await."""
     yield
+    for task in list(autopilot_mod._TASKS.values()):
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            task.cancel()
+            await task
     autopilot_mod._TASKS.clear()
 
 
@@ -277,6 +286,59 @@ async def test_autopilot_background_task_lifecycle(tmp_path, mongo_db, store, mo
     assert not autopilot_mod.is_running(mandate_id)
     # Idempotent — a second stop is a no-op.
     await autopilot_mod.stop_autopilot(mandate_id)
+
+
+async def test_reconciler_restarts_only_active_autopilot_on_mandates(
+    tmp_path, mongo_db, store, monkeypatch
+):
+    """The lifespan startup reconciler re-derives the background loops from the
+    persisted ``autopilot.on`` flags: an ACTIVE autopilot-on mandate gets its
+    loop back after a (simulated) restart; an autopilot-off mandate and a PAUSED
+    autopilot-on mandate are ignored. The shutdown drain then cancels every
+    registered loop."""
+    from pocketpaw_ee.cloud.mandates.domain import MandateDoc
+
+    async def _mk(name: str) -> str:
+        repo = _seed_repo(tmp_path, f"{name}-repo")
+        created = await mandate_service.create_mandate(
+            WS, USER, {"name": name, "surface": {"repo_id": str(repo)}, "charter": _charter()}
+        )
+        return created["mandate"]["id"]
+
+    on_id = await _mk("ap-on")
+    off_id = await _mk("ap-off")
+    paused_id = await _mk("ap-paused")
+
+    # Turn autopilot on for two of them through the real service path.
+    await mandate_service.set_autopilot(WS, USER, on_id, {"action": "start", "users": 2})
+    await mandate_service.set_autopilot(WS, USER, paused_id, {"action": "start", "users": 2})
+    # Pause the third mandate AFTER autopilot was enabled — its persisted flag
+    # stays on=True, but the reconciler must skip it (a paused mandate is inert).
+    from bson import ObjectId
+
+    paused_doc = await MandateDoc.find_one(
+        MandateDoc.workspace == WS, MandateDoc.id == ObjectId(paused_id)
+    )
+    paused_doc.status = "paused"
+    await paused_doc.save()
+
+    # Simulate a process restart: drain every live loop — the registry empties
+    # but the persisted flags survive in Mongo.
+    await autopilot_mod.shutdown_all_autopilot_tasks()
+    assert not autopilot_mod.is_running(on_id)
+    assert not autopilot_mod.is_running(paused_id)
+
+    # The reconciler (the lifespan startup hook's body) restarts exactly the
+    # ACTIVE autopilot-on mandate — run_immediate=False, so no cycle storms.
+    started = await autopilot_mod.reconcile_autopilot_tasks()
+    assert started == 1
+    assert autopilot_mod.is_running(on_id)
+    assert not autopilot_mod.is_running(off_id)
+    assert not autopilot_mod.is_running(paused_id)
+
+    # The shutdown drain (the lifespan shutdown hook's body) cancels it again.
+    await autopilot_mod.shutdown_all_autopilot_tasks()
+    assert not autopilot_mod.is_running(on_id)
 
 
 async def test_autopilot_users_clamped_and_deterministic(tmp_path, mongo_db, store, monkeypatch):

--- a/tests/cloud/test_belt_mandates.py
+++ b/tests/cloud/test_belt_mandates.py
@@ -149,8 +149,15 @@ class RecorderDispatcher:
 @pytest.fixture
 def dispatcher(monkeypatch) -> type[RecorderDispatcher]:
     """Make the executor's DEFAULT dispatcher the recorder, keeping the
-    router→executor seam real — only the station boundary is replaced."""
+    router→executor seam real — only the station boundary is replaced.
+
+    The default dispatcher is now ``station`` (feat/belt-autopilot); these tests
+    exercise the dispatch SEAM (the recorder), so pin the selection to ``bus``
+    and patch ``BusTaskDispatcher`` to the recorder — ``resolve_dispatcher()``
+    then returns the recorder. The real StationTaskDispatcher path is covered by
+    test_belt_autopilot."""
     RecorderDispatcher.instances = []
+    monkeypatch.setenv("POCKETPAW_MANDATE_DISPATCHER", "bus")
     monkeypatch.setattr(mandate_executor, "BusTaskDispatcher", RecorderDispatcher)
     return RecorderDispatcher
 


### PR DESCRIPTION
## What this adds

The two pieces that close the mandate loop. Stacked on #1428 — review the 3 commits above its tip.

**Autopilot.** `POST /belt/mandates/{id}/autopilot {action, users?}` spawns Foresight-seeded persona loops (OceanDrift temperaments, deterministic in mock mode) that read the mandate's surface — README plus recent commit titles — and file structured feedback through the existing intake, tagged `autopilot:<persona>`. Those become the sightings the next shift's Foreman cites. Cycles run on an interval (default 5 min), survive process restarts via a startup reconciler under the same scheduler gate as the run sweeper, and drain cleanly on shutdown. Per-cycle failures log and never kill the loop or a shift.

**Real dispatch.** `POCKETPAW_MANDATE_DISPATCHER=station` (default) replaces the announce-only dispatcher: each approved plan task files a real `code_change` Action in a queued, `station_pending` state — visible live in the console's run feed, repo pre-bound, one click opens the station that drives it to a diff through the normal belt gate. The belt executor refuses a `station_pending` blob before any git mutation, including via bulk approve.

## The honest finding

A genuinely headless task-to-diff runner does not exist in the codebase today — the develop station is an interactive agent session, and the diff is that session's output. This PR ships the closest real thing rather than faking it, and the `TaskDispatcher` protocol is the seam a future headless runner slots into. Documented in docs/internal/2026-06-belt-mandates.md.

## Deferred with eyes open (review minors, for a GA hardening pass)

The autopilot interval env var bypasses the Settings pattern (matches this module's existing shortcut), and surface reads trust the repo path the same way the belt executor already does for admins.

## Tests

63 passed across the belt suites: reconciler restarts exactly the active autopilot-on mandates after a simulated restart, station dispatch persists queued runs (asserted on the records, not bus echoes), the full loop (autopilot sightings → shift cites them → approve → queued runs), users clamp, tenant isolation on both endpoints, and the existing 54 stayed green.