### PR TITLE
fix(fabric): scope fabric_stats to the caller's workspace

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
@@ -1,6 +1,10 @@
 # fabric.py — in-process MCP server exposing read-only Fabric ontology access
 # to the claude_agent_sdk cloud chat backend. Created: 2026-06-11
 # (feat/fabric-instinct-mcp-providers).
+# Updated: 2026-06-11 (fix/fabric-stats-workspace-scope) — fabric_stats now
+# passes the resolved workspace into the store's scoped stats()/list_types(),
+# closing the live cross-tenant type-name leak the original instance-wide
+# stats had on a shared fabric.db.
 #
 # Why this exists: on the claude_agent_sdk backend, PocketPaw registry tools
 # (BaseTool) never reach the agent — only MCP servers do — and there was no
@@ -26,10 +30,12 @@
 #     returned JSON-friendly ({total, returned, truncated, objects}) and
 #     size-capped: the limit clamps to MAX_QUERY_LIMIT and oversized result
 #     sets are truncated from the tail under MAX_RESULT_BYTES.
-#   * fabric_stats — ontology counts + type names. NOTE: the store's ``stats``
-#     / ``list_types`` have no workspace scope yet — counts are instance-wide.
-#     Workspace identity is still required for parity with the sibling tools
-#     (and so a scoped stats can slot in without an interface change).
+#   * fabric_stats — ontology counts + type names, scoped to the caller's
+#     workspace (fix/fabric-stats-workspace-scope: the original instance-wide
+#     stats leaked another tenant's experimental type names into chat on a
+#     shared box). Counts mirror fabric_query's visibility exactly; the type
+#     list holds only types with object rows visible to the workspace (type
+#     DEFINITIONS are global in the schema — see FabricStore.list_types).
 #
 # Read-only: neither tool writes anything. FabricCreateTool is deliberately
 # NOT wrapped — ontology writes from the SDK backend should arrive as gated
@@ -224,9 +230,10 @@ async def _fabric_stats_handler(args: dict) -> dict:
     """MCP handler for ``fabric__fabric_stats``.
 
     Returns ontology counts + type names: ``{types, objects, links,
-    type_names}``. Read-only. NOTE: the store's stats are instance-wide (no
-    workspace-scoped stats yet); identity is still required for parity with
-    the sibling tools.
+    type_names}``, scoped to the caller's workspace so stats and fabric_query
+    agree (own rows plus legacy NULL-workspace rows). The type list holds only
+    types with object rows visible to the workspace — never another tenant's
+    experiment names. Read-only.
     """
     workspace_id, _user_id = _identity()
     if not workspace_id:
@@ -239,8 +246,8 @@ async def _fabric_stats_handler(args: dict) -> dict:
         return _error_response("Fabric is not available (enterprise feature).")
 
     try:
-        stats = await store.stats()
-        types = await store.list_types()
+        stats = await store.stats(workspace_id=workspace_id)
+        types = await store.list_types(workspace_id=workspace_id)
     except Exception as exc:  # noqa: BLE001
         logger.warning("fabric_stats failed", exc_info=True)
         return _error_response(f"could not read Fabric stats: {exc}")
@@ -320,7 +327,8 @@ def build_fabric_server() -> tuple[str, Any] | None:
         "fabric_stats",
         (
             "Get statistics about the Fabric ontology: number of object types, "
-            "objects, and links, plus the list of type names. READ-ONLY. Takes "
+            "objects, and links, plus the list of type names — scoped to the "
+            "current workspace, consistent with fabric_query. READ-ONLY. Takes "
             "no arguments. Returns {types, objects, links, type_names}. An "
             "error means relay the reason."
         ),

--- a/ee/pocketpaw_ee/fabric/router.py
+++ b/ee/pocketpaw_ee/fabric/router.py
@@ -25,8 +25,16 @@
 #   (``list_objects`` / ``list_links`` / ``query_fabric`` / ``get_object``) are
 #   scoped to that tenant; writes (``create_object`` / ``create_link``) stamp
 #   it. Legacy NULL-workspace rows stay visible to all tenants (see the store
