### PR TITLE
feat(mandates): cadence scheduler + first live-signal patrol

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,11 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-06-13 (feat/patrol-engine) — Registers the mandate cadence
+    SCHEDULER lifespan pair next to the autopilot pair, under the same
+    POCKETPAW_CLOUD_SCHEDULER_ENABLED gate: ``reconcile_scheduler`` at startup
+    (starts the single sweeper loop, run_immediate=False) and
+    ``shutdown_scheduler`` at shutdown (cancels + awaits it). The loop fires
+    cadence-due shifts so "weekly" mandates run without a manual trigger.
 Modified: 2026-06-11 (feat/belt-autopilot) — Registers the mandate-autopilot
     lifespan pair under the POCKETPAW_CLOUD_SCHEDULER_ENABLED gate:
     ``reconcile_autopilot_tasks`` at startup (re-derives per-mandate autopilot
@@ -773,6 +779,28 @@ def mount_cloud(app: FastAPI) -> None:
         @app.on_event("shutdown")
         async def _stop_mandate_autopilot() -> None:
             await shutdown_all_autopilot_tasks()
+
+        # Mandate cadence scheduler (feat/patrol-engine). A single sweeper loop
+        # that wakes every interval and fires ``service.trigger_shift`` for each
+        # ACTIVE mandate whose charter cadence is DUE (a "weekly" mandate whose
+        # last shift is >7 days old; "manual" mandates are never fired). This
+        # turns ``Charter.cadence`` from a persisted label into an always-on
+        # trigger — until now shifts were manual-only. Same scheduler gate as the
+        # autopilot/decisions loops so pytest runs never spawn a loop that
+        # outlives the test; reconcile starts with run_immediate=False (a boot
+        # never storms a tick).
+        from pocketpaw_ee.cloud.mandates.scheduler import (
+            reconcile_scheduler,
+            shutdown_scheduler,
+        )
+
+        @app.on_event("startup")
+        async def _start_mandate_scheduler() -> None:
+            await reconcile_scheduler()
+
+        @app.on_event("shutdown")
+        async def _stop_mandate_scheduler() -> None:
+            await shutdown_scheduler()
 
     # Mission Control activity buffer — per-workspace ring buffer fed by
     # agent.* bus events. Same constraint as the upload listeners: subscribe

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -785,10 +785,12 @@ def mount_cloud(app: FastAPI) -> None:
         # ACTIVE mandate whose charter cadence is DUE (a "weekly" mandate whose
         # last shift is >7 days old; "manual" mandates are never fired). This
         # turns ``Charter.cadence`` from a persisted label into an always-on
-        # trigger — until now shifts were manual-only. Same scheduler gate as the
-        # autopilot/decisions loops so pytest runs never spawn a loop that
-        # outlives the test; reconcile starts with run_immediate=False (a boot
-        # never storms a tick).
+        # trigger — until now shifts were manual-only. INTENTIONALLY nested in the
+        # autopilot block: it deliberately shares the SAME
+        # POCKETPAW_CLOUD_SCHEDULER_ENABLED gate as the autopilot/decisions loops,
+        # so a host that runs background loops runs all of them, and pytest runs
+        # (gate off) never spawn a loop that outlives the test. Reconcile starts
+        # with run_immediate=False (a boot never storms a tick).
         from pocketpaw_ee.cloud.mandates.scheduler import (
             reconcile_scheduler,
             shutdown_scheduler,

--- a/ee/pocketpaw_ee/cloud/mandates/patrols.py
+++ b/ee/pocketpaw_ee/cloud/mandates/patrols.py
@@ -1,12 +1,20 @@
 # ee/pocketpaw_ee/cloud/mandates/patrols.py
 # Created: 2026-06-11 (feat/belt-mandates, slice 2 — patrols).
 #
+# Updated: 2026-06-13 (feat/patrol-engine) — added ``issues_patrol``, the FIRST
+#   LIVE patrol: it reads a REAL signal (open issues on the bound repo's GitLab
+#   project) through the existing ``connectors_service.execute`` cloud path and
+#   emits a populated SightingDraft per open issue — not the hardcoded stub the
+#   ``deps`` patrol uses. The external call is injectable so tests mock the
+#   payload instead of hitting the network. The ``deps`` / ``feedback`` patrols
+#   are unchanged.
+#
 # The PATROL framework — a patrol is an async callable that senses a mandate's
 # surface and produces Sighting DRAFTS (plain dicts; the service persists them
 # as SightingDoc rows — patrols never touch the store, keeping service.py the
 # sole Beanie importer).
 #
-# Two patrols ship in v1:
+# Patrols that ship:
 #   * ``deps``    — parses the bound repo's manifest (pyproject.toml /
 #                   package.json) and flags entries found in a DETERMINISTIC
 #                   STUB TABLE of known-stale / CVE-carrying packages.
@@ -14,13 +22,19 @@
 #                   table, not a live advisory feed. The patrol's parse +
 #                   sighting plumbing is production-shaped; only the data
 #                   source is stubbed. <<<
+#   * ``issues``  — the FIRST LIVE patrol. Reads OPEN issues on the bound repo's
+#                   GitLab project via ``connectors_service.execute`` (a real
+#                   httpx call in CLOUD mode) and emits one SightingDraft per
+#                   open issue. No hardcoded table — this is a genuine live feed.
 #   * ``feedback`` — intake-only (no sense loop); humans file sightings via
 #                   ``POST /belt/mandates/{id}/feedback`` (service.file_feedback).
 #                   It has no callable here on purpose.
 #
 # Security: the repo manifest is DATA — parsed with tomllib/json, never
 # executed or shell-interpolated. A repo path that doesn't resolve or parse
-# yields zero sightings (the patrol never raises into the shift trigger).
+# yields zero sightings (the patrol never raises into the shift trigger). The
+# issues patrol's connector call is wrapped the same way — a failure (unbound
+# connector, network error, malformed payload) yields zero sightings.
 
 from __future__ import annotations
 
@@ -149,11 +163,166 @@ async def deps_patrol(repo_id: str) -> list[SightingDraft]:
     return drafts
 
 
+# ---------------------------------------------------------------------------
+# ``issues`` — the FIRST LIVE patrol. Reads OPEN issues on the bound repo's
+# GitLab project through the existing connector execute path (a real httpx call
+# in CLOUD mode), and emits one SightingDraft per open issue. The external call
+# is injected so tests mock the payload; the live caller passes the real
+# ``connectors_service.execute``.
+# ---------------------------------------------------------------------------
+
+# The connector + action the issues patrol reads. GitLab's ``list_issues`` is a
+# CLOUD-mode bearer REST action (real httpx) the catalog already ships.
+_ISSUES_CONNECTOR = "gitlab"
+_ISSUES_ACTION = "list_issues"
+# How many open issues a single patrol pass turns into sightings (cap so a noisy
+# project doesn't flood the foreman in one shift).
+_MAX_ISSUE_SIGHTINGS = 25
+
+# A connector-execute callable: async (workspace_id, name, body, *, user_id) ->
+# a result with ``.success`` / ``.data`` (the ExecuteActionResponse shape). Kept
+# as a Protocol-free alias so the patrol stays decoupled from the connectors DTO.
+ConnectorExecuteFn = Callable[..., Awaitable[Any]]
+
+
+def _issue_severity(issue: dict[str, Any]) -> int:
+    """Map a GitLab issue to a 1-5 severity from its labels — a ``critical`` /
+    ``security`` / ``bug`` label lifts urgency; everything else is baseline 2.
+    Deterministic so the sighting dedup key is stable across passes."""
+    labels = {str(label).strip().lower() for label in (issue.get("labels") or [])}
+    if labels & {"critical", "security", "p0", "blocker"}:
+        return 5
+    if labels & {"bug", "regression", "p1", "high"}:
+        return 4
+    if labels & {"p2", "medium"}:
+        return 3
+    return 2
+
+
+async def issues_patrol(
+    repo_id: str,
+    *,
+    workspace_id: str,
+    project: str | None = None,
+    connector: str = _ISSUES_CONNECTOR,
+    execute: ConnectorExecuteFn | None = None,
+) -> list[SightingDraft]:
+    """The ``issues`` patrol — flag OPEN issues on the bound repo's GitLab project.
+
+    Reads a LIVE signal: calls the ``gitlab`` connector's ``list_issues`` action
+    through ``connectors_service.execute`` (a genuine httpx call in CLOUD mode),
+    then emits one SightingDraft per OPEN issue. Unlike ``deps`` there is NO
+    hardcoded table — the data is whatever the project's tracker reports right now.
+
+    ``project`` is the GitLab project id / URL-encoded path; it defaults to the
+    bound repo's directory name (the common ``repo-dir == project`` convention).
+    ``execute`` is the connector-execute callable, injected so tests mock the
+    payload; the live caller leaves it ``None`` to use ``connectors_service``.
+
+    Resilience: a connector failure, an unbound connector, a non-success response,
+    or a malformed payload all yield ZERO sightings — the patrol NEVER raises into
+    the shift trigger (same contract as ``deps``)."""
+    proj = project or Path(repo_id).expanduser().name
+    if not proj:
+        logger.warning(
+            "issues patrol: no project resolvable from repo %r — zero sightings", repo_id
+        )
+        return []
+
+    runner = execute or _default_execute
+    try:
+        result = await runner(
+            workspace_id,
+            connector,
+            {
+                "action": _ISSUES_ACTION,
+                "params": {"project_id": proj, "state": "opened"},
+                "scope": "workspace",
+            },
+        )
+    except Exception:  # noqa: BLE001 — a connector failure must not wedge the shift
+        logger.warning(
+            "issues patrol: connector %r execute failed for project %r — zero sightings",
+            connector,
+            proj,
+            exc_info=True,
+        )
+        return []
+
+    if not getattr(result, "success", False):
+        logger.info(
+            "issues patrol: connector %r returned no success for project %r — zero sightings",
+            connector,
+            proj,
+        )
+        return []
+
+    raw = getattr(result, "data", None)
+    if not isinstance(raw, list):
+        logger.info("issues patrol: unexpected payload shape for project %r — zero sightings", proj)
+        return []
+
+    drafts: list[SightingDraft] = []
+    for issue in raw:
+        if not isinstance(issue, dict):
+            continue
+        # Defensive: even though we asked for state=opened, skip anything closed.
+        if str(issue.get("state") or "opened").lower() != "opened":
+            continue
+        title = str(issue.get("title") or "").strip()
+        if not title:
+            continue
+        iid = issue.get("iid") if issue.get("iid") is not None else issue.get("id")
+        drafts.append(
+            {
+                "patrol": "issues",
+                "severity": _issue_severity(issue),
+                "summary": f"Open issue: {title}"[:280],
+                "evidence": {
+                    "iid": iid,
+                    "title": title,
+                    "labels": list(issue.get("labels") or []),
+                    "web_url": issue.get("web_url"),
+                    "project": proj,
+                    "source": "gitlab:list_issues",
+                },
+            }
+        )
+        if len(drafts) >= _MAX_ISSUE_SIGHTINGS:
+            break
+    return drafts
+
+
+async def _default_execute(workspace_id: str, name: str, body: dict[str, Any]) -> Any:
+    """The live connector-execute seam — the real ``connectors_service.execute``.
+
+    Imported lazily so the patrols module stays importable without the connectors
+    package wired (and so tests that inject ``execute`` never touch it)."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+
+    return await connectors_service.execute(
+        workspace_id, name, ExecuteActionRequest.model_validate(body)
+    )
+
+
 # Patrol registry — the service iterates this on a shift trigger. ``feedback``
-# is intake-only (service.file_feedback), so it doesn't appear here.
+# is intake-only (service.file_feedback), so it doesn't appear here. The
+# ``issues`` patrol needs the workspace + project context the ``deps`` patrol
+# doesn't; ``service.run_patrols`` inspects each patrol's signature and passes
+# ``workspace_id`` only to the patrols that accept it (backward-compatible).
 PATROLS: dict[str, PatrolFn] = {
     "deps": deps_patrol,
+    "issues": issues_patrol,  # type: ignore[dict-item] — wider signature, called via kwargs
 }
 
 
-__all__ = ["KNOWN_STALE", "PATROLS", "PatrolFn", "SightingDraft", "deps_patrol"]
+__all__ = [
+    "KNOWN_STALE",
+    "PATROLS",
+    "ConnectorExecuteFn",
+    "PatrolFn",
+    "SightingDraft",
+    "deps_patrol",
+    "issues_patrol",
+]

--- a/ee/pocketpaw_ee/cloud/mandates/patrols.py
+++ b/ee/pocketpaw_ee/cloud/mandates/patrols.py
@@ -8,6 +8,11 @@
 #   ``deps`` patrol uses. The external call is injectable so tests mock the
 #   payload instead of hitting the network. The ``deps`` / ``feedback`` patrols
 #   are unchanged.
+# Updated: 2026-06-13 (PR #1463 review) — ``issues_patrol`` + ``_default_execute``
+#   now thread ``user_id`` through to the connector so a scheduler-fired patrol is
+#   attributed to its system actor (not ``None``); and the dir-name project
+#   fallback now logs a warning (a namespaced GitLab project returns zero
+#   sightings silently — bind ``project='group/name'``).
 #
 # The PATROL framework — a patrol is an async callable that senses a mandate's
 # surface and produces Sighting DRAFTS (plain dicts; the service persists them
@@ -203,6 +208,7 @@ async def issues_patrol(
     repo_id: str,
     *,
     workspace_id: str,
+    user_id: str | None = None,
     project: str | None = None,
     connector: str = _ISSUES_CONNECTOR,
     execute: ConnectorExecuteFn | None = None,
@@ -215,14 +221,28 @@ async def issues_patrol(
     hardcoded table — the data is whatever the project's tracker reports right now.
 
     ``project`` is the GitLab project id / URL-encoded path; it defaults to the
-    bound repo's directory name (the common ``repo-dir == project`` convention).
+    bound repo's directory name (the common ``repo-dir == project`` convention),
+    which is WRONG for any namespaced project — a warning fires so the operator
+    knows to bind an explicit ``project='group/name'``. ``user_id`` is the actor
+    the connector call is attributed to (the scheduler passes its system actor).
     ``execute`` is the connector-execute callable, injected so tests mock the
     payload; the live caller leaves it ``None`` to use ``connectors_service``.
 
     Resilience: a connector failure, an unbound connector, a non-success response,
     or a malformed payload all yield ZERO sightings — the patrol NEVER raises into
     the shift trigger (same contract as ``deps``)."""
-    proj = project or Path(repo_id).expanduser().name
+    proj = project
+    if not proj:
+        proj = Path(repo_id).expanduser().name
+        # The dir-name default is a best-effort convenience: a namespaced GitLab
+        # project (``group/name``) won't match a bare dir name and ``list_issues``
+        # returns zero issues with NO error. Tell the operator to bind it.
+        logger.warning(
+            "issues patrol: no explicit project bound — defaulting to repo dir name %r. "
+            "A namespaced GitLab project will return zero sightings silently; "
+            "bind project='group/name' on the mandate surface.",
+            proj,
+        )
     if not proj:
         logger.warning(
             "issues patrol: no project resolvable from repo %r — zero sightings", repo_id
@@ -239,6 +259,7 @@ async def issues_patrol(
                 "params": {"project_id": proj, "state": "opened"},
                 "scope": "workspace",
             },
+            user_id=user_id,
         )
     except Exception:  # noqa: BLE001 — a connector failure must not wedge the shift
         logger.warning(
@@ -293,16 +314,20 @@ async def issues_patrol(
     return drafts
 
 
-async def _default_execute(workspace_id: str, name: str, body: dict[str, Any]) -> Any:
+async def _default_execute(
+    workspace_id: str, name: str, body: dict[str, Any], *, user_id: str | None = None
+) -> Any:
     """The live connector-execute seam — the real ``connectors_service.execute``.
 
     Imported lazily so the patrols module stays importable without the connectors
-    package wired (and so tests that inject ``execute`` never touch it)."""
+    package wired (and so tests that inject ``execute`` never touch it). ``user_id``
+    is threaded to the connector so a scheduler-fired patrol is attributed to its
+    system actor, not ``None``."""
     from pocketpaw_ee.cloud.connectors import service as connectors_service
     from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
 
     return await connectors_service.execute(
-        workspace_id, name, ExecuteActionRequest.model_validate(body)
+        workspace_id, name, ExecuteActionRequest.model_validate(body), user_id=user_id
     )
 
 

--- a/ee/pocketpaw_ee/cloud/mandates/scheduler.py
+++ b/ee/pocketpaw_ee/cloud/mandates/scheduler.py
@@ -1,5 +1,9 @@
 # ee/pocketpaw_ee/cloud/mandates/scheduler.py
 # Created: 2026-06-13 (feat/patrol-engine).
+# Updated: 2026-06-13 (PR #1463 review) — the run_immediate tick no longer
+#   swallows CancelledError: a cancel mid-tick now propagates and exits the loop
+#   instead of falling through into the long interval sleep (shutdown could hang
+#   for up to an hour). See ``_scheduler_loop``.
 #
 # CADENCE SCHEDULER — the piece that turns ``Charter.cadence`` from a persisted
 # label into an always-on trigger. Until now shifts were MANUAL-ONLY (the
@@ -146,11 +150,16 @@ async def _scheduler_loop(interval: int, *, run_immediate: bool) -> None:
     await cleanly."""
     logger.info("scheduler: loop started (interval=%ds)", interval)
     if run_immediate:
-        with contextlib.suppress(asyncio.CancelledError):
-            try:
-                await run_scheduler_tick()
-            except Exception:  # noqa: BLE001 — already swallowed inside; belt-and-braces
-                logger.warning("scheduler: immediate tick failed", exc_info=True)
+        try:
+            await run_scheduler_tick()
+        except asyncio.CancelledError:
+            # A cancel WHILE the immediate tick is suspended must propagate, not be
+            # swallowed — otherwise the loop falls through into the long
+            # ``asyncio.sleep(interval)`` and shutdown blocks for up to an hour.
+            logger.info("scheduler: immediate tick cancelled — exiting")
+            raise
+        except Exception:  # noqa: BLE001 — already swallowed inside; belt-and-braces
+            logger.warning("scheduler: immediate tick failed", exc_info=True)
 
     while True:
         try:

--- a/ee/pocketpaw_ee/cloud/mandates/scheduler.py
+++ b/ee/pocketpaw_ee/cloud/mandates/scheduler.py
@@ -1,0 +1,243 @@
+# ee/pocketpaw_ee/cloud/mandates/scheduler.py
+# Created: 2026-06-13 (feat/patrol-engine).
+#
+# CADENCE SCHEDULER — the piece that turns ``Charter.cadence`` from a persisted
+# label into an always-on trigger. Until now shifts were MANUAL-ONLY (the
+# ``service.trigger_shift`` "DEMO BAR: manual trigger only" note); a "weekly"
+# cadence persisted but nothing fired it. This module closes that gap.
+#
+# SHAPE (mirrors ``autopilot.py``'s lifecycle, with one difference): autopilot
+# runs a per-mandate task; the scheduler is a SINGLE process-local sweeper loop
+# (like ``decisions._action_sweeper``) that wakes every interval, asks the
+# service which ACTIVE mandates are cadence-DUE, and fires one shift per due
+# mandate. One loop is enough — due-ness is computed per tick from the persisted
+# charter + the last shift's timestamp, so there is no per-mandate state to hold.
+#
+# DETERMINISM: the unit of work is ``run_scheduler_tick(now, trigger)``. Both the
+# clock (``now()``) and the shift trigger are INJECTABLE so a test can drive a
+# tick with a frozen clock and a fake trigger — no wall-clock sleeps, no real
+# LLM/foreman call. The live loop passes the real wall clock + the real
+# ``service.trigger_shift``.
+#
+# RESILIENCE: the scheduler must NEVER crash the app. A due-list read failure,
+# or any single mandate's ``trigger_shift`` raising, is logged and swallowed; the
+# tick keeps sweeping the rest, the loop sleeps and tries again next interval.
+#
+# LIFESPAN: ``reconcile_scheduler`` starts the loop at startup (idempotent — a
+# second call is a no-op when a loop is already live); ``shutdown_scheduler``
+# cancels + awaits it at shutdown. Both are wired into
+# ``cloud/__init__.mount_cloud`` next to the autopilot pair, under the SAME
+# ``POCKETPAW_CLOUD_SCHEDULER_ENABLED`` gate (so pytest runs never spawn a
+# background loop that outlives the test).
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default sweep interval (seconds) — env ``POCKETPAW_MANDATE_SCHEDULER_INTERVAL``.
+# Hourly by default: cadence resolution is days (weekly), so an hourly sweep is
+# far finer than the smallest cadence window and keeps the boot-to-first-fire lag
+# small without busy-spinning.
+_DEFAULT_INTERVAL_SECONDS = 3600
+
+# Process-local registry for the single sweeper loop (None when not running).
+_TASK: asyncio.Task | None = None
+
+
+# A shift trigger: async (workspace_id, user_id, mandate_id) -> dict. Matches
+# ``service.trigger_shift``'s signature so the real function drops straight in.
+TriggerFn = Callable[[str, str, str], Awaitable[dict[str, Any]]]
+# A clock: () -> aware datetime. Injected so ticks are deterministic in tests.
+NowFn = Callable[[], datetime]
+
+
+def _wall_now() -> datetime:
+    """The real wall clock (UTC-aware) — the live loop's default ``now``."""
+    return datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# One tick — the unit the loop runs (and the unit a test drives directly).
+# ---------------------------------------------------------------------------
+
+
+async def run_scheduler_tick(
+    *,
+    now: NowFn | None = None,
+    trigger: TriggerFn | None = None,
+) -> list[str]:
+    """Run ONE scheduler sweep: ask the service which ACTIVE mandates are cadence
+    -DUE at ``now()``, and fire one shift per due mandate via ``trigger``.
+
+    Returns the list of mandate ids whose shift FIRED successfully (a mandate
+    whose trigger raised is logged + skipped, NOT in the list). NEVER raises —
+    the due-list read and every trigger call are wrapped so a bad mandate or a
+    transient store error can't sink the sweep, the loop, or the app.
+
+    ``now`` defaults to the wall clock; ``trigger`` defaults to the real
+    ``service.trigger_shift``. Both are injected in tests for determinism."""
+    from pocketpaw_ee.cloud.mandates import service as mandate_service
+
+    clock: NowFn = now or _wall_now
+    fire: TriggerFn = trigger or mandate_service.trigger_shift
+
+    try:
+        due = await mandate_service.list_cadence_due(clock())
+    except Exception:  # noqa: BLE001 — a due-list read failure must not sink the tick
+        logger.warning("scheduler: due-list read failed — skipping this tick", exc_info=True)
+        return []
+
+    fired: list[str] = []
+    for row in due:
+        workspace_id = str(row["workspace_id"])
+        mandate_id = str(row["mandate_id"])
+        user_id = str(row.get("user_id") or "system:scheduler")
+        try:
+            await fire(workspace_id, user_id, mandate_id)
+            fired.append(mandate_id)
+        except Exception:  # noqa: BLE001 — one mandate's shift failure never sinks the sweep
+            logger.warning(
+                "scheduler: trigger_shift failed for mandate %s (workspace %s)",
+                mandate_id,
+                workspace_id,
+                exc_info=True,
+            )
+    if fired:
+        logger.info("scheduler: tick fired %d cadence-due shift(s)", len(fired))
+    return fired
+
+
+# ---------------------------------------------------------------------------
+# The background loop + the single-task registry (start / stop).
+# ---------------------------------------------------------------------------
+
+
+def _interval_seconds() -> int:
+    """Read the sweep interval from env, default 3600s. A non-int / non-positive
+    value falls back to the default."""
+    raw = os.environ.get("POCKETPAW_MANDATE_SCHEDULER_INTERVAL", "").strip()
+    if not raw:
+        return _DEFAULT_INTERVAL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "POCKETPAW_MANDATE_SCHEDULER_INTERVAL=%r is not an int — using %d",
+            raw,
+            _DEFAULT_INTERVAL_SECONDS,
+        )
+        return _DEFAULT_INTERVAL_SECONDS
+    return value if value > 0 else _DEFAULT_INTERVAL_SECONDS
+
+
+async def _scheduler_loop(interval: int, *, run_immediate: bool) -> None:
+    """The sweeper loop body. Optionally runs ONE tick immediately, then a tick
+    every ``interval`` seconds. Per-tick failures are caught inside
+    ``run_scheduler_tick`` already; the loop also guards the sleep + tick so
+    nothing escapes. ``CancelledError`` propagates so shutdown can cancel-and-
+    await cleanly."""
+    logger.info("scheduler: loop started (interval=%ds)", interval)
+    if run_immediate:
+        with contextlib.suppress(asyncio.CancelledError):
+            try:
+                await run_scheduler_tick()
+            except Exception:  # noqa: BLE001 — already swallowed inside; belt-and-braces
+                logger.warning("scheduler: immediate tick failed", exc_info=True)
+
+    while True:
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            logger.info("scheduler: loop cancelled — exiting")
+            raise
+        try:
+            await run_scheduler_tick()
+        except Exception:  # noqa: BLE001 — a bad tick never sinks the loop
+            logger.warning("scheduler: tick failed", exc_info=True)
+
+
+async def start_scheduler(
+    *, interval_seconds: int | None = None, run_immediate: bool = True
+) -> None:
+    """Start (or restart) the single background sweeper loop.
+
+    Idempotent on restart: an existing live loop is cancelled first, then a fresh
+    one is created. ``interval_seconds`` overrides the env default (tests pass a
+    large value to keep the loop parked on its sleep). ``run_immediate=False``
+    skips the first tick — a boot should not storm a tick the instant the process
+    comes up (let the first interval elapse)."""
+    global _TASK
+    await stop_scheduler()
+    interval = interval_seconds if interval_seconds is not None else _interval_seconds()
+    _TASK = asyncio.create_task(
+        _scheduler_loop(interval, run_immediate=run_immediate),
+        name="mandate-scheduler",
+    )
+
+
+async def stop_scheduler() -> None:
+    """Cancel + await the background sweeper loop. Safe + idempotent — a no-op
+    when no loop is running."""
+    global _TASK
+    task, _TASK = _TASK, None
+    if task is None or task.done():
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+
+
+def is_running() -> bool:
+    """True when the background sweeper loop is live."""
+    return _TASK is not None and not _TASK.done()
+
+
+# ---------------------------------------------------------------------------
+# Lifespan wiring — the startup reconciler + the shutdown drain. Registered in
+# ``cloud/__init__.mount_cloud`` under the same POCKETPAW_CLOUD_SCHEDULER_ENABLED
+# gate the autopilot reconciler / decisions reconciler use.
+# ---------------------------------------------------------------------------
+
+
+async def reconcile_scheduler(*, interval_seconds: int | None = None) -> int:
+    """STARTUP RECONCILER — start the single sweeper loop at lifespan startup.
+
+    Idempotent: if a loop is already live (a double-mount, a re-entrant call),
+    this is a no-op and returns 0. Otherwise it starts the loop with
+    ``run_immediate=False`` (a boot never storms a tick) and returns 1. Never
+    raises — a start failure logs and returns 0 so app startup is never blocked."""
+    if is_running():
+        return 0
+    try:
+        await start_scheduler(interval_seconds=interval_seconds, run_immediate=False)
+    except Exception:  # noqa: BLE001 — a start failure must not block startup
+        logger.warning("scheduler: startup reconcile failed to start the loop", exc_info=True)
+        return 0
+    logger.info("scheduler: startup reconciler started the sweeper loop")
+    return 1
+
+
+async def shutdown_scheduler() -> None:
+    """SHUTDOWN DRAIN — cancel + await the sweeper loop at lifespan shutdown so
+    the process exits without an orphaned task. Idempotent; never raises."""
+    await stop_scheduler()
+
+
+__all__ = [
+    "NowFn",
+    "TriggerFn",
+    "is_running",
+    "reconcile_scheduler",
+    "run_scheduler_tick",
+    "shutdown_scheduler",
+    "start_scheduler",
+    "stop_scheduler",
+]

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -8,6 +8,12 @@
 #   patrol whose signature accepts it (the LIVE ``issues`` patrol needs it to
 #   reach its connector) via signature inspection — the legacy ``deps_patrol``
 #   ``(repo_id)`` shape is unchanged. Additive only.
+# Updated: 2026-06-13 (PR #1463 review) — ``run_patrols`` also threads ``user_id``
+#   to patrols that accept it (audit attribution); the sighting dedup key is
+#   generalized to ``_dedup_signal`` (issues key on ``evidence.iid``, deps on
+#   ``evidence.package``, else summary) so a retitled issue no longer
+#   double-persists; ``list_cadence_due`` carries an explicit N+1 demo-bar
+#   concession note (TODO: single aggregation pipeline).
 #
 # Business logic for the MANDATE primitive — the standing Belt JOB. Sole owner
 # of writes to MandateDoc / ShiftDoc / SightingDoc (the only module that imports
@@ -368,12 +374,25 @@ async def list_sightings(workspace_id: str, user_id: str, mandate_id: str) -> di
     return {"sightings": [_sighting_to_wire(s) for s in docs]}
 
 
+def _dedup_signal(evidence: dict[str, Any] | None, summary: str | None) -> str:
+    """The stable per-patrol dedup signal for a sighting / draft.
+
+    Generalized across patrols: ``issues`` carry ``evidence.iid`` (stable across a
+    retitle), ``deps`` carry ``evidence.package``; anything else falls back to the
+    summary. Without the ``iid`` branch an issue retitle would change the summary
+    and double-persist the same issue."""
+    ev = evidence or {}
+    signal = ev.get("iid") or ev.get("package") or summary or ""
+    return str(signal)
+
+
 async def run_patrols(workspace_id: str, user_id: str, mandate_id: str) -> dict[str, Any]:
     """Run every registered patrol over the mandate's surface and persist the
     resulting Sightings.
 
-    Dedup: a draft whose ``evidence.package`` already has a sighting from the
-    same patrol on this mandate is skipped — repeated shift triggers must not
+    Dedup: a draft whose dedup signal (``evidence.iid`` for issues,
+    ``evidence.package`` for deps, else the summary) already has a sighting from
+    the same patrol on this mandate is skipped — repeated shift triggers must not
     spam the foreman with identical signals. Returns the NEW sightings only."""
     from pocketpaw_ee.cloud.mandates.patrols import PATROLS
 
@@ -382,7 +401,7 @@ async def run_patrols(workspace_id: str, user_id: str, mandate_id: str) -> dict[
     existing = await SightingDoc.find(
         SightingDoc.workspace == workspace_id, SightingDoc.mandate_id == mandate_id
     ).to_list()
-    seen_keys = {(s.patrol, str((s.evidence or {}).get("package") or s.summary)) for s in existing}
+    seen_keys = {(s.patrol, _dedup_signal(s.evidence, s.summary)) for s in existing}
 
     created: list[SightingDoc] = []
     enabled = set(doc.patrols or [])
@@ -394,13 +413,16 @@ async def run_patrols(workspace_id: str, user_id: str, mandate_id: str) -> dict[
             continue
         try:
             # Patrols take ``repo_id`` positionally; a LIVE patrol (e.g. ``issues``)
-            # also needs the workspace to reach its connector, so pass
-            # ``workspace_id`` ONLY when the patrol's signature accepts it. This
-            # keeps the legacy ``deps_patrol(repo_id)`` shape working unchanged.
+            # also needs the workspace to reach its connector, and the actor to
+            # attribute the connector call to, so pass ``workspace_id`` / ``user_id``
+            # ONLY when the patrol's signature accepts them. This keeps the legacy
+            # ``deps_patrol(repo_id)`` shape working unchanged.
             kwargs: dict[str, Any] = {}
             params = inspect.signature(patrol).parameters
             if "workspace_id" in params:
                 kwargs["workspace_id"] = workspace_id
+            if "user_id" in params:
+                kwargs["user_id"] = user_id
             drafts = await patrol(doc.surface.repo_id, **kwargs)
         except Exception:  # noqa: BLE001 — a broken patrol must not wedge the shift
             logger.warning("mandate: patrol %r raised — skipping", patrol_name, exc_info=True)
@@ -408,7 +430,7 @@ async def run_patrols(workspace_id: str, user_id: str, mandate_id: str) -> dict[
         for draft in drafts:
             key = (
                 str(draft.get("patrol") or patrol_name),
-                str((draft.get("evidence") or {}).get("package") or draft.get("summary") or ""),
+                _dedup_signal(draft.get("evidence"), draft.get("summary")),
             )
             if key in seen_keys:
                 continue
@@ -1349,6 +1371,9 @@ async def list_autopilot_enabled() -> list[dict[str, Any]]:
 # table so a later cadence value ("daily", etc.) only adds a row here.
 _CADENCE_INTERVALS: dict[str, timedelta] = {"weekly": timedelta(days=7)}
 
+# The SYSTEM actor a scheduled shift runs as (no human user_id on a cadence fire).
+_SCHEDULER_ACTOR = "system:scheduler"
+
 
 async def list_cadence_due(now: datetime) -> list[dict[str, Any]]:
     """All ACTIVE mandates whose charter cadence is DUE at ``now`` — the cadence
@@ -1369,6 +1394,11 @@ async def list_cadence_due(now: datetime) -> list[dict[str, Any]]:
     ``now`` is injected so the scheduler can pass a deterministic clock — tests
     never depend on wall time."""
     # no-event: read-only path; emit only on writes.
+    # DEMO-BAR CONCESSION (N+1): one MandateDoc.find + one ShiftDoc.find per active
+    # mandate. Fine at demo-bar mandate counts; at scale this should be a SINGLE
+    # aggregation pipeline ($lookup the latest shift per mandate + a $match on the
+    # cadence window). TODO: single aggregation pipeline before this runs against a
+    # real tenant population.
     docs = await MandateDoc.find(MandateDoc.status == "active").to_list()
     due: list[dict[str, Any]] = []
     for doc in docs:
@@ -1392,10 +1422,6 @@ async def list_cadence_due(now: datetime) -> list[dict[str, Any]]:
             }
         )
     return due
-
-
-# The SYSTEM actor a scheduled shift runs as (no human user_id on a cadence fire).
-_SCHEDULER_ACTOR = "system:scheduler"
 
 
 async def executor_revalidate(workspace_id: str, mandate_id: str) -> dict[str, Any]:

--- a/ee/pocketpaw_ee/cloud/mandates/service.py
+++ b/ee/pocketpaw_ee/cloud/mandates/service.py
@@ -1,6 +1,14 @@
 # ee/pocketpaw_ee/cloud/mandates/service.py
 # Created: 2026-06-11 (feat/belt-mandates, slice 1 — models + CRUD).
 #
+# Updated: 2026-06-13 (feat/patrol-engine) — added ``list_cadence_due(now)``, the
+#   cadence scheduler's read: all ACTIVE mandates whose charter cadence interval
+#   has elapsed since their last shift (or that never shifted). "manual" mandates
+#   are never returned. Also: ``run_patrols`` now passes ``workspace_id`` to any
+#   patrol whose signature accepts it (the LIVE ``issues`` patrol needs it to
+#   reach its connector) via signature inspection — the legacy ``deps_patrol``
+#   ``(repo_id)`` shape is unchanged. Additive only.
+#
 # Business logic for the MANDATE primitive — the standing Belt JOB. Sole owner
 # of writes to MandateDoc / ShiftDoc / SightingDoc (the only module that imports
 # those Beanie classes, per the 4-file entity rule).
@@ -21,8 +29,9 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
@@ -384,7 +393,15 @@ async def run_patrols(workspace_id: str, user_id: str, mandate_id: str) -> dict[
         if patrol_name not in enabled:
             continue
         try:
-            drafts = await patrol(doc.surface.repo_id)
+            # Patrols take ``repo_id`` positionally; a LIVE patrol (e.g. ``issues``)
+            # also needs the workspace to reach its connector, so pass
+            # ``workspace_id`` ONLY when the patrol's signature accepts it. This
+            # keeps the legacy ``deps_patrol(repo_id)`` shape working unchanged.
+            kwargs: dict[str, Any] = {}
+            params = inspect.signature(patrol).parameters
+            if "workspace_id" in params:
+                kwargs["workspace_id"] = workspace_id
+            drafts = await patrol(doc.surface.repo_id, **kwargs)
         except Exception:  # noqa: BLE001 — a broken patrol must not wedge the shift
             logger.warning("mandate: patrol %r raised — skipping", patrol_name, exc_info=True)
             continue
@@ -1325,6 +1342,60 @@ async def list_autopilot_enabled() -> list[dict[str, Any]]:
         }
         for d in docs
     ]
+
+
+# Cadence → due-interval. A "weekly" mandate is due once its last shift is older
+# than this; "manual" mandates are never scheduled (no entry → not due). Kept as a
+# table so a later cadence value ("daily", etc.) only adds a row here.
+_CADENCE_INTERVALS: dict[str, timedelta] = {"weekly": timedelta(days=7)}
+
+
+async def list_cadence_due(now: datetime) -> list[dict[str, Any]]:
+    """All ACTIVE mandates whose charter cadence is DUE at ``now`` — the cadence
+    scheduler's read (``scheduler.run_scheduler_tick``).
+
+    A mandate is DUE when its cadence has a scheduling interval (currently only
+    ``"weekly"`` → 7 days) AND its most recent shift's ``createdAt`` is older than
+    that interval before ``now`` (a mandate that has NEVER shifted is always due).
+    ``"manual"`` mandates have no interval, so they are never returned — the demo
+    bar's manual-trigger path is untouched.
+
+    DELIBERATELY cross-workspace: this is a SYSTEM sweeper read (same posture as
+    ``list_autopilot_enabled`` / the stale-run sweeper), not a request-path find.
+    Paused mandates are excluded — a paused mandate is inert. Returns
+    ``[{workspace_id, mandate_id, user_id}]`` (``user_id`` is the SYSTEM actor the
+    scheduler triggers shifts as).
+
+    ``now`` is injected so the scheduler can pass a deterministic clock — tests
+    never depend on wall time."""
+    # no-event: read-only path; emit only on writes.
+    docs = await MandateDoc.find(MandateDoc.status == "active").to_list()
+    due: list[dict[str, Any]] = []
+    for doc in docs:
+        interval = _CADENCE_INTERVALS.get(doc.charter.cadence)
+        if interval is None:
+            continue  # manual (or an unscheduled cadence) — never auto-fired
+        last = (
+            await ShiftDoc.find(
+                ShiftDoc.workspace == doc.workspace, ShiftDoc.mandate_id == str(doc.id)
+            )
+            .sort("-no")
+            .first_or_none()
+        )
+        if last is not None and _aware(last.createdAt) > (now - interval):
+            continue  # shifted inside the cadence window — not due yet
+        due.append(
+            {
+                "workspace_id": doc.workspace,
+                "mandate_id": str(doc.id),
+                "user_id": _SCHEDULER_ACTOR,
+            }
+        )
+    return due
+
+
+# The SYSTEM actor a scheduled shift runs as (no human user_id on a cadence fire).
+_SCHEDULER_ACTOR = "system:scheduler"
 
 
 async def executor_revalidate(workspace_id: str, mandate_id: str) -> dict[str, Any]:

--- a/tests/cloud/test_belt_scheduler.py
+++ b/tests/cloud/test_belt_scheduler.py
@@ -1,0 +1,321 @@
+# tests/cloud/test_belt_scheduler.py — the Belt MANDATE cadence scheduler + the
+# first LIVE-signal patrol (feat/patrol-engine).
+#
+# Created: 2026-06-13.
+#
+# Two pieces under test:
+#
+#   PIECE 1 — the CADENCE SCHEDULER. A single sweeper loop ticks every interval
+#     and fires ``service.trigger_shift`` for each ACTIVE mandate whose charter
+#     cadence is DUE (a "weekly" mandate is due when its last shift was >= 7 days
+#     ago, or it has never had a shift). A "manual" mandate is NEVER fired by the
+#     scheduler. The clock is injectable (a ``now()`` callable) so due-ness is
+#     deterministic in tests — no wall-clock sleeps. ``trigger_shift`` is invoked
+#     through an injectable callable so the tick can be proven WITHOUT a real LLM.
+#     Lifecycle mirrors autopilot: a startup reconciler starts the loop, a
+#     shutdown drain cancels + awaits it.
+#
+#   PIECE 2 — the ISSUES patrol (the FIRST live patrol). It reads a REAL signal —
+#     open issues from the bound repo's GitLab project — via the EXISTING
+#     ``connectors_service.execute`` cloud path, and emits a populated
+#     ``SightingDraft`` per issue (NOT the hardcoded deps stub). The connector
+#     call is injectable so tests mock the payload instead of hitting the network.
+#
+# All tests use a deterministic clock / injected trigger / mocked connector —
+# none call a real LLM or the network.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+pytest.importorskip("mongomock_motor")
+
+from pocketpaw_ee.cloud.mandates import patrols as patrols_mod  # noqa: E402
+from pocketpaw_ee.cloud.mandates import scheduler as scheduler_mod  # noqa: E402
+from pocketpaw_ee.cloud.mandates import service as mandate_service  # noqa: E402
+
+WS = "w1"
+USER = "u1"
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+async def _drain_scheduler_task():
+    """Cancel + AWAIT any scheduler loop a test left running before clearing the
+    registry, so a leaked loop never bleeds into the next test."""
+    yield
+    await scheduler_mod.shutdown_scheduler()
+
+
+def _charter(cadence: str = "weekly", budget: int = 3) -> dict:
+    return {
+        "goal": "keep the surface healthy",
+        "kpis": [{"name": "open_issues", "target": 0, "direction": "down"}],
+        "says_no": ["major version bumps"],
+        "boundaries": ["never touch auth code"],
+        "budget": {"max_tasks_per_shift": budget, "gate_minutes_per_week": 15},
+        "cadence": cadence,
+    }
+
+
+async def _make_mandate(name: str, *, cadence: str = "weekly", repo_id: str = "/tmp/x") -> str:
+    created = await mandate_service.create_mandate(
+        WS,
+        USER,
+        {"name": name, "surface": {"repo_id": repo_id}, "charter": _charter(cadence=cadence)},
+    )
+    return created["mandate"]["id"]
+
+
+# ---------------------------------------------------------------------------
+# PIECE 1 — list_cadence_due: a weekly mandate with no shift is due; a manual
+# mandate is never due; a weekly mandate whose last shift is recent is not due.
+# ---------------------------------------------------------------------------
+
+
+async def test_list_cadence_due_weekly_never_shifted_is_due(tmp_path, mongo_db):
+    weekly = await _make_mandate("weekly-fresh", cadence="weekly")
+    manual = await _make_mandate("manual", cadence="manual")
+
+    now = datetime(2026, 6, 13, tzinfo=UTC)
+    due = await mandate_service.list_cadence_due(now)
+    due_ids = {row["mandate_id"] for row in due}
+
+    assert weekly in due_ids, "a weekly mandate that has never shifted is due"
+    assert manual not in due_ids, "a manual mandate is never scheduled"
+
+
+async def test_list_cadence_due_recent_shift_not_due(tmp_path, mongo_db):
+    from pocketpaw_ee.cloud.mandates.domain import ShiftDoc
+
+    weekly = await _make_mandate("weekly-recent", cadence="weekly")
+
+    now = datetime(2026, 6, 13, tzinfo=UTC)
+    # A shift two days ago — inside the weekly window, so NOT due.
+    shift = ShiftDoc(workspace=WS, mandate_id=weekly, no=1, state="done")
+    shift.createdAt = now - timedelta(days=2)
+    await shift.insert()
+
+    due_ids = {row["mandate_id"] for row in await mandate_service.list_cadence_due(now)}
+    assert weekly not in due_ids, "a weekly mandate shifted 2 days ago is not yet due"
+
+    # ...but eight days later the same mandate IS due again.
+    later = now + timedelta(days=8)
+    due_ids_later = {row["mandate_id"] for row in await mandate_service.list_cadence_due(later)}
+    assert weekly in due_ids_later, "a weekly mandate becomes due once a week has elapsed"
+
+
+async def test_list_cadence_due_excludes_paused(tmp_path, mongo_db):
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.mandates.domain import MandateDoc
+
+    weekly = await _make_mandate("weekly-paused", cadence="weekly")
+    doc = await MandateDoc.find_one(MandateDoc.workspace == WS, MandateDoc.id == ObjectId(weekly))
+    doc.status = "paused"
+    await doc.save()
+
+    now = datetime(2026, 6, 13, tzinfo=UTC)
+    due_ids = {row["mandate_id"] for row in await mandate_service.list_cadence_due(now)}
+    assert weekly not in due_ids, "a paused mandate is inert — never scheduled"
+
+
+# ---------------------------------------------------------------------------
+# PIECE 1 — the scheduler TICK fires trigger_shift for the due mandate and NOT
+# for the manual one, using a deterministic clock + an injected trigger (no LLM).
+# ---------------------------------------------------------------------------
+
+
+async def test_scheduler_tick_fires_only_due_mandates(tmp_path, mongo_db):
+    weekly = await _make_mandate("weekly-due", cadence="weekly")
+    manual = await _make_mandate("manual-never", cadence="manual")
+
+    fired: list[str] = []
+
+    async def _fake_trigger(workspace_id: str, user_id: str, mandate_id: str) -> dict:
+        fired.append(mandate_id)
+        return {}
+
+    now = datetime(2026, 6, 13, tzinfo=UTC)
+    fired_ids = await scheduler_mod.run_scheduler_tick(now=lambda: now, trigger=_fake_trigger)
+
+    assert weekly in fired, "the due weekly mandate's shift must fire"
+    assert manual not in fired, "the manual mandate's shift must NOT fire on a tick"
+    assert fired_ids == fired == [weekly]
+
+
+async def test_scheduler_tick_swallows_trigger_failure(tmp_path, mongo_db):
+    """A failing trigger_shift on one mandate must not sink the whole tick — the
+    scheduler swallows it and keeps sweeping (always-on perception must not crash
+    the app)."""
+    boom = await _make_mandate("weekly-boom", cadence="weekly")
+    ok = await _make_mandate("weekly-ok", cadence="weekly")
+
+    fired_ok: list[str] = []
+
+    async def _trigger(workspace_id: str, user_id: str, mandate_id: str) -> dict:
+        if mandate_id == boom:
+            raise RuntimeError("foreman exploded")
+        fired_ok.append(mandate_id)
+        return {}
+
+    now = datetime(2026, 6, 13, tzinfo=UTC)
+    # Must not raise even though one mandate's trigger blew up.
+    fired_ids = await scheduler_mod.run_scheduler_tick(now=lambda: now, trigger=_trigger)
+    assert ok in fired_ok, "the healthy mandate still fires after a sibling's failure"
+    # The boom mandate counts as attempted-but-failed → not in the fired total.
+    assert boom not in fired_ok
+    assert boom not in fired_ids and ok in fired_ids
+
+
+# ---------------------------------------------------------------------------
+# PIECE 1 — lifecycle: startup reconciler starts the loop, shutdown drains it
+# (mirrors the autopilot reconciler/drain tests).
+# ---------------------------------------------------------------------------
+
+
+async def test_scheduler_lifecycle_start_and_drain(tmp_path, mongo_db):
+    assert not scheduler_mod.is_running()
+
+    # A huge interval keeps the loop alive on its sleep so we can observe it.
+    await scheduler_mod.start_scheduler(interval_seconds=10_000, run_immediate=False)
+    assert scheduler_mod.is_running()
+
+    await scheduler_mod.shutdown_scheduler()
+    assert not scheduler_mod.is_running()
+    # Idempotent — a second drain is a no-op.
+    await scheduler_mod.shutdown_scheduler()
+
+
+async def test_scheduler_reconciler_starts_loop(tmp_path, mongo_db):
+    """The lifespan startup reconciler starts exactly one sweeper loop."""
+    assert not scheduler_mod.is_running()
+    started = await scheduler_mod.reconcile_scheduler(interval_seconds=10_000)
+    assert started == 1
+    assert scheduler_mod.is_running()
+
+    # A second reconcile is idempotent — it does not stack a second loop.
+    started_again = await scheduler_mod.reconcile_scheduler(interval_seconds=10_000)
+    assert started_again == 0
+    assert scheduler_mod.is_running()
+
+    await scheduler_mod.shutdown_scheduler()
+    assert not scheduler_mod.is_running()
+
+
+# ---------------------------------------------------------------------------
+# PIECE 2 — the ISSUES patrol (FIRST live patrol) reads a real connector signal
+# and produces a POPULATED SightingDraft per open issue (not the hardcoded stub).
+# ---------------------------------------------------------------------------
+
+
+async def test_issues_patrol_produces_sightings_from_connector_payload():
+    """Given a mocked connector-execute returning a GitLab-shaped issues payload,
+    the issues patrol produces a populated SightingDraft per open issue — proving
+    the patrol reads a LIVE signal path, not a hardcoded table."""
+
+    from types import SimpleNamespace
+
+    async def _fake_execute(workspace_id, name, body, *, user_id=None):
+        # Mirror the ExecuteActionResponse shape: success + a data payload.
+        return SimpleNamespace(
+            success=True,
+            data=[
+                {
+                    "iid": 42,
+                    "title": "Login button is broken",
+                    "labels": ["bug"],
+                    "state": "opened",
+                },
+                {"iid": 43, "title": "Slow dashboard load", "labels": [], "state": "opened"},
+                {"iid": 7, "title": "Old closed thing", "state": "closed"},
+            ],
+        )
+
+    drafts = await patrols_mod.issues_patrol(
+        "/tmp/repo",
+        workspace_id=WS,
+        project="my-group/my-project",
+        execute=_fake_execute,
+    )
+
+    assert len(drafts) == 2, "only OPEN issues become sightings"
+    summaries = [d["summary"] for d in drafts]
+    assert any("Login button is broken" in s for s in summaries)
+    for d in drafts:
+        assert d["patrol"] == "issues"
+        assert isinstance(d["severity"], int) and 1 <= d["severity"] <= 5
+        assert d["evidence"].get("source") == "gitlab:list_issues"
+        assert "iid" in d["evidence"]
+
+
+async def test_issues_patrol_empty_on_connector_failure():
+    """A connector failure (or an unbound connector) yields ZERO sightings — the
+    patrol never raises into the shift trigger."""
+
+    async def _boom_execute(workspace_id, name, body, *, user_id=None):
+        raise RuntimeError("connector not connected")
+
+    drafts = await patrols_mod.issues_patrol(
+        "/tmp/repo", workspace_id=WS, project="g/p", execute=_boom_execute
+    )
+    assert drafts == [], "a connector failure degrades to zero sightings"
+
+
+async def test_issues_patrol_registered_in_catalog():
+    """The issues patrol is registered so the sense loop can run it."""
+    assert "issues" in patrols_mod.PATROLS
+
+
+async def test_run_patrols_persists_issue_sightings_via_connector_seam(
+    tmp_path, mongo_db, monkeypatch
+):
+    """End-to-end through the REAL ``service.run_patrols`` sense loop: a mandate
+    with the ``issues`` patrol enabled, the DEFAULT connector seam patched to
+    return a live-shaped payload, persists a SightingDoc per open issue with the
+    live ``gitlab:list_issues`` source — proving the patrol rides the real
+    signature-inspection call path AND the default ``connectors_service.execute``
+    seam (not just the injected mock)."""
+    from types import SimpleNamespace
+
+    # Patch the patrol's DEFAULT connector seam — proves run_patrols reaches the
+    # live execute path without injecting ``execute`` at the call site.
+    async def _fake_default_execute(workspace_id, name, body):
+        assert name == "gitlab"
+        assert body["action"] == "list_issues"
+        return SimpleNamespace(
+            success=True,
+            data=[
+                {"iid": 11, "title": "Crash on save", "labels": ["bug"], "state": "opened"},
+                {"iid": 12, "title": "Typo in footer", "labels": [], "state": "opened"},
+            ],
+        )
+
+    monkeypatch.setattr(patrols_mod, "_default_execute", _fake_default_execute)
+
+    created = await mandate_service.create_mandate(
+        WS,
+        USER,
+        {
+            "name": "issues-mandate",
+            "surface": {"repo_id": str(tmp_path / "my-project")},
+            "charter": _charter(),
+            "patrols": ["issues", "feedback"],
+        },
+    )
+    mandate_id = created["mandate"]["id"]
+
+    result = await mandate_service.run_patrols(WS, USER, mandate_id)
+    sightings = result["sightings"]
+    assert len(sightings) == 2, sightings
+    for s in sightings:
+        assert s["patrol"] == "issues"
+        assert s["evidence"]["source"] == "gitlab:list_issues"
+    # The deps patrol was NOT enabled on this mandate — no deps sighting leaked.
+    assert all(s["patrol"] == "issues" for s in sightings)

--- a/tests/cloud/test_belt_scheduler.py
+++ b/tests/cloud/test_belt_scheduler.py
@@ -2,6 +2,9 @@
 # first LIVE-signal patrol (feat/patrol-engine).
 #
 # Created: 2026-06-13.
+# Updated: 2026-06-13 (PR #1463 review) — added a shutdown-during-immediate-tick
+#   regression test (the loop must not hang), an exact-7-day cadence boundary
+#   test, and a user_id-threading assertion on the issues patrol.
 #
 # Two pieces under test:
 #
@@ -26,6 +29,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -112,6 +116,27 @@ async def test_list_cadence_due_recent_shift_not_due(tmp_path, mongo_db):
     assert weekly in due_ids_later, "a weekly mandate becomes due once a week has elapsed"
 
 
+async def test_list_cadence_due_exact_7_day_boundary_is_due(tmp_path, mongo_db):
+    """The window is EXCLUSIVE: a shift EXACTLY 7 days ago is due (a mandate must
+    not slip a beat at the boundary), and a shift a hair under 7 days is not."""
+    from pocketpaw_ee.cloud.mandates.domain import ShiftDoc
+
+    weekly = await _make_mandate("weekly-boundary", cadence="weekly")
+    now = datetime(2026, 6, 13, tzinfo=UTC)
+
+    shift = ShiftDoc(workspace=WS, mandate_id=weekly, no=1, state="done")
+    shift.createdAt = now - timedelta(days=7)  # exactly the interval ago
+    await shift.insert()
+
+    due_ids = {row["mandate_id"] for row in await mandate_service.list_cadence_due(now)}
+    assert weekly in due_ids, "a shift exactly 7 days ago is DUE (exclusive boundary)"
+
+    # A minute short of 7 days is still inside the window → NOT due.
+    just_short = now - timedelta(minutes=1)
+    due_short = {row["mandate_id"] for row in await mandate_service.list_cadence_due(just_short)}
+    assert weekly not in due_short, "a hair under 7 days is not yet due"
+
+
 async def test_list_cadence_due_excludes_paused(tmp_path, mongo_db):
     from bson import ObjectId
     from pocketpaw_ee.cloud.mandates.domain import MandateDoc
@@ -193,6 +218,31 @@ async def test_scheduler_lifecycle_start_and_drain(tmp_path, mongo_db):
     await scheduler_mod.shutdown_scheduler()
 
 
+async def test_shutdown_during_immediate_tick_does_not_hang(tmp_path, mongo_db, monkeypatch):
+    """REGRESSION: a cancel WHILE the run_immediate tick is in flight must abort
+    the loop promptly, NOT fall through into the hour-long ``asyncio.sleep``.
+    Before the fix, ``contextlib.suppress(CancelledError)`` ate the cancel and
+    shutdown blocked until the next interval (up to 3600s)."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_tick(*args, **kwargs):
+        started.set()
+        await release.wait()  # park here until the test cancels us
+        return []
+
+    monkeypatch.setattr(scheduler_mod, "run_scheduler_tick", _slow_tick)
+
+    # Huge interval: if the cancel were swallowed, the loop would park on this
+    # sleep and the drain below would time out.
+    await scheduler_mod.start_scheduler(interval_seconds=10_000, run_immediate=True)
+    await asyncio.wait_for(started.wait(), timeout=1.0)  # the immediate tick is running
+
+    # Drain must complete fast — the cancel propagates out of the immediate tick.
+    await asyncio.wait_for(scheduler_mod.shutdown_scheduler(), timeout=1.0)
+    assert not scheduler_mod.is_running()
+
+
 async def test_scheduler_reconciler_starts_loop(tmp_path, mongo_db):
     """The lifespan startup reconciler starts exactly one sweeper loop."""
     assert not scheduler_mod.is_running()
@@ -222,8 +272,11 @@ async def test_issues_patrol_produces_sightings_from_connector_payload():
 
     from types import SimpleNamespace
 
+    seen_user: list[str | None] = []
+
     async def _fake_execute(workspace_id, name, body, *, user_id=None):
         # Mirror the ExecuteActionResponse shape: success + a data payload.
+        seen_user.append(user_id)
         return SimpleNamespace(
             success=True,
             data=[
@@ -241,10 +294,12 @@ async def test_issues_patrol_produces_sightings_from_connector_payload():
     drafts = await patrols_mod.issues_patrol(
         "/tmp/repo",
         workspace_id=WS,
+        user_id="system:scheduler",
         project="my-group/my-project",
         execute=_fake_execute,
     )
 
+    assert seen_user == ["system:scheduler"], "the actor is threaded to the connector"
     assert len(drafts) == 2, "only OPEN issues become sightings"
     summaries = [d["summary"] for d in drafts]
     assert any("Login button is broken" in s for s in summaries)
@@ -286,9 +341,11 @@ async def test_run_patrols_persists_issue_sightings_via_connector_seam(
 
     # Patch the patrol's DEFAULT connector seam — proves run_patrols reaches the
     # live execute path without injecting ``execute`` at the call site.
-    async def _fake_default_execute(workspace_id, name, body):
+    async def _fake_default_execute(workspace_id, name, body, *, user_id=None):
         assert name == "gitlab"
         assert body["action"] == "list_issues"
+        # The run_patrols actor is threaded to the connector for audit attribution.
+        assert user_id == USER
         return SimpleNamespace(
             success=True,
             data=[


### PR DESCRIPTION
## What

Two pieces of the mandate "always-on perception" that were stubbed before:

1. **Cadence scheduler** (`mandates/scheduler.py`) — a single asyncio sweeper modelled on the autopilot lifecycle. Each tick asks the service which active mandates are cadence-due and fires `trigger_shift` for them. "weekly" is due when the last shift is over 7 days old or never happened; "manual" is never auto-fired; paused mandates are inert. The clock and the trigger callable are both injectable, so ticks are deterministic in tests — no wall-clock sleeps, no real LLM. Startup reconciler and shutdown drain are wired into the cloud lifespan next to autopilot, behind `POCKETPAW_CLOUD_SCHEDULER_ENABLED` (off by default).

2. **First live-signal patrol** (`issues_patrol` in `patrols.py`) — reads open issues from the bound repo over the real connector execute path (`connectors_service.execute`, real httpx in CLOUD mode) and emits one populated `SightingDraft` per issue. This replaces the pattern where the only patrols were `deps` (a hardcoded CVE table, kept as-is) and `feedback` (manual intake). The connector call is injectable so tests don't hit the network.

## Why

Before this, mandate shifts only fired when a human triggered them, and no patrol read a live signal — so "the job watches its world and proposes work" was aspirational. This gives the loop a real clock and its first real sense.

## Scope and limits

This is the spine, not the whole engine. One live patrol (repo issues), one cadence rule (weekly/manual). More patrols and richer cadence parsing are follow-ups. The scheduler is flagged off by default.

## Tests

`uv run pytest tests/cloud/test_belt_scheduler.py tests/cloud/test_belt_mandates.py tests/cloud/test_belt_autopilot.py -q` → 33 passed. Written test-first (red on the missing module). Covers due-ness logic, tick-fires-only-due, sibling-failure isolation, lifecycle start/drain, and the live patrol producing populated drafts from a mocked connector payload.

Captain reviews; not merging.