### PR TITLE
Cloud connector state rehydrates through the store seam

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,10 @@
 <!--
   Connectors documentation.
+  Updated: 2026-06-12 (connector-store-unification CS-6) — added the
+  "Lifecycle: definitions, state, cache" section: the three layers a connector
+  lives in (YAML definitions with two scan dirs + CWD precedence, the durable
+  state store at ~/.pocketpaw/connectors/state, and the in-memory adapter
+  cache), restart semantics, and the presence-based "connected" status.
   Updated: 2026-06-11 (connector cookie/session auth) — documented two new
   auth methods on the DirectREST engine: `cookie` (emits a Cookie: header from
   a declared credential, name set via auth.credential) and `header` (emits an
@@ -57,6 +62,45 @@ pocket.db (data lands in SQLite tables)
     ↓
 Pocket widgets auto-update with fresh data
 ```
+
+## Lifecycle: definitions, state, cache
+
+A connector lives in three layers with different lifetimes:
+
+| Layer | What it holds | Where | Lifetime |
+|-------|--------------|-------|----------|
+| **Definition** | What the connector *is* — endpoints, auth schema, actions | `~/.pocketpaw/connectors/*.yaml`, then `connectors/*.yaml` (CWD) | As long as the file exists |
+| **State** | That a connector *is configured* — the config passed to `/connect`, keyed by (name, pocket) | `~/.pocketpaw/connectors/state/*.json` (the durable state store) | Until `/disconnect` |
+| **Cache** | Live adapter instances (HTTP clients, DB pools, OAuth sessions) | In-memory, per process | Until the process exits |
+
+**Definition scan.** The registry scans the home dir
+(`~/.pocketpaw/connectors/`) first, then the CWD `connectors/` dir. On a name
+collision the CWD definition wins — deploys override user-installed
+definitions. A definition dropped in after startup is picked up on the next
+lookup miss (the registry rescans cheaply instead of requiring a restart).
+
+**State.** `/connect` is write-through: the config is persisted to the state
+store before the adapter connects, and rolled back if the connect fails.
+`/disconnect` deletes the row. State files are chmod 0600 and live under a
+0700 dir — the config can carry credentials, same posture as the OAuth token
+store.
+
+**Restart semantics.** The cache dies with the process; definitions and state
+do not. After a restart the list/detail/status endpoints report a configured
+connector as `connected` (derived from definition-present + config-persisted,
+never from the in-memory adapter map), and `/execute` lazily reconnects the
+adapter from the persisted config via `ensure_connected` — no manual
+re-`/connect` step.
+
+**What "connected" means.** Status is a *presence* semantic: a definition
+exists and config is persisted. It does not probe the remote service per
+request — a revoked API key still shows `connected` until an execute fails.
+Use a connector's `health()` for a live check.
+
+**Orphaned state.** A state row whose definition is gone (YAML deleted, or a
+deploy dropped it) surfaces in list/status as `definition_missing` instead of
+disappearing or crashing. It heals automatically once the definition is back,
+or can be cleared with `/disconnect`.
 
 ## Writing a Connector YAML
 

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -25,6 +25,14 @@
 #   ``backend_type="connector"`` backend. Keeps the WorkspaceConnector Beanie
 #   read in THIS service (the owner of the connector docs) so the pockets
 #   service never imports the connector model.
+# Updated: 2026-06-12 (connector-store-unification CS-3) — the cloud
+#   ``execute()`` path now goes through ``registry.ensure_connected`` (scope
+#   keys ``pocket:<pocket_id>`` / ``ws:<workspace_id>``) backed by the
+#   WorkspaceConnector state store, so a fresh process executes from a seeded
+#   doc with NO prior /connect; the inline ``adapter._connected`` check is
+#   gone. ``enable_connector`` / ``update_config`` / ``disable_connector``
+#   drop any live registry adapter for the touched row so the next execute
+#   rehydrates with current config instead of serving a stale connection.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -172,6 +180,27 @@ async def _rederive_pocket_surface_profile(workspace_id: str, pocket_id: str) ->
     await apply_derived_surface_profile(workspace_id, pocket_id, profile)
 
 
+async def _drop_live_adapter(doc: _WCDoc) -> None:
+    """Drop any live registry adapter for this row's scope keys.
+
+    Called after enable/disable/config writes so the next execute rehydrates
+    through ``ensure_connected`` with the row's CURRENT state instead of
+    serving an adapter connected with stale config (or one for a row that was
+    just disabled). ``registry.disconnect`` closes the adapter's held handles;
+    the durable row itself is untouched — the cloud state store's delete is a
+    deliberate no-op for namespaced keys (see ``state_provider.py``).
+    """
+    reg = _get_registry()
+    keys = [f"ws:{doc.workspace}"]
+    if doc.pocket_id:
+        keys.append(f"pocket:{doc.pocket_id}")
+    for key in keys:
+        try:
+            await reg.disconnect(key, doc.name)
+        except Exception as exc:  # noqa: BLE001 — best-effort cache drop
+            logger.warning("live adapter drop failed for %s (%s): %s", doc.name, key, exc)
+
+
 # ---------------------------------------------------------------------------
 # Mapping helpers
 # ---------------------------------------------------------------------------
@@ -298,6 +327,9 @@ async def enable_connector(
         if body.config:
             doc.config = body.config
         await doc.save()
+        # Re-enable may have changed config/scope — a live adapter from a
+        # previous execute must not keep serving the old connection.
+        await _drop_live_adapter(doc)
 
     a = available[name]
     await event_bus.emit(
@@ -343,6 +375,9 @@ async def disable_connector(workspace_id: str, name: str) -> ConnectorResponse:
     pocket_id_for_rederive = doc.pocket_id
     doc.enabled = False
     await doc.save()
+    # A disabled connector must stop executing immediately — drop any live
+    # adapter so the next execute can't reuse the old connection.
+    await _drop_live_adapter(doc)
     await event_bus.emit(
         "connector.disabled",
         {"workspace_id": workspace_id, "name": name},
@@ -379,6 +414,9 @@ async def update_config(
         raise NotFound("connector", name)
     doc.config = {**doc.config, **body.config}
     await doc.save()
+    # Config changed — drop any live adapter so the next execute reconnects
+    # with the patched config instead of the one it was built with.
+    await _drop_live_adapter(doc)
     await event_bus.emit(
         "connector.config_updated",
         {"workspace_id": workspace_id, "name": name},
@@ -708,15 +746,29 @@ async def execute(
             "which isn't connected. Open your local app and retry.",
         )
 
-    # CLOUD path — run in-process. Connect first if needed, using the
-    # workspace's saved config from the connector entity.
-    doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
-    config = dict(doc.config) if doc else {}
-    pocket_key = body.pocket_id or workspace_id
-    if not adapter._connected:  # noqa: SLF001 — adapter API doesn't expose is_connected
-        await adapter.connect(pocket_key, config)
+    # CLOUD path — run in-process through the registry's durable seam (CS-3).
+    # ``ensure_connected`` rehydrates the adapter from the WorkspaceConnector
+    # row's config on a fresh process, so execute works with no prior
+    # /connect call. Pocket-keyed lookup is gated on the tenant bind check —
+    # ``pocket:<pocket_id>`` alone carries no workspace filter, so an
+    # unverified foreign pocket_id must never select another tenant's config.
+    exec_adapter = None
+    if body.pocket_id and await is_connector_bound_to_pocket(workspace_id, body.pocket_id, name):
+        exec_adapter = await reg.ensure_connected(name, f"pocket:{body.pocket_id}")
+    if exec_adapter is None:
+        exec_adapter = await reg.ensure_connected(name, f"ws:{workspace_id}")
+    if exec_adapter is None:
+        # Legacy fallback — no enabled row with usable config (or the
+        # reconnect failed). Preserve the pre-CS-3 semantics: one-shot
+        # adapter, best-effort connect with whatever the workspace row
+        # carries, and let the adapter surface its own failure on execute.
+        doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+        config = dict(doc.config) if doc else {}
+        pocket_key = body.pocket_id or workspace_id
+        exec_adapter = adapter
+        await exec_adapter.connect(pocket_key, config)
 
-    result = await adapter.execute(body.action, body.params)
+    result = await exec_adapter.execute(body.action, body.params)
     return ExecuteActionResponse(
         success=result.success,
         data=result.data,

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -33,6 +33,10 @@
 #   gone. ``enable_connector`` / ``update_config`` / ``disable_connector``
 #   drop any live registry adapter for the touched row so the next execute
 #   rehydrates with current config instead of serving a stale connection.
+# Updated: 2026-06-12 (PR #1449 review fix) — the legacy one-shot fallback in
+#   ``execute()`` filters its doc read on ``enabled == True``, so a disabled
+#   row's credentials can never connect through the fallback: disable now
+#   revokes on every execute path, not just the durable seam.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -759,10 +763,18 @@ async def execute(
         exec_adapter = await reg.ensure_connected(name, f"ws:{workspace_id}")
     if exec_adapter is None:
         # Legacy fallback — no enabled row with usable config (or the
-        # reconnect failed). Preserve the pre-CS-3 semantics: one-shot
-        # adapter, best-effort connect with whatever the workspace row
-        # carries, and let the adapter surface its own failure on execute.
-        doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+        # reconnect failed). Preserve the pre-CS-3 shape (one-shot adapter,
+        # best-effort connect, the adapter surfaces its own failure on
+        # execute) for ENABLED rows only: the enabled filter below is what
+        # makes disable actually revoke on this path — a disabled row's
+        # credentials must never reach connect(), so a disabled (or
+        # never-enabled) connector gets {} config and real adapters fail
+        # to connect.
+        doc = await _WCDoc.find_one(
+            _WCDoc.workspace == workspace_id,
+            _WCDoc.name == name,
+            _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+        )
         config = dict(doc.config) if doc else {}
         pocket_key = body.pocket_id or workspace_id
         exec_adapter = adapter

--- a/ee/pocketpaw_ee/cloud/connectors/state_provider.py
+++ b/ee/pocketpaw_ee/cloud/connectors/state_provider.py
@@ -1,0 +1,163 @@
+# Cloud connector state store — durable connector config from WorkspaceConnector docs.
+# Created: 2026-06-12 (connector-store-unification CS-3) — The OSS registry's
+#   restart-survival seam (ConnectorStateStore) backed by the cloud DB instead
+#   of ~/.pocketpaw files. ``registry.ensure_connected`` on a fresh process
+#   reads the connector's config straight from the ``WorkspaceConnector``
+#   Beanie doc, so a cloud execute succeeds with no prior /connect call.
+#   Discovered by core via the ``pocketpaw.connector_state_stores``
+#   entry-point (see ``CloudConnectorStateStoreProvider`` in
+#   ``pocketpaw_ee/extensions.py``); core never imports this module.
+#
+# Scope-key namespacing (the contract with ``connectors/service.py``):
+#   ``ws:<workspace_id>``     — the workspace's row for a connector name
+#                               (workspace tenancy filter; scope-agnostic to
+#                               match the legacy execute() doc lookup).
+#   ``pocket:<pocket_id>``    — the row bound to one pocket (scope=="pocket").
+#                               Callers MUST validate the pocket belongs to
+#                               the caller's workspace before composing this
+#                               key (service.execute gates with
+#                               ``is_connector_bound_to_pocket``).
+#   anything else             — delegated to the file store, so the
+#                               single-tenant OSS surfaces (/api/v1/connectors,
+#                               agent connector tools) keep their exact
+#                               behavior in a cloud install.
+#
+# Ownership: the WorkspaceConnector row LIFECYCLE belongs to
+# ``connectors/service.py`` (enable/disable/update_config). This module is the
+# read-mostly sister seam of the same entity: ``get`` reads config, ``set``
+# only mirrors config onto an EXISTING row, ``delete`` is a deliberate no-op
+# for namespaced keys (a registry-level disconnect must drop the live adapter
+# without destroying service-owned durable state). ``list`` is sync (the
+# registry's sync ``status()`` calls it) and returns the file-delegate rows
+# only — cloud rows are tenant-scoped and surface through the cloud DTOs.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+logger = logging.getLogger(__name__)
+
+_WS_PREFIX = "ws:"
+_POCKET_PREFIX = "pocket:"
+
+
+def _parse_scope_key(scope_key: str) -> tuple[str, str] | None:
+    """Split a namespaced scope key into ``(kind, ident)``, or ``None``.
+
+    Non-namespaced keys (the OSS single-tenant path) return ``None`` and are
+    delegated to the file store.
+    """
+    if scope_key.startswith(_WS_PREFIX):
+        return ("ws", scope_key[len(_WS_PREFIX) :])
+    if scope_key.startswith(_POCKET_PREFIX):
+        return ("pocket", scope_key[len(_POCKET_PREFIX) :])
+    return None
+
+
+class CloudConnectorStateStore:
+    """``ConnectorStateStore`` backed by the ``WorkspaceConnector`` Beanie doc.
+
+    ``get``/``set``/``delete`` are async for namespaced keys (the registry
+    awaits awaitable results); non-namespaced keys delegate to the sync file
+    store. Every Beanie failure is soft — a registry built where the cloud DB
+    isn't initialized (OSS tests, partial installs) degrades to "no persisted
+    cloud config" instead of crashing connector support.
+    """
+
+    def __init__(self, file_fallback: FileConnectorStateStore | None = None) -> None:
+        self._file = file_fallback or FileConnectorStateStore()
+
+    # -- internals ----------------------------------------------------------
+
+    async def _find_doc(self, name: str, kind: str, ident: str) -> Any | None:
+        """Resolve the enabled WorkspaceConnector row for a namespaced key."""
+        from pocketpaw_ee.cloud.models.connector import WorkspaceConnector as _WCDoc
+
+        if kind == "ws":
+            # Workspace key: tenancy filter only, scope-agnostic — mirrors the
+            # legacy execute() lookup (workspace + name), so a pocket- or
+            # user-scoped row still rehydrates a workspace-keyed execute.
+            return await _WCDoc.find_one(
+                _WCDoc.workspace == ident,
+                _WCDoc.name == name,
+                _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+            )
+        return await _WCDoc.find_one(
+            _WCDoc.pocket_id == ident,
+            _WCDoc.scope == "pocket",
+            _WCDoc.name == name,
+            _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+        )
+
+    # -- ConnectorStateStore --------------------------------------------------
+
+    def get(self, name: str, scope_key: str) -> Any:
+        parsed = _parse_scope_key(scope_key)
+        if parsed is None:
+            return self._file.get(name, scope_key)
+        return self._get_cloud(name, *parsed)
+
+    async def _get_cloud(self, name: str, kind: str, ident: str) -> dict[str, Any] | None:
+        try:
+            doc = await self._find_doc(name, kind, ident)
+        except Exception as exc:  # noqa: BLE001 — degrade, don't break connectors
+            logger.warning("cloud connector state read failed for %s: %s", name, exc)
+            return None
+        if doc is None:
+            return None
+        # An enabled row with empty config is still a valid binding (CLI/no-cred
+        # connectors) — return the dict, never coerce {} to None.
+        return dict(doc.config)
+
+    def set(self, name: str, scope_key: str, config: dict[str, Any]) -> Any:
+        parsed = _parse_scope_key(scope_key)
+        if parsed is None:
+            return self._file.set(name, scope_key, config)
+        return self._set_cloud(name, *parsed, config=config)
+
+    async def _set_cloud(self, name: str, kind: str, ident: str, *, config: dict[str, Any]) -> None:
+        """Mirror config onto an existing row — never create one.
+
+        Row creation (with its scope/tenancy validation) belongs to
+        ``service.enable_connector``; a registry-seam write for a key with no
+        row is logged and skipped so the seam can't conjure tenant state.
+        """
+        try:
+            doc = await self._find_doc(name, kind, ident)
+            if doc is None:
+                logger.warning(
+                    "no WorkspaceConnector row for %s (%s:%s) — rows are created via "
+                    "enable_connector; skipping registry config write",
+                    name,
+                    kind,
+                    ident,
+                )
+                return
+            doc.config = dict(config)
+            # no-event: registry-seam config mirror of a row the connectors
+            # service owns; service-level writes emit their own events.
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001 — degrade, don't break connectors
+            logger.warning("cloud connector state write failed for %s: %s", name, exc)
+
+    def delete(self, name: str, scope_key: str) -> Any:
+        parsed = _parse_scope_key(scope_key)
+        if parsed is None:
+            return self._file.delete(name, scope_key)
+        # Deliberate no-op for namespaced keys: the WorkspaceConnector row
+        # lifecycle is owned by enable/disable_connector. A registry-level
+        # disconnect() against a cloud key only needs the LIVE adapter dropped;
+        # destroying the durable row here would let a registry rollback wipe
+        # service-owned state.
+        logger.debug("skipping registry delete for cloud connector row %s (%s)", name, scope_key)
+        return None
+
+    def list(self) -> list[tuple[str, str]]:
+        # Sync by contract (the registry's sync status() calls it). Cloud rows
+        # are tenant-scoped and never match a single-tenant pocket filter, so
+        # they are intentionally not enumerated here — the cloud status/list
+        # DTOs derive from WorkspaceConnector docs in connectors/service.py.
+        return self._file.list()

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -59,6 +59,12 @@ agent proposes a connector call through Instinct; the ee instinct router fires
 approval. Propose-only — the tool never fires the connector itself. Ambient
 (not opt-in).
 
+Updated: 2026-06-12 (connector-store-unification CS-3) — added
+``CloudConnectorStateStoreProvider`` (``pocketpaw.connector_state_stores``)
+supplying the ``WorkspaceConnector``-backed ``CloudConnectorStateStore`` as the
+ConnectorRegistry's default durable state store, so cloud connector config
+rehydrates from the tenant DB after a process restart (no /connect needed).
+
 Updated: 2026-06-11 (feat/fabric-instinct-mcp-providers) — added
 ``CloudFabricMcpProvider`` (entry ``fabric``; server ``pocketpaw_fabric``,
 tools ``fabric_query`` / ``fabric_stats``) and ``CloudInstinctMcpProvider``
@@ -862,6 +868,24 @@ class CloudAgentExtension:
             if value:
                 env[var] = str(value)
         return env
+
+
+class CloudConnectorStateStoreProvider:
+    """`pocketpaw.connector_state_stores` — durable connector state from the
+    cloud DB.
+
+    Backs the ConnectorRegistry's restart-survival seam with the
+    ``WorkspaceConnector`` Beanie doc (namespaced ``ws:<workspace_id>`` /
+    ``pocket:<pocket_id>`` scope keys; everything else delegates to the OSS
+    file store). With this registered, ``registry.ensure_connected`` on a
+    fresh process rehydrates a connector from its workspace row — a cloud
+    execute needs no prior /connect call.
+    """
+
+    def get_state_store(self) -> Any:
+        from pocketpaw_ee.cloud.connectors.state_provider import CloudConnectorStateStore
+
+        return CloudConnectorStateStore()
 
 
 class CloudComposioToolProvider:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -6,6 +6,10 @@
 # depends on the OSS core package `pocketpaw`.
 #
 # Changes:
+#   - 2026-06-12 (connector-store-unification CS-3): registered the
+#     `pocketpaw.connector_state_stores` entry-point
+#     (CloudConnectorStateStoreProvider) so the ConnectorRegistry's durable
+#     state defaults to the WorkspaceConnector-backed cloud store.
 #   - 2026-06-10 (sov/w0a-license): added the `pocketpaw-ee-license`
 #     console script (operator license MINTING / keypair / verify) — see
 #     `[project.scripts]` and `pocketpaw_ee/cloud/mint.py`.
@@ -207,6 +211,9 @@ cloud = "pocketpaw_ee.extensions:CloudAgentExtension"
 
 [project.entry-points."pocketpaw.composio_tools"]
 cloud = "pocketpaw_ee.extensions:CloudComposioToolProvider"
+
+[project.entry-points."pocketpaw.connector_state_stores"]
+cloud = "pocketpaw_ee.extensions:CloudConnectorStateStoreProvider"
 
 [tool.hatch.metadata]
 # Allow git+ direct references in dependencies (PEP 440 disallows them

--- a/src/pocketpaw/api/v1/connectors.py
+++ b/src/pocketpaw/api/v1/connectors.py
@@ -3,6 +3,13 @@
 # Updated: 2026-04-19 (Cluster C / PR2) — Added GET /connectors/{kind}/status
 #   returning a structured {connected, last_sync, cred_state, scope} payload
 #   for the ConnectorCard UI. Gap C5 in docs/plans/FEATURE-HARDENING-PLAN.md.
+# Updated: 2026-06-12 (connector-store-unification CS-6) — Endpoints stop
+#   lying after a restart. /status and the list/detail status fields derive
+#   "connected" from the registry's durable state (definition + persisted
+#   config) instead of the in-process adapter map; /execute calls
+#   registry.ensure_connected() so a configured connector works without a
+#   prior /connect in the same process; the list endpoint surfaces orphaned
+#   state rows (config persisted, definition gone) as "definition_missing".
 
 from __future__ import annotations
 
@@ -15,6 +22,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from pocketpaw.api.deps import require_scope
+from pocketpaw.connectors.protocol import ConnectorStatus
 from pocketpaw.connectors.registry import ConnectorRegistry
 
 logger = logging.getLogger(__name__)
@@ -178,8 +186,13 @@ async def get_connector_status(
 
         raise HTTPException(status_code=404, detail=f"Connector '{connector_name}' not found")
 
-    adapter = reg.get_adapter(pocket_id, connector_name)
-    connected = adapter is not None
+    # Derive "connected" from the registry's durable state (definition +
+    # persisted config), not from the in-process adapter map — a configured
+    # connector stays connected across restarts (CS-6).
+    connected = any(
+        s["name"] == connector_name and s["status"] == ConnectorStatus.CONNECTED
+        for s in reg.status(pocket_id)
+    )
 
     extras = _STATUS_EXTRAS.get(_extras_key(pocket_id, connector_name), {})
     cred_state = extras.get("cred_state") or ("valid" if connected else "missing")
@@ -198,11 +211,18 @@ async def get_connector_status(
 
 @router.get("/connectors", response_model=list[ConnectorInfo])
 async def list_connectors(pocket_id: str = "default"):
-    """List all available connectors with their connection status."""
-    reg = _get_registry()
-    status_map = {s["name"]: s["status"].value for s in reg.status(pocket_id)}
+    """List all available connectors with their connection status.
 
-    return [
+    Status comes from ``registry.status()``, which derives "connected" from
+    durable state, so the list is truthful after a restart. Orphaned state
+    rows (config persisted but the YAML definition is gone) are appended
+    with status ``definition_missing`` rather than silently dropped.
+    """
+    reg = _get_registry()
+    reg_status = reg.status(pocket_id)
+    status_map = {s["name"]: s["status"].value for s in reg_status}
+
+    infos = [
         ConnectorInfo(
             name=c["name"],
             display_name=c["display_name"],
@@ -212,6 +232,19 @@ async def list_connectors(pocket_id: str = "default"):
         )
         for c in reg.available
     ]
+    known = {c["name"] for c in reg.available}
+    infos.extend(
+        ConnectorInfo(
+            name=s["name"],
+            display_name=s["display_name"],
+            type="unknown",
+            icon=s.get("icon", "plug"),
+            status=s["status"].value,
+        )
+        for s in reg_status
+        if s["name"] not in known and s["status"] == ConnectorStatus.DEFINITION_MISSING
+    )
+    return infos
 
 
 @router.get("/connectors/{connector_name}", response_model=ConnectorDetailResponse)
@@ -307,11 +340,17 @@ async def disconnect_connector(req: DisconnectRequest):
 
 @router.post("/connectors/execute", response_model=ExecuteResponse)
 async def execute_connector_action(req: ExecuteRequest):
-    """Execute an action on a connected data source."""
+    """Execute an action on a connected data source.
+
+    Uses ``registry.ensure_connected()`` instead of assuming a prior
+    /connect in the same process: if the adapter isn't live but config is
+    persisted in the state store (e.g. after a restart), the registry
+    reconnects on the fly (CS-6).
+    """
     from datetime import datetime
 
     reg = _get_registry()
-    adapter = reg.get_adapter(req.pocket_id, req.connector_name)
+    adapter = await reg.ensure_connected(req.connector_name, req.pocket_id)
     if not adapter:
         return ExecuteResponse(
             success=False,

--- a/src/pocketpaw/connectors/db_adapter.py
+++ b/src/pocketpaw/connectors/db_adapter.py
@@ -2,6 +2,11 @@
 # Created: 2026-03-30
 # Supports: PostgreSQL, MySQL, MariaDB, SQLite, MSSQL, CockroachDB, etc.
 # Uses sqlalchemy async engine under the hood — single dependency for all databases.
+# Updated: 2026-06-12 (connector-store-unification CS-5) — reconnect-safe
+#   connect(): a second connect() disposes the previous engine before building
+#   a new one (no leaked pool on double-connect / config change), and a failed
+#   connect resets ``_connected`` so the adapter never reports a connection it
+#   no longer has.
 
 from __future__ import annotations
 
@@ -140,6 +145,14 @@ class DatabaseAdapter:
         # Check the async driver is installed
         pip_pkg = self._dialect.get("pip", "")
         try:
+            # Reconnect-safety (CS-5): a second connect() — config change,
+            # post-restart recovery race — must not leak the previous
+            # engine's connection pool.
+            if self._engine is not None:
+                await self._engine.dispose()
+                self._engine = None
+                self._connected = False
+
             url = self._build_url(normalized)
             ssl_args: dict[str, Any] = {}
             if normalized.get("DB_SSL", "").lower() == "true":
@@ -169,6 +182,7 @@ class DatabaseAdapter:
                 message=f"Connected to {db_name}@{host}",
             )
         except ImportError:
+            self._connected = False
             return ConnectionResult(
                 success=False,
                 connector_name=self.name,
@@ -177,6 +191,7 @@ class DatabaseAdapter:
             )
         except Exception as e:
             self._engine = None
+            self._connected = False
             return ConnectionResult(
                 success=False,
                 connector_name=self.name,

--- a/src/pocketpaw/connectors/mongo_adapter.py
+++ b/src/pocketpaw/connectors/mongo_adapter.py
@@ -1,5 +1,10 @@
 # MongoDB adapter — document database connector via motor (async pymongo).
 # Created: 2026-03-30
+# Updated: 2026-06-12 (connector-store-unification CS-5) — reconnect-safe
+#   connect(): a second connect() closes the previous motor client before
+#   building a new one (no leaked socket pool on double-connect / config
+#   change), and a failed connect resets ``_connected`` so the adapter never
+#   reports a connection it no longer has.
 
 from __future__ import annotations
 
@@ -70,6 +75,15 @@ class MongoDBAdapter:
             )
 
         try:
+            # Reconnect-safety (CS-5): a second connect() — config change,
+            # post-restart recovery race — must not leak the previous
+            # client's socket pool.
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+                self._db = None
+                self._connected = False
+
             self._client = AsyncIOMotorClient(uri, serverSelectionTimeoutMS=5000)
             # Test connection
             await self._client.admin.command("ping")
@@ -84,6 +98,7 @@ class MongoDBAdapter:
         except Exception as e:
             self._client = None
             self._db = None
+            self._connected = False
             return ConnectionResult(
                 success=False,
                 connector_name=self.name,

--- a/src/pocketpaw/connectors/protocol.py
+++ b/src/pocketpaw/connectors/protocol.py
@@ -9,6 +9,10 @@
 #   methods on ConnectorProtocol. See ee/cloud/connectors/CHARTER.md
 #   §4 + §6.2 for the rationale (CLI connectors can't multi-tenant in
 #   cloud, so the runtime needs to know where each action runs).
+# Updated: 2026-06-12 (connector-store-unification CS-2) — Added
+#   ConnectorStatus.DEFINITION_MISSING for orphaned state rows: config is
+#   persisted in the state store but the connector's YAML definition is
+#   gone (deleted, or the deploy dropped it). Surfaced, never crashed on.
 
 from __future__ import annotations
 
@@ -18,12 +22,19 @@ from typing import Any, Literal, Protocol
 
 
 class ConnectorStatus(StrEnum):
-    """Connection status."""
+    """Connection status.
+
+    ``DEFINITION_MISSING`` marks an orphaned state row: config persisted in
+    the connector state store, but the YAML definition no longer resolves
+    (file deleted, or a deploy dropped it). The row stays visible so the
+    operator can fix or remove it instead of the registry silently hiding it.
+    """
 
     DISCONNECTED = "disconnected"
     CONNECTED = "connected"
     SYNCING = "syncing"
     ERROR = "error"
+    DEFINITION_MISSING = "definition_missing"
 
 
 class TrustLevel(StrEnum):

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -309,6 +309,14 @@ class ConnectorRegistry:
         connected must not read as configured. If a live adapter exists with
         *different* config, it is disconnected first and reconnected with the
         new config. Serialized per key with ``ensure_connected``.
+
+        WARNING: never pass a namespaced (``ws:``/``pocket:``) scope key as
+        ``pocket_id`` — against the EE cloud store, the write-through ``set``
+        would mirror this unproven config onto the service-owned
+        WorkspaceConnector row, and the rollback ``delete`` no-ops there, so
+        a failed connect could not undo it. Cloud rows reconnect through
+        ``ensure_connected`` only; their lifecycle belongs to the connectors
+        service.
         """
         defn = self.get_definition(connector_name)
         if not defn:

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -17,6 +17,15 @@
 #   from persisted config so the execute path no longer assumes a prior
 #   /connect in the same process. ``disconnect()`` deletes the persisted row.
 #   With an empty store, behavior is identical to before.
+# Updated: 2026-06-12 (connector-store-unification CS-2) — Status tells the
+#   truth + home-dir definitions. ``status()`` derives "connected" from
+#   durable state (definition present + config persisted in the state store),
+#   never from the in-process adapter dict, so a fresh process reports the
+#   same status as the one that connected. Definition scan now reads
+#   ~/.pocketpaw/connectors/*.yaml first, then CWD connectors/*.yaml — CWD
+#   wins on name collision (deploys override). ``get_definition`` rescans on
+#   miss. Orphan state rows whose definition is gone surface as
+#   ``definition_missing`` instead of vanishing or crashing.
 
 from __future__ import annotations
 
@@ -126,6 +135,15 @@ def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
     return None
 
 
+def _default_home_connectors_dir() -> Path:
+    """Default home-dir location for user-installed connector definitions.
+
+    Resolved lazily (not at construction) so tests can patch this function
+    and already-built registries pick up the override.
+    """
+    return Path.home() / ".pocketpaw" / "connectors"
+
+
 class ConnectorRegistry:
     """Discovers available connectors and manages instances per pocket."""
 
@@ -134,23 +152,32 @@ class ConnectorRegistry:
         connectors_dir: Path | None = None,
         *,
         state_store: ConnectorStateStore | None = None,
+        home_connectors_dir: Path | None = None,
     ) -> None:
         self._connectors_dir = connectors_dir or Path("connectors")
+        self._home_connectors_dir = home_connectors_dir
         self._state_store: ConnectorStateStore = state_store or FileConnectorStateStore()
         self._definitions: dict[str, ConnectorDef] = {}
         self._instances: dict[str, AnyAdapter] = {}  # key = "{pocket_id}:{connector_name}"
         self._scan()
 
     def _scan(self) -> None:
-        """Scan connectors directory for YAML definitions."""
-        if not self._connectors_dir.exists():
-            return
-        for path in sorted(self._connectors_dir.glob("*.yaml")):
-            try:
-                defn = parse_connector_yaml(path)
-                self._definitions[defn.name] = defn
-            except Exception:
-                pass  # Skip malformed YAMLs
+        """Scan both connector directories for YAML definitions.
+
+        Home dir (``~/.pocketpaw/connectors``) first, then the CWD dir —
+        scanned second so it overwrites on name collision: deploys override
+        user-installed definitions.
+        """
+        home_dir = self._home_connectors_dir or _default_home_connectors_dir()
+        for directory in (home_dir, self._connectors_dir):
+            if not directory.exists():
+                continue
+            for path in sorted(directory.glob("*.yaml")):
+                try:
+                    defn = parse_connector_yaml(path)
+                    self._definitions[defn.name] = defn
+                except Exception:
+                    pass  # Skip malformed YAMLs
 
     @property
     def available(self) -> list[dict[str, str]]:
@@ -178,8 +205,17 @@ class ConnectorRegistry:
         return list(self._definitions.values())
 
     def get_definition(self, name: str) -> ConnectorDef | None:
-        """Get a connector definition by name."""
-        return self._definitions.get(name)
+        """Get a connector definition by name, rescanning once on a miss.
+
+        The rescan is cheap (a few dozen small YAMLs) and lets a definition
+        dropped into either scan dir after registry construction resolve
+        without a process restart.
+        """
+        defn = self._definitions.get(name)
+        if defn is None:
+            self.reload()
+            defn = self._definitions.get(name)
+        return defn
 
     def get_adapter(self, pocket_id: str, connector_name: str) -> AnyAdapter | None:
         """Get an active adapter instance for a pocket+connector."""
@@ -282,19 +318,41 @@ class ConnectorRegistry:
         return True
 
     def status(self, pocket_id: str) -> list[dict[str, Any]]:
-        """Get connection status for all connectors in a pocket."""
+        """Get connection status for all connectors in a pocket.
+
+        "Connected" is derived from durable state — definition present +
+        config persisted in the state store — never from the in-process
+        adapter dict, so a fresh process reports the same status as the one
+        that ran /connect. Persisted rows whose definition no longer resolves
+        surface as ``definition_missing`` instead of disappearing.
+        """
+        persisted = {name for name, scope in self._state_store.list() if scope == pocket_id}
+        orphans = persisted - set(self._definitions)
+        if orphans:
+            # A definition may have landed since the last scan — rescan once
+            # before declaring rows orphaned.
+            self.reload()
+            orphans = persisted - set(self._definitions)
+
         results = []
         for name, defn in self._definitions.items():
-            key = f"{pocket_id}:{name}"
-            adapter = self._instances.get(key)
             results.append(
                 {
                     "name": name,
                     "display_name": defn.display_name,
                     "icon": defn.icon,
                     "status": ConnectorStatus.CONNECTED
-                    if adapter
+                    if name in persisted
                     else ConnectorStatus.DISCONNECTED,
+                }
+            )
+        for name in sorted(orphans):
+            results.append(
+                {
+                    "name": name,
+                    "display_name": name,
+                    "icon": "plug",
+                    "status": ConnectorStatus.DEFINITION_MISSING,
                 }
             )
         return results

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -38,10 +38,20 @@
 #   *raises*, not just when it returns a failure result; (3) connect() routes
 #   through get_definition() so a YAML dropped in after startup is connectable
 #   without a restart (it was already visible to detail/status).
+# Updated: 2026-06-12 (connector-store-unification CS-3) — The default state
+#   store is now pluggable: when no explicit ``state_store`` is passed, the
+#   registry asks the ``pocketpaw.connector_state_stores`` entry-point group
+#   (see ``ConnectorStateStoreProvider`` in pocketpaw/extensions.py) before
+#   falling back to FileConnectorStateStore — so an EE install transparently
+#   backs every registry with the cloud DB. Store ``get``/``set``/``delete``
+#   calls on async paths go through ``_maybe_await`` so an async (DB-backed)
+#   store and the sync file store both work behind the same seam.
 
 from __future__ import annotations
 
 import asyncio
+import inspect
+import logging
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -53,6 +63,21 @@ from pocketpaw.connectors.protocol import (
 )
 from pocketpaw.connectors.state_store import ConnectorStateStore, FileConnectorStateStore
 from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter, parse_connector_yaml
+
+logger = logging.getLogger(__name__)
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Await *value* if it is awaitable, else return it as-is.
+
+    The seam that lets one registry speak to both store shapes: the sync
+    file store returns plain values; the EE cloud store's ``get``/``set``/
+    ``delete`` are async (Beanie). Only ``list`` must stay sync — it is
+    called from the sync ``status()``.
+    """
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
 @runtime_checkable
@@ -157,6 +182,28 @@ def _default_home_connectors_dir() -> Path:
     return Path.home() / ".pocketpaw" / "connectors"
 
 
+def _provider_state_store() -> ConnectorStateStore | None:
+    """State store from the ``pocketpaw.connector_state_stores`` entry-point.
+
+    Same discovery pattern as every other extension point (see
+    ``pocketpaw.extensions.ConnectorStateStoreProvider``): an OSS install
+    finds no provider and returns ``None``; a cloud install returns the
+    DB-backed store so connector config rehydrates from the tenant database
+    after a restart. A provider that blows up is skipped — a broken plugin
+    must not take connector support down with it.
+    """
+    from pocketpaw._registry import first
+
+    provider = first("pocketpaw.connector_state_stores")
+    if provider is None:
+        return None
+    try:
+        return provider.get_state_store()
+    except Exception as exc:  # noqa: BLE001 — isolate plugin failures
+        logger.warning("connector state store provider failed, using file store: %s", exc)
+        return None
+
+
 class ConnectorRegistry:
     """Discovers available connectors and manages instances per pocket."""
 
@@ -169,7 +216,9 @@ class ConnectorRegistry:
     ) -> None:
         self._connectors_dir = connectors_dir or Path("connectors")
         self._home_connectors_dir = home_connectors_dir
-        self._state_store: ConnectorStateStore = state_store or FileConnectorStateStore()
+        self._state_store: ConnectorStateStore = (
+            state_store or _provider_state_store() or FileConnectorStateStore()
+        )
         self._definitions: dict[str, ConnectorDef] = {}
         self._instances: dict[str, AnyAdapter] = {}  # key = "{pocket_id}:{connector_name}"
         # Per-key locks serializing the connect paths — see _lock_for().
@@ -268,20 +317,20 @@ class ConnectorRegistry:
         key = f"{pocket_id}:{connector_name}"
         async with self._lock_for(key):
             if key in self._instances:
-                previous = self._state_store.get(connector_name, pocket_id)
+                previous = await _maybe_await(self._state_store.get(connector_name, pocket_id))
                 if previous is not None and previous != config:
                     await self.disconnect(pocket_id, connector_name)
 
-            self._state_store.set(connector_name, pocket_id, config)
+            await _maybe_await(self._state_store.set(connector_name, pocket_id, config))
             try:
                 result = await self._connect_adapter(pocket_id, connector_name, defn, config)
             except BaseException:
                 # adapter.connect blew up (or was cancelled) — the row must
                 # not survive, same invariant as a failure result.
-                self._state_store.delete(connector_name, pocket_id)
+                await _maybe_await(self._state_store.delete(connector_name, pocket_id))
                 raise
             if result is None or not result.success:
-                self._state_store.delete(connector_name, pocket_id)
+                await _maybe_await(self._state_store.delete(connector_name, pocket_id))
             return result
 
     async def _connect_adapter(
@@ -341,7 +390,7 @@ class ConnectorRegistry:
             if adapter is not None:
                 return adapter
 
-            config = self._state_store.get(connector_name, scope_key)
+            config = await _maybe_await(self._state_store.get(connector_name, scope_key))
             if config is None:
                 return None
             defn = self.get_definition(connector_name)
@@ -367,9 +416,9 @@ class ConnectorRegistry:
         adapter = self._instances.pop(key, None)
         if adapter is not None:
             await adapter.disconnect(pocket_id)
-        had_state = self._state_store.get(connector_name, pocket_id) is not None
+        had_state = await _maybe_await(self._state_store.get(connector_name, pocket_id)) is not None
         if had_state:
-            self._state_store.delete(connector_name, pocket_id)
+            await _maybe_await(self._state_store.delete(connector_name, pocket_id))
         return adapter is not None or had_state
 
     def status(self, pocket_id: str) -> list[dict[str, Any]]:

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -7,6 +7,16 @@
 #   ConnectorDef list incl. ``.senses``) so the EE SenseResolver can index
 #   connectors by sense without reaching into the private ``_definitions``
 #   dict. OSS-only change; must not import pocketpaw_ee.
+# Updated: 2026-06-12 (connector-store-unification CS-1) — Connector config now
+#   survives restarts. The registry takes an optional ``state_store``
+#   (default: FileConnectorStateStore at ~/.pocketpaw/connectors/state/).
+#   ``connect()`` is write-through: persist config, then connect the adapter
+#   (rolled back on a failed connect so a bad config never reads as
+#   configured); a live adapter with different config is disconnected and
+#   reconnected. New ``ensure_connected(name, scope_key)`` lazily reconnects
+#   from persisted config so the execute path no longer assumes a prior
+#   /connect in the same process. ``disconnect()`` deletes the persisted row.
+#   With an empty store, behavior is identical to before.
 
 from __future__ import annotations
 
@@ -19,6 +29,7 @@ from pocketpaw.connectors.protocol import (
     ConnectionResult,
     ConnectorStatus,
 )
+from pocketpaw.connectors.state_store import ConnectorStateStore, FileConnectorStateStore
 from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter, parse_connector_yaml
 
 
@@ -118,8 +129,14 @@ def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
 class ConnectorRegistry:
     """Discovers available connectors and manages instances per pocket."""
 
-    def __init__(self, connectors_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        connectors_dir: Path | None = None,
+        *,
+        state_store: ConnectorStateStore | None = None,
+    ) -> None:
         self._connectors_dir = connectors_dir or Path("connectors")
+        self._state_store: ConnectorStateStore = state_store or FileConnectorStateStore()
         self._definitions: dict[str, ConnectorDef] = {}
         self._instances: dict[str, AnyAdapter] = {}  # key = "{pocket_id}:{connector_name}"
         self._scan()
@@ -170,11 +187,44 @@ class ConnectorRegistry:
         return self._instances.get(key)
 
     async def connect(self, pocket_id: str, connector_name: str, config: dict[str, Any]) -> Any:
-        """Create and connect a connector adapter for a pocket."""
+        """Create and connect a connector adapter for a pocket.
+
+        Write-through: the config is persisted to the state store before the
+        adapter connects, so the binding survives a process restart (see
+        ``ensure_connected``). A failed connect rolls the persisted row back —
+        a config that never connected must not read as configured. If a live
+        adapter exists with *different* config, it is disconnected first and
+        reconnected with the new config.
+        """
         defn = self._definitions.get(connector_name)
         if not defn:
             return None
 
+        key = f"{pocket_id}:{connector_name}"
+        if key in self._instances:
+            previous = self._state_store.get(connector_name, pocket_id)
+            if previous is not None and previous != config:
+                await self.disconnect(pocket_id, connector_name)
+
+        self._state_store.set(connector_name, pocket_id, config)
+        result = await self._connect_adapter(pocket_id, connector_name, defn, config)
+        if result is None or not result.success:
+            self._state_store.delete(connector_name, pocket_id)
+        return result
+
+    async def _connect_adapter(
+        self,
+        pocket_id: str,
+        connector_name: str,
+        defn: ConnectorDef,
+        config: dict[str, Any],
+    ) -> ConnectionResult:
+        """Build and connect an adapter; register it on success.
+
+        Internal — never touches the state store, so the restart-recovery
+        path (``ensure_connected``) can retry a transient failure without
+        wiping the persisted config.
+        """
         # Use native adapter if available, otherwise fall back to YAML/REST.
         adapter: AnyAdapter
         native = _create_native_adapter(connector_name)
@@ -191,14 +241,44 @@ class ConnectorRegistry:
 
         return result
 
+    async def ensure_connected(self, connector_name: str, scope_key: str) -> AnyAdapter | None:
+        """Return a live adapter for (connector, scope_key), reconnecting if needed.
+
+        The execute path calls this instead of assuming a prior ``connect()``
+        in the same process: if no adapter is live, the persisted config is
+        read from the state store and the adapter reconnects. No-op when
+        already connected (a live adapter always carries the current config —
+        ``connect()`` keeps the store and the instance map in sync). Returns
+        ``None`` when there is no persisted config, the definition is gone,
+        or the reconnect fails; the persisted config is kept either way so a
+        transient failure can be retried.
+        """
+        key = f"{scope_key}:{connector_name}"
+        adapter = self._instances.get(key)
+        if adapter is not None:
+            return adapter
+
+        config = self._state_store.get(connector_name, scope_key)
+        if config is None:
+            return None
+        defn = self.get_definition(connector_name)
+        if defn is None:
+            return None
+
+        result = await self._connect_adapter(scope_key, connector_name, defn, config)
+        if not result.success:
+            return None
+        return self._instances.get(key)
+
     async def disconnect(self, pocket_id: str, connector_name: str) -> bool:
-        """Disconnect a connector from a pocket."""
+        """Disconnect a connector from a pocket and forget its persisted config."""
         key = f"{pocket_id}:{connector_name}"
         adapter = self._instances.get(key)
         if not adapter:
             return False
         await adapter.disconnect(pocket_id)
         del self._instances[key]
+        self._state_store.delete(connector_name, pocket_id)
         return True
 
     def status(self, pocket_id: str) -> list[dict[str, Any]]:

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -26,6 +26,11 @@
 #   wins on name collision (deploys override). ``get_definition`` rescans on
 #   miss. Orphan state rows whose definition is gone surface as
 #   ``definition_missing`` instead of vanishing or crashing.
+# Updated: 2026-06-12 (connector-store-unification CS-6) — ``disconnect()``
+#   now operates on durable state, not just live adapters: it deletes the
+#   persisted row even when no adapter is in memory (post-restart disconnect,
+#   orphan-row cleanup). Returns True when an adapter was disconnected OR a
+#   row was deleted; still False when there was nothing to forget.
 
 from __future__ import annotations
 
@@ -307,15 +312,23 @@ class ConnectorRegistry:
         return self._instances.get(key)
 
     async def disconnect(self, pocket_id: str, connector_name: str) -> bool:
-        """Disconnect a connector from a pocket and forget its persisted config."""
+        """Disconnect a connector from a pocket and forget its persisted config.
+
+        Works on durable state, not just live adapters: after a restart there
+        is no adapter in memory, but the persisted row must still be deletable
+        or the connector could never be disconnected again. Also the only way
+        to clear an orphaned (``definition_missing``) row. Returns ``True``
+        when either a live adapter was disconnected or a persisted row was
+        deleted.
+        """
         key = f"{pocket_id}:{connector_name}"
-        adapter = self._instances.get(key)
-        if not adapter:
-            return False
-        await adapter.disconnect(pocket_id)
-        del self._instances[key]
-        self._state_store.delete(connector_name, pocket_id)
-        return True
+        adapter = self._instances.pop(key, None)
+        if adapter is not None:
+            await adapter.disconnect(pocket_id)
+        had_state = self._state_store.get(connector_name, pocket_id) is not None
+        if had_state:
+            self._state_store.delete(connector_name, pocket_id)
+        return adapter is not None or had_state
 
     def status(self, pocket_id: str) -> list[dict[str, Any]]:
         """Get connection status for all connectors in a pocket.

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -31,9 +31,17 @@
 #   persisted row even when no adapter is in memory (post-restart disconnect,
 #   orphan-row cleanup). Returns True when an adapter was disconnected OR a
 #   row was deleted; still False when there was nothing to forget.
+# Updated: 2026-06-12 (PR #1447 review fixes) — (1) per-key asyncio.Lock
+#   serializes connect()/ensure_connected() so the post-restart thundering
+#   herd (two concurrent executes) can't double-connect and leak the losing
+#   adapter; (2) connect() rolls the persisted row back when adapter.connect
+#   *raises*, not just when it returns a failure result; (3) connect() routes
+#   through get_definition() so a YAML dropped in after startup is connectable
+#   without a restart (it was already visible to detail/status).
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -164,7 +172,22 @@ class ConnectorRegistry:
         self._state_store: ConnectorStateStore = state_store or FileConnectorStateStore()
         self._definitions: dict[str, ConnectorDef] = {}
         self._instances: dict[str, AnyAdapter] = {}  # key = "{pocket_id}:{connector_name}"
+        # Per-key locks serializing the connect paths — see _lock_for().
+        self._connect_locks: dict[str, asyncio.Lock] = {}
         self._scan()
+
+    def _lock_for(self, key: str) -> asyncio.Lock:
+        """Per-(pocket, connector) lock for connect()/ensure_connected().
+
+        Two concurrent executes for the same key right after a restart (the
+        thundering-herd shape ensure_connected creates) would otherwise both
+        build and connect an adapter; the last ``_instances`` write wins and
+        the loser's adapter (DB engine, HTTP client) leaks without a
+        disconnect. ``setdefault`` on a plain dict is safe here — it runs
+        between awaits on the event loop, so no two coroutines can interleave
+        inside it.
+        """
+        return self._connect_locks.setdefault(key, asyncio.Lock())
 
     def _scan(self) -> None:
         """Scan both connector directories for YAML definitions.
@@ -232,26 +255,34 @@ class ConnectorRegistry:
 
         Write-through: the config is persisted to the state store before the
         adapter connects, so the binding survives a process restart (see
-        ``ensure_connected``). A failed connect rolls the persisted row back —
-        a config that never connected must not read as configured. If a live
-        adapter exists with *different* config, it is disconnected first and
-        reconnected with the new config.
+        ``ensure_connected``). A failed connect — failure result *or* raised
+        exception — rolls the persisted row back: a config that never
+        connected must not read as configured. If a live adapter exists with
+        *different* config, it is disconnected first and reconnected with the
+        new config. Serialized per key with ``ensure_connected``.
         """
-        defn = self._definitions.get(connector_name)
+        defn = self.get_definition(connector_name)
         if not defn:
             return None
 
         key = f"{pocket_id}:{connector_name}"
-        if key in self._instances:
-            previous = self._state_store.get(connector_name, pocket_id)
-            if previous is not None and previous != config:
-                await self.disconnect(pocket_id, connector_name)
+        async with self._lock_for(key):
+            if key in self._instances:
+                previous = self._state_store.get(connector_name, pocket_id)
+                if previous is not None and previous != config:
+                    await self.disconnect(pocket_id, connector_name)
 
-        self._state_store.set(connector_name, pocket_id, config)
-        result = await self._connect_adapter(pocket_id, connector_name, defn, config)
-        if result is None or not result.success:
-            self._state_store.delete(connector_name, pocket_id)
-        return result
+            self._state_store.set(connector_name, pocket_id, config)
+            try:
+                result = await self._connect_adapter(pocket_id, connector_name, defn, config)
+            except BaseException:
+                # adapter.connect blew up (or was cancelled) — the row must
+                # not survive, same invariant as a failure result.
+                self._state_store.delete(connector_name, pocket_id)
+                raise
+            if result is None or not result.success:
+                self._state_store.delete(connector_name, pocket_id)
+            return result
 
     async def _connect_adapter(
         self,
@@ -293,23 +324,34 @@ class ConnectorRegistry:
         ``None`` when there is no persisted config, the definition is gone,
         or the reconnect fails; the persisted config is kept either way so a
         transient failure can be retried.
+
+        The miss path is serialized per key (see ``_lock_for``): concurrent
+        post-restart executes wait for the first reconnect instead of each
+        building an adapter and leaking all but the last one.
         """
         key = f"{scope_key}:{connector_name}"
         adapter = self._instances.get(key)
         if adapter is not None:
             return adapter
 
-        config = self._state_store.get(connector_name, scope_key)
-        if config is None:
-            return None
-        defn = self.get_definition(connector_name)
-        if defn is None:
-            return None
+        async with self._lock_for(key):
+            # Re-check under the lock — a racing call may have connected
+            # while this one waited.
+            adapter = self._instances.get(key)
+            if adapter is not None:
+                return adapter
 
-        result = await self._connect_adapter(scope_key, connector_name, defn, config)
-        if not result.success:
-            return None
-        return self._instances.get(key)
+            config = self._state_store.get(connector_name, scope_key)
+            if config is None:
+                return None
+            defn = self.get_definition(connector_name)
+            if defn is None:
+                return None
+
+            result = await self._connect_adapter(scope_key, connector_name, defn, config)
+            if not result.success:
+                return None
+            return self._instances.get(key)
 
     async def disconnect(self, pocket_id: str, connector_name: str) -> bool:
         """Disconnect a connector from a pocket and forget its persisted config.

--- a/src/pocketpaw/connectors/state_store.py
+++ b/src/pocketpaw/connectors/state_store.py
@@ -9,6 +9,10 @@
 #   same prefix never share a file and no key can path-traverse out of the dir.
 #   Files are chmod 0600 (config may carry credentials, same posture as the
 #   OAuth token store).
+# Updated: 2026-06-12 (connector-store-unification CS-3) — Protocol docs note
+#   that implementations may make get/set/delete async (the registry awaits
+#   awaitable results via _maybe_await); list must stay sync. Lets the EE
+#   WorkspaceConnector-backed store satisfy the same seam.
 
 from __future__ import annotations
 
@@ -62,7 +66,14 @@ class ConnectorStateStore(Protocol):
     """Durable store for connector config, keyed by (name, scope_key).
 
     ``scope_key`` is the registry's scoping segment — the pocket_id on the
-    OSS path. Implementations must treat both key parts as untrusted input.
+    OSS path, a namespaced ``ws:<workspace_id>`` / ``pocket:<pocket_id>``
+    key on the cloud path. Implementations must treat both key parts as
+    untrusted input.
+
+    Implementations may make ``get``/``set``/``delete`` async (return an
+    awaitable) — every registry call site on an async path awaits awaitable
+    results (see ``ConnectorRegistry._maybe_await``). ``list`` must stay
+    sync: it is called from the registry's sync ``status()``.
     """
 
     def get(self, name: str, scope_key: str) -> dict[str, Any] | None:

--- a/src/pocketpaw/connectors/state_store.py
+++ b/src/pocketpaw/connectors/state_store.py
@@ -1,0 +1,157 @@
+# Connector state store — durable connector config at ~/.pocketpaw/connectors/state/.
+# Created: 2026-06-12 (connector-store-unification CS-1) — Connector lifecycle
+#   must survive process restarts. The ConnectorRegistry previously held adapter
+#   config only in memory, so every restart silently dropped all connections
+#   until someone re-ran /connect. This module is the durable layer: a small
+#   Protocol (so EE can swap in a DB-backed store) plus the file-backed default.
+#   Naming/sanitization mirrors clients/token_store.py — sanitized human-readable
+#   prefix + short sha256 of the raw value, so distinct keys that sanitize to the
+#   same prefix never share a file and no key can path-traverse out of the dir.
+#   Files are chmod 0600 (config may carry credentials, same posture as the
+#   OAuth token store).
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from pocketpaw.config import get_config_dir
+
+logger = logging.getLogger(__name__)
+
+# Characters safe to use verbatim in an on-disk filename segment. Anything else
+# (e.g. ``@``, ``/``, ``..``) is replaced so a connector name or scope key can
+# never escape the state dir or collide with the segment separator.
+_SAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+
+# Separator between the connector-name segment and the scope-key segment.
+# Double underscore keeps a single underscore inside either value from being
+# mistaken for the boundary (same convention as token_store).
+_SEP = "__"
+
+
+def _default_state_dir() -> Path:
+    """Default on-disk location for connector state.
+
+    Resolved lazily (not at construction) so tests can patch this function
+    and already-built stores pick up the override.
+    """
+    return get_config_dir() / "connectors" / "state"
+
+
+def _segment(value: str) -> str:
+    """Build a filesystem-safe, collision-resistant segment for a key part.
+
+    Sanitized, human-readable prefix for debuggability, plus a short hash of
+    the *raw* value so two distinct values that sanitize to the same prefix
+    (``a@x.com`` vs ``a/x.com``) never share a file.
+    """
+    safe = _SAFE_CHARS.sub("-", value).strip("-") or "x"
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
+    return f"{safe}-{digest}"
+
+
+@runtime_checkable
+class ConnectorStateStore(Protocol):
+    """Durable store for connector config, keyed by (name, scope_key).
+
+    ``scope_key`` is the registry's scoping segment — the pocket_id on the
+    OSS path. Implementations must treat both key parts as untrusted input.
+    """
+
+    def get(self, name: str, scope_key: str) -> dict[str, Any] | None:
+        """Return the persisted config for (name, scope_key), or None."""
+        ...
+
+    def set(self, name: str, scope_key: str, config: dict[str, Any]) -> None:
+        """Persist config for (name, scope_key), overwriting any prior row."""
+        ...
+
+    def delete(self, name: str, scope_key: str) -> None:
+        """Remove the row for (name, scope_key). No-op if absent."""
+        ...
+
+    def list(self) -> list[tuple[str, str]]:
+        """Return all persisted (name, scope_key) pairs."""
+        ...
+
+
+class FileConnectorStateStore:
+    """File-backed ConnectorStateStore at ``~/.pocketpaw/connectors/state/``.
+
+    One JSON file per (name, scope_key): ``{name}__{scope_key}.json`` with
+    both segments sanitized + hash-suffixed (see :func:`_segment`). The raw
+    name and scope_key are stored inside the payload so :meth:`list` can
+    return the originals — the hashed filename is not reversible.
+
+    Files are chmod 0600; the directory 0700. ``base_dir`` overrides the
+    default location (tests point it at tmp_path).
+    """
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base_dir_override = base_dir
+
+    # -- internals ----------------------------------------------------------
+
+    def _dir(self, *, create: bool = False) -> Path:
+        d = self._base_dir_override or _default_state_dir()
+        if create:
+            d.mkdir(parents=True, exist_ok=True)
+            try:
+                d.chmod(0o700)
+            except OSError:
+                pass  # Windows / exotic filesystems
+        return d
+
+    def _path(self, name: str, scope_key: str) -> Path:
+        return self._dir() / f"{_segment(name)}{_SEP}{_segment(scope_key)}.json"
+
+    # -- ConnectorStateStore ------------------------------------------------
+
+    def get(self, name: str, scope_key: str) -> dict[str, Any] | None:
+        path = self._path(name, scope_key)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+            config = data.get("config")
+            return config if isinstance(config, dict) else None
+        except Exception as e:
+            logger.warning("Failed to load connector state for %s: %s", name, e)
+            return None
+
+    def set(self, name: str, scope_key: str, config: dict[str, Any]) -> None:
+        self._dir(create=True)
+        path = self._path(name, scope_key)
+        payload = {"name": name, "scope_key": scope_key, "config": config}
+        path.write_text(json.dumps(payload, indent=2))
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        logger.info("Persisted connector state for %s (scope %s)", name, scope_key)
+
+    def delete(self, name: str, scope_key: str) -> None:
+        path = self._path(name, scope_key)
+        if path.exists():
+            path.unlink()
+            logger.info("Deleted connector state for %s (scope %s)", name, scope_key)
+
+    def list(self) -> list[tuple[str, str]]:
+        d = self._dir()
+        if not d.exists():
+            return []
+        rows: list[tuple[str, str]] = []
+        for path in sorted(d.glob("*.json")):
+            try:
+                data = json.loads(path.read_text())
+                name = data.get("name")
+                scope_key = data.get("scope_key")
+                if isinstance(name, str) and isinstance(scope_key, str):
+                    rows.append((name, scope_key))
+            except Exception as e:
+                logger.warning("Skipping unreadable connector state file %s: %s", path, e)
+        return rows

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -10,6 +10,11 @@ contract enforces it.
 Each Protocol documents the entry-point group that carries its implementations.
 An entry-point points at a zero-arg callable (usually the class itself) that
 the registry instantiates once and caches.
+
+Updated: 2026-06-12 (connector-store-unification CS-3) — added
+``ConnectorStateStoreProvider`` (group ``pocketpaw.connector_state_stores``)
+so EE can back the ConnectorRegistry's durable state with the cloud DB
+instead of the file store.
 """
 
 from __future__ import annotations
@@ -199,6 +204,27 @@ class PocketWriter(Protocol):
         """Create the pocket + linked session. Returns the new pocket id,
         or ``None`` on failure."""
         ...
+
+
+@runtime_checkable
+class ConnectorStateStoreProvider(Protocol):
+    """Entry-point group: ``pocketpaw.connector_state_stores``
+
+    Supplies the durable ``ConnectorStateStore`` that backs
+    ``ConnectorRegistry`` when no explicit store is passed. Core ships the
+    file-backed default (``~/.pocketpaw/connectors/state/``); the cloud
+    product swaps in a store backed by the ``WorkspaceConnector`` document
+    so connector config rehydrates from the tenant database after a
+    process restart.
+
+    The returned store satisfies
+    ``pocketpaw.connectors.state_store.ConnectorStateStore``. Its
+    ``get``/``set``/``delete`` methods may be async (return awaitables) —
+    the registry awaits awaitable results; ``list`` must stay sync (it is
+    called from the registry's sync ``status()``).
+    """
+
+    def get_state_store(self) -> Any: ...
 
 
 @runtime_checkable

--- a/src/pocketpaw/tools/builtin/connector_tools.py
+++ b/src/pocketpaw/tools/builtin/connector_tools.py
@@ -1,5 +1,10 @@
 # Connector tools — let the agent list, connect, and execute connector actions.
 # Created: 2026-03-29 — Wires ConnectorRegistry into agent tool interface.
+# Updated: 2026-06-12 (connector-store-unification, PR-A review follow-up) —
+#   ConnectorExecuteTool goes through registry.ensure_connected instead of
+#   get_adapter, so agent-tool executes survive a process restart exactly like
+#   the HTTP /connectors/execute router: a persisted config reconnects lazily,
+#   no in-session connector_connect required.
 
 import json
 import logging
@@ -188,7 +193,10 @@ class ConnectorExecuteTool(BaseTool):
         pocket_id: str = "default",
     ) -> str:
         reg = _get_registry()
-        adapter = reg.get_adapter(pocket_id, connector_name)
+        # ensure_connected (not get_adapter): if no adapter is live but config
+        # is persisted in the state store — e.g. after a restart — reconnect
+        # on the fly, matching the HTTP /connectors/execute behavior.
+        adapter = await reg.ensure_connected(connector_name, pocket_id)
         if not adapter:
             return f"Connector '{connector_name}' is not connected. Use connector_connect first."
 

--- a/tests/cloud/connectors/test_state_provider.py
+++ b/tests/cloud/connectors/test_state_provider.py
@@ -8,6 +8,10 @@
 #   (set mirrors config onto existing rows only; delete on namespaced keys is
 #   a no-op; non-namespaced keys delegate to the file store), and the
 #   stale-adapter drops on update_config / disable_connector.
+# Updated: 2026-06-12 (PR #1449 review fix) — added the credential-provenance
+#   test: a disabled row's credentials must never reach the legacy fallback's
+#   connect() (the fallback doc read now filters enabled == True), so disable
+#   revokes on the HTTP execute path too, not just the durable seam.
 
 from __future__ import annotations
 
@@ -312,3 +316,53 @@ async def test_disable_drops_live_adapter(
     assert fresh_registry.get_adapter("ws:ws-1", "github") is None
     # And the durable read now reports no binding (enabled filter).
     assert await fresh_registry._state_store.get("github", "ws:ws-1") is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_row_credentials_never_reach_fallback_connect(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    """Disable must revoke on EVERY execute path (PR #1449 review fix).
+
+    The durable seam already refuses disabled rows (enabled filter in the
+    cloud store), but the legacy one-shot fallback used to re-read the doc
+    WITHOUT an enabled filter — a disabled row's credentials still connected
+    and executed via the HTTP router. Provenance check: seed a DISABLED row
+    with credentials, spy on every config that reaches connect(), and assert
+    the credentials never appear — the fallback gets {} and real adapters
+    fail to connect.
+    """
+    from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
+
+    await _seed_doc(enabled=False, config={"GITHUB_TOKEN": "ghp_revoked"})
+
+    connect_configs: list[dict] = []
+    original_connect = DirectRESTAdapter.connect
+
+    async def _spy_connect(self, pocket_id, config):
+        connect_configs.append(dict(config))
+        return await original_connect(self, pocket_id, config)
+
+    with (
+        patch.object(DirectRESTAdapter, "connect", _spy_connect),
+        patch.object(
+            DirectRESTAdapter,
+            "execute",
+            return_value=ActionResult(success=True, data=[], records_affected=0),
+        ),
+    ):
+        await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(action="list_issues", params={"owner": "a", "repo": "b"}),
+            user_id="u-1",
+        )
+
+    # The disabled row's credentials never reached any connect() call: the
+    # durable seam refused the row, and the fallback's enabled-filtered doc
+    # read fell through to {} config.
+    assert connect_configs == [{}]
+    assert all("GITHUB_TOKEN" not in c for c in connect_configs)
+    # Nothing was cached under the durable key either.
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is None

--- a/tests/cloud/connectors/test_state_provider.py
+++ b/tests/cloud/connectors/test_state_provider.py
@@ -1,0 +1,314 @@
+# test_state_provider.py — connector-store-unification CS-3 — cloud state store.
+# Created: 2026-06-12 — Locks the cloud restart-survival contract: a fresh
+#   process (fresh ConnectorRegistry) with only a seeded WorkspaceConnector doc
+#   executes through registry.ensure_connected with NO prior /connect call,
+#   for both ws:<workspace_id> and pocket:<pocket_id> scope keys. Also pins
+#   the entry-point wiring (the registry's DEFAULT store is the cloud store
+#   when pocketpaw-ee is installed), the store's namespacing/ownership rules
+#   (set mirrors config onto existing rows only; delete on namespaced keys is
+#   a no-op; non-namespaced keys delegate to the file store), and the
+#   stale-adapter drops on update_config / disable_connector.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.dto import (
+    ExecuteActionRequest,
+    UpdateConnectorConfigRequest,
+)
+from pocketpaw_ee.cloud.connectors.state_provider import CloudConnectorStateStore
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+from pocketpaw.connectors.protocol import ActionResult
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+
+async def _seed_doc(
+    *,
+    workspace: str = "ws-1",
+    name: str = "github",
+    scope: str = "workspace",
+    pocket_id: str | None = None,
+    enabled: bool = True,
+    config: dict | None = None,
+) -> WorkspaceConnector:
+    doc = WorkspaceConnector(
+        workspace=workspace,
+        name=name,
+        enabled=enabled,
+        scope=scope,
+        pocket_id=pocket_id,
+        config=config if config is not None else {"GITHUB_TOKEN": "ghp_test"},
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture
+def cloud_store(tmp_path) -> CloudConnectorStateStore:
+    """Cloud store with a hermetic file fallback (never the real ~/.pocketpaw)."""
+    return CloudConnectorStateStore(
+        file_fallback=FileConnectorStateStore(base_dir=tmp_path / "file-state")
+    )
+
+
+@pytest.fixture
+def fresh_registry(cloud_store, monkeypatch) -> ConnectorRegistry:
+    """A registry simulating a FRESH PROCESS, installed as the service's
+    singleton: no live adapters, durable state only in the cloud store."""
+    reg = ConnectorRegistry(Path("connectors"), state_store=cloud_store)
+    monkeypatch.setattr(connectors_service, "_registry", reg)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# The CS-3 behavior contract: seeded doc → fresh process → execute works.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cloud_execute_rehydrates_workspace_row_without_connect(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    """A fresh process with only a seeded workspace-scope doc executes
+    successfully — registry.ensure_connected rehydrates from the doc's config,
+    no /connect call ever happens in this process."""
+    await _seed_doc(scope="workspace")
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is None
+
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(success=True, data=[{"number": 7}], records_affected=1),
+    ):
+        resp = await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(action="list_issues", params={"owner": "a", "repo": "b"}),
+            user_id="u-1",
+        )
+
+    assert resp.success is True
+    assert resp.execution_mode == "cloud"
+    # Proof the DURABLE path ran (not the legacy one-shot fallback): the
+    # registry now holds the rehydrated adapter under the ws: scope key.
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is not None
+
+
+@pytest.mark.asyncio
+async def test_cloud_execute_rehydrates_pocket_row_without_connect(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    """Same restart contract for a pocket-bound row, keyed pocket:<pocket_id>."""
+    await _seed_doc(scope="pocket", pocket_id="pk-1")
+
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(success=True, data=[], records_affected=0),
+    ):
+        resp = await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(
+                action="list_issues",
+                params={"owner": "a", "repo": "b"},
+                scope="pocket",
+                pocket_id="pk-1",
+            ),
+            user_id="u-1",
+        )
+
+    assert resp.success is True
+    assert fresh_registry.get_adapter("pocket:pk-1", "github") is not None
+
+
+@pytest.mark.asyncio
+async def test_pocket_key_is_tenant_gated(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    """A pocket_id bound in ANOTHER workspace must not select that tenant's
+    config — the bind check fails and the caller falls back to its own ws row
+    (which doesn't exist here), so no pocket-keyed adapter appears."""
+    await _seed_doc(workspace="ws-OTHER", scope="pocket", pocket_id="pk-foreign")
+
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(success=True, data=[], records_affected=0),
+    ):
+        await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(
+                action="list_issues",
+                params={"owner": "a", "repo": "b"},
+                scope="pocket",
+                pocket_id="pk-foreign",
+            ),
+            user_id="u-1",
+        )
+
+    assert fresh_registry.get_adapter("pocket:pk-foreign", "github") is None
+
+
+# ---------------------------------------------------------------------------
+# Entry-point wiring — the registry's DEFAULT store is the cloud store.
+# ---------------------------------------------------------------------------
+
+
+def test_registry_default_store_comes_from_entry_point():
+    """With pocketpaw-ee installed, a registry built with no explicit store
+    picks up CloudConnectorStateStore via pocketpaw.connector_state_stores."""
+    from pocketpaw._registry import clear_cache, first
+
+    clear_cache()
+    provider = first("pocketpaw.connector_state_stores")
+    assert provider is not None
+
+    reg = ConnectorRegistry(Path("connectors"))
+    assert isinstance(reg._state_store, CloudConnectorStateStore)
+
+
+# ---------------------------------------------------------------------------
+# Store unit contracts — namespacing, ownership, file delegation.
+# ---------------------------------------------------------------------------
+
+
+class TestCloudStoreGet:
+    @pytest.mark.asyncio
+    async def test_ws_key_returns_enabled_row_config(self, mongo_db, cloud_store):  # noqa: ARG002
+        await _seed_doc(config={"GITHUB_TOKEN": "x"})
+        assert await cloud_store.get("github", "ws:ws-1") == {"GITHUB_TOKEN": "x"}
+
+    @pytest.mark.asyncio
+    async def test_ws_key_is_workspace_scoped(self, mongo_db, cloud_store):  # noqa: ARG002
+        await _seed_doc(workspace="ws-OTHER")
+        assert await cloud_store.get("github", "ws:ws-1") is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_row_reads_as_absent(self, mongo_db, cloud_store):  # noqa: ARG002
+        await _seed_doc(enabled=False)
+        assert await cloud_store.get("github", "ws:ws-1") is None
+
+    @pytest.mark.asyncio
+    async def test_pocket_key_requires_pocket_scope_binding(
+        self,
+        mongo_db,  # noqa: ARG002
+        cloud_store,
+    ):
+        await _seed_doc(scope="pocket", pocket_id="pk-1", config={"GITHUB_TOKEN": "x"})
+        assert await cloud_store.get("github", "pocket:pk-1") == {"GITHUB_TOKEN": "x"}
+        assert await cloud_store.get("github", "pocket:pk-2") is None
+
+    @pytest.mark.asyncio
+    async def test_empty_config_is_still_a_binding(self, mongo_db, cloud_store):  # noqa: ARG002
+        """CLI / no-cred connectors persist config={} — that must read as a
+        valid binding ({}), never coerced to None."""
+        await _seed_doc(config={})
+        assert await cloud_store.get("github", "ws:ws-1") == {}
+
+    def test_plain_key_delegates_to_file_store(self, cloud_store):
+        cloud_store.set("testsvc", "default", {"k": "v"})
+        assert cloud_store.get("testsvc", "default") == {"k": "v"}
+        cloud_store.delete("testsvc", "default")
+        assert cloud_store.get("testsvc", "default") is None
+
+
+class TestCloudStoreOwnership:
+    @pytest.mark.asyncio
+    async def test_set_mirrors_config_onto_existing_row(
+        self,
+        mongo_db,  # noqa: ARG002
+        cloud_store,
+    ):
+        doc = await _seed_doc(config={"GITHUB_TOKEN": "old"})
+        await cloud_store.set("github", "ws:ws-1", {"GITHUB_TOKEN": "new"})
+        refreshed = await WorkspaceConnector.get(doc.id)
+        assert refreshed.config == {"GITHUB_TOKEN": "new"}
+
+    @pytest.mark.asyncio
+    async def test_set_never_creates_a_row(self, mongo_db, cloud_store):  # noqa: ARG002
+        await cloud_store.set("github", "ws:ws-1", {"GITHUB_TOKEN": "x"})
+        assert await WorkspaceConnector.find_one(WorkspaceConnector.name == "github") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_on_namespaced_key_is_noop(self, mongo_db, cloud_store):  # noqa: ARG002
+        """The WorkspaceConnector lifecycle belongs to enable/disable_connector
+        — a registry-level delete must not destroy the durable row."""
+        await _seed_doc()
+        cloud_store.delete("github", "ws:ws-1")
+        assert await cloud_store.get("github", "ws:ws-1") is not None
+
+    def test_list_returns_file_rows_only(self, cloud_store):
+        cloud_store.set("testsvc", "default", {"k": "v"})
+        assert cloud_store.list() == [("testsvc", "default")]
+
+    @pytest.mark.asyncio
+    async def test_get_degrades_softly_when_db_unavailable(self, cloud_store, monkeypatch):
+        """A failing Beanie read (uninitialized DB, partial install) must
+        degrade to 'no persisted config', not crash connector support."""
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("beanie not initialized")
+
+        monkeypatch.setattr(WorkspaceConnector, "find_one", _boom)
+        assert await cloud_store.get("github", "ws:ws-1") is None
+
+
+# ---------------------------------------------------------------------------
+# Stale-adapter drops — config writes / disable invalidate live connections.
+# ---------------------------------------------------------------------------
+
+
+async def _connect_once(fresh_registry: ConnectorRegistry) -> None:
+    """Prime a live adapter under the ws: key via the durable path."""
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(success=True, data=[], records_affected=0),
+    ):
+        await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(action="list_issues", params={"owner": "a", "repo": "b"}),
+            user_id="u-1",
+        )
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is not None
+
+
+@pytest.mark.asyncio
+async def test_update_config_drops_live_adapter(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    await _seed_doc()
+    await _connect_once(fresh_registry)
+
+    await connectors_service.update_config(
+        "ws-1",
+        "github",
+        UpdateConnectorConfigRequest(config={"GITHUB_TOKEN": "rotated"}),
+    )
+
+    # The stale adapter is gone; the next execute rehydrates with new config.
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is None
+
+
+@pytest.mark.asyncio
+async def test_disable_drops_live_adapter(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    await _seed_doc()
+    await _connect_once(fresh_registry)
+
+    await connectors_service.disable_connector("ws-1", "github")
+
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is None
+    # And the durable read now reports no binding (enabled filter).
+    assert await fresh_registry._state_store.get("github", "ws:ws-1") is None

--- a/tests/cloud/connectors/test_ui_agent_invariant.py
+++ b/tests/cloud/connectors/test_ui_agent_invariant.py
@@ -1,0 +1,148 @@
+# test_ui_agent_invariant.py — connector-store-unification CS-4 — one truth.
+# Created: 2026-06-12 — THE INVARIANT TEST: the UI-facing connectors list DTO
+#   (service.list_connectors) and the agent MCP surface
+#   (service.list_pocket_connectors) must report the SAME connector set and
+#   state from the SAME durable source (WorkspaceConnector docs + registry
+#   definitions). This is the structural kill of the 2026-06-12 bug class,
+#   where the two surfaces read different state (durable docs vs in-process
+#   adapter connection state) and could disagree — the UI showing a connector
+#   "connected" while the agent couldn't see it after a restart, or vice
+#   versa. Both surfaces are also asserted against a FRESH registry instance
+#   (simulated restart): neither may depend on in-process adapter state.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.state_provider import CloudConnectorStateStore
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+_WS = "ws-1"
+_POCKET = "pk-1"
+
+
+async def _seed_pocket_connector(
+    name: str = "github", *, enabled: bool = True, pocket_id: str = _POCKET
+) -> None:
+    """The ONE workspace_connectors fixture both surfaces must agree on."""
+    await WorkspaceConnector(
+        workspace=_WS,
+        name=name,
+        enabled=enabled,
+        scope="pocket",
+        pocket_id=pocket_id,
+        config={"GITHUB_TOKEN": "ghp_test"},
+    ).insert()
+
+
+async def _ui_connected_names() -> set[str]:
+    """The UI surface: GET /cloud/connectors rows with status=connected."""
+    rows = await connectors_service.list_connectors(_WS)
+    return {r.name for r in rows if r.status == "connected"}
+
+
+async def _agent_visible_names(pocket_id: str = _POCKET) -> set[str]:
+    """The agent surface: what the MCP server enumerates for this pocket."""
+    infos = await connectors_service.list_pocket_connectors(_WS, pocket_id)
+    return {i.name for i in infos}
+
+
+@pytest.fixture
+def fresh_registry(tmp_path, monkeypatch) -> ConnectorRegistry:
+    """Simulated restart: a registry with no live adapters, installed as the
+    service singleton. Both surfaces must read identically through it."""
+    reg = ConnectorRegistry(
+        Path("connectors"),
+        state_store=CloudConnectorStateStore(
+            file_fallback=FileConnectorStateStore(base_dir=tmp_path / "file-state")
+        ),
+    )
+    monkeypatch.setattr(connectors_service, "_registry", reg)
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_ui_and_agent_connector_surfaces_never_disagree(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,  # noqa: ARG001 — simulated restart, no live adapters
+):
+    """Structural kill of the 2026-06-12 UI-vs-agent divergence bug class.
+
+    One seeded workspace_connectors row; the UI list DTO and the agent MCP
+    enumeration must report the same connector set and state — derived from
+    durable state only, on a registry with zero in-process adapters.
+    """
+    await _seed_pocket_connector("github")
+
+    ui = await _ui_connected_names()
+    agent = await _agent_visible_names()
+
+    assert ui == agent == {"github"}
+
+
+@pytest.mark.asyncio
+async def test_surfaces_agree_on_disabled_connector(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,  # noqa: ARG001
+):
+    """A disabled row must vanish from BOTH surfaces, not just one."""
+    await _seed_pocket_connector("github", enabled=False)
+
+    assert await _ui_connected_names() == set()
+    assert await _agent_visible_names() == set()
+
+
+@pytest.mark.asyncio
+async def test_surfaces_agree_after_disable_transition(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,  # noqa: ARG001
+):
+    """Enable → both see it; disable → both drop it. No surface may lag the
+    other through the transition (the in-process-state failure mode).
+
+    Uses a REAL pocket (created through the pockets service) because
+    disabling a pocket-scoped connector re-derives that pocket's
+    surface_profile — a synthetic pocket id would 404 the rederive."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+    wire = await pockets_service.create(_WS, "u-1", CreatePocketRequest(name="Invariant"))
+    pocket_id = wire["_id"]
+
+    await _seed_pocket_connector("github", pocket_id=pocket_id)
+    ui = await _ui_connected_names()
+    agent = await _agent_visible_names(pocket_id)
+    assert ui == agent == {"github"}
+
+    await connectors_service.disable_connector(_WS, "github")
+
+    assert await _ui_connected_names() == set()
+    assert await _agent_visible_names(pocket_id) == set()
+
+
+@pytest.mark.asyncio
+async def test_widget_recipes_follow_durable_state(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,  # noqa: ARG001
+):
+    """The widget-recipe rail derives from _WCDoc presence + registry
+    definition presence — a fresh process (no adapter ever connected) still
+    serves recipes for an enabled connector, and none for a disabled one."""
+    await WorkspaceConnector(
+        workspace=_WS,
+        name="gmail",
+        enabled=True,
+        scope="workspace",
+        config={},
+    ).insert()
+
+    recipes = await connectors_service.list_widget_recipes(_WS)
+    assert {r.connector for r in recipes} == {"gmail"}
+
+    await connectors_service.disable_connector(_WS, "gmail")
+    assert await connectors_service.list_widget_recipes(_WS) == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,9 @@
-"""Pytest configuration."""
+"""Pytest configuration.
+
+Updated: 2026-06-12 (connector-store-unification CS-1) — added
+_isolate_connector_state so the registry's write-through state store never
+persists test config to the real ~/.pocketpaw/connectors/state.
+"""
 
 import asyncio
 import os
@@ -44,6 +49,22 @@ def _enable_test_full_access(request, monkeypatch):
     if "enforce_scope" in request.keywords:
         return
     monkeypatch.setattr("pocketpaw.api.deps._TESTING_FULL_ACCESS", True)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_connector_state(tmp_path, monkeypatch):
+    """Prevent tests from persisting connector config to the real ~/.pocketpaw.
+
+    ConnectorRegistry.connect() is write-through to a state store that
+    defaults to ~/.pocketpaw/connectors/state (CS-1). Point the default at a
+    per-test temp dir so suites that build a registry with the default store
+    stay hermetic. Tests that exercise the store directly pass an explicit
+    ``base_dir`` instead.
+    """
+    monkeypatch.setattr(
+        "pocketpaw.connectors.state_store._default_state_dir",
+        lambda: tmp_path / "connector-state",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@
 Updated: 2026-06-12 (connector-store-unification CS-1) — added
 _isolate_connector_state so the registry's write-through state store never
 persists test config to the real ~/.pocketpaw/connectors/state.
+Updated: 2026-06-12 (CS-2) — the same fixture also redirects the registry's
+home-dir definition scan (~/.pocketpaw/connectors/*.yaml) to a temp dir so
+YAMLs on a dev machine can't leak into test registries.
 """
 
 import asyncio
@@ -64,6 +67,10 @@ def _isolate_connector_state(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "pocketpaw.connectors.state_store._default_state_dir",
         lambda: tmp_path / "connector-state",
+    )
+    monkeypatch.setattr(
+        "pocketpaw.connectors.registry._default_home_connectors_dir",
+        lambda: tmp_path / "home-connectors",
     )
 
 

--- a/tests/connectors/test_adapter_reconnect.py
+++ b/tests/connectors/test_adapter_reconnect.py
@@ -1,0 +1,176 @@
+# test_adapter_reconnect.py — connector-store-unification CS-5 — reconnect audit.
+# Created: 2026-06-12 — Locks the reconnect-safety fixes from the native
+#   adapter audit: DatabaseAdapter disposes its previous engine on a second
+#   connect() (no leaked pool) and resets _connected on a failed connect;
+#   MongoDBAdapter closes its previous motor client on a second connect()
+#   (no leaked socket pool) and resets _connected on a failed connect. These
+#   are the double-connect shapes ensure_connected's restart-recovery path
+#   makes more likely (config change → disconnect+reconnect; racing executes).
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pocketpaw.connectors.db_adapter import DatabaseAdapter
+from pocketpaw.connectors.mongo_adapter import MongoDBAdapter
+
+# ---------------------------------------------------------------------------
+# DatabaseAdapter (sqlalchemy engine)
+# ---------------------------------------------------------------------------
+
+
+class _FakeConn:
+    async def execute(self, _stmt: Any) -> None:
+        return None
+
+    async def __aenter__(self) -> _FakeConn:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+
+class _FakeEngine:
+    fail_connect = False
+
+    def __init__(self) -> None:
+        self.disposed = False
+
+    def connect(self) -> Any:
+        if self.fail_connect:
+            raise RuntimeError("db unreachable")
+        return _FakeConn()
+
+    async def dispose(self) -> None:
+        self.disposed = True
+
+
+@pytest.fixture
+def fake_engines(monkeypatch) -> list[_FakeEngine]:
+    """Route create_async_engine to fakes; returns the created instances.
+
+    Per-engine failure is staged by monkeypatching ``_FakeEngine.fail_connect``
+    (a class attribute) before the connect under test.
+    """
+    created: list[_FakeEngine] = []
+
+    def _fake_create(*_args: Any, **_kwargs: Any) -> _FakeEngine:
+        engine = _FakeEngine()
+        created.append(engine)
+        return engine
+
+    import sqlalchemy.ext.asyncio as sa_asyncio
+
+    monkeypatch.setattr(sa_asyncio, "create_async_engine", _fake_create)
+    return created
+
+
+_DB_CONFIG = {"DB_HOST": "h", "DB_NAME": "d", "DB_USER": "u", "DB_PASSWORD": "p"}
+
+
+@pytest.mark.asyncio
+async def test_db_double_connect_disposes_previous_engine(fake_engines) -> None:
+    adapter = DatabaseAdapter("postgresql")
+    assert (await adapter.connect("p1", _DB_CONFIG)).success is True
+    assert (await adapter.connect("p1", {**_DB_CONFIG, "DB_PASSWORD": "p2"})).success is True
+
+    assert len(fake_engines) == 2
+    assert fake_engines[0].disposed is True  # the old pool must not leak
+    assert fake_engines[1].disposed is False
+    assert adapter._engine is fake_engines[1]
+    assert adapter._connected is True
+
+
+@pytest.mark.asyncio
+async def test_db_failed_reconnect_resets_connected_flag(fake_engines, monkeypatch) -> None:
+    adapter = DatabaseAdapter("postgresql")
+    assert (await adapter.connect("p1", _DB_CONFIG)).success is True
+    assert adapter._connected is True
+
+    # Next engine refuses to connect (service down / bad creds).
+    monkeypatch.setattr(_FakeEngine, "fail_connect", True)
+    result = await adapter.connect("p1", {**_DB_CONFIG, "DB_PASSWORD": "bad"})
+    assert result.success is False
+    # The adapter must not report a connection it no longer has.
+    assert adapter._connected is False
+    assert adapter._engine is None
+    # And the original engine was still disposed, not leaked.
+    assert fake_engines[0].disposed is True
+
+
+# ---------------------------------------------------------------------------
+# MongoDBAdapter (motor client)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdmin:
+    def __init__(self, fail_ping: bool) -> None:
+        self._fail_ping = fail_ping
+
+    async def command(self, _name: str) -> None:
+        if self._fail_ping:
+            raise RuntimeError("mongo unreachable")
+        return None
+
+
+class _FakeMotorClient:
+    fail_ping = False
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.closed = False
+        self.admin = _FakeAdmin(self.fail_ping)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __getitem__(self, _name: str) -> Any:
+        return object()
+
+
+@pytest.fixture
+def fake_motor_clients(monkeypatch) -> list[_FakeMotorClient]:
+    created: list[_FakeMotorClient] = []
+
+    class _Recording(_FakeMotorClient):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    import motor.motor_asyncio as motor_asyncio
+
+    monkeypatch.setattr(motor_asyncio, "AsyncIOMotorClient", _Recording)
+    return created
+
+
+_MONGO_CONFIG = {"MONGO_URI": "mongodb://h:27017", "MONGO_DATABASE": "d"}
+
+
+@pytest.mark.asyncio
+async def test_mongo_double_connect_closes_previous_client(fake_motor_clients) -> None:
+    adapter = MongoDBAdapter()
+    assert (await adapter.connect("p1", _MONGO_CONFIG)).success is True
+    assert (await adapter.connect("p1", _MONGO_CONFIG)).success is True
+
+    assert len(fake_motor_clients) == 2
+    assert fake_motor_clients[0].closed is True  # the old socket pool must not leak
+    assert fake_motor_clients[1].closed is False
+    assert adapter._client is fake_motor_clients[1]
+    assert adapter._connected is True
+
+
+@pytest.mark.asyncio
+async def test_mongo_failed_reconnect_resets_connected_flag(
+    fake_motor_clients, monkeypatch
+) -> None:
+    adapter = MongoDBAdapter()
+    assert (await adapter.connect("p1", _MONGO_CONFIG)).success is True
+    assert adapter._connected is True
+
+    monkeypatch.setattr(_FakeMotorClient, "fail_ping", True)
+    result = await adapter.connect("p1", _MONGO_CONFIG)
+    assert result.success is False
+    assert adapter._connected is False
+    assert adapter._client is None
+    assert fake_motor_clients[0].closed is True

--- a/tests/connectors/test_connector_tools_restart.py
+++ b/tests/connectors/test_connector_tools_restart.py
@@ -1,0 +1,137 @@
+# test_connector_tools_restart.py — connector-store-unification (PR-A review
+#   follow-up) — agent-tool execute parity with the HTTP router.
+# Created: 2026-06-12 — Locks: ConnectorExecuteTool reconnects from persisted
+#   state on a fresh process (registry B shares registry A's state store, no
+#   connector_connect in session B), exactly like /connectors/execute. Before
+#   the fix the tool used get_adapter and failed with "not connected" after
+#   every restart while the HTTP path succeeded.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pocketpaw.connectors.registry as registry_module
+import pocketpaw.tools.builtin.connector_tools as connector_tools
+from pocketpaw.connectors.protocol import ActionResult, ConnectionResult, ConnectorStatus
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+from pocketpaw.tools.builtin.connector_tools import ConnectorExecuteTool
+
+_TEST_YAML = """\
+name: testsvc
+display_name: Test Service
+type: rest
+icon: plug
+auth:
+  type: api_key
+  credentials:
+    - name: api_key
+      required: true
+actions:
+  - name: ping
+    description: Ping the service
+    method: GET
+    url: https://example.invalid/ping
+"""
+
+
+class _FakeAdapter:
+    """Minimal adapter recording connect calls; execute returns a dict."""
+
+    def __init__(self) -> None:
+        self.connect_calls: list[tuple[str, dict[str, Any]]] = []
+
+    @property
+    def name(self) -> str:
+        return "testsvc"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Service"
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        self.connect_calls.append((pocket_id, config))
+        return ConnectionResult(
+            success=True,
+            connector_name=self.name,
+            status=ConnectorStatus.CONNECTED,
+            message="connected",
+        )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        return True
+
+    async def actions(self) -> list:
+        return []
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        return ActionResult(success=True, data={"action": action}, records_affected=1)
+
+
+@pytest.fixture
+def defs_dir(tmp_path) -> Path:
+    d = tmp_path / "defs"
+    d.mkdir()
+    (d / "testsvc.yaml").write_text(_TEST_YAML)
+    return d
+
+
+@pytest.fixture
+def store(tmp_path) -> FileConnectorStateStore:
+    return FileConnectorStateStore(base_dir=tmp_path / "state")
+
+
+@pytest.fixture
+def fake_adapters(monkeypatch) -> list[_FakeAdapter]:
+    created: list[_FakeAdapter] = []
+
+    def _fake_create(connector_name: str):
+        if connector_name != "testsvc":
+            return None
+        adapter = _FakeAdapter()
+        created.append(adapter)
+        return adapter
+
+    monkeypatch.setattr(registry_module, "_create_native_adapter", _fake_create)
+    return created
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_reconnects_after_restart(
+    defs_dir, store, fake_adapters, monkeypatch
+) -> None:
+    """Session A connects; session B (fresh registry, same store) executes via
+    the agent tool with NO connector_connect — parity with the HTTP router."""
+    reg_a = ConnectorRegistry(defs_dir, state_store=store)
+    result = await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+    assert result.success is True
+
+    # Simulated restart: the tool module's singleton is a fresh registry that
+    # only shares the durable store.
+    reg_b = ConnectorRegistry(defs_dir, state_store=store)
+    assert reg_b.get_adapter("default", "testsvc") is None
+    monkeypatch.setattr(connector_tools, "_registry", reg_b)
+
+    out = await ConnectorExecuteTool().execute("testsvc", "ping", {})
+
+    assert "not connected" not in out
+    assert '"action": "ping"' in out
+    # The reconnect came from the persisted config, lazily.
+    assert reg_b.get_adapter("default", "testsvc") is not None
+    assert fake_adapters[-1].connect_calls == [("default", {"api_key": "k1"})]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_without_persisted_state_still_errors(
+    defs_dir, store, fake_adapters, monkeypatch
+) -> None:
+    """No live adapter AND no persisted config keeps the clear error message."""
+    reg = ConnectorRegistry(defs_dir, state_store=store)
+    monkeypatch.setattr(connector_tools, "_registry", reg)
+
+    out = await ConnectorExecuteTool().execute("testsvc", "ping", {})
+
+    assert "not connected" in out

--- a/tests/connectors/test_registry_definitions.py
+++ b/tests/connectors/test_registry_definitions.py
@@ -1,0 +1,164 @@
+# test_registry_definitions.py — connector-store-unification CS-2 — truthful
+# status + two-dir definition scan.
+# Created: 2026-06-12 — Locks: status() derives "connected" from durable state
+#   (a fresh registry instance reports the same status as the one that
+#   connected); home-dir YAML pickup (~/.pocketpaw/connectors); CWD precedence
+#   on name collision; orphan state rows surface as definition_missing without
+#   crashing; get_definition rescans on miss.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.connectors.protocol import ConnectorStatus
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+_YAML_TEMPLATE = """\
+name: {name}
+display_name: {display_name}
+type: rest
+icon: plug
+auth:
+  type: api_key
+  credentials:
+    - name: api_key
+      required: true
+actions:
+  - name: ping
+    method: GET
+    url: https://example.invalid/ping
+"""
+
+
+def _write_yaml(directory: Path, name: str, display_name: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / f"{name}.yaml").write_text(
+        _YAML_TEMPLATE.format(name=name, display_name=display_name)
+    )
+
+
+@pytest.fixture
+def defs_dir(tmp_path) -> Path:
+    d = tmp_path / "defs"
+    _write_yaml(d, "testsvc", "Test Service")
+    return d
+
+
+@pytest.fixture
+def home_dir(tmp_path) -> Path:
+    d = tmp_path / "home-defs"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def store(tmp_path) -> FileConnectorStateStore:
+    return FileConnectorStateStore(base_dir=tmp_path / "state")
+
+
+def _registry(defs_dir: Path, store: FileConnectorStateStore, home_dir: Path) -> ConnectorRegistry:
+    return ConnectorRegistry(defs_dir, state_store=store, home_connectors_dir=home_dir)
+
+
+def _status_of(reg: ConnectorRegistry, pocket_id: str, name: str):
+    return next(s for s in reg.status(pocket_id) if s["name"] == name)
+
+
+class TestDurableStatus:
+    @pytest.mark.asyncio
+    async def test_status_survives_fresh_instance(self, defs_dir, store, home_dir) -> None:
+        reg_a = _registry(defs_dir, store, home_dir)
+        result = await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+        assert result.success is True
+        assert _status_of(reg_a, "default", "testsvc")["status"] == ConnectorStatus.CONNECTED
+
+        # Fresh instance, same store — simulated restart. No adapter is live,
+        # yet status still reports connected because the config is persisted.
+        reg_b = _registry(defs_dir, store, home_dir)
+        assert reg_b.get_adapter("default", "testsvc") is None
+        assert _status_of(reg_b, "default", "testsvc")["status"] == ConnectorStatus.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_status_is_scope_isolated(self, defs_dir, store, home_dir) -> None:
+        reg = _registry(defs_dir, store, home_dir)
+        await reg.connect("alpha", "testsvc", {"api_key": "k1"})
+        assert _status_of(reg, "alpha", "testsvc")["status"] == ConnectorStatus.CONNECTED
+        assert _status_of(reg, "beta", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+    @pytest.mark.asyncio
+    async def test_disconnect_reports_disconnected_everywhere(
+        self, defs_dir, store, home_dir
+    ) -> None:
+        reg_a = _registry(defs_dir, store, home_dir)
+        await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+        await reg_a.disconnect("default", "testsvc")
+        assert _status_of(reg_a, "default", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+        reg_b = _registry(defs_dir, store, home_dir)
+        assert _status_of(reg_b, "default", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+    def test_empty_store_reads_disconnected(self, defs_dir, store, home_dir) -> None:
+        reg = _registry(defs_dir, store, home_dir)
+        assert _status_of(reg, "default", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+
+class TestOrphanRows:
+    def test_orphan_row_surfaces_as_definition_missing(self, defs_dir, store, home_dir) -> None:
+        store.set("ghost", "default", {"api_key": "k"})
+        reg = _registry(defs_dir, store, home_dir)
+        row = _status_of(reg, "default", "ghost")
+        assert row["status"] == ConnectorStatus.DEFINITION_MISSING
+        assert row["display_name"] == "ghost"
+        # The defined connector is unaffected.
+        assert _status_of(reg, "default", "testsvc")["status"] == ConnectorStatus.DISCONNECTED
+
+    def test_orphan_recovers_when_definition_lands(self, defs_dir, store, home_dir) -> None:
+        store.set("latecomer", "default", {"api_key": "k"})
+        reg = _registry(defs_dir, store, home_dir)
+        assert _status_of(reg, "default", "latecomer")["status"] == (
+            ConnectorStatus.DEFINITION_MISSING
+        )
+        # Definition shows up after registry construction — the orphan check
+        # rescans before declaring rows orphaned, so status heals itself.
+        _write_yaml(defs_dir, "latecomer", "Latecomer")
+        assert _status_of(reg, "default", "latecomer")["status"] == ConnectorStatus.CONNECTED
+
+
+class TestDefinitionScan:
+    def test_home_dir_yaml_pickup(self, defs_dir, store, home_dir) -> None:
+        _write_yaml(home_dir, "homesvc", "Home Service")
+        reg = _registry(defs_dir, store, home_dir)
+        defn = reg.get_definition("homesvc")
+        assert defn is not None
+        assert defn.display_name == "Home Service"
+        assert "homesvc" in [c["name"] for c in reg.available]
+
+    def test_cwd_wins_on_name_collision(self, defs_dir, store, home_dir) -> None:
+        _write_yaml(home_dir, "testsvc", "Home Override")
+        reg = _registry(defs_dir, store, home_dir)
+        defn = reg.get_definition("testsvc")
+        assert defn is not None
+        # The CWD definition (display_name "Test Service") beats the home one.
+        assert defn.display_name == "Test Service"
+        # And the name appears once, not twice.
+        names = [c["name"] for c in reg.available]
+        assert names.count("testsvc") == 1
+
+    def test_get_definition_reloads_on_miss(self, defs_dir, store, home_dir) -> None:
+        reg = _registry(defs_dir, store, home_dir)
+        assert reg.get_definition("latesvc") is None
+        _write_yaml(defs_dir, "latesvc", "Late Service")
+        defn = reg.get_definition("latesvc")
+        assert defn is not None
+        assert defn.display_name == "Late Service"
+
+    def test_missing_dirs_scan_to_empty(self, tmp_path, store) -> None:
+        reg = ConnectorRegistry(
+            tmp_path / "absent",
+            state_store=store,
+            home_connectors_dir=tmp_path / "also-absent",
+        )
+        assert reg.available == []

--- a/tests/connectors/test_registry_definitions.py
+++ b/tests/connectors/test_registry_definitions.py
@@ -5,6 +5,9 @@
 #   connected); home-dir YAML pickup (~/.pocketpaw/connectors); CWD precedence
 #   on name collision; orphan state rows surface as definition_missing without
 #   crashing; get_definition rescans on miss.
+# Updated: 2026-06-12 (PR #1447 review fixes) — connect() routes through
+#   get_definition, so a YAML dropped in after registry construction is
+#   connectable, not just visible to detail/status.
 
 from __future__ import annotations
 
@@ -154,6 +157,17 @@ class TestDefinitionScan:
         defn = reg.get_definition("latesvc")
         assert defn is not None
         assert defn.display_name == "Late Service"
+
+    @pytest.mark.asyncio
+    async def test_connect_picks_up_late_definition(self, defs_dir, store, home_dir) -> None:
+        """connect() routes through the rescan-on-miss path too — drop a YAML,
+        then /connect, without a restart in between."""
+        reg = _registry(defs_dir, store, home_dir)
+        _write_yaml(defs_dir, "latesvc", "Late Service")
+        result = await reg.connect("default", "latesvc", {"api_key": "k1"})
+        assert result is not None
+        assert result.success is True
+        assert _status_of(reg, "default", "latesvc")["status"] == ConnectorStatus.CONNECTED
 
     def test_missing_dirs_scan_to_empty(self, tmp_path, store) -> None:
         reg = ConnectorRegistry(

--- a/tests/connectors/test_registry_state.py
+++ b/tests/connectors/test_registry_state.py
@@ -1,0 +1,256 @@
+# test_registry_state.py — connector-store-unification CS-1 — registry + state store.
+# Created: 2026-06-12 — Locks the restart-survival contract: connect() is
+#   write-through to the state store; a second registry sharing the same store
+#   (a simulated process restart) can ensure_connected + execute with no new
+#   /connect; a config change disconnects and reconnects the live adapter; a
+#   failed connect rolls the persisted row back; an empty store keeps behavior
+#   identical to the pre-store registry.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pocketpaw.connectors.registry as registry_module
+from pocketpaw.connectors.protocol import ActionResult, ConnectionResult, ConnectorStatus
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+_TEST_YAML = """\
+name: testsvc
+display_name: Test Service
+type: rest
+icon: plug
+auth:
+  type: api_key
+  credentials:
+    - name: api_key
+      required: true
+actions:
+  - name: ping
+    description: Ping the service
+    method: GET
+    url: https://example.invalid/ping
+"""
+
+
+class FakeAdapter:
+    """Minimal AnyAdapter that records connect/disconnect/execute calls."""
+
+    def __init__(self) -> None:
+        self.connect_calls: list[tuple[str, dict[str, Any]]] = []
+        self.disconnect_calls: list[str] = []
+        self.fail_connect = False
+
+    @property
+    def name(self) -> str:
+        return "testsvc"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Service"
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        self.connect_calls.append((pocket_id, config))
+        if self.fail_connect:
+            return ConnectionResult(
+                success=False,
+                connector_name=self.name,
+                status=ConnectorStatus.ERROR,
+                message="bad credentials",
+            )
+        return ConnectionResult(
+            success=True,
+            connector_name=self.name,
+            status=ConnectorStatus.CONNECTED,
+            message="connected",
+        )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        self.disconnect_calls.append(pocket_id)
+        return True
+
+    async def actions(self) -> list:
+        return []
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        return ActionResult(success=True, data={"action": action})
+
+
+@pytest.fixture
+def defs_dir(tmp_path) -> Path:
+    d = tmp_path / "defs"
+    d.mkdir()
+    (d / "testsvc.yaml").write_text(_TEST_YAML)
+    return d
+
+
+@pytest.fixture
+def store(tmp_path) -> FileConnectorStateStore:
+    return FileConnectorStateStore(base_dir=tmp_path / "state")
+
+
+@pytest.fixture
+def fake_adapters(monkeypatch) -> list[FakeAdapter]:
+    """Route testsvc through FakeAdapter; returns the created instances."""
+    created: list[FakeAdapter] = []
+
+    def _fake_create(connector_name: str):
+        if connector_name != "testsvc":
+            return None
+        adapter = FakeAdapter()
+        created.append(adapter)
+        return adapter
+
+    monkeypatch.setattr(registry_module, "_create_native_adapter", _fake_create)
+    return created
+
+
+def _registry(defs_dir: Path, store: FileConnectorStateStore) -> ConnectorRegistry:
+    return ConnectorRegistry(defs_dir, state_store=store)
+
+
+class TestRestartSurvival:
+    @pytest.mark.asyncio
+    async def test_ensure_connected_and_execute_on_fresh_registry(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        """Registry A connects; registry B (same store, fresh process) executes
+        with no /connect of its own."""
+        reg_a = _registry(defs_dir, store)
+        result = await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+        assert result.success is True
+
+        reg_b = _registry(defs_dir, store)  # simulated restart
+        assert reg_b.get_adapter("default", "testsvc") is None
+
+        adapter = await reg_b.ensure_connected("testsvc", "default")
+        assert adapter is not None
+        # Reconnected from the persisted config, not from anything in-process.
+        assert adapter.connect_calls == [("default", {"api_key": "k1"})]
+
+        executed = await adapter.execute("ping", {})
+        assert executed.success is True
+
+    @pytest.mark.asyncio
+    async def test_ensure_connected_is_noop_when_live(self, defs_dir, store, fake_adapters) -> None:
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+
+        first = await reg.ensure_connected("testsvc", "default")
+        second = await reg.ensure_connected("testsvc", "default")
+        assert first is second
+        # One connect from connect(); ensure_connected added none.
+        assert len(first.connect_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_ensure_connected_without_persisted_config(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        reg = _registry(defs_dir, store)
+        assert await reg.ensure_connected("testsvc", "default") is None
+
+    @pytest.mark.asyncio
+    async def test_ensure_connected_keeps_config_on_transient_failure(
+        self, defs_dir, store, fake_adapters, monkeypatch
+    ) -> None:
+        reg_a = _registry(defs_dir, store)
+        await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+
+        reg_b = _registry(defs_dir, store)
+        # Next adapter built will refuse to connect (service down).
+        original = registry_module._create_native_adapter
+
+        def _failing_create(connector_name: str):
+            adapter = original(connector_name)
+            if adapter is not None:
+                adapter.fail_connect = True
+            return adapter
+
+        monkeypatch.setattr(registry_module, "_create_native_adapter", _failing_create)
+        assert await reg_b.ensure_connected("testsvc", "default") is None
+        # The persisted config must survive so a later retry can succeed.
+        assert store.get("testsvc", "default") == {"api_key": "k1"}
+
+
+class TestWriteThrough:
+    @pytest.mark.asyncio
+    async def test_connect_persists_config(self, defs_dir, store, fake_adapters) -> None:
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        assert store.get("testsvc", "default") == {"api_key": "k1"}
+
+    @pytest.mark.asyncio
+    async def test_failed_connect_rolls_back_state(
+        self, defs_dir, store, fake_adapters, monkeypatch
+    ) -> None:
+        original = registry_module._create_native_adapter
+
+        def _failing_create(connector_name: str):
+            adapter = original(connector_name)
+            if adapter is not None:
+                adapter.fail_connect = True
+            return adapter
+
+        monkeypatch.setattr(registry_module, "_create_native_adapter", _failing_create)
+        reg = _registry(defs_dir, store)
+        result = await reg.connect("default", "testsvc", {"api_key": "bad"})
+        assert result.success is False
+        assert store.get("testsvc", "default") is None
+
+    @pytest.mark.asyncio
+    async def test_config_change_disconnects_then_reconnects(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        old_adapter = reg.get_adapter("default", "testsvc")
+
+        await reg.connect("default", "testsvc", {"api_key": "k2"})
+        new_adapter = reg.get_adapter("default", "testsvc")
+
+        assert old_adapter.disconnect_calls == ["default"]
+        assert new_adapter is not old_adapter
+        assert new_adapter.connect_calls == [("default", {"api_key": "k2"})]
+        assert store.get("testsvc", "default") == {"api_key": "k2"}
+
+    @pytest.mark.asyncio
+    async def test_reconnect_same_config_does_not_disconnect(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        """Identical config keeps today's overwrite path — no disconnect."""
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        old_adapter = reg.get_adapter("default", "testsvc")
+
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        assert old_adapter.disconnect_calls == []
+
+    @pytest.mark.asyncio
+    async def test_disconnect_forgets_persisted_config(
+        self, defs_dir, store, fake_adapters
+    ) -> None:
+        reg = _registry(defs_dir, store)
+        await reg.connect("default", "testsvc", {"api_key": "k1"})
+        assert await reg.disconnect("default", "testsvc") is True
+        assert store.get("testsvc", "default") is None
+        # And a fresh registry can no longer resurrect the connection.
+        reg_b = _registry(defs_dir, store)
+        assert await reg_b.ensure_connected("testsvc", "default") is None
+
+
+class TestEmptyStoreRegression:
+    """With an empty store the registry behaves exactly like the pre-store one."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_connector_returns_none(self, defs_dir, store) -> None:
+        reg = _registry(defs_dir, store)
+        assert await reg.connect("default", "nope", {}) is None
+
+    @pytest.mark.asyncio
+    async def test_no_adapter_until_connect(self, defs_dir, store) -> None:
+        reg = _registry(defs_dir, store)
+        assert reg.get_adapter("default", "testsvc") is None
+        assert await reg.disconnect("default", "testsvc") is False

--- a/tests/connectors/test_registry_state.py
+++ b/tests/connectors/test_registry_state.py
@@ -5,9 +5,14 @@
 #   /connect; a config change disconnects and reconnects the live adapter; a
 #   failed connect rolls the persisted row back; an empty store keeps behavior
 #   identical to the pre-store registry.
+# Updated: 2026-06-12 (PR #1447 review fixes) — added the concurrency contract
+#   (two racing ensure_connected calls connect exactly once, no leaked
+#   adapter) and the raised-exception rollback contract (adapter.connect that
+#   raises must not leave the never-connected config in the store).
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -37,12 +42,20 @@ actions:
 
 
 class FakeAdapter:
-    """Minimal AnyAdapter that records connect/disconnect/execute calls."""
+    """Minimal AnyAdapter that records connect/disconnect/execute calls.
+
+    ``connect_delay`` (class attribute, patchable per test) makes connect()
+    slow so races can be staged; ``raise_connect`` makes it blow up instead
+    of returning a failure result.
+    """
+
+    connect_delay: float = 0.0
 
     def __init__(self) -> None:
         self.connect_calls: list[tuple[str, dict[str, Any]]] = []
         self.disconnect_calls: list[str] = []
         self.fail_connect = False
+        self.raise_connect = False
 
     @property
     def name(self) -> str:
@@ -53,7 +66,11 @@ class FakeAdapter:
         return "Test Service"
 
     async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        if self.connect_delay:
+            await asyncio.sleep(self.connect_delay)
         self.connect_calls.append((pocket_id, config))
+        if self.raise_connect:
+            raise RuntimeError("connect exploded")
         if self.fail_connect:
             return ConnectionResult(
                 success=False,
@@ -174,6 +191,29 @@ class TestRestartSurvival:
         # The persisted config must survive so a later retry can succeed.
         assert store.get("testsvc", "default") == {"api_key": "k1"}
 
+    @pytest.mark.asyncio
+    async def test_concurrent_ensure_connected_connects_exactly_once(
+        self, defs_dir, store, fake_adapters, monkeypatch
+    ) -> None:
+        """Post-restart thundering herd: two racing executes for the same key
+        must share one adapter — no double connect, no leaked instance."""
+        store.set("testsvc", "default", {"api_key": "k1"})
+        reg = _registry(defs_dir, store)
+        # Slow connect so the second call arrives while the first is mid-flight.
+        monkeypatch.setattr(FakeAdapter, "connect_delay", 0.05)
+
+        first, second = await asyncio.gather(
+            reg.ensure_connected("testsvc", "default"),
+            reg.ensure_connected("testsvc", "default"),
+        )
+
+        assert first is not None
+        assert first is second
+        # Exactly one adapter was ever built and connected — nothing to leak.
+        assert len(fake_adapters) == 1
+        assert len(fake_adapters[0].connect_calls) == 1
+        assert reg.get_adapter("default", "testsvc") is first
+
 
 class TestWriteThrough:
     @pytest.mark.asyncio
@@ -199,6 +239,27 @@ class TestWriteThrough:
         result = await reg.connect("default", "testsvc", {"api_key": "bad"})
         assert result.success is False
         assert store.get("testsvc", "default") is None
+
+    @pytest.mark.asyncio
+    async def test_raising_connect_rolls_back_state(
+        self, defs_dir, store, fake_adapters, monkeypatch
+    ) -> None:
+        """A raised exception is rolled back like a failure result — the
+        never-connected config must not survive in the store."""
+        original = registry_module._create_native_adapter
+
+        def _raising_create(connector_name: str):
+            adapter = original(connector_name)
+            if adapter is not None:
+                adapter.raise_connect = True
+            return adapter
+
+        monkeypatch.setattr(registry_module, "_create_native_adapter", _raising_create)
+        reg = _registry(defs_dir, store)
+        with pytest.raises(RuntimeError, match="connect exploded"):
+            await reg.connect("default", "testsvc", {"api_key": "boom"})
+        assert store.get("testsvc", "default") is None
+        assert reg.get_adapter("default", "testsvc") is None
 
     @pytest.mark.asyncio
     async def test_config_change_disconnects_then_reconnects(

--- a/tests/connectors/test_state_store.py
+++ b/tests/connectors/test_state_store.py
@@ -1,0 +1,133 @@
+# test_state_store.py — connector-store-unification CS-1 — FileConnectorStateStore.
+# Created: 2026-06-12 — Locks the durable connector-state contract: JSON rows
+#   keyed by (name, scope_key), sanitized + hash-suffixed filenames that can't
+#   path-traverse or collide, 0600 file perms, and tolerant reads (corrupt
+#   files degrade to "no state", never crash).
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from pocketpaw.connectors.state_store import (
+    ConnectorStateStore,
+    FileConnectorStateStore,
+)
+
+
+@pytest.fixture
+def store(tmp_path) -> FileConnectorStateStore:
+    return FileConnectorStateStore(base_dir=tmp_path / "state")
+
+
+class TestRoundTrip:
+    def test_set_then_get(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "sk_test_123"})
+        assert store.get("stripe", "pocket-1") == {"api_key": "sk_test_123"}
+
+    def test_get_missing_returns_none(self, store: FileConnectorStateStore) -> None:
+        assert store.get("stripe", "pocket-1") is None
+
+    def test_set_overwrites(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "old"})
+        store.set("stripe", "pocket-1", {"api_key": "new"})
+        assert store.get("stripe", "pocket-1") == {"api_key": "new"}
+
+    def test_rows_are_scope_isolated(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "one"})
+        store.set("stripe", "pocket-2", {"api_key": "two"})
+        assert store.get("stripe", "pocket-1") == {"api_key": "one"}
+        assert store.get("stripe", "pocket-2") == {"api_key": "two"}
+
+    def test_delete(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        store.delete("stripe", "pocket-1")
+        assert store.get("stripe", "pocket-1") is None
+
+    def test_delete_missing_is_noop(self, store: FileConnectorStateStore) -> None:
+        store.delete("stripe", "pocket-1")  # must not raise
+
+    def test_list_returns_original_keys(self, store: FileConnectorStateStore) -> None:
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        store.set("github", "alice@example.com", {"token": "t"})
+        assert sorted(store.list()) == [
+            ("github", "alice@example.com"),
+            ("stripe", "pocket-1"),
+        ]
+
+    def test_list_empty_dir_absent(self, tmp_path) -> None:
+        store = FileConnectorStateStore(base_dir=tmp_path / "never-created")
+        assert store.list() == []
+
+
+class TestSanitization:
+    def test_hostile_keys_stay_inside_base_dir(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("../../evil", "../escape", {"k": "v"})
+        # Everything written must live directly under the base dir.
+        written = list(base.glob("*.json"))
+        assert len(written) == 1
+        assert written[0].parent == base
+        assert store.get("../../evil", "../escape") == {"k": "v"}
+
+    def test_distinct_keys_with_same_sanitized_prefix_do_not_collide(
+        self, store: FileConnectorStateStore
+    ) -> None:
+        # Both scope keys sanitize to "a-x.com"; the raw-value hash keeps
+        # them in separate files (token_store convention).
+        store.set("svc", "a@x.com", {"who": "at"})
+        store.set("svc", "a/x.com", {"who": "slash"})
+        assert store.get("svc", "a@x.com") == {"who": "at"}
+        assert store.get("svc", "a/x.com") == {"who": "slash"}
+
+    def test_separator_inside_name_does_not_cross_segments(
+        self, store: FileConnectorStateStore
+    ) -> None:
+        store.set("a__b", "c", {"k": "1"})
+        store.set("a", "b__c", {"k": "2"})
+        assert store.get("a__b", "c") == {"k": "1"}
+        assert store.get("a", "b__c") == {"k": "2"}
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions")
+class TestPermissions:
+    def test_state_files_are_0600(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("stripe", "pocket-1", {"api_key": "secret"})
+        path = next(base.glob("*.json"))
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+
+class TestTolerantReads:
+    def test_corrupt_file_reads_as_missing(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        path = next(base.glob("*.json"))
+        path.write_text("{not json")
+        assert store.get("stripe", "pocket-1") is None
+
+    def test_list_skips_corrupt_files(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        (base / "garbage__row.json").write_text("{not json")
+        assert store.list() == [("stripe", "pocket-1")]
+
+    def test_payload_without_config_dict_reads_as_missing(self, tmp_path) -> None:
+        base = tmp_path / "state"
+        store = FileConnectorStateStore(base_dir=base)
+        store.set("stripe", "pocket-1", {"api_key": "k"})
+        path = next(base.glob("*.json"))
+        path.write_text(json.dumps({"name": "stripe", "scope_key": "pocket-1", "config": "nope"}))
+        assert store.get("stripe", "pocket-1") is None
+
+
+def test_file_store_satisfies_protocol() -> None:
+    assert isinstance(FileConnectorStateStore(), ConnectorStateStore)

--- a/tests/v1/test_api_v1_connector_lifecycle.py
+++ b/tests/v1/test_api_v1_connector_lifecycle.py
@@ -1,0 +1,227 @@
+# test_api_v1_connector_lifecycle.py — connector-store-unification CS-6 —
+# the OSS router survives restarts.
+# Created: 2026-06-12 — Locks the restart contract at the HTTP layer with a
+#   REAL ConnectorRegistry on tmp dirs (no fakes): connect → fresh registry
+#   instance (simulated process restart, _STATUS_EXTRAS cleared) → list,
+#   detail, and status endpoints all report "connected"; /execute reconnects
+#   from persisted config via ensure_connected; /disconnect works after the
+#   restart; orphaned state rows surface as definition_missing in the list.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import pocketpaw.api.v1.connectors as connectors_module
+import pocketpaw.connectors.registry as registry_module
+from pocketpaw.api.deps import require_scope
+from pocketpaw.connectors.protocol import ActionResult, ConnectionResult, ConnectorStatus
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+_TEST_YAML = """\
+name: testsvc
+display_name: Test Service
+type: rest
+icon: plug
+auth:
+  type: api_key
+  credentials:
+    - name: api_key
+      required: true
+actions:
+  - name: ping
+    description: Ping the service
+    method: GET
+    url: https://example.invalid/ping
+"""
+
+
+class FakeAdapter:
+    """Minimal adapter so /execute works without real HTTP."""
+
+    def __init__(self) -> None:
+        self.connect_calls: list[tuple[str, dict[str, Any]]] = []
+
+    @property
+    def name(self) -> str:
+        return "testsvc"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Service"
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        self.connect_calls.append((pocket_id, config))
+        return ConnectionResult(
+            success=True,
+            connector_name=self.name,
+            status=ConnectorStatus.CONNECTED,
+            message="connected",
+        )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        return True
+
+    async def actions(self) -> list:
+        return []
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        return ActionResult(success=True, data={"action": action})
+
+
+@pytest.fixture
+def dirs(tmp_path) -> dict[str, Path]:
+    defs = tmp_path / "defs"
+    defs.mkdir()
+    (defs / "testsvc.yaml").write_text(_TEST_YAML)
+    return {
+        "defs": defs,
+        "home": tmp_path / "home-defs",
+        "state": tmp_path / "state",
+    }
+
+
+@pytest.fixture
+def fake_adapters(monkeypatch) -> list[FakeAdapter]:
+    created: list[FakeAdapter] = []
+
+    def _fake_create(connector_name: str):
+        if connector_name != "testsvc":
+            return None
+        adapter = FakeAdapter()
+        created.append(adapter)
+        return adapter
+
+    monkeypatch.setattr(registry_module, "_create_native_adapter", _fake_create)
+    return created
+
+
+def _build_registry(dirs: dict[str, Path]) -> ConnectorRegistry:
+    return ConnectorRegistry(
+        dirs["defs"],
+        state_store=FileConnectorStateStore(base_dir=dirs["state"]),
+        home_connectors_dir=dirs["home"],
+    )
+
+
+@pytest.fixture
+def client(dirs, monkeypatch) -> TestClient:
+    monkeypatch.setattr(connectors_module, "_registry", _build_registry(dirs))
+    connectors_module._STATUS_EXTRAS.clear()
+    app = FastAPI()
+    app.dependency_overrides[require_scope("connectors")] = lambda: None
+    app.include_router(connectors_module.router, prefix="/api/v1")
+    yield TestClient(app)
+    connectors_module._STATUS_EXTRAS.clear()
+
+
+def _simulate_restart(dirs: dict[str, Path], monkeypatch) -> None:
+    """Fresh registry instance + cleared in-memory side-table = new process."""
+    monkeypatch.setattr(connectors_module, "_registry", _build_registry(dirs))
+    connectors_module._STATUS_EXTRAS.clear()
+
+
+def _connect(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/connectors/connect",
+        json={
+            "connector_name": "testsvc",
+            "pocket_id": "default",
+            "config": {"api_key": "k1"},
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+
+
+class TestRestartTruth:
+    def test_list_shows_connected_after_restart(
+        self, client, dirs, monkeypatch, fake_adapters
+    ) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        listed = client.get("/api/v1/connectors").json()
+        testsvc = next(c for c in listed if c["name"] == "testsvc")
+        assert testsvc["status"] == "connected"
+
+    def test_status_shows_connected_after_restart(
+        self, client, dirs, monkeypatch, fake_adapters
+    ) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        status = client.get("/api/v1/connectors/testsvc/status").json()
+        assert status["connected"] is True
+        # Extras died with the process; cred_state falls back from connected.
+        assert status["cred_state"] == "valid"
+
+    def test_detail_shows_connected_after_restart(
+        self, client, dirs, monkeypatch, fake_adapters
+    ) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        detail = client.get("/api/v1/connectors/testsvc").json()
+        assert detail["status"] == "connected"
+
+    def test_execute_reconnects_after_restart(
+        self, client, dirs, monkeypatch, fake_adapters
+    ) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        resp = client.post(
+            "/api/v1/connectors/execute",
+            json={"connector_name": "testsvc", "action": "ping", "pocket_id": "default"},
+        ).json()
+        assert resp["success"] is True
+        assert resp["data"] == {"action": "ping"}
+        # The post-restart adapter reconnected from the PERSISTED config.
+        assert fake_adapters[-1].connect_calls == [("default", {"api_key": "k1"})]
+
+    def test_disconnect_works_after_restart(self, client, dirs, monkeypatch, fake_adapters) -> None:
+        _connect(client)
+        _simulate_restart(dirs, monkeypatch)
+
+        resp = client.post(
+            "/api/v1/connectors/disconnect",
+            json={"connector_name": "testsvc", "pocket_id": "default"},
+        ).json()
+        assert resp["success"] is True
+
+        status = client.get("/api/v1/connectors/testsvc/status").json()
+        assert status["connected"] is False
+
+
+class TestNeverConfigured:
+    def test_execute_without_config_still_errors(self, client, fake_adapters) -> None:
+        resp = client.post(
+            "/api/v1/connectors/execute",
+            json={"connector_name": "testsvc", "action": "ping", "pocket_id": "default"},
+        ).json()
+        assert resp["success"] is False
+        assert "not connected" in resp["error"]
+
+    def test_status_disconnected_without_config(self, client) -> None:
+        status = client.get("/api/v1/connectors/testsvc/status").json()
+        assert status["connected"] is False
+        assert status["cred_state"] == "missing"
+
+
+class TestOrphanRows:
+    def test_orphan_row_listed_as_definition_missing(self, client, dirs) -> None:
+        FileConnectorStateStore(base_dir=dirs["state"]).set("ghost", "default", {"k": "v"})
+
+        listed = client.get("/api/v1/connectors").json()
+        ghost = next(c for c in listed if c["name"] == "ghost")
+        assert ghost["status"] == "definition_missing"
+        assert ghost["type"] == "unknown"
+        # Defined connectors are unaffected.
+        testsvc = next(c for c in listed if c["name"] == "testsvc")
+        assert testsvc["status"] == "disconnected"


### PR DESCRIPTION
Part 2 of the connector store unification. **Stacked on #1447** (`feat/connector-state-store`) — this PR's base is that branch, not `dev`. Merge order: #1447 first, with `--rebase` (it has this PR stacked on its head), then this one.

## Cloud rehydrates through the same seam (CS-3)

The cloud `execute()` path used to check `adapter._connected` inline and connect from a fresh doc read on every call. It now goes through `registry.ensure_connected`, the same seam the OSS router got in #1447, backed by a new EE state store:

- New extension point: `ConnectorStateStoreProvider` in `pocketpaw/extensions.py`, entry-point group `pocketpaw.connector_state_stores`, discovered through `pocketpaw/_registry.py` like the other 14 EE providers. When no explicit store is passed, the registry asks the provider before falling back to the file store. OSS installs find no provider and behave exactly as before; `lint-imports` stays green on both configs.
- `CloudConnectorStateStore` (new, `ee/pocketpaw_ee/cloud/connectors/state_provider.py`) reads connector config from the `WorkspaceConnector` doc. Scope-key namespacing: `ws:<workspace_id>` for the workspace's row, `pocket:<pocket_id>` for a pocket-bound row. Plain keys (the single-tenant OSS surfaces) delegate to the file store, so those keep their exact behavior in a cloud install.
- Row ownership stays with the connectors service: the store's `set` only mirrors config onto an existing row, never creates one, and `delete` on namespaced keys is a no-op so a registry-level disconnect drops the live adapter without destroying service-owned state. `registry.connect`'s docstring now warns that namespaced keys must never be passed to `connect()` — its write-through `set` would mirror unproven config onto the service-owned row and the rollback `delete` no-ops there; cloud rows reconnect through `ensure_connected` only.
- The registry awaits awaitable store results (`_maybe_await`), so the sync file store and the async Beanie store share one seam.
- Pocket-keyed lookups are tenant-gated: `execute()` only composes `pocket:<pocket_id>` after `is_connector_bound_to_pocket` passes, since the pocket key alone carries no workspace filter.
- `enable_connector` / `update_config` / `disable_connector` now drop any live registry adapter for the touched row. Without this, a cached adapter would keep serving the config it was built with after a config rotation, or keep executing after a disable.
- The legacy one-shot fallback in `execute()` (kept for enabled rows whose reconnect failed) reads the doc with an `enabled == True` filter (review fix — the first cut read without it and overclaimed disable semantics). Disabled rows are excluded: their credentials never reach `connect()`, the fallback gets `{}` config, and real adapters fail to connect — disable revokes on every execute path, not just the durable seam.

Behavior contract, pinned in `tests/cloud/connectors/test_state_provider.py`: seed a `WorkspaceConnector` doc with config, build a fresh registry (simulated restart), cloud execute succeeds with **no** prior `/connect` call — for both `ws:` and `pocket:` keys. The test asserts the adapter landed under the namespaced key, so it can't pass through the legacy fallback by accident. The disable side is pinned by a credential-provenance test: seed a disabled row WITH credentials, spy on every config that reaches `connect()`, assert the credentials never appear.

## UI and agent surfaces cannot disagree (CS-4)

`tests/cloud/connectors/test_ui_agent_invariant.py` is the structural fix for the 2026-06-12 bug class where the UI list DTO and the agent MCP surface read different state and diverged. One seeded `workspace_connectors` row, read through both `list_connectors` (UI) and `list_pocket_connectors` (agent MCP), asserted equal — on a registry with zero live adapters, so neither surface can be leaning on in-process connection state. Also covers the disabled state, the enable→disable transition, and the widget-recipe rail.

No production change was needed in this slice: the only remaining in-process state read on the cloud surfaces was the `adapter._connected` check that CS-3 removed; `_row_response` and `list_widget_recipes` already derive from doc presence + registry definitions.

## Native-adapter reconnect audit (CS-5)

**db_adapter (DatabaseAdapter — postgresql/mysql/mssql/sqlite).** Double-connect leaked the previous sqlalchemy engine's pool (`self._engine` was overwritten without `dispose()`), and a failed reconnect left `_connected = True` with no engine. Both fixed; covered in `tests/connectors/test_adapter_reconnect.py`. Config (creds/URL) is fully sufficient to reconnect cold; `disconnect()` disposes the pool. Lazy reconnect is safe.

**mongo_adapter (MongoDBAdapter).** Same two defects with the motor client (overwrite without `close()`, stale `_connected` after a failed ping). Fixed and tested. Config (URI or host/creds + database) is sufficient to reconnect cold. Lazy reconnect is safe.

**firebase_adapter (FirebaseAdapter).** Stateless CLI wrapper: holds a binary path and project string, no sessions or handles. Double-connect just re-runs the `projects:list` auth probe — already idempotent. Config alone can't rehydrate it in an arbitrary process because the real auth lives in the firebase CLI's login state on the user's host, but that's by design: every action is `execution_mode=local` and dispatches to the user's machine over the bus. Keeps eager probe semantics behind `ensure_connected`. No change.

**gcp_adapter (GCPAdapter).** Same shape as firebase: binary discovery plus a `gcloud auth list` probe, no held handles, idempotent double-connect, auth lives in gcloud's host state, all actions local-mode. No change.

**drive/ (DriveSourceAdapter).** Not a registry adapter: it implements the soul-protocol `SourceAdapter` seam for retrieval federation, is constructed per request with a broker-issued `Credential`, resolves a bearer token per call, and has no connect/disconnect lifecycle. Nothing to rehydrate; outside `ensure_connected`'s scope. (The Drive *connector* is `connectors/adapters/gdrive.py`, one of the native comm adapters.) No change.

## Builtin tool execute parity (from PR-A review)

`ConnectorExecuteTool` still used `registry.get_adapter` on its execute path, so agent-tool executes failed with "not connected" after a restart while the HTTP router succeeded. Swapped to `ensure_connected`; `tests/connectors/test_connector_tools_restart.py` pins the parity (and that the clear error message survives when there's genuinely no persisted state).

## Verification

```
uv run pytest tests/ -k "connector or registry" --ignore=tests/e2e -q
319 passed, 1 skipped, 6312 deselected in 11.81s

uv run pytest tests/cloud/connectors/ tests/cloud/test_connectors_execute.py -q
6 failed, 50 passed in 2.77s

uv run pytest tests/cloud/test_connectors_execute.py tests/ee/agent/test_connectors_mcp_server/ tests/cloud/connectors/ -q
6 failed, 72 passed

uv run lint-imports                              → Contracts: 1 kept, 0 broken.
uv run lint-imports --config ee/pyproject.toml   → Contracts: 23 kept, 0 broken.
```

The 6 failures in `test_connectors_execute.py` are the known pre-existing 401s from the auth fixture (verified identical on the base commit via a detached checkout — same 9-failed/3-passed shape on `test_connectors_router.py` at `31cef972`). The failure count does not grow; all 41 tests in `tests/cloud/connectors/` (18 new CS-3 incl. the provenance test, 4 new CS-4, 19 existing) pass.

