### PR TITLE
Connectors: workspace-scoped connectors reachable from the agent surface and unanchored chats

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,12 @@
 <!--
   Connectors documentation.
+  Updated: 2026-06-12 (workspace-scope reach) — the agent tool surface now
+  reaches workspace-scoped connectors: list_connector_actions returns the
+  current pocket's bound connectors PLUS the workspace-enabled ones (deduped
+  by name), unanchored chats (no pocket) reach exactly the workspace-scoped
+  set, and connector_execute passes for pocket-bound OR workspace-scoped
+  rows (executing with workspace-scope credentials when unanchored). The
+  read-first / write-blocked trust gate is unchanged.
   Updated: 2026-06-11 (connector cookie/session auth) — documented two new
   auth methods on the DirectREST engine: `cookie` (emits a Cookie: header from
   a declared credential, name set via auth.credential) and `header` (emits an
@@ -256,13 +263,16 @@ server exposes two tools to the agent, namespaced
 
 | Tool | What it does |
 |------|--------------|
-| `list_connector_actions()` | Lists the connectors bound to the **current pocket** and, per connector, its READ actions (runnable) and WRITE actions (listed, blocked). No arguments — the pocket comes from the active chat. |
+| `list_connector_actions()` | Lists the connectors **reachable from the current chat** — the current pocket's bound connectors plus the workspace-enabled ones, deduped by name — and, per connector, its READ actions (runnable) and WRITE actions (listed, blocked). No arguments — the identity comes from the active chat. |
 | `connector_execute(connector_name, action, params)` | Runs ONE action. Read (auto-trust) actions execute; write actions are refused (see below). |
 
 The agent reads the pocket it is in from the per-run identity (the same
 mechanism that scopes pocket reads/writes), so the tools always act on the room
-the user is chatting in. Outside a chat stream — or in a chat not anchored to a
-pocket — the tools return a clear message instead of mis-scoping.
+the user is chatting in. A chat not anchored to a pocket (a plain DM or group
+thread) still reaches the **workspace-scoped** connectors — the workspace is
+the tenant boundary, so anything enabled workspace-wide is available from any
+chat in it. Pocket-scoped connectors stay private to their room. Outside a
+chat stream entirely, the tools return a clear error instead of mis-scoping.
 
 ### v1 policy: read-first, writes blocked
 
@@ -285,9 +295,11 @@ reads `auto` and writes `confirm` and the tool surface does the rest.
 
 Three things make a connector callable from a pocket's chat:
 
-1. **Bind it at `scope=pocket`** — enable the connector with the pocket's id.
-   The tools are tenant-scoped: a connector bound to pocket A is not reachable
-   from pocket B.
+1. **Bind it** — either at `scope=pocket` (enable with the pocket's id; private
+   to that room — a connector bound to pocket A is not reachable from pocket B)
+   or at `scope=workspace` (enable workspace-wide; reachable from every chat in
+   the workspace, anchored or not). When the same connector is enabled at both
+   scopes, the listing dedupes it by name.
 2. **Put a token in the connector's config** — v1 auth is the PAT / API token
    already stored in the connector config (no OAuth flow). For GitHub that's a
    `GITHUB_TOKEN`; for a bearer/`api_key` connector it's the credential named in

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -370,11 +370,9 @@ async def _sense_execute_handler(args: dict) -> dict:
         return _error_response(
             "no active workspace — sense_execute can only be called from inside a cloud chat stream"
         )
-    if not pocket_id:
-        return _error_response(
-            "this chat isn't anchored to a pocket — sense_execute needs a "
-            "pocket-scoped room with a bound connector"
-        )
+    # No pocket guard: ``execute_sense`` takes ``pocket_id=None`` natively and
+    # resolves workspace-scoped providers, matching ``_list_senses_handler`` —
+    # a sense the agent can list must also be executable from the same chat.
 
     sense = args.get("sense")
     if not isinstance(sense, str) or not sense:

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -24,21 +24,30 @@
 #   the read-first gate (only trust=auto runs) so this module does NOT re-gate.
 #   Tool ids namespace as ``mcp__pocketpaw_connectors__list_senses`` /
 #   ``…__sense_execute``.
-"""Agent-side MCP surface for executing a pocket's bound connectors.
+# Updated: 2026-06-12 (workspace-scope reach) — unanchored chats (DM/group
+#   threads with ``pocket_id=None``) no longer short-circuit to "no pocket":
+#   both tools now fall through to the service with the workspace identity, so
+#   WORKSPACE-scoped connectors are listable and executable from any chat in
+#   the tenant. Pocket-scoped connectors stay room-private (the service's
+#   pocket arm matches nothing for a null pocket). Execute uses
+#   ``scope="workspace"`` credentials when unanchored. Trust gate unchanged —
+#   writes still refuse pre-execute.
+"""Agent-side MCP surface for executing a chat's reachable connectors.
 
 Tools registered:
 
-  - ``list_connector_actions()`` — for the CURRENT pocket (``pocket_id`` from
-    the per-stream ContextVar), list each enabled, pocket-scoped connector and
-    its READ actions (``trust=auto``) the agent may call, plus its WRITE actions
-    flagged "(needs approval — v2, blocked)". No pocket / no connectors → a clear
-    message rather than a silent empty list.
+  - ``list_connector_actions()`` — for the CURRENT chat, list each reachable
+    connector and its READ actions (``trust=auto``) the agent may call, plus
+    its WRITE actions flagged "(needs approval — v2, blocked)". Reachable =
+    enabled pocket-scoped connectors of the chat's pocket (when anchored) plus
+    the workspace-scoped connectors of the tenant (always). No connectors → a
+    clear message rather than a silent empty list.
   - ``connector_execute(connector_name, action, params)`` — run ONE read action.
-    Gates in order: (a) connector must be enabled + bound to THIS pocket
-    (tenant-scoped on workspace+pocket); (b) the action's trust level decides
-    read vs write; (c) ``auto`` → call ``connectors.service.execute`` and return
-    the result; (d) ``confirm`` / ``restricted`` → refuse with the v2 message,
-    never executing the write.
+    Gates in order: (a) connector must be enabled for this chat's reach (bound
+    to THIS pocket, or workspace-scoped in THIS workspace); (b) the action's
+    trust level decides read vs write; (c) ``auto`` → call
+    ``connectors.service.execute`` and return the result; (d) ``confirm`` /
+    ``restricted`` → refuse with the v2 message, never executing the write.
 
 Identity comes from ``agent_service.current_workspace_id`` /
 ``current_user_id`` / ``current_pocket_id``. Outside an SSE chat stream those
