### PR TITLE
Connector state survives restarts: durable store, truthful status, lazy reconnect

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,10 @@
 <!--
   Connectors documentation.
+  Updated: 2026-06-12 (connector-store-unification CS-6) — added the
+  "Lifecycle: definitions, state, cache" section: the three layers a connector
+  lives in (YAML definitions with two scan dirs + CWD precedence, the durable
+  state store at ~/.pocketpaw/connectors/state, and the in-memory adapter
+  cache), restart semantics, and the presence-based "connected" status.
   Updated: 2026-06-12 (workspace-scope reach) — the agent tool surface now
   reaches workspace-scoped connectors: list_connector_actions returns the
   current pocket's bound connectors PLUS the workspace-enabled ones (deduped
@@ -64,6 +69,45 @@ pocket.db (data lands in SQLite tables)
     ↓
 Pocket widgets auto-update with fresh data
 ```
+
+## Lifecycle: definitions, state, cache
+
+A connector lives in three layers with different lifetimes:
+
+| Layer | What it holds | Where | Lifetime |
+|-------|--------------|-------|----------|
+| **Definition** | What the connector *is* — endpoints, auth schema, actions | `~/.pocketpaw/connectors/*.yaml`, then `connectors/*.yaml` (CWD) | As long as the file exists |
+| **State** | That a connector *is configured* — the config passed to `/connect`, keyed by (name, pocket) | `~/.pocketpaw/connectors/state/*.json` (the durable state store) | Until `/disconnect` |
+| **Cache** | Live adapter instances (HTTP clients, DB pools, OAuth sessions) | In-memory, per process | Until the process exits |
+
+**Definition scan.** The registry scans the home dir
+(`~/.pocketpaw/connectors/`) first, then the CWD `connectors/` dir. On a name
+collision the CWD definition wins — deploys override user-installed
+definitions. A definition dropped in after startup is picked up on the next
+lookup miss (the registry rescans cheaply instead of requiring a restart).
+
+**State.** `/connect` is write-through: the config is persisted to the state
+store before the adapter connects, and rolled back if the connect fails.
+`/disconnect` deletes the row. State files are chmod 0600 and live under a
+0700 dir — the config can carry credentials, same posture as the OAuth token
+store.
+
+**Restart semantics.** The cache dies with the process; definitions and state
+do not. After a restart the list/detail/status endpoints report a configured
+connector as `connected` (derived from definition-present + config-persisted,
+never from the in-memory adapter map), and `/execute` lazily reconnects the
+adapter from the persisted config via `ensure_connected` — no manual
+re-`/connect` step.
+
+**What "connected" means.** Status is a *presence* semantic: a definition
+exists and config is persisted. It does not probe the remote service per
+request — a revoked API key still shows `connected` until an execute fails.
+Use a connector's `health()` for a live check.
+
+**Orphaned state.** A state row whose definition is gone (YAML deleted, or a
+deploy dropped it) surfaces in list/status as `definition_missing` instead of
+disappearing or crashing. It heals automatically once the definition is back,
+or can be cleared with `/disconnect`.
 
 ## Writing a Connector YAML
 

--- a/src/pocketpaw/api/v1/connectors.py
+++ b/src/pocketpaw/api/v1/connectors.py
@@ -3,6 +3,13 @@
 # Updated: 2026-04-19 (Cluster C / PR2) — Added GET /connectors/{kind}/status
 #   returning a structured {connected, last_sync, cred_state, scope} payload
 #   for the ConnectorCard UI. Gap C5 in docs/plans/FEATURE-HARDENING-PLAN.md.
+# Updated: 2026-06-12 (connector-store-unification CS-6) — Endpoints stop
+#   lying after a restart. /status and the list/detail status fields derive
+#   "connected" from the registry's durable state (definition + persisted
+#   config) instead of the in-process adapter map; /execute calls
+#   registry.ensure_connected() so a configured connector works without a
+#   prior /connect in the same process; the list endpoint surfaces orphaned
+#   state rows (config persisted, definition gone) as "definition_missing".
 
 from __future__ import annotations
 
@@ -15,6 +22,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from pocketpaw.api.deps import require_scope
+from pocketpaw.connectors.protocol import ConnectorStatus
 from pocketpaw.connectors.registry import ConnectorRegistry
 
 logger = logging.getLogger(__name__)
@@ -178,8 +186,13 @@ async def get_connector_status(
 
         raise HTTPException(status_code=404, detail=f"Connector '{connector_name}' not found")
 
-    adapter = reg.get_adapter(pocket_id, connector_name)
-    connected = adapter is not None
+    # Derive "connected" from the registry's durable state (definition +
+    # persisted config), not from the in-process adapter map — a configured
+    # connector stays connected across restarts (CS-6).
+    connected = any(
+        s["name"] == connector_name and s["status"] == ConnectorStatus.CONNECTED
+        for s in reg.status(pocket_id)
+    )
 
     extras = _STATUS_EXTRAS.get(_extras_key(pocket_id, connector_name), {})
     cred_state = extras.get("cred_state") or ("valid" if connected else "missing")
@@ -198,11 +211,18 @@ async def get_connector_status(
 
 @router.get("/connectors", response_model=list[ConnectorInfo])
 async def list_connectors(pocket_id: str = "default"):
-    """List all available connectors with their connection status."""
-    reg = _get_registry()
-    status_map = {s["name"]: s["status"].value for s in reg.status(pocket_id)}
+    """List all available connectors with their connection status.
 
-    return [
+    Status comes from ``registry.status()``, which derives "connected" from
+    durable state, so the list is truthful after a restart. Orphaned state
+    rows (config persisted but the YAML definition is gone) are appended
+    with status ``definition_missing`` rather than silently dropped.
+    """
+    reg = _get_registry()
+    reg_status = reg.status(pocket_id)
+    status_map = {s["name"]: s["status"].value for s in reg_status}
+
+    infos = [
         ConnectorInfo(
             name=c["name"],
             display_name=c["display_name"],
@@ -212,6 +232,19 @@ async def list_connectors(pocket_id: str = "default"):
         )
         for c in reg.available
     ]
+    known = {c["name"] for c in reg.available}
+    infos.extend(
+        ConnectorInfo(
+            name=s["name"],
+            display_name=s["display_name"],
+            type="unknown",
+            icon=s.get("icon", "plug"),
+            status=s["status"].value,
+        )
+        for s in reg_status
+        if s["name"] not in known and s["status"] == ConnectorStatus.DEFINITION_MISSING
+    )
+    return infos
 
 
 @router.get("/connectors/{connector_name}", response_model=ConnectorDetailResponse)
@@ -307,11 +340,17 @@ async def disconnect_connector(req: DisconnectRequest):
 
 @router.post("/connectors/execute", response_model=ExecuteResponse)
 async def execute_connector_action(req: ExecuteRequest):
-    """Execute an action on a connected data source."""
+    """Execute an action on a connected data source.
+
+    Uses ``registry.ensure_connected()`` instead of assuming a prior
+    /connect in the same process: if the adapter isn't live but config is
+    persisted in the state store (e.g. after a restart), the registry
+    reconnects on the fly (CS-6).
+    """
     from datetime import datetime
 
     reg = _get_registry()
-    adapter = reg.get_adapter(req.pocket_id, req.connector_name)
+    adapter = await reg.ensure_connected(req.connector_name, req.pocket_id)
     if not adapter:
         return ExecuteResponse(
             success=False,

--- a/src/pocketpaw/connectors/protocol.py
+++ b/src/pocketpaw/connectors/protocol.py
@@ -9,6 +9,10 @@
 #   methods on ConnectorProtocol. See ee/cloud/connectors/CHARTER.md
 #   §4 + §6.2 for the rationale (CLI connectors can't multi-tenant in
 #   cloud, so the runtime needs to know where each action runs).
+# Updated: 2026-06-12 (connector-store-unification CS-2) — Added
+#   ConnectorStatus.DEFINITION_MISSING for orphaned state rows: config is
+#   persisted in the state store but the connector's YAML definition is
+#   gone (deleted, or the deploy dropped it). Surfaced, never crashed on.
 
 from __future__ import annotations
 
@@ -18,12 +22,19 @@ from typing import Any, Literal, Protocol
 
 
 class ConnectorStatus(StrEnum):
-    """Connection status."""
+    """Connection status.
+
+    ``DEFINITION_MISSING`` marks an orphaned state row: config persisted in
+    the connector state store, but the YAML definition no longer resolves
+    (file deleted, or a deploy dropped it). The row stays visible so the
+    operator can fix or remove it instead of the registry silently hiding it.
+    """
 
     DISCONNECTED = "disconnected"
     CONNECTED = "connected"
     SYNCING = "syncing"
     ERROR = "error"
+    DEFINITION_MISSING = "definition_missing"
 
 
 class TrustLevel(StrEnum):

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -17,6 +17,15 @@
 #   from persisted config so the execute path no longer assumes a prior
 #   /connect in the same process. ``disconnect()`` deletes the persisted row.
 #   With an empty store, behavior is identical to before.
+# Updated: 2026-06-12 (connector-store-unification CS-2) — Status tells the
+#   truth + home-dir definitions. ``status()`` derives "connected" from
+#   durable state (definition present + config persisted in the state store),
+#   never from the in-process adapter dict, so a fresh process reports the
+#   same status as the one that connected. Definition scan now reads
+#   ~/.pocketpaw/connectors/*.yaml first, then CWD connectors/*.yaml — CWD
+#   wins on name collision (deploys override). ``get_definition`` rescans on
+#   miss. Orphan state rows whose definition is gone surface as
+#   ``definition_missing`` instead of vanishing or crashing.
 
 from __future__ import annotations
 
@@ -126,6 +135,15 @@ def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
     return None
 
 
+def _default_home_connectors_dir() -> Path:
+    """Default home-dir location for user-installed connector definitions.
+
+    Resolved lazily (not at construction) so tests can patch this function
+    and already-built registries pick up the override.
+    """
+    return Path.home() / ".pocketpaw" / "connectors"
+
+
 class ConnectorRegistry:
     """Discovers available connectors and manages instances per pocket."""
 
@@ -134,23 +152,32 @@ class ConnectorRegistry:
         connectors_dir: Path | None = None,
         *,
         state_store: ConnectorStateStore | None = None,
+        home_connectors_dir: Path | None = None,
     ) -> None:
         self._connectors_dir = connectors_dir or Path("connectors")
+        self._home_connectors_dir = home_connectors_dir
         self._state_store: ConnectorStateStore = state_store or FileConnectorStateStore()
         self._definitions: dict[str, ConnectorDef] = {}
         self._instances: dict[str, AnyAdapter] = {}  # key = "{pocket_id}:{connector_name}"
         self._scan()
 
     def _scan(self) -> None:
-        """Scan connectors directory for YAML definitions."""
-        if not self._connectors_dir.exists():
-            return
-        for path in sorted(self._connectors_dir.glob("*.yaml")):
-            try:
-                defn = parse_connector_yaml(path)
-                self._definitions[defn.name] = defn
-            except Exception:
-                pass  # Skip malformed YAMLs
+        """Scan both connector directories for YAML definitions.
+
+        Home dir (``~/.pocketpaw/connectors``) first, then the CWD dir —
+        scanned second so it overwrites on name collision: deploys override
+        user-installed definitions.
+        """
+        home_dir = self._home_connectors_dir or _default_home_connectors_dir()
+        for directory in (home_dir, self._connectors_dir):
+            if not directory.exists():
+                continue
+            for path in sorted(directory.glob("*.yaml")):
+                try:
+                    defn = parse_connector_yaml(path)
+                    self._definitions[defn.name] = defn
+                except Exception:
+                    pass  # Skip malformed YAMLs
 
     @property
     def available(self) -> list[dict[str, str]]:
@@ -178,8 +205,17 @@ class ConnectorRegistry:
         return list(self._definitions.values())
 
     def get_definition(self, name: str) -> ConnectorDef | None:
-        """Get a connector definition by name."""
-        return self._definitions.get(name)
+        """Get a connector definition by name, rescanning once on a miss.
+
+        The rescan is cheap (a few dozen small YAMLs) and lets a definition
+        dropped into either scan dir after registry construction resolve
+        without a process restart.
+        """
+        defn = self._definitions.get(name)
+        if defn is None:
+            self.reload()
+            defn = self._definitions.get(name)
+        return defn
 
     def get_adapter(self, pocket_id: str, connector_name: str) -> AnyAdapter | None:
         """Get an active adapter instance for a pocket+connector."""
@@ -282,19 +318,41 @@ class ConnectorRegistry:
         return True
 
     def status(self, pocket_id: str) -> list[dict[str, Any]]:
-        """Get connection status for all connectors in a pocket."""
+        """Get connection status for all connectors in a pocket.
+
+        "Connected" is derived from durable state — definition present +
+        config persisted in the state store — never from the in-process
+        adapter dict, so a fresh process reports the same status as the one
+        that ran /connect. Persisted rows whose definition no longer resolves
+        surface as ``definition_missing`` instead of disappearing.
+        """
+        persisted = {name for name, scope in self._state_store.list() if scope == pocket_id}
+        orphans = persisted - set(self._definitions)
+        if orphans:
+            # A definition may have landed since the last scan — rescan once
+            # before declaring rows orphaned.
+            self.reload()
+            orphans = persisted - set(self._definitions)
+
         results = []
         for name, defn in self._definitions.items():
-            key = f"{pocket_id}:{name}"
-            adapter = self._instances.get(key)
             results.append(
                 {
                     "name": name,
                     "display_name": defn.display_name,
                     "icon": defn.icon,
                     "status": ConnectorStatus.CONNECTED
-                    if adapter
+                    if name in persisted
                     else ConnectorStatus.DISCONNECTED,
+                }
+            )
+        for name in sorted(orphans):
+            results.append(
+                {
+                    "name": name,
+                    "display_name": name,
+                    "icon": "plug",
+                    "status": ConnectorStatus.DEFINITION_MISSING,
                 }
             )
         return results

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -7,6 +7,16 @@
 #   ConnectorDef list incl. ``.senses``) so the EE SenseResolver can index
 #   connectors by sense without reaching into the private ``_definitions``
 #   dict. OSS-only change; must not import pocketpaw_ee.
+# Updated: 2026-06-12 (connector-store-unification CS-1) — Connector config now
+#   survives restarts. The registry takes an optional ``state_store``
+#   (default: FileConnectorStateStore at ~/.pocketpaw/connectors/state/).
+#   ``connect()`` is write-through: persist config, then connect the adapter
+#   (rolled back on a failed connect so a bad config never reads as
+#   configured); a live adapter with different config is disconnected and
+#   reconnected. New ``ensure_connected(name, scope_key)`` lazily reconnects
+#   from persisted config so the execute path no longer assumes a prior
+#   /connect in the same process. ``disconnect()`` deletes the persisted row.
+#   With an empty store, behavior is identical to before.
 
 from __future__ import annotations
 
@@ -19,6 +29,7 @@ from pocketpaw.connectors.protocol import (
     ConnectionResult,
     ConnectorStatus,
 )
+from pocketpaw.connectors.state_store import ConnectorStateStore, FileConnectorStateStore
 from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter, parse_connector_yaml
 
 
@@ -118,8 +129,14 @@ def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
 class ConnectorRegistry:
     """Discovers available connectors and manages instances per pocket."""
 
-    def __init__(self, connectors_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        connectors_dir: Path | None = None,
+        *,
+        state_store: ConnectorStateStore | None = None,
+    ) -> None:
         self._connectors_dir = connectors_dir or Path("connectors")
+        self._state_store: ConnectorStateStore = state_store or FileConnectorStateStore()
         self._definitions: dict[str, ConnectorDef] = {}
         self._instances: dict[str, AnyAdapter] = {}  # key = "{pocket_id}:{connector_name}"
         self._scan()
@@ -170,11 +187,44 @@ class ConnectorRegistry:
         return self._instances.get(key)
 
     async def connect(self, pocket_id: str, connector_name: str, config: dict[str, Any]) -> Any:
-        """Create and connect a connector adapter for a pocket."""
+        """Create and connect a connector adapter for a pocket.
+
+        Write-through: the config is persisted to the state store before the
+        adapter connects, so the binding survives a process restart (see
+        ``ensure_connected``). A failed connect rolls the persisted row back —
+        a config that never connected must not read as configured. If a live
+        adapter exists with *different* config, it is disconnected first and
+        reconnected with the new config.
+        """
         defn = self._definitions.get(connector_name)
         if not defn:
             return None
 
+        key = f"{pocket_id}:{connector_name}"
+        if key in self._instances:
+            previous = self._state_store.get(connector_name, pocket_id)
+            if previous is not None and previous != config:
+                await self.disconnect(pocket_id, connector_name)
+
+        self._state_store.set(connector_name, pocket_id, config)
+        result = await self._connect_adapter(pocket_id, connector_name, defn, config)
+        if result is None or not result.success:
+            self._state_store.delete(connector_name, pocket_id)
+        return result
+
+    async def _connect_adapter(
+        self,
+        pocket_id: str,
+        connector_name: str,
+        defn: ConnectorDef,
+        config: dict[str, Any],
+    ) -> ConnectionResult:
+        """Build and connect an adapter; register it on success.
+
+        Internal — never touches the state store, so the restart-recovery
+        path (``ensure_connected``) can retry a transient failure without
+        wiping the persisted config.
+        """
         # Use native adapter if available, otherwise fall back to YAML/REST.
         adapter: AnyAdapter
         native = _create_native_adapter(connector_name)
@@ -191,14 +241,44 @@ class ConnectorRegistry:
 
         return result
 
+    async def ensure_connected(self, connector_name: str, scope_key: str) -> AnyAdapter | None:
+        """Return a live adapter for (connector, scope_key), reconnecting if needed.
+
+        The execute path calls this instead of assuming a prior ``connect()``
+        in the same process: if no adapter is live, the persisted config is
+        read from the state store and the adapter reconnects. No-op when
+        already connected (a live adapter always carries the current config —
+        ``connect()`` keeps the store and the instance map in sync). Returns
+        ``None`` when there is no persisted config, the definition is gone,
+        or the reconnect fails; the persisted config is kept either way so a
+        transient failure can be retried.
+        """
+        key = f"{scope_key}:{connector_name}"
+        adapter = self._instances.get(key)
+        if adapter is not None:
+            return adapter
+
+        config = self._state_store.get(connector_name, scope_key)
+        if config is None:
+            return None
+        defn = self.get_definition(connector_name)
+        if defn is None:
+            return None
+
+        result = await self._connect_adapter(scope_key, connector_name, defn, config)
+        if not result.success:
+            return None
+        return self._instances.get(key)
+
     async def disconnect(self, pocket_id: str, connector_name: str) -> bool:
-        """Disconnect a connector from a pocket."""
+        """Disconnect a connector from a pocket and forget its persisted config."""
         key = f"{pocket_id}:{connector_name}"
         adapter = self._instances.get(key)
         if not adapter:
             return False
         await adapter.disconnect(pocket_id)
         del self._instances[key]
+        self._state_store.delete(connector_name, pocket_id)
         return True
 
     def status(self, pocket_id: str) -> list[dict[str, Any]]:

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -26,6 +26,11 @@
 #   wins on name collision (deploys override). ``get_definition`` rescans on
 #   miss. Orphan state rows whose definition is gone surface as
 #   ``definition_missing`` instead of vanishing or crashing.
+# Updated: 2026-06-12 (connector-store-unification CS-6) — ``disconnect()``
+#   now operates on durable state, not just live adapters: it deletes the
+#   persisted row even when no adapter is in memory (post-restart disconnect,
+#   orphan-row cleanup). Returns True when an adapter was disconnected OR a
+#   row was deleted; still False when there was nothing to forget.
 
 from __future__ import annotations
 
@@ -307,15 +312,23 @@ class ConnectorRegistry:
         return self._instances.get(key)
 
     async def disconnect(self, pocket_id: str, connector_name: str) -> bool:
-        """Disconnect a connector from a pocket and forget its persisted config."""
+        """Disconnect a connector from a pocket and forget its persisted config.
+
+        Works on durable state, not just live adapters: after a restart there
+        is no adapter in memory, but the persisted row must still be deletable
+        or the connector could never be disconnected again. Also the only way
+        to clear an orphaned (``definition_missing``) row. Returns ``True``
+        when either a live adapter was disconnected or a persisted row was
+        deleted.
+        """
         key = f"{pocket_id}:{connector_name}"
-        adapter = self._instances.get(key)
-        if not adapter:
-            return False
-        await adapter.disconnect(pocket_id)
-        del self._instances[key]
-        self._state_store.delete(connector_name, pocket_id)
-        return True
+        adapter = self._instances.pop(key, None)
+        if adapter is not None:
+            await adapter.disconnect(pocket_id)
+        had_state = self._state_store.get(connector_name, pocket_id) is not None
+        if had_state:
+            self._state_store.delete(connector_name, pocket_id)
+        return adapter is not None or had_state
 
     def status(self, pocket_id: str) -> list[dict[str, Any]]:
         """Get connection status for all connectors in a pocket.

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -31,9 +31,17 @@
 #   persisted row even when no adapter is in memory (post-restart disconnect,
 #   orphan-row cleanup). Returns True when an adapter was disconnected OR a
 #   row was deleted; still False when there was nothing to forget.
+# Updated: 2026-06-12 (PR #1447 review fixes) — (1) per-key asyncio.Lock
+#   serializes connect()/ensure_connected() so the post-restart thundering
+#   herd (two concurrent executes) can't double-connect and leak the losing
+#   adapter; (2) connect() rolls the persisted row back when adapter.connect
+#   *raises*, not just when it returns a failure result; (3) connect() routes
+#   through get_definition() so a YAML dropped in after startup is connectable
+#   without a restart (it was already visible to detail/status).
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -164,7 +172,22 @@ class ConnectorRegistry:
         self._state_store: ConnectorStateStore = state_store or FileConnectorStateStore()
         self._definitions: dict[str, ConnectorDef] = {}
         self._instances: dict[str, AnyAdapter] = {}  # key = "{pocket_id}:{connector_name}"
+        # Per-key locks serializing the connect paths — see _lock_for().
+        self._connect_locks: dict[str, asyncio.Lock] = {}
         self._scan()
+
+    def _lock_for(self, key: str) -> asyncio.Lock:
+        """Per-(pocket, connector) lock for connect()/ensure_connected().
+
+        Two concurrent executes for the same key right after a restart (the
+        thundering-herd shape ensure_connected creates) would otherwise both
+        build and connect an adapter; the last ``_instances`` write wins and
+        the loser's adapter (DB engine, HTTP client) leaks without a
+        disconnect. ``setdefault`` on a plain dict is safe here — it runs
+        between awaits on the event loop, so no two coroutines can interleave
+        inside it.
+        """
+        return self._connect_locks.setdefault(key, asyncio.Lock())
 
     def _scan(self) -> None:
         """Scan both connector directories for YAML definitions.
@@ -232,26 +255,34 @@ class ConnectorRegistry:
 
         Write-through: the config is persisted to the state store before the
         adapter connects, so the binding survives a process restart (see
-        ``ensure_connected``). A failed connect rolls the persisted row back —
-        a config that never connected must not read as configured. If a live
-        adapter exists with *different* config, it is disconnected first and
-        reconnected with the new config.
+        ``ensure_connected``). A failed connect — failure result *or* raised
+        exception — rolls the persisted row back: a config that never
+        connected must not read as configured. If a live adapter exists with
+        *different* config, it is disconnected first and reconnected with the
+        new config. Serialized per key with ``ensure_connected``.
         """
-        defn = self._definitions.get(connector_name)
+        defn = self.get_definition(connector_name)
         if not defn:
             return None
 
         key = f"{pocket_id}:{connector_name}"
-        if key in self._instances:
-            previous = self._state_store.get(connector_name, pocket_id)
-            if previous is not None and previous != config:
-                await self.disconnect(pocket_id, connector_name)
+        async with self._lock_for(key):
+            if key in self._instances:
+                previous = self._state_store.get(connector_name, pocket_id)
+                if previous is not None and previous != config:
+                    await self.disconnect(pocket_id, connector_name)
 
-        self._state_store.set(connector_name, pocket_id, config)
-        result = await self._connect_adapter(pocket_id, connector_name, defn, config)
-        if result is None or not result.success:
-            self._state_store.delete(connector_name, pocket_id)
-        return result
+            self._state_store.set(connector_name, pocket_id, config)
+            try:
+                result = await self._connect_adapter(pocket_id, connector_name, defn, config)
+            except BaseException:
+                # adapter.connect blew up (or was cancelled) — the row must
+                # not survive, same invariant as a failure result.
+                self._state_store.delete(connector_name, pocket_id)
+                raise
+            if result is None or not result.success:
+                self._state_store.delete(connector_name, pocket_id)
+            return result
 
     async def _connect_adapter(
         self,
@@ -293,23 +324,34 @@ class ConnectorRegistry:
         ``None`` when there is no persisted config, the definition is gone,
         or the reconnect fails; the persisted config is kept either way so a
         transient failure can be retried.
+
+        The miss path is serialized per key (see ``_lock_for``): concurrent
+        post-restart executes wait for the first reconnect instead of each
+        building an adapter and leaking all but the last one.
         """
         key = f"{scope_key}:{connector_name}"
         adapter = self._instances.get(key)
         if adapter is not None:
             return adapter
 
-        config = self._state_store.get(connector_name, scope_key)
-        if config is None:
-            return None
-        defn = self.get_definition(connector_name)
-        if defn is None:
-            return None
+        async with self._lock_for(key):
+            # Re-check under the lock — a racing call may have connected
+            # while this one waited.
+            adapter = self._instances.get(key)
+            if adapter is not None:
+                return adapter
 
-        result = await self._connect_adapter(scope_key, connector_name, defn, config)
-        if not result.success:
-            return None
-        return self._instances.get(key)
+            config = self._state_store.get(connector_name, scope_key)
+            if config is None:
+                return None
+            defn = self.get_definition(connector_name)
+            if defn is None:
+                return None
+
+            result = await self._connect_adapter(scope_key, connector_name, defn, config)
+            if not result.success:
+                return None
+            return self._instances.get(key)
 
     async def disconnect(self, pocket_id: str, connector_name: str) -> bool:
         """Disconnect a connector from a pocket and forget its persisted config.

--- a/src/pocketpaw/connectors/state_store.py
+++ b/src/pocketpaw/connectors/state_store.py
@@ -1,0 +1,157 @@
+# Connector state store — durable connector config at ~/.pocketpaw/connectors/state/.
+# Created: 2026-06-12 (connector-store-unification CS-1) — Connector lifecycle
+#   must survive process restarts. The ConnectorRegistry previously held adapter
+#   config only in memory, so every restart silently dropped all connections
+#   until someone re-ran /connect. This module is the durable layer: a small
+#   Protocol (so EE can swap in a DB-backed store) plus the file-backed default.
+#   Naming/sanitization mirrors clients/token_store.py — sanitized human-readable
+#   prefix + short sha256 of the raw value, so distinct keys that sanitize to the
+#   same prefix never share a file and no key can path-traverse out of the dir.
+#   Files are chmod 0600 (config may carry credentials, same posture as the
+#   OAuth token store).
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from pocketpaw.config import get_config_dir
+
+logger = logging.getLogger(__name__)
+
+# Characters safe to use verbatim in an on-disk filename segment. Anything else
+# (e.g. ``@``, ``/``, ``..``) is replaced so a connector name or scope key can
+# never escape the state dir or collide with the segment separator.
+_SAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+# Separator between the connector-name segment and the scope-key segment.
+# Double underscore keeps a single underscore inside either value from being
+# mistaken for the boundary (same convention as token_store).
+_SEP = "__"
+
+
+def _default_state_dir() -> Path:
+    """Default on-disk location for connector state.
+
+    Resolved lazily (not at construction) so tests can patch this function
+    and already-built stores pick up the override.
+    """
+    return get_config_dir() / "connectors" / "state"
+
+
+def _segment(value: str) -> str:
+    """Build a filesystem-safe, collision-resistant segment for a key part.
+
+    Sanitized, human-readable prefix for debuggability, plus a short hash of
+    the *raw* value so two distinct values that sanitize to the same prefix
+    (``a@x.com`` vs ``a/x.com``) never share a file.
+    """
+    safe = _SAFE_CHARS.sub("-", value).strip("-") or "x"
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
+    return f"{safe}-{digest}"
+
+
+@runtime_checkable
+class ConnectorStateStore(Protocol):
+    """Durable store for connector config, keyed by (name, scope_key).
+
+    ``scope_key`` is the registry's scoping segment — the pocket_id on the
+    OSS path. Implementations must treat both key parts as untrusted input.
+    """
+
+    def get(self, name: str, scope_key: str) -> dict[str, Any] | None:
+        """Return the persisted config for (name, scope_key), or None."""
+        ...
+
+    def set(self, name: str, scope_key: str, config: dict[str, Any]) -> None:
+        """Persist config for (name, scope_key), overwriting any prior row."""
+        ...
+
+    def delete(self, name: str, scope_key: str) -> None:
+        """Remove the row for (name, scope_key). No-op if absent."""
+        ...
+
+    def list(self) -> list[tuple[str, str]]:
+        """Return all persisted (name, scope_key) pairs."""
+        ...
+
+
+class FileConnectorStateStore:
+    """File-backed ConnectorStateStore at ``~/.pocketpaw/connectors/state/``.
+
+    One JSON file per (name, scope_key): ``{name}__{scope_key}.json`` with
+    both segments sanitized + hash-suffixed (see :func:`_segment`). The raw
+    name and scope_key are stored inside the payload so :meth:`list` can
+    return the originals — the hashed filename is not reversible.
+
+    Files are chmod 0600; the directory 0700. ``base_dir`` overrides the
+    default location (tests point it at tmp_path).
+    """
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base_dir_override = base_dir
+
+    # -- internals ----------------------------------------------------------
+
+    def _dir(self, *, create: bool = False) -> Path:
+        d = self._base_dir_override or _default_state_dir()
+        if create:
+            d.mkdir(parents=True, exist_ok=True)
+            try:
+                d.chmod(0o700)
+            except OSError:
+                pass  # Windows / exotic filesystems
+        return d
+
+    def _path(self, name: str, scope_key: str) -> Path:
+        return self._dir() / f"{_segment(name)}{_SEP}{_segment(scope_key)}.json"
+
+    # -- ConnectorStateStore ------------------------------------------------
+
+    def get(self, name: str, scope_key: str) -> dict[str, Any] | None:
+        path = self._path(name, scope_key)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+            config = data.get("config")
+            return config if isinstance(config, dict) else None
+        except Exception as e:
+            logger.warning("Failed to load connector state for %s: %s", name, e)
+            return None
+
+    def set(self, name: str, scope_key: str, config: dict[str, Any]) -> None:
+        self._dir(create=True)
+        path = self._path(name, scope_key)
+        payload = {"name": name, "scope_key": scope_key, "config": config}
+        path.write_text(json.dumps(payload, indent=2))
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        logger.info("Persisted connector state for %s (scope %s)", name, scope_key)
+
+    def delete(self, name: str, scope_key: str) -> None:
+        path = self._path(name, scope_key)
+        if path.exists():
+            path.unlink()
+            logger.info("Deleted connector state for %s (scope %s)", name, scope_key)
+
+    def list(self) -> list[tuple[str, str]]:
+        d = self._dir()
+        if not d.exists():
+            return []
+        rows: list[tuple[str, str]] = []
+        for path in sorted(d.glob("*.json")):
+            try:
+                data = json.loads(path.read_text())
+                name = data.get("name")
+                scope_key = data.get("scope_key")
+                if isinstance(name, str) and isinstance(scope_key, str):
+                    rows.append((name, scope_key))
+            except Exception as e:
+                logger.warning("Skipping unreadable connector state file %s: %s", path, e)
+        return rows

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,9 @@
-"""Pytest configuration."""
+"""Pytest configuration.
+
+Updated: 2026-06-12 (connector-store-unification CS-1) — added
+_isolate_connector_state so the registry's write-through state store never
+persists test config to the real ~/.pocketpaw/connectors/state.
+"""
 
 import asyncio
 import os
@@ -44,6 +49,22 @@ def _enable_test_full_access(request, monkeypatch):
     if "enforce_scope" in request.keywords:
         return
     monkeypatch.setattr("pocketpaw.api.deps._TESTING_FULL_ACCESS", True)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_connector_state(tmp_path, monkeypatch):
+    """Prevent tests from persisting connector config to the real ~/.pocketpaw.
+
+    ConnectorRegistry.connect() is write-through to a state store that
+    defaults to ~/.pocketpaw/connectors/state (CS-1). Point the default at a
+    per-test temp dir so suites that build a registry with the default store
+    stay hermetic. Tests that exercise the store directly pass an explicit
+    ``base_dir`` instead.
+    """
+    monkeypatch.setattr(
+        "pocketpaw.connectors.state_store._default_state_dir",
+        lambda: tmp_path / "connector-state",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@
 Updated: 2026-06-12 (connector-store-unification CS-1) — added
 _isolate_connector_state so the registry's write-through state store never
 persists test config to the real ~/.pocketpaw/connectors/state.
+Updated: 2026-06-12 (CS-2) — the same fixture also redirects the registry's
+home-dir definition scan (~/.pocketpaw/connectors/*.yaml) to a temp dir so
+YAMLs on a dev machine can't leak into test registries.
 """
 
 import asyncio
@@ -64,6 +67,10 @@ def _isolate_connector_state(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "pocketpaw.connectors.state_store._default_state_dir",
         lambda: tmp_path / "connector-state",
+    )
+    monkeypatch.setattr(
+        "pocketpaw.connectors.registry._default_home_connectors_dir",
+        lambda: tmp_path / "home-connectors",
     )
 
 

--- a/tests/connectors/test_registry_definitions.py
+++ b/tests/connectors/test_registry_definitions.py
@@ -1,0 +1,164 @@
+# test_registry_definitions.py — connector-store-unification CS-2 — truthful
+# status + two-dir definition scan.
+# Created: 2026-06-12 — Locks: status() derives "connected" from durable state
+#   (a fresh registry instance reports the same status as the one that
+#   connected); home-dir YAML pickup (~/.pocketpaw/connectors); CWD precedence
+#   on name collision; orphan state rows surface as definition_missing without
+#   crashing; get_definition rescans on miss.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.connectors.protocol import ConnectorStatus
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+_YAML_TEMPLATE = """\
+name: {name}
+display_name: {display_name}
+type: rest
+icon: plug
+auth:
+  type: api_key
+  credentials:
+    - name: api_key
+      required: true
+actions:
+  - name: ping
+    method: GET
+    url: https://example.invalid/ping
+"""
+
+
+def _write_yaml(directory: Path, name: str, display_name: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / f"{name}.yaml").write_text(
+        _YAML_TEMPLATE.format(name=name, display_name=display_name)
+    )
+
+
+@pytest.fixture
+def defs_dir(tmp_path) -> Path:
+    d = tmp_path / "defs"
+    _write_yaml(d, "testsvc", "Test Service")
+    return d
+
+
+@pytest.fixture
+def home_dir(tmp_path) -> Path:
+    d = tmp_path / "home-defs"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def store(tmp_path) -> FileConnectorStateStore:
+    return FileConnectorStateStore(base_dir=tmp_path / "state")
+
+
+def _registry(defs_dir: Path, store: FileConnectorStateStore, home_dir: Path) -> ConnectorRegistry:
+    return ConnectorRegistry(defs_dir, state_store=store, home_connectors_dir=home_dir)
+
+
+def _status_of(reg: ConnectorRegistry, pocket_id: str, name: str):
+    return next(s for s in reg.status(pocket_id) if s["name"] == name)
+
+
+class TestDurableStatus:
+    @pytest.mark.asyncio
+    async def test_status_survives_fresh_instance(self, defs_dir, store, home_dir) -> None:
+        reg_a = _registry(defs_dir, store, home_dir)
+        result = await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+        assert result.success is True
+        assert _status_of(reg_a, "default", "testsvc")["status"] == ConnectorStatus.CONNECTED
+
+        # Fresh instance, same store — simulated restart. No adapter is live,
+        # yet status still reports connected because the config is persisted.
+        reg_b = _registry(defs_dir, store, home_dir)
+        assert reg_b.get_adapter("default", "testsvc") is None
+        assert _status_of(reg_b, "default", "testsvc")["status"] == ConnectorStatus.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_status_is_scope_isolated(self, defs_dir, store, home_dir) -> None:
+        reg = _registry(defs_dir, store, home_dir)
+        await reg.connect("alpha", "testsvc", {"api_key": "k1"})
+        assert _status_of(reg, "alpha", "testsvc")["status"] == ConnectorStatus.CONNECTED
+        assert _status_of(reg, "beta", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+    @pytest.mark.asyncio
+    async def test_disconnect_reports_disconnected_everywhere(
+        self, defs_dir, store, home_dir
+    ) -> None:
+        reg_a = _registry(defs_dir, store, home_dir)
+        await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+        await reg_a.disconnect("default", "testsvc")
+        assert _status_of(reg_a, "default", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+        reg_b = _registry(defs_dir, store, home_dir)
+        assert _status_of(reg_b, "default", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+    def test_empty_store_reads_disconnected(self, defs_dir, store, home_dir) -> None:
+        reg = _registry(defs_dir, store, home_dir)
+        assert _status_of(reg, "default", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+
+class TestOrphanRows:
+    def test_orphan_row_surfaces_as_definition_missing(self, defs_dir, store, home_dir) -> None:
+        store.set("ghost", "default", {"api_key": "k"})
+        reg = _registry(defs_dir, store, home_dir)
+        row = _status_of(reg, "default", "ghost")
+        assert row["status"] == ConnectorStatus.DEFINITION_MISSING
+        assert row["display_name"] == "ghost"
+        # The defined connector is unaffected.
+        assert _status_of(reg, "default", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+    def test_orphan_recovers_when_definition_lands(self, defs_dir, store, home_dir) -> None:
+        store.set("latecomer", "default", {"api_key": "k"})
+        reg = _registry(defs_dir, store, home_dir)
+        assert _status_of(reg, "default", "latecomer")["status"] == (
+            ConnectorStatus.DEFINITION_MISSING
+        )
+        # Definition shows up after registry construction — the orphan check
+        # rescans before declaring rows orphaned, so status heals itself.
+        _write_yaml(defs_dir, "latecomer", "Latecomer")
+        assert _status_of(reg, "default", "latecomer")["status"] == ConnectorStatus.CONNECTED
+
+
+class TestDefinitionScan:
+    def test_home_dir_yaml_pickup(self, defs_dir, store, home_dir) -> None:
+        _write_yaml(home_dir, "homesvc", "Home Service")
+        reg = _registry(defs_dir, store, home_dir)
+        defn = reg.get_definition("homesvc")
+        assert defn is not None
+        assert defn.display_name == "Home Service"
+        assert "homesvc" in [c["name"] for c in reg.available]
+
+    def test_cwd_wins_on_name_collision(self, defs_dir, store, home_dir) -> None:
+        _write_yaml(home_dir, "testsvc", "Home Override")
+        reg = _registry(defs_dir, store, home_dir)
+        defn = reg.get_definition("testsvc")
+        assert defn is not None
+        # The CWD definition (display_name "Test Service") beats the home one.
+        assert defn.display_name == "Test Service"
+        # And the name appears once, not twice.
+        names = [c["name"] for c in reg.available]
+        assert names.count("testsvc") == 1
+
+    def test_get_definition_reloads_on_miss(self, defs_dir, store, home_dir) -> None:
+        reg = _registry(defs_dir, store, home_dir)
+        assert reg.get_definition("latesvc") is None
+        _write_yaml(defs_dir, "latesvc", "Late Service")
+        defn = reg.get_definition("latesvc")
+        assert defn is not None
+        assert defn.display_name == "Late Service"
+
+    def test_missing_dirs_scan_to_empty(self, tmp_path, store) -> None:
+        reg = ConnectorRegistry(
+            tmp_path / "absent",
+            state_store=store,
+            home_connectors_dir=tmp_path / "also-absent",
+        )
+        assert reg.available == []

--- a/tests/connectors/test_registry_definitions.py
+++ b/tests/connectors/test_registry_definitions.py
@@ -5,6 +5,9 @@
 #   connected); home-dir YAML pickup (~/.pocketpaw/connectors); CWD precedence
 #   on name collision; orphan state rows surface as definition_missing without
 #   crashing; get_definition rescans on miss.
+# Updated: 2026-06-12 (PR #1447 review fixes) — connect() routes through
+#   get_definition, so a YAML dropped in after registry construction is
+#   connectable, not just visible to detail/status.
 
 from __future__ import annotations
 
@@ -154,6 +157,17 @@ class TestDefinitionScan:
         defn = reg.get_definition("latesvc")
         assert defn is not None
         assert defn.display_name == "Late Service"
+
+    @pytest.mark.asyncio
+    async def test_connect_picks_up_late_definition(self, defs_dir, store, home_dir) -> None:
+        """connect() routes through the rescan-on-miss path too — drop a YAML,
+        then /connect, without a restart in between."""
+        reg = _registry(defs_dir, store, home_dir)
+        _write_yaml(defs_dir, "latesvc", "Late Service")
+        result = await reg.connect("default", "latesvc", {"api_key": "k1"})
+        assert result is not None
+        assert result.success is True
+        assert _status_of(reg, "default", "latesvc")["status"] == ConnectorStatus.CONNECTED
 
     def test_missing_dirs_scan_to_empty(self, tmp_path, store) -> None:
         reg = ConnectorRegistry(

--- a/tests/connectors/test_registry_state.py
+++ b/tests/connectors/test_registry_state.py
@@ -1,0 +1,256 @@
+# test_registry_state.py — connector-store-unification CS-1 — registry + state store.
+# Created: 2026-06-12 — Locks the restart-survival contract: connect() is
+#   write-through to the state store; a second registry sharing the same store
+#   (a simulated process restart) can ensure_connected + execute with no new
+#   /connect; a config change disconnects and reconnects the live adapter; a
+#   failed connect rolls the persisted row back; an empty store keeps behavior
+#   identical to the pre-store registry.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pocketpaw.connectors.registry as registry_module
+from pocketpaw.connectors.protocol import ActionResult, ConnectionResult, ConnectorStatus
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+_TEST_YAML = """\
+name: testsvc
+display_name: Test Service
+type: rest
+icon: plug
+auth:
+  type: api_key
+  credentials:
+    - name: api_key
+      required: true
+actions:
+  - name: ping
+    description: Ping the service
+    method: GET
+    url: https://example.invalid/ping
+"""
+
+
+class FakeAdapter:
+    """Minimal AnyAdapter that records connect/disconnect/execute calls."""
+
+    def __init__(self) -> None:
+        self.connect_calls: list[tuple[str, dict[str, Any]]] = []
+        self.disconnect_calls: list[str] = []
+        self.fail_connect = False
+
+    @property
+    def name(self) -> str:
+        return "testsvc"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Service"
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        self.connect_calls.append((pocket_id, config))
+        if self.fail_connect:
+            return ConnectionResult(
+                success=False,
+                connector_name=self.name,
+                status=ConnectorStatus.ERROR,
+                message="bad credentials",
+            )
+        return ConnectionResult(
+            success=True,
+            connector_name=self.name,
+            status=ConnectorStatus.CONNECTED,
+            message="connected",
+        )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        self.disconnect_calls.append(pocket_id)
+        return True
+
+    async def actions(self) -> list:
+        return []
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        return ActionResult(success=True, data={"action": action})
+
+
+@pytest.fixture
+def defs_dir(tmp_path) -> Path:
+    d = tmp_path / "defs"
+    d.mkdir()
+    (d / "testsvc.yaml").write_text(_TEST_YAML)
+    return d
+
+
+@pytest.fixture
+def store(tmp_path) -> FileConnectorStateStore:
+    return FileConnectorStateStore(base_dir=tmp_path / "state")
+
+
+@pytest.fixture
+def fake_adapters(monkeypatch) -> list[FakeAdapter]:
+    """Route testsvc through FakeAdapter; returns the created instances."""
+    created: list[FakeAdapter] = []
+
+    def _fake_create(connector_name: str):
+        if connector_name != "testsvc":
+            return None
+        adapter = FakeAdapter()
+        created.append(adapter)
+        return adapter
+
+    monkeypatch.setattr(registry_module, "_create_native_adapter", _fake_create)
+    return created
+
+
+def _registry(defs_dir: Path, store: FileConnectorStateStore) -> ConnectorRegistry:
+    return ConnectorRegistry(defs_dir, state_store=store)
+
+
+class TestRestartSurvival:
+    @pytest.mark.asyncio
+    async def test_ensure_connected_and_execute_on_fresh_registry(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        """Registry A connects; registry B (same store, fresh process) executes
+        with no /connect of its own."""
+        reg_a = _registry(defs_dir, store)
+        result = await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+        assert result.success is True
+
+        reg_b = _registry(defs_dir, store)  # simulated restart
+        assert reg_b.get_adapter("default", "testsvc") is None
+
+        adapter = await reg_b.ensure_connected("testsvc", "default")
+        assert adapter is not None
+        # Reconnected from the persisted config, not from anything in-process.
+        assert adapter.connect_calls == [("default", {"api_key": "k1"})]
+
+        executed = await adapter.execute("ping", {})
+        assert executed.success is True
+
+    @pytest.mark.asyncio
+    async def test_ensure_connected_is_noop_when_live(self, defs_dir, store, fake_adapters) -> None:
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+
+        first = await reg.ensure_connected("testsvc", "default")
+        second = await reg.ensure_connected("testsvc", "default")
+        assert first is second
+        # One connect from connect(); ensure_connected added none.
+        assert len(first.connect_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_ensure_connected_without_persisted_config(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        reg = _registry(defs_dir, store)
+        assert await reg.ensure_connected("testsvc", "default") is None
+
+    @pytest.mark.asyncio
+    async def test_ensure_connected_keeps_config_on_transient_failure(
+        self, defs_dir, store, fake_adapters, monkeypatch
+    ) -> None:
+        reg_a = _registry(defs_dir, store)
+        await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+
+        reg_b = _registry(defs_dir, store)
+        # Next adapter built will refuse to connect (service down).
+        original = registry_module._create_native_adapter
+
+        def _failing_create(connector_name: str):
+            adapter = original(connector_name)
+            if adapter is not None:
+                adapter.fail_connect = True
+            return adapter
+
+        monkeypatch.setattr(registry_module, "_create_native_adapter", _failing_create)
+        assert await reg_b.ensure_connected("testsvc", "default") is None
+        # The persisted config must survive so a later retry can succeed.
+        assert store.get("testsvc", "default") == {"api_key": "k1"}
+
+
+class TestWriteThrough:
+    @pytest.mark.asyncio
+    async def test_connect_persists_config(self, defs_dir, store, fake_adapters) -> None:
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        assert store.get("testsvc", "default") == {"api_key": "k1"}
+
+    @pytest.mark.asyncio
+    async def test_failed_connect_rolls_back_state(
+        self, defs_dir, store, fake_adapters, monkeypatch
+    ) -> None:
+        original = registry_module._create_native_adapter
+
+        def _failing_create(connector_name: str):
+            adapter = original(connector_name)
+            if adapter is not None:
+                adapter.fail_connect = True
+            return adapter
+
+        monkeypatch.setattr(registry_module, "_create_native_adapter", _failing_create)
+        reg = _registry(defs_dir, store)
+        result = await reg.connect("default", "testsvc", {"api_key": "bad"})
+        assert result.success is False
+        assert store.get("testsvc", "default") is None
+
+    @pytest.mark.asyncio
+    async def test_config_change_disconnects_then_reconnects(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        old_adapter = reg.get_adapter("default", "testsvc")
+
+        await reg.connect("default", "testsvc", {"api_key": "k2"})
+        new_adapter = reg.get_adapter("default", "testsvc")
+
+        assert old_adapter.disconnect_calls == ["default"]
+        assert new_adapter is not old_adapter
+        assert new_adapter.connect_calls == [("default", {"api_key": "k2"})]
+        assert store.get("testsvc", "default") == {"api_key": "k2"}
+
+    @pytest.mark.asyncio
+    async def test_reconnect_same_config_does_not_disconnect(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        """Identical config keeps today's overwrite path — no disconnect."""
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        old_adapter = reg.get_adapter("default", "testsvc")
+
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        assert old_adapter.disconnect_calls == []
+
+    @pytest.mark.asyncio
+    async def test_disconnect_forgets_persisted_config(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        assert await reg.disconnect("default", "testsvc") is True
+        assert store.get("testsvc", "default") is None
+        # And a fresh registry can no longer resurrect the connection.
+        reg_b = _registry(defs_dir, store)
+        assert await reg_b.ensure_connected("testsvc", "default") is None
+
+
+class TestEmptyStoreRegression:
+    """With an empty store the registry behaves exactly like the pre-store one."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_connector_returns_none(self, defs_dir, store) -> None:
+        reg = _registry(defs_dir, store)
+        assert await reg.connect("default", "nope", {}) is None
+
+    @pytest.mark.asyncio
+    async def test_no_adapter_until_connect(self, defs_dir, store) -> None:
+        reg = _registry(defs_dir, store)
+        assert reg.get_adapter("default", "testsvc") is None
+        assert await reg.disconnect("default", "testsvc") is False

--- a/tests/connectors/test_registry_state.py
+++ b/tests/connectors/test_registry_state.py
@@ -5,9 +5,14 @@
 #   /connect; a config change disconnects and reconnects the live adapter; a
 #   failed connect rolls the persisted row back; an empty store keeps behavior
 #   identical to the pre-store registry.
+# Updated: 2026-06-12 (PR #1447 review fixes) — added the concurrency contract
+#   (two racing ensure_connected calls connect exactly once, no leaked
+#   adapter) and the raised-exception rollback contract (adapter.connect that
+#   raises must not leave the never-connected config in the store).
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -37,12 +42,20 @@ actions:
 
 
 class FakeAdapter:
-    """Minimal AnyAdapter that records connect/disconnect/execute calls."""
+    """Minimal AnyAdapter that records connect/disconnect/execute calls.
+
+    ``connect_delay`` (class attribute, patchable per test) makes connect()
+    slow so races can be staged; ``raise_connect`` makes it blow up instead
+    of returning a failure result.
+    """
+
+    connect_delay: float = 0.0
 
     def __init__(self) -> None:
         self.connect_calls: list[tuple[str, dict[str, Any]]] = []
         self.disconnect_calls: list[str] = []
         self.fail_connect = False
+        self.raise_connect = False
 
     @property
     def name(self) -> str:
@@ -53,7 +66,11 @@ class FakeAdapter:
         return "Test Service"
 
     async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        if self.connect_delay:
+            await asyncio.sleep(self.connect_delay)
         self.connect_calls.append((pocket_id, config))
+        if self.raise_connect:
+            raise RuntimeError("connect exploded")
         if self.fail_connect:
             return ConnectionResult(
                 success=False,
@@ -174,6 +191,29 @@ class TestRestartSurvival:
         # The persisted config must survive so a later retry can succeed.
         assert store.get("testsvc", "default") == {"api_key": "k1"}
 
+    @pytest.mark.asyncio
+    async def test_concurrent_ensure_connected_connects_exactly_once(
+        self, defs_dir, store, fake_adapters, monkeypatch
+    ) -> None:
+        """Post-restart thundering herd: two racing executes for the same key
+        must share one adapter — no double connect, no leaked instance."""
+        store.set("testsvc", "default", {"api_key": "k1"})
+        reg = _registry(defs_dir, store)
+        # Slow connect so the second call arrives while the first is mid-flight.
+        monkeypatch.setattr(FakeAdapter, "connect_delay", 0.05)
+
+        first, second = await asyncio.gather(
+            reg.ensure_connected("testsvc", "default"),
+            reg.ensure_connected("testsvc", "default"),
+        )
+
+        assert first is not None
+        assert first is second
+        # Exactly one adapter was ever built and connected — nothing to leak.
+        assert len(fake_adapters) == 1
+        assert len(fake_adapters[0].connect_calls) == 1
+        assert reg.get_adapter("default", "testsvc") is first
+
 
 class TestWriteThrough:
     @pytest.mark.asyncio
@@ -199,6 +239,27 @@ class TestWriteThrough:
         result = await reg.connect("default", "testsvc", {"api_key": "bad"})
         assert result.success is False
         assert store.get("testsvc", "default") is None
+
+    @pytest.mark.asyncio
+    async def test_raising_connect_rolls_back_state(
+        self, defs_dir, store, fake_adapters, monkeypatch
+    ) -> None:
+        """A raised exception is rolled back like a failure result — the
+        never-connected config must not survive in the store."""
+        original = registry_module._create_native_adapter
+
+        def _raising_create(connector_name: str):
+            adapter = original(connector_name)
+            if adapter is not None:
+                adapter.raise_connect = True
+            return adapter
+
+        monkeypatch.setattr(registry_module, "_create_native_adapter", _raising_create)
+        reg = _registry(defs_dir, store)
+        with pytest.raises(RuntimeError, match="connect exploded"):
+            await reg.connect("default", "testsvc", {"api_key": "boom"})
+        assert store.get("testsvc", "default") is None
+        assert reg.get_adapter("default", "testsvc") is None
 
     @pytest.mark.asyncio
     async def test_config_change_disconnects_then_reconnects(

--- a/tests/connectors/test_state_store.py
+++ b/tests/connectors/test_state_store.py
@@ -1,0 +1,133 @@
+# test_state_store.py — connector-store-unification CS-1 — FileConnectorStateStore.
+# Created: 2026-06-12 — Locks the durable connector-state contract: JSON rows
+#   keyed by (name, scope_key), sanitized + hash-suffixed filenames that can't
+#   path-traverse or collide, 0600 file perms, and tolerant reads (corrupt
+#   files degrade to "no state", never crash).
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from pocketpaw.connectors.state_store import (
+    ConnectorStateStore,
+    FileConnectorStateStore,
+)
+
+
+@pytest.fixture
+def store(tmp_path) -> FileConnectorStateStore:
+    return FileConnectorStateStore(base_dir=tmp_path / "state")
+
+
+class TestRoundTrip:
+    def test_set_then_get(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "sk_test_123"})
+        assert store.get("stripe", "pocket-1") == {"api_key": "sk_test_123"}
+
+    def test_get_missing_returns_none(self, store: FileConnectorStateStore) -> None:
+        assert store.get("stripe", "pocket-1") is None
+
+    def test_set_overwrites(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "old"})
+        store.set("stripe", "pocket-1", {"api_key": "new"})
+        assert store.get("stripe", "pocket-1") == {"api_key": "new"}
+
+    def test_rows_are_scope_isolated(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "one"})
+        store.set("stripe", "pocket-2", {"api_key": "two"})
+        assert store.get("stripe", "pocket-1") == {"api_key": "one"}
+        assert store.get("stripe", "pocket-2") == {"api_key": "two"}
+
+    def test_delete(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        store.delete("stripe", "pocket-1")
+        assert store.get("stripe", "pocket-1") is None
+
+    def test_delete_missing_is_noop(self, store: FileConnectorStateStore) -> None:
+        store.delete("stripe", "pocket-1")  # must not raise
+
+    def test_list_returns_original_keys(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        store.set("github", "alice@example.com", {"token": "t"})
+        assert sorted(store.list()) == [
+            ("github", "alice@example.com"),
+            ("stripe", "pocket-1"),
+        ]
+
+    def test_list_empty_dir_absent(self, tmp_path) -> None:
+        store = FileConnectorStateStore(base_dir=tmp_path / "never-created")
+        assert store.list() == []
+
+
+class TestSanitization:
+    def test_hostile_keys_stay_inside_base_dir(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("../../evil", "../escape", {"k": "v"})
+        # Everything written must live directly under the base dir.
+        written = list(base.glob("*.json"))
+        assert len(written) == 1
+        assert written[0].parent == base
+        assert store.get("../../evil", "../escape") == {"k": "v"}
+
+    def test_distinct_keys_with_same_sanitized_prefix_do_not_collide(
+        self, store: FileConnectorStateStore
+    ) -> None:
+        # Both scope keys sanitize to "a-x.com"; the raw-value hash keeps
+        # them in separate files (token_store convention).
+        store.set("svc", "a@x.com", {"who": "at"})
+        store.set("svc", "a/x.com", {"who": "slash"})
+        assert store.get("svc", "a@x.com") == {"who": "at"}
+        assert store.get("svc", "a/x.com") == {"who": "slash"}
+
+    def test_separator_inside_name_does_not_cross_segments(
+        self, store: FileConnectorStateStore
+    ) -> None:
+        store.set("a__b", "c", {"k": "1"})
+        store.set("a", "b__c", {"k": "2"})
+        assert store.get("a__b", "c") == {"k": "1"}
+        assert store.get("a", "b__c") == {"k": "2"}
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions")
+class TestPermissions:
+    def test_state_files_are_0600(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("stripe", "pocket-1", {"api_key": "secret"})
+        path = next(base.glob("*.json"))
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+
+class TestTolerantReads:
+    def test_corrupt_file_reads_as_missing(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        path = next(base.glob("*.json"))
+        path.write_text("{not json")
+        assert store.get("stripe", "pocket-1") is None
+
+    def test_list_skips_corrupt_files(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        (base / "garbage__row.json").write_text("{not json")
+        assert store.list() == [("stripe", "pocket-1")]
+
+    def test_payload_without_config_dict_reads_as_missing(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        path = next(base.glob("*.json"))
+        path.write_text(json.dumps({"name": "stripe", "scope_key": "pocket-1", "config": "nope"}))
+        assert store.get("stripe", "pocket-1") is None
+
+
+def test_file_store_satisfies_protocol() -> None:
+    assert isinstance(FileConnectorStateStore(), ConnectorStateStore)

--- a/tests/v1/test_api_v1_connector_lifecycle.py
+++ b/tests/v1/test_api_v1_connector_lifecycle.py
@@ -1,0 +1,227 @@
+# test_api_v1_connector_lifecycle.py — connector-store-unification CS-6 —
+# the OSS router survives restarts.
+# Created: 2026-06-12 — Locks the restart contract at the HTTP layer with a
+#   REAL ConnectorRegistry on tmp dirs (no fakes): connect → fresh registry
+#   instance (simulated process restart, _STATUS_EXTRAS cleared) → list,
+#   detail, and status endpoints all report "connected"; /execute reconnects
+#   from persisted config via ensure_connected; /disconnect works after the
+#   restart; orphaned state rows surface as definition_missing in the list.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import pocketpaw.api.v1.connectors as connectors_module
+import pocketpaw.connectors.registry as registry_module
+from pocketpaw.api.deps import require_scope
+from pocketpaw.connectors.protocol import ActionResult, ConnectionResult, ConnectorStatus
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+_TEST_YAML = """\
+name: testsvc
+display_name: Test Service
+type: rest
+icon: plug
+auth:
+  type: api_key
+  credentials:
+    - name: api_key
+      required: true
+actions:
+  - name: ping
+    description: Ping the service
+    method: GET
+    url: https://example.invalid/ping
+"""
+
+
+class FakeAdapter:
+    """Minimal adapter so /execute works without real HTTP."""
+
+    def __init__(self) -> None:
+        self.connect_calls: list[tuple[str, dict[str, Any]]] = []
+
+    @property
+    def name(self) -> str:
+        return "testsvc"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Service"
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        self.connect_calls.append((pocket_id, config))
+        return ConnectionResult(
+            success=True,
+            connector_name=self.name,
+            status=ConnectorStatus.CONNECTED,
+            message="connected",
+        )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        return True
+
+    async def actions(self) -> list:
+        return []
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        return ActionResult(success=True, data={"action": action})
+
+
+@pytest.fixture
+def dirs(tmp_path) -> dict[str, Path]:
+    defs = tmp_path / "defs"
+    defs.mkdir()
+    (defs / "testsvc.yaml").write_text(_TEST_YAML)
+    return {
+        "defs": defs,
+        "home": tmp_path / "home-defs",
+        "state": tmp_path / "state",
+    }
+
+
+@pytest.fixture
+def fake_adapters(monkeypatch) -> list[FakeAdapter]:
+    created: list[FakeAdapter] = []
+
+    def _fake_create(connector_name: str):
+        if connector_name != "testsvc":
+            return None
+        adapter = FakeAdapter()
+        created.append(adapter)
+        return adapter
+
+    monkeypatch.setattr(registry_module, "_create_native_adapter", _fake_create)
+    return created
+
+
+def _build_registry(dirs: dict[str, Path]) -> ConnectorRegistry:
+    return ConnectorRegistry(
+        dirs["defs"],
+        state_store=FileConnectorStateStore(base_dir=dirs["state"]),
+        home_connectors_dir=dirs["home"],
+    )
+
+
+@pytest.fixture
+def client(dirs, monkeypatch) -> TestClient:
+    monkeypatch.setattr(connectors_module, "_registry", _build_registry(dirs))
+    connectors_module._STATUS_EXTRAS.clear()
+    app = FastAPI()
+    app.dependency_overrides[require_scope("connectors")] = lambda: None
+    app.include_router(connectors_module.router, prefix="/api/v1")
+    yield TestClient(app)
+    connectors_module._STATUS_EXTRAS.clear()
+
+
+def _simulate_restart(dirs: dict[str, Path], monkeypatch) -> None:
+    """Fresh registry instance + cleared in-memory side-table = new process."""
+    monkeypatch.setattr(connectors_module, "_registry", _build_registry(dirs))
+    connectors_module._STATUS_EXTRAS.clear()
+
+
+def _connect(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/connectors/connect",
+        json={
+            "connector_name": "testsvc",
+            "pocket_id": "default",
+            "config": {"api_key": "k1"},
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+
+
+class TestRestartTruth:
+    def test_list_shows_connected_after_restart(
+        self, client, dirs, monkeypatch, fake_adapters
+    ) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        listed = client.get("/api/v1/connectors").json()
+        testsvc = next(c for c in listed if c["name"] == "testsvc")
+        assert testsvc["status"] == "connected"
+
+    def test_status_shows_connected_after_restart(
+        self, client, dirs, monkeypatch, fake_adapters
+    ) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        status = client.get("/api/v1/connectors/testsvc/status").json()
+        assert status["connected"] is True
+        # Extras died with the process; cred_state falls back from connected.
+        assert status["cred_state"] == "valid"
+
+    def test_detail_shows_connected_after_restart(
+        self, client, dirs, monkeypatch, fake_adapters
+    ) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        detail = client.get("/api/v1/connectors/testsvc").json()
+        assert detail["status"] == "connected"
+
+    def test_execute_reconnects_after_restart(
+        self, client, dirs, monkeypatch, fake_adapters
+    ) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        resp = client.post(
+            "/api/v1/connectors/execute",
+            json={"connector_name": "testsvc", "action": "ping", "pocket_id": "default"},
+        ).json()
+        assert resp["success"] is True
+        assert resp["data"] == {"action": "ping"}
+        # The post-restart adapter reconnected from the PERSISTED config.
+        assert fake_adapters[-1].connect_calls == [("default", {"api_key": "k1"})]
+
+    def test_disconnect_works_after_restart(self, client, dirs, monkeypatch, fake_adapters) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        resp = client.post(
+            "/api/v1/connectors/disconnect",
+            json={"connector_name": "testsvc", "pocket_id": "default"},
+        ).json()
+        assert resp["success"] is True
+
+        status = client.get("/api/v1/connectors/testsvc/status").json()
+        assert status["connected"] is False
+
+
+class TestNeverConfigured:
+    def test_execute_without_config_still_errors(self, client, fake_adapters) -> None:
+        resp = client.post(
+            "/api/v1/connectors/execute",
+            json={"connector_name": "testsvc", "action": "ping", "pocket_id": "default"},
+        ).json()
+        assert resp["success"] is False
+        assert "not connected" in resp["error"]
+
+    def test_status_disconnected_without_config(self, client) -> None:
+        status = client.get("/api/v1/connectors/testsvc/status").json()
+        assert status["connected"] is False
+        assert status["cred_state"] == "missing"
+
+
+class TestOrphanRows:
+    def test_orphan_row_listed_as_definition_missing(self, client, dirs) -> None:
+        FileConnectorStateStore(base_dir=dirs["state"]).set("ghost", "default", {"k": "v"})
+
+        listed = client.get("/api/v1/connectors").json()
+        ghost = next(c for c in listed if c["name"] == "ghost")
+        assert ghost["status"] == "definition_missing"
+        assert ghost["type"] == "unknown"
+        # Defined connectors are unaffected.
+        testsvc = next(c for c in listed if c["name"] == "testsvc")
+        assert testsvc["status"] == "disconnected"


### PR DESCRIPTION
## Problem

Connector lifecycle lives entirely in process memory. The ConnectorRegistry holds adapter instances and config in dicts, and definitions load from a CWD-relative `connectors/` dir. Every restart silently drops all connections: status endpoints report "not found" or disconnected for connectors that were configured minutes earlier, and `/execute` fails until someone re-runs `/connect`. That volatile state produced three bugs in one week and left us with a bind-after-restart runbook step that nobody should need.

## What this does

Three slices, one commit each:

**CS-1 — config survives restart.** New `ConnectorStateStore` protocol plus a file-backed default (`~/.pocketpaw/connectors/state/`, one JSON row per (name, pocket), 0600 perms, filename sanitization borrowed from the OAuth token store). `connect()` is write-through: persist config, then connect the adapter, roll back the row on failure. A live adapter handed different config gets disconnected and reconnected. New `ensure_connected(name, scope_key)` lazily reconnects from persisted config.

**CS-2 — status tells the truth, definitions in two dirs.** `status()` derives "connected" from durable state (definition present + config persisted), never from the in-process adapter dict, so a fresh process reports the same status as the one that connected. The definition scan reads `~/.pocketpaw/connectors/*.yaml` first, then CWD `connectors/*.yaml`; CWD wins on collision so deploys override. `get_definition` rescans on a miss. State rows whose definition is gone surface as `definition_missing` instead of vanishing or crashing.

**CS-6 — router stops lying.** List/detail/status endpoints read the derived state, so a configured connector shows `connected` after a restart. `/execute` calls `ensure_connected()` instead of assuming a prior `/connect` in the same process. `/disconnect` now works post-restart too (deletes the persisted row even with no live adapter — also the cleanup path for orphan rows). `docs/CONNECTORS.md` gains a lifecycle section: definitions vs state vs cache, scan precedence, restart semantics.

## Semantics worth knowing

- **"Connected" is a presence semantic**: definition exists + config persisted. It does not probe the remote service per request — a revoked key still reads connected until an execute fails. `health()` remains the live check.
- **Empty store = today's behavior.** A registry with an empty state store is byte-identical to the old one; the existing regression suites pass unchanged. The only behavioral delta with a non-empty store is the intended one: state outlives the process.

## Tests

- `tests/connectors/test_state_store.py` — store contract: round-trip, scope isolation, hostile-key sanitization, 0600 perms, corrupt-file tolerance.
- `tests/connectors/test_registry_state.py` — registry A connects, registry B (same store, fresh instance) ensure_connected + executes with no new `/connect`; config change disconnects + reconnects; failed connect rolls back; transient reconnect failure keeps config.
- `tests/connectors/test_registry_definitions.py` — status after fresh instance, home-dir YAML pickup, collision precedence, orphan rows.
- `tests/v1/test_api_v1_connector_lifecycle.py` — full HTTP restart contract against a real registry: list/detail/status show connected after restart, execute reconnects, disconnect works, orphans listed.
- A conftest fixture redirects the default store and home scan dir to tmp paths so test runs never write to the real `~/.pocketpaw`.

`pytest -k "connector or registry"`: 313 passed. `tests/v1/`: 240 passed. `lint-imports`: OSS/EE contract kept.

## Merge-order note

#1445 (workspace-scope reach) also edits `docs/CONNECTORS.md`. This branch is off dev and edits the doc as it exists there; whichever merges second will need a trivial doc rebase.

## Review fixes (31cef972)

- **Concurrency**: a per-key `asyncio.Lock` serializes `connect()`/`ensure_connected()`. Two concurrent post-restart executes for the same (name, pocket) used to both connect; the losing adapter leaked without a disconnect. Covered by a racing-double-execute test against a slow adapter.
- **Rollback on raised exceptions**: `connect()` now rolls the persisted row back when `adapter.connect` raises, not only when it returns a failure result.
- **Late definitions**: `connect()` routes through `get_definition()`, so a YAML dropped in after startup is connectable, not just visible to detail/status.
