### PR TITLE
Make chat and pocket replies use ripple's rich widgets, not primitive rebuilds

### DIFF
--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -641,7 +641,8 @@ Final self-check before sending:
 ✔ Matched the reply SHAPE to its typed widget (comparison-table / data-grid /
   timeline / kv-table / status-dot / pricing-table) — did NOT rebuild it from a
   plain table / text / flex
-✔ Used a core widget, an inlined typed widget, or called `get_inline_widget_help` BEFORE emitting any other type
+✔ Used a core widget, an inlined typed widget, or called `get_inline_widget_help`
+  BEFORE emitting any other type
 ✔ Multi-step / wizard / intake flow → called `start_flow`, not a hand-authored or `set`-stepped spec
 ✔ Pending Instinct approvals → Approve/Reject buttons `api`-POST the route, NOT chat.send
 ✔ Open Tray affordance navigates to /deep-work (not a chat.send)
@@ -706,7 +707,8 @@ source-card    — { source, title, url?, color? }
 callout        — { variant:"info|insight|warning", title, text }
 definition-list— { items:[{term,definition}], layout?:"inline|stacked" }
 metric         — { label, value, trend?, description? }
-funnel         — { data:[{label,value}], title?, sort?:"descending|ascending|none", colors?, height? }
+funnel         — { data:[{label,value}], title?, colors?, height?,
+                   sort?:"descending|ascending|none" }
 gauge          — { value, max?, label?, title?, color?, height? }
 
 Worked examples — the typed-widget choice in action (data already in hand):
@@ -717,7 +719,7 @@ Worked examples — the typed-widget choice in action (data already in hand):
   "deployment status of services"  -> flex(column) of [text + status-dot] rows, or a kv-table
                                       with a status-dot per value  (NOT prose, NOT a plain table)
   "our pricing"                    -> ONE pricing-table
-  "sales funnel leads to closed"   -> ONE funnel  (data:[{label,value}] per stage, NOT a plain table)
+  "sales funnel leads to closed"   -> ONE funnel  (data:[{label,value}] per stage, NOT a table)
   "capacity at 75 of 100"          -> ONE gauge  (value + max, NOT a bare stat tile)
 
 Keep it tight: ONE typed widget is the answer most of the time. Wrap it in

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -641,7 +641,7 @@ Final self-check before sending:
 ✔ Matched the reply SHAPE to its typed widget (comparison-table / data-grid /
   timeline / kv-table / status-dot / pricing-table) — did NOT rebuild it from a
   plain table / text / flex
-✔ Used a core widget, an inlined typed widget, or called `get_inline_widget_help`
+✔ Used a core widget, an inlined typed widget, or called `get_widget_spec`
   BEFORE emitting any other type
 ✔ Multi-step / wizard / intake flow → called `start_flow`, not a hand-authored or `set`-stepped spec
 ✔ Pending Instinct approvals → Approve/Reject buttons `api`-POST the route, NOT chat.send
@@ -659,7 +659,7 @@ _INLINE_TYPED_WIDGET_RULE = """\
 The most common chat-quality miss is answering a SHAPED request with a
 plain `table` / `text` / `flex` when a dedicated widget exists. When the
 reply matches a shape below, emit that widget — its props are inlined
-right here, so NO `get_inline_widget_help` call is needed.
+right here, so NO `get_widget_spec` call is needed.
 
   compare X vs Y / feature or plan matrix      -> comparison-table
   ranked list / top N / leaderboard            -> data-grid (sortable)
@@ -695,13 +695,15 @@ data-grid — { columns:[{key,label,sortable,align}], rows, defaultSort?, search
       "defaultSort":"revenue:desc","searchable":true }}
 
 timeline — { events:[{date,title,detail?,type?}], density? }
-  type: default | success | warning | destructive | info
+  type: default | success | warning | error | info
   { "type":"timeline","props":{"density":"compact","events":[
       {"date":"Jan 2026","title":"Alpha","type":"success"},
       {"date":"Mar 2026","title":"Public beta"} ]}}
 
 kv-table       — { rows:[{key,value}], columns?:1|2, striped? }
-status-dot     — { variant:"online|offline|degraded|warning", label, pulse? }
+status-dot     — { variant:"online|offline|busy|away|custom", label, pulse?, color? (custom only) }
+  degraded/warning are NOT variants — use "busy" (amber) or "custom" + color; an unknown
+  variant silently renders the online GREEN.
 pricing-table  — { currency, tiers:[{id,name,price,period,features:[{label,included}],cta}] }
 source-card    — { source, title, url?, color? }
 callout        — { variant:"info|insight|warning", title, text }

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -52,6 +52,11 @@
 #   approval (it lands in their Instinct Tray and fires on approve) rather than
 #   running inline. `call_binding` remains the first reach for backend/connector
 #   data; `invoke_tool` is for a named tool/connector grant the owner allow-listed.
+# Modified: 2026-06-15 - widget-richness fix: added _INLINE_TYPED_WIDGET_RULE
+#   (shape->typed-widget map + inlined schemas/examples for comparison-table,
+#   data-grid, timeline, kv-table, status-dot, pricing-table) so chat reaches
+#   for the typed widget instead of rebuilding shapes from table/text/flex;
+#   reframed the core-catalog opening and added a self-check line.
 # Modified: 2026-06-16 (feat/invoke-tool-v1 — close the in-chat approval loop)
 #   — added `_INSTINCT_TRAY_RULE`: when the agent renders the pending-Instinct-
 #   approvals view (the items `instinct_pending` returns), the Approve / Reject
@@ -261,9 +266,13 @@ Interaction rules:
 
 _INLINE_CORE_CATALOG = """\
 
