### PR TITLE
feat(belt): headless develop runner produces the diff, human still approves

### DIFF
--- a/ee/pocketpaw_ee/cloud/belt/headless.py
+++ b/ee/pocketpaw_ee/cloud/belt/headless.py
@@ -1,6 +1,15 @@
 # ee/pocketpaw_ee/cloud/belt/headless.py — the HEADLESS develop runner.
 # Created: 2026-06-13 (feat/belt-headless-exec).
 #
+# Updated: 2026-06-13 (PR #1464 review) — store the produced diff VERBATIM (only
+#   normalizing a single trailing newline) instead of the leading/trailing-
+#   stripped value: stripping a real diff's trailing newline corrupts it for
+#   ``git apply``. Emptiness is still decided on the stripped value, so a
+#   whitespace-only diff stays safely queued. Also: dropped the dead ``_calls``
+#   field, and added a best-effort ``headless_diff_attached`` audit-log entry at
+#   diff attachment — the first point LLM-produced content enters the Instinct
+#   store without a human typing it, so an operator trail is worth keeping.
+#
 # WHAT THIS CLOSES — the mandate→belt path was NOT autonomous. An approved
 # mandate plan task became a QUEUED ``code_change`` Instinct Action
 # (``station_pending=True``, NO diff) filed by ``mandates.executor.
@@ -42,7 +51,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Protocol
 from uuid import uuid4
 
@@ -104,7 +113,6 @@ class HeadlessDevelopRunner:
     per-diff human gate is preserved (the runner never approves or executes)."""
 
     develop_fn: DevelopFn
-    _calls: list[str] = field(default_factory=list)
 
     async def run(self, action_id: str) -> str:
         """Produce a diff for a queued ``code_change`` action and attach it.
@@ -158,10 +166,14 @@ class HeadlessDevelopRunner:
             await self._note_failure(store, action_id, f"headless develop failed: {exc}")
             return action_id
 
-        diff = (result.diff or "").strip()
-        if not diff:
-            # An empty diff is a no-op failure, not an applyable run. Leave the
-            # queued run untouched (a human can still drive the station).
+        raw_diff = result.diff or ""
+        if not raw_diff.strip():
+            # A whitespace-only (or empty) diff is a no-op failure, not an
+            # applyable run. Leave the queued run untouched (a human can still
+            # drive the station). We test EMPTINESS on the stripped value but
+            # never STORE the stripped value — stripping a real diff's trailing
+            # newline corrupts it for ``git apply`` (the executor reads the diff
+            # verbatim into ``git apply <file>``).
             logger.warning(
                 "headless: develop loop produced an empty diff for action %s — "
                 "leaving the run queued",
@@ -169,6 +181,11 @@ class HeadlessDevelopRunner:
             )
             await self._note_failure(store, action_id, "headless develop produced an empty diff")
             return action_id
+
+        # Store the diff VERBATIM, only guaranteeing a single trailing newline so
+        # ``git apply`` can parse the final hunk line. Leading/internal content is
+        # never altered.
+        diff = raw_diff if raw_diff.endswith("\n") else raw_diff + "\n"
 
         base_branch = (result.base_branch or request.base_branch or "").strip()
         if not base_branch:
@@ -187,7 +204,7 @@ class HeadlessDevelopRunner:
         await self._attach_diff(
             store,
             action_id,
-            diff=result.diff,
+            diff=diff,
             base_branch=base_branch,
             summary=result.summary or request.summary,
             files_changed=result.files_changed,
@@ -229,6 +246,9 @@ class HeadlessDevelopRunner:
             if not isinstance(blob, dict):
                 return
             blob = dict(blob)
+            # Provenance for the audit trail below (read before mutating).
+            workspace_id = str(blob.get("workspace_id") or "")
+            mandate_id = str(blob.get("mandate_id") or "")
             blob["diff"] = diff
             blob["base_branch"] = base_branch
             blob["summary"] = summary
@@ -263,6 +283,43 @@ class HeadlessDevelopRunner:
             )
             await self._note_failure(
                 store, action_id, "headless failed to persist the produced diff"
+            )
+            return
+
+        # Audit trail — this is the FIRST place LLM-produced content enters the
+        # Instinct store without a human typing it, so leave an operator trail of
+        # "headless diff attached, awaiting the gate". Written AFTER the attach
+        # commit so the trail never claims an attach that didn't land, and kept
+        # best-effort (the store's ``log`` raises ``AuditChainError`` loudly on a
+        # ledger failure — that must not undo the attach or crash dispatch).
+        try:
+            from pocketpaw.instinct.models import AuditCategory
+
+            await store.log(
+                actor="agent:belt-headless",
+                event="headless_diff_attached",
+                description=(
+                    f"Headless develop attached a diff to {action_id} "
+                    f"(base {base_branch}, {files_changed} file(s)) — awaiting the "
+                    "per-diff Instinct gate"
+                ),
+                action_id=action_id,
+                pocket_id=workspace_id or None,
+                category=AuditCategory.DECISION,
+                workspace_id=workspace_id or None,
+                context={
+                    "mandate_id": mandate_id,
+                    "base_branch": base_branch,
+                    "files_changed": files_changed,
+                    "headless": True,
+                },
+            )
+        except Exception:  # noqa: BLE001 — the audit trail is best-effort here
+            logger.warning(
+                "headless: audit log for headless_diff_attached failed for action %s "
+                "(the diff IS attached) — operator trail missing this entry",
+                action_id,
+                exc_info=True,
             )
 
     async def _note_failure(self, store: Any, action_id: str, reason: str) -> None:

--- a/ee/pocketpaw_ee/cloud/belt/headless.py
+++ b/ee/pocketpaw_ee/cloud/belt/headless.py
@@ -1,0 +1,396 @@
+# ee/pocketpaw_ee/cloud/belt/headless.py — the HEADLESS develop runner.
+# Created: 2026-06-13 (feat/belt-headless-exec).
+#
+# WHAT THIS CLOSES — the mandate→belt path was NOT autonomous. An approved
+# mandate plan task became a QUEUED ``code_change`` Instinct Action
+# (``station_pending=True``, NO diff) filed by ``mandates.executor.
+# StationTaskDispatcher``, and a HUMAN then had to open the interactive ``/belt``
+# chat surface to PRODUCE the diff. This module removes the human from PRODUCING
+# the diff — and ONLY from that. The per-diff human approval gate is preserved:
+# the runner leaves the action PENDING, carrying a real diff awaiting the
+# Instinct gate exactly as a human-driven ``belt_propose_change`` would.
+#
+# THE SHAPE:
+#   * ``DevelopFn`` — an injectable async callable ``(DevelopRequest) ->
+#     DevelopResult``. It is the LLM develop loop (the genuine external boundary,
+#     the analogue of ``GhCliPrOpener`` / ``PrOpener`` in ``belt/executor.py``).
+#     Tests inject a deterministic fake that returns a canned diff — code under
+#     test NEVER calls a real LLM or spawns a real agent. Production wires the
+#     real develop loop here (a follow-up; the runner is agnostic to it).
+#   * ``HeadlessDevelopRunner.run(action_id)`` — reads the queued ``code_change``
+#     blob, calls the ``DevelopFn`` for a diff, then back-writes the diff +
+#     base_branch onto the blob, CLEARS ``station_pending``, and mints a
+#     Decision-Graph ``correlation_id`` so the gate closes the chain on approve.
+#     The action stays PENDING. NEVER raises — a ``DevelopFn`` failure (or an
+#     empty diff) leaves the run SAFE (still queued, no diff) and records a note.
+#   * ``HeadlessTaskDispatcher`` — a ``TaskDispatcher`` (the mandates seam) that
+#     files the queued run via the existing ``StationTaskDispatcher`` and then
+#     runs the headless runner on it, so one dispatch turns an approved plan task
+#     into a real pending diff. Additive + selectable via
+#     ``POCKETPAW_MANDATE_DISPATCHER=headless`` — the interactive ``station`` and
+#     announce-only ``bus`` dispatchers are untouched.
+#
+# WHY back-write the SAME action rather than file a fresh one: the queued run is
+# already the row the console Runs tab reads and the belt gate would execute.
+# Populating its diff in place keeps one durable run record per task (provenance
+# to the mandate shift stays on the blob) and reuses the EXACT applyable shape
+# the belt executor expects (``base_branch`` + ``diff`` + cleared
+# ``station_pending`` — see ``belt/executor.py`` schema-2 guard). The direct-SQL
+# blob update mirrors ``belt/executor.py::_persist_run_result`` and the MCP
+# server's ``_persist_chain_ids`` — the same pattern, no new store method.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+# Kept in sync with ``belt/executor.py`` and the agent MCP server's literals.
+# Duplicated (not imported) so this module has no hard dependency on the
+# agent-side MCP module — same OSS/EE discipline the rest of the belt subsystem
+# uses for these literals.
+_CODE_CHANGE_PARAM_KEY = "_code_change"
+_CODE_CHANGE_SCHEMA = 2
+
+
+@dataclass(frozen=True)
+class DevelopRequest:
+    """Everything the develop loop needs to produce a diff for one task.
+
+    Built from the queued ``code_change`` blob. ``task`` is the human-readable
+    task text (title + why) the station agent would have picked up; ``repo`` is
+    the mandate's bound repo path; ``base_branch`` is the blob's base (often
+    empty for a queued run — the develop loop / the result decides it)."""
+
+    task: str
+    summary: str
+    repo: str
+    base_branch: str
+    workspace_id: str
+    mandate_id: str = ""
+    shift_no: int = 0
+
+
+@dataclass(frozen=True)
+class DevelopResult:
+    """The output of one headless develop run — a unified diff plus the branch
+    it bases on. ``files_changed`` is optional metadata for the run feed."""
+
+    diff: str
+    base_branch: str
+    summary: str = ""
+    files_changed: int = 0
+
+
+class DevelopFn(Protocol):
+    """Injectable develop loop — the genuine external boundary (the LLM session
+    that turns a task into a diff). Tests inject a deterministic fake; production
+    wires the real loop. Async so the real implementation can await an LLM."""
+
+    async def __call__(self, request: DevelopRequest) -> DevelopResult: ...
+
+
+@dataclass
+class HeadlessDevelopRunner:
+    """Turns a QUEUED ``code_change`` run into a real PENDING diff, headlessly.
+
+    Takes an injectable ``DevelopFn`` so tests pass a canned-diff fake and the
+    runner never calls a real LLM. ``run(action_id)`` never raises — every
+    failure path leaves the queued run SAFE (no diff, ``station_pending`` intact)
+    and records a note on the blob. The produced diff is left PENDING: the
+    per-diff human gate is preserved (the runner never approves or executes)."""
+
+    develop_fn: DevelopFn
+    _calls: list[str] = field(default_factory=list)
+
+    async def run(self, action_id: str) -> str:
+        """Produce a diff for a queued ``code_change`` action and attach it.
+
+        Returns the action id (a run reference) in every case — success or
+        handled failure. Never raises: a develop-loop crash or an empty diff
+        leaves the run queued and records ``headless_error`` on the blob so a
+        human can still drive the station or the dispatcher can retry."""
+        from pocketpaw.stores import get_instinct_store
+
+        store = get_instinct_store()
+        action = await store.get_action(action_id)
+        if action is None:
+            logger.warning("headless: action %s not found — nothing to develop", action_id)
+            return action_id
+
+        blob = (getattr(action, "parameters", None) or {}).get(_CODE_CHANGE_PARAM_KEY)
+        if not isinstance(blob, dict):
+            logger.warning("headless: action %s carries no _code_change blob", action_id)
+            return action_id
+
+        # Only a QUEUED run (station_pending, no diff) is ours to develop. A run
+        # that already carries a diff is left alone (idempotent / re-entrant
+        # safe) — never overwrite an existing proposed diff.
+        if not blob.get("station_pending") or (blob.get("diff") or "").strip():
+            logger.info(
+                "headless: action %s is not a queued station run (or already has a "
+                "diff) — skipping",
+                action_id,
+            )
+            return action_id
+
+        request = DevelopRequest(
+            task=str(blob.get("task") or ""),
+            summary=str(blob.get("summary") or ""),
+            repo=str(blob.get("repo") or ""),
+            base_branch=str(blob.get("base_branch") or ""),
+            workspace_id=str(blob.get("workspace_id") or ""),
+            mandate_id=str(blob.get("mandate_id") or ""),
+            shift_no=int(blob.get("shift_no") or 0),
+        )
+
+        try:
+            result = await self.develop_fn(request)
+        except Exception as exc:  # noqa: BLE001 — the develop loop must not crash dispatch
+            logger.warning(
+                "headless: develop loop failed for action %s — leaving the run queued",
+                action_id,
+                exc_info=True,
+            )
+            await self._note_failure(store, action_id, f"headless develop failed: {exc}")
+            return action_id
+
+        diff = (result.diff or "").strip()
+        if not diff:
+            # An empty diff is a no-op failure, not an applyable run. Leave the
+            # queued run untouched (a human can still drive the station).
+            logger.warning(
+                "headless: develop loop produced an empty diff for action %s — "
+                "leaving the run queued",
+                action_id,
+            )
+            await self._note_failure(
+                store, action_id, "headless develop produced an empty diff"
+            )
+            return action_id
+
+        base_branch = (result.base_branch or request.base_branch or "").strip()
+        if not base_branch:
+            logger.warning(
+                "headless: develop loop returned no base_branch for action %s — "
+                "leaving the run queued",
+                action_id,
+            )
+            await self._note_failure(
+                store, action_id, "headless develop returned no base_branch"
+            )
+            return action_id
+
+        # Back-write the produced diff onto the SAME action's blob — clearing
+        # ``station_pending`` and minting a Decision-Graph ``correlation_id`` so
+        # the run is the EXACT applyable shape the belt gate expects. The action
+        # stays PENDING: the per-diff human gate is preserved.
+        await self._attach_diff(
+            store,
+            action_id,
+            diff=result.diff,
+            base_branch=base_branch,
+            summary=result.summary or request.summary,
+            files_changed=result.files_changed,
+        )
+        logger.info(
+            "headless: produced a diff for action %s (base %s) — now a real "
+            "pending code_change awaiting the Instinct gate",
+            action_id,
+            base_branch,
+        )
+        return action_id
+
+    async def _attach_diff(
+        self,
+        store: Any,
+        action_id: str,
+        *,
+        diff: str,
+        base_branch: str,
+        summary: str,
+        files_changed: int,
+    ) -> None:
+        """Populate the queued blob with the produced diff and clear
+        ``station_pending``. Direct-SQL blob update — the SAME pattern as
+        ``belt/executor.py::_persist_run_result`` and the MCP server's
+        ``_persist_chain_ids`` (no new store method). The schema stays 2 so the
+        belt executor's schema guard passes. Best-effort but loud: a write
+        failure records a note and leaves the run queued, never applyable."""
+        import json as _json
+
+        import aiosqlite
+
+        try:
+            action = await store.get_action(action_id)
+            if action is None:
+                return
+            params = dict(getattr(action, "parameters", None) or {})
+            blob = params.get(_CODE_CHANGE_PARAM_KEY)
+            if not isinstance(blob, dict):
+                return
+            blob = dict(blob)
+            blob["diff"] = diff
+            blob["base_branch"] = base_branch
+            blob["summary"] = summary
+            blob["files_changed"] = files_changed
+            # The run is no longer a queued placeholder — it is an applyable diff.
+            blob["station_pending"] = False
+            blob["schema"] = _CODE_CHANGE_SCHEMA
+            # Mint a chain correlation id if the queued blob never had one (the
+            # StationTaskDispatcher files queued runs without one). The belt
+            # executor reads it off the blob to close the Decision-Graph chain on
+            # approve; a fresh id is the headless-produced run's chain anchor.
+            if not blob.get("correlation_id"):
+                blob["correlation_id"] = str(uuid4())
+            blob.setdefault("proposed_event_id", None)
+            # Provenance — record that this diff was produced headlessly.
+            blob["headless"] = True
+            blob.pop("headless_error", None)
+            params[_CODE_CHANGE_PARAM_KEY] = blob
+
+            async with aiosqlite.connect(store._db_path) as db:
+                await db.execute(
+                    "UPDATE instinct_actions SET parameters = ?,"
+                    " updated_at = datetime('now') WHERE id = ?",
+                    (_json.dumps(params), action_id),
+                )
+                await db.commit()
+        except Exception:  # noqa: BLE001 — a write failure must not crash dispatch
+            logger.warning(
+                "headless: failed to attach diff to action %s — leaving it queued",
+                action_id,
+                exc_info=True,
+            )
+            await self._note_failure(
+                store, action_id, "headless failed to persist the produced diff"
+            )
+
+    async def _note_failure(self, store: Any, action_id: str, reason: str) -> None:
+        """Record a headless-develop failure ON the blob WITHOUT making the run
+        applyable. The run STAYS queued (``station_pending=True``, no diff) so a
+        human can still drive the station or the dispatcher can retry — we never
+        approve or fail the Action out from under the human gate. Best-effort."""
+        import json as _json
+
+        import aiosqlite
+
+        try:
+            action = await store.get_action(action_id)
+            if action is None:
+                return
+            params = dict(getattr(action, "parameters", None) or {})
+            blob = params.get(_CODE_CHANGE_PARAM_KEY)
+            if not isinstance(blob, dict):
+                return
+            blob = dict(blob)
+            # Keep the run SAFE: still queued, no diff. Only annotate the failure.
+            blob["station_pending"] = True
+            blob["diff"] = ""
+            blob["headless_error"] = reason
+            params[_CODE_CHANGE_PARAM_KEY] = blob
+            async with aiosqlite.connect(store._db_path) as db:
+                await db.execute(
+                    "UPDATE instinct_actions SET parameters = ?,"
+                    " updated_at = datetime('now') WHERE id = ?",
+                    (_json.dumps(params), action_id),
+                )
+                await db.commit()
+        except Exception:  # noqa: BLE001 — never crash on the failure-note path
+            logger.debug("headless: failed to record headless_error note", exc_info=True)
+
+
+@dataclass
+class HeadlessTaskDispatcher:
+    """A ``TaskDispatcher`` (the mandates dispatch seam) that files a queued
+    ``code_change`` run via the existing ``StationTaskDispatcher`` and then runs
+    the headless runner on it — so an approved plan task becomes a real PENDING
+    diff in one dispatch, with NO human in the diff-producing loop. The per-diff
+    human gate is preserved: the produced diff is left pending the Instinct gate.
+
+    Additive + selectable. The interactive ``station`` (human-driven) and the
+    announce-only ``bus`` dispatchers in ``mandates/executor.py`` are untouched.
+    A develop failure degrades gracefully: the queued run survives (a human can
+    still drive the station), so a headless miss never loses the task."""
+
+    runner: HeadlessDevelopRunner
+
+    async def dispatch(
+        self,
+        *,
+        workspace_id: str,
+        mandate_id: str,
+        shift_no: int,
+        plan_action_id: str,
+        index: int,
+        task: dict[str, Any],
+    ) -> str:
+        from pocketpaw_ee.cloud.mandates.executor import StationTaskDispatcher
+
+        # 1. File the queued run exactly as the station dispatcher does (real
+        #    code_change Action, station_pending, no diff, run-feed event).
+        run_ref = await StationTaskDispatcher().dispatch(
+            workspace_id=workspace_id,
+            mandate_id=mandate_id,
+            shift_no=shift_no,
+            plan_action_id=plan_action_id,
+            index=index,
+            task=task,
+        )
+        # 2. Produce the diff headlessly and attach it (the run becomes a real
+        #    pending diff). Never raises — a miss leaves the queued run for a
+        #    human to drive.
+        await self.runner.run(run_ref)
+        return run_ref
+
+
+# ---------------------------------------------------------------------------
+# Production wiring seam — the develop loop.
+# ---------------------------------------------------------------------------
+#
+# The real LLM develop loop is a follow-up; this hook lets it be wired without
+# touching ``mandates/executor.py`` again. A deploy that wires a production
+# ``DevelopFn`` sets ``_PRODUCTION_DEVELOP_FN`` (via ``set_production_develop_fn``)
+# and ``POCKETPAW_MANDATE_DISPATCHER=headless`` then selects the autonomous path.
+# Until one is wired, ``resolve_headless_dispatcher`` returns ``None`` and the
+# mandates executor falls back to the queued-run station dispatcher — a deploy is
+# never left filing un-developable runs, and code under test NEVER reaches a real
+# LLM (tests construct ``HeadlessTaskDispatcher`` with a fake ``DevelopFn``
+# directly, bypassing this seam).
+_PRODUCTION_DEVELOP_FN: DevelopFn | None = None
+
+
+def set_production_develop_fn(fn: DevelopFn | None) -> None:
+    """Wire (or clear) the production develop loop the headless dispatcher uses.
+
+    Called once at app wiring time by a deploy that ships a real develop loop.
+    Tests do NOT use this — they inject a fake ``DevelopFn`` into
+    ``HeadlessDevelopRunner`` / ``HeadlessTaskDispatcher`` directly."""
+    global _PRODUCTION_DEVELOP_FN
+    _PRODUCTION_DEVELOP_FN = fn
+
+
+def resolve_headless_dispatcher() -> HeadlessTaskDispatcher | None:
+    """Build the headless dispatcher IF a production develop loop is wired.
+
+    Returns ``None`` when no ``DevelopFn`` is wired so the mandates executor can
+    degrade to the queued-run station dispatcher (a human can still drive the
+    run). This keeps the autonomous path strictly opt-in and never silently
+    files runs that nothing can develop."""
+    if _PRODUCTION_DEVELOP_FN is None:
+        return None
+    return HeadlessTaskDispatcher(runner=HeadlessDevelopRunner(develop_fn=_PRODUCTION_DEVELOP_FN))
+
+
+__all__ = [
+    "DevelopFn",
+    "DevelopRequest",
+    "DevelopResult",
+    "HeadlessDevelopRunner",
+    "HeadlessTaskDispatcher",
+    "resolve_headless_dispatcher",
+    "set_production_develop_fn",
+]

