### PR TITLE
feat(fabric): multi-hop path traversal in the query layer

### DIFF
--- a/src/pocketpaw/fabric/models.py
+++ b/src/pocketpaw/fabric/models.py
@@ -1,10 +1,23 @@
 # Fabric data models — Pydantic models for the ontology layer.
 # Created: 2026-03-28
+# Updated: 2026-06-13 (feat/fabric-multihop) — Added multi-hop / path traversal
+#   to FabricQuery. A new PathHop model expresses ONE traversal step (a
+#   link_type, an optional terminal object_type, an optional property-filter
+#   bag, and a direction); FabricQuery gains an additive ``path: list[PathHop]``
+#   field. When ``path`` is set, the query walks the link chain server-side and
+#   returns the objects at the terminal hop — the 2-hop ontology join (e.g.
+#   "open Deals whose Customer competes_with a Competitor") that previously had
+#   to be hand-stitched as separate get_linked_objects calls in app code. The
+#   existing single-hop ``linked_to``/``link_type`` fields are untouched and
+#   keep working exactly as before (backward compatible). Each hop traverses
+#   the named link in the FORWARD direction by default (from_object_id ->
+#   to_object_id, the direction store.link() records), with an explicit
+#   ``direction="in"`` for reverse traversal.
 
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -67,14 +80,59 @@ class FabricLink(BaseModel):
     created_at: datetime = Field(default_factory=datetime.now)
 
 
+class PathHop(BaseModel):
+    """One step in a multi-hop traversal across the Fabric link graph.
+
+    A hop says: from the objects reached so far, follow links of ``link_type``
+    to the objects on the other end, optionally constraining those objects to a
+    given ``object_type`` and/or matching a property ``filters`` bag.
+
+    ``direction`` controls how the named link is read relative to the current
+    frontier:
+
+    - ``"out"`` (default) — follow ``from_object_id -> to_object_id``. This is
+      the direction ``store.link(from_id, to_id, link_type)`` records, so it
+      reads as "the current object HAS this link to the next object" (Deal
+      --deal_for--> Customer).
+    - ``"in"`` — follow ``to_object_id -> from_object_id`` (reverse).
+    - ``"any"`` — match the link in either direction (the symmetric semantics
+      the legacy single-hop ``linked_to`` uses).
+
+    ``filters`` reuses the exact ``FabricQuery.filters`` shape (scalar =
+    equality, operator-map = comparison) so the same parser applies at every
+    hop.
+    """
+
+    link_type: str
+    object_type: str | None = None
+    filters: dict[str, Any] = Field(default_factory=dict)
+    direction: Literal["out", "in", "any"] = "out"
+
+
 class FabricQuery(BaseModel):
-    """Query parameters for finding objects."""
+    """Query parameters for finding objects.
+
+    Single-hop traversal (legacy, unchanged): set ``linked_to`` (+ optional
+    ``link_type``) to find objects linked to a given object id.
+
+    Multi-hop / path traversal (additive): set ``linked_to`` as the START
+    object id and ``path`` to a list of :class:`PathHop` steps. The query walks
+    the chain server-side and returns the objects reached at the FINAL hop (with
+    that hop's ``object_type`` / ``filters`` applied). Top-level ``type_name`` /
+    ``type_id`` / ``filters`` still constrain the terminal result set too, so
+    "open Deals whose Customer competes_with a Competitor" is a single query:
+    start at the Competitor, walk back, or start at the Deals and walk out — see
+    ``FabricStore.query`` for the traversal contract. ``path`` and the legacy
+    single-hop ``link_type`` are mutually exclusive (``path`` wins when both are
+    present, and ``link_type`` is ignored — the per-hop ``link_type`` governs).
+    """
 
     type_name: str | None = None
     type_id: str | None = None
     filters: dict[str, Any] = Field(default_factory=dict)
     linked_to: str | None = None
     link_type: str | None = None
+    path: list[PathHop] = Field(default_factory=list)
     limit: int = 50
     offset: int = 0
 

--- a/src/pocketpaw/fabric/models.py
+++ b/src/pocketpaw/fabric/models.py
@@ -13,13 +13,27 @@
 #   the named link in the FORWARD direction by default (from_object_id ->
 #   to_object_id, the direction store.link() records), with an explicit
 #   ``direction="in"`` for reverse traversal.
+# Updated: 2026-06-13 (review fixes #1465) — bounded the path: FabricQuery.path
+#   is capped at MAX_HOPS (5) by a field_validator that rejects a longer path
+#   with a clear ValueError (an unbounded, cycle-blind iterative walk is a
+#   latency / infinite-loop risk); PathHop.link_type carries Field(max_length=200)
+#   as a sanity bound on an LLM-facing string (values are already bound params,
+#   so this is hygiene, not injection defense).
 
 from __future__ import annotations
 
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# Cap on path depth (number of hops) for a multi-hop FabricQuery. A path is
+# resolved iteratively, one DB round-trip per hop, with no cycle de-duplication
+# across hops — so an unbounded path is both a latency risk and a way to walk a
+# cyclic graph forever. Five hops covers every join the ontology layer needs in
+# practice (the audit's hardest case is two); anything deeper is almost
+# certainly a mistake and is rejected up front with a clear error.
+MAX_HOPS = 5
 
 
 def _gen_id(prefix: str) -> str:
