### PR TITLE
feat(templates): demo-grade events, renewals, orders, and revenue templates

### DIFF
--- a/src/pocketpaw/bundled_templates/_bundled/README.md
+++ b/src/pocketpaw/bundled_templates/_bundled/README.md
@@ -2,6 +2,9 @@
 src/pocketpaw/bundled_templates/_bundled/README.md
 Created: 2026-05-22 (feat/bundled-templates, Increment 2a) — explains the
 two-file sibling convention each template directory follows.
+Modified: 2026-06-11 (feat/demo-template-suite) — documented the four
+demo-suite vertical templates (events-board, renewals-radar,
+orders-fulfillment, revenue-pulse) that join the original two.
 Modified: 2026-06-11 (feat/triage-member-templates) — documented the two
 generic vertical templates (applications-triage, member-360) that carry
 the richer v2 surface (needs / actions / outcomes / data_sources) the
@@ -83,6 +86,28 @@ decision chain. The executor performs the connector call only on human
 approval. Nothing approves inline — the button only proposes. For a
 Fabric write instead of a connector call, the pocket-write proposal
 bridge is the parallel seam.
+
+## Demo-suite templates (events-board, renewals-radar, orders-fulfillment, revenue-pulse)
+
+Four more generic, install-ready templates carry the full v2 surface and
+match the demo-grade visual bar set by the triage redesign — color-banded
+strips, score/risk rings, status pills, and dense-but-scannable detail
+panels, all populated with story-grade seed data:
+
+| Template | What it is | v2 surface it uses |
+|----------|-----------|--------------------|
+| `events-board` | A sell-through console: a color-banded status strip, an events queue with sell-through bars, and a detail panel with a sell-through ring, a revenue/attendee/check-in stat row, the ticket-tier grid, and a run-of-show timeline. | `shape: custom`, `needs: [paw.db.v1]`, `data_sources`, one gated `promote_event` action, `outcomes`. |
+| `renewals-radar` | A renewal-risk console: a revenue-at-risk strip, a member queue ordered by churn risk with days-left chips and risk bars, and a detail panel with a churn-risk ring, a grace-deadline callout, renewal facts, and renewal history. | `shape: custom`, `needs: [paw.db.v1]`, `data_sources`, two gated actions (`renew_membership`, `send_renewal_reminder`), `outcomes`. |
+| `orders-fulfillment` | A fulfillment console: a per-stage count strip, a `kanban` stage board over the order list, plus a queue + detail pair with the line-items grid, shipping facts, and a fulfillment timeline. | `shape: kanban`, `needs: [paw.db.v1]`, `data_sources`, two gated actions (`mark_shipped`, `process_refund`), `outcomes`. |
+| `revenue-pulse` | A read-only executive dashboard: a KPI stat row, a six-month revenue-trend `area` chart, a by-category `bar` chart beside a breakdown grid, and an approval-funnel strip. | `shape: chart`, `needs: [paw.db.v1]`, `data_sources`. No actions (read-only). |
+
+All four are fully generic — no client names. The three with action rows
+follow the same propose-not-execute binding seam documented above for
+`applications-triage`: each button sets `state.pending_proposal` to a
+generic `{action, <entity>_id, summary}` shape, wired to the Instinct gate
+by a deployment. `revenue-pulse` is read-only by design. Their shape,
+compile, render-populated, and gated-action contracts are covered in
+`tests/unit/test_vertical_templates.py` alongside the original two.
 
 ## Adding a template
 