--- a/ee/pocketpaw_ee/cloud/belt/headless.py
+++ b/ee/pocketpaw_ee/cloud/belt/headless.py
@@ -167,9 +167,7 @@ class HeadlessDevelopRunner:
                 "leaving the run queued",
                 action_id,
             )
-            await self._note_failure(
-                store, action_id, "headless develop produced an empty diff"
-            )
+            await self._note_failure(store, action_id, "headless develop produced an empty diff")
             return action_id
 
         base_branch = (result.base_branch or request.base_branch or "").strip()
@@ -179,9 +177,7 @@ class HeadlessDevelopRunner:
                 "leaving the run queued",
                 action_id,
             )
-            await self._note_failure(
-                store, action_id, "headless develop returned no base_branch"
-            )
+            await self._note_failure(store, action_id, "headless develop returned no base_branch")
             return action_id
 
         # Back-write the produced diff onto the SAME action's blob — clearing

--- a/ee/pocketpaw_ee/cloud/mandates/executor.py
+++ b/ee/pocketpaw_ee/cloud/mandates/executor.py
@@ -1,6 +1,18 @@
 # ee/pocketpaw_ee/cloud/mandates/executor.py
 # Created: 2026-06-11 (feat/belt-mandates, slice 4 — plan gate + executor).
 #
