### PR TITLE
Adopt the template ui tree when creating a pocket from a template

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -144,6 +144,18 @@ stamps both onto the persisted ``Pocket``. The marketing-site brain
 ``type_="custom"`` and never carried ``pattern``, so site intent was
 dropped (pockets persisted as type="custom", pattern=None). Both keep
 today's defaults when unset — additive, no Mongo migration.
+Changes: 2026-06-11 (fix/template-ui-compile) — the template merge now
+carries the template's authored canvas through. Found on a live deploy:
+pockets created via ``create(template_slug=...)`` rendered an empty
+canvas because the compile pass translates YAML metadata only and the
+merge treated ``ui`` as user-authored-only, so a fresh create never
+adopted the template's ``ui`` tree. ``_merge_compile_into_ripple_spec``
+gains a ``template_ripple_spec`` kwarg and an ownership rule: an
+empty/absent existing ``ui`` is template-owned (adopt the template's
+``ui`` + merge its seed ``state`` / placeholder ``sources`` under the
+compiled values); a non-empty ``ui`` is user-owned (machinery-only
+merge, exactly the prior recompile semantics). Both ``create`` and
+``update`` pass the loader's ``ripple_spec`` sibling through.
 """
 
 from __future__ import annotations
@@ -802,10 +814,21 @@ async def _gate_widget_spec_for_agent(
 # template off disk, the OSS compile pass translates it into a runtime-
 # shaped dict, and the EE service MERGES that dict into the pocket's
 # ``rippleSpec`` (option B — keep user-customized fields, replace the
-# compile-output keys). The merge strategy is intentional: a user can
-# tweak ``rippleSpec.ui`` after instantiation and a subsequent
-# template-recompile (template upgraded out-of-band) won't blow those
-# tweaks away — only the fields the compile pass produced get replaced.
+# compile-output keys).
+#
+# Canvas ownership rule (extends option B; fix for the empty-canvas bug
+# found when templates were deployed to a live instance): the compile
+# pass translates the template's YAML metadata only — the render tree
+# lives in the hand-authored sibling ``ripple_spec.json``. The merge
+# decides who owns the canvas by looking at the pocket's EXISTING ``ui``:
+#
+#   * empty/absent ``ui``  → template-owned. The template's ``ui`` is
+#     adopted, and its seed ``state`` / placeholder ``sources`` merge
+#     UNDER the compiled values so the canvas renders non-empty.
+#   * non-empty ``ui``     → user-owned. A recompile (template upgraded
+#     out-of-band) refreshes the machinery only and never touches the
+#     canvas — a user can tweak ``rippleSpec.ui`` after instantiation
+#     and a re-apply won't blow those tweaks away.
 #
 # Tolerance posture: ``load_template(slug, strict=False)`` never raises;
 # a stale / missing / malformed template returns ``None``. The pocket
@@ -847,28 +870,78 @@ def _compile_template_to_runtime_dict(loaded: dict[str, Any] | None) -> dict[str
         return None
 
 
+def _ui_is_empty(ui: Any) -> bool:
+    """True when a rippleSpec ``ui`` value counts as "no authored canvas".
+
+    Absent, ``None``, a non-dict, or an empty dict are all empty. A dict
+    with ANY content (even just ``{"type": "stack"}``) is a real canvas —
+    we never second-guess a node the user (or an agent) authored.
+    """
+    return not isinstance(ui, dict) or not ui
+
+
 def _merge_compile_into_ripple_spec(
     existing: dict[str, Any] | None,
     compiled: dict[str, Any],
+    *,
+    template_ripple_spec: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Merge a ``compile_template`` result into an existing rippleSpec.
 
     Merge strategy (option B in the Wave 3e brief): keys produced by
     the compile pass (``sources``, ``state``, ``actions``, ``agents``,
     ``triggers``, ``outcomes``, etc.) REPLACE matching keys in the
-    existing spec. Keys the compile pass does NOT produce
-    (e.g. ``ui`` — a user-authored render tree) survive unchanged.
-    The result is a NEW dict; neither input is mutated.
+    existing spec. The result is a NEW dict; no input is mutated.
 
-    Rationale: a pocket created from a template carries the template's
-    sources / state / actions verbatim, but the user may have edited
-    ``rippleSpec.ui`` to rearrange the canvas. A subsequent template
-    re-apply (template upgraded out-of-band) should refresh the
-    machinery without nuking the user's layout.
+    The ``ui`` tree follows an ownership rule keyed on the EXISTING
+    spec's canvas (fix for the empty-canvas bug found on a live deploy —
+    pockets created from a template rendered ``ui.children: 0``):
+
+    * **Existing ``ui`` empty/absent → template-owned.** The pocket has
+      no authored canvas, so the template's hand-authored sibling
+      ``ripple_spec.json`` supplies it: its ``ui`` tree is adopted, and
+      its seed ``state`` / placeholder ``sources`` are merged UNDER the
+      compiled values (compiled wins per key) so the adopted canvas has
+      the bindings it references and renders non-empty on first install.
+    * **Existing ``ui`` non-empty → user-owned.** A re-apply (template
+      upgraded out-of-band, recompile-on-update) refreshes the machinery
+      without touching the canvas — exactly the pre-fix behaviour.
+
+    ``template_ripple_spec`` is the loader's ``loaded["ripple_spec"]``
+    sibling dict; pass ``None`` to skip canvas adoption entirely (the
+    pre-fix machinery-only merge). The authoring-only
+    ``_placeholder_note`` key is never copied — only ``ui`` / ``state``
+    / ``sources`` participate in adoption. Adopted blocks are
+    deep-copied so the merged spec never aliases the loader's dicts.
     """
     out: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    canvas_is_template_owned = _ui_is_empty(out.get("ui"))
