### PR TITLE
Point a pocket at a bound connector for its backend, with source transforms

### DIFF
--- a/ee/pocketpaw_ee/agent/pocket_router/router.py
+++ b/ee/pocketpaw_ee/agent/pocket_router/router.py
@@ -342,7 +342,19 @@ async def _run_tier0(
     # write must reach the approval surface with the pocket's configured
     # approver route — exactly as the REST `/actions/run` path passes it to
     # `propose_pocket_write`.
-    base_url, auth_type, auth_header, token, allowed_writes, approval_route = creds
+    # The connector-backend feature appended `backend_type` / `connector_name`
+    # to the executor tuple — threaded into `run_sources` below so a connector
+    # backend routes correctly; the write-action branch ignores them.
+    (
+        base_url,
+        auth_type,
+        auth_header,
+        token,
+        allowed_writes,
+        approval_route,
+        backend_type,
+        connector_name,
+    ) = creds
 
     if classification.op == "run_source":
         # A source run mirrors ``POST /pockets/{id}/sources/run`` — read
@@ -360,6 +372,8 @@ async def _run_tier0(
             token=token,
             only_source=classification.op_args.get("source"),
             workspace_id=workspace_id,
+            backend_type=backend_type,
+            connector_name=connector_name,
         )
         errors = result.get("errors") or []
         if errors:

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -19,6 +19,12 @@
 #   doc (OSS-EE boundary §2). The MCP ``connector_execute`` tool reuses the
 #   existing ``execute(...)`` for read (auto-trust) actions and blocks
 #   write/confirm-trust actions in v1.
+# Updated: 2026-06-12 (feat/connector-as-pocket-backend) — added
+#   ``is_connector_enabled_for_workspace``: the validation gate
+#   ``pockets.service.set_pocket_backend`` calls before binding a pocket to a
+#   ``backend_type="connector"`` backend. Keeps the WorkspaceConnector Beanie
+#   read in THIS service (the owner of the connector docs) so the pockets
+#   service never imports the connector model.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -590,6 +596,31 @@ async def is_connector_bound_to_pocket(workspace_id: str, pocket_id: str, name: 
     return doc is not None
 
 
+async def is_connector_enabled_for_workspace(workspace_id: str, name: str) -> bool:
+    """True when ``name`` is a real registry connector AND enabled for the workspace.
+
+    The validation gate ``pockets.service.set_pocket_backend`` uses before it
+    binds a pocket to ``backend_type="connector"``: a connector backend must
+    name a connector the registry knows and that this workspace has actually
+    enabled (any scope). Keeping the ``WorkspaceConnector`` Beanie read HERE
+    (not in the pockets service) holds the boundary — the pockets service owns
+    the pocket/backend docs, this service owns the connector docs. Both stay
+    sole writers/readers of their own collection.
+
+    Tenant-filtered on ``workspace`` (cloud rule §7). An unknown registry name
+    or a workspace with no enabled row for it returns ``False``.
+    """
+    available = {a.name for a in _available_from_registry()}
+    if name not in available:
+        return False
+    doc = await _WCDoc.find_one(
+        _WCDoc.workspace == workspace_id,
+        _WCDoc.name == name,
+        _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+    )
+    return doc is not None
+
+
 def _adapter_for_definition(defn, name: str):
     """Build an adapter without connecting — for static metadata reads.
 
@@ -731,6 +762,7 @@ __all__ = [
     "get_action_trust",
     "get_connector",
     "is_connector_bound_to_pocket",
+    "is_connector_enabled_for_workspace",
     "list_connectors",
     "list_pocket_connectors",
     "list_widget_recipes",

--- a/ee/pocketpaw_ee/cloud/models/pocket_backend.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket_backend.py
@@ -27,6 +27,13 @@
 #   against this secret. It lives HERE — generated server-side, on the
 #   credential row, NEVER in the agent-authored spec — so the spec stays
 #   shareable and secret-free. `None` until an owner generates / rotates it.
+# Updated: 2026-06-12 (feat/connector-as-pocket-backend) — a pocket's backend
+#   can now be an existing CONNECTOR, not only an HTTP base_url. `backend_type`
+#   is `"http"` (the default — every pre-existing row reads as http via the
+#   field default, so this is fully back-compatible) or `"connector"`. When
+#   `"connector"`, `connector_name` names a workspace-bound connector and the
+#   `base_url`/`auth_*` fields are unused — source execution routes each source
+#   through `connectors_service.execute(...)` instead of an HTTP GET.
 
 from __future__ import annotations
 
@@ -66,17 +73,37 @@ class ApprovalRoute(BaseModel):
 
 
 class PocketBackendCredential(TimestampedDocument):
-    """Per-pocket backend binding: base URL + (encrypted) auth credential.
+    """Per-pocket backend binding: an HTTP base URL or a bound connector.
 
-    One row per pocket. The run-sources executor decrypts the token at call
-    time; every other read path returns only `base_url` / `auth_type` /
-    `configured` / `allowed_writes` so the secret never leaves this
+    One row per pocket. ``backend_type`` selects the shape:
+
+    * ``"http"`` (the default, and every legacy row) — ``base_url`` +
+      optional encrypted auth credential. The run-sources executor decrypts
+      the token at call time and fetches each source with an SSRF-guarded GET.
+    * ``"connector"`` — ``connector_name`` names a workspace-bound connector.
+      ``base_url`` / ``auth_*`` are unused; source execution routes each
+      source's ``action``/``params`` through ``connectors_service.execute``
+      (the same read-first path senses use).
+
+    Every read path returns only the non-secret summary (``backend_type`` /
+    ``connector_name`` / ``base_url`` / ``auth_type`` / ``configured`` /
+    ``allowed_writes`` / ``approval_route``) — the secret never leaves this
     collection.
     """
 
     pocket_id: Indexed(str)  # type: ignore[valid-type]
     workspace_id: Indexed(str)  # type: ignore[valid-type]
-    base_url: str
+    # "http" (base_url + auth) | "connector" (bound connector action surface).
+    # Defaults to "http" so every row written before this feature reads as an
+    # http backend — fully back-compatible.
+    backend_type: Literal["http", "connector"] = "http"
+    # For backend_type == "connector": the workspace-bound connector this
+    # pocket fetches through. None for http backends.
+    connector_name: str | None = None
+    # The HTTP base URL. Empty string for a connector backend (base_url is
+    # unused there). Kept required-with-default so legacy http rows are
+    # unaffected and the field is never None.
+    base_url: str = ""
     # bearer | api_key | basic | none
     auth_type: str = "none"
     # Custom header name for the api_key auth type. Defaults to "X-Api-Key".

--- a/ee/pocketpaw_ee/cloud/pockets/_source_transform.py
+++ b/ee/pocketpaw_ee/cloud/pockets/_source_transform.py
@@ -1,0 +1,156 @@
+# _source_transform.py — pure, declarative shaping of a raw source result.
+# Created: 2026-06-12 (feat/connector-as-pocket-backend) — a pocket source
+#   binding may carry a small `transform` spec that maps the raw result of a
+#   fetch (http GET / sense / connector action) into the shape the widget's
+#   state wants BEFORE it is bound. This module is the ONLY place that
+#   interprets that spec. It is PURE: no network, no eval, no arbitrary code,
+#   no I/O — given the same (raw, spec) it always returns the same value, so
+#   it is exhaustively unit-testable and can never widen the source path's
+#   blast radius.
+#
+# v1 spec (intentionally tiny — reject anything not listed):
+#   { "select": "dotted.path" }       drill into the raw response to the
+#                                     array/value to bind (e.g. data.applications).
+#   { "map": [ {field def}, ... ] }   for a LIST input, one output row per input
+#                                     row. Each field def is exactly one of:
+#                                       {"to": "...", "from": "dotted.path"}      copy by path
+#                                       {"to": "...", "from": "p", "values": {...},
+#                                        "default": x}                            lookup-map a value
+#                                       {"to": "...", "const": <json>}            constant
+#   select + map compose: select drills first, map shapes the drilled list.
+#   Both optional. No transform (None / {}) -> the raw value, unchanged
+#   (today's behavior). An unknown/missing `from` resolves to None — it never
+#   raises. A `transform` that contains an unrecognized key, or a malformed
+#   field def, is rejected up front with `TransformError` so a hallucinated
+#   spec fails loud at apply-time instead of silently mangling data.
+
+from __future__ import annotations
+
+from typing import Any
+
+# The only top-level keys a v1 transform may carry.
+_ALLOWED_KEYS = frozenset({"select", "map"})
+# The only keys a single map-field def may carry.
+_ALLOWED_FIELD_KEYS = frozenset({"to", "from", "values", "default", "const"})
+
+
+class TransformError(ValueError):
+    """A transform spec is not valid per the v1 grammar.
+
+    Raised at apply-time (not at fetch-time) so the caller maps it onto the
+    same per-source error envelope every other source failure uses — one bad
+    transform never aborts a sibling source.
+    """
+
+
+def _resolve_path(value: Any, dotted: str) -> Any:
+    """Walk a dotted path into nested dicts (and list-index segments).
+
+    ``a.b.c`` reads ``value["a"]["b"]["c"]``. A numeric segment indexes a
+    list (``items.0.name``). A missing key, a non-subscriptable value, or an
+    out-of-range index all resolve to ``None`` — this never raises, so an
+    unknown/missing ``from`` is null rather than a crash.
+    """
+    if not dotted:
+        return value
+    cur = value
+    for seg in dotted.split("."):
+        if cur is None:
+            return None
+        if isinstance(cur, dict):
+            cur = cur.get(seg)
+        elif isinstance(cur, (list, tuple)):
+            # A numeric segment indexes a sequence; anything else misses.
+            if seg.lstrip("-").isdigit():
+                idx = int(seg)
+                cur = cur[idx] if -len(cur) <= idx < len(cur) else None
+            else:
+                return None
+        else:
+            return None
+    return cur
+
+
+def _validate_field_def(field: Any) -> None:
+    """Reject a map-field def that is not exactly one of the three shapes."""
+    if not isinstance(field, dict):
+        raise TransformError("each map field must be an object")
+    extra = set(field) - _ALLOWED_FIELD_KEYS
+    if extra:
+        raise TransformError(f"map field has unknown keys: {sorted(extra)}")
+    if not isinstance(field.get("to"), str) or not field["to"]:
+        raise TransformError("each map field needs a non-empty string 'to'")
+    has_const = "const" in field
+    has_from = "from" in field
+    if has_const and has_from:
+        raise TransformError("a map field is 'const' OR 'from', not both")
+    if not has_const and not has_from:
+        raise TransformError("a map field needs either 'from' or 'const'")
+    if has_const and ("values" in field or "default" in field):
+        raise TransformError("'values'/'default' only apply to a 'from' field")
+    if has_from and not isinstance(field["from"], str):
+        raise TransformError("'from' must be a dotted-path string")
+    if "values" in field and not isinstance(field["values"], dict):
+        raise TransformError("'values' must be an object")
+
+
+def _apply_field(field: dict, row: Any) -> Any:
+    """Produce one output value for one map-field def against one input row."""
+    if "const" in field:
+        return field["const"]
+    raw = _resolve_path(row, field["from"])
+    if "values" in field:
+        # Lookup-map: only str/int/bool keys can match a JSON object's keys.
+        table: dict = field["values"]
+        if isinstance(raw, (str, int, bool)) and raw in table:
+            return table[raw]
+        return field.get("default")  # None when no default declared
+    return raw
+
+
+def _validate_spec(spec: dict) -> None:
+    """Reject anything outside the v1 grammar before any data is touched."""
+    extra = set(spec) - _ALLOWED_KEYS
+    if extra:
+        raise TransformError(f"transform has unknown keys: {sorted(extra)}")
+    if "select" in spec and not isinstance(spec["select"], str):
+        raise TransformError("'select' must be a dotted-path string")
+    if "map" in spec:
+        if not isinstance(spec["map"], list):
+            raise TransformError("'map' must be a list of field definitions")
+        for field in spec["map"]:
+            _validate_field_def(field)
+
+
+def apply_transform(raw: Any, spec: dict | None) -> Any:
+    """Shape ``raw`` per the transform ``spec``. Pure; never touches the network.
+
+    ``None`` (or an empty ``{}``) returns ``raw`` unchanged — the default
+    no-transform behavior every source had before this feature. Otherwise:
+
+    1. ``select`` drills into ``raw`` along a dotted path (missing -> ``None``).
+    2. ``map`` reshapes a LIST into one output row per input row. If the
+       (post-select) value is not a list, ``map`` yields an empty list — a
+       map over a non-list is a no-op, not a crash.
+
+    Raises ``TransformError`` for any spec outside the v1 grammar so a
+    malformed/hallucinated transform fails loud at the per-source boundary.
+    """
+    if not spec:
+        return raw
+    if not isinstance(spec, dict):
+        raise TransformError("transform must be an object")
+    _validate_spec(spec)
+
+    value = _resolve_path(raw, spec["select"]) if "select" in spec else raw
+
+    if "map" in spec:
+        if not isinstance(value, list):
+            return []
+        fields: list[dict] = spec["map"]
+        return [{f["to"]: _apply_field(f, row) for f in fields} for row in value]
+
+    return value
+
+
+__all__ = ["apply_transform", "TransformError"]

--- a/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
@@ -399,7 +399,9 @@ async def _fire_executions(
             )
             for row in plan.executions
         ]
