### PR TITLE
Resolve pocket action path from the binding when the client omits it

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -102,6 +102,19 @@ PocketBackendConfigRequest gained ``backend_type`` ("http" default |
 connector backend needs none; the service still requires a valid URL for an
 http backend). PocketBackendConfigResponse echoes ``backend_type`` /
 ``connector_name`` back (never the token).
+Updated: 2026-06-13 (fix/ripple-normalizer-path-drop, native gated actions
+step 1) — ``RunActionRequest.path`` is now OPTIONAL (``str | None``, default
+``None``). The read-time ripple normalizer rewrites an inline write ``api``
+handler into a PATHLESS ``call_binding`` handler (it has no request context to
+carry a path), so the client fires ``/actions/run`` with only ``{action,
+params}``. The path is author-time data the server already persists on the
+``rippleSpec.actions`` binding (it must, to read the HTTP method), so the route
+resolves it from there when the client omits it. A required ``path`` 422'd
+every relative-URL api button (caught live on the Nerve demo's "Score next 20").
+Client-sent ``path`` (a row-scoped binding whose stored path holds an unresolved
+``{item.id}`` template, resolved client-side) still wins — the binding path is
+only the fallback. The server still reads the verb from the binding, so a
+compromised client cannot pick method OR a path the allowlist would reject.
 """
 
 from __future__ import annotations
@@ -440,17 +453,29 @@ class RunActionRequest(BaseModel):
     """Body for ``POST /pockets/{id}/actions/run``.
 
     The client sends the action's NAME (``action``) plus the *resolved*
-    ``path`` and ``params`` — Ripple's ``{...}`` expression resolver runs
-    client-side at click time. The server loads the named action from the
-    persisted ``rippleSpec.actions`` block to read the HTTP ``method`` —
-    the client never picks the verb.
+    ``params`` — Ripple's ``{...}`` expression resolver runs client-side at
+    click time. The server loads the named action from the persisted
+    ``rippleSpec.actions`` block to read the HTTP ``method`` — the client
+    never picks the verb.
+
+    ``path`` is OPTIONAL. The read-time ripple normalizer rewrites an inline
+    write ``api`` handler into a PATHLESS ``call_binding`` handler, so the
+    normal client fires with no ``path`` and the route resolves it from the
+    persisted binding's ``path`` (which the spec already carries — see
+    :class:`~pocketpaw_ee.cloud.pockets.action_executor.ActionBinding`). A
+    client MAY still send a ``path`` — a row-scoped binding whose stored path
+    holds an unresolved ``{item.id}`` template gets resolved client-side, and
+    that resolved value takes precedence over the binding's templated one.
+    Either way the server reads the verb from the binding and the executor
+    matches the final ``(method, path)`` against the owner's allowlist, so a
+    client cannot pick a path the allowlist would reject.
 
     ``idempotency_key`` is optional: when omitted the server generates one
     so a write retried after a timeout cannot double-submit.
     """
 
     action: str = Field(min_length=1)
-    path: str = Field(min_length=1)
+    path: str | None = Field(default=None, min_length=1)
     params: dict[str, Any] = Field(default_factory=dict)
     idempotency_key: str | None = None
 

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -1010,6 +1010,25 @@ async def run_pocket_action(
             code="bad_binding",
         )
 
+    # Resolve the request path. The read-time normalizer rewrites an inline
+    # write `api` handler into a PATHLESS `call_binding` handler (it has no
+    # request context to carry a path), so the normal client fires with
+    # `{action, params}` and no `path`. The path is author-time data already
+    # persisted on the binding (the spec must carry it to know the HTTP
+    # method), so fall back to it. A client that DID send a resolved path —
+    # a row-scoped binding whose stored path holds an unresolved `{item.id}`
+    # template, resolved client-side — keeps precedence; the binding path is
+    # only the fallback. The executor still matches the final (method, path)
+    # against the owner's allowlist, so the fallback cannot widen blast radius.
+    resolved_path = body.path or raw_action.get("path")
+    if not isinstance(resolved_path, str) or not resolved_path:
+        return RunActionResponse(
+            ok=False,
+            action=body.action,
+            error=f"action '{body.action}' has no path — send one or declare it on the binding",
+            code="bad_binding",
+        )
+
     creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, pocket_id)
     if creds is None:
         raise CloudError(
@@ -1053,7 +1072,7 @@ async def run_pocket_action(
         user_id=user_id,
         action=body.action,
         raw_action=raw_action,
-        path=body.path,
+        path=resolved_path,
         params=body.params,
         base_url=base_url,
         auth_type=auth_type,

--- a/tests/cloud/test_pocket_actions_lift.py
+++ b/tests/cloud/test_pocket_actions_lift.py
@@ -63,6 +63,53 @@ def test_relative_inline_write_api_is_lifted_into_actions():
     assert handler["binding"] == next(iter(actions.keys()))
 
 
+def test_lifted_call_binding_is_pathless_and_path_lives_on_the_binding():
+    """The rewritten `call_binding` handler carries ONLY the binding name —
+    no `path`. The path lives on the persisted `actions` entry, and the
+    `/actions/run` route resolves it server-side from there.
+
+    This pins the contract the path-resolution fix relies on: the read-time
+    normalizer cannot put a path on the handler (it has no request context),
+    so the server must read it off the stored binding. Regression for the
+    live Nerve-demo 422, where the pathless handler hit `RunActionRequest`'s
+    once-required `path`.
+    """
+    spec = {
+        "title": "Lead Scorer",
+        "version": "1.0",
+        "state": {},
+        "ui": {
+            "type": "flex",
+            "children": [
+                {
+                    "type": "button",
+                    "props": {"label": "Score next 20"},
+                    "on_click": {
+                        "action": "api",
+                        "method": "POST",
+                        "url": "/leads/score-next",
+                        "body": {"batch": 20},
+                    },
+                }
+            ],
+        },
+    }
+    normalized = normalize_ripple_spec(spec)
+    assert normalized is not None
+
+    handler = normalized["ui"]["children"][0]["on_click"]
+    assert handler["action"] == "call_binding"
+    # The handler is pathless — the only routing key is the binding name.
+    assert "path" not in handler
+    assert "url" not in handler
+
+    binding_name = handler["binding"]
+    actions = normalized["actions"]
+    # The path the route resolves at run time lives on the persisted binding.
+    assert actions[binding_name]["path"] == "/leads/score-next"
+    assert actions[binding_name]["method"] == "POST"
+
+
 def test_absolute_url_inline_api_is_left_untouched():
     """An ABSOLUTE-url `api` call is a different (third-party) intent and
     must NEVER be redirected onto the pocket's credentialed backend."""

