### PR TITLE
feat(sprints): add start sprint & detach items from sprint

### DIFF
--- a/ee/pocketpaw_ee/cloud/cycles/router.py
+++ b/ee/pocketpaw_ee/cloud/cycles/router.py
@@ -58,6 +58,14 @@ async def update_cycle(
     return await cycles_service.agent_update_cycle(ctx, cycle_id, body)
 
 
+@router.post("/{cycle_id}/start", response_model=CycleResponse)
+async def start_cycle(
+    cycle_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> CycleResponse:
+    return await cycles_service.agent_start_cycle(ctx, cycle_id)
+
+
 @router.post("/{cycle_id}/close", response_model=CycleResponse)
 async def close_cycle(
     cycle_id: str,

--- a/ee/pocketpaw_ee/cloud/cycles/service.py
+++ b/ee/pocketpaw_ee/cloud/cycles/service.py
@@ -413,6 +413,42 @@ async def agent_update_cycle(
     return response
 
 
+async def agent_start_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse:
+    """Transition a cycle from ``upcoming`` to ``active``.
+
+    Only upcoming cycles can be started — already-active cycles should
+    continue via the normal close flow, and completed cycles are immutable.
+    Validates workspace tenancy and that no overlapping active cycle exists
+    on the same pocket.
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, cycle_id)
+
+    if doc.status == "active":
+        raise ConflictError("cycle.already_active", "This cycle is already active")
+    if doc.status == "completed":
+        raise ConflictError("cycle.already_closed", "This cycle is already completed")
+
+    if doc.pocket_id is not None and await _has_active_overlap(
+        workspace_id,
+        doc.pocket_id,
+        doc.start,
+        doc.end,
+        exclude_id=cycle_id,
+    ):
+        raise ConflictError(
+            "cycle.overlap",
+            "Another active cycle on the same pocket overlaps this date range",
+        )
+
+    doc.status = "active"
+    await doc.save()
+
+    response = _to_response(_to_domain(doc))
+    await emit(CycleUpdated(data=response.model_dump()))
+    return response
+
+
 async def agent_close_cycle(ctx: RequestContext, cycle_id: str) -> CycleResponse:
     """Mark a cycle ``completed`` and roll incomplete tasks forward.
 
@@ -686,6 +722,7 @@ __all__ = [
     "agent_get_cycle",
     "agent_list_cycle_items",
     "agent_list_cycles",
+    "agent_start_cycle",
     "agent_update_cycle",
     "list_active_cycle_ids",
     "list_active_workspace_ids",

--- a/ee/pocketpaw_ee/cloud/mission_control/dto.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/dto.py
@@ -199,6 +199,23 @@ class AttachCycleItemsResponse(BaseModel):
     cycle_id: str
 
 
+DetachCycleItemsRequest = AttachCycleItemsRequest
+
+
+class DetachCycleItemsResponse(BaseModel):
+    """Result of a bulk-detach call.
+
+    Same partial-success posture as ``AttachCycleItemsResponse``.
+    ``detached`` lists ids that were successfully removed from the
+    sprint; ``skipped`` lists ids the caller couldn't see or that
+    weren't in this sprint.
+    """
+
+    detached: list[str]
+    skipped: list[str] = Field(default_factory=list)
+    cycle_id: str
+
+
 class CreateCycleRequest(BaseModel):
     """Body for ``POST /mission-control/cycles``.
 
@@ -408,10 +425,14 @@ class AnalyticsResponse(BaseModel):
 __all__ = [
     "ActivityEventResponse",
     "AnalyticsResponse",
+    "AttachCycleItemsRequest",
+    "AttachCycleItemsResponse",
     "BulkActionRequest",
     "BulkReassignRequest",
     "BulkSnoozeRequest",
     "CreateCycleRequest",
+    "DetachCycleItemsRequest",
+    "DetachCycleItemsResponse",
     "ListActivityRequest",
     "ListPlanSessionsRequest",
     "ListWorkItemsRequest",

--- a/ee/pocketpaw_ee/cloud/mission_control/router.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/router.py
@@ -55,6 +55,8 @@ from pocketpaw_ee.cloud.mission_control.dto import (
     BulkReassignRequest,
     BulkSnoozeRequest,
     CreateCycleRequest,
+    DetachCycleItemsRequest,
+    DetachCycleItemsResponse,
     ListActivityRequest,
     ListPlanSessionsRequest,
     ListWorkItemsRequest,
@@ -231,6 +233,24 @@ async def attach_cycle_items(
     so a half-stale selection still partially succeeds.
     """
     return await mc_service.agent_attach_cycle_items(ctx, cycle_id, body)
+
+
+@router.post(
+    "/cycles/{cycle_id}/items/detach",
+    response_model=DetachCycleItemsResponse,
+)
+async def detach_cycle_items(
+    cycle_id: str,
+    body: DetachCycleItemsRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> DetachCycleItemsResponse:
+    """Detach work items from a sprint.
+
+    Removes items from the sprint by clearing their ``cycle_id``.
+    Items the caller can't see are reported back in ``skipped``
+    rather than failing the whole batch.
+    """
+    return await mc_service.agent_detach_cycle_items(ctx, cycle_id, body)
 
 
 @router.get("/analytics", response_model=AnalyticsResponse)

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -141,6 +141,7 @@ from pocketpaw_ee.cloud.mission_control.dto import (
     BulkReassignRequest,
     BulkSnoozeRequest,
     CreateCycleRequest,
+    DetachCycleItemsResponse,
     ListActivityRequest,
     ListPlanSessionsRequest,
     ListWorkItemsRequest,
@@ -1172,6 +1173,56 @@ async def agent_attach_cycle_items(
 
     return AttachCycleItemsResponse(
         attached=attached,
+        skipped=skipped,
+        cycle_id=cycle_id,
+    )
+
+
+async def agent_detach_cycle_items(
+    ctx: RequestContext,
+    cycle_id: str,
+    body: AttachCycleItemsRequest,
+) -> DetachCycleItemsResponse:
+    """Detach a batch of work items from a sprint.
+
+    Validates the sprint exists in the caller's workspace, then for each
+    item id calls ``tasks.service.agent_set_task_cycle`` with ``None``
+    to clear the cycle pointer. Items the caller can't see are reported
+    back as ``skipped`` rather than failing the whole batch.
+    """
+
+    body = AttachCycleItemsRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+
+    from pocketpaw_ee.cloud.cycles import service as cycles_service
+    from pocketpaw_ee.cloud.tasks import service as tasks_service
+
+    # Tenancy check on the cycle itself
+    await cycles_service._fetch_in_workspace(workspace_id, cycle_id)
+
+    detached: list[str] = []
+    skipped: list[str] = []
+    for task_id in body.item_ids:
+        try:
+            raw_id = task_id.removeprefix("task:")
+            await tasks_service.agent_set_task_cycle(ctx, raw_id, None)
+            detached.append(task_id)
+        except Exception:
+            skipped.append(task_id)
+
+    # Refresh counters on the cycle so scope/started/completed update
+    tasks = await cycles_service._tasks_for_cycle(ctx, cycle_id)
+    if tasks is not None:
+        scope, started, completed = cycles_service._counters_from_tasks(tasks)
+        doc = await cycles_service._fetch_in_workspace(workspace_id, cycle_id)
+        if (doc.scope, doc.started, doc.completed) != (scope, started, completed):
+            doc.scope = scope
+            doc.started = started
+            doc.completed = completed
+            await doc.save()
+
+    return DetachCycleItemsResponse(
+        detached=detached,
         skipped=skipped,
         cycle_id=cycle_id,
     )

--- a/ee/pocketpaw_ee/cloud/mission_control/service.py
+++ b/ee/pocketpaw_ee/cloud/mission_control/service.py
@@ -638,13 +638,18 @@ async def agent_bulk_approve(
 async def agent_bulk_reject(
     ctx: RequestContext, body: BulkActionRequest | dict[str, Any]
 ) -> dict[str, Any]:
-    """Reject N pending Nudges in one call. ``reason`` is required.
+    """Reject N pending items in one call. ``reason`` is required.
 
-    Same tenancy semantics as ``agent_bulk_approve``. The reason text is
-    surfaced on every Action's ``rejected_reason`` AND on every audit
-    row's ``context.reason`` so the soul-bridge correction pipeline can
-    learn from bulk rejects the same way it learns from single-item
-    rejects.
+    Handles both Tasks (``task:`` prefix) and Instinct Nudges (bare or
+    ``nudge:`` prefix) — mirrors the same split that ``agent_bulk_approve``
+    performs. Tasks are blocked with the given reason so they surface in
+    the operator's Snags section; Nudges flow through the Instinct store's
+    native reject path.
+
+    The reason text is surfaced on every Action's ``rejected_reason`` AND
+    on every audit row's ``context.reason`` so the soul-bridge correction
+    pipeline can learn from bulk rejects the same way it learns from
+    single-item rejects.
     """
     body = BulkActionRequest.model_validate(body)
     if not body.reason:
@@ -653,17 +658,63 @@ async def agent_bulk_reject(
             "bulk-reject requires a reason — pass a non-empty string in ``reason``.",
         )
     _require_workspace(ctx)
-    visible = await _visible_pocket_ids(ctx)
-    store = get_instinct_store()
-    eligible, blocked = await _split_ids_by_tenancy(store, list(body.ids), visible)
-    rejected, missing, bulk_id = await store.bulk_reject(
-        eligible, reason=body.reason, rejector=ctx.user_id
-    )
-    # no-event: per-item approve/reject inside the loop already emits the events
+
+    from uuid import uuid4
+
+    bulk_id = uuid4().hex
+    rejected: list[dict] = []
+    missing: list[str] = []
+
+    # Split IDs by prefix — same pattern as agent_bulk_approve
+    task_ids: list[str] = []
+    nudge_store_ids: list[str] = []
+    nudge_id_map: dict[str, str] = {}
+    for raw_id in body.ids:
+        if raw_id.startswith("task:"):
+            task_ids.append(raw_id)
+            continue
+        bare = raw_id[len("nudge:") :] if raw_id.startswith("nudge:") else raw_id
+        nudge_store_ids.append(bare)
+        nudge_id_map[bare] = raw_id
+
+    # Handle tasks: block each one so it surfaces in Snags
+    if task_ids:
+        from pocketpaw_ee.cloud.tasks import service as tasks_service
+        from pocketpaw_ee.cloud.tasks.dto import BlockTaskRequest
+
+        for raw_id in task_ids:
+            task_id = _classify_task_id(raw_id)
+            if task_id is None:
+                missing.append(raw_id)
+                continue
+            try:
+                result = await tasks_service.agent_block_task(
+                    ctx,
+                    task_id,
+                    BlockTaskRequest(reason=body.reason),
+                )
+                rejected.append(result.model_dump(mode="json"))
+            except Exception as e:
+                logger.info("bulk_reject: task %s failed: %s", raw_id, e)
+                missing.append(raw_id)
+
+    # Handle nudges via Instinct store
+    if nudge_store_ids:
+        visible = await _visible_pocket_ids(ctx)
+        store = get_instinct_store()
+        eligible, blocked = await _split_ids_by_tenancy(store, nudge_store_ids, visible)
+        nudge_rejected, nudge_missing, _ = await store.bulk_reject(
+            eligible, reason=body.reason, rejector=ctx.user_id
+        )
+        rejected.extend(a.model_dump(mode="json") for a in nudge_rejected)
+        missing.extend(nudge_id_map.get(mid, mid) for mid in nudge_missing)
+        missing.extend(nudge_id_map.get(bid, bid) for bid in blocked)
+
+    # no-event: per-item block/reject inside the loops already emit events
     return {
         "bulk_id": bulk_id,
-        "rejected": [a.model_dump(mode="json") for a in rejected],
-        "missing": [*missing, *blocked],
+        "rejected": rejected,
+        "missing": missing,
     }
 
 

--- a/ee/pocketpaw_ee/cloud/tasks/service.py
+++ b/ee/pocketpaw_ee/cloud/tasks/service.py
@@ -498,8 +498,9 @@ async def agent_block_task(
     body = BlockTaskRequest.model_validate(body)
     doc = await _fetch_task(ctx, task_id)
     if doc.creator_id != ctx.user_id and doc.assignee_id != ctx.user_id:
-        # Only the creator or assignee can flag a task blocked.
-        raise Forbidden("task.block_denied", "Only the creator or assignee can block this task")
+        # Workspace owners can also block tasks (bulk reject from MC feed).
+        if not await _is_workspace_owner(ctx.user_id, doc.workspace_id):
+            raise Forbidden("task.block_denied", "Only the creator or assignee can block this task")
     doc.status = "blocked"
     doc.blocked_reason = body.reason
     await doc.save()


### PR DESCRIPTION
## Summary

Three features + one fix for sprint management in Mission Control:

### 1. Start Sprint Button
Previously sprints auto-started based on date comparison. Now sprints are always created as "upcoming" and have a **Start sprint** button to manually transition them to active.

**Backend:** `POST /cycles/{id}/start` endpoint + `agent_start_cycle()` service with overlap validation
**Frontend:** Start button in both the sidebar cycle list and the sprint detail panel

### 2. Remove Items from Sprint
Sprint items can now be removed from a sprint. A **Remove** button appears on each sprint item row (fades in on hover) and detaches the item by clearing its `cycle_id`.

**Backend:** `POST /mission-control/cycles/{cycle_id}/items/detach` endpoint + `agent_detach_cycle_items()` service
**Frontend:** Remove button in sprint items list with optimistic UI update

### 3. Fix: Done Button on Sprint Items (cycles list)
The "Done" button in the sprint items list was sending bare IDs (`t_xxx`) to the bulk-approve endpoint, but the backend routes bare IDs to the nudge service via `_classify_task_id`. Fixed by prefixing with `task:` so it routes to the tasks service. Also fixed reactivity via `bind:cycleItems`.

### 4. Fix: Reject Button in Feed tab
The reject button in the Feed tab was not working for Task items. The backend `agent_bulk_reject` only handled Instinct Nudges — `task:` prefixed IDs were passed to the Instinct store which silently dropped them. Updated to split IDs by prefix (same pattern as `agent_bulk_approve`) and route task IDs through `tasks.service.agent_block_task` so rejected tasks surface in the Snags section. Also added workspace-owner bypass to `agent_block_task` (matching `agent_complete_task`) so operators can reject any task in their workspace.

### Files changed
- `ee/pocketpaw_ee/cloud/cycles/service.py` — `agent_start_cycle()` + `agent_list_cycle_items()`
- `ee/pocketpaw_ee/cloud/cycles/router.py` — `POST /{cycle_id}/start` route
- `ee/pocketpaw_ee/cloud/mission_control/service.py` — `agent_detach_cycle_items()`, fixed `agent_bulk_reject()` to handle task IDs
- `ee/pocketpaw_ee/cloud/mission_control/router.py` — `POST /cycles/{cycle_id}/items/detach` route
- `ee/pocketpaw_ee/cloud/mission_control/dto.py` — `DetachCycleItemsRequest/Response`
- `ee/pocketpaw_ee/cloud/tasks/service.py` — workspace-owner bypass in `agent_block_task`