@@ -127,23 +136,15 @@ async def _list_connector_actions_handler(args: dict) -> dict:  # noqa: ARG001 �
             "no active workspace — list_connector_actions can only be called "
             "from inside a cloud chat stream"
         )
-    if not pocket_id:
-        return _success_response(
-            {
-                "pocket_id": None,
-                "connectors": [],
-                "message": (
-                    "This chat isn't anchored to a pocket, so it has no bound "
-                    "connectors. Open this conversation inside a pocket/room and "
-                    "bind a connector to use connector actions."
-                ),
-            }
-        )
-
     from pocketpaw_ee.cloud.connectors import service as connectors_service
 
     try:
-        connectors = await connectors_service.list_pocket_connectors(workspace_id, pocket_id)
+        # Unanchored chats (pocket_id=None) pass "" — the pocket arm of the
+        # service query matches nothing, so only workspace-scoped connectors
+        # come back. Anchored chats get pocket-scoped + workspace-scoped.
+        connectors = await connectors_service.list_pocket_connectors(
+            workspace_id, pocket_id or ""
+        )
     except Exception as exc:  # noqa: BLE001
         logger.warning("list_connector_actions failed", exc_info=True)
         return _error_response(f"list_connector_actions failed: {exc}")
@@ -154,8 +155,9 @@ async def _list_connector_actions_handler(args: dict) -> dict:  # noqa: ARG001 �
                 "pocket_id": pocket_id,
                 "connectors": [],
                 "message": (
-                    "No connectors are bound to this pocket yet. Bind one "
-                    "(scope=pocket) and add its token to the connector config to "
+                    "No connectors are reachable from this chat — none bound to "
+                    "this pocket and none enabled workspace-wide. Enable a "
+                    "connector (workspace scope) or bind one to this pocket to "
                     "use its actions here."
                 ),
             }
