### PR TITLE
Add the propose_external_action MCP tool for gated external actions

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/external_actions.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/external_actions.py
@@ -1,0 +1,292 @@
+# external_actions.py — in-process MCP server exposing the gated external-action
+# proposal type to the claude_agent_sdk cloud chat backend. Created: 2026-06-11
+# (feat/external-action-mcp-tool).
+#
+# What this file does: it is the agent-facing surface for the THIRD gated
+# Instinct proposal type — the external action (#1425 added the propose/execute
+# halves under ee/cloud/external_actions/ but no agent-facing tool). It clones
+# the belt.py shape — a single ``create_sdk_mcp_server`` with an SDK import-
+# guard, ``SERVER_NAME`` / ``*_TOOL_ID`` allowlist constants, ContextVar-sourced
+# identity (the same ``current_workspace_id`` / ``current_user_id`` /
+# ``current_session_mongo_id`` accessors in ``ee.cloud.chat.agent_service`` the
+# belt / media / sites servers read), and the ``_error_response`` /
+# ``_success_response`` helpers. The single tool id namespaces as
+# ``mcp__pocketpaw_external_actions__propose_external_action`` so the Claude
+# Code allowlist machinery matches it.
+#
+# One SDK @tool def:
+#   * propose_external_action — a chat agent proposes a call to an external
+#     system through a bound connector ("call action ``approveApplication`` on
+#     connector ``crm`` with params ``{...}``"). This tool does NOT execute
+#     anything: it validates the inputs (identity present; connector / action /
+#     summary / reason non-empty; params is an object) and then DELEGATES to
+#     ``ee.cloud.external_actions.propose.propose_external_action``, which files
+#     an Instinct Action carrying the ``_external_action`` blob and opens the
+#     Decision-Graph chain. A human approves it in The Tray; ONLY then does the
+#     apply-on-approve executor (ee/cloud/external_actions/executor.py) make the
+#     connector call. Propose-only — the tool never fires the connector itself.
+#
+# Why delegate (vs. rebuilding belt's blob-build inline): the propose half
+# already builds the blob, computes the params hash, mints the chain
+# correlation_id, emits ``agent.proposed``, and back-writes the chain ids. This
+# server is the thin agent-facing adapter over it — resolve identity, validate,
+# call, relay. No connector secret ever passes through here.
+#
+# Security: ``params`` is DATA — it is passed verbatim to the propose helper
+# (which hashes it and stores it in the Action blob) and never interpolated into
+# a shell or eval'd. The connector NAME + scope are stored; the credential is
+# resolved fresh at execution by the cloud connector service. NO phantom
+# successes: the tool returns ok only after the propose helper returns a durable
+# action id. Params content is never logged — only the connector + action +
+# action id.
+#
+# EE→OSS boundary: this module lives in pocketpaw_ee; the surface service loads
+# the tool ids as a plain frozenset[str] inside a try/except (never importing a
+# pocketpaw_ee symbol into src/pocketpaw), exactly as it does for BELT_TOOL_IDS.
+"""Agent-side MCP surface for the gated external-action proposal type."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_external_actions"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form. Keep this id stable — the surface
+# allowlist machinery matches it.
+PROPOSE_EXTERNAL_ACTION_TOOL_ID = f"mcp__{SERVER_NAME}__propose_external_action"
+
+EXTERNAL_ACTIONS_TOOL_IDS = (PROPOSE_EXTERNAL_ACTION_TOOL_ID,)
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects. The agent
+    reads ``text`` and surfaces the reason."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None, str | None]:
+    """Resolve the active workspace + user + session id from the per-stream
+    ContextVars set by the cloud chat agent runtime. Returns
+    ``(workspace_id, user_id, session_mongo_id)``."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_session_mongo_id,
+            current_user_id,
+            current_workspace_id,
+        )
+
+        return current_workspace_id(), current_user_id(), current_session_mongo_id()
+    except Exception:  # noqa: BLE001
+        return None, None, None
+
+
+async def _propose_external_action_handler(args: dict) -> dict:
+    """MCP handler for ``external_actions__propose_external_action``.
+
+    Resolves identity, validates inputs, then DELEGATES to
+    ``ee.cloud.external_actions.propose.propose_external_action`` — which files
+    the Instinct Action carrying the ``_external_action`` blob and opens the
+    Decision-Graph chain. Returns ``{action_id, status: "pending_approval",
+    summary}`` on success, or an ``is_error`` response with a plain relayable
+    reason. NO phantom successes: ok is returned only after the propose helper
+    hands back a durable action id. This handler NEVER executes the connector —
+    propose only.
+    """
+    workspace_id, user_id, _session_mongo_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "propose_external_action requires workspace and user context "
+            "(call from a cloud chat session)."
+        )
+
+    connector = args.get("connector")
+    action = args.get("action")
+    params = args.get("params")
+    summary = args.get("summary")
+    reason = args.get("reason")
+
+    if not isinstance(connector, str) or not connector.strip():
+        return _error_response(
+            "propose_external_action requires a non-empty `connector` (the bound "
+            "connector name to call, e.g. 'crm')."
+        )
+    if not isinstance(action, str) or not action.strip():
+        return _error_response(
+            "propose_external_action requires a non-empty `action` (the named "
+            "connector action to call, e.g. 'approveApplication')."
+        )
+    if not isinstance(summary, str) or not summary.strip():
+        return _error_response(
+            "propose_external_action requires a non-empty `summary` (a one-line "
+            "human-readable description of the call for the approval gate)."
+        )
+    if not isinstance(reason, str) or not reason.strip():
+        return _error_response(
+            "propose_external_action requires a non-empty `reason` (why this call "
+            "should be made — surfaced to the human reviewer in The Tray)."
+        )
+    # ``params`` is the proposed call payload — it must be a JSON object (or
+    # absent, treated as empty). Reject a non-object so a malformed call is
+    # refused before anything is filed.
+    if params is None:
+        params = {}
+    if not isinstance(params, dict):
+        return _error_response(
+            "propose_external_action `params` must be a JSON object (the call "
+            "parameters passed verbatim to the connector action)."
+        )
+
+    # The gate one-liner the human sees in The Tray. Compose the agent's own
+    # ``summary`` (what) with its ``reason`` (why) so the reviewer has both on
+    # the Action's surface. The propose helper stores this on the blob's
+    # ``summary`` field and in the Action recommendation.
+    gate_summary = f"{summary.strip()} — {reason.strip()}"
+
+    try:
+        from pocketpaw_ee.cloud.external_actions.propose import propose_external_action
+    except ImportError as exc:  # pragma: no cover — ee always present when this runs
+        logger.warning("external_actions: propose import failed", exc_info=True)
+        return _error_response(f"external-action proposals are unavailable: {exc}")
+
+    try:
+        action_id = await propose_external_action(
+            workspace_id=workspace_id,
+            connector_name=connector.strip(),
+            action=action.strip(),
+            params=params,
+            requested_by=user_id,
+            summary=gate_summary,
+        )
+    except ValueError as exc:
+        # A validation error from the propose helper (e.g. an empty field that
+        # slipped past) — relay it plainly; nothing was stored.
+        return _error_response(str(exc))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "external_actions: propose raised for connector=%s action=%s",
+            connector,
+            action,
+            exc_info=True,
+        )
+        return _error_response(f"could not propose the external action: {exc}")
+
+    if not action_id:
+        return _error_response("the external action was not stored — please retry.")
+
+    logger.info(
+        "external_actions: proposed call '%s' on connector '%s' → Instinct action %s "
+        "(workspace=%s)",
+        action.strip(),
+        connector.strip(),
+        action_id,
+        workspace_id,
+    )
+
+    return _success_response(
+        {
+            "action_id": action_id,
+            "status": "pending_approval",
+            "summary": gate_summary,
+        }
+    )
+
+
+def build_external_actions_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for the external-action gate, or
+    return ``None`` if the Claude Agent SDK isn't installed.
+
+    Matches the shape returned by ``build_belt_server`` (``(name, server)`` or
+    ``None``) so the backend's MCP registration loop treats it identically.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_external_actions MCP disabled")
+        return None
+
+    @tool(
+        "propose_external_action",
+        (
+            "Propose a call to an EXTERNAL system through a bound connector, for "
+            "HUMAN APPROVAL. Call this when the user wants you to take an action "
+            "in an external tool (a CRM, a ticketing system, etc.) via a "
+            "connector. This does NOT execute anything: it files the proposed "
+            "call in The Tray for a human to approve or reject. ONLY on approval "
+            "does the connector call actually fire — you never run it yourself. "
+            "Args: `connector` (the bound connector name, e.g. 'crm'), `action` "
+            "(the named connector action, e.g. 'approveApplication'), `params` "
+            "(a JSON object of call parameters, passed verbatim to the action), "
+            "`summary` (a one-line human-readable description of the call), "
+            "`reason` (why this call should be made — shown to the reviewer). "
+            "Returns {action_id, status:'pending_approval', summary}. An error "
+            "means relay the reason — do NOT claim the action ran or succeeded; "
+            "it is only PROPOSED until a human approves it."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "connector": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The bound connector name to call (e.g. 'crm').",
+                },
+                "action": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The named connector action (e.g. 'approveApplication').",
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Call parameters, passed verbatim to the connector action.",
+                },
+                "summary": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "One-line human-readable description of the call.",
+                },
+                "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Why this call should be made (shown to the reviewer).",
+                },
+            },
+            "required": ["connector", "action", "params", "summary", "reason"],
+            "additionalProperties": False,
+        },
+    )
+    async def propose_external_action(args):  # type: ignore[no-untyped-def]
+        return await _propose_external_action_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[propose_external_action],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "EXTERNAL_ACTIONS_TOOL_IDS",
+    "PROPOSE_EXTERNAL_ACTION_TOOL_ID",
+    "SERVER_NAME",
+    "build_external_actions_server",
+]