@@ -103,7 +117,7 @@ class PathHop(BaseModel):
     hop.
     """
 
-    link_type: str
+    link_type: str = Field(max_length=200)
     object_type: str | None = None
     filters: dict[str, Any] = Field(default_factory=dict)
     direction: Literal["out", "in", "any"] = "out"
@@ -135,6 +149,24 @@ class FabricQuery(BaseModel):
     path: list[PathHop] = Field(default_factory=list)
     limit: int = 50
     offset: int = 0
+
+    @field_validator("path")
+    @classmethod
+    def _cap_path_depth(cls, value: list[PathHop]) -> list[PathHop]:
+        """Reject a path deeper than ``MAX_HOPS``.
+
+        The walk in ``FabricStore.query`` is iterative and does NOT de-duplicate
+        visited objects across hops, so a long (or cyclic-graph) path is a
+        latency / runaway risk. Cap it at the model boundary with a clear error
+        — the agent tool's outer ``except`` turns this ValueError into a readable
+        message the LLM can act on, rather than letting it reach the DB.
+        """
+        if len(value) > MAX_HOPS:
+            raise ValueError(
+                f"path has {len(value)} hops; the maximum is {MAX_HOPS}. "
+                "Express the join with fewer hops."
+            )
+        return value
 
 
 class FabricQueryResult(BaseModel):

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -89,6 +89,16 @@
 #   remain bound parameters; only fixed SQL fragments are concatenated. The
 #   single-hop linked_to/link_type path is UNTOUCHED (backward compatible) —
 #   path and the legacy single-hop are mutually exclusive (path wins).
+# Updated: 2026-06-13 (review fixes #1465) — bounded the traversal so it can't
+#   crash SQLite or run away: (1) MAX_FRONTIER (500) guards _advance_hop on entry
+#   AND the terminal re-fetch, raising a clear ValueError before a frontier IN-
+#   list could exceed SQLite's 999 bound-variable limit (path depth itself is
+#   capped at MAX_HOPS=5 by the FabricQuery validator). (2) the terminal re-fetch
+#   now carries the same (workspace_id = ? OR workspace_id IS NULL) scope as the
+#   single-hop query()'s SELECT — defense-in-depth; the frontier ids are already
+#   tenant-scoped per hop, so this changes no result, it just makes the last read
+#   self-guarding. Walk is iterative, fixed-depth, no cross-hop cycle re-visit
+#   (see the note in _query_path).
 
 
 from __future__ import annotations
@@ -111,6 +121,17 @@ from pocketpaw.fabric.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Hard cap on the working set during a multi-hop traversal. The per-hop query
+# binds one ``?`` per frontier id in a ``WHERE l.<col> IN (?, ?, …)`` list; left
+# unbounded a frontier of thousands would blow past SQLite's 999-bound-variable
+# limit (SQLITE_MAX_VARIABLE_NUMBER) with an OperationalError, and a wide fan-out
+# is a latency / memory risk regardless. 500 keeps every per-hop and terminal
+# IN-list comfortably under 999 (500 ids + link_type + a few filter params) while
+# covering any realistic ontology join. A frontier that exceeds it raises a clear
+# ValueError, which the agent tool turns into a readable message — much better
+# than a raw SQLite crash.
+MAX_FRONTIER = 500
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS fabric_object_types (
@@ -891,6 +912,15 @@ class FabricStore:
         re-fetched as full objects (newest-first, paginated). Every step is
         tenant-scoped (W4a) and every value is a bound parameter.
         """
+        # Walk properties: the traversal is ITERATIVE (one DB round-trip per
+        # hop, frontier threaded forward), FIXED-DEPTH (len(q.path) hops, capped
+        # at MAX_HOPS by the FabricQuery validator), and does NOT track visited
+        # objects across hops — there is no cycle re-visit suppression, so a
+        # cyclic graph relies on MAX_HOPS + MAX_FRONTIER to stay bounded rather
+        # than on de-duplication. Each hop's frontier is a set, so duplicates
+        # WITHIN a single hop's output collapse; revisiting an object on a LATER
+        # hop is allowed (and meaningful — A may legitimately be both 2 and 4
+        # hops from the seed).
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
 
@@ -933,17 +963,36 @@ class FabricStore:
             if not frontier:
                 return FabricQueryResult(objects=[], total=0)
 
+            # Guard the terminal frontier too: a wide fan-out on the LAST hop is
+            # only checked by _advance_hop on the NEXT hop's entry, which never
+            # comes. Keep the terminal IN-list under SQLite's variable limit.
+            if len(frontier) > MAX_FRONTIER:
+                raise ValueError(
+                    f"multi-hop result reached {len(frontier)} objects, "
+                    f"exceeding the cap of {MAX_FRONTIER}. Narrow the path with a "
+                    "more selective start filter or a terminal object_type."
+                )
+
             # --- Re-fetch the terminal frontier as full objects -------------
             # Bound the IN-list with placeholders (ids are server-generated, but
-            # parameterize anyway — never interpolate). Newest-first + paginate
-            # to match the single-hop query()'s ordering contract.
+            # parameterize anyway — never interpolate). The frontier was already
+            # tenant-scoped at every hop, so the terminal ids cannot belong to
+            # another workspace; the scope clause below is defense-in-depth that
+            # mirrors the single-hop query()'s terminal SELECT exactly. Newest-
+            # first + paginate to match the single-hop ordering contract.
             terminal_ids = list(frontier)
             placeholders = ",".join("?" for _ in terminal_ids)
             total = len(terminal_ids)
+            term_params: list[Any] = [*terminal_ids]
+            ws_cond, ws_params = _workspace_scope(workspace_id, column="o.workspace_id")
+            ws_clause = f" AND {ws_cond}" if ws_cond else ""
+            if ws_cond:
+                term_params.extend(ws_params)
             async with db.execute(
                 f"SELECT o.* FROM fabric_objects o WHERE o.id IN ({placeholders})"
+                f"{ws_clause}"
                 " ORDER BY o.created_at DESC LIMIT ? OFFSET ?",
-                [*terminal_ids, q.limit, q.offset],
+                [*term_params, q.limit, q.offset],
             ) as cur:
                 objects = [self._row_to_object(row) async for row in cur]
 
@@ -965,7 +1014,17 @@ class FabricStore:
         ``object_type`` / ``filters`` / W4a tenant scope are applied to the FAR
         object — the one that becomes the new frontier and is eventually
         returned.
