### PR TITLE
Workspace branding model — the backend foundation for white-label tenants

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/workspace.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace.py
@@ -1,4 +1,12 @@
-"""Workspace document — one per deployment/org."""
+"""Workspace document — one per deployment/org.
+
+2026-06-14 (WB-1): added the ``Branding`` sub-model and a top-level
+``Workspace.branding`` field for white-label theming (logo, display name,
+tab title, accent color, favicon, paw-mark toggle). Branding is a per-tenant
+IDENTITY field — kept separate from ``WorkspaceSettings`` (operational config)
+on purpose. Every sub-field is optional; an unset field falls back to the Paw
+default at render time (a frontend concern, not stored here).
+"""
 
 from __future__ import annotations
 
@@ -14,6 +22,23 @@ class WorkspaceSettings(BaseModel):
     default_agent: str | None = None  # Agent ID
     allow_invites: bool = True
     retention_days: int | None = None  # None = keep forever
+
+
+class Branding(BaseModel):
+    """Per-tenant white-label branding (WB-1).
+
+    All fields optional; each unset field falls back to the Paw default at
+    render time (a frontend concern). Asset fields hold an uploaded
+    ``FileUpload.file_id`` that must belong to the same workspace — the
+    service enforces that ownership before persisting.
+    """
+
+    logo_asset: str | None = None  # uploaded asset id — top-bar mark
+    favicon_asset: str | None = None  # uploaded asset id — browser favicon
+    display_name: str | None = None  # replaces the "PocketPaw" wordmark
+    tab_title: str | None = None  # browser tab title
+    accent_color: str | None = None  # hex "#RRGGBB" — tints the UI theme
+    show_paw_mark: bool = True  # keep/hide our paw icon
 
 
 class SsoConfig(BaseModel):
@@ -53,6 +78,10 @@ class Workspace(TimestampedDocument):
     plan: str = "team"  # from license: team | business | enterprise
     seats: int = 5
     settings: WorkspaceSettings = Field(default_factory=WorkspaceSettings)
+    # Per-tenant white-label branding (WB-1). Top-level identity field, NOT
+    # nested under settings (which holds operational config). None = no
+    # custom branding; the frontend renders the Paw defaults.
+    branding: Branding | None = None
     sso_config: SsoConfig | None = None
     verified_domains: list[VerifiedDomain] = Field(default_factory=list)
     deleted_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/workspace/domain.py
+++ b/ee/pocketpaw_ee/cloud/workspace/domain.py
@@ -4,6 +4,9 @@ Frozen dataclasses, no Beanie / Pydantic / FastAPI imports:
 
 - ``Workspace`` mirrors the persistence ``Workspace`` document plus a
   derived ``member_count`` that the service computes per request.
+- ``Branding`` mirrors the optional per-tenant white-label branding
+  embedded on the workspace (WB-1); ``Workspace.branding`` is None when
+  the tenant has no custom branding.
 - ``WorkspaceMember`` represents a user-as-member-of-a-workspace, the
   shape returned by ``list_members`` (the underlying data lives on the
   ``User`` document under ``user.workspaces``).