+# Updated: 2026-06-13 (feat/belt-headless-exec) — ``resolve_dispatcher`` now
+#   honours ``POCKETPAW_MANDATE_DISPATCHER=headless``: the ``HeadlessTaskDispatcher``
+#   (``cloud/belt/headless.py``) files the SAME queued ``code_change`` run as the
+#   station dispatcher, then PRODUCES the diff programmatically via the headless
+#   develop runner and attaches it, so the run becomes a real PENDING change
+#   awaiting the per-diff Instinct gate — no human in the diff-producing loop
+#   (the approval gate is preserved). It degrades to the plain ``station``
+#   dispatcher when no production develop loop is wired, so the older HONESTY
+#   note below still describes the DEFAULT (``station``) path; ``headless`` is the
+#   additive autonomous path. The ``station`` and ``bus`` dispatchers are
+#   untouched.
+#
 # Updated: 2026-06-11 (feat/belt-autopilot — REAL task dispatcher) — added the
 #   ``StationTaskDispatcher`` and ``resolve_dispatcher()`` so an approved plan
 #   task starts a REAL Belt station run instead of a bus-only echo. The
@@ -272,8 +284,16 @@ def resolve_dispatcher() -> TaskDispatcher:
 
     * ``station`` (default) — the REAL ``StationTaskDispatcher``: each approved
       task becomes a queued belt station run (a real ``code_change`` Instinct
-      Action) that shows in the console Runs tab. Falls back to ``bus`` if the
-      belt plumbing can't be imported (an OSS-only / partial install).
+      Action) that shows in the console Runs tab. A HUMAN then drives the
+      interactive ``/belt`` station to a diff. Falls back to ``bus`` if the belt
+      plumbing can't be imported (an OSS-only / partial install).
+    * ``headless`` — the ``HeadlessTaskDispatcher`` (feat/belt-headless-exec):
+      files the SAME queued run, then PRODUCES the diff programmatically via the
+      headless develop runner and attaches it, so the run becomes a real PENDING
+      ``code_change`` awaiting the per-diff Instinct gate — NO human in the
+      diff-producing loop (the approval gate is still preserved). Degrades to the
+      plain ``station`` dispatcher when no production develop loop is wired (so a
+      deploy without the LLM runner files queued runs a human can still drive).
     * ``bus`` — the announce-only ``BusTaskDispatcher`` (the prior default).
 
     An unrecognized value falls back to the station default.