+
+        Raises ``ValueError`` if the incoming frontier exceeds ``MAX_FRONTIER`` —
+        the IN-list would otherwise risk SQLite's bound-variable limit. The
+        caller (the agent tool) renders this as a clean error string.
         """
+        if len(frontier) > MAX_FRONTIER:
+            raise ValueError(
+                f"multi-hop frontier reached {len(frontier)} objects, "
+                f"exceeding the cap of {MAX_FRONTIER}. Narrow the path with a "
+                "more selective start filter or an earlier object_type."
+            )
         near_ids = list(frontier)
         near_ph = ",".join("?" for _ in near_ids)
 

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -72,6 +72,23 @@
 #   workspace_id column on fabric_object_types), but which types a tenant sees
 #   is tenant metadata. workspace_id=None keeps the original unscoped behavior
 #   (OSS / registry-tool / single-tenant callers).
+# Updated: 2026-06-13 (feat/fabric-multihop) — query() now supports multi-hop /
+#   path traversal. When FabricQuery.path is non-empty it walks an ontology join
+#   server-side instead of the single linked_to hop: the audit's 2-hop query
+#   ("open Deals whose Customer competes_with a Competitor") that returned [] as
+#   one query and had to be hand-stitched as two get_linked_objects calls is now
+#   ONE call. New _query_path() resolves a START frontier (the linked_to seed, or
+#   every object matching the top-level type/filters when linked_to is absent),
+#   then _advance_hop() steps the frontier one PathHop at a time across
+#   fabric_links — each hop applies its direction (out/in/any), link_type,
+#   terminal object_type, property filters, AND the W4a workspace scope to the
+#   FAR object. Iterative per-hop resolution (one parameterized query per hop)
+#   was chosen over a recursive CTE: per-hop type+property+direction+tenant
+#   filters stay simple and injection-safe as a normal parameterized WHERE, and
+#   paths are shallow (2-3 hops). All link_type / object_type / filter values
+#   remain bound parameters; only fixed SQL fragments are concatenated. The
+#   single-hop linked_to/link_type path is UNTOUCHED (backward compatible) —
+#   path and the legacy single-hop are mutually exclusive (path wins).
 
 
 from __future__ import annotations
@@ -89,6 +106,7 @@ from pocketpaw.fabric.models import (
     FabricQuery,
     FabricQueryResult,
     ObjectType,
+    PathHop,
     PropertyDef,
 )
 
@@ -757,7 +775,41 @@ class FabricStore:
         sets on the query body. When supplied, results are restricted to that
         workspace (plus legacy NULL-workspace rows). When ``None``, the query is
         unscoped, exactly as before W4a (OSS / agent-tool callers).
+
+        Multi-hop / path traversal (feat/fabric-multihop): when ``q.path`` is
+        non-empty the query walks an ontology join server-side instead of doing
+        the single ``linked_to`` hop. This is the 2-hop join the code audit
+        flagged ("open Deals whose Customer competes_with a Competitor") that
+        previously returned [] from one query and had to be hand-stitched in app
+        code. The traversal contract:
+
+        - START frontier: the seed object set the path walks from. If
+          ``linked_to`` is set, the seed is exactly that one object id. Otherwise
+          the seed is every object matching the top-level ``type_name`` /
+          ``type_id`` / ``filters`` (e.g. the open Deals), so a path can read
+          "from these objects, walk out…".
+        - Each :class:`PathHop` advances the frontier one edge across
+          ``fabric_links`` in the hop's ``direction`` (out / in / any), keeping
+          only objects that match the hop's ``object_type`` and ``filters``.
+        - The RESULT is the objects at the terminal hop, constrained by that
+          hop's type/filters. Top-level type/filters constrain the START, not
+          the terminal (the terminal is described by the final hop).
+        - Tenant scope (W4a) is applied at EVERY hop AND on the seed, so a linked
+          object in another workspace can never be reached or returned.
+
+        Implementation note: an ITERATIVE per-hop frontier resolution (one
+        parameterized query per hop, threading the id set forward) was chosen
+        over a recursive CTE. Per-hop type + property + direction + tenant
+        filters are far simpler to express and keep injection-safe as a normal
+        parameterized WHERE per hop than as a single recursive CTE, and the path
+        depth here is small (2-3 hops). All link_type / object_type / filter
+        values remain bound ``?`` parameters; only fixed SQL fragments are
+        concatenated.
         """
+        await self._ensure_schema()
+        if q.path:
+            return await self._query_path(q, workspace_id)
+
         conditions: list[str] = []
         params: list[Any] = []
 
@@ -829,6 +881,139 @@ class FabricStore:
                 objects = [self._row_to_object(row) async for row in cur]
 
         return FabricQueryResult(objects=objects, total=total)
+
+    async def _query_path(self, q: FabricQuery, workspace_id: str | None) -> FabricQueryResult:
+        """Walk ``q.path`` server-side and return the terminal-hop objects.
+
+        See :meth:`query` for the full traversal contract. Iterative per-hop
+        frontier resolution: resolve the START frontier (the seed object ids),
+        then advance it one :class:`PathHop` at a time; the terminal frontier is
+        re-fetched as full objects (newest-first, paginated). Every step is
+        tenant-scoped (W4a) and every value is a bound parameter.
+        """
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+
+            # --- START frontier ---------------------------------------------
+            # linked_to => exactly that one seed object (still tenant-scoped, so
+            # a cross-tenant seed id resolves to nothing). Otherwise the seed is
+            # every object matching the top-level type/filters.
+            if q.linked_to:
+                seed_cond = ["o.id = ?"]
+                seed_params: list[Any] = [q.linked_to]
+            else:
+                seed_cond = []
+                seed_params = []
+                if q.type_id:
+                    seed_cond.append("o.type_id = ?")
+                    seed_params.append(q.type_id)
+                elif q.type_name:
+                    seed_cond.append("LOWER(o.type_name) = LOWER(?)")
+                    seed_params.append(q.type_name)
+                if q.filters:
+                    fconds, fparams = _build_filter_conditions(q.filters)
+                    seed_cond.extend(fconds)
+                    seed_params.extend(fparams)
+            ws_cond, ws_params = _workspace_scope(workspace_id, column="o.workspace_id")
+            if ws_cond:
+                seed_cond.append(ws_cond)
+                seed_params.extend(ws_params)
+            seed_where = f"WHERE {' AND '.join(seed_cond)}" if seed_cond else ""
+            async with db.execute(
+                f"SELECT o.id FROM fabric_objects o {seed_where}", seed_params
+            ) as cur:
+                frontier = {row["id"] async for row in cur}
+
+            # --- Advance one hop at a time ----------------------------------
+            for hop in q.path:
+                if not frontier:
+                    break  # dead end — no path can revive an empty frontier
+                frontier = await self._advance_hop(db, frontier, hop, workspace_id)
+
+            if not frontier:
+                return FabricQueryResult(objects=[], total=0)
+
+            # --- Re-fetch the terminal frontier as full objects -------------
+            # Bound the IN-list with placeholders (ids are server-generated, but
+            # parameterize anyway — never interpolate). Newest-first + paginate
+            # to match the single-hop query()'s ordering contract.
+            terminal_ids = list(frontier)
+            placeholders = ",".join("?" for _ in terminal_ids)
+            total = len(terminal_ids)
+            async with db.execute(
+                f"SELECT o.* FROM fabric_objects o WHERE o.id IN ({placeholders})"
+                " ORDER BY o.created_at DESC LIMIT ? OFFSET ?",
+                [*terminal_ids, q.limit, q.offset],
+            ) as cur:
+                objects = [self._row_to_object(row) async for row in cur]
+
+        return FabricQueryResult(objects=objects, total=total)
+
+    async def _advance_hop(
+        self,
+        db: aiosqlite.Connection,
+        frontier: set[str],
+        hop: PathHop,
+        workspace_id: str | None,
+    ) -> set[str]:
+        """Return the next frontier: objects reached from ``frontier`` via ``hop``.
+
+        One parameterized query. The direction decides which link endpoint is
+        the "near" side (matched against the current frontier) and which is the
+        "far" side (the object reached). ``"any"`` matches the link in either
+        orientation (the legacy single-hop symmetric semantics). Per-hop
+        ``object_type`` / ``filters`` / W4a tenant scope are applied to the FAR
+        object — the one that becomes the new frontier and is eventually
+        returned.
+        """
+        near_ids = list(frontier)
+        near_ph = ",".join("?" for _ in near_ids)
+
+        # near/far endpoint columns by direction. The current frontier is the
+        # NEAR end; the object we step to is the FAR end.
+        #   out: frontier is from_object_id -> step to to_object_id
+        #   in : frontier is to_object_id   -> step to from_object_id
+        #   any: union of both orientations
+        if hop.direction == "out":
+            orientations = [("from_object_id", "to_object_id")]
+        elif hop.direction == "in":
+            orientations = [("to_object_id", "from_object_id")]
+        else:  # "any"
+            orientations = [("from_object_id", "to_object_id"), ("to_object_id", "from_object_id")]
+
+        # Far-object filters (type + property + tenant) are shared across the
+        # orientation union, so build them once.
+        far_conds: list[str] = []
+        far_params: list[Any] = []
+        if hop.object_type:
+            far_conds.append("LOWER(o.type_name) = LOWER(?)")
+            far_params.append(hop.object_type)
+        if hop.filters:
+            fconds, fparams = _build_filter_conditions(hop.filters)
+            far_conds.extend(fconds)
+            far_params.extend(fparams)
+        ws_cond, ws_params = _workspace_scope(workspace_id, column="o.workspace_id")
+        if ws_cond:
+            far_conds.append(ws_cond)
+            far_params.extend(ws_params)
+        far_where = (" AND " + " AND ".join(far_conds)) if far_conds else ""
+
+        next_frontier: set[str] = set()
+        for near_col, far_col in orientations:
+            # Join the link's FAR endpoint to fabric_objects so the far-object
+            # type/property/tenant filters apply. link_type is a bound param.
+            sql = (
+                f"SELECT o.id FROM fabric_links l"
+                f" JOIN fabric_objects o ON o.id = l.{far_col}"
+                f" WHERE l.{near_col} IN ({near_ph})"
+                f" AND l.link_type = ?"
+                f"{far_where}"
+            )
+            params = [*near_ids, hop.link_type, *far_params]
+            async with db.execute(sql, params) as cur:
+                async for row in cur:
+                    next_frontier.add(row["id"])
+        return next_frontier
 
     # --- Stats ---
 