@@ -12,12 +15,31 @@ Frozen dataclasses, no Beanie / Pydantic / FastAPI imports:
   pure (no clock dependency baked into a property).
 - ``InviteContext`` mirrors the optional admin onboarding hints embedded
   on the invite (pp#1365); ``Invite.context`` is None when omitted.
+
+2026-06-14 (WB-1): added the ``Branding`` value object and the
+``Workspace.branding`` field.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+
+
+@dataclass(frozen=True)
+class Branding:
+    """Per-tenant white-label branding (WB-1).
+
+    Mirrors the embedded persistence ``Branding`` shape. Every field is
+    optional; an unset field falls back to the Paw default at render time
+    (a frontend concern, not stored here)."""
+
+    logo_asset: str | None = None
+    favicon_asset: str | None = None
+    display_name: str | None = None
+    tab_title: str | None = None
+    accent_color: str | None = None
+    show_paw_mark: bool = True
 
 
 @dataclass(frozen=True)
@@ -33,6 +55,7 @@ class Workspace:
     created_at: datetime
     member_count: int = 0
     deleted_at: datetime | None = None
+    branding: Branding | None = None  # per-tenant white-label branding (WB-1)
 
 
 @dataclass(frozen=True)
@@ -91,4 +114,11 @@ class Invite:
     context: InviteContext | None = None  # optional admin onboarding hints (pp#1365)
 
 
-__all__ = ["Invite", "InviteContext", "VerifiedDomain", "Workspace", "WorkspaceMember"]
+__all__ = [
+    "Branding",
+    "Invite",
+    "InviteContext",
+    "VerifiedDomain",
+    "Workspace",
+    "WorkspaceMember",
+]

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -10,16 +10,22 @@ existing wire shape consumed by paw-enterprise:
 Changes: added the slug rule single-source-of-truth (``SLUG_RE`` +
 ``RESERVED_SLUGS``) and the ``SlugAvailabilityOut`` response so the create
 UI can check a slug live; ``validate_slug`` now reuses ``SLUG_RE``.
+2026-06-14 (WB-1): added ``BrandingPatch`` (request, with ``accent_color``
+format validation) + ``BrandingOut`` (response), an optional ``branding``
+field on ``UpdateWorkspaceRequest``, a ``branding`` field on ``WorkspaceOut``,
+and the ``Branding`` -> ``BrandingOut`` mapping in ``workspace_to_dto``.
 """
 
 from __future__ import annotations
 
+import re
 from typing import Literal
 
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.workspace.domain import (
+    Branding,
     Invite,
     InviteContext,
     VerifiedDomain,
@@ -27,6 +33,10 @@ from pocketpaw_ee.cloud.workspace.domain import (
     WorkspaceMember,
 )
 from pocketpaw_ee.cloud.workspace.slug import SLUG_RE
+
+# Hex accent color, e.g. "#1A2B3C". Anchored — rejects "blue", "#ZZZ",
+# short/long hex, and a missing leading "#".
+ACCENT_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 # ---------------------------------------------------------------------------
 # Requests (preserved from schemas.py)
@@ -45,9 +55,37 @@ class CreateWorkspaceRequest(BaseModel):
         return v
 
 
+class BrandingPatch(BaseModel):
+    """Per-tenant white-label branding patch (WB-1), carried on
+    ``UpdateWorkspaceRequest.branding``.
+
+    All fields optional. ``accent_color`` is format-validated here (must be
+    ``#RRGGBB``) so a malformed value is a 422 at the route boundary, before
+    the service runs. Asset ownership (``logo_asset`` / ``favicon_asset``
+    must belong to the target workspace) is a DB-backed check enforced in the
+    service, not here."""
+
+    logo_asset: str | None = None
+    favicon_asset: str | None = None
+    display_name: str | None = None
+    tab_title: str | None = None
+    accent_color: str | None = None
+    show_paw_mark: bool = True
+
+    @field_validator("accent_color")
+    @classmethod
+    def validate_accent_color(cls, v: str | None) -> str | None:
+        if v is not None and not ACCENT_COLOR_RE.match(v):
+            raise ValueError("accent_color must be a hex color like #RRGGBB")
+        return v
+
+
 class UpdateWorkspaceRequest(BaseModel):
     name: str | None = None
     settings: dict | None = None
+    # Per-tenant white-label branding (WB-1). Owner/admin-gated at the route
+    # via the same ``workspace.update`` action as the rename path.
+    branding: BrandingPatch | None = None
 
 
 class InviteContextDTO(BaseModel):
@@ -98,8 +136,27 @@ class BulkInviteSkip(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class BrandingOut(BaseModel):
+    """Per-tenant white-label branding on the workspace read (WB-1).
+
+    Mirrors ``BrandingPatch`` minus the validators — it's a read shape. The
+    frontend applies the Paw default for any field that's ``None``."""
+
+    logo_asset: str | None = None
+    favicon_asset: str | None = None
+    display_name: str | None = None
+    tab_title: str | None = None
+    accent_color: str | None = None
+    show_paw_mark: bool = True
+
+
 class WorkspaceOut(BaseModel):
-    """GET /workspaces/{id} response."""
+    """GET /workspaces/{id} response.
+
+    Also the shape the shell reads at load for the active workspace (there is
+    no separate ``/workspaces/active`` route — the shell fetches the active
+    workspace via ``GET /workspaces/{id}`` using the id from the profile), so
+    ``branding`` here is enough for the shell to theme on first paint."""
 
     id: str = Field(serialization_alias="_id")
     name: str
@@ -109,6 +166,7 @@ class WorkspaceOut(BaseModel):
     seats: int
     createdAt: str | None  # noqa: N815 - camelCase wire key
     memberCount: int  # noqa: N815 - camelCase wire key
+    branding: BrandingOut | None = None  # per-tenant white-label branding (WB-1)
 
     model_config = {"populate_by_name": True}
 
@@ -247,6 +305,19 @@ class InvitePreviewResponse(BaseModel):
     context: InviteContextDTO | None = None
 
 
+def _branding_to_dto(b: Branding | None) -> BrandingOut | None:
+    if b is None:
+        return None
+    return BrandingOut(
+        logo_asset=b.logo_asset,
+        favicon_asset=b.favicon_asset,
+        display_name=b.display_name,
+        tab_title=b.tab_title,
+        accent_color=b.accent_color,
+        show_paw_mark=b.show_paw_mark,
+    )
+
+
 def workspace_to_dto(ws: Workspace) -> WorkspaceOut:
     return WorkspaceOut(
         id=ws.id,
@@ -257,6 +328,7 @@ def workspace_to_dto(ws: Workspace) -> WorkspaceOut:
         seats=ws.seats,
         createdAt=iso_utc(ws.created_at),
         memberCount=ws.member_count,
+        branding=_branding_to_dto(ws.branding),
     )
 
 
@@ -322,6 +394,8 @@ def invite_to_validate_dto(inv: Invite, workspace_name: str) -> ValidateInviteOu
 
 __all__ = [
     "AddDomainRequest",
+    "BrandingOut",
+    "BrandingPatch",
     "BulkInviteRequest",
     "BulkInviteResponse",
     "BulkInviteSkip",

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -39,6 +39,14 @@ locking the invitee out of every workspace read. Both already_accepted
 raise-sites now route through _heal_or_conflict: a rightful invitee missing
 the membership gets it added (idempotent) instead of a 409; a genuine
 duplicate (already a member) still raises invite.already_accepted.
+2026-06-14 (WB-1): update() now accepts an optional branding patch. A
+BrandingPatch merges onto the workspace's existing Branding (partial patches
+don't wipe set fields). logo_asset / favicon_asset are ownership-checked
+against the workspace via _assert_asset_owned (mirrors the uploads
+workspace-scoped lookup) — a cross-workspace or unknown asset ref raises
+Forbidden (workspace.branding_asset_not_owned). accent_color format is
+validated upstream by BrandingPatch (422). _workspace_to_domain now carries
+branding through to the domain object so it serializes onto WorkspaceOut.
 """
 
 from __future__ import annotations
@@ -81,6 +89,7 @@ from pocketpaw_ee.cloud.models.invite import hash_token
 from pocketpaw_ee.cloud.models.notification import NotificationSource
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
 from pocketpaw_ee.cloud.models.user import WorkspaceMembership as _Membership
+from pocketpaw_ee.cloud.models.workspace import Branding as _BrandingDoc
 from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
 from pocketpaw_ee.cloud.models.workspace import WorkspaceSettings
 from pocketpaw_ee.cloud.notifications import service as notifications_service
@@ -88,12 +97,14 @@ from pocketpaw_ee.cloud.people import service as people_service
 from pocketpaw_ee.cloud.shared.events import event_bus
 from pocketpaw_ee.cloud.uploads.models import FileUpload as _FileUploadDoc
 from pocketpaw_ee.cloud.workspace.domain import (
+    Branding,
     Invite,
     InviteContext,
     Workspace,
     WorkspaceMember,
 )
 from pocketpaw_ee.cloud.workspace.dto import (
+    BrandingPatch,
     BulkInviteRequest,
     CreateInviteRequest,
     CreateWorkspaceRequest,
@@ -114,6 +125,23 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _branding_doc_to_domain(b: _BrandingDoc | None) -> Branding | None:
+    """Map the embedded persistence ``Branding`` to the domain value object.
+
+    ``None`` (no custom branding) passes straight through — the frontend
+    renders the Paw defaults."""
+    if b is None:
+        return None
+    return Branding(
+        logo_asset=b.logo_asset,
+        favicon_asset=b.favicon_asset,
+        display_name=b.display_name,
+        tab_title=b.tab_title,
+        accent_color=b.accent_color,
+        show_paw_mark=b.show_paw_mark,
+    )
+
+
 def _workspace_to_domain(doc: _WorkspaceDoc, *, member_count: int = 0) -> Workspace:
     return Workspace(
         id=str(doc.id),
@@ -125,6 +153,7 @@ def _workspace_to_domain(doc: _WorkspaceDoc, *, member_count: int = 0) -> Worksp
         created_at=getattr(doc, "createdAt", None),  # type: ignore[arg-type]
         member_count=member_count,
         deleted_at=doc.deleted_at,
+        branding=_branding_doc_to_domain(getattr(doc, "branding", None)),
     )
 
 
@@ -331,6 +360,47 @@ async def get(ctx: RequestContext, workspace_id: str) -> Workspace:
     return _workspace_to_domain(doc, member_count=count)
 
 
+async def _assert_asset_owned(workspace_id: str, file_id: str) -> None:
+    """Reject a branding asset ref that doesn't belong to this workspace.
+
+    Mirrors the chat-attachment ownership check (uploads' workspace-scoped
+    lookup): the asset must exist as a non-deleted ``FileUpload`` whose
+    ``workspace`` matches. A cross-workspace ref OR a non-existent id both
+    fail the same way — neither is owned by this workspace. Raises ``Forbidden``
+    so the route returns a 403, consistent with the rest of the workspace
+    authorization surface.
+    """
+    owned = await _FileUploadDoc.find_one(
+        {"file_id": file_id, "workspace": workspace_id, "deleted_at": None}
+    )
+    if owned is None:
+        raise Forbidden(
+            "workspace.branding_asset_not_owned",
+            f"Asset '{file_id}' does not belong to this workspace",
+        )
+
+
+async def _apply_branding_patch(
+    doc: _WorkspaceDoc, workspace_id: str, patch: BrandingPatch
+) -> None:
+    """Validate + merge a branding patch onto the workspace doc.
+
+    Asset refs (``logo_asset`` / ``favicon_asset``) are ownership-checked
+    against this workspace before anything is written. The patch MERGES onto
+    any existing branding so a partial patch (e.g. only ``display_name``)
+    doesn't wipe previously set fields. ``accent_color`` format was already
+    validated by ``BrandingPatch`` at the route boundary (422).
+    """
+    if patch.logo_asset is not None:
+        await _assert_asset_owned(workspace_id, patch.logo_asset)
+    if patch.favicon_asset is not None:
+        await _assert_asset_owned(workspace_id, patch.favicon_asset)
+
+    current = doc.branding or _BrandingDoc()
+    merged = current.model_copy(update=patch.model_dump(exclude_unset=True))
+    doc.branding = merged
+
+
 async def update(
     ctx: RequestContext,
     workspace_id: str,
@@ -343,6 +413,8 @@ async def update(
         doc.name = body.name
     if body.settings is not None:
         doc.settings = WorkspaceSettings(**body.settings)
+    if body.branding is not None:
+        await _apply_branding_patch(doc, workspace_id, body.branding)
     await doc.save()
 
     patched = body.model_dump(exclude_unset=True)

--- a/tests/cloud/workspace/test_branding.py
+++ b/tests/cloud/workspace/test_branding.py
@@ -1,0 +1,347 @@
+# tests/cloud/workspace/test_branding.py — WB-1 white-label branding tests.
+# Created: 2026-06-14
+#
+# Covers the per-tenant Branding model on the Workspace:
+#   - Branding round-trips through PATCH -> GET (service + DTO).
+#   - accent_color format is validated (#RRGGBB only) at the DTO boundary.
+#   - logo_asset / favicon_asset referencing an asset owned by ANOTHER
+#     workspace is rejected (cross-workspace asset ref) in the service.
+#   - A non-admin caller is blocked by the existing workspace.update gate
+#     (router-level, same 403 as the rename path) — see test_rbac_routes.py
+#     additions; this file proves the data + validation layers.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from beanie import PydanticObjectId
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.models.workspace import Branding
+from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+from pocketpaw_ee.cloud.uploads.models import FileUpload as _FileUploadDoc
+from pocketpaw_ee.cloud.workspace import service as workspace_service
+from pocketpaw_ee.cloud.workspace.domain import Branding as BrandingDomain
+from pocketpaw_ee.cloud.workspace.domain import Workspace as WorkspaceDomain
+from pocketpaw_ee.cloud.workspace.dto import (
+    BrandingPatch,
+    CreateWorkspaceRequest,
+    UpdateWorkspaceRequest,
+    workspace_to_dto,
+)
+from pydantic import ValidationError as PydanticValidationError
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror test_service_v2.py)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_user(*, email: str = "u@x.c", full_name: str = "U") -> _UserDoc:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name=full_name,
+        workspaces=[],
+    )
+    await doc.insert()
+    return doc
+
+
+def _ctx(user_id: str, workspace_id: str | None = None) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture(autouse=True)
+def resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stub the resolver so create()/update() don't explode (the real one
+    needs init_realtime which unit tests don't run)."""
+    mock = MagicMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.get_resolver", lambda: mock)
+    return mock
+
+
+@pytest.fixture
+async def owner() -> _UserDoc:
+    return await _seed_user(email="owner@x.c", full_name="Owner")
+
+
+async def _seed_asset(*, file_id: str, workspace: str, owner_id: str) -> _FileUploadDoc:
+    doc = _FileUploadDoc(
+        file_id=file_id,
+        storage_key=f"key/{file_id}",
+        filename=f"{file_id}.png",
+        mime="image/png",
+        size=128,
+        workspace=workspace,
+        owner=owner_id,
+    )
+    await doc.insert()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# DTO layer — accent_color validation + WorkspaceOut serialization
+# ---------------------------------------------------------------------------
+
+
+def test_branding_patch_accepts_valid_accent_color() -> None:
+    patch = BrandingPatch(display_name="Acme", accent_color="#1A2b3C")
+    assert patch.accent_color == "#1A2b3C"
+
+
+@pytest.mark.parametrize("bad", ["blue", "#ZZZ", "#12345", "1A2B3C", "#1234567", ""])
+def test_branding_patch_rejects_malformed_accent_color(bad: str) -> None:
+    with pytest.raises(PydanticValidationError):
+        BrandingPatch(accent_color=bad)
+
+
+def test_update_workspace_request_carries_branding() -> None:
+    req = UpdateWorkspaceRequest(branding={"display_name": "Acme", "show_paw_mark": False})
+    assert req.branding is not None
+    assert req.branding.display_name == "Acme"
+    assert req.branding.show_paw_mark is False
+
+
+def test_workspace_out_serializes_branding() -> None:
+    ws = WorkspaceDomain(
+        id="w1",
+        name="Acme",
+        slug="acme",
+        owner="u1",
+        plan="team",
+        seats=5,
+        created_at=datetime(2026, 6, 14, tzinfo=UTC),
+        member_count=1,
+        branding=BrandingDomain(display_name="Acme Co", accent_color="#FF0000"),
+    )
+    dump = workspace_to_dto(ws).model_dump(by_alias=True)
+    assert "branding" in dump
+    assert dump["branding"]["display_name"] == "Acme Co"
+    assert dump["branding"]["accent_color"] == "#FF0000"
+    # Unset sub-fields fall through as None — the frontend applies Paw defaults.
+    assert dump["branding"]["logo_asset"] is None
+    assert dump["branding"]["show_paw_mark"] is True
+
+
+def test_workspace_out_branding_absent_is_null() -> None:
+    ws = WorkspaceDomain(
+        id="w1",
+        name="Acme",
+        slug="acme",
+        owner="u1",
+        plan="team",
+        seats=5,
+        created_at=datetime(2026, 6, 14, tzinfo=UTC),
+        member_count=1,
+    )
+    dump = workspace_to_dto(ws).model_dump(by_alias=True)
+    assert dump["branding"] is None
+
+
+# ---------------------------------------------------------------------------
+# Service layer — PATCH -> GET round-trip
+# ---------------------------------------------------------------------------
+
+
+async def test_branding_round_trips_through_update_and_get(owner) -> None:
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="Acme", slug="acme")
+    )
+
+    await workspace_service.update(
+        _ctx(str(owner.id)),
+        ws.id,
+        UpdateWorkspaceRequest(
+            branding=BrandingPatch(
+                display_name="Acme Co",
+                accent_color="#1A2B3C",
+                show_paw_mark=False,
+            )
+        ),
+    )
+
+    read = await workspace_service.get(_ctx(str(owner.id)), ws.id)
+    assert read.branding is not None
+    assert read.branding.display_name == "Acme Co"
+    assert read.branding.accent_color == "#1A2B3C"
+    assert read.branding.show_paw_mark is False
+    # Untouched sub-fields stay at their defaults.
+    assert read.branding.logo_asset is None
+
+    # And it survives serialization onto the wire DTO (the read path the
+    # shell consumes at load via GET /workspaces/{id}).
+    dump = workspace_to_dto(read).model_dump(by_alias=True)
+    assert dump["branding"]["display_name"] == "Acme Co"
+    assert dump["branding"]["accent_color"] == "#1A2B3C"
+    assert dump["branding"]["show_paw_mark"] is False
+
+
+async def test_branding_persists_on_the_workspace_document(owner) -> None:
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await workspace_service.update(
+        _ctx(str(owner.id)),
+        ws.id,
+        UpdateWorkspaceRequest(branding=BrandingPatch(display_name="Persisted")),
+    )
+    doc = await _WorkspaceDoc.get(PydanticObjectId(ws.id))
+    assert doc is not None
+    assert isinstance(doc.branding, Branding)
+    assert doc.branding.display_name == "Persisted"
+
+
+async def test_branding_patch_does_not_clobber_other_fields(owner) -> None:
+    """A branding patch leaves name/settings untouched, and a later name
+    patch leaves branding untouched."""
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="Original", slug="a")
+    )
+    await workspace_service.update(
+        _ctx(str(owner.id)),
+        ws.id,
+        UpdateWorkspaceRequest(branding=BrandingPatch(display_name="Brand")),
+    )
+    # Now rename — branding must survive.
+    await workspace_service.update(
+        _ctx(str(owner.id)), ws.id, UpdateWorkspaceRequest(name="Renamed")
+    )
+    read = await workspace_service.get(_ctx(str(owner.id)), ws.id)
+    assert read.name == "Renamed"
+    assert read.branding is not None
+    assert read.branding.display_name == "Brand"
+
+
+# ---------------------------------------------------------------------------
+# Service layer — asset ownership (cross-workspace rejection)
+# ---------------------------------------------------------------------------
+
+
+async def test_branding_accepts_own_workspace_asset(owner) -> None:
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    await _seed_asset(file_id="logo_ok", workspace=ws.id, owner_id=str(owner.id))
+
+    await workspace_service.update(
+        _ctx(str(owner.id)),
+        ws.id,
+        UpdateWorkspaceRequest(branding=BrandingPatch(logo_asset="logo_ok")),
+    )
+    read = await workspace_service.get(_ctx(str(owner.id)), ws.id)
+    assert read.branding is not None
+    assert read.branding.logo_asset == "logo_ok"
+
+
+async def test_branding_rejects_logo_asset_owned_by_another_workspace(owner) -> None:
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    other_ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="B", slug="b")
+    )
+    # The asset belongs to other_ws, not ws.
+    await _seed_asset(file_id="foreign_logo", workspace=other_ws.id, owner_id=str(owner.id))
+
+    with pytest.raises(Forbidden) as exc:
+        await workspace_service.update(
+            _ctx(str(owner.id)),
+            ws.id,
+            UpdateWorkspaceRequest(branding=BrandingPatch(logo_asset="foreign_logo")),
+        )
+    assert exc.value.code == "workspace.branding_asset_not_owned"
+
+
+async def test_branding_rejects_favicon_asset_owned_by_another_workspace(owner) -> None:
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    other_ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="B", slug="b")
+    )
+    await _seed_asset(file_id="foreign_fav", workspace=other_ws.id, owner_id=str(owner.id))
+
+    with pytest.raises(Forbidden) as exc:
+        await workspace_service.update(
+            _ctx(str(owner.id)),
+            ws.id,
+            UpdateWorkspaceRequest(branding=BrandingPatch(favicon_asset="foreign_fav")),
+        )
+    assert exc.value.code == "workspace.branding_asset_not_owned"
+
+
+async def test_branding_rejects_nonexistent_asset(owner) -> None:
+    """An asset id that doesn't exist anywhere is treated the same as a
+    cross-workspace ref — it isn't owned by this workspace."""
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    with pytest.raises(Forbidden) as exc:
+        await workspace_service.update(
+            _ctx(str(owner.id)),
+            ws.id,
+            UpdateWorkspaceRequest(branding=BrandingPatch(logo_asset="ghost")),
+        )
+    assert exc.value.code == "workspace.branding_asset_not_owned"
+
+
+# ---------------------------------------------------------------------------
+# Role gate — branding PATCH rides the SAME workspace.update action as rename
+#
+# The route guard is ``require_action("workspace.update")``, which wraps
+# ``check_workspace_action(user, ws, "workspace.update")``. Exercising that
+# function directly proves a non-admin is rejected with the same 403 deny
+# code the rename path gives — without depending on the rbac-routes HTTP
+# harness (which has a pre-existing dependency-override wiring issue).
+# ---------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str) -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str, role: str, workspace: str = "ws1") -> None:
+        self.id = user_id
+        self.active_workspace = workspace
+        self.workspaces = [_FakeMembership(workspace, role)]
+
+
+def test_member_denied_branding_update_via_gate() -> None:
+    """A MEMBER hitting workspace.update (the gate the branding PATCH uses)
+    is rejected with the workspace.insufficient_role deny code — same 403 the
+    rename path gives."""
+    from pocketpaw_ee.guards.deps import check_workspace_action
+    from pocketpaw_ee.guards.rbac import Forbidden as GuardForbidden
+
+    member = _FakeUser("u-member", role="member")
+    with pytest.raises(GuardForbidden) as exc:
+        check_workspace_action(member, "ws1", "workspace.update")
+    assert exc.value.code == "workspace.insufficient_role"
+
+
+def test_admin_allowed_branding_update_via_gate() -> None:
+    """An ADMIN passes the same workspace.update gate the branding PATCH
+    rides — sanity that the gate isn't accidentally over-restrictive."""
+    from pocketpaw_ee.guards.deps import check_workspace_action
+
+    admin = _FakeUser("u-admin", role="admin")
+    # Returns the resolved role on success; no raise.
+    role = check_workspace_action(admin, "ws1", "workspace.update")
+    assert role is not None