-    base_url, auth_type, auth_header, token, allowed_writes, _approval_route = creds
+    # Trailing `backend_type` / `connector_name` (connector-backend feature)
+    # don't apply to the http write executor — absorbed and ignored.
+    base_url, auth_type, auth_header, token, allowed_writes, _approval_route, *_ = creds
 
     # Per-row path/params: the OSS planner does not resolve Ripple
     # ``{...}`` expressions — that's a frontend / executor concern. For

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -95,6 +95,13 @@ Updated: 2026-06-07 (feat/entity-pocket-profile-field) — import
 importing ``models.*``; the class is a plain value object, not a Beanie doc,
 so sharing it via the leaf domain module keeps one shape without crossing the
 boundary.
+Updated: 2026-06-12 (feat/connector-as-pocket-backend) — a pocket backend
+can be an existing CONNECTOR, not only an http base_url.
+PocketBackendConfigRequest gained ``backend_type`` ("http" default |
+"connector") + ``connector_name`` and made ``base_url`` optional (a
+connector backend needs none; the service still requires a valid URL for an
+http backend). PocketBackendConfigResponse echoes ``backend_type`` /
+``connector_name`` back (never the token).
 """
 
 from __future__ import annotations
@@ -329,21 +336,31 @@ class AllowedWriteDTO(BaseModel):
 class PocketBackendConfigRequest(BaseModel):
     """Body for ``PUT /pockets/{id}/backend`` — bind a pocket to one backend.
 
-    ``auth_token`` carries the secret only on the way IN; it is encrypted
-    server-side and never returned. Its meaning depends on ``auth_type``:
+    ``backend_type`` selects the shape:
 
-    * ``bearer`` — the bearer token, sent as ``Authorization: Bearer <token>``.
-    * ``api_key`` — the API key value, sent in the ``auth_header`` header.
-    * ``basic`` — the raw ``user:pass`` credential. The server base64-encodes
-      it to form a valid ``Authorization: Basic`` header — do NOT pre-encode.
-    * ``none`` — unused.
+    * ``"http"`` (the default) — ``base_url`` + optional auth. ``auth_token``
+      carries the secret only on the way IN; it is encrypted server-side and
+      never returned. Its meaning depends on ``auth_type``:
+        - ``bearer`` — the bearer token (``Authorization: Bearer <token>``).
+        - ``api_key`` — the API key value, sent in the ``auth_header`` header.
+        - ``basic`` — the raw ``user:pass`` credential. The server
+          base64-encodes it — do NOT pre-encode.
+        - ``none`` — unused.
+      ``auth_header`` names the custom header for the ``api_key`` auth type
+      (defaults to ``X-Api-Key`` when omitted).
+    * ``"connector"`` — ``connector_name`` names a workspace-bound connector.
+      ``base_url``/``auth_*`` are unused (and not required); the service
+      validates the connector is enabled for the workspace.
 
-    ``auth_header`` names the custom header for the ``api_key`` auth type
-    (defaults to ``X-Api-Key`` when omitted).
+    ``base_url`` is OPTIONAL here (defaults to ``""``) so a connector backend
+    needn't send one; the service still requires a valid URL for an http
+    backend.
     """
 
-    base_url: str = Field(min_length=1)
-    auth_type: Literal["bearer", "api_key", "basic", "none"]
+    backend_type: Literal["http", "connector"] = "http"
+    connector_name: str | None = None
+    base_url: str = ""
+    auth_type: Literal["bearer", "api_key", "basic", "none"] = "none"
     auth_token: str = ""
     auth_header: str | None = None
 
@@ -369,6 +386,12 @@ class ApprovalRouteDTO(BaseModel):
 class PocketBackendConfigResponse(BaseModel):
     """Backend binding as returned to clients — never carries the token.
 
+    ``backend_type`` is ``"http"`` (the default / legacy) or ``"connector"``;
+    ``connector_name`` names the bound connector when ``backend_type`` is
+    ``"connector"`` (``None`` for http). For an http backend ``base_url`` /
+    ``auth_type`` describe the endpoint; for a connector backend ``base_url``
+    is ``""`` and ``auth_type`` is ``"none"``.
+
     ``allowed_writes`` is the per-pocket write allowlist (RFC 05 M2a) —
     an owner/editor-facing non-secret. Empty by default (fail-closed: no
     write fires until a human allow-lists it).
@@ -378,6 +401,8 @@ class PocketBackendConfigResponse(BaseModel):
     default — the pocket owner approves.
     """
 
+    backend_type: str = "http"
+    connector_name: str | None = None
     base_url: str
     auth_type: str
     configured: bool

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
@@ -525,9 +525,11 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
         )
         return
 
-    # The executor-creds tuple is a 6-tuple (M2b.1); `approval_route` is
-    # unused at execution — the approver already approved.
-    base_url, auth_type, auth_header, token, allowed_writes, _approval_route = creds
+    # The executor-creds tuple gained trailing `backend_type` /
+    # `connector_name` (connector-backend feature); the http write executor
+    # ignores them, and `approval_route` is unused at execution — the approver
+    # already approved.
+    base_url, auth_type, auth_header, token, allowed_writes, _approval_route, *_ = creds
 
     try:
         result = await action_executor.run_action(

--- a/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
+++ b/ee/pocketpaw_ee/cloud/pockets/refresh_scheduler.py
@@ -137,7 +137,7 @@ async def _refresh_one_pocket(pocket: dict) -> None:
             _last_run[(pocket_id, key)] = now
         logger.debug("refresh-scheduler: pocket %s has interval sources but no backend", pocket_id)
         return
-    base_url, auth_type, auth_header, token, _allowed, _route = creds
+    base_url, auth_type, auth_header, token, _allowed, _route, backend_type, connector_name = creds
     ripple_spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
     if ripple_spec is None:
         return
@@ -164,6 +164,8 @@ async def _refresh_one_pocket(pocket: dict) -> None:
                 token=token,
                 only_source=key,
                 workspace_id=workspace_id,
+                backend_type=backend_type,
+                connector_name=connector_name,
             )
             if result.get("errors"):
                 logger.debug(

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -621,10 +621,13 @@ async def set_pocket_backend(
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> PocketBackendConfigResponse:
-    """Bind this pocket to one external backend (base URL + auth credential).
+    """Bind this pocket to one external backend.
 
-    The token is encrypted server-side; the response never echoes it back.
-    A bad base URL (non-https, internal host) yields a 400.
+    ``backend_type="http"`` (the default) binds a base URL + auth credential;
+    the token is encrypted server-side and never echoed back, and a bad base
+    URL (non-https, internal host) yields a 400. ``backend_type="connector"``
+    binds an existing workspace connector by ``connector_name`` (no base_url
+    needed); an unknown / not-enabled connector yields a 400.
     """
     result = await pockets_service.set_pocket_backend(
         workspace_id,
@@ -634,6 +637,8 @@ async def set_pocket_backend(
         body.auth_type,
         body.auth_token,
         body.auth_header,
+        backend_type=body.backend_type,
+        connector_name=body.connector_name,
     )
     return PocketBackendConfigResponse(**result)
 
@@ -731,8 +736,19 @@ async def run_pocket_sources(
             ],
         }
     # M2b.1 — the executor-creds tuple gained `allowed_writes` (M2a) and
