### PR TITLE
fix(claude-sdk): reuse warm client on skill runs instead of re-spawning

### DIFF
--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,26 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-13 (fix/claude-sdk-warm-client-skills) — skill/tool-bearing
+  runs now REUSE the warm persistent CLI subprocess instead of re-spawning a
+  fresh stateless query every turn (a ~6s/turn floor on any skill chat). The
+  2026-06-07 entry below BYPASSED the warm client for skill runs because
+  ``_client_cache_key`` did not hash the plugin set, so a warm client could not
+  tell a skill turn from a non-skill one. The cache key now folds in
+  ``_plugin_digest`` — a hash of the skill IDENTITY (sorted ``skill_names`` +
+  whether the bundled-skills plugin is loaded), NEVER the materialized
+  ``plugins=`` PATH (``materialize_run_skills`` mints a fresh ``mkdtemp`` per
+  run, so hashing the path would change the key every turn and defeat reuse).
+  With identity in the key, ``_get_or_create_client`` reuses the subprocess for
+  a same-skill turn and rebuilds it for a changed skill set. Lifecycle: because
+  the warm subprocess keeps the ``plugins=`` path from its first ``connect()``,
+  the materialized dir is cached per digest on the instance
+  (``_skills_dir_by_digest``) and reused across same-skill turns; it is removed
+  only when its warm client is evicted (``_get_or_create_client``) or on
+  ``cleanup()`` — NOT by the per-run ``finally``, which now rmtree's the dir
+  ONLY in the genuine stateless-fallback case (when ``_client_in_use`` forced a
+  stateless query and no warm client adopted the dir). The ``skip_warm_client``
+  bypass is removed. ``prewarm`` is intentionally out of scope (separate
+  follow-up).
 Updated: 2026-06-07 (feat/entity-pocket-profile-field, entity-rooms A2) — ``run``
   also accepts ``skill_names: frozenset[str]``, the per-entity skill subset
   (resolved upstream from the entity pocket's ``surface_profile.skill_names``).
@@ -262,6 +283,18 @@ class ClaudeSDKBackend(BaseAgentBackend):
         self._client = None
         self._client_options_key: str | None = None
         self._client_in_use = False
+        # Plugin-identity digest of the currently-live warm client, and a map of
+        # plugin_digest -> materialized per-run skills dir (fix/claude-sdk-warm-
+        # client-skills). A skill run now REUSES the warm subprocess instead of
+        # re-spawning, so the materialized dir it was connected with must outlive
+        # the per-run finally — the subprocess holds that path from its first
+        # connect(). The dir is keyed on the stable plugin IDENTITY (sorted skill
+        # names + bundled flag), never the throwaway mkdtemp PATH, so two turns
+        # with the same skills find the same cached dir. Ownership: the dir is
+        # removed only when its warm client is evicted (_get_or_create_client) or
+        # on cleanup() — NOT by a normal per-run finally.
+        self._client_plugin_digest: str = ""
+        self._skills_dir_by_digest: dict[str, Path] = {}
 
         # Per-run subprocess env injected by the pocket-specialist
         # runtime via ``attach_subprocess_env`` (PR #1222 R1 Blocker 1).
@@ -859,16 +892,47 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 cut = min(cut, idx)
         return system_prompt[:cut]
 
+    @staticmethod
+    def _plugin_digest(skill_names: frozenset[str], *, bundled: bool) -> str:
+        """Stable digest of the agent's plugin IDENTITY for the cache key.
+
+        Folds the per-entity skill subset (sorted ``skill_names``) and whether
+        the bundled-skills plugin is loaded into one short hash. Empty when no
+        skills and no bundled plugin participate, so a plain run's key is
+        unchanged.
+
+        CRITICAL: this digests the IDENTITY of the skills, never the
+        materialized ``plugins=`` PATH. ``materialize_run_skills`` creates a
+        fresh ``tempfile.mkdtemp`` dir on every run, so hashing the path would
+        change the cache key every turn and defeat warm-client reuse entirely —
+        the exact latency bug this fix removes. Two turns that request the same
+        skills (and the same bundled state) MUST hash identically so the warm
+        subprocess is reused; a changed skill set MUST hash differently so it
+        rebuilds.
+        """
+        if not skill_names and not bundled:
+            return ""
+        payload = ("b1:" if bundled else "b0:") + ",".join(sorted(skill_names))
+        return hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:16]
+
     @classmethod
-    def _client_cache_key(cls, options: Any, *, session_key: str | None = None) -> str:
+    def _client_cache_key(
+        cls, options: Any, *, session_key: str | None = None, plugin_digest: str = ""
+    ) -> str:
         """Persistent-client cache key: session + model + tools + a digest of
-        the system prompt's stable behavioral prefix.
+        the system prompt's stable behavioral prefix + the plugin-identity
+        digest.
 
         The prefix digest is what makes a mid-session backend config change
         (configured:false -> configured:true, baked into the static home
         prompt) evict and rebuild the warm subprocess on the next turn, instead
-        of staying frozen until a cold restart. Hashing keeps the key bounded
-        regardless of prompt length.
+        of staying frozen until a cold restart. The ``plugin_digest`` does the
+        same for the agent's skill set (per-entity ``skill_names`` + bundled
+        flag): folding it in lets a warm client tell a skill run apart from a
+        non-skill one, so a skill run can REUSE the subprocess instead of
+        re-spawning every turn. Empty ``plugin_digest`` (the default) leaves the
+        key byte-for-byte identical to the pre-fix behavior for non-skill
+        callers. Hashing keeps the key bounded regardless of prompt length.
         """
         prefix = cls._behavior_prefix(getattr(options, "system_prompt", None))
         prefix_digest = hashlib.sha256(prefix.encode("utf-8", "replace")).hexdigest()[:16]