-# WIDGET CATALOG — chat-inline allowlist
+# WIDGET CATALOG — chat-inline
 
-Six core widgets cover ~90% of chat replies. Use these from memory:
+These six core widgets handle SIMPLE replies from memory. They are the
+base, NOT the ceiling: the moment a reply has a SHAPE (a comparison, a
+ranked list, dated events, a status row, plans/tiers), the typed widget in
+"REACH FOR THE TYPED WIDGET" below reads far better — use it instead of
+rebuilding the shape out of `table` / `text` / `flex`. The six base widgets:
 
   text       — plain or rich text. Props: text, variant ('h1'..'h4',
                'body','muted','small'), align.
@@ -623,7 +632,10 @@ Final self-check before sending:
 ✔ Actions emit chat.send to close the loop
 ✔ One focal widget — clean, minimal layout, no clutter
 ✔ flex/grid `gap` is tight for inline — numeric 2 or 4, not 10/12+
-✔ Used a core widget, or called `get_inline_widget_help` BEFORE emitting the type
+✔ Matched the reply SHAPE to its typed widget (comparison-table / data-grid /
+  timeline / kv-table / status-dot / pricing-table) — did NOT rebuild it from a
+  plain table / text / flex
+✔ Used a core widget, an inlined typed widget, or called `get_inline_widget_help` BEFORE emitting any other type
 ✔ Multi-step / wizard / intake flow → called `start_flow`, not a hand-authored or `set`-stepped spec
 ✔ Pending Instinct approvals → Approve/Reject buttons `api`-POST the route, NOT chat.send
 ✔ Open Tray affordance navigates to /deep-work (not a chat.send)
