### PR TITLE
Ruff format fix in the instinct router

### DIFF
--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -834,9 +834,7 @@ async def bulk_approve_actions(
             try:
                 from pocketpaw_ee.cloud.mandates import executor as mandate_executor
 
-                await mandate_executor.execute_approved_plan(
-                    action, human_event_id=human_event_id
-                )
+                await mandate_executor.execute_approved_plan(action, human_event_id=human_event_id)
             except Exception:
                 logger.exception(
                     "bulk-approve belt_plan execution failed for %s (non-fatal)",


### PR DESCRIPTION
One call in the bulk-approve belt_plan hook was wrapped across three lines where ruff format wants a single line — a leftover from the hand-resolved merge in #1442. The Lint gate fails every open PR until this lands (it surfaced on #1323's run). Format-only, no behavior change.