-    # `approval_route` (M2b.1); read-only source runs need neither.
-    base_url, auth_type, auth_header, token, _allowed_writes, _approval_route = creds
+    # `approval_route` (M2b.1); read-only source runs need neither. The
+    # connector-backend feature appended `backend_type` / `connector_name`,
+    # which the run DOES need to pick the http vs connector transport.
+    (
+        base_url,
+        auth_type,
+        auth_header,
+        token,
+        _allowed_writes,
+        _approval_route,
+        backend_type,
+        connector_name,
+    ) = creds
 
     # no-event: source hydration is response-body delivery, not persisted
     return await source_executor.run_sources(
@@ -746,6 +762,8 @@ async def run_pocket_sources(
         trigger=body.trigger,
         only_source=body.source,
         workspace_id=workspace_id,
+        backend_type=backend_type,
+        connector_name=connector_name,
     )
 
 
@@ -999,7 +1017,10 @@ async def run_pocket_action(
             "pocket_backend.not_configured",
             "This pocket has no backend configured — set one via PUT /pockets/{id}/backend",
         )
-    base_url, auth_type, auth_header, token, allowed_writes, approval_route = creds
+    # Write-action run: the trailing `backend_type` / `connector_name` (added
+    # by the connector-backend feature) don't apply to the http write executor,
+    # so they're ignored here.
+    base_url, auth_type, auth_header, token, allowed_writes, approval_route, *_ = creds
 
     from pocketpaw_ee.cloud.pockets import action_executor
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -156,6 +156,18 @@ empty/absent existing ``ui`` is template-owned (adopt the template's
 compiled values); a non-empty ``ui`` is user-owned (machinery-only
 merge, exactly the prior recompile semantics). Both ``create`` and
 ``update`` pass the loader's ``ripple_spec`` sibling through.
+Changes: 2026-06-12 (feat/connector-as-pocket-backend) — a pocket backend
+can now be an existing CONNECTOR, not only an HTTP base_url.
+``set_pocket_backend`` gained ``backend_type`` (``"http"`` default |
+``"connector"``) + ``connector_name``: a connector backend validates the
+connector is enabled for the workspace (via
+``connectors.service.is_connector_enabled_for_workspace``), needs no
+``base_url``, and clears any stale http credential. ``get_pocket_backend``
++ ``get_pocket_backend_for_executor`` now carry ``backend_type`` /
+``connector_name`` (``getattr`` defaults so a legacy row reads as http) so
+the source executor can route a connector backend through
+``connectors_service.execute`` instead of an HTTP GET. The executor tuple
+grew two trailing elements; the write-path consumers ignore them.
 """
 
 from __future__ import annotations
@@ -2127,7 +2139,11 @@ async def _agent_backend_summary(doc: _PocketDoc) -> dict[str, Any]:
     # so the edit specialist can see which write methods+paths the owner
     # has authorized before it authors a write action; ``approval_route``
     # so it knows who approves a `requires_instinct` write.
+    # ``backend_type`` / ``connector_name`` so the specialist knows whether to
+    # author http-path sources or connector-action sources.
     return {
+        "backend_type": summary.get("backend_type", "http"),
+        "connector_name": summary.get("connector_name"),
         "base_url": summary.get("base_url"),
         "auth_type": summary.get("auth_type"),
         "configured": True,
@@ -3635,38 +3651,86 @@ async def set_pocket_backend(
     auth_type: str,
     auth_token: str,
     auth_header: str | None = None,
+    *,
+    backend_type: str = "http",
+    connector_name: str | None = None,
 ) -> dict:
     """Bind a pocket to one backend — upsert its credential row.
 
-    ``base_url`` is validated strictly (https-only, no internal hosts). The
-    token is encrypted via ``backend_crypto`` before it touches the DB; the
-    plaintext is never persisted or logged. Returns the non-secret summary.
+    Two backend shapes:
+
+    * ``backend_type="http"`` (the default) — ``base_url`` is validated
+      strictly (https-only, no internal hosts), the token is encrypted via
+      ``backend_crypto`` before it touches the DB, and the plaintext is never
+      persisted or logged.
+    * ``backend_type="connector"`` — ``connector_name`` names a
+      workspace-bound connector. ``base_url``/``auth_*`` are ignored (and NOT
+      required); the connector is validated to actually exist + be enabled for
+      this workspace via ``connectors.service.is_connector_enabled_for_workspace``
+      (rejected with ``pocket_backend.unknown_connector`` otherwise).
+
+    Returns the non-secret summary (carries ``backend_type`` +
+    ``connector_name``, never the token).
     """
-    from pocketpaw.security.url_validators import validate_external_url_strict
-
-    # Raises ValueError on a bad URL — surfaces as a 400 via the router.
-    try:
-        base_url = validate_external_url_strict(base_url)
-    except ValueError as exc:
-        raise ValidationError("pocket_backend.invalid_url", str(exc)) from exc
-
-    if auth_type != "none" and not auth_token:
+    if backend_type not in ("http", "connector"):
         raise ValidationError(
-            "pocket_backend.missing_token",
-            f"auth_type '{auth_type}' requires a non-empty auth_token",
+            "pocket_backend.invalid_backend_type",
+            f"backend_type must be 'http' or 'connector', got {backend_type!r}",
         )
 
-    encrypted_token: bytes | None = None
-    nonce: bytes | None = None
-    salt: bytes | None = None
-    if auth_type != "none":
-        encrypted_token, nonce, salt = backend_crypto.encrypt_token(auth_token)
+    if backend_type == "connector":
+        if not connector_name:
+            raise ValidationError(
+                "pocket_backend.missing_connector",
+                "backend_type 'connector' requires a connector_name",
+            )
+        # The connector must be a real registry connector AND enabled for this
+        # workspace. The Beanie read lives in the connectors service (the owner
+        # of the connector docs) — imported lazily to keep the static import
+        # graph free of a cycle (the connectors service imports this service).
+        from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+        if not await connectors_service.is_connector_enabled_for_workspace(
+            workspace_id, connector_name
+        ):
+            raise ValidationError(
+                "pocket_backend.unknown_connector",
+                f"connector {connector_name!r} is not enabled for this workspace — "
+                "enable it before binding it as a pocket backend",
+            )
+        # A connector backend carries no base_url / auth — clear them so a
+        # row that switched http -> connector never keeps a stale credential.
+        base_url = ""
+        auth_type = "none"
+        auth_header = None
+        encrypted_token = nonce = salt = None
+    else:
+        from pocketpaw.security.url_validators import validate_external_url_strict
+
+        # Raises ValueError on a bad URL — surfaces as a 400 via the router.
+        try:
+            base_url = validate_external_url_strict(base_url)
+        except ValueError as exc:
+            raise ValidationError("pocket_backend.invalid_url", str(exc)) from exc
+
+        if auth_type != "none" and not auth_token:
+            raise ValidationError(
+                "pocket_backend.missing_token",
+                f"auth_type '{auth_type}' requires a non-empty auth_token",
+            )
+
+        encrypted_token = nonce = salt = None
+        if auth_type != "none":
+            encrypted_token, nonce, salt = backend_crypto.encrypt_token(auth_token)
+        connector_name = None
 
     existing = await _BackendCredentialDoc.find_one(
         _BackendCredentialDoc.pocket_id == pocket_id,
         _BackendCredentialDoc.workspace_id == workspace_id,
     )
     if existing is not None:
+        existing.backend_type = backend_type
+        existing.connector_name = connector_name
         existing.base_url = base_url
         existing.auth_type = auth_type
         existing.auth_header = auth_header
@@ -3678,6 +3742,8 @@ async def set_pocket_backend(
         await _BackendCredentialDoc(
             pocket_id=pocket_id,
             workspace_id=workspace_id,
+            backend_type=backend_type,
+            connector_name=connector_name,
             base_url=base_url,
             auth_type=auth_type,
             auth_header=auth_header,
@@ -3696,7 +3762,13 @@ async def set_pocket_backend(
     )
     # no-event: backend credentials are a separate collection, not pocket
     # state — no downstream handler keys off a PocketUpdated for them.
-    return {"base_url": base_url, "auth_type": auth_type, "configured": True}
+    return {
+        "backend_type": backend_type,
+        "connector_name": connector_name,
+        "base_url": base_url,
+        "auth_type": auth_type,
+        "configured": True,
+    }
 
 
 def _allowed_writes_wire(doc: _BackendCredentialDoc) -> list[dict[str, str]]:
@@ -3727,21 +3799,17 @@ def _approval_route_wire(doc: _BackendCredentialDoc) -> dict[str, str | None] | 
     return {"mode": route.mode, "user_id": route.user_id}
 
 
-async def get_pocket_backend(workspace_id: str, pocket_id: str) -> dict | None:
-    """Return the pocket's backend binding summary, or ``None`` if unset.
+def _backend_summary_wire(doc: _BackendCredentialDoc) -> dict:
+    """Render the full NON-SECRET backend summary for a credential row.
 
-    NEVER returns the token — only ``base_url`` / ``auth_type`` /
-    ``configured`` / ``allowed_writes`` (the write allowlist) /
-    ``approval_route`` (the gated-write approver routing; ``None`` when
-    unset). All owner/editor-facing non-secrets.
+    The ONE place the wire summary is shaped so ``get_pocket_backend`` and the
+    write-policy / approval-route setters never drift. NEVER includes the
+    token. ``backend_type`` / ``connector_name`` come via ``getattr`` defaults
+    so a legacy row reads as an http backend — back-compatible.
     """
-    doc = await _BackendCredentialDoc.find_one(
-        _BackendCredentialDoc.pocket_id == pocket_id,
-        _BackendCredentialDoc.workspace_id == workspace_id,
-    )
-    if doc is None:
-        return None
     return {
+        "backend_type": getattr(doc, "backend_type", "http"),
+        "connector_name": getattr(doc, "connector_name", None),
         "base_url": doc.base_url,
         "auth_type": doc.auth_type,
         "configured": True,
@@ -3750,18 +3818,56 @@ async def get_pocket_backend(workspace_id: str, pocket_id: str) -> dict | None:
     }
 
 
+async def get_pocket_backend(workspace_id: str, pocket_id: str) -> dict | None:
+    """Return the pocket's backend binding summary, or ``None`` if unset.
+
+    NEVER returns the token — only ``backend_type`` / ``connector_name`` /
+    ``base_url`` / ``auth_type`` / ``configured`` / ``allowed_writes`` (the
+    write allowlist) / ``approval_route`` (the gated-write approver routing;
+    ``None`` when unset). All owner/editor-facing non-secrets.
+
+    ``backend_type`` / ``connector_name`` come via ``getattr`` defaults so a
+    row written before this feature reads as ``backend_type="http"`` /
+    ``connector_name=None`` — back-compatible.
+    """
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if doc is None:
+        return None
+    return _backend_summary_wire(doc)
+
+
 async def get_pocket_backend_for_executor(
     workspace_id: str, pocket_id: str
-) -> tuple[str, str, str | None, str, list[dict[str, str]], dict[str, str | None] | None] | None:
+) -> (
+    tuple[
+        str,
+        str,
+        str | None,
+        str,
+        list[dict[str, str]],
+        dict[str, str | None] | None,
+        str,
+        str | None,
+    ]
+    | None
+):
     """Internal — return ``(base_url, auth_type, auth_header, token,
-    allowed_writes, approval_route)``.
+    allowed_writes, approval_route, backend_type, connector_name)``.
 
-    Decrypts the stored token. Used by the run-sources route handler (it
-    ignores the trailing elements), the run-action route handler (it needs
-    ``allowed_writes`` and ``approval_route``), and ``instinct_bridge``.
-    Returns ``None`` when the pocket has no backend configured. The
-    plaintext token returned here must never be logged or returned to a
-    client. ``approval_route`` is ``None`` when no route is set.
+    Decrypts the stored token (http backends only; a connector backend has no
+    token). Used by the run-sources route handler (which now also reads the
+    trailing ``backend_type`` / ``connector_name`` to route the run), the
+    run-action route handler (it needs ``allowed_writes`` / ``approval_route``),
+    and ``instinct_bridge`` / ``temporal_dispatcher`` / ``bulk_dispatch`` (which
+    ignore the trailing elements). Returns ``None`` when the pocket has no
+    backend configured. The plaintext token must never be logged or returned to
+    a client.
+
+    ``backend_type`` / ``connector_name`` come via ``getattr`` defaults so a
+    legacy row reads as ``"http"`` / ``None`` — back-compatible.
     """
     doc = await _BackendCredentialDoc.find_one(
         _BackendCredentialDoc.pocket_id == pocket_id,
@@ -3780,6 +3886,8 @@ async def get_pocket_backend_for_executor(
         token,
         _allowed_writes_wire(doc),
         _approval_route_wire(doc),
+        getattr(doc, "backend_type", "http"),
+        getattr(doc, "connector_name", None),
     )
 
 
@@ -3829,13 +3937,7 @@ async def set_pocket_write_policy(
     # no-event: backend credentials (and the write policy on them) are a
     # separate collection, not pocket state — no downstream handler keys
     # off a PocketUpdated for them.
-    return {
-        "base_url": doc.base_url,
-        "auth_type": doc.auth_type,
-        "configured": True,
-        "allowed_writes": _allowed_writes_wire(doc),
-        "approval_route": _approval_route_wire(doc),
-    }
+    return _backend_summary_wire(doc)
 
 
 async def set_pocket_approval_route(
@@ -3901,13 +4003,7 @@ async def set_pocket_approval_route(
         auth_type=doc.auth_type,
     )
     # no-event: see set_pocket_write_policy — credential rows aren't pocket state.
-    return {
-        "base_url": doc.base_url,
-        "auth_type": doc.auth_type,
-        "configured": True,
-        "allowed_writes": _allowed_writes_wire(doc),
-        "approval_route": _approval_route_wire(doc),
-    }
+    return _backend_summary_wire(doc)
 
 
 async def remove_pocket_backend(workspace_id: str, user_id: str, pocket_id: str) -> None:

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -63,6 +63,26 @@
 #   with a `_SourceError(code="bad_source")` so a missing workspace context
 #   lands in the errors aggregation as a CLEAR error (mirrors the http-no-path
 #   guard), never a silent no-provider.
+# Updated: 2026-06-12 (feat/connector-as-pocket-backend) — two additions.
+#   (1) CONNECTOR BACKEND: `run_sources` gained `backend_type` ("http" default
+#   | "connector") + `connector_name`. When the pocket's backend is a connector,
+#   each non-sense source runs against the BOUND connector via
+#   `_run_connector_binding` → `connectors_service.execute` (the SAME read-first
+#   path senses use: only `auto`-trust actions run; confirm/restricted is
+#   refused per-source). The binding's `action`/`params` name the connector
+#   action. `base_url` is unused and the SSRF re-validation is skipped for a
+#   connector backend. http/sense paths are byte-for-byte unchanged when
+#   `backend_type="http"`. (2) SOURCE TRANSFORM: `SourceBinding.transform` (a
+#   small declarative `{select, map}` spec, interpreted by the pure
+#   `_source_transform.apply_transform`) shapes the RAW result of ANY source
+#   type before it binds — applied in the shared `_shape_result` row builder. A
+#   malformed transform fails THAT source cleanly (`bad_transform`), never a
+#   sibling. `SourceBinding.type` gained the `"connector"` literal.
+#
+# IMPORT-LINTER: still must NOT import `pocketpaw_ee.cloud.models.*`. The new
+# `_source_transform` helper is pure (no imports beyond typing); the connectors
+# service is imported LAZILY inside `_run_connector_binding` (same pattern as
+# the sense resolver import) so the static graph stays clean and cycle-free.
 
 from __future__ import annotations
 
@@ -85,6 +105,7 @@ from pocketpaw_ee.cloud.pockets._http_guard import (
     _resolve_url,
     _strip_query,
 )
+from pocketpaw_ee.cloud.pockets._source_transform import TransformError, apply_transform
 
 logger = logging.getLogger(__name__)
 
@@ -129,20 +150,31 @@ class SourceBinding(BaseModel):
     honored. ``None`` means "use the floor as the interval".
     """
 
-    type: Literal["http", "sense"] = "http"
+    type: Literal["http", "sense", "connector"] = "http"
     method: Literal["GET"] = "GET"
-    # ``path`` is required for http sources, unused for sense sources. Kept
-    # optional here so a sense entry survives parse; the http path raises a
-    # clean per-source error if a misconfigured http source has no path.
+    # ``path`` is required for http sources, unused for sense/connector sources.
+    # Kept optional here so a sense/connector entry survives parse; the http
+    # path raises a clean per-source error if a misconfigured http source has
+    # no path.
     path: str | None = None
     bind: str
     refresh: list[RefreshTrigger] = Field(default_factory=lambda: _DEFAULT_REFRESH.copy())
     refresh_interval_seconds: int | None = Field(default=None, ge=1)
-    # Sense-source fields (type == "sense"). ``params`` are STATIC in v1 —
-    # passed through to the Sense resolver as-is (no ``{state.x}`` evaluation).
+    # Sense/connector-source fields. ``params`` are STATIC in v1 — passed
+    # through to the Sense resolver / connector as-is (no ``{state.x}``
+    # evaluation). For ``type == "sense"`` the resolver picks the connector via
+    # ``sense_id``; for ``type == "connector"`` the pocket's bound connector is
+    # used and only ``action``/``params`` matter (the binding does not name the
+    # connector — the backend does).
     sense_id: str | None = None
     action: str | None = None
     params: dict | None = None
+    # Optional declarative transform applied to the RAW fetch result before it
+    # is bound to state — for ALL source types. v1 grammar: ``{"select": ...}``
+    # (drill a dotted path) and/or ``{"map": [...]}`` (reshape a list row by
+    # row). Interpreted by the pure ``_source_transform.apply_transform``; a
+    # spec outside the grammar fails the source cleanly (never a sibling).
+    transform: dict | None = None
 
 
 def _normalize_bind(bind: str) -> str:
@@ -151,6 +183,23 @@ def _normalize_bind(bind: str) -> str:
     ``state.prs`` and ``prs`` both target the ``prs`` key of pocket state.
     """
     return bind[len("state.") :] if bind.startswith("state.") else bind
+
+
+def _shape_result(*, key: str, binding: SourceBinding, raw: object) -> dict:
+    """Apply the binding's transform (if any) to ``raw`` and build the row.
+
+    The ONE place every source type (http / sense / connector) funnels its
+    raw result through before binding to state. With no ``transform`` it
+    returns the raw value unchanged — today's behavior for http/sense.
+    A ``transform`` outside the v1 grammar raises ``_SourceError`` (mapped from
+    the pure transformer's ``TransformError``) so a hallucinated/ malformed
+    transform fails THIS source cleanly without touching a sibling.
+    """
+    try:
+        value = apply_transform(raw, binding.transform)
+    except TransformError as exc:
+        raise _SourceError(f"source transform is invalid: {exc}", code="bad_transform") from exc
+    return {"source": key, "bind": _normalize_bind(binding.bind), "value": value}
 
 
 async def _rate_limited(pocket_id: str, user_id: str) -> bool:
@@ -331,9 +380,97 @@ async def _run_sense_binding(
         )
 
     # result.data is the ExecuteActionResponse; result.data.data is the
-    # payload that should land in pocket state.
+    # payload that should land in pocket state. The binding's transform (if
+    # any) shapes that payload before it binds.
     payload = getattr(result.data, "data", None)
-    return {"source": key, "bind": _normalize_bind(binding.bind), "value": payload}
+    return _shape_result(key=key, binding=binding, raw=payload)
+
+
+async def _run_connector_binding(
+    *,
+    key: str,
+    binding: SourceBinding,
+    connector_name: str | None,
+    workspace_id: str | None,
+    pocket_id: str,
+    user_id: str,
+) -> dict:
+    """Run a source against the pocket's BOUND connector (backend_type="connector").
+
+    The pocket's backend names the connector; the binding's ``action`` /
+    ``params`` name which connector action to call. Routes through the SAME
+    ``connectors_service.execute`` path senses use — read-first (v1): the
+    action's ``trust_level`` must be exactly ``"auto"``; a confirm / restricted
+    / unknown action is REFUSED here with a clean per-source error and
+    ``execute`` is never called (so a sibling source keeps running).
+
+    Returns the SAME ``{source, bind, value}`` row shape the http/sense paths
+    return, with the connector's ``ExecuteActionResponse.data`` payload shaped
+    by the binding's transform before it binds. ``params`` are STATIC in v1
+    (no ``{state.x}`` evaluation).
+    """
+    if not workspace_id:
+        # Mirror the sense-path guard: a connector executes FOR a workspace; a
+        # falsy workspace context would mis-scope the execute. Loud per-source
+        # error instead of a silent mis-resolution.
+        raise _SourceError("connector source requires a workspace context", code="bad_source")
+    if not connector_name:
+        # The pocket's backend is supposed to name the connector. A connector
+        # backend with no name is a misconfiguration — fail this source clearly.
+        raise _SourceError("connector backend has no connector_name", code="bad_source")
+    if not binding.action:
+        raise _SourceError("connector source has no action", code="bad_source")
+
+    # Lazy import — keeps the SSRF/http core importable without the connectors
+    # subsystem and avoids a top-level import cycle (the connectors service
+    # imports pockets.service, which the source executor lives alongside).
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+
+    # READ-FIRST GATE — identical policy to the sense resolver: only an
+    # ``auto``-trust action runs. Anything else is refused BEFORE execute.
+    trust_info = await connectors_service.get_action_trust(connector_name, binding.action)
+    if trust_info is None or not getattr(trust_info, "is_read", False):
+        trust = getattr(trust_info, "trust_level", None) if trust_info else None
+        raise _SourceError(
+            f"action {binding.action!r} on {connector_name!r} is not auto-trust "
+            f"(trust_level={trust!r}) — refused in v1 (read-first)",
+            code="action_needs_approval",
+        )
+
+    try:
+        response = await connectors_service.execute(
+            workspace_id,
+            connector_name,
+            ExecuteActionRequest(
+                action=binding.action,
+                params=binding.params or {},
+                pocket_id=pocket_id,
+            ),
+            user_id=user_id,
+        )
+    except Exception as exc:
+        # connectors_service raises CloudError/NotFound for an unknown
+        # connector/action, a local-runtime-unavailable action, etc. Contain
+        # it as a per-source error — never let it abort a sibling source.
+        logger.warning(
+            "connector source %s: execute on %s failed: %s",
+            key,
+            connector_name,
+            type(exc).__name__,
+        )
+        raise _SourceError("connector action execution failed", code="connector_error") from exc
+
+    # A connector action can fail at the adapter without raising — surface that
+    # as a per-source error too, mirroring the sense resolver's ok=False path.
+    if not getattr(response, "success", False):
+        raise _SourceError(
+            getattr(response, "error", None) or "connector action returned an error",
+            code="connector_error",
+        )
+
+    payload = getattr(response, "data", None)
+    return _shape_result(key=key, binding=binding, raw=payload)
 
 
 async def _run_one(
@@ -346,18 +483,39 @@ async def _run_one(
     workspace_id: str | None,
     pocket_id: str,
     user_id: str,
+    backend_type: str = "http",
+    connector_name: str | None = None,
 ) -> dict:
     """Fetch a single source. Returns a ``ran`` row; raises ``_GuardError``
     (the shared guard rejections) or its ``_SourceError`` subclass (the
     read executor's own per-source failures).
 
-    Branches on ``binding.type``: a ``"sense"`` source resolves via the
-    Sense resolver (``_run_sense_binding``); the default ``"http"`` source
-    runs the SSRF-guarded GET below, unchanged."""
+    Dispatch order:
+      1. A ``type="sense"`` binding ALWAYS resolves via the Sense resolver
+         (``_run_sense_binding``) — sense sources are backend-agnostic, so the
+         pocket's backend type never changes how they run.
+      2. Otherwise, when the pocket's backend is ``backend_type="connector"``,
+         the source runs against the BOUND connector via
+         ``_run_connector_binding`` (action surface, not an HTTP GET).
+      3. Otherwise (the default ``backend_type="http"``) it runs the
+         SSRF-guarded GET below, unchanged.
+
+    The transform (if any) is applied inside whichever runner builds the row,
+    so it composes with all three transports."""
     if binding.type == "sense":
         return await _run_sense_binding(
             key=key,
             binding=binding,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+        )
+
+    if binding.type == "connector" or backend_type == "connector":
+        return await _run_connector_binding(
+            key=key,
+            binding=binding,
+            connector_name=connector_name,
             workspace_id=workspace_id,
             pocket_id=pocket_id,
             user_id=user_id,
@@ -398,7 +556,9 @@ async def _run_one(
     except ValueError as exc:
         raise _SourceError("backend response is not valid JSON", code="bad_json") from exc
 
-    return {"source": key, "bind": _normalize_bind(binding.bind), "value": value}
+    # The binding's transform (if any) shapes the parsed JSON before it binds;
+    # with no transform this is the raw value — today's behavior, unchanged.
+    return _shape_result(key=key, binding=binding, raw=value)
 
 
 async def run_sources(
@@ -413,6 +573,8 @@ async def run_sources(
     trigger: str | None = None,
     only_source: str | None = None,
     workspace_id: str,
+    backend_type: str = "http",
+    connector_name: str | None = None,
 ) -> dict:
     """Run the pocket's selected read-only sources and return the results.
 
@@ -432,6 +594,13 @@ async def run_sources(
     workspace, and a None would silently mis-resolve to "no provider". All
     callers already pass a real value, so a caller that omits it raises a loud
     TypeError rather than running a mis-resolved sense.
+
+    ``backend_type`` / ``connector_name`` select the transport for non-sense
+    sources. ``"http"`` (the default) fetches each source with the SSRF-guarded
+    GET against ``base_url`` — unchanged. ``"connector"`` routes each non-sense
+    source through the pocket's bound connector (``connector_name``) via
+    ``connectors_service.execute``; ``base_url`` is then unused (and not
+    validated, since a connector backend has none).
     """
     # D16 — per-(pocket, user) rate limit. On breach, return a source-level
     # error for every selected source without making any call.
@@ -456,19 +625,22 @@ async def run_sources(
         }
 
     # D6/D15 — re-validate the base URL at call time even though config-time
-    # validation already ran. Defense in depth against a tampered row.
-    try:
-        validate_external_url_strict(base_url)
-    except ValueError:
-        _audit_source_run(
-            actor=user_id,
-            pocket_id=pocket_id,
-            status="rejected",
-            base_url=base_url,
-            ran=0,
-            errors=0,
-        )
-        raise
+    # validation already ran. Defense in depth against a tampered row. A
+    # connector backend has no base_url (it routes through the connector action
+    # surface, not an HTTP GET), so the SSRF re-validation does not apply.
+    if backend_type != "connector":
+        try:
+            validate_external_url_strict(base_url)
+        except ValueError:
+            _audit_source_run(
+                actor=user_id,
+                pocket_id=pocket_id,
+                status="rejected",
+                base_url=base_url,
+                ran=0,
+                errors=0,
+            )
+            raise
 
     bindings, parse_errors = _parse_bindings(ripple_spec)
     selected = _select_sources(bindings, trigger=trigger, only_source=only_source)
@@ -506,6 +678,8 @@ async def run_sources(
                         workspace_id=workspace_id,
                         pocket_id=pocket_id,
                         user_id=user_id,
+                        backend_type=backend_type,
+                        connector_name=connector_name,
                     ),
                     timeout=_PER_SOURCE_TIMEOUT_S,
                 )

--- a/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
+++ b/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
@@ -285,7 +285,9 @@ async def _invoke_executor(
             "code": "pocket_backend.not_configured",
             "on_error": [],
         }
-    base_url, auth_type, auth_header, token, allowed_writes, _approval_route = creds
+    # Trailing `backend_type` / `connector_name` (connector-backend feature)
+    # don't apply to the http write executor — absorbed and ignored.
+    base_url, auth_type, auth_header, token, allowed_writes, _approval_route, *_ = creds
 
     ripple_spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
     actions = (ripple_spec or {}).get("actions")

--- a/tests/cloud/pockets/test_sources_run_endpoint.py
+++ b/tests/cloud/pockets/test_sources_run_endpoint.py
@@ -127,7 +127,9 @@ async def test_pocket_open_no_ripple_spec_no_backend_is_noop():
 async def test_configured_backend_runs_executor():
     """With a backend bound, the route delegates to the executor unchanged."""
     pocket = _pocket({"version": "1.0", "sources": {"revenue": dict(_REVENUE_SOURCE)}, "ui": {}})
-    creds = ("https://api.example.com", "bearer", None, "tok", [], None)
+    # connector-as-backend: the executor tuple is an 8-tuple — trailing
+    # backend_type / connector_name (http / None for this http backend).
+    creds = ("https://api.example.com", "bearer", None, "tok", [], None, "http", None)
     executor_result = {"ran": [{"source": "revenue", "bind": "revenue", "value": 42}], "errors": []}
     with _patch_service(pocket=pocket, creds=creds):
         with patch(

--- a/tests/cloud/test_connectors_execute.py
+++ b/tests/cloud/test_connectors_execute.py
@@ -345,6 +345,41 @@ async def test_get_action_trust_reads_vs_writes(mongo_db):  # noqa: ARG001
     write = await connectors_service.get_action_trust("github", "create_issue")
     assert write is not None and not write.is_read and write.trust_level == "confirm"
 
+
+@pytest.mark.asyncio
+async def test_is_connector_enabled_for_workspace(mongo_db):  # noqa: ARG001
+    """The validation gate the pocket-backend setter uses: True only when the
+    connector is a real registry connector AND enabled for the workspace."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    # Enable github at workspace scope.
+    await WorkspaceConnector(
+        workspace="ws-1", name="github", enabled=True, scope="workspace"
+    ).insert()
+
+    assert await connectors_service.is_connector_enabled_for_workspace("ws-1", "github")
+    # Not enabled in another workspace.
+    assert not await connectors_service.is_connector_enabled_for_workspace("ws-OTHER", "github")
+    # A registry connector with no enabled row → False.
+    assert not await connectors_service.is_connector_enabled_for_workspace("ws-1", "gmail")
+    # A name the registry doesn't know → False.
+    assert not await connectors_service.is_connector_enabled_for_workspace(
+        "ws-1", "no-such-connector"
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_connector_enabled_false_when_disabled(mongo_db):  # noqa: ARG001
+    """A disabled row does not count as enabled."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+    await WorkspaceConnector(
+        workspace="ws-1", name="github", enabled=False, scope="workspace"
+    ).insert()
+    assert not await connectors_service.is_connector_enabled_for_workspace("ws-1", "github")
+
     assert await connectors_service.get_action_trust("github", "nope") is None
 
 

--- a/tests/cloud/test_pocket_agent_backend_view.py
+++ b/tests/cloud/test_pocket_agent_backend_view.py
@@ -101,6 +101,9 @@ async def test_agent_view_includes_configured_backend_summary(mongo_db, agent_id
     assert err is None
     assert view is not None
     assert view["backend"] == {
+        # connector-as-backend: backend_type/connector_name lead the summary.
+        "backend_type": "http",
+        "connector_name": None,
         "base_url": "https://jsonplaceholder.typicode.com",
         "auth_type": "none",
         "configured": True,
@@ -139,6 +142,8 @@ async def test_agent_view_backend_summary_never_leaks_the_token(mongo_db, agent_
     # `allowed_writes` — the write allowlist; M2b.1 adds `approval_route`
     # — the gated-write approver routing — both non-secret).
     assert set(backend) == {
+        "backend_type",
+        "connector_name",
         "base_url",
         "auth_type",
         "configured",
@@ -198,6 +203,8 @@ async def test_fetch_pocket_for_agent_carries_backend_summary(mongo_db, agent_id
 
     assert result["ok"] is True
     assert result["pocket"]["backend"] == {
+        "backend_type": "http",
+        "connector_name": None,
         "base_url": "https://jsonplaceholder.typicode.com",
         "auth_type": "none",
         "configured": True,

--- a/tests/cloud/test_pocket_backend_routes.py
+++ b/tests/cloud/test_pocket_backend_routes.py
@@ -73,7 +73,18 @@ def client(app: FastAPI) -> TestClient:
 def test_put_backend_configures(monkeypatch, client):
     captured = {}
 
-    async def _set(workspace_id, user_id, pocket_id, base_url, auth_type, auth_token, auth_header):
+    async def _set(
+        workspace_id,
+        user_id,
+        pocket_id,
+        base_url,
+        auth_type,
+        auth_token,
+        auth_header,
+        *,
+        backend_type="http",
+        connector_name=None,
+    ):
         captured.update(
             workspace_id=workspace_id,
             user_id=user_id,
@@ -81,8 +92,16 @@ def test_put_backend_configures(monkeypatch, client):
             base_url=base_url,
             auth_type=auth_type,
             auth_token=auth_token,
+            backend_type=backend_type,
+            connector_name=connector_name,
         )
-        return {"base_url": base_url, "auth_type": auth_type, "configured": True}
+        return {
+            "backend_type": backend_type,
+            "connector_name": connector_name,
+            "base_url": base_url,
+            "auth_type": auth_type,
+            "configured": True,
+        }
 
     monkeypatch.setattr(pockets_service, "set_pocket_backend", _set)
 
@@ -97,6 +116,11 @@ def test_put_backend_configures(monkeypatch, client):
     assert res.status_code == 200, res.text
     body = res.json()
     assert body == {
+        # connector-as-backend: the response now carries backend_type +
+        # connector_name. The faked service omits them, so the response model
+        # fills the http defaults.
+        "backend_type": "http",
+        "connector_name": None,
         "base_url": "https://api.example.com",
         "auth_type": "bearer",
         "configured": True,
@@ -229,9 +253,10 @@ def test_run_sources_happy_path(monkeypatch, client):
         return {"_id": pocket_id, "rippleSpec": spec}
 
     async def _get_creds(workspace_id, pocket_id):
-        # RFC 05 M2b.1: 6-tuple — trailing elements are the write
-        # allowlist and the approval route (None = owner approves).
-        return ("https://api.example.com", "bearer", None, "tok", [], None)
+        # connector-as-backend: 8-tuple — trailing elements are the write
+        # allowlist, approval route (None = owner approves), backend_type,
+        # connector_name.
+        return ("https://api.example.com", "bearer", None, "tok", [], None, "http", None)
 
     monkeypatch.setattr(pockets_service, "get", _get_pocket)
     monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _get_creds)

--- a/tests/cloud/test_pocket_backend_service.py
+++ b/tests/cloud/test_pocket_backend_service.py
@@ -14,6 +14,14 @@
 # `approval_route`, and set_pocket_approval_route is covered: it
 # validates a mode=user approver as a workspace member and rejects when
 # the pocket has no backend.
+# Updated: 2026-06-12 (feat/connector-as-pocket-backend) — the set/get
+# summaries now carry `backend_type` + `connector_name`, and the executor
+# tuple is an 8-tuple (trailing backend_type/connector_name). Added
+# CONNECTOR-backend coverage: a connector backend stores backend_type/
+# connector_name with no base_url and validates the connector is enabled
+# (rejects unknown connector / missing name / bad backend_type); the executor
+# tuple carries them with no token; switching http->connector clears the stale
+# credential; and a legacy row (no backend_type) reads back as http.
 #
 # What this pins:
 #   - set_pocket_backend then get_pocket_backend returns configured:true
@@ -45,7 +53,11 @@ async def test_set_then_get_backend(mongo_db):
         auth_type="bearer",
         auth_token="secret-token-xyz",
     )
+    # feat/connector-as-pocket-backend: the set/get summary now carries
+    # `backend_type` ("http" here) + `connector_name` (None for http).
     assert result == {
+        "backend_type": "http",
+        "connector_name": None,
         "base_url": "https://api.example.com",
         "auth_type": "bearer",
         "configured": True,
@@ -57,9 +69,12 @@ async def test_set_then_get_backend(mongo_db):
     summary = await pockets_service.get_pocket_backend("w1", "pocket-1")
     # RFC 05 M2a: the summary carries the write allowlist (empty by
     # default — fail-closed). RFC 05 M2b.1: it also carries the approval
-    # route (None by default — the owner approves). The token is still
+    # route (None by default — the owner approves). connector-as-backend:
+    # it also carries backend_type/connector_name. The token is still
     # never present.
     assert summary == {
+        "backend_type": "http",
+        "connector_name": None,
         "base_url": "https://api.example.com",
         "auth_type": "bearer",
         "configured": True,
@@ -99,7 +114,18 @@ async def test_get_for_executor_decrypts_token(mongo_db):
     )
     creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
     assert creds is not None
-    base_url, auth_type, auth_header, token, allowed_writes, approval_route = creds
+    # connector-as-backend: the executor tuple is now an 8-tuple — trailing
+    # `backend_type` / `connector_name` after the write allowlist + route.
+    (
+        base_url,
+        auth_type,
+        auth_header,
+        token,
+        allowed_writes,
+        approval_route,
+        backend_type,
+        connector_name,
+    ) = creds
     assert base_url == "https://api.example.com"
     assert auth_type == "api_key"
     assert auth_header == "X-Custom-Key"
@@ -107,6 +133,8 @@ async def test_get_for_executor_decrypts_token(mongo_db):
     assert allowed_writes == []
     # RFC 05 M2b.1: no route set → None (the pocket owner approves).
     assert approval_route is None
+    assert backend_type == "http"
+    assert connector_name is None
 
 
 async def test_get_for_executor_none_when_unset(mongo_db):
@@ -124,13 +152,16 @@ async def test_get_for_executor_no_token_for_none_auth(mongo_db):
     )
     creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
     assert creds is not None
-    # RFC 05 M2b.1: the executor tuple is a 6-tuple — trailing elements
-    # are the write allowlist and the approval route.
-    _, auth_type, _, token, allowed_writes, approval_route = creds
+    # connector-as-backend: the executor tuple is now an 8-tuple — trailing
+    # elements are write allowlist, approval route, backend_type,
+    # connector_name.
+    _, auth_type, _, token, allowed_writes, approval_route, backend_type, connector_name = creds
     assert auth_type == "none"
     assert token == ""
     assert allowed_writes == []
     assert approval_route is None
+    assert backend_type == "http"
+    assert connector_name is None
 
 
 async def test_set_backend_upserts(mongo_db):
@@ -184,6 +215,195 @@ async def test_set_backend_rejects_internal_url(mongo_db):
             auth_type="none",
             auth_token="",
         )
+
+
+# ---------------------------------------------------------------------------
+# Connector backend (feat/connector-as-pocket-backend)
+# ---------------------------------------------------------------------------
+
+
+async def _enable_connector(workspace_id: str, name: str) -> None:
+    """Enable a real registry connector for a workspace (workspace scope)."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.connectors.dto import EnableConnectorRequest
+
+    await connectors_service.enable_connector(
+        workspace_id, name, EnableConnectorRequest(scope="workspace")
+    )
+
+
+async def test_set_connector_backend_summary(mongo_db):
+    """A connector backend stores backend_type/connector_name, needs no
+    base_url, and the summary carries both (never a token)."""
+    await _enable_connector("w1", "github")
+
+    result = await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="",  # not required for a connector backend
+        auth_type="none",
+        auth_token="",
+        backend_type="connector",
+        connector_name="github",
+    )
+    assert result == {
+        "backend_type": "connector",
+        "connector_name": "github",
+        "base_url": "",
+        "auth_type": "none",
+        "configured": True,
+    }
+
+    summary = await pockets_service.get_pocket_backend("w1", "pocket-1")
+    assert summary == {
+        "backend_type": "connector",
+        "connector_name": "github",
+        "base_url": "",
+        "auth_type": "none",
+        "configured": True,
+        "allowed_writes": [],
+        "approval_route": None,
+    }
+    assert "token" not in summary
+    assert "encrypted_token" not in summary
+
+
+async def test_set_connector_backend_rejects_unknown_connector(mongo_db):
+    """A connector_name that names no enabled workspace connector is rejected
+    with a clear error — never silently stored."""
+    with pytest.raises(ValidationError) as excinfo:
+        await pockets_service.set_pocket_backend(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id="pocket-1",
+            base_url="",
+            auth_type="none",
+            auth_token="",
+            backend_type="connector",
+            connector_name="not-enabled-anywhere",
+        )
+    assert excinfo.value.code == "pocket_backend.unknown_connector"
+
+
+async def test_set_connector_backend_requires_connector_name(mongo_db):
+    """backend_type='connector' without a connector_name is rejected."""
+    with pytest.raises(ValidationError) as excinfo:
+        await pockets_service.set_pocket_backend(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id="pocket-1",
+            base_url="",
+            auth_type="none",
+            auth_token="",
+            backend_type="connector",
+            connector_name=None,
+        )
+    assert excinfo.value.code == "pocket_backend.missing_connector"
+
+
+async def test_set_backend_rejects_unknown_backend_type(mongo_db):
+    with pytest.raises(ValidationError) as excinfo:
+        await pockets_service.set_pocket_backend(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id="pocket-1",
+            base_url="",
+            auth_type="none",
+            auth_token="",
+            backend_type="weird",
+            connector_name=None,
+        )
+    assert excinfo.value.code == "pocket_backend.invalid_backend_type"
+
+
+async def test_connector_backend_for_executor_tuple(mongo_db):
+    """The executor tuple carries backend_type='connector' + connector_name and
+    no token (a connector backend has no credential)."""
+    await _enable_connector("w1", "github")
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="",
+        auth_type="none",
+        auth_token="",
+        backend_type="connector",
+        connector_name="github",
+    )
+    creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
+    assert creds is not None
+    base_url, auth_type, _hdr, token, _aw, _route, backend_type, connector_name = creds
+    assert backend_type == "connector"
+    assert connector_name == "github"
+    assert base_url == ""
+    assert auth_type == "none"
+    assert token == ""
+
+
+async def test_switch_http_to_connector_clears_credential(mongo_db):
+    """Switching an existing http backend to a connector backend clears the
+    stale base_url / encrypted token so no credential lingers."""
+    from pocketpaw_ee.cloud.models.pocket_backend import PocketBackendCredential
+
+    # First an http backend with a real encrypted token.
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="bearer",
+        auth_token="secret-token",
+    )
+    # Then switch it to a connector backend.
+    await _enable_connector("w1", "github")
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="",
+        auth_type="none",
+        auth_token="",
+        backend_type="connector",
+        connector_name="github",
+    )
+    row = await PocketBackendCredential.find_one(
+        PocketBackendCredential.pocket_id == "pocket-1",
+        PocketBackendCredential.workspace_id == "w1",
+    )
+    assert row.backend_type == "connector"
+    assert row.connector_name == "github"
+    assert row.base_url == ""
+    assert row.auth_type == "none"
+    assert row.encrypted_token is None
+    assert row.nonce is None
+    assert row.salt is None
+
+
+async def test_legacy_row_reads_as_http_backend(mongo_db):
+    """Back-compat: a row written WITHOUT backend_type/connector_name (a legacy
+    http backend) reads as backend_type='http' / connector_name=None — both via
+    the model default and the service summaries."""
+    from pocketpaw_ee.cloud.models.pocket_backend import PocketBackendCredential
+
+    # Insert a row the way pre-feature code did — no backend_type / connector_name
+    # passed. The model default fills backend_type='http'.
+    await PocketBackendCredential(
+        pocket_id="legacy-pocket",
+        workspace_id="w1",
+        base_url="https://legacy.example.com",
+        auth_type="none",
+    ).insert()
+
+    summary = await pockets_service.get_pocket_backend("w1", "legacy-pocket")
+    assert summary["backend_type"] == "http"
+    assert summary["connector_name"] is None
+    assert summary["base_url"] == "https://legacy.example.com"
+
+    creds = await pockets_service.get_pocket_backend_for_executor("w1", "legacy-pocket")
+    assert creds is not None
+    assert creds[6] == "http"  # backend_type
+    assert creds[7] is None  # connector_name
 
 
 async def test_set_backend_requires_token_for_auth(mongo_db):

--- a/tests/cloud/test_pocket_refresh_scheduler.py
+++ b/tests/cloud/test_pocket_refresh_scheduler.py
@@ -66,7 +66,12 @@ def _patch_executor(monkeypatch, calls: list, *, raises_for=None):
 
 
 def _patch_service(
-    monkeypatch, pockets: list, *, creds=("https://api.example.com", "none", None, "", [], None)
+    monkeypatch,
+    pockets: list,
+    *,
+    # connector-as-backend: the executor tuple is now an 8-tuple — trailing
+    # backend_type / connector_name (http / None for the scheduler's http path).
+    creds=("https://api.example.com", "none", None, "", [], None, "http", None),
 ):
     """Patch the pockets service calls the scheduler makes."""
     from pocketpaw_ee.cloud.pockets import service as pockets_service

--- a/tests/cloud/test_pocket_source_executor.py
+++ b/tests/cloud/test_pocket_source_executor.py
@@ -12,6 +12,17 @@
 # unwrapped .data.data payload to state in the same {source,bind,value} row
 # shape; an ok=False result lands in the errors aggregation with the
 # resolver's stable code/message and does NOT abort a sibling http source.
+# Updated: 2026-06-12 (feat/connector-as-pocket-backend) — coverage for the
+# CONNECTOR backend + the source TRANSFORM. With backend_type="connector" each
+# non-sense source routes through a mocked connectors_service.execute (read-first:
+# only auto-trust actions run; a confirm/restricted/unknown action is refused
+# with `action_needs_approval` and execute is never called); the response's
+# `.data` binds in the same {source,bind,value} row shape; a failed connector
+# source is contained (sibling keeps running); the empty connector base_url
+# skips the SSRF validation. The transform (select+map+values+const+missing)
+# shapes the raw result before binding for BOTH http and connector sources; a
+# malformed transform fails that source cleanly (`bad_transform`). The http path
+# with no transform is asserted unchanged (regression).
 #
 # What this pins:
 #   - SSRF rejections: absolute-URL path, `..` traversal, path to a
@@ -904,3 +915,510 @@ async def test_sense_source_with_falsy_workspace_is_clear_bad_source(monkeypatch
     assert err["source"] == "inbox"
     assert err["code"] == "bad_source"
     assert "workspace" in err["error"]
+
+
+# ---------------------------------------------------------------------------
+# Connector backend (feat/connector-as-pocket-backend) — when the pocket's
+# backend is `backend_type="connector"`, each non-sense source runs against the
+# BOUND connector via connectors_service.execute (read-first: auto-trust only).
+# The connectors service is mocked; no real connectors are needed.
+# ---------------------------------------------------------------------------
+
+
+class _FakeTrust:
+    """Stand-in for ConnectorActionInfo — only `is_read` / `trust_level` read."""
+
+    def __init__(self, is_read: bool, trust_level: str):
+        self.is_read = is_read
+        self.trust_level = trust_level
+
+
+class _FakeExecResp:
+    """Stand-in for ExecuteActionResponse — `success` / `data` / `error` read."""
+
+    def __init__(self, success=True, data=None, error=None):
+        self.success = success
+        self.data = data
+        self.error = error
+
+
+def _patch_connector_service(monkeypatch, *, trust, execute):
+    """Patch the lazily-imported connectors service used by the connector path.
+
+    `_run_connector_binding` does `from ...connectors import service` at call
+    time, so patching the attributes on that module is what takes effect.
+    `trust` fakes `get_action_trust`; `execute` fakes `execute`.
+    """
+    import pocketpaw_ee.cloud.connectors.service as cs
+
+    monkeypatch.setattr(cs, "get_action_trust", trust)
+    monkeypatch.setattr(cs, "execute", execute)
+
+
+async def test_connector_backend_source_executes_via_connector(monkeypatch):
+    """A connector-backed source routes each source through
+    connectors_service.execute and binds the response's `.data` payload in the
+    same `{source, bind, value}` row shape the http/sense paths return."""
+    captured = {}
+
+    async def _trust(name, action):
+        return _FakeTrust(is_read=True, trust_level="auto")
+
+    async def _execute(workspace_id, name, body, *, user_id=None):
+        captured.update(
+            workspace_id=workspace_id,
+            name=name,
+            action=body.action,
+            params=body.params,
+            user_id=user_id,
+            pocket_id=body.pocket_id,
+        )
+        return _FakeExecResp(success=True, data=[{"id": "app-1", "fullName": "Ada"}])
+
+    _patch_connector_service(monkeypatch, trust=_trust, execute=_execute)
+
+    spec = {
+        "sources": {
+            "apps": {
+                "type": "connector",
+                "action": "list_applications",
+                "params": {"status": "new"},
+                "bind": "state.apps",
+            }
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url="",  # a connector backend has no base_url
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+        backend_type="connector",
+        connector_name="snctm-admin",
+    )
+
+    assert result["errors"] == []
+    assert len(result["ran"]) == 1
+    ran = result["ran"][0]
+    assert ran["source"] == "apps"
+    assert ran["bind"] == "apps"  # `state.` stripped
+    assert ran["value"] == [{"id": "app-1", "fullName": "Ada"}]
+    # The pocket's bound connector + the binding's action/params were threaded.
+    assert captured["name"] == "snctm-admin"
+    assert captured["action"] == "list_applications"
+    assert captured["params"] == {"status": "new"}
+    assert captured["workspace_id"] == "ws-1"
+    assert captured["pocket_id"] == "p1"
+    assert captured["user_id"] == "runner-1"
+
+
+async def test_connector_backend_routes_plain_http_typed_source(monkeypatch):
+    """A source that omits `type` (defaults to "http") STILL routes through the
+    connector when the pocket's BACKEND is a connector — the backend, not the
+    source's type, selects the transport for non-sense sources."""
+
+    async def _trust(name, action):
+        return _FakeTrust(is_read=True, trust_level="auto")
+
+    async def _execute(workspace_id, name, body, *, user_id=None):
+        return _FakeExecResp(success=True, data={"ok": True})
+
+    _patch_connector_service(monkeypatch, trust=_trust, execute=_execute)
+
+    spec = {"sources": {"s": {"action": "ping", "bind": "state.s"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url="",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+        backend_type="connector",
+        connector_name="snctm-admin",
+    )
+    assert result["errors"] == []
+    assert result["ran"][0]["value"] == {"ok": True}
+
+
+async def test_connector_backend_applies_transform(monkeypatch):
+    """The binding's transform shapes the connector response BEFORE it binds —
+    select drills, map reshapes (values + const + missing-field)."""
+
+    async def _trust(name, action):
+        return _FakeTrust(is_read=True, trust_level="auto")
+
+    async def _execute(workspace_id, name, body, *, user_id=None):
+        return _FakeExecResp(
+            success=True,
+            data={
+                "applications": [
+                    {"fullName": "Ada", "status": "new", "id": "x1"},
+                    {"fullName": "Bo", "status": "rejected", "id": "x2"},
+                ]
+            },
+        )
+
+    _patch_connector_service(monkeypatch, trust=_trust, execute=_execute)
+
+    spec = {
+        "sources": {
+            "apps": {
+                "type": "connector",
+                "action": "list_applications",
+                "bind": "state.apps",
+                "transform": {
+                    "select": "applications",
+                    "map": [
+                        {"to": "applicant", "from": "fullName"},
+                        {
+                            "to": "status_variant",
+                            "from": "status",
+                            "values": {"new": "warning", "rejected": "destructive"},
+                            "default": "muted",
+                        },
+                        {"to": "id", "from": "id"},
+                        {"to": "source", "const": "snctm-admin"},
+                        {"to": "missing", "from": "nope"},
+                    ],
+                },
+            }
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url="",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+        backend_type="connector",
+        connector_name="snctm-admin",
+    )
+    assert result["errors"] == []
+    assert result["ran"][0]["value"] == [
+        {
+            "applicant": "Ada",
+            "status_variant": "warning",
+            "id": "x1",
+            "source": "snctm-admin",
+            "missing": None,
+        },
+        {
+            "applicant": "Bo",
+            "status_variant": "destructive",
+            "id": "x2",
+            "source": "snctm-admin",
+            "missing": None,
+        },
+    ]
+
+
+async def test_connector_backend_refuses_non_auto_trust_action(monkeypatch):
+    """READ-FIRST: a confirm/restricted action is refused with a clean
+    per-source error and execute is NEVER called."""
+    called = {"execute": False}
+
+    async def _trust(name, action):
+        return _FakeTrust(is_read=False, trust_level="confirm")
+
+    async def _execute(workspace_id, name, body, *, user_id=None):
+        called["execute"] = True
+        raise AssertionError("execute must not run for a non-auto action")
+
+    _patch_connector_service(monkeypatch, trust=_trust, execute=_execute)
+
+    spec = {
+        "sources": {
+            "danger": {
+                "type": "connector",
+                "action": "delete_application",
+                "bind": "state.danger",
+            }
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url="",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+        backend_type="connector",
+        connector_name="snctm-admin",
+    )
+    assert called["execute"] is False
+    assert result["ran"] == []
+    assert len(result["errors"]) == 1
+    err = result["errors"][0]
+    assert err["source"] == "danger"
+    assert err["code"] == "action_needs_approval"
+
+
+async def test_connector_backend_unknown_action_refused(monkeypatch):
+    """An action the connector doesn't expose (get_action_trust -> None) is
+    refused at the read-first gate — execute is never called."""
+
+    async def _trust(name, action):
+        return None
+
+    async def _execute(workspace_id, name, body, *, user_id=None):
+        raise AssertionError("execute must not run for an unknown action")
+
+    _patch_connector_service(monkeypatch, trust=_trust, execute=_execute)
+
+    spec = {"sources": {"s": {"type": "connector", "action": "nope", "bind": "state.s"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url="",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+        backend_type="connector",
+        connector_name="snctm-admin",
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["code"] == "action_needs_approval"
+
+
+async def test_connector_backend_execute_failure_is_per_source_error(monkeypatch):
+    """A connector action that returns success=False lands in the errors
+    aggregation — it does NOT crash the run."""
+
+    async def _trust(name, action):
+        return _FakeTrust(is_read=True, trust_level="auto")
+
+    async def _execute(workspace_id, name, body, *, user_id=None):
+        return _FakeExecResp(success=False, data=None, error="upstream 500")
+
+    _patch_connector_service(monkeypatch, trust=_trust, execute=_execute)
+
+    spec = {"sources": {"s": {"type": "connector", "action": "list", "bind": "state.s"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url="",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+        backend_type="connector",
+        connector_name="snctm-admin",
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["source"] == "s"
+    assert result["errors"][0]["code"] == "connector_error"
+
+
+async def test_connector_backend_failed_source_does_not_abort_sibling(monkeypatch):
+    """A refused connector source is contained — a sibling auto-trust source in
+    the same run still completes."""
+
+    async def _trust(name, action):
+        # `ok_action` is auto; `bad_action` is confirm (refused).
+        if action == "ok_action":
+            return _FakeTrust(is_read=True, trust_level="auto")
+        return _FakeTrust(is_read=False, trust_level="confirm")
+
+    async def _execute(workspace_id, name, body, *, user_id=None):
+        return _FakeExecResp(success=True, data={"ran": body.action})
+
+    _patch_connector_service(monkeypatch, trust=_trust, execute=_execute)
+
+    spec = {
+        "sources": {
+            "good": {"type": "connector", "action": "ok_action", "bind": "state.good"},
+            "bad": {"type": "connector", "action": "bad_action", "bind": "state.bad"},
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url="",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+        backend_type="connector",
+        connector_name="snctm-admin",
+    )
+    ran_sources = {r["source"] for r in result["ran"]}
+    err_sources = {e["source"] for e in result["errors"]}
+    assert ran_sources == {"good"}
+    assert err_sources == {"bad"}
+
+
+async def test_connector_backend_missing_connector_name_is_bad_source(monkeypatch):
+    """A connector backend with no connector_name fails the source cleanly —
+    get_action_trust / execute are never reached."""
+
+    async def _boom(*a, **k):
+        raise AssertionError("connector service must not be reached")
+
+    _patch_connector_service(monkeypatch, trust=_boom, execute=_boom)
+
+    spec = {"sources": {"s": {"type": "connector", "action": "list", "bind": "state.s"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url="",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+        backend_type="connector",
+        connector_name=None,  # backend is connector but names no connector
+    )
+    assert result["ran"] == []
+    assert result["errors"][0]["code"] == "bad_source"
+
+
+async def test_connector_backend_skips_base_url_ssrf_validation(monkeypatch):
+    """A connector backend has an empty base_url — run_sources must NOT run the
+    SSRF base-URL validation (which would reject "") for a connector backend."""
+
+    async def _trust(name, action):
+        return _FakeTrust(is_read=True, trust_level="auto")
+
+    async def _execute(workspace_id, name, body, *, user_id=None):
+        return _FakeExecResp(success=True, data={"ok": True})
+
+    _patch_connector_service(monkeypatch, trust=_trust, execute=_execute)
+
+    spec = {"sources": {"s": {"type": "connector", "action": "ping", "bind": "state.s"}}}
+    # base_url="" would raise ValueError under validate_external_url_strict on
+    # the http path; the connector path must skip that validation entirely.
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url="",
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+        backend_type="connector",
+        connector_name="snctm-admin",
+    )
+    assert result["errors"] == []
+    assert result["ran"][0]["value"] == {"ok": True}
+
+
+async def test_http_backend_unchanged_with_no_transform(monkeypatch):
+    """Regression: the http path with no transform behaves byte-for-byte as
+    before — the connector-backend / transform additions are transparent."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[{"id": 1, "title": "PR one"}])
+
+    _mock_client_patch(monkeypatch, handler)
+
+    spec = {"sources": {"prs": {"method": "GET", "path": "/pulls", "bind": "state.prs"}}}
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="runner-1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-test",
+        # backend_type defaults to "http" — explicitly here for clarity.
+        backend_type="http",
+    )
+    assert result["errors"] == []
+    assert result["ran"][0]["value"] == [{"id": 1, "title": "PR one"}]
+
+
+async def test_http_backend_applies_transform(monkeypatch):
+    """An http source can ALSO carry a transform — it shapes the parsed JSON
+    before binding, exactly like the connector path."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"data": {"rows": [{"name": "Ada", "state": "open"}]}},
+        )
+
+    _mock_client_patch(monkeypatch, handler)
+
+    spec = {
+        "sources": {
+            "items": {
+                "method": "GET",
+                "path": "/list",
+                "bind": "state.items",
+                "transform": {
+                    "select": "data.rows",
+                    "map": [
+                        {"to": "label", "from": "name"},
+                        {
+                            "to": "variant",
+                            "from": "state",
+                            "values": {"open": "success"},
+                            "default": "muted",
+                        },
+                    ],
+                },
+            }
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+    )
+    assert result["errors"] == []
+    assert result["ran"][0]["value"] == [{"label": "Ada", "variant": "success"}]
+
+
+async def test_bad_transform_is_per_source_error(monkeypatch):
+    """A transform outside the v1 grammar fails THAT source cleanly with a
+    `bad_transform` code — it does not crash the run or a sibling."""
+    _mock_client_patch(monkeypatch, lambda r: httpx.Response(200, json={"x": 1}))
+
+    spec = {
+        "sources": {
+            "broken": {
+                "method": "GET",
+                "path": "/x",
+                "bind": "state.broken",
+                "transform": {"map": [{"to": "a"}]},  # field needs from/const
+            },
+            "fine": {"method": "GET", "path": "/y", "bind": "state.fine"},
+        }
+    }
+    result = await source_executor.run_sources(
+        pocket_id="p1",
+        user_id="u1",
+        ripple_spec=spec,
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        workspace_id="ws-1",
+    )
+    err_by_source = {e["source"]: e for e in result["errors"]}
+    ran_sources = {r["source"] for r in result["ran"]}
+    assert "broken" in err_by_source
+    assert err_by_source["broken"]["code"] == "bad_transform"
+    assert ran_sources == {"fine"}

--- a/tests/cloud/test_source_transform.py
+++ b/tests/cloud/test_source_transform.py
@@ -1,0 +1,219 @@
+# tests/cloud/test_source_transform.py — feat/connector-as-pocket-backend.
+# Created: 2026-06-12 — unit coverage for the pure source-transform function
+# (`_source_transform.apply_transform`). The transform shapes a raw fetch
+# result (http / sense / connector) into the widget's display shape before it
+# binds to pocket state. No network, no eval — this is a pure function, so it
+# is exhaustively unit-testable here.
+#
+# What this pins:
+#   - No transform (None / {}) -> the raw value, unchanged (back-compat).
+#   - select drills a dotted path (incl. list-index segments); missing -> None.
+#   - map reshapes a list row-by-row: copy-by-path, values-lookup (+default),
+#     const, and missing `from` -> None.
+#   - select + map compose.
+#   - map over a non-list -> [] (no crash).
+#   - Anything outside the v1 grammar raises TransformError.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets._source_transform import TransformError, apply_transform
+
+# ---------------------------------------------------------------------------
+# No transform — raw passthrough (today's behavior)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("spec", [None, {}])
+def test_no_transform_returns_raw_unchanged(spec):
+    raw = [{"id": 1}, {"id": 2}]
+    assert apply_transform(raw, spec) is raw
+
+
+def test_no_transform_passes_scalars_and_dicts():
+    assert apply_transform({"a": 1}, None) == {"a": 1}
+    assert apply_transform(42, {}) == 42
+
+
+# ---------------------------------------------------------------------------
+# select — drill a dotted path
+# ---------------------------------------------------------------------------
+
+
+def test_select_drills_to_nested_list():
+    raw = {"data": {"applications": [{"id": "a1"}, {"id": "a2"}]}}
+    assert apply_transform(raw, {"select": "data.applications"}) == [
+        {"id": "a1"},
+        {"id": "a2"},
+    ]
+
+
+def test_select_missing_path_is_none():
+    assert apply_transform({"data": {}}, {"select": "data.applications"}) is None
+    assert apply_transform({"a": 1}, {"select": "x.y.z"}) is None
+
+
+def test_select_indexes_a_list_segment():
+    raw = {"items": [{"name": "first"}, {"name": "second"}]}
+    assert apply_transform(raw, {"select": "items.1.name"}) == "second"
+
+
+def test_select_empty_path_returns_raw():
+    raw = {"a": 1}
+    assert apply_transform(raw, {"select": ""}) == {"a": 1}
+
+
+# ---------------------------------------------------------------------------
+# map — reshape a list row by row
+# ---------------------------------------------------------------------------
+
+
+def test_map_copy_by_path():
+    raw = [{"fullName": "Ada"}, {"fullName": "Bo"}]
+    out = apply_transform(raw, {"map": [{"to": "applicant", "from": "fullName"}]})
+    assert out == [{"applicant": "Ada"}, {"applicant": "Bo"}]
+
+
+def test_map_copy_by_dotted_path():
+    raw = [{"profile": {"name": "Ada"}}]
+    out = apply_transform(raw, {"map": [{"to": "name", "from": "profile.name"}]})
+    assert out == [{"name": "Ada"}]
+
+
+def test_map_values_lookup_with_default():
+    raw = [{"status": "new"}, {"status": "rejected"}, {"status": "weird"}]
+    spec = {
+        "map": [
+            {
+                "to": "variant",
+                "from": "status",
+                "values": {"new": "warning", "rejected": "destructive"},
+                "default": "muted",
+            }
+        ]
+    }
+    out = apply_transform(raw, spec)
+    assert out == [{"variant": "warning"}, {"variant": "destructive"}, {"variant": "muted"}]
+
+
+def test_map_values_lookup_no_default_is_none():
+    raw = [{"status": "unknown"}]
+    out = apply_transform(
+        raw, {"map": [{"to": "v", "from": "status", "values": {"new": "warning"}}]}
+    )
+    assert out == [{"v": None}]
+
+
+def test_map_const():
+    raw = [{"id": "x1"}, {"id": "x2"}]
+    out = apply_transform(raw, {"map": [{"to": "source", "const": "snctm-admin"}]})
+    assert out == [{"source": "snctm-admin"}, {"source": "snctm-admin"}]
+
+
+def test_map_missing_from_is_none_not_crash():
+    raw = [{"id": "x1"}]
+    out = apply_transform(raw, {"map": [{"to": "name", "from": "nope"}]})
+    assert out == [{"name": None}]
+
+
+def test_map_multiple_fields_compose_per_row():
+    raw = [{"fullName": "Ada", "status": "new", "id": "x1"}]
+    spec = {
+        "map": [
+            {"to": "applicant", "from": "fullName"},
+            {
+                "to": "status_variant",
+                "from": "status",
+                "values": {"new": "warning", "rejected": "destructive"},
+            },
+            {"to": "id", "from": "id"},
+            {"to": "source", "const": "snctm-admin"},
+        ]
+    }
+    out = apply_transform(raw, spec)
+    assert out == [
+        {
+            "applicant": "Ada",
+            "status_variant": "warning",
+            "id": "x1",
+            "source": "snctm-admin",
+        }
+    ]
+
+
+def test_map_over_non_list_is_empty():
+    # The post-select value is a dict, not a list — map yields [] (no crash).
+    assert apply_transform({"x": 1}, {"map": [{"to": "a", "from": "b"}]}) == []
+    assert apply_transform(None, {"map": [{"to": "a", "from": "b"}]}) == []
+
+
+# ---------------------------------------------------------------------------
+# select + map compose
+# ---------------------------------------------------------------------------
+
+
+def test_select_then_map_compose():
+    raw = {
+        "data": {
+            "applications": [
+                {"fullName": "Ada", "status": "new", "id": "x1"},
+                {"fullName": "Bo", "status": "rejected", "id": "x2"},
+            ]
+        }
+    }
+    spec = {
+        "select": "data.applications",
+        "map": [
+            {"to": "applicant", "from": "fullName"},
+            {
+                "to": "status_variant",
+                "from": "status",
+                "values": {"new": "warning", "rejected": "destructive"},
+                "default": "muted",
+            },
+            {"to": "id", "from": "id"},
+            {"to": "source", "const": "snctm-admin"},
+        ],
+    }
+    out = apply_transform(raw, spec)
+    assert out == [
+        {"applicant": "Ada", "status_variant": "warning", "id": "x1", "source": "snctm-admin"},
+        {
+            "applicant": "Bo",
+            "status_variant": "destructive",
+            "id": "x2",
+            "source": "snctm-admin",
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Grammar rejection — anything outside the v1 spec raises TransformError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_spec",
+    [
+        {"unknown_key": 1},  # unknown top-level key
+        {"select": 123},  # select must be a string
+        {"map": "not-a-list"},  # map must be a list
+        {"map": [{"from": "b"}]},  # field needs a 'to'
+        {"map": [{"to": ""}]},  # empty 'to'
+        {"map": [{"to": "a"}]},  # field needs 'from' or 'const'
+        {"map": [{"to": "a", "from": "b", "const": 1}]},  # not both
+        {"map": [{"to": "a", "const": 1, "values": {}}]},  # values only on 'from'
+        {"map": [{"to": "a", "from": 5}]},  # 'from' must be a string
+        {"map": [{"to": "a", "from": "b", "values": "x"}]},  # values must be an object
+        {"map": [{"to": "a", "from": "b", "bogus": 1}]},  # unknown field key
+        {"map": ["not-an-object"]},  # field must be an object
+    ],
+)
+def test_invalid_spec_raises_transform_error(bad_spec):
+    with pytest.raises(TransformError):
+        apply_transform([{"b": 1}], bad_spec)
+
+
+def test_non_dict_spec_raises():
+    with pytest.raises(TransformError):
+        apply_transform([], "not-a-dict")

--- a/tests/ee/agent/test_pocket_router/test_router.py
+++ b/tests/ee/agent/test_pocket_router/test_router.py
@@ -171,7 +171,16 @@ async def test_tier0_invokes_source_executor_and_handles():
         patch(
             "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
             new=AsyncMock(
-                return_value=("https://api.example.com", "bearer", None, "tok", [], None)
+                return_value=(
+                    "https://api.example.com",
+                    "bearer",
+                    None,
+                    "tok",
+                    [],
+                    None,
+                    "http",
+                    None,
+                )
             ),
         ),
         patch("pocketpaw_ee.cloud.pockets.source_executor.run_sources", new=fake_run),
@@ -209,7 +218,16 @@ async def test_tier0_emits_execution_frame_with_zero_tokens_and_skipped_stages()
             patch(
                 "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
                 new=AsyncMock(
-                    return_value=("https://api.example.com", "bearer", None, "tok", [], None)
+                    return_value=(
+                        "https://api.example.com",
+                        "bearer",
+                        None,
+                        "tok",
+                        [],
+                        None,
+                        "http",
+                        None,
+                    )
                 ),
             ),
             patch(
@@ -252,7 +270,16 @@ async def test_tier0_source_errors_escalate():
         patch(
             "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
             new=AsyncMock(
-                return_value=("https://api.example.com", "bearer", None, "tok", [], None)
+                return_value=(
+                    "https://api.example.com",
+                    "bearer",
+                    None,
+                    "tok",
+                    [],
+                    None,
+                    "http",
+                    None,
+                )
             ),
         ),
         patch(
@@ -306,7 +333,16 @@ async def test_router_resolves_spec_via_agent_view_when_pocket_absent():
         patch(
             "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
             new=AsyncMock(
-                return_value=("https://api.example.com", "bearer", None, "tok", [], None)
+                return_value=(
+                    "https://api.example.com",
+                    "bearer",
+                    None,
+                    "tok",
+                    [],
+                    None,
+                    "http",
+                    None,
+                )
             ),
         ),
         patch("pocketpaw_ee.cloud.pockets.source_executor.run_sources", new=fake_run),
@@ -539,7 +575,16 @@ async def test_tier0_deny_by_default_write_lands_in_instinct_pending(monkeypatch
         patch(
             "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
             new=AsyncMock(
-                return_value=("https://api.example.com", "none", None, "", _ALLOWLIST, None)
+                return_value=(
+                    "https://api.example.com",
+                    "none",
+                    None,
+                    "",
+                    _ALLOWLIST,
+                    None,
+                    "http",
+                    None,
+                )
             ),
         ),
         patch(
@@ -605,7 +650,16 @@ async def test_tier0_explicitly_exempt_write_still_fires(monkeypatch, tmp_path):
         patch(
             "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor",
             new=AsyncMock(
-                return_value=("https://api.example.com", "none", None, "", _ALLOWLIST, None)
+                return_value=(
+                    "https://api.example.com",
+                    "none",
+                    None,
+                    "",
+                    _ALLOWLIST,
+                    None,
+                    "http",
+                    None,
+                )
             ),
         ),
         patch(


### PR DESCRIPTION
## What this does

A pocket source could only reach two places: an HTTP GET against the backend's `base_url`, or a Sense that resolves to a connector. There was no way to point a pocket directly at a connector you've already bound — say `snctm-admin` — and read live data by running its actions. A connector is an action surface (`connectors_service.execute({connector_name, action, params})`), not a URL, so the http source path simply couldn't reach it.

This makes "use this connector as the pocket's backend" a first-class backend type, and adds a small source transform so a raw connector/HTTP/Sense result can be mapped into the shape a widget wants before it binds to state.

This is the runtime half of a two-PR feature. A frontend PR builds the backend-picker modal against the same contract below.

## The contract (shared with the frontend half)

**Backend type**
- `PocketBackendCredential` gains `backend_type: "http" | "connector"` (default `"http"` — every existing row reads as http, fully back-compatible) and `connector_name: str | None`.
- `set_pocket_backend(..., backend_type=, connector_name=)`: for a connector backend it validates the connector is enabled for the workspace (rejects `pocket_backend.unknown_connector` / `pocket_backend.missing_connector` otherwise) and does **not** require a `base_url`. Switching an http backend to a connector clears the stale URL + encrypted token.
- `get_pocket_backend` and the executor tuple report `backend_type` / `connector_name`. The summary never carries a token.

**Wire shapes**
- `PocketBackendConfigRequest`: `{ backend_type?: "http"|"connector", connector_name?: string|null, base_url?: string, auth_type?, auth_token?, auth_header? }` — `base_url` is now optional (a connector backend needs none).
- `PocketBackendConfigResponse`: adds `backend_type` + `connector_name` (never a token).

**Source execution**
- When the pocket's backend is `backend_type == "connector"`, each non-Sense source runs against the bound connector via `connectors_service.execute(workspace_id, connector_name, ExecuteActionRequest(action=source.action, params=source.params))` — the same read-first path Senses use. Only `auto`-trust actions run; a `confirm`/`restricted`/unknown action is refused with a clean per-source error (`action_needs_approval`) and its siblings keep running. The result maps into the same `{source, bind, value}` row shape http/Sense paths return.
- Sense sources stay backend-agnostic (they resolve their own connector), unchanged.

**Source transform** — optional `transform: dict | None` on a source binding, applied to the raw result of any source type before it binds. Pure, declarative, no eval:
- `{ "select": "dotted.path.to.list" }` — drill into the response (e.g. `data.applications`). Missing path -> `null`.
- `{ "map": [ <field defs> ] }` — for a list, one output row per input row. Each field is one of:
  - `{"to": "applicant", "from": "fullName"}` — copy by dotted path
  - `{"to": "status_variant", "from": "status", "values": {"new": "warning", "rejected": "destructive"}, "default": "muted"}` — value lookup
  - `{"to": "source", "const": "snctm-admin"}` — constant
  - unknown/missing `from` -> `null` (no crash)
- `select` + `map` compose. No transform = raw bind (today's behavior). A spec outside the grammar fails that one source with `bad_transform`, never a sibling or the run.

http and Sense paths are byte-for-byte unchanged when `backend_type="http"` and no transform is set.

## What the frontend half adds

The backend-picker modal: a toggle between "HTTP URL" and "Connector", a connector selector populated from the workspace's enabled connectors, and a per-source action + transform editor — all PUT against `PUT /pockets/{id}/backend` and the `sources` block, using the request/response/transform shapes above.

## Tests

- New `_source_transform` pure function: select, map (copy / value-lookup+default / const / missing-field), compose, map-over-non-list, full grammar rejection (29 cases).
- Connector-backed source executes via a fake `connectors_service`; transform applied to the connector result; read-first auto-trust enforcement (confirm/restricted/unknown refused, `execute` never called); failed source contained from siblings; empty connector `base_url` skips SSRF validation; http path unchanged regression; http + transform.
- Service: connector backend stores type/name with no base_url, validates the connector, executor tuple carries them without a token, http->connector clears the credential, legacy rows read as http; `is_connector_enabled_for_workspace`.
- All dependent callers (refresh scheduler, temporal/bulk/instinct write paths, agent pocket-router, sources-run route) updated for the widened executor tuple and green.
- Both import-linter configs pass (24 contracts): `source_executor` still imports no Beanie models — the connectors service is imported lazily, the transform helper is pure.

## Notes

`pocket_backend_credentials` rows pick up the new fields via field defaults / `getattr`, so no migration is needed. Two pre-existing test failures in this area (`test_run_sources_400_when_no_backend`, the `test_connectors_execute` license/auth cases) are unrelated to this change and fail identically on `dev`.