@@ -631,6 +643,75 @@ Final self-check before sending:
 ✔ No static lists for open-ended queries
 ✔ Valid JSON, concrete values, one fence
 </ripple>"""
+
+
+_INLINE_TYPED_WIDGET_RULE = """\
+
+# REACH FOR THE TYPED WIDGET (chat) — the #1 chat-quality lever
+
+The most common chat-quality miss is answering a SHAPED request with a
+plain `table` / `text` / `flex` when a dedicated widget exists. When the
+reply matches a shape below, emit that widget — its props are inlined
+right here, so NO `get_inline_widget_help` call is needed.
+
+  compare X vs Y / feature or plan matrix      -> comparison-table
+  ranked list / top N / leaderboard            -> data-grid (sortable)
+  dated events / history / roadmap / releases  -> timeline
+  facts about ONE thing / key:value pairs      -> kv-table
+  service / system / job status                -> status-dot (one per item)
+  plans / tiers / pricing                      -> pricing-table
+  a single KPI with a trend                    -> metric (NOT a bare stat)
+  a cited source / link                        -> source-card
+  a 1-2 line takeaway / warning                -> callout
+  term : definition pairs                      -> definition-list
+
+Inlined prop shapes — copy these, put the data in props:
+
+comparison-table — { label, columns:[{key,label,highlight?}], rows:[{feature, <colKey>:value}] }
+  a cell value may be true/false (renders check/cross), a string, or a number.
+  { "type":"comparison-table","props":{
+      "label":"Feature",
+      "columns":[{"key":"a","label":"Plan A"},{"key":"b","label":"Plan B","highlight":true}],
+      "rows":[ {"feature":"Price","a":"$29/mo","b":"$99/mo"},
+               {"feature":"Seats","a":5,"b":25},
+               {"feature":"SSO","a":false,"b":true} ] }}
+
+data-grid — { columns:[{key,label,sortable,align}], rows, defaultSort?, searchable?, dense? }
+  { "type":"data-grid","props":{
+      "columns":[{"key":"name","label":"Customer","sortable":true},
+                 {"key":"revenue","label":"Revenue","align":"right","sortable":true},
+                 {"key":"deals","label":"Deals","align":"right","sortable":true}],
+      "rows":[{"id":1,"name":"Globex","revenue":"$1.24M","deals":14},
+              {"id":2,"name":"Stark","revenue":"$980K","deals":9}],
+      "defaultSort":"revenue:desc","searchable":true }}
+
+timeline — { events:[{date,title,detail?,type?}], density? }
+  type: default | success | warning | destructive | info
+  { "type":"timeline","props":{"density":"compact","events":[
+      {"date":"Jan 2026","title":"Alpha","type":"success"},
+      {"date":"Mar 2026","title":"Public beta"} ]}}
+
+kv-table       — { rows:[{key,value}], columns?:1|2, striped? }
+status-dot     — { variant:"online|offline|degraded|warning", label, pulse? }
+pricing-table  — { currency, tiers:[{id,name,price,period,features:[{label,included}],cta}] }
+source-card    — { source, title, url?, color? }
+callout        — { variant:"info|insight|warning", title, text }
+definition-list— { items:[{term,definition}], layout?:"inline|stacked" }
+metric         — { label, value, trend?, description? }
+
+Worked examples — the typed-widget choice in action (data already in hand):
+
+  "compare Plan A vs Plan B"       -> ONE comparison-table  (NOT two cards, NOT a plain table)
+  "top 5 customers by revenue"     -> ONE data-grid sorted desc  (NOT text rows, NOT a bare table)
+  "release timeline for v2"        -> ONE timeline  (NOT numbered text, NOT a table of dates)
+  "deployment status of services"  -> flex(column) of [text + status-dot] rows, or a kv-table
+                                      with a status-dot per value  (NOT prose, NOT a plain table)
+  "our pricing"                    -> ONE pricing-table
+
+Keep it tight: ONE typed widget is the answer most of the time. Wrap it in
+at most a heading + a chat.send follow-up — never surround it with
+redundant stat tiles or a second table.
+"""
 
 
 INLINE_RIPPLE_SYSTEM_PROMPT = (
@@ -641,6 +722,8 @@ INLINE_RIPPLE_SYSTEM_PROMPT = (
     + USE_THE_WIDGET_RULE
     + "\n"
     + _INLINE_CORE_CATALOG
+    + "\n"
+    + _INLINE_TYPED_WIDGET_RULE
     + "\n"
     + _MULTI_STEP_FLOW_RULE
     + "\n"

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -57,6 +57,12 @@
 #   data-grid, timeline, kv-table, status-dot, pricing-table) so chat reaches
 #   for the typed widget instead of rebuilding shapes from table/text/flex;
 #   reframed the core-catalog opening and added a self-check line.
+# Modified: 2026-06-15 - inlined funnel + gauge into _INLINE_TYPED_WIDGET_RULE
+#   (two shape->widget map rows, prop shapes, and worked examples) so
+#   conversion/drop-off funnels and metric-vs-target dials reach for the
+#   typed widget with no tool-call friction. Props sourced from the ripple
+#   manifest (funnel: data[{label,value}]/title/sort/colors/height;
+#   gauge: value/max/label/title/color/height).
 # Modified: 2026-06-16 (feat/invoke-tool-v1 — close the in-chat approval loop)
 #   — added `_INSTINCT_TRAY_RULE`: when the agent renders the pending-Instinct-
 #   approvals view (the items `instinct_pending` returns), the Approve / Reject
@@ -661,6 +667,8 @@ right here, so NO `get_inline_widget_help` call is needed.
   service / system / job status                -> status-dot (one per item)
   plans / tiers / pricing                      -> pricing-table
   a single KPI with a trend                    -> metric (NOT a bare stat)
+  conversion / drop-off / pipeline funnel      -> funnel
+  a single metric vs a target/threshold (dial) -> gauge
   a cited source / link                        -> source-card
   a 1-2 line takeaway / warning                -> callout
   term : definition pairs                      -> definition-list
@@ -698,6 +706,8 @@ source-card    — { source, title, url?, color? }
 callout        — { variant:"info|insight|warning", title, text }
 definition-list— { items:[{term,definition}], layout?:"inline|stacked" }
 metric         — { label, value, trend?, description? }
+funnel         — { data:[{label,value}], title?, sort?:"descending|ascending|none", colors?, height? }
+gauge          — { value, max?, label?, title?, color?, height? }
 
 Worked examples — the typed-widget choice in action (data already in hand):
 
@@ -707,6 +717,8 @@ Worked examples — the typed-widget choice in action (data already in hand):
   "deployment status of services"  -> flex(column) of [text + status-dot] rows, or a kv-table
                                       with a status-dot per value  (NOT prose, NOT a plain table)
   "our pricing"                    -> ONE pricing-table
+  "sales funnel leads to closed"   -> ONE funnel  (data:[{label,value}] per stage, NOT a plain table)
+  "capacity at 75 of 100"          -> ONE gauge  (value + max, NOT a bare stat tile)
 
 Keep it tight: ONE typed widget is the answer most of the time. Wrap it in
 at most a heading + a chat.send follow-up — never surround it with

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1813,10 +1813,13 @@ do NOT surround it with sibling ``stat`` / ``funnel`` / ``chart`` nodes
 
 An "app for triaging X" brief (tickets, leads, inbox, moderation queue)
 is an ``app-shell`` root with a ``sidebar`` (grouped nav, NOT a column of
-``button`` widgets), a ``master-detail`` in the content (list + selected
-detail), and ``comment-thread`` inside the detail (NOT a flex of
-``card`` widgets). Reach for these structural widgets — do NOT rebuild
-the shell / list / thread from ``split`` / ``flex`` / ``each`` / ``card``.
+``button`` widgets), a ``master-detail`` for the list, and a
+``comment-thread`` beside it for the selected item (NOT a flex of
+``card`` widgets). ``master-detail`` has NO ``detail`` prop — it owns the
+list only (``items`` + ``valueKey``/``labelKey``); put the detail widgets
+next to it in the content and bind them to the selection. Reach for these
+structural widgets — do NOT rebuild the shell / list / thread from
+``split`` / ``flex`` / ``each`` / ``card``.
 
   create_pocket(
     name="Support inbox",
@@ -1826,20 +1829,21 @@ the shell / list / thread from ``split`` / ``flex`` / ``each`` / ``card``.
         {"id": 1, "title": "Webhook 500s", "customer": "Globex", "status": "in-progress"},
         {"id": 2, "title": "Slow exports", "customer": "Stark", "status": "open"}]},
       "ui": {"type": "app-shell", "children": [
-        {"slot": "sidebar", "type": "sidebar", "props": {"groups": [
-          {"label": "INBOX", "items": [
-            {"label": "All tickets", "value": "all", "count": 47},
-            {"label": "Assigned to me", "value": "mine", "count": 12}]}]}},
-        {"type": "master-detail", "bind": "selected", "props": {
-          "items": "{state.tickets}", "width": "340px",
-          "detail": {"type": "flex",
-            "props": {"direction": "column", "gap": "12px"},
-            "children": [
-              {"type": "heading", "props": {"text": "{item.title}", "level": 3}},
-              {"type": "comment-thread", "props": {"messages": [
-                {"author": "Customer", "body": "Webhooks 500 for 2h.", "time": "2h ago"},
-                {"author": "Alex", "body": "On it — retry storm from the outage.", "time": "12m ago"}]}}
-            ]}}}
+        {"slot": "sidebar", "type": "sidebar", "props": {"title": "Inbox", "items": [
+            {"label": "All tickets", "value": "all", "group": "INBOX", "badge": "47"},
+            {"label": "Assigned to me", "value": "mine", "group": "INBOX", "badge": "12"}]}},
+        {"type": "split", "props": {"direction": "horizontal", "defaultSize": 40}, "children": [
+          {"type": "master-detail", "bind": "selected", "props": {
+            "items": "{state.tickets}", "valueKey": "id", "labelKey": "title",
+            "descriptionKey": "customer", "badgeKey": "status", "width": "100%"}},
+          {"type": "flex", "props": {"direction": "column", "gap": 12}, "children": [
+            {"type": "heading", "props": {"text": "Webhook 500s", "level": 3}},
+            {"type": "comment-thread", "props": {"comments": [
+              {"id": 1, "author": "Customer", "body": "Webhooks 500 for 2h.", "timestamp": "2h ago"},
+              {"id": 2, "author": "Alex", "body": "On it — retry storm from the outage.",
+               "timestamp": "12m ago"}]}}
+          ]}
+        ]}
       ]}
     }
   )

--- a/src/pocketpaw/ripple/_pockets.py
+++ b/src/pocketpaw/ripple/_pockets.py
@@ -1680,7 +1680,10 @@ The pocket already exists.
 
 _CREATION_EXAMPLES_MCP = """\
 <creation-examples>
