### PR TITLE
Dynamic sites: create_dynamic_site authoring tool + skill

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites.py
@@ -6,7 +6,10 @@
 # identity (the same ``current_workspace_id`` / ``current_user_id`` accessors in
 # ``ee.cloud.chat.agent_service`` the pocket specialist + tasks servers read).
 # Tool ids namespace as ``mcp__pocketpaw_sites_manager__<tool>`` so the Claude
-# Code allowlist machinery matches them.
+# Code allowlist machinery matches them. The create tools (create_landing_site /
+# create_svelte_site / create_dynamic_site) register on this SAME server object
+# via sites_create.py — a second create_sdk_mcp_server under this name would
+# clobber it (claude_sdk keys servers by name).
 #
 # Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2): the
 # ``edit_svelte_component`` tool also registers on this SAME server (built via
@@ -14,6 +17,11 @@
 # site's source map and republishes — so the create → publish → edit hops sit on
 # one allowlisted server. Its id rides ``SITES_TOOL_IDS``, so the per-surface
 # allowlist (extensions.py + surface/service.py) picks it up automatically.
+#
+# Updated 2026-06-14 (feat/dynamic-sites-authoring, RFC 12 A2): the
+# ``create_dynamic_site`` tool also registers on this SAME server. Dynamic sites
+# are ripple-engine sites whose spec carries live-data bindings; publish carries
+# those through to the paw-sites generator.
 """Agent-side MCP surface for publishing a PocketPaw pocket as a Paw Site.
 
 A site is published FROM a pocket: the chat agent identifies the pocket to
@@ -64,12 +72,17 @@ CREATE_SVELTE_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_svelte_site"
 # The targeted svelte-component edit tool — also registers on this SAME server
 # (see sites_create.py).
 EDIT_SVELTE_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_svelte_component"
+# The dynamic-track create tool (RFC 12 A2) also registers on this SAME server
+# (see sites_create.py). Dynamic sites are ripple-engine sites whose spec carries
+# live-data bindings; publish carries those through to the paw-sites generator.
+CREATE_DYNAMIC_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_dynamic_site"
 
 SITES_TOOL_IDS = (
     PUBLISH_TOOL_ID,
     CREATE_LANDING_SITE_TOOL_ID,
     CREATE_SVELTE_SITE_TOOL_ID,
     EDIT_SVELTE_COMPONENT_TOOL_ID,
+    CREATE_DYNAMIC_SITE_TOOL_ID,
 )
 
 
@@ -235,6 +248,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     # separate create_sdk_mcp_server) because the claude_sdk registration loop
     # keys servers by name and a second server under this name would clobber it.
     from pocketpaw_ee.agent.mcp_servers.sites_create import (
+        make_create_dynamic_site_tool,
         make_create_landing_site_tool,
         make_create_svelte_site_tool,
         make_edit_svelte_component_tool,
@@ -247,16 +261,27 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     # The targeted svelte-component edit tool — same server, so the
     # create → publish → edit hops sit on one allowlisted server.
     edit_svelte_component = make_edit_svelte_component_tool(tool)
+    # The dynamic-track create tool (RFC 12 A2) — same server, so the
+    # author-spec → create_dynamic_site → publish hops sit on one allowlisted
+    # server. Publish carries the spec's dynamic blocks through to the generator.
+    create_dynamic_site = make_create_dynamic_site_tool(tool)
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[publish, create_landing_site, create_svelte_site, edit_svelte_component],
+        tools=[
+            publish,
+            create_landing_site,
+            create_svelte_site,
+            edit_svelte_component,
+            create_dynamic_site,
+        ],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
+    "CREATE_DYNAMIC_SITE_TOOL_ID",
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
     "EDIT_SVELTE_COMPONENT_TOOL_ID",

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,25 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated 2026-06-14 (feat/dynamic-sites-authoring — Paw Sites "Dynamic track",
+# RFC 12 A2) — added the create tool ``create_dynamic_site``. It mirrors
+# ``create_svelte_site`` (the agent IS the author; the payload is persisted
+# verbatim via ``agent_create`` with ``trusted=True`` and the post-create
+# session-bind + SSE side effects on the SAME ``pocketpaw_sites_manager`` server;
+# it also runs the same identity → record_tool_call → validate →
+# _require_sites_plan_or_error plan gate the other create handlers do) but the
+# payload is a rippleSpec carrying the DYNAMIC blocks (``objects`` / ``sources`` /
+# ``actions`` / ``auth``) that back the published site with the customer's own live
+# Cloudflare D1. There is no ``assemble_*`` step. It persists via
+# ``agent_create(type_="site", pattern="dynamic", ripple_spec=<spec>,
+# engine="ripple", trusted=True)``: a dynamic site IS a ripple-engine site whose
+# spec carries the dynamic declarations as sibling keys, so publish_pocket carries
+# them through generator_client.build() unchanged and the paw-sites generator
+# scaffolds the D1 migration + read/write remote functions off the same spec.
+# ``_validate_dynamic_spec`` fails the create CLOSED on a spec that isn't actually
+# dynamic (no objects, or no sources/actions/auth) so the agent fixes it instead
+# of persisting a static page through the dynamic tool.
+#
 # Updated: 2026-06-21 (DSV-5 — dynamic svelte sites write-side) — create_svelte_site
 # now accepts a DYNAMIC svelte site. The ``source`` envelope may carry live-data
 # bindings (``objects``/``sources``/``actions``/``auth``) as SIBLING keys on the
@@ -14,7 +33,7 @@
 # satisfy a §4.3 required FILE key, so they are simply ignored by the missing-keys
 # check.
 #
-# Updated: 2026-06-17 (fix/sites-plan-gate-asymmetry) — both create handlers now
+# Updated: 2026-06-17 (fix/sites-plan-gate-asymmetry) — the create handlers now
 # call _require_sites_plan_or_error(workspace_id) right after input validation,
 # delegating to the shared sites.service.require_sites_plan gate. Sites is the
 # "sites" plan feature (go+); these create tools reach agent_create directly and
@@ -136,11 +155,17 @@ CREATE_SVELTE_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_svelte_site"
 # svelte site's source map and safely republishes. Registers on the SAME server
 # (see sites.py) so the create → publish → edit hops sit side by side.
 EDIT_SVELTE_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_svelte_component"
+# The dynamic-track create tool (RFC 12 A2) — also the SAME server. The skill flow
+# is: author the dynamic rippleSpec (UI + objects/sources/actions) →
+# create_dynamic_site → publish (publish carries the dynamic blocks through to the
+# paw-sites generator, which scaffolds the per-tenant D1 + read/write remote fns).
+CREATE_DYNAMIC_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_dynamic_site"
 
 SITES_CREATE_TOOL_IDS = (
     CREATE_LANDING_SITE_TOOL_ID,
     CREATE_SVELTE_SITE_TOOL_ID,
     EDIT_SVELTE_COMPONENT_TOOL_ID,
+    CREATE_DYNAMIC_SITE_TOOL_ID,
 )
 
 
@@ -216,6 +241,72 @@ def _missing_source_keys(source: dict[str, Any]) -> list[str]:
         if not any(k.startswith(prefix) for k in source):
             missing.append(f"{prefix}*.svelte")
     return missing
+
+
+# ── Dynamic-track spec surface (RFC 12 A2) ──────────────────────────────────
+# A dynamic Paw Site is a normal ripple-engine site whose rippleSpec ALSO carries
+# the optional top-level blocks the paw-sites generator reads to back the page
+# with the customer's own live D1 (docs/dynamic-spec-surface.md in paw-sites):
+#   - ``objects``  : the D1 schema (table defs) — derives migrations/0001_init.sql
+#   - ``sources``  : read bindings — compile to ``query`` remote fns (D1 → page)
+#   - ``actions``  : write bindings — compile to ``form`` remote fns (page → D1)
+#   - ``auth``     : a top-level bool gating the site behind end-customer accounts
+# A spec is dynamic when it declares any ``sources``, any ``actions``, or
+# ``auth: true`` (this mirrors paw-sites' parseBindings.isDynamic). The generator
+# already routes a ripple build through the dynamic path on these keys, so the
+# create tool only has to PERSIST them verbatim on the rippleSpec — publish carries
+# the whole spec through generator_client.build() unchanged.
+
+
+def _validate_dynamic_spec(spec: dict) -> list[str]:
+    """Return a list of human-readable problems with a dynamic-site ``spec``
+    (empty list = valid). Fails the create CLOSED with an actionable message
+    rather than persisting a spec the generator can't turn into a live site.
+
+    Checks the minimum contract for a dynamic site (matching paw-sites'
+    ``parseBindings``): a ``ui`` tree, an ``objects`` block, at least one live
+    binding (``sources`` / ``actions`` / ``auth``), and that every source/action
+    references a declared object. Pure — no identity / Mongo needed."""
+    problems: list[str] = []
+    ui = spec.get("ui")
+    if not (isinstance(ui, dict) and ui.get("type")):
+        problems.append("a `ui` tree (a node with a `type`) that renders the page")
+
+    objects = spec.get("objects")
+    object_names: set[str] = set()
+    if not isinstance(objects, list) or not objects:
+        problems.append("an `objects` array declaring at least one D1 table")
+    else:
+        for obj in objects:
+            if isinstance(obj, dict) and isinstance(obj.get("name"), str):
+                object_names.add(obj["name"])
+
+    sources = spec.get("sources") if isinstance(spec.get("sources"), list) else []
+    actions = spec.get("actions") if isinstance(spec.get("actions"), list) else []
+    is_dynamic = bool(sources) or bool(actions) or spec.get("auth") is True
+    if not is_dynamic:
+        problems.append(
+            "at least one live binding — a `sources` entry (read), an `actions` "
+            "entry (write), or `auth: true`. Without one the site is static, not "
+            "dynamic; use create_landing_site instead"
+        )
+
+    # Every source/action must reference a declared object (the generator errors
+    # otherwise). Only check when objects parsed, so the message stays specific.
+    if object_names:
+        for s in sources:
+            if isinstance(s, dict) and s.get("object") not in object_names:
+                problems.append(
+                    f"source `{s.get('name', '?')}` references undeclared "
+                    f"object `{s.get('object')}`"
+                )
+        for a in actions:
+            if isinstance(a, dict) and a.get("object") not in object_names:
+                problems.append(
+                    f"action `{a.get('name', '?')}` references undeclared "
+                    f"object `{a.get('object')}`"
+                )
+    return problems
 
 
 def _identity() -> tuple[str | None, str | None]:
@@ -458,6 +549,186 @@ def make_create_landing_site_tool(tool: Any) -> Any:
         return await _create_landing_site_handler(args)
 
     return create_landing_site
+
+
+async def _create_dynamic_site_handler(args: dict) -> dict:
+    """MCP handler for ``sites_manager__create_dynamic_site`` (the Dynamic track,
+    RFC 12 A2).
+
+    Reads workspace/user identity from the per-stream ContextVars, validates the
+    ``spec`` (a rippleSpec carrying the dynamic blocks — ``objects`` + at least
+    one ``sources`` / ``actions`` / ``auth``), and persists it DIRECTLY via
+    ``agent_create`` (type="site", pattern="dynamic", ripple_spec=<spec>,
+    engine="ripple", trusted=True). Returns ``{ok, pocket_id, pocket}`` on
+    success; sets ``is_error`` when identity is missing, ``spec`` is absent /
+    not dynamic / malformed, or the persist fails.
+
+    Unlike ``create_landing_site`` there is no ``assemble_*`` step — the agent
+    authored the dynamic spec (UI + data bindings) via the
+    pocketpaw-create-dynamic-site skill, so it is persisted verbatim. The dynamic
+    blocks ride the rippleSpec as sibling keys, so ``publish_pocket`` carries them
+    through ``generator_client.build()`` unchanged and the paw-sites generator
+    scaffolds the D1 migration + read/write remote functions. ``trusted=True``
+    skips the STRICT catalog gate (same reason as create_landing_site: the
+    published widget manifest is stale; the logged catalog walk + embed audit
+    still run) — the dynamic blocks are not widgets and pass through untouched."""
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "create_dynamic_site requires workspace and user context (call from a "
+            "cloud chat session)."
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        tool_server="pocketpaw_sites",
+        tool_name="_create_dynamic_site",
+        status="ok",
+        ok=True,
+    )
+
+    spec = args.get("spec")
+    if not isinstance(spec, dict) or not spec:
+        return _error_response(
+            "create_dynamic_site requires a `spec` object — the rippleSpec for the "
+            "dynamic site: a `ui` tree PLUS the dynamic blocks (`objects` for the "
+            "D1 schema, `sources` for reads, `actions` for writes, optional "
+            "`auth`). You author the spec; this tool persists it."
+        )
+
+    problems = _validate_dynamic_spec(spec)
+    if problems:
+        return _error_response(
+            "create_dynamic_site `spec` is not a valid dynamic site — it needs "
+            + "; ".join(problems)
+            + ". See the pocketpaw-create-dynamic-site skill for the shape."
+        )
+
+    # Plan gate (Sites = "sites"): reject a free-plan workspace here so the
+    # create can't bypass the router's require_plan_feature("sites") gate.
+    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:
+        return gate
+
+    name_raw = args.get("name")
+    name = name_raw.strip() if isinstance(name_raw, str) and name_raw.strip() else "Dynamic site"
+    description_raw = args.get("description")
+    description = description_raw if isinstance(description_raw, str) else ""
+    icon_raw = args.get("icon")
+    icon = icon_raw if isinstance(icon_raw, str) else ""
+    color_raw = args.get("color")
+    color = color_raw if isinstance(color_raw, str) else ""
+
+    # Persist DIRECTLY through the pockets service — NO pocket_specialist, NO
+    # draft/redraft loop. ``type_="site"`` keeps the site identity the rest of the
+    # pipeline (publish, /sites listing) keys on; ``pattern="dynamic"`` marks the
+    # live-data track (informational — publish routes on the rippleSpec's dynamic
+    # blocks, not the pattern). ``engine="ripple"`` (the default): a dynamic site
+    # IS a ripple-engine site whose spec carries dynamic declarations, so the
+    # generator compiles the rippleSpec AND scaffolds the D1 path off the same spec.
+    from pocketpaw_ee.cloud.pockets.service import agent_create
+
+    try:
+        view, new_pocket_id, err = await agent_create(
+            workspace_id=workspace_id,
+            owner_id=user_id,
+            name=name,
+            description=description,
+            type_="site",
+            pattern="dynamic",
+            icon=icon,
+            color=color,
+            ripple_spec=spec,
+            trusted=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("create_dynamic_site: persist raised", exc_info=True)
+        return _error_response(f"create failed: {exc}")
+
+    if err is not None or view is None or new_pocket_id is None:
+        return _error_response(f"create failed: {err or 'create returned no view'}")
+
+    await _bind_session_and_emit(new_pocket_id, view, user_id)
+
+    return _success_response(
+        {
+            "ok": True,
+            "pocket_id": new_pocket_id,
+            "pocket": {
+                "id": new_pocket_id,
+                "name": view.get("name"),
+                "type": view.get("type"),
+                "pattern": view.get("pattern"),
+            },
+        }
+    )
+
+
+def make_create_dynamic_site_tool(tool: Any) -> Any:
+    """Build the ``create_dynamic_site`` SDK tool object using the SDK's ``tool``
+    decorator (passed in by the caller that already imported it).
+
+    Registered on the SAME ``pocketpaw_sites_manager`` server as publish +
+    create_landing_site + create_svelte_site (see ``make_create_landing_site_tool``
+    for why one server)."""
+
+    @tool(
+        "create_dynamic_site",
+        (
+            "Create a DYNAMIC Paw Site — a published website backed by the "
+            "customer's OWN LIVE DATA (a per-tenant Cloudflare D1), with reads and "
+            "writes, NOT a static brochure. You AUTHOR a rippleSpec that carries "
+            "both the UI and the dynamic data bindings, and pass it as `spec`; the "
+            "tool persists it and stamps the pocket type='site', pattern='dynamic'. "
+            "Use this when the user wants a site that LISTS live records and/or has "
+            "a form that SAVES records (a guestbook, a booking list, a submissions "
+            "board, an order tracker). For a static marketing page use "
+            "create_landing_site instead. The `spec` (a rippleSpec) carries these "
+            "DYNAMIC blocks as top-level keys (see the pocketpaw-create-dynamic-site "
+            "skill): `objects` [{name, fields:{col: text|integer|real|boolean|"
+            "timestamp}, primaryKey}] = the D1 tables; `sources` [{name, "
+            "kind:'data', object, where?, orderBy?, limit?, refresh:'pocket_open'|"
+            "'interval'|'manual'|'live'}] = READ bindings (the UI binds a table to "
+            "'{<source name>}'); `actions` [{name, object, op:'insert', confirm?, "
+            "requiresOwnerReview?}] = WRITE bindings (rendered as a native form); "
+            "optional `auth: true` gates the site behind end-customer accounts. A "
+            "spec must declare `objects` AND at least one source/action/auth, and "
+            "every source/action must reference a declared object. Returns {ok, "
+            "pocket_id, pocket}; hand `pocket_id` to "
+            "`mcp__pocketpaw_sites_manager__publish` to publish. ok=false with an "
+            "error means relay the reason, do NOT report a created pocket."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "spec": {
+                    "type": "object",
+                    "description": (
+                        "The dynamic rippleSpec you authored — a `ui` tree PLUS the "
+                        "dynamic blocks (`objects`, `sources`, `actions`, optional "
+                        "`auth`). See the tool description / skill for the shape."
+                    ),
+                    "additionalProperties": True,
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Optional pocket/site name. Defaults to 'Dynamic site'.",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional one-line pocket description.",
+                },
+                "icon": {"type": "string", "description": "Optional lucide icon name."},
+                "color": {"type": "string", "description": "Optional accent color hex."},
+            },
+            "required": ["spec"],
+            "additionalProperties": False,
+        },
+    )
+    async def create_dynamic_site(args):  # type: ignore[no-untyped-def]
+        return await _create_dynamic_site_handler(args)
+
+    return create_dynamic_site
 
 
 async def _create_svelte_site_handler(args: dict) -> dict:
@@ -945,6 +1216,7 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
 
 
 __all__ = [
+    "CREATE_DYNAMIC_SITE_TOOL_ID",
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
     "EDIT_SVELTE_COMPONENT_TOOL_ID",
@@ -952,6 +1224,7 @@ __all__ = [
     "SITES_CREATE_TOOL_IDS",
     "SVELTE_REQUIRED_EXACT_KEYS",
     "SVELTE_REQUIRED_PREFIXES",
+    "make_create_dynamic_site_tool",
     "make_create_landing_site_tool",
     "make_create_svelte_site_tool",
     "make_edit_svelte_component_tool",

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-dynamic-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-dynamic-site/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: pocketpaw-create-dynamic-site
+description: |
+  Build a DYNAMIC Paw Site — a published website backed by the customer's
+  OWN LIVE DATA (a per-tenant Cloudflare D1), with reads AND writes, not a
+  static brochure. Invoke when the user wants a site that LISTS live records
+  and/or has a form that SAVES records: "a guestbook site", "a public
+  booking list people can add to", "a submissions board", "an order tracker
+  page", "a site where visitors sign up and it remembers them". This is the
+  live-data authoring brain — YOU author a rippleSpec that carries both the
+  UI and the dynamic data bindings (objects = the D1 tables, sources = read
+  bindings, actions = write bindings, optional auth), and a deterministic
+  tool persists the pocket stamped type="site" + pattern="dynamic" so publish
+  scaffolds the D1 migration + read/write remote functions. For a STATIC
+  marketing page use pocketpaw-create-paw-site (ripple) or
+  pocketpaw-create-svelte-site (svelte); for publishing an EXISTING pocket
+  use pocketpaw-create-site. Loading this skill keeps the chat agent's
+  always-on system prompt small while still delivering the full dynamic-site
+  authoring brain when a live-data site is actually requested.
+---
+
+# Build a Paw Site — the dynamic (live-data) authoring brain
+
+You're building a **dynamic Paw Site**: a real, standalone website backed by
+the customer's **own live Cloudflare D1**. Unlike a marketing page, it **reads
+records from a database and lists them**, and/or has a **form that writes
+records**. A guestbook, a public booking list, a submissions board, an order
+tracker — anything where the page shows live data and visitors can add to it.
+
+This is the sibling of the marketing-site skills. The difference is the
+**payload and what gets generated**:
+
+| | `create-paw-site` / `create-svelte-site` | **`create-dynamic-site` (this skill)** |
+|---|---|---|
+| Backs the page with | nothing (static brochure) | **the customer's own live D1** |
+| What you provide | copy / Svelte components | **a rippleSpec with data bindings** |
+| What publish generates | prerendered static HTML | **SSR routes + D1 migration + read/write remote functions** |
+| Persisted as | `pattern="landing"` | `pattern="dynamic"` |
+
+A dynamic site is a **ripple-engine** site whose spec carries extra **dynamic
+blocks** as top-level keys. You author the `ui` (the page) **plus** those blocks;
+the tool persists the whole spec, and publish carries it to the paw-sites
+generator, which scaffolds the D1 and compiles the bindings into SvelteKit
+remote functions. You do **NOT** call `pocket_specialist`, and you do **NOT**
+provision Cloudflare yourself — the generator handles the D1.
+
+## The dynamic blocks (this is the whole skill)
+
+A spec is **dynamic** when it declares any `sources`, any `actions`, or
+`auth: true`. Add these four optional top-level keys alongside `ui`:
+
+### `objects` — the data schema (the D1 tables)
+
+An array of table definitions. The generator derives the D1 migration from
+this. Every `source`/`action` references an object by `name`.
+
+```jsonc
+"objects": [
+  {
+    "name": "entry",                          // table name
+    "fields": {                               // column -> field type
+      "id": "text",
+      "name": "text",
+      "message": "text"
+    },
+    "primaryKey": "id"                        // the column used as PRIMARY KEY
+  }
+]
+```
+
+Field types (spec → D1): `text`→TEXT, `integer`→INTEGER, `real`→REAL,
+`boolean`→INTEGER (0/1), `timestamp`→TEXT (ISO 8601).
+
+### `sources` — READ bindings (D1 → page)
+
+Each compiles to a `query` remote function over the D1. The UI references a
+source by `"{<source name>}"` (e.g. a table bound to `"{entries}"`).
+
+```jsonc
+"sources": [
+  {
+    "name": "entries",        // export name; the UI binds a table to "{entries}"
+    "kind": "data",           // only "data" is supported
+    "object": "entry",        // must be a declared object
+    "where": "id = ?",        // optional SQL WHERE
+    "orderBy": "name",        // optional SQL ORDER BY column
+    "limit": 50,              // optional LIMIT
+    "refresh": "pocket_open"  // pocket_open | interval | manual | live
+  }
+]
+```
+
+`refresh` modes: `pocket_open` (query on page load — the default you want),
+`interval`/`manual` (same query, client re-fetches), `live` (compiles to a
+`query.live` generator that re-queries every ~3s and streams updates with no
+reload — use for an order/status tracker).
+
+### `actions` — WRITE bindings (page → D1)
+
+Each compiles to a validated `form` remote function that INSERTs into D1, and
+the generated page renders a **native `<form>`** for it (works with JS off). A
+write that touches an object single-flight-refreshes any source reading it, so
+the list updates after a submit.
+
+```jsonc
+"actions": [
+  {
+    "name": "sign",                  // export name; rendered as a form
+    "object": "entry",               // must be a declared object
+    "op": "insert",                  // "insert" is the path built today
+    "confirm": "Sign the guestbook?",   // optional client confirm before submit
+    "requiresOwnerReview": false        // optional; flags the row for owner review
+  }
+]
+```
+
+The form's inputs are derived from the object's **non-primary-key fields**
+(here: `name`, `message`), so the writer fills those. Keep the object lean —
+every non-PK field becomes a required form input. Auto-set columns (a created
+timestamp, a status) are friction on a write form; leave them out of the object
+unless the writer should provide them.
+
+### `auth` — end-customer accounts (optional)
+
+A top-level boolean. `auth: true` makes the generator add `users`/`sessions`
+tables, signup/login/logout remote functions, and a protected route group.
+**Auth wiring is a thin slice today** — emit `auth: true` only if the user
+explicitly asks for accounts; otherwise leave it off.
+
+## STEP 1 — Author the spec (UI + dynamic blocks)
+
+Write the `ui` tree the way you would for any pocket page: a container with the
+content. For the dynamic part:
+
+- To **show a list**, bind a `table` (or list widget) to a source:
+  `{ "type": "table", "props": { "data": "{entries}" } }`. The source seeds its
+  rows into the page at render.
+- The **write form** is generated automatically from each `action` — you do
+  **not** hand-author the form widget in `ui`. Just declare the `action`.
+
+Use **real, concrete copy** (a real heading, real field intent) — never "TBD".
+
+### Worked example — a guestbook (read + write)
+
+```json
+{
+  "ui": {
+    "type": "container",
+    "children": [
+      { "type": "heading", "props": { "text": "Guestbook" } },
+      { "type": "table", "props": { "data": "{entries}" } }
+    ]
+  },
+  "objects": [
+    {
+      "name": "entry",
+      "fields": { "id": "text", "name": "text", "message": "text" },
+      "primaryKey": "id"
+    }
+  ],
+  "sources": [
+    { "name": "entries", "kind": "data", "object": "entry", "orderBy": "name", "refresh": "pocket_open" }
+  ],
+  "actions": [
+    { "name": "sign", "object": "entry", "op": "insert", "confirm": "Sign the guestbook?" }
+  ]
+}
+```
+
+This generates a site that **lists** the `entry` rows (the `entries` source)
+and renders a **form** with `name` + `message` inputs (the `sign` action) that
+writes a new row and refreshes the list.
+
+## STEP 2 — Call `create_dynamic_site`
+
+Hand the spec to the tool. It validates the dynamic contract (a `ui`, an
+`objects` block, at least one source/action/auth, every binding referencing a
+declared object), then persists the pocket stamped `type="site"` +
+`pattern="dynamic"` with your spec as the rippleSpec — directly, no specialist.
+
+```
+mcp__pocketpaw_sites_manager__create_dynamic_site(
+  spec = <the spec from STEP 1>,
+  name = "Guestbook"           // optional; defaults to "Dynamic site"
+)
+```
+
+It returns `{ ok, pocket_id, pocket }`. Keep `pocket_id` for STEP 3. If `ok` is
+false, **relay the error** — do **not** claim a phantom create. The tool fails
+closed and tells you what's wrong (e.g. "needs at least one live binding", or a
+source referencing an undeclared object); fix the spec and retry. If the request
+is actually a static marketing page (no live data), the tool steers you to
+`create_landing_site` — follow that.
+
+## STEP 3 — Publish
+
+Publish the new pocket as a site:
+
+```
+mcp__pocketpaw_sites_manager__publish(pocket_id = <the id from STEP 2>)
+```
+
+Publish carries the spec's dynamic blocks to the generator, which scaffolds the
+D1 migration + the read/write remote functions, runs the smoke gate, and
+deploys. Show the user the returned `url` plus a pointer to **/sites**. Relay any
+`ok: false` error — never claim a phantom publish.
+
+> Note on data: real per-tenant Cloudflare D1 provisioning is a deploy-time
+> concern handled by the control plane. Locally (no Cloudflare creds) the site
+> serves against a local D1. Either way you don't provision anything — you only
+> author the spec.
+
+## Quality bar — done right when
+
+1. **The spec is genuinely dynamic.** It declares `objects` AND at least one
+   `source` / `action` / `auth` — not a static page pushed through the dynamic
+   tool. Every source/action references a declared object.
+2. **Read and write are both wired** (when the user wants both): a `source` the
+   UI lists via `"{name}"`, and an `action` whose object's non-PK fields are the
+   form inputs.
+3. **The object is lean.** Only the columns the writer provides plus the
+   primary key — no auto-set columns forced into the write form.
+4. **You showed the live URL.** The user got the `url` from publish and a
+   pointer to /sites — not just "done". Errors were relayed, never masked.
+
+## Related tools (via MCP)
+
+- `mcp__pocketpaw_sites_manager__create_dynamic_site` — **the create step.**
+  Pass the dynamic `spec` you authored; the tool persists the pocket stamped
+  `type="site"` + `pattern="dynamic"`. Returns `{ok, pocket_id, pocket}`.
+- `mcp__pocketpaw_sites_manager__publish` — publish the pocket as a live site
+  (generates the D1 + remote functions); show the user the `url`.
+- `mcp__pocketpaw_sites_manager__create_landing_site` — for a STATIC marketing
+  page instead (no live data).

--- a/tests/ee/agent/test_sites_mcp_server/test_create_dynamic_site.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_create_dynamic_site.py
@@ -1,0 +1,318 @@
+# tests/ee/agent/test_sites_mcp_server/test_create_dynamic_site.py
+# Created: 2026-06-14 (feat/dynamic-sites-authoring) — coverage for the Paw Sites
+# "Dynamic track" create tool ``create_dynamic_site`` (RFC 12 A2) on the
+# in-process ``pocketpaw_sites_manager`` server. Three layers:
+#   1. Dynamic-spec validation (``_validate_dynamic_spec``) — a spec must declare
+#      a `ui` tree, an `objects` block, AND at least one live binding
+#      (sources/actions/auth), with every source/action referencing a declared
+#      object; the create fails CLOSED otherwise so a static / malformed spec
+#      can't slip through the dynamic tool.
+#   2. Registration — the tool id rides the SAME server allowlist as publish +
+#      create_landing_site + create_svelte_site, and the provider advertises it.
+#   3. End-to-end handler — against a real (mongomock) Beanie DB it persists the
+#      dynamic rippleSpec via ``agent_create`` and reads the PERSISTED _PocketDoc
+#      back to confirm type=="site", pattern=="dynamic", and — the load-bearing
+#      assertion — that the dynamic blocks (objects/sources/actions) SURVIVED
+#      normalization on the persisted rippleSpec (ground truth in Mongo, NOT agent
+#      narration). If the normalizer ever strips them the publish path silently
+#      generates a static site, so this guards the whole dynamic pipeline.
+# Updated: rebase onto dev — create_dynamic_site now runs the shared Sites plan
+# gate (require_sites_plan) before agent_create, like the landing + svelte create
+# handlers. Added the autouse ``_default_sites_plan`` fixture (mirrors
+# test_create_svelte_site.py) defaulting the plan to "go" so the end-to-end create
+# test exercises the persist mechanics; gate DENIAL is covered in
+# tests/ee/sites/test_plan_gate.py.
+"""Tests for the dynamic-track create tool (create_dynamic_site)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture(autouse=True)
+def _default_sites_plan():
+    """create_dynamic_site now calls the shared Sites plan gate
+    (sites.service.require_sites_plan) before agent_create — same gate the landing
+    + svelte create handlers run (fix/sites-plan-gate-asymmetry, then
+    decouple-sites-from-fabric moved it onto the dedicated "sites" flag). These
+    tests use synthetic workspace ids with no seeded Workspace doc, so default the
+    plan to one that unlocks Sites ("go") to exercise the create mechanics. Plan-
+    gate denial is covered separately in tests/ee/sites/test_plan_gate.py. Mirrors
+    the autouse fixture in test_create_svelte_site.py."""
+    with patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value="go"),
+    ):
+        yield
+
+
+# A representative guestbook dynamic spec: read source + write action over one
+# D1 object. Mirrors paw-sites/tests/fixtures/guestbook-spec.json.
+def _guestbook_spec() -> dict:
+    return {
+        "ui": {
+            "type": "container",
+            "children": [
+                {"type": "heading", "props": {"text": "Guestbook"}},
+                {"type": "table", "props": {"data": "{entries}"}},
+            ],
+        },
+        "objects": [
+            {
+                "name": "entry",
+                "fields": {"id": "text", "name": "text", "message": "text"},
+                "primaryKey": "id",
+            }
+        ],
+        "sources": [
+            {
+                "name": "entries",
+                "kind": "data",
+                "object": "entry",
+                "orderBy": "name",
+                "refresh": "pocket_open",
+            }
+        ],
+        "actions": [
+            {"name": "sign", "object": "entry", "op": "insert", "confirm": "Sign the guestbook?"}
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dynamic-spec validation (pure — no identity / Mongo needed)
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicSpecValidation:
+    def test_complete_guestbook_spec_is_valid(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _validate_dynamic_spec
+
+        assert _validate_dynamic_spec(_guestbook_spec()) == []
+
+    def test_auth_only_spec_is_valid(self) -> None:
+        """auth:true with objects but no sources/actions is still dynamic."""
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _validate_dynamic_spec
+
+        spec = {
+            "ui": {"type": "container", "children": []},
+            "objects": [{"name": "x", "fields": {"id": "text"}}],
+            "auth": True,
+        }
+        assert _validate_dynamic_spec(spec) == []
+
+    def test_static_spec_no_bindings_is_rejected(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _validate_dynamic_spec
+
+        spec = {
+            "ui": {"type": "container", "children": []},
+            "objects": [{"name": "entry", "fields": {"id": "text"}}],
+        }
+        problems = _validate_dynamic_spec(spec)
+        assert any("live binding" in p for p in problems)
+
+    def test_missing_objects_is_rejected(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _validate_dynamic_spec
+
+        spec = {
+            "ui": {"type": "container", "children": []},
+            "sources": [{"name": "s", "kind": "data", "object": "entry", "refresh": "pocket_open"}],
+        }
+        problems = _validate_dynamic_spec(spec)
+        assert any("objects" in p for p in problems)
+
+    def test_missing_ui_is_rejected(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _validate_dynamic_spec
+
+        spec = {k: v for k, v in _guestbook_spec().items() if k != "ui"}
+        problems = _validate_dynamic_spec(spec)
+        assert any("`ui`" in p for p in problems)
+
+    def test_source_referencing_undeclared_object_is_rejected(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _validate_dynamic_spec
+
+        spec = _guestbook_spec()
+        spec["sources"][0]["object"] = "ghost"
+        problems = _validate_dynamic_spec(spec)
+        assert any("undeclared object" in p and "ghost" in p for p in problems)
+
+
+# ---------------------------------------------------------------------------
+# Registration — the tool rides the shared sites_manager allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_tool_id_on_shared_server_allowlist(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import (
+            CREATE_DYNAMIC_SITE_TOOL_ID,
+            SITES_TOOL_IDS,
+        )
+
+        assert CREATE_DYNAMIC_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_dynamic_site"
+        assert CREATE_DYNAMIC_SITE_TOOL_ID in SITES_TOOL_IDS
+
+    def test_provider_advertises_dynamic_tool_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import CREATE_DYNAMIC_SITE_TOOL_ID
+        from pocketpaw_ee.extensions import CloudSitesMcpProvider
+
+        assert CREATE_DYNAMIC_SITE_TOOL_ID in CloudSitesMcpProvider().tool_ids()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end handler — persist + read back from Mongo (ground truth)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def recording_bus():
+    """Install a recording EventBus so ``agent_create``'s ``emit(PocketCreated)``
+    doesn't raise (the real bus is only wired by ``init_realtime()`` at boot).
+    Mirrors tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+class TestCreateDynamicSiteEndToEnd:
+    @pytest.mark.asyncio
+    async def test_persists_dynamic_pocket_with_bindings_intact(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """Drive the handler against a real (mongomock) Beanie DB and read the
+        persisted _PocketDoc back. Proves a pocket lands with type=="site",
+        pattern=="dynamic", and the dynamic blocks SURVIVED on the rippleSpec —
+        the load-bearing guarantee for the publish→generator path."""
+        from unittest.mock import patch
+
+        from bson import ObjectId
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=workspace_id,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=user_id,
+            ),
+        ):
+            out = await sites_create_mcp._create_dynamic_site_handler(
+                {"spec": _guestbook_spec(), "name": "Guestbook"}
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        pocket_id = body["pocket_id"]
+        assert pocket_id
+
+        # Ground truth: read the persisted doc straight from Mongo.
+        doc = await _PocketDoc.get(ObjectId(pocket_id))
+        assert doc is not None
+        assert doc.type == "site"
+        assert doc.pattern == "dynamic"
+        # The dynamic blocks MUST survive normalization on the persisted rippleSpec
+        # — publish carries the whole spec to the paw-sites generator, which only
+        # scaffolds the D1 + remote fns when these keys are present.
+        spec = doc.rippleSpec
+        assert isinstance(spec, dict)
+        assert [o["name"] for o in spec["objects"]] == ["entry"]
+        assert [s["name"] for s in spec["sources"]] == ["entries"]
+        assert [a["name"] for a in spec["actions"]] == ["sign"]
+        # The source's table binding the UI reads survived too.
+        assert spec["sources"][0]["object"] == "entry"
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_is_error(self) -> None:
+        from unittest.mock import patch
+
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=None,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=None,
+            ),
+        ):
+            out = await sites_create_mcp._create_dynamic_site_handler({"spec": _guestbook_spec()})
+
+        assert out.get("is_error") is True
+        assert "workspace and user context" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_spec_is_error(self) -> None:
+        from unittest.mock import patch
+
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value="ws_1",
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value="u_1",
+            ),
+        ):
+            out = await sites_create_mcp._create_dynamic_site_handler({"name": "X"})
+
+        assert out.get("is_error") is True
+        assert "`spec`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_static_spec_is_error_pointing_at_landing(self) -> None:
+        """A spec with no live bindings fails closed and steers the agent to
+        create_landing_site instead of persisting a static page as 'dynamic'."""
+        from unittest.mock import patch
+
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        static_spec = {
+            "ui": {"type": "container", "children": []},
+            "objects": [{"name": "entry", "fields": {"id": "text"}}],
+        }
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value="ws_1",
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value="u_1",
+            ),
+        ):
+            out = await sites_create_mcp._create_dynamic_site_handler({"spec": static_spec})
+
+        assert out.get("is_error") is True
+        assert "create_landing_site" in out["content"][0]["text"]

--- a/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
@@ -25,6 +25,7 @@ pytest.importorskip("pocketpaw_ee")
 class TestSitesMcpServerRegistration:
     def test_server_name_and_tool_id(self) -> None:
         from pocketpaw_ee.agent.mcp_servers.sites import (
+            CREATE_DYNAMIC_SITE_TOOL_ID,
             CREATE_LANDING_SITE_TOOL_ID,
             CREATE_SVELTE_SITE_TOOL_ID,
             EDIT_SVELTE_COMPONENT_TOOL_ID,
@@ -39,18 +40,20 @@ class TestSitesMcpServerRegistration:
         # The deterministic create tools + the targeted edit tool register on the
         # SAME server (two create_sdk_mcp_server calls under one name would clobber
         # each other), so all ids ride the one ``pocketpaw_sites_manager`` server:
-        # the ripple landing tool, the svelte-track tool, and the component-edit
-        # tool sit beside publish.
+        # the ripple landing tool, the svelte-track tool, the component-edit tool,
+        # and the dynamic-track tool sit beside publish.
         assert CREATE_LANDING_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_landing_site"
         assert CREATE_SVELTE_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_svelte_site"
         assert (
             EDIT_SVELTE_COMPONENT_TOOL_ID == "mcp__pocketpaw_sites_manager__edit_svelte_component"
         )
+        assert CREATE_DYNAMIC_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_dynamic_site"
         assert PUBLISH_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_LANDING_SITE_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_SVELTE_SITE_TOOL_ID in SITES_TOOL_IDS
         assert EDIT_SVELTE_COMPONENT_TOOL_ID in SITES_TOOL_IDS
-        assert len(SITES_TOOL_IDS) == 4
+        assert CREATE_DYNAMIC_SITE_TOOL_ID in SITES_TOOL_IDS
+        assert len(SITES_TOOL_IDS) == 5
 
     def test_extension_provider_advertises_tool_id(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk


### PR DESCRIPTION
Lights up the authoring side of dynamic Paw Sites. The generator already does D1 + read/write remote functions (RFC 12 A2, merged in paw-sites M1-M6) -- what was missing was a way for the chat agent to actually create one.

## What's here
- `create_dynamic_site` MCP tool -- mirrors `create_landing_site`. The agent authors a rippleSpec that carries both the UI and the data bindings (objects -> D1 tables, sources -> reads, actions -> writes, optional auth); the tool persists the pocket stamped `type="site"` + `pattern="dynamic"` so publish routes it through the dynamic generator path.
- A `pocketpaw-create-dynamic-site` skill that teaches the agent what read/write declarations to emit. It loads on demand, so it stays out of the always-on prompt.
- Publish wiring so the dynamic spec reaches the generator.

## Verified
23 tests pass (`test_create_dynamic_site.py` + the sites MCP tool suite). The generator side -- a real guestbook reading and writing under workerd -- is the paired paw-sites PR.

## Deferred
Real Cloudflare D1 provisioning + per-tenant creds (LOCAL/workerd today). A `/sites` front-end create flow for dynamic (chat-create works now). C4 regen.

Pairs with the paw-sites guestbook PR. Please don't merge yet -- for review.