+
     for key, value in compiled.items():
         out[key] = value
+
+    if canvas_is_template_owned and isinstance(template_ripple_spec, dict):
+        template_ui = template_ripple_spec.get("ui")
+        if isinstance(template_ui, dict) and template_ui:
+            out["ui"] = copy.deepcopy(template_ui)
+            # The adopted canvas binds against the template's seed state
+            # ({state.records}, {state.draft}, ...) and its placeholder
+            # sources. Merge them under the compiled values: compiled
+            # keys (the validated schema output) win every collision.
+            template_state = template_ripple_spec.get("state")
+            if isinstance(template_state, dict):
+                compiled_state = out.get("state")
+                out["state"] = {
+                    **copy.deepcopy(template_state),
+                    **(compiled_state if isinstance(compiled_state, dict) else {}),
+                }
+            template_sources = template_ripple_spec.get("sources")
+            if isinstance(template_sources, dict):
+                compiled_sources = out.get("sources")
+                out["sources"] = {
+                    **copy.deepcopy(template_sources),
+                    **(compiled_sources if isinstance(compiled_sources, dict) else {}),
+                }
     return out
 
 
@@ -1005,7 +1078,11 @@ async def create(workspace_id: str, user_id: str, body: CreatePocketRequest) -> 
         loaded = load_template(body.template_slug, strict=False)
         compiled = _compile_template_to_runtime_dict(loaded)
         if compiled is not None:
-            normalized_spec = _merge_compile_into_ripple_spec(normalized_spec, compiled)
+            normalized_spec = _merge_compile_into_ripple_spec(
+                normalized_spec,
+                compiled,
+                template_ripple_spec=loaded.get("ripple_spec") if loaded else None,
+            )
 
     if normalized_spec:
         validate_ripple_spec_logged(normalized_spec, workspace_id=workspace_id)
@@ -1233,7 +1310,11 @@ async def update(pocket_id: str, user_id: str, body: UpdatePocketRequest) -> dic
         compiled = _compile_template_to_runtime_dict(loaded)
         if compiled is not None:
             merge_base = normalized_spec if normalized_spec is not None else doc.rippleSpec
