### PR TITLE
Add applications-triage and member-360 bundled pockets

### DIFF
--- a/src/pocketpaw/bundled_templates/_bundled/README.md
+++ b/src/pocketpaw/bundled_templates/_bundled/README.md
@@ -2,6 +2,10 @@
 src/pocketpaw/bundled_templates/_bundled/README.md
 Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — explains the
 two-file sibling convention each template directory follows.
+Modified: 2026-06-11 (feat/triage-member-templates) — documented the two
+generic vertical templates (applications-triage, member-360) that carry
+the richer v2 surface (needs / actions / outcomes / data_sources) the
+seed templates omit, and the gated-action binding point.
 -->
 # Bundled pocket templates
 
@@ -44,6 +48,41 @@ Outcomes are not wired yet, and a dead action declaration is worse than
 none. `outcomes`, `instinct_rules`, `triggers`, and `agents` are omitted
 entirely for the same reason. Increment 2b adds per-backend API skills;
 later increments populate `actions` once Instinct lands.
+
+## Vertical templates (applications-triage, member-360)
+
+Two generic, install-ready templates carry the full v2 surface the seed
+templates leave empty:
+
+| Template | What it is | v2 surface it uses |
+|----------|-----------|--------------------|
+| `applications-triage` | A review queue: status/summary/score/age list, a Q&A detail panel for the selected item, a backlog burndown stat row, and an approve / reject / needs-review action row. | `needs: [paw.db.v1]`, `data_sources`, three gated `actions` (`instinct_policy: require_approval`), `outcomes`. |
+| `member-360` | A single-pane, read-only view of one member: header, key-value profile, membership panel, ticket/order/note lists, attendance/spend stats. | `needs: [paw.db.v1]`, `data_sources`. No actions. |
+
+Both are fully generic — no client names, no domain-specific fields
+beyond what any application-triage or member-view needs. They declare
+`needs: [paw.db.v1]` (the generic database Sense) so a deployment is
+prompted to connect a data source; with none, the seeded sample rows
+render. Their seed-only field-set assertions are intentionally excluded
+in `tests/unit/test_bundled_templates.py`; their richer shape, compile,
+and service-create round-trip are covered by
+`tests/unit/test_vertical_templates.py` and
+`tests/cloud/pockets/test_vertical_template_create.py`.
+
+### Action-row binding point (applications-triage)
+
+The approve / reject / needs-review buttons do **not** execute. Each
+button sets `state.pending_proposal` to a generic proposal shape
+`{action, application_id, summary}`. That is the seam a deployment wires
+to the Instinct gate so a human confirms in The Tray: read
+`state.pending_proposal` and call
+`pocketpaw_ee.cloud.external_actions.propose.propose_external_action(...)`
+with the bound connector name + action + params, which files an Instinct
+`Action` (`kind="external_action"`) and opens the `agent.proposed`
+decision chain. The executor performs the connector call only on human
+approval. Nothing approves inline — the button only proposes. For a
+Fabric write instead of a connector call, the pocket-write proposal
+bridge is the parallel seam.
 
 ## Adding a template
 