@@ -876,44 +940,69 @@ class ClaudeSDKBackend(BaseAgentBackend):
             f"{session_key or ''}:"
             f"{getattr(options, 'model', '')}:"
             f"{sorted(getattr(options, 'allowed_tools', []) or [])}:"
-            f"{prefix_digest}"
+            f"{prefix_digest}:"
+            f"{plugin_digest}"
         )
 
-    async def _get_or_create_client(self, options: Any, *, session_key: str | None = None) -> Any:
+    async def _get_or_create_client(
+        self, options: Any, *, session_key: str | None = None, plugin_digest: str = ""
+    ) -> Any:
         """Get or create a persistent ClaudeSDKClient.
 
-        Reuses the existing subprocess if model, tools, session, **and the
-        system prompt's behavioral prefix** haven't changed. Different sessions
-        get a fresh subprocess so the CLI's internal conversation context
-        doesn't leak between chats; a changed behavioral prefix (e.g. the home
-        pocket's backend summary flipping to "configured" mid-session) also
-        forces a fresh subprocess so the new prompt actually takes effect — the
-        SDK applies the system prompt only at connect() time.
+        Reuses the existing subprocess if model, tools, session, the system
+        prompt's behavioral prefix, **and the plugin-identity digest** haven't
+        changed. Different sessions get a fresh subprocess so the CLI's internal
+        conversation context doesn't leak between chats; a changed behavioral
+        prefix (e.g. the home pocket's backend summary flipping to "configured"
+        mid-session) or a changed skill set (``plugin_digest``) also forces a
+        fresh subprocess so the new prompt / plugins actually take effect — the
+        SDK applies both only at connect() time.
+
+        When a stale client is evicted, its materialized per-run skills dir
+        (tracked by the old ``plugin_digest``) is removed here: the subprocess
+        that held that path is being torn down, so nothing references it
+        anymore. Re-materializing the dir per turn does NOT work — the warm
+        subprocess keeps the original path from its first connect — so the dir
+        is cached per digest and only dropped on eviction or cleanup().
         """
         import time
 
-        key = self._client_cache_key(options, session_key=session_key)
+        key = self._client_cache_key(options, session_key=session_key, plugin_digest=plugin_digest)
 
         if self._client is not None and self._client_options_key == key:
             logger.debug("Reusing persistent client (key=%s)", key)
             return self._client
 
-        # Disconnect stale client
+        # Disconnect stale client and drop the skills dir it was connected with.
         if self._client is not None:
             try:
                 await self._client.disconnect()
             except Exception as e:
                 logger.debug("Failed to disconnect Claude client: %s", e)
             self._client = None
+            self._drop_skills_dir(self._client_plugin_digest)
 
         # Create and connect new client
         t0 = time.monotonic()
         self._client = self._ClaudeSDKClient(options=options)
         await self._client.connect()
         self._client_options_key = key
+        self._client_plugin_digest = plugin_digest
         t1 = time.monotonic()
         logger.info("Persistent client connected in %.0fms (key=%s)", (t1 - t0) * 1000, key)
         return self._client
+
+    def _drop_skills_dir(self, plugin_digest: str) -> None:
+        """Remove the materialized per-run skills dir cached under
+        ``plugin_digest`` (if any). Best-effort; never raises. Called when the
+        warm client that referenced the dir is evicted or on cleanup()."""
+        if not plugin_digest:
+            return
+        root = self._skills_dir_by_digest.pop(plugin_digest, None)
+        if root is not None:
+            from pocketpaw.skills import cleanup_run_skills
+
+            cleanup_run_skills(root)
 
     async def cleanup(self) -> None:
         """Disconnect the persistent client and release resources."""
@@ -926,6 +1015,15 @@ class ClaudeSDKBackend(BaseAgentBackend):
             self._client_options_key = None
             self._client_in_use = False
             logger.info("Persistent client disconnected")
+        # Sweep every materialized per-run skills dir adopted by a warm client.
+        # Safe even when no client existed (the map is just empty).
+        if self._skills_dir_by_digest:
+            from pocketpaw.skills import cleanup_run_skills
+
+            for root in self._skills_dir_by_digest.values():
+                cleanup_run_skills(root)
+            self._skills_dir_by_digest.clear()
+        self._client_plugin_digest = ""
 
     async def _resilient_query(self, prompt: str, options):
         """Wrap stateless _query with MessageParseError recovery."""
@@ -1078,6 +1176,17 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # exception fires before/after materialization. None on every run that
         # doesn't pass a non-empty ``skill_names``.
         run_skills_root: Path | None = None