-            normalized_spec = _merge_compile_into_ripple_spec(merge_base, compiled)
+            normalized_spec = _merge_compile_into_ripple_spec(
+                merge_base,
+                compiled,
+                template_ripple_spec=loaded.get("ripple_spec") if loaded else None,
+            )
 
     if normalized_spec:
         validate_ripple_spec_logged(

--- a/tests/cloud/pockets/test_vertical_template_create.py
+++ b/tests/cloud/pockets/test_vertical_template_create.py
@@ -7,16 +7,29 @@
 # load_template + _compile_template_to_runtime_dict -> merge into the pocket
 # rippleSpec. The seed-shape + compile unit assertions live in
 # tests/unit/test_vertical_templates.py; this file proves the service path.
-"""Service-level create() round-trip for the bundled vertical templates.
+# Modified: 2026-06-11 (fix/template-ui-compile) — regression coverage for
+# the empty-canvas bug found on a live deploy: the round-trips now assert
+# the template's ui tree and seed state actually land on the created
+# pocket (previously only sources/state-binding/actions were asserted,
+# which is how the dropped ui slipped through). Added the canvas-ownership
+# tests: a caller-supplied ui survives create-with-template, a
+# user-modified ui survives a recompile, and a recompile over an empty
+# canvas adopts the template ui.
+"""Service-level create()/update() round-trips for the bundled vertical templates.
 
 Installs the real bundled templates into a tmp dir, repoints the OSS
 loader's default templates root at it (the service calls
 ``load_template(slug, strict=False)`` with no override), then drives