-#   header). ``list_types`` / ``stats`` remain global — object-type definitions
-#   and bare counts are not tenant data; the leak is in object/link CONTENT.
+#   header).
+# Updated: 2026-06-11 (fix/fabric-stats-workspace-scope) — scoped the LAST two
+#   reads, ``list_types`` and ``fabric_stats``. W4a left them global on the
+#   assumption that type definitions and bare counts are not tenant data; a
+#   live shared box disproved it — one tenant's chat listed another context's
+#   experimental type names through the unscoped stats path. Type NAMES are
+#   tenant metadata. Both endpoints now thread ``current_workspace_id`` into
+#   the store's scoped ``list_types()`` / ``stats()`` (own rows + legacy NULL
+#   rows, matching every other scoped read; type list = defined types with at
+#   least one visible object row — definitions stay global in the schema).
 
 from __future__ import annotations
 
@@ -101,8 +109,14 @@ class LinkRequest(BaseModel):
     response_model=list[ObjectType],
     dependencies=[Depends(require_action_any_workspace("fabric.read"))],
 )
-async def list_types():
-    return await _store().list_types()
+async def list_types(workspace_id: str = Depends(current_workspace_id)):
+    """List object types visible to the caller's workspace.
+
+    Scoped (fix/fabric-stats-workspace-scope): only types with at least one
+    object row visible to the workspace — type names are tenant metadata on a
+    shared deployment.
+    """
+    return await _store().list_types(workspace_id=workspace_id)
 
 
 @router.post(
@@ -263,5 +277,13 @@ async def create_link(
     "/fabric/stats",
     dependencies=[Depends(require_action_any_workspace("fabric.read"))],
 )
-async def fabric_stats():
-    return await _store().stats()
+async def fabric_stats(workspace_id: str = Depends(current_workspace_id)):
+    """Ontology counts scoped to the caller's workspace.
+
+    Scoped (fix/fabric-stats-workspace-scope): counts mirror ``list_objects``
+    / ``query`` visibility exactly (own rows plus legacy NULL-workspace rows),
+    and ``types`` counts only types with at least one visible object row — type
+    names are tenant metadata on a shared deployment, so an unscoped stats here
+    leaked another tenant's experimental type names into chat.
+    """
+    return await _store().stats(workspace_id=workspace_id)

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -62,6 +62,16 @@
 #       get_object_by_source, so the write has its OWN tenancy guard rather than
 #       trusting the caller to have scoped the prior read. connectors.fabric_ingest
 #       passes workspace_id through.
+# Updated: 2026-06-11 (fix/fabric-stats-workspace-scope) — stats() and
+#   list_types() take an optional workspace_id, closing the LAST unscoped W4a
+#   reads (a live shared box leaked one tenant's experimental type names into
+#   another tenant's chat via fabric_stats). Scoped stats mirrors query()'s
+#   visibility exactly (own rows + legacy NULL rows, via _workspace_scope) so
+#   stats and query always agree; scoped types/list_types return only DEFINED
+#   types with at least one visible object row — definitions are global (no
+#   workspace_id column on fabric_object_types), but which types a tenant sees
+#   is tenant metadata. workspace_id=None keeps the original unscoped behavior
+#   (OSS / registry-tool / single-tenant callers).
 
 
 from __future__ import annotations
@@ -417,11 +427,36 @@ class FabricStore:
                     return None
                 return self._row_to_type(row)
 
-    async def list_types(self) -> list[ObjectType]:
+    async def list_types(self, workspace_id: str | None = None) -> list[ObjectType]:
+        """List object types, optionally scoped to a tenant (W4a follow-up).
+
+        Type DEFINITIONS are global — ``fabric_object_types`` has no
+        ``workspace_id`` column (a deliberate W4a choice: the shared schema is
+        not per-tenant data). But the type NAMES a tenant can see are tenant
+        metadata: on a shared deployment, listing every defined type leaks what
+        other tenants are modeling. So a scoped call returns only the types
+        with at least one object row VISIBLE to that workspace — the same
+        visibility ``query()`` applies (own rows plus legacy NULL-workspace
+        rows, via ``_workspace_scope``). A defined type with no visible rows
+        (including the caller's own empty types) is omitted; it reappears the
+        moment a visible object exists. ``workspace_id=None`` keeps the
+        original unscoped behavior (all defined types) for OSS / single-tenant
+        callers.
+        """
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute("SELECT * FROM fabric_object_types ORDER BY name") as cur:
+            if workspace_id is None:
+                sql = "SELECT * FROM fabric_object_types ORDER BY name"
+                params: list[Any] = []
+            else:
+                ws_cond, params = _workspace_scope(workspace_id, column="o.workspace_id")
+                sql = (
+                    "SELECT DISTINCT t.* FROM fabric_object_types t"
+                    " JOIN fabric_objects o ON o.type_id = t.id"
+                    f" WHERE {ws_cond} ORDER BY t.name"
+                )
+            async with db.execute(sql, params) as cur:
                 return [self._row_to_type(row) async for row in cur]
 
     async def remove_type(self, type_id: str) -> None:
@@ -797,12 +832,46 @@ class FabricStore:
 
     # --- Stats ---
 
-    async def stats(self) -> dict[str, int]:
+    async def stats(self, workspace_id: str | None = None) -> dict[str, int]:
+        """Ontology counts, optionally scoped to a tenant (W4a follow-up).
+
+        A scoped call mirrors ``query()``'s visibility EXACTLY (own rows plus
+        legacy NULL-workspace rows, via ``_workspace_scope``) so stats and
+        query always agree: ``stats(workspace_id=w)["objects"]`` equals the
+        ``total`` of an unfiltered scoped query. ``links`` applies the same
+        scope to ``fabric_links``. ``types`` counts the DEFINED types with at
+        least one visible object row — matching ``list_types(workspace_id=w)``
+        — because type definitions are global but which types a tenant sees is
+        tenant metadata (the cross-tenant type-name leak this closes).
+        ``workspace_id=None`` keeps the original unscoped, instance-wide
+        behavior for OSS / single-tenant callers.
+        """
         await self._ensure_schema()
         async with self._conn() as db:
-            types = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_object_types")
-            objects = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_objects")
-            links = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_links")
+            if workspace_id is None:
+                types = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_object_types")
+                objects = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_objects")
+                links = await db.execute_fetchall("SELECT COUNT(*) FROM fabric_links")
+                return {
+                    "types": types[0][0] if types else 0,
+                    "objects": objects[0][0] if objects else 0,
+                    "links": links[0][0] if links else 0,
+                }
+            obj_cond, obj_params = _workspace_scope(workspace_id)
+            link_cond, link_params = _workspace_scope(workspace_id)
+            type_cond, type_params = _workspace_scope(workspace_id, column="o.workspace_id")
+            types = await db.execute_fetchall(
+                "SELECT COUNT(DISTINCT t.id) FROM fabric_object_types t"
+                " JOIN fabric_objects o ON o.type_id = t.id"
+                f" WHERE {type_cond}",
+                type_params,
+            )
+            objects = await db.execute_fetchall(
+                f"SELECT COUNT(*) FROM fabric_objects WHERE {obj_cond}", obj_params
+            )
+            links = await db.execute_fetchall(
+                f"SELECT COUNT(*) FROM fabric_links WHERE {link_cond}", link_params
+            )
             return {
                 "types": types[0][0] if types else 0,
                 "objects": objects[0][0] if objects else 0,

--- a/tests/cloud/test_ee_fabric.py
+++ b/tests/cloud/test_ee_fabric.py
@@ -19,6 +19,14 @@
 #   unique index exists and a pre-existing duplicate-name DB is de-duped on first
 #   _ensure_schema) and TestUpdateObjectWorkspaceScope (update_object honours its
 #   own W4a tenancy guard — a cross-tenant id writes nothing and returns None).
+# Updated: 2026-06-11 (fix/fabric-stats-workspace-scope) — Added
+#   TestStatsWorkspaceScoping: scoped stats() / list_types() close the LAST two
+#   unscoped W4a reads. Pins the live leak (another tenant's experimental type
+#   names "Lease"/"Lease2" must NOT appear in a scoped type list), proves a
+#   scoped object/link/type count excludes other-tenant rows, asserts the
+#   stats/query consistency invariant (scoped stats["objects"] == scoped query
+#   total — the count mismatch that surfaced the bug), confirms legacy NULL rows
+#   stay visible, and that workspace_id=None keeps the instance-wide behavior.
 
 from __future__ import annotations
 
@@ -389,6 +397,134 @@ class TestWorkspaceScoping:
 
         result = await store.query(FabricQuery(type_name="Item"))
         assert result.total == 3
+
+
+class TestStatsWorkspaceScoping:
+    """fix/fabric-stats-workspace-scope — scoped stats() and list_types().
+
+    The last two W4a reads were left instance-wide. On a shared ``fabric.db``
+    that leaked: a tenant's chat called fabric_stats and got back another
+    context's experimental type names (``Lease`` / ``Lease2``), and the global
+    object count (13) disagreed with what the workspace-scoped query actually
+    saw (11). These tests pin both: scoped counts mirror ``query()`` exactly,
+    and a scoped type list never names a type only another tenant has rows for.
+
+    Subtlety being guarded: ``fabric_object_types`` has NO workspace column —
+    type DEFINITIONS are global. So a scoped type list cannot come from the
+    type table; it must be derived from types with at least one object row
+    VISIBLE to the workspace.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stats_objects_excludes_other_workspace(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Customer", properties=[])
+        await store.create_object(t.id, {"name": "A1"}, workspace_id="ws-a")
+        await store.create_object(t.id, {"name": "A2"}, workspace_id="ws-a")
+        await store.create_object(t.id, {"name": "B1"}, workspace_id="ws-b")
+
+        a_stats = await store.stats(workspace_id="ws-a")
+        assert a_stats["objects"] == 2  # B1 is excluded
+        b_stats = await store.stats(workspace_id="ws-b")
+        assert b_stats["objects"] == 1
+
+    @pytest.mark.asyncio
+    async def test_stats_links_excludes_other_workspace(self, store: FabricStore) -> None:
+        t = await store.define_type(name="Node", properties=[])
+        a1 = await store.create_object(t.id, {"n": 1}, workspace_id="ws-a")
+        a2 = await store.create_object(t.id, {"n": 2}, workspace_id="ws-a")
+        b1 = await store.create_object(t.id, {"n": 3}, workspace_id="ws-b")
+        b2 = await store.create_object(t.id, {"n": 4}, workspace_id="ws-b")
+        await store.link(a1.id, a2.id, "rel", workspace_id="ws-a")
+        await store.link(b1.id, b2.id, "rel", workspace_id="ws-b")
+
+        assert (await store.stats(workspace_id="ws-a"))["links"] == 1
+        assert (await store.stats(workspace_id="ws-b"))["links"] == 1
+
+    @pytest.mark.asyncio
+    async def test_scoped_type_list_excludes_other_tenant_type_names(
+        self, store: FabricStore
+    ) -> None:
+        # The exact live leak: ws-b defines "Lease" / "Lease2" and only B has
+        # rows of them. ws-a, which only models "Customer", must NOT see those
+        # type names — even though the type DEFINITIONS are global.
+        customer = await store.define_type(name="Customer", properties=[])
+        lease = await store.define_type(name="Lease", properties=[])
+        lease2 = await store.define_type(name="Lease2", properties=[])
+        await store.create_object(customer.id, {"name": "A1"}, workspace_id="ws-a")
+        await store.create_object(lease.id, {"tenant": "B-co"}, workspace_id="ws-b")
+        await store.create_object(lease2.id, {"tenant": "B-co"}, workspace_id="ws-b")
+
+        a_types = {t.name for t in await store.list_types(workspace_id="ws-a")}
+        assert a_types == {"Customer"}
+        assert "Lease" not in a_types
+        assert "Lease2" not in a_types
+
+        b_types = {t.name for t in await store.list_types(workspace_id="ws-b")}
+        assert b_types == {"Lease", "Lease2"}
+
+    @pytest.mark.asyncio
+    async def test_stats_types_count_matches_scoped_type_list(self, store: FabricStore) -> None:
+        # stats["types"] is the count of types VISIBLE to the workspace — it
+        # must equal len(list_types(workspace_id)), not the global type count.
+        customer = await store.define_type(name="Customer", properties=[])
+        lease = await store.define_type(name="Lease", properties=[])
+        await store.create_object(customer.id, {"name": "A1"}, workspace_id="ws-a")
+        await store.create_object(lease.id, {"tenant": "B-co"}, workspace_id="ws-b")
+
+        a_stats = await store.stats(workspace_id="ws-a")
+        a_types = await store.list_types(workspace_id="ws-a")
+        assert a_stats["types"] == len(a_types) == 1  # NOT 2 (the global count)
+
+    @pytest.mark.asyncio
+    async def test_stats_objects_consistent_with_query_total(self, store: FabricStore) -> None:
+        # The invariant that surfaced the bug: scoped stats and scoped query
+        # must agree on the object count. Mixed-tenant + legacy NULL rows.
+        t = await store.define_type(name="Customer", properties=[])
+        await store.create_object(t.id, {"name": "A1"}, workspace_id="ws-a")
+        await store.create_object(t.id, {"name": "A2"}, workspace_id="ws-a")
+        await store.create_object(t.id, {"name": "B1"}, workspace_id="ws-b")
+        await store.create_object(t.id, {"name": "legacy"})  # NULL workspace
+
+        a_stats = await store.stats(workspace_id="ws-a")
+        a_query = await store.query(FabricQuery(), workspace_id="ws-a")
+        assert a_stats["objects"] == a_query.total == 3  # A1, A2, legacy — not B1
+
+    @pytest.mark.asyncio
+    async def test_legacy_null_type_visible_to_all_scoped_readers(self, store: FabricStore) -> None:
+        # A type whose only rows predate tenancy (NULL workspace) stays visible
+        # to every scoped reader — matching the query()-side legacy rule.
+        legacy_type = await store.define_type(name="Legacy", properties=[])
+        await store.create_object(legacy_type.id, {"name": "pre-tenancy"})  # NULL
+
+        for ws in ("ws-a", "ws-b"):
+            names = {t.name for t in await store.list_types(workspace_id=ws)}
+            assert "Legacy" in names
+            assert (await store.stats(workspace_id=ws))["objects"] == 1
+
+    @pytest.mark.asyncio
+    async def test_unscoped_stats_is_instance_wide(self, store: FabricStore) -> None:
+        # workspace_id=None keeps the original instance-wide behavior for OSS /
+        # registry-tool / single-tenant callers (full backward-compat).
+        customer = await store.define_type(name="Customer", properties=[])
+        lease = await store.define_type(name="Lease", properties=[])
+        await store.create_object(customer.id, {"name": "A1"}, workspace_id="ws-a")
+        await store.create_object(lease.id, {"tenant": "B-co"}, workspace_id="ws-b")
+
+        s = await store.stats()
+        assert s["objects"] == 2
+        assert s["types"] == 2  # both defined types
+        names = {t.name for t in await store.list_types()}
+        assert names == {"Customer", "Lease"}
+
+    @pytest.mark.asyncio
+    async def test_scoped_type_with_no_visible_rows_is_omitted(self, store: FabricStore) -> None:
+        # A defined type with zero visible rows (even the caller's own empty
+        # type) is omitted, and reappears the moment a visible object exists.
+        empty = await store.define_type(name="Empty", properties=[])
+        assert {t.name for t in await store.list_types(workspace_id="ws-a")} == set()
+
+        await store.create_object(empty.id, {"k": "v"}, workspace_id="ws-a")
+        assert {t.name for t in await store.list_types(workspace_id="ws-a")} == {"Empty"}
 
 
 class TestTypeNameUniqueIndex:

--- a/tests/cloud/test_fabric_mcp.py
+++ b/tests/cloud/test_fabric_mcp.py
@@ -203,7 +203,13 @@ async def test_query_truncates_oversized_results(store, monkeypatch):
 
 
 async def test_stats_returns_counts_and_type_names(store):
-    """Stats come back JSON-friendly with counts + type names."""
+    """Stats come back JSON-friendly with counts + type names, scoped to the
+    caller's workspace.
+
+    fix/fabric-stats-workspace-scope: the seed puts 2 Customer rows in w1 and 1
+    in w2. A w1-scoped stats counts only w1's 2 objects (NOT the instance-wide
+    3) so it agrees with fabric_query.
+    """
     await _seed_customers(store)
 
     with _identity(workspace="w1"):
@@ -211,9 +217,46 @@ async def test_stats_returns_counts_and_type_names(store):
 
     body = await _result_body(res)
     assert body["types"] == 1
-    assert body["objects"] == 3  # instance-wide — the store has no scoped stats yet
+    assert body["objects"] == 2  # w1's two rows — NOT the instance-wide 3
     assert body["type_names"] == ["Customer"]
     assert "links" in body
+
+
+async def test_stats_does_not_leak_other_tenant_type_names(store):
+    """The live leak, pinned at the MCP boundary.
+
+    w2 alone models "Lease" / "Lease2"; w1 models "Customer". A w1-scoped
+    fabric_stats must NOT name w2's experimental types — even though the type
+    DEFINITIONS are global in the schema.
+    """
+    await _seed_customers(store)  # Customer rows in w1 (+ one in w2)
+    lease = await store.define_type(name="Lease", properties=[])
+    lease2 = await store.define_type(name="Lease2", properties=[])
+    await store.create_object(lease.id, {"tenant": "X"}, workspace_id="w2")
+    await store.create_object(lease2.id, {"tenant": "Y"}, workspace_id="w2")
+
+    with _identity(workspace="w1"):
+        res = await fabric_mcp._fabric_stats_handler({})
+    body = await _result_body(res)
+
+    assert body["type_names"] == ["Customer"]
+    assert "Lease" not in body["type_names"]
+    assert "Lease2" not in body["type_names"]
+    assert body["types"] == 1  # count matches the visible type list
+
+
+async def test_stats_agrees_with_query_object_count(store):
+    """The stats/query consistency invariant that surfaced the bug: a w1-scoped
+    stats object count equals the total of a w1-scoped (unfiltered) query."""
+    await _seed_customers(store)  # 2 in w1, 1 in w2
+
+    with _identity(workspace="w1"):
+        stats_res = await fabric_mcp._fabric_stats_handler({})
+        query_res = await fabric_mcp._fabric_query_handler({})
+
+    stats_body = await _result_body(stats_res)
+    query_body = await _result_body(query_res)
+    assert stats_body["objects"] == query_body["total"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The leak

`fabric_stats` and `list_types` were the last two Fabric reads W4a left instance-wide. On a shared `fabric.db` (the micro tier, or an agency running several client tenants on one box) that leaked type metadata across tenants.

## Live repro

In the SNCTM workspace's chat, `fabric_stats` listed type names — `Lease`, `Lease2` — that belong to a different context. And the count was wrong too: stats reported 13 objects while the workspace-scoped query only saw 11. Stats and query were reading different things, so they disagreed in front of the user.

## The fix

`stats()` and `list_types()` now take an optional `workspace_id`:

- **Counts mirror `query()` exactly** — own rows plus legacy NULL-workspace rows, via the same `_workspace_scope` helper. So `stats(workspace_id=w)["objects"]` equals the total of an unfiltered scoped query. Consistency is the whole point.
- **`workspace_id=None` keeps the instance-wide behavior** for OSS, registry-tool, and single-tenant callers. Fully backward compatible.

### The global-type-table subtlety

`fabric_object_types` has no `workspace_id` column — type **definitions are global** by design. So a scoped type list can't come from the type table. It's derived from the types that have at least one object row **visible to the workspace**. A tenant sees a type name only if it owns (or shares, via legacy NULL rows) an object of that type — never another tenant's experiment. `stats["types"]` counts those same visible types, so it agrees with `list_types(workspace_id=w)`.

## Threaded through both surfaces

- **MCP** — the `pocketpaw_fabric` provider's `fabric_stats` passes the resolved workspace, so it agrees with `fabric_query`.
- **REST** — `GET /fabric/stats` and `GET /fabric/types` take `current_workspace_id` like every other scoped read.

## Tests

`TestStatsWorkspaceScoping` (store) and three MCP tests:

- Pin the `Lease` / `Lease2` leak — a scoped type list must not name another tenant's types.
- Scoped object / link / type counts exclude other-workspace rows.
- The stats/query object-count consistency invariant that surfaced the bug.
- Legacy NULL rows stay visible; a defined type with no visible rows is omitted (and reappears when one exists).

Targeted suites green: `test_ee_fabric.py`, `test_fabric_mcp.py`, `test_mcp_claude_sdk.py`, `test_w4a_migration.py`, `test_ee_fabric_list_endpoints.py` — 110 passed.