--- a/ee/pocketpaw_ee/cloud/external_actions/README.md
+++ b/ee/pocketpaw_ee/cloud/external_actions/README.md
@@ -4,6 +4,9 @@ Created: 2026-06-11 (feat/external-action-proposal).
 Documents the third gated proposal kind (alongside `_pocket_write` and
 `_code_change`): its blob contract, the propose/execute split, the
 exactly-one-terminal Decision-Graph discipline, and the router wiring.
+Updated: 2026-06-11 (feat/external-action-mcp-tool) — added the "Agent-facing
+MCP tool surface" section documenting the `propose_external_action` tool that
+lets a chat agent file one of these proposals.
 -->
 
 # Gated external actions
@@ -43,6 +46,42 @@ resolved fresh at execution from the workspace's saved connector config.
 | `correlation_id` / `proposed_event_id` | Decision-Graph chain ids minted at propose time |
 | `summary` | human-readable one-liner for the gate UI |
 | `outcome` | `{status, response_summary, executed_at}` back-written by the executor after the call |
+
+## Agent-facing MCP tool surface
+
+A chat agent files an external-action proposal through one in-process MCP tool.
+The tool is a thin adapter over `propose.propose_external_action` — it resolves
+identity, validates inputs, and delegates; it **never** executes the connector.
+
+| | |
+|---|---|
+| Server name | `pocketpaw_external_actions` |
+| Tool id | `mcp__pocketpaw_external_actions__propose_external_action` |
+| Module | `agent/mcp_servers/external_actions.py` |
+| Provider | `extensions.CloudExternalActionsMcpProvider` (entry point `external_actions`) |
+
+The server is **ambient** (not opt-in) — surfaces scope access via their profile
+allowlist, the same regime the belt / loom / media / sites servers use. It is
+disabled (the registration loop skips it) when the `claude_agent_sdk` isn't
+installed, so chat never breaks.
+
+`propose_external_action(connector, action, params, summary, reason)`:
+
+| Arg | Meaning |
+|-----|---------|
+| `connector` | the bound connector name to call (e.g. `"crm"`) |
+| `action` | the named connector action (e.g. `"approveApplication"`) |
+| `params` | a JSON object of call parameters, passed verbatim to the action |
+| `summary` | a one-line human-readable description of the call (the *what*) |
+| `reason` | why the call should be made — shown to the reviewer (the *why*) |
+
+The tool resolves the `workspace_id` + `requested_by` from the cloud chat
+session's identity ContextVars (never from the agent's args), folds
+`summary` + `reason` into the blob's gate summary, and returns
+`{action_id, status: "pending_approval", summary}` on success. An error
+returns a plain relayable message and files **nothing**. The agent must not
+claim the action ran — it is only **proposed** until a human approves it in The
+Tray, at which point the executor below fires the call.
 
 ## Execute-on-approve contract
 

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -48,6 +48,16 @@ code-change gate in-process server (``pocketpaw_belt``; one tool
 ``CloudMediaMcpProvider``. The develop station proposes a diff through Instinct;
 the ee instinct router fires ``ee.cloud.belt.executor.execute_approved_change``
 on approval. Ambient (not opt-in).
+
+Updated: 2026-06-11 (feat/external-action-mcp-tool) — added
+``CloudExternalActionsMcpProvider`` (``pocketpaw.mcp_servers`` entry
+``external_actions``) exposing the gated external-action proposal server
+(``pocketpaw_external_actions``; one tool ``propose_external_action``) to the
+claude_agent_sdk cloud chat backend, mirroring ``CloudBeltMcpProvider``. A chat
+agent proposes a connector call through Instinct; the ee instinct router fires
+``ee.cloud.external_actions.executor.execute_approved_external_action`` on
+approval. Propose-only — the tool never fires the connector itself. Ambient
+(not opt-in).
 """
 
 from __future__ import annotations
@@ -690,6 +700,44 @@ class CloudBeltMcpProvider:
         from pocketpaw_ee.agent.mcp_servers.belt import BELT_TOOL_IDS
 
         return list(BELT_TOOL_IDS)
+
+
+class CloudExternalActionsMcpProvider:
+    """`pocketpaw.mcp_servers` — the gated external-action proposal in-process
+    server (``pocketpaw_external_actions``). Hosts ``propose_external_action``
+    only.
+
+    A chat agent proposes a call to an external system through a bound connector
+    THROUGH Instinct (the human approve/reject layer) via this tool. On approval
+    the ee instinct router fires
+    ``ee.cloud.external_actions.executor.execute_approved_external_action`` to
+    make the connector call — the tool itself never executes anything (propose
+    only).
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — surfaces scope access via their
+    profile allowlist, the same regime the sibling belt / loom / media / sites
+    servers use. ``build_external_actions_server`` returns None — and the loop
+    skips it — when the claude_agent_sdk isn't installed, so chat never breaks.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.external_actions import (
+                build_external_actions_server,
+            )
+
+            return build_external_actions_server()
+        except ImportError:
+            # claude_agent_sdk not installed — the server is unavailable, same as
+            # the other in-process servers.
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.external_actions import (
+            EXTERNAL_ACTIONS_TOOL_IDS,
+        )
+
+        return list(EXTERNAL_ACTIONS_TOOL_IDS)
 
 
 class CloudAgentExtension:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -198,6 +198,7 @@ sites = "pocketpaw_ee.extensions:CloudSitesMcpProvider"
 media = "pocketpaw_ee.extensions:CloudMediaMcpProvider"
 loom = "pocketpaw_ee.extensions:CloudLoomMcpProvider"
 belt = "pocketpaw_ee.extensions:CloudBeltMcpProvider"