-``pockets_service.create`` with each vertical template_slug and asserts
-the compiled runtime dict (sources + state + actions) merged into the
-created pocket's rippleSpec. Uses the shared ``mongo_db`` + autouse
-RecordingBus fixtures from tests/cloud/conftest.py, mirroring
-test_template_needs.py.
+``pockets_service.create`` / ``update`` and asserts both halves of the
+template instantiation land on the pocket:
+
+* the compiled runtime machinery (sources + state binding + actions), and
+* the authored canvas (the sibling ripple_spec's ``ui`` tree + seed
+  state) — adopted only while the pocket's own canvas is empty, never
+  over a user-authored ``ui``.
+
+Uses the shared ``mongo_db`` + autouse RecordingBus fixtures from
+tests/cloud/conftest.py, mirroring test_template_needs.py.
 """
 
 from __future__ import annotations
@@ -25,7 +38,7 @@ from pathlib import Path
 
 import pytest
 from pocketpaw_ee.cloud.pockets import service as pockets_service
-from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest, UpdatePocketRequest
 
 pytestmark = pytest.mark.usefixtures("mongo_db")
 
@@ -46,11 +59,17 @@ def installed_templates(tmp_path: Path, monkeypatch) -> Path:
     return root
 
 
+# ---------------------------------------------------------------------------
+# create(template_slug=...) — machinery AND canvas both land
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_create_applications_triage_pocket(installed_templates: Path) -> None:
-    """Creating a pocket from applications-triage compiles the template:
-    the data_source becomes a runtime ``sources`` entry, the gated actions
-    flow through, and the pocket is created (never blocked)."""
+    """Creating a pocket from applications-triage compiles the template AND
+    adopts its canvas: the data_source becomes a runtime ``sources`` entry,
+    the gated actions flow through, the ui tree renders non-empty, and the
+    seed state the ui binds against is present."""
     wire = await pockets_service.create(
         _WS,
         _USER,
@@ -71,12 +90,26 @@ async def test_create_applications_triage_pocket(installed_templates: Path) -> N
     assert action_names == {"approve_application", "reject_application", "flag_for_review"}
     assert all(a["instinct_policy"] == "require_approval" for a in spec["actions"])
 
+    # THE EMPTY-CANVAS REGRESSION (live-deploy bug): the template's ui
+    # tree must be adopted on a fresh create — previously the merge
+    # dropped it and the pocket rendered ui.children: 0.
+    ui = spec.get("ui")
+    assert isinstance(ui, dict) and ui, "template ui was not adopted"
+    assert ui.get("children"), "adopted ui has no children — empty canvas"
+    # The seed state the ui binds against rode along (compiled binding
+    # keys coexist with the seed keys; compiled wins collisions).
+    assert spec["state"]["applications"], "seed applications missing"
+    assert spec["state"]["status_counts"], "burndown seed counts missing"
+    assert "selected_id" in spec["state"]
+    # Authoring-only sibling key never lands on a pocket.
+    assert "_placeholder_note" not in spec
+
 
 @pytest.mark.asyncio
 async def test_create_member_360_pocket(installed_templates: Path) -> None:
-    """Creating a pocket from member-360 compiles the template: the
-    data_source becomes a runtime ``sources`` entry, the view stays
-    action-free, and the pocket is created."""
+    """Creating a pocket from member-360 compiles the template AND adopts
+    its canvas: runtime source, no actions, a non-empty ui tree, and the
+    seed member/profile/lists state."""
     wire = await pockets_service.create(
         _WS,
         _USER,
@@ -93,3 +126,94 @@ async def test_create_member_360_pocket(installed_templates: Path) -> None:
     assert spec["state"]["entity_type"] == "Member"
     # Read-only: no actions compiled in.
     assert spec.get("actions") == []
+
+    # Empty-canvas regression: ui adopted, seed state present.
+    ui = spec.get("ui")
+    assert isinstance(ui, dict) and ui, "template ui was not adopted"
+    assert ui.get("children"), "adopted ui has no children — empty canvas"
+    assert spec["state"]["member"]["name"], "seed member missing"
+    for key in ("profile", "membership", "tickets", "orders", "notes"):
+        assert spec["state"].get(key), f"seed state missing {key}"
+    assert "_placeholder_note" not in spec
+
+
+# ---------------------------------------------------------------------------
+# Canvas ownership — user-authored ui is never clobbered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_with_user_ui_keeps_user_canvas(installed_templates: Path) -> None:
+    """A caller-supplied non-empty ui at create is user-owned: the template
+    machinery merges in but the template canvas is NOT adopted."""
+    user_ui = {"type": "card", "props": {"title": "user-owned"}}
+    wire = await pockets_service.create(
+        _WS,
+        _USER,
+        CreatePocketRequest(
+            name="Custom canvas",
+            template_slug="applications-triage",
+            ripple_spec={"ui": user_ui},
+        ),
+    )
+
+    spec = wire["rippleSpec"]
+    assert spec["ui"]["type"] == "card"
+    assert spec["ui"]["props"]["title"] == "user-owned"
+    # Machinery still landed.
+    assert "applications" in spec["sources"]
+    assert spec["state"]["entity_type"] == "Application"
+
+
+@pytest.mark.asyncio
+async def test_recompile_preserves_user_modified_ui(installed_templates: Path) -> None:
+    """A recompile (update with the same template_slug) over a pocket whose
+    ui the user has since modified refreshes the machinery only — the
+    user's canvas survives untouched."""
+    created = await pockets_service.create(
+        _WS,
+        _USER,
+        CreatePocketRequest(name="Edited later", template_slug="applications-triage"),
+    )
+    pocket_id = created["_id"]
+
+    # Simulate a user rearranging the canvas: replace the spec with their
+    # own ui (an update without template_slug is a wholesale spec write).
+    user_ui = {"type": "card", "props": {"title": "rearranged-by-user"}}
+    await pockets_service.update(pocket_id, _USER, UpdatePocketRequest(ripple_spec={"ui": user_ui}))
+
+    # Recompile against the template (same slug = forced refresh).
+    updated = await pockets_service.update(
+        pocket_id, _USER, UpdatePocketRequest(template_slug="applications-triage")
+    )
+
+    spec = updated["rippleSpec"]
+    # The user's canvas survived the recompile.
+    assert spec["ui"]["type"] == "card"
+    assert spec["ui"]["props"]["title"] == "rearranged-by-user"
+    # The machinery was refreshed from the template.
+    assert "applications" in spec["sources"]
+    assert {a["name"] for a in spec["actions"]} == {
+        "approve_application",
+        "reject_application",
+        "flag_for_review",
+    }
+
+
+@pytest.mark.asyncio
+async def test_recompile_adopts_template_ui_when_canvas_empty(installed_templates: Path) -> None:
+    """An update that sets a template_slug on a pocket with NO canvas adopts
+    the template ui — empty ui means template-owned, on update as well as
+    create."""
+    created = await pockets_service.create(_WS, _USER, CreatePocketRequest(name="plain"))
+    pocket_id = created["_id"]
+    assert created["rippleSpec"] is None
+
+    updated = await pockets_service.update(
+        pocket_id, _USER, UpdatePocketRequest(template_slug="member-360")
+    )
+
+    spec = updated["rippleSpec"]
+    ui = spec.get("ui")
+    assert isinstance(ui, dict) and ui.get("children"), "template ui not adopted on update"
+    assert spec["state"]["member"]["name"]