-Two minimal examples showing the ``create_pocket`` envelope.
+Four examples: two minimal (prop shapes) + two rich patterns (a
+composite dashboard and a full app). The rich ones exist because the
+#1 pocket-quality miss is rebuilding a composite/app shape out of
+flex/card/table primitives instead of reaching for the typed widget.
 
 These show PROP SHAPES — how state seeds work, how a controls row
 wires to actions, how `accessorKey` maps to row keys, how `stat` and
@@ -1773,6 +1776,71 @@ recipes, notes, articles, profile cards, how-to references, runbooks.
           "variant": "body"
         }}
       ]
+    }
+  )
+
+## Dashboard pocket (composite widget — ALL data in PROPS, no sibling rebuild)
+
+A "sales pipeline / quota / revenue dashboard" brief is ONE
+``pipeline-dashboard`` at the root — NOT a grid of ``stat`` tiles + a
+``chart`` + a ``table``. The composite renders its own funnel,
+leaderboard, deals table, and ticker internally; pass data via props and
+do NOT surround it with sibling ``stat`` / ``funnel`` / ``chart`` nodes
+(that duplicates its internals). Same rule for ``analytics-dashboard``,
+``exec-dashboard``, ``ops-dashboard``, ``project-dashboard``.
+
+  create_pocket(
+    name="Sales pipeline",
+    type="deep-work",
+    ripple_spec={"type": "pipeline-dashboard", "props": {
+      "title": "Sales pipeline", "period": "Q3 2026",
+      "quota": {"label": "Team quota", "current": 1820000,
+        "target": 2500000, "currency": "$"},
+      "funnel": {"stages": [
+        {"label": "Leads", "value": 1240}, {"label": "Qualified", "value": 480},
+        {"label": "Proposal", "value": 180}, {"label": "Closed won", "value": 38}]},
+      "leaderboard": {"items": [
+        {"name": "Alex Liu", "value": "$420k", "sublabel": "12 deals"},
+        {"name": "Sam Patel", "value": "$380k", "sublabel": "9 deals"}]},
+      "deals": {"columns": [
+        {"key": "name", "label": "Deal"}, {"key": "stage", "label": "Stage"},
+        {"key": "value", "label": "Value", "align": "right"}],
+        "rows": [{"name": "Globex Q3", "stage": "Negotiation", "value": "$120k"}]}
+    }}
+  )
+
+## Full app pocket (app-shell chrome + master-detail — NOT a flex rebuild)
+
+An "app for triaging X" brief (tickets, leads, inbox, moderation queue)
+is an ``app-shell`` root with a ``sidebar`` (grouped nav, NOT a column of
+``button`` widgets), a ``master-detail`` in the content (list + selected
+detail), and ``comment-thread`` inside the detail (NOT a flex of
+``card`` widgets). Reach for these structural widgets — do NOT rebuild
+the shell / list / thread from ``split`` / ``flex`` / ``each`` / ``card``.
+
+  create_pocket(
+    name="Support inbox",
+    type="deep-work",
+    ripple_spec={
+      "state": {"selected": 1, "tickets": [
+        {"id": 1, "title": "Webhook 500s", "customer": "Globex", "status": "in-progress"},
+        {"id": 2, "title": "Slow exports", "customer": "Stark", "status": "open"}]},
+      "ui": {"type": "app-shell", "children": [
+        {"slot": "sidebar", "type": "sidebar", "props": {"groups": [
+          {"label": "INBOX", "items": [
+            {"label": "All tickets", "value": "all", "count": 47},
+            {"label": "Assigned to me", "value": "mine", "count": 12}]}]}},
+        {"type": "master-detail", "bind": "selected", "props": {
+          "items": "{state.tickets}", "width": "340px",
+          "detail": {"type": "flex",
+            "props": {"direction": "column", "gap": "12px"},
+            "children": [
+              {"type": "heading", "props": {"text": "{item.title}", "level": 3}},
+              {"type": "comment-thread", "props": {"messages": [
+                {"author": "Customer", "body": "Webhooks 500 for 2h.", "time": "2h ago"},
+                {"author": "Alex", "body": "On it — retry storm from the outage.", "time": "12m ago"}]}}
+            ]}}}
+      ]}
     }
   )
 </creation-examples>