+external_actions = "pocketpaw_ee.extensions:CloudExternalActionsMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]
 cloud = "pocketpaw_ee.extensions:CloudAgentExtension"

--- a/tests/cloud/test_external_action_mcp.py
+++ b/tests/cloud/test_external_action_mcp.py
@@ -1,0 +1,262 @@
+# tests/cloud/test_external_action_mcp.py — the agent-facing MCP surface for the
+# gated external-action proposal type (feat/external-action-mcp-tool).
+#
+# Created: 2026-06-11 (feat/external-action-mcp-tool).
+#
+# What this pins — the MCP tool, driven through the REAL handler:
+#   * tool-id / server-name contract (SERVER_NAME, *_TOOL_ID, *_TOOL_IDS).
+#   * the provider exposes the server + tool ids (extensions wiring).
+#   * propose_external_action (the real MCP handler) resolves identity, validates
+#     inputs, files an Instinct Action carrying the ``_external_action`` blob via
+#     the REAL propose helper, and returns {action_id, status:'pending_approval',
+#     summary} — only after a durable action id comes back.
+#   * the stored blob carries the connector ref + params + workspace and NO
+#     connector secret; the tool's `summary` + `reason` are folded into the gate
+#     summary.
+#   * error relaying: missing connector / action / summary / reason, and a
+#     non-object `params`, each refuse cleanly with NO Action filed.
+#   * workspace resolution: no identity ContextVars → an explicit error, no
+#     Action.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The handler reads
+# identity through ee.cloud.chat.agent_service ContextVars (set in-test via
+# attach_agent_identity) and the store through pocketpaw.stores.get_instinct_store
+# (patched to a tmp-file store so nothing touches ~/.pocketpaw/instinct.db).
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+import pocketpaw_ee.agent.mcp_servers.external_actions as ea_mcp  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.extensions import CloudExternalActionsMcpProvider  # noqa: E402
+
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired in everywhere the propose
+    helper reads it (``pocketpaw.stores.get_instinct_store``)."""
+    st = InstinctStore(tmp_path / "instinct_ea_mcp_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+class _identity:
+    """Context manager that sets the workspace/user/session ContextVars the
+    handler reads, then resets them."""
+
+    def __init__(self, *, workspace="w1", user="u1", session="sess-1"):
+        self._ws, self._user, self._sess = workspace, user, session
+        self._tokens = None
+
+    def __enter__(self):
+        self._tokens = attach_agent_identity(
+            workspace_id=self._ws, user_id=self._user, session_mongo_id=self._sess
+        )
+        return self
+
+    def __exit__(self, *exc):
+        detach_agent_identity(self._tokens)
+        return False
+
+
+async def _result_body(res: dict) -> dict:
+    """Parse the JSON body out of a success MCP response."""
+    assert res.get("is_error") is not True, res
+    return json.loads(res["content"][0]["text"])
+
+
+def _good_args() -> dict:
+    """A well-formed propose_external_action call."""
+    return {
+        "connector": "crm",
+        "action": "approveApplication",
+        "params": {"application_id": "app-42", "note": "verified"},
+        "summary": "Approve application app-42 in the CRM.",
+        "reason": "The applicant passed the verification checks the user asked about.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# tool-id / provider contract pins
+# ---------------------------------------------------------------------------
+
+
+def test_tool_id_contract_pin() -> None:
+    """The server + tool id are the exact namespaced strings the allowlist
+    machinery matches."""
+    assert ea_mcp.SERVER_NAME == "pocketpaw_external_actions"
+    assert (
+        ea_mcp.PROPOSE_EXTERNAL_ACTION_TOOL_ID
+        == "mcp__pocketpaw_external_actions__propose_external_action"
+    )
+    assert ea_mcp.EXTERNAL_ACTIONS_TOOL_IDS == (
+        "mcp__pocketpaw_external_actions__propose_external_action",
+    )
+
+
+def test_provider_exposes_server_and_tool_ids() -> None:
+    """The extensions provider builds the server and reports the tool ids — the
+    pocketpaw.mcp_servers registration loop reads both."""
+    provider = CloudExternalActionsMcpProvider()
+    assert provider.tool_ids() == [ea_mcp.PROPOSE_EXTERNAL_ACTION_TOOL_ID]
+
+    built = provider.build_server()
+    # claude_agent_sdk is a dev dep here, so the server builds; if it's ever
+    # absent the loop skips it (None) — either is a valid contract.
+    if built is not None:
+        name, server = built
+        assert name == "pocketpaw_external_actions"
+        assert server is not None
+
+
+def test_build_server_registers_one_tool() -> None:
+    """The built server is named correctly and is constructed from exactly the
+    one propose tool."""
+    built = ea_mcp.build_external_actions_server()
+    if built is None:
+        pytest.skip("claude_agent_sdk not installed")
+    name, server = built
+    assert name == "pocketpaw_external_actions"
+
+
+# ---------------------------------------------------------------------------
+# the REAL propose path
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_files_action_with_blob(store):
+    """Drive the real handler: it files an Instinct Action carrying the
+    ``_external_action`` blob and returns {action_id, status, summary}."""
+    with _identity():
+        res = await ea_mcp._propose_external_action_handler(_good_args())
+
+    body = await _result_body(res)
+    assert body["status"] == "pending_approval"
+    assert "action_id" in body
+    # The gate summary folds the agent's summary + reason.
+    assert "Approve application app-42" in body["summary"]
+    assert "verification checks" in body["summary"]
+
+    action = await store.get_action(body["action_id"])
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+
+    blob = action.parameters["_external_action"]
+    assert blob["kind"] == "external_action"
+    assert blob["connector_name"] == "crm"
+    assert blob["action"] == "approveApplication"
+    assert blob["workspace_id"] == "w1"
+    assert blob["requested_by"] == "u1"
+    # params stored verbatim — it's data.
+    assert blob["params"]["application_id"] == "app-42"
+    # A params hash is computed so a post-propose edit can be refused at execute.
+    assert blob["params_hash"]
+    # NO connector secret is written — only the connector name + scope.
+    blob_json = json.dumps(blob).lower()
+    assert "secret" not in blob_json
+    assert "token" not in blob_json
+    assert "password" not in blob_json
+
+
+async def test_propose_defaults_missing_params_to_empty(store):
+    """`params` omitted is treated as an empty object (not an error)."""
+    args = _good_args()
+    del args["params"]
+    with _identity():
+        res = await ea_mcp._propose_external_action_handler(args)
+    body = await _result_body(res)
+    action = await store.get_action(body["action_id"])
+    assert action.parameters["_external_action"]["params"] == {}
+
+
+# ---------------------------------------------------------------------------
+# workspace resolution
+# ---------------------------------------------------------------------------
+
+
+async def test_identity_missing_errors(store):
+    """Called without workspace/user ContextVars → an explicit error, no
+    Action."""
+    res = await ea_mcp._propose_external_action_handler(_good_args())
+    assert res.get("is_error") is True
+    assert "workspace and user context" in res["content"][0]["text"]
+    assert await store.list_actions() == []
+
+
+# ---------------------------------------------------------------------------
+# input validation / error relaying
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "drop,needle",
+    [
+        ("connector", "`connector`"),
+        ("action", "`action`"),
+        ("summary", "`summary`"),
+        ("reason", "`reason`"),
+    ],
+)
+async def test_missing_required_field_refused(store, drop, needle):
+    """Each missing required string field refuses cleanly with NO Action filed."""
+    args = _good_args()
+    del args[drop]
+    with _identity():
+        res = await ea_mcp._propose_external_action_handler(args)
+    assert res.get("is_error") is True
+    assert needle in res["content"][0]["text"]
+    assert await store.list_actions() == []
+
+
+@pytest.mark.parametrize("field", ["connector", "action", "summary", "reason"])
+async def test_blank_required_field_refused(store, field):
+    """A whitespace-only required field is refused — no Action filed."""
+    args = _good_args()
+    args[field] = "   "
+    with _identity():
+        res = await ea_mcp._propose_external_action_handler(args)
+    assert res.get("is_error") is True
+    assert await store.list_actions() == []
+
+
+async def test_non_object_params_refused(store):
+    """A `params` that isn't a JSON object is refused before anything is stored."""
+    args = _good_args()
+    args["params"] = "not-an-object"
+    with _identity():
+        res = await ea_mcp._propose_external_action_handler(args)
+    assert res.get("is_error") is True
+    assert "must be a JSON object" in res["content"][0]["text"]
+    assert await store.list_actions() == []
+
+
+async def test_propose_helper_error_is_relayed(store, monkeypatch):
+    """A ValueError raised by the propose helper is relayed as a plain error,
+    not a crash — and surfaces no phantom success."""
+
+    async def _boom(**kwargs):
+        raise ValueError("connector 'crm' is not bound in this workspace")
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.external_actions.propose.propose_external_action", _boom
+    )
+    with _identity():
+        res = await ea_mcp._propose_external_action_handler(_good_args())
+    assert res.get("is_error") is True
+    assert "not bound in this workspace" in res["content"][0]["text"]

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -1,5 +1,10 @@
 """Tests for MCP + Claude Agent SDK integration — Sprint 17.
 
+Updated: 2026-06-11 (feat/external-action-mcp-tool) — ``_strip_builtin_servers``
+  now also drops ``pocketpaw_external_actions`` (the new always-on gated
+  external-action proposal server: propose_external_action), so the
+  external-config assertions stay focused after that MCP server became
+  ambient. Same regime as pocketpaw_belt / pocketpaw_media.
 Updated: 2026-06-10 (integration/belt-thin-slice) — ``_strip_builtin_servers``
   now also drops ``pocketpaw_belt`` (the always-on Belt gate server:
   belt_propose_change — the bundled `belt` skill calls it without an explicit
@@ -52,6 +57,9 @@ from unittest.mock import patch
 from pocketpaw_ee.agent.mcp_servers.belt import SERVER_NAME as _BELT_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.connectors import SERVER_NAME as _CONNECTORS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.decisions import SERVER_NAME as _DECISIONS_MCP_SERVER_NAME
+from pocketpaw_ee.agent.mcp_servers.external_actions import (
+    SERVER_NAME as _EXTERNAL_ACTIONS_MCP_SERVER_NAME,
+)
 from pocketpaw_ee.agent.mcp_servers.foresight import SERVER_NAME as _FORESIGHT_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.loom import SERVER_NAME as _LOOM_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.media import SERVER_NAME as _MEDIA_MCP_SERVER_NAME
@@ -110,6 +118,10 @@ def _strip_builtin_servers(result: dict) -> dict:
     # otherwise register it in these tests.
     out.pop(_BELT_MCP_SERVER_NAME, None)
     out.pop(_LOOM_MCP_SERVER_NAME, None)
+    # ``pocketpaw_external_actions`` is always-on too — a chat agent proposes a
+    # gated connector call (propose_external_action) without an explicit
+    # opt-in; the connector only fires after human approval.
+    out.pop(_EXTERNAL_ACTIONS_MCP_SERVER_NAME, None)
     return out
 
 


### PR DESCRIPTION
## What

[#1425](https://github.com/pocketpaw/pocketpaw/pull/1425) added the gated external-action proposal type — the propose helper that files a `_external_action` Instinct blob, and the executor that fires the connector call once a human approves. What it didn't add was a way for a chat agent to propose one. This fills that gap.

A new in-process MCP server, `pocketpaw_external_actions`, registers a single tool:

```
propose_external_action(connector, action, params, summary, reason)
```

The tool resolves the workspace and user from the cloud chat session, validates the inputs, and delegates to `external_actions.propose.propose_external_action`. That helper does the real work — builds the blob, hashes the params, mints the Decision-Graph chain. On success the tool returns `{action_id, status: "pending_approval", summary}`; on any failure it returns a plain message the agent relays to the user.

## It only proposes

The tool never calls the connector. The connector call happens later, in the executor, and only after a human approves the action in The Tray. The docstring says so, and the tests pin it. The agent can't claim the action ran.

## How it's built

Same shape as the belt code-change gate server:

- identity from the cloud chat ContextVars, never from the agent's args
- the workspace and `requested_by` come from the session, not the tool input
- no connector secret passes through — only the connector name and scope are stored
- shared error/success response helpers
- registered next to the belt provider as the `external_actions` entry point, ambient (surfaces scope access via their profile allowlist)

`summary` (the what) and `reason` (the why) are folded into one gate line so a reviewer sees both on the action.

## Tests

`tests/cloud/test_external_action_mcp.py`, driven through the real handler against a tmp-file Instinct store:

- tool-id / server-name contract and the provider wiring
- happy-path propose files the action with the right blob, no secret written
- `params` omitted defaults to an empty object
- workspace resolution — no identity ContextVars refuses cleanly with nothing filed
- every missing or blank required field, and a non-object `params`, refused with no action filed
- a `ValueError` from the propose helper is relayed, not crashed

16 pass. The existing belt-gate and external-action-gate suites still pass (22), so nothing upstream moved.

## Docs

The `external_actions` README from #1425 gains an "Agent-facing MCP tool surface" section covering the server name, tool id, args, and the propose-only contract.