+
+        # fix/claude-sdk-warm-client-skills: ``skills_dir_adopted`` is True when
+        # ``run_skills_root`` was handed to (or reused by) a WARM client — its
+        # lifetime then belongs to ``self._skills_dir_by_digest`` and the
+        # per-run finally must NOT rmtree it (the live subprocess still holds the
+        # path). It stays False on the genuine stateless-fallback path, where the
+        # dir is this run's alone and the finally is the only thing that removes
+        # it. ``plugin_digest`` is the plugin-identity hash threaded into the
+        # cache key + the dir cache.
+        skills_dir_adopted = False
+        plugin_digest = ""
 
         # Ownership flag — True only if THIS run acquired the shared
         # _client_in_use lease. Declared above the try/except so it is always
@@ -1371,35 +1480,66 @@ class ClaudeSDKBackend(BaseAgentBackend):
             # (CLAUDE.md, output styles). Empirically verified 2026-06-03: the
             # ``skills=`` option is also gated by setting_sources, but
             # ``plugins=`` is not. Toggle via ``sdk_load_bundled_skills``.
+            bundled_loaded = False
             if self.settings.sdk_load_bundled_skills:
                 from pocketpaw.bundled_skills import bundled_skills_plugin_dir
 
                 plugin_dir = bundled_skills_plugin_dir()
                 if plugin_dir is not None:
                     options_kwargs["plugins"] = [{"type": "local", "path": str(plugin_dir)}]
+                    bundled_loaded = True
                     logger.info("SDK: loading bundled-skills plugin from %s", plugin_dir)
 
+            # Plugin-identity digest (fix/claude-sdk-warm-client-skills): folds
+            # the requested skill set + the bundled flag into the cache key so a
+            # skill run can REUSE the warm subprocess instead of re-spawning.
+            # Keyed on identity, never the mkdtemp path (see _plugin_digest).
+            plugin_digest = self._plugin_digest(skill_names, bundled=bundled_loaded)
+
             # Per-entity skill subset (entity-rooms A2). Materialize ONLY the
-            # named skills into a throwaway local plugin and append it to the
-            # ``plugins=`` list (creating the list if the bundled plugin above
-            # was off). It coexists with the bundled entry. ``run_skills_root`` is
-            # cleaned up in the ``finally`` after the stream drains, and its
-            # presence forces the fresh stateless path below (the warm client
-            # would ignore these plugins). Empty ``skill_names`` is a no-op.
+            # named skills into a local plugin and append it to the ``plugins=``
+            # list (creating the list if the bundled plugin above was off). It
+            # coexists with the bundled entry. Empty ``skill_names`` is a no-op.
+            #
+            # The warm client keeps whatever ``plugins=`` path it was connected
+            # with from its first connect(), so the materialized dir must be
+            # STABLE per plugin_digest across turns. When this run will reuse the
+            # warm client and a dir for this digest already exists, reuse it
+            # rather than re-materializing — the live subprocess already points
+            # at it. Otherwise materialize fresh; cache + adopt it on the warm
+            # path (cleaned on eviction/cleanup), or leave it owned by this run
+            # on the stateless path (the per-run finally removes it).
             if skill_names:
                 from pocketpaw.skills import materialize_run_skills
 
-                run_skills_root = materialize_run_skills(skill_names, run_id=session_key)
+                will_reuse_warm = not self._client_in_use
+                cached_dir = self._skills_dir_by_digest.get(plugin_digest)
+                if will_reuse_warm and cached_dir is not None and cached_dir.exists():
+                    run_skills_root = cached_dir
+                    skills_dir_adopted = True
+                    logger.info(
+                        "SDK: reusing cached per-run skill plugin (%d requested) at %s",
+                        len(skill_names),
+                        run_skills_root,
+                    )
+                else:
+                    run_skills_root = materialize_run_skills(skill_names, run_id=session_key)
+                    if run_skills_root is not None and will_reuse_warm:
+                        self._skills_dir_by_digest[plugin_digest] = run_skills_root
+                        skills_dir_adopted = True
+
                 if run_skills_root is not None:
                     options_kwargs.setdefault("plugins", [])
                     options_kwargs["plugins"].append(
                         {"type": "local", "path": str(run_skills_root)}
                     )
-                    logger.info(
-                        "SDK: loading per-run skill plugin (%d requested) from %s",
-                        len(skill_names),
-                        run_skills_root,
-                    )
+                    if not skills_dir_adopted:
+                        logger.info(
+                            "SDK: loading per-run skill plugin (%d requested) from %s "
+                            "(stateless — dir owned by this run)",
+                            len(skill_names),
+                            run_skills_root,
+                        )
 
             # Configure LLM provider for the Claude CLI subprocess.
             # Ollama/OpenAI-compat providers set their own env vars via to_sdk_env().
@@ -1512,22 +1652,21 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 session_key,
             )
             _persistent_client = None
-            # WARM-CLIENT BYPASS (entity-rooms A2): when this run materialized a
-            # per-entity skill plugin, the warm client MUST NOT be reused. The
-            # persistent client applies its options (incl. ``plugins=``) only at
-            # first ``connect()``, and ``_client_cache_key`` does NOT hash
-            # ``plugins=`` — so a warm client connected without these skills would
-            # silently ignore them, and conversely a warm client connected WITH
-            # them would leak them into later non-skill turns. A fresh stateless
-            # query rebuilds the subprocess with this run's exact ``options``, so
-            # the materialized plugin actually takes effect and never persists.
-            skip_warm_client = run_skills_root is not None
-            if not self._client_in_use and not skip_warm_client:
+            # fix/claude-sdk-warm-client-skills: the warm-client bypass for skill
+            # runs is REMOVED. ``_client_cache_key`` now folds in
+            # ``plugin_digest`` (the skill-identity hash), so a warm client can
+            # distinguish a skill run from a non-skill one — a same-skill turn
+            # reuses the subprocess and a changed skill set rebuilds it. The
+            # materialized plugin dir was cached + adopted above so the warm
+            # subprocess keeps a valid path across turns. The only fallback to
+            # the stateless path now is the original concurrency guard: a sibling
+            # run already holds the lease (_client_in_use).
+            if not self._client_in_use:
                 try:
                     self._client_in_use = True
                     acquired_lease = True
                     _persistent_client = await self._get_or_create_client(
-                        options, session_key=session_key
+                        options, session_key=session_key, plugin_digest=plugin_digest
                     )
                     logger.info("Persistent client: sending query (%d chars)", len(message))
                     await _persistent_client.query(message)
@@ -1558,14 +1697,19 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     self._client_in_use = False
                     acquired_lease = False
                     _persistent_client = None
+                    # No warm client adopted the skills dir we cached for this
+                    # digest (connect failed before/at adoption). The stateless
+                    # query below uses ``options`` (which already point at the
+                    # dir) for THIS run only, so transfer ownership back to the
+                    # per-run finally: drop it from the digest cache and clear the
+                    # adopted flag so the finally cleans it up exactly once.
+                    if skills_dir_adopted:
+                        self._skills_dir_by_digest.pop(plugin_digest, None)
+                        self._client_plugin_digest = ""
+                        skills_dir_adopted = False
 
             if event_stream is None:
-                logger.info(
-                    "Starting stateless query (reason: %s)",
-                    "per-run skill plugin (warm-client bypass)"
-                    if skip_warm_client
-                    else "fallback — _client_in_use was True",
-                )
+                logger.info("Starting stateless query (reason: _client_in_use was True)")
                 # final_prompt already carries Mongo history (injected above),
                 # so the stateless path uses the same options as the persistent
                 # path — no separate system prompt swap is needed.
@@ -1861,10 +2005,16 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     content=llm.format_api_error(e, stderr=stderr_text),
                 )
         finally:
-            # Always remove the per-run materialized-skills plugin dir
-            # (entity-rooms A2), whether the run finished cleanly, errored, or
-            # the generator was closed early. Best-effort; never raises.
-            if run_skills_root is not None:
+            # Remove the per-run materialized-skills plugin dir (entity-rooms
+            # A2) ONLY when this run owns it — i.e. the genuine stateless-
+            # fallback case where no warm client adopted the dir
+            # (fix/claude-sdk-warm-client-skills). When ``skills_dir_adopted`` is
+            # True the dir belongs to ``self._skills_dir_by_digest`` and a LIVE
+            # warm subprocess still references its path; deleting it here would
+            # leave the next reuse pointing at a missing dir. Adopted dirs are
+            # instead removed on client eviction (_get_or_create_client) or
+            # cleanup(). Best-effort; never raises.
+            if run_skills_root is not None and not skills_dir_adopted:
                 from pocketpaw.skills import cleanup_run_skills
 
                 cleanup_run_skills(run_skills_root)

--- a/tests/test_claude_sdk_skill_names.py
+++ b/tests/test_claude_sdk_skill_names.py
@@ -2,9 +2,16 @@
 # Created: 2026-06-07 (feat/entity-pocket-profile-field, entity-rooms A2) —
 # pins the OSS Claude SDK backend's acceptance of the threaded per-entity
 # ``skill_names`` kwarg (the keystone that makes SurfaceProfile.skill_names
-# LIVE) and the warm-client bypass invariant: a run that materializes a per-run
-# skill plugin must NOT reuse a warm client, because the persistent-client cache
-# key omits ``plugins=`` and options apply only at first connect.
+# LIVE).
+# Modified: 2026-06-13 (fix/claude-sdk-warm-client-skills) — the warm-client
+# BYPASS invariant is RETIRED. The persistent-client cache key now folds in a
+# digest of the plugin IDENTITY (sorted skill names + bundled flag) via
+# ``_client_cache_key(..., plugin_digest=...)``, so a skill run can REUSE the
+# warm subprocess instead of re-spawning a fresh stateless query every turn
+# (the ~6s/turn latency bug). This test was the one that codified the old gap;
+# it now asserts the inverse — equal skill sets → equal key, different →
+# different. The end-to-end reuse/no-leak/lifecycle behavior lives in
+# tests/test_claude_sdk_skill_warm_reuse.py.
 
 from __future__ import annotations
 
@@ -22,28 +29,33 @@ def test_run_accepts_skill_names_kwarg() -> None:
     )
 
 
-def test_cache_key_omits_plugins_so_warm_client_must_be_bypassed() -> None:
-    """The persistent-client cache key is built from session + model + tools +
-    a prompt-prefix digest — it does NOT fold in ``plugins=``. This is exactly
-    why a skill run (which only changes ``plugins=``) MUST bypass the warm
-    client; this test documents the gap the bypass closes."""
+def test_cache_key_folds_in_plugin_digest_so_warm_client_can_be_reused() -> None:
+    """The persistent-client cache key now folds in the plugin-identity digest,
+    so the warm client CAN tell a skill run apart from a non-skill run — equal
+    skill sets produce an equal key (warm reuse) and different sets produce a
+    different key (rebuild). This is the inverse of the old behavior that forced
+    a bypass. CRITICAL: the digest is keyed on skill IDENTITY, never the
+    materialized ``plugins=`` PATH (a fresh ``mkdtemp`` per run), so reuse is not
+    defeated by path churn."""
+    digest_a = ClaudeSDKBackend._plugin_digest(frozenset({"skillA"}), bundled=False)
+    digest_a_again = ClaudeSDKBackend._plugin_digest(frozenset({"skillA"}), bundled=False)
+    digest_b = ClaudeSDKBackend._plugin_digest(frozenset({"skillB"}), bundled=False)
+
     from types import SimpleNamespace
 
     base = SimpleNamespace(
         system_prompt="IDENTITY",
         model="claude",
         allowed_tools=["Read"],
-        plugins=[],
     )
-    with_plugin = SimpleNamespace(
-        system_prompt="IDENTITY",
-        model="claude",
-        allowed_tools=["Read"],
-        plugins=[{"type": "local", "path": "/tmp/x"}],
+
+    key_a = ClaudeSDKBackend._client_cache_key(base, session_key="s1", plugin_digest=digest_a)
+    key_a2 = ClaudeSDKBackend._client_cache_key(
+        base, session_key="s1", plugin_digest=digest_a_again
     )
-    k1 = ClaudeSDKBackend._client_cache_key(base, session_key="s1")
-    k2 = ClaudeSDKBackend._client_cache_key(with_plugin, session_key="s1")
-    assert k1 == k2, (
-        "cache key ignores plugins= — so the warm client cannot distinguish a "
-        "skill run; the backend bypasses the warm client when skill_names is set"
-    )
+    key_b = ClaudeSDKBackend._client_cache_key(base, session_key="s1", plugin_digest=digest_b)
+    key_none = ClaudeSDKBackend._client_cache_key(base, session_key="s1")
+
+    assert key_a == key_a2, "same skill set → same key, so the warm client is reused"
+    assert key_a != key_b, "different skill set → different key, so the client rebuilds"
+    assert key_a != key_none, "a skill run must not collide with a non-skill run"

--- a/tests/test_claude_sdk_skill_warm_reuse.py
+++ b/tests/test_claude_sdk_skill_warm_reuse.py
@@ -1,0 +1,373 @@
+# tests/test_claude_sdk_skill_warm_reuse.py
+# Created: 2026-06-13 (fix/claude-sdk-warm-client-skills) — pins the latency fix
+# that lets a skill/tool-bearing run REUSE the warm persistent CLI subprocess
+# instead of re-spawning a fresh stateless query every turn (~6s/turn floor).
+#
+# Four groups:
+#   1. KEY-LEVEL (pure)   — ``_plugin_digest`` / ``_client_cache_key`` fold in
+#      the skill IDENTITY (sorted names + bundled flag), never the materialized
+#      PATH (which is a fresh ``mkdtemp`` per run and would defeat reuse).
+#   2. BEHAVIORAL         — the latency invariant: two identical-skill turns on
+#      one session ``connect()`` the subprocess ONCE (re-spawn → count==2 today,
+#      reuse → count==1 after the fix).
+#   3. NO-LEAK            — a skill turn then a non-skill turn forces a fresh
+#      connect and the non-skill turn's options carry NO per-run skills plugin.
+#   4. LIFECYCLE          — the materialized dir a live warm client references
+#      SURVIVES turn 1's finally and is removed on ``cleanup()``.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from pocketpaw.agents.claude_sdk import ClaudeAgentSDK, ClaudeSDKBackend
+from pocketpaw.agents.model_router import ModelSelection, TaskComplexity
+
+_LLM_CLIENT = "pocketpaw.llm.client.resolve_llm_client"
+_MODEL_ROUTER = "pocketpaw.agents.model_router.ModelRouter"
+# ``run()`` imports these lazily from ``pocketpaw.skills`` — patch them there.
+_MATERIALIZE = "pocketpaw.skills.materialize_run_skills"
+_CLEANUP = "pocketpaw.skills.cleanup_run_skills"
+
+
+# ===========================================================================
+# 1. KEY-LEVEL (pure) — digest the skill identity, never the path
+# ===========================================================================
+
+
+def test_plugin_digest_same_skill_set_is_stable() -> None:
+    """Same skill names + same bundled flag → identical digest. This stability
+    across runs is the whole point: ``materialize_run_skills`` mints a fresh
+    ``mkdtemp`` path every turn, so keying on identity (not path) is what lets
+    the warm client be reused."""
+    d1 = ClaudeSDKBackend._plugin_digest(frozenset({"skillA", "skillB"}), bundled=True)
+    d2 = ClaudeSDKBackend._plugin_digest(frozenset({"skillB", "skillA"}), bundled=True)
+    assert d1 == d2 and d1 != ""
+
+
+def test_plugin_digest_differs_by_skill_set() -> None:
+    """A different skill set must produce a different digest (and thus a
+    different cache key) so the warm subprocess rebuilds with the new skills."""
+    a = ClaudeSDKBackend._plugin_digest(frozenset({"skillA"}), bundled=False)
+    b = ClaudeSDKBackend._plugin_digest(frozenset({"skillB"}), bundled=False)
+    assert a != b
+
+
+def test_plugin_digest_skillset_vs_empty_no_collision() -> None:
+    """A skill run and a no-skill run must NOT collide — otherwise a warm client
+    connected for a skill turn would be reused (silently skill-less) on a plain
+    turn, or vice versa."""
+    empty = ClaudeSDKBackend._plugin_digest(frozenset(), bundled=False)
+    with_skill = ClaudeSDKBackend._plugin_digest(frozenset({"skillA"}), bundled=False)
+    assert empty == "" and with_skill != ""
+    assert empty != with_skill
+
+
+def test_plugin_digest_bundled_flag_changes_digest() -> None:
+    """The bundled-skills plugin participating or not is part of the plugin set
+    identity — flipping it must change the digest."""
+    no_bundle = ClaudeSDKBackend._plugin_digest(frozenset({"skillA"}), bundled=False)
+    with_bundle = ClaudeSDKBackend._plugin_digest(frozenset({"skillA"}), bundled=True)
+    assert no_bundle != with_bundle
+    # Bundled-only (no per-entity skills) is still a non-empty digest.
+    assert ClaudeSDKBackend._plugin_digest(frozenset(), bundled=True) != ""
+
+
+def _opts(system_prompt="IDENTITY", *, model="claude", tools=("Read",)):
+    return SimpleNamespace(
+        model=model,
+        allowed_tools=list(tools),
+        system_prompt=system_prompt,
+    )
+
+
+def test_cache_key_folds_in_plugin_digest() -> None:
+    """The persistent-client cache key now folds in the plugin digest, so equal
+    skill sets → equal key and different skill sets → different key. This is the
+    direct inverse of the OLD behavior (key ignored plugins entirely)."""
+    base = _opts()
+    digest_a = ClaudeSDKBackend._plugin_digest(frozenset({"skillA"}), bundled=False)
+    digest_b = ClaudeSDKBackend._plugin_digest(frozenset({"skillB"}), bundled=False)
+
+    key_a1 = ClaudeSDKBackend._client_cache_key(base, session_key="s1", plugin_digest=digest_a)
+    key_a2 = ClaudeSDKBackend._client_cache_key(base, session_key="s1", plugin_digest=digest_a)
+    key_b = ClaudeSDKBackend._client_cache_key(base, session_key="s1", plugin_digest=digest_b)
+    key_none = ClaudeSDKBackend._client_cache_key(base, session_key="s1")
+
+    assert key_a1 == key_a2, "same skill set → same key (warm reuse)"
+    assert key_a1 != key_b, "different skill set → different key (rebuild)"
+    assert key_a1 != key_none, "skill set vs no-skill must not collide"
+
+
+def test_cache_key_default_plugin_digest_unchanged() -> None:
+    """Omitting ``plugin_digest`` (the default) must produce the same key as an
+    empty digest, so every existing non-skill call site is byte-for-byte
+    unaffected."""
+    base = _opts()
+    assert ClaudeSDKBackend._client_cache_key(
+        base, session_key="s1"
+    ) == ClaudeSDKBackend._client_cache_key(base, session_key="s1", plugin_digest="")
+
+
+# ===========================================================================
+# Behavioral / lifecycle harness — drive the full run() with fakes, the same
+# way tests/test_fast_path.py does.
+# ===========================================================================
+
+
+def _make_settings(**overrides):
+    defaults = {
+        "agent_backend": "claude_agent_sdk",
+        "tool_profile": "full",
+        "tools_allow": [],
+        "tools_deny": [],
+        "smart_routing_enabled": False,
+        "claude_sdk_provider": "anthropic",
+        "claude_sdk_model": None,
+        "claude_sdk_max_turns": None,
+        # Keep the bundled-skills plugin OFF so ``bundled`` is deterministically
+        # False and no real bundled plugin dir is wired into options.
+        "sdk_load_bundled_skills": False,
+        "anthropic_api_key": "sk-test-key",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class _Options:
+    """Real options object so ``_plugin_digest`` / ``_client_cache_key`` and the
+    dispatch can read ``system_prompt`` / ``model`` / ``allowed_tools`` / ``plugins``."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.model = kwargs.get("model", "")
+        self.allowed_tools = kwargs.get("allowed_tools", [])
+        self.system_prompt = kwargs.get("system_prompt", "")
+        self.plugins = kwargs.get("plugins", [])
+
+
+class _ResultMsg:
+    """Minimal stand-in for the SDK ResultMessage sentinel."""
+
+    def __init__(self):
+        self.is_error = False
+        self.result = "ok"
+        self.total_cost_usd = None
+        self.usage = {}
+
+
+class _FakeClient:
+    """Warm persistent client whose connect() bumps a shared counter."""
+
+    def __init__(self, counter: list[int], options=None, **_kw):
+        self._counter = counter
+        self.options = options
+        self.connected = False
+        self.disconnected = False
+        self.queries: list[str] = []
+
+    async def connect(self, prompt=None):
+        self._counter[0] += 1
+        self.connected = True
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def receive_messages(self):
+        yield _ResultMsg()
+
+    async def disconnect(self):
+        self.connected = False
+        self.disconnected = True
+
+    async def interrupt(self):
+        pass
+
+
+def _wire_fakes(sdk, counter):
+    sdk._ClaudeAgentOptions = _Options
+    sdk._ResultMessage = _ResultMsg
+    sdk._ClaudeSDKClient = lambda **kwargs: _FakeClient(counter, **kwargs)
+    sdk._HookMatcher = MagicMock()
+    sdk._StreamEvent = None
+    sdk._AssistantMessage = None
+    sdk._SystemMessage = None
+    sdk._UserMessage = None
+
+
+def _make_sdk(counter, settings=None):
+    s = settings or _make_settings()
+    with patch.object(ClaudeSDKBackend, "_initialize"):
+        sdk = ClaudeAgentSDK(s)
+    sdk._sdk_available = True
+    sdk._cli_available = True
+    _wire_fakes(sdk, counter)
+    return sdk
+
+
+async def _drive(sdk, message, *, skill_names=frozenset(), session_key="s1"):
+    """Drive one full run() turn to completion under the standard patches."""
+    selection = ModelSelection(
+        complexity=TaskComplexity.MODERATE,
+        model="claude-sonnet-4-5-20250929",
+        reason="test",
+    )
+    with patch(_LLM_CLIENT) as mock_resolve:
+        mock_llm = MagicMock()
+        mock_llm.is_ollama = False
+        mock_llm.is_openai_compatible = False
+        mock_llm.is_gemini = False
+        mock_llm.is_litellm = False
+        mock_llm.is_openrouter = False
+        mock_llm.to_sdk_env.return_value = {"ANTHROPIC_API_KEY": "sk-test"}
+        mock_resolve.return_value = mock_llm
+        with patch(_MODEL_ROUTER) as MockRouter:
+            MockRouter.return_value.classify.return_value = selection
+            with patch.object(ClaudeSDKBackend, "_get_mcp_servers", return_value={}):
+                events = []
+                async for ev in sdk.run(
+                    message,
+                    system_prompt="identity",
+                    session_key=session_key,
+                    skill_names=skill_names,
+                ):
+                    events.append(ev)
+    return events
+
+
+# ===========================================================================
+# 2. BEHAVIORAL — the latency invariant
+# ===========================================================================
+
+
+async def test_two_same_skill_turns_reuse_warm_client(tmp_path):
+    """THE FIX: two turns with the SAME ``skill_names`` on one session must
+    ``connect()`` the subprocess exactly ONCE.
+
+    FAILS today (skill runs bypass the warm client and re-spawn → count == 2).
+    PASSES after the fix (the plugin digest is in the cache key, so the warm
+    client is reused → count == 1).
+    """
+    counter = [0]
+    sdk = _make_sdk(counter)
+    stable = tmp_path / "skills_plugin"
+    stable.mkdir()
+
+    with patch(_MATERIALIZE, return_value=stable) as mat, patch(_CLEANUP):
+        ev1 = await _drive(sdk, "turn one", skill_names=frozenset({"skillA"}))
+        ev2 = await _drive(sdk, "turn two", skill_names=frozenset({"skillA"}))
+
+    assert any(e.type == "done" for e in ev1)
+    assert any(e.type == "done" for e in ev2)
+    # Isolate key behavior from mkdtemp: materialize is patched to a stable path,
+    # so any re-spawn is a cache-key/lifecycle failure, not a path-churn artifact.
+    assert mat.call_count >= 1
+    assert counter[0] == 1, (
+        f"expected the warm subprocess to be reused across two identical-skill "
+        f"turns (connect_count == 1); got {counter[0]} — a skill run is still "
+        f"re-spawning a fresh subprocess every turn (the ~6s/turn latency bug)"
+    )
+
+
+# ===========================================================================
+# 3. NO-LEAK — a skill turn must not poison a later non-skill turn
+# ===========================================================================
+
+
+async def test_skill_then_non_skill_turn_rebuilds_without_plugin(tmp_path):
+    """A skill turn followed by a non-skill turn on the same session must (a)
+    rebuild the subprocess (different plugin digest → fresh connect, count == 2)
+    and (b) the non-skill turn's options must carry NO per-run skills plugin."""
+    counter = [0]
+    sdk = _make_sdk(counter)
+    stable = tmp_path / "skills_plugin"
+    stable.mkdir()
+
+    captured_clients: list[_FakeClient] = []
+    orig_factory = sdk._ClaudeSDKClient
+
+    def _factory(**kwargs):
+        c = orig_factory(**kwargs)
+        captured_clients.append(c)
+        return c
+
+    sdk._ClaudeSDKClient = _factory
+
+    with patch(_MATERIALIZE, return_value=stable), patch(_CLEANUP):
+        await _drive(sdk, "skill turn", skill_names=frozenset({"skillA"}))
+        await _drive(sdk, "plain turn", skill_names=frozenset())
+
+    assert counter[0] == 2, (
+        f"a non-skill turn after a skill turn must rebuild the subprocess "
+        f"(different plugin digest); got connect_count == {counter[0]}"
+    )
+    # The most recent client (the plain turn) must carry no per-run skills plugin.
+    plain_opts = captured_clients[-1].options
+    plugins = getattr(plain_opts, "plugins", []) or []
+    paths = [p.get("path") for p in plugins if isinstance(p, dict)]
+    assert str(stable) not in paths, (
+        f"the non-skill turn's options leaked the per-run skills plugin {stable}: plugins={plugins}"
+    )
+
+
+# ===========================================================================
+# 4. LIFECYCLE — the live subprocess's dir survives the per-run finally
+# ===========================================================================
+
+
+async def test_warm_client_dir_survives_finally_and_cleaned_on_cleanup(tmp_path):
+    """Two same-skill turns reuse the client; the materialized dir the live
+    subprocess references must still EXIST after turn 1's per-run finally (the
+    subprocess holds that path from its first connect), and must be removed on
+    ``backend.cleanup()``."""
+    counter = [0]
+    sdk = _make_sdk(counter)
+
+    stable = tmp_path / "skills_plugin"
+
+    def _materialize(skill_names, run_id=None):
+        # Re-create the stable dir on disk if a prior cleanup removed it; return
+        # the SAME path every call (what an identity-keyed reuse depends on).
+        stable.mkdir(exist_ok=True)
+        return stable
+
+    import shutil
+
+    def _cleanup(root):
+        if root is not None:
+            shutil.rmtree(root, ignore_errors=True)
+
+    with patch(_MATERIALIZE, side_effect=_materialize), patch(_CLEANUP, side_effect=_cleanup):
+        await _drive(sdk, "turn one", skill_names=frozenset({"skillA"}))
+        # Turn 1's finally has run. The warm client is still live and references
+        # ``stable`` — it must NOT have been rmtree'd by the per-run cleanup.
+        assert stable.exists(), (
+            "the per-run finally removed the materialized dir that the live warm "
+            "subprocess still references — turn 2 would point at a deleted path"
+        )
+
+        await _drive(sdk, "turn two", skill_names=frozenset({"skillA"}))
+        assert counter[0] == 1, "turn two must reuse the warm client (connect_count == 1)"
+        assert stable.exists(), "the reused dir must still exist after turn two"
+
+        # cleanup() tears down the warm client AND sweeps its materialized dir.
+        await sdk.cleanup()
+
+    assert sdk._client is None
+    assert not stable.exists(), (
+        "cleanup() must remove the materialized skills dir once the warm client "
+        "that owned it is disconnected"
+    )
+
+
+def test_run_still_accepts_skill_names_kwarg() -> None:
+    """Guard the public contract the fix must preserve: ``run`` still accepts
+    ``skill_names`` defaulting to an empty frozenset."""
+    import inspect
+
+    params = inspect.signature(ClaudeSDKBackend.run).parameters
+    assert "skill_names" in params
+    assert params["skill_names"].default == frozenset()


### PR DESCRIPTION
## What

Skill and tool-bearing chats on the `claude_agent_sdk` backend re-spawned a fresh CLI subprocess on every turn. That was a ~6s/turn floor, confirmed live. This makes those runs reuse the warm persistent client, the same way plain chats already do.

## Why it happened

The backend bypassed the warm client whenever a run materialized a skill plugin. The reason for the bypass was real: the persistent-client cache key (`_client_cache_key`) didn't hash the plugin set, and a warm client applies its `options` (including `plugins=`) only at the first `connect()`. So a warm client connected without the skills would silently ignore them, and one connected with them would leak them into later non-skill turns. The safe-but-slow workaround was to drop to a fresh stateless query every skill turn.

## The fix

Fold the skill identity into the cache key.

- New `_plugin_digest(skill_names, *, bundled)` hashes the sorted skill names plus whether the bundled-skills plugin is loaded. `_client_cache_key` takes a `plugin_digest` param and appends it.
- With identity in the key, `_get_or_create_client` reuses the subprocess for a same-skill turn and rebuilds it for a changed skill set. A skill turn and a plain turn no longer collide.
- The digest is keyed on skill **identity**, never on the materialized plugin **path**. `materialize_run_skills` creates a fresh `mkdtemp` dir every run, so hashing the path would change the key every turn and defeat reuse entirely.

### Lifecycle

The warm subprocess keeps the `plugins=` path it was given at first `connect()`, so the materialized dir has to stay stable across same-skill turns. The dir is now cached on the backend keyed by digest (`_skills_dir_by_digest`), reused across same-skill turns, and removed only when its client is evicted (`_get_or_create_client`) or on `cleanup()`. The per-run `finally` still removes the dir, but only in the genuine stateless-fallback case where a sibling run held the lease and no warm client adopted the dir. The `skip_warm_client` bypass is removed.

## Tests

TDD, written before the fix and confirmed failing first:

- **Key-level (pure):** same skill set → same digest/key; different set → different key; skill set vs no-skill → no collision; bundled flag changes the digest.
- **Latency invariant:** two identical-skill turns on one session `connect()` the subprocess once (was twice).
- **No leak:** a skill turn then a non-skill turn forces a fresh connect, and the non-skill turn's options carry no per-run skills plugin.
- **Lifecycle:** the dir the live subprocess references survives turn 1's `finally` and is removed on `cleanup()`.

The existing `test_claude_sdk_skill_names.py` test that codified the bypass is flipped to assert the new behavior. The pre-existing `test_claude_sdk_client_cache_key.py` tests still pass, confirming the default `plugin_digest` keeps non-skill cache keys backward-compatible.

```
uv run pytest tests/ -k claude_sdk -q
83 passed, 1 skipped
```

Scope is limited to `claude_sdk.py` plus the two test files. Prewarm is a separate follow-up. Internal runtime change, no public API or CLI surface, so no doc updates.