--- a/src/pocketpaw/tools/builtin/fabric_tools.py
+++ b/src/pocketpaw/tools/builtin/fabric_tools.py
@@ -5,6 +5,16 @@
 #   "leases where rent > X" actually filter. Previously the tool advertised
 #   property filtering but never accepted or forwarded filters, so the store
 #   (which also ignored them) returned every object of the type.
+# Updated: 2026-06-13 (feat/fabric-multihop) — FabricQueryTool now exposes a
+#   `path` parameter for multi-hop ontology joins. Previously the tool only
+#   advertised the single-hop `linked_to`/`link_type` traversal, so an LLM
+#   asking "which open Deals link to a Customer that competes_with a Competitor"
+#   could only reach the first hop and had to chain two tool calls in app logic.
+#   `path` is a list of hop dicts ({link_type, object_type?, filters?,
+#   direction?}) forwarded as FabricQuery.path; the store walks the join in ONE
+#   server-side query. Hops are validated into PathHop models (a bad hop returns
+#   a clear error string rather than raising). The single-hop params are
+#   unchanged and keep working.
 
 import logging
 from typing import Any
@@ -91,6 +101,25 @@ class FabricQueryTool(BaseTool):
                         "stored property to be a number."
                     ),
                 },
+                "path": {
+                    "type": "array",
+                    "description": (
+                        "Multi-hop ontology join. A list of traversal steps; the query "
+                        "walks the chain server-side and returns the objects at the FINAL "
+                        "hop. Set 'linked_to' to the START object id (or omit it and use "
+                        "'type_name'/'filters' to start from a SET of objects). Each step "
+                        "is an object: {'link_type' (required), 'object_type' (optional, "
+                        "constrain the reached objects' type), 'filters' (optional, same "
+                        "shape as the top-level filters), 'direction' (optional: 'out' "
+                        "follows the link forward from->to [default], 'in' follows it "
+                        "backward, 'any' matches either way)}. Example — open Deals whose "
+                        "Customer competes_with a Competitor, starting from the competitor "
+                        "id: [{'link_type':'competes_with','object_type':'Customer',"
+                        "'direction':'in'},{'link_type':'deal_for','object_type':'Deal',"
+                        "'direction':'in','filters':{'stage':'open'}}]."
+                    ),
+                    "items": {"type": "object"},
+                },
                 "limit": {
                     "type": "integer",
                     "description": "Max results (default: 20)",
@@ -105,6 +134,7 @@ class FabricQueryTool(BaseTool):
         linked_to: str | None = None,
         link_type: str | None = None,
         filters: dict[str, Any] | None = None,
+        path: list[dict[str, Any]] | None = None,
         limit: int = 20,
     ) -> str:
         store = _get_fabric_store()
@@ -112,7 +142,20 @@ class FabricQueryTool(BaseTool):
             return "Fabric is not available (enterprise feature)."
 
         try:
-            from pocketpaw.fabric.models import FabricQuery
+            from pocketpaw.fabric.models import FabricQuery, PathHop
+
+            # Validate each hop into a PathHop. A malformed hop (unknown
+            # direction, missing link_type) becomes a clear error string rather
+            # than a 500 — the LLM can read it and retry.
+            hops: list[PathHop] = []
+            if path:
+                for i, raw_hop in enumerate(path):
+                    if not isinstance(raw_hop, dict):
+                        return f"path[{i}] must be an object with at least a 'link_type'."
+                    try:
+                        hops.append(PathHop(**raw_hop))
+                    except Exception as exc:  # pydantic ValidationError or TypeError
+                        return f"Invalid path hop at index {i}: {exc}"
 
             result = await store.query(
                 FabricQuery(
@@ -120,6 +163,7 @@ class FabricQueryTool(BaseTool):
                     linked_to=linked_to,
                     link_type=link_type,
                     filters=filters or {},
+                    path=hops,
                     limit=min(limit, 50),
                 )
             )
@@ -134,7 +178,18 @@ class FabricQueryTool(BaseTool):
             )
 
             if not result.objects:
-                query_desc = type_name or f"linked to {linked_to}" or "all"
+                if hops:
+                    hop_desc = " -> ".join(
+                        h.link_type + (f"[{h.object_type}]" if h.object_type else "") for h in hops
+                    )
+                    start_desc = f"from {linked_to}" if linked_to else (type_name or "all objects")
+                    query_desc = f"{start_desc} via {hop_desc}"
+                elif type_name:
+                    query_desc = type_name
+                elif linked_to:
+                    query_desc = f"linked to {linked_to}"
+                else:
+                    query_desc = "all"
                 return f"No objects found matching: {query_desc}"
 
             lines = [f"Found {result.total} object(s):\n"]