@@ -283,8 +303,8 @@ def resolve_dispatcher() -> TaskDispatcher:
     choice = (os.environ.get("POCKETPAW_MANDATE_DISPATCHER") or "station").strip().lower()
     if choice == "bus":
         return BusTaskDispatcher()
-    # Default / "station": prefer the real station dispatcher, but degrade to the
-    # bus dispatcher cleanly if the belt service can't be imported.
+    # "station" / "headless" / default: both need the belt plumbing — degrade to
+    # the bus dispatcher cleanly if it can't be imported (a partial install).
     try:
         import pocketpaw_ee.cloud.belt.service  # noqa: F401
         from pocketpaw.stores import get_instinct_store  # noqa: F401
@@ -294,6 +314,20 @@ def resolve_dispatcher() -> TaskDispatcher:
             exc_info=True,
         )
         return BusTaskDispatcher()
+    if choice == "headless":
+        # The headless dispatcher needs a wired develop loop. ``resolve_headless_
+        # dispatcher`` returns it when one is available, else ``None`` so we fall
+        # through to the queued-run station dispatcher (a human-drivable run is
+        # never lost just because the LLM loop isn't wired in this deploy).
+        from pocketpaw_ee.cloud.belt.headless import resolve_headless_dispatcher
+
+        headless = resolve_headless_dispatcher()
+        if headless is not None:
+            return headless
+        logger.warning(
+            "mandate: headless dispatcher requested but no develop loop is wired — "
+            "falling back to the queued-run station dispatcher",
+        )
     return StationTaskDispatcher()
 
 

--- a/tests/cloud/test_belt_headless.py
+++ b/tests/cloud/test_belt_headless.py
@@ -140,6 +140,13 @@ async def test_headless_runner_produces_pending_diff(store: InstinctStore):
     # CRITICAL — still PENDING. Not auto-approved, not executed.
     assert after.status == ActionStatus.PENDING
 
+    # An operator trail entry was written — the first place LLM-produced content
+    # enters the store without a human typing it.
+    audit = await store.query_audit(event="headless_diff_attached")
+    assert len(audit) == 1
+    assert audit[0].action_id == action_id
+    assert audit[0].context.get("base_branch") == "main"
+
 
 # ---------------------------------------------------------------------------
 # GATE PRESERVED — the produced diff still requires human approval; the belt
@@ -212,6 +219,29 @@ async def test_headless_runner_rejects_empty_diff(store: InstinctStore):
     assert not cc["diff"]
 
 
+async def test_headless_runner_rejects_missing_base_branch(store: InstinctStore):
+    """A DevelopFn that returns a real diff but NO base_branch is not applyable
+    (the belt executor needs a base to worktree off) — leave the run queued via
+    the no_base_branch safety path, not a half-attached applyable run."""
+    action_id = await _queue_station_run(store)
+
+    async def no_base(req: DevelopRequest) -> DevelopResult:
+        return DevelopResult(diff=CANNED_DIFF, base_branch="", summary="")
+
+    runner = HeadlessDevelopRunner(develop_fn=no_base)
+    ref = await runner.run(action_id)
+    assert ref == action_id
+
+    after = await store.get_action(action_id)
+    assert after is not None
+    cc = after.parameters["_code_change"]
+    # The run is left SAFE: still queued, no diff written.
+    assert cc["station_pending"] is True
+    assert cc["diff"] == ""
+    assert after.status == ActionStatus.PENDING
+    assert "base_branch" in (cc.get("headless_error") or "")
+
+
 # ---------------------------------------------------------------------------
 # DISPATCHER WIRING — the HeadlessTaskDispatcher files the queued run AND runs
 # the headless runner, so an approved plan task becomes a real pending diff in
@@ -264,24 +294,24 @@ def test_headless_selection_requires_wired_develop_loop(monkeypatch):
     monkeypatch.setenv("POCKETPAW_MANDATE_DISPATCHER", "headless")
 
     # No develop loop wired → falls back to the queued-run station dispatcher.
-    headless_mod.set_production_develop_fn(None)
+    # monkeypatch.setattr restores the global even if an assertion below raises,
+    # so the wired/unwired state never leaks into another test under
+    # asyncio_mode=auto.
+    monkeypatch.setattr(headless_mod, "_PRODUCTION_DEVELOP_FN", None)
     assert isinstance(ex.resolve_dispatcher(), ex.StationTaskDispatcher)
 
     # Wire a (fake) develop loop → the headless dispatcher is selected.
     async def fake_develop(req: DevelopRequest) -> DevelopResult:
         return DevelopResult(diff=CANNED_DIFF, base_branch="main")
 
