### PR TITLE
Fix Fabric and other scoped tools in group/DM chat

### DIFF
--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -18,6 +18,13 @@ User-message attachments ride the ``message.sent`` payload so channel
 agents see the same filename/mime/size context DM agents already get —
 appended to the user prompt as an ``Attached files:`` block before
 ``pool.run`` (matching ``src/pocketpaw/agents/loop.py``'s DM shape).
+
+Updated 2026-06-12: ``_run_agent_response`` now binds the agent's
+workspace/user identity (``attach_agent_identity``) around ``pool.run`` so
+in-process MCP tools that resolve scope from ContextVars (fabric, instinct,
+decisions, connectors) work on the group/DM bridge path. The SSE chat path
+already did this in ``run_core``; the bridge path skipped it, so every
+scoped tool returned "requires workspace context".
 """
 
 from __future__ import annotations
@@ -407,6 +414,10 @@ async def _run_agent_response(
     """
     from pocketpaw.agents.pool import get_agent_pool
     from pocketpaw_ee.cloud.chat import message_service
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        attach_agent_identity,
+        detach_agent_identity,
+    )
 
     pool = get_agent_pool()
     session_key = f"cloud:{group_id}:{agent_id}"
@@ -470,6 +481,15 @@ async def _run_agent_response(
     error_summary = ""
     last_emit_ts = 0.0
     STREAM_CHUNK_THROTTLE_S = 0.2
+    # Bind the agent's workspace/user identity for the duration of the run so
+    # in-process MCP tools that resolve scope from ContextVars (fabric,
+    # instinct, decisions, connectors, …) can reach the store. The SSE chat
+    # path does this in ``run_core.attach_agent_identity``; the group/DM bridge
+    # path (this function) calls ``pool.run`` directly and previously skipped
+    # it, so every ContextVar-scoped tool returned "requires workspace context
+    # (call from a cloud chat session)". ``user_id`` is the agent itself — it is
+    # the actor on this path, matching the cloud MCP tests' setup.
+    identity_tokens = attach_agent_identity(workspace_id=workspace_id, user_id=agent_id)
     try:
         async for event in pool.run(
             agent_id, user_message, session_key, history, knowledge_context=knowledge_context
@@ -526,6 +546,8 @@ async def _run_agent_response(
     except Exception:
         logger.exception("Agent %s response failed in group %s", agent_id, group_id)
         full_text = full_text or "[Agent response failed]"
+    finally:
+        detach_agent_identity(identity_tokens)
 
     if saw_error_event and not full_text.strip():
         details = f": {error_summary}" if error_summary else ""

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -74,6 +74,13 @@ Updated: 2026-05-25 (PR #1222 R1 Blocker 1) — added
   cannot accidentally clobber the auth key. Each isolated backend
   instance carries its own stash, so one request's tenancy can never
   leak into another's subprocess.
+Updated: 2026-06-12 — ``_collect_mcp_tool_ids`` now also allowlists EXTERNAL
+  MCP servers from ``load_mcp_config`` (``~/.pocketpaw/mcp_servers.json``) with
+  a bare ``mcp__<server>`` entry. They are registered with the SDK in
+  ``_get_mcp_servers`` but, lacking an in-process ``tool_ids()`` provider, their
+  tools never reached the allowlist and were uncallable (a deployment's
+  ``fabric`` server was registered yet the agent could not call
+  ``fabric_query`` / ``fabric_stats``).
 Updated: 2026-05-22 (#1174) — extracted the in-process MCP tool-id allowlist
   collection into ``_collect_mcp_tool_ids``. The cloud ``pocketpaw_pocket``
   server now carries a writable ``add_widget`` tool alongside the read tools;
@@ -790,6 +797,31 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 ):
                     continue
                 ids.append(tool_id)
+
+        # External stdio/http MCP servers (``~/.pocketpaw/mcp_servers.json`` via
+        # ``load_mcp_config``) are registered with the SDK in ``_get_mcp_servers``
+        # but have no in-process ``tool_ids()`` provider — their tool names are
+        # only known after the SDK connects to the server. Without an allowlist
+        # entry the SDK refuses every call (e.g. a deployment's ``fabric`` server
+        # exposing ``fabric_query`` / ``fabric_stats`` was registered yet
+        # uncallable). Allow each enabled external server wholesale with a bare
+        # ``mcp__<server>`` entry — the Claude Code permission convention that
+        # admits all of a server's tools — gated by the same tool policy that
+        # gates registration.
+        try:
+            from pocketpaw.mcp.config import load_mcp_config
+
+            for cfg in load_mcp_config():
+                if not cfg.enabled:
+                    continue
+                if cfg.name in self._BUILTIN_SEARCH_MCP_NAMES:
+                    continue
+                if not self._policy.is_mcp_server_allowed(cfg.name):
+                    continue
+                ids.append(f"mcp__{cfg.name}")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("External MCP server allowlist not added: %s", exc)
+
         return ids
 
     # Section markers that ``AgentPool.run`` appends to the system prompt

--- a/tests/cloud/shared/test_agent_bridge_identity.py
+++ b/tests/cloud/shared/test_agent_bridge_identity.py
@@ -1,0 +1,121 @@
+"""Regression test: the group/DM agent bridge binds workspace/user identity
+around ``pool.run`` so in-process MCP tools that read scope from ContextVars
+(fabric, instinct, decisions, connectors) can reach the store.
+
+Before the fix, ``_run_agent_response`` called ``pool.run`` directly without
+``attach_agent_identity``, so ``current_workspace_id()`` was ``None`` during
+the run and every ContextVar-scoped tool returned "requires workspace context
+(call from a cloud chat session)". The SSE chat path set identity in
+``run_core``; this path did not.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_run_agent_response_sets_workspace_contextvar_during_run() -> None:
+    """During ``pool.run``, the workspace/user ContextVars read by in-process
+    MCP tools must resolve to the dispatched agent's workspace and id."""
+    from pocketpaw_ee.cloud.chat.agent_service import (
+        current_user_id,
+        current_workspace_id,
+    )
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    seen: dict[str, str | None] = {}
+
+    async def fake_run(agent_id, user_message, session_key, history, **kwargs):
+        # Captured at the moment a tool would observe the ContextVars.
+        seen["workspace_id"] = current_workspace_id()
+        seen["user_id"] = current_user_id()
+        # Yield a minimal terminal stream so the function completes.
+        yield SimpleNamespace(type="message", content="ok")
+        yield SimpleNamespace(type="done", content="")
+
+    pool = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(agent_name="PocketPaw")),
+        run=fake_run,
+        observe=AsyncMock(return_value=None),
+    )
+
+    with (
+        patch(
+            "pocketpaw.agents.pool.get_agent_pool",
+            return_value=pool,
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.message_service.list_recent_for_group",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.message_service.create_agent_message",
+            new=AsyncMock(return_value=SimpleNamespace(id="m1")),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context",
+            new=AsyncMock(return_value=""),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=AsyncMock()),
+    ):
+        await agent_bridge._run_agent_response(
+            agent_id="agent-x",
+            group_id="group-x",
+            workspace_id="ws-x",
+            user_message="How many Application objects are in Fabric, by status?",
+            group_members=["user-1"],
+        )
+
+    assert seen["workspace_id"] == "ws-x"
+    assert seen["user_id"] == "agent-x"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_response_resets_contextvar_after_run() -> None:
+    """The identity tokens must be reset after the run so a later run in the
+    same task/loop doesn't inherit a stale workspace."""
+    from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    async def fake_run(agent_id, user_message, session_key, history, **kwargs):
+        yield SimpleNamespace(type="message", content="ok")
+        yield SimpleNamespace(type="done", content="")
+
+    pool = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(agent_name="PocketPaw")),
+        run=fake_run,
+        observe=AsyncMock(return_value=None),
+    )
+
+    assert current_workspace_id() is None
+
+    with (
+        patch("pocketpaw.agents.pool.get_agent_pool", return_value=pool),
+        patch(
+            "pocketpaw_ee.cloud.chat.message_service.list_recent_for_group",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.message_service.create_agent_message",
+            new=AsyncMock(return_value=SimpleNamespace(id="m1")),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context",
+            new=AsyncMock(return_value=""),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=AsyncMock()),
+    ):
+        await agent_bridge._run_agent_response(
+            agent_id="agent-y",
+            group_id="group-y",
+            workspace_id="ws-y",
+            user_message="hi",
+            group_members=["user-1"],
+        )
+
+    # Reset after the run — no leak into the surrounding context.
+    assert current_workspace_id() is None

