### PR TITLE
Ship real copy in the triage and member-360 templates

### DIFF
--- a/src/pocketpaw/bundled_templates/_bundled/applications-triage/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/applications-triage/ripple_spec.json
@@ -1,5 +1,5 @@
 {
-  "_placeholder_note": "Built-in pocket template (applications-triage). The rows and Q&A pairs below carry [bracketed] placeholders — the create specialist rewrites them to the user's real applications and domain. The `sources` block is a PLACEHOLDER live-data binding: if a backend is configured, keep it so GET /applications hydrates state.applications; with NO backend, REMOVE the `sources` block and keep the seeded applications as the working data. ACTION-ROW BINDING POINT: the approve / reject / needs-review buttons set state.pending_proposal to a generic proposal shape {action, application_id, summary} — they do NOT execute. A deployment wires this state event to the Instinct gate so a human confirms in The Tray: read state.pending_proposal, call external_actions.propose.propose_external_action({connector_name, action, params:{application_id}, summary}) (or the pocket-write proposal bridge for a Fabric write), which files an Instinct Action (kind=external_action) and opens the agent.proposed decision chain. Nothing approves inline — the button only proposes. Keep the master-detail selected_id wiring and the each-over-status_counts burndown intact.",
+  "_placeholder_note": "Built-in pocket template (applications-triage). The rows and Q&A pairs below are real sample copy — no placeholder brackets, so a pocket created straight from this template renders as finished UI (live-deploy feedback: brackets read as unfinished). The create specialist still rewrites the sample rows to the user's real applications and domain. The `sources` block is a PLACEHOLDER live-data binding: if a backend is configured, keep it so GET /applications hydrates state.applications; with NO backend, REMOVE the `sources` block and keep the seeded applications as the working data. ACTION-ROW BINDING POINT: the approve / reject / needs-review buttons set state.pending_proposal to a generic proposal shape {action, application_id, summary} — they do NOT execute. A deployment wires this state event to the Instinct gate so a human confirms in The Tray: read state.pending_proposal, call external_actions.propose.propose_external_action({connector_name, action, params:{application_id}, summary}) (or the pocket-write proposal bridge for a Fabric write), which files an Instinct Action (kind=external_action) and opens the agent.proposed decision chain. Nothing approves inline — the button only proposes. Keep the master-detail selected_id wiring and the each-over-status_counts burndown intact.",
   "sources": {
     "applications": {
       "method": "GET",
@@ -20,72 +20,72 @@
     "applications": [
       {
         "id": "a1",
-        "applicant": "[Amara Okafor]",
-        "summary": "[Applying for the standard plan; referred by an existing member]",
+        "applicant": "Amara Okafor",
+        "summary": "Applying for the standard plan; referred by an existing member",
         "status": "Pending",
         "score": 82,
         "recommendation": "Approve",
         "age_days": 2,
         "answers": [
-          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[Referral from a current member]" },
-          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[Access to the workspace and the monthly sessions]" },
-          { "id": "q3", "question": "[Anything we should know?]", "answer": "[Available to start immediately]" }
+          { "id": "q1", "question": "How did you hear about us?", "answer": "Referral from a current member" },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Access to the workspace and the monthly sessions" },
+          { "id": "q3", "question": "Anything we should know?", "answer": "Available to start immediately" }
         ]
       },
       {
         "id": "a2",
-        "applicant": "[Liam Petrov]",
-        "summary": "[First-time applicant; submitted without a referral]",
+        "applicant": "Liam Petrov",
+        "summary": "First-time applicant; submitted without a referral",
         "status": "In review",
         "score": 64,
         "recommendation": "Needs review",
         "age_days": 5,
         "answers": [
-          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[Found you through a web search]" },
-          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[Still figuring that out]" },
-          { "id": "q3", "question": "[Anything we should know?]", "answer": "[Prefers to start next month]" }
+          { "id": "q1", "question": "How did you hear about us?", "answer": "Found you through a web search" },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Still figuring that out" },
+          { "id": "q3", "question": "Anything we should know?", "answer": "Prefers to start next month" }
         ]
       },
       {
         "id": "a3",
-        "applicant": "[Sofia Marchetti]",
-        "summary": "[Renewal of a lapsed application; strong prior history]",
+        "applicant": "Sofia Marchetti",
+        "summary": "Renewal of a lapsed application; strong prior history",
         "status": "Pending",
         "score": 91,
         "recommendation": "Approve",
         "age_days": 1,
         "answers": [
-          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[Returning after a break]" },
-          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[Picking up where I left off]" },
-          { "id": "q3", "question": "[Anything we should know?]", "answer": "[Was a member two years ago]" }
+          { "id": "q1", "question": "How did you hear about us?", "answer": "Returning after a break" },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Picking up where I left off" },
+          { "id": "q3", "question": "Anything we should know?", "answer": "Was a member two years ago" }
         ]
       },
       {
         "id": "a4",
-        "applicant": "[Daniel Cho]",
-        "summary": "[Incomplete answers; waiting on missing details]",
+        "applicant": "Daniel Cho",
+        "summary": "Incomplete answers; waiting on missing details",
         "status": "In review",
         "score": 48,
         "recommendation": "Needs review",
         "age_days": 8,
         "answers": [
-          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[—]" },
-          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[Did not answer]" },
-          { "id": "q3", "question": "[Anything we should know?]", "answer": "[—]" }
+          { "id": "q1", "question": "How did you hear about us?", "answer": "—" },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Did not answer" },
+          { "id": "q3", "question": "Anything we should know?", "answer": "—" }
         ]
       },
       {
         "id": "a5",
-        "applicant": "[Priya Nair]",
-        "summary": "[Clear fit; references checked out]",
+        "applicant": "Priya Nair",
+        "summary": "Clear fit; references checked out",
         "status": "Pending",
         "score": 88,
         "recommendation": "Approve",
         "age_days": 3,
         "answers": [
-          { "id": "q1", "question": "[How did you hear about us?]", "answer": "[Recommended by a colleague]" },
-          { "id": "q2", "question": "[What are you hoping to get out of this?]", "answer": "[The community and the events]" },
-          { "id": "q3", "question": "[Anything we should know?]", "answer": "[Happy to answer follow-up questions]" }
+          { "id": "q1", "question": "How did you hear about us?", "answer": "Recommended by a colleague" },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "The community and the events" },
+          { "id": "q3", "question": "Anything we should know?", "answer": "Happy to answer follow-up questions" }
         ]
       }
     ]
@@ -97,8 +97,8 @@
       {
         "type": "page-header",
         "props": {
-          "title": "[Applications]",
-          "subtitle": "[Work the queue top to bottom — approve, reject, or flag for a second look]"
+          "title": "Applications",
+          "subtitle": "Work the queue top to bottom — approve, reject, or flag for a second look"
         }
       },
       {

--- a/src/pocketpaw/bundled_templates/_bundled/member-360/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/member-360/ripple_spec.json
@@ -1,5 +1,5 @@
 {
-  "_placeholder_note": "Built-in pocket template (member-360). The member, profile fields, lists, and stats below carry [bracketed] placeholders — the create specialist rewrites them to the user's real member record and domain. The `sources` block is a PLACEHOLDER live-data binding: if a backend is configured, keep it so GET /members/current hydrates state.member; with NO backend, REMOVE the `sources` block and keep the seeded member as the working data. This view is READ-ONLY — no buttons, no on_click, no mutation. Keep the stat strip, the key-value profile cards, the membership panel, and the three record lists intact; reshape the list rows for the user's real tickets / orders / notes.",
+  "_placeholder_note": "Built-in pocket template (member-360). The member, profile fields, lists, and stats below are real sample copy — no placeholder brackets, so a pocket created straight from this template renders as finished UI (live-deploy feedback: brackets read as unfinished). The create specialist still rewrites the sample record to the user's real member and domain. The `sources` block is a PLACEHOLDER live-data binding: if a backend is configured, keep it so GET /members/current hydrates state.member; with NO backend, REMOVE the `sources` block and keep the seeded member as the working data. This view is READ-ONLY — no buttons, no on_click, no mutation. Keep the stat strip, the key-value profile cards, the membership panel, and the three record lists intact; reshape the list rows for the user's real tickets / orders / notes.",
   "sources": {
     "member": {
       "method": "GET",
@@ -11,36 +11,36 @@
   "state": {
     "member": {
       "id": "m1",
-      "name": "[Amara Okafor]",
-      "tier": "[Gold]",
+      "name": "Amara Okafor",
+      "tier": "Gold",
       "status": "Active"
     },
     "stats": [
-      { "id": "st1", "label": "Sessions attended", "value": "[42]" },
-      { "id": "st2", "label": "Total spend", "value": "[$3,180]" }
+      { "id": "st1", "label": "Sessions attended", "value": "42" },
+      { "id": "st2", "label": "Total spend", "value": "$3,180" }
     ],
     "profile": [
-      { "id": "p1", "label": "Email", "value": "[amara@example.com]" },
-      { "id": "p2", "label": "Phone", "value": "[+1 555 0142]" },
-      { "id": "p3", "label": "Member since", "value": "[March 2023]" },
-      { "id": "p4", "label": "Location", "value": "[Lagos]" }
+      { "id": "p1", "label": "Email", "value": "amara@example.com" },
+      { "id": "p2", "label": "Phone", "value": "+1 555 0142" },
+      { "id": "p3", "label": "Member since", "value": "March 2023" },
+      { "id": "p4", "label": "Location", "value": "Lagos" }
     ],
     "membership": [
-      { "id": "mb1", "label": "Package", "value": "[Annual — Gold]" },
-      { "id": "mb2", "label": "Renewal date", "value": "[2027-03-01]" },
-      { "id": "mb3", "label": "Standing", "value": "[Paid in full]" }
+      { "id": "mb1", "label": "Package", "value": "Annual — Gold" },
+      { "id": "mb2", "label": "Renewal date", "value": "2027-03-01" },
+      { "id": "mb3", "label": "Standing", "value": "Paid in full" }
     ],
     "tickets": [
-      { "id": "t1", "title": "[Locker access not working]", "status": "Open", "date": "2026-06-05" },
-      { "id": "t2", "title": "[Question about guest passes]", "status": "Resolved", "date": "2026-05-21" }
+      { "id": "t1", "title": "Locker access not working", "status": "Open", "date": "2026-06-05" },
+      { "id": "t2", "title": "Question about guest passes", "status": "Resolved", "date": "2026-05-21" }
     ],
     "orders": [
-      { "id": "o1", "title": "[Event ticket — Summer Mixer]", "amount": "[$45]", "date": "2026-05-30" },
-      { "id": "o2", "title": "[Merch — branded tote]", "amount": "[$25]", "date": "2026-05-12" }
+      { "id": "o1", "title": "Event ticket — Summer Mixer", "amount": "$45", "date": "2026-05-30" },
+      { "id": "o2", "title": "Merch — branded tote", "amount": "$25", "date": "2026-05-12" }
     ],
     "notes": [
-      { "id": "n1", "title": "[Prefers email over phone]", "date": "2026-04-18" },
-      { "id": "n2", "title": "[Interested in the mentorship track]", "date": "2026-03-22" }
+      { "id": "n1", "title": "Prefers email over phone", "date": "2026-04-18" },
+      { "id": "n2", "title": "Interested in the mentorship track", "date": "2026-03-22" }
     ]
   },
   "ui": {


### PR DESCRIPTION
Live-deploy feedback: pockets created from the two new templates rendered with literal square-bracket placeholder copy. The triage pocket's heading showed "[Applications]", its subtitle "[Work the queue top to bottom — approve, reject, or flag for a second look]", and member-360 carried the same pattern across its member record, profile, and lists. Brackets read as unfinished UI to a client.

The bracket convention exists for the create-specialist path, which rewrites seed rows before persisting. The service path (`create(template_slug=...)`) adopts the canvas as-is — so since #1432 the brackets land verbatim on real pockets.

## What changed

Every bracketed string in both `ripple_spec.json` files is now the same copy, unbracketed — real product copy that renders as finished UI on a fresh install:

- **applications-triage** (29 strings): the page heading and subtitle, five applicant names, their one-line summaries, and all Q&A questions and answers.
- **member-360** (19 strings): the member name and tier, both stat values, the four profile fields, the three membership fields, and every ticket, order, and note row.

The two `_placeholder_note` blocks are reworded to match reality: the seed rows are real sample copy the create specialist may rewrite, not bracketed placeholders. The sources guidance and the action-row binding documentation are unchanged.

No structural changes — widget trees, bindings, sources, and actions are byte-identical apart from the copy. No tests asserted the bracketed strings, so none needed updating.

## Tests

Targeted suites (vertical + bundled template units, compile, service create round-trips, template resolution, template needs): 111 passed.