### PR DESCRIPTION
## What

Ripple's catalog is deep — composite dashboards, app-shell, master-detail, comparison-table, data-grid, timeline, audit-log, and more. But the chat agent and the pocket specialist kept building from the basic primitives (flex / text / table / stat) instead of reaching for those typed widgets. This is the "ripple has great components but the chat and pockets don't use them" problem.

This is a prompt-only change in two files. No logic changes.

## How I found it (and confirmed the fix)

I ran a prompt eval: take the *exact* production prompts, give a sub-agent a realistic request, have it author the spec under those prompts' rules, then score the result for widget richness vs. the ideal typed widget. Same harness before and after, so the delta is the signal.

The baseline isolated two real leaks:

| Surface | Before | What it did |
|---|---|---|
| Chat (data in hand) | **3.25 / 10** | rebuilt a comparison as a plain `table`, a ranked list as `table`+`stat`, a timeline as text rows |
| Complex "app for X" pockets | **3 / 10** | declined `app-shell` / `master-detail` / `comment-thread`, hand-built from `split`/`flex`/`each` |
| Composite dashboards | wrapped | sometimes surrounded a `pipeline-dashboard` with redundant sibling `stat` tiles (duplicating its internals) |

Simple pockets were already fine (8–10) — the prompt's rules carry them. The gap was chat across the board, and complex pockets.