### PR DESCRIPTION
Found by deploying the new bundled templates (#1431) to a live instance: pockets created from templates rendered empty canvases — `ui.children: 0` on both applications-triage and member-360.

## Root cause

Three pieces lined up:

- `load_template` returns the full ui tree, but it lives in the hand-authored sibling `ripple_spec.json`, not the YAML metadata.
- `_compile_template_to_runtime_dict` compiles the YAML metadata only, so its output carries no `ui` key.
- The merge docstring treated `ui` as user-authored-only — keys the compile pass doesn't produce survive, keys it produces replace. Correct for recompiles over an edited canvas, but it means a fresh create never adopts the template's ui at all.

The original round-trip test asserted sources, state binding, and actions — never ui. That's how it slipped through.

## The fix

`_merge_compile_into_ripple_spec` gains a `template_ripple_spec` kwarg and a canvas-ownership rule keyed on the pocket's existing ui:

- **Empty/absent ui → template-owned.** The template's ui tree is adopted. Its seed state and placeholder sources merge under the compiled values (compiled keys win every collision), so the adopted canvas has the bindings it references and renders non-empty on first install — this matters for templates like kanban-board whose composer binds `state.draft`, not just the two new ones.
- **Non-empty ui → user-owned.** A recompile (template upgraded out-of-band, update with the same slug) refreshes the machinery only and never touches the canvas. This is the documented option-B behaviour, unchanged — the rule extends it rather than replacing it.

"Empty" means absent, `None`, or `{}`. Any dict with content — even a bare `{"type": "stack"}` — counts as an authored canvas and is never second-guessed. Adopted blocks are deep-copied; the authoring-only `_placeholder_note` is never copied. Both `create` and `update` pass the loader's `ripple_spec` sibling through.

## Tests

- The create round-trips for both vertical templates now assert `ui.children` is non-empty and the seed state landed — the assertion gap that let this through.
- A caller-supplied ui at create and a user-modified ui at recompile both survive untouched.
- A recompile over an empty canvas adopts the template ui (empty = template-owned, on update as well as create).
- The pre-existing wave-3e merge-semantics tests (`test_create_with_template_preserves_user_supplied_ui`, `test_update_with_template_slug_recompiles`, and friends) pass unchanged.

Targeted runs: `tests/cloud/pockets/` + all template unit suites — 299 passed. Wider `tests/cloud -k "pocket or template or spec"` — 942 passed, 15 failed; all 15 fail identically on clean origin/dev (verified by stash/unstash), so they're pre-existing local-env failures, not regressions.