--- a/src/pocketpaw/tools/builtin/fabric_tools.py
+++ b/src/pocketpaw/tools/builtin/fabric_tools.py
@@ -15,6 +15,12 @@
 #   server-side query. Hops are validated into PathHop models (a bad hop returns
 #   a clear error string rather than raising). The single-hop params are
 #   unchanged and keep working.
+# Updated: 2026-06-13 (review fixes #1465) — the path bounds added on the store
+#   side (MAX_HOPS path-depth cap on FabricQuery, MAX_FRONTIER fan-out guard in
+#   the walk) both raise ValueError; the FabricQuery construction and store.query
+#   call sit inside this tool's try/except, so a too-deep path or a runaway
+#   fan-out surfaces as a readable "Error querying Fabric: …" string the LLM can
+#   act on — never a raised exception or a raw SQLite crash.
 
 import logging
 from typing import Any

--- a/tests/cloud/test_critical_gaps.py
+++ b/tests/cloud/test_critical_gaps.py
@@ -3,6 +3,11 @@
 # Updated: 2026-06-10 (W0d) — Added test_fabric_query_forwards_filters: the
 #   FabricQueryTool must forward its `filters` arg into FabricQuery so chat-driven
 #   property filters ("rent > X") narrow results instead of returning all objects.
+# Updated: 2026-06-13 (feat/fabric-multihop) — Added test_fabric_query_forwards_path
+#   and test_fabric_query_rejects_bad_hop: the FabricQueryTool must forward its
+#   new `path` arg into FabricQuery.path so an LLM can issue the 2-hop ontology
+#   join (open Deals -> Customer -> Competitor) as ONE tool call, and must turn a
+#   malformed hop into a readable error string rather than raising.
 
 from __future__ import annotations
 
@@ -181,6 +186,67 @@ class TestFabricTools:
         assert "Found 1" in result
         assert "Globex" in result
         assert "Acme" not in result
+
+    @pytest.mark.asyncio
+    async def test_fabric_query_forwards_path(self, tmp_path):
+        # feat/fabric-multihop: the agent tool must forward `path` into
+        # FabricQuery.path so an LLM issues the 2-hop join as ONE call. Real
+        # store so the whole tool -> FabricQuery -> store.query path runs.
+        from pocketpaw.fabric.store import FabricStore
+        from pocketpaw.tools.builtin.fabric_tools import FabricQueryTool
+
+        store = FabricStore(tmp_path / "fabric.db")
+        deal_t = await store.define_type(name="Deal", properties=[])
+        cust_t = await store.define_type(name="Customer", properties=[])
+        comp_t = await store.define_type(name="Competitor", properties=[])
+        acme = await store.create_object(cust_t.id, {"name": "Acme"})
+        rival = await store.create_object(comp_t.id, {"name": "Rival Inc"})
+        open_deal = await store.create_object(deal_t.id, {"name": "Acme deal", "stage": "open"})
+        won_deal = await store.create_object(deal_t.id, {"name": "Won deal", "stage": "won"})
+        await store.link(open_deal.id, acme.id, "deal_for")
+        await store.link(won_deal.id, acme.id, "deal_for")
+        await store.link(acme.id, rival.id, "competes_with")
+
+        tool = FabricQueryTool()
+        with patch("pocketpaw.tools.builtin.fabric_tools._get_fabric_store", return_value=store):
+            # From the Competitor, walk back to the OPEN Deals via the Customer.
+            result = await tool.execute(
+                linked_to=rival.id,
+                path=[
+                    {"link_type": "competes_with", "object_type": "Customer", "direction": "in"},
+                    {
+                        "link_type": "deal_for",
+                        "object_type": "Deal",
+                        "direction": "in",
+                        "filters": {"stage": "open"},
+                    },
+                ],
+            )
+
+        assert "Found 1" in result
+        assert "Acme deal" in result
+        assert "Won deal" not in result
+
+    @pytest.mark.asyncio
+    async def test_fabric_query_rejects_bad_hop(self):
+        # A malformed hop (unknown direction) must surface a readable error, not
+        # raise — the LLM can read it and retry. No store call should happen.
+        from pocketpaw.tools.builtin.fabric_tools import FabricQueryTool
+
+        mock_store = MagicMock()
+        mock_store.query = AsyncMock()
+
+        tool = FabricQueryTool()
+        with patch(
+            "pocketpaw.tools.builtin.fabric_tools._get_fabric_store", return_value=mock_store
+        ):
+            result = await tool.execute(
+                linked_to="obj-x",
+                path=[{"link_type": "deal_for", "direction": "sideways"}],
+            )
+
+        assert "Invalid path hop at index 0" in result
+        mock_store.query.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_fabric_create_object(self):

--- a/tests/cloud/test_critical_gaps.py
+++ b/tests/cloud/test_critical_gaps.py
@@ -8,6 +8,10 @@
 #   new `path` arg into FabricQuery.path so an LLM can issue the 2-hop ontology
 #   join (open Deals -> Customer -> Competitor) as ONE tool call, and must turn a
 #   malformed hop into a readable error string rather than raising.
+# Updated: 2026-06-13 (review fixes #1465) — Added
+#   test_fabric_query_too_deep_path_returns_clean_error: a path deeper than
+#   MAX_HOPS is rejected at FabricQuery construction and surfaces through the
+#   tool as a clean error string (no store call, no raised exception).
 
 from __future__ import annotations
 
@@ -246,6 +250,29 @@ class TestFabricTools:
             )
 
         assert "Invalid path hop at index 0" in result
+        mock_store.query.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fabric_query_too_deep_path_returns_clean_error(self):
+        # review fixes #1465: a path deeper than MAX_HOPS is rejected when the
+        # FabricQuery is built (inside the tool's try), so it surfaces as a clean
+        # "Error querying Fabric" string rather than raising out of the tool.
+        from pocketpaw.fabric.models import MAX_HOPS
+        from pocketpaw.tools.builtin.fabric_tools import FabricQueryTool
+
+        mock_store = MagicMock()
+        mock_store.query = AsyncMock()
+
+        tool = FabricQueryTool()
+        with patch(
+            "pocketpaw.tools.builtin.fabric_tools._get_fabric_store", return_value=mock_store
+        ):
+            result = await tool.execute(
+                linked_to="obj-x",
+                path=[{"link_type": "rel"} for _ in range(MAX_HOPS + 1)],
+            )
+
+        assert "Error querying Fabric" in result
         mock_store.query.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/cloud/test_ee_fabric.py
