### PR TITLE
Cloud connector state rehydrates through the store seam

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -142,9 +142,7 @@ async def _list_connector_actions_handler(args: dict) -> dict:  # noqa: ARG001 â
         # Unanchored chats (pocket_id=None) pass "" â€” the pocket arm of the
         # service query matches nothing, so only workspace-scoped connectors
         # come back. Anchored chats get pocket-scoped + workspace-scoped.
-        connectors = await connectors_service.list_pocket_connectors(
-            workspace_id, pocket_id or ""
-        )
+        connectors = await connectors_service.list_pocket_connectors(workspace_id, pocket_id or "")
     except Exception as exc:  # noqa: BLE001
         logger.warning("list_connector_actions failed", exc_info=True)
         return _error_response(f"list_connector_actions failed: {exc}")

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -33,6 +33,14 @@
 #   reads the workspace catalog; the agent MCP tool read only pocket-scoped
 #   rows). Cross-tenant posture unchanged — workspace scope IS the tenant; the
 #   read/write trust gate still applies per action.
+# Updated: 2026-06-12 (connector-store-unification CS-3) — the cloud
+#   ``execute()`` path now goes through ``registry.ensure_connected`` (scope
+#   keys ``pocket:<pocket_id>`` / ``ws:<workspace_id>``) backed by the
+#   WorkspaceConnector state store, so a fresh process executes from a seeded
+#   doc with NO prior /connect; the inline ``adapter._connected`` check is
+#   gone. ``enable_connector`` / ``update_config`` / ``disable_connector``
+#   drop any live registry adapter for the touched row so the next execute
+#   rehydrates with current config instead of serving a stale connection.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -182,6 +190,27 @@ async def _rederive_pocket_surface_profile(workspace_id: str, pocket_id: str) ->
     await apply_derived_surface_profile(workspace_id, pocket_id, profile)
 
 
+async def _drop_live_adapter(doc: _WCDoc) -> None:
+    """Drop any live registry adapter for this row's scope keys.
+
+    Called after enable/disable/config writes so the next execute rehydrates
+    through ``ensure_connected`` with the row's CURRENT state instead of
+    serving an adapter connected with stale config (or one for a row that was
+    just disabled). ``registry.disconnect`` closes the adapter's held handles;
+    the durable row itself is untouched — the cloud state store's delete is a
+    deliberate no-op for namespaced keys (see ``state_provider.py``).
+    """
+    reg = _get_registry()
+    keys = [f"ws:{doc.workspace}"]
+    if doc.pocket_id:
+        keys.append(f"pocket:{doc.pocket_id}")
+    for key in keys:
+        try:
+            await reg.disconnect(key, doc.name)
+        except Exception as exc:  # noqa: BLE001 — best-effort cache drop
+            logger.warning("live adapter drop failed for %s (%s): %s", doc.name, key, exc)
+
+
 # ---------------------------------------------------------------------------
 # Mapping helpers
 # ---------------------------------------------------------------------------