--- a/tests/test_claude_sdk_external_mcp_allowlist.py
+++ b/tests/test_claude_sdk_external_mcp_allowlist.py
@@ -1,0 +1,91 @@
+# tests/test_claude_sdk_external_mcp_allowlist.py — external MCP servers reach
+# the SDK allowlist.
+#
+# External MCP servers from ``~/.pocketpaw/mcp_servers.json`` (``load_mcp_config``)
+# are registered with the SDK in ``_get_mcp_servers`` but have no in-process
+# ``tool_ids()`` provider, so before the fix their tools never reached
+# ``allowed_tools`` and the SDK refused every call (a deployment's ``fabric``
+# server was registered yet ``fabric_query`` was uncallable).
+#
+# ``_collect_mcp_tool_ids`` now appends a bare ``mcp__<server>`` entry (the
+# Claude Code convention that admits all of a server's tools) for each enabled
+# external server that passes the tool policy.
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_settings() -> MagicMock:
+    settings = MagicMock()
+    settings.bypass_permissions = False
+    settings.agent_backend = "claude_agent_sdk"
+    settings.anthropic_api_key = "sk-ant-test-key"
+    settings.claude_sdk_model = ""
+    settings.claude_sdk_max_turns = 0
+    settings.smart_routing_enabled = False
+    settings.tool_profile = "full"
+    settings.tools_allow = []
+    settings.tools_deny = []
+    settings.mcp_servers = {}
+    settings.claude_sdk_provider = "anthropic"
+    return settings
+
+
+def _ext_cfg(name: str, *, enabled: bool = True):
+    return SimpleNamespace(
+        name=name,
+        transport="stdio",
+        command="python",
+        args=["server.py"],
+        env={},
+        url="",
+        enabled=enabled,
+    )
+
+
+def test_enabled_external_server_added_to_allowlist() -> None:
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+    backend = ClaudeSDKBackend(_make_settings())
+
+    with patch(
+        "pocketpaw.mcp.config.load_mcp_config",
+        return_value=[_ext_cfg("fabric")],
+    ):
+        ids = backend._collect_mcp_tool_ids()
+
+    assert "mcp__fabric" in ids, (
+        "an enabled external MCP server must be allowlisted wholesale so its "
+        "tools are callable by the agent"
+    )
+
+
+def test_disabled_external_server_not_added() -> None:
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+    backend = ClaudeSDKBackend(_make_settings())
+
+    with patch(
+        "pocketpaw.mcp.config.load_mcp_config",
+        return_value=[_ext_cfg("fabric", enabled=False)],
+    ):
+        ids = backend._collect_mcp_tool_ids()
+
+    assert "mcp__fabric" not in ids
+
+
+def test_external_server_blocked_by_policy_not_added() -> None:
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+    backend = ClaudeSDKBackend(_make_settings())
+    # Deny the server at the policy layer — registration and allowlist must agree.
+    backend._policy.is_mcp_server_allowed = lambda name: name != "fabric"  # type: ignore[method-assign]
+
+    with patch(
+        "pocketpaw.mcp.config.load_mcp_config",
+        return_value=[_ext_cfg("fabric")],
+    ):
+        ids = backend._collect_mcp_tool_ids()
+
+    assert "mcp__fabric" not in ids