+++ b/tests/cloud/test_ee_fabric.py
@@ -27,6 +27,16 @@
 #   stats/query consistency invariant (scoped stats["objects"] == scoped query
 #   total — the count mismatch that surfaced the bug), confirms legacy NULL rows
 #   stay visible, and that workspace_id=None keeps the instance-wide behavior.
+# Updated: 2026-06-13 (feat/fabric-multihop) — Added TestMultiHopPath: proves the
+#   2-hop ontology join the code audit flagged is now ONE server-side query.
+#   Reproduces the exact competitive-intel scenario — Deal --deal_for--> Customer
+#   --competes_with--> Competitor, filtered to open deals — that previously
+#   returned [] from a single query() and had to be hand-stitched as two
+#   get_linked_objects calls in app code. Also covers: property filters applied
+#   at the intended hop, terminal object_type constraint, per-hop tenant scoping
+#   (a linked object in another workspace must not leak across a hop), reverse
+#   ("in") and symmetric ("any") hop directions, and backward-compat (single-hop
+#   linked_to and an empty path behave exactly as before).
 
 from __future__ import annotations
 
@@ -36,7 +46,7 @@ from pathlib import Path
 import aiosqlite
 import pytest
 
-from pocketpaw.fabric.models import FabricQuery, PropertyDef
+from pocketpaw.fabric.models import FabricQuery, PathHop, PropertyDef
 from pocketpaw.fabric.store import FabricStore
 
 
@@ -640,3 +650,269 @@ class TestUpdateObjectWorkspaceScope:
         updated = await store.update_object(legacy.id, {"rent": 175}, workspace_id="ws-a")
         assert updated is not None
         assert updated.properties["rent"] == 175