@@ -308,6 +337,9 @@ async def enable_connector(
         if body.config:
             doc.config = body.config
         await doc.save()
+        # Re-enable may have changed config/scope — a live adapter from a
+        # previous execute must not keep serving the old connection.
+        await _drop_live_adapter(doc)
 
     a = available[name]
     await event_bus.emit(
@@ -353,6 +385,9 @@ async def disable_connector(workspace_id: str, name: str) -> ConnectorResponse:
     pocket_id_for_rederive = doc.pocket_id
     doc.enabled = False
     await doc.save()
+    # A disabled connector must stop executing immediately — drop any live
+    # adapter so the next execute can't reuse the old connection.
+    await _drop_live_adapter(doc)
     await event_bus.emit(
         "connector.disabled",
         {"workspace_id": workspace_id, "name": name},
@@ -389,6 +424,9 @@ async def update_config(
         raise NotFound("connector", name)
     doc.config = {**doc.config, **body.config}
     await doc.save()
+    # Config changed — drop any live adapter so the next execute reconnects
+    # with the patched config instead of the one it was built with.
+    await _drop_live_adapter(doc)
     await event_bus.emit(
         "connector.config_updated",
         {"workspace_id": workspace_id, "name": name},
@@ -729,15 +767,29 @@ async def execute(
             "which isn't connected. Open your local app and retry.",
         )
 
-    # CLOUD path — run in-process. Connect first if needed, using the
-    # workspace's saved config from the connector entity.
-    doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
-    config = dict(doc.config) if doc else {}
-    pocket_key = body.pocket_id or workspace_id
-    if not adapter._connected:  # noqa: SLF001 — adapter API doesn't expose is_connected
-        await adapter.connect(pocket_key, config)
+    # CLOUD path — run in-process through the registry's durable seam (CS-3).
+    # ``ensure_connected`` rehydrates the adapter from the WorkspaceConnector
+    # row's config on a fresh process, so execute works with no prior
+    # /connect call. Pocket-keyed lookup is gated on the tenant bind check —
+    # ``pocket:<pocket_id>`` alone carries no workspace filter, so an
+    # unverified foreign pocket_id must never select another tenant's config.
+    exec_adapter = None
+    if body.pocket_id and await is_connector_bound_to_pocket(workspace_id, body.pocket_id, name):
+        exec_adapter = await reg.ensure_connected(name, f"pocket:{body.pocket_id}")
+    if exec_adapter is None:
+        exec_adapter = await reg.ensure_connected(name, f"ws:{workspace_id}")
+    if exec_adapter is None:
+        # Legacy fallback — no enabled row with usable config (or the
+        # reconnect failed). Preserve the pre-CS-3 semantics: one-shot
+        # adapter, best-effort connect with whatever the workspace row
+        # carries, and let the adapter surface its own failure on execute.
+        doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+        config = dict(doc.config) if doc else {}
+        pocket_key = body.pocket_id or workspace_id
+        exec_adapter = adapter
+        await exec_adapter.connect(pocket_key, config)
 
-    result = await adapter.execute(body.action, body.params)
+    result = await exec_adapter.execute(body.action, body.params)
     return ExecuteActionResponse(
         success=result.success,
         data=result.data,

--- a/ee/pocketpaw_ee/cloud/connectors/service.py
+++ b/ee/pocketpaw_ee/cloud/connectors/service.py
@@ -41,6 +41,10 @@
 #   gone. ``enable_connector`` / ``update_config`` / ``disable_connector``
 #   drop any live registry adapter for the touched row so the next execute
 #   rehydrates with current config instead of serving a stale connection.
+# Updated: 2026-06-12 (PR #1449 review fix) — the legacy one-shot fallback in
+#   ``execute()`` filters its doc read on ``enabled == True``, so a disabled
+#   row's credentials can never connect through the fallback: disable now
+#   revokes on every execute path, not just the durable seam.
 # Module-level async API. Sole owner of writes to the
 # ``WorkspaceConnector`` Beanie document. Reads merge the static
 # registry catalog from src/pocketpaw/connectors/registry.py with the
@@ -780,10 +784,18 @@ async def execute(
         exec_adapter = await reg.ensure_connected(name, f"ws:{workspace_id}")
     if exec_adapter is None:
         # Legacy fallback — no enabled row with usable config (or the
-        # reconnect failed). Preserve the pre-CS-3 semantics: one-shot
-        # adapter, best-effort connect with whatever the workspace row
-        # carries, and let the adapter surface its own failure on execute.
-        doc = await _WCDoc.find_one(_WCDoc.workspace == workspace_id, _WCDoc.name == name)
+        # reconnect failed). Preserve the pre-CS-3 shape (one-shot adapter,
+        # best-effort connect, the adapter surfaces its own failure on
+        # execute) for ENABLED rows only: the enabled filter below is what
+        # makes disable actually revoke on this path — a disabled row's
+        # credentials must never reach connect(), so a disabled (or
+        # never-enabled) connector gets {} config and real adapters fail
+        # to connect.
+        doc = await _WCDoc.find_one(
+            _WCDoc.workspace == workspace_id,
+            _WCDoc.name == name,
+            _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+        )
         config = dict(doc.config) if doc else {}
         pocket_key = body.pocket_id or workspace_id
         exec_adapter = adapter

--- a/ee/pocketpaw_ee/cloud/connectors/state_provider.py
+++ b/ee/pocketpaw_ee/cloud/connectors/state_provider.py
@@ -1,0 +1,163 @@
+# Cloud connector state store — durable connector config from WorkspaceConnector docs.
+# Created: 2026-06-12 (connector-store-unification CS-3) — The OSS registry's
+#   restart-survival seam (ConnectorStateStore) backed by the cloud DB instead
+#   of ~/.pocketpaw files. ``registry.ensure_connected`` on a fresh process
+#   reads the connector's config straight from the ``WorkspaceConnector``
+#   Beanie doc, so a cloud execute succeeds with no prior /connect call.
+#   Discovered by core via the ``pocketpaw.connector_state_stores``
+#   entry-point (see ``CloudConnectorStateStoreProvider`` in
+#   ``pocketpaw_ee/extensions.py``); core never imports this module.
+#
+# Scope-key namespacing (the contract with ``connectors/service.py``):
+#   ``ws:<workspace_id>``     — the workspace's row for a connector name
+#                               (workspace tenancy filter; scope-agnostic to
+#                               match the legacy execute() doc lookup).
+#   ``pocket:<pocket_id>``    — the row bound to one pocket (scope=="pocket").
+#                               Callers MUST validate the pocket belongs to
+#                               the caller's workspace before composing this
+#                               key (service.execute gates with
+#                               ``is_connector_bound_to_pocket``).
+#   anything else             — delegated to the file store, so the
+#                               single-tenant OSS surfaces (/api/v1/connectors,
+#                               agent connector tools) keep their exact
+#                               behavior in a cloud install.
+#
+# Ownership: the WorkspaceConnector row LIFECYCLE belongs to
+# ``connectors/service.py`` (enable/disable/update_config). This module is the
+# read-mostly sister seam of the same entity: ``get`` reads config, ``set``
+# only mirrors config onto an EXISTING row, ``delete`` is a deliberate no-op
+# for namespaced keys (a registry-level disconnect must drop the live adapter
+# without destroying service-owned durable state). ``list`` is sync (the
+# registry's sync ``status()`` calls it) and returns the file-delegate rows
+# only — cloud rows are tenant-scoped and surface through the cloud DTOs.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+logger = logging.getLogger(__name__)
+
+_WS_PREFIX = "ws:"
+_POCKET_PREFIX = "pocket:"
+
+
+def _parse_scope_key(scope_key: str) -> tuple[str, str] | None:
+    """Split a namespaced scope key into ``(kind, ident)``, or ``None``.
+
+    Non-namespaced keys (the OSS single-tenant path) return ``None`` and are
+    delegated to the file store.
+    """
+    if scope_key.startswith(_WS_PREFIX):
+        return ("ws", scope_key[len(_WS_PREFIX) :])
+    if scope_key.startswith(_POCKET_PREFIX):
+        return ("pocket", scope_key[len(_POCKET_PREFIX) :])
+    return None
+
+
+class CloudConnectorStateStore:
+    """``ConnectorStateStore`` backed by the ``WorkspaceConnector`` Beanie doc.
+
+    ``get``/``set``/``delete`` are async for namespaced keys (the registry
+    awaits awaitable results); non-namespaced keys delegate to the sync file
+    store. Every Beanie failure is soft — a registry built where the cloud DB
+    isn't initialized (OSS tests, partial installs) degrades to "no persisted
+    cloud config" instead of crashing connector support.
+    """
+
+    def __init__(self, file_fallback: FileConnectorStateStore | None = None) -> None:
+        self._file = file_fallback or FileConnectorStateStore()
+
+    # -- internals ----------------------------------------------------------
+
+    async def _find_doc(self, name: str, kind: str, ident: str) -> Any | None:
+        """Resolve the enabled WorkspaceConnector row for a namespaced key."""
+        from pocketpaw_ee.cloud.models.connector import WorkspaceConnector as _WCDoc
+
+        if kind == "ws":
+            # Workspace key: tenancy filter only, scope-agnostic — mirrors the
+            # legacy execute() lookup (workspace + name), so a pocket- or
+            # user-scoped row still rehydrates a workspace-keyed execute.
+            return await _WCDoc.find_one(
+                _WCDoc.workspace == ident,
+                _WCDoc.name == name,
+                _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+            )
+        return await _WCDoc.find_one(
+            _WCDoc.pocket_id == ident,
+            _WCDoc.scope == "pocket",
+            _WCDoc.name == name,
+            _WCDoc.enabled == True,  # noqa: E712 — Beanie expects ==
+        )
+
+    # -- ConnectorStateStore --------------------------------------------------
+
+    def get(self, name: str, scope_key: str) -> Any:
+        parsed = _parse_scope_key(scope_key)
+        if parsed is None:
+            return self._file.get(name, scope_key)
+        return self._get_cloud(name, *parsed)
+
+    async def _get_cloud(self, name: str, kind: str, ident: str) -> dict[str, Any] | None:
+        try:
+            doc = await self._find_doc(name, kind, ident)
+        except Exception as exc:  # noqa: BLE001 — degrade, don't break connectors
+            logger.warning("cloud connector state read failed for %s: %s", name, exc)
+            return None
+        if doc is None:
+            return None
+        # An enabled row with empty config is still a valid binding (CLI/no-cred
+        # connectors) — return the dict, never coerce {} to None.
+        return dict(doc.config)
+
+    def set(self, name: str, scope_key: str, config: dict[str, Any]) -> Any:
+        parsed = _parse_scope_key(scope_key)
+        if parsed is None:
+            return self._file.set(name, scope_key, config)
+        return self._set_cloud(name, *parsed, config=config)
+
+    async def _set_cloud(self, name: str, kind: str, ident: str, *, config: dict[str, Any]) -> None:
+        """Mirror config onto an existing row — never create one.
+
+        Row creation (with its scope/tenancy validation) belongs to
+        ``service.enable_connector``; a registry-seam write for a key with no
+        row is logged and skipped so the seam can't conjure tenant state.
+        """
+        try:
+            doc = await self._find_doc(name, kind, ident)
+            if doc is None:
+                logger.warning(
+                    "no WorkspaceConnector row for %s (%s:%s) — rows are created via "
+                    "enable_connector; skipping registry config write",
+                    name,
+                    kind,
+                    ident,
+                )
+                return
+            doc.config = dict(config)
+            # no-event: registry-seam config mirror of a row the connectors
+            # service owns; service-level writes emit their own events.
+            await doc.save()
+        except Exception as exc:  # noqa: BLE001 — degrade, don't break connectors
+            logger.warning("cloud connector state write failed for %s: %s", name, exc)
+
+    def delete(self, name: str, scope_key: str) -> Any:
+        parsed = _parse_scope_key(scope_key)
+        if parsed is None:
+            return self._file.delete(name, scope_key)
+        # Deliberate no-op for namespaced keys: the WorkspaceConnector row
+        # lifecycle is owned by enable/disable_connector. A registry-level
+        # disconnect() against a cloud key only needs the LIVE adapter dropped;
+        # destroying the durable row here would let a registry rollback wipe
+        # service-owned state.
+        logger.debug("skipping registry delete for cloud connector row %s (%s)", name, scope_key)
+        return None
+
+    def list(self) -> list[tuple[str, str]]:
+        # Sync by contract (the registry's sync status() calls it). Cloud rows
+        # are tenant-scoped and never match a single-tenant pocket filter, so
+        # they are intentionally not enumerated here — the cloud status/list
+        # DTOs derive from WorkspaceConnector docs in connectors/service.py.
+        return self._file.list()

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -59,6 +59,12 @@ agent proposes a connector call through Instinct; the ee instinct router fires
 approval. Propose-only — the tool never fires the connector itself. Ambient
 (not opt-in).
 
+Updated: 2026-06-12 (connector-store-unification CS-3) — added
+``CloudConnectorStateStoreProvider`` (``pocketpaw.connector_state_stores``)
+supplying the ``WorkspaceConnector``-backed ``CloudConnectorStateStore`` as the
+ConnectorRegistry's default durable state store, so cloud connector config
+rehydrates from the tenant DB after a process restart (no /connect needed).
+
 Updated: 2026-06-11 (feat/fabric-instinct-mcp-providers) — added
 ``CloudFabricMcpProvider`` (entry ``fabric``; server ``pocketpaw_fabric``,
 tools ``fabric_query`` / ``fabric_stats``) and ``CloudInstinctMcpProvider``
@@ -862,6 +868,24 @@ class CloudAgentExtension:
             if value:
                 env[var] = str(value)
         return env
+
+
+class CloudConnectorStateStoreProvider:
+    """`pocketpaw.connector_state_stores` — durable connector state from the
+    cloud DB.
+
+    Backs the ConnectorRegistry's restart-survival seam with the
+    ``WorkspaceConnector`` Beanie doc (namespaced ``ws:<workspace_id>`` /
+    ``pocket:<pocket_id>`` scope keys; everything else delegates to the OSS
+    file store). With this registered, ``registry.ensure_connected`` on a
+    fresh process rehydrates a connector from its workspace row — a cloud
+    execute needs no prior /connect call.
+    """
+
+    def get_state_store(self) -> Any:
+        from pocketpaw_ee.cloud.connectors.state_provider import CloudConnectorStateStore
+
+        return CloudConnectorStateStore()
 
 
 class CloudComposioToolProvider:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -6,6 +6,10 @@
 # depends on the OSS core package `pocketpaw`.
 #
 # Changes:
+#   - 2026-06-12 (connector-store-unification CS-3): registered the
+#     `pocketpaw.connector_state_stores` entry-point
+#     (CloudConnectorStateStoreProvider) so the ConnectorRegistry's durable
+#     state defaults to the WorkspaceConnector-backed cloud store.
 #   - 2026-06-10 (sov/w0a-license): added the `pocketpaw-ee-license`
 #     console script (operator license MINTING / keypair / verify) — see
 #     `[project.scripts]` and `pocketpaw_ee/cloud/mint.py`.
@@ -207,6 +211,9 @@ cloud = "pocketpaw_ee.extensions:CloudAgentExtension"
 
 [project.entry-points."pocketpaw.composio_tools"]
 cloud = "pocketpaw_ee.extensions:CloudComposioToolProvider"
+
+[project.entry-points."pocketpaw.connector_state_stores"]
+cloud = "pocketpaw_ee.extensions:CloudConnectorStateStoreProvider"
 
 [tool.hatch.metadata]
 # Allow git+ direct references in dependencies (PEP 440 disallows them

--- a/src/pocketpaw/connectors/db_adapter.py
+++ b/src/pocketpaw/connectors/db_adapter.py
@@ -2,6 +2,11 @@
 # Created: 2026-03-30
 # Supports: PostgreSQL, MySQL, MariaDB, SQLite, MSSQL, CockroachDB, etc.
 # Uses sqlalchemy async engine under the hood — single dependency for all databases.
+# Updated: 2026-06-12 (connector-store-unification CS-5) — reconnect-safe
+#   connect(): a second connect() disposes the previous engine before building
+#   a new one (no leaked pool on double-connect / config change), and a failed
+#   connect resets ``_connected`` so the adapter never reports a connection it
+#   no longer has.
 
 from __future__ import annotations
 
@@ -140,6 +145,14 @@ class DatabaseAdapter:
         # Check the async driver is installed
         pip_pkg = self._dialect.get("pip", "")
         try:
+            # Reconnect-safety (CS-5): a second connect() — config change,
+            # post-restart recovery race — must not leak the previous
+            # engine's connection pool.
+            if self._engine is not None:
+                await self._engine.dispose()
+                self._engine = None
+                self._connected = False
+
             url = self._build_url(normalized)
             ssl_args: dict[str, Any] = {}
             if normalized.get("DB_SSL", "").lower() == "true":
@@ -169,6 +182,7 @@ class DatabaseAdapter:
                 message=f"Connected to {db_name}@{host}",
             )
         except ImportError:
+            self._connected = False
             return ConnectionResult(
                 success=False,
                 connector_name=self.name,
@@ -177,6 +191,7 @@ class DatabaseAdapter:
             )
         except Exception as e:
             self._engine = None
+            self._connected = False
             return ConnectionResult(
                 success=False,
                 connector_name=self.name,

--- a/src/pocketpaw/connectors/mongo_adapter.py
+++ b/src/pocketpaw/connectors/mongo_adapter.py
@@ -1,5 +1,10 @@
 # MongoDB adapter — document database connector via motor (async pymongo).
 # Created: 2026-03-30
+# Updated: 2026-06-12 (connector-store-unification CS-5) — reconnect-safe
+#   connect(): a second connect() closes the previous motor client before
+#   building a new one (no leaked socket pool on double-connect / config
+#   change), and a failed connect resets ``_connected`` so the adapter never
+#   reports a connection it no longer has.
 
 from __future__ import annotations
 
@@ -70,6 +75,15 @@ class MongoDBAdapter:
             )
 
         try:
+            # Reconnect-safety (CS-5): a second connect() — config change,
+            # post-restart recovery race — must not leak the previous
+            # client's socket pool.
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+                self._db = None
+                self._connected = False
+
             self._client = AsyncIOMotorClient(uri, serverSelectionTimeoutMS=5000)
             # Test connection
             await self._client.admin.command("ping")
@@ -84,6 +98,7 @@ class MongoDBAdapter:
         except Exception as e:
             self._client = None
             self._db = None
+            self._connected = False
             return ConnectionResult(
                 success=False,
                 connector_name=self.name,

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -309,6 +309,14 @@ class ConnectorRegistry:
         connected must not read as configured. If a live adapter exists with
         *different* config, it is disconnected first and reconnected with the
         new config. Serialized per key with ``ensure_connected``.
+
+        WARNING: never pass a namespaced (``ws:``/``pocket:``) scope key as
+        ``pocket_id`` — against the EE cloud store, the write-through ``set``
+        would mirror this unproven config onto the service-owned
+        WorkspaceConnector row, and the rollback ``delete`` no-ops there, so
+        a failed connect could not undo it. Cloud rows reconnect through
+        ``ensure_connected`` only; their lifecycle belongs to the connectors
+        service.
         """
         defn = self.get_definition(connector_name)
         if not defn:

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -38,10 +38,20 @@
 #   *raises*, not just when it returns a failure result; (3) connect() routes
 #   through get_definition() so a YAML dropped in after startup is connectable
 #   without a restart (it was already visible to detail/status).
+# Updated: 2026-06-12 (connector-store-unification CS-3) — The default state
+#   store is now pluggable: when no explicit ``state_store`` is passed, the
+#   registry asks the ``pocketpaw.connector_state_stores`` entry-point group
+#   (see ``ConnectorStateStoreProvider`` in pocketpaw/extensions.py) before
+#   falling back to FileConnectorStateStore — so an EE install transparently
+#   backs every registry with the cloud DB. Store ``get``/``set``/``delete``
+#   calls on async paths go through ``_maybe_await`` so an async (DB-backed)
+#   store and the sync file store both work behind the same seam.
 
 from __future__ import annotations
 
 import asyncio
+import inspect
+import logging
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -53,6 +63,21 @@ from pocketpaw.connectors.protocol import (
 )
 from pocketpaw.connectors.state_store import ConnectorStateStore, FileConnectorStateStore
 from pocketpaw.connectors.yaml_engine import ConnectorDef, DirectRESTAdapter, parse_connector_yaml
+
+logger = logging.getLogger(__name__)
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Await *value* if it is awaitable, else return it as-is.
+
+    The seam that lets one registry speak to both store shapes: the sync
+    file store returns plain values; the EE cloud store's ``get``/``set``/
+    ``delete`` are async (Beanie). Only ``list`` must stay sync — it is
+    called from the sync ``status()``.
+    """
+    if inspect.isawaitable(value):
+        return await value
+    return value
 
 
 @runtime_checkable
@@ -157,6 +182,28 @@ def _default_home_connectors_dir() -> Path:
     return Path.home() / ".pocketpaw" / "connectors"
 
 
+def _provider_state_store() -> ConnectorStateStore | None:
+    """State store from the ``pocketpaw.connector_state_stores`` entry-point.
+
+    Same discovery pattern as every other extension point (see
+    ``pocketpaw.extensions.ConnectorStateStoreProvider``): an OSS install
+    finds no provider and returns ``None``; a cloud install returns the
+    DB-backed store so connector config rehydrates from the tenant database
+    after a restart. A provider that blows up is skipped — a broken plugin
+    must not take connector support down with it.
+    """
+    from pocketpaw._registry import first
+
+    provider = first("pocketpaw.connector_state_stores")
+    if provider is None:
+        return None
+    try:
+        return provider.get_state_store()
+    except Exception as exc:  # noqa: BLE001 — isolate plugin failures
+        logger.warning("connector state store provider failed, using file store: %s", exc)
+        return None
+
+
 class ConnectorRegistry:
     """Discovers available connectors and manages instances per pocket."""
 
@@ -169,7 +216,9 @@ class ConnectorRegistry:
     ) -> None:
         self._connectors_dir = connectors_dir or Path("connectors")
         self._home_connectors_dir = home_connectors_dir
-        self._state_store: ConnectorStateStore = state_store or FileConnectorStateStore()
+        self._state_store: ConnectorStateStore = (
+            state_store or _provider_state_store() or FileConnectorStateStore()
+        )
         self._definitions: dict[str, ConnectorDef] = {}
         self._instances: dict[str, AnyAdapter] = {}  # key = "{pocket_id}:{connector_name}"
         # Per-key locks serializing the connect paths — see _lock_for().
@@ -268,20 +317,20 @@ class ConnectorRegistry:
         key = f"{pocket_id}:{connector_name}"
         async with self._lock_for(key):
             if key in self._instances:
-                previous = self._state_store.get(connector_name, pocket_id)
+                previous = await _maybe_await(self._state_store.get(connector_name, pocket_id))
                 if previous is not None and previous != config:
                     await self.disconnect(pocket_id, connector_name)
 
-            self._state_store.set(connector_name, pocket_id, config)
+            await _maybe_await(self._state_store.set(connector_name, pocket_id, config))
             try:
                 result = await self._connect_adapter(pocket_id, connector_name, defn, config)
             except BaseException:
                 # adapter.connect blew up (or was cancelled) — the row must
                 # not survive, same invariant as a failure result.
-                self._state_store.delete(connector_name, pocket_id)
+                await _maybe_await(self._state_store.delete(connector_name, pocket_id))
                 raise
             if result is None or not result.success:
-                self._state_store.delete(connector_name, pocket_id)
+                await _maybe_await(self._state_store.delete(connector_name, pocket_id))
             return result
 
     async def _connect_adapter(
@@ -341,7 +390,7 @@ class ConnectorRegistry:
             if adapter is not None:
                 return adapter
 
-            config = self._state_store.get(connector_name, scope_key)
+            config = await _maybe_await(self._state_store.get(connector_name, scope_key))
             if config is None:
                 return None
             defn = self.get_definition(connector_name)
@@ -367,9 +416,9 @@ class ConnectorRegistry:
         adapter = self._instances.pop(key, None)
         if adapter is not None:
             await adapter.disconnect(pocket_id)
-        had_state = self._state_store.get(connector_name, pocket_id) is not None
+        had_state = await _maybe_await(self._state_store.get(connector_name, pocket_id)) is not None
         if had_state:
-            self._state_store.delete(connector_name, pocket_id)
+            await _maybe_await(self._state_store.delete(connector_name, pocket_id))
         return adapter is not None or had_state
 
     def status(self, pocket_id: str) -> list[dict[str, Any]]:

--- a/src/pocketpaw/connectors/state_store.py
+++ b/src/pocketpaw/connectors/state_store.py
@@ -9,6 +9,10 @@
 #   same prefix never share a file and no key can path-traverse out of the dir.
 #   Files are chmod 0600 (config may carry credentials, same posture as the
 #   OAuth token store).
+# Updated: 2026-06-12 (connector-store-unification CS-3) — Protocol docs note
+#   that implementations may make get/set/delete async (the registry awaits
+#   awaitable results via _maybe_await); list must stay sync. Lets the EE
+#   WorkspaceConnector-backed store satisfy the same seam.
 
 from __future__ import annotations
 
@@ -62,7 +66,14 @@ class ConnectorStateStore(Protocol):
     """Durable store for connector config, keyed by (name, scope_key).
 
     ``scope_key`` is the registry's scoping segment — the pocket_id on the
-    OSS path. Implementations must treat both key parts as untrusted input.
+    OSS path, a namespaced ``ws:<workspace_id>`` / ``pocket:<pocket_id>``
+    key on the cloud path. Implementations must treat both key parts as
+    untrusted input.
+
+    Implementations may make ``get``/``set``/``delete`` async (return an
+    awaitable) — every registry call site on an async path awaits awaitable
+    results (see ``ConnectorRegistry._maybe_await``). ``list`` must stay
+    sync: it is called from the registry's sync ``status()``.
     """
 
     def get(self, name: str, scope_key: str) -> dict[str, Any] | None:

--- a/src/pocketpaw/extensions.py
+++ b/src/pocketpaw/extensions.py
@@ -10,6 +10,11 @@ contract enforces it.
 Each Protocol documents the entry-point group that carries its implementations.
 An entry-point points at a zero-arg callable (usually the class itself) that
 the registry instantiates once and caches.
+
+Updated: 2026-06-12 (connector-store-unification CS-3) — added
+``ConnectorStateStoreProvider`` (group ``pocketpaw.connector_state_stores``)
+so EE can back the ConnectorRegistry's durable state with the cloud DB
+instead of the file store.
 """
 
 from __future__ import annotations
@@ -199,6 +204,27 @@ class PocketWriter(Protocol):
         """Create the pocket + linked session. Returns the new pocket id,
         or ``None`` on failure."""
         ...
+
+
+@runtime_checkable
+class ConnectorStateStoreProvider(Protocol):
+    """Entry-point group: ``pocketpaw.connector_state_stores``
+
+    Supplies the durable ``ConnectorStateStore`` that backs
+    ``ConnectorRegistry`` when no explicit store is passed. Core ships the
+    file-backed default (``~/.pocketpaw/connectors/state/``); the cloud
+    product swaps in a store backed by the ``WorkspaceConnector`` document
+    so connector config rehydrates from the tenant database after a
+    process restart.
+
+    The returned store satisfies
+    ``pocketpaw.connectors.state_store.ConnectorStateStore``. Its
+    ``get``/``set``/``delete`` methods may be async (return awaitables) —
+    the registry awaits awaitable results; ``list`` must stay sync (it is
+    called from the registry's sync ``status()``).
+    """
+
+    def get_state_store(self) -> Any: ...
 
 
 @runtime_checkable

--- a/src/pocketpaw/tools/builtin/connector_tools.py
+++ b/src/pocketpaw/tools/builtin/connector_tools.py
@@ -1,5 +1,10 @@
 # Connector tools — let the agent list, connect, and execute connector actions.
 # Created: 2026-03-29 — Wires ConnectorRegistry into agent tool interface.
+# Updated: 2026-06-12 (connector-store-unification, PR-A review follow-up) —
+#   ConnectorExecuteTool goes through registry.ensure_connected instead of
+#   get_adapter, so agent-tool executes survive a process restart exactly like
+#   the HTTP /connectors/execute router: a persisted config reconnects lazily,
+#   no in-session connector_connect required.
 
 import json
 import logging
@@ -188,7 +193,10 @@ class ConnectorExecuteTool(BaseTool):
         pocket_id: str = "default",
     ) -> str:
         reg = _get_registry()
-        adapter = reg.get_adapter(pocket_id, connector_name)
+        # ensure_connected (not get_adapter): if no adapter is live but config
+        # is persisted in the state store — e.g. after a restart — reconnect
+        # on the fly, matching the HTTP /connectors/execute behavior.
+        adapter = await reg.ensure_connected(connector_name, pocket_id)
         if not adapter:
             return f"Connector '{connector_name}' is not connected. Use connector_connect first."
 

--- a/tests/cloud/connectors/test_state_provider.py
+++ b/tests/cloud/connectors/test_state_provider.py
@@ -8,6 +8,10 @@
 #   (set mirrors config onto existing rows only; delete on namespaced keys is
 #   a no-op; non-namespaced keys delegate to the file store), and the
 #   stale-adapter drops on update_config / disable_connector.
+# Updated: 2026-06-12 (PR #1449 review fix) — added the credential-provenance
+#   test: a disabled row's credentials must never reach the legacy fallback's
+#   connect() (the fallback doc read now filters enabled == True), so disable
+#   revokes on the HTTP execute path too, not just the durable seam.
 
 from __future__ import annotations
 
@@ -312,3 +316,53 @@ async def test_disable_drops_live_adapter(
     assert fresh_registry.get_adapter("ws:ws-1", "github") is None
     # And the durable read now reports no binding (enabled filter).
     assert await fresh_registry._state_store.get("github", "ws:ws-1") is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_row_credentials_never_reach_fallback_connect(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    """Disable must revoke on EVERY execute path (PR #1449 review fix).
+
+    The durable seam already refuses disabled rows (enabled filter in the
+    cloud store), but the legacy one-shot fallback used to re-read the doc
+    WITHOUT an enabled filter — a disabled row's credentials still connected
+    and executed via the HTTP router. Provenance check: seed a DISABLED row
+    with credentials, spy on every config that reaches connect(), and assert
+    the credentials never appear — the fallback gets {} and real adapters
+    fail to connect.
+    """
+    from pocketpaw.connectors.yaml_engine import DirectRESTAdapter
+
+    await _seed_doc(enabled=False, config={"GITHUB_TOKEN": "ghp_revoked"})
+
+    connect_configs: list[dict] = []
+    original_connect = DirectRESTAdapter.connect
+
+    async def _spy_connect(self, pocket_id, config):
+        connect_configs.append(dict(config))
+        return await original_connect(self, pocket_id, config)
+
+    with (
+        patch.object(DirectRESTAdapter, "connect", _spy_connect),
+        patch.object(
+            DirectRESTAdapter,
+            "execute",
+            return_value=ActionResult(success=True, data=[], records_affected=0),
+        ),
+    ):
+        await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(action="list_issues", params={"owner": "a", "repo": "b"}),
+            user_id="u-1",
+        )
+
+    # The disabled row's credentials never reached any connect() call: the
+    # durable seam refused the row, and the fallback's enabled-filtered doc
+    # read fell through to {} config.
+    assert connect_configs == [{}]
+    assert all("GITHUB_TOKEN" not in c for c in connect_configs)
+    # Nothing was cached under the durable key either.
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is None

--- a/tests/cloud/connectors/test_state_provider.py
+++ b/tests/cloud/connectors/test_state_provider.py
@@ -1,0 +1,314 @@
+# test_state_provider.py — connector-store-unification CS-3 — cloud state store.
+# Created: 2026-06-12 — Locks the cloud restart-survival contract: a fresh
+#   process (fresh ConnectorRegistry) with only a seeded WorkspaceConnector doc
+#   executes through registry.ensure_connected with NO prior /connect call,
+#   for both ws:<workspace_id> and pocket:<pocket_id> scope keys. Also pins
+#   the entry-point wiring (the registry's DEFAULT store is the cloud store
+#   when pocketpaw-ee is installed), the store's namespacing/ownership rules
+#   (set mirrors config onto existing rows only; delete on namespaced keys is
+#   a no-op; non-namespaced keys delegate to the file store), and the
+#   stale-adapter drops on update_config / disable_connector.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.dto import (
+    ExecuteActionRequest,
+    UpdateConnectorConfigRequest,
+)
+from pocketpaw_ee.cloud.connectors.state_provider import CloudConnectorStateStore
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+from pocketpaw.connectors.protocol import ActionResult
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+
+async def _seed_doc(
+    *,
+    workspace: str = "ws-1",
+    name: str = "github",
+    scope: str = "workspace",
+    pocket_id: str | None = None,
+    enabled: bool = True,
+    config: dict | None = None,
+) -> WorkspaceConnector:
+    doc = WorkspaceConnector(
+        workspace=workspace,
+        name=name,
+        enabled=enabled,
+        scope=scope,
+        pocket_id=pocket_id,
+        config=config if config is not None else {"GITHUB_TOKEN": "ghp_test"},
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture
+def cloud_store(tmp_path) -> CloudConnectorStateStore:
+    """Cloud store with a hermetic file fallback (never the real ~/.pocketpaw)."""
+    return CloudConnectorStateStore(
+        file_fallback=FileConnectorStateStore(base_dir=tmp_path / "file-state")
+    )
+
+
+@pytest.fixture
+def fresh_registry(cloud_store, monkeypatch) -> ConnectorRegistry:
+    """A registry simulating a FRESH PROCESS, installed as the service's
+    singleton: no live adapters, durable state only in the cloud store."""
+    reg = ConnectorRegistry(Path("connectors"), state_store=cloud_store)
+    monkeypatch.setattr(connectors_service, "_registry", reg)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# The CS-3 behavior contract: seeded doc → fresh process → execute works.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cloud_execute_rehydrates_workspace_row_without_connect(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    """A fresh process with only a seeded workspace-scope doc executes
+    successfully — registry.ensure_connected rehydrates from the doc's config,
+    no /connect call ever happens in this process."""
+    await _seed_doc(scope="workspace")
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is None
+
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(success=True, data=[{"number": 7}], records_affected=1),
+    ):
+        resp = await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(action="list_issues", params={"owner": "a", "repo": "b"}),
+            user_id="u-1",
+        )
+
+    assert resp.success is True
+    assert resp.execution_mode == "cloud"
+    # Proof the DURABLE path ran (not the legacy one-shot fallback): the
+    # registry now holds the rehydrated adapter under the ws: scope key.
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is not None
+
+
+@pytest.mark.asyncio
+async def test_cloud_execute_rehydrates_pocket_row_without_connect(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    """Same restart contract for a pocket-bound row, keyed pocket:<pocket_id>."""
+    await _seed_doc(scope="pocket", pocket_id="pk-1")
+
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(success=True, data=[], records_affected=0),
+    ):
+        resp = await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(
+                action="list_issues",
+                params={"owner": "a", "repo": "b"},
+                scope="pocket",
+                pocket_id="pk-1",
+            ),
+            user_id="u-1",
+        )
+
+    assert resp.success is True
+    assert fresh_registry.get_adapter("pocket:pk-1", "github") is not None
+
+
+@pytest.mark.asyncio
+async def test_pocket_key_is_tenant_gated(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    """A pocket_id bound in ANOTHER workspace must not select that tenant's
+    config — the bind check fails and the caller falls back to its own ws row
+    (which doesn't exist here), so no pocket-keyed adapter appears."""
+    await _seed_doc(workspace="ws-OTHER", scope="pocket", pocket_id="pk-foreign")
+
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(success=True, data=[], records_affected=0),
+    ):
+        await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(
+                action="list_issues",
+                params={"owner": "a", "repo": "b"},
+                scope="pocket",
+                pocket_id="pk-foreign",
+            ),
+            user_id="u-1",
+        )
+
+    assert fresh_registry.get_adapter("pocket:pk-foreign", "github") is None
+
+
+# ---------------------------------------------------------------------------
+# Entry-point wiring — the registry's DEFAULT store is the cloud store.
+# ---------------------------------------------------------------------------
+
+
+def test_registry_default_store_comes_from_entry_point():
+    """With pocketpaw-ee installed, a registry built with no explicit store
+    picks up CloudConnectorStateStore via pocketpaw.connector_state_stores."""
+    from pocketpaw._registry import clear_cache, first
+
+    clear_cache()
+    provider = first("pocketpaw.connector_state_stores")
+    assert provider is not None
+
+    reg = ConnectorRegistry(Path("connectors"))
+    assert isinstance(reg._state_store, CloudConnectorStateStore)
+
+
+# ---------------------------------------------------------------------------
+# Store unit contracts — namespacing, ownership, file delegation.
+# ---------------------------------------------------------------------------
+
+
+class TestCloudStoreGet:
+    @pytest.mark.asyncio
+    async def test_ws_key_returns_enabled_row_config(self, mongo_db, cloud_store):  # noqa: ARG002
+        await _seed_doc(config={"GITHUB_TOKEN": "x"})
+        assert await cloud_store.get("github", "ws:ws-1") == {"GITHUB_TOKEN": "x"}
+
+    @pytest.mark.asyncio
+    async def test_ws_key_is_workspace_scoped(self, mongo_db, cloud_store):  # noqa: ARG002
+        await _seed_doc(workspace="ws-OTHER")
+        assert await cloud_store.get("github", "ws:ws-1") is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_row_reads_as_absent(self, mongo_db, cloud_store):  # noqa: ARG002
+        await _seed_doc(enabled=False)
+        assert await cloud_store.get("github", "ws:ws-1") is None
+
+    @pytest.mark.asyncio
+    async def test_pocket_key_requires_pocket_scope_binding(
+        self,
+        mongo_db,  # noqa: ARG002
+        cloud_store,
+    ):
+        await _seed_doc(scope="pocket", pocket_id="pk-1", config={"GITHUB_TOKEN": "x"})
+        assert await cloud_store.get("github", "pocket:pk-1") == {"GITHUB_TOKEN": "x"}
+        assert await cloud_store.get("github", "pocket:pk-2") is None
+
+    @pytest.mark.asyncio
+    async def test_empty_config_is_still_a_binding(self, mongo_db, cloud_store):  # noqa: ARG002
+        """CLI / no-cred connectors persist config={} — that must read as a
+        valid binding ({}), never coerced to None."""
+        await _seed_doc(config={})
+        assert await cloud_store.get("github", "ws:ws-1") == {}
+
+    def test_plain_key_delegates_to_file_store(self, cloud_store):
+        cloud_store.set("testsvc", "default", {"k": "v"})
+        assert cloud_store.get("testsvc", "default") == {"k": "v"}
+        cloud_store.delete("testsvc", "default")
+        assert cloud_store.get("testsvc", "default") is None
+
+
+class TestCloudStoreOwnership:
+    @pytest.mark.asyncio
+    async def test_set_mirrors_config_onto_existing_row(
+        self,
+        mongo_db,  # noqa: ARG002
+        cloud_store,
+    ):
+        doc = await _seed_doc(config={"GITHUB_TOKEN": "old"})
+        await cloud_store.set("github", "ws:ws-1", {"GITHUB_TOKEN": "new"})
+        refreshed = await WorkspaceConnector.get(doc.id)
+        assert refreshed.config == {"GITHUB_TOKEN": "new"}
+
+    @pytest.mark.asyncio
+    async def test_set_never_creates_a_row(self, mongo_db, cloud_store):  # noqa: ARG002
+        await cloud_store.set("github", "ws:ws-1", {"GITHUB_TOKEN": "x"})
+        assert await WorkspaceConnector.find_one(WorkspaceConnector.name == "github") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_on_namespaced_key_is_noop(self, mongo_db, cloud_store):  # noqa: ARG002
+        """The WorkspaceConnector lifecycle belongs to enable/disable_connector
+        — a registry-level delete must not destroy the durable row."""
+        await _seed_doc()
+        cloud_store.delete("github", "ws:ws-1")
+        assert await cloud_store.get("github", "ws:ws-1") is not None
+
+    def test_list_returns_file_rows_only(self, cloud_store):
+        cloud_store.set("testsvc", "default", {"k": "v"})
+        assert cloud_store.list() == [("testsvc", "default")]
+
+    @pytest.mark.asyncio
+    async def test_get_degrades_softly_when_db_unavailable(self, cloud_store, monkeypatch):
+        """A failing Beanie read (uninitialized DB, partial install) must
+        degrade to 'no persisted config', not crash connector support."""
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("beanie not initialized")
+
+        monkeypatch.setattr(WorkspaceConnector, "find_one", _boom)
+        assert await cloud_store.get("github", "ws:ws-1") is None
+
+
+# ---------------------------------------------------------------------------
+# Stale-adapter drops — config writes / disable invalidate live connections.
+# ---------------------------------------------------------------------------
+
+
+async def _connect_once(fresh_registry: ConnectorRegistry) -> None:
+    """Prime a live adapter under the ws: key via the durable path."""
+    with patch(
+        "pocketpaw.connectors.yaml_engine.DirectRESTAdapter.execute",
+        return_value=ActionResult(success=True, data=[], records_affected=0),
+    ):
+        await connectors_service.execute(
+            "ws-1",
+            "github",
+            ExecuteActionRequest(action="list_issues", params={"owner": "a", "repo": "b"}),
+            user_id="u-1",
+        )
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is not None
+
+
+@pytest.mark.asyncio
+async def test_update_config_drops_live_adapter(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    await _seed_doc()
+    await _connect_once(fresh_registry)
+
+    await connectors_service.update_config(
+        "ws-1",
+        "github",
+        UpdateConnectorConfigRequest(config={"GITHUB_TOKEN": "rotated"}),
+    )
+
+    # The stale adapter is gone; the next execute rehydrates with new config.
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is None
+
+
+@pytest.mark.asyncio
+async def test_disable_drops_live_adapter(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,
+):
+    await _seed_doc()
+    await _connect_once(fresh_registry)
+
+    await connectors_service.disable_connector("ws-1", "github")
+
+    assert fresh_registry.get_adapter("ws:ws-1", "github") is None
+    # And the durable read now reports no binding (enabled filter).
+    assert await fresh_registry._state_store.get("github", "ws:ws-1") is None

--- a/tests/cloud/connectors/test_ui_agent_invariant.py
+++ b/tests/cloud/connectors/test_ui_agent_invariant.py
@@ -1,0 +1,148 @@
+# test_ui_agent_invariant.py — connector-store-unification CS-4 — one truth.
+# Created: 2026-06-12 — THE INVARIANT TEST: the UI-facing connectors list DTO
+#   (service.list_connectors) and the agent MCP surface
+#   (service.list_pocket_connectors) must report the SAME connector set and
+#   state from the SAME durable source (WorkspaceConnector docs + registry
+#   definitions). This is the structural kill of the 2026-06-12 bug class,
+#   where the two surfaces read different state (durable docs vs in-process
+#   adapter connection state) and could disagree — the UI showing a connector
+#   "connected" while the agent couldn't see it after a restart, or vice
+#   versa. Both surfaces are also asserted against a FRESH registry instance
+#   (simulated restart): neither may depend on in-process adapter state.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud.connectors import service as connectors_service
+from pocketpaw_ee.cloud.connectors.state_provider import CloudConnectorStateStore
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+_WS = "ws-1"
+_POCKET = "pk-1"
+
+
+async def _seed_pocket_connector(
+    name: str = "github", *, enabled: bool = True, pocket_id: str = _POCKET
+) -> None:
+    """The ONE workspace_connectors fixture both surfaces must agree on."""
+    await WorkspaceConnector(
+        workspace=_WS,
+        name=name,
+        enabled=enabled,
+        scope="pocket",
+        pocket_id=pocket_id,
+        config={"GITHUB_TOKEN": "ghp_test"},
+    ).insert()
+
+
+async def _ui_connected_names() -> set[str]:
+    """The UI surface: GET /cloud/connectors rows with status=connected."""
+    rows = await connectors_service.list_connectors(_WS)
+    return {r.name for r in rows if r.status == "connected"}
+
+
+async def _agent_visible_names(pocket_id: str = _POCKET) -> set[str]:
+    """The agent surface: what the MCP server enumerates for this pocket."""
+    infos = await connectors_service.list_pocket_connectors(_WS, pocket_id)
+    return {i.name for i in infos}
+
+
+@pytest.fixture
+def fresh_registry(tmp_path, monkeypatch) -> ConnectorRegistry:
+    """Simulated restart: a registry with no live adapters, installed as the
+    service singleton. Both surfaces must read identically through it."""
+    reg = ConnectorRegistry(
+        Path("connectors"),
+        state_store=CloudConnectorStateStore(
+            file_fallback=FileConnectorStateStore(base_dir=tmp_path / "file-state")
+        ),
+    )
+    monkeypatch.setattr(connectors_service, "_registry", reg)
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_ui_and_agent_connector_surfaces_never_disagree(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,  # noqa: ARG001 — simulated restart, no live adapters
+):
+    """Structural kill of the 2026-06-12 UI-vs-agent divergence bug class.
+
+    One seeded workspace_connectors row; the UI list DTO and the agent MCP
+    enumeration must report the same connector set and state — derived from
+    durable state only, on a registry with zero in-process adapters.
+    """
+    await _seed_pocket_connector("github")
+
+    ui = await _ui_connected_names()
+    agent = await _agent_visible_names()
+
+    assert ui == agent == {"github"}
+
+
+@pytest.mark.asyncio
+async def test_surfaces_agree_on_disabled_connector(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,  # noqa: ARG001
+):
+    """A disabled row must vanish from BOTH surfaces, not just one."""
+    await _seed_pocket_connector("github", enabled=False)
+
+    assert await _ui_connected_names() == set()
+    assert await _agent_visible_names() == set()
+
+
+@pytest.mark.asyncio
+async def test_surfaces_agree_after_disable_transition(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,  # noqa: ARG001
+):
+    """Enable → both see it; disable → both drop it. No surface may lag the
+    other through the transition (the in-process-state failure mode).
+
+    Uses a REAL pocket (created through the pockets service) because
+    disabling a pocket-scoped connector re-derives that pocket's
+    surface_profile — a synthetic pocket id would 404 the rederive."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+    wire = await pockets_service.create(_WS, "u-1", CreatePocketRequest(name="Invariant"))
+    pocket_id = wire["_id"]
+
+    await _seed_pocket_connector("github", pocket_id=pocket_id)
+    ui = await _ui_connected_names()
+    agent = await _agent_visible_names(pocket_id)
+    assert ui == agent == {"github"}
+
+    await connectors_service.disable_connector(_WS, "github")
+
+    assert await _ui_connected_names() == set()
+    assert await _agent_visible_names(pocket_id) == set()
+
+
+@pytest.mark.asyncio
+async def test_widget_recipes_follow_durable_state(
+    mongo_db,  # noqa: ARG001 — wires Beanie
+    fresh_registry,  # noqa: ARG001
+):
+    """The widget-recipe rail derives from _WCDoc presence + registry
+    definition presence — a fresh process (no adapter ever connected) still
+    serves recipes for an enabled connector, and none for a disabled one."""
+    await WorkspaceConnector(
+        workspace=_WS,
+        name="gmail",
+        enabled=True,
+        scope="workspace",
+        config={},
+    ).insert()
+
+    recipes = await connectors_service.list_widget_recipes(_WS)
+    assert {r.connector for r in recipes} == {"gmail"}
+
+    await connectors_service.disable_connector(_WS, "gmail")
+    assert await connectors_service.list_widget_recipes(_WS) == []

--- a/tests/connectors/test_adapter_reconnect.py
+++ b/tests/connectors/test_adapter_reconnect.py
@@ -1,0 +1,176 @@
+# test_adapter_reconnect.py — connector-store-unification CS-5 — reconnect audit.
+# Created: 2026-06-12 — Locks the reconnect-safety fixes from the native
+#   adapter audit: DatabaseAdapter disposes its previous engine on a second
+#   connect() (no leaked pool) and resets _connected on a failed connect;
+#   MongoDBAdapter closes its previous motor client on a second connect()
+#   (no leaked socket pool) and resets _connected on a failed connect. These
+#   are the double-connect shapes ensure_connected's restart-recovery path
+#   makes more likely (config change → disconnect+reconnect; racing executes).
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from pocketpaw.connectors.db_adapter import DatabaseAdapter
+from pocketpaw.connectors.mongo_adapter import MongoDBAdapter
+
+# ---------------------------------------------------------------------------
+# DatabaseAdapter (sqlalchemy engine)
+# ---------------------------------------------------------------------------
+
+
+class _FakeConn:
+    async def execute(self, _stmt: Any) -> None:
+        return None
+
+    async def __aenter__(self) -> _FakeConn:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+
+class _FakeEngine:
+    fail_connect = False
+
+    def __init__(self) -> None:
+        self.disposed = False
+
+    def connect(self) -> Any:
+        if self.fail_connect:
+            raise RuntimeError("db unreachable")
+        return _FakeConn()
+
+    async def dispose(self) -> None:
+        self.disposed = True
+
+
+@pytest.fixture
+def fake_engines(monkeypatch) -> list[_FakeEngine]:
+    """Route create_async_engine to fakes; returns the created instances.
+
+    Per-engine failure is staged by monkeypatching ``_FakeEngine.fail_connect``
+    (a class attribute) before the connect under test.
+    """
+    created: list[_FakeEngine] = []
+
+    def _fake_create(*_args: Any, **_kwargs: Any) -> _FakeEngine:
+        engine = _FakeEngine()
+        created.append(engine)
+        return engine
+
+    import sqlalchemy.ext.asyncio as sa_asyncio
+
+    monkeypatch.setattr(sa_asyncio, "create_async_engine", _fake_create)
+    return created
+
+
+_DB_CONFIG = {"DB_HOST": "h", "DB_NAME": "d", "DB_USER": "u", "DB_PASSWORD": "p"}
+
+
+@pytest.mark.asyncio
+async def test_db_double_connect_disposes_previous_engine(fake_engines) -> None:
+    adapter = DatabaseAdapter("postgresql")
+    assert (await adapter.connect("p1", _DB_CONFIG)).success is True
+    assert (await adapter.connect("p1", {**_DB_CONFIG, "DB_PASSWORD": "p2"})).success is True
+
+    assert len(fake_engines) == 2
+    assert fake_engines[0].disposed is True  # the old pool must not leak
+    assert fake_engines[1].disposed is False
+    assert adapter._engine is fake_engines[1]
+    assert adapter._connected is True
+
+
+@pytest.mark.asyncio
+async def test_db_failed_reconnect_resets_connected_flag(fake_engines, monkeypatch) -> None:
+    adapter = DatabaseAdapter("postgresql")
+    assert (await adapter.connect("p1", _DB_CONFIG)).success is True
+    assert adapter._connected is True
+
+    # Next engine refuses to connect (service down / bad creds).
+    monkeypatch.setattr(_FakeEngine, "fail_connect", True)
+    result = await adapter.connect("p1", {**_DB_CONFIG, "DB_PASSWORD": "bad"})
+    assert result.success is False
+    # The adapter must not report a connection it no longer has.
+    assert adapter._connected is False
+    assert adapter._engine is None
+    # And the original engine was still disposed, not leaked.
+    assert fake_engines[0].disposed is True
+
+
+# ---------------------------------------------------------------------------
+# MongoDBAdapter (motor client)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAdmin:
+    def __init__(self, fail_ping: bool) -> None:
+        self._fail_ping = fail_ping
+
+    async def command(self, _name: str) -> None:
+        if self._fail_ping:
+            raise RuntimeError("mongo unreachable")
+        return None
+
+
+class _FakeMotorClient:
+    fail_ping = False
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.closed = False
+        self.admin = _FakeAdmin(self.fail_ping)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __getitem__(self, _name: str) -> Any:
+        return object()
+
+
+@pytest.fixture
+def fake_motor_clients(monkeypatch) -> list[_FakeMotorClient]:
+    created: list[_FakeMotorClient] = []
+
+    class _Recording(_FakeMotorClient):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    import motor.motor_asyncio as motor_asyncio
+
+    monkeypatch.setattr(motor_asyncio, "AsyncIOMotorClient", _Recording)
+    return created
+
+
+_MONGO_CONFIG = {"MONGO_URI": "mongodb://h:27017", "MONGO_DATABASE": "d"}
+
+
+@pytest.mark.asyncio
+async def test_mongo_double_connect_closes_previous_client(fake_motor_clients) -> None:
+    adapter = MongoDBAdapter()
+    assert (await adapter.connect("p1", _MONGO_CONFIG)).success is True
+    assert (await adapter.connect("p1", _MONGO_CONFIG)).success is True
+
+    assert len(fake_motor_clients) == 2
+    assert fake_motor_clients[0].closed is True  # the old socket pool must not leak
+    assert fake_motor_clients[1].closed is False
+    assert adapter._client is fake_motor_clients[1]
+    assert adapter._connected is True
+
+
+@pytest.mark.asyncio
+async def test_mongo_failed_reconnect_resets_connected_flag(
+    fake_motor_clients, monkeypatch
+) -> None:
+    adapter = MongoDBAdapter()
+    assert (await adapter.connect("p1", _MONGO_CONFIG)).success is True
+    assert adapter._connected is True
+
+    monkeypatch.setattr(_FakeMotorClient, "fail_ping", True)
+    result = await adapter.connect("p1", _MONGO_CONFIG)
+    assert result.success is False
+    assert adapter._connected is False
+    assert adapter._client is None
+    assert fake_motor_clients[0].closed is True

--- a/tests/connectors/test_connector_tools_restart.py
+++ b/tests/connectors/test_connector_tools_restart.py
@@ -1,0 +1,137 @@
+# test_connector_tools_restart.py — connector-store-unification (PR-A review
+#   follow-up) — agent-tool execute parity with the HTTP router.
+# Created: 2026-06-12 — Locks: ConnectorExecuteTool reconnects from persisted
+#   state on a fresh process (registry B shares registry A's state store, no
+#   connector_connect in session B), exactly like /connectors/execute. Before
+#   the fix the tool used get_adapter and failed with "not connected" after
+#   every restart while the HTTP path succeeded.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import pocketpaw.connectors.registry as registry_module
+import pocketpaw.tools.builtin.connector_tools as connector_tools
+from pocketpaw.connectors.protocol import ActionResult, ConnectionResult, ConnectorStatus
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+from pocketpaw.tools.builtin.connector_tools import ConnectorExecuteTool
+
+_TEST_YAML = """\
+name: testsvc
+display_name: Test Service
+type: rest
+icon: plug
+auth:
+  type: api_key
+  credentials:
+    - name: api_key
+      required: true
+actions:
+  - name: ping
+    description: Ping the service
+    method: GET
+    url: https://example.invalid/ping
+"""
+
+
+class _FakeAdapter:
+    """Minimal adapter recording connect calls; execute returns a dict."""
+
+    def __init__(self) -> None:
+        self.connect_calls: list[tuple[str, dict[str, Any]]] = []
+
+    @property
+    def name(self) -> str:
+        return "testsvc"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Service"
+
+    async def connect(self, pocket_id: str, config: dict[str, Any]) -> ConnectionResult:
+        self.connect_calls.append((pocket_id, config))
+        return ConnectionResult(
+            success=True,
+            connector_name=self.name,
+            status=ConnectorStatus.CONNECTED,
+            message="connected",
+        )
+
+    async def disconnect(self, pocket_id: str) -> bool:
+        return True
+
+    async def actions(self) -> list:
+        return []
+
+    async def execute(self, action: str, params: dict[str, Any]) -> ActionResult:
+        return ActionResult(success=True, data={"action": action}, records_affected=1)
+
+
+@pytest.fixture
+def defs_dir(tmp_path) -> Path:
+    d = tmp_path / "defs"
+    d.mkdir()
+    (d / "testsvc.yaml").write_text(_TEST_YAML)
+    return d
+
+
+@pytest.fixture
+def store(tmp_path) -> FileConnectorStateStore:
+    return FileConnectorStateStore(base_dir=tmp_path / "state")
+
+
+@pytest.fixture
+def fake_adapters(monkeypatch) -> list[_FakeAdapter]:
+    created: list[_FakeAdapter] = []
+
+    def _fake_create(connector_name: str):
+        if connector_name != "testsvc":
+            return None
+        adapter = _FakeAdapter()
+        created.append(adapter)
+        return adapter
+
+    monkeypatch.setattr(registry_module, "_create_native_adapter", _fake_create)
+    return created
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_reconnects_after_restart(
+    defs_dir, store, fake_adapters, monkeypatch
+) -> None:
+    """Session A connects; session B (fresh registry, same store) executes via
+    the agent tool with NO connector_connect — parity with the HTTP router."""
+    reg_a = ConnectorRegistry(defs_dir, state_store=store)
+    result = await reg_a.connect("default", "testsvc", {"api_key": "k1"})
+    assert result.success is True
+
+    # Simulated restart: the tool module's singleton is a fresh registry that
+    # only shares the durable store.
+    reg_b = ConnectorRegistry(defs_dir, state_store=store)
+    assert reg_b.get_adapter("default", "testsvc") is None
+    monkeypatch.setattr(connector_tools, "_registry", reg_b)
+
+    out = await ConnectorExecuteTool().execute("testsvc", "ping", {})
+
+    assert "not connected" not in out
+    assert '"action": "ping"' in out
+    # The reconnect came from the persisted config, lazily.
+    assert reg_b.get_adapter("default", "testsvc") is not None
+    assert fake_adapters[-1].connect_calls == [("default", {"api_key": "k1"})]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_without_persisted_state_still_errors(
+    defs_dir, store, fake_adapters, monkeypatch
+) -> None:
+    """No live adapter AND no persisted config keeps the clear error message."""
+    reg = ConnectorRegistry(defs_dir, state_store=store)
+    monkeypatch.setattr(connector_tools, "_registry", reg)
+
+    out = await ConnectorExecuteTool().execute("testsvc", "ping", {})
+
+    assert "not connected" in out


### PR DESCRIPTION
Continuation of #1449, which GitHub auto-closed when its stacked base branch (feat/connector-state-store, merged as #1447) was deleted. Same five commits, rebased onto dev — full review history and the adapter audit notes live on #1449.

What this ships, on top of #1447's durable store:

- A `ConnectorStateStoreProvider` extension point (same entry-point idiom as the existing 14 providers) and an EE store backed by the `WorkspaceConnector` doc, keyed `ws:<workspace_id>` / `pocket:<pocket_id>`. The cloud `execute()` path now goes through `registry.ensure_connected` — a fresh process executes from a seeded doc with no prior /connect. This is what removes the rebind-after-restart step from cloud deployments.
- An invariant test that reads the UI connectors list and the agent `list_pocket_connectors` surface from one seeded fixture and asserts they agree — the structural fix for the "UI says connected, agent says no" class.
- Reconnect-safe native adapters: db and mongo adapters disposed their old engine/client on re-connect and reset their connected flag on failure paths. Firebase/gcp/drive need no change (notes on #1449).
- The builtin `connector_execute` tool reconnects after restart, matching the HTTP router.
- Security fix surfaced in review: the legacy one-shot fallback in `execute()` now filters on `enabled == True`, so disabling a connector actually revokes its credentials on every execute path. The old code would happily connect with a disabled row's stored credentials.

Tested: 319 OSS connector/registry tests, 63 cloud-connector + MCP-server tests, import-linter contracts green (OSS 1/0, EE 23/0). The 6 pre-existing 401 failures in test_connectors_execute.py are environment auth-fixture failures, unchanged by this branch.