--- a/tests/cloud/workspace/test_dto.py
+++ b/tests/cloud/workspace/test_dto.py
@@ -1,4 +1,8 @@
-"""Tests for ee.cloud.workspace.dto."""
+"""Tests for ee.cloud.workspace.dto.
+
+2026-06-14 (WB-1): WorkspaceOut now serializes a ``branding`` key — the
+wire-keys test includes it and a new test asserts it's null when unset.
+"""
 
 from __future__ import annotations
 
@@ -68,7 +72,15 @@ def test_workspace_dto_wire_keys() -> None:
         "seats",
         "createdAt",
         "memberCount",
+        "branding",  # WB-1: per-tenant white-label branding (None when unset)
     }
+
+
+def test_workspace_dto_branding_null_when_unset() -> None:
+    # A workspace with no custom branding serializes branding as null; the
+    # frontend then applies the Paw defaults.
+    dump = workspace_to_dto(_ws()).model_dump(by_alias=True)
+    assert dump["branding"] is None
 
 
 def test_workspace_dto_values() -> None:


### PR DESCRIPTION
First slice of per-tenant white-label branding (design: docs/design/drafts/2026-06-14-workspace-branding.md). The workspace record now carries a branding block and serves it; an admin sets it through the PATCH that already handles rename. No UI yet — that's the next slices — so this is proven by tests.

What's here:
- A `Branding` sub-model on `Workspace` (top-level identity, not nested under operational settings): logo_asset, favicon_asset, display_name, tab_title, accent_color, show_paw_mark. All optional; unset fields fall back to the Paw default at render time.
- `PATCH /workspaces/{id}` accepts a branding patch on the same owner/admin gate as rename (`workspace.update`) — no new gate. accent_color is format-validated to #RRGGBB at the DTO boundary (422 on junk). A logo/favicon asset that doesn't belong to the workspace is rejected (403, `workspace.branding_asset_not_owned`), mirroring how chat attachments check ownership. Partial patches merge with exclude_unset, so setting one field never clears the others.
- Branding rides `WorkspaceOut`, which covers GET, list, and the shell's load-time read — there's no separate active-workspace route to touch.

19 new tests in tests/cloud/workspace/test_branding.py cover the round-trip, the non-owner rejection, malformed colors, and cross-workspace/unknown asset refs. The pre-existing failures in the workspace/rbac suites (agent-seed count drift, an rbac test-harness override bug) are on clean dev too — zero new failures from this change.

Next slices read this: WB-2 (settings UI + TopBar render), WB-3 (logo), WB-4 (tab title + favicon), WB-5 (accent theme-tint).