--- a/tests/cloud/test_pocket_backend_routes.py
+++ b/tests/cloud/test_pocket_backend_routes.py
@@ -433,6 +433,124 @@ def test_run_action_happy_path(monkeypatch, client):
     assert captured["workspace_id"]
 
 
+def test_run_action_resolves_path_from_binding_when_client_omits_it(monkeypatch, client):
+    """A `call_binding` handler fires with `{action, params}` and NO `path`
+    — the read-time normalizer rewrites inline write `api` handlers to
+    `call_binding` without a `path`, so the client cannot supply one. The
+    route must resolve the path from the persisted binding (which already
+    carries it, to know the HTTP method) instead of rejecting the request.
+
+    Regression for the live Nerve-demo 422: every relative-URL api button
+    POSTed `{action, params}` to `/actions/run` and hit `RunActionRequest`'s
+    required `path`, failing validation before the route ever ran.
+    """
+    spec = {
+        "actions": {
+            "score_next_20": {
+                "kind": "write_binding",
+                "method": "POST",
+                "path": "/leads/score-next",
+            }
+        }
+    }
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id, "rippleSpec": spec}
+
+    async def _get_creds(workspace_id, pocket_id):
+        return (
+            "https://api.example.com",
+            "bearer",
+            None,
+            "tok",
+            [{"method": "POST", "path_pattern": "/leads/score-next"}],
+            None,
+        )
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _get_creds)
+
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    captured = {}
+
+    async def _run_action(**kwargs):
+        captured.update(kwargs)
+        return {
+            "ok": True,
+            "action": kwargs["action"],
+            "status": 200,
+            "response": {"scored": 20},
+            "on_success": [],
+            "on_error": [],
+        }
+
+    monkeypatch.setattr(action_executor, "run_action", _run_action)
+
+    # No `path` in the body — exactly what the normalized `call_binding`
+    # handler produces.
+    res = client.post(
+        "/pockets/pocket-1/actions/run",
+        json={"action": "score_next_20", "params": {"batch": 20}},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is True
+    assert body["response"] == {"scored": 20}
+    # The route fell back to the binding's persisted path.
+    assert captured["path"] == "/leads/score-next"
+    assert captured["params"] == {"batch": 20}
+
+
+def test_run_action_client_path_wins_over_binding_path(monkeypatch, client):
+    """When the client DOES send a resolved path (e.g. a row-scoped binding
+    whose stored path holds an unresolved `{item.id}` template), the
+    client's value is used — the binding path is only a fallback."""
+    spec = {
+        "actions": {
+            "mark_renewed": {
+                "kind": "write_binding",
+                "method": "POST",
+                "path": "/leases/{item.id}/renew",
+            }
+        }
+    }
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id, "rippleSpec": spec}
+
+    async def _get_creds(workspace_id, pocket_id):
+        return (
+            "https://api.example.com",
+            "bearer",
+            None,
+            "tok",
+            [{"method": "POST", "path_pattern": "/leases/*/renew"}],
+            None,
+        )
+
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _get_creds)
+
+    from pocketpaw_ee.cloud.pockets import action_executor
+
+    captured = {}
+
+    async def _run_action(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True, "action": kwargs["action"], "status": 200, "response": {}}
+
+    monkeypatch.setattr(action_executor, "run_action", _run_action)
+
+    res = client.post(
+        "/pockets/pocket-1/actions/run",
+        json={"action": "mark_renewed", "path": "/leases/42/renew"},
+    )
+    assert res.status_code == 200, res.text
+    # The client's resolved path, not the binding's templated one.
+    assert captured["path"] == "/leases/42/renew"
+
+
 def test_run_action_404_when_action_not_declared(monkeypatch, client):
     """An action name not in the persisted spec returns an `ok:false`
     body with code `action_not_found` — no executor call."""


### PR DESCRIPTION
Every relative-URL `api` button on a pocket was returning 422. The read-time ripple normalizer rewrites an inline write `api` handler into a `call_binding` handler — and a call_binding has no path, because the normalizer has no request context to put one there. But `RunActionRequest.path` was required, so the client POSTed `{action, params}` to `/actions/run` and failed validation before the route even ran. It surfaced on the Nerve demo's "Score next 20" button, which couldn't fire from the canvas at all.

`path` is now optional. The route resolves it from the persisted `rippleSpec.actions` binding, which already carries the path (it has to, so the server can read the HTTP method without trusting the client to pick the verb). A client that does send a path still wins — a row-scoped binding whose stored path holds an unresolved `{item.id}` template gets resolved client-side, and that resolved value takes precedence over the templated one. Either way the executor matches the final `(method, path)` against the owner's allowlist, so resolving from the binding can't widen the blast radius.

This is the first step toward native gated pocket actions: a button can now fire a declared binding through the gate without the client reconstructing a path the spec already holds. A new regression test covers the omitted-path case; the one unrelated failure in test_pocket_backend_routes (test_run_sources_400_when_no_backend) is pre-existing on dev.