+
+
+class TestMultiHopPath:
+    """Multi-hop / path traversal — the 2-hop ontology join in ONE query.
+
+    The code audit found that ``FabricStore.query()`` could only do ONE hop, so
+    the competitive-intel question "which open Deals link to a Customer that
+    ``competes_with`` a Competitor" returned [] as a single query and had to be
+    hand-stitched as two separate ``get_linked_objects`` calls in app code.
+    These tests pin the join as a single server-side query. The seed graph:
+
+        Deal(Acme deal, stage=open)   --deal_for-->   Customer(Acme)
+        Deal(Beta deal, stage=open)   --deal_for-->   Customer(Beta)
+        Deal(Won deal,  stage=won)    --deal_for-->   Customer(Acme)
+        Customer(Acme)  --competes_with-->  Competitor(Rival Inc)
+        (Customer(Beta) competes with nobody)
+
+    The 2-hop join from Competitor back to open Deals (or from Deals out to a
+    competing Customer) must return exactly the Acme open deal.
+    """
+
+    async def _seed(self, store: FabricStore, workspace_id: str | None = None):
+        """Build the audit graph. Returns a dict of the key objects/types."""
+        deal_t = await store.define_type(
+            name="Deal",
+            properties=[
+                PropertyDef(name="name", type="string"),
+                PropertyDef(name="stage", type="string"),
+            ],
+        )
+        cust_t = await store.define_type(name="Customer", properties=[])
+        comp_t = await store.define_type(name="Competitor", properties=[])
+
+        acme = await store.create_object(cust_t.id, {"name": "Acme"}, workspace_id=workspace_id)
+        beta = await store.create_object(cust_t.id, {"name": "Beta"}, workspace_id=workspace_id)
+        rival = await store.create_object(
+            comp_t.id, {"name": "Rival Inc"}, workspace_id=workspace_id
+        )
+
+        acme_deal = await store.create_object(
+            deal_t.id, {"name": "Acme deal", "stage": "open"}, workspace_id=workspace_id
+        )
+        beta_deal = await store.create_object(
+            deal_t.id, {"name": "Beta deal", "stage": "open"}, workspace_id=workspace_id
+        )
+        won_deal = await store.create_object(
+            deal_t.id, {"name": "Won deal", "stage": "won"}, workspace_id=workspace_id
+        )
+
+        # Deal --deal_for--> Customer (forward / "out")
+        await store.link(acme_deal.id, acme.id, "deal_for", workspace_id=workspace_id)
+        await store.link(beta_deal.id, beta.id, "deal_for", workspace_id=workspace_id)
+        await store.link(won_deal.id, acme.id, "deal_for", workspace_id=workspace_id)
+        # Customer --competes_with--> Competitor (forward / "out")
+        await store.link(acme.id, rival.id, "competes_with", workspace_id=workspace_id)
+
+        return {
+            "deal_t": deal_t,
+            "cust_t": cust_t,
+            "comp_t": comp_t,
+            "acme": acme,
+            "beta": beta,
+            "rival": rival,
+            "acme_deal": acme_deal,
+            "beta_deal": beta_deal,
+            "won_deal": won_deal,
+        }
+
+    @pytest.mark.asyncio
+    async def test_audit_scenario_two_hop_join_in_one_query(self, store: FabricStore) -> None:
+        """THE audit scenario: start at the Competitor, walk back to the OPEN
+        Deals whose Customer competes_with it — exactly the Acme open deal.
+
+        This is the query that returned [] before multi-hop. It walks:
+          Competitor(Rival) <--competes_with-- Customer <--deal_for-- Deal(open)
+        Each backward edge is a reverse ("in") hop; the terminal hop pins the
+        Deal type + stage=open filter.
+        """
+        g = await self._seed(store)
+
+        result = await store.query(
+            FabricQuery(
+                linked_to=g["rival"].id,
+                path=[
+                    # Competitor -> the Customers that compete_with it (reverse).
+                    PathHop(link_type="competes_with", object_type="Customer", direction="in"),
+                    # Customer -> the Deals that are deal_for it (reverse), open only.
+                    PathHop(
+                        link_type="deal_for",
+                        object_type="Deal",
+                        direction="in",
+                        filters={"stage": "open"},
+                    ),
+                ],
+            )
+        )
+
+        names = {o.properties["name"] for o in result.objects}
+        assert names == {"Acme deal"}
+        assert result.total == 1
+        # The won deal links to the same Customer but is filtered out by stage.
+        assert "Won deal" not in names
+        # The Beta deal's customer competes with nobody, so it never appears.
+        assert "Beta deal" not in names
+
+    @pytest.mark.asyncio
+    async def test_old_code_single_query_returns_empty(self, store: FabricStore) -> None:
+        """Documents the gap: the single-hop query CANNOT express the join.
+
+        ``linked_to=rival, link_type=competes_with`` reaches the Customer only
+        — never the Deal — so asking for Deals via that one hop is empty. This
+        is the exact shortfall the audit hit before ``path`` existed.
+        """
+        g = await self._seed(store)
+
+        one_hop = await store.query(
+            FabricQuery(
+                type_name="Deal",
+                linked_to=g["rival"].id,
+                link_type="competes_with",
+            )
+        )
+        # One hop from the Competitor lands on the Customer, which is not a Deal.
+        assert one_hop.total == 0
+
+    @pytest.mark.asyncio
+    async def test_forward_direction_from_deals_out(self, store: FabricStore) -> None:
+        """The same join read the other way: start at the open Deals, walk OUT
+        to a Customer, then OUT to a Competitor — keep only deals that reach one.
+
+        Returns the terminal Competitor here (the path's last hop is Competitor).
+        Proves forward ("out") traversal and that the START filter (open deals)
+        plus terminal type both apply.
+        """
+        await self._seed(store)
+
+        result = await store.query(
+            FabricQuery(
+                type_name="Deal",
+                filters={"stage": "open"},
+                # linked_to omitted -> start frontier is every object matching the
+                # top-level type/filters (open Deals), then walk the path out.
+                path=[
+                    PathHop(link_type="deal_for", object_type="Customer", direction="out"),
+                    PathHop(link_type="competes_with", object_type="Competitor", direction="out"),
+                ],
+            )
+        )
+        # Only Acme's open deal reaches a Competitor; terminal objects are the
+        # Competitor(s) reached -> Rival Inc, once.
+        names = {o.properties["name"] for o in result.objects}
+        assert names == {"Rival Inc"}
+
+    @pytest.mark.asyncio
+    async def test_property_filter_applies_at_intended_hop(self, store: FabricStore) -> None:
+        """Dropping the stage=open filter lets the won deal through too — proof
+        the filter is what excludes it, applied at the terminal (Deal) hop."""
+        g = await self._seed(store)
+
+        no_filter = await store.query(
+            FabricQuery(
+                linked_to=g["rival"].id,
+                path=[
+                    PathHop(link_type="competes_with", object_type="Customer", direction="in"),
+                    PathHop(link_type="deal_for", object_type="Deal", direction="in"),
+                ],
+            )
+        )
+        names = {o.properties["name"] for o in no_filter.objects}
+        assert names == {"Acme deal", "Won deal"}  # both Acme deals, no stage filter
+
+    @pytest.mark.asyncio
+    async def test_terminal_object_type_constrains_result(self, store: FabricStore) -> None:
+        """Without the terminal object_type, a hop returns whatever is on the
+        other end; with it, only matching-type objects survive."""
+        g = await self._seed(store)
+
+        # Hop once from the Competitor back along competes_with — reaches the
+        # Customer. Constrain to Customer: present. Constrain to Deal: empty.
+        as_customer = await store.query(
+            FabricQuery(
+                linked_to=g["rival"].id,
+                path=[PathHop(link_type="competes_with", object_type="Customer", direction="in")],
+            )
+        )
+        assert {o.properties["name"] for o in as_customer.objects} == {"Acme"}
+
+        as_deal = await store.query(
+            FabricQuery(
+                linked_to=g["rival"].id,
+                path=[PathHop(link_type="competes_with", object_type="Deal", direction="in")],
+            )
+        )
+        assert as_deal.total == 0
+
+    @pytest.mark.asyncio
+    async def test_tenant_scoping_holds_across_hops(self, store: FabricStore) -> None:
+        """A linked object in another workspace must not leak across a hop.
+
+        ws-a owns the full chain. ws-b owns a Competitor that an A-owned link
+        (mis)points at. An A-scoped 2-hop query must never surface ws-b's
+        objects, and a B-scoped query must not see ws-a's deal.
+        """
+        g = await self._seed(store, workspace_id="ws-a")
+
+        # A cross-tenant Competitor + a link from A's Customer into it. Even
+        # though the LINK is A-owned, the terminal object belongs to ws-b.
+        b_rival = await store.create_object(
+            g["comp_t"].id, {"name": "B Rival"}, workspace_id="ws-b"
+        )
+        await store.link(g["acme"].id, b_rival.id, "competes_with", workspace_id="ws-a")
+
+        # A-scoped: walk Deal(open) --deal_for--> Customer --competes_with-->
+        # Competitor. b_rival must be excluded; only Rival Inc (ws-a) survives.
+        a_result = await store.query(
+            FabricQuery(
+                type_name="Deal",
+                filters={"stage": "open"},
+                path=[
+                    PathHop(link_type="deal_for", object_type="Customer", direction="out"),
+                    PathHop(link_type="competes_with", object_type="Competitor", direction="out"),
+                ],
+            ),
+            workspace_id="ws-a",
+        )
+        assert {o.properties["name"] for o in a_result.objects} == {"Rival Inc"}
+        assert "B Rival" not in {o.properties["name"] for o in a_result.objects}
+
+        # B-scoped: B owns no Deal/Customer, so the same path yields nothing.
+        b_result = await store.query(
+            FabricQuery(
+                type_name="Deal",
+                filters={"stage": "open"},
+                path=[
+                    PathHop(link_type="deal_for", object_type="Customer", direction="out"),
+                    PathHop(link_type="competes_with", object_type="Competitor", direction="out"),
+                ],
+            ),
+            workspace_id="ws-b",
+        )
+        assert b_result.total == 0
+
+    @pytest.mark.asyncio
+    async def test_any_direction_matches_either_way(self, store: FabricStore) -> None:
+        """``direction="any"`` traverses a link regardless of stored direction —
+        the symmetric semantics of the legacy single-hop ``linked_to``."""
+        g = await self._seed(store)
+
+        # competes_with was stored Customer->Competitor. From the Competitor,
+        # an "any" hop still reaches the Customer.
+        result = await store.query(
+            FabricQuery(
+                linked_to=g["rival"].id,
+                path=[PathHop(link_type="competes_with", object_type="Customer", direction="any")],
+            )
+        )
+        assert {o.properties["name"] for o in result.objects} == {"Acme"}
+
+    @pytest.mark.asyncio
+    async def test_empty_path_is_backward_compatible(self, store: FabricStore) -> None:
+        """An empty ``path`` (default) leaves single-hop behavior untouched."""
+        g = await self._seed(store)
+
+        # Legacy single-hop: customers linked to the rival via competes_with.
+        legacy = await store.query(FabricQuery(linked_to=g["rival"].id, link_type="competes_with"))
+        assert {o.properties["name"] for o in legacy.objects} == {"Acme"}

--- a/tests/cloud/test_ee_fabric.py
+++ b/tests/cloud/test_ee_fabric.py
@@ -37,6 +37,12 @@
 #   (a linked object in another workspace must not leak across a hop), reverse
 #   ("in") and symmetric ("any") hop directions, and backward-compat (single-hop
 #   linked_to and an empty path behave exactly as before).
