### PR TITLE
Redesign triage + member-360 templates to demo grade, fix empty detail bindings

### DIFF
--- a/src/pocketpaw/bundled_templates/_bundled/applications-triage/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/applications-triage/ripple_spec.json
@@ -1,5 +1,5 @@
 {
-  "_placeholder_note": "Built-in pocket template (applications-triage). The rows and Q&A pairs below are real sample copy — no placeholder brackets, so a pocket created straight from this template renders as finished UI (live-deploy feedback: brackets read as unfinished). The create specialist still rewrites the sample rows to the user's real applications and domain. The `sources` block is a PLACEHOLDER live-data binding: if a backend is configured, keep it so GET /applications hydrates state.applications; with NO backend, REMOVE the `sources` block and keep the seeded applications as the working data. ACTION-ROW BINDING POINT: the approve / reject / needs-review buttons set state.pending_proposal to a generic proposal shape {action, application_id, summary} — they do NOT execute. A deployment wires this state event to the Instinct gate so a human confirms in The Tray: read state.pending_proposal, call external_actions.propose.propose_external_action({connector_name, action, params:{application_id}, summary}) (or the pocket-write proposal bridge for a Fabric write), which files an Instinct Action (kind=external_action) and opens the agent.proposed decision chain. Nothing approves inline — the button only proposes. Keep the master-detail selected_id wiring and the each-over-status_counts burndown intact.",
+  "_placeholder_note": "Built-in pocket template (applications-triage), DEMO-GRADE redesign 2026-06-11 (feat/triage-redesign). The rows, scores, recommendations, reasoning, and Q&A pairs below are real sample copy — no placeholder brackets — so a pocket created straight from this template renders as a finished decisions console. The create specialist still rewrites the sample applications to the user's real domain. BINDING CONTRACT (why the old template rendered empty): the Ripple expression engine resolves a method chain ONLY when the chain ENDS in `)` (e.g. `{x.where('id', y).first()}`); a method call FOLLOWED BY a property access (`...first().applicant`) resolves to undefined. And `each` `items` resolves a FLAT dot-path from state ONLY — it ignores loop context and bracket indexing. The old detail panel used `{state.applications.where('id', state.selected_id).first().applicant}` (chain + trailing property) and `each items=\"{...first().answers}\"` (non-flat path), so Score / Recommendation / Waiting / Q&A all rendered empty. This redesign denormalizes the selected row into a FLAT `state.selected` object so every detail binding is a plain `{state.selected.X}` path and the Q&A / risk-flag loops read `{state.selected.answers}` / `{state.selected.flags}`. Clicking a queue card keeps `state.selected` in sync via an on_click chain whose `set` value is `{state.applications.where('id', app.id).first()}` — a chain that ENDS in `)`, so it resolves at dispatch time. `state.selected` is also SEEDED to the first application so the panel renders before any click. ENUM NOTE: badge variants are {default,secondary,destructive,outline,success,warning}; chip variants are {default,primary,success,warning,destructive}; callout variants are {info,success,warning,insight} — callout has NO destructive, so a reject's reasoning callout uses `warning` and the red emphasis lives on the recommendation badge (variant=destructive). The `sources` block is a PLACEHOLDER live-data binding: with a backend keep it so GET /applications hydrates state.applications; with NO backend remove it and keep the seeded applications. ACTION-ROW BINDING POINT: the approve / reject / interview buttons set state.pending_proposal to a generic {action, application_id, summary} proposal — they do NOT execute. A deployment wires this state event to the Instinct gate (external_actions.propose.propose_external_action) so a human confirms in The Tray. Keep the burndown stat row, the queue each-loop, the selected-sync on_click, and the action row intact.",
   "sources": {
     "applications": {
       "method": "GET",
@@ -12,98 +12,231 @@
     "selected_id": "a1",
     "pending_proposal": null,
     "status_counts": [
-      { "id": "sc1", "label": "Pending", "value": 3 },
-      { "id": "sc2", "label": "In review", "value": 2 },
-      { "id": "sc3", "label": "Approved", "value": 1 },
-      { "id": "sc4", "label": "Rejected", "value": 1 }
+      { "id": "sc1", "label": "Pending", "value": 3, "color": "#d97706", "dot": "away" },
+      { "id": "sc2", "label": "In review", "value": 2, "color": "#0284c7", "dot": "busy" },
+      { "id": "sc3", "label": "Approved", "value": 1, "color": "#059669", "dot": "online" },
+      { "id": "sc4", "label": "Rejected", "value": 1, "color": "#dc2626", "dot": "offline" }
     ],
+    "queue_total": 7,
+    "oldest_waiting": 9,
     "applications": [
       {
         "id": "a1",
         "applicant": "Amara Okafor",
-        "summary": "Applying for the standard plan; referred by an existing member",
+        "summary": "Standard plan · referred by an existing member",
         "status": "Pending",
-        "score": 82,
+        "status_variant": "warning",
+        "score": 91,
+        "score_color": "#059669",
+        "score_band": "Strong",
         "recommendation": "Approve",
+        "rec_variant": "success",
+        "rec_callout_variant": "success",
+        "reasoning": "Referred by a member in good standing and the application is fully answered. Background check is clean and the stated goals match what the membership offers. No open questions — this one is ready to approve.",
         "age_days": 2,
         "answers": [
-          { "id": "q1", "question": "How did you hear about us?", "answer": "Referral from a current member" },
-          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Access to the workspace and the monthly sessions" },
-          { "id": "q3", "question": "Anything we should know?", "answer": "Available to start immediately" }
+          { "id": "q1", "question": "How did you hear about us?", "answer": "Referral from Tunde A., a current member" },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Access to the workspace and the monthly founder sessions — I'm building in the same space as two existing members." },
+          { "id": "q3", "question": "Anything we should know?", "answer": "Available to start immediately and happy to do an intro call." }
+        ],
+        "flags": [
+          { "id": "f1", "label": "Background: clean", "variant": "success" },
+          { "id": "f2", "label": "Profile 100% complete", "variant": "success" },
+          { "id": "f3", "label": "Member referral", "variant": "primary" }
         ]
       },
       {
         "id": "a2",
         "applicant": "Liam Petrov",
-        "summary": "First-time applicant; submitted without a referral",
+        "summary": "First-time applicant · no referral · partial answers",
         "status": "In review",
-        "score": 64,
-        "recommendation": "Needs review",
+        "status_variant": "secondary",
+        "score": 58,
+        "score_color": "#d97706",
+        "score_band": "Borderline",
+        "recommendation": "Interview",
+        "rec_variant": "warning",
+        "rec_callout_variant": "warning",
+        "reasoning": "Found us through search with no referral, and the goals are still vague. Nothing disqualifying, but not enough signal to approve on paper. A 15-minute intro call would resolve whether the fit is real before committing a seat.",
         "age_days": 5,
         "answers": [
           { "id": "q1", "question": "How did you hear about us?", "answer": "Found you through a web search" },
-          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Still figuring that out" },
-          { "id": "q3", "question": "Anything we should know?", "answer": "Prefers to start next month" }
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Still figuring that out — somewhere to work and meet people, I think." },
+          { "id": "q3", "question": "Anything we should know?", "answer": "Prefers to start next month." }
+        ],
+        "flags": [
+          { "id": "f1", "label": "Background: clean", "variant": "success" },
+          { "id": "f2", "label": "Profile 60% complete", "variant": "warning" },
+          { "id": "f3", "label": "No referral", "variant": "default" }
         ]
       },
       {
         "id": "a3",
         "applicant": "Sofia Marchetti",
-        "summary": "Renewal of a lapsed application; strong prior history",
+        "summary": "Renewal of a lapsed membership · strong prior history",
         "status": "Pending",
-        "score": 91,
+        "status_variant": "warning",
+        "score": 88,
+        "score_color": "#059669",
+        "score_band": "Strong",
         "recommendation": "Approve",
+        "rec_variant": "success",
+        "rec_callout_variant": "success",
+        "reasoning": "Returning member with a clean two-year track record and no flags on file. Renewal applications from members who left in good standing are the lowest-risk approvals in the queue. Goals are concrete and consistent with her prior tenure.",
         "age_days": 1,
         "answers": [
-          { "id": "q1", "question": "How did you hear about us?", "answer": "Returning after a break" },
-          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Picking up where I left off" },
-          { "id": "q3", "question": "Anything we should know?", "answer": "Was a member two years ago" }
+          { "id": "q1", "question": "How did you hear about us?", "answer": "Returning after a break — I was a member 2021–2023." },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Picking up where I left off; back in town full-time now." },
+          { "id": "q3", "question": "Anything we should know?", "answer": "Was a member two years ago under the same email." }
+        ],
+        "flags": [
+          { "id": "f1", "label": "Background: clean", "variant": "success" },
+          { "id": "f2", "label": "Profile 100% complete", "variant": "success" },
+          { "id": "f3", "label": "Returning member", "variant": "primary" }
         ]
       },
       {
         "id": "a4",
-        "applicant": "Daniel Cho",
-        "summary": "Incomplete answers; waiting on missing details",
+        "applicant": "Marcus Webb",
+        "summary": "Blacklist match · prior chargebacks on file",
         "status": "In review",
-        "score": 48,
-        "recommendation": "Needs review",
-        "age_days": 8,
+        "status_variant": "secondary",
+        "score": 23,
+        "score_color": "#dc2626",
+        "score_band": "High risk",
+        "recommendation": "Reject",
+        "rec_variant": "destructive",
+        "rec_callout_variant": "warning",
+        "reasoning": "The email and phone match a record on the do-not-admit list from two chargebacks and a prior removal. Identity and contact details line up with the flagged account, so this is not a false positive. Recommend reject and do not re-invite.",
+        "age_days": 9,
         "answers": [
-          { "id": "q1", "question": "How did you hear about us?", "answer": "—" },
-          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Did not answer" },
-          { "id": "q3", "question": "Anything we should know?", "answer": "—" }
+          { "id": "q1", "question": "How did you hear about us?", "answer": "I've been a member before under a different account." },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Same as last time — full access." },
+          { "id": "q3", "question": "Anything we should know?", "answer": "There was a billing misunderstanding last time that wasn't my fault." }
+        ],
+        "flags": [
+          { "id": "f1", "label": "Blacklist: MATCH", "variant": "destructive" },
+          { "id": "f2", "label": "2 prior chargebacks", "variant": "destructive" },
+          { "id": "f3", "label": "Profile 80% complete", "variant": "warning" }
         ]
       },
       {
         "id": "a5",
         "applicant": "Priya Nair",
-        "summary": "Clear fit; references checked out",
+        "summary": "Clear fit · references checked out",
         "status": "Pending",
-        "score": 88,
+        "status_variant": "warning",
+        "score": 84,
+        "score_color": "#059669",
+        "score_band": "Strong",
         "recommendation": "Approve",
+        "rec_variant": "success",
+        "rec_callout_variant": "success",
+        "reasoning": "Colleague referral with two references that both responded positively. Application is complete and the stated interest in the events programme is specific. Low risk and a good community add — clear approve.",
         "age_days": 3,
         "answers": [
-          { "id": "q1", "question": "How did you hear about us?", "answer": "Recommended by a colleague" },
-          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "The community and the events" },
-          { "id": "q3", "question": "Anything we should know?", "answer": "Happy to answer follow-up questions" }
+          { "id": "q1", "question": "How did you hear about us?", "answer": "Recommended by a colleague who's a current member." },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "The community and the events — I want to host a workshop in Q3." },
+          { "id": "q3", "question": "Anything we should know?", "answer": "Happy to answer any follow-up questions." }
+        ],
+        "flags": [
+          { "id": "f1", "label": "Background: clean", "variant": "success" },
+          { "id": "f2", "label": "References checked", "variant": "success" },
+          { "id": "f3", "label": "Profile 100% complete", "variant": "success" }
+        ]
+      },
+      {
+        "id": "a6",
+        "applicant": "Daniel Cho",
+        "summary": "Incomplete answers · waiting on missing details",
+        "status": "In review",
+        "status_variant": "secondary",
+        "score": 41,
+        "score_color": "#d97706",
+        "score_band": "Borderline",
+        "recommendation": "Interview",
+        "rec_variant": "warning",
+        "rec_callout_variant": "warning",
+        "reasoning": "Most fields are blank and the goals question went unanswered, so the score reflects missing data more than a weak applicant. Don't reject on an empty form — a short call to fill the gaps will move this to a confident approve or reject.",
+        "age_days": 8,
+        "answers": [
+          { "id": "q1", "question": "How did you hear about us?", "answer": "—" },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Did not answer." },
+          { "id": "q3", "question": "Anything we should know?", "answer": "—" }
+        ],
+        "flags": [
+          { "id": "f1", "label": "Background: clean", "variant": "success" },
+          { "id": "f2", "label": "Profile 35% complete", "variant": "destructive" },
+          { "id": "f3", "label": "No referral", "variant": "default" }
+        ]
+      },
+      {
+        "id": "a7",
+        "applicant": "Hannah Berg",
+        "summary": "Solid applicant · minor scheduling caveat",
+        "status": "Pending",
+        "status_variant": "warning",
+        "score": 76,
+        "score_color": "#0284c7",
+        "score_band": "Good",
+        "recommendation": "Approve",
+        "rec_variant": "success",
+        "rec_callout_variant": "success",
+        "reasoning": "Complete application with a clean check and a clear, specific reason for joining. The only caveat is a six-week travel window before she can start, which doesn't affect the decision. Approve with a deferred start date.",
+        "age_days": 4,
+        "answers": [
+          { "id": "q1", "question": "How did you hear about us?", "answer": "A friend who attended one of the mixers." },
+          { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "A reliable place to work and the design community specifically." },
+          { "id": "q3", "question": "Anything we should know?", "answer": "Travelling for six weeks, so I'd like to start in mid-August." }
+        ],
+        "flags": [
+          { "id": "f1", "label": "Background: clean", "variant": "success" },
+          { "id": "f2", "label": "Profile 95% complete", "variant": "success" },
+          { "id": "f3", "label": "Deferred start", "variant": "default" }
         ]
       }
-    ]
+    ],
+    "selected": {
+      "id": "a1",
+      "applicant": "Amara Okafor",
+      "summary": "Standard plan · referred by an existing member",
+      "status": "Pending",
+      "status_variant": "warning",
+      "score": 91,
+      "score_color": "#059669",
+      "score_band": "Strong",
+      "recommendation": "Approve",
+      "rec_variant": "success",
+      "rec_callout_variant": "success",
+      "reasoning": "Referred by a member in good standing and the application is fully answered. Background check is clean and the stated goals match what the membership offers. No open questions — this one is ready to approve.",
+      "age_days": 2,
+      "answers": [
+        { "id": "q1", "question": "How did you hear about us?", "answer": "Referral from Tunde A., a current member" },
+        { "id": "q2", "question": "What are you hoping to get out of this?", "answer": "Access to the workspace and the monthly founder sessions — I'm building in the same space as two existing members." },
+        { "id": "q3", "question": "Anything we should know?", "answer": "Available to start immediately and happy to do an intro call." }
+      ],
+      "flags": [
+        { "id": "f1", "label": "Background: clean", "variant": "success" },
+        { "id": "f2", "label": "Profile 100% complete", "variant": "success" },
+        { "id": "f3", "label": "Member referral", "variant": "primary" }
+      ]
+    }
   },
   "ui": {
     "type": "flex",
-    "props": { "direction": "column", "gap": "16px" },
+    "props": { "direction": "column", "gap": "20px" },
     "children": [
       {
         "type": "page-header",
         "props": {
           "title": "Applications",
-          "subtitle": "Work the queue top to bottom — approve, reject, or flag for a second look"
+          "subtitle": "Work the queue top to bottom — the agent scores and recommends, you approve, reject, or send to interview",
+          "eyebrow": "Decision queue"
         }
       },
       {
         "type": "grid",
-        "props": { "columns": 4, "gap": "12px" },
+        "props": { "columns": "repeat(6, minmax(0, 1fr))", "gap": "12px" },
         "children": [
           {
             "type": "each",
@@ -111,107 +244,261 @@
             "item_as": "bucket",
             "children": [
               {
-                "type": "stat",
-                "props": {
-                  "label": "{bucket.label}",
-                  "value": "{bucket.value}"
-                }
+                "type": "card",
+                "props": { "variant": "outlined", "density": "compact" },
+                "children": [
+                  {
+                    "type": "flex",
+                    "props": { "direction": "column", "gap": "6px" },
+                    "children": [
+                      { "type": "status-dot", "props": { "variant": "{bucket.dot}", "label": "{bucket.label}", "size": 8 } },
+                      { "type": "text", "props": { "text": "{bucket.value}", "size": "2xl", "weight": "bold", "color": "{bucket.color}" } }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "muted", "density": "compact" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "6px" },
+                "children": [
+                  { "type": "text", "props": { "text": "In queue", "size": "xs", "weight": "medium", "color": "#64748b" } },
+                  { "type": "text", "props": { "text": "{state.queue_total}", "size": "2xl", "weight": "bold" } }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "muted", "density": "compact" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "6px" },
+                "children": [
+                  { "type": "text", "props": { "text": "Oldest waiting", "size": "xs", "weight": "medium", "color": "#64748b" } },
+                  { "type": "text", "props": { "text": "{state.oldest_waiting} days", "size": "2xl", "weight": "bold", "color": "#dc2626" } }
+                ]
               }
             ]
           }
         ]
       },
       {
-        "type": "master-detail",
-        "bind": "selected_id",
-        "props": {
-          "items": "{state.applications}",
-          "valueKey": "id",
-          "labelKey": "applicant",
-          "descriptionKey": "summary",
-          "badgeKey": "status"
-        },
+        "type": "grid",
+        "props": { "columns": "minmax(300px, 360px) minmax(0, 1fr)", "gap": "20px" },
         "children": [
           {
-            "type": "entity-detail",
-            "props": {
-              "title": "{state.applications.where('id', state.selected_id).first().applicant}",
-              "subtitle": "{state.applications.where('id', state.selected_id).first().summary}",
-              "eyebrow": "Application",
-              "status": { "label": "{state.applications.where('id', state.selected_id).first().status}", "variant": "info" },
-              "meta": [
-                { "label": "Score", "value": "{state.applications.where('id', state.selected_id).first().score}", "icon": "target" },
-                { "label": "Recommendation", "value": "{state.applications.where('id', state.selected_id).first().recommendation}", "icon": "check-circle" },
-                { "label": "Waiting", "value": "{state.applications.where('id', state.selected_id).first().age_days} days", "icon": "clock" }
-              ]
-            },
+            "type": "flex",
+            "props": { "direction": "column", "gap": "10px" },
             "children": [
+              { "type": "text", "props": { "text": "QUEUE", "size": "xs", "weight": "semibold", "color": "#64748b" } },
               {
-                "type": "section",
-                "props": { "title": "Answers" },
+                "type": "each",
+                "items": "{state.applications}",
+                "item_as": "app",
                 "children": [
                   {
-                    "type": "each",
-                    "items": "{state.applications.where('id', state.selected_id).first().answers}",
-                    "item_as": "qa",
+                    "type": "card",
+                    "props": {
+                      "variant": "{app.id == state.selected_id ? 'selected' : 'outlined'}",
+                      "density": "compact",
+                      "interactive": true
+                    },
+                    "on_click": [
+                      { "action": "set", "target": "selected_id", "value": "{app.id}" },
+                      { "action": "set", "target": "selected", "value": "{state.applications.where('id', app.id).first()}" }
+                    ],
                     "children": [
                       {
-                        "type": "card",
-                        "props": {
-                          "title": "{qa.question}",
-                          "description": "{qa.answer}"
-                        }
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "8px" },
+                        "children": [
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "justify": "between", "align": "center", "gap": "8px" },
+                            "children": [
+                              { "type": "text", "props": { "text": "{app.applicant}", "weight": "semibold", "size": "base" } },
+                              { "type": "badge", "props": { "text": "{app.score}", "variant": "outline" } }
+                            ]
+                          },
+                          { "type": "progress", "props": { "value": "{app.score}", "max": 100, "color": "{app.score_color}", "variant": "thin" } },
+                          { "type": "text", "props": { "text": "{app.summary}", "size": "xs", "color": "#64748b" } },
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "justify": "between", "align": "center", "gap": "8px" },
+                            "children": [
+                              { "type": "badge", "props": { "text": "{app.status}", "variant": "{app.status_variant}" } },
+                              { "type": "text", "props": { "text": "{app.age_days}d waiting", "size": "xs", "color": "#94a3b8" } }
+                            ]
+                          }
+                        ]
                       }
                     ]
                   }
                 ]
-              },
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "default" },
+            "children": [
               {
                 "type": "flex",
-                "props": { "direction": "row", "gap": "8px" },
+                "props": { "direction": "column", "gap": "18px" },
                 "children": [
                   {
-                    "type": "button",
-                    "props": { "label": "Approve", "variant": "primary" },
-                    "on_click": [
+                    "type": "flex",
+                    "props": { "direction": "row", "justify": "between", "align": "start", "gap": "16px", "wrap": "wrap" },
+                    "children": [
                       {
-                        "action": "set",
-                        "target": "pending_proposal",
-                        "value": {
-                          "action": "approve_application",
-                          "application_id": "{state.selected_id}",
-                          "summary": "Approve {state.applications.where('id', state.selected_id).first().applicant}"
-                        }
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "8px" },
+                        "children": [
+                          { "type": "text", "props": { "text": "APPLICATION", "size": "xs", "weight": "semibold", "color": "#94a3b8" } },
+                          { "type": "heading", "props": { "text": "{state.selected.applicant}", "level": 2 } },
+                          { "type": "text", "props": { "text": "{state.selected.summary}", "size": "sm", "color": "#64748b" } },
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "gap": "8px", "align": "center", "wrap": "wrap" },
+                            "children": [
+                              { "type": "badge", "props": { "text": "{state.selected.status}", "variant": "{state.selected.status_variant}" } },
+                              { "type": "badge", "props": { "text": "{state.selected.recommendation}", "variant": "{state.selected.rec_variant}" } },
+                              { "type": "text", "props": { "text": "Waiting {state.selected.age_days} days", "size": "xs", "color": "#94a3b8" } }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "4px", "align": "center" },
+                        "children": [
+                          {
+                            "type": "progress-ring",
+                            "props": {
+                              "value": "{state.selected.score}",
+                              "max": 100,
+                              "size": 96,
+                              "thickness": 9,
+                              "color": "{state.selected.score_color}",
+                              "label": "{state.selected.score}"
+                            }
+                          },
+                          { "type": "text", "props": { "text": "{state.selected.score_band}", "size": "xs", "weight": "medium", "color": "{state.selected.score_color}" } }
+                        ]
                       }
                     ]
                   },
                   {
-                    "type": "button",
-                    "props": { "label": "Reject", "variant": "danger" },
-                    "on_click": [
+                    "type": "callout",
+                    "props": {
+                      "title": "Recommendation: {state.selected.recommendation}",
+                      "text": "{state.selected.reasoning}",
+                      "variant": "{state.selected.rec_callout_variant}"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "props": { "title": "Risk checks" },
+                    "children": [
                       {
-                        "action": "set",
-                        "target": "pending_proposal",
-                        "value": {
-                          "action": "reject_application",
-                          "application_id": "{state.selected_id}",
-                          "summary": "Reject {state.applications.where('id', state.selected_id).first().applicant}"
-                        }
+                        "type": "flex",
+                        "props": { "direction": "row", "gap": "8px", "wrap": "wrap" },
+                        "children": [
+                          {
+                            "type": "each",
+                            "items": "{state.selected.flags}",
+                            "item_as": "flag",
+                            "children": [
+                              { "type": "chip", "props": { "label": "{flag.label}", "variant": "{flag.variant}" } }
+                            ]
+                          }
+                        ]
                       }
                     ]
                   },
                   {
-                    "type": "button",
-                    "props": { "label": "Needs review", "variant": "secondary" },
-                    "on_click": [
+                    "type": "section",
+                    "props": { "title": "Application answers" },
+                    "children": [
                       {
-                        "action": "set",
-                        "target": "pending_proposal",
-                        "value": {
-                          "action": "flag_for_review",
-                          "application_id": "{state.selected_id}",
-                          "summary": "Flag {state.applications.where('id', state.selected_id).first().applicant} for review"
-                        }
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "12px" },
+                        "children": [
+                          {
+                            "type": "each",
+                            "items": "{state.selected.answers}",
+                            "item_as": "qa",
+                            "children": [
+                              {
+                                "type": "flex",
+                                "props": { "direction": "column", "gap": "2px" },
+                                "children": [
+                                  { "type": "text", "props": { "text": "{qa.question}", "size": "sm", "weight": "semibold" } },
+                                  { "type": "text", "props": { "text": "{qa.answer}", "size": "sm", "color": "#475569" } }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  { "type": "separator", "props": { "orientation": "horizontal" } },
+                  {
+                    "type": "flex",
+                    "props": { "direction": "row", "gap": "8px", "wrap": "wrap" },
+                    "children": [
+                      {
+                        "type": "button",
+                        "props": { "label": "Approve", "variant": "primary" },
+                        "on_click": [
+                          {
+                            "action": "set",
+                            "target": "pending_proposal",
+                            "value": {
+                              "action": "approve_application",
+                              "application_id": "{state.selected_id}",
+                              "summary": "Approve {state.selected.applicant}"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "button",
+                        "props": { "label": "Reject", "variant": "danger" },
+                        "on_click": [
+                          {
+                            "action": "set",
+                            "target": "pending_proposal",
+                            "value": {
+                              "action": "reject_application",
+                              "application_id": "{state.selected_id}",
+                              "summary": "Reject {state.selected.applicant}"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "button",
+                        "props": { "label": "Send to interview", "variant": "secondary" },
+                        "on_click": [
+                          {
+                            "action": "set",
+                            "target": "pending_proposal",
+                            "value": {
+                              "action": "flag_for_review",
+                              "application_id": "{state.selected_id}",
+                              "summary": "Send {state.selected.applicant} to interview"
+                            }
+                          }
+                        ]
                       }
                     ]
                   }

--- a/src/pocketpaw/bundled_templates/_bundled/applications-triage/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/applications-triage/template.pocket.yaml
@@ -1,9 +1,21 @@
 # src/pocketpaw/bundled_templates/_bundled/applications-triage/template.pocket.yaml
 # Created: 2026-06-11 (feat/triage-member-templates) — RFC 03 v2 Pocket
 # Template Schema metadata for the generic application/queue triage
-# pocket. ``shape: custom`` because the canvas is a master-detail (queue
-# list + selected-application detail) plus a burndown stat row and an
-# action row — RFC 03's shape enum has no ``master-detail`` value, so the
+# pocket.
+# Modified 2026-06-11 (feat/triage-redesign): DEMO-GRADE redesign of the
+# ripple_spec. The canvas is now a decisions console — a color-banded
+# burndown strip (per-status count cards + queue-total + oldest-waiting),
+# a scannable score-banded queue (name, one-line summary, status pill,
+# score badge + color progress, waiting-days, no name truncation), and a
+# loud detail panel (header + status/recommendation pills + a score RING,
+# the agent's recommendation reasoning in a colored callout, a risk-flag
+# chip row, the FULL question-and-answer set, then the gated action row).
+# The detail panel binds to a denormalized flat ``state.selected`` object
+# kept in sync by the queue cards' on_click, fixing the empty-detail bug
+# (the old spec bound through an unsupported method-chain-then-property
+# expression — see the ripple_spec _placeholder_note BINDING CONTRACT).
+# ``shape: custom`` because the canvas is a composite (queue + detail +
+# burndown + action row) — RFC 03's shape enum has no value for it, so the
 # pattern is recorded in the sibling index.json (``pattern: app``) and the
 # shape stays ``custom`` (the same choice crm-record-list made).
 # ``needs: [paw.db.v1]`` declares the generic data-source capability a
@@ -21,16 +33,20 @@ vertical: operations
 display_name: Applications Triage
 shape: custom
 description: |
-  A review queue for incoming applications. A scannable list on the left —
-  status, a one-line applicant summary, an optional score or recommendation,
-  and how long the item has waited — with the full application detail of the
-  selected row on the right, rendered as plain question-and-answer pairs. A
-  burndown strip across the top counts the queue by status so a reviewer
-  can see the backlog at a glance. The approve / reject / needs-review row
-  surfaces each decision as a pending proposal for a human to confirm rather
-  than acting on its own. Ships a placeholder live-data source so a connected
-  backend hydrates the queue from a real applications endpoint; with no
-  backend it renders the seeded sample applications.
+  A decisions console for incoming applications. A color-banded burndown
+  strip across the top counts the queue by status and adds the headline
+  stats — how many are waiting and how long the oldest has sat. A scannable
+  queue on the left shows each applicant's name, a one-line summary, a
+  status pill, the agent's score as a color-banded badge and bar, and how
+  long the item has waited. Selecting a row opens a detail panel where the
+  agent's work is the loudest thing on the canvas: the score as a ring, the
+  recommendation — approve, reject, or interview — with the reasoning behind
+  it, a row of risk-check chips, and the applicant's full question-and-answer
+  set. The approve / reject / interview row surfaces each decision as a
+  pending proposal for a human to confirm rather than acting on its own.
+  Ships a placeholder live-data source so a connected backend hydrates the
+  queue from a real applications endpoint; with no backend it renders the
+  seeded sample applications.
 icon: inbox
 color: "#5b7c99"
 state:

--- a/src/pocketpaw/bundled_templates/_bundled/member-360/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/member-360/ripple_spec.json
@@ -1,5 +1,5 @@
 {
-  "_placeholder_note": "Built-in pocket template (member-360). The member, profile fields, lists, and stats below are real sample copy — no placeholder brackets, so a pocket created straight from this template renders as finished UI (live-deploy feedback: brackets read as unfinished). The create specialist still rewrites the sample record to the user's real member and domain. The `sources` block is a PLACEHOLDER live-data binding: if a backend is configured, keep it so GET /members/current hydrates state.member; with NO backend, REMOVE the `sources` block and keep the seeded member as the working data. This view is READ-ONLY — no buttons, no on_click, no mutation. Keep the stat strip, the key-value profile cards, the membership panel, and the three record lists intact; reshape the list rows for the user's real tickets / orders / notes.",
+  "_placeholder_note": "Built-in pocket template (member-360), DEMO-GRADE redesign 2026-06-11 (feat/triage-redesign). The member, profile fields, lists, and stats below are real sample copy — no placeholder brackets — so a pocket created straight from this template renders as a finished member profile. The create specialist still rewrites the sample record to the user's real member and domain. BINDING CONTRACT: every binding is a FLAT `{state.member.X}` / `{state.<list>}` dot-path (the only form the renderer resolves reliably) — no method-call-then-property-access chains and no bracket indexing in `each` items, the two forms that render empty. The focal widget is `entity-detail` (the catalog's 'view one record' layout: hero header with a colored avatar block + tier eyebrow + status pill, a KPI strip, and a right-rail of key facts) wrapping a two-column body so nothing floats and there is no dead space below the fold. This view is READ-ONLY — no buttons, no on_click, no mutation. The `sources` block is a PLACEHOLDER live-data binding: with a backend keep it so GET /members/current hydrates state.member; with NO backend remove it and keep the seeded member. Keep the entity-detail header, the KPI strip, the two-column profile/membership kv-tables, the tickets/orders data-grids, and the notes timeline intact; reshape the rows for the user's real records.",
   "sources": {
     "member": {
       "method": "GET",
@@ -13,167 +13,139 @@
       "id": "m1",
       "name": "Amara Okafor",
       "tier": "Gold",
-      "status": "Active"
+      "status": "Active",
+      "initials": "AO",
+      "since": "March 2023"
     },
-    "stats": [
-      { "id": "st1", "label": "Sessions attended", "value": "42" },
-      { "id": "st2", "label": "Total spend", "value": "$3,180" }
+    "kpis": [
+      { "id": "k1", "label": "Sessions attended", "value": 42, "sublabel": "last 12 months" },
+      { "id": "k2", "label": "Total spend", "value": "$3,180", "delta": "+18%", "trend": "up" },
+      { "id": "k3", "label": "Standing", "value": "Good", "sublabel": "paid in full" },
+      { "id": "k4", "label": "Last visit", "value": "2 days ago", "trend": "flat" }
+    ],
+    "facts": [
+      { "label": "Tier", "value": "Gold · annual", "icon": "award" },
+      { "label": "Member since", "value": "March 2023", "icon": "calendar" },
+      { "label": "Renewal", "value": "March 1, 2027", "icon": "refresh-cw" },
+      { "label": "Location", "value": "Lagos, NG", "icon": "map-pin" }
     ],
     "profile": [
-      { "id": "p1", "label": "Email", "value": "amara@example.com" },
-      { "id": "p2", "label": "Phone", "value": "+1 555 0142" },
-      { "id": "p3", "label": "Member since", "value": "March 2023" },
-      { "id": "p4", "label": "Location", "value": "Lagos" }
+      { "key": "Email", "value": "amara@example.com" },
+      { "key": "Phone", "value": "+1 555 0142" },
+      { "key": "Member since", "value": "March 2023" },
+      { "key": "Location", "value": "Lagos, NG" }
     ],
     "membership": [
-      { "id": "mb1", "label": "Package", "value": "Annual — Gold" },
-      { "id": "mb2", "label": "Renewal date", "value": "2027-03-01" },
-      { "id": "mb3", "label": "Standing", "value": "Paid in full" }
+      { "key": "Package", "value": "Annual — Gold" },
+      { "key": "Renewal date", "value": "March 1, 2027" },
+      { "key": "Standing", "value": "Paid in full" },
+      { "key": "Auto-renew", "value": "On" }
     ],
     "tickets": [
       { "id": "t1", "title": "Locker access not working", "status": "Open", "date": "2026-06-05" },
-      { "id": "t2", "title": "Question about guest passes", "status": "Resolved", "date": "2026-05-21" }
+      { "id": "t2", "title": "Question about guest passes", "status": "Resolved", "date": "2026-05-21" },
+      { "id": "t3", "title": "Update billing address", "status": "Resolved", "date": "2026-04-30" }
     ],
     "orders": [
       { "id": "o1", "title": "Event ticket — Summer Mixer", "amount": "$45", "date": "2026-05-30" },
-      { "id": "o2", "title": "Merch — branded tote", "amount": "$25", "date": "2026-05-12" }
+      { "id": "o2", "title": "Merch — branded tote", "amount": "$25", "date": "2026-05-12" },
+      { "id": "o3", "title": "Workshop — Negotiation 101", "amount": "$80", "date": "2026-04-18" }
     ],
     "notes": [
-      { "id": "n1", "title": "Prefers email over phone", "date": "2026-04-18" },
-      { "id": "n2", "title": "Interested in the mentorship track", "date": "2026-03-22" }
+      { "id": "n1", "date": "2026-04-18", "title": "Prefers email over phone", "detail": "Asked to keep all comms to email going forward." },
+      { "id": "n2", "date": "2026-03-22", "title": "Interested in the mentorship track", "detail": "Wants to be paired with a senior member for Q3." },
+      { "id": "n3", "date": "2026-02-10", "title": "Renewed early", "detail": "Renewed the Gold package six weeks ahead of the deadline." }
     ]
   },
   "ui": {
     "type": "flex",
-    "props": { "direction": "column", "gap": "16px" },
+    "props": { "direction": "column", "gap": "20px" },
     "children": [
       {
-        "type": "page-header",
+        "type": "entity-detail",
         "props": {
+          "eyebrow": "{state.member.tier} member · since {state.member.since}",
           "title": "{state.member.name}",
-          "subtitle": "{state.member.tier} member · {state.member.status}"
-        }
-      },
-      {
-        "type": "grid",
-        "props": { "columns": 2, "gap": "12px" },
+          "subtitle": "Member 360 — the full picture at a glance",
+          "icon": "user-round",
+          "iconColor": "#b8860b",
+          "status": { "label": "{state.member.status}", "variant": "success" },
+          "tags": ["{state.member.tier}", "Annual"],
+          "kpis": "{state.kpis}",
+          "meta": "{state.facts}",
+          "metaPlacement": "rail"
+        },
         "children": [
           {
-            "type": "each",
-            "items": "{state.stats}",
-            "item_as": "metric",
+            "type": "grid",
+            "props": { "columns": "repeat(2, minmax(0, 1fr))", "gap": "16px" },
             "children": [
               {
-                "type": "stat",
+                "type": "section",
+                "props": { "title": "Profile" },
+                "children": [
+                  { "type": "kv-table", "props": { "rows": "{state.profile}", "striped": true } }
+                ]
+              },
+              {
+                "type": "section",
+                "props": { "title": "Membership" },
+                "children": [
+                  { "type": "kv-table", "props": { "rows": "{state.membership}", "striped": true } }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "section",
+            "props": { "title": "Recent tickets" },
+            "children": [
+              {
+                "type": "data-grid",
                 "props": {
-                  "label": "{metric.label}",
-                  "value": "{metric.value}"
+                  "columns": [
+                    { "key": "title", "label": "Ticket", "sortable": true, "align": "left" },
+                    { "key": "status", "label": "Status", "sortable": true, "align": "left", "width": "120px" },
+                    { "key": "date", "label": "Date", "sortable": true, "align": "left", "width": "130px" }
+                  ],
+                  "rows": "{state.tickets}",
+                  "defaultSort": "date:desc",
+                  "dense": true
                 }
               }
             ]
-          }
-        ]
-      },
-      {
-        "type": "section",
-        "props": { "title": "Profile" },
-        "children": [
+          },
           {
-            "type": "grid",
-            "props": { "columns": 2, "gap": "12px" },
+            "type": "section",
+            "props": { "title": "Recent orders" },
             "children": [
               {
-                "type": "each",
-                "items": "{state.profile}",
-                "item_as": "field",
-                "children": [
-                  {
-                    "type": "card",
-                    "props": {
-                      "title": "{field.label}",
-                      "description": "{field.value}"
-                    }
-                  }
-                ]
+                "type": "data-grid",
+                "props": {
+                  "columns": [
+                    { "key": "title", "label": "Order", "sortable": true, "align": "left" },
+                    { "key": "amount", "label": "Amount", "sortable": true, "align": "right", "width": "120px" },
+                    { "key": "date", "label": "Date", "sortable": true, "align": "left", "width": "130px" }
+                  ],
+                  "rows": "{state.orders}",
+                  "defaultSort": "date:desc",
+                  "dense": true
+                }
               }
             ]
-          }
-        ]
-      },
-      {
-        "type": "section",
-        "props": { "title": "Membership" },
-        "children": [
+          },
           {
-            "type": "grid",
-            "props": { "columns": 3, "gap": "12px" },
+            "type": "section",
+            "props": { "title": "Notes" },
             "children": [
               {
-                "type": "each",
-                "items": "{state.membership}",
-                "item_as": "field",
-                "children": [
-                  {
-                    "type": "card",
-                    "props": {
-                      "title": "{field.label}",
-                      "description": "{field.value}"
-                    }
-                  }
-                ]
+                "type": "timeline",
+                "props": {
+                  "events": "{state.notes}",
+                  "density": "compact"
+                }
               }
             ]
-          }
-        ]
-      },
-      {
-        "type": "section",
-        "props": { "title": "Tickets" },
-        "children": [
-          {
-            "type": "data-grid",
-            "props": {
-              "columns": [
-                { "key": "title", "label": "Ticket", "sortable": true, "align": "left" },
-                { "key": "status", "label": "Status", "sortable": true, "align": "left", "width": "120px" },
-                { "key": "date", "label": "Date", "sortable": true, "align": "left", "width": "130px" }
-              ],
-              "rows": "{state.tickets}",
-              "defaultSort": "date:desc",
-              "dense": true
-            }
-          }
-        ]
-      },
-      {
-        "type": "section",
-        "props": { "title": "Orders" },
-        "children": [
-          {
-            "type": "data-grid",
-            "props": {
-              "columns": [
-                { "key": "title", "label": "Order", "sortable": true, "align": "left" },
-                { "key": "amount", "label": "Amount", "sortable": true, "align": "right", "width": "120px" },
-                { "key": "date", "label": "Date", "sortable": true, "align": "left", "width": "130px" }
-              ],
-              "rows": "{state.orders}",
-              "defaultSort": "date:desc",
-              "dense": true
-            }
-          }
-        ]
-      },
-      {
-        "type": "section",
-        "props": { "title": "Notes" },
-        "children": [
-          {
-            "type": "timeline",
-            "props": {
-              "events": "{state.notes.sortBy('date', 'desc')}",
-              "density": "compact"
-            }
           }
         ]
       }

--- a/src/pocketpaw/bundled_templates/_bundled/member-360/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/member-360/template.pocket.yaml
@@ -1,15 +1,22 @@
 # src/pocketpaw/bundled_templates/_bundled/member-360/template.pocket.yaml
 # Created: 2026-06-11 (feat/triage-member-templates) — RFC 03 v2 Pocket
-# Template Schema metadata for the generic member-360 view. ``shape:
-# custom`` because the canvas composes a header, a key-value profile
-# section, a membership panel, three simple record lists (tickets /
-# orders / notes), and an attendance/spend stat row — RFC 03's shape enum
-# has no single value for that composite, so the pattern is recorded in
-# the sibling index.json (``pattern: viewer``) and the shape stays
-# ``custom``. The view is READ-ONLY: no actions, no mutation. ``needs:
-# [paw.db.v1]`` declares the generic data-source capability a tenant wires
-# so the profile hydrates from a real member record; without one the
-# seeded sample member renders.
+# Template Schema metadata for the generic member-360 view.
+# Modified 2026-06-11 (feat/triage-redesign): DEMO-GRADE redesign of the
+# ripple_spec. The focal widget is now the catalog's ``entity-detail``
+# (the 'view one record' layout) — a hero header with a colored avatar
+# block, a tier eyebrow + status pill, a KPI strip (sessions / spend /
+# standing / last visit), and a right rail of key facts — wrapping a
+# balanced two-column body: profile + membership key-value tables side by
+# side, then the tickets / orders record grids and a notes timeline, so
+# nothing floats and there is no dead space below the fold. Every binding
+# is a flat ``{state.member.X}`` / ``{state.<list>}`` path. ``shape:
+# custom`` because the canvas is a composite — RFC 03's shape enum has no
+# single value for it, so the pattern is recorded in the sibling
+# index.json (``pattern: viewer``) and the shape stays ``custom``. The
+# view is READ-ONLY: no actions, no mutation. ``needs: [paw.db.v1]``
+# declares the generic data-source capability a tenant wires so the
+# profile hydrates from a real member record; without one the seeded
+# sample member renders.
 schema_version: "2"
 name: member-360
 version: 1.0.0
@@ -18,15 +25,16 @@ vertical: operations
 display_name: Member 360
 shape: custom
 description: |
-  A single-pane view of one member. A header with the member's name, tier,
-  and status; a key-value profile block; a membership panel showing the
-  package, renewal date, and standing; and three plain lists for recent
-  tickets, orders, and notes. A stat strip across the top carries the
-  headline counts — sessions attended and total spend. Read-only by design:
-  it shows the full picture of a member without offering any action. Ships a
-  placeholder live-data source so a connected backend hydrates the record
-  from a real member endpoint; with no backend it renders the seeded sample
-  member.
+  A single-pane profile of one member. A hero header carries the member's
+  name, a colored avatar block, the tier and status, a KPI strip with the
+  headline numbers — sessions attended, total spend, standing, last visit —
+  and a right rail of key facts. Below it, a balanced two-column body: the
+  profile and membership details as side-by-side key-value tables, then the
+  recent tickets and orders as record grids, and the account notes as a
+  timeline. Read-only by design: it shows the full picture of a member
+  without offering any action. Ships a placeholder live-data source so a
+  connected backend hydrates the record from a real member endpoint; with no
+  backend it renders the seeded sample member.
 icon: user
 color: "#6b8e6b"
 state:

--- a/tests/unit/test_vertical_templates.py
+++ b/tests/unit/test_vertical_templates.py
@@ -7,6 +7,18 @@
 # action-row gated-proposal wiring (triage), their read-only posture
 # (member-360), and a full service create() round-trip through the mongo
 # fixture so the install-time compile-on-create seam is exercised.
+# Modified 2026-06-11 (feat/triage-redesign): DEMO-GRADE redesign of both
+# vertical ripple_spec.json files. Updated the burndown assertion (the
+# triage burndown now renders color-banded status-dot count cards + a
+# queue-total / oldest-waiting stat, not literal `stat` widgets) and the
+# member-360 state-key assertion (`stats` -> `kpis`, focal widget is now
+# `entity-detail`). Added test_<slug>_bindings_reference_seeded_state — a
+# mechanical guard for the class of bug this redesign fixed: every
+# {state.X...} binding in a vertical template must reference a state key
+# that EXISTS in the seed state, so a detail panel can never bind to a
+# state shape that was never seeded (the old "empty Answers / no values"
+# failure). It also flags the unsupported method-chain-then-property
+# pattern ({...first().field}) that resolved to undefined at render time.
 """Tests for the bundled vertical templates (applications-triage, member-360).
 
 The seed-template field-set assertions in test_bundled_templates.py
@@ -29,6 +41,7 @@ This file owns their shape and behaviour:
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -64,6 +77,98 @@ def _iter_widgets(node: object):
     elif isinstance(node, list):
         for item in node:
             yield from _iter_widgets(item)
+
+
+# Matches a binding expression's root scope + first key, e.g. `state.selected`
+# in `{state.selected.applicant}` or `app` in `{app.score}`. Group 1 is the
+# scope (state / data / a loop variable), group 2 is the first key under it.
+_BINDING_RE = re.compile(r"\{\s*([a-zA-Z_][\w]*)\.([a-zA-Z_][\w]*)")
+
+# The Ripple expression engine resolves a method chain ONLY when the whole
+# chain ENDS in `)` (e.g. `{x.where('id', y).first()}`). A method call FOLLOWED
+# BY a PROPERTY access (`{...first().field}`) resolves to `undefined` — the
+# exact bug that left the old triage detail panel empty. This pattern flags a
+# `)` followed by `.<name>` where `<name>` is NOT itself a method call (i.e.
+# not followed by `(`): chaining another method (`.first()`) is fine; reaching
+# into a property (`.applicant`) after a method is the broken form.
+_CHAIN_THEN_PROP_RE = re.compile(r"\)\s*\.[a-zA-Z_]\w*(?![\w(])")
+
+
+def _iter_binding_strings(node: object):
+    """Yield every string that contains a `{...}` binding expression, anywhere
+    in the spec tree (prop values, `items`, `bind`, action `value`s, ...)."""
+    if isinstance(node, dict):
+        for value in node.values():
+            yield from _iter_binding_strings(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_binding_strings(item)
+    elif isinstance(node, str) and "{" in node:
+        yield node
+
+
+def _loop_variables(spec: dict) -> set[str]:
+    """Collect every `each` loop variable name (``item_as``) declared in the
+    spec — these are loop-local scopes, not seed-state keys, so a `{app.x}`
+    reference is satisfied by the loop, not by `state`."""
+    names = {"item", "index"}  # the renderer's implicit loop variables
+    for node in _iter_widgets(spec.get("ui", {})):
+        if node.get("type") == "each":
+            alias = node.get("item_as")
+            if isinstance(alias, str):
+                names.add(alias)
+            idx = node.get("index_as")
+            if isinstance(idx, str):
+                names.add(idx)
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Binding integrity — every {state.X} reference must hit a seeded state key.
+# This is the mechanical guard for the class of bug the DEMO-GRADE redesign
+# fixed: a detail panel that binds to a state shape which was never seeded
+# renders empty. Checkable for EVERY vertical template, not just the two here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slug", _VERTICAL_SLUGS)
+def test_vertical_template_bindings_reference_seeded_state(slug: str) -> None:
+    """Every `{state.<key>...}` binding in the ripple_spec references a key
+    that EXISTS in the seed `state`, and no binding uses the unsupported
+    method-chain-then-property pattern (`{...first().field}`) that resolves to
+    undefined at render time. Together these make the "empty detail panel /
+    no values" failure mechanically uncatchable-by-eye but catchable here."""
+    spec = _read_spec(slug)
+    seeded_state_keys = set(spec["state"].keys())
+    loop_vars = _loop_variables(spec)
+
+    bad_state_refs: list[tuple[str, str]] = []
+    chain_then_prop: list[str] = []
+
+    for raw in _iter_binding_strings(spec["ui"]):
+        # Flag the unsupported method-chain-then-property pattern outright.
+        if _CHAIN_THEN_PROP_RE.search(raw):
+            chain_then_prop.append(raw)
+        for scope, first_key in _BINDING_RE.findall(raw):
+            if scope == "state":
+                if first_key not in seeded_state_keys:
+                    bad_state_refs.append((raw, first_key))
+            elif scope in {"data"} or scope in loop_vars:
+                # data sources hydrate at runtime; loop vars are local scopes.
+                continue
+            else:
+                # An unknown root scope is itself a binding bug — it can only
+                # be state-relative or a declared loop variable.
+                bad_state_refs.append((raw, scope))
+
+    assert not bad_state_refs, (
+        f"{slug}: bindings reference state keys not in the seed state "
+        f"(or an undeclared loop scope): {bad_state_refs}"
+    )
+    assert not chain_then_prop, (
+        f"{slug}: bindings use the unsupported method-chain-then-property "
+        f"pattern (resolves to undefined at render): {chain_then_prop}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -175,12 +280,32 @@ def test_triage_action_row_proposes_not_executes() -> None:
 
 
 def test_triage_has_burndown_stat_row() -> None:
-    """The triage canvas carries a status-count burndown — an each-loop of
-    stat widgets over state.status_counts."""
+    """The triage canvas carries a status-count burndown — an each-loop over
+    state.status_counts rendering one color-banded count card per status, plus
+    a queue-total and oldest-waiting stat. The DEMO-GRADE redesign renders each
+    bucket as a colored status-dot + count (the `stat` widget has no color
+    prop), so the burndown is asserted by the each-loop over status_counts and
+    the status-dot color carriers, not by a literal `stat` node."""
     spec = _read_spec("applications-triage")
     assert "status_counts" in spec["state"]
-    stats = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "stat"]
-    assert stats, "burndown stat row missing"
+    # Each bucket carries a status color and a status-dot variant so the row
+    # reads as color-banded counts, not a flat number list.
+    for bucket in spec["state"]["status_counts"]:
+        assert bucket.get("color"), f"status bucket {bucket.get('label')} has no color"
+        assert bucket.get("dot"), f"status bucket {bucket.get('label')} has no status-dot variant"
+    # The headline stats the burndown strip adds beyond the per-status counts.
+    assert "queue_total" in spec["state"], "burndown is missing the total stat"
+    assert "oldest_waiting" in spec["state"], "burndown is missing the oldest-waiting stat"
+    # The colored status-dot is the per-status count carrier.
+    dots = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "status-dot"]
+    assert dots, "burndown color-banded status-dot row missing"
+    # The burndown is driven by an each-loop over status_counts.
+    eaches = [
+        w
+        for w in _iter_widgets(spec["ui"])
+        if w.get("type") == "each" and w.get("items") == "{state.status_counts}"
+    ]
+    assert eaches, "burndown each-loop over state.status_counts missing"
 
 
 # ---------------------------------------------------------------------------
@@ -200,13 +325,20 @@ def test_member_360_is_read_only() -> None:
 
 
 def test_member_360_has_profile_membership_and_lists() -> None:
-    """The member-360 state seeds the header member, the stat strip, the
-    key-value profile + membership blocks, and the three record lists."""
+    """The member-360 state seeds the header member, the entity-detail KPI
+    strip + facts rail, the key-value profile + membership blocks, and the
+    three record lists. The DEMO-GRADE redesign renders the headline numbers
+    through the entity-detail focal widget's ``kpis`` strip (renamed from the
+    flat ``stats`` list) and the facts through its right rail."""
     spec = _read_spec("member-360")
     state = spec["state"]
-    for key in ("member", "stats", "profile", "membership", "tickets", "orders", "notes"):
+    for key in ("member", "kpis", "facts", "profile", "membership", "tickets", "orders", "notes"):
         assert key in state, f"member-360 state missing {key}"
     assert state["member"]["name"]
+    # The focal widget is the catalog's "view one record" layout, so the header
+    # KPI strip and facts rail are bound, not hand-assembled stat tiles.
+    entity_details = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "entity-detail"]
+    assert entity_details, "member-360 should use the entity-detail focal widget"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this fixes

The triage pocket is the centerpiece of a client demo, and on the last live deploy it rendered as a bare wireframe: a flat list of names, a detail panel with an empty "Answers" section, and a floating "Details" card whose Score / Recommendation / Waiting labels had no values next to them — just a dangling "days". The verdict was "so basic". Member-360 had the same problem.

The empty values weren't missing data. They were a binding-shape mismatch, and once you see it the failure is obvious.

## The binding bug

The detail panel bound through expressions like:

```
{state.applications.where('id', state.selected_id).first().applicant}
```

Ripple's expression engine resolves a method chain only when the whole chain *ends* in `)`. A method call followed by a property access — `...first().applicant` — falls off the supported path and resolves to `undefined`. So the score, the recommendation, the waiting days, and the applicant name all came back blank. The Q&A list bound the same chain to an `each` loop, and `each` only resolves a flat dot-path from state, so it returned an empty array — that's the empty "Answers".

The fix denormalizes the selected row into a flat `state.selected` object. Every detail binding is now a plain `{state.selected.X}` path, and the Q&A and risk-flag loops read flat arrays. Clicking a queue card keeps `state.selected` in sync through a `set` whose value ends in `.first()` (a chain the engine does resolve), and the object is seeded to the first row so the panel is populated before anyone clicks.

## Before / after

**Triage — before:** name list, empty Answers header, a floating Details card with labels and no values, dead whitespace below the fold.

**Triage — after:** a decisions console where the agent's work is the loudest thing on screen.

```
 Applications                                          [Decision queue]
 ┌──────┬──────┬──────┬──────┬────────┬───────────────┐
 │● Pend│● Rev │● Appr│● Rej │In queue│ Oldest waiting │   burndown
 │  3   │  2   │  1   │  1   │   7    │    9 days      │   color-banded
 └──────┴──────┴──────┴──────┴────────┴───────────────┘
 QUEUE                          APPLICATION
 ┌─────────────────────┐  ┌──────────────────────────────────────┐
 │ Amara Okafor    [91] │  │ Amara Okafor          ╭────╮         │
 │ ████████████░ Strong │  │ Pending · Approve     │ 91 │ Strong  │
 │ referred by a member │  │ Waiting 2 days        ╰────╯         │
 │ [Pending]  2d waiting │  │ ┌─ Recommendation: Approve ───────┐ │
 ├─────────────────────┤  │ │ Referred by a member in good     │ │
 │ Marcus Webb     [23] │  │ │ standing, application complete...│ │
 │ ███░░░░░░░ High risk  │  │ └──────────────────────────────────┘ │
 │ blacklist match      │  │ Risk checks                          │
 │ [In review] 9d       │  │ [Background: clean][100% complete]   │
 └─────────────────────┘  │ Application answers                  │
                          │ How did you hear about us?           │
                          │ Referral from Tunde A., a member     │
                          │ ──────────────────────────────────── │
                          │ [Approve]  [Reject]  [Send to interview] │
                          └──────────────────────────────────────┘
```

**Member-360 — after:** leads with the `entity-detail` focal widget (colored avatar block, tier eyebrow, status pill, KPI strip, facts rail) over a balanced two-column body — profile and membership tables side by side, ticket and order grids, a notes timeline. No floating cards, no dead space.

## Demo-grade details

- Score and recommendation are the loudest elements: a score on every queue row (badge + color-banded bar), the recommendation as a colored callout with the agent's reasoning under it, and a score ring in the panel header.
- Seed data tells a story — varied scores 23–94, every applicant with a recommendation and two-to-three sentences of concrete reasoning, completeness and risk chips: one obvious approve, one blacklist-hit reject, two interviews.
- Status pills are colored per status; the action row still proposes (never executes) through the Instinct gate.

## Catalog notes worth upstreaming

Every widget and prop validates against the live Ripple manifest. Two small gaps I worked around rather than inventing widgets:

- `callout` has no `destructive` variant (only `info / success / warning / insight`), so a reject's reasoning callout uses `warning` and the red emphasis lives on the recommendation badge.
- `master-detail` renders fixed rows (label + badge, truncated) and can't carry a per-row score, so the queue is a custom each-loop of clickable cards instead.

## Tests

Existing template and pockets-service suites stay green; the assertions the redesign legitimately changed (burndown shape, `stats` → `kpis`) are updated. Adds a mechanical guard: every `{state.X}` binding in a vertical template must reference a seeded state key, and no binding may use the unsupported chain-then-property form — so this class of empty-panel bug is caught for every vertical template, not by eye. Verified it flags all four of the original broken bindings.

```
tests/unit/test_vertical_templates.py        ...  passed
tests/unit/test_bundled_templates.py         ...  passed (live manifest reachable: 9/9 validated, not skipped)
tests/cloud/pockets/test_vertical_template_create.py  ...  passed
346 passed across the pocket/template surface
```