### PR DESCRIPTION
## What

Chat agents on the group/DM path couldn't use any workspace-scoped MCP tool. Two separate gaps:

1. `agent_bridge._run_agent_response` calls `pool.run` directly and never bound the agent's identity. The in-process MCP tools that read workspace/user from ContextVars — fabric, instinct, decisions, connectors — all came back with "requires workspace context (call from a cloud chat session)." The SSE chat path sets this in `run_core`; the bridge path skipped it.

2. `_collect_mcp_tool_ids` only allowlisted in-process MCP providers. External stdio/http servers from `mcp_servers.json` were registered with the SDK but their tools never reached the allowlist, so the agent wasn't permitted to call them.

The combined effect: an agent told to read an external Fabric MCP server answered "0" or errored out, even though the server was running and held the data.

## Fix

- Bind the agent's workspace/user identity around the `pool.run` loop in the bridge, and reset it in a `finally`. `user_id` is the agent itself, matching the cloud MCP test setup.
- In `_collect_mcp_tool_ids`, add a bare `mcp__<server>` allowlist entry for each enabled external server, gated by the same tool policy that gates registration.

## Verification

Against a live deployment with an external Fabric server, "How many Application objects are in Fabric, by status?" now returns the real counts instead of zero. New tests cover the identity binding + reset and the external-server allowlist; the touched suites pass (`tests/cloud/shared/test_agent_bridge_*`, `tests/test_claude_sdk_*`).

## Scope

Backend only. No API or schema change. The bridge fix affects every group/DM agent run; the allowlist fix is a no-op when no external MCP servers are configured.