+# Updated: 2026-06-13 (review fixes #1465) — extended TestMultiHopPath with the
+#   bounds the reviewer asked for: a 3-hop chain (depth beyond the audit's 2), a
+#   walk that collapses mid-path (empty intermediate frontier returns an empty
+#   result, NOT an error), a single-hop fan-out exceeding MAX_FRONTIER (clean
+#   ValueError, never a SQLite bound-variable crash), and a path deeper than
+#   MAX_HOPS rejected at FabricQuery construction.
 
 from __future__ import annotations
 
@@ -46,8 +52,8 @@ from pathlib import Path
 import aiosqlite
 import pytest
 
-from pocketpaw.fabric.models import FabricQuery, PathHop, PropertyDef
-from pocketpaw.fabric.store import FabricStore
+from pocketpaw.fabric.models import MAX_HOPS, FabricQuery, PathHop, PropertyDef
+from pocketpaw.fabric.store import MAX_FRONTIER, FabricStore
 
 
 @pytest.fixture
@@ -916,3 +922,86 @@ class TestMultiHopPath:
         # Legacy single-hop: customers linked to the rival via competes_with.
         legacy = await store.query(FabricQuery(linked_to=g["rival"].id, link_type="competes_with"))
         assert {o.properties["name"] for o in legacy.objects} == {"Acme"}
+
+    @pytest.mark.asyncio
+    async def test_three_hop_path(self, store: FabricStore) -> None:
+        """A 3-hop chain resolves end to end in one query.
+
+        Region <--in_region-- Competitor <--competes_with-- Customer
+        <--deal_for-- Deal(open). Start at the Region, walk back three reverse
+        hops to the open Deal(s). Exercises depth beyond the audit's 2 hops.
+        """
+        g = await self._seed(store)
+        region_t = await store.define_type(name="Region", properties=[])
+        emea = await store.create_object(region_t.id, {"name": "EMEA"})
+        # Competitor(Rival Inc) --in_region--> Region(EMEA)
+        await store.link(g["rival"].id, emea.id, "in_region")
+
+        result = await store.query(
+            FabricQuery(
+                linked_to=emea.id,
+                path=[
+                    PathHop(link_type="in_region", object_type="Competitor", direction="in"),
+                    PathHop(link_type="competes_with", object_type="Customer", direction="in"),
+                    PathHop(
+                        link_type="deal_for",
+                        object_type="Deal",
+                        direction="in",
+                        filters={"stage": "open"},
+                    ),
+                ],
+            )
+        )
+        assert {o.properties["name"] for o in result.objects} == {"Acme deal"}
+
+    @pytest.mark.asyncio
+    async def test_empty_intermediate_frontier_returns_empty_not_error(
+        self, store: FabricStore
+    ) -> None:
+        """A walk that collapses mid-path (a hop reaches nothing) returns an
+        empty result, NOT an error — the dead end is a normal outcome."""
+        g = await self._seed(store)
+
+        # Hop 1 reaches the Customer (Acme). Hop 2 follows a link_type that no
+        # object has -> the frontier empties. Hop 3 must not run / error.
+        result = await store.query(
+            FabricQuery(
+                linked_to=g["rival"].id,
+                path=[
+                    PathHop(link_type="competes_with", object_type="Customer", direction="in"),
+                    PathHop(link_type="no_such_link", direction="in"),
+                    PathHop(link_type="deal_for", object_type="Deal", direction="in"),
+                ],
+            )
+        )
+        assert result.objects == []
+        assert result.total == 0
+
+    @pytest.mark.asyncio
+    async def test_fan_out_exceeding_max_frontier_raises_clean_value_error(
+        self, store: FabricStore
+    ) -> None:
+        """A single hop that fans out past MAX_FRONTIER raises a clear ValueError
+        rather than crashing SQLite on the bound-variable limit."""
+        hub_t = await store.define_type(name="Hub", properties=[])
+        leaf_t = await store.define_type(name="Leaf", properties=[])
+        hub = await store.create_object(hub_t.id, {"name": "hub"})
+        # Link the hub out to MAX_FRONTIER + 1 leaves on one link_type.
+        for i in range(MAX_FRONTIER + 1):
+            leaf = await store.create_object(leaf_t.id, {"i": i})
+            await store.link(hub.id, leaf.id, "has_leaf")
+
+        with pytest.raises(ValueError, match="exceeding the cap"):
+            await store.query(
+                FabricQuery(
+                    linked_to=hub.id,
+                    path=[PathHop(link_type="has_leaf", object_type="Leaf", direction="out")],
+                )
+            )
+
+    @pytest.mark.asyncio
+    async def test_path_deeper_than_max_hops_rejected(self) -> None:
+        """FabricQuery rejects a path deeper than MAX_HOPS at construction —
+        before any DB work — with a clear ValueError."""
+        with pytest.raises(ValueError, match="maximum is"):
+            FabricQuery(path=[PathHop(link_type="r") for _ in range(MAX_HOPS + 1)])


### PR DESCRIPTION
## What

Multi-hop / path traversal in the Fabric query layer, so a 2-hop ontology join runs as one server-side query instead of being hand-stitched from two calls in application code.

- New `PathHop` model (link_type, optional target object_type, property filters, direction out/in/any) and an additive `FabricQuery.path` field.
- `FabricStore.query()` walks the path one edge at a time across `fabric_links`, applying each hop's direction, link type, terminal object type, property filters, and workspace scope, then re-fetches the terminal frontier as full objects.
- The agent tool `FabricQueryTool` gained a `path` argument so an LLM can issue the join directly; a malformed hop returns a readable error instead of raising.

## Why

The query layer only did one hop. The competitive-intel query — "which open deals link to a customer that competes with a competitor" — returned empty in a single query and had to be stitched together in app code. The data model (typed objects, typed links, provenance) already supported the join; only the query layer couldn't express it.

## Design note

Chose iterative per-hop resolution over a recursive CTE — simpler to keep per-hop type, property, direction, and tenant filters parameterized and injection-safe at shallow depth. Single-hop `linked_to`/`link_type` is unchanged and backward compatible; `path` wins when both are set. When `path` is set, the top-level type/filters constrain the start frontier and the final hop describes the terminal — documented in the docstrings.

## Tests

`uv run pytest tests/cloud/test_ee_fabric.py -q` → 51 passed (TestMultiHopPath added). Written test-first: the 2-hop join failed on the old code (returned the unfiltered single-hop set) and passes now, returning exactly the open deal. Also covers both traversal directions, property filters at the intended hop, cross-workspace isolation across hops (a linked object in another tenant does not leak), and backward compatibility of single-hop queries.

Captain reviews; not merging.