### PR TITLE
Give the SDK backend first-class Fabric and Instinct MCP servers

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/__init__.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/__init__.py
@@ -1,10 +1,38 @@
 """In-process MCP servers exposed to agent backends for cloud features.
 
+Updated: 2026-06-11 (feat/fabric-instinct-mcp-providers) — added the server
+surface listing below, plus the two new read-only servers (``fabric.py`` /
+``instinct.py``). On the claude_agent_sdk backend, registry tools (BaseTool)
+never reach the agent — only MCP servers do — so anything the cloud chat agent
+must touch needs a server here.
+
 Each module here builds a Claude Agent SDK ``create_sdk_mcp_server`` and is
 surfaced to core via a ``pocketpaw.mcp_servers`` ``McpServerProvider`` entry-
 point (see ``pocketpaw_ee.extensions``). Core discovers them through
 ``pocketpaw._registry`` and never imports this package directly — the OSS-EE
 boundary.
+
+Server surfaces (module → server name → tools):
+
+* ``belt.py`` → ``pocketpaw_belt`` → ``belt_propose_change`` (gated code change)
+* ``connectors.py`` → ``pocketpaw_connectors`` → connector listing + execution
+* ``decisions.py`` → ``pocketpaw_decisions`` → Decision-Graph queries
+* ``external_actions.py`` → ``pocketpaw_external_actions`` →
+  ``propose_external_action`` (gated connector call — the propose path for
+  this backend)
+* ``fabric.py`` → ``pocketpaw_fabric`` → ``fabric_query`` / ``fabric_stats``
+  (READ-ONLY ontology access, workspace-scoped)
+* ``foresight.py`` → ``pocketpaw_foresight`` → scenario save/run
+* ``instinct.py`` → ``pocketpaw_instinct`` → ``instinct_pending`` /
+  ``instinct_audit`` (READ-ONLY gate visibility, workspace-scoped; proposing
+  goes through ``pocketpaw_external_actions``)
+* ``loom.py`` → ``loom`` (stdio config) → codebase orientation reads
+* ``media.py`` → ``pocketpaw_media`` → ``image_generate`` / ``video_generate``
+* ``meetings.py`` → ``pocketpaw_meetings`` → meeting queries
+* ``planner.py`` → ``pocketpaw_planner`` (opt-in) + ``pocketpaw_pocket_planner``
+* ``pockets.py`` → ``pocketpaw_pocket`` → pocket context + widget pinning
+* ``sites.py`` / ``sites_create.py`` → ``pocketpaw_sites_manager`` → Paw Sites
+* ``tasks.py`` → ``pocketpaw_tasks`` → task CRUD
 
 Moved here from ``src/pocketpaw/agents/sdk_mcp_*.py`` in the OSS-EE split
 (Phase 3b): these servers are cloud-only (tasks, planner, pocket context),

--- a/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
@@ -1,0 +1,350 @@
+# fabric.py — in-process MCP server exposing read-only Fabric ontology access
+# to the claude_agent_sdk cloud chat backend. Created: 2026-06-11
+# (feat/fabric-instinct-mcp-providers).
+#
+# Why this exists: on the claude_agent_sdk backend, PocketPaw registry tools
+# (BaseTool) never reach the agent — only MCP servers do — and there was no
+# fabric MCP provider, so the cloud chat agent had ZERO path to the Fabric
+# ontology (a live deployment had to ship its own stdio workaround). This
+# module makes Fabric first-class on that backend.
+#
+# It clones the external_actions.py / belt.py shape — a single
+# ``create_sdk_mcp_server`` with an SDK import-guard, ``SERVER_NAME`` /
+# ``*_TOOL_ID`` allowlist constants, ContextVar-sourced identity (the same
+# ``current_workspace_id`` / ``current_user_id`` accessors in
+# ``ee.cloud.chat.agent_service`` the sibling servers read), and the
+# ``_error_response`` / ``_success_response`` helpers. The tool ids namespace
+# as ``mcp__pocketpaw_fabric__<tool>`` so the Claude Code allowlist machinery
+# matches them.
+#
+# Two SDK @tool defs, wrapping the existing registry-tool logic
+# (``pocketpaw.tools.builtin.fabric_tools``) — the tool NAMES are pinned
+# (``fabric_query`` / ``fabric_stats``): a deployed skill already calls them.
+#   * fabric_query — runs a FabricQuery against the fabric store, scoped to the
+#     caller's workspace (W4a read filter: the tenant's rows plus legacy
+#     NULL-workspace rows). Unlike the BaseTool (formatted text), results are
+#     returned JSON-friendly ({total, returned, truncated, objects}) and
+#     size-capped: the limit clamps to MAX_QUERY_LIMIT and oversized result
+#     sets are truncated from the tail under MAX_RESULT_BYTES.
+#   * fabric_stats — ontology counts + type names. NOTE: the store's ``stats``
+#     / ``list_types`` have no workspace scope yet — counts are instance-wide.
+#     Workspace identity is still required for parity with the sibling tools
+#     (and so a scoped stats can slot in without an interface change).
+#
+# Read-only: neither tool writes anything. FabricCreateTool is deliberately
+# NOT wrapped — ontology writes from the SDK backend should arrive as gated
+# proposals, not ambient writes.
+#
+# Security: query inputs are DATA — they are bound as SQL parameters by the
+# fabric store, never interpolated. The workspace id comes from the session's
+# ContextVars, never from the agent's args, so an agent cannot query another
+# tenant's rows. Result payloads are size-capped so a huge ontology can't blow
+# the model context.
+#
+# EE→OSS boundary: this module lives in pocketpaw_ee and imports only
+# ``pocketpaw`` (OSS) symbols at call time; core never imports this package.
+"""Agent-side MCP surface for read-only Fabric ontology access."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_fabric"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form. A deployed skill already calls
+# ``fabric_query`` / ``fabric_stats`` — keep the tool names stable.
+FABRIC_QUERY_TOOL_ID = f"mcp__{SERVER_NAME}__fabric_query"
+FABRIC_STATS_TOOL_ID = f"mcp__{SERVER_NAME}__fabric_stats"
+
+FABRIC_TOOL_IDS = (FABRIC_QUERY_TOOL_ID, FABRIC_STATS_TOOL_ID)
+
+# Result-size caps. ``MAX_QUERY_LIMIT`` mirrors the registry tool's clamp
+# (``min(limit, 50)``); ``MAX_RESULT_BYTES`` bounds the serialized JSON body so
+# a wide ontology row set can't blow the model context — objects are dropped
+# from the TAIL until the body fits, and the response says so (truncated=true).
+MAX_QUERY_LIMIT = 50
+MAX_RESULT_BYTES = 48 * 1024
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects. The agent
+    reads ``text`` and surfaces the reason."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None]:
+    """Resolve the active workspace + user from the per-stream ContextVars set
+    by the cloud chat agent runtime. Returns ``(workspace_id, user_id)``."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_user_id,
+            current_workspace_id,
+        )
+
+        return current_workspace_id(), current_user_id()
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+def _get_fabric_store() -> Any | None:
+    """Resolve the fabric store, or None when Fabric isn't available — the
+    same lazy-import guard the registry tools use."""
+    try:
+        from pocketpaw.stores import get_fabric_store
+
+        return get_fabric_store()
+    except ImportError:
+        return None
+
+
+def _serialize_object(obj: Any) -> dict[str, Any]:
+    """A JSON-friendly projection of a FabricObject — the fields the registry
+    tool's text rendering surfaces, structured."""
+    return {
+        "id": obj.id,
+        "type_name": obj.type_name,
+        "properties": dict(obj.properties or {}),
+        "source_connector": obj.source_connector,
+        "source_id": obj.source_id,
+    }
+
+
+def _cap_objects(objects: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
+    """Drop objects from the tail until the serialized list fits under
+    ``MAX_RESULT_BYTES``. Returns ``(kept, truncated)``."""
+    kept = list(objects)
+    truncated = False
+    while kept and len(json.dumps(kept, default=str).encode("utf-8")) > MAX_RESULT_BYTES:
+        kept.pop()
+        truncated = True
+    return kept, truncated
+
+
+async def _fabric_query_handler(args: dict) -> dict:
+    """MCP handler for ``fabric__fabric_query``.
+
+    Resolves identity, validates inputs, runs the FabricQuery scoped to the
+    caller's workspace, and returns ``{total, returned, truncated, objects}``.
+    Read-only — never writes. Errors return a plain relayable message.
+    """
+    workspace_id, _user_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "fabric_query requires workspace context (call from a cloud chat session)."
+        )
+
+    type_name = args.get("type_name")
+    linked_to = args.get("linked_to")
+    link_type = args.get("link_type")
+    filters = args.get("filters")
+    limit = args.get("limit", 20)
+
+    for field_name, value in (
+        ("type_name", type_name),
+        ("linked_to", linked_to),
+        ("link_type", link_type),
+    ):
+        if value is not None and not isinstance(value, str):
+            return _error_response(f"fabric_query `{field_name}` must be a string.")
+    if filters is not None and not isinstance(filters, dict):
+        return _error_response(
+            "fabric_query `filters` must be a JSON object mapping property names "
+            "to a scalar (equality) or an operator map (comparison)."
+        )
+    if not isinstance(limit, int) or limit < 1:
+        return _error_response("fabric_query `limit` must be a positive integer.")
+
+    store = _get_fabric_store()
+    if store is None:
+        return _error_response("Fabric is not available (enterprise feature).")
+
+    try:
+        from pocketpaw.fabric.models import FabricQuery
+
+        result = await store.query(
+            FabricQuery(
+                type_name=type_name,
+                linked_to=linked_to,
+                link_type=link_type,
+                filters=filters or {},
+                limit=min(limit, MAX_QUERY_LIMIT),
+            ),
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("fabric_query failed (type=%s)", type_name, exc_info=True)
+        return _error_response(f"could not query Fabric: {exc}")
+
+    # Best-effort trace emission — same telemetry the registry tool publishes
+    # (a no-op unless a proposal trace is actively collecting). Never fails the
+    # query response.
+    try:
+        from pocketpaw.tools.builtin.fabric_tools import _emit_trace_events
+
+        await _emit_trace_events(
+            "fabric_query",
+            [{"object_id": o.id, "object_type": o.type_name} for o in result.objects],
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break the read
+        logger.debug("fabric_query trace emission skipped", exc_info=True)
+
+    objects = [_serialize_object(o) for o in result.objects]
+    objects, truncated = _cap_objects(objects)
+
+    return _success_response(
+        {
+            "total": result.total,
+            "returned": len(objects),
+            "truncated": truncated,
+            "objects": objects,
+        }
+    )
+
+
+async def _fabric_stats_handler(args: dict) -> dict:
+    """MCP handler for ``fabric__fabric_stats``.
+
+    Returns ontology counts + type names: ``{types, objects, links,
+    type_names}``. Read-only. NOTE: the store's stats are instance-wide (no
+    workspace-scoped stats yet); identity is still required for parity with
+    the sibling tools.
+    """
+    workspace_id, _user_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "fabric_stats requires workspace context (call from a cloud chat session)."
+        )
+
+    store = _get_fabric_store()
+    if store is None:
+        return _error_response("Fabric is not available (enterprise feature).")
+
+    try:
+        stats = await store.stats()
+        types = await store.list_types()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("fabric_stats failed", exc_info=True)
+        return _error_response(f"could not read Fabric stats: {exc}")
+
+    return _success_response(
+        {
+            "types": stats.get("types", 0),
+            "objects": stats.get("objects", 0),
+            "links": stats.get("links", 0),
+            "type_names": [t.name for t in types],
+        }
+    )
+
+
+def build_fabric_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for read-only Fabric access, or
+    return ``None`` if the Claude Agent SDK isn't installed.
+
+    Matches the shape returned by ``build_belt_server`` (``(name, server)`` or
+    ``None``) so the backend's MCP registration loop treats it identically.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_fabric MCP disabled")
+        return None
+
+    @tool(
+        "fabric_query",
+        (
+            "Query the Fabric ontology to find business objects and their "
+            "relationships. Search by object type (e.g. 'Customer', 'Order'), "
+            "filter by property values, or traverse links between objects. "
+            "READ-ONLY — never creates or modifies anything. Results are scoped "
+            "to the current workspace. Args: `type_name` (object type to "
+            "search), `linked_to` (find objects linked to this object id), "
+            "`link_type` (filter links by type), `filters` (property filters — "
+            'a scalar for equality or an operator map like {"rent": {">": '
+            "1000}}), `limit` (max results, default 20, cap 50). Returns "
+            "{total, returned, truncated, objects:[{id, type_name, properties, "
+            "source_connector, source_id}]}. An error means relay the reason."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "type_name": {
+                    "type": "string",
+                    "description": "Object type to search (e.g. 'Customer', 'Order').",
+                },
+                "linked_to": {
+                    "type": "string",
+                    "description": "Find objects linked to this object ID.",
+                },
+                "link_type": {
+                    "type": "string",
+                    "description": "Filter links by type (e.g. 'has_order', 'belongs_to').",
+                },
+                "filters": {
+                    "type": "object",
+                    "description": (
+                        "Filter objects by property values. Scalar = equality; "
+                        "operator map = comparison (=, !=, >, >=, <, <=)."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (default 20, cap 50).",
+                },
+            },
+            "additionalProperties": False,
+        },
+    )
+    async def fabric_query(args):  # type: ignore[no-untyped-def]
+        return await _fabric_query_handler(args)
+
+    @tool(
+        "fabric_stats",
+        (
+            "Get statistics about the Fabric ontology: number of object types, "
+            "objects, and links, plus the list of type names. READ-ONLY. Takes "
+            "no arguments. Returns {types, objects, links, type_names}. An "
+            "error means relay the reason."
+        ),
+        {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    )
+    async def fabric_stats(args):  # type: ignore[no-untyped-def]
+        return await _fabric_stats_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[fabric_query, fabric_stats],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "FABRIC_QUERY_TOOL_ID",
+    "FABRIC_STATS_TOOL_ID",
+    "FABRIC_TOOL_IDS",
+    "SERVER_NAME",
+    "build_fabric_server",
+]

--- a/ee/pocketpaw_ee/agent/mcp_servers/instinct.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/instinct.py
@@ -1,0 +1,331 @@
+# instinct.py — in-process MCP server exposing read-only Instinct gate
+# visibility to the claude_agent_sdk cloud chat backend. Created: 2026-06-11
+# (feat/fabric-instinct-mcp-providers).
+#
+# Why this exists: on the claude_agent_sdk backend, PocketPaw registry tools
+# (BaseTool) never reach the agent — only MCP servers do — and there was no
+# instinct MCP provider, so the cloud chat agent had ZERO path to the Instinct
+# gate (a live deployment had to ship its own stdio workaround). This module
+# makes gate VISIBILITY first-class on that backend.
+#
+# It clones the external_actions.py / belt.py shape — a single
+# ``create_sdk_mcp_server`` with an SDK import-guard, ``SERVER_NAME`` /
+# ``*_TOOL_ID`` allowlist constants, ContextVar-sourced identity (the same
+# ``current_workspace_id`` / ``current_user_id`` accessors in
+# ``ee.cloud.chat.agent_service`` the sibling servers read), and the
+# ``_error_response`` / ``_success_response`` helpers. The tool ids namespace
+# as ``mcp__pocketpaw_instinct__<tool>`` so the Claude Code allowlist machinery
+# matches them.
+#
+# Two SDK @tool defs, wrapping the existing registry-tool logic
+# (``pocketpaw.tools.builtin.instinct_tools``):
+#   * instinct_pending — list actions awaiting human approval, scoped to the
+#     caller's workspace (W4a read filter). JSON-friendly, size-capped.
+#   * instinct_audit — query the decision audit log (approvals, rejections,
+#     proposals), workspace-scoped, limit-capped. JSON-friendly, size-capped.
+#
+# READ-ONLY — gate visibility only. InstinctProposeTool is deliberately NOT
+# wrapped: gated proposing on the SDK backend goes through the
+# ``pocketpaw_external_actions`` server (``propose_external_action``), which
+# files a structured, executor-backed ``_external_action`` blob instead of a
+# free-text Action. Neither tool here approves, rejects, executes, or proposes
+# anything.
+#
+# Security: query inputs are bound as SQL parameters by the instinct store,
+# never interpolated. The workspace id comes from the session's ContextVars,
+# never from the agent's args, so an agent cannot read another tenant's
+# pending queue or audit trail. Result payloads are size-capped so a large
+# queue can't blow the model context. Action ``parameters`` blobs (which can
+# carry diffs / call params) are NOT serialized — only gate-surface fields.
+#
+# EE→OSS boundary: this module lives in pocketpaw_ee and imports only
+# ``pocketpaw`` (OSS) symbols at call time; core never imports this package.
+"""Agent-side MCP surface for read-only Instinct gate visibility."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_instinct"
+# Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
+# Allowlist entries must use this exact form — keep the ids stable.
+INSTINCT_PENDING_TOOL_ID = f"mcp__{SERVER_NAME}__instinct_pending"
+INSTINCT_AUDIT_TOOL_ID = f"mcp__{SERVER_NAME}__instinct_audit"
+
+INSTINCT_TOOL_IDS = (INSTINCT_PENDING_TOOL_ID, INSTINCT_AUDIT_TOOL_ID)
+
+# Result-size caps. ``MAX_AUDIT_LIMIT`` mirrors the registry tool's clamp
+# (``min(limit, 50)``); ``MAX_RESULT_BYTES`` bounds the serialized JSON body so
+# a deep queue / audit trail can't blow the model context — rows are dropped
+# from the TAIL until the body fits, and the response says so (truncated=true).
+MAX_AUDIT_LIMIT = 50
+MAX_RESULT_BYTES = 48 * 1024
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    """Build an MCP error response in the shape Claude's SDK expects. The agent
+    reads ``text`` and surfaces the reason."""
+    return {
+        "content": [{"type": "text", "text": f"Error: {message}"}],
+        "is_error": True,
+    }
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    """Build an MCP success response carrying ``body`` as JSON."""
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(body, separators=(",", ":"), default=str),
+            }
+        ]
+    }
+
+
+def _identity() -> tuple[str | None, str | None]:
+    """Resolve the active workspace + user from the per-stream ContextVars set
+    by the cloud chat agent runtime. Returns ``(workspace_id, user_id)``."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_user_id,
+            current_workspace_id,
+        )
+
+        return current_workspace_id(), current_user_id()
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+def _get_instinct_store() -> Any | None:
+    """Resolve the instinct store, or None when Instinct isn't available — the
+    same lazy-import guard the registry tools use."""
+    try:
+        from pocketpaw.stores import get_instinct_store
+
+        return get_instinct_store()
+    except ImportError:
+        return None
+
+
+def _serialize_action(action: Any) -> dict[str, Any]:
+    """A JSON-friendly projection of a pending Action — gate-surface fields
+    only. The ``parameters`` blob (which can carry diffs / call params) is
+    deliberately NOT serialized."""
+    return {
+        "id": action.id,
+        "title": action.title,
+        "recommendation": action.recommendation,
+        "priority": action.priority.value,
+        "category": action.category.value,
+        "status": action.status.value,
+        "pocket_id": action.pocket_id,
+        "assignee": action.assignee,
+        "created_at": action.created_at,
+    }
+
+
+def _serialize_audit_entry(entry: Any) -> dict[str, Any]:
+    """A JSON-friendly projection of an AuditEntry — the fields the registry
+    tool's text rendering surfaces, structured."""
+    return {
+        "id": entry.id,
+        "action_id": entry.action_id,
+        "pocket_id": entry.pocket_id,
+        "timestamp": entry.timestamp,
+        "actor": entry.actor,
+        "event": entry.event,
+        "category": entry.category.value,
+        "description": entry.description,
+        "ai_recommendation": entry.ai_recommendation,
+        "outcome": entry.outcome,
+    }
+
+
+def _cap_rows(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
+    """Drop rows from the tail until the serialized list fits under
+    ``MAX_RESULT_BYTES``. Returns ``(kept, truncated)``."""
+    kept = list(rows)
+    truncated = False
+    while kept and len(json.dumps(kept, default=str).encode("utf-8")) > MAX_RESULT_BYTES:
+        kept.pop()
+        truncated = True
+    return kept, truncated
+
+
+async def _instinct_pending_handler(args: dict) -> dict:
+    """MCP handler for ``instinct__instinct_pending``.
+
+    Resolves identity, then lists actions pending human approval scoped to the
+    caller's workspace. Returns ``{count, returned, truncated, actions}``.
+    Read-only — never approves, rejects, executes, or proposes anything.
+    """
+    workspace_id, _user_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "instinct_pending requires workspace context (call from a cloud chat session)."
+        )
+
+    pocket_id = args.get("pocket_id")
+    if pocket_id is not None and not isinstance(pocket_id, str):
+        return _error_response("instinct_pending `pocket_id` must be a string.")
+
+    store = _get_instinct_store()
+    if store is None:
+        return _error_response("Instinct is not available (enterprise feature).")
+
+    try:
+        pending = await store.pending(pocket_id=pocket_id, workspace_id=workspace_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("instinct_pending failed", exc_info=True)
+        return _error_response(f"could not read pending actions: {exc}")
+
+    actions = [_serialize_action(a) for a in pending]
+    actions, truncated = _cap_rows(actions)
+
+    return _success_response(
+        {
+            "count": len(pending),
+            "returned": len(actions),
+            "truncated": truncated,
+            "actions": actions,
+        }
+    )
+
+
+async def _instinct_audit_handler(args: dict) -> dict:
+    """MCP handler for ``instinct__instinct_audit``.
+
+    Resolves identity, then queries the decision audit log scoped to the
+    caller's workspace. Returns ``{count, returned, truncated, entries}``.
+    Read-only.
+    """
+    workspace_id, _user_id = _identity()
+    if not workspace_id:
+        return _error_response(
+            "instinct_audit requires workspace context (call from a cloud chat session)."
+        )
+
+    pocket_id = args.get("pocket_id")
+    limit = args.get("limit", 10)
+    if pocket_id is not None and not isinstance(pocket_id, str):
+        return _error_response("instinct_audit `pocket_id` must be a string.")
+    if not isinstance(limit, int) or limit < 1:
+        return _error_response("instinct_audit `limit` must be a positive integer.")
+
+    store = _get_instinct_store()
+    if store is None:
+        return _error_response("Instinct is not available (enterprise feature).")
+
+    try:
+        entries = await store.query_audit(
+            pocket_id=pocket_id,
+            limit=min(limit, MAX_AUDIT_LIMIT),
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("instinct_audit failed", exc_info=True)
+        return _error_response(f"could not read the audit log: {exc}")
+
+    rows = [_serialize_audit_entry(e) for e in entries]
+    rows, truncated = _cap_rows(rows)
+
+    return _success_response(
+        {
+            "count": len(entries),
+            "returned": len(rows),
+            "truncated": truncated,
+            "entries": rows,
+        }
+    )
+
+
+def build_instinct_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for read-only Instinct gate
+    visibility, or return ``None`` if the Claude Agent SDK isn't installed.
+
+    Matches the shape returned by ``build_belt_server`` (``(name, server)`` or
+    ``None``) so the backend's MCP registration loop treats it identically.
+    """
+    try:
+        from claude_agent_sdk import create_sdk_mcp_server, tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; pocketpaw_instinct MCP disabled")
+        return None
+
+    @tool(
+        "instinct_pending",
+        (
+            "List actions pending HUMAN APPROVAL in the Instinct gate (The "
+            "Tray), scoped to the current workspace. READ-ONLY — this does not "
+            "approve, reject, execute, or propose anything; use it to tell the "
+            "user what's waiting on their decision. To PROPOSE a gated external "
+            "call, use propose_external_action instead. Args: `pocket_id` "
+            "(optional filter). Returns {count, returned, truncated, actions:"
+            "[{id, title, recommendation, priority, category, status, "
+            "pocket_id, assignee, created_at}]}. An error means relay the "
+            "reason."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "description": "Filter by pocket (optional).",
+                },
+            },
+            "additionalProperties": False,
+        },
+    )
+    async def instinct_pending(args):  # type: ignore[no-untyped-def]
+        return await _instinct_pending_handler(args)
+
+    @tool(
+        "instinct_audit",
+        (
+            "Query the Instinct decision audit log — recent proposals, "
+            "approvals, rejections, and system events — scoped to the current "
+            "workspace. READ-ONLY; useful for compliance questions and 'what "
+            "happened' summaries. Args: `pocket_id` (optional filter), `limit` "
+            "(max entries, default 10, cap 50). Returns {count, returned, "
+            "truncated, entries:[{id, action_id, pocket_id, timestamp, actor, "
+            "event, category, description, ai_recommendation, outcome}]}. An "
+            "error means relay the reason."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "description": "Filter by pocket (optional).",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max entries (default 10, cap 50).",
+                },
+            },
+            "additionalProperties": False,
+        },
+    )
+    async def instinct_audit(args):  # type: ignore[no-untyped-def]
+        return await _instinct_audit_handler(args)
+
+    server = create_sdk_mcp_server(
+        name=SERVER_NAME,
+        version="1.0.0",
+        tools=[instinct_pending, instinct_audit],
+    )
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "INSTINCT_AUDIT_TOOL_ID",
+    "INSTINCT_PENDING_TOOL_ID",
+    "INSTINCT_TOOL_IDS",
+    "SERVER_NAME",
+    "build_instinct_server",
+]

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -58,6 +58,17 @@ agent proposes a connector call through Instinct; the ee instinct router fires
 ``ee.cloud.external_actions.executor.execute_approved_external_action`` on
 approval. Propose-only — the tool never fires the connector itself. Ambient
 (not opt-in).
+
+Updated: 2026-06-11 (feat/fabric-instinct-mcp-providers) — added
+``CloudFabricMcpProvider`` (entry ``fabric``; server ``pocketpaw_fabric``,
+tools ``fabric_query`` / ``fabric_stats``) and ``CloudInstinctMcpProvider``
+(entry ``instinct``; server ``pocketpaw_instinct``, tools ``instinct_pending``
+/ ``instinct_audit``), both mirroring ``CloudExternalActionsMcpProvider``. On
+the claude_agent_sdk backend, registry tools (BaseTool) never reach the agent —
+only MCP servers do — so without these the cloud chat agent had no path to the
+Fabric ontology or Instinct gate visibility. Both are READ-ONLY and
+workspace-scoped via the chat ContextVars. Gated proposing stays on
+``pocketpaw_external_actions``. Ambient (not opt-in).
 """
 
 from __future__ import annotations
@@ -738,6 +749,72 @@ class CloudExternalActionsMcpProvider:
         )
 
         return list(EXTERNAL_ACTIONS_TOOL_IDS)
+
+
+class CloudFabricMcpProvider:
+    """`pocketpaw.mcp_servers` — read-only Fabric ontology access in-process
+    server (``pocketpaw_fabric``). Hosts ``fabric_query`` + ``fabric_stats``.
+
+    On the claude_agent_sdk backend, registry tools (BaseTool) never reach the
+    agent — only MCP servers do — so this server is the cloud chat agent's only
+    path to the Fabric ontology. Both tools are READ-ONLY and workspace-scoped
+    via the chat ContextVars; ontology writes from this backend should arrive
+    as gated proposals, never ambient writes.
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — surfaces scope access via their
+    profile allowlist, the same regime the sibling belt / external-actions /
+    media servers use. ``build_fabric_server`` returns None — and the loop
+    skips it — when the claude_agent_sdk isn't installed, so chat never breaks.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.fabric import build_fabric_server
+
+            return build_fabric_server()
+        except ImportError:
+            # claude_agent_sdk not installed — the server is unavailable, same as
+            # the other in-process servers.
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.fabric import FABRIC_TOOL_IDS
+
+        return list(FABRIC_TOOL_IDS)
+
+
+class CloudInstinctMcpProvider:
+    """`pocketpaw.mcp_servers` — read-only Instinct gate visibility in-process
+    server (``pocketpaw_instinct``). Hosts ``instinct_pending`` +
+    ``instinct_audit``.
+
+    On the claude_agent_sdk backend, registry tools (BaseTool) never reach the
+    agent — only MCP servers do — so this server is the cloud chat agent's only
+    view into the Instinct gate (pending approvals + the decision audit log).
+    READ-ONLY: it never approves, rejects, executes, or proposes. Gated
+    proposing on this backend goes through ``pocketpaw_external_actions``
+    (``propose_external_action``), not a wrapped InstinctProposeTool.
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — surfaces scope access via their
+    profile allowlist, the same regime the sibling belt / external-actions /
+    media servers use. ``build_instinct_server`` returns None — and the loop
+    skips it — when the claude_agent_sdk isn't installed, so chat never breaks.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.instinct import build_instinct_server
+
+            return build_instinct_server()
+        except ImportError:
+            # claude_agent_sdk not installed — the server is unavailable, same as
+            # the other in-process servers.
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.instinct import INSTINCT_TOOL_IDS
+
+        return list(INSTINCT_TOOL_IDS)
 
 
 class CloudAgentExtension:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -199,6 +199,8 @@ media = "pocketpaw_ee.extensions:CloudMediaMcpProvider"
 loom = "pocketpaw_ee.extensions:CloudLoomMcpProvider"
 belt = "pocketpaw_ee.extensions:CloudBeltMcpProvider"
 external_actions = "pocketpaw_ee.extensions:CloudExternalActionsMcpProvider"
+fabric = "pocketpaw_ee.extensions:CloudFabricMcpProvider"
+instinct = "pocketpaw_ee.extensions:CloudInstinctMcpProvider"
 
 [project.entry-points."pocketpaw.agent_extensions"]
 cloud = "pocketpaw_ee.extensions:CloudAgentExtension"

--- a/tests/cloud/test_fabric_mcp.py
+++ b/tests/cloud/test_fabric_mcp.py
@@ -1,0 +1,266 @@
+# tests/cloud/test_fabric_mcp.py — the agent-facing MCP surface for read-only
+# Fabric ontology access (feat/fabric-instinct-mcp-providers).
+#
+# Created: 2026-06-11 (feat/fabric-instinct-mcp-providers).
+#
+# What this pins — the MCP tools, driven through the REAL handlers against a
+# tmp-file FabricStore:
+#   * tool-id / server-name contract (SERVER_NAME, *_TOOL_ID, *_TOOL_IDS —
+#     fabric_query / fabric_stats names are pinned: a deployed skill calls them).
+#   * the provider exposes the server + tool ids (extensions wiring).
+#   * fabric_query resolves the workspace from ContextVars, runs the query
+#     scoped to it (W4a: own rows + legacy NULL rows, never another tenant's),
+#     forwards property filters, clamps the limit, and returns JSON-friendly
+#     {total, returned, truncated, objects}.
+#   * fabric_stats returns {types, objects, links, type_names}.
+#   * results are size-capped: an oversized object list is truncated from the
+#     tail and flagged truncated=true.
+#   * error relaying: bad input types refuse cleanly; a store failure returns a
+#     plain relayable error; missing identity refuses.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The handlers read
+# identity through ee.cloud.chat.agent_service ContextVars (set in-test via
+# attach_agent_identity) and the store through pocketpaw.stores.get_fabric_store
+# (patched to a tmp-file store so nothing touches ~/.pocketpaw/fabric.db).
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+import pocketpaw_ee.agent.mcp_servers.fabric as fabric_mcp  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.extensions import CloudFabricMcpProvider  # noqa: E402
+
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> FabricStore:
+    """Isolated FabricStore on a tmp file, wired in where the handlers read it
+    (``pocketpaw.stores.get_fabric_store``)."""
+    st = FabricStore(tmp_path / "fabric_mcp_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda: st)
+    return st
+
+
+async def _seed_customers(store: FabricStore) -> list[str]:
+    """Define a Customer type and create three objects: two in workspace w1,
+    one in workspace w2. Returns the w1 object ids."""
+    obj_type = await store.define_type(name="Customer", properties=[])
+    a = await store.create_object(
+        type_id=obj_type.id,
+        properties={"name": "Acme", "status": "active", "mrr": 100},
+        workspace_id="w1",
+    )
+    b = await store.create_object(
+        type_id=obj_type.id,
+        properties={"name": "Bolt", "status": "churned", "mrr": 50},
+        workspace_id="w1",
+    )
+    await store.create_object(
+        type_id=obj_type.id,
+        properties={"name": "Other-Tenant", "status": "active", "mrr": 999},
+        workspace_id="w2",
+    )
+    return [a.id, b.id]
+
+
+class _identity:
+    """Context manager that sets the workspace/user/session ContextVars the
+    handlers read, then resets them."""
+
+    def __init__(self, *, workspace="w1", user="u1", session="sess-1"):
+        self._ws, self._user, self._sess = workspace, user, session
+        self._tokens = None
+
+    def __enter__(self):
+        self._tokens = attach_agent_identity(
+            workspace_id=self._ws, user_id=self._user, session_mongo_id=self._sess
+        )
+        return self
+
+    def __exit__(self, *exc):
+        detach_agent_identity(self._tokens)
+        return False
+
+
+async def _result_body(res: dict) -> dict:
+    """Parse the JSON body out of a success MCP response."""
+    assert res.get("is_error") is not True, res
+    return json.loads(res["content"][0]["text"])
+
+
+# ---------------------------------------------------------------------------
+# tool-id / provider contract pins
+# ---------------------------------------------------------------------------
+
+
+def test_tool_id_contract_pin() -> None:
+    """The server + tool ids are the exact namespaced strings the allowlist
+    machinery (and a deployed skill) match."""
+    assert fabric_mcp.SERVER_NAME == "pocketpaw_fabric"
+    assert fabric_mcp.FABRIC_QUERY_TOOL_ID == "mcp__pocketpaw_fabric__fabric_query"
+    assert fabric_mcp.FABRIC_STATS_TOOL_ID == "mcp__pocketpaw_fabric__fabric_stats"
+    assert fabric_mcp.FABRIC_TOOL_IDS == (
+        "mcp__pocketpaw_fabric__fabric_query",
+        "mcp__pocketpaw_fabric__fabric_stats",
+    )
+
+
+def test_provider_exposes_server_and_tool_ids() -> None:
+    """The extensions provider builds the server and reports the tool ids — the
+    pocketpaw.mcp_servers registration loop reads both."""
+    provider = CloudFabricMcpProvider()
+    assert provider.tool_ids() == list(fabric_mcp.FABRIC_TOOL_IDS)
+
+    built = provider.build_server()
+    if built is not None:
+        name, server = built
+        assert name == "pocketpaw_fabric"
+        assert server is not None
+
+
+# ---------------------------------------------------------------------------
+# fabric_query — the REAL read path
+# ---------------------------------------------------------------------------
+
+
+async def test_query_returns_workspace_scoped_objects(store):
+    """Objects come back JSON-friendly and scoped to the caller's workspace —
+    another tenant's rows never appear."""
+    w1_ids = await _seed_customers(store)
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_query_handler({"type_name": "Customer"})
+
+    body = await _result_body(res)
+    assert body["total"] == 2
+    assert body["returned"] == 2
+    assert body["truncated"] is False
+    got_ids = {o["id"] for o in body["objects"]}
+    assert got_ids == set(w1_ids)
+    names = {o["properties"]["name"] for o in body["objects"]}
+    assert names == {"Acme", "Bolt"}
+    assert "Other-Tenant" not in names
+    for o in body["objects"]:
+        assert o["type_name"] == "Customer"
+
+
+async def test_query_forwards_filters(store):
+    """Property filters reach the store — only matching objects return."""
+    await _seed_customers(store)
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_query_handler(
+            {"type_name": "Customer", "filters": {"status": "active"}}
+        )
+
+    body = await _result_body(res)
+    assert body["total"] == 1
+    assert body["objects"][0]["properties"]["name"] == "Acme"
+
+
+async def test_query_clamps_limit(store):
+    """A limit over the cap is clamped, not refused."""
+    await _seed_customers(store)
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_query_handler({"type_name": "Customer", "limit": 10_000})
+
+    body = await _result_body(res)
+    assert body["returned"] <= fabric_mcp.MAX_QUERY_LIMIT
+
+
+async def test_query_truncates_oversized_results(store, monkeypatch):
+    """An object list over the byte budget is truncated from the tail and
+    flagged — the agent sees truncated=true instead of a blown context."""
+    await _seed_customers(store)
+    monkeypatch.setattr(fabric_mcp, "MAX_RESULT_BYTES", 80)
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_query_handler({"type_name": "Customer"})
+
+    body = await _result_body(res)
+    assert body["truncated"] is True
+    assert body["returned"] < body["total"]
+
+
+# ---------------------------------------------------------------------------
+# fabric_stats
+# ---------------------------------------------------------------------------
+
+
+async def test_stats_returns_counts_and_type_names(store):
+    """Stats come back JSON-friendly with counts + type names."""
+    await _seed_customers(store)
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_stats_handler({})
+
+    body = await _result_body(res)
+    assert body["types"] == 1
+    assert body["objects"] == 3  # instance-wide — the store has no scoped stats yet
+    assert body["type_names"] == ["Customer"]
+    assert "links" in body
+
+
+# ---------------------------------------------------------------------------
+# workspace resolution + error relaying
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "handler,args",
+    [
+        (fabric_mcp._fabric_query_handler, {"type_name": "Customer"}),
+        (fabric_mcp._fabric_stats_handler, {}),
+    ],
+)
+async def test_identity_missing_errors(store, handler, args):
+    """Called without workspace ContextVars → an explicit error."""
+    res = await handler(args)
+    assert res.get("is_error") is True
+    assert "workspace context" in res["content"][0]["text"]
+
+
+@pytest.mark.parametrize(
+    "args,needle",
+    [
+        ({"type_name": 42}, "`type_name`"),
+        ({"filters": "not-an-object"}, "`filters`"),
+        ({"limit": 0}, "`limit`"),
+        ({"limit": "ten"}, "`limit`"),
+    ],
+)
+async def test_bad_input_refused(store, args, needle):
+    """Malformed inputs refuse cleanly with the offending field named."""
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_query_handler(args)
+    assert res.get("is_error") is True
+    assert needle in res["content"][0]["text"]
+
+
+async def test_store_error_is_relayed(store, monkeypatch):
+    """A store failure is relayed as a plain error, not a crash."""
+
+    class _Boom:
+        async def query(self, q, workspace_id=None):
+            raise RuntimeError("fabric db is locked")
+
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda: _Boom())
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_query_handler({"type_name": "Customer"})
+    assert res.get("is_error") is True
+    assert "fabric db is locked" in res["content"][0]["text"]