-    headless_mod.set_production_develop_fn(fake_develop)
-    try:
-        assert isinstance(ex.resolve_dispatcher(), HeadlessTaskDispatcher)
-    finally:
-        headless_mod.set_production_develop_fn(None)
+    monkeypatch.setattr(headless_mod, "_PRODUCTION_DEVELOP_FN", fake_develop)
+    assert isinstance(ex.resolve_dispatcher(), HeadlessTaskDispatcher)
 
 
-def test_headless_resolve_returns_none_when_unwired():
+def test_headless_resolve_returns_none_when_unwired(monkeypatch):
     import pocketpaw_ee.cloud.belt.headless as headless_mod
 
-    headless_mod.set_production_develop_fn(None)
+    monkeypatch.setattr(headless_mod, "_PRODUCTION_DEVELOP_FN", None)
     assert headless_mod.resolve_headless_dispatcher() is None
 
 

--- a/tests/cloud/test_belt_headless.py
+++ b/tests/cloud/test_belt_headless.py
@@ -1,0 +1,394 @@
+# tests/cloud/test_belt_headless.py — the HEADLESS develop runner that closes
+# the mandate→belt autonomy gap (feat/belt-headless-exec).
+#
+# Created: 2026-06-13.
+#
+# THE GAP UNDER TEST — before this, an approved mandate plan task became a
+# QUEUED ``code_change`` Instinct Action (``station_pending=True``, NO diff) and
+# a HUMAN had to open the ``/belt`` chat surface to produce the diff. The
+# headless runner removes the human from PRODUCING the diff (not from approving
+# it): given a queued ``code_change`` action and an injectable ``DevelopFn`` that
+# returns a unified diff, it back-writes the diff onto the action's blob, clears
+# ``station_pending``, and leaves the action PENDING — a real diff awaiting the
+# per-diff Instinct gate, exactly as a human-driven ``belt_propose_change`` would.
+#
+# What is asserted:
+#   * SUCCESS — a canned-diff ``DevelopFn`` turns a queued run into a real,
+#     pending ``code_change`` carrying the diff + base_branch, station_pending
+#     cleared, NOT approved / executed.
+#   * GATE PRESERVED — the produced action is PENDING; the belt executor will
+#     ONLY apply it after a human approves it. We prove the per-diff gate still
+#     stands (the runner never approves or executes).
+#   * FAILURE — a ``DevelopFn`` that raises leaves the action SAFE (still queued,
+#     no diff, station_pending intact) and never crashes.
+#   * The ``DevelopFn`` is injectable: the test passes a deterministic fake — the
+#     runner NEVER calls a real LLM or spawns a real agent.
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.belt.headless import (  # noqa: E402
+    DevelopRequest,
+    DevelopResult,
+    HeadlessDevelopRunner,
+    HeadlessTaskDispatcher,
+)
+from pocketpaw_ee.cloud.mandates.executor import StationTaskDispatcher  # noqa: E402
+
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+WS = "w1"
+
+CANNED_DIFF = """\
+diff --git a/hello.txt b/hello.txt
+index e69de29..3b18e51 100644
+--- a/hello.txt
++++ b/hello.txt
+@@ -0,0 +1 @@
++hello
+"""
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore wired into the global resolver the runner reads."""
+    st = InstinctStore(tmp_path / "instinct_headless.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+async def _queue_station_run(store: InstinctStore, *, repo: str = "demo-repo") -> str:
+    """File a QUEUED code_change run the way the StationTaskDispatcher does, then
+    return its action id. We patch the repo lookup so the dispatcher doesn't need
+    a live Mongo-backed mandate."""
+    import pocketpaw_ee.cloud.mandates.executor as ex
+
+    async def _fake_repo(workspace_id: str, mandate_id: str) -> str | None:
+        return repo
+
+    orig = ex._repo_for_mandate
+    ex._repo_for_mandate = _fake_repo  # type: ignore[assignment]
+    try:
+        dispatcher = StationTaskDispatcher()
+        run_ref = await dispatcher.dispatch(
+            workspace_id=WS,
+            mandate_id="m1",
+            shift_no=1,
+            plan_action_id="plan-act-1",
+            index=1,
+            task={
+                "title": "Add a hello file",
+                "why": "demonstrate the headless runner",
+                "expected_outcome": "hello.txt exists",
+                "requested_by": "u1",
+            },
+        )
+    finally:
+        ex._repo_for_mandate = orig  # type: ignore[assignment]
+    return run_ref
+
+
+# ---------------------------------------------------------------------------
+# SUCCESS — fake DevelopFn → real pending diff, station_pending cleared.
+# ---------------------------------------------------------------------------
+
+
+async def test_headless_runner_produces_pending_diff(store: InstinctStore):
+    action_id = await _queue_station_run(store)
+
+    # Pre-condition: it is a QUEUED run (station_pending, no diff).
+    queued = await store.get_action(action_id)
+    assert queued is not None
+    assert queued.status == ActionStatus.PENDING
+    assert queued.parameters["_code_change"]["station_pending"] is True
+    assert not queued.parameters["_code_change"]["diff"]
+
+    calls: list[DevelopRequest] = []
+
+    async def fake_develop(req: DevelopRequest) -> DevelopResult:
+        calls.append(req)
+        return DevelopResult(diff=CANNED_DIFF, base_branch="main", summary="adds hello.txt")
+
+    runner = HeadlessDevelopRunner(develop_fn=fake_develop)
+    result_ref = await runner.run(action_id)
+
+    # The fake was invoked with the task text from the queued blob.
+    assert len(calls) == 1
+    assert "Add a hello file" in calls[0].task
+    assert calls[0].repo == "demo-repo"
+    assert result_ref == action_id
+
+    after = await store.get_action(action_id)
+    assert after is not None
+    cc = after.parameters["_code_change"]
+    # The diff is now real, base_branch populated, station_pending CLEARED.
+    assert cc["diff"] == CANNED_DIFF
+    assert cc["base_branch"] == "main"
+    assert cc["station_pending"] is False
+    # It is APPLYABLE-SHAPED: a chain correlation id was minted so the gate
+    # closes the Decision-Graph chain on approve.
+    assert cc.get("correlation_id")
+    # CRITICAL — still PENDING. Not auto-approved, not executed.
+    assert after.status == ActionStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# GATE PRESERVED — the produced diff still requires human approval; the belt
+# executor only applies it AFTER approve. The runner never approves/executes.
+# ---------------------------------------------------------------------------
+
+
+async def test_headless_diff_still_requires_human_approval(store: InstinctStore):
+    action_id = await _queue_station_run(store)
+
+    async def fake_develop(req: DevelopRequest) -> DevelopResult:
+        return DevelopResult(diff=CANNED_DIFF, base_branch="main", summary="adds hello.txt")
+
+    runner = HeadlessDevelopRunner(develop_fn=fake_develop)
+    await runner.run(action_id)
+
+    produced = await store.get_action(action_id)
+    assert produced is not None
+    # The runner left it PENDING — the per-diff Instinct gate is intact. The
+    # belt executor refuses to apply anything that isn't an APPROVED action; the
+    # only path that applies a diff is execute_approved_change, called by the
+    # router AFTER store.approve(). The runner touches neither.
+    assert produced.status == ActionStatus.PENDING
+    assert produced.approved_by is None
+
+
+# ---------------------------------------------------------------------------
+# FAILURE — a DevelopFn that raises leaves the run SAFE, never crashes.
+# ---------------------------------------------------------------------------
+
+
+async def test_headless_runner_handles_develop_failure(store: InstinctStore):
+    action_id = await _queue_station_run(store)
+
+    async def boom(req: DevelopRequest) -> DevelopResult:
+        raise RuntimeError("model unavailable")
+
+    runner = HeadlessDevelopRunner(develop_fn=boom)
+    # Must NOT raise.
+    ref = await runner.run(action_id)
+    assert ref == action_id
+
+    after = await store.get_action(action_id)
+    assert after is not None
+    cc = after.parameters["_code_change"]
+    # The run is left SAFE: still queued, no diff written, NOT applyable. A
+    # human can still drive the station, or the dispatcher can retry.
+    assert cc["station_pending"] is True
+    assert not cc["diff"]
+    # The action is NOT auto-approved / executed; it carries a failure note.
+    assert after.status in (ActionStatus.PENDING, ActionStatus.FAILED)
+    assert "headless" in (cc.get("headless_error") or "").lower() or after.error
+
+
+async def test_headless_runner_rejects_empty_diff(store: InstinctStore):
+    """A DevelopFn that returns an empty diff is a no-op failure, not an
+    applyable run — leave the queued run untouched."""
+    action_id = await _queue_station_run(store)
+
+    async def empty(req: DevelopRequest) -> DevelopResult:
+        return DevelopResult(diff="   \n", base_branch="main", summary="nothing")
+
+    runner = HeadlessDevelopRunner(develop_fn=empty)
+    await runner.run(action_id)
+
+    after = await store.get_action(action_id)
+    assert after is not None
+    cc = after.parameters["_code_change"]
+    assert cc["station_pending"] is True
+    assert not cc["diff"]
+
+
+# ---------------------------------------------------------------------------
+# DISPATCHER WIRING — the HeadlessTaskDispatcher files the queued run AND runs
+# the headless runner, so an approved plan task becomes a real pending diff in
+# one dispatch (no human in the diff-producing loop).
+# ---------------------------------------------------------------------------
+
+
+async def test_headless_dispatcher_produces_diff_on_dispatch(store: InstinctStore, monkeypatch):
+    import pocketpaw_ee.cloud.mandates.executor as ex
+
+    async def _fake_repo(workspace_id: str, mandate_id: str) -> str | None:
+        return "demo-repo"
+
+    monkeypatch.setattr(ex, "_repo_for_mandate", _fake_repo)
+
+    async def fake_develop(req: DevelopRequest) -> DevelopResult:
+        return DevelopResult(diff=CANNED_DIFF, base_branch="dev", summary="adds hello.txt")
+
+    dispatcher = HeadlessTaskDispatcher(runner=HeadlessDevelopRunner(develop_fn=fake_develop))
+    run_ref = await dispatcher.dispatch(
+        workspace_id=WS,
+        mandate_id="m1",
+        shift_no=1,
+        plan_action_id="plan-act-1",
+        index=1,
+        task={"title": "Add hello", "why": "demo", "expected_outcome": "ok", "requested_by": "u1"},
+    )
+
+    action = await store.get_action(run_ref)
+    assert action is not None
+    cc = action.parameters["_code_change"]
+    # The dispatch produced a real pending diff — NOT a queued placeholder.
+    assert cc["diff"] == CANNED_DIFF
+    assert cc["base_branch"] == "dev"
+    assert cc["station_pending"] is False
+    assert action.status == ActionStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# SELECTION — POCKETPAW_MANDATE_DISPATCHER=headless selects the headless
+# dispatcher when a production develop loop is wired, else degrades to the
+# queued-run station dispatcher (the autonomous path is strictly opt-in).
+# ---------------------------------------------------------------------------
+
+
+def test_headless_selection_requires_wired_develop_loop(monkeypatch):
+    import pocketpaw_ee.cloud.belt.headless as headless_mod
+    import pocketpaw_ee.cloud.mandates.executor as ex
+
+    monkeypatch.setenv("POCKETPAW_MANDATE_DISPATCHER", "headless")
+
+    # No develop loop wired → falls back to the queued-run station dispatcher.
+    headless_mod.set_production_develop_fn(None)
+    assert isinstance(ex.resolve_dispatcher(), ex.StationTaskDispatcher)
+
+    # Wire a (fake) develop loop → the headless dispatcher is selected.
+    async def fake_develop(req: DevelopRequest) -> DevelopResult:
+        return DevelopResult(diff=CANNED_DIFF, base_branch="main")
+
+    headless_mod.set_production_develop_fn(fake_develop)
+    try:
+        assert isinstance(ex.resolve_dispatcher(), HeadlessTaskDispatcher)
+    finally:
+        headless_mod.set_production_develop_fn(None)
+
+
+def test_headless_resolve_returns_none_when_unwired():
+    import pocketpaw_ee.cloud.belt.headless as headless_mod
+
+    headless_mod.set_production_develop_fn(None)
+    assert headless_mod.resolve_headless_dispatcher() is None
+
+
+# ---------------------------------------------------------------------------
+# END-TO-END — the headless-produced diff is a GENUINELY applyable run: after a
+# human approves it, the REAL belt executor applies it to a real git repo. This
+# proves the whole point — the human was removed from PRODUCING the diff, NOT
+# from approving it, and the produced diff really lands through the existing gate.
+# ---------------------------------------------------------------------------
+
+_PATH = os.environ.get("PATH", "/usr/bin:/bin")
+
+
+def _git(cwd: Path, *args: str) -> str:
+    res = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            "GIT_AUTHOR_NAME": "Belt Test",
+            "GIT_AUTHOR_EMAIL": "belt@test.local",
+            "GIT_COMMITTER_NAME": "Belt Test",
+            "GIT_COMMITTER_EMAIL": "belt@test.local",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "PATH": _PATH,
+            "HOME": str(cwd),
+        },
+    )
+    return res.stdout
+
+
+# A diff that applies cleanly to the seeded ``app.py`` (matches the gate test's
+# local_repo fixture: ``def hello():\n    return 'hi'\n``).
+_APP_DIFF = """\
+diff --git a/app.py b/app.py
+index 0000000..1111111 100644
+--- a/app.py
++++ b/app.py
+@@ -1,2 +1,2 @@
+ def hello():
+-    return 'hi'
++    return 'bye'
+"""
+
+
+@pytest.fixture
+def local_repo(tmp_path: Path) -> Path:
+    """A git repo with NO origin — mirrors the gate test's local-only fixture so
+    the executor lands the change locally (no push/PR) without network."""
+    if shutil.which("git") is None:  # pragma: no cover - CI always has git
+        pytest.skip("git not available")
+    work = tmp_path / "local-work"
+    work.mkdir()
+    _git(work, "init")
+    _git(work, "config", "user.name", "Belt Test")
+    _git(work, "config", "user.email", "belt@test.local")
+    (work / "app.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
+    _git(work, "add", "app.py")
+    _git(work, "commit", "-m", "init")
+    _git(work, "branch", "-M", "main")
+    return work
+
+
+@pytest.fixture
+def allowlist(local_repo: Path, monkeypatch):
+    """Point belt_repo_allowlist at the repo's parent so the executor's
+    re-resolve passes."""
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+
+    class _S:
+        belt_repo_allowlist = [str(local_repo.parent)]
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+
+async def test_headless_diff_applies_after_human_approval(
+    store: InstinctStore, local_repo: Path, allowlist
+):
+    from pocketpaw_ee.cloud.belt.executor import execute_approved_change
+
+    action_id = await _queue_station_run(store, repo=str(local_repo))
+
+    async def fake_develop(req: DevelopRequest) -> DevelopResult:
+        return DevelopResult(diff=_APP_DIFF, base_branch="main", summary="flip the greeting")
+
+    await HeadlessDevelopRunner(develop_fn=fake_develop).run(action_id)
+
+    produced = await store.get_action(action_id)
+    assert produced is not None
+    assert produced.status == ActionStatus.PENDING  # still gated
+
+    # The human approves (the per-diff gate). ONLY THEN does the executor apply.
+    await store.approve(produced.id)
+    approved = await store.get_action(produced.id)
+    await execute_approved_change(approved)
+
+    landed = await store.get_action(produced.id)
+    assert landed is not None
+    assert landed.status == ActionStatus.EXECUTED, landed.error
+    # A real belt branch was created carrying the headless-produced change.
+    branches = _git(local_repo, "branch", "--list", "feat/belt-*")
+    assert branches.strip(), "expected a feat/belt-* branch from the applied diff"


### PR DESCRIPTION
## What

A headless develop runner so an approved mandate task can produce a diff without a human driving the interactive `/belt` session. Today the default dispatcher files a `code_change` Instinct action in a queued state (`station_pending=True`, no diff) and waits for a person to open `/belt` and write the change by hand. This adds a `HeadlessTaskDispatcher` (selectable via `POCKETPAW_MANDATE_DISPATCHER=headless`) that files the queued run, then runs a develop function to generate the diff and attaches it to the action — clearing `station_pending` and leaving a real diff **pending the per-diff Instinct gate**.

## What this does NOT do

It does not remove the human gate. The runner never approves or executes; it only produces the diff. The existing apply-on-approve path (`belt/executor.py`: git worktree, `git apply --3way`, PR) still runs only after a human approves. A test asserts the produced action is `pending` with `approved_by is None` and is not auto-executed. The interactive station path and the announce-only path are untouched.

## Honest limitation — read before merging

The diff-generation step is an injectable `DevelopFn` Protocol. In tests it's a deterministic fake that returns a canned diff. **The real production develop loop (the LLM that actually writes the code) is not wired in this PR** — `set_production_develop_fn` is the seam for it, and with nothing wired the dispatcher correctly **degrades to the interactive station**. So this PR ships the wiring, the dispatcher selection, and the gate-preservation guarantees with full test coverage; it does not yet autonomously write code in production. Wiring a real `DevelopFn` is the follow-up that makes the loop genuinely hands-off.

## Tests

`uv run pytest tests/cloud/test_belt_headless.py tests/cloud/test_belt_mandates.py tests/cloud/test_belt_gate.py -q` → 32 passed. Written test-first. Covers: canned diff → real pending diff with `station_pending` cleared and not auto-approved; gate preserved; `DevelopFn` raising leaves the run safe (queued, no diff, no crash); empty diff is a no-op; dispatcher selection wired vs unwired; and an end-to-end test that approves the headless diff and runs the real executor against a local git repo, landing a branch.

Captain reviews; not merging.