@@ -204,12 +206,6 @@ async def _connector_execute_handler(args: dict) -> dict:
             "no active workspace — connector_execute can only be called from "
             "inside a cloud chat stream"
         )
-    if not pocket_id:
-        return _error_response(
-            "this chat isn't anchored to a pocket — connector_execute needs a "
-            "pocket-scoped room with a bound connector"
-        )
-
     connector_name = args.get("connector_name")
     if not isinstance(connector_name, str) or not connector_name:
         return _error_response("connector_name is required (string)")
@@ -224,18 +220,21 @@ async def _connector_execute_handler(args: dict) -> dict:
     from pocketpaw_ee.cloud.connectors import service as connectors_service
     from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
 
-    # Gate 1 — the connector must be enabled AND bound to THIS pocket. An agent
-    # in pocket A must never reach a connector bound only to pocket B / workspace.
+    # Gate 1 — the connector must be reachable from THIS chat: bound to this
+    # pocket, or enabled workspace-wide in this workspace. An agent in pocket A
+    # must never reach a connector bound only to pocket B; workspace scope is
+    # the tenant boundary, so it passes from any chat (anchored or not).
     try:
         bound = await connectors_service.is_connector_bound_to_pocket(
-            workspace_id, pocket_id, connector_name
+            workspace_id, pocket_id or "", connector_name
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("connector bind check failed", exc_info=True)
         return _error_response(f"connector_execute failed: {exc}")
     if not bound:
         return _error_response(
-            f"connector '{connector_name}' is not bound to this pocket. "
+            f"connector '{connector_name}' is not reachable from this chat — "
+            "not bound to this pocket and not workspace-enabled. "
             "Call list_connector_actions to see what's available here."
         )
 
@@ -263,12 +262,14 @@ async def _connector_execute_handler(args: dict) -> dict:
 
     # Gate 4 — READ (auto-trust): run via the existing cloud execute path. It
     # uses the connector's stored config (PAT/token) through the
-    # DirectRESTAdapter / native adapter — no OAuth flow in v1.
+    # DirectRESTAdapter / native adapter — no OAuth flow in v1. Anchored chats
+    # execute with the pocket's credentials; unanchored chats fall back to the
+    # workspace scope's credentials.
     body = ExecuteActionRequest(
         action=action,
         params=params,
-        scope="pocket",
-        pocket_id=pocket_id,
+        scope="pocket" if pocket_id else "workspace",
+        pocket_id=pocket_id or None,
     )
     try:
         result = await connectors_service.execute(

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -25,6 +25,14 @@
 #   ``backend_type="connector"`` backend. Keeps the WorkspaceConnector Beanie
 #   read in THIS service (the owner of the connector docs) so the pockets
 #   service never imports the connector model.
+# Updated: 2026-06-12 (workspace-scope visibility) — ``list_pocket_connectors``
+#   and ``is_connector_bound_to_pocket`` now ALSO match ``scope="workspace"``
+#   rows: a workspace-enabled connector is visible/usable from every pocket in
+#   that workspace, not only pockets with an explicit pocket-scoped row. Fixes
+#   the UI-says-connected / agent-says-no-connectors split (the connectors page
+#   reads the workspace catalog; the agent MCP tool read only pocket-scoped
+#   rows). Cross-tenant posture unchanged — workspace scope IS the tenant; the
+#   read/write trust gate still applies per action.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -42,6 +50,8 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from pathlib import Path
+
+from beanie.operators import And, Or
 
 from pocketpaw.connectors.protocol import ExecutionMode
 from pocketpaw_ee.cloud._core.errors import CloudError, NotFound, ValidationError
@@ -499,10 +509,12 @@ async def list_pocket_connectors(workspace_id: str, pocket_id: str) -> list[Pock
     classified by trust level so the agent MCP server can show read actions as
     callable and write actions as "needs approval (v2)".
 
-    Tenant-filtered on ``workspace`` AND ``pocket_id`` (cloud rule §7) and
-    further on ``scope == "pocket"`` + ``enabled``. The Beanie read lives here
-    (not in the MCP layer) so the OSS-EE boundary holds: the MCP server imports
-    this service, never the ``WorkspaceConnector`` doc.
+    Tenant-filtered on ``workspace`` (cloud rule §7); matches rows enabled for
+    THIS pocket (``scope == "pocket"`` + ``pocket_id``) OR workspace-wide
+    (``scope == "workspace"`` — available from every pocket in the tenant).
+    The Beanie read lives here (not in the MCP layer) so the OSS-EE boundary
+    holds: the MCP server imports this service, never the
+    ``WorkspaceConnector`` doc.
 
     Trust gating: ``auto``-trust actions are read-first (``is_read=True``);
     ``confirm`` / ``restricted`` actions are write-shaped and marked
@@ -510,8 +522,10 @@ async def list_pocket_connectors(workspace_id: str, pocket_id: str) -> list[Pock
     """
     enabled_docs = await _WCDoc.find(
         _WCDoc.workspace == workspace_id,
-        _WCDoc.pocket_id == pocket_id,
-        _WCDoc.scope == "pocket",
+        Or(
+            _WCDoc.scope == "workspace",
+            And(_WCDoc.scope == "pocket", _WCDoc.pocket_id == pocket_id),
+        ),
         _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
     ).to_list()
     if not enabled_docs:
@@ -520,7 +534,11 @@ async def list_pocket_connectors(workspace_id: str, pocket_id: str) -> list[Pock
     reg = _get_registry()
     available = {a.name: a for a in _available_from_registry()}
     out: list[PocketConnectorInfo] = []
+    seen: set[str] = set()
     for doc in enabled_docs:
+        if doc.name in seen:
+            continue
+        seen.add(doc.name)
         a = available.get(doc.name)
         defn = reg.get_definition(doc.name)
         if a is None or defn is None:
@@ -580,16 +598,19 @@ async def get_action_trust(name: str, action: str) -> ConnectorActionInfo | None
 
 
 async def is_connector_bound_to_pocket(workspace_id: str, pocket_id: str, name: str) -> bool:
-    """True when ``name`` is enabled at ``scope=pocket`` for this exact pocket.
+    """True when ``name`` is enabled for this pocket or workspace-wide.
 
     The tenant gate the MCP ``connector_execute`` tool checks first: an agent in
-    pocket A must not run a connector only bound to pocket B (or workspace-wide
-    only). Tenant-filtered (cloud rule §7).
+    pocket A must not run a connector only bound to pocket B. Workspace-scoped
+    rows pass for every pocket in the tenant — workspace scope IS the tenant
+    boundary, so there is no cross-pocket leak. Tenant-filtered (cloud rule §7).
     """
     doc = await _WCDoc.find_one(
         _WCDoc.workspace == workspace_id,
-        _WCDoc.pocket_id == pocket_id,
-        _WCDoc.scope == "pocket",
+        Or(
+            _WCDoc.scope == "workspace",
+            And(_WCDoc.scope == "pocket", _WCDoc.pocket_id == pocket_id),
+        ),
         _WCDoc.name == name,
         _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
     )

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -618,15 +618,27 @@ class TestSenseTools:
     @pytest.mark.asyncio
     async def test_sense_execute_guards_and_validation(self) -> None:
         from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
 
-        # No pocket → refused.
+        # No pocket → flows through with pocket_id=None (workspace-scoped
+        # providers stay reachable from unanchored chats, matching list_senses).
         ws_p, u_p, pk_p = _patch_identity("ws_1", "u_1", None)
-        with ws_p, u_p, pk_p:
+        mock_exec = AsyncMock(
+            return_value=SenseExecutionResult(
+                ok=True, sense_id="paw.email.v1", action="gmail_search"
+            )
+        )
+        with (
+            ws_p,
+            u_p,
+            pk_p,
+            patch("pocketpaw_ee.cloud.senses.resolver.execute_sense", new=mock_exec),
+        ):
             out = await connectors_mcp._sense_execute_handler(
                 {"sense": "paw.email.v1", "action": "gmail_search"}
             )
-        assert out.get("is_error") is True
-        assert "pocket" in out["content"][0]["text"]
+        assert out.get("is_error") is not True
+        assert mock_exec.await_args.kwargs["pocket_id"] is None
 
         # Missing sense → refused.
         ws_p, u_p, pk_p = _patch_identity("ws_1", "u_1", "pk_1")

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -178,7 +178,9 @@ class TestListConnectorActionsHandler:
         mock_list.assert_awaited_once_with("ws_1", "pk_1")
 
     @pytest.mark.asyncio
-    async def test_no_pocket_returns_clear_message(self) -> None:
+    async def test_no_pocket_falls_through_to_workspace_scope(self) -> None:
+        """Unanchored chats (pocket_id=None) query the service with pocket ""
+        so workspace-scoped connectors stay reachable from any chat."""
         from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
 
         ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", None)
@@ -188,15 +190,15 @@ class TestListConnectorActionsHandler:
             pocket_patch,
             patch(
                 "pocketpaw_ee.cloud.connectors.service.list_pocket_connectors",
-                new=AsyncMock(),
+                new=AsyncMock(return_value=[]),
             ) as mock_list,
         ):
             out = await connectors_mcp._list_connector_actions_handler({})
 
         body = _decode_payload(out)
         assert body["connectors"] == []
-        assert "isn't anchored to a pocket" in body["message"]
-        mock_list.assert_not_awaited()
+        assert "No connectors are reachable" in body["message"]
+        mock_list.assert_awaited_once_with("ws_1", "")
 
     @pytest.mark.asyncio
     async def test_no_connectors_returns_clear_message(self) -> None:
@@ -216,7 +218,7 @@ class TestListConnectorActionsHandler:
 
         body = _decode_payload(out)
         assert body["connectors"] == []
-        assert "No connectors are bound" in body["message"]
+        assert "No connectors are reachable" in body["message"]
 
     @pytest.mark.asyncio
     async def test_no_workspace_is_error(self) -> None:


### PR DESCRIPTION
## The bug

Enable a connector workspace-wide and the connectors page shows it as Connected, but the agent in any chat says there are no connectors. The two agent-side consumers only matched `scope="pocket"` rows: `list_pocket_connectors` (behind the `list_connector_actions` MCP tool) and `is_connector_bound_to_pocket` (the tenant gate in `connector_execute`). Workspace-enabled connectors were invisible to the agent, and unanchored chats (plain DM/group threads, `pocket_id=None`) short-circuited to a "bind a connector" message before ever asking the service.

## The fix

**`ee/pocketpaw_ee/cloud/connectors/service.py`** — both readers now match `scope="workspace"` OR (`scope="pocket"` AND this pocket's id) via beanie `Or`/`And` operators. The listing dedupes by connector name when the same connector is enabled at both scopes. Docstrings updated to state the new contract.

**`ee/pocketpaw_ee/agent/mcp_servers/connectors.py`** — dropped the `pocket_id=None` short-circuits in `list_connector_actions` and `connector_execute`. Both handlers now call the service with `pocket_id or ""`: the pocket arm of the query matches nothing for an empty id, so unanchored chats reach exactly the workspace-scoped set. Execute builds `ExecuteActionRequest(scope="workspace", pocket_id=None)` when unanchored and keeps `scope="pocket"` when anchored, so credentials resolve from the right scope. Test expectations in `tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py` updated to match.

**`docs/CONNECTORS.md`** — the agent-tool-surface section described the old pocket-only behavior; updated to the new reach.

## Why this is safe tenancy-wise

Workspace scope IS the tenant boundary. A workspace-scoped row passing from every chat in that workspace leaks nothing across tenants: the query is still filtered on `workspace_id`, and cross-workspace checks stay False. Pocket-scoped connectors remain private to their room — pocket A's binding is still unreachable from pocket B and from unanchored chats. The read-first trust gate is untouched: `confirm`/`restricted` actions are still refused before execution.

## Tests

- `tests/ee/agent/test_connectors_mcp_server/` — 22/22 green.
- `tests/cloud/test_connectors_execute.py` — 9 passed; 6 failures are pre-existing and environment-sensitive (401s from the auth posture), verified to fail identically on the base commit (`origin/dev`) with the base file versions.

Proven live on the nerve demo stack: from an unanchored chat the agent enumerated 14 actions across the workspace-enabled connectors and executed an `application_count` read end to end.