--- a/src/pocketpaw/bundled_templates/_bundled/events-board/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/events-board/ripple_spec.json
@@ -1,0 +1,459 @@
+{
+  "_placeholder_note": "Built-in pocket template (events-board), DEMO-GRADE 2026-06-11 (feat/demo-template-suite). The events, sell-through numbers, ticket tiers, and run-of-show below are real sample copy — no placeholder brackets — so a pocket created straight from this template renders as a finished sell-through console. The create specialist still rewrites the sample events to the user's real domain. BINDING CONTRACT (same as applications-triage): the Ripple expression engine resolves a method chain ONLY when the chain ENDS in `)` (e.g. `{x.where('id', y).first()}`); a method call FOLLOWED BY a property access (`...first().name`) resolves to undefined, and `each` `items` resolves a FLAT dot-path from state ONLY. So the detail panel binds to a denormalized FLAT `state.selected` object — every detail binding is a plain `{state.selected.X}` path and the ticket-tier / run-of-show loops read `{state.selected.tiers}` / `{state.selected.run_of_show}`. Clicking a queue card keeps `state.selected` in sync via an on_click chain whose `set` value is `{state.events.where('id', ev.id).first()}` — a chain that ENDS in `)`, so it resolves at dispatch time. `state.selected` is also SEEDED to the first event so the panel renders before any click. ENUM NOTE: badge variants are {default,secondary,destructive,outline,success,warning}; chip variants are {default,primary,success,warning,destructive}; callout variants are {info,success,warning,insight}. Sell-through color bands: green (#059669) >=80% full, blue (#0284c7) 50-79%, amber (#d97706) <50% (needs a push), slate for past/draft. The `sources` block is a PLACEHOLDER live-data binding: with a backend keep it so GET /events hydrates state.events; with NO backend remove it and keep the seeded events. ACTION-ROW BINDING POINT: the promote button sets state.pending_proposal to a generic {action, event_id, summary} proposal — it does NOT execute. A deployment wires this state event to the Instinct gate (external_actions.propose.propose_external_action) so a human confirms in The Tray. Keep the sell-through strip, the queue each-loop, the selected-sync on_click, the ring + stat row, the ticket-tier grid, the run-of-show timeline, and the action row intact.",
+  "sources": {
+    "events": {
+      "method": "GET",
+      "path": "/events?status=upcoming",
+      "bind": "state.events",
+      "refresh": ["pocket_open", "manual"]
+    }
+  },
+  "state": {
+    "selected_id": "e1",
+    "pending_proposal": null,
+    "status_counts": [
+      { "id": "sc1", "label": "On sale", "value": 3, "color": "#0284c7", "dot": "online" },
+      { "id": "sc2", "label": "Sold out", "value": 1, "color": "#059669", "dot": "busy" },
+      { "id": "sc3", "label": "Draft", "value": 1, "color": "#94a3b8", "dot": "offline" }
+    ],
+    "total_events": 5,
+    "total_sold": 1132,
+    "total_revenue": "$214,800",
+    "events": [
+      {
+        "id": "e1",
+        "name": "Midsummer Masquerade",
+        "date": "Sat 21 Jun · 9:00 PM",
+        "venue": "The Vault, Manhattan",
+        "status": "On sale",
+        "status_variant": "warning",
+        "sold": 188,
+        "capacity": 200,
+        "sold_pct": 94,
+        "pct_color": "#059669",
+        "pct_band": "Nearly sold out",
+        "revenue": "$67,400",
+        "checked_in": 0,
+        "summary": "94% sold · 12 tickets left · expected to sell out this week",
+        "tiers": [
+          { "id": "t1", "tier": "General", "price": "$250", "sold": "140 / 140", "left": "0" },
+          { "id": "t2", "tier": "Premium", "price": "$450", "sold": "40 / 45", "left": "5" },
+          { "id": "t3", "tier": "Founders box", "price": "$1,200", "sold": "8 / 15", "left": "7" }
+        ],
+        "run_of_show": [
+          { "id": "r1", "date": "9:00 PM", "title": "Doors + welcome", "detail": "Coat check, masks issued at the door" },
+          { "id": "r2", "date": "10:00 PM", "title": "Headline performance", "detail": "Main floor, 40 minutes" },
+          { "id": "r3", "date": "11:30 PM", "title": "Late lounge opens", "detail": "Members-only upper floor" }
+        ]
+      },
+      {
+        "id": "e2",
+        "name": "Founders Dinner — July",
+        "date": "Thu 10 Jul · 7:30 PM",
+        "venue": "The Library Room",
+        "status": "On sale",
+        "status_variant": "warning",
+        "sold": 11,
+        "capacity": 50,
+        "sold_pct": 22,
+        "pct_color": "#d97706",
+        "pct_band": "Needs a push",
+        "revenue": "$3,300",
+        "checked_in": 0,
+        "summary": "Only 22% sold with three weeks to go — a member email could lift this fast",
+        "tiers": [
+          { "id": "t1", "tier": "Seat", "price": "$300", "sold": "11 / 50", "left": "39" }
+        ],
+        "run_of_show": [
+          { "id": "r1", "date": "7:30 PM", "title": "Reception", "detail": "Champagne on arrival" },
+          { "id": "r2", "date": "8:15 PM", "title": "Seated dinner", "detail": "Four courses, paired" },
+          { "id": "r3", "date": "10:00 PM", "title": "Fireside chat", "detail": "Guest founder, Q&A" }
+        ]
+      },
+      {
+        "id": "e3",
+        "name": "Summer Mixer",
+        "date": "Fri 30 May · 8:00 PM",
+        "venue": "Rooftop Terrace",
+        "status": "Sold out",
+        "status_variant": "success",
+        "sold": 150,
+        "capacity": 150,
+        "sold_pct": 100,
+        "pct_color": "#059669",
+        "pct_band": "Sold out",
+        "revenue": "$22,500",
+        "checked_in": 142,
+        "summary": "Sold out · 142 of 150 checked in (95% turnout) · closed",
+        "tiers": [
+          { "id": "t1", "tier": "General", "price": "$150", "sold": "150 / 150", "left": "0" }
+        ],
+        "run_of_show": [
+          { "id": "r1", "date": "8:00 PM", "title": "Doors", "detail": "Check-in at the elevator lobby" },
+          { "id": "r2", "date": "9:00 PM", "title": "DJ set", "detail": "Resident DJ, two hours" },
+          { "id": "r3", "date": "11:00 PM", "title": "Last call", "detail": "Bar closes at 11:30 PM" }
+        ]
+      },
+      {
+        "id": "e4",
+        "name": "Negotiation Workshop",
+        "date": "Wed 16 Jul · 6:00 PM",
+        "venue": "Studio B",
+        "status": "On sale",
+        "status_variant": "warning",
+        "sold": 38,
+        "capacity": 60,
+        "sold_pct": 63,
+        "pct_color": "#0284c7",
+        "pct_band": "Tracking well",
+        "revenue": "$3,040",
+        "checked_in": 0,
+        "summary": "63% sold and climbing steadily — on pace to fill",
+        "tiers": [
+          { "id": "t1", "tier": "Workshop seat", "price": "$80", "sold": "38 / 60", "left": "22" }
+        ],
+        "run_of_show": [
+          { "id": "r1", "date": "6:00 PM", "title": "Intro + framing", "detail": "Workbook handed out" },
+          { "id": "r2", "date": "6:45 PM", "title": "Live role-play", "detail": "Paired exercises" },
+          { "id": "r3", "date": "7:45 PM", "title": "Debrief + drinks", "detail": "Open bar to close" }
+        ]
+      },
+      {
+        "id": "e5",
+        "name": "Autumn Gala (planning)",
+        "date": "Sat 27 Sep · TBC",
+        "venue": "Venue TBC",
+        "status": "Draft",
+        "status_variant": "secondary",
+        "sold": 0,
+        "capacity": 300,
+        "sold_pct": 0,
+        "pct_color": "#94a3b8",
+        "pct_band": "Not on sale",
+        "revenue": "$0",
+        "checked_in": 0,
+        "summary": "Draft — tiers and venue not finalised, not yet on sale",
+        "tiers": [
+          { "id": "t1", "tier": "General (planned)", "price": "$350", "sold": "0 / 240", "left": "240" },
+          { "id": "t2", "tier": "VIP (planned)", "price": "$800", "sold": "0 / 60", "left": "60" }
+        ],
+        "run_of_show": [
+          { "id": "r1", "date": "TBC", "title": "Run-of-show not set", "detail": "Drafting begins once the venue is confirmed" }
+        ]
+      }
+    ],
+    "selected": {
+      "id": "e1",
+      "name": "Midsummer Masquerade",
+      "date": "Sat 21 Jun · 9:00 PM",
+      "venue": "The Vault, Manhattan",
+      "status": "On sale",
+      "status_variant": "warning",
+      "sold": 188,
+      "capacity": 200,
+      "sold_pct": 94,
+      "pct_color": "#059669",
+      "pct_band": "Nearly sold out",
+      "revenue": "$67,400",
+      "checked_in": 0,
+      "summary": "94% sold · 12 tickets left · expected to sell out this week",
+      "tiers": [
+        { "id": "t1", "tier": "General", "price": "$250", "sold": "140 / 140", "left": "0" },
+        { "id": "t2", "tier": "Premium", "price": "$450", "sold": "40 / 45", "left": "5" },
+        { "id": "t3", "tier": "Founders box", "price": "$1,200", "sold": "8 / 15", "left": "7" }
+      ],
+      "run_of_show": [
+        { "id": "r1", "date": "9:00 PM", "title": "Doors + welcome", "detail": "Coat check, masks issued at the door" },
+        { "id": "r2", "date": "10:00 PM", "title": "Headline performance", "detail": "Main floor, 40 minutes" },
+        { "id": "r3", "date": "11:30 PM", "title": "Late lounge opens", "detail": "Members-only upper floor" }
+      ]
+    }
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "20px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "Events",
+          "subtitle": "Track sell-through across the calendar — green is filling, amber needs a push",
+          "eyebrow": "Sell-through"
+        }
+      },
+      {
+        "type": "grid",
+        "props": { "columns": "repeat(6, minmax(0, 1fr))", "gap": "12px" },
+        "children": [
+          {
+            "type": "each",
+            "items": "{state.status_counts}",
+            "item_as": "bucket",
+            "children": [
+              {
+                "type": "card",
+                "props": { "variant": "outlined", "density": "compact" },
+                "children": [
+                  {
+                    "type": "flex",
+                    "props": { "direction": "column", "gap": "6px" },
+                    "children": [
+                      { "type": "status-dot", "props": { "variant": "{bucket.dot}", "label": "{bucket.label}", "size": 8 } },
+                      { "type": "text", "props": { "text": "{bucket.value}", "size": "2xl", "weight": "bold", "color": "{bucket.color}" } }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "muted", "density": "compact" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "6px" },
+                "children": [
+                  { "type": "text", "props": { "text": "Tickets sold", "size": "xs", "weight": "medium", "color": "#64748b" } },
+                  { "type": "text", "props": { "text": "{state.total_sold}", "size": "2xl", "weight": "bold" } }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "muted", "density": "compact" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "6px" },
+                "children": [
+                  { "type": "text", "props": { "text": "Revenue", "size": "xs", "weight": "medium", "color": "#64748b" } },
+                  { "type": "text", "props": { "text": "{state.total_revenue}", "size": "2xl", "weight": "bold", "color": "#059669" } }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "grid",
+        "props": { "columns": "minmax(300px, 360px) minmax(0, 1fr)", "gap": "20px" },
+        "children": [
+          {
+            "type": "flex",
+            "props": { "direction": "column", "gap": "10px" },
+            "children": [
+              { "type": "text", "props": { "text": "EVENTS", "size": "xs", "weight": "semibold", "color": "#64748b" } },
+              {
+                "type": "each",
+                "items": "{state.events}",
+                "item_as": "ev",
+                "children": [
+                  {
+                    "type": "card",
+                    "props": {
+                      "variant": "{ev.id == state.selected_id ? 'selected' : 'outlined'}",
+                      "density": "compact",
+                      "interactive": true
+                    },
+                    "on_click": [
+                      { "action": "set", "target": "selected_id", "value": "{ev.id}" },
+                      { "action": "set", "target": "selected", "value": "{state.events.where('id', ev.id).first()}" }
+                    ],
+                    "children": [
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "8px" },
+                        "children": [
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "justify": "between", "align": "center", "gap": "8px" },
+                            "children": [
+                              { "type": "text", "props": { "text": "{ev.name}", "weight": "semibold", "size": "base" } },
+                              { "type": "badge", "props": { "text": "{ev.sold_pct}%", "variant": "outline" } }
+                            ]
+                          },
+                          { "type": "progress", "props": { "value": "{ev.sold_pct}", "max": 100, "color": "{ev.pct_color}", "variant": "thin" } },
+                          { "type": "text", "props": { "text": "{ev.date}", "size": "xs", "color": "#64748b" } },
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "justify": "between", "align": "center", "gap": "8px" },
+                            "children": [
+                              { "type": "badge", "props": { "text": "{ev.status}", "variant": "{ev.status_variant}" } },
+                              { "type": "text", "props": { "text": "{ev.sold} / {ev.capacity}", "size": "xs", "color": "#94a3b8" } }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "default" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "18px" },
+                "children": [
+                  {
+                    "type": "flex",
+                    "props": { "direction": "row", "justify": "between", "align": "start", "gap": "16px", "wrap": "wrap" },
+                    "children": [
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "8px" },
+                        "children": [
+                          { "type": "text", "props": { "text": "EVENT", "size": "xs", "weight": "semibold", "color": "#94a3b8" } },
+                          { "type": "heading", "props": { "text": "{state.selected.name}", "level": 2 } },
+                          { "type": "text", "props": { "text": "{state.selected.date} · {state.selected.venue}", "size": "sm", "color": "#64748b" } },
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "gap": "8px", "align": "center", "wrap": "wrap" },
+                            "children": [
+                              { "type": "badge", "props": { "text": "{state.selected.status}", "variant": "{state.selected.status_variant}" } },
+                              { "type": "badge", "props": { "text": "{state.selected.pct_band}", "variant": "outline" } }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "4px", "align": "center" },
+                        "children": [
+                          {
+                            "type": "progress-ring",
+                            "props": {
+                              "value": "{state.selected.sold_pct}",
+                              "max": 100,
+                              "size": 96,
+                              "thickness": 9,
+                              "color": "{state.selected.pct_color}",
+                              "label": "{state.selected.sold_pct}%"
+                            }
+                          },
+                          { "type": "text", "props": { "text": "sold", "size": "xs", "weight": "medium", "color": "#94a3b8" } }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "grid",
+                    "props": { "columns": "repeat(3, minmax(0, 1fr))", "gap": "12px" },
+                    "children": [
+                      {
+                        "type": "card",
+                        "props": { "variant": "muted", "density": "compact" },
+                        "children": [
+                          {
+                            "type": "flex",
+                            "props": { "direction": "column", "gap": "4px" },
+                            "children": [
+                              { "type": "text", "props": { "text": "Revenue", "size": "xs", "color": "#64748b" } },
+                              { "type": "text", "props": { "text": "{state.selected.revenue}", "size": "xl", "weight": "bold", "color": "#059669" } }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "card",
+                        "props": { "variant": "muted", "density": "compact" },
+                        "children": [
+                          {
+                            "type": "flex",
+                            "props": { "direction": "column", "gap": "4px" },
+                            "children": [
+                              { "type": "text", "props": { "text": "Attendees", "size": "xs", "color": "#64748b" } },
+                              { "type": "text", "props": { "text": "{state.selected.sold}", "size": "xl", "weight": "bold" } }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "card",
+                        "props": { "variant": "muted", "density": "compact" },
+                        "children": [
+                          {
+                            "type": "flex",
+                            "props": { "direction": "column", "gap": "4px" },
+                            "children": [
+                              { "type": "text", "props": { "text": "Checked in", "size": "xs", "color": "#64748b" } },
+                              { "type": "text", "props": { "text": "{state.selected.checked_in}", "size": "xl", "weight": "bold", "color": "#0284c7" } }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "callout",
+                    "props": {
+                      "title": "Status",
+                      "text": "{state.selected.summary}",
+                      "variant": "info"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "props": { "title": "Ticket tiers" },
+                    "children": [
+                      {
+                        "type": "data-grid",
+                        "props": {
+                          "columns": [
+                            { "key": "tier", "label": "Tier", "sortable": true, "align": "left" },
+                            { "key": "price", "label": "Price", "sortable": true, "align": "right", "width": "110px" },
+                            { "key": "sold", "label": "Sold", "sortable": true, "align": "right", "width": "120px" },
+                            { "key": "left", "label": "Left", "sortable": true, "align": "right", "width": "90px" }
+                          ],
+                          "rows": "{state.selected.tiers}",
+                          "dense": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "props": { "title": "Run of show" },
+                    "children": [
+                      {
+                        "type": "timeline",
+                        "props": { "events": "{state.selected.run_of_show}", "density": "compact" }
+                      }
+                    ]
+                  },
+                  { "type": "separator", "props": { "orientation": "horizontal" } },
+                  {
+                    "type": "flex",
+                    "props": { "direction": "row", "gap": "8px", "wrap": "wrap" },
+                    "children": [
+                      {
+                        "type": "button",
+                        "props": { "label": "Promote this event", "variant": "primary" },
+                        "on_click": [
+                          {
+                            "action": "set",
+                            "target": "pending_proposal",
+                            "value": {
+                              "action": "promote_event",
+                              "event_id": "{state.selected_id}",
+                              "summary": "Promote {state.selected.name}"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/events-board/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/events-board/template.pocket.yaml
@@ -1,0 +1,79 @@
+# src/pocketpaw/bundled_templates/_bundled/events-board/template.pocket.yaml
+# Created: 2026-06-11 (feat/demo-template-suite) — RFC 03 v2 Pocket Template
+# Schema metadata for the generic events-board pocket. DEMO-GRADE from the
+# start, mirroring the applications-triage redesign (#1435): a color-banded
+# sell-through strip across the top (capacity vs sold per status + headline
+# stats), a scannable left queue of events (name, sell-through bar
+# color-banded by how full it is, status pill, date), and a loud detail
+# panel (header + status/sell-through pills + a sell-through RING, a
+# revenue / attendee / check-in stat row, the ticket-tier breakdown as a
+# record grid, and a run-of-show timeline). The detail panel binds to a
+# denormalized flat `state.selected` object kept in sync by the queue cards'
+# on_click (the on_click `set` value is a method chain that ENDS in `)`, the
+# only chain form the renderer resolves) so every detail binding is a plain
+# `{state.selected.X}` path — no method-chain-then-property access, the bug
+# that left the old triage detail panel empty. `state.selected` is also
+# SEEDED to the first event so the panel renders before any click.
+# `shape: custom` because the canvas is a composite (sell-through strip +
+# queue + detail + run-of-show) — RFC 03's shape enum has no value for it,
+# so the pattern is recorded in the sibling index.json (`pattern: app`) and
+# the shape stays `custom` (the same choice applications-triage made).
+# `needs: [paw.db.v1]` declares the generic data-source capability a tenant
+# wires so the queue hydrates from a real events endpoint; without one the
+# seeded sample events render. The one promote action declares
+# `instinct_policy: require_approval` so it surfaces as a PENDING gated
+# proposal in The Tray rather than executing inline — the deployment wires
+# the action row to external_actions.propose at the documented binding point
+# (see the ripple_spec _placeholder_note).
+schema_version: "2"
+name: events-board
+version: 1.0.0
+pattern: app
+vertical: operations
+display_name: Events Board
+shape: custom
+description: |
+  A sell-through console for upcoming events. A color-banded strip across the
+  top counts events by status — on sale, sold out, draft — and adds the
+  headline numbers: total events, total tickets sold, and total revenue. A
+  scannable queue on the left shows each event's name, date, a sell-through
+  bar color-banded by how full it is, and a status pill. Selecting an event
+  opens a detail panel where the booking picture is the loudest thing on the
+  canvas: the sell-through as a ring, a revenue / attendees / checked-in stat
+  row, the ticket tiers as a record grid with price, sold, and capacity, and
+  a run-of-show timeline. A promote action proposes a push for events selling
+  slowly, surfaced as a pending proposal for a human to confirm rather than
+  acting on its own. Ships a placeholder live-data source so a connected
+  backend hydrates the queue from a real events endpoint; with no backend it
+  renders the seeded sample events.
+icon: calendar
+color: "#7c5b99"
+state:
+  entity_type: Event
+  id_field: id
+  columns:
+    - { field: name, label: Event, widget: text }
+    - { field: date, label: Date, widget: text }
+    - { field: status, label: Status, widget: badge }
+    - { field: sold_pct, label: Sell-through, widget: number }
+    - { field: revenue, label: Revenue, widget: text }
+    - { field: sold, label: Sold, widget: number }
+data_sources:
+  - name: events
+    method: GET
+    path: /events?status=upcoming
+    bind: state.events
+    refresh: [pocket_open, manual]
+needs:
+  - paw.db.v1
+actions:
+  - name: promote_event
+    label: Promote
+    kind: single-row
+    instinct_policy: require_approval
+    outcomes_emitted: [event_promoted]
+    description: Proposes a promotional push for the selected event. Gated — a human confirms in The Tray.
+outcomes:
+  - event_promoted
+connectors: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/_bundled/index.json
+++ b/src/pocketpaw/bundled_templates/_bundled/index.json
@@ -80,6 +80,38 @@
       "pattern": "viewer",
       "keywords": ["member", "member 360", "member profile", "customer 360", "member view", "single view", "profile view", "member record", "membership", "account profile", "customer profile"],
       "connectors_hint": []
+    },
+    {
+      "slug": "events-board",
+      "title": "Events Board",
+      "shape": "custom",
+      "pattern": "app",
+      "keywords": ["events", "event", "events board", "sell-through", "sell through", "ticket sales", "tickets", "capacity", "attendees", "run of show", "event calendar", "shows", "performances", "bookings"],
+      "connectors_hint": []
+    },
+    {
+      "slug": "renewals-radar",
+      "title": "Renewals Radar",
+      "shape": "custom",
+      "pattern": "app",
+      "keywords": ["renewals", "renewal", "renewals radar", "expiring", "churn", "churn risk", "retention", "lapsed", "memberships expiring", "subscription renewal", "renew", "at risk", "grace period"],
+      "connectors_hint": []
+    },
+    {
+      "slug": "orders-fulfillment",
+      "title": "Orders Fulfillment",
+      "shape": "kanban",
+      "pattern": "app",
+      "keywords": ["orders", "order", "fulfillment", "fulfilment", "shipping", "ship", "shipped", "delivered", "refund", "refunds", "order queue", "to ship", "shipments", "tracking", "warehouse"],
+      "connectors_hint": []
+    },
+    {
+      "slug": "revenue-pulse",
+      "title": "Revenue Pulse",
+      "shape": "chart",
+      "pattern": "dashboard",
+      "keywords": ["revenue", "revenue pulse", "executive dashboard", "exec dashboard", "mrr", "revenue dashboard", "financials", "sales dashboard", "income", "revenue trend", "by category", "approval rate", "business overview"],
+      "connectors_hint": []
     }
   ]
 }

--- a/src/pocketpaw/bundled_templates/_bundled/orders-fulfillment/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/orders-fulfillment/ripple_spec.json
@@ -1,0 +1,535 @@
+{
+  "_placeholder_note": "Built-in pocket template (orders-fulfillment), DEMO-GRADE 2026-06-11 (feat/demo-template-suite). The orders, customers, line items, and shipping below are real sample copy — no placeholder brackets — so a pocket created straight from this template renders as a finished fulfillment console. The create specialist still rewrites the sample orders to the user's real domain. BINDING CONTRACT (same as applications-triage): the Ripple expression engine resolves a method chain ONLY when the chain ENDS in `)`; a method call FOLLOWED BY a property access resolves to undefined, and `each` `items` resolves a FLAT dot-path from state ONLY. So the detail panel binds to a denormalized FLAT `state.selected` object — every detail binding is a plain `{state.selected.X}` path and the items / shipping / timeline loops read `{state.selected.items}` / `{state.selected.shipping}` / `{state.selected.timeline}`. Clicking a queue card keeps `state.selected` in sync via an on_click chain whose `set` value is `{state.orders.where('id', ord.id).first()}` — a chain that ENDS in `)`, so it resolves at dispatch time. `state.selected` is also SEEDED to the first order so the panel renders before any click. KANBAN: the stage board binds the order list with `bind: orders` and `columnKey: stage_id`; each order carries a `stage_id` matching one of the four column ids (to_ship / shipped / delivered / refund_requested) so the board groups them — kanban is the ONLY widget here with a top-level `bind`. ENUM NOTE: badge variants are {default,secondary,destructive,outline,success,warning}; chip variants are {default,primary,success,warning,destructive}; callout variants are {info,success,warning,insight}. Stage colors: amber (#d97706) to-ship, blue (#0284c7) shipped, green (#059669) delivered, red (#dc2626) refund-requested. The `sources` block is a PLACEHOLDER live-data binding: with a backend keep it so GET /orders hydrates state.orders; with NO backend remove it and keep the seeded orders. ACTION-ROW BINDING POINT: the ship / refund buttons set state.pending_proposal to a generic {action, order_id, summary} proposal — they do NOT execute. A deployment wires this state event to the Instinct gate so a human confirms in The Tray. Keep the fulfillment stat strip, the kanban stage board, the queue each-loop, the selected-sync on_click, the items grid, the shipping kv-table, the fulfillment timeline, and the action row intact.",
+  "sources": {
+    "orders": {
+      "method": "GET",
+      "path": "/orders?open=true",
+      "bind": "state.orders",
+      "refresh": ["pocket_open", "manual"]
+    }
+  },
+  "state": {
+    "selected_id": "o1",
+    "pending_proposal": null,
+    "stage_counts": [
+      { "id": "st1", "label": "To ship", "value": 3, "color": "#d97706", "dot": "away" },
+      { "id": "st2", "label": "Shipped", "value": 2, "color": "#0284c7", "dot": "busy" },
+      { "id": "st3", "label": "Delivered", "value": 1, "color": "#059669", "dot": "online" },
+      { "id": "st4", "label": "Refund req.", "value": 1, "color": "#dc2626", "dot": "offline" }
+    ],
+    "to_ship_count": 3,
+    "units_in_flight": 14,
+    "open_refunds": 1,
+    "stage_columns": [
+      { "id": "to_ship", "title": "To ship" },
+      { "id": "shipped", "title": "Shipped" },
+      { "id": "delivered", "title": "Delivered" },
+      { "id": "refund_requested", "title": "Refund requested" }
+    ],
+    "orders": [
+      {
+        "id": "o1",
+        "ref": "#SN-4821",
+        "title": "#SN-4821 · Amara Okafor",
+        "customer": "Amara Okafor",
+        "stage": "To ship",
+        "stage_id": "to_ship",
+        "stage_variant": "warning",
+        "payment": "Paid",
+        "payment_variant": "success",
+        "total": "$340",
+        "units": 3,
+        "placed": "2026-06-09",
+        "summary": "Paid two days ago, awaiting pick + pack — oldest unshipped order in the queue",
+        "items": [
+          { "id": "i1", "item": "Branded tote", "qty": "1", "price": "$25" },
+          { "id": "i2", "item": "Event ticket — Midsummer", "qty": "1", "price": "$250" },
+          { "id": "i3", "item": "Members' candle set", "qty": "1", "price": "$65" }
+        ],
+        "shipping": [
+          { "key": "Recipient", "value": "Amara Okafor" },
+          { "key": "Address", "value": "14 Park Ave, New York, NY 10016" },
+          { "key": "Carrier", "value": "UPS Ground (Shippo)" },
+          { "key": "Tracking", "value": "Not yet generated" }
+        ],
+        "timeline": [
+          { "id": "tl1", "date": "2026-06-09", "title": "Order placed", "detail": "Web checkout" },
+          { "id": "tl2", "date": "2026-06-09", "title": "Payment captured", "detail": "$340 — Authorize.Net" }
+        ]
+      },
+      {
+        "id": "o2",
+        "ref": "#SN-4822",
+        "title": "#SN-4822 · Liam Petrov",
+        "customer": "Liam Petrov",
+        "stage": "To ship",
+        "stage_id": "to_ship",
+        "stage_variant": "warning",
+        "payment": "Paid",
+        "payment_variant": "success",
+        "total": "$90",
+        "units": 2,
+        "placed": "2026-06-10",
+        "summary": "Paid, ready to pack — two small items, ships same-day if picked this afternoon",
+        "items": [
+          { "id": "i1", "item": "Branded cap", "qty": "1", "price": "$35" },
+          { "id": "i2", "item": "Sticker pack", "qty": "1", "price": "$10" }
+        ],
+        "shipping": [
+          { "key": "Recipient", "value": "Liam Petrov" },
+          { "key": "Address", "value": "302 Mission St, San Francisco, CA 94105" },
+          { "key": "Carrier", "value": "USPS First Class (Shippo)" },
+          { "key": "Tracking", "value": "Not yet generated" }
+        ],
+        "timeline": [
+          { "id": "tl1", "date": "2026-06-10", "title": "Order placed", "detail": "Web checkout" },
+          { "id": "tl2", "date": "2026-06-10", "title": "Payment captured", "detail": "$90 — Authorize.Net" }
+        ]
+      },
+      {
+        "id": "o3",
+        "ref": "#SN-4818",
+        "title": "#SN-4818 · Priya Nair",
+        "customer": "Priya Nair",
+        "stage": "To ship",
+        "stage_id": "to_ship",
+        "stage_variant": "warning",
+        "payment": "Paid",
+        "payment_variant": "success",
+        "total": "$160",
+        "units": 4,
+        "placed": "2026-06-08",
+        "summary": "Bulk merch order — four units, needs the larger box, otherwise ready",
+        "items": [
+          { "id": "i1", "item": "Branded tote", "qty": "2", "price": "$50" },
+          { "id": "i2", "item": "Members' candle set", "qty": "1", "price": "$65" },
+          { "id": "i3", "item": "Sticker pack", "qty": "1", "price": "$10" }
+        ],
+        "shipping": [
+          { "key": "Recipient", "value": "Priya Nair" },
+          { "key": "Address", "value": "55 Hudson Yards, New York, NY 10001" },
+          { "key": "Carrier", "value": "UPS Ground (Shippo)" },
+          { "key": "Tracking", "value": "Not yet generated" }
+        ],
+        "timeline": [
+          { "id": "tl1", "date": "2026-06-08", "title": "Order placed", "detail": "Web checkout" },
+          { "id": "tl2", "date": "2026-06-08", "title": "Payment captured", "detail": "$160 — Authorize.Net" }
+        ]
+      },
+      {
+        "id": "o4",
+        "ref": "#SN-4805",
+        "title": "#SN-4805 · Sofia Marchetti",
+        "customer": "Sofia Marchetti",
+        "stage": "Shipped",
+        "stage_id": "shipped",
+        "stage_variant": "secondary",
+        "payment": "Paid",
+        "payment_variant": "success",
+        "total": "$120",
+        "units": 2,
+        "placed": "2026-06-05",
+        "summary": "Shipped yesterday — in transit, expected delivery June 12",
+        "items": [
+          { "id": "i1", "item": "Members' candle set", "qty": "1", "price": "$65" },
+          { "id": "i2", "item": "Branded cap", "qty": "1", "price": "$35" }
+        ],
+        "shipping": [
+          { "key": "Recipient", "value": "Sofia Marchetti" },
+          { "key": "Address", "value": "88 Greene St, New York, NY 10012" },
+          { "key": "Carrier", "value": "UPS Ground (Shippo)" },
+          { "key": "Tracking", "value": "1Z999AA10123456784" }
+        ],
+        "timeline": [
+          { "id": "tl1", "date": "2026-06-05", "title": "Order placed", "detail": "Web checkout" },
+          { "id": "tl2", "date": "2026-06-05", "title": "Payment captured", "detail": "$120" },
+          { "id": "tl3", "date": "2026-06-10", "title": "Shipped", "detail": "UPS — tracking generated" }
+        ]
+      },
+      {
+        "id": "o5",
+        "ref": "#SN-4801",
+        "title": "#SN-4801 · Hannah Berg",
+        "customer": "Hannah Berg",
+        "stage": "Shipped",
+        "stage_id": "shipped",
+        "stage_variant": "secondary",
+        "payment": "Paid",
+        "payment_variant": "success",
+        "total": "$50",
+        "units": 1,
+        "placed": "2026-06-04",
+        "summary": "In transit — single tote, expected delivery June 11",
+        "items": [
+          { "id": "i1", "item": "Branded tote", "qty": "2", "price": "$50" }
+        ],
+        "shipping": [
+          { "key": "Recipient", "value": "Hannah Berg" },
+          { "key": "Address", "value": "21 Pearl St, Brooklyn, NY 11201" },
+          { "key": "Carrier", "value": "USPS Priority (Shippo)" },
+          { "key": "Tracking", "value": "9400111899223818796534" }
+        ],
+        "timeline": [
+          { "id": "tl1", "date": "2026-06-04", "title": "Order placed", "detail": "Web checkout" },
+          { "id": "tl2", "date": "2026-06-04", "title": "Payment captured", "detail": "$50" },
+          { "id": "tl3", "date": "2026-06-09", "title": "Shipped", "detail": "USPS — tracking generated" }
+        ]
+      },
+      {
+        "id": "o6",
+        "ref": "#SN-4790",
+        "title": "#SN-4790 · Daniel Cho",
+        "customer": "Daniel Cho",
+        "stage": "Delivered",
+        "stage_id": "delivered",
+        "stage_variant": "success",
+        "payment": "Paid",
+        "payment_variant": "success",
+        "total": "$65",
+        "units": 1,
+        "placed": "2026-05-30",
+        "summary": "Delivered June 6 and confirmed — order complete, no issues",
+        "items": [
+          { "id": "i1", "item": "Members' candle set", "qty": "1", "price": "$65" }
+        ],
+        "shipping": [
+          { "key": "Recipient", "value": "Daniel Cho" },
+          { "key": "Address", "value": "9 Beacon St, Boston, MA 02108" },
+          { "key": "Carrier", "value": "UPS Ground (Shippo)" },
+          { "key": "Tracking", "value": "1Z999AA10198765432 — delivered" }
+        ],
+        "timeline": [
+          { "id": "tl1", "date": "2026-05-30", "title": "Order placed", "detail": "Web checkout" },
+          { "id": "tl2", "date": "2026-06-02", "title": "Shipped", "detail": "UPS" },
+          { "id": "tl3", "date": "2026-06-06", "title": "Delivered", "detail": "Left at front desk — confirmed" }
+        ]
+      },
+      {
+        "id": "o7",
+        "ref": "#SN-4777",
+        "title": "#SN-4777 · Marcus Webb",
+        "customer": "Marcus Webb",
+        "stage": "Refund requested",
+        "stage_id": "refund_requested",
+        "stage_variant": "destructive",
+        "payment": "Refund pending",
+        "payment_variant": "destructive",
+        "total": "$250",
+        "units": 1,
+        "placed": "2026-05-22",
+        "summary": "Customer requested a refund — event ticket, cannot attend. Within policy window, awaiting approval.",
+        "items": [
+          { "id": "i1", "item": "Event ticket — Summer Mixer", "qty": "1", "price": "$250" }
+        ],
+        "shipping": [
+          { "key": "Recipient", "value": "Marcus Webb" },
+          { "key": "Fulfillment", "value": "Digital — e-ticket" },
+          { "key": "Refund reason", "value": "Cannot attend" },
+          { "key": "Policy", "value": "Within 14-day refund window" }
+        ],
+        "timeline": [
+          { "id": "tl1", "date": "2026-05-22", "title": "Order placed", "detail": "Web checkout" },
+          { "id": "tl2", "date": "2026-05-22", "title": "E-ticket issued", "detail": "Delivered by email" },
+          { "id": "tl3", "date": "2026-06-08", "title": "Refund requested", "detail": "Customer cannot attend" }
+        ]
+      }
+    ],
+    "selected": {
+      "id": "o1",
+      "ref": "#SN-4821",
+      "title": "#SN-4821 · Amara Okafor",
+      "customer": "Amara Okafor",
+      "stage": "To ship",
+      "stage_id": "to_ship",
+      "stage_variant": "warning",
+      "payment": "Paid",
+      "payment_variant": "success",
+      "total": "$340",
+      "units": 3,
+      "placed": "2026-06-09",
+      "summary": "Paid two days ago, awaiting pick + pack — oldest unshipped order in the queue",
+      "items": [
+        { "id": "i1", "item": "Branded tote", "qty": "1", "price": "$25" },
+        { "id": "i2", "item": "Event ticket — Midsummer", "qty": "1", "price": "$250" },
+        { "id": "i3", "item": "Members' candle set", "qty": "1", "price": "$65" }
+      ],
+      "shipping": [
+        { "key": "Recipient", "value": "Amara Okafor" },
+        { "key": "Address", "value": "14 Park Ave, New York, NY 10016" },
+        { "key": "Carrier", "value": "UPS Ground (Shippo)" },
+        { "key": "Tracking", "value": "Not yet generated" }
+      ],
+      "timeline": [
+        { "id": "tl1", "date": "2026-06-09", "title": "Order placed", "detail": "Web checkout" },
+        { "id": "tl2", "date": "2026-06-09", "title": "Payment captured", "detail": "$340 — Authorize.Net" }
+      ]
+    }
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "20px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "Orders",
+          "subtitle": "Move orders left to right across the board — to ship, shipped, delivered",
+          "eyebrow": "Fulfillment"
+        }
+      },
+      {
+        "type": "grid",
+        "props": { "columns": "repeat(7, minmax(0, 1fr))", "gap": "12px" },
+        "children": [
+          {
+            "type": "each",
+            "items": "{state.stage_counts}",
+            "item_as": "bucket",
+            "children": [
+              {
+                "type": "card",
+                "props": { "variant": "outlined", "density": "compact" },
+                "children": [
+                  {
+                    "type": "flex",
+                    "props": { "direction": "column", "gap": "6px" },
+                    "children": [
+                      { "type": "status-dot", "props": { "variant": "{bucket.dot}", "label": "{bucket.label}", "size": 8 } },
+                      { "type": "text", "props": { "text": "{bucket.value}", "size": "2xl", "weight": "bold", "color": "{bucket.color}" } }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "muted", "density": "compact" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "6px" },
+                "children": [
+                  { "type": "text", "props": { "text": "To ship", "size": "xs", "weight": "medium", "color": "#64748b" } },
+                  { "type": "text", "props": { "text": "{state.to_ship_count}", "size": "2xl", "weight": "bold", "color": "#d97706" } }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "muted", "density": "compact" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "6px" },
+                "children": [
+                  { "type": "text", "props": { "text": "Units in flight", "size": "xs", "weight": "medium", "color": "#64748b" } },
+                  { "type": "text", "props": { "text": "{state.units_in_flight}", "size": "2xl", "weight": "bold" } }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "muted", "density": "compact" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "6px" },
+                "children": [
+                  { "type": "text", "props": { "text": "Open refunds", "size": "xs", "weight": "medium", "color": "#64748b" } },
+                  { "type": "text", "props": { "text": "{state.open_refunds}", "size": "2xl", "weight": "bold", "color": "#dc2626" } }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "props": { "title": "Fulfillment board" },
+        "children": [
+          {
+            "type": "kanban",
+            "bind": "orders",
+            "props": {
+              "columns": "{state.stage_columns}",
+              "columnKey": "stage_id"
+            }
+          }
+        ]
+      },
+      {
+        "type": "grid",
+        "props": { "columns": "minmax(300px, 360px) minmax(0, 1fr)", "gap": "20px" },
+        "children": [
+          {
+            "type": "flex",
+            "props": { "direction": "column", "gap": "10px" },
+            "children": [
+              { "type": "text", "props": { "text": "ORDERS", "size": "xs", "weight": "semibold", "color": "#64748b" } },
+              {
+                "type": "each",
+                "items": "{state.orders}",
+                "item_as": "ord",
+                "children": [
+                  {
+                    "type": "card",
+                    "props": {
+                      "variant": "{ord.id == state.selected_id ? 'selected' : 'outlined'}",
+                      "density": "compact",
+                      "interactive": true
+                    },
+                    "on_click": [
+                      { "action": "set", "target": "selected_id", "value": "{ord.id}" },
+                      { "action": "set", "target": "selected", "value": "{state.orders.where('id', ord.id).first()}" }
+                    ],
+                    "children": [
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "8px" },
+                        "children": [
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "justify": "between", "align": "center", "gap": "8px" },
+                            "children": [
+                              { "type": "text", "props": { "text": "{ord.ref}", "weight": "semibold", "size": "base" } },
+                              { "type": "text", "props": { "text": "{ord.total}", "weight": "semibold", "size": "base", "color": "#059669" } }
+                            ]
+                          },
+                          { "type": "text", "props": { "text": "{ord.customer} · {ord.units} units", "size": "xs", "color": "#64748b" } },
+                          { "type": "badge", "props": { "text": "{ord.stage}", "variant": "{ord.stage_variant}" } }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "default" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "18px" },
+                "children": [
+                  {
+                    "type": "flex",
+                    "props": { "direction": "row", "justify": "between", "align": "start", "gap": "16px", "wrap": "wrap" },
+                    "children": [
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "8px" },
+                        "children": [
+                          { "type": "text", "props": { "text": "ORDER", "size": "xs", "weight": "semibold", "color": "#94a3b8" } },
+                          { "type": "heading", "props": { "text": "{state.selected.ref}", "level": 2 } },
+                          { "type": "text", "props": { "text": "{state.selected.customer} · placed {state.selected.placed}", "size": "sm", "color": "#64748b" } },
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "gap": "8px", "align": "center", "wrap": "wrap" },
+                            "children": [
+                              { "type": "badge", "props": { "text": "{state.selected.stage}", "variant": "{state.selected.stage_variant}" } },
+                              { "type": "badge", "props": { "text": "{state.selected.payment}", "variant": "{state.selected.payment_variant}" } }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "4px", "align": "end" },
+                        "children": [
+                          { "type": "text", "props": { "text": "{state.selected.total}", "size": "2xl", "weight": "bold", "color": "#059669" } },
+                          { "type": "text", "props": { "text": "{state.selected.units} units", "size": "xs", "color": "#94a3b8" } }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "callout",
+                    "props": {
+                      "title": "Status",
+                      "text": "{state.selected.summary}",
+                      "variant": "info"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "props": { "title": "Items" },
+                    "children": [
+                      {
+                        "type": "data-grid",
+                        "props": {
+                          "columns": [
+                            { "key": "item", "label": "Item", "sortable": true, "align": "left" },
+                            { "key": "qty", "label": "Qty", "sortable": true, "align": "right", "width": "80px" },
+                            { "key": "price", "label": "Price", "sortable": true, "align": "right", "width": "110px" }
+                          ],
+                          "rows": "{state.selected.items}",
+                          "dense": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "props": { "title": "Shipping" },
+                    "children": [
+                      { "type": "kv-table", "props": { "rows": "{state.selected.shipping}", "striped": true } }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "props": { "title": "Fulfillment timeline" },
+                    "children": [
+                      { "type": "timeline", "props": { "events": "{state.selected.timeline}", "density": "compact" } }
+                    ]
+                  },
+                  { "type": "separator", "props": { "orientation": "horizontal" } },
+                  {
+                    "type": "flex",
+                    "props": { "direction": "row", "gap": "8px", "wrap": "wrap" },
+                    "children": [
+                      {
+                        "type": "button",
+                        "props": { "label": "Mark shipped", "variant": "primary" },
+                        "on_click": [
+                          {
+                            "action": "set",
+                            "target": "pending_proposal",
+                            "value": {
+                              "action": "mark_shipped",
+                              "order_id": "{state.selected_id}",
+                              "summary": "Mark {state.selected.ref} shipped"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "button",
+                        "props": { "label": "Refund", "variant": "danger" },
+                        "on_click": [
+                          {
+                            "action": "set",
+                            "target": "pending_proposal",
+                            "value": {
+                              "action": "process_refund",
+                              "order_id": "{state.selected_id}",
+                              "summary": "Refund {state.selected.ref}"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/orders-fulfillment/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/orders-fulfillment/template.pocket.yaml
@@ -1,0 +1,88 @@
+# src/pocketpaw/bundled_templates/_bundled/orders-fulfillment/template.pocket.yaml
+# Created: 2026-06-11 (feat/demo-template-suite) — RFC 03 v2 Pocket Template
+# Schema metadata for the generic orders-fulfillment pocket. DEMO-GRADE from
+# the start, mirroring the applications-triage redesign (#1435) but with a
+# distinct layout so it never reads like the other queue pockets: a
+# fulfillment stat strip across the top (count cards per stage + headline
+# stats: orders to ship, units in flight, refunds open), a real `kanban`
+# widget showing every order as a card moving across the fulfillment stages
+# (to-ship / shipped / delivered / refund-requested), and below it a
+# queue+detail pair — a left order list and a right detail panel (order
+# header + stage/payment pills, a fulfillment stat row, the line items as a
+# record grid, the shipping facts as a key-value table, and a fulfillment
+# timeline). The detail binds to a denormalized flat `state.selected` object
+# kept in sync by the queue cards' on_click (the on_click `set` value is a
+# method chain that ENDS in `)`, the only chain form the renderer resolves)
+# so every detail binding is a plain `{state.selected.X}` path.
+# `state.selected` is also SEEDED to the first order so the panel renders
+# before any click. `shape: kanban` because the focal organising widget IS
+# the stage board (the RFC 03 shape enum has a kanban value, unlike the
+# composite triage canvas) and the pattern is `app` in the sibling
+# index.json. `needs: [paw.db.v1]` declares the generic data-source
+# capability a tenant wires so the board hydrates from a real orders
+# endpoint; without one the seeded sample orders render. The two fulfillment
+# actions declare `instinct_policy: require_approval` so each surfaces as a
+# PENDING gated proposal in The Tray rather than executing inline — the
+# deployment wires the action row to external_actions.propose at the
+# documented binding point (see the ripple_spec _placeholder_note).
+schema_version: "2"
+name: orders-fulfillment
+version: 1.0.0
+pattern: app
+vertical: operations
+display_name: Orders Fulfillment
+shape: kanban
+description: |
+  A fulfillment console for the order queue. A color-banded strip across the
+  top counts orders by stage — to ship, shipped, delivered, refund requested —
+  and adds the headline numbers: orders waiting to ship, units in flight, and
+  open refunds. A stage board shows every order as a card moving across the
+  fulfillment pipeline. Below it, a queue and detail pair: a left order list
+  and a right panel where the fulfillment picture is the loudest thing on the
+  canvas — the order header with stage and payment pills, a values and units
+  stat row, the line items as a record grid, the shipping address and carrier
+  as a key-value table, and a fulfillment timeline. Ship and refund actions
+  propose the next step, surfaced as pending proposals for a human to confirm
+  rather than acting on their own. Ships a placeholder live-data source so a
+  connected backend hydrates the board from a real orders endpoint; with no
+  backend it renders the seeded sample orders.
+icon: package
+color: "#5b8e99"
+state:
+  entity_type: Order
+  id_field: id
+  columns:
+    - { field: ref, label: Order, widget: text }
+    - { field: customer, label: Customer, widget: text }
+    - { field: stage, label: Stage, widget: badge }
+    - { field: total, label: Total, widget: text }
+    - { field: units, label: Units, widget: number }
+data_sources:
+  - name: orders
+    method: GET
+    path: /orders?open=true
+    bind: state.orders
+    refresh: [pocket_open, manual]
+needs:
+  - paw.db.v1
+actions:
+  - name: mark_shipped
+    label: Mark shipped
+    kind: single-row
+    instinct_policy: require_approval
+    outcomes_emitted: [order_shipped]
+    description: Proposes marking the selected order as shipped. Gated — a human confirms in The Tray.
+  - name: process_refund
+    label: Refund
+    kind: single-row
+    instinct_policy: require_approval
+    outcomes_emitted: [order_refunded]
+    confirm:
+      message: "Propose refunding this order?"
+      destructive: false
+    description: Proposes refunding the selected order. Gated — a human confirms in The Tray.
+outcomes:
+  - order_shipped
+  - order_refunded
+connectors: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/_bundled/renewals-radar/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/renewals-radar/ripple_spec.json
@@ -1,0 +1,528 @@
+{
+  "_placeholder_note": "Built-in pocket template (renewals-radar), DEMO-GRADE 2026-06-11 (feat/demo-template-suite). The members, renewal dates, risk scores, and history below are real sample copy — no placeholder brackets — so a pocket created straight from this template renders as a finished renewal-risk console. The create specialist still rewrites the sample members to the user's real domain. BINDING CONTRACT (same as applications-triage): the Ripple expression engine resolves a method chain ONLY when the chain ENDS in `)`; a method call FOLLOWED BY a property access resolves to undefined, and `each` `items` resolves a FLAT dot-path from state ONLY. So the detail panel binds to a denormalized FLAT `state.selected` object — every detail binding is a plain `{state.selected.X}` path and the facts / history loops read `{state.selected.facts}` / `{state.selected.history}`. Clicking a queue card keeps `state.selected` in sync via an on_click chain whose `set` value is `{state.members.where('id', mem.id).first()}` — a chain that ENDS in `)`, so it resolves at dispatch time. `state.selected` is also SEEDED to the first member so the panel renders before any click. ENUM NOTE: badge variants are {default,secondary,destructive,outline,success,warning}; chip variants are {default,primary,success,warning,destructive}; callout variants are {info,success,warning,insight}. RISK COLOR BANDS: red (#dc2626) high risk, amber (#d97706) medium, green (#059669) safe. The risk RING value is the churn-risk score (higher = more at risk), so the ring color tracks the band. The `sources` block is a PLACEHOLDER live-data binding: with a backend keep it so GET /memberships hydrates state.members; with NO backend remove it and keep the seeded members. ACTION-ROW BINDING POINT: the renew / remind buttons set state.pending_proposal to a generic {action, membership_id, summary} proposal — they do NOT execute. A deployment wires this state event to the Instinct gate so a human confirms in The Tray. Keep the risk strip, the queue each-loop ordered by risk, the selected-sync on_click, the risk ring, the grace-deadline callout, the facts kv-table, the history timeline, and the action row intact.",
+  "sources": {
+    "memberships": {
+      "method": "GET",
+      "path": "/memberships?expiring=true",
+      "bind": "state.members",
+      "refresh": ["pocket_open", "manual"]
+    }
+  },
+  "state": {
+    "selected_id": "m1",
+    "pending_proposal": null,
+    "risk_counts": [
+      { "id": "rc1", "label": "High risk", "value": 3, "color": "#dc2626", "dot": "offline" },
+      { "id": "rc2", "label": "Medium", "value": 3, "color": "#d97706", "dot": "away" },
+      { "id": "rc3", "label": "Safe", "value": 2, "color": "#059669", "dot": "online" }
+    ],
+    "expiring_count": 8,
+    "revenue_at_risk": "$18,640",
+    "auto_renew_share": "50%",
+    "members": [
+      {
+        "id": "m1",
+        "member": "Jordan Avery",
+        "tier": "Platinum",
+        "status": "Lapsed",
+        "status_variant": "destructive",
+        "initials": "JA",
+        "risk_score": 92,
+        "risk_color": "#dc2626",
+        "risk_band": "High risk",
+        "days_left": -6,
+        "days_label": "6 days past due",
+        "auto_renew": "Off",
+        "auto_renew_variant": "destructive",
+        "value": "$4,200",
+        "grace_deadline": "Grace period ends in 4 days — June 15",
+        "summary": "Lapsed six days ago but a long-standing member — auto-renew failed, card on file expired. Recoverable with a quick call.",
+        "facts": [
+          { "key": "Package", "value": "Annual — Platinum" },
+          { "key": "Renewal due", "value": "June 5, 2026" },
+          { "key": "Grace deadline", "value": "June 15, 2026" },
+          { "key": "Auto-renew", "value": "Off (card expired)" },
+          { "key": "Lifetime value", "value": "$12,600 over 3 years" }
+        ],
+        "history": [
+          { "id": "h1", "date": "2026-06-05", "title": "Auto-renew failed", "detail": "Card on file declined — expired" },
+          { "id": "h2", "date": "2025-06-05", "title": "Renewed — Platinum", "detail": "On time, paid in full" },
+          { "id": "h3", "date": "2024-06-05", "title": "Renewed — Gold → Platinum", "detail": "Upgraded tier" }
+        ]
+      },
+      {
+        "id": "m2",
+        "member": "Priya Sharma",
+        "tier": "Gold",
+        "status": "Expiring",
+        "status_variant": "warning",
+        "initials": "PS",
+        "risk_score": 78,
+        "risk_color": "#dc2626",
+        "risk_band": "High risk",
+        "days_left": 3,
+        "days_label": "3 days left",
+        "auto_renew": "Off",
+        "auto_renew_variant": "destructive",
+        "value": "$2,400",
+        "grace_deadline": "Renewal due in 3 days — June 14",
+        "summary": "Renewal due in three days with auto-renew off and no response to the last two reminders. Needs a personal nudge.",
+        "facts": [
+          { "key": "Package", "value": "Annual — Gold" },
+          { "key": "Renewal due", "value": "June 14, 2026" },
+          { "key": "Auto-renew", "value": "Off" },
+          { "key": "Reminders sent", "value": "2 (no response)" },
+          { "key": "Lifetime value", "value": "$4,800 over 2 years" }
+        ],
+        "history": [
+          { "id": "h1", "date": "2026-06-01", "title": "Second reminder sent", "detail": "Email — not opened" },
+          { "id": "h2", "date": "2026-05-25", "title": "First reminder sent", "detail": "Email — opened, no action" },
+          { "id": "h3", "date": "2025-06-14", "title": "Renewed — Gold", "detail": "Manual, late by 2 days" }
+        ]
+      },
+      {
+        "id": "m3",
+        "member": "Marcus Lindqvist",
+        "tier": "Gold",
+        "status": "Expiring",
+        "status_variant": "warning",
+        "initials": "ML",
+        "risk_score": 71,
+        "risk_color": "#dc2626",
+        "risk_band": "High risk",
+        "days_left": 8,
+        "days_label": "8 days left",
+        "auto_renew": "Off",
+        "auto_renew_variant": "destructive",
+        "value": "$2,400",
+        "grace_deadline": "Renewal due in 8 days — June 19",
+        "summary": "Attendance dropped to one event this quarter and auto-renew is off. Engagement signal is weak — worth a check-in.",
+        "facts": [
+          { "key": "Package", "value": "Annual — Gold" },
+          { "key": "Renewal due", "value": "June 19, 2026" },
+          { "key": "Auto-renew", "value": "Off" },
+          { "key": "Events this quarter", "value": "1 (down from 6)" },
+          { "key": "Lifetime value", "value": "$7,200 over 3 years" }
+        ],
+        "history": [
+          { "id": "h1", "date": "2026-04-10", "title": "Last event attended", "detail": "Spring Mixer" },
+          { "id": "h2", "date": "2025-06-19", "title": "Renewed — Gold", "detail": "On time" },
+          { "id": "h3", "date": "2024-06-19", "title": "Renewed — Gold", "detail": "On time" }
+        ]
+      },
+      {
+        "id": "m4",
+        "member": "Aisha Bello",
+        "tier": "Silver",
+        "status": "Expiring",
+        "status_variant": "warning",
+        "initials": "AB",
+        "risk_score": 54,
+        "risk_color": "#d97706",
+        "risk_band": "Medium",
+        "days_left": 12,
+        "days_label": "12 days left",
+        "auto_renew": "Off",
+        "auto_renew_variant": "destructive",
+        "value": "$1,200",
+        "grace_deadline": "Renewal due in 12 days — June 23",
+        "summary": "Steady attendance but auto-renew is off, so the renewal is manual. Likely to renew with a single reminder.",
+        "facts": [
+          { "key": "Package", "value": "Annual — Silver" },
+          { "key": "Renewal due", "value": "June 23, 2026" },
+          { "key": "Auto-renew", "value": "Off" },
+          { "key": "Events this quarter", "value": "4" },
+          { "key": "Lifetime value", "value": "$2,400 over 2 years" }
+        ],
+        "history": [
+          { "id": "h1", "date": "2026-05-30", "title": "Attended — Negotiation Workshop", "detail": "Checked in" },
+          { "id": "h2", "date": "2025-06-23", "title": "Renewed — Silver", "detail": "After one reminder" }
+        ]
+      },
+      {
+        "id": "m5",
+        "member": "Daniel Okonkwo",
+        "tier": "Gold",
+        "status": "Expiring",
+        "status_variant": "warning",
+        "initials": "DO",
+        "risk_score": 47,
+        "risk_color": "#d97706",
+        "risk_band": "Medium",
+        "days_left": 16,
+        "days_label": "16 days left",
+        "auto_renew": "On",
+        "auto_renew_variant": "success",
+        "value": "$2,400",
+        "grace_deadline": "Auto-renews in 16 days — June 27",
+        "summary": "Auto-renew is on and the card is valid, but spend dipped this quarter. Low effort — monitor, no action needed yet.",
+        "facts": [
+          { "key": "Package", "value": "Annual — Gold" },
+          { "key": "Renewal due", "value": "June 27, 2026" },
+          { "key": "Auto-renew", "value": "On (card valid)" },
+          { "key": "Spend this quarter", "value": "$180 (down 20%)" },
+          { "key": "Lifetime value", "value": "$7,200 over 3 years" }
+        ],
+        "history": [
+          { "id": "h1", "date": "2025-06-27", "title": "Auto-renewed — Gold", "detail": "Charged on file" },
+          { "id": "h2", "date": "2024-06-27", "title": "Auto-renewed — Gold", "detail": "Charged on file" }
+        ]
+      },
+      {
+        "id": "m6",
+        "member": "Elena Rossi",
+        "tier": "Silver",
+        "status": "Expiring",
+        "status_variant": "warning",
+        "initials": "ER",
+        "risk_score": 41,
+        "risk_color": "#d97706",
+        "risk_band": "Medium",
+        "days_left": 21,
+        "days_label": "21 days left",
+        "auto_renew": "On",
+        "auto_renew_variant": "success",
+        "value": "$1,200",
+        "grace_deadline": "Auto-renews in 21 days — July 2",
+        "summary": "Auto-renew on, engaged, but expressed interest in pausing over the summer. Watch for a cancel request.",
+        "facts": [
+          { "key": "Package", "value": "Annual — Silver" },
+          { "key": "Renewal due", "value": "July 2, 2026" },
+          { "key": "Auto-renew", "value": "On" },
+          { "key": "Note", "value": "Asked about summer pause" },
+          { "key": "Lifetime value", "value": "$2,400 over 2 years" }
+        ],
+        "history": [
+          { "id": "h1", "date": "2026-05-18", "title": "Asked about pausing", "detail": "Over the summer months" },
+          { "id": "h2", "date": "2025-07-02", "title": "Auto-renewed — Silver", "detail": "Charged on file" }
+        ]
+      },
+      {
+        "id": "m7",
+        "member": "Thomas Chen",
+        "tier": "Platinum",
+        "status": "Active",
+        "status_variant": "success",
+        "initials": "TC",
+        "risk_score": 18,
+        "risk_color": "#059669",
+        "risk_band": "Safe",
+        "days_left": 28,
+        "days_label": "28 days left",
+        "auto_renew": "On",
+        "auto_renew_variant": "success",
+        "value": "$4,200",
+        "grace_deadline": "Auto-renews in 28 days — July 9",
+        "summary": "High engagement, auto-renew on, paid in full every year. No action needed — a model member.",
+        "facts": [
+          { "key": "Package", "value": "Annual — Platinum" },
+          { "key": "Renewal due", "value": "July 9, 2026" },
+          { "key": "Auto-renew", "value": "On (card valid)" },
+          { "key": "Events this quarter", "value": "9" },
+          { "key": "Lifetime value", "value": "$16,800 over 4 years" }
+        ],
+        "history": [
+          { "id": "h1", "date": "2025-07-09", "title": "Auto-renewed — Platinum", "detail": "Charged on file" },
+          { "id": "h2", "date": "2024-07-09", "title": "Auto-renewed — Platinum", "detail": "Charged on file" }
+        ]
+      },
+      {
+        "id": "m8",
+        "member": "Sofia Reyes",
+        "tier": "Gold",
+        "status": "Active",
+        "status_variant": "success",
+        "initials": "SR",
+        "risk_score": 12,
+        "risk_color": "#059669",
+        "risk_band": "Safe",
+        "days_left": 34,
+        "days_label": "34 days left",
+        "auto_renew": "On",
+        "auto_renew_variant": "success",
+        "value": "$2,400",
+        "grace_deadline": "Auto-renews in 34 days — July 15",
+        "summary": "Auto-renew on, attends regularly, recently referred two new members. Lowest-risk renewal in the queue.",
+        "facts": [
+          { "key": "Package", "value": "Annual — Gold" },
+          { "key": "Renewal due", "value": "July 15, 2026" },
+          { "key": "Auto-renew", "value": "On" },
+          { "key": "Referrals", "value": "2 new members this year" },
+          { "key": "Lifetime value", "value": "$7,200 over 3 years" }
+        ],
+        "history": [
+          { "id": "h1", "date": "2026-04-22", "title": "Referred a new member", "detail": "Joined on Silver" },
+          { "id": "h2", "date": "2025-07-15", "title": "Auto-renewed — Gold", "detail": "Charged on file" }
+        ]
+      }
+    ],
+    "selected": {
+      "id": "m1",
+      "member": "Jordan Avery",
+      "tier": "Platinum",
+      "status": "Lapsed",
+      "status_variant": "destructive",
+      "initials": "JA",
+      "risk_score": 92,
+      "risk_color": "#dc2626",
+      "risk_band": "High risk",
+      "days_left": -6,
+      "days_label": "6 days past due",
+      "auto_renew": "Off",
+      "auto_renew_variant": "destructive",
+      "value": "$4,200",
+      "grace_deadline": "Grace period ends in 4 days — June 15",
+      "summary": "Lapsed six days ago but a long-standing member — auto-renew failed, card on file expired. Recoverable with a quick call.",
+      "facts": [
+        { "key": "Package", "value": "Annual — Platinum" },
+        { "key": "Renewal due", "value": "June 5, 2026" },
+        { "key": "Grace deadline", "value": "June 15, 2026" },
+        { "key": "Auto-renew", "value": "Off (card expired)" },
+        { "key": "Lifetime value", "value": "$12,600 over 3 years" }
+      ],
+      "history": [
+        { "id": "h1", "date": "2026-06-05", "title": "Auto-renew failed", "detail": "Card on file declined — expired" },
+        { "id": "h2", "date": "2025-06-05", "title": "Renewed — Platinum", "detail": "On time, paid in full" },
+        { "id": "h3", "date": "2024-06-05", "title": "Renewed — Gold → Platinum", "detail": "Upgraded tier" }
+      ]
+    }
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "20px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "Renewals",
+          "subtitle": "Work the radar top to bottom — highest churn risk first, save the revenue before it lapses",
+          "eyebrow": "Renewal risk"
+        }
+      },
+      {
+        "type": "grid",
+        "props": { "columns": "repeat(6, minmax(0, 1fr))", "gap": "12px" },
+        "children": [
+          {
+            "type": "each",
+            "items": "{state.risk_counts}",
+            "item_as": "bucket",
+            "children": [
+              {
+                "type": "card",
+                "props": { "variant": "outlined", "density": "compact" },
+                "children": [
+                  {
+                    "type": "flex",
+                    "props": { "direction": "column", "gap": "6px" },
+                    "children": [
+                      { "type": "status-dot", "props": { "variant": "{bucket.dot}", "label": "{bucket.label}", "size": 8 } },
+                      { "type": "text", "props": { "text": "{bucket.value}", "size": "2xl", "weight": "bold", "color": "{bucket.color}" } }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "muted", "density": "compact" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "6px" },
+                "children": [
+                  { "type": "text", "props": { "text": "Expiring soon", "size": "xs", "weight": "medium", "color": "#64748b" } },
+                  { "type": "text", "props": { "text": "{state.expiring_count}", "size": "2xl", "weight": "bold" } }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "muted", "density": "compact" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "6px" },
+                "children": [
+                  { "type": "text", "props": { "text": "Revenue at risk", "size": "xs", "weight": "medium", "color": "#64748b" } },
+                  { "type": "text", "props": { "text": "{state.revenue_at_risk}", "size": "2xl", "weight": "bold", "color": "#dc2626" } }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "grid",
+        "props": { "columns": "minmax(300px, 360px) minmax(0, 1fr)", "gap": "20px" },
+        "children": [
+          {
+            "type": "flex",
+            "props": { "direction": "column", "gap": "10px" },
+            "children": [
+              { "type": "text", "props": { "text": "BY RISK", "size": "xs", "weight": "semibold", "color": "#64748b" } },
+              {
+                "type": "each",
+                "items": "{state.members}",
+                "item_as": "mem",
+                "children": [
+                  {
+                    "type": "card",
+                    "props": {
+                      "variant": "{mem.id == state.selected_id ? 'selected' : 'outlined'}",
+                      "density": "compact",
+                      "interactive": true
+                    },
+                    "on_click": [
+                      { "action": "set", "target": "selected_id", "value": "{mem.id}" },
+                      { "action": "set", "target": "selected", "value": "{state.members.where('id', mem.id).first()}" }
+                    ],
+                    "children": [
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "8px" },
+                        "children": [
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "justify": "between", "align": "center", "gap": "8px" },
+                            "children": [
+                              { "type": "text", "props": { "text": "{mem.member}", "weight": "semibold", "size": "base" } },
+                              { "type": "chip", "props": { "label": "{mem.days_label}", "variant": "{mem.days_left <= 7 ? 'destructive' : 'default'}" } }
+                            ]
+                          },
+                          { "type": "progress", "props": { "value": "{mem.risk_score}", "max": 100, "color": "{mem.risk_color}", "variant": "thin" } },
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "justify": "between", "align": "center", "gap": "8px" },
+                            "children": [
+                              { "type": "badge", "props": { "text": "{mem.tier}", "variant": "outline" } },
+                              { "type": "badge", "props": { "text": "Auto-renew {mem.auto_renew}", "variant": "{mem.auto_renew_variant}" } }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "card",
+            "props": { "variant": "default" },
+            "children": [
+              {
+                "type": "flex",
+                "props": { "direction": "column", "gap": "18px" },
+                "children": [
+                  {
+                    "type": "flex",
+                    "props": { "direction": "row", "justify": "between", "align": "start", "gap": "16px", "wrap": "wrap" },
+                    "children": [
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "8px" },
+                        "children": [
+                          { "type": "text", "props": { "text": "MEMBER", "size": "xs", "weight": "semibold", "color": "#94a3b8" } },
+                          { "type": "heading", "props": { "text": "{state.selected.member}", "level": 2 } },
+                          { "type": "text", "props": { "text": "{state.selected.tier} · {state.selected.value} at stake", "size": "sm", "color": "#64748b" } },
+                          {
+                            "type": "flex",
+                            "props": { "direction": "row", "gap": "8px", "align": "center", "wrap": "wrap" },
+                            "children": [
+                              { "type": "badge", "props": { "text": "{state.selected.status}", "variant": "{state.selected.status_variant}" } },
+                              { "type": "badge", "props": { "text": "Auto-renew {state.selected.auto_renew}", "variant": "{state.selected.auto_renew_variant}" } }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "flex",
+                        "props": { "direction": "column", "gap": "4px", "align": "center" },
+                        "children": [
+                          {
+                            "type": "progress-ring",
+                            "props": {
+                              "value": "{state.selected.risk_score}",
+                              "max": 100,
+                              "size": 96,
+                              "thickness": 9,
+                              "color": "{state.selected.risk_color}",
+                              "label": "{state.selected.risk_score}"
+                            }
+                          },
+                          { "type": "text", "props": { "text": "{state.selected.risk_band}", "size": "xs", "weight": "medium", "color": "{state.selected.risk_color}" } }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "callout",
+                    "props": {
+                      "title": "{state.selected.grace_deadline}",
+                      "text": "{state.selected.summary}",
+                      "variant": "warning"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "props": { "title": "Renewal details" },
+                    "children": [
+                      { "type": "kv-table", "props": { "rows": "{state.selected.facts}", "striped": true } }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "props": { "title": "Renewal history" },
+                    "children": [
+                      { "type": "timeline", "props": { "events": "{state.selected.history}", "density": "compact" } }
+                    ]
+                  },
+                  { "type": "separator", "props": { "orientation": "horizontal" } },
+                  {
+                    "type": "flex",
+                    "props": { "direction": "row", "gap": "8px", "wrap": "wrap" },
+                    "children": [
+                      {
+                        "type": "button",
+                        "props": { "label": "Renew now", "variant": "primary" },
+                        "on_click": [
+                          {
+                            "action": "set",
+                            "target": "pending_proposal",
+                            "value": {
+                              "action": "renew_membership",
+                              "membership_id": "{state.selected_id}",
+                              "summary": "Renew {state.selected.member}"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "button",
+                        "props": { "label": "Send reminder", "variant": "secondary" },
+                        "on_click": [
+                          {
+                            "action": "set",
+                            "target": "pending_proposal",
+                            "value": {
+                              "action": "send_renewal_reminder",
+                              "membership_id": "{state.selected_id}",
+                              "summary": "Remind {state.selected.member} to renew"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/renewals-radar/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/renewals-radar/template.pocket.yaml
@@ -1,0 +1,84 @@
+# src/pocketpaw/bundled_templates/_bundled/renewals-radar/template.pocket.yaml
+# Created: 2026-06-11 (feat/demo-template-suite) — RFC 03 v2 Pocket Template
+# Schema metadata for the generic renewals-radar pocket. DEMO-GRADE from the
+# start, mirroring the applications-triage redesign (#1435): a revenue-at-risk
+# stat strip across the top (count cards banded by churn risk + headline
+# stats: members expiring, revenue at risk, auto-renew share), a scannable
+# left queue of members ordered by renewal risk (name, a days-left countdown
+# chip, a risk bar color-banded high/medium/safe, auto-renew status), and a
+# loud detail panel (member header + risk/auto-renew pills + a risk RING, a
+# grace-deadline callout, the renewal facts as a key-value table, and a
+# renewal-history timeline). The detail binds to a denormalized flat
+# `state.selected` object kept in sync by the queue cards' on_click (the
+# on_click `set` value is a method chain that ENDS in `)`, the only chain
+# form the renderer resolves) so every detail binding is a plain
+# `{state.selected.X}` path. `state.selected` is also SEEDED to the first
+# member so the panel renders before any click. `shape: custom` because the
+# canvas is a composite — RFC 03's shape enum has no value for it, so the
+# pattern is recorded in the sibling index.json (`pattern: app`) and the
+# shape stays `custom`. `needs: [paw.db.v1]` declares the generic data-source
+# capability a tenant wires so the queue hydrates from a real memberships
+# endpoint; without one the seeded sample members render. The two renewal
+# actions declare `instinct_policy: require_approval` so each surfaces as a
+# PENDING gated proposal in The Tray rather than executing inline — the
+# deployment wires the action row to external_actions.propose at the
+# documented binding point (see the ripple_spec _placeholder_note).
+schema_version: "2"
+name: renewals-radar
+version: 1.0.0
+pattern: app
+vertical: operations
+display_name: Renewals Radar
+shape: custom
+description: |
+  A renewal-risk console for memberships. A color-banded strip across the top
+  counts members by churn risk — high, medium, safe — and adds the headline
+  numbers: how many are expiring soon, how much revenue is at risk, and what
+  share have auto-renew on. A scannable queue on the left orders members by
+  risk and shows each one's name, a days-left countdown chip, a risk bar
+  color-banded by churn likelihood, and whether auto-renew is on. Selecting a
+  member opens a detail panel where the renewal picture is the loudest thing
+  on the canvas: the churn risk as a ring, a grace-deadline callout, the
+  renewal facts as a key-value table, and a renewal-history timeline. Renew
+  and remind actions propose the next step, surfaced as pending proposals for
+  a human to confirm rather than acting on their own. Ships a placeholder
+  live-data source so a connected backend hydrates the queue from a real
+  memberships endpoint; with no backend it renders the seeded sample members.
+icon: refresh-cw
+color: "#99775b"
+state:
+  entity_type: Membership
+  id_field: id
+  columns:
+    - { field: member, label: Member, widget: text }
+    - { field: tier, label: Tier, widget: badge }
+    - { field: risk_band, label: Risk, widget: badge }
+    - { field: days_left, label: Days left, widget: number }
+    - { field: auto_renew, label: Auto-renew, widget: badge }
+    - { field: value, label: Value, widget: text }
+data_sources:
+  - name: memberships
+    method: GET
+    path: /memberships?expiring=true
+    bind: state.members
+    refresh: [pocket_open, manual]
+needs:
+  - paw.db.v1
+actions:
+  - name: renew_membership
+    label: Renew
+    kind: single-row
+    instinct_policy: require_approval
+    outcomes_emitted: [membership_renewed]
+    description: Proposes renewing the selected membership. Gated — a human confirms in The Tray.
+  - name: send_renewal_reminder
+    label: Send reminder
+    kind: single-row
+    instinct_policy: require_approval
+    outcomes_emitted: [renewal_reminder_sent]
+    description: Proposes sending a renewal reminder to the member. Gated — a human confirms in The Tray.
+outcomes:
+  - membership_renewed
+  - renewal_reminder_sent
+connectors: []
+skill_refs: []

--- a/src/pocketpaw/bundled_templates/_bundled/revenue-pulse/ripple_spec.json
+++ b/src/pocketpaw/bundled_templates/_bundled/revenue-pulse/ripple_spec.json
@@ -1,0 +1,159 @@
+{
+  "_placeholder_note": "Built-in pocket template (revenue-pulse), DEMO-GRADE 2026-06-11 (feat/demo-template-suite). The six months of revenue, the category split, and the approval funnel below are real sample copy — no placeholder brackets — so a pocket created straight from this template renders as a finished executive dashboard. The create specialist still rewrites the sample numbers to the user's real domain. BINDING CONTRACT (same as the other vertical templates): every binding is a FLAT `{state.<key>}` dot-path — the chart `data`, the data-grid `rows`, and the stat each-loop all read seeded top-level lists, with no method-chain-then-property access and no bracket indexing in `each` items (the two forms that render empty). This is the ONLY dashboard in the suite, so it uses the hero+grid layout the create-pocket guidance reserves for dashboards (stat row -> full-width trend chart -> by-category split -> approval strip); the three sibling pockets are app/queue layouts so they never look alike. ENUM NOTE: stat `direction` is {up-good, down-good, up-bad, down-bad, flat}; chart `type` is one of {area, bar, line}. The trend chart reads `{label, value}` rows and the by-category bar chart reads `{label, value}` rows. READ-ONLY: no buttons, no on_click, no mutation. The `sources` block is a PLACEHOLDER live-data binding: with a backend keep it so GET /reports/revenue hydrates state.trend; with NO backend remove it and keep the seeded numbers. Keep the stat row, the trend area chart, the by-category bar chart + breakdown grid, and the approval-rate strip intact; reshape every list for the user's real reporting.",
+  "sources": {
+    "revenue": {
+      "method": "GET",
+      "path": "/reports/revenue?window=6m",
+      "bind": "state.trend",
+      "refresh": ["pocket_open", "manual"]
+    }
+  },
+  "state": {
+    "period_label": "Last 6 months · through June 2026",
+    "kpis": [
+      { "id": "k1", "label": "Recurring revenue", "value": "$48,200 / mo", "delta": "+9%", "direction": "up-good" },
+      { "id": "k2", "label": "Events revenue", "value": "$115,400", "delta": "+22%", "direction": "up-good" },
+      { "id": "k3", "label": "Store revenue", "value": "$19,860", "delta": "+6%", "direction": "up-good" },
+      { "id": "k4", "label": "Active memberships", "value": "412", "delta": "+14", "direction": "up-good" }
+    ],
+    "trend": [
+      { "label": "Jan", "value": 142000 },
+      { "label": "Feb", "value": 138500 },
+      { "label": "Mar", "value": 161200 },
+      { "label": "Apr", "value": 158900 },
+      { "label": "May", "value": 184600 },
+      { "label": "Jun", "value": 203400 }
+    ],
+    "category_chart": [
+      { "label": "Memberships", "value": 289200 },
+      { "label": "Events", "value": 115400 },
+      { "label": "Store", "value": 19860 },
+      { "label": "Comps / other", "value": 4140 }
+    ],
+    "categories": [
+      { "id": "c1", "category": "Memberships", "revenue": "$289,200", "share": "67%", "change_pct": 9 },
+      { "id": "c2", "category": "Events", "revenue": "$115,400", "share": "27%", "change_pct": 22 },
+      { "id": "c3", "category": "Store", "revenue": "$19,860", "share": "5%", "change_pct": 6 },
+      { "id": "c4", "category": "Comps / other", "revenue": "$4,140", "share": "1%", "change_pct": -3 }
+    ],
+    "approvals": [
+      { "id": "a1", "label": "Applications submitted", "value": "184", "sublabel": "last 6 months", "direction": "flat" },
+      { "id": "a2", "label": "Approved", "value": "121", "sublabel": "66% of submitted", "direction": "up-good" },
+      { "id": "a3", "label": "Approval rate", "value": "66%", "delta": "+4%", "direction": "up-good" }
+    ]
+  },
+  "ui": {
+    "type": "flex",
+    "props": { "direction": "column", "gap": "20px" },
+    "children": [
+      {
+        "type": "page-header",
+        "props": {
+          "title": "Revenue Pulse",
+          "subtitle": "{state.period_label}",
+          "eyebrow": "Executive dashboard"
+        }
+      },
+      {
+        "type": "grid",
+        "props": { "columns": "repeat(4, minmax(0, 1fr))", "gap": "16px" },
+        "children": [
+          {
+            "type": "each",
+            "items": "{state.kpis}",
+            "item_as": "kpi",
+            "children": [
+              {
+                "type": "stat",
+                "props": {
+                  "label": "{kpi.label}",
+                  "value": "{kpi.value}",
+                  "delta": "{kpi.delta}",
+                  "direction": "{kpi.direction}"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "chart",
+        "props": {
+          "type": "area",
+          "title": "Total revenue — last 6 months",
+          "data": "{state.trend}",
+          "height": 300
+        }
+      },
+      {
+        "type": "grid",
+        "props": { "columns": "minmax(0, 1fr) minmax(0, 1.2fr)", "gap": "20px" },
+        "children": [
+          {
+            "type": "section",
+            "props": { "title": "Revenue by category" },
+            "children": [
+              {
+                "type": "chart",
+                "props": {
+                  "type": "bar",
+                  "title": "This period",
+                  "data": "{state.category_chart}",
+                  "height": 260
+                }
+              }
+            ]
+          },
+          {
+            "type": "section",
+            "props": { "title": "Breakdown" },
+            "children": [
+              {
+                "type": "data-grid",
+                "props": {
+                  "columns": [
+                    { "key": "category", "label": "Category", "sortable": true, "align": "left" },
+                    { "key": "revenue", "label": "Revenue", "sortable": true, "align": "right", "width": "130px" },
+                    { "key": "share", "label": "Share", "sortable": true, "align": "right", "width": "90px" },
+                    { "key": "change_pct", "label": "Change %", "sortable": true, "align": "right", "width": "110px" }
+                  ],
+                  "rows": "{state.categories}",
+                  "defaultSort": "revenue:desc",
+                  "dense": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "section",
+        "props": { "title": "Application funnel" },
+        "children": [
+          {
+            "type": "grid",
+            "props": { "columns": "repeat(3, minmax(0, 1fr))", "gap": "16px" },
+            "children": [
+              {
+                "type": "each",
+                "items": "{state.approvals}",
+                "item_as": "ap",
+                "children": [
+                  {
+                    "type": "stat",
+                    "props": {
+                      "label": "{ap.label}",
+                      "value": "{ap.value}",
+                      "delta": "{ap.delta}",
+                      "direction": "{ap.direction}"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/pocketpaw/bundled_templates/_bundled/revenue-pulse/template.pocket.yaml
+++ b/src/pocketpaw/bundled_templates/_bundled/revenue-pulse/template.pocket.yaml
@@ -1,0 +1,60 @@
+# src/pocketpaw/bundled_templates/_bundled/revenue-pulse/template.pocket.yaml
+# Created: 2026-06-11 (feat/demo-template-suite) — RFC 03 v2 Pocket Template
+# Schema metadata for the generic revenue-pulse executive dashboard. This is
+# the ONE dashboard in the demo suite, so it deliberately uses the hero+grid
+# layout the create-pocket guidance reserves for dashboards (a KPI stat row,
+# full-width trend charts, then a breakdown table) — the three sibling
+# pockets (events-board / renewals-radar / orders-fulfillment) are app/queue
+# layouts, so this reads as a distinct, finished surface. The canvas: a top
+# stat row (recurring revenue, events revenue, store revenue, active
+# memberships), a full-width six-month revenue-trend `area` chart, a
+# by-category split (a `bar` chart beside a breakdown record grid), and an
+# approval-rate stat strip. Every chart and grid binds to a flat seeded
+# `{state.<key>}` list — no method-chain-then-property access. `shape: chart`
+# because the focal organising widget IS the trend chart (the RFC 03 shape
+# enum has a chart value) and the pattern is `dashboard` in the sibling
+# index.json. `needs: [paw.db.v1]` declares the generic data-source
+# capability a tenant wires so the numbers hydrate from a real reports
+# endpoint; without one the seeded six-month sample renders. READ-ONLY by
+# design: no actions, no on_click, no mutation — an executive review surface,
+# not an operating tool.
+schema_version: "2"
+name: revenue-pulse
+version: 1.0.0
+pattern: dashboard
+vertical: operations
+display_name: Revenue Pulse
+shape: chart
+description: |
+  An executive dashboard for the business at a glance. A top stat row carries
+  the headline numbers — recurring revenue, events revenue, store revenue, and
+  active memberships, each with its month-over-month change. Below it, a
+  full-width six-month revenue-trend chart, then a by-category split: a bar
+  chart of revenue by line of business beside a breakdown table with each
+  category's revenue, share, and change. An approval-rate strip closes the
+  view with the application funnel — submitted, approved, and the approval
+  rate. Read-only by design: it shows the shape of the business without
+  offering any action. Ships a placeholder live-data source so a connected
+  backend hydrates the numbers from a real reports endpoint; with no backend
+  it renders the seeded six-month sample.
+icon: trending-up
+color: "#5b995b"
+state:
+  entity_type: RevenueSnapshot
+  id_field: id
+  columns:
+    - { field: category, label: Category, widget: text }
+    - { field: revenue, label: Revenue, widget: text }
+    - { field: share, label: Share, widget: text }
+    - { field: change_pct, label: Change %, widget: number }
+data_sources:
+  - name: revenue
+    method: GET
+    path: /reports/revenue?window=6m
+    bind: state.trend
+    refresh: [pocket_open, manual]
+needs:
+  - paw.db.v1
+actions: []
+connectors: []
+skill_refs: []

--- a/tests/unit/test_bundled_templates.py
+++ b/tests/unit/test_bundled_templates.py
@@ -78,6 +78,10 @@ _SEED_SLUGS = {
 _VERTICAL_SLUGS = {
     "applications-triage",
     "member-360",
+    "events-board",
+    "renewals-radar",
+    "orders-fulfillment",
+    "revenue-pulse",
 }
 
 # Every bundled template the installer ships and index.json registers.

--- a/tests/unit/test_vertical_templates.py
+++ b/tests/unit/test_vertical_templates.py
@@ -19,7 +19,19 @@
 # state shape that was never seeded (the old "empty Answers / no values"
 # failure). It also flags the unsupported method-chain-then-property
 # pattern ({...first().field}) that resolved to undefined at render time.
-"""Tests for the bundled vertical templates (applications-triage, member-360).
+# Modified 2026-06-11 (feat/demo-template-suite): extended _VERTICAL_SLUGS to
+# the four new demo-suite templates — events-board, renewals-radar,
+# orders-fulfillment, revenue-pulse — so the generic binding-guard /
+# well-formed / data-sense / compile / installer / loader parametrizations
+# cover them too. The pydantic shape assertion is now per-slug
+# (_VERTICAL_SHAPES) because orders-fulfillment is `kanban` and revenue-pulse
+# is `chart`, not `custom`. Added a demo-suite block: a render-populated guard
+# (ui.children non-empty + the focal seed list carries rows), a
+# compile-round-trip that asserts the same on the loaded spec, the gated
+# action-row contract for the three action templates, and per-template story
+# checks (events sell-through + run-of-show, renewals risk bands + lapsed
+# member, orders stage board, revenue read-only charts).
+"""Tests for the bundled vertical templates (triage, member-360, demo suite).
 
 The seed-template field-set assertions in test_bundled_templates.py
 intentionally exclude these two slugs — they carry the full v2 surface
@@ -51,7 +63,27 @@ from pocketpaw.bundled_templates import PocketTemplate, compile_template
 from pocketpaw.bundled_templates.installer import install_bundled_templates
 from pocketpaw.bundled_templates.loader import load_template
 
-_VERTICAL_SLUGS = ("applications-triage", "member-360")
+_VERTICAL_SLUGS = (
+    "applications-triage",
+    "member-360",
+    "events-board",
+    "renewals-radar",
+    "orders-fulfillment",
+    "revenue-pulse",
+)
+
+# The RFC 03 v2 shape each vertical template declares. Most are ``custom``
+# composite canvases, but the focal-widget-driven ones pin their organising
+# shape: orders-fulfillment is a kanban stage board, revenue-pulse a chart
+# dashboard. The shape assertion is per-slug, not a blanket ``custom``.
+_VERTICAL_SHAPES = {
+    "applications-triage": "custom",
+    "member-360": "custom",
+    "events-board": "custom",
+    "renewals-radar": "custom",
+    "orders-fulfillment": "kanban",
+    "revenue-pulse": "chart",
+}
 
 _BUNDLED_DIR = (
     Path(__file__).resolve().parents[2] / "src" / "pocketpaw" / "bundled_templates" / "_bundled"
@@ -183,7 +215,7 @@ def test_vertical_template_passes_pydantic_validation(slug: str) -> None:
     template = PocketTemplate.model_validate(_read_meta(slug))
     assert template.name == slug
     assert template.schema_version == "2"
-    assert template.shape == "custom"
+    assert template.shape == _VERTICAL_SHAPES[slug]
 
 
 @pytest.mark.parametrize("slug", _VERTICAL_SLUGS)
@@ -342,7 +374,181 @@ def test_member_360_has_profile_membership_and_lists() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Installer — both vertical templates mirror like every other template
+# Demo-suite templates — events-board / renewals-radar / orders-fulfillment /
+# revenue-pulse. The render-surface guard (ui.children non-empty + the focal
+# seeded list carries rows) and the gated-action / read-only posture checks
+# that mirror the triage + member-360 contracts for the four new templates.
+# ---------------------------------------------------------------------------
+
+# The four demo-suite templates and the focal seeded state list whose rows
+# the rendered canvas iterates — the list that MUST carry seed rows so a
+# pocket created from the template renders populated, never an empty shell.
+_DEMO_SUITE = {
+    "events-board": "events",
+    "renewals-radar": "members",
+    "orders-fulfillment": "orders",
+    "revenue-pulse": "trend",
+}
+
+# The three demo-suite templates that ship gated action rows, mapped to the
+# proposal-payload entity-id key each button carries. revenue-pulse is a
+# read-only dashboard and is excluded.
+_DEMO_GATED = {
+    "events-board": "event_id",
+    "renewals-radar": "membership_id",
+    "orders-fulfillment": "order_id",
+}
+
+
+@pytest.mark.parametrize("slug", sorted(_DEMO_SUITE))
+def test_demo_template_renders_populated(slug: str) -> None:
+    """Each demo-suite template renders a populated canvas: the ui tree has
+    top-level children (so a pocket created from it is never an empty shell —
+    the #1431 empty-canvas class of bug) and the focal seeded list carries
+    rows. Asserts the user-visible surface, not just the compiled machinery."""
+    spec = _read_spec(slug)
+    children = spec["ui"].get("children")
+    assert children, f"{slug}: ui tree has no top-level children — empty canvas"
+
+    focal_key = _DEMO_SUITE[slug]
+    rows = spec["state"].get(focal_key)
+    assert isinstance(rows, list) and rows, (
+        f"{slug}: focal seed list state.{focal_key} is empty — nothing to render"
+    )
+
+
+@pytest.mark.parametrize("slug", sorted(_DEMO_SUITE))
+def test_demo_template_compile_round_trips_with_ui_and_seed(tmp_path: Path, slug: str) -> None:
+    """``load_template`` round-trips each demo-suite template back to a spec
+    whose ui carries children and whose focal seed list carries rows — the
+    install-time compile-on-create seam preserves the rendered surface, not
+    just the sources/state-binding machinery."""
+    install_bundled_templates(destination_root=tmp_path)
+    loaded = load_template(slug, templates_dir=tmp_path)
+    assert loaded is not None
+    spec = loaded["ripple_spec"]
+    assert spec["ui"].get("children"), f"{slug}: round-tripped ui has no children"
+    focal_key = _DEMO_SUITE[slug]
+    assert spec["state"].get(focal_key), f"{slug}: round-tripped seed list empty"
+
+
+@pytest.mark.parametrize("slug", sorted(_DEMO_GATED))
+def test_demo_template_actions_are_all_gated_require_approval(slug: str) -> None:
+    """Every action on a gated demo-suite template declares
+    ``instinct_policy: require_approval`` so it surfaces as a PENDING proposal
+    in The Tray, never auto-runs — the same contract triage clears."""
+    template = PocketTemplate.model_validate(_read_meta(slug))
+    assert template.actions, f"{slug}: expected gated actions"
+    for action in template.actions:
+        assert action.instinct_policy == "require_approval", action.name
+
+
+@pytest.mark.parametrize("slug", sorted(_DEMO_GATED))
+def test_demo_template_action_outcomes_are_declared_in_catalog(slug: str) -> None:
+    """Each gated action's outcomes_emitted is declared in the top-level
+    outcomes[] catalog — the RFC 03 v2 subset rule."""
+    template = PocketTemplate.model_validate(_read_meta(slug))
+    catalog = set(template.outcomes)
+    for action in template.actions:
+        for outcome in action.outcomes_emitted:
+            assert outcome in catalog, f"{slug}: {action.name} emits undeclared {outcome}"
+
+
+@pytest.mark.parametrize("slug", sorted(_DEMO_GATED))
+def test_demo_template_action_row_proposes_not_executes(slug: str) -> None:
+    """The ripple_spec action buttons set ``state.pending_proposal`` (a
+    generic {action, <entity>_id, summary} proposal) instead of executing —
+    the binding seam a deployment wires to external_actions.propose. The
+    state seeds an empty proposal slot."""
+    spec = _read_spec(slug)
+    id_key = _DEMO_GATED[slug]
+    buttons = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "button"]
+    assert buttons, f"{slug}: no action buttons"
+    for button in buttons:
+        actions = button.get("on_click")
+        assert actions, f"{slug}: button {button['props']['label']} has no on_click"
+        targets = {a.get("target") for a in actions}
+        assert targets == {"pending_proposal"}, button["props"]["label"]
+        value = actions[0]["value"]
+        assert set(value.keys()) == {"action", id_key, "summary"}, button["props"]["label"]
+    assert spec["state"].get("pending_proposal") is None
+
+
+def test_events_board_has_sell_through_and_run_of_show() -> None:
+    """events-board seeds the sell-through strip (status counts + headline
+    stats), the events queue, and per-event ticket tiers + run-of-show, and
+    renders a sell-through ring + progress bars."""
+    spec = _read_spec("events-board")
+    state = spec["state"]
+    for key in ("status_counts", "total_sold", "total_revenue", "events", "selected"):
+        assert key in state, f"events-board state missing {key}"
+    # Every event carries the story fields the canvas reads.
+    for ev in state["events"]:
+        assert ev.get("sold_pct") is not None and ev.get("pct_color"), ev.get("name")
+        assert ev.get("tiers") and ev.get("run_of_show"), ev.get("name")
+    # The redesign tells a story: one nearly sold out, one needing a push, one past.
+    pcts = {ev["sold_pct"] for ev in state["events"]}
+    assert max(pcts) >= 90, "no nearly-sold-out event"
+    assert any(p < 30 for p in pcts), "no slow event needing a push"
+    rings = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "progress-ring"]
+    assert rings, "events-board should render a sell-through ring"
+
+
+def test_renewals_radar_bands_by_risk_with_lapsed_recoverable() -> None:
+    """renewals-radar seeds members across high/medium/safe risk bands with a
+    revenue-at-risk strip, a churn-risk ring, and at least one lapsed member
+    (negative days_left) that is recoverable within grace."""
+    spec = _read_spec("renewals-radar")
+    state = spec["state"]
+    for key in ("risk_counts", "revenue_at_risk", "members", "selected"):
+        assert key in state, f"renewals-radar state missing {key}"
+    bands = {m["risk_band"] for m in state["members"]}
+    assert {"High risk", "Medium", "Safe"} <= bands, f"missing a risk band: {bands}"
+    assert any(m["days_left"] < 0 for m in state["members"]), "no lapsed member"
+    rings = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "progress-ring"]
+    assert rings, "renewals-radar should render a churn-risk ring"
+
+
+def test_orders_fulfillment_has_stage_board_and_detail() -> None:
+    """orders-fulfillment seeds orders across the four stages, drives a kanban
+    stage board bound to the order list, and seeds per-order items + shipping
+    + timeline for the detail panel."""
+    spec = _read_spec("orders-fulfillment")
+    state = spec["state"]
+    for key in ("stage_counts", "stage_columns", "orders", "selected"):
+        assert key in state, f"orders-fulfillment state missing {key}"
+    stages = {o["stage_id"] for o in state["orders"]}
+    assert {"to_ship", "shipped", "delivered", "refund_requested"} <= stages, stages
+    for o in state["orders"]:
+        assert o.get("items") and o.get("shipping") and o.get("timeline"), o.get("ref")
+    kanbans = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "kanban"]
+    assert len(kanbans) == 1, "orders-fulfillment should drive one kanban stage board"
+    assert kanbans[0].get("bind") == "orders", "kanban must bind the order list"
+    assert kanbans[0]["props"].get("columnKey") == "stage_id"
+
+
+def test_revenue_pulse_is_read_only_dashboard_with_charts() -> None:
+    """revenue-pulse is a read-only executive dashboard: zero actions, no
+    on_click anywhere, a six-month trend series, a by-category split, and the
+    approval funnel — rendered through stat tiles + chart widgets."""
+    template = PocketTemplate.model_validate(_read_meta("revenue-pulse"))
+    assert template.actions == []
+
+    spec = _read_spec("revenue-pulse")
+    for widget in _iter_widgets(spec["ui"]):
+        assert "on_click" not in widget, f"dashboard has an on_click: {widget.get('type')}"
+    state = spec["state"]
+    for key in ("kpis", "trend", "category_chart", "categories", "approvals"):
+        assert key in state, f"revenue-pulse state missing {key}"
+    assert len(state["trend"]) == 6, "expected six months of trend data"
+    charts = [w for w in _iter_widgets(spec["ui"]) if w.get("type") == "chart"]
+    assert len(charts) >= 2, "revenue-pulse should render trend + category charts"
+    chart_types = {c["props"].get("type") for c in charts}
+    assert chart_types <= {"area", "bar", "line"}, f"non-catalog chart type: {chart_types}"
+
+
+# ---------------------------------------------------------------------------
+# Installer — every vertical template mirrors like every other template
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## What this adds

Four bundled vertical templates that round out the demo suite, built to the
visual bar the triage redesign set in #1435: color-banded strips, score and
risk rings, status pills, dense-but-scannable detail panels, and seed data
that tells a story rather than reading like filler. A pocket created from any
of them renders as a finished console straight away — no empty canvas, no
"[placeholder]" copy.

| Template | Shape | What it is |
|----------|-------|-----------|
| `events-board` | `custom` | Sell-through console: an events queue with sell-through bars, a per-event detail panel with a sell-through ring, ticket tiers, and a run-of-show timeline. |
| `renewals-radar` | `custom` | Memberships banded by churn risk: days-left chips, a revenue-at-risk strip, a churn-risk ring, and grace-deadline callouts. |
| `orders-fulfillment` | `kanban` | A stage board over the order list, plus a queue + detail pair with line items, shipping, and a fulfillment timeline. |
| `revenue-pulse` | `chart` | A read-only executive dashboard: KPI row, six-month revenue-trend area chart, a by-category bar chart and breakdown grid, and an approval-rate funnel. |

## Seed data

Each template carries story-grade sample data so the demo lands without a
backend connected:

- **events-board** — five events: one at 94% (nearly sold out), one at 22%
  (needs a push), one past event with full check-in stats, plus two mid-flight.
- **renewals-radar** — eight members across high / medium / safe risk bands,
  including one lapsed member still inside the grace window (recoverable).
- **orders-fulfillment** — seven orders spread across to-ship, shipped,
  delivered, and refund-requested.
- **revenue-pulse** — six months of plausible revenue with a category split
  and an application funnel.

## Design notes

- The three operating templates carry gated action rows that **propose** a
  decision (`state.pending_proposal`) rather than execute it — the same
  Instinct-gate binding seam `applications-triage` uses. `revenue-pulse` is
  read-only.
- Every detail binding is a flat `{state.selected.X}` path, and the selected
  row is denormalized + seeded, so detail panels render before any click and
  never hit the method-chain-then-property form that left the old triage panel
  empty.
- Every widget node is in the curated catalog — checked offline against the
  shared widget catalog, no non-catalog types.

## Tests

Extended `test_vertical_templates.py` to cover all four new slugs:

- the binding-guard (`bindings_reference_seeded_state`) — every `{state.X}`
  reference hits a seeded key, no broken chains;
- a render-populated guard — `ui.children` non-empty and the focal seed list
  carries rows, asserted on the loaded spec too (the compile round-trip);
- the gated-action contract for the three action templates and the read-only
  posture for the dashboard;
- per-template story checks (sell-through + run-of-show, risk bands + lapsed
  member, the stage board, the read-only charts).

`index.json` registers all four with keyword sets for the chat agent's
template match. Full template suite: 176 passing.
