### PR TITLE
Materialize an agent's own skill_refs on every chat path

### DIFF
--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -243,6 +243,20 @@ class AgentPool:
         instance = await self.get(agent_id)
         instance.last_active = datetime.now(UTC)
 
+        # An agent's OWN declared skills (config.skill_refs) must materialize on
+        # EVERY run path, not only entity-room runs that thread skill_names in.
+        # The SSE chat path resolves this upstream and passes skill_names; the
+        # group/DM bridge (agent_bridge) calls run() without it, so a deployment
+        # agent with skill_refs got none of its skills. Union the agent's own
+        # skill_refs here so run() is the single source of truth for them; the
+        # passed-in skill_names stays an additive per-entity subset.
+        cfg = getattr(instance, "config", None) or {}
+        own_skills = (
+            frozenset(cfg.get("skill_refs", []) or []) if isinstance(cfg, dict) else frozenset()
+        )
+        if own_skills:
+            skill_names = skill_names | own_skills
+
         # Build system prompt via soul bootstrap if available
         system_prompt = None
         if instance.soul_manager and instance.soul_manager.bootstrap_provider:

--- a/tests/test_agent_pool_entity_profile_runtime.py
+++ b/tests/test_agent_pool_entity_profile_runtime.py
@@ -130,3 +130,54 @@ async def test_skill_names_withheld_when_empty(monkeypatch):
     assert "skill_names" not in backend.last_kwargs, (
         "empty skill_names must be withheld so non-Claude backends keep their signature"
     )
+
+
+# ---------------------------------------------------------------------------
+# A2b — agent's OWN skill_refs materialize on every run path
+# ---------------------------------------------------------------------------
+
+
+def _instance_with_skill_refs(backend, refs):
+    inst = _instance_with(backend)
+    inst.config = {**inst.config, "skill_refs": refs}
+    return inst
+
+
+async def _run_with_instance(monkeypatch, inst, **run_kwargs):
+    pool = AgentPool()
+
+    async def _fake_get(agent_id):
+        return inst
+
+    monkeypatch.setattr(pool, "get", _fake_get)
+    await _drain(pool, **run_kwargs)
+
+
+async def test_agent_skill_refs_forwarded_without_explicit_skill_names(monkeypatch):
+    backend = _CapturingBackend()
+    inst = _instance_with_skill_refs(backend, ["snctm-vetting"])
+    await _run_with_instance(monkeypatch, inst)
+    # No skill_names passed by the caller (the DM/bridge path) — the agent's own
+    # skill_refs must still reach the backend.
+    assert backend.last_kwargs.get("skill_names") == frozenset({"snctm-vetting"})
+
+
+async def test_agent_skill_refs_union_with_explicit_skill_names(monkeypatch):
+    backend = _CapturingBackend()
+    inst = _instance_with_skill_refs(backend, ["snctm-vetting"])
+    await _run_with_instance(monkeypatch, inst, skill_names=frozenset({"github"}))
+    assert backend.last_kwargs.get("skill_names") == frozenset({"snctm-vetting", "github"})
+
+
+async def test_no_skill_refs_keeps_caller_skill_names(monkeypatch):
+    backend = _CapturingBackend()
+    inst = _instance_with(backend)  # no skill_refs
+    await _run_with_instance(monkeypatch, inst, skill_names=frozenset({"github"}))
+    assert backend.last_kwargs.get("skill_names") == frozenset({"github"})
+
+
+async def test_no_skill_refs_no_skill_names_withheld(monkeypatch):
+    backend = _CapturingBackend()
+    inst = _instance_with(backend)  # no skill_refs, no caller skill_names
+    await _run_with_instance(monkeypatch, inst)
+    assert "skill_names" not in backend.last_kwargs


### PR DESCRIPTION
An agent that declares `skill_refs` in its config only actually got those skills on the SSE chat path, which resolves them upstream and threads `skill_names` into `pool.run`. The group/DM bridge (`agent_bridge`) calls `run()` without `skill_names`, so a deployment agent configured with a skill ran with **none of it** — the skill's instructions never reached the model.

Found live on a deployment: the agent had `skill_refs: ["snctm-vetting"]` set, answered Fabric questions fine (those are MCP tools, identity-scoped per #1439), but improvised connector action names the skill explicitly forbids and mis-recognized a domain term the skill disambiguates — because the skill was never in its context. Asked directly, the agent reported the skill was "not in the available skills list."

The fix: `pool.run` unions the agent's own `config.skill_refs` into `skill_names` right after loading the instance, so `run()` is the single source of truth for an agent's declared skills regardless of which path called it (SSE, group/DM bridge, entity room). The passed-in `skill_names` stays an additive per-entity subset. This is the exact sibling of #1439, which fixed the identity half of the same bridge gap.

Four regression tests: skill_refs forwarded with no caller skill_names, union with caller skill_names, caller-only when no refs, and withheld when neither is present (preserves the non-Claude-backend signature contract).