--- a/tests/cloud/test_instinct_mcp.py
+++ b/tests/cloud/test_instinct_mcp.py
@@ -1,0 +1,307 @@
+# tests/cloud/test_instinct_mcp.py — the agent-facing MCP surface for read-only
+# Instinct gate visibility (feat/fabric-instinct-mcp-providers).
+#
+# Created: 2026-06-11 (feat/fabric-instinct-mcp-providers).
+#
+# What this pins — the MCP tools, driven through the REAL handlers against a
+# tmp-file InstinctStore:
+#   * tool-id / server-name contract (SERVER_NAME, *_TOOL_ID, *_TOOL_IDS).
+#   * the provider exposes the server + tool ids (extensions wiring).
+#   * instinct_pending resolves the workspace from ContextVars and lists the
+#     tenant's pending actions only (W4a scope) — JSON-friendly gate-surface
+#     fields, and the Action ``parameters`` blob (diffs / call params) is NOT
+#     serialized.
+#   * instinct_audit returns the workspace's audit entries, clamps the limit,
+#     JSON-friendly.
+#   * results are size-capped: an oversized list is truncated from the tail and
+#     flagged truncated=true.
+#   * READ-ONLY pin: the module exposes exactly the two read tools — no
+#     propose/approve/reject/execute surface (proposing goes through
+#     pocketpaw_external_actions).
+#   * error relaying: bad input types refuse cleanly; a store failure returns a
+#     plain relayable error; missing identity refuses.
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The handlers read
+# identity through ee.cloud.chat.agent_service ContextVars (set in-test via
+# attach_agent_identity) and the store through pocketpaw.stores.get_instinct_store
+# (patched to a tmp-file store so nothing touches ~/.pocketpaw/instinct.db).
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+import pocketpaw_ee.agent.mcp_servers.instinct as instinct_mcp  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.extensions import CloudInstinctMcpProvider  # noqa: E402
+
+from pocketpaw.instinct.models import ActionTrigger  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired in where the handlers read
+    it (``pocketpaw.stores.get_instinct_store``)."""
+    st = InstinctStore(tmp_path / "instinct_mcp_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+async def _seed_actions(store: InstinctStore) -> list[str]:
+    """Propose three actions: two in workspace w1 (one carrying a parameters
+    blob), one in workspace w2. Returns the w1 action ids."""
+    trigger = ActionTrigger(type="agent", source="test", reason="seed")
+    a = await store.propose(
+        pocket_id="p1",
+        title="Reorder oat milk",
+        description="stock is low",
+        recommendation="Order 20 units",
+        trigger=trigger,
+        workspace_id="w1",
+    )
+    b = await store.propose(
+        pocket_id="p2",
+        title="Flag invoice",
+        description="amount looks off",
+        recommendation="Hold for review",
+        trigger=trigger,
+        parameters={"_external_action": {"params": {"secret_payload": True}}},
+        workspace_id="w1",
+    )
+    await store.propose(
+        pocket_id="p9",
+        title="Other tenant action",
+        description="not ours",
+        recommendation="Should never be visible",
+        trigger=trigger,
+        workspace_id="w2",
+    )
+    return [a.id, b.id]
+
+
+class _identity:
+    """Context manager that sets the workspace/user/session ContextVars the
+    handlers read, then resets them."""
+
+    def __init__(self, *, workspace="w1", user="u1", session="sess-1"):
+        self._ws, self._user, self._sess = workspace, user, session
+        self._tokens = None
+
+    def __enter__(self):
+        self._tokens = attach_agent_identity(
+            workspace_id=self._ws, user_id=self._user, session_mongo_id=self._sess
+        )
+        return self
+
+    def __exit__(self, *exc):
+        detach_agent_identity(self._tokens)
+        return False
+
+
+async def _result_body(res: dict) -> dict:
+    """Parse the JSON body out of a success MCP response."""
+    assert res.get("is_error") is not True, res
+    return json.loads(res["content"][0]["text"])
+
+
+# ---------------------------------------------------------------------------
+# tool-id / provider contract pins
+# ---------------------------------------------------------------------------
+
+
+def test_tool_id_contract_pin() -> None:
+    """The server + tool ids are the exact namespaced strings the allowlist
+    machinery matches."""
+    assert instinct_mcp.SERVER_NAME == "pocketpaw_instinct"
+    assert instinct_mcp.INSTINCT_PENDING_TOOL_ID == "mcp__pocketpaw_instinct__instinct_pending"
+    assert instinct_mcp.INSTINCT_AUDIT_TOOL_ID == "mcp__pocketpaw_instinct__instinct_audit"
+    assert instinct_mcp.INSTINCT_TOOL_IDS == (
+        "mcp__pocketpaw_instinct__instinct_pending",
+        "mcp__pocketpaw_instinct__instinct_audit",
+    )
+
+
+def test_read_only_surface_pin() -> None:
+    """The server exposes exactly the two READ tools — no propose / approve /
+    reject / execute surface. Gated proposing on this backend goes through
+    pocketpaw_external_actions."""
+    assert len(instinct_mcp.INSTINCT_TOOL_IDS) == 2
+    for tool_id in instinct_mcp.INSTINCT_TOOL_IDS:
+        assert "propose" not in tool_id
+        assert "approve" not in tool_id
+        assert "reject" not in tool_id
+        assert "execute" not in tool_id
+
+
+def test_provider_exposes_server_and_tool_ids() -> None:
+    """The extensions provider builds the server and reports the tool ids — the
+    pocketpaw.mcp_servers registration loop reads both."""
+    provider = CloudInstinctMcpProvider()
+    assert provider.tool_ids() == list(instinct_mcp.INSTINCT_TOOL_IDS)
+
+    built = provider.build_server()
+    if built is not None:
+        name, server = built
+        assert name == "pocketpaw_instinct"
+        assert server is not None
+
+
+# ---------------------------------------------------------------------------
+# instinct_pending — the REAL read path
+# ---------------------------------------------------------------------------
+
+
+async def test_pending_lists_workspace_actions_only(store):
+    """Pending actions come back JSON-friendly and scoped to the caller's
+    workspace — another tenant's queue never appears."""
+    w1_ids = await _seed_actions(store)
+
+    with _identity(workspace="w1"):
+        res = await instinct_mcp._instinct_pending_handler({})
+
+    body = await _result_body(res)
+    assert body["count"] == 2
+    assert body["truncated"] is False
+    got_ids = {a["id"] for a in body["actions"]}
+    assert got_ids == set(w1_ids)
+    titles = {a["title"] for a in body["actions"]}
+    assert "Other tenant action" not in titles
+    for a in body["actions"]:
+        assert a["status"] == "pending"
+        assert a["recommendation"]
+        assert a["priority"]
+
+
+async def test_pending_never_serializes_parameters_blob(store):
+    """The Action ``parameters`` blob (diffs / call params) must NOT ride on
+    the gate-visibility response."""
+    await _seed_actions(store)
+
+    with _identity(workspace="w1"):
+        res = await instinct_mcp._instinct_pending_handler({})
+
+    raw = res["content"][0]["text"]
+    assert "secret_payload" not in raw
+    assert "_external_action" not in raw
+    body = json.loads(raw)
+    for a in body["actions"]:
+        assert "parameters" not in a
+
+
+async def test_pending_pocket_filter(store):
+    """The optional pocket_id filter narrows the list."""
+    await _seed_actions(store)
+
+    with _identity(workspace="w1"):
+        res = await instinct_mcp._instinct_pending_handler({"pocket_id": "p1"})
+
+    body = await _result_body(res)
+    assert body["count"] == 1
+    assert body["actions"][0]["title"] == "Reorder oat milk"
+
+
+async def test_pending_truncates_oversized_results(store, monkeypatch):
+    """An action list over the byte budget is truncated from the tail and
+    flagged."""
+    await _seed_actions(store)
+    monkeypatch.setattr(instinct_mcp, "MAX_RESULT_BYTES", 80)
+
+    with _identity(workspace="w1"):
+        res = await instinct_mcp._instinct_pending_handler({})
+
+    body = await _result_body(res)
+    assert body["truncated"] is True
+    assert body["returned"] < body["count"]
+
+
+# ---------------------------------------------------------------------------
+# instinct_audit
+# ---------------------------------------------------------------------------
+
+
+async def test_audit_returns_workspace_entries(store):
+    """Proposing writes audit entries; the handler returns the workspace's
+    entries JSON-friendly."""
+    await _seed_actions(store)
+
+    with _identity(workspace="w1"):
+        res = await instinct_mcp._instinct_audit_handler({})
+
+    body = await _result_body(res)
+    assert body["count"] >= 2
+    events = {e["event"] for e in body["entries"]}
+    assert any("propose" in ev for ev in events)
+    descriptions = " ".join(e["description"] or "" for e in body["entries"])
+    assert "Other tenant action" not in descriptions
+    for e in body["entries"]:
+        assert e["actor"]
+        assert e["category"]
+
+
+async def test_audit_clamps_limit(store):
+    """A limit over the cap is clamped, not refused."""
+    await _seed_actions(store)
+
+    with _identity(workspace="w1"):
+        res = await instinct_mcp._instinct_audit_handler({"limit": 10_000})
+
+    body = await _result_body(res)
+    assert body["returned"] <= instinct_mcp.MAX_AUDIT_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# workspace resolution + error relaying
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "handler",
+    [instinct_mcp._instinct_pending_handler, instinct_mcp._instinct_audit_handler],
+)
+async def test_identity_missing_errors(store, handler):
+    """Called without workspace ContextVars → an explicit error."""
+    res = await handler({})
+    assert res.get("is_error") is True
+    assert "workspace context" in res["content"][0]["text"]
+
+
+@pytest.mark.parametrize(
+    "handler,args,needle",
+    [
+        (instinct_mcp._instinct_pending_handler, {"pocket_id": 42}, "`pocket_id`"),
+        (instinct_mcp._instinct_audit_handler, {"limit": 0}, "`limit`"),
+        (instinct_mcp._instinct_audit_handler, {"limit": "ten"}, "`limit`"),
+    ],
+)
+async def test_bad_input_refused(store, handler, args, needle):
+    """Malformed inputs refuse cleanly with the offending field named."""
+    with _identity(workspace="w1"):
+        res = await handler(args)
+    assert res.get("is_error") is True
+    assert needle in res["content"][0]["text"]
+
+
+async def test_store_error_is_relayed(store, monkeypatch):
+    """A store failure is relayed as a plain error, not a crash."""
+
+    class _Boom:
+        async def pending(self, pocket_id=None, workspace_id=None):
+            raise RuntimeError("instinct db is locked")
+
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: _Boom())
+    with _identity(workspace="w1"):
+        res = await instinct_mcp._instinct_pending_handler({})
+    assert res.get("is_error") is True
+    assert "instinct db is locked" in res["content"][0]["text"]

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -1,5 +1,10 @@
 """Tests for MCP + Claude Agent SDK integration — Sprint 17.
 
+Updated: 2026-06-11 (feat/fabric-instinct-mcp-providers) —
+  ``_strip_builtin_servers`` now also drops ``pocketpaw_fabric`` (fabric_query /
+  fabric_stats) and ``pocketpaw_instinct`` (instinct_pending / instinct_audit),
+  the two new always-on read-only servers, so the external-config assertions
+  stay focused. Same regime as pocketpaw_external_actions / pocketpaw_belt.
 Updated: 2026-06-11 (feat/external-action-mcp-tool) — ``_strip_builtin_servers``
   now also drops ``pocketpaw_external_actions`` (the new always-on gated
   external-action proposal server: propose_external_action), so the
@@ -60,7 +65,9 @@ from pocketpaw_ee.agent.mcp_servers.decisions import SERVER_NAME as _DECISIONS_M
 from pocketpaw_ee.agent.mcp_servers.external_actions import (
     SERVER_NAME as _EXTERNAL_ACTIONS_MCP_SERVER_NAME,
 )
+from pocketpaw_ee.agent.mcp_servers.fabric import SERVER_NAME as _FABRIC_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.foresight import SERVER_NAME as _FORESIGHT_MCP_SERVER_NAME
+from pocketpaw_ee.agent.mcp_servers.instinct import SERVER_NAME as _INSTINCT_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.loom import SERVER_NAME as _LOOM_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.media import SERVER_NAME as _MEDIA_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.meetings import SERVER_NAME as _MEETINGS_MCP_SERVER_NAME
@@ -122,6 +129,12 @@ def _strip_builtin_servers(result: dict) -> dict:
     # gated connector call (propose_external_action) without an explicit
     # opt-in; the connector only fires after human approval.
     out.pop(_EXTERNAL_ACTIONS_MCP_SERVER_NAME, None)
+    # ``pocketpaw_fabric`` + ``pocketpaw_instinct`` are always-on too — the
+    # cloud chat agent's only path to the Fabric ontology and Instinct gate
+    # visibility on this backend (registry BaseTools never reach it). Both are
+    # read-only.
+    out.pop(_FABRIC_MCP_SERVER_NAME, None)
+    out.pop(_INSTINCT_MCP_SERVER_NAME, None)
     return out
 
 


### PR DESCRIPTION
## Why

On the claude_agent_sdk backend, PocketPaw registry tools (BaseTool) never reach the agent — only MCP servers do. There was no fabric or instinct MCP provider, so the cloud chat agent on that backend had zero path to the Fabric ontology or the Instinct gate. A live deployment hit this and had to ship its own stdio workaround. This PR makes both first-class, on the same pattern as the external-actions server (#1430).

## What

Two new in-process MCP servers under `ee/pocketpaw_ee/agent/mcp_servers/`:

**`pocketpaw_fabric`** — read-only ontology access

- `fabric_query` and `fabric_stats` — the names are pinned, a deployed skill already calls them
- wraps the existing `FabricQueryTool`/`FabricStatsTool` logic, but returns structured JSON instead of formatted text: `{total, returned, truncated, objects}`
- queries are scoped to the session's workspace (W4a read filter) — the workspace comes from the chat ContextVars, never from the agent's args, so one tenant can't read another's rows
- size-capped: the limit clamps to 50 and oversized result sets are truncated from the tail under a byte budget, flagged `truncated: true`
- `FabricCreateTool` is not wrapped — ontology writes from this backend should arrive as gated proposals, not ambient writes
- one caveat, noted in the module and pinned in a test: the store's `stats()` has no workspace scope yet, so counts are instance-wide

**`pocketpaw_instinct`** — read-only gate visibility

- `instinct_pending` and `instinct_audit`, wrapping the existing registry tools, workspace-scoped, JSON results with the same truncation regime
- the Action `parameters` blob (which can carry diffs and call params) is never serialized — only gate-surface fields; a test pins this
- `InstinctProposeTool` is deliberately not wrapped: gated proposing on this backend goes through `pocketpaw_external_actions` (`propose_external_action`). The module docstring and tool descriptions say so, and a test pins that the surface stays read-only

## Wiring

- `CloudFabricMcpProvider` + `CloudInstinctMcpProvider` in `extensions.py`, entry points `fabric` / `instinct` — ambient, same regime as belt/media/external-actions
- the `mcp_servers` package docstring now lists every server surface (module → server name → tools), so the next person doesn't have to grep for them
- `test_mcp_claude_sdk.py` baseline strips the two new always-on servers — the same fix every ambient server has needed (most recently in #1430)

## Tests

Two new suites driven through the real handlers against tmp-file stores:

- `tests/cloud/test_fabric_mcp.py` (14): contract pins, provider wiring, workspace-scoped query (another tenant's rows never appear), filter passthrough, limit clamp, truncation flag, stats shape, missing identity, malformed inputs, store-error relay
- `tests/cloud/test_instinct_mcp.py` (15): contract pins, read-only surface pin, provider wiring, workspace-scoped pending list, no-parameters-blob pin, pocket filter, truncation, audit entries + limit clamp, missing identity, malformed inputs, store-error relay

`tests/ee/test_mcp_claude_sdk.py` passes (32), and the sibling external-action + belt gate suites still pass (25). Lint and format clean.