--- a/src/pocketpaw/bundled_templates/_bundled/applications-triage/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/applications-triage/ripple_spec.json
@@ -1,0 +1,226 @@
+{
+  "_placeholder_note": "Built-in pocket template (applications-triage). The rows and Q&A pairs below carry [bracketed] placeholders — the create specialist rewrites them to the user's real applications and domain. The `sources` block is a PLACEHOLDER live-data binding: if a backend is configured, keep it so GET /applications hydrates state.applications; with NO backend, REMOVE the `sources` block and keep the seeded applications as the working data. ACTION-ROW BINDING POINT: the approve / reject / needs-review buttons set state.pending_proposal to a generic proposal shape {action, application_id, summary} — they do NOT execute. A deployment wires this state event to the Instinct gate so a human confirms in The Tray: read state.pending_proposal, call external_actions.propose.propose_external_action({connector_name, action, params:{application_id}, summary}) (or the pocket-write proposal bridge for a Fabric write), which files an Instinct Action (kind=external_action) and opens the agent.proposed decision chain. Nothing approves inline — the button only proposes. Keep the master-detail selected_id wiring and the each-over-status_counts burndown intact.",
+  "sources": {
+    "applications": {
+      "method": "GET",
+      "path": "/applications?status=open",
+      "bind": "state.applications",
+      "refresh": ["pocket_open", "manual"]
+    }
+  },
+  "state": {
+    "selected_id": "a1",
+    "pending_proposal": null,
+    "status_counts": [
+      { "id": "sc1", "label": "Pending", "value": 3 },
+      { "id": "sc2", "label": "In review", "value": 2 },
+      { "id": "sc3", "label": "Approved", "value": 1 },
+      { "id": "sc4", "label": "Rejected", "value": 1 }
+    ],
+    "applications": [
+      {
+        "id": "a1",
+        "applicant": "[Amara Okafor]",
+        "summary": "[Applying for the standard plan; referred by an existing member]",
+        "status": "Pending",
+        "score": 82,
+        "recommendation": "Approve",
+        "age_days": 2,
+        "answers": [
+          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[Referral from a current member]" },
+          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[Access to the workspace and the monthly sessions]" },
+          { "id": "q3", "question": "[Anything we should know?]", "answer": "[Available to start immediately]" }
+        ]
+      },
+      {
+        "id": "a2",
+        "applicant": "[Liam Petrov]",
+        "summary": "[First-time applicant; submitted without a referral]",
+        "status": "In review",
+        "score": 64,
+        "recommendation": "Needs review",
+        "age_days": 5,
+        "answers": [
+          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[Found you through a web search]" },
+          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[Still figuring that out]" },
+          { "id": "q3", "question": "[Anything we should know?]", "answer": "[Prefers to start next month]" }
+        ]
+      },
+      {
+        "id": "a3",
+        "applicant": "[Sofia Marchetti]",
+        "summary": "[Renewal of a lapsed application; strong prior history]",
+        "status": "Pending",
+        "score": 91,
+        "recommendation": "Approve",
+        "age_days": 1,
+        "answers": [
+          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[Returning after a break]" },
+          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[Picking up where I left off]" },
+          { "id": "q3", "question": "[Anything we should know?]", "answer": "[Was a member two years ago]" }
+        ]
+      },
+      {
+        "id": "a4",
+        "applicant": "[Daniel Cho]",
+        "summary": "[Incomplete answers; waiting on missing details]",
+        "status": "In review",
+        "score": 48,
+        "recommendation": "Needs review",
+        "age_days": 8,
+        "answers": [
+          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[—]" },
+          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[Did not answer]" },
+          { "id": "q3", "question": "[Anything we should know?]", "answer": "[—]" }
+        ]
+      },
+      {
+        "id": "a5",
+        "applicant": "[Priya Nair]",
+        "summary": "[Clear fit; references checked out]",
+        "status": "Pending",
+        "score": 88,
+        "recommendation": "Approve",
+        "age_days": 3,
+        "answers": [
+          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[Recommended by a colleague]" },
+          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[The community and the events]" },
+          { "id": "q3", "question": "[Anything we should know?]", "answer": "[Happy to answer follow-up questions]" }
+        ]
+      }
+    ]
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "16px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "[Applications]",
+          "subtitle": "[Work the queue top to bottom — approve, reject, or flag for a second look]"
+        }
+      },
+      {
+        "type": "grid",
+        "props": { "columns": 4, "gap": "12px" },
+        "children": [
+          {
+            "type": "each",
+            "items": "{state.status_counts}",
+            "item_as": "bucket",
+            "children": [
+              {
+                "type": "stat",
+                "props": {
+                  "label": "{bucket.label}",
+                  "value": "{bucket.value}"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "master-detail",
+        "bind": "selected_id",
+        "props": {
+          "items": "{state.applications}",
+          "valueKey": "id",
+          "labelKey": "applicant",
+          "descriptionKey": "summary",
+          "badgeKey": "status"
+        },
+        "children": [
+          {
+            "type": "entity-detail",
+            "props": {
+              "title": "{state.applications.where('id', state.selected_id).first().applicant}",
+              "subtitle": "{state.applications.where('id', state.selected_id).first().summary}",
+              "eyebrow": "Application",
+              "status": { "label": "{state.applications.where('id', state.selected_id).first().status}", "variant": "info" },
+              "meta": [
+                { "label": "Score", "value": "{state.applications.where('id', state.selected_id).first().score}", "icon": "target" },
+                { "label": "Recommendation", "value": "{state.applications.where('id', state.selected_id).first().recommendation}", "icon": "check-circle" },
+                { "label": "Waiting", "value": "{state.applications.where('id', state.selected_id).first().age_days} days", "icon": "clock" }
+              ]
+            },
+            "children": [
+              {
+                "type": "section",
+                "props": { "title": "Answers" },
+                "children": [
+                  {
+                    "type": "each",
+                    "items": "{state.applications.where('id', state.selected_id).first().answers}",
+                    "item_as": "qa",
+                    "children": [
+                      {
+                        "type": "card",
+                        "props": {
+                          "title": "{qa.question}",
+                          "description": "{qa.answer}"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "flex",
+                "props": { "direction": "row", "gap": "8px" },
+                "children": [
+                  {
+                    "type": "button",
+                    "props": { "label": "Approve", "variant": "primary" },
+                    "on_click": [
+                      {
+                        "action": "set",
+                        "target": "pending_proposal",
+                        "value": {
+                          "action": "approve_application",
+                          "application_id": "{state.selected_id}",
+                          "summary": "Approve {state.applications.where('id', state.selected_id).first().applicant}"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "button",
+                    "props": { "label": "Reject", "variant": "danger" },
+                    "on_click": [
+                      {
+                        "action": "set",
+                        "target": "pending_proposal",
+                        "value": {
+                          "action": "reject_application",
+                          "application_id": "{state.selected_id}",
+                          "summary": "Reject {state.applications.where('id', state.selected_id).first().applicant}"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "button",
+                    "props": { "label": "Needs review", "variant": "secondary" },
+                    "on_click": [
+                      {
+                        "action": "set",
+                        "target": "pending_proposal",
+                        "value": {
+                          "action": "flag_for_review",
+                          "application_id": "{state.selected_id}",
+                          "summary": "Flag {state.applications.where('id', state.selected_id).first().applicant} for review"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/applications-triage/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/applications-triage/template.pocket.yaml
@@ -1,0 +1,81 @@
+# src/pocketpaw/bundled_templates/_bundled/applications-triage/template.pocket.yaml
+# Created: 2026-06-11 (feat/triage-member-templates) — RFC 03 v2 Pocket
+# Template Schema metadata for the generic application/queue triage
+# pocket. ``shape: custom`` because the canvas is a master-detail (queue
+# list + selected-application detail) plus a burndown stat row and an
+# action row — RFC 03's shape enum has no ``master-detail`` value, so the
+# pattern is recorded in the sibling index.json (``pattern: app``) and the
+# shape stays ``custom`` (the same choice crm-record-list made).
+# ``needs: [paw.db.v1]`` declares the generic data-source capability a
+# tenant must wire so the queue hydrates from a real backend; without one
+# the seeded sample applications render. The three review actions declare
+# ``instinct_policy: require_approval`` so each surfaces as a PENDING gated
+# proposal in The Tray rather than executing inline — the deployment wires
+# the action row to external_actions.propose at the documented binding
+# point (see the ripple_spec _placeholder_note).
+schema_version: "2"
+name: applications-triage
+version: 1.0.0
+pattern: app
+vertical: operations
+display_name: Applications Triage
+shape: custom
+description: |
+  A review queue for incoming applications. A scannable list on the left —
+  status, a one-line applicant summary, an optional score or recommendation,
+  and how long the item has waited — with the full application detail of the
+  selected row on the right, rendered as plain question-and-answer pairs. A
+  burndown strip across the top counts the queue by status so a reviewer
+  can see the backlog at a glance. The approve / reject / needs-review row
+  surfaces each decision as a pending proposal for a human to confirm rather
+  than acting on its own. Ships a placeholder live-data source so a connected
+  backend hydrates the queue from a real applications endpoint; with no
+  backend it renders the seeded sample applications.
+icon: inbox
+color: "#5b7c99"
+state:
+  entity_type: Application
+  id_field: id
+  columns:
+    - { field: applicant, label: Applicant, widget: text }
+    - { field: summary, label: Summary, widget: text }
+    - { field: status, label: Status, widget: badge }
+    - { field: score, label: Score, widget: number }
+    - { field: recommendation, label: Recommendation, widget: badge }
+    - { field: age_days, label: Waiting, widget: number }
+data_sources:
+  - name: applications
+    method: GET
+    path: /applications?status=open
+    bind: state.applications
+    refresh: [pocket_open, manual]
+needs:
+  - paw.db.v1
+actions:
+  - name: approve_application
+    label: Approve
+    kind: single-row
+    instinct_policy: require_approval
+    outcomes_emitted: [application_approved]
+    description: Proposes approving the selected application. Gated — a human confirms in The Tray.
+  - name: reject_application
+    label: Reject
+    kind: single-row
+    instinct_policy: require_approval
+    outcomes_emitted: [application_rejected]
+    confirm:
+      message: "Propose rejecting this application?"
+      destructive: false
+    description: Proposes rejecting the selected application. Gated — a human confirms in The Tray.
+  - name: flag_for_review
+    label: Needs review
+    kind: single-row
+    instinct_policy: require_approval
+    outcomes_emitted: [application_flagged]
+    description: Proposes flagging the selected application for a second look. Gated.
+outcomes:
+  - application_approved
+  - application_rejected
+  - application_flagged
+connectors: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/_bundled/index.json
+++ b/src/pocketpaw/bundled_templates/_bundled/index.json
@@ -64,6 +64,22 @@
       "pattern": "landing",
       "keywords": ["landing page", "landing site", "marketing page", "marketing site", "sales page", "website for", "site for", "website", "homepage", "home page", "portfolio site", "personal site", "personal website", "about page"],
       "connectors_hint": []
+    },
+    {
+      "slug": "applications-triage",
+      "title": "Applications Triage",
+      "shape": "custom",
+      "pattern": "app",
+      "keywords": ["triage", "application queue", "applications", "review queue", "approval queue", "intake", "applicants", "submissions", "approve reject", "vetting", "screening", "queue"],
+      "connectors_hint": []
+    },
+    {
+      "slug": "member-360",
+      "title": "Member 360",
+      "shape": "custom",
+      "pattern": "viewer",
+      "keywords": ["member", "member 360", "member profile", "customer 360", "member view", "single view", "profile view", "member record", "membership", "account profile", "customer profile"],
+      "connectors_hint": []
     }
   ]
 }

--- a/src/pocketpaw/bundled_templates/_bundled/member-360/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/member-360/ripple_spec.json
@@ -1,0 +1,182 @@
+{
+  "_placeholder_note": "Built-in pocket template (member-360). The member, profile fields, lists, and stats below carry [bracketed] placeholders — the create specialist rewrites them to the user's real member record and domain. The `sources` block is a PLACEHOLDER live-data binding: if a backend is configured, keep it so GET /members/current hydrates state.member; with NO backend, REMOVE the `sources` block and keep the seeded member as the working data. This view is READ-ONLY — no buttons, no on_click, no mutation. Keep the stat strip, the key-value profile cards, the membership panel, and the three record lists intact; reshape the list rows for the user's real tickets / orders / notes.",
+  "sources": {
+    "member": {
+      "method": "GET",
+      "path": "/members/current",
+      "bind": "state.member",
+      "refresh": ["pocket_open", "manual"]
+    }
+  },
+  "state": {
+    "member": {
+      "id": "m1",
+      "name": "[Amara Okafor]",
+      "tier": "[Gold]",
+      "status": "Active"
+    },
+    "stats": [
+      { "id": "st1", "label": "Sessions attended", "value": "[42]" },
+      { "id": "st2", "label": "Total spend", "value": "[$3,180]" }
+    ],
+    "profile": [
+      { "id": "p1", "label": "Email", "value": "[amara@example.com]" },
+      { "id": "p2", "label": "Phone", "value": "[+1 555 0142]" },
+      { "id": "p3", "label": "Member since", "value": "[March 2023]" },
+      { "id": "p4", "label": "Location", "value": "[Lagos]" }
+    ],
+    "membership": [
+      { "id": "mb1", "label": "Package", "value": "[Annual — Gold]" },
+      { "id": "mb2", "label": "Renewal date", "value": "[2027-03-01]" },
+      { "id": "mb3", "label": "Standing", "value": "[Paid in full]" }
+    ],
+    "tickets": [
+      { "id": "t1", "title": "[Locker access not working]", "status": "Open", "date": "2026-06-05" },
+      { "id": "t2", "title": "[Question about guest passes]", "status": "Resolved", "date": "2026-05-21" }
+    ],
+    "orders": [
+      { "id": "o1", "title": "[Event ticket — Summer Mixer]", "amount": "[$45]", "date": "2026-05-30" },
+      { "id": "o2", "title": "[Merch — branded tote]", "amount": "[$25]", "date": "2026-05-12" }
+    ],
+    "notes": [
+      { "id": "n1", "title": "[Prefers email over phone]", "date": "2026-04-18" },
+      { "id": "n2", "title": "[Interested in the mentorship track]", "date": "2026-03-22" }
+    ]
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "16px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "{state.member.name}",
+          "subtitle": "{state.member.tier} member · {state.member.status}"
+        }
+      },
+      {
+        "type": "grid",
+        "props": { "columns": 2, "gap": "12px" },
+        "children": [
+          {
+            "type": "each",
+            "items": "{state.stats}",
+            "item_as": "metric",
+            "children": [
+              {
+                "type": "stat",
+                "props": {
+                  "label": "{metric.label}",
+                  "value": "{metric.value}"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "props": { "title": "Profile" },
+        "children": [
+          {
+            "type": "grid",
+            "props": { "columns": 2, "gap": "12px" },
+            "children": [
+              {
+                "type": "each",
+                "items": "{state.profile}",
+                "item_as": "field",
+                "children": [
+                  {
+                    "type": "card",
+                    "props": {
+                      "title": "{field.label}",
+                      "description": "{field.value}"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "props": { "title": "Membership" },
+        "children": [
+          {
+            "type": "grid",
+            "props": { "columns": 3, "gap": "12px" },
+            "children": [
+              {
+                "type": "each",
+                "items": "{state.membership}",
+                "item_as": "field",
+                "children": [
+                  {
+                    "type": "card",
+                    "props": {
+                      "title": "{field.label}",
+                      "description": "{field.value}"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "props": { "title": "Tickets" },
+        "children": [
+          {
+            "type": "data-grid",
+            "props": {
+              "columns": [
+                { "key": "title", "label": "Ticket", "sortable": true, "align": "left" },
+                { "key": "status", "label": "Status", "sortable": true, "align": "left", "width": "120px" },
+                { "key": "date", "label": "Date", "sortable": true, "align": "left", "width": "130px" }
+              ],
+              "rows": "{state.tickets}",
+              "defaultSort": "date:desc",
+              "dense": true
+            }
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "props": { "title": "Orders" },
+        "children": [
+          {
+            "type": "data-grid",
+            "props": {
+              "columns": [
+                { "key": "title", "label": "Order", "sortable": true, "align": "left" },
+                { "key": "amount", "label": "Amount", "sortable": true, "align": "right", "width": "120px" },
+                { "key": "date", "label": "Date", "sortable": true, "align": "left", "width": "130px" }
+              ],
+              "rows": "{state.orders}",
+              "defaultSort": "date:desc",
+              "dense": true
+            }
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "props": { "title": "Notes" },
+        "children": [
+          {
+            "type": "timeline",
+            "props": {
+              "events": "{state.notes.sortBy('date', 'desc')}",
+              "density": "compact"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/member-360/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/member-360/template.pocket.yaml
@@ -1,0 +1,49 @@
+# src/pocketpaw/bundled_templates/_bundled/member-360/template.pocket.yaml
+# Created: 2026-06-11 (feat/triage-member-templates) — RFC 03 v2 Pocket
+# Template Schema metadata for the generic member-360 view. ``shape:
+# custom`` because the canvas composes a header, a key-value profile
+# section, a membership panel, three simple record lists (tickets /
+# orders / notes), and an attendance/spend stat row — RFC 03's shape enum
+# has no single value for that composite, so the pattern is recorded in
+# the sibling index.json (``pattern: viewer``) and the shape stays
+# ``custom``. The view is READ-ONLY: no actions, no mutation. ``needs:
+# [paw.db.v1]`` declares the generic data-source capability a tenant wires
+# so the profile hydrates from a real member record; without one the
+# seeded sample member renders.
+schema_version: "2"
+name: member-360
+version: 1.0.0
+pattern: viewer
+vertical: operations
+display_name: Member 360
+shape: custom
+description: |
+  A single-pane view of one member. A header with the member's name, tier,
+  and status; a key-value profile block; a membership panel showing the
+  package, renewal date, and standing; and three plain lists for recent
+  tickets, orders, and notes. A stat strip across the top carries the
+  headline counts — sessions attended and total spend. Read-only by design:
+  it shows the full picture of a member without offering any action. Ships a
+  placeholder live-data source so a connected backend hydrates the record
+  from a real member endpoint; with no backend it renders the seeded sample
+  member.
+icon: user
+color: "#6b8e6b"
+state:
+  entity_type: Member
+  id_field: id
+  columns:
+    - { field: name, label: Name, widget: text }
+    - { field: tier, label: Tier, widget: badge }
+    - { field: status, label: Status, widget: badge }
+data_sources:
+  - name: member
+    method: GET
+    path: /members/current
+    bind: state.member
+    refresh: [pocket_open, manual]
+needs:
+  - paw.db.v1
+actions: []
+connectors: []
+skill_refs: []

--- a/tests/cloud/pockets/test_vertical_template_create.py
+++ b/tests/cloud/pockets/test_vertical_template_create.py
@@ -1,0 +1,95 @@
+# tests/cloud/pockets/test_vertical_template_create.py
+# Created: 2026-06-11 (feat/triage-member-templates) — end-to-end create()
+# of a pocket from each generic vertical template (applications-triage,
+# member-360) through the EE pockets service with the mongo fixture. This
+# pins the full install-time seam: install_bundled_templates -> the loader
+# default points at the tmp install -> service.create(template_slug=...) ->
+# load_template + _compile_template_to_runtime_dict -> merge into the pocket
+# rippleSpec. The seed-shape + compile unit assertions live in
+# tests/unit/test_vertical_templates.py; this file proves the service path.
+"""Service-level create() round-trip for the bundled vertical templates.
+
+Installs the real bundled templates into a tmp dir, repoints the OSS
+loader's default templates root at it (the service calls
+``load_template(slug, strict=False)`` with no override), then drives
+``pockets_service.create`` with each vertical template_slug and asserts
+the compiled runtime dict (sources + state + actions) merged into the
+created pocket's rippleSpec. Uses the shared ``mongo_db`` + autouse
+RecordingBus fixtures from tests/cloud/conftest.py, mirroring
+test_template_needs.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_vertical"
+_USER = "user_vertical"
+
+
+@pytest.fixture
+def installed_templates(tmp_path: Path, monkeypatch) -> Path:
+    """Install the bundled templates into a tmp dir and point the OSS
+    loader default at it, so service.create resolves the real templates."""
+    import pocketpaw.bundled_templates.loader as loader_mod
+    from pocketpaw.bundled_templates.installer import install_bundled_templates
+
+    root = tmp_path / "templates"
+    install_bundled_templates(destination_root=root)
+    monkeypatch.setattr(loader_mod, "_DEFAULT_TEMPLATES_DIR", root)
+    return root
+
+
+@pytest.mark.asyncio
+async def test_create_applications_triage_pocket(installed_templates: Path) -> None:
+    """Creating a pocket from applications-triage compiles the template:
+    the data_source becomes a runtime ``sources`` entry, the gated actions
+    flow through, and the pocket is created (never blocked)."""
+    wire = await pockets_service.create(
+        _WS,
+        _USER,
+        CreatePocketRequest(name="Membership intake", template_slug="applications-triage"),
+    )
+
+    assert wire["name"] == "Membership intake"
+    assert wire["_id"]
+    assert wire["templateSlug"] == "applications-triage"
+
+    spec = wire["rippleSpec"]
+    assert spec is not None
+    # Compile-on-install merged the runtime machinery in.
+    assert "applications" in spec["sources"]
+    assert spec["state"]["entity_type"] == "Application"
+    # The three gated actions rode through the compile passthrough.
+    action_names = {a["name"] for a in spec["actions"]}
+    assert action_names == {"approve_application", "reject_application", "flag_for_review"}
+    assert all(a["instinct_policy"] == "require_approval" for a in spec["actions"])
+
+
+@pytest.mark.asyncio
+async def test_create_member_360_pocket(installed_templates: Path) -> None:
+    """Creating a pocket from member-360 compiles the template: the
+    data_source becomes a runtime ``sources`` entry, the view stays
+    action-free, and the pocket is created."""
+    wire = await pockets_service.create(
+        _WS,
+        _USER,
+        CreatePocketRequest(name="Member lookup", template_slug="member-360"),
+    )
+
+    assert wire["name"] == "Member lookup"
+    assert wire["_id"]
+    assert wire["templateSlug"] == "member-360"
+
+    spec = wire["rippleSpec"]
+    assert spec is not None
+    assert "member" in spec["sources"]
+    assert spec["state"]["entity_type"] == "Member"
+    # Read-only: no actions compiled in.
+    assert spec.get("actions") == []

--- a/tests/unit/test_bundled_templates.py
+++ b/tests/unit/test_bundled_templates.py
@@ -19,6 +19,15 @@
 # new template ships shape:"custom" + pattern:"landing"). The landing
 # fast-path's STEP-0 routing + skeleton-shape assertions live in the
 # sibling tests/unit/test_landing_template_fastpath.py.
+# Modified 2026-06-11 (feat/triage-member-templates): split the slug set
+# into ``_SEED_SLUGS`` (the actions:[] seed templates) and
+# ``_VERTICAL_SLUGS`` (applications-triage, member-360 — richer v2
+# templates carrying needs:/actions:/outcomes:/data_sources:). The
+# seed-only field-set + "actions == []" parametrisation runs over
+# ``_SEED_SLUGS``; the installer / index / Pydantic / valid-JSON
+# parametrisations run over the combined ``_EXPECTED_SLUGS`` so both new
+# templates are covered. Vertical-specific shape assertions live in the
+# sibling tests/unit/test_vertical_templates.py.
 """Tests for the ``pocketpaw.bundled_templates`` package and its wiring.
 
 The installer + loader tests mirror into a ``tmp_path`` destination so
@@ -41,11 +50,13 @@ from pocketpaw.bundled_templates.installer import (
 )
 from pocketpaw.bundled_templates.loader import load_template
 
-# The built-in templates the bundled installer ships. Increment 2a
-# shipped six; RFC 07 Slice 3a added `decision-graph`. Update when a
-# new bundled template lands so the parametrized RFC03-shape tests
-# cover it automatically.
-_EXPECTED_SLUGS = {
+# The SEED bundled templates — the Increment-2a-era set that ships
+# ``actions: []`` and omits the not-yet-wired Instinct / Outcomes /
+# data-source blocks. The strict field-set + manifest assertions below
+# parametrize over THIS set only (a seed template's field set is a
+# subset of ``_RFC03_ALLOWED_FIELDS``). RFC 07 Slice 3a added
+# `decision-graph`; the marketing fast-path added `landing-page`.
+_SEED_SLUGS = {
     "todo-task-tracker",
     "kanban-board",
     "metrics-dashboard",
@@ -55,6 +66,22 @@ _EXPECTED_SLUGS = {
     "decision-graph",
     "landing-page",
 }
+
+# The VERTICAL bundled templates — richer, install-ready templates that
+# legitimately carry the full v2 surface: ``needs:`` Senses, gated
+# ``actions:`` + ``outcomes:``, and ``data_sources:``. They are excluded
+# from the seed-only field-set / "actions == []" assertions and covered
+# instead by their own Pydantic-validated shape test in
+# tests/unit/test_vertical_templates.py. Both still ship via the same
+# installer + index and validate against the ``PocketTemplate`` model,
+# so the installer / index / Pydantic parametrizations cover them.
+_VERTICAL_SLUGS = {
+    "applications-triage",
+    "member-360",
+}
+
+# Every bundled template the installer ships and index.json registers.
+_EXPECTED_SLUGS = _SEED_SLUGS | _VERTICAL_SLUGS
 
 # RFC 03 v2 Pocket Template Schema — the field set a seed template may
 # carry after the v1 -> v2 migration. Seed templates still ship
@@ -212,10 +239,13 @@ def test_loader_rejects_path_traversal_slug(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("slug", sorted(_EXPECTED_SLUGS))
+@pytest.mark.parametrize("slug", sorted(_SEED_SLUGS))
 def test_template_yaml_matches_rfc03_field_set(slug: str) -> None:
-    """Each bundled template.pocket.yaml uses ONLY RFC 03 fields, carries
-    every required field, ships ``actions: []``, and uses a valid shape."""
+    """Each SEED bundled template.pocket.yaml uses ONLY the seed RFC 03
+    field subset, carries every required field, ships ``actions: []``,
+    and uses a valid shape. Vertical templates (applications-triage,
+    member-360) carry the richer v2 surface and are asserted separately
+    in tests/unit/test_vertical_templates.py."""
     import yaml
 
     meta_path = _BUNDLED_DIR / slug / "template.pocket.yaml"
@@ -296,7 +326,7 @@ _MANIFEST_PROP_DRIFT_EXEMPT = {"landing-page"}
 
 
 @pytest.mark.parametrize("slug", sorted(_EXPECTED_SLUGS - _MANIFEST_PROP_DRIFT_EXEMPT))
-def test_template_ripple_spec_passes_manifest_validation_if_reachable(slug: str) -> None:
+def test_template_ripple_spec_passes_manifest_validation_if_reachable(slug: str) -> None:  # noqa: D401
     """Each ripple_spec.json passes the Ripple manifest validator when a
     manifest is reachable. The validator needs a network-fetched manifest;
     when offline (CI default) it returns no manifest and the check is

--- a/tests/unit/test_vertical_templates.py
+++ b/tests/unit/test_vertical_templates.py
@@ -1,0 +1,238 @@
+# tests/unit/test_vertical_templates.py
+# Created: 2026-06-11 (feat/triage-member-templates) — covers the two
+# generic bundled vertical templates, applications-triage and member-360.
+# These are richer than the seed templates: they declare needs: Senses,
+# data_sources:, and (for triage) gated actions: + outcomes:. This file
+# pins their RFC 03 v2 shape, their load_template + compile path, their
+# action-row gated-proposal wiring (triage), their read-only posture
+# (member-360), and a full service create() round-trip through the mongo
+# fixture so the install-time compile-on-create seam is exercised.
+"""Tests for the bundled vertical templates (applications-triage, member-360).
+
+The seed-template field-set assertions in test_bundled_templates.py
+intentionally exclude these two slugs — they carry the full v2 surface
+(needs / actions / outcomes / data_sources) the seed templates omit.
+This file owns their shape and behaviour:
+
+* RFC 03 v2 Pydantic validation of each template.pocket.yaml.
+* The OSS ``compile_template`` translation (data_sources -> sources,
+  passthrough of actions / outcomes / needs).
+* applications-triage's gated action row: every action declares
+  ``instinct_policy: require_approval`` and the ripple_spec buttons set
+  ``state.pending_proposal`` instead of executing — the binding seam a
+  deployment wires to the Instinct gate.
+* member-360's read-only posture: zero actions, no ``on_click`` anywhere.
+* End-to-end create() through the EE service with the mongo fixture, so
+  the compile-on-install merge into the pocket rippleSpec is proven.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from pocketpaw.bundled_templates import PocketTemplate, compile_template
+from pocketpaw.bundled_templates.installer import install_bundled_templates
+from pocketpaw.bundled_templates.loader import load_template
+
+_VERTICAL_SLUGS = ("applications-triage", "member-360")
+
+_BUNDLED_DIR = (
+    Path(__file__).resolve().parents[2] / "src" / "pocketpaw" / "bundled_templates" / "_bundled"
+)
+
+
+def _read_meta(slug: str) -> dict:
+    return yaml.safe_load(
+        (_BUNDLED_DIR / slug / "template.pocket.yaml").read_text(encoding="utf-8")
+    )
+
+
+def _read_spec(slug: str) -> dict:
+    return json.loads((_BUNDLED_DIR / slug / "ripple_spec.json").read_text(encoding="utf-8"))
+
+
+def _iter_widgets(node: object):
+    """Yield every dict node in a ripple_spec tree (depth-first)."""
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_widgets(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_widgets(item)
+
+
+# ---------------------------------------------------------------------------
+# RFC 03 v2 schema — both templates validate through the Pydantic chokepoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slug", _VERTICAL_SLUGS)
+def test_vertical_template_passes_pydantic_validation(slug: str) -> None:
+    """Each vertical template.pocket.yaml validates against PocketTemplate
+    — the same RFC 03 v2 chokepoint every bundled template clears."""
+    template = PocketTemplate.model_validate(_read_meta(slug))
+    assert template.name == slug
+    assert template.schema_version == "2"
+    assert template.shape == "custom"
+
+
+@pytest.mark.parametrize("slug", _VERTICAL_SLUGS)
+def test_vertical_template_declares_generic_data_sense(slug: str) -> None:
+    """Both templates declare the generic database Sense as a need so the
+    create path can prompt-to-connect a data source. ``paw.db.v1`` is a
+    curated core sense, so it validates rather than fragmenting the core."""
+    template = PocketTemplate.model_validate(_read_meta(slug))
+    assert template.needs == ["paw.db.v1"]
+    # A placeholder live-data source is declared for compile-on-install.
+    assert len(template.data_sources) == 1
+    assert template.data_sources[0].method == "GET"
+    assert template.data_sources[0].bind.startswith("state.")
+
+
+@pytest.mark.parametrize("slug", _VERTICAL_SLUGS)
+def test_vertical_template_ripple_spec_is_well_formed(slug: str) -> None:
+    """Each ripple_spec.json carries ui + state + the mandated
+    _placeholder_note, and a placeholder sources block (removed at
+    instantiation when there is no backend)."""
+    spec = _read_spec(slug)
+    assert "ui" in spec and "state" in spec
+    assert "_placeholder_note" in spec
+    assert isinstance(spec.get("sources"), dict) and spec["sources"]
+
+
+# ---------------------------------------------------------------------------
+# compile_template — data_sources translate, needs/actions pass through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slug", _VERTICAL_SLUGS)
+def test_vertical_template_compiles_to_runtime_dict(slug: str) -> None:
+    """``compile_template`` turns each template's data_source into a
+    runtime ``sources`` entry keyed by name, and preserves state."""
+    template = PocketTemplate.model_validate(_read_meta(slug))
+    out = compile_template(template)
+
+    src_name = template.data_sources[0].name
+    assert src_name in out["sources"]
+    entry = out["sources"][src_name]
+    assert entry["method"] == "GET"
+    assert "name" not in entry  # name became the dict key
+    # State carries the primary entity binding through to the runtime.
+    assert out["state"]["entity_type"] == template.state.entity_type
+
+
+# ---------------------------------------------------------------------------
+# applications-triage — gated action row
+# ---------------------------------------------------------------------------
+
+
+def test_triage_actions_are_all_gated_require_approval() -> None:
+    """Every triage action declares ``instinct_policy: require_approval``
+    so it surfaces as a PENDING proposal in The Tray, never auto-runs."""
+    template = PocketTemplate.model_validate(_read_meta("applications-triage"))
+    assert len(template.actions) == 3
+    names = {a.name for a in template.actions}
+    assert names == {"approve_application", "reject_application", "flag_for_review"}
+    for action in template.actions:
+        assert action.instinct_policy == "require_approval", action.name
+
+
+def test_triage_action_outcomes_are_declared_in_catalog() -> None:
+    """Each action's outcomes_emitted is declared in the top-level
+    outcomes[] catalog — the RFC 03 v2 subset rule (enforced by the model
+    validator, asserted here for documentation)."""
+    template = PocketTemplate.model_validate(_read_meta("applications-triage"))
+    catalog = set(template.outcomes)
+    for action in template.actions:
+        for outcome in action.outcomes_emitted:
+            assert outcome in catalog, f"{action.name} emits undeclared {outcome}"
+
+
+def test_triage_action_row_proposes_not_executes() -> None:
+    """The ripple_spec action buttons set ``state.pending_proposal`` (a
+    generic proposal shape) instead of executing — this is the binding
+    seam a deployment wires to external_actions.propose. No button mutates
+    application status directly."""
+    spec = _read_spec("applications-triage")
+    buttons = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "button"]
+    assert len(buttons) == 3, "approve / reject / needs-review"
+    for button in buttons:
+        actions = button.get("on_click")
+        assert actions, f"button {button['props']['label']} has no on_click"
+        # Every click sets pending_proposal — nothing else.
+        targets = {a.get("target") for a in actions}
+        assert targets == {"pending_proposal"}, button["props"]["label"]
+        # The proposal value carries the generic {action, application_id, summary} shape.
+        value = actions[0]["value"]
+        assert set(value.keys()) == {"action", "application_id", "summary"}
+    # The state seeds the binding seam with an empty proposal slot.
+    assert spec["state"].get("pending_proposal") is None
+
+
+def test_triage_has_burndown_stat_row() -> None:
+    """The triage canvas carries a status-count burndown — an each-loop of
+    stat widgets over state.status_counts."""
+    spec = _read_spec("applications-triage")
+    assert "status_counts" in spec["state"]
+    stats = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "stat"]
+    assert stats, "burndown stat row missing"
+
+
+# ---------------------------------------------------------------------------
+# member-360 — read-only
+# ---------------------------------------------------------------------------
+
+
+def test_member_360_is_read_only() -> None:
+    """member-360 declares zero actions and its ripple_spec has no on_click
+    anywhere — a pure read-only view."""
+    template = PocketTemplate.model_validate(_read_meta("member-360"))
+    assert template.actions == []
+
+    spec = _read_spec("member-360")
+    for widget in _iter_widgets(spec["ui"]):
+        assert "on_click" not in widget, f"read-only view has an on_click: {widget.get('type')}"
+
+
+def test_member_360_has_profile_membership_and_lists() -> None:
+    """The member-360 state seeds the header member, the stat strip, the
+    key-value profile + membership blocks, and the three record lists."""
+    spec = _read_spec("member-360")
+    state = spec["state"]
+    for key in ("member", "stats", "profile", "membership", "tickets", "orders", "notes"):
+        assert key in state, f"member-360 state missing {key}"
+    assert state["member"]["name"]
+
+
+# ---------------------------------------------------------------------------
+# Installer — both vertical templates mirror like every other template
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slug", _VERTICAL_SLUGS)
+def test_installer_mirrors_vertical_template(tmp_path: Path, slug: str) -> None:
+    """The installer copies each vertical template directory + both files."""
+    results = install_bundled_templates(destination_root=tmp_path)
+    result = next(r for r in results if r.name == slug)
+    assert result.status == "installed"
+    assert (tmp_path / slug / "template.pocket.yaml").is_file()
+    assert (tmp_path / slug / "ripple_spec.json").is_file()
+
+
+@pytest.mark.parametrize("slug", _VERTICAL_SLUGS)
+def test_loader_round_trips_vertical_template(tmp_path: Path, slug: str) -> None:
+    """``load_template`` reads each installed vertical template back to
+    {meta, ripple_spec}, and the strict path validates it clean."""
+    install_bundled_templates(destination_root=tmp_path)
+    loaded = load_template(slug, templates_dir=tmp_path)
+    assert loaded is not None
+    assert loaded["meta"]["name"] == slug
+    assert "ui" in loaded["ripple_spec"]
+    # strict=True must not raise — the template is schema-clean.
+    strict = load_template(slug, templates_dir=tmp_path, strict=True)
+    assert strict is not None


### PR DESCRIPTION
Two generic bundled pocket templates that deployments can install and instantiate out of the box. Both are fully generic — no client names, no domain-specific fields beyond what any application-triage or member view needs.

## applications-triage

A review queue for incoming applications:

- A scannable list — status, a one-line applicant summary, an optional score or recommendation, and how long the item has waited.
- A detail panel for the selected row, rendered as plain question-and-answer pairs.
- A backlog burndown stat row across the top (counts by status).
- An approve / reject / needs-review action row.

The action row does not execute. Each button sets `state.pending_proposal` to a generic `{action, application_id, summary}` shape instead of acting. That is the seam a deployment wires to the Instinct gate so a human confirms the decision in The Tray. The full binding instructions live in the bundled README and the `ripple_spec` placeholder note.

## member-360

A read-only single-pane view of one member:

- Header with name, tier, and status.
- A key-value profile block.
- A membership panel with package, renewal date, and standing.
- Plain lists for recent tickets, orders, and notes.
- An attendance/spend stat strip.

No actions, no mutation.

## Data binding

Both templates declare `needs: [paw.db.v1]` — the generic database Sense. A connected backend hydrates the data through the declared `data_sources`; with none, the seeded sample rows render so the pocket is non-empty on first install. Both use only catalog widgets already shipped by other bundled templates.

## Tests

- RFC 03 v2 Pydantic validation of each template.
- The `load_template` → `compile_template` path (data_sources translate to runtime sources; needs/actions/outcomes pass through).
- The triage gated-action wiring (every action is `require_approval`; every button only proposes).
- The member-360 read-only posture (zero actions, no `on_click` anywhere).
- The installer mirror and a full service `create()` round-trip through the mongo fixture, so the compile-on-install merge into the pocket rippleSpec is proven.

The seed-only field-set assertions in `test_bundled_templates.py` are split into a seed set and a vertical set so the richer templates are covered separately without loosening the seed checks.

Targeted run (vertical + bundled + compile + cloud create + template-needs): 89 passed, 4 skipped (the 4 are pre-existing EE create-specialist tests gated on `pocketpaw_ee` import). The manifest validator ran live and validated every widget type in both templates against the shipped catalog.