## The fix

- **`_inline.py` (chat):** a "REACH FOR THE TYPED WIDGET" block — a shape→widget map with **inlined prop schemas + worked examples** for `comparison-table`, `data-grid`, `timeline`, `kv-table`, `status-dot`, `pricing-table`. Because the schemas are inline, there's no `get_inline_widget_help` round-trip to discourage reaching for them. Also reframed the "six core widgets cover ~90%" opening so it reads as the base, not the ceiling.
- **`_pockets.py` (pockets):** two rich worked examples added to `_CREATION_EXAMPLES_MCP` — a composite dashboard (`pipeline-dashboard`, all data in props, with an explicit "don't wrap it in sibling stat tiles" note) and a full app (`app-shell` + `sidebar` + `master-detail` + `comment-thread`). The examples there were only a basic todo + an espresso viewer, so complex briefs had no rich pattern to imitate.

## After (same eval)

| Surface | Before | After |
|---|---|---|
| Chat (data in hand) | 3.25 | **9.1** — data-grid, comparison-table, timeline, status-dot |
| Pocket floor (recipe-fetch disabled) | 8.2 | **9.2** |
| support-app | 3 | **9** — app-shell + master-detail + comment-thread |
| sales-pipeline | 8 | **10** — one clean pipeline-dashboard |

57 prompt tests pass (`test_ripple_catalog`, `test_widget_diversity`, `test_pocket_prompts_single_source`, `test_inline_prompt_source_of_truth`).

## Honest caveats

- The eval is a **proxy** — Claude sub-agents authoring under the real prompts, not the live runtime (the local backend is degraded, no API key). The model family matches production (Claude) and the before/after uses one harness, so the delta is trustworthy; absolute production numbers may differ.
- The fix raises the **floor** (it works even when the agent skips the optional `kb search` recipe fetch). It doesn't change the recipe mechanism itself — a separate, larger option would be to auto-inject the matching recipe at dispatch instead of relying on the agent to fetch it.
- Minor residuals: a status reply sometimes hand-rolls the row frame instead of using `kv-table` (still uses `status-dot`); no-fetch pocket specs occasionally guess a prop name that the persist-time alias-fix reconciles.

Findings writeup: `docs/design/drafts/2026-06-15-ripple-authoring-widget-richness.md`.
