### PR TITLE
fix(mission-control): workspace-scoped external-action proposals never reached The Tray

### DIFF
--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -74,6 +74,18 @@
 # shared ``ee.instinct.chain_emitters`` module instead of reaching into the
 # Instinct router's private internals. Behavior is identical (same helpers,
 # same call order) — the façade no longer couples to the router.
+# Updated: 2026-06-12 (fix/tray-workspace-scoped-nudges) — workspace-scoped
+# nudges now reach The Tray. External-action proposals stamp
+# ``Action.pocket_id = workspace_id`` (they aren't pocket-bound — see
+# ``external_actions/propose.py``), but ``agent_list_work_items`` dropped any
+# action whose ``pocket_id`` wasn't a visible POCKET id, so every gated
+# external action sat pending without ever surfacing in the feed. The
+# per-action filter now also admits ``a.pocket_id == workspace_id`` (the
+# caller's own workspace only — the W4c store-level scope still keeps other
+# tenants' rows out in SQL), the instinct block runs even when the workspace
+# has zero visible pockets, and a workspace-scoped item projects with
+# pocket_name "Workspace" instead of leaking the raw workspace hex id.
+# Pocket-bound nudges keep the exact same visibility filter as before.
 """Mission Control façade service.
 
 Every function is module-level ``async def`` per ee/cloud rule #5. The
@@ -95,7 +107,10 @@ Tenancy:
          is visible to the caller's workspace. ``pockets_service.list_pockets``
          enforces this as the chokepoint. This stays as a second filter
          (owner / shared_with / visibility within the tenant), layered on
-         top of the store scope, not in place of it.
+         top of the store scope, not in place of it. Workspace-scoped
+         nudges (``pocket_id == workspace_id``, e.g. external-action
+         proposals) bypass only this pocket layer — the store scope in
+         (1) is still what isolates them per tenant.
 
 No Beanie writes here — the façade is read-only against Instinct + the
 activity buffer. Bulk-approve / bulk-reject delegate to
@@ -385,40 +400,50 @@ async def agent_list_work_items(
 
     items: list[WorkItem] = []
 
-    # --- Instinct Nudges (pocket-scoped) -----------------------------------
-    # Nudges always live inside a pocket, so an empty visible set means
-    # there are no Nudges to show. Tasks below have their own workspace-
-    # level tenancy and are NOT gated by pocket visibility.
-    if visible:
-        store = get_instinct_store()
-        # W4c — scope the instinct reads to the caller's workspace (plus legacy
-        # NULL rows) at the store/SQL layer so a tenant never reads another
-        # tenant's Nudges off the shared DB. The pocket-visibility filter below
-        # is a second, intra-tenant layer (owner / shared_with / visibility).
-        pending = await store.pending(pocket_id=body.pocket, workspace_id=workspace_id)
-        resolved = await store.list_actions(
-            pocket_id=body.pocket, limit=200, workspace_id=workspace_id
-        )
+    # --- Instinct Nudges (pocket- or workspace-scoped) ----------------------
+    # Most Nudges live inside a pocket and only surface when that pocket is
+    # visible. External-action proposals are the exception: they stamp
+    # ``pocket_id = workspace_id`` (see ``external_actions/propose.py``), so
+    # they're admitted by workspace identity instead — which also means the
+    # block must run even when the workspace has zero visible pockets. Tasks
+    # below have their own workspace-level tenancy and are NOT gated by
+    # pocket visibility.
+    store = get_instinct_store()
+    # W4c — scope the instinct reads to the caller's workspace (plus legacy
+    # NULL rows) at the store/SQL layer so a tenant never reads another
+    # tenant's Nudges off the shared DB. The pocket-visibility filter below
+    # is a second, intra-tenant layer (owner / shared_with / visibility);
+    # the store scope is also what keeps OTHER tenants' workspace-scoped
+    # nudges out — ``a.pocket_id == workspace_id`` below can only ever match
+    # the caller's own rows.
+    pending = await store.pending(pocket_id=body.pocket, workspace_id=workspace_id)
+    resolved = await store.list_actions(pocket_id=body.pocket, limit=200, workspace_id=workspace_id)
 
-        actions: list[Action] = []
-        seen: set[str] = set()
-        for a in (*pending, *resolved):
-            if a.id in seen:
-                continue
-            if a.pocket_id not in visible:
-                continue
-            if body.agent and a.trigger.source != body.agent:
-                continue
-            seen.add(a.id)
-            actions.append(a)
-        items.extend(
-            _action_to_work_item(
-                a,
-                workspace_id,
-                pocket_name=name_map.get(a.pocket_id, a.pocket_id or ""),
-            )
-            for a in actions
+    actions: list[Action] = []
+    seen: set[str] = set()
+    for a in (*pending, *resolved):
+        if a.id in seen:
+            continue
+        if a.pocket_id not in visible and a.pocket_id != workspace_id:
+            continue
+        if body.agent and a.trigger.source != body.agent:
+            continue
+        seen.add(a.id)
+        actions.append(a)
+    items.extend(
+        _action_to_work_item(
+            a,
+            workspace_id,
+            # A workspace-scoped nudge has no pocket — show "Workspace"
+            # rather than leaking the raw workspace hex id as a name.
+            pocket_name=(
+                "Workspace"
+                if a.pocket_id == workspace_id
+                else name_map.get(a.pocket_id, a.pocket_id or "")
+            ),
         )
+        for a in actions
+    )
 
     # --- Tasks (workspace-scoped) ------------------------------------------
     # Lazy import keeps the façade installable on forks that haven't

--- a/tests/cloud/test_mission_control_service.py
+++ b/tests/cloud/test_mission_control_service.py
@@ -31,6 +31,15 @@
 # (decoupling the façade from the router). The bulk-approve chain-emit spy test
 # now monkeypatches ``ee.instinct.chain_emitters._emit_*`` (where the service
 # imports them from) instead of the old router path.
+# Updated: 2026-06-12 (fix/tray-workspace-scoped-nudges) — added
+# ``TestWorkspaceScopedNudges`` pinning the Tray fix: an external-action
+# proposal stamps ``Action.pocket_id = workspace_id`` (workspace-scoped, not
+# pocket-bound — see ``external_actions/propose.py``), so the old
+# pocket-visibility filter in ``agent_list_work_items`` dropped every such
+# proposal from the feed. The tests assert (1) a workspace-scoped pending
+# action projects as ``nudge:<id>`` with pocket_name "Workspace", even when
+# the workspace has zero visible pockets, and (2) another tenant's
+# workspace-scoped action stays invisible (store-level W4c scoping intact).
 
 from __future__ import annotations
 
@@ -263,6 +272,80 @@ class TestListWorkItems:
         monkeypatch.setattr(mc_service.pockets_service, "list_pockets", AsyncMock(return_value=[]))
         out2 = await mc_service.agent_list_work_items(_ctx(), {})
         assert "Drafted from the modal" in [it.title for it in out2]
+
+
+# ---------------------------------------------------------------------------
+# workspace-scoped nudges (external-action proposals) must reach The Tray
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceScopedNudges:
+    """External-action proposals stamp ``Action.pocket_id = workspace_id``
+    (they're workspace-scoped, not pocket-bound — see
+    ``external_actions/propose.py``). Before the fix, the façade's
+    pocket-visibility filter (``a.pocket_id not in visible``) dropped every
+    such proposal: a workspace id is never a visible pocket id, so gated
+    external actions sat pending forever without ever surfacing in The Tray.
+    """
+
+    @pytest.mark.asyncio
+    async def test_workspace_scoped_action_surfaces_in_tray(self, store: InstinctStore) -> None:
+        a = await store.propose(
+            "w1",  # pocket_id carries the workspace for external actions
+            "External action — send invoice",
+            "gated call",
+            "approve to call 'send_invoice' on connector 'stripe'",
+            _trigger(),
+            parameters={"_external_action": {"connector": "stripe", "action": "send_invoice"}},
+            workspace_id="w1",
+        )
+        items = await mc_service.agent_list_work_items(_ctx(workspace_id="w1"), {})
+        assert [it.id for it in items] == [f"nudge:{a.id}"]
+        item = items[0]
+        assert item.section == WorkItemSection.TRAY
+        assert item.status == WorkItemStatus.AWAITING_APPROVAL
+        # Don't leak the raw workspace hex id where a pocket name belongs.
+        assert item.pocket_name == "Workspace"
+
+    @pytest.mark.asyncio
+    async def test_workspace_scoped_action_surfaces_even_with_no_visible_pockets(
+        self, monkeypatch, store: InstinctStore
+    ) -> None:
+        # The old code skipped the whole instinct block when the workspace
+        # had zero visible pockets — workspace-scoped nudges vanished too.
+        monkeypatch.setattr(mc_service.pockets_service, "list_pockets", AsyncMock(return_value=[]))
+        a = await store.propose(
+            "w1",
+            "External action — pocketless workspace",
+            "",
+            "",
+            _trigger(),
+            parameters={"_external_action": {"connector": "gmail", "action": "send"}},
+            workspace_id="w1",
+        )
+        items = await mc_service.agent_list_work_items(_ctx(workspace_id="w1"), {})
+        assert [it.id for it in items] == [f"nudge:{a.id}"]
+        assert items[0].pocket_name == "Workspace"
+
+    @pytest.mark.asyncio
+    async def test_other_tenants_workspace_scoped_action_stays_invisible(
+        self, store: InstinctStore
+    ) -> None:
+        # Tenancy guard: w2's workspace-scoped proposal (stored under w2)
+        # must never surface for a w1 caller. The store-level W4c scope is
+        # what isolates it — accepting pocket_id == workspace_id must not
+        # loosen that.
+        await store.propose(
+            "w2",
+            "theirs — external action",
+            "",
+            "",
+            _trigger(),
+            parameters={"_external_action": {"connector": "stripe", "action": "refund"}},
+            workspace_id="w2",
+        )
+        items = await mc_service.agent_list_work_items(_ctx(workspace_id="w1"), {})
+        assert items == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Gated external-action proposals were invisible in the Tray. The propose endpoint returned 201 and the pending count kept climbing, but GET /api/v1/mission-control/items came back empty, so there was nothing to approve.

The cause is a scoping mismatch. `external_actions/propose.py` deliberately stamps `Action.pocket_id = workspace_id` because external actions are workspace-scoped, not bound to a pocket. But the feed projection in `agent_list_work_items` filters actions against the set of visible pocket ids, and a workspace id is never in that set, so every external-action proposal got dropped. The whole instinct block was also skipped when a workspace had zero visible pockets, which hid these proposals for the same reason.

The fix lives entirely in `agent_list_work_items`:

- the per-action filter now also admits `pocket_id == workspace_id`, the caller's own workspace only. Pocket-bound nudges keep the exact same visibility filter as before.
- the instinct block always runs instead of bailing when no pockets are visible. The W4c workspace-scoped store reads are untouched.
- workspace-scoped items project with pocket_name "Workspace" instead of leaking the raw workspace hex id.

Tenancy is unchanged: the store reads were already restricted to the caller's workspace at the SQL layer, so another tenant's workspace-scoped proposal can never match the new condition. A test pins this.

Tests added to `test_mission_control_service.py`: a workspace-scoped pending action projects into the feed as `nudge:<id>` with pocket_name "Workspace", the same holds when the workspace has zero visible pockets, and a guard asserts another workspace's proposal stays invisible to this caller.

Heads up for reviewers: `test_mission_control_project_filter.py::test_project_id_empty_string_filters_for_unassigned` fails on dev before this change too. Pre-existing, not touched here.