### PR TITLE
perf(claude-sdk): prewarm the CLI subprocess when a session opens

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,18 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-13 (feat/claude-sdk-prewarm) — ``execute_run`` now fires
+  ``_prewarm_session(ctx)`` as a fire-and-forget ``asyncio.create_task`` right
+  after the entity-aware profile is resolved, so the agent's Claude CLI
+  subprocess warms CONCURRENTLY with the remaining pre-turn work (knowledge
+  context, soul recall, SSE setup, prompt assembly) and turn 1 reuses it instead
+  of paying the ~12s cold ``connect()``. ``_prewarm_session`` resolves the SAME
+  inputs ``_drive_agent_loop`` will (instructions, the entity-aware
+  deny/allow/skills/override, session_key) and calls ``AgentPool.prewarm`` so the
+  prewarmed client's cache key matches the first turn's. It is gated to
+  smart-routing-OFF (the model is message-derived when routing is on, so a
+  message-less prewarm could warm the wrong tier and churn) and swallows every
+  error. Skill sessions on smart-routing-ON deployments keep today's cold turn-1.
 - 2026-06-10 (sov/w3a-igw — per-run token metering) — real token usage is now
   threaded through the run instead of being dropped. Every backend emits a
   ``token_usage`` ``AgentEvent`` (input / output / cached token counts +
@@ -652,6 +664,82 @@ def _agent_skill_set(instance: Any) -> frozenset[str]:
     return direct | plugin_skills
 
 
+async def _prewarm_session(ctx: ScopeContext) -> None:
+    """Eagerly warm the agent's CLI subprocess for this run's session BEFORE the
+    first model turn (feat/claude-sdk-prewarm).
+
+    The warm-client fix (#1456) made skill-bearing turns REUSE the warm CLI
+    subprocess across turns, but the FIRST send of every new session still paid a
+    cold ~12s ``connect()`` because the warm client was created lazily inside the
+    first ``run``. This fires concurrently with the remaining pre-turn work
+    (knowledge-context build, soul recall, SSE setup, prompt assembly) so the
+    subprocess is already live by the time ``pool.run`` calls
+    ``_get_or_create_client`` — turn 1 then reuses it.
+
+    It resolves the SAME inputs ``_drive_agent_loop`` will (instructions, the
+    entity-aware deny/allow/skills/override, session_key) so the prewarmed
+    client's cache key MATCHES the first turn's — a mismatch would make turn 1
+    EVICT the prewarmed client (a net loss).
+
+    FIRE-AND-FORGET, never-break-a-turn: meant to be wrapped in
+    ``asyncio.create_task``. Every failure path is swallowed (this guard +
+    ``AgentPool.prewarm`` + the backend's ``prewarm``), so a failed prewarm just
+    leaves turn 1 to pay the cold connect it would have paid anyway.
+
+    LIMITATION: skipped when smart routing is ON, because the model is then
+    classified from the message (which we don't have yet) — prewarming a guessed
+    tier could warm the wrong subprocess and cause evict-churn. Those deployments
+    keep today's cold turn-1.
+    """
+    try:
+        from pocketpaw.config import Settings
+
+        # Smart routing makes the model message-dependent → can't match the
+        # turn-1 cache key from a message-less prewarm. Skip to avoid churn.
+        if Settings.load().smart_routing_enabled:
+            return
+
+        pool = get_agent_pool()
+        instance = await pool.get(ctx.target_agent_id)
+
+        backend_name = (
+            instance.config.get("backend", "claude_agent_sdk")
+            if hasattr(instance, "config")
+            else None
+        )
+        # Only the Claude SDK backend has a warm subprocess to prewarm.
+        if backend_name is not None and "claude" not in backend_name:
+            return
+
+        # Mirror _drive_agent_loop's resolution EXACTLY so the cache key matches.
+        behavior_instructions = build_behavior_instructions(ctx, backend_name=backend_name)
+        surface_deny: frozenset[str] = frozenset()
+        surface_allow: frozenset[str] = frozenset()
+        surface_allow_mcp: frozenset[str] | None = None
+        surface_sys_override: str | None = None
+        surface_skills: frozenset[str] = frozenset()
+        if ctx.resolved_profile is not None:
+            surface_deny = ctx.resolved_profile.deny_mcp_tool_ids
+            surface_allow = ctx.resolved_profile.allowed_sdk_tools or frozenset()
+            surface_allow_mcp = ctx.resolved_profile.allow_mcp_tool_ids
+            surface_sys_override = ctx.resolved_profile.system_message_override
+            surface_skills = ctx.resolved_profile.skill_names or frozenset()
+        surface_skills = surface_skills | _agent_skill_set(instance)
+
+        await pool.prewarm(
+            ctx.target_agent_id,
+            session_key_for(ctx),
+            instructions=behavior_instructions,
+            deny_mcp_tool_ids=surface_deny,
+            allow_sdk_tools=surface_allow,
+            allow_mcp_tool_ids=surface_allow_mcp,
+            system_message_override=surface_sys_override,
+            skill_names=surface_skills,
+        )
+    except Exception as exc:  # noqa: BLE001 — prewarm must NEVER break a run
+        logger.debug("prewarm_session skipped (swallowed): %s", exc)
+
+
 async def _drive_agent_loop(
     ctx: ScopeContext,
     *,
@@ -1011,6 +1099,16 @@ async def execute_run(spec: RunSpec) -> None:
     # instead of re-resolving. Never raises — a missing/foreign pocket degrades
     # to the surface base (today's behavior).
     ctx.resolved_profile = await _resolve_entity_profile(ctx)
+
+    # PREWARM (feat/claude-sdk-prewarm): kick off warming the agent's CLI
+    # subprocess for this session NOW — concurrently with the remaining pre-turn
+    # work below (mark-running, typing broadcast, and inside _drive_agent_loop:
+    # knowledge-context build, soul recall, SSE setup, prompt assembly). By the
+    # time pool.run reaches the first connect(), the subprocess is already live
+    # and turn 1 reuses it instead of paying the ~12s cold connect. Fire-and-
+    # forget: _prewarm_session swallows every error, so it can never delay or
+    # break this run; the task is intentionally not awaited.
+    asyncio.create_task(_prewarm_session(ctx))
 
     await _mark_running(spec.run_id)
     await _broadcast_agent_typing(ctx, active=True)

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,23 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-06-13 (feat/claude-sdk-prewarm) — added ``prewarm``: eagerly
+  ``connect()`` the warm CLI subprocess for a session BEFORE its first turn so
+  the first real ``run`` reuses it instead of paying the ~12s cold connect. To
+  make the prewarmed client's cache key MATCH the first turn's (else turn 1
+  evicts it — a net loss), the whole ``options_kwargs`` -> ``options`` assembly
+  was extracted from ``run`` into a shared ``_build_options`` helper that both
+  call; ``run``'s behavior is byte-identical (the only behavioral fix: ``llm`` is
+  now declared above the ``try`` so the error handler is safe if option assembly
+  itself raises). ``prewarm`` is fire-and-forget: it swallows ALL errors, never
+  raises, no-ops when a run holds the lease or the SDK/CLI is unavailable, and on
+  failure tears down only a client no run owns. A new ``_client_lock`` serializes
+  the reuse-or-connect critical section in ``_get_or_create_client`` so a prewarm
+  racing the first ``run`` (the trigger fires prewarm as a background task)
+  cannot double-connect — the loser of the lock reuses the winner's client. The
+  EE trigger lives in ``run_core._prewarm_session`` (gated to smart-routing-OFF,
+  where the model is message-independent so a message-less prewarm matches the
+  turn's key). Skill sessions on smart-routing-ON deployments still cold-start
+  turn 1 (documented limitation). Supersedes the prior "prewarm out of scope" note.
 Updated: 2026-06-13 (fix/claude-sdk-warm-client-skills) — skill/tool-bearing
   runs now REUSE the warm persistent CLI subprocess instead of re-spawning a
   fresh stateless query every turn (a ~6s/turn floor on any skill chat). The
@@ -19,8 +37,8 @@ Updated: 2026-06-13 (fix/claude-sdk-warm-client-skills) — skill/tool-bearing
   ``cleanup()`` — NOT by the per-run ``finally``, which now rmtree's the dir
   ONLY in the genuine stateless-fallback case (when ``_client_in_use`` forced a
   stateless query and no warm client adopted the dir). The ``skip_warm_client``
-  bypass is removed. ``prewarm`` is intentionally out of scope (separate
-  follow-up).
+  bypass is removed. (``prewarm`` was deferred here and shipped in the
+  feat/claude-sdk-prewarm follow-up above.)
 Updated: 2026-06-07 (feat/entity-pocket-profile-field, entity-rooms A2) — ``run``
   also accepts ``skill_names: frozenset[str]``, the per-entity skill subset
   (resolved upstream from the entity pocket's ``surface_profile.skill_names``).
@@ -143,7 +161,7 @@ import logging
 import re
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from pocketpaw.agents.backend import BackendInfo, BaseAgentBackend, Capability
 from pocketpaw.agents.protocol import AgentEvent
@@ -152,6 +170,34 @@ from pocketpaw.security.rails import is_substring_blocked
 from pocketpaw.tools.policy import OPT_IN_MCP_SERVERS, ToolPolicy
 
 logger = logging.getLogger(__name__)
+
+
+class _BuiltOptions(NamedTuple):
+    """The product of ``ClaudeSDKBackend._build_options`` (feat/claude-sdk-prewarm).
+
+    Bundles the assembled ``ClaudeAgentOptions`` plus everything ``run``'s
+    dispatch + finally still need after option assembly was extracted into a
+    shared helper so ``prewarm`` can build the IDENTICAL options the first turn
+    will (same cache key → the prewarmed warm client is reused, not evicted):
+
+      * ``options`` — the ``ClaudeAgentOptions`` instance to connect / query with.
+      * ``options_kwargs`` — the raw kwargs dict; the token-usage event reads
+        ``model`` off it.
+      * ``llm`` — the resolved LLM client; ``run`` uses it to format API errors.
+      * ``run_skills_root`` / ``skills_dir_adopted`` / ``plugin_digest`` — the
+        per-run materialized-skills-plugin lifecycle triple (entity-rooms A2 +
+        the warm-reuse fix): the dir path (or None), whether a warm client
+        adopted it (so the per-run finally must NOT rmtree it), and the
+        plugin-identity hash threaded into the cache key + the dir cache.
+    """
+
+    options: Any
+    options_kwargs: dict[str, Any]
+    llm: Any
+    run_skills_root: Path | None
+    skills_dir_adopted: bool
+    plugin_digest: str
+
 
 # Default identity fallback (used when AgentContextBuilder prompt is not available)
 _DEFAULT_IDENTITY = (
@@ -283,6 +329,17 @@ class ClaudeSDKBackend(BaseAgentBackend):
         self._client = None
         self._client_options_key: str | None = None
         self._client_in_use = False
+        # Serializes the connect-or-reuse critical section in
+        # ``_get_or_create_client`` (feat/claude-sdk-prewarm). ``prewarm`` runs
+        # CONCURRENTLY with the first ``run`` (fired as a background task before
+        # the turn), and ``_get_or_create_client`` ``await``s ``disconnect()`` /
+        # ``connect()`` — without this lock the run could enter the section while
+        # prewarm is mid-connect and the two would race to create / evict the
+        # subprocess (double connect, or the run throwing away the half-built
+        # prewarmed client). With the lock, whichever arrives second sees the
+        # other's finished client under a MATCHING key and reuses it — which is
+        # exactly the win. Lazily created so a backend built off-loop is safe.
+        self._client_lock: asyncio.Lock | None = None
         # Plugin-identity digest of the currently-live warm client, and a map of
         # plugin_digest -> materialized per-run skills dir (fix/claude-sdk-warm-
         # client-skills). A skill run now REUSES the warm subprocess instead of
@@ -967,30 +1024,41 @@ class ClaudeSDKBackend(BaseAgentBackend):
         """
         import time
 
+        # Serialize the whole reuse-or-connect section so a concurrent prewarm +
+        # first run (feat/claude-sdk-prewarm) cannot both create / evict the
+        # client across the ``connect()`` await. Whichever wins the lock first
+        # connects; the other then re-reads ``_client`` / ``_client_options_key``
+        # under the SAME key and reuses it. Lazily created on the running loop.
+        if self._client_lock is None:
+            self._client_lock = asyncio.Lock()
+
         key = self._client_cache_key(options, session_key=session_key, plugin_digest=plugin_digest)
 
-        if self._client is not None and self._client_options_key == key:
-            logger.debug("Reusing persistent client (key=%s)", key)
+        async with self._client_lock:
+            # Re-check INSIDE the lock: a prewarm (or sibling) may have connected
+            # a matching client while we awaited the lock — reuse it, don't churn.
+            if self._client is not None and self._client_options_key == key:
+                logger.debug("Reusing persistent client (key=%s)", key)
+                return self._client
+
+            # Disconnect stale client and drop the skills dir it was connected with.
+            if self._client is not None:
+                try:
+                    await self._client.disconnect()
+                except Exception as e:
+                    logger.debug("Failed to disconnect Claude client: %s", e)
+                self._client = None
+                self._drop_skills_dir(self._client_plugin_digest)
+
+            # Create and connect new client
+            t0 = time.monotonic()
+            self._client = self._ClaudeSDKClient(options=options)
+            await self._client.connect()
+            self._client_options_key = key
+            self._client_plugin_digest = plugin_digest
+            t1 = time.monotonic()
+            logger.info("Persistent client connected in %.0fms (key=%s)", (t1 - t0) * 1000, key)
             return self._client
-
-        # Disconnect stale client and drop the skills dir it was connected with.
-        if self._client is not None:
-            try:
-                await self._client.disconnect()
-            except Exception as e:
-                logger.debug("Failed to disconnect Claude client: %s", e)
-            self._client = None
-            self._drop_skills_dir(self._client_plugin_digest)
-
-        # Create and connect new client
-        t0 = time.monotonic()
-        self._client = self._ClaudeSDKClient(options=options)
-        await self._client.connect()
-        self._client_options_key = key
-        self._client_plugin_digest = plugin_digest
-        t1 = time.monotonic()
-        logger.info("Persistent client connected in %.0fms (key=%s)", (t1 - t0) * 1000, key)
-        return self._client
 
     def _drop_skills_dir(self, plugin_digest: str) -> None:
         """Remove the materialized per-run skills dir cached under
@@ -1077,6 +1145,578 @@ class ClaudeSDKBackend(BaseAgentBackend):
                     continue
                 raise  # re-raise non-parse errors
         logger.error("Too many consecutive MessageParseErrors — aborting stream")
+
+    async def _build_options(
+        self,
+        message: str,
+        *,
+        system_prompt: str | None,
+        history: list[dict] | None,
+        session_key: str | None,
+        deny_mcp_tool_ids: frozenset[str],
+        allow_sdk_tools: frozenset[str],
+        allow_mcp_tool_ids: frozenset[str] | None,
+        skill_names: frozenset[str],
+        stderr_sink: list[str],
+    ) -> _BuiltOptions:
+        """Assemble the ``ClaudeAgentOptions`` a turn (or a prewarm) will run on.
+
+        Extracted from ``run`` (feat/claude-sdk-prewarm) so ``prewarm`` can build
+        the EXACT same options the first real turn will, and therefore compute
+        the same ``_client_cache_key`` — model + tools + system-prompt behavioral
+        prefix + ``plugin_digest``. If the keys diverged, the prewarmed warm
+        client would be EVICTED on the first turn (a net loss: prewarm paid a
+        connect the run then threw away), which is the whole hazard this
+        extraction removes.
+
+        Returns a ``_BuiltOptions`` carrying everything ``run``'s dispatch +
+        finally still need: the ``options`` object, the raw ``options_kwargs``
+        (the token-usage event reads ``model`` off it), the resolved ``llm`` (for
+        error formatting), and the per-run skills-plugin lifecycle triple
+        (``run_skills_root`` / ``skills_dir_adopted`` / ``plugin_digest``).
+
+        Pure assembly — no ``yield``, no streaming, no client creation. Reads the
+        warm-client state (``self._client_in_use`` / ``self._skills_dir_by_digest``)
+        only to decide whether to reuse a cached materialized skills dir, exactly
+        as the inline block did. ``stderr_sink`` is the caller's list that the
+        ``stderr`` callback appends to (so ``run`` keeps capturing CLI stderr for
+        diagnostics; ``prewarm`` passes a throwaway list).
+        """
+        import os
+
+        run_skills_root: Path | None = None
+        skills_dir_adopted = False
+        plugin_digest = ""
+
+        # Resolve LLM provider early -- needed for routing + env.
+        # Use per-backend provider setting (defaults to "anthropic").
+        # An API key is REQUIRED for Anthropic provider -- OAuth tokens from
+        # Claude Free/Pro/Max plans are not permitted for third-party use.
+        # See: https://code.claude.com/docs/en/legal-and-compliance
+        from pocketpaw.llm.client import resolve_llm_client
+
+        provider = self.settings.claude_sdk_provider or "anthropic"
+        llm = resolve_llm_client(self.settings, force_provider=provider)
+
+        # ── API key check for Anthropic provider ──────────────
+        # Skip if using a non-Anthropic provider, or if the active
+        # provider is claude_code (it handles OAuth auth via its CLI).
+        is_non_anthropic = (
+            llm.is_ollama
+            or llm.is_openai_compatible
+            or llm.is_gemini
+            or llm.is_litellm
+            or llm.is_openrouter
+        )
+
+        # Smart model routing — classify complexity to pick the model tier.
+        # All messages go through the Claude Code CLI subprocess, which
+        # handles conversation compaction automatically (PreCompact hook).
+        if self.settings.smart_routing_enabled and not is_non_anthropic:
+            from pocketpaw.agents.model_router import ModelRouter
+
+            model_router = ModelRouter(self.settings)
+            selection = model_router.classify(message)
+            logger.info(
+                "Smart routing: %s -> %s (%s)",
+                selection.complexity.value,
+                selection.model,
+                selection.reason,
+            )
+
+        # System prompt — instructions are now part of identity
+        # (injected by BootstrapContext.to_system_prompt() via INSTRUCTIONS.md)
+        identity = system_prompt or _DEFAULT_IDENTITY
+
+        # Inject connector instructions so the agent can use data sources
+        try:
+            from pocketpaw.connectors.registry import ConnectorRegistry
+
+            reg = ConnectorRegistry()
+            if reg.available:
+                names = ", ".join(c["name"] for c in reg.available)
+                identity += (
+                    "\n\n# Data Connectors\n"
+                    f"Available connectors: {names}\n"
+                    "To manage connectors, use Bash to call the local API:\n"
+                    "- List: curl -s http://localhost:8888/api/v1/connectors\n"
+                    "- Detail: curl -s http://localhost:8888/api/v1/connectors/<name>\n"
+                    "- Connect: curl -s -X POST "
+                    "http://localhost:8888/api/v1/connectors/connect "
+                    "-H 'Content-Type: application/json' "
+                    '-d \'{"connector_name":"<name>","config":{...}}\'\n'
+                    "- Execute: curl -s -X POST "
+                    "http://localhost:8888/api/v1/connectors/execute "
+                    "-H 'Content-Type: application/json' "
+                    '-d \'{"connector_name":"<name>","action":"<action>"'
+                    ',"params":{...}}\'\n'
+                    "- Disconnect: curl -s -X POST "
+                    "http://localhost:8888/api/v1/connectors/disconnect "
+                    "-H 'Content-Type: application/json' "
+                    '-d \'{"connector_name":"<name>"}\'\n'
+                )
+        except Exception:
+            pass  # Don't break agent if connector registry fails
+
+        # Inject prior turns into the system prompt at connect time. The
+        # persistent ClaudeSDKClient accumulates new turns natively after
+        # connect, but a fresh subprocess (after eviction, restart, or
+        # session switch) has empty native history — without this, those
+        # cold-start runs lose all conversation context. Reused clients
+        # keep the prompt set at first connect and ignore later option
+        # changes, so there's no duplication on the warm path.
+        final_prompt = identity
+        if history:
+            lines = ["# Recent Conversation"]
+            for msg in history:
+                role = msg.get("role", "user").capitalize()
+                content = msg.get("content", "")
+                if len(content) > 2000:
+                    content = content[:2000] + "..."
+                lines.append(f"**{role}**: {content}")
+            final_prompt += "\n\n" + "\n".join(lines)
+
+        # Pocket sessions don't need shell or filesystem access — the
+        # MCP pocket tools (get_pocket / list_pockets / set_state /
+        # set_node_prop / add_node / etc.) are the complete interface.
+        # Detect via the <pocket-scope> marker every pocket prompt
+        # carries; lock tools down to delegation + web + pocket MCP.
+        #
+        # Without this gate, the agent has been observed reaching for
+        # shell introspection (e.g. `env | grep pocket; curl localhost`)
+        # to "figure out" pocket state, which trips the security rails
+        # AND is the wrong path — the MCP tools already expose
+        # everything the agent needs.
+        is_pocket_session = "<pocket-scope>" in (final_prompt or "")
+
+        if is_pocket_session:
+            all_sdk_tools = ["Agent", "WebSearch", "WebFetch"]
+            logger.info(
+                "Pocket session detected — tool surface locked to %s",
+                all_sdk_tools,
+            )
+        else:
+            all_sdk_tools = [
+                "Agent",
+                "Bash",
+                "Read",
+                "Write",
+                "Edit",
+                "Glob",
+                "Grep",
+                "WebSearch",
+                "WebFetch",
+                "Skill",
+            ]
+        allowed_tools = [
+            t
+            for t in all_sdk_tools
+            if self._policy.is_tool_allowed(self._TOOL_POLICY_MAP.get(t, t))
+        ]
+        if len(allowed_tools) < len(all_sdk_tools):
+            blocked = set(all_sdk_tools) - set(allowed_tools)
+            logger.info("Tool policy blocked SDK tools: %s", blocked)
+
+        # In-process MCP tool ids must be on the allowlist to be
+        # callable. The ripple widget-spec tools are core; the cloud
+        # pocket / Mission Control tasks / planner / pocket-specialist
+        # ids come from the ``pocketpaw.mcp_servers`` providers (none on
+        # an OSS install). The cloud ``pocketpaw_pocket`` server carries
+        # both read tools (get_pocket / list_pockets) and the writable
+        # ``add_widget`` tool — they all flow through the loop below.
+        allowed_tools.extend(self._collect_mcp_tool_ids())
+
+        # Per-entity ADDITIVE allowlist (entity-rooms chunk ①). UNION the
+        # entity's ``allowed_sdk_tools`` into the allowlist BEFORE the deny
+        # subtraction below, so the precedence is
+        # ``effective = (agent_tools ∪ allow) − deny``. Dedup-preserve order:
+        # only append ids not already present. Empty for legacy / non-entity
+        # runs, so this is a no-op there. The deny set (subtracted next) is
+        # the hard cap — an id in BOTH allow and deny stays denied.
+        if allow_sdk_tools:
+            existing = set(allowed_tools)
+            for tool_id in allow_sdk_tools:
+                if tool_id not in existing:
+                    allowed_tools.append(tool_id)
+                    existing.add(tool_id)
+            logger.info("Surface tool-allow: unioned %s into allowlist", sorted(allow_sdk_tools))
+
+        # Per-surface MCP-tool deny set (threaded from the chat loop's
+        # resolved ``SurfaceProfile``). Any denied id is subtracted from the
+        # allowlist BEFORE the SDK launches, so the agent is physically
+        # unable to call it. On the /sites svelte-create surface this forbids
+        # the two ripple-create tools (``create_landing_site`` +
+        # ``pocket_specialist__create``) so the agent CANNOT fall back to
+        # building a rippleSpec landing page — prose-only "do not call the
+        # ripple tool" routing was proven to fail. Empty for every other
+        # surface (a no-op), so ``create_svelte_site`` / ``publish`` /
+        # ``pocket_specialist__edit`` and the ripple-engine / refine /
+        # non-sites flows are untouched. This is the typed replacement for
+        # the old prompt-sniffing ``engine="svelte"`` marker gate.
+        if deny_mcp_tool_ids:
+            before_count = len(allowed_tools)
+            allowed_tools = [t for t in allowed_tools if t not in deny_mcp_tool_ids]
+            if len(allowed_tools) < before_count:
+                logger.info(
+                    "Surface tool-deny: excluded %s from allowlist",
+                    sorted(deny_mcp_tool_ids),
+                )
+
+        # Per-MODE restrictive MCP allow-list (distinct from the additive
+        # ``allow_sdk_tools`` above). ``None`` keeps every MCP tool (broad
+        # surfaces like /chat). When set, keep only MCP tools that are in the
+        # mode's set, in the pocket-creation grant, a ripple widget tool, OR
+        # from an always-allowed server (connectors + pocket lifecycle).
+        # Built-in SDK tools (Read/Write/Bash/...) are NEVER filtered here —
+        # only ``mcp__*`` ids — so scoping a mode can't strip core tools.
+        # Applied AFTER deny so a denied id can't sneak back via the grant.
+        if allow_mcp_tool_ids is not None:
+            from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+
+            grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT | frozenset(WIDGET_TOOL_IDS)
+            before_count = len(allowed_tools)
+            allowed_tools = [
+                t
+                for t in allowed_tools
+                if not t.startswith("mcp__")
+                or t in grant
+                or _mcp_server_of(t) in ALWAYS_ALLOWED_MCP_SERVERS
+            ]
+            if len(allowed_tools) < before_count:
+                logger.info(
+                    "Mode MCP-allow: scoped to %s (+ general grant)",
+                    sorted(allow_mcp_tool_ids),
+                )
+
+        # Build hooks for security
+        hooks = {
+            "PreToolUse": [
+                self._HookMatcher(
+                    matcher="Bash",  # Only hook Bash commands
+                    hooks=[self._block_dangerous_hook],
+                )
+            ]
+        }
+
+        # Build options
+        #
+        # Windows note: CreateProcess caps the entire command line at
+        # ~32,767 chars. The SDK passes string ``system_prompt`` inline
+        # via ``--system-prompt``; long KB/identity blobs blow that limit
+        # and surface as a misleading ``CLINotFoundError``. Since SDK
+        # 0.1.72 we can pass a ``SystemPromptFile`` dict instead, which
+        # the CLI reads via ``--system-prompt-file <path>``.
+        system_prompt_arg: Any = final_prompt
+        if os.name == "nt" and len(final_prompt) > 24_000:
+            runtime_dir = Path.home() / ".pocketpaw" / "runtime"
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+            prompt_path = runtime_dir / "system_prompt.md"
+            prompt_path.write_text(final_prompt, encoding="utf-8")
+            system_prompt_arg = {"type": "file", "path": str(prompt_path)}
+            logger.info(
+                "System prompt %d chars exceeds Windows CLI safe limit; "
+                "passing via --system-prompt-file %s",
+                len(final_prompt),
+                prompt_path,
+            )
+
+        # ``setting_sources=[]`` keeps the agent on its OWN persona.
+        # PocketPaw is not Claude Code: we pass a custom ``system_prompt``
+        # string (never the ``claude_code`` preset), and an empty
+        # setting-source list stops the SDK from injecting CLAUDE.md,
+        # output styles, or filesystem settings as context. The repo
+        # CLAUDE.md literally opens with "guidance to Claude Code
+        # (claude.ai/code)" — loading it bled that identity into the
+        # agent. Hooks, MCP servers, allowed_tools and permissions are
+        # all passed explicitly below, so none of them depend on
+        # setting sources. See
+        # https://code.claude.com/docs/en/agent-sdk/modifying-system-prompts
+        options_kwargs = {
+            "system_prompt": system_prompt_arg,
+            "allowed_tools": allowed_tools,
+            "setting_sources": [],
+            "hooks": hooks,
+            "cwd": str(self._cwd),
+            "max_turns": self.settings.claude_sdk_max_turns or None,
+        }
+
+        # Load PocketPaw's bundled skills as a Claude Code *local plugin*.
+        # ``setting_sources=[]`` above disables the SDK's ~/.claude/skills
+        # discovery, so the boot-time ~/.claude/skills mirror is invisible
+        # to this backend and a local plugin is the ONLY way the bundled
+        # skills reach it. Persona isolation is preserved — a plugin loads
+        # only its own ``skills/`` directory, never the rest of ~/.claude
+        # (CLAUDE.md, output styles). Empirically verified 2026-06-03: the
+        # ``skills=`` option is also gated by setting_sources, but
+        # ``plugins=`` is not. Toggle via ``sdk_load_bundled_skills``.
+        bundled_loaded = False
+        if self.settings.sdk_load_bundled_skills:
+            from pocketpaw.bundled_skills import bundled_skills_plugin_dir
+
+            plugin_dir = bundled_skills_plugin_dir()
+            if plugin_dir is not None:
+                options_kwargs["plugins"] = [{"type": "local", "path": str(plugin_dir)}]
+                bundled_loaded = True
+                logger.info("SDK: loading bundled-skills plugin from %s", plugin_dir)
+
+        # Plugin-identity digest (fix/claude-sdk-warm-client-skills): folds
+        # the requested skill set + the bundled flag into the cache key so a
+        # skill run can REUSE the warm subprocess instead of re-spawning.
+        # Keyed on identity, never the mkdtemp path (see _plugin_digest).
+        plugin_digest = self._plugin_digest(skill_names, bundled=bundled_loaded)
+
+        # Per-entity skill subset (entity-rooms A2). Materialize ONLY the
+        # named skills into a local plugin and append it to the ``plugins=``
+        # list (creating the list if the bundled plugin above was off). It
+        # coexists with the bundled entry. Empty ``skill_names`` is a no-op.
+        #
+        # The warm client keeps whatever ``plugins=`` path it was connected
+        # with from its first connect(), so the materialized dir must be
+        # STABLE per plugin_digest across turns. When this run will reuse the
+        # warm client and a dir for this digest already exists, reuse it
+        # rather than re-materializing — the live subprocess already points
+        # at it. Otherwise materialize fresh; cache + adopt it on the warm
+        # path (cleaned on eviction/cleanup), or leave it owned by this run
+        # on the stateless path (the per-run finally removes it).
+        if skill_names:
+            from pocketpaw.skills import materialize_run_skills
+
+            will_reuse_warm = not self._client_in_use
+            cached_dir = self._skills_dir_by_digest.get(plugin_digest)
+            if will_reuse_warm and cached_dir is not None and cached_dir.exists():
+                run_skills_root = cached_dir
+                skills_dir_adopted = True
+                logger.info(
+                    "SDK: reusing cached per-run skill plugin (%d requested) at %s",
+                    len(skill_names),
+                    run_skills_root,
+                )
+            else:
+                run_skills_root = materialize_run_skills(skill_names, run_id=session_key)
+                if run_skills_root is not None and will_reuse_warm:
+                    self._skills_dir_by_digest[plugin_digest] = run_skills_root
+                    skills_dir_adopted = True
+
+            if run_skills_root is not None:
+                options_kwargs.setdefault("plugins", [])
+                options_kwargs["plugins"].append({"type": "local", "path": str(run_skills_root)})
+                if not skills_dir_adopted:
+                    logger.info(
+                        "SDK: loading per-run skill plugin (%d requested) from %s "
+                        "(stateless — dir owned by this run)",
+                        len(skill_names),
+                        run_skills_root,
+                    )
+
+        # Configure LLM provider for the Claude CLI subprocess.
+        # Ollama/OpenAI-compat providers set their own env vars via to_sdk_env().
+        sdk_env = llm.to_sdk_env()
+        if not sdk_env:
+            env_key = os.environ.get("ANTHROPIC_API_KEY")
+            if env_key:
+                sdk_env = {"ANTHROPIC_API_KEY": env_key}
+
+        # Pass Claude Code OAuth token (Max/Pro subscription in Docker/headless)
+        oauth_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+        if oauth_token:
+            sdk_env = sdk_env or {}
+            sdk_env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
+
+        # Strip nesting-detection env vars (set when launched from
+        # a Claude Code terminal) so the subprocess starts cleanly.
+        # These should already be removed by main(), but do it here
+        # too as a safety net.
+        for _strip_key in ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"):
+            os.environ.pop(_strip_key, None)
+        # Merge per-run subprocess env (PR #1222 R1 Blocker 1) —
+        # e.g. the pocket-specialist runtime attaches
+        # ``POCKETPAW_WORKSPACE_ID`` / ``POCKETPAW_USER_ID`` /
+        # ``POCKETPAW_INTERNAL_TOKEN`` here instead of writing to
+        # the parent process's ``os.environ``. LLM-auth env wins:
+        # we lay extras DOWN FIRST so anything the caller attaches
+        # cannot accidentally clobber the auth key. An isolated
+        # backend has its own ``_extra_subprocess_env`` so the
+        # tenancy of one request cannot leak into another.
+        if self._extra_subprocess_env:
+            merged_env = dict(self._extra_subprocess_env)
+            if sdk_env:
+                merged_env.update(sdk_env)
+            sdk_env = merged_env
+        if sdk_env:
+            options_kwargs["env"] = sdk_env
+        if is_non_anthropic:
+            options_kwargs["model"] = llm.model
+
+        # ── Debug logging for troubleshooting SDK startup ──
+        import shutil as _shutil
+
+        logger.info(
+            "SDK launch: provider=%s, has_api_key=%s, "
+            "CLAUDECODE=%s, CLAUDE_CODE_ENTRYPOINT=%s, "
+            "ANTHROPIC_API_KEY=%s, sdk_env_keys=%s, "
+            "cli_path=%s, cwd=%s",
+            provider,
+            bool(llm.api_key),
+            os.environ.get("CLAUDECODE", "<unset>"),
+            os.environ.get("CLAUDE_CODE_ENTRYPOINT", "<unset>"),
+            "set" if os.environ.get("ANTHROPIC_API_KEY") else "<unset>",
+            list(sdk_env.keys()) if sdk_env else "none",
+            _shutil.which("claude") or "<not found>",
+            self._cwd,
+        )
+
+        # Wire in MCP servers (policy-filtered)
+        mcp_servers = self._get_mcp_servers()
+        if mcp_servers:
+            options_kwargs["mcp_servers"] = mcp_servers
+            logger.info("MCP: passing %d servers to Claude SDK", len(mcp_servers))
+
+        # Enable token-by-token streaming if StreamEvent is available
+        if self._StreamEvent is not None:
+            options_kwargs["include_partial_messages"] = True
+
+        # Permission handling — PocketPaw always runs headless (web dashboard,
+        # Telegram, Discord, Slack, etc.) with no terminal for interactive
+        # permission prompts. Without bypassPermissions, tool calls that need
+        # approval (like Bash — used by memory save, web search, etc.) hang
+        # indefinitely on messaging channels.
+        # Dangerous Bash commands are still caught by the PreToolUse hook.
+        options_kwargs["permission_mode"] = "bypassPermissions"
+
+        # Model selection for Anthropic providers:
+        # 1. Smart routing (opt-in) — overrides with complexity-based model
+        # 2. Explicit claude_sdk_model — user-chosen fixed model
+        # 3. Neither set — let Claude Code CLI auto-select (recommended)
+        if not is_non_anthropic:
+            if self.settings.smart_routing_enabled:
+                from pocketpaw.agents.model_router import ModelRouter
+
+                model_router = ModelRouter(self.settings)
+                selection = model_router.classify(message)
+                options_kwargs["model"] = selection.model
+            elif self.settings.claude_sdk_model:
+                options_kwargs["model"] = self.settings.claude_sdk_model
+
+        # Capture stderr for better error diagnostics
+        def _on_stderr(line: str) -> None:
+            stderr_sink.append(line)
+            logger.debug("Claude CLI stderr: %s", line)
+
+        options_kwargs["stderr"] = _on_stderr
+
+        # Create options (after all kwargs are set, including model)
+        options = self._ClaudeAgentOptions(**options_kwargs)
+
+        return _BuiltOptions(
+            options=options,
+            options_kwargs=options_kwargs,
+            llm=llm,
+            run_skills_root=run_skills_root,
+            skills_dir_adopted=skills_dir_adopted,
+            plugin_digest=plugin_digest,
+        )
+
+    async def prewarm(
+        self,
+        *,
+        session_key: str,
+        system_prompt: str | None = None,
+        history: list[dict] | None = None,
+        deny_mcp_tool_ids: frozenset[str] = frozenset(),
+        allow_sdk_tools: frozenset[str] = frozenset(),
+        allow_mcp_tool_ids: frozenset[str] | None = None,
+        skill_names: frozenset[str] = frozenset(),
+    ) -> None:
+        """Eagerly ``connect()`` the warm CLI subprocess for a session before its
+        first turn, so the first real ``run`` reuses it instead of paying the
+        ~12s cold ``connect()`` (feat/claude-sdk-prewarm).
+
+        Builds the SAME options the first turn will (via ``_build_options``) and
+        hands them to ``_get_or_create_client`` with the SAME ``session_key`` +
+        ``plugin_digest`` — so the cache key matches and the first turn finds the
+        client already live. If the keys diverged the first turn would EVICT the
+        prewarmed client (a net loss), which is why the caller must prewarm with
+        the same model/tools/prefix/skills the first turn will use.
+
+        FIRE-AND-FORGET, never-break-a-turn semantics:
+          * ALL exceptions are logged and SWALLOWED — a failed prewarm must never
+            propagate to (or poison) a later turn. On failure the half-built
+            client is torn down and the lease released, so the next ``run`` starts
+            clean and simply pays the cold connect it would have paid anyway (no
+            regression).
+          * If a run is already active (``_client_in_use``) prewarm is a NO-OP —
+            it must not contend for the lease or disturb an in-flight stream.
+          * If the SDK / CLI is unavailable it is a no-op (nothing to warm).
+
+        The skills-dir lifecycle is identical to ``run``'s warm path: when
+        ``skill_names`` is non-empty ``_build_options`` materializes + adopts the
+        plugin dir into ``self._skills_dir_by_digest`` keyed on ``plugin_digest``,
+        and the warm client created here owns it until eviction / ``cleanup()``.
+        On a prewarm failure that adopted dir is dropped so it doesn't leak.
+        """
+        if not self._sdk_available or not self._cli_available:
+            return
+        # A run holds the lease — never contend. The in-flight turn will create
+        # (or already created) the warm client itself.
+        if self._client_in_use:
+            logger.debug("prewarm skipped: a run is active (_client_in_use)")
+            return
+
+        adopted_digest = ""
+        try:
+            built = await self._build_options(
+                "",  # no real message yet — safe only when the model is
+                # message-independent (smart routing OFF). The trigger gates on
+                # this; see prewarm_session in run_core.
+                system_prompt=system_prompt,
+                history=history,
+                session_key=session_key,
+                deny_mcp_tool_ids=deny_mcp_tool_ids,
+                allow_sdk_tools=allow_sdk_tools,
+                allow_mcp_tool_ids=allow_mcp_tool_ids,
+                skill_names=skill_names,
+                stderr_sink=[],
+            )
+            # Remember the digest we may have adopted a dir under, so a failed
+            # connect can release it instead of leaking.
+            if built.skills_dir_adopted:
+                adopted_digest = built.plugin_digest
+            await self._get_or_create_client(
+                built.options,
+                session_key=session_key,
+                plugin_digest=built.plugin_digest,
+            )
+            logger.info(
+                "Prewarmed Claude client for session_key=%s (skills=%d)",
+                session_key,
+                len(skill_names),
+            )
+        except Exception as exc:  # noqa: BLE001 — prewarm must NEVER raise
+            logger.warning("Prewarm failed (swallowed, turn unaffected): %s", exc)
+            # Tear down any half-built client so the next run starts on a clean
+            # slate (and just pays the cold connect). CRITICAL: prewarm never
+            # acquired the ``_client_in_use`` lease, so it must NEVER clear it —
+            # a run firing concurrently may legitimately own it, and stealing it
+            # would corrupt that run. Do the teardown UNDER the client lock and
+            # only when no run holds the lease, so we can't disconnect a client a
+            # sibling run is actively using.
+            if self._client_lock is None:
+                self._client_lock = asyncio.Lock()
+            async with self._client_lock:
+                if not self._client_in_use:
+                    try:
+                        if self._client is not None:
+                            await self._client.disconnect()
+                    except Exception as disc_exc:  # noqa: BLE001
+                        logger.debug("prewarm cleanup disconnect error (ignored): %s", disc_exc)
+                    self._client = None
+                    self._client_options_key = None
+                    # If _build_options adopted a materialized skills dir for this
+                    # digest but no live client now references it, drop it so it
+                    # doesn't leak.
+                    if adopted_digest:
+                        self._drop_skills_dir(adopted_digest)
+                        self._client_plugin_digest = ""
 
     async def run(
         self,
@@ -1196,449 +1836,41 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # non-owning run (stateless fallback, or a failure before acquisition)
         # can never release a sibling's lease or destroy its subprocess.
         acquired_lease = False
+        # Resolved LLM client — bound by ``_build_options`` below. Declared above
+        # the try (feat/claude-sdk-prewarm) so the ``except`` handler's
+        # ``llm.format_api_error`` call is safe even when ``_build_options`` itself
+        # raises before returning (e.g. the provider resolves but options
+        # construction fails); the handler guards ``llm is None`` for that case.
+        llm: Any = None
         try:
-            # Resolve LLM provider early -- needed for routing + env.
-            # Use per-backend provider setting (defaults to "anthropic").
-            # An API key is REQUIRED for Anthropic provider -- OAuth tokens from
-            # Claude Free/Pro/Max plans are not permitted for third-party use.
-            # See: https://code.claude.com/docs/en/legal-and-compliance
-            from pocketpaw.llm.client import resolve_llm_client
-
-            provider = self.settings.claude_sdk_provider or "anthropic"
-            llm = resolve_llm_client(self.settings, force_provider=provider)
-
-            # ── API key check for Anthropic provider ──────────────
-            # Skip if using a non-Anthropic provider, or if the active
-            # provider is claude_code (it handles OAuth auth via its CLI).
-            _is_claude_code_provider = provider in ("claude_code", "claude_agent_sdk")
-            is_non_anthropic = (
-                llm.is_ollama
-                or llm.is_openai_compatible
-                or llm.is_gemini
-                or llm.is_litellm
-                or llm.is_openrouter
+            # Assemble the SDK options (feat/claude-sdk-prewarm). The whole
+            # block that built ``options_kwargs`` -> ``options`` (LLM resolve,
+            # model routing, system-prompt assembly, tool allow/deny, bundled +
+            # per-run skills materialization, subprocess env, MCP wiring) now
+            # lives in the shared ``_build_options`` helper so ``prewarm`` can
+            # build the IDENTICAL options the first turn will — same cache key,
+            # so a prewarmed warm client is REUSED here, not evicted. The
+            # returned triple (run_skills_root / skills_dir_adopted /
+            # plugin_digest) drives the dispatch + finally exactly as before; the
+            # stderr sink is this run's ``_stderr_lines`` so CLI diagnostics still
+            # flow to the error handlers below.
+            _built = await self._build_options(
+                message,
+                system_prompt=system_prompt,
+                history=history,
+                session_key=session_key,
+                deny_mcp_tool_ids=deny_mcp_tool_ids,
+                allow_sdk_tools=allow_sdk_tools,
+                allow_mcp_tool_ids=allow_mcp_tool_ids,
+                skill_names=skill_names,
+                stderr_sink=_stderr_lines,
             )
-            # if not is_non_anthropic:
-            #     has_api_key = bool(llm.api_key or os.environ.get("ANTHROPIC_API_KEY"))
-            #     if not has_api_key and not is_claude_code_provider:
-            #         yield AgentEvent(
-            #             type="error",
-            #             content=(
-            #                 "**API key required** -- The Claude SDK backend needs "
-            #                 "an Anthropic API key.\n\n"
-            #                 "**How to fix:**\n"
-            #                 "1. Get an API key at "
-            #                 "[console.anthropic.com](https://console.anthropic.com/settings/keys)\n"
-            #                 "2. Add it in **Settings > API Keys > Anthropic API Key**\n"
-            #                 "3. Or set the `ANTHROPIC_API_KEY` environment variable\n\n"
-            #                 "*Alternatively, switch to **Ollama (Local)** in Settings "
-            #                 "> General for free local inference.*"
-            #             ),
-            #         )
-            #         return
-
-            # Smart model routing — classify complexity to pick the model tier.
-            # All messages go through the Claude Code CLI subprocess, which
-            # handles conversation compaction automatically (PreCompact hook).
-            selection = None
-            if self.settings.smart_routing_enabled and not is_non_anthropic:
-                from pocketpaw.agents.model_router import ModelRouter
-
-                model_router = ModelRouter(self.settings)
-                selection = model_router.classify(message)
-                logger.info(
-                    "Smart routing: %s -> %s (%s)",
-                    selection.complexity.value,
-                    selection.model,
-                    selection.reason,
-                )
-
-            # System prompt — instructions are now part of identity
-            # (injected by BootstrapContext.to_system_prompt() via INSTRUCTIONS.md)
-            identity = system_prompt or _DEFAULT_IDENTITY
-
-            # Inject connector instructions so the agent can use data sources
-            try:
-                from pocketpaw.connectors.registry import ConnectorRegistry
-
-                reg = ConnectorRegistry()
-                if reg.available:
-                    names = ", ".join(c["name"] for c in reg.available)
-                    identity += (
-                        "\n\n# Data Connectors\n"
-                        f"Available connectors: {names}\n"
-                        "To manage connectors, use Bash to call the local API:\n"
-                        "- List: curl -s http://localhost:8888/api/v1/connectors\n"
-                        "- Detail: curl -s http://localhost:8888/api/v1/connectors/<name>\n"
-                        "- Connect: curl -s -X POST "
-                        "http://localhost:8888/api/v1/connectors/connect "
-                        "-H 'Content-Type: application/json' "
-                        '-d \'{"connector_name":"<name>","config":{...}}\'\n'
-                        "- Execute: curl -s -X POST "
-                        "http://localhost:8888/api/v1/connectors/execute "
-                        "-H 'Content-Type: application/json' "
-                        '-d \'{"connector_name":"<name>","action":"<action>"'
-                        ',"params":{...}}\'\n'
-                        "- Disconnect: curl -s -X POST "
-                        "http://localhost:8888/api/v1/connectors/disconnect "
-                        "-H 'Content-Type: application/json' "
-                        '-d \'{"connector_name":"<name>"}\'\n'
-                    )
-            except Exception:
-                pass  # Don't break agent if connector registry fails
-
-            # Inject prior turns into the system prompt at connect time. The
-            # persistent ClaudeSDKClient accumulates new turns natively after
-            # connect, but a fresh subprocess (after eviction, restart, or
-            # session switch) has empty native history — without this, those
-            # cold-start runs lose all conversation context. Reused clients
-            # keep the prompt set at first connect and ignore later option
-            # changes, so there's no duplication on the warm path.
-            final_prompt = identity
-            if history:
-                lines = ["# Recent Conversation"]
-                for msg in history:
-                    role = msg.get("role", "user").capitalize()
-                    content = msg.get("content", "")
-                    if len(content) > 2000:
-                        content = content[:2000] + "..."
-                    lines.append(f"**{role}**: {content}")
-                final_prompt += "\n\n" + "\n".join(lines)
-
-            # Pocket sessions don't need shell or filesystem access — the
-            # MCP pocket tools (get_pocket / list_pockets / set_state /
-            # set_node_prop / add_node / etc.) are the complete interface.
-            # Detect via the <pocket-scope> marker every pocket prompt
-            # carries; lock tools down to delegation + web + pocket MCP.
-            #
-            # Without this gate, the agent has been observed reaching for
-            # shell introspection (e.g. `env | grep pocket; curl localhost`)
-            # to "figure out" pocket state, which trips the security rails
-            # AND is the wrong path — the MCP tools already expose
-            # everything the agent needs.
-            is_pocket_session = "<pocket-scope>" in (final_prompt or "")
-
-            if is_pocket_session:
-                all_sdk_tools = ["Agent", "WebSearch", "WebFetch"]
-                logger.info(
-                    "Pocket session detected — tool surface locked to %s",
-                    all_sdk_tools,
-                )
-            else:
-                all_sdk_tools = [
-                    "Agent",
-                    "Bash",
-                    "Read",
-                    "Write",
-                    "Edit",
-                    "Glob",
-                    "Grep",
-                    "WebSearch",
-                    "WebFetch",
-                    "Skill",
-                ]
-            allowed_tools = [
-                t
-                for t in all_sdk_tools
-                if self._policy.is_tool_allowed(self._TOOL_POLICY_MAP.get(t, t))
-            ]
-            if len(allowed_tools) < len(all_sdk_tools):
-                blocked = set(all_sdk_tools) - set(allowed_tools)
-                logger.info("Tool policy blocked SDK tools: %s", blocked)
-
-            # In-process MCP tool ids must be on the allowlist to be
-            # callable. The ripple widget-spec tools are core; the cloud
-            # pocket / Mission Control tasks / planner / pocket-specialist
-            # ids come from the ``pocketpaw.mcp_servers`` providers (none on
-            # an OSS install). The cloud ``pocketpaw_pocket`` server carries
-            # both read tools (get_pocket / list_pockets) and the writable
-            # ``add_widget`` tool — they all flow through the loop below.
-            allowed_tools.extend(self._collect_mcp_tool_ids())
-
-            # Per-entity ADDITIVE allowlist (entity-rooms chunk ①). UNION the
-            # entity's ``allowed_sdk_tools`` into the allowlist BEFORE the deny
-            # subtraction below, so the precedence is
-            # ``effective = (agent_tools ∪ allow) − deny``. Dedup-preserve order:
-            # only append ids not already present. Empty for legacy / non-entity
-            # runs, so this is a no-op there. The deny set (subtracted next) is
-            # the hard cap — an id in BOTH allow and deny stays denied.
-            if allow_sdk_tools:
-                existing = set(allowed_tools)
-                for tool_id in allow_sdk_tools:
-                    if tool_id not in existing:
-                        allowed_tools.append(tool_id)
-                        existing.add(tool_id)
-                logger.info(
-                    "Surface tool-allow: unioned %s into allowlist", sorted(allow_sdk_tools)
-                )
-
-            # Per-surface MCP-tool deny set (threaded from the chat loop's
-            # resolved ``SurfaceProfile``). Any denied id is subtracted from the
-            # allowlist BEFORE the SDK launches, so the agent is physically
-            # unable to call it. On the /sites svelte-create surface this forbids
-            # the two ripple-create tools (``create_landing_site`` +
-            # ``pocket_specialist__create``) so the agent CANNOT fall back to
-            # building a rippleSpec landing page — prose-only "do not call the
-            # ripple tool" routing was proven to fail. Empty for every other
-            # surface (a no-op), so ``create_svelte_site`` / ``publish`` /
-            # ``pocket_specialist__edit`` and the ripple-engine / refine /
-            # non-sites flows are untouched. This is the typed replacement for
-            # the old prompt-sniffing ``engine="svelte"`` marker gate.
-            if deny_mcp_tool_ids:
-                before_count = len(allowed_tools)
-                allowed_tools = [t for t in allowed_tools if t not in deny_mcp_tool_ids]
-                if len(allowed_tools) < before_count:
-                    logger.info(
-                        "Surface tool-deny: excluded %s from allowlist",
-                        sorted(deny_mcp_tool_ids),
-                    )
-
-            # Per-MODE restrictive MCP allow-list (distinct from the additive
-            # ``allow_sdk_tools`` above). ``None`` keeps every MCP tool (broad
-            # surfaces like /chat). When set, keep only MCP tools that are in the
-            # mode's set, in the pocket-creation grant, a ripple widget tool, OR
-            # from an always-allowed server (connectors + pocket lifecycle).
-            # Built-in SDK tools (Read/Write/Bash/...) are NEVER filtered here —
-            # only ``mcp__*`` ids — so scoping a mode can't strip core tools.
-            # Applied AFTER deny so a denied id can't sneak back via the grant.
-            if allow_mcp_tool_ids is not None:
-                from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
-
-                grant = allow_mcp_tool_ids | POCKET_CREATION_GRANT | frozenset(WIDGET_TOOL_IDS)
-                before_count = len(allowed_tools)
-                allowed_tools = [
-                    t
-                    for t in allowed_tools
-                    if not t.startswith("mcp__")
-                    or t in grant
-                    or _mcp_server_of(t) in ALWAYS_ALLOWED_MCP_SERVERS
-                ]
-                if len(allowed_tools) < before_count:
-                    logger.info(
-                        "Mode MCP-allow: scoped to %s (+ general grant)",
-                        sorted(allow_mcp_tool_ids),
-                    )
-
-            # Build hooks for security
-            hooks = {
-                "PreToolUse": [
-                    self._HookMatcher(
-                        matcher="Bash",  # Only hook Bash commands
-                        hooks=[self._block_dangerous_hook],
-                    )
-                ]
-            }
-
-            # Build options
-            #
-            # Windows note: CreateProcess caps the entire command line at
-            # ~32,767 chars. The SDK passes string ``system_prompt`` inline
-            # via ``--system-prompt``; long KB/identity blobs blow that limit
-            # and surface as a misleading ``CLINotFoundError``. Since SDK
-            # 0.1.72 we can pass a ``SystemPromptFile`` dict instead, which
-            # the CLI reads via ``--system-prompt-file <path>``.
-            system_prompt_arg: Any = final_prompt
-            if os.name == "nt" and len(final_prompt) > 24_000:
-                runtime_dir = Path.home() / ".pocketpaw" / "runtime"
-                runtime_dir.mkdir(parents=True, exist_ok=True)
-                prompt_path = runtime_dir / "system_prompt.md"
-                prompt_path.write_text(final_prompt, encoding="utf-8")
-                system_prompt_arg = {"type": "file", "path": str(prompt_path)}
-                logger.info(
-                    "System prompt %d chars exceeds Windows CLI safe limit; "
-                    "passing via --system-prompt-file %s",
-                    len(final_prompt),
-                    prompt_path,
-                )
-
-            # ``setting_sources=[]`` keeps the agent on its OWN persona.
-            # PocketPaw is not Claude Code: we pass a custom ``system_prompt``
-            # string (never the ``claude_code`` preset), and an empty
-            # setting-source list stops the SDK from injecting CLAUDE.md,
-            # output styles, or filesystem settings as context. The repo
-            # CLAUDE.md literally opens with "guidance to Claude Code
-            # (claude.ai/code)" — loading it bled that identity into the
-            # agent. Hooks, MCP servers, allowed_tools and permissions are
-            # all passed explicitly below, so none of them depend on
-            # setting sources. See
-            # https://code.claude.com/docs/en/agent-sdk/modifying-system-prompts
-            options_kwargs = {
-                "system_prompt": system_prompt_arg,
-                "allowed_tools": allowed_tools,
-                "setting_sources": [],
-                "hooks": hooks,
-                "cwd": str(self._cwd),
-                "max_turns": self.settings.claude_sdk_max_turns or None,
-            }
-
-            # Load PocketPaw's bundled skills as a Claude Code *local plugin*.
-            # ``setting_sources=[]`` above disables the SDK's ~/.claude/skills
-            # discovery, so the boot-time ~/.claude/skills mirror is invisible
-            # to this backend and a local plugin is the ONLY way the bundled
-            # skills reach it. Persona isolation is preserved — a plugin loads
-            # only its own ``skills/`` directory, never the rest of ~/.claude
-            # (CLAUDE.md, output styles). Empirically verified 2026-06-03: the
-            # ``skills=`` option is also gated by setting_sources, but
-            # ``plugins=`` is not. Toggle via ``sdk_load_bundled_skills``.
-            bundled_loaded = False
-            if self.settings.sdk_load_bundled_skills:
-                from pocketpaw.bundled_skills import bundled_skills_plugin_dir
-
-                plugin_dir = bundled_skills_plugin_dir()
-                if plugin_dir is not None:
-                    options_kwargs["plugins"] = [{"type": "local", "path": str(plugin_dir)}]
-                    bundled_loaded = True
-                    logger.info("SDK: loading bundled-skills plugin from %s", plugin_dir)
-
-            # Plugin-identity digest (fix/claude-sdk-warm-client-skills): folds
-            # the requested skill set + the bundled flag into the cache key so a
-            # skill run can REUSE the warm subprocess instead of re-spawning.
-            # Keyed on identity, never the mkdtemp path (see _plugin_digest).
-            plugin_digest = self._plugin_digest(skill_names, bundled=bundled_loaded)
-
-            # Per-entity skill subset (entity-rooms A2). Materialize ONLY the
-            # named skills into a local plugin and append it to the ``plugins=``
-            # list (creating the list if the bundled plugin above was off). It
-            # coexists with the bundled entry. Empty ``skill_names`` is a no-op.
-            #
-            # The warm client keeps whatever ``plugins=`` path it was connected
-            # with from its first connect(), so the materialized dir must be
-            # STABLE per plugin_digest across turns. When this run will reuse the
-            # warm client and a dir for this digest already exists, reuse it
-            # rather than re-materializing — the live subprocess already points
-            # at it. Otherwise materialize fresh; cache + adopt it on the warm
-            # path (cleaned on eviction/cleanup), or leave it owned by this run
-            # on the stateless path (the per-run finally removes it).
-            if skill_names:
-                from pocketpaw.skills import materialize_run_skills
-
-                will_reuse_warm = not self._client_in_use
-                cached_dir = self._skills_dir_by_digest.get(plugin_digest)
-                if will_reuse_warm and cached_dir is not None and cached_dir.exists():
-                    run_skills_root = cached_dir
-                    skills_dir_adopted = True
-                    logger.info(
-                        "SDK: reusing cached per-run skill plugin (%d requested) at %s",
-                        len(skill_names),
-                        run_skills_root,
-                    )
-                else:
-                    run_skills_root = materialize_run_skills(skill_names, run_id=session_key)
-                    if run_skills_root is not None and will_reuse_warm:
-                        self._skills_dir_by_digest[plugin_digest] = run_skills_root
-                        skills_dir_adopted = True
-
-                if run_skills_root is not None:
-                    options_kwargs.setdefault("plugins", [])
-                    options_kwargs["plugins"].append(
-                        {"type": "local", "path": str(run_skills_root)}
-                    )
-                    if not skills_dir_adopted:
-                        logger.info(
-                            "SDK: loading per-run skill plugin (%d requested) from %s "
-                            "(stateless — dir owned by this run)",
-                            len(skill_names),
-                            run_skills_root,
-                        )
-
-            # Configure LLM provider for the Claude CLI subprocess.
-            # Ollama/OpenAI-compat providers set their own env vars via to_sdk_env().
-            sdk_env = llm.to_sdk_env()
-            if not sdk_env:
-                env_key = os.environ.get("ANTHROPIC_API_KEY")
-                if env_key:
-                    sdk_env = {"ANTHROPIC_API_KEY": env_key}
-
-            # Pass Claude Code OAuth token (Max/Pro subscription in Docker/headless)
-            oauth_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
-            if oauth_token:
-                sdk_env = sdk_env or {}
-                sdk_env["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
-
-            # Strip nesting-detection env vars (set when launched from
-            # a Claude Code terminal) so the subprocess starts cleanly.
-            # These should already be removed by main(), but do it here
-            # too as a safety net.
-            for _strip_key in ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"):
-                os.environ.pop(_strip_key, None)
-            # Merge per-run subprocess env (PR #1222 R1 Blocker 1) —
-            # e.g. the pocket-specialist runtime attaches
-            # ``POCKETPAW_WORKSPACE_ID`` / ``POCKETPAW_USER_ID`` /
-            # ``POCKETPAW_INTERNAL_TOKEN`` here instead of writing to
-            # the parent process's ``os.environ``. LLM-auth env wins:
-            # we lay extras DOWN FIRST so anything the caller attaches
-            # cannot accidentally clobber the auth key. An isolated
-            # backend has its own ``_extra_subprocess_env`` so the
-            # tenancy of one request cannot leak into another.
-            if self._extra_subprocess_env:
-                merged_env = dict(self._extra_subprocess_env)
-                if sdk_env:
-                    merged_env.update(sdk_env)
-                sdk_env = merged_env
-            if sdk_env:
-                options_kwargs["env"] = sdk_env
-            if is_non_anthropic:
-                options_kwargs["model"] = llm.model
-
-            # ── Debug logging for troubleshooting SDK startup ──
-            import shutil as _shutil
-
-            logger.info(
-                "SDK launch: provider=%s, has_api_key=%s, "
-                "CLAUDECODE=%s, CLAUDE_CODE_ENTRYPOINT=%s, "
-                "ANTHROPIC_API_KEY=%s, sdk_env_keys=%s, "
-                "cli_path=%s, cwd=%s",
-                provider,
-                bool(llm.api_key),
-                os.environ.get("CLAUDECODE", "<unset>"),
-                os.environ.get("CLAUDE_CODE_ENTRYPOINT", "<unset>"),
-                "set" if os.environ.get("ANTHROPIC_API_KEY") else "<unset>",
-                list(sdk_env.keys()) if sdk_env else "none",
-                _shutil.which("claude") or "<not found>",
-                self._cwd,
-            )
-
-            # Wire in MCP servers (policy-filtered)
-            mcp_servers = self._get_mcp_servers()
-            if mcp_servers:
-                options_kwargs["mcp_servers"] = mcp_servers
-                logger.info("MCP: passing %d servers to Claude SDK", len(mcp_servers))
-
-            # Enable token-by-token streaming if StreamEvent is available
-            if self._StreamEvent is not None:
-                options_kwargs["include_partial_messages"] = True
-
-            # Permission handling — PocketPaw always runs headless (web dashboard,
-            # Telegram, Discord, Slack, etc.) with no terminal for interactive
-            # permission prompts. Without bypassPermissions, tool calls that need
-            # approval (like Bash — used by memory save, web search, etc.) hang
-            # indefinitely on messaging channels.
-            # Dangerous Bash commands are still caught by the PreToolUse hook.
-            options_kwargs["permission_mode"] = "bypassPermissions"
-
-            # Model selection for Anthropic providers:
-            # 1. Smart routing (opt-in) — overrides with complexity-based model
-            # 2. Explicit claude_sdk_model — user-chosen fixed model
-            # 3. Neither set — let Claude Code CLI auto-select (recommended)
-            if not is_non_anthropic:
-                if self.settings.smart_routing_enabled:
-                    from pocketpaw.agents.model_router import ModelRouter
-
-                    model_router = ModelRouter(self.settings)
-                    selection = model_router.classify(message)
-                    options_kwargs["model"] = selection.model
-                elif self.settings.claude_sdk_model:
-                    options_kwargs["model"] = self.settings.claude_sdk_model
-
-            # Capture stderr for better error diagnostics
-            def _on_stderr(line: str) -> None:
-                _stderr_lines.append(line)
-                logger.debug("Claude CLI stderr: %s", line)
-
-            options_kwargs["stderr"] = _on_stderr
-
-            # Create options (after all kwargs are set, including model)
-            options = self._ClaudeAgentOptions(**options_kwargs)
+            options = _built.options
+            options_kwargs = _built.options_kwargs
+            llm = _built.llm
+            run_skills_root = _built.run_skills_root
+            skills_dir_adopted = _built.skills_dir_adopted
+            plugin_digest = _built.plugin_digest
 
             logger.debug(f"🚀 Starting Claude Agent SDK query: {message[:100]}...")
 
@@ -1710,9 +1942,9 @@ class ClaudeSDKBackend(BaseAgentBackend):
 
             if event_stream is None:
                 logger.info("Starting stateless query (reason: _client_in_use was True)")
-                # final_prompt already carries Mongo history (injected above),
-                # so the stateless path uses the same options as the persistent
-                # path — no separate system prompt swap is needed.
+                # ``_build_options`` already baked Mongo history into the system
+                # prompt inside ``options``, so the stateless path uses the same
+                # options as the persistent path — no separate prompt swap needed.
                 event_stream = self._resilient_query(prompt=message, options=options)
 
             # State tracking for StreamEvent deduplication
@@ -1999,10 +2231,17 @@ class ClaudeSDKBackend(BaseAgentBackend):
                         "(OpenAI Agents, Google ADK, Codex, etc.)."
                     ),
                 )
-            else:
+            elif llm is not None:
                 yield AgentEvent(
                     type="error",
                     content=llm.format_api_error(e, stderr=stderr_text),
+                )
+            else:
+                # ``_build_options`` raised before binding ``llm`` — fall back to
+                # a plain message so the error still surfaces (no UnboundLocalError).
+                yield AgentEvent(
+                    type="error",
+                    content=f"❌ Claude Agent SDK error: {error_msg}",
                 )
         finally:
             # Remove the per-run materialized-skills plugin dir (entity-rooms

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -39,6 +39,17 @@ Updated: 2026-06-07 (feat/entity-pocket-profile-field, entity-rooms A1/A2) —
      the Claude SDK backend (withhold-when-empty, same idiom as deny/allow). The
      SDK backend materializes those skills into a throwaway local plugin so ONLY
      the named skills are surfaced. Empty = legacy all-skills behavior.
+Updated: 2026-06-13 (feat/claude-sdk-prewarm) — added ``prewarm``, which eagerly
+  warms the agent's CLI subprocess for a session before its first turn (only the
+  Claude SDK backend has one; no-op elsewhere). ``run``'s system-prompt assembly
+  was factored into a shared ``_assemble_system_prompt`` so ``prewarm`` builds
+  the IDENTICAL prompt the first turn will — the backend's warm-client cache key
+  hashes the prompt's stable behavioral prefix, so a divergent prefix would make
+  turn 1 evict the prewarmed client. ``prewarm`` folds in the agent's own skills
+  (``skill_refs`` + enabled-plugin skills) exactly as ``run`` does so the plugin
+  digest matches too. Fire-and-forget: never raises (the backend's ``prewarm``
+  swallows its own errors; this guards instance load + prompt assembly). The EE
+  trigger fires it as a background task in ``run_core.execute_run``.
 """
 
 from __future__ import annotations
@@ -183,6 +194,189 @@ class AgentPool:
                 await self._evict_oldest()
             return await self._build(agent_doc)
 
+    async def _assemble_system_prompt(
+        self,
+        instance: AgentInstance,
+        *,
+        agent_id: str,
+        message: str,
+        instructions: str,
+        knowledge_context: str,
+        system_message_override: str | None,
+    ) -> str | None:
+        """Build the agent's system prompt from soul/persona + override +
+        instructions + per-message soul recall + knowledge wrapper.
+
+        Factored out of ``run`` (feat/claude-sdk-prewarm) so ``prewarm`` builds
+        the IDENTICAL prompt the first real turn will. The Claude SDK warm-client
+        cache key hashes the prompt's STABLE behavioral prefix (soul/persona +
+        override + ``instructions``); the volatile tail this also appends
+        (``## Relevant Past Memories`` soul recall, ``## Your Knowledge Base``)
+        is stripped before hashing, so a prewarm that passes ``message=""`` /
+        ``knowledge_context=""`` still hashes to the SAME prefix as the run that
+        passes the real values — which is exactly what makes the prewarmed client
+        reused rather than evicted on turn 1.
+        """
+        # Build system prompt via soul bootstrap if available
+        system_prompt = None
+        if instance.soul_manager and instance.soul_manager.bootstrap_provider:
+            try:
+                ctx = await instance.soul_manager.bootstrap_provider.get_context()
+                system_prompt = ctx.identity
+                # Append soul-level knowledge (semantic memories, bond info, etc.)
+                # into the identity block so the agent carries persistent context.
+                if ctx.knowledge:
+                    knowledge_lines = "\n".join(f"- {k}" for k in ctx.knowledge)
+                    system_prompt = f"{system_prompt}\n\n# Key Knowledge\n{knowledge_lines}"
+            except Exception:
+                logger.warning("Failed to build soul prompt for agent %s", agent_id)
+
+        # Fall back to config system_prompt or persona
+        if not system_prompt:
+            persona = instance.config.get("soul_persona", "")
+            extra = instance.config.get("system_prompt", "")
+            system_prompt = f"{persona}\n\n{extra}".strip() if persona or extra else ""
+
+        # Per-entity system-message override (entity-rooms A1): SWAP the base,
+        # KEEP the layers. Everything assembled ABOVE this point is the base
+        # persona/soul identity — exactly what the override replaces. The
+        # downstream layers (authoritative ``instructions`` incl. the ripple LAW,
+        # the soul-memory recall, the knowledge wrapper) are appended BELOW, so
+        # they still ride on top of the override. ``None`` leaves the base
+        # untouched (legacy path). Applied here so a backend never needs to know
+        # the override exists — it rides the existing ``system_prompt`` channel.
+        if system_message_override is not None:
+            system_prompt = system_message_override
+
+        # Authoritative behavior rules — injected BEFORE the knowledge
+        # wrapper so the model reads them as instructions, not reference.
+        if instructions:
+            system_prompt = f"{system_prompt}\n\n{instructions}" if system_prompt else instructions
+
+        # Query-specific soul memory recall — inject relevant past interactions
+        # so the agent can reference cross-session memories. This complements
+        # the general semantic facts already injected by SoulBootstrapProvider.
+        # Skipped on an empty message (e.g. prewarm) — and stripped from the
+        # cache key's behavioral prefix regardless, so it never affects reuse.
+        if instance.soul_manager and instance.soul_manager.soul and message.strip():
+            try:
+                soul_ctx = await instance.soul_manager.soul.context_for(
+                    message,
+                    max_memories=5,
+                    include_state=False,
+                    include_self_model=False,
+                )
+                if soul_ctx:
+                    memory_block = (
+                        "## Relevant Past Memories\n"
+                        "Below are memories from previous conversations that "
+                        "are relevant to the current question. Use them to "
+                        "provide continuity and a personalized response.\n\n"
+                        f"{soul_ctx}"
+                    )
+                    if system_prompt:
+                        system_prompt = f"{system_prompt}\n\n{memory_block}"
+                    else:
+                        system_prompt = memory_block
+            except Exception:
+                logger.debug("Soul context_for() failed for agent %s", agent_id)
+
+        # Inject knowledge context directly into system prompt
+        if knowledge_context:
+            system_prompt = (
+                f"{system_prompt}\n\n"
+                "## Your Knowledge Base\n"
+                "Use the following information from your knowledge base to answer questions. "
+                "Always reference this data when relevant instead of "
+                "making things up or using tools to search.\n\n"
+                f"{knowledge_context}"
+            )
+
+        return system_prompt
+
+    async def prewarm(
+        self,
+        agent_id: str,
+        session_key: str,
+        *,
+        instructions: str = "",
+        deny_mcp_tool_ids: frozenset[str] = frozenset(),
+        allow_sdk_tools: frozenset[str] = frozenset(),
+        allow_mcp_tool_ids: frozenset[str] | None = None,
+        system_message_override: str | None = None,
+        skill_names: frozenset[str] = frozenset(),
+    ) -> None:
+        """Eagerly warm the agent's CLI subprocess for ``session_key`` before its
+        first turn, so the first ``run`` reuses it instead of paying the cold
+        ~12s ``connect()`` (feat/claude-sdk-prewarm).
+
+        Only the Claude SDK backend has a warm-client subprocess, so this no-ops
+        on every other backend (it checks for a ``prewarm`` attribute). It
+        assembles the SAME system prompt and folds in the SAME agent-own skills
+        (``skill_refs`` + enabled-plugin skills) that ``run`` will, so the
+        backend computes a matching cache key — a mismatched key would make the
+        first turn EVICT the prewarmed client (a net loss).
+
+        FIRE-AND-FORGET: the call is designed to be wrapped in
+        ``asyncio.create_task`` by the caller. It NEVER raises — the backend's
+        ``prewarm`` swallows its own errors, and this method guards instance load
+        + prompt assembly in try/except. A failed prewarm leaves the next ``run``
+        to pay the cold connect it would have paid anyway (no regression).
+
+        IMPORTANT: the caller must only invoke this when the first turn's model
+        is message-INDEPENDENT (smart routing OFF). With smart routing ON the
+        model is classified from the message, which prewarm doesn't have, so a
+        prewarm could warm the wrong model tier and cause evict-churn. The
+        run_core trigger gates on this.
+        """
+        try:
+            instance = await self.get(agent_id)
+        except Exception:
+            logger.debug("prewarm: could not load agent %s (skipped)", agent_id)
+            return
+
+        # Only the Claude SDK backend has a warm subprocess to prewarm.
+        backend_prewarm = getattr(instance.backend, "prewarm", None)
+        if backend_prewarm is None:
+            return
+
+        # Fold the agent's OWN skills into the set, mirroring ``run`` exactly so
+        # the plugin digest (and thus the cache key) matches the first turn.
+        cfg = getattr(instance, "config", None) or {}
+        own_skills = (
+            frozenset(cfg.get("skill_refs", []) or []) if isinstance(cfg, dict) else frozenset()
+        )
+        effective_skills = skill_names | own_skills
+
+        try:
+            system_prompt = await self._assemble_system_prompt(
+                instance,
+                agent_id=agent_id,
+                message="",  # no turn yet — the volatile tail is stripped anyway
+                instructions=instructions,
+                knowledge_context="",  # stripped from the cache-key prefix
+                system_message_override=system_message_override,
+            )
+        except Exception:
+            logger.debug("prewarm: prompt assembly failed for %s (skipped)", agent_id)
+            return
+
+        # The backend's prewarm swallows ALL of its own errors, so this is
+        # already safe; the outer guards above cover instance/prompt failures.
+        prewarm_kwargs: dict[str, Any] = {
+            "session_key": session_key,
+            "system_prompt": system_prompt,
+        }
+        if deny_mcp_tool_ids:
+            prewarm_kwargs["deny_mcp_tool_ids"] = deny_mcp_tool_ids
+        if allow_sdk_tools:
+            prewarm_kwargs["allow_sdk_tools"] = allow_sdk_tools
+        if allow_mcp_tool_ids is not None:
+            prewarm_kwargs["allow_mcp_tool_ids"] = allow_mcp_tool_ids
+        if effective_skills:
+            prewarm_kwargs["skill_names"] = effective_skills
+        await backend_prewarm(**prewarm_kwargs)
+
     async def run(
         self,
         agent_id: str,
@@ -257,78 +451,18 @@ class AgentPool:
         if own_skills:
             skill_names = skill_names | own_skills
 
-        # Build system prompt via soul bootstrap if available
-        system_prompt = None
-        if instance.soul_manager and instance.soul_manager.bootstrap_provider:
-            try:
-                ctx = await instance.soul_manager.bootstrap_provider.get_context()
-                system_prompt = ctx.identity
-                # Append soul-level knowledge (semantic memories, bond info, etc.)
-                # into the identity block so the agent carries persistent context.
-                if ctx.knowledge:
-                    knowledge_lines = "\n".join(f"- {k}" for k in ctx.knowledge)
-                    system_prompt = f"{system_prompt}\n\n# Key Knowledge\n{knowledge_lines}"
-            except Exception:
-                logger.warning("Failed to build soul prompt for agent %s", agent_id)
-
-        # Fall back to config system_prompt or persona
-        if not system_prompt:
-            persona = instance.config.get("soul_persona", "")
-            extra = instance.config.get("system_prompt", "")
-            system_prompt = f"{persona}\n\n{extra}".strip() if persona or extra else ""
-
-        # Per-entity system-message override (entity-rooms A1): SWAP the base,
-        # KEEP the layers. Everything assembled ABOVE this point is the base
-        # persona/soul identity — exactly what the override replaces. The
-        # downstream layers (authoritative ``instructions`` incl. the ripple LAW,
-        # the soul-memory recall, the knowledge wrapper) are appended BELOW, so
-        # they still ride on top of the override. ``None`` leaves the base
-        # untouched (legacy path). Applied here so a backend never needs to know
-        # the override exists — it rides the existing ``system_prompt`` channel.
-        if system_message_override is not None:
-            system_prompt = system_message_override
-
-        # Authoritative behavior rules — injected BEFORE the knowledge
-        # wrapper so the model reads them as instructions, not reference.
-        if instructions:
-            system_prompt = f"{system_prompt}\n\n{instructions}" if system_prompt else instructions
-
-        # Query-specific soul memory recall — inject relevant past interactions
-        # so the agent can reference cross-session memories. This complements
-        # the general semantic facts already injected by SoulBootstrapProvider.
-        if instance.soul_manager and instance.soul_manager.soul and message.strip():
-            try:
-                soul_ctx = await instance.soul_manager.soul.context_for(
-                    message,
-                    max_memories=5,
-                    include_state=False,
-                    include_self_model=False,
-                )
-                if soul_ctx:
-                    memory_block = (
-                        "## Relevant Past Memories\n"
-                        "Below are memories from previous conversations that "
-                        "are relevant to the current question. Use them to "
-                        "provide continuity and a personalized response.\n\n"
-                        f"{soul_ctx}"
-                    )
-                    if system_prompt:
-                        system_prompt = f"{system_prompt}\n\n{memory_block}"
-                    else:
-                        system_prompt = memory_block
-            except Exception:
-                logger.debug("Soul context_for() failed for agent %s", agent_id)
-
-        # Inject knowledge context directly into system prompt
-        if knowledge_context:
-            system_prompt = (
-                f"{system_prompt}\n\n"
-                "## Your Knowledge Base\n"
-                "Use the following information from your knowledge base to answer questions. "
-                "Always reference this data when relevant instead of "
-                "making things up or using tools to search.\n\n"
-                f"{knowledge_context}"
-            )
+        # Assemble the system prompt (factored into ``_assemble_system_prompt``
+        # so ``prewarm`` builds the SAME prompt this run will — the warm-client
+        # cache key hashes the prompt's stable behavioral prefix, so a divergent
+        # prefix would make the first turn evict the prewarmed client).
+        system_prompt = await self._assemble_system_prompt(
+            instance,
+            agent_id=agent_id,
+            message=message,
+            instructions=instructions,
+            knowledge_context=knowledge_context,
+            system_message_override=system_message_override,
+        )
 
         # Mark this instance as actively running for the duration of the
         # stream. ``last_active`` alone isn't enough because the LLM can have

--- a/tests/test_claude_sdk_prewarm.py
+++ b/tests/test_claude_sdk_prewarm.py
@@ -1,0 +1,345 @@
+# tests/test_claude_sdk_prewarm.py
+# Created: 2026-06-13 (feat/claude-sdk-prewarm) — pins the PREWARM follow-up
+# stacked on fix/claude-sdk-warm-client-skills (#1456). The warm-client fix made
+# skill/tool-bearing turns REUSE the warm CLI subprocess across turns, but the
+# FIRST send of every new session still paid a cold ``connect()`` (~12s live)
+# because the warm client was only created lazily inside the first ``run()``.
+# ``ClaudeSDKBackend.prewarm`` eagerly assembles the SAME options the first turn
+# will use (via the extracted ``_build_options`` helper) and ``connect()``s the
+# subprocess when a session opens, so the first real turn reuses it.
+#
+# Three behavioral guarantees, all driven through the fake-SDK connect-counter
+# harness reused from tests/test_claude_sdk_skill_warm_reuse.py:
+#   1. REUSE (no skills) — prewarm a session, then run() on it → connect_count
+#      == 1 (prewarm created the client; the run reused it, no second connect).
+#   2. REUSE (with skills) — prewarm with skills X, then run with the SAME skills
+#      X → connect_count == 1 (the prewarmed client's cache key, incl. the
+#      plugin digest, matches the first turn's key, so it is reused not evicted).
+#   3. SWALLOW — a prewarm whose connect() raises must NOT propagate and must NOT
+#      leave broken state: a later run on the same session still completes.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from pocketpaw.agents.claude_sdk import ClaudeAgentSDK, ClaudeSDKBackend
+from pocketpaw.agents.model_router import ModelSelection, TaskComplexity
+
+_LLM_CLIENT = "pocketpaw.llm.client.resolve_llm_client"
+_MODEL_ROUTER = "pocketpaw.agents.model_router.ModelRouter"
+# ``run()`` / ``prewarm()`` import these lazily from ``pocketpaw.skills`` —
+# patch them there.
+_MATERIALIZE = "pocketpaw.skills.materialize_run_skills"
+_CLEANUP = "pocketpaw.skills.cleanup_run_skills"
+
+
+# ===========================================================================
+# Fakes — same shape as the warm-reuse harness (connect() bumps a counter).
+# ===========================================================================
+
+
+def _make_settings(**overrides):
+    defaults = {
+        "agent_backend": "claude_agent_sdk",
+        "tool_profile": "full",
+        "tools_allow": [],
+        "tools_deny": [],
+        # Smart routing OFF: the model stays constant regardless of message, so
+        # a prewarm with no real message assembles the SAME ``model`` the first
+        # turn will. With routing ON the model is message-derived and a
+        # placeholder-message prewarm could mismatch — the trigger skips it then.
+        "smart_routing_enabled": False,
+        "claude_sdk_provider": "anthropic",
+        "claude_sdk_model": None,
+        "claude_sdk_max_turns": None,
+        # Bundled-skills plugin OFF → ``bundled`` is deterministically False.
+        "sdk_load_bundled_skills": False,
+        "anthropic_api_key": "sk-test-key",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class _Options:
+    """Real options object so ``_plugin_digest`` / ``_client_cache_key`` and the
+    dispatch can read ``system_prompt`` / ``model`` / ``allowed_tools`` / ``plugins``."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.model = kwargs.get("model", "")
+        self.allowed_tools = kwargs.get("allowed_tools", [])
+        self.system_prompt = kwargs.get("system_prompt", "")
+        self.plugins = kwargs.get("plugins", [])
+
+
+class _ResultMsg:
+    def __init__(self):
+        self.is_error = False
+        self.result = "ok"
+        self.total_cost_usd = None
+        self.usage = {}
+
+
+class _FakeClient:
+    """Warm persistent client whose connect() bumps a shared counter. An
+    optional ``fail_connect`` makes connect() raise once, to prove prewarm
+    swallows the failure."""
+
+    def __init__(self, counter: list[int], options=None, *, fail_connect=False, **_kw):
+        self._counter = counter
+        self.options = options
+        self._fail_connect = fail_connect
+        self.connected = False
+        self.disconnected = False
+        self.queries: list[str] = []
+
+    async def connect(self, prompt=None):
+        self._counter[0] += 1
+        if self._fail_connect:
+            raise RuntimeError("simulated cold connect failure")
+        self.connected = True
+
+    async def query(self, prompt, session_id="default"):
+        self.queries.append(prompt)
+
+    async def receive_messages(self):
+        yield _ResultMsg()
+
+    async def disconnect(self):
+        self.connected = False
+        self.disconnected = True
+
+    async def interrupt(self):
+        pass
+
+
+def _wire_fakes(sdk, counter, *, fail_connect=False):
+    sdk._ClaudeAgentOptions = _Options
+    sdk._ResultMessage = _ResultMsg
+    sdk._ClaudeSDKClient = lambda **kwargs: _FakeClient(
+        counter, fail_connect=fail_connect, **kwargs
+    )
+    sdk._HookMatcher = MagicMock()
+    sdk._StreamEvent = None
+    sdk._AssistantMessage = None
+    sdk._SystemMessage = None
+    sdk._UserMessage = None
+
+
+def _make_sdk(counter, settings=None, *, fail_connect=False):
+    s = settings or _make_settings()
+    with patch.object(ClaudeSDKBackend, "_initialize"):
+        sdk = ClaudeAgentSDK(s)
+    sdk._sdk_available = True
+    sdk._cli_available = True
+    _wire_fakes(sdk, counter, fail_connect=fail_connect)
+    return sdk
+
+
+def _patched(fn):
+    """Run ``fn()`` (an async no-arg coroutine factory) under the standard LLM /
+    router / MCP patches the run+prewarm paths both need."""
+
+    async def _inner():
+        selection = ModelSelection(
+            complexity=TaskComplexity.MODERATE,
+            model="claude-sonnet-4-5-20250929",
+            reason="test",
+        )
+        with patch(_LLM_CLIENT) as mock_resolve:
+            mock_llm = MagicMock()
+            mock_llm.is_ollama = False
+            mock_llm.is_openai_compatible = False
+            mock_llm.is_gemini = False
+            mock_llm.is_litellm = False
+            mock_llm.is_openrouter = False
+            mock_llm.to_sdk_env.return_value = {"ANTHROPIC_API_KEY": "sk-test"}
+            mock_resolve.return_value = mock_llm
+            with patch(_MODEL_ROUTER) as MockRouter:
+                MockRouter.return_value.classify.return_value = selection
+                with patch.object(ClaudeSDKBackend, "_get_mcp_servers", return_value={}):
+                    return await fn()
+
+    return _inner
+
+
+async def _drive_run(sdk, message, *, skill_names=frozenset(), session_key="s1"):
+    """Drive one full run() turn to completion under the standard patches."""
+
+    async def _go():
+        events = []
+        async for ev in sdk.run(
+            message,
+            system_prompt="identity",
+            session_key=session_key,
+            skill_names=skill_names,
+        ):
+            events.append(ev)
+        return events
+
+    return await _patched(_go)()
+
+
+async def _drive_prewarm(sdk, *, skill_names=frozenset(), session_key="s1"):
+    """Drive one prewarm() call to completion under the standard patches."""
+
+    async def _go():
+        await sdk.prewarm(
+            session_key=session_key,
+            system_prompt="identity",
+            skill_names=skill_names,
+        )
+
+    return await _patched(_go)()
+
+
+# ===========================================================================
+# 1. REUSE (no skills) — prewarm then run reuses, connect_count == 1
+# ===========================================================================
+
+
+async def test_prewarm_then_run_reuses_warm_client_no_skills():
+    """prewarm a session, then run() on the SAME session → connect_count == 1.
+
+    FAILS today (``prewarm`` does not exist → AttributeError). PASSES after the
+    fix: prewarm eagerly connects the warm client; the first run finds a
+    matching cache key and reuses it instead of paying a second connect."""
+    counter = [0]
+    sdk = _make_sdk(counter)
+
+    await _drive_prewarm(sdk, session_key="s1", skill_names=frozenset())
+    assert counter[0] == 1, "prewarm must eagerly connect the warm client exactly once"
+
+    ev = await _drive_run(sdk, "first real turn", session_key="s1", skill_names=frozenset())
+    assert any(e.type == "done" for e in ev)
+    assert counter[0] == 1, (
+        f"the first real turn must REUSE the prewarmed client (connect_count == 1); "
+        f"got {counter[0]} — the prewarmed client was evicted, so prewarm bought "
+        f"nothing (a net loss: it paid a connect the run then threw away)"
+    )
+
+
+# ===========================================================================
+# 2. REUSE (with skills) — matched plugin digest, connect_count == 1
+# ===========================================================================
+
+
+async def test_prewarm_then_run_same_skills_reuses_warm_client(tmp_path):
+    """prewarm with skills X, then run with the SAME skills X → connect_count
+    == 1. The prewarmed client's cache key (incl. the plugin digest) must match
+    the first turn's key, or the run evicts it and re-connects."""
+    counter = [0]
+    sdk = _make_sdk(counter)
+    stable = tmp_path / "skills_plugin"
+    stable.mkdir()
+
+    with patch(_MATERIALIZE, return_value=stable), patch(_CLEANUP):
+        await _drive_prewarm(sdk, session_key="s1", skill_names=frozenset({"skillA"}))
+        assert counter[0] == 1, "prewarm must connect the skill-bearing client once"
+
+        ev = await _drive_run(
+            sdk, "first real turn", session_key="s1", skill_names=frozenset({"skillA"})
+        )
+
+    assert any(e.type == "done" for e in ev)
+    assert counter[0] == 1, (
+        f"a same-skill run after a same-skill prewarm must REUSE the warm client "
+        f"(connect_count == 1); got {counter[0]} — the prewarmed client's plugin "
+        f"digest did not match the run's, so prewarm was wasted (evict-churn)"
+    )
+
+
+# ===========================================================================
+# 3. SWALLOW — a failing prewarm must never break a later turn
+# ===========================================================================
+
+
+async def test_prewarm_connect_failure_is_swallowed_and_run_still_works():
+    """A prewarm whose connect() raises must NOT propagate and must NOT poison
+    later turns: a subsequent run() on the same session still completes."""
+    counter = [0]
+    # First client (the prewarm's) raises in connect(); rewire to a healthy
+    # factory before the run so the run's fresh connect succeeds.
+    sdk = _make_sdk(counter, fail_connect=True)
+
+    # Must not raise even though connect() blows up inside prewarm.
+    await _drive_prewarm(sdk, session_key="s1", skill_names=frozenset())
+
+    # Prewarm's failed connect must have left no live/poisoned client behind.
+    assert sdk._client is None, "a failed prewarm must not leave a broken client wired in"
+    assert sdk._client_in_use is False, "a failed prewarm must not leave the lease held"
+
+    # Heal the SDK factory and prove a real turn still works end to end.
+    _wire_fakes(sdk, counter, fail_connect=False)
+    ev = await _drive_run(sdk, "turn after failed prewarm", session_key="s1")
+    assert any(e.type == "done" for e in ev), (
+        "a run after a failed prewarm must still complete — prewarm errors are "
+        "swallowed and never break a later turn"
+    )
+
+
+# ===========================================================================
+# 4. CONCURRENCY — a prewarm racing the first run must not double-connect
+# ===========================================================================
+
+
+async def test_concurrent_prewarm_and_run_single_connect():
+    """prewarm and the first run() fire CONCURRENTLY (the real trigger fires
+    prewarm as a background task just before the run). The client lock must
+    serialize them so exactly ONE connect() happens and the run still completes
+    — never two subprocesses, never the run evicting a mid-connect prewarm."""
+    import asyncio
+
+    counter = [0]
+    sdk = _make_sdk(counter)
+
+    # Make connect() slow enough that the two coroutines genuinely overlap: the
+    # run will reach _get_or_create_client while prewarm is still inside it.
+    orig_factory = sdk._ClaudeSDKClient
+
+    def _slow_factory(**kwargs):
+        c = orig_factory(**kwargs)
+        orig_connect = c.connect
+
+        async def _slow_connect(prompt=None):
+            await asyncio.sleep(0.02)
+            await orig_connect(prompt)
+
+        c.connect = _slow_connect
+        return c
+
+    sdk._ClaudeSDKClient = _slow_factory
+
+    async def _go():
+        prewarm_task = asyncio.create_task(
+            _drive_prewarm(sdk, session_key="s1", skill_names=frozenset())
+        )
+        # Give prewarm a beat to enter the lock + start its slow connect, then
+        # start the run so the two overlap inside _get_or_create_client.
+        await asyncio.sleep(0.005)
+        ev = await _drive_run(sdk, "first turn", session_key="s1", skill_names=frozenset())
+        await prewarm_task
+        return ev
+
+    ev = await _patched(_go)()
+    assert any(e.type == "done" for e in ev), "the run must complete despite the race"
+    assert counter[0] == 1, (
+        f"a prewarm racing the first run must yield exactly ONE connect "
+        f"(the lock serializes them; the loser reuses the winner's client); "
+        f"got {counter[0]} — the race double-connected or churned the subprocess"
+    )
+
+
+def test_prewarm_exists_with_expected_signature() -> None:
+    """Guard the public contract: ``prewarm`` is an async method taking a
+    keyword ``session_key`` and an optional ``skill_names`` frozenset."""
+    import inspect
+
+    assert inspect.iscoroutinefunction(ClaudeSDKBackend.prewarm)
+    params = inspect.signature(ClaudeSDKBackend.prewarm).parameters
+    assert "session_key" in params
+    assert "skill_names" in params
+    assert params["skill_names"].default == frozenset()


### PR DESCRIPTION
> Stacked on #1456 (`fix/claude-sdk-warm-client-skills`). This PR targets that branch, not `dev`, so the diff shows only the prewarm work. Merge #1456 first.

## What this fixes

#1456 made skill-bearing turns reuse the warm CLI subprocess across turns. But the first send of every new session still paid a cold `connect()` of around 12s, because the warm client was only created lazily inside the first `run()`. Pocket and agent chats — the skill-carrying ones — felt that cold start on their opening message.

This warms the subprocess when a session opens, so the first real turn reuses it instead of paying the connect.

## How it works

- **`ClaudeSDKBackend.prewarm()`** builds the same options the first turn will use and connects the client eagerly. It is fire-and-forget: it swallows every error, no-ops when a run already holds the lease or the SDK/CLI is unavailable, and can never block or break a later turn. A failed prewarm just leaves turn 1 to pay the connect it would have paid anyway.

- **`_build_options` extraction.** The hazard with prewarm is the cache key: if the prewarmed client's key (model + tools + system-prompt prefix + plugin digest) doesn't match the first turn's, the turn evicts it and the prewarm is wasted. To guarantee a match, `run()`'s entire options-assembly block was pulled into a shared `_build_options` helper that both `run` and `prewarm` call. `run`'s behavior is byte-identical — verified by a normalized diff of the moved block against the original. The only behavioral change: `llm` is now declared above the `try` so the error handler stays safe if option assembly itself raises (this was a latent `UnboundLocalError` the extraction surfaced; a regression test in `test_agents.py` caught it and now passes).

- **`_client_lock`.** Because the trigger fires prewarm as a background task, it runs concurrently with the first `run`. `_get_or_create_client` awaits `disconnect()`/`connect()`, so without a lock the two could race to create or evict the subprocess. A new lock serializes the reuse-or-connect section — whichever coroutine loses the lock re-reads the client under a matching key and reuses it.

- **`AgentPool.prewarm` + `_assemble_system_prompt`.** `run`'s system-prompt assembly was factored into a shared method so the prewarmed prompt's stable prefix matches the run's. Prewarm folds in the agent's own skills (`skill_refs` + enabled-plugin skills) exactly as `run` does, so the plugin digest matches too.

- **Trigger.** `run_core.execute_run` fires `_prewarm_session(ctx)` as a background task right after the entity-aware profile resolves. The subprocess then warms concurrently with the remaining pre-turn work (knowledge context, soul recall, SSE setup, prompt assembly), so it's live by the time `pool.run` reaches the first `connect()`.

## Limitation

The trigger only fires when smart routing is off. With smart routing on, the model is classified from the message — which prewarm doesn't have yet — so a message-less prewarm could warm the wrong model tier and cause evict-churn. Those deployments keep today's cold turn-1. This is documented in the trigger and the file-top comments.

## Tests

New `tests/test_claude_sdk_prewarm.py`, written failing-first against the fake-SDK connect-counter harness from `test_claude_sdk_skill_warm_reuse.py`:

- prewarm then run with no skills reuses the client (`connect_count == 1`)
- prewarm then run with the same skills reuses it (matched plugin digest)
- a prewarm whose `connect()` raises is swallowed and a later run still completes
- a prewarm racing the first run yields exactly one connect (the lock)
- signature guard

**Failing before, passing after:**

```
# before implementation (prewarm method absent):
$ uv run pytest tests/test_claude_sdk_prewarm.py -q
E   AttributeError: 'ClaudeSDKBackend' object has no attribute 'prewarm'
4 failed

# after:
$ uv run pytest tests/test_claude_sdk_prewarm.py tests/test_claude_sdk_skill_warm_reuse.py -v
15 passed
```

No regressions:

```
$ uv run pytest tests/ -k claude_sdk -q
88 passed, 1 skipped
$ uv run pytest tests/cloud/runs/ -q
115 passed
```

(`test_auto_resolve_no_key_gives_ollama` and two cloud tests fail on this machine, but they fail identically on the base branch with this change stashed — local env / missing optional deps, not this PR.)

## Scope

Diff is `claude_sdk.py` + `pool.py` + `run_core.py` (the trigger) + the new test. No public API change, no schema change.
