### PR TITLE
Chain Flow v2: agent authors a flat step-graph, Python owns the tree

### DIFF
--- a/src/pocketpaw/agents/sdk_mcp_widgets.py
+++ b/src/pocketpaw/agents/sdk_mcp_widgets.py
@@ -23,10 +23,24 @@ Changes:
     (the anti-pattern start_flow exists to prevent). Hosting it on this
     already-ambient core server is the minimal reachable bridge — it rides
     the same registration + allowlist path as ``get_inline_widget_help``.
+  - 2026-06-15 (feat/chain-flow-v2 — SPLIT-BRAIN FIX): this server's
+    ``start_flow`` was still PRESET-ONLY (``flow_type`` required, ``steps``
+    ignored) while the inline prompt now tells the model to author a FLAT
+    step-graph. Because this is the ``start_flow`` the default
+    ``claude_agent_sdk`` backend actually calls, every flat-graph authoring
+    attempt was rejected at the tool boundary with "needs a flow_type" — the
+    #1 cause of Chain Flow v2 flakiness. ``_start_flow_handler`` and the
+    ``@tool`` definition are rewritten to MIRROR
+    ``tools/builtin/flow_tool.py::execute``: a flat ``steps`` graph routes to
+    ``build_flow_from_descriptor`` (the general path), a bare ``flow_type``
+    routes to ``build_flow`` (the preset shorthand), JSON-string args are
+    coerced, and a ``FlowBuildError`` is surfaced verbatim so the model can
+    fix the graph and retry.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -126,55 +140,114 @@ def _text_result(text: str, *, is_error: bool = False) -> dict:
     return out
 
 
+def _coerce_json_arg(value: Any, name: str) -> Any:
+    """Coerce a JSON-string arg into a structure; pass through if already one.
+
+    Mirrors ``StartFlowTool._coerce_json``: SDK / subprocess callers that can't
+    pass a nested object through a flat signature send ``steps`` / ``complete``
+    / ``config`` as a JSON string. Returns an ``Error: …`` string on bad JSON so
+    the handler can relay it verbatim.
+    """
+    if value is None or not isinstance(value, str):
+        return value
+    s = value.strip()
+    if not s:
+        return None
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        return f"Error: `{name}` was a string but not valid JSON."
+
+
 async def _start_flow_handler(args: dict) -> dict:
     """Expand a flow descriptor into a ``{version, ui}`` Chain Flow doc.
 
-    Backs the ``start_flow`` MCP tool. Shares the deterministic
-    ``pocketpaw.ripple._flows.build_flow`` builder with the runtime
-    ``StartFlowTool`` so the cloud agent and the runtime registry scaffold
-    identical trees. The model emits only ``flow_type`` (+ optional ``domain``
-    / ``config``); Python owns the recursively-nested chain / chain_map tree.
+    Backs the ``start_flow`` MCP tool on the default ``claude_agent_sdk``
+    backend. MIRRORS ``tools/builtin/flow_tool.py::StartFlowTool.execute`` so
+    the SDK chat agent and the runtime builtin registry scaffold identical
+    trees from identical input.
 
-    Args:
-      flow_type: required template name (one of ``FLOW_TYPES``).
-      domain:    optional forward-compatible hint; does not change the tree.
-      config:    optional per-template copy overrides (shape-stable). May
-                 arrive as a JSON string from some callers — coerced here.
+    Routing (flat graph takes precedence, then preset shorthand):
+      - a flat ``steps`` graph (with ``flow`` / ``entry``, optional ``title`` /
+        ``complete``) → :func:`build_flow_from_descriptor` (the GENERAL path the
+        inline prompt teaches);
+      - a bare ``flow_type`` (+ optional ``domain`` / ``config``) →
+        :func:`build_flow` (the preset shorthand for the two known shapes).
+
+    ``steps`` / ``complete`` / ``config`` may arrive as JSON strings — coerced.
+    On a :class:`FlowBuildError` the precise, agent-readable message is surfaced
+    verbatim (via ``is_error``) so the model can fix the flat graph and retry
+    (genesis's forgiving-author loop), instead of getting a stack trace.
     """
-    import json
+    from pocketpaw.ripple._flows import (
+        FLOW_TYPES,
+        FlowBuildError,
+        build_flow,
+        build_flow_from_descriptor,
+    )
 
-    from pocketpaw.ripple._flows import FLOW_TYPES, build_flow
+    # Coerce JSON-string structures back to objects (matches StartFlowTool).
+    steps = _coerce_json_arg(args.get("steps"), "steps")
+    if isinstance(steps, str):  # coercion failed → it returned an Error string
+        return _text_result(steps, is_error=True)
+    complete = _coerce_json_arg(args.get("complete"), "complete")
+    if isinstance(complete, str) and complete.startswith("Error:"):
+        return _text_result(complete, is_error=True)
+    config = _coerce_json_arg(args.get("config"), "config")
+    if isinstance(config, str) and config.startswith("Error:"):
+        return _text_result(config, is_error=True)
 
-    flow_type = args.get("flow_type") or ""
-    if not isinstance(flow_type, str) or not flow_type:
-        valid = ", ".join(sorted(FLOW_TYPES))
-        return _text_result(
-            f"Error: start_flow needs a `flow_type`. Known templates: {valid}.",
-            is_error=True,
-        )
-
-    domain = args.get("domain")
-    if domain is not None and not isinstance(domain, str):
-        domain = None
-
-    config = args.get("config")
-    # `config` may arrive as a JSON string from callers that can't pass a
-    # nested object through a flat signature. Coerce it, matching StartFlowTool.
-    if isinstance(config, str):
+    # Route 1: a flat `steps` graph (the general authoring path).
+    if steps is not None:
+        if not isinstance(steps, list):
+            return _text_result("Error: `steps` must be an array of step objects.", is_error=True)
+        flow = args.get("flow")
+        entry = args.get("entry")
+        title = args.get("title")
+        descriptor: dict[str, Any] = {
+            "flow": flow if isinstance(flow, str) and flow else "flow",
+            "entry": entry if isinstance(entry, str) else "",
+            "steps": steps,
+        }
+        if isinstance(title, str) and title:
+            descriptor["title"] = title
+        if complete is not None:
+            descriptor["complete"] = complete
         try:
-            config = json.loads(config) if config.strip() else None
-        except json.JSONDecodeError:
-            return _text_result("Error: `config` was a string but not valid JSON.", is_error=True)
-    if config is not None and not isinstance(config, dict):
-        return _text_result("Error: `config` must be an object (key/value map).", is_error=True)
+            doc = build_flow_from_descriptor(descriptor)
+        except FlowBuildError as exc:
+            # Precise, agent-readable: the model fixes the flat graph and retries.
+            return _text_result(f"Error: {exc}", is_error=True)
+        return _text_result(_dump_flow_doc(doc))
 
-    try:
-        doc = build_flow(flow_type, domain=domain, config=config)
-    except ValueError as exc:
-        # Unknown flow_type — surface the valid set so the model can retry.
-        return _text_result(f"Error: {exc}", is_error=True)
+    # Route 2: the optional `flow_type` preset shorthand.
+    flow_type = args.get("flow_type") or ""
+    if isinstance(flow_type, str) and flow_type:
+        if config is not None and not isinstance(config, dict):
+            return _text_result("Error: `config` must be an object (key/value map).", is_error=True)
+        domain = args.get("domain")
+        if domain is not None and not isinstance(domain, str):
+            domain = None
+        try:
+            doc = build_flow(flow_type, domain=domain, config=config)
+        except (FlowBuildError, ValueError) as exc:
+            return _text_result(f"Error: {exc}", is_error=True)
+        return _text_result(_dump_flow_doc(doc))
 
-    return _text_result(json.dumps(doc, ensure_ascii=False))
+    valid = ", ".join(sorted(FLOW_TYPES))
+    return _text_result(
+        "Error: start_flow needs either a flat `steps` graph (with `flow` and "
+        f"`entry`) or a `flow_type` preset shorthand (one of: {valid}).",
+        is_error=True,
+    )
+
+
+def _dump_flow_doc(doc: dict[str, Any]) -> str:
+    """Serialize a flow doc, dropping the internal ``_warnings`` key (soft
+    single-branch-reachability notes are build-time guidance, not part of the
+    rendered spec). Mirrors ``StartFlowTool._dump``."""
+    clean = {k: v for k, v in doc.items() if k != "_warnings"}
+    return json.dumps(clean, ensure_ascii=False)
 
 
 def build_widgets_context_server() -> tuple[str, Any] | None:
@@ -232,56 +305,131 @@ def build_widgets_context_server() -> tuple[str, Any] | None:
     @tool(
         "start_flow",
         (
-            "Scaffold a complete multi-step flow (wizard / intake / survey / "
-            "any step-by-step or collect-then-act sequence) from a tiny "
-            "descriptor. DO NOT hand-author nested chain / chain_map step "
-            "trees and DO NOT fake a multi-step flow with a single `set`-"
-            "stepped spec — both are fragile and render only the first step. "
-            "Pick a `flow_type` template and this tool returns the ENTIRE "
-            "nested flow tree as a {version, ui} doc, ready to drop verbatim "
-            "into a ```ui-spec fenced block. The flow then advances entirely "
-            "client-side with no further model calls between steps.\n\n"
-            "Templates (`flow_type`):\n"
-            "- `onboarding_wizard` — pick a goal -> enter workspace details "
-            "(branches on the goal) -> confirm. A new-user setup wizard.\n"
-            "- `due_diligence_intake` — pick a deal stage -> stage-specific "
-            "financials (branches on the stage) -> risk flags -> review. A "
-            "multi-step vertical intake; the same shape works for a survey.\n\n"
-            "Optional `config` tweaks copy without changing the tree's shape "
-            "(onboarding_wizard accepts {product_name, goals}; "
-            "due_diligence_intake accepts {company_name, submit_event}). When "
-            "in doubt, pass just `flow_type`. Returns the JSON doc to emit — "
-            "wrap it verbatim in a ```ui-spec fence; do not edit the chain / "
-            "chain_map structure."
+            "Scaffold a complete multi-step flow OR interactive mini-app (a "
+            "wizard, intake, survey, onboarding sequence, or a 'collect "
+            "details then DO something' flow) from a FLAT step-graph. DO NOT "
+            "hand-author nested chain / chain_map step trees and DO NOT fake a "
+            "flow with a single `set`-stepped spec — both render only the first "
+            "step and dead-end. You describe a flat list of steps; this tool "
+            "materializes the ENTIRE nested, validated flow tree as a "
+            "{version, ui} doc, ready to drop into a ```ui-spec fence. The flow "
+            "then advances entirely client-side with no further model calls "
+            "between steps.\n\n"
+            "AUTHOR A FLAT GRAPH (think in states, not screens):\n"
+            "- `flow`: a stable id for the flow (e.g. 'vendor_intake').\n"
+            "- `entry`: the id of the first step.\n"
+            "- `steps`: a list. Each step has an `id`, a `kind` "
+            "(select | form | confirm | info), a `title`, its content "
+            "(`options` for select, `fields` for form, `review` for confirm, "
+            "`body` for info), and where it goes next:\n"
+            '    * `next: "<id>"` — linear next step;\n'
+            '    * `branch: { "<optionId>": "<id>" }` — branch on the '
+            "picked option.\n"
+            "  A step with NEITHER `next` nor `branch` is the TERMINAL step and "
+            "carries `complete` (what to do with the answers). A terminal "
+            "`complete` uses `action:` (chat | navigate | emit | call_binding | "
+            "create_pocket | invoke_tool) — NEVER `type:`/`kind:`:\n"
+            "    chat → hand the answers back to you (default); navigate / emit "
+            "→ go somewhere / raise an event; call_binding → write to the "
+            "backend (works today); create_pocket → materialize a permanent "
+            "pocket; invoke_tool → run a named tool (may be unavailable until "
+            "the tool registry ships — prefer call_binding to act on data).\n"
+            "- Per-step `actions` (optional) are buttons that call a "
+            "tool/API/binding MID-FLOW without leaving the step (verb: "
+            "call_binding | api | invoke_tool). When the user says approve / "
+            "reject / fulfill / take action — that is a `call_binding` ACTION "
+            "BUTTON wired to the verb, not a yes/no select.\n"
+            "- Reference earlier answers with `{stepId.field}` "
+            "(e.g. `{pick_goal.label}`, `{enter_details.company}`) in review "
+            "rows and action args — this tool rewrites them correctly; you "
+            "NEVER write the raw `{state.…_selection/_formData}` form.\n\n"
+            "The builder REPAIRS recoverable slips (a missing terminal "
+            "`complete`, a dead-end last step) and REJECTS only genuine "
+            "structural bugs (a transition to an undeclared id, a duplicate "
+            "step id, a branch key that is not an option id) with a precise "
+            "error you can fix and retry.\n\n"
+            "PRESET SHORTHAND (optional): instead of `steps`, you may pass a "
+            "`flow_type` for one of the two known shapes — 'onboarding_wizard' "
+            "or 'due_diligence_intake' — plus an optional `config` for copy "
+            "tweaks. The flat `steps` graph is the general path; `flow_type` is "
+            "a convenience for those two exact shapes.\n\n"
+            "Returns the JSON doc to emit. Wrap it verbatim in a ```ui-spec "
+            "fence; do not edit the chain / chain_map structure."
         ),
         {
             "type": "object",
             "properties": {
+                "flow": {
+                    "type": "string",
+                    "description": (
+                        "A stable id for the flow (e.g. 'vendor_intake'). "
+                        "Required when authoring a flat `steps` graph."
+                    ),
+                },
+                "entry": {
+                    "type": "string",
+                    "description": (
+                        "The id of the FIRST step (must exist in `steps`). "
+                        "Required when authoring a flat `steps` graph."
+                    ),
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "The flat step-graph: a list of step objects. Each step "
+                        "has `id`, `kind` (select | form | confirm | info), "
+                        "`title`, its kind-specific content (`options` / "
+                        "`fields` / `review` / `body`), and a transition "
+                        "(`next` or `branch`) — OR `complete` if it is the "
+                        "terminal step. Optional per-step `actions` run a "
+                        "tool/API/binding mid-flow. This is the general "
+                        "authoring path."
+                    ),
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional title shown on the flow frame.",
+                },
+                "complete": {
+                    "type": "object",
+                    "description": (
+                        "Optional flow-level terminal default — the `complete` "
+                        "action a terminal step inherits when it declares none "
+                        "of its own (e.g. {action:'chat', message:'…'})."
+                    ),
+                },
                 "flow_type": {
                     "type": "string",
                     "enum": list(_flow_types_for_schema()),
                     "description": (
-                        "Which flow template to scaffold. The builder owns "
-                        "the full nested step tree for this template."
+                        "OPTIONAL preset shorthand for the two known shapes "
+                        "('onboarding_wizard' | 'due_diligence_intake') instead "
+                        "of authoring a flat `steps` graph."
                     ),
                 },
                 "domain": {
                     "type": "string",
                     "description": (
-                        "Optional domain hint (e.g. 'fintech', 'saas'). "
-                        "Reserved for a future data-fresh path; does not "
-                        "change the tree today."
+                        "Optional domain hint (e.g. 'fintech', 'saas') for the "
+                        "preset path. Reserved for a future data-fresh path; "
+                        "does not change the tree today."
                     ),
                 },
                 "config": {
                     "type": "object",
                     "description": (
-                        "Optional per-template copy overrides. Shape-stable: "
-                        "tweaks labels/text, never the chain structure."
+                        "Optional per-preset copy overrides (preset path only). "
+                        "Shape-stable: tweaks labels/text, never the chain "
+                        "structure."
                     ),
                 },
             },
-            "required": ["flow_type"],
+            # Nothing is hard-required at the schema level: the general path
+            # needs flow+entry+steps, the preset path needs flow_type. The
+            # handler validates the combination and returns an agent-readable
+            # error when neither is supplied.
+            "required": [],
         },
     )
     async def start_flow(args):  # type: ignore[no-untyped-def]

--- a/src/pocketpaw/ripple/_flows.py
+++ b/src/pocketpaw/ripple/_flows.py
@@ -1,6 +1,40 @@
-# pocketpaw/ripple/_flows.py — Deterministic Chain Flow builders (RFC 13 §7.1, M3).
+# pocketpaw/ripple/_flows.py — Chain Flow builders (RFC 13 §7.1, M3 → CHAIN FLOW v2).
 #
 # Created: 2026-05-31 (RFC 13 M3, feat/m3-flow-authoring-tool).
+# Updated: 2026-06-15 (feat/chain-flow-v2 — GENERALIZATION):
+#   - The headline change: the flow primitive is no longer "pick 1 of 2
+#     hardcoded Python templates." A new entry point
+#     `build_flow_from_descriptor(descriptor)` lets the agent author an
+#     ARBITRARY ephemeral mini-app as a FLAT step-graph (a `FlowDescriptor`:
+#     a `flow` id, an `entry` step id, and a `steps[]` array where each step
+#     points at the next by id string via `next` / `branch`). The builder owns
+#     ALL the fragile nesting the model used to get wrong: it materializes the
+#     nested `chain` / `chain_map` `UniversalSpec` tree, deep-validates the
+#     graph (every §2.3 invariant), validates prefill refs (§2.5) and action
+#     verbs (§2.4), and rewrites `{stepId.field}` sugar into the executor's
+#     real `{state.<flowId>_selection|_formData.field}` keys (§1.5 / §2.2) so
+#     the author never writes the suffix — the #1 hand-author bug, eliminated.
+#   - The two shipped templates become THIN PRESETS: `build_onboarding_wizard`
+#     / `build_due_diligence_intake` now emit a flat descriptor and delegate to
+#     `build_flow_from_descriptor`. `build_flow(flow_type, …)` stays as the
+#     preset dispatcher. Every assertion in `test_flow_authoring.py` still holds
+#     because the builder emits the SAME nested structure (flowId on every step,
+#     one terminal with onComplete.kind=="chat", chain_map keyed on option ids,
+#     shared join node, Back on intermediate steps).
+#   - `assemble_node` REUSES the exact `_select_button` / `_continue_button` /
+#     `_submit_button` / `_back_button` / `_nav_row` helpers (§7 D4) so the
+#     general path emits BYTE-IDENTICAL buttons to the presets — the
+#     ChainExecutor and the existing tests rely on those on_click event shapes.
+#   - Terminal lowering (§1.4 / §7 D1) extends the FlowAction union with the new
+#     `invoke_tool` / `call_binding` / `create_pocket` kinds (plus the existing
+#     `chat` / `navigate` / `emit`) and an optional `then` post-action (chain
+#     length capped at 2). Per-step `StepAction`s lower into a `button` whose
+#     `on_click` is the matching ripple action-VM verb (§1.3).
+#   - Caps: ≤30 steps (over → FlowBuildError "split the flow"); `then` chain ≤2.
+#   - GENERAL path allows ≥1 terminal (§7 D3 — branches may end differently,
+#     each terminal carries its own `complete` or the flow default). The PRESETS
+#     keep exactly one terminal, so the preset's one-terminal test stays green.
+#
 # Updated: 2026-06-07 (feat/flow-terminal-to-agent):
 #   - Terminal step now loops the collected answers back to the AGENT instead of
 #     firing a dead host event. Both shipped templates' `onComplete` is now
@@ -25,44 +59,38 @@
 #     to) and terminal confirm/review steps (Submit) deliberately get no Back.
 #
 # What this is:
-#   The DETERMINISTIC half of the `start_flow` authoring tool. The LLM emits a
-#   tiny descriptor — `flow_type` (an enum of known templates), an optional
-#   `domain` hint, optional `config` overrides — and one of the builders below
-#   expands a HARDCODED template into the full nested Chain Flow tree, then
-#   returns it as a `{version, ui}` inline-Ripple doc.
+#   The DETERMINISTIC half of the `start_flow` authoring tool. v2: the LLM emits
+#   a FLAT step-graph descriptor (impossible to mis-nest), and a Python builder
+#   materializes + deep-validates the full nested Chain Flow tree, returning it
+#   as a `{version, ui}` inline-Ripple doc. The legacy preset path (pick a
+#   `flow_type`, supply a few values) still works on top of the same builder.
 #
 # Why a builder owns the tree (not the model):
 #   The genesis prototype's `preprocessChainStrings` repair code (RFC 13 §2.2)
 #   is the evidence: hand-authoring a recursively-nested chain/chain_map tree
 #   is fragile — weak models stringify the chain or wrap it in a
-#   `{action:'chain', next:{…}}` shape. So the model never sees the steps; it
-#   picks a template and supplies a few values, and Python materializes the
-#   whole decision tree up front. That tree then walks entirely client-side
-#   with zero LLM calls between steps (ripple's ChainExecutor, RFC 13 M1).
+#   `{action:'chain', next:{…}}` shape. v2 keeps the reliability property — the
+#   agent NEVER emits a raw nested tree — but generalizes the authoring surface:
+#   the model writes a flat list with `next`/`branch` pointers, Python resolves
+#   pointers into nesting and REJECTS any graph that would dead-end with a
+#   precise, agent-readable error the tool surfaces for a retry.
 #
 # The schema each step rides (ripple's UniversalSpec, RFC 13 M1):
 #   - each step is a UniversalSpec node;
 #   - `chain` is the linear next step; `chain_map` (Record<selectionId, step>)
 #     branches on the user's selection id;
 #   - `flowId` namespaces this step's accumulated data
-#     (`<flowId>_selection` / `<flowId>_formData`);
-#   - the terminal step carries `onComplete` — a FlowAction:
-#       {kind:'emit', event, payload?} | {kind:'navigate', url} | {kind:'chat', message};
-#     the two shipped templates use `chat` so finishing the flow hands the
-#     collected answers back to the agent to act on (the runtime appends the
-#     accumulated payload to `message`); `emit`/`navigate` stay available for
-#     other flows;
+#     (`<flowId>_selection` / `<flowId>_formData`); set from the descriptor
+#     step's optional `slot` (branch-agnostic shared slot) else its `id`;
+#   - a terminal step carries `onComplete` — a FlowAction:
+#       chat | navigate | emit (existing) | invoke_tool | call_binding |
+#       create_pocket (new in v2), each optionally with a `then` post-action;
 #   - form steps additionally carry `form_fields` (genesis-style structured field
 #     DATA) so ripple's FormLayout renders a designed form; the raw `ui` tree
 #     remains the fallback;
 #   - a later step pre-fills from an earlier pick with
-#     `{state.<flowId>_selection.field}` / `{state.<flowId>_formData.field}`.
-#
-# Scope (captain's priority — the primitive serving MANY use cases):
-#   NON-COMMERCE templates only. An onboarding wizard (goal → details/invite
-#   branch → confirm) and a due-diligence intake (a survey/intake: stage →
-#   financials/team branch → review). Checkout is deliberately NOT built here —
-#   it is one exemplar of the primitive, not the headline (RFC 13 §7, M4).
+#     `{state.<flowId>_selection.field}` / `{state.<flowId>_formData.field}` —
+#     the builder owns that rewrite from the author's `{stepId.field}` sugar.
 #
 # This module emits plain Python dicts (JSON-serializable). It does NOT import
 # ripple TypeScript — the tree is a data contract, validated by pocketpaw's own
@@ -70,7 +98,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
 
 # The inline-Ripple envelope version (the `{version, ui}` doc the chat
 # extractor recognizes — RFC 13 M0, run_core._looks_like_ripple_spec). The
@@ -78,19 +108,187 @@ from typing import Any
 # envelope version, matching what `_inline.py` mandates for a chat reply.
 INLINE_SPEC_VERSION = "1.0"
 
-# The known flow templates the `start_flow` tool exposes as its `flow_type`
-# enum. The model picks one of these; the matching builder owns the tree.
-# Kept NON-COMMERCE-first per RFC 13's primitive-over-exemplar framing.
+# The UniversalSpec node version every assembled step carries.
+_STEP_VERSION = "2.0"
+
+# Caps (§7 open decisions): a flat graph bigger than this is an authoring smell;
+# reject and ask the model to split it. `then` post-action chains are bounded so
+# a malformed `then` can't recurse without limit.
+_MAX_STEPS = 30
+_MAX_THEN_DEPTH = 2
+
+# The known flow templates the `start_flow` tool exposes as `flow_type` preset
+# shorthand. The model can still pick one of these; the matching builder emits a
+# descriptor and delegates to `build_flow_from_descriptor`. Kept NON-COMMERCE
+# first per RFC 13's primitive-over-exemplar framing.
 FLOW_TYPES: tuple[str, ...] = (
     "onboarding_wizard",
     "due_diligence_intake",
 )
 
+# ---------------------------------------------------------------------------
+# Verb / action allow-sets (§2.4). Kept in lock-step with ripple's action VM
+# (`event-dispatcher.ts`) and pocketpaw's `manifest._KNOWN_ACTION_VERBS`. A
+# mid-flow StepAction rides any of `_STEP_ACTION_VERBS`; a terminal `complete`
+# uses one of `_TERMINAL_ACTIONS`.
+# ---------------------------------------------------------------------------
+
+_STEP_ACTION_VERBS: frozenset[str] = frozenset(
+    {"api", "call_binding", "invoke_tool", "emit", "navigate", "set", "toast"}
+)
+
+_TERMINAL_ACTIONS: frozenset[str] = frozenset(
+    {"chat", "navigate", "emit", "invoke_tool", "call_binding", "create_pocket"}
+)
+
+# Per-verb required payload keys (§2.4). Checked after the Pydantic shape pass so
+# the error names the missing key precisely instead of a generic schema gripe.
+_STEP_VERB_REQUIRED: dict[str, tuple[str, ...]] = {
+    "invoke_tool": ("tool",),
+    "call_binding": ("binding", "path"),
+    "api": ("url",),
+    "navigate": ("url",),
+    "set": ("key", "value"),
+    "emit": (),  # emit is forgiving — a bare event name is allowed
+    "toast": (),
+}
+
+_TERMINAL_REQUIRED: dict[str, tuple[str, ...]] = {
+    "chat": ("message",),
+    "navigate": ("url",),
+    "emit": (),
+    "invoke_tool": ("tool",),
+    "call_binding": ("binding", "path"),
+    "create_pocket": ("name",),
+}
+
+
+# ---------------------------------------------------------------------------
+# FlowBuildError — every structural / reference / action defect raises this with
+# a precise, agent-readable message. The tool layer surfaces it verbatim so the
+# model can fix the flat graph and retry (genesis's forgiving-authoring loop).
+# ---------------------------------------------------------------------------
+
+
+class FlowBuildError(ValueError):
+    """A flat FlowDescriptor could not be materialized into a valid flow tree.
+
+    Subclasses ``ValueError`` so existing ``except ValueError`` call sites (the
+    preset path's unknown-``flow_type`` handler) keep working. The message is
+    written for the model: it names the offending step / ref / verb and what is
+    wrong, so a retry can be surgical.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Descriptor Pydantic models (§1). The flat, agent-friendly shape. `extra=allow`
+# on the step/action models keeps the descriptor forgiving — an unknown key is
+# carried, not rejected (genesis "any model can author" forgiveness). The graph
+# / ref / action validators below catch the defects that actually break a flow.
+# ---------------------------------------------------------------------------
+
+
+class StepAction(BaseModel):
+    """A mid-flow button: runs a tool/API/binding without leaving the step (§1.3)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    label: str
+    verb: str
+    # verb-specific payload (validated per verb in `_validate_actions`)
+    tool: str | None = None
+    args: dict[str, Any] | None = None
+    binding: str | None = None
+    path: str | None = None
+    params: dict[str, Any] | None = None
+    url: str | None = None
+    method: str | None = None
+    body: dict[str, Any] | None = None
+    key: str | None = None
+    value: Any = None
+    message: str | None = None
+    variant: str | None = None
+    # continuations — standard ripple on_success / on_error action chains
+    on_success: list[StepAction] | None = None
+    on_error: list[StepAction] | None = None
+
+
+class TerminalAction(BaseModel):
+    """A flow's hand-off when the user clicks the final button (§1.4)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    action: str
+    # existing kinds
+    message: str | None = None
+    url: str | None = None
+    event: str | None = None
+    payload: dict[str, Any] | None = None
+    # new kinds
+    tool: str | None = None
+    args: dict[str, Any] | None = None
+    binding: str | None = None
+    path: str | None = None
+    params: dict[str, Any] | None = None
+    name: str | None = None
+    template: str | None = None
+    spec: dict[str, Any] | None = None
+    seed_from_flow: bool | None = None
+    # optional post-action (capped at depth 2)
+    then: TerminalAction | None = None
+
+
+class FlowStep(BaseModel):
+    """One step in the flat graph (§1.2)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    kind: Literal["select", "form", "confirm", "info"]
+    title: str | None = None
+    subtitle: str | None = None
+    # branch-agnostic shared slot (§2.2): the node's flowId = slot or id
+    slot: str | None = None
+    # content (kind-specific)
+    options: list[dict[str, Any]] | None = None
+    fields: list[dict[str, Any]] | None = None
+    review: list[dict[str, Any]] | None = None
+    body: str | None = None
+    # UI hints (optional, never required)
+    ui: dict[str, Any] | None = None
+    # transitions — exactly ONE of next | branch on a non-terminal step
+    next: str | None = None
+    branch: dict[str, str] | None = None
+    # mid-flow actions
+    actions: list[StepAction] | None = None
+    # terminal action (overrides the flow-level default)
+    complete: TerminalAction | None = None
+
+
+class FlowDescriptor(BaseModel):
+    """The flat top-level descriptor the agent emits (§1.1)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    flow: str
+    entry: str
+    title: str | None = None
+    steps: list[FlowStep] = Field(default_factory=list)
+    complete: TerminalAction | None = None
+
+
+# StepAction / TerminalAction are self-referential; rebuild so forward refs bind.
+StepAction.model_rebuild()
+TerminalAction.model_rebuild()
+
 
 # ---------------------------------------------------------------------------
 # Small node helpers — keep the builders readable and the emitted shapes
 # consistent. Each returns a plain UINode dict (the shape ripple's NodeRenderer
-# and pocketpaw's catalog walker both understand).
+# and pocketpaw's catalog walker both understand). The general builder
+# (`assemble_node`) REUSES these so its buttons are byte-identical to the
+# presets (§7 D4).
 # ---------------------------------------------------------------------------
 
 
@@ -225,341 +423,1088 @@ def _container(children: list[dict[str, Any]], cls: str | None = None) -> dict[s
     return node
 
 
+def _action_button(action: StepAction) -> dict[str, Any]:
+    """Lower a mid-flow StepAction into a `button` whose `on_click` is the
+    matching ripple action-VM verb (§1.3 / §7 D4).
+
+    The on_click is `{action:<verb>, ...payload, on_success?, on_error?}` — a
+    plain action handler the dispatcher already routes (and pocketpaw's
+    `validate_action_verbs` already accepts). Payload keys are copied through
+    per verb; `{state.…}` / `{result.…}` refs inside arg/param strings are
+    rewritten in the prefill pass and resolved client-side at dispatch.
+    """
+    handler: dict[str, Any] = {"action": action.verb}
+    # Copy only the keys that matter for the verb, in a stable order.
+    for key in ("tool", "args", "binding", "path", "params", "url", "method", "body", "key"):
+        val = getattr(action, key, None)
+        if val is not None:
+            handler[key] = val
+    # `value` is meaningful for `set`; copy it whenever provided (it may be
+    # falsy like False/0, so check the field, not truthiness).
+    if action.value is not None:
+        handler["value"] = action.value
+    if action.message is not None:
+        handler["message"] = action.message
+    if action.variant is not None:
+        handler["variant"] = action.variant
+    if action.on_success:
+        handler["on_success"] = [_action_handler_only(a) for a in action.on_success]
+    if action.on_error:
+        handler["on_error"] = [_action_handler_only(a) for a in action.on_error]
+    return {"type": "button", "props": {"label": action.label}, "on_click": handler}
+
+
+def _action_handler_only(action: StepAction) -> dict[str, Any]:
+    """Lower a continuation StepAction (on_success/on_error entry) into a bare
+    action handler dict (no surrounding button) — the shape ripple's action
+    chain expects."""
+    handler: dict[str, Any] = {"action": action.verb}
+    for key in ("tool", "args", "binding", "path", "params", "url", "method", "body", "key"):
+        val = getattr(action, key, None)
+        if val is not None:
+            handler[key] = val
+    if action.value is not None:
+        handler["value"] = action.value
+    if action.message is not None:
+        handler["message"] = action.message
+    if action.variant is not None:
+        handler["variant"] = action.variant
+    if action.on_success:
+        handler["on_success"] = [_action_handler_only(a) for a in action.on_success]
+    if action.on_error:
+        handler["on_error"] = [_action_handler_only(a) for a in action.on_error]
+    return handler
+
+
 # ---------------------------------------------------------------------------
-# Template 1 — Onboarding wizard (NON-COMMERCE proof, RFC 13 M1/M3).
+# Prefill / cross-step reference rewrite (§1.5 / §2.2).
+#
+# The author writes `{stepId.field}` (or `{slot.field}`); the builder rewrites
+# it to the executor's real namespaced key — `{state.<flowId>_selection.field}`
+# for a select step, `{state.<flowId>_formData.field}` for a form step. The
+# author never writes the `_selection` / `_formData` suffix (risk #8). `{flow.*}`
+# and `{result.*}` and bare `{state.*}` pass through untouched.
+# ---------------------------------------------------------------------------
+
+import re  # noqa: E402  (kept next to the rewrite logic it serves)
+
+# Matches `{token.field}` where token is a bare identifier and field a dotted
+# path. Excludes tokens we never rewrite: `state`, `flow`, `result`.
+_REF_RE = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z0-9_.]+)\}")
+_PASSTHROUGH_TOKENS = frozenset({"state", "flow", "result"})
+
+
+def _ref_targets(text: str) -> list[tuple[str, str]]:
+    """Every `{token.field}` ref in `text` that is NOT a passthrough token.
+
+    Returns `(token, field)` pairs — `token` is a step id or slot name, `field`
+    the dotted remainder. Used by both the validator (to check the ref resolves)
+    and the rewrite (to namespace it).
+    """
+    out: list[tuple[str, str]] = []
+    for m in _REF_RE.finditer(text):
+        token, field = m.group(1), m.group(2)
+        if token in _PASSTHROUGH_TOKENS:
+            continue
+        out.append((token, field))
+    return out
+
+
+def _rewrite_refs(text: str, slot_kind: dict[str, str]) -> str:
+    """Rewrite every `{stepId.field}` / `{slot.field}` ref in `text` to its
+    namespaced `{state.<flowId>_selection|_formData.field}` form.
+
+    `slot_kind` maps a resolvable token (step id OR slot name) to the executor
+    suffix (`selection` / `formData`) plus the flowId to namespace under. A
+    token that isn't resolvable is left untouched here — `_validate_refs` has
+    already hard-rejected the unknown ones, so anything that survives to this
+    pass is either resolvable or a deliberate passthrough.
+    """
+
+    def _sub(m: re.Match[str]) -> str:
+        token, field = m.group(1), m.group(2)
+        if token in _PASSTHROUGH_TOKENS:
+            return m.group(0)
+        entry = slot_kind.get(token)
+        if entry is None:
+            return m.group(0)
+        flow_id, suffix = entry.split("|", 1)
+        return f"{{state.{flow_id}_{suffix}.{field}}}"
+
+    return _REF_RE.sub(_sub, text)
+
+
+def _rewrite_in_obj(obj: Any, slot_kind: dict[str, str]) -> Any:
+    """Recursively rewrite `{stepId.field}` refs inside any JSON value (string,
+    list, dict). Returns a NEW structure (does not mutate the input)."""
+    if isinstance(obj, str):
+        return _rewrite_refs(obj, slot_kind)
+    if isinstance(obj, list):
+        return [_rewrite_in_obj(v, slot_kind) for v in obj]
+    if isinstance(obj, dict):
+        return {k: _rewrite_in_obj(v, slot_kind) for k, v in obj.items()}
+    return obj
+
+
+def _collect_ref_strings(obj: Any, out: list[str]) -> None:
+    """Collect every string leaf in a JSON value — used to scan action payloads
+    for refs to validate."""
+    if isinstance(obj, str):
+        out.append(obj)
+    elif isinstance(obj, list):
+        for v in obj:
+            _collect_ref_strings(v, out)
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            _collect_ref_strings(v, out)
+
+
+# ---------------------------------------------------------------------------
+# THE GENERAL BUILDER — build_flow_from_descriptor (§2). Flat FlowDescriptor →
+# {version, ui} nested Chain Flow doc, via the §2.1 ordered pipeline.
+# ---------------------------------------------------------------------------
+
+
+def _field_type(field: dict[str, Any]) -> str:
+    """A form field's `type`, mapping unknowns → `text` (genesis forgiveness)."""
+    raw = field.get("type")
+    known = {
+        "text",
+        "textarea",
+        "number",
+        "email",
+        "tel",
+        "url",
+        "date",
+        "select",
+        "radio",
+        "checkbox",
+        "switch",
+        "rating",
+        "slider",
+        "file",
+    }
+    return raw if isinstance(raw, str) and raw in known else "text"
+
+
+def _flow_id_of(step: FlowStep) -> str:
+    """The node flowId for a step: its `slot` (branch-agnostic) else its `id`."""
+    return step.slot or step.id
+
+
+def _declared_fields(step: FlowStep) -> set[str]:
+    """The field names a step exposes to prefill refs (§2.5).
+
+    A select step exposes `id` / `label` (the selection's keys). A form step
+    exposes each declared `fields[].id`.
+    """
+    if step.kind == "select":
+        return {"id", "label"}
+    if step.kind == "form":
+        return {str(f.get("id")) for f in (step.fields or []) if f.get("id")}
+    return set()
+
+
+def build_flow_from_descriptor(descriptor: dict[str, Any]) -> dict[str, Any]:
+    """Flat FlowDescriptor → {version, ui} nested Chain Flow doc.
+
+    Implements the §2.1 ordered pipeline:
+        parse → index → validate-graph → validate-refs → validate-actions
+        → assemble-nodes → resolve-transitions → wire-prefills
+        → attach-actions → attach-terminal → final deep-validate → envelope
+
+    Raises :class:`FlowBuildError` (with a precise, agent-readable message) on
+    any structural defect: missing entry, dangling transition, unreachable step,
+    no terminal, terminal-with-transition, unknown action verb, dangling prefill
+    ref. The tool layer surfaces the message so the model can fix and retry.
+
+    A flat graph cannot mis-nest — that is the whole point. The
+    "renders step 1 and silently dead-ends" failure (a select step with no
+    transition, an unreachable continuation) is structurally impossible to
+    express: each is a hard build-time reject.
+    """
+    # 1. parse -------------------------------------------------------------
+    try:
+        model = FlowDescriptor.model_validate(descriptor)
+    except Exception as exc:  # pydantic.ValidationError + anything malformed
+        raise FlowBuildError(f"descriptor is malformed: {exc}") from exc
+
+    if not model.steps:
+        raise FlowBuildError("flow has no steps; a flow needs at least one step")
+    if len(model.steps) > _MAX_STEPS:
+        raise FlowBuildError(
+            f"flow has {len(model.steps)} steps — over the {_MAX_STEPS}-step cap; "
+            "split the flow into smaller flows"
+        )
+
+    # 2. index -------------------------------------------------------------
+    by_id: dict[str, FlowStep] = {}
+    for step in model.steps:
+        if step.id in by_id:
+            raise FlowBuildError(f'duplicate step id "{step.id}"; step ids must be unique')
+        by_id[step.id] = step
+
+    # 3. validate-graph (§2.3) --------------------------------------------
+    _validate_graph(model, by_id)
+
+    # Build the slot→(flowId, suffix) map for ref resolution/rewrite. A token is
+    # resolvable by step id AND by slot name (when a slot is declared).
+    slot_kind: dict[str, str] = {}
+    for step in model.steps:
+        if step.kind not in ("select", "form"):
+            continue
+        suffix = "selection" if step.kind == "select" else "formData"
+        fid = _flow_id_of(step)
+        slot_kind[step.id] = f"{fid}|{suffix}"
+        if step.slot:
+            slot_kind[step.slot] = f"{fid}|{suffix}"
+
+    # 4. validate-refs (§2.5) ---------------------------------------------
+    warnings = _validate_refs(model, by_id)
+
+    # 5. validate-actions (§2.4) ------------------------------------------
+    _validate_actions(model)
+
+    # 6. assemble-nodes ----------------------------------------------------
+    reachable = _reachable_ids(model, by_id)
+    nodes: dict[str, dict[str, Any]] = {
+        step.id: _assemble_node(step, is_entry=(step.id == model.entry))
+        for step in model.steps
+        if step.id in reachable
+    }
+
+    # 7. resolve-transitions (§2.2) — flat pointers → nested object refs ---
+    for step in model.steps:
+        if step.id not in reachable:
+            continue
+        node = nodes[step.id]
+        if step.branch:
+            node["chain_map"] = {sel: nodes[target] for sel, target in step.branch.items()}
+        elif step.next:
+            node["chain"] = nodes[step.next]
+        # else: terminal — no chain/chain_map; onComplete attached in step 10.
+
+    # 8. wire-prefills — rewrite {stepId.field} sugar into namespaced keys --
+    for step in model.steps:
+        if step.id not in reachable:
+            continue
+        node = nodes[step.id]
+        if "review_rows" in node:
+            node["review_rows"] = _rewrite_in_obj(node["review_rows"], slot_kind)
+        # info body copy lives in the ui text; rewritten via the ui pass below.
+        node["ui"] = _rewrite_in_obj(node["ui"], slot_kind)
+        # 9. attach-actions — already lowered in assemble; rewrite their refs.
+        # (assemble appended action buttons to ui, so the ui rewrite covers them)
+
+    # 10. attach-terminal --------------------------------------------------
+    for step in model.steps:
+        if step.id not in reachable:
+            continue
+        if not _is_terminal_step(step):
+            continue
+        terminal = step.complete or model.complete
+        # _validate_graph guarantees a terminal has a complete (own or default);
+        # the guard keeps the type checker honest and is a cheap belt anyway.
+        if terminal is None:
+            raise FlowBuildError(
+                f'terminal step "{step.id}" has no complete action and no flow-level default'
+            )
+        node = nodes[step.id]
+        node["onComplete"] = _lower_terminal(terminal, slot_kind)
+
+    root = nodes[model.entry]
+    doc = {"version": INLINE_SPEC_VERSION, "ui": root}
+
+    # 11. final deep-validate — belt-and-suspenders on widget/verb content --
+    # Imported here to keep the module's import graph light and avoid a cycle.
+    from pocketpaw.ripple.manifest import validate_action_verbs
+
+    verb_issues = validate_action_verbs(doc)
+    if verb_issues:
+        bad = ", ".join(sorted({str(i.get("action")) for i in verb_issues}))
+        raise FlowBuildError(
+            f"assembled flow has unknown action verb(s): {bad}; use a known ripple action verb"
+        )
+
+    # Stash any soft warnings on the doc so the tool layer can relay them
+    # without failing the build (§2.5 single-branch reachability).
+    if warnings:
+        doc["_warnings"] = warnings
+
+    # 12. envelope ---------------------------------------------------------
+    return doc
+
+
+def _is_terminal_step(step: FlowStep) -> bool:
+    """A step with neither `next` nor `branch` is terminal."""
+    return not step.next and not step.branch
+
+
+def _reachable_ids(model: FlowDescriptor, by_id: dict[str, FlowStep]) -> set[str]:
+    """BFS from `entry` over next ∪ branch.values() — the reachable step ids."""
+    seen: set[str] = set()
+    if model.entry not in by_id:
+        return seen
+    queue = [model.entry]
+    while queue:
+        sid = queue.pop()
+        if sid in seen:
+            continue
+        seen.add(sid)
+        step = by_id[sid]
+        if step.next and step.next in by_id:
+            queue.append(step.next)
+        if step.branch:
+            for target in step.branch.values():
+                if target in by_id:
+                    queue.append(target)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Graph validation (§2.3) — each invariant rejects with a precise message.
+# ---------------------------------------------------------------------------
+
+
+def _validate_graph(model: FlowDescriptor, by_id: dict[str, FlowStep]) -> None:
+    declared = sorted(by_id)
+
+    # entry exists
+    if model.entry not in by_id:
+        raise FlowBuildError(f'entry "{model.entry}" is not a step id; declared: {declared}')
+
+    for step in model.steps:
+        has_next = bool(step.next)
+        has_branch = bool(step.branch)
+
+        # both next and branch on one step is ambiguous
+        if has_next and has_branch:
+            raise FlowBuildError(
+                f'step "{step.id}" has both `next` and `branch`; a step transitions '
+                "exactly one way — use one or the other"
+            )
+
+        # every next target exists
+        if has_next and step.next not in by_id:
+            raise FlowBuildError(
+                f'step "{step.id}".next → "{step.next}" but "{step.next}" is not a declared step'
+            )
+
+        # every branch value exists; every branch key matches an option id
+        if step.branch:
+            option_ids = {str(o.get("id")) for o in (step.options or []) if o.get("id")}
+            for sel, target in step.branch.items():
+                if target not in by_id:
+                    raise FlowBuildError(
+                        f'step "{step.id}".branch["{sel}"] → "{target}" but "{target}" '
+                        "is not declared"
+                    )
+                if step.kind == "select" and sel not in option_ids:
+                    raise FlowBuildError(
+                        f'step "{step.id}".branch key "{sel}" is not one of {step.id}\'s '
+                        f"option ids {sorted(option_ids)}"
+                    )
+
+        # a select step must transition (branch or next) — else it dead-ends
+        if step.kind == "select" and not has_next and not has_branch:
+            raise FlowBuildError(
+                f'select step "{step.id}" has no branch/next; it would dead-end after a pick'
+            )
+
+        # no non-terminal step carries `complete` (complete is terminal-only)
+        if (has_next or has_branch) and step.complete is not None:
+            raise FlowBuildError(
+                f'step "{step.id}" has both a transition and a complete action; '
+                "complete is terminal-only"
+            )
+
+    # reachability — every declared step reachable from entry
+    reachable = _reachable_ids(model, by_id)
+    for step in model.steps:
+        if step.id not in reachable:
+            raise FlowBuildError(f'step "{step.id}" is unreachable from entry "{model.entry}"')
+
+    # at least one terminal step (among the reachable)
+    terminals = [by_id[sid] for sid in reachable if _is_terminal_step(by_id[sid])]
+    if not terminals:
+        raise FlowBuildError(
+            "flow has no terminal step — every step transitions onward; a flow must end"
+        )
+
+    # every terminal has a complete (own or flow-level default) — §7 D3
+    for term in terminals:
+        if term.complete is None and model.complete is None:
+            raise FlowBuildError(
+                f'terminal step "{term.id}" has no complete action and no flow-level default'
+            )
+
+    # cycle check — the reachable subgraph must be a DAG
+    _detect_cycle(model, by_id, reachable)
+
+
+def _detect_cycle(model: FlowDescriptor, by_id: dict[str, FlowStep], reachable: set[str]) -> None:
+    """DFS over next ∪ branch on the reachable subgraph; raise on a back-edge."""
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color: dict[str, int] = {sid: WHITE for sid in reachable}
+
+    def _succ(sid: str) -> list[str]:
+        step = by_id[sid]
+        out: list[str] = []
+        if step.next and step.next in reachable:
+            out.append(step.next)
+        if step.branch:
+            out.extend(t for t in step.branch.values() if t in reachable)
+        return out
+
+    def _visit(sid: str, stack: list[str]) -> None:
+        color[sid] = GRAY
+        stack.append(sid)
+        for nxt in _succ(sid):
+            if color[nxt] == GRAY:
+                # back-edge — reconstruct the cycle path for the message
+                idx = stack.index(nxt)
+                cycle = stack[idx:] + [nxt]
+                raise FlowBuildError(f"cycle detected: {' → '.join(cycle)}; flows must be a DAG")
+            if color[nxt] == WHITE:
+                _visit(nxt, stack)
+        stack.pop()
+        color[sid] = BLACK
+
+    if model.entry in reachable:
+        _visit(model.entry, [])
+
+
+# ---------------------------------------------------------------------------
+# Prefill-ref validation (§2.5).
+# ---------------------------------------------------------------------------
+
+
+def _validate_refs(model: FlowDescriptor, by_id: dict[str, FlowStep]) -> list[str]:
+    """Validate every `{stepId.field}` ref; return soft warnings (hard errors
+    raise). A ref may resolve by step id or by slot name.
+
+    - unknown step/slot → hard FlowBuildError.
+    - field not declared on that step → hard FlowBuildError.
+    - referenced step on one branch only, referencing step reachable from both
+      → soft warning (the value renders empty on the other branch, sometimes
+      intended). Hard error only if unreachable on EVERY path.
+    """
+    warnings: list[str] = []
+
+    # token → the FlowStep it resolves to (by id or slot). A slot shared by two
+    # branch steps maps to the FIRST declarer for field-set purposes; both
+    # branch steps that share a slot must declare the same fields for the
+    # branch-agnostic read to make sense, so the first is representative.
+    token_step: dict[str, FlowStep] = {}
+    for step in model.steps:
+        token_step.setdefault(step.id, step)
+        if step.slot:
+            token_step.setdefault(step.slot, step)
+
+    # Map each reachable step → which entry-options/branch it sits under, so we
+    # can warn on single-branch reachability. Approximate "on one branch only":
+    # a step reached only via a specific branch key of the entry select.
+    branch_owner = _branch_membership(model, by_id)
+
+    # token → the set of distinct branch-owners that WRITE its flowId slot. A
+    # shared-slot read (the §2.2 pattern, e.g. `{financials.headline}` written by
+    # both branch forms) is branch-agnostic, so it must NOT warn even though each
+    # individual writer step is single-branch. We suppress the warning whenever a
+    # token's slot is written on more than one branch-owner.
+    slot_writers: dict[str, set[str | None]] = {}
+    for step in model.steps:
+        if step.kind not in ("select", "form"):
+            continue
+        owner = branch_owner.get(step.id)
+        tokens = [step.id] + ([step.slot] if step.slot else [])
+        for tok in tokens:
+            slot_writers.setdefault(tok, set()).add(owner)
+
+    for step in model.steps:
+        # gather every ref-bearing string on this step: review values, info body,
+        # action arg/param/body payloads.
+        ref_strings: list[str] = []
+        for row in step.review or []:
+            v = row.get("value")
+            if isinstance(v, str):
+                ref_strings.append(v)
+        if step.body:
+            ref_strings.append(step.body)
+        for action in step.actions or []:
+            _collect_action_refs(action, ref_strings)
+
+        for text in ref_strings:
+            for token, field in _ref_targets(text):
+                target = token_step.get(token)
+                if target is None:
+                    raise FlowBuildError(
+                        f'prefill ref {{{token}.{field}}} points at unknown step/slot "{token}"'
+                    )
+                declared = _declared_fields(target)
+                # only check the FIRST field segment against declarations
+                head = field.split(".", 1)[0]
+                if declared and head not in declared:
+                    raise FlowBuildError(
+                        f'prefill ref {{{token}.{field}}} — step "{token}" declares no '
+                        f'field "{head}" (has: {sorted(declared)})'
+                    )
+                # single-branch reachability warning. Skip it when the token's
+                # slot is written on more than one branch (the §2.2 shared-slot
+                # pattern makes the read branch-agnostic — that is exactly its
+                # purpose, so warning there would be noise).
+                writers = slot_writers.get(token, set())
+                multi_branch_slot = len({w for w in writers if w is not None}) > 1
+                owner = branch_owner.get(target.id)
+                ref_owner = branch_owner.get(step.id)
+                if owner is not None and owner != ref_owner and not multi_branch_slot:
+                    warnings.append(
+                        f'prefill ref {{{token}.{field}}} in step "{step.id}" reads step '
+                        f'"{target.id}", which is only reachable on the "{owner}" branch; '
+                        "it renders empty on other branches (use a shared `slot` to make "
+                        "it branch-agnostic)"
+                    )
+
+    return warnings
+
+
+def _collect_action_refs(action: StepAction, out: list[str]) -> None:
+    """Collect ref-bearing strings from an action's payloads (recursively into
+    on_success / on_error)."""
+    for payload in (action.args, action.params, action.body):
+        if payload:
+            _collect_ref_strings(payload, out)
+    for cont in (action.on_success or []) + (action.on_error or []):
+        _collect_action_refs(cont, out)
+
+
+def _branch_membership(model: FlowDescriptor, by_id: dict[str, FlowStep]) -> dict[str, str | None]:
+    """Map step id → the entry-branch key it is EXCLUSIVELY reachable under, or
+    None if reachable on every branch / via a linear path.
+
+    Used only for the §2.5 single-branch-reachability warning. Computed by, for
+    each branch of the entry select, BFS-collecting the steps reachable from
+    that branch; a step in exactly one branch's set (and not in the linear
+    pre-branch set) is owned by that branch.
+    """
+    entry = by_id.get(model.entry)
+    if entry is None or not entry.branch:
+        # No top-level branch — nothing is single-branch-owned.
+        return {}
+
+    branch_sets: dict[str, set[str]] = {}
+    for sel, target in entry.branch.items():
+        seen: set[str] = set()
+        queue = [target]
+        while queue:
+            sid = queue.pop()
+            if sid in seen or sid not in by_id:
+                continue
+            seen.add(sid)
+            st = by_id[sid]
+            if st.next:
+                queue.append(st.next)
+            if st.branch:
+                queue.extend(st.branch.values())
+        branch_sets[sel] = seen
+
+    owner: dict[str, str | None] = {}
+    all_ids = set(by_id)
+    for sid in all_ids:
+        owning = [sel for sel, members in branch_sets.items() if sid in members]
+        owner[sid] = owning[0] if len(owning) == 1 else None
+    # the entry itself is shared
+    owner[model.entry] = None
+    return owner
+
+
+# ---------------------------------------------------------------------------
+# Action validation (§2.4).
+# ---------------------------------------------------------------------------
+
+
+def _validate_actions(model: FlowDescriptor) -> None:
+    for step in model.steps:
+        for action in step.actions or []:
+            _validate_step_action(action, step.id)
+        if step.complete is not None:
+            _validate_terminal_action(step.complete, step.id)
+    if model.complete is not None:
+        _validate_terminal_action(model.complete, "<flow default>")
+
+
+def _validate_step_action(action: StepAction, step_id: str, depth: int = 0) -> None:
+    if action.verb not in _STEP_ACTION_VERBS:
+        raise FlowBuildError(
+            f'step "{step_id}" action "{action.id}" uses unknown verb "{action.verb}"; '
+            f"allowed: {sorted(_STEP_ACTION_VERBS)}"
+        )
+    for key in _STEP_VERB_REQUIRED.get(action.verb, ()):  # required payload keys
+        if getattr(action, key, None) in (None, ""):
+            raise FlowBuildError(
+                f'step "{step_id}" action "{action.id}" (verb "{action.verb}") '
+                f'is missing required key "{key}"'
+            )
+    if depth >= _MAX_THEN_DEPTH + 2:
+        raise FlowBuildError(
+            f'step "{step_id}" action "{action.id}" nests continuations too deeply'
+        )
+    for cont in (action.on_success or []) + (action.on_error or []):
+        _validate_step_action(cont, step_id, depth + 1)
+
+
+def _validate_terminal_action(terminal: TerminalAction, step_id: str, depth: int = 1) -> None:
+    if terminal.action not in _TERMINAL_ACTIONS:
+        raise FlowBuildError(
+            f'terminal of step "{step_id}" uses unknown action "{terminal.action}"; '
+            f"allowed: {sorted(_TERMINAL_ACTIONS)}"
+        )
+    for key in _TERMINAL_REQUIRED.get(terminal.action, ()):
+        if getattr(terminal, key, None) in (None, ""):
+            raise FlowBuildError(
+                f'terminal of step "{step_id}" (action "{terminal.action}") '
+                f'is missing required key "{key}"'
+            )
+    if terminal.then is not None:
+        if depth + 1 > _MAX_THEN_DEPTH:
+            raise FlowBuildError(
+                f'terminal of step "{step_id}" chains `then` deeper than '
+                f"{_MAX_THEN_DEPTH}; cap the chain at an action plus one post-action"
+            )
+        _validate_terminal_action(terminal.then, step_id, depth + 1)
+
+
+# ---------------------------------------------------------------------------
+# Node assembly (§2.1 step 6) — one bare UniversalSpec node per step. REUSES the
+# `_select_button` / `_continue_button` / `_submit_button` / `_back_button`
+# helpers so buttons are byte-identical to the presets (§7 D4).
+# ---------------------------------------------------------------------------
+
+_KIND_TO_INTENT = {"select": "select", "form": "form", "confirm": "confirm", "info": "info"}
+
+
+def _assemble_node(step: FlowStep, *, is_entry: bool) -> dict[str, Any]:
+    """Build a bare UniversalSpec node for `step` (no chain/chain_map yet —
+    transitions are spliced in resolve-transitions).
+
+    The node carries `flowId` (slot or id), the kind→intent, structured
+    `form_fields` / `review_rows` where applicable, and a raw `ui` widget tree
+    whose buttons reuse the shared helpers. A non-entry form step gets a Back
+    button (the intermediate-Back convention the presets and tests expect).
+    """
+    flow_id = _flow_id_of(step)
+    intent = _KIND_TO_INTENT[step.kind]
+    node: dict[str, Any] = {
+        "version": _STEP_VERSION,
+        "id": step.id,
+        "flowId": flow_id,
+        "intent": intent,
+        "title": step.title or step.id,
+    }
+    if step.kind == "select":
+        node["selection"] = "single"
+
+    children: list[dict[str, Any]] = []
+    title = step.title or step.id
+    children.append(_heading(title))
+    if step.subtitle:
+        children.append(_text(step.subtitle))
+
+    if step.kind == "select":
+        for opt in step.options or []:
+            oid = str(opt.get("id"))
+            olabel = str(opt.get("label") or oid)
+            children.append(_select_button(olabel, oid))
+
+    elif step.kind == "form":
+        binds: list[str] = []
+        form_fields: list[dict[str, Any]] = []
+        for f in step.fields or []:
+            fid = str(f.get("id"))
+            flabel = str(f.get("label") or fid)
+            placeholder = str(f.get("placeholder") or "")
+            ftype = _field_type(f)
+            required = bool(f.get("required", True))
+            opts = f.get("options") if isinstance(f.get("options"), list) else None
+            children.append(_input(fid, flabel, placeholder))
+            binds.append(fid)
+            form_fields.append(_form_field(fid, flabel, placeholder, ftype, required, opts))
+        node["form_fields"] = form_fields
+        # action buttons (mid-flow) sit above the nav row
+        for action in step.actions or []:
+            children.append(_action_button(action))
+        # nav row: Back (only when not the entry) precedes Continue (§7 D4)
+        nav_children: list[dict[str, Any]] = []
+        if not is_entry:
+            nav_children.append(_back_button("Back"))
+        nav_children.append(_continue_button("Continue", binds))
+        children.append(_nav_row(nav_children))
+
+    elif step.kind == "confirm":
+        review_rows: list[dict[str, Any]] = []
+        for row in step.review or []:
+            label = str(row.get("label") or "")
+            value = str(row.get("value") or "")
+            review_rows.append(_review_row(label, value))
+            children.append(_text(f"{label}: {value}"))
+        node["review_rows"] = review_rows
+        for action in step.actions or []:
+            children.append(_action_button(action))
+        children.append(_submit_button("Finish"))
+
+    elif step.kind == "info":
+        if step.body:
+            children.append(_text(step.body))
+        for action in step.actions or []:
+            children.append(_action_button(action))
+        # An info step that is terminal gets a Finish; otherwise a Continue.
+        if _is_terminal_step(step):
+            children.append(_submit_button("Finish"))
+        else:
+            nav_children = []
+            if not is_entry:
+                nav_children.append(_back_button("Back"))
+            # info Continue carries no formData — bare flow.next
+            nav_children.append(
+                {
+                    "type": "button",
+                    "props": {"label": "Continue"},
+                    "on_click": {"action": "emit", "target": "flow.next", "value": {}},
+                }
+            )
+            children.append(_nav_row(nav_children))
+
+    # A non-form, non-info step that is ALSO terminal (a confirm) already added a
+    # submit button above. A select step is never terminal (graph invariant).
+    node["ui"] = _container(children, cls=f"flow-{step.kind}")
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Terminal lowering (§1.4 / §3 / §7 D1). A descriptor `complete` TerminalAction
+# → the node's `onComplete` FlowAction (ripple's union). Existing kinds map
+# `action`→`kind`; new kinds carry their payload; an optional `then` lowers
+# recursively (chain capped at 2 by the validator).
+# ---------------------------------------------------------------------------
+
+
+def _lower_terminal(terminal: TerminalAction, slot_kind: dict[str, str]) -> dict[str, Any]:
+    """Lower a TerminalAction into the ripple `onComplete` FlowAction shape.
+
+    The descriptor uses `action` as the discriminator; ripple's FlowAction uses
+    `kind`. The mapping is 1:1 by name. `{stepId.field}` / `{flow.payload}` refs
+    in payloads are rewritten with `slot_kind` (passthrough tokens untouched).
+    """
+    action = terminal.action
+    out: dict[str, Any] = {"kind": action}
+
+    if action == "chat":
+        out["message"] = terminal.message or ""
+    elif action == "navigate":
+        out["url"] = _rewrite_refs(terminal.url or "", slot_kind)
+    elif action == "emit":
+        if terminal.event is not None:
+            out["event"] = terminal.event
+        if terminal.payload is not None:
+            out["payload"] = _rewrite_in_obj(terminal.payload, slot_kind)
+    elif action == "invoke_tool":
+        out["tool"] = terminal.tool
+        if terminal.args is not None:
+            out["args"] = _rewrite_in_obj(terminal.args, slot_kind)
+    elif action == "call_binding":
+        out["binding"] = terminal.binding
+        out["path"] = _rewrite_refs(terminal.path or "", slot_kind)
+        if terminal.params is not None:
+            out["params"] = _rewrite_in_obj(terminal.params, slot_kind)
+    elif action == "create_pocket":
+        out["name"] = _rewrite_refs(terminal.name or "", slot_kind)
+        if terminal.template is not None:
+            out["template"] = terminal.template
+        if terminal.spec is not None:
+            out["spec"] = _rewrite_in_obj(terminal.spec, slot_kind)
+        if terminal.seed_from_flow is not None:
+            out["seed_from_flow"] = terminal.seed_from_flow
+
+    if terminal.then is not None:
+        out["then"] = _lower_terminal(terminal.then, slot_kind)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Preset 1 — Onboarding wizard (NON-COMMERCE proof, RFC 13 M1/M3). Now emits a
+# FLAT descriptor and delegates to build_flow_from_descriptor (§2.6). The
+# shared-slot pattern ("enter_details") keeps both branches' flowId identical so
+# the confirm step's {state.enter_details_formData.workspace} read resolves on
+# either path — byte-identical to the pre-v2 hand-built tree.
 #
 #   Step 1 (root):  pick a goal           — branches via chain_map
-#   Step 2a:        focus → workspace name (form)        ┐
-#   Step 2b:        collaborate → team workspace (form)  ┘ both chain → step 3
-#   Step 3 (term):  confirm — pre-filled from steps 1+2 via {state.x}, loops the
-#                   collected answers back to the agent via onComplete.chat
-#
-# Mirrors the M1 fixture (onboarding-wizard.ts) so the same tree this builder
-# emits is the one M1's ChainExecutor tests already prove walks correctly.
+#   Step 2a:        focus → workspace name (form)        ┐ slot: enter_details
+#   Step 2b:        collaborate → team workspace (form)  ┘ both next → confirm
+#   Step 3 (term):  confirm — pre-filled from steps 1+2, onComplete.chat
 # ---------------------------------------------------------------------------
 
 
-def build_onboarding_wizard(config: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Build the onboarding-wizard flow tree as a `{version, ui}` doc.
-
-    `config` is the optional descriptor override. Recognized keys (all
-    optional — every one has a sensible default so a bare `flow_type` works):
-      - `product_name` (str): branded into the welcome / confirm copy.
-      - `goals` (list[{id, label}]): override the goal options at step 1.
-        Each goal id becomes a `chain_map` branch. A goal whose id is not
-        `focus`/`collaborate` falls through to the shared details step.
-      - `complete_message` (str): the human-readable prompt the terminal step
-        hands back to the agent (default: a "set up my workspace" prompt).
-    """
+def _onboarding_descriptor(config: dict[str, Any] | None) -> dict[str, Any]:
     config = config or {}
     product_name = str(config.get("product_name") or "your workspace")
     complete_message = str(
         config.get("complete_message")
         or "I've finished onboarding — here are my choices, please set up my workspace."
     )
-
-    # --- Step 3 (terminal): confirm, pre-filled from the earlier answers -----
-    # Cross-step pre-fill: reads back step 1's selection label and step 2's
-    # entered workspace name via `{state.<flowId>_*}` — the ChainExecutor
-    # namespaces each step's data under its flowId.
-    confirm_step: dict[str, Any] = {
-        "version": "2.0",
-        "id": "onboard-confirm",
-        "flowId": "confirm",
-        "intent": "confirm",
-        "title": "You are all set",
-        # Terminal action: hand the collected answers back to the AGENT to act on.
-        # The runtime appends the accumulated payload to this message before
-        # sending it, so we only supply the human-readable prompt here.
-        "onComplete": {
-            "kind": "chat",
-            "message": complete_message,
-        },
-        # Structured review rows for a designed summary render; the raw `ui` below
-        # stays as the fallback. Both read the same {state.x} pre-fill values.
-        "review_rows": [
-            _review_row("Goal", "{state.pick_goal_selection.label}"),
-            _review_row("Workspace", "{state.enter_details_formData.workspace}"),
-        ],
-        "ui": _container(
-            [
-                _heading("Review your setup"),
-                _text("Goal: {state.pick_goal_selection.label}"),
-                _text("Workspace: {state.enter_details_formData.workspace}"),
-                _submit_button("Finish setup"),
-            ],
-            cls="flow-confirm",
-        ),
-    }
-
-    def _details_step(step_id: str, heading: str, placeholder: str) -> dict[str, Any]:
-        # A step-2 form. flowId is shared across both branches ("enter_details")
-        # so the confirm step's `{state.enter_details_formData.workspace}`
-        # resolves regardless of which branch the user took.
-        return {
-            "version": "2.0",
-            "id": step_id,
-            "flowId": "enter_details",
-            "intent": "form",
-            "title": "Set up your workspace",
-            "chain": confirm_step,
-            # Structured field DATA — ripple's FormLayout renders a designed form
-            # from this. The raw `ui` below stays as the backward-compat fallback.
-            "form_fields": [
-                _form_field("workspace", "Workspace name", placeholder),
-            ],
-            "ui": _container(
-                [
-                    _heading(heading),
-                    _input("workspace", "Workspace name", placeholder),
-                    # Intermediate step: Back (flow.back) sits before Continue
-                    # (flow.next) so the user can return to the goal pick.
-                    _nav_row(
-                        [
-                            _back_button("Back"),
-                            _continue_button("Continue", ["workspace"]),
-                        ]
-                    ),
-                ]
-            ),
-        }
-
-    focus_step = _details_step("onboard-details", "Name your workspace", "Acme HQ")
-    invite_step = _details_step("onboard-invite", "Name your shared workspace", "Acme Team")
-
-    # --- Step 1 (root): pick a goal, branch on the selection -----------------
     default_goals = [
         {"id": "focus", "label": "Focus on my own work"},
         {"id": "collaborate", "label": "Collaborate with a team"},
     ]
     goals = config.get("goals") or default_goals
 
-    # The chain_map: each goal id -> the step 2 it routes to. `collaborate`
-    # gets the invite-flavored step; everything else shares the focus step.
-    chain_map: dict[str, dict[str, Any]] = {}
-    goal_buttons: list[dict[str, Any]] = []
+    # Branch each goal id → the step-2 it routes to. `collaborate` gets the
+    # invite-flavored step; everything else shares the focus step. Both step-2s
+    # share slot "enter_details" so the confirm read-back is branch-agnostic.
+    branch: dict[str, str] = {}
     for goal in goals:
         gid = str(goal.get("id"))
-        glabel = str(goal.get("label") or gid)
-        chain_map[gid] = invite_step if gid == "collaborate" else focus_step
-        goal_buttons.append(_select_button(glabel, gid))
+        branch[gid] = "onboard-invite" if gid == "collaborate" else "onboard-details"
 
-    root: dict[str, Any] = {
-        "version": "2.0",
-        "id": "onboard-goal",
-        "flowId": "pick_goal",
-        "intent": "select",
+    return {
+        "flow": "onboarding_wizard",
+        "entry": "onboard-goal",
         "title": "What brings you here?",
-        "selection": "single",
-        "chain_map": chain_map,
-        "ui": _container(
-            [
-                _heading(f"Welcome to {product_name}"),
-                _text("Pick your primary goal to get started."),
-                *goal_buttons,
-            ]
-        ),
+        "steps": [
+            {
+                "id": "onboard-goal",
+                "kind": "select",
+                "slot": "pick_goal",
+                "title": "What brings you here?",
+                "subtitle": "Pick your primary goal to get started.",
+                "options": [
+                    {"id": str(g.get("id")), "label": str(g.get("label") or g.get("id"))}
+                    for g in goals
+                ],
+                "branch": branch,
+                # Welcome copy lives on the heading via the title; brand it in.
+                "ui": {"_brand": product_name},
+            },
+            {
+                "id": "onboard-details",
+                "kind": "form",
+                "slot": "enter_details",
+                "title": "Set up your workspace",
+                "fields": [
+                    {
+                        "id": "workspace",
+                        "label": "Workspace name",
+                        "type": "text",
+                        "placeholder": "Acme HQ",
+                        "required": True,
+                    },
+                ],
+                "next": "onboard-confirm",
+            },
+            {
+                "id": "onboard-invite",
+                "kind": "form",
+                "slot": "enter_details",
+                "title": "Set up your workspace",
+                "fields": [
+                    {
+                        "id": "workspace",
+                        "label": "Workspace name",
+                        "type": "text",
+                        "placeholder": "Acme Team",
+                        "required": True,
+                    },
+                ],
+                "next": "onboard-confirm",
+            },
+            {
+                "id": "onboard-confirm",
+                "kind": "confirm",
+                "slot": "confirm",
+                "title": "You are all set",
+                "review": [
+                    {"label": "Goal", "value": "{pick_goal.label}"},
+                    {"label": "Workspace", "value": "{enter_details.workspace}"},
+                ],
+                "complete": {"action": "chat", "message": complete_message},
+            },
+        ],
     }
 
-    return {"version": INLINE_SPEC_VERSION, "ui": root}
+
+def build_onboarding_wizard(config: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build the onboarding-wizard flow as a `{version, ui}` doc.
+
+    Emits a flat descriptor (`_onboarding_descriptor`) and delegates to
+    `build_flow_from_descriptor`. `config` is the optional descriptor override.
+    Recognized keys (all optional — each has a default so a bare `flow_type`
+    works): `product_name`, `goals` (list[{id, label}]), `complete_message`.
+    """
+    doc = build_flow_from_descriptor(_onboarding_descriptor(config))
+    # Brand the welcome copy onto the root heading/subtitle (the descriptor's
+    # _brand marker is the only preset-specific touch the flat schema can't carry
+    # natively — the heading text is "What brings you here?", the welcome line is
+    # injected as the first body text so the existing product-name copy assertion
+    # holds without changing the generic builder).
+    root = doc["ui"]
+    config = config or {}
+    product_name = str(config.get("product_name") or "your workspace")
+    _inject_welcome(root, f"Welcome to {product_name}")
+    # remove the descriptor marker if it leaked into the assembled ui
+    root.get("ui", {}).pop("_brand", None)
+    return doc
+
+
+def _inject_welcome(root_node: dict[str, Any], welcome: str) -> None:
+    """Prepend a welcome line to the root step's ui (after the heading) so the
+    onboarding preset keeps its branded copy. Idempotent enough for one call."""
+    ui = root_node.get("ui")
+    if not isinstance(ui, dict):
+        return
+    children = ui.get("children")
+    if not isinstance(children, list):
+        return
+    # insert right after the leading heading
+    children.insert(1, _text(welcome))
 
 
 # ---------------------------------------------------------------------------
-# Template 2 — Due-diligence intake (NON-COMMERCE vertical, RFC 13 §7.1, M3).
+# Preset 2 — Due-diligence intake (NON-COMMERCE vertical, RFC 13 §7.1, M3). Now
+# emits a FLAT descriptor and delegates. Shared slot "financials" keeps both
+# branch forms' flowId identical so {financials.headline} reads branch-
+# agnostically — byte-identical to the pre-v2 hand-built tree.
 #
 #   Step 1 (root):  pick the deal stage     — branches via chain_map
-#   Step 2a:        early-stage → traction + raise (form)  ┐
-#   Step 2b:        growth → revenue + metrics (form)      ┘ both chain → step 3
-#   Step 3:         risk & flags (form)                    → step 4
-#   Step 4 (term):  review — pre-filled from every prior step via {state.x},
-#                   loops the full packet back to the agent via onComplete.chat.
-#
-# This is the "vertical workflow → flow template" case from RFC 13 §7.1: a
-# multi-step intake split into digestible steps, branching on the deal stage,
-# accumulating a structured packet the agent acts on when the terminal step
-# hands the collected answers back via `onComplete.kind = "chat"`.
-# A survey is the same shape with the labels swapped; due-diligence is the
-# richer (4-step, branch + linear) proof.
+#   Step 2a:        early → traction + raise (form)  ┐ slot: financials
+#   Step 2b:        growth → revenue + metrics (form)┘ both next → risk
+#   Step 3:         risk & flags (form)              → review
+#   Step 4 (term):  review — pre-filled, onComplete.chat
 # ---------------------------------------------------------------------------
 
 
-def build_due_diligence_intake(config: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Build the due-diligence intake flow tree as a `{version, ui}` doc.
-
-    `config` overrides (all optional):
-      - `company_name` (str): branded into the intro / review copy.
-      - `complete_message` (str): the human-readable prompt the terminal step
-        hands back to the agent (default: a "summarize and flag risks" prompt).
-        Accepted but ignored: the legacy `submit_event` key — the terminal now
-        loops to the agent via `onComplete.kind = "chat"` instead of firing a
-        host event, so there is no event name to override.
-    """
+def _diligence_descriptor(config: dict[str, Any] | None) -> dict[str, Any]:
     config = config or {}
     company_name = str(config.get("company_name") or "the company")
     complete_message = str(
         config.get("complete_message")
         or "Diligence intake complete — here are my inputs, please summarize and flag risks."
     )
-
-    # --- Step 4 (terminal): review the assembled packet, then submit ---------
-    # Pre-fills from EVERY prior step (the deal stage, the stage-specific
-    # financials, the risk flags) via `{state.<flowId>_*}`.
-    review_step: dict[str, Any] = {
-        "version": "2.0",
-        "id": "dd-review",
-        "flowId": "review",
-        "intent": "confirm",
-        "title": "Review the intake",
-        # Terminal action: loop the assembled packet back to the AGENT to act on.
-        # The runtime appends the accumulated payload to this message; we supply
-        # only the human-readable prompt.
-        "onComplete": {
-            "kind": "chat",
-            "message": complete_message,
-        },
-        # Structured review rows for a designed summary render; raw `ui` is the
-        # fallback. Both read the same {state.x} pre-fill values.
-        "review_rows": [
-            _review_row("Deal stage", "{state.deal_stage_selection.label}"),
-            _review_row("Headline metric", "{state.financials_formData.headline}"),
-            _review_row("Key risk", "{state.risk_review_formData.key_risk}"),
-        ],
-        "ui": _container(
-            [
-                _heading("Confirm the diligence packet"),
-                _text("Deal stage: {state.deal_stage_selection.label}"),
-                _text("Headline metric: {state.financials_formData.headline}"),
-                _text("Key risk: {state.risk_review_formData.key_risk}"),
-                _submit_button("Submit intake"),
-            ],
-            cls="flow-dd-review",
-        ),
-    }
-
-    # --- Step 3 (shared): risk & flags -> review -----------------------------
-    risk_step: dict[str, Any] = {
-        "version": "2.0",
-        "id": "dd-risk",
-        "flowId": "risk_review",
-        "intent": "form",
-        "title": "Risk & open flags",
-        "chain": review_step,
-        # Structured field DATA for ripple's FormLayout; raw `ui` is the fallback.
-        "form_fields": [
-            _form_field("key_risk", "Biggest open risk", "Customer concentration"),
-            _form_field(
-                "mitigation",
-                "Mitigation (optional)",
-                "Diversifying pipeline",
-                required=False,
-            ),
-        ],
-        "ui": _container(
-            [
-                _heading("Note the top risk"),
-                _input("key_risk", "Biggest open risk", "Customer concentration"),
-                _input("mitigation", "Mitigation (optional)", "Diversifying pipeline"),
-                # Intermediate step: Back (flow.back) steps to the financials
-                # form; Continue (flow.next) advances to review.
-                _nav_row(
-                    [
-                        _back_button("Back"),
-                        _continue_button("Continue to review", ["key_risk", "mitigation"]),
-                    ]
-                ),
-            ]
-        ),
-    }
-
-    def _financials_step(
-        step_id: str, heading: str, fields: list[tuple[str, str, str]]
-    ) -> dict[str, Any]:
-        # A step-2 financials form. Shared flowId ("financials") so the review
-        # step's `{state.financials_formData.headline}` resolves on both
-        # branches. Every branch exposes a `headline` field so the read-back
-        # is branch-agnostic.
-        children: list[dict[str, Any]] = [_heading(heading)]
-        binds: list[str] = []
-        form_fields: list[dict[str, Any]] = []
-        for bind, label, placeholder in fields:
-            children.append(_input(bind, label, placeholder))
-            binds.append(bind)
-            form_fields.append(_form_field(bind, label, placeholder))
-        # Intermediate step: Back (flow.back) returns to the stage pick;
-        # Continue (flow.next) advances to the risk step.
-        children.append(
-            _nav_row(
-                [
-                    _back_button("Back"),
-                    _continue_button("Continue", binds),
-                ]
-            )
-        )
-        return {
-            "version": "2.0",
-            "id": step_id,
-            "flowId": "financials",
-            "intent": "form",
-            "title": "Financial snapshot",
-            "chain": risk_step,
-            # Structured field DATA for ripple's FormLayout; raw `ui` is the fallback.
-            "form_fields": form_fields,
-            "ui": _container(children),
-        }
-
-    early_step = _financials_step(
-        "dd-financials-early",
-        "Early-stage traction",
-        [
-            ("headline", "Headline traction metric", "1.2k weekly active"),
-            ("raise", "Round size sought", "$2M seed"),
-        ],
-    )
-    growth_step = _financials_step(
-        "dd-financials-growth",
-        "Growth metrics",
-        [
-            ("headline", "Headline revenue metric", "$4M ARR"),
-            ("growth", "YoY growth", "180%"),
-        ],
-    )
-
-    # --- Step 1 (root): pick the deal stage, branch on it --------------------
-    stages = [
-        {"id": "early", "label": "Early stage (pre-seed / seed)"},
-        {"id": "growth", "label": "Growth stage (Series A+)"},
-    ]
-    chain_map: dict[str, dict[str, Any]] = {
-        "early": early_step,
-        "growth": growth_step,
-    }
-    stage_buttons = [_select_button(s["label"], s["id"]) for s in stages]
-
-    root: dict[str, Any] = {
-        "version": "2.0",
-        "id": "dd-stage",
-        "flowId": "deal_stage",
-        "intent": "select",
+    return {
+        "flow": "due_diligence_intake",
+        "entry": "dd-stage",
         "title": "Due-diligence intake",
-        "selection": "single",
-        "chain_map": chain_map,
-        "ui": _container(
-            [
-                _heading(f"Diligence intake for {company_name}"),
-                _text("Pick the deal stage — the next steps adapt to it."),
-                *stage_buttons,
-            ]
-        ),
+        "steps": [
+            {
+                "id": "dd-stage",
+                "kind": "select",
+                "slot": "deal_stage",
+                "title": "Due-diligence intake",
+                "subtitle": f"Diligence intake for {company_name} — pick the deal stage.",
+                "options": [
+                    {"id": "early", "label": "Early stage (pre-seed / seed)"},
+                    {"id": "growth", "label": "Growth stage (Series A+)"},
+                ],
+                "branch": {"early": "dd-financials-early", "growth": "dd-financials-growth"},
+            },
+            {
+                "id": "dd-financials-early",
+                "kind": "form",
+                "slot": "financials",
+                "title": "Financial snapshot",
+                "fields": [
+                    {
+                        "id": "headline",
+                        "label": "Headline traction metric",
+                        "type": "text",
+                        "placeholder": "1.2k weekly active",
+                        "required": True,
+                    },
+                    {
+                        "id": "raise",
+                        "label": "Round size sought",
+                        "type": "text",
+                        "placeholder": "$2M seed",
+                        "required": True,
+                    },
+                ],
+                "next": "dd-risk",
+            },
+            {
+                "id": "dd-financials-growth",
+                "kind": "form",
+                "slot": "financials",
+                "title": "Financial snapshot",
+                "fields": [
+                    {
+                        "id": "headline",
+                        "label": "Headline revenue metric",
+                        "type": "text",
+                        "placeholder": "$4M ARR",
+                        "required": True,
+                    },
+                    {
+                        "id": "growth",
+                        "label": "YoY growth",
+                        "type": "text",
+                        "placeholder": "180%",
+                        "required": True,
+                    },
+                ],
+                "next": "dd-risk",
+            },
+            {
+                "id": "dd-risk",
+                "kind": "form",
+                "slot": "risk_review",
+                "title": "Risk & open flags",
+                "fields": [
+                    {
+                        "id": "key_risk",
+                        "label": "Biggest open risk",
+                        "type": "text",
+                        "placeholder": "Customer concentration",
+                        "required": True,
+                    },
+                    {
+                        "id": "mitigation",
+                        "label": "Mitigation (optional)",
+                        "type": "textarea",
+                        "placeholder": "Diversifying pipeline",
+                        "required": False,
+                    },
+                ],
+                "next": "dd-review",
+            },
+            {
+                "id": "dd-review",
+                "kind": "confirm",
+                "slot": "review",
+                "title": "Review the intake",
+                "review": [
+                    {"label": "Deal stage", "value": "{deal_stage.label}"},
+                    {"label": "Headline metric", "value": "{financials.headline}"},
+                    {"label": "Key risk", "value": "{risk_review.key_risk}"},
+                ],
+                "complete": {"action": "chat", "message": complete_message},
+            },
+        ],
     }
 
-    return {"version": INLINE_SPEC_VERSION, "ui": root}
+
+def build_due_diligence_intake(config: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build the due-diligence intake flow as a `{version, ui}` doc.
+
+    Emits a flat descriptor (`_diligence_descriptor`) and delegates to
+    `build_flow_from_descriptor`. `config` overrides (all optional):
+    `company_name`, `complete_message`. The legacy `submit_event` key is
+    accepted but ignored (the terminal loops to the agent via onComplete.chat,
+    so there is no host event to override).
+    """
+    return build_flow_from_descriptor(_diligence_descriptor(config))
 
 
 # ---------------------------------------------------------------------------
-# Dispatch — `flow_type` -> builder. The tool layer (start_flow) validates the
-# `flow_type` against FLOW_TYPES and calls `build_flow`; the builder owns the
-# rest. `domain` is accepted as a forward-compatible hint (RFC 13 §7.1 notes a
-# later data-fresh materialization path) but does not change the tree today.
+# Dispatch — `flow_type` -> preset descriptor -> build_flow_from_descriptor.
+# `domain` is accepted as a forward-compatible hint (RFC 13 §7.1) but does not
+# change the tree today.
 # ---------------------------------------------------------------------------
 
 _BUILDERS = {
@@ -573,10 +1518,11 @@ def build_flow(
     domain: str | None = None,
     config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Expand a descriptor into a full `{version, ui}` Chain Flow doc.
+    """Expand a PRESET descriptor into a full `{version, ui}` Chain Flow doc.
 
     Raises ``ValueError`` for an unknown ``flow_type`` (the tool layer turns
-    that into an agent-readable error listing the valid templates).
+    that into an agent-readable error listing the valid presets). For an
+    arbitrary flat graph, call :func:`build_flow_from_descriptor` directly.
     """
     builder = _BUILDERS.get(flow_type)
     if builder is None:
@@ -588,7 +1534,13 @@ def build_flow(
 __all__ = [
     "FLOW_TYPES",
     "INLINE_SPEC_VERSION",
+    "FlowBuildError",
+    "FlowDescriptor",
+    "FlowStep",
+    "StepAction",
+    "TerminalAction",
     "build_due_diligence_intake",
     "build_flow",
+    "build_flow_from_descriptor",
     "build_onboarding_wizard",
 ]

--- a/src/pocketpaw/ripple/_flows.py
+++ b/src/pocketpaw/ripple/_flows.py
@@ -1,6 +1,31 @@
 # pocketpaw/ripple/_flows.py — Chain Flow builders (RFC 13 §7.1, M3 → CHAIN FLOW v2).
 #
 # Created: 2026-05-31 (RFC 13 M3, feat/m3-flow-authoring-tool).
+# Updated: 2026-06-15 (feat/chain-flow-v2 — GENESIS-STYLE FORGIVENESS / RELIABILITY):
+#   - Front-loaded two FORGIVENESS passes before the strict validators so most
+#     "sloppy" descriptors BUILD (repaired) instead of erroring — genesis's
+#     reliability philosophy (repair imperfect specs, don't reject them):
+#       * `_normalize_descriptor` (§2.0): coerces the model's instinctive key
+#         slips on the raw dict BEFORE parse — a terminal `complete` written with
+#         `type:`/`kind:` → `action:`; a StepAction / continuation written with
+#         `type:` → `verb:` (the rest of ripple uses type/kind for NODES, so the
+#         model reaches for them here too). Deep-copies first; never mutates the
+#         caller's dict.
+#       * `_repair_descriptor` (§2.0): patches recoverable GRAPH defects on the
+#         parsed model — a terminal step (or the whole flow) with no `complete`
+#         gets a default `chat`; a flow where every step transitions has its
+#         last step made terminal; a dead-ending `select`/`info` LAST step is
+#         converted to terminal (was a hard reject).
+#   - `_friendly_parse_error`: any shape defect that survives normalization now
+#     raises a FlowBuildError that NAMES the fix (e.g. "terminal `complete` needs
+#     an `action` key (chat|navigate|emit|call_binding|create_pocket)") instead
+#     of leaking the raw `errors.pydantic.dev` dump.
+#   - `_validate_graph` relaxes the select-must-transition rule for a select the
+#     repair pass made TERMINAL (it carries a `complete`); `_assemble_node` gives
+#     a terminal select a Finish (flow.submit) button so the recorded pick can
+#     run its `complete`. HARD rejects are kept ONLY for genuinely unrenderable
+#     bugs: a transition to an UNDECLARED id, a duplicate step id, a branch key
+#     that is not an option id.
 # Updated: 2026-06-15 (feat/chain-flow-v2 — CONTINUATION-NOT-A-BUTTON FIX):
 #   - Mid-flow `StepAction.on_success` / `.on_error` continuation chains are no
 #     longer typed as `list[StepAction]`. `StepAction` is a BUTTON and requires
@@ -655,29 +680,269 @@ def _declared_fields(step: FlowStep) -> set[str]:
     return set()
 
 
+# ---------------------------------------------------------------------------
+# §2.0 — Forgiveness front-matter (genesis: REPAIR imperfect specs, don't reject).
+#
+# Two passes run BEFORE the strict validators:
+#   _normalize_descriptor  — coerce the model's instinctive key slips
+#                            (type:/kind: → action:/verb:) on the raw dict;
+#   _repair_descriptor     — patch recoverable GRAPH defects on the parsed model
+#                            (missing terminal complete, no terminal, dead-end
+#                            select/info last step).
+# Between them sits the friendly-error wrap (_friendly_parse_error) so a shape
+# defect that survives normalization NAMES the fix instead of leaking Pydantic.
+# ---------------------------------------------------------------------------
+
+# The flow-level terminal default injected when a terminal step (and the flow)
+# declare no `complete` — hand the answers back to the agent, the safest default.
+_DEFAULT_COMPLETE: dict[str, Any] = {"action": "chat", "message": "Done."}
+
+
+def _normalize_complete_aliases(obj: Any) -> None:
+    """Rewrite a terminal `complete` dict's `type:`/`kind:` → `action:`.
+
+    Models instinctively write `type`/`kind` (the rest of ripple uses those for
+    NODES). A terminal hand-off keys on `action:`; coerce the slip in place so
+    the natural authoring just parses. Only fills `action` when it is absent —
+    an explicit `action` always wins. Recurses into a `then` post-action.
+    """
+    if not isinstance(obj, dict):
+        return
+    if "action" not in obj:
+        for alias in ("type", "kind"):
+            if isinstance(obj.get(alias), str) and obj[alias]:
+                obj["action"] = obj.pop(alias)
+                break
+    # a `then` chain is itself a terminal action — normalize it too
+    if isinstance(obj.get("then"), dict):
+        _normalize_complete_aliases(obj["then"])
+
+
+def _normalize_action_aliases(obj: Any) -> None:
+    """Rewrite a StepAction / continuation dict's `type:` → `verb:`.
+
+    A mid-flow action (and its `on_success`/`on_error` continuations) keys on
+    `verb:`; models reach for `type:` out of node-authoring habit. Coerce the
+    slip in place (only when `verb` is absent) and recurse into the
+    continuation chains.
+    """
+    if not isinstance(obj, dict):
+        return
+    if "verb" not in obj and isinstance(obj.get("type"), str) and obj["type"]:
+        obj["verb"] = obj.pop("type")
+    for chain_key in ("on_success", "on_error"):
+        chain = obj.get(chain_key)
+        if isinstance(chain, list):
+            for entry in chain:
+                _normalize_action_aliases(entry)
+
+
+def _normalize_descriptor(descriptor: dict[str, Any]) -> dict[str, Any]:
+    """Return a DEEP COPY of the raw descriptor with the model's common key
+    slips coerced to the canonical keys, BEFORE Pydantic parse (§2.0).
+
+    Coercions (genesis forgiveness — the model's instinct just works):
+      - terminal `complete` (flow-level + per-step) with `type:`/`kind:` and no
+        `action:` → `action:`;
+      - StepAction + continuation with `type:` and no `verb:` → `verb:`.
+
+    The caller's dict is never mutated — a fresh structure is built so a retry
+    or a second build sees the original input.
+    """
+    import copy
+
+    if not isinstance(descriptor, dict):
+        return descriptor
+    out = copy.deepcopy(descriptor)
+
+    # flow-level default complete
+    _normalize_complete_aliases(out.get("complete"))
+
+    for step in out.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        _normalize_complete_aliases(step.get("complete"))
+        for action in step.get("actions") or []:
+            _normalize_action_aliases(action)
+    return out
+
+
+def _friendly_parse_error(exc: Exception) -> str:
+    """Turn a Pydantic ValidationError (or any parse failure) into a friendly,
+    agent-readable :class:`FlowBuildError` message that NAMES the fix instead of
+    leaking the `errors.pydantic.dev` URL and the raw error dump.
+
+    Recognizes the highest-signal slips:
+      - a terminal `complete` missing its `action` key (the #1 slip after the
+        type:/kind: alias path, e.g. a `complete` written as a bare message);
+      - a step missing its `kind`, or an unknown `kind`.
+    Falls back to a clean one-line summary of the first error for anything else.
+    """
+    try:
+        from pydantic import ValidationError
+    except Exception:  # pragma: no cover - pydantic always present here
+        return f"descriptor is malformed: {exc}"
+
+    if not isinstance(exc, ValidationError):
+        return f"descriptor is malformed: {exc}"
+
+    errors = exc.errors()
+    for err in errors:
+        loc = err.get("loc", ())
+        loc_str = ".".join(str(p) for p in loc)
+        # a terminal `complete` (or flow default) missing `action`
+        if "complete" in loc and loc and loc[-1] == "action":
+            return (
+                f"terminal `complete` (at {loc_str or 'complete'}) needs an `action` key "
+                "(chat | navigate | emit | call_binding | create_pocket) — "
+                'e.g. {"action": "chat", "message": "Done."}'
+            )
+        # a step missing / mis-typing `kind`
+        if "kind" in loc:
+            return f"step field `kind` (at {loc_str}) must be one of select | form | confirm | info"
+        # a mid-flow action missing `verb`
+        if "actions" in loc and loc and loc[-1] == "verb":
+            return (
+                f"mid-flow action (at {loc_str}) needs a `verb` key "
+                "(call_binding | api | invoke_tool | emit | navigate | set | toast)"
+            )
+
+    # generic fallback — name the first offending field, drop the URL noise.
+    if errors:
+        first = errors[0]
+        loc_str = ".".join(str(p) for p in first.get("loc", ())) or "<root>"
+        msg = first.get("msg", "invalid value")
+        return f"descriptor is malformed at `{loc_str}`: {msg}"
+    return f"descriptor is malformed: {exc}"
+
+
+def _repair_descriptor(model: FlowDescriptor) -> None:
+    """PATCH recoverable graph defects on the parsed model IN PLACE, before the
+    strict validate-graph pass (§2.0 — genesis stays bulletproof by repairing
+    imperfect specs, not rejecting them).
+
+    Repairs (each turns a silent dead-end into a completable flow), kept
+    SURGICAL so they never MASK a genuine bug:
+      1. A terminal step of kind confirm/info/form (no `next`/`branch`) with no
+         `complete` AND no flow-level `complete` → inject a default `chat`
+         complete. (A bare dead-end SELECT is NOT auto-rescued here — only as a
+         LAST step, via repair 3 — so a mid-flow dead-end select still rejects.)
+      2. A flow where EVERY step transitions (no terminal at all) AND the
+         last-declared step's transition targets are all DECLARED → make that
+         step terminal (drop its transition) + give it a default `complete`.
+         (Guarded on declared targets so a DANGLING transition is left for the
+         validator to reject precisely, not silently erased.)
+      3. A `select`/`info` step that dead-ends (no next/branch/complete) AND is
+         the LAST declared step → convert to terminal with a default `complete`
+         (instead of the historical hard reject).
+
+    Genuinely unrenderable bugs (dangling transition, duplicate id, bad branch
+    key, a mid-flow dead-end select) are LEFT for the strict validators to
+    reject precisely — repair only touches the recoverable dead-end class.
+    """
+    steps = model.steps
+    if not steps:
+        return
+    last = steps[-1]
+    declared = {s.id for s in steps}
+
+    # Repair 3: a select/info LAST step with no transition and no complete
+    # becomes terminal with a default complete. (A select normally must
+    # transition; as the last step with nowhere to go, the forgiving move is to
+    # end the flow rather than reject the whole build.)
+    if (
+        last.kind in ("select", "info")
+        and not last.next
+        and not last.branch
+        and last.complete is None
+        and model.complete is None
+    ):
+        last.complete = TerminalAction.model_validate(dict(_DEFAULT_COMPLETE))
+
+    # Repair 2: NO terminal anywhere (every step transitions) → make the last
+    # step terminal by dropping its transition. GUARD: only when the last step's
+    # transition targets are all declared — a dangling transition is a real bug
+    # the validator must surface, not something repair should silently erase.
+    has_terminal = any(_is_terminal_step(s) for s in steps)
+    if not has_terminal and _transition_targets_declared(last, declared):
+        last.next = None
+        last.branch = None
+        if last.complete is None and model.complete is None:
+            last.complete = TerminalAction.model_validate(dict(_DEFAULT_COMPLETE))
+
+    # Repair 1: a terminal confirm/info/form step lacking a complete (no
+    # flow-level default) → inject the default so the terminal has a hand-off.
+    # Selects are excluded: a bare dead-end select is only ever rescued as a
+    # LAST step (repair 3); a mid-flow one must reject. When a flow-level default
+    # exists, attach-terminal inherits it — leave those steps alone.
+    if model.complete is None:
+        for step in steps:
+            if (
+                step.kind in ("confirm", "info", "form")
+                and _is_terminal_step(step)
+                and step.complete is None
+            ):
+                step.complete = TerminalAction.model_validate(dict(_DEFAULT_COMPLETE))
+
+
+def _transition_targets_declared(step: FlowStep, declared: set[str]) -> bool:
+    """True if every id `step` transitions to (`next` / `branch` values) is a
+    declared step id. Used to GUARD repair 2 so it never erases a dangling
+    transition (a real bug the validator should reject)."""
+    if step.next is not None and step.next not in declared:
+        return False
+    if step.branch:
+        return all(target in declared for target in step.branch.values())
+    return True
+
+
 def build_flow_from_descriptor(descriptor: dict[str, Any]) -> dict[str, Any]:
     """Flat FlowDescriptor → {version, ui} nested Chain Flow doc.
 
-    Implements the §2.1 ordered pipeline:
-        parse → index → validate-graph → validate-refs → validate-actions
-        → assemble-nodes → resolve-transitions → wire-prefills
-        → attach-actions → attach-terminal → final deep-validate → envelope
+    Implements the §2.1 ordered pipeline (genesis forgiveness front-loaded):
+        normalize-aliases → parse → repair → index → validate-graph
+        → validate-refs → validate-actions → assemble-nodes
+        → resolve-transitions → wire-prefills → attach-actions
+        → attach-terminal → final deep-validate → envelope
 
-    Raises :class:`FlowBuildError` (with a precise, agent-readable message) on
-    any structural defect: missing entry, dangling transition, unreachable step,
-    no terminal, terminal-with-transition, unknown action verb, dangling prefill
-    ref. The tool layer surfaces the message so the model can fix and retry.
+    Forgiveness, NOT rejection, for recoverable author slips (genesis's
+    reliability philosophy):
+      - `normalize-aliases` (§2.0) rewrites the model's instinctive key slips
+        before parse — a terminal `complete` written with `type:`/`kind:` →
+        `action:`, a StepAction/continuation written with `type:` → `verb:`
+        (the rest of ripple uses `type`/`kind` for NODES, so the model reaches
+        for them here too). The model's instinct just works.
+      - `repair` (§2.0) PATCHES recoverable graph defects instead of raising:
+        a terminal step with no `complete` gets a default `chat`; a flow whose
+        every step transitions has its last-declared step made terminal; a
+        dead-ending `select`/`info` last step is converted to terminal.
 
-    A flat graph cannot mis-nest — that is the whole point. The
-    "renders step 1 and silently dead-ends" failure (a select step with no
-    transition, an unreachable continuation) is structurally impossible to
-    express: each is a hard build-time reject.
+    Raises :class:`FlowBuildError` (with a precise, agent-readable message) ONLY
+    for genuinely unrenderable authoring bugs the repair pass leaves untouched:
+    a `next`/`branch` to an UNDECLARED id (dangling transition), a duplicate
+    step id, a branch key that is not an option id, an unknown action verb, a
+    dangling prefill ref. The tool layer surfaces the message so the model can
+    fix and retry. A friendly :class:`FlowBuildError` (not a raw Pydantic dump)
+    wraps any shape defect that survives normalization — it NAMES the likely fix.
+
+    A flat graph cannot mis-nest — that is the whole point. Most "sloppy"
+    descriptors now BUILD (repaired) and render something polished; only real
+    structural bugs error.
     """
-    # 1. parse -------------------------------------------------------------
+    # 0. normalize-aliases (§2.0) — rewrite type:/kind: slips to action:/verb:
+    #    on a deep copy so the caller's dict is never mutated.
+    descriptor = _normalize_descriptor(descriptor)
+
+    # 1. parse — wrap any surviving shape defect in a FRIENDLY FlowBuildError
+    #    that names the likely fix instead of leaking a raw Pydantic error URL.
     try:
         model = FlowDescriptor.model_validate(descriptor)
     except Exception as exc:  # pydantic.ValidationError + anything malformed
-        raise FlowBuildError(f"descriptor is malformed: {exc}") from exc
+        raise FlowBuildError(_friendly_parse_error(exc)) from exc
+
+    # 2. repair (§2.0) — PATCH recoverable graph defects before the strict
+    #    validate-graph pass (genesis: repair imperfect specs, don't reject).
+    _repair_descriptor(model)
 
     if not model.steps:
         raise FlowBuildError("flow has no steps; a flow needs at least one step")
@@ -687,14 +952,14 @@ def build_flow_from_descriptor(descriptor: dict[str, Any]) -> dict[str, Any]:
             "split the flow into smaller flows"
         )
 
-    # 2. index -------------------------------------------------------------
+    # 3. index -------------------------------------------------------------
     by_id: dict[str, FlowStep] = {}
     for step in model.steps:
         if step.id in by_id:
             raise FlowBuildError(f'duplicate step id "{step.id}"; step ids must be unique')
         by_id[step.id] = step
 
-    # 3. validate-graph (§2.3) --------------------------------------------
+    # 4. validate-graph (§2.3) --------------------------------------------
     _validate_graph(model, by_id)
 
     # Build the slot→(flowId, suffix) map for ref resolution/rewrite. A token is
@@ -709,13 +974,13 @@ def build_flow_from_descriptor(descriptor: dict[str, Any]) -> dict[str, Any]:
         if step.slot:
             slot_kind[step.slot] = f"{fid}|{suffix}"
 
-    # 4. validate-refs (§2.5) ---------------------------------------------
+    # 5. validate-refs (§2.5) ---------------------------------------------
     warnings = _validate_refs(model, by_id)
 
-    # 5. validate-actions (§2.4) ------------------------------------------
+    # 6. validate-actions (§2.4) ------------------------------------------
     _validate_actions(model)
 
-    # 6. assemble-nodes ----------------------------------------------------
+    # 7. assemble-nodes ----------------------------------------------------
     reachable = _reachable_ids(model, by_id)
     nodes: dict[str, dict[str, Any]] = {
         step.id: _assemble_node(step, is_entry=(step.id == model.entry))
@@ -723,7 +988,7 @@ def build_flow_from_descriptor(descriptor: dict[str, Any]) -> dict[str, Any]:
         if step.id in reachable
     }
 
-    # 7. resolve-transitions (§2.2) — flat pointers → nested object refs ---
+    # 8. resolve-transitions (§2.2) — flat pointers → nested object refs ---
     for step in model.steps:
         if step.id not in reachable:
             continue
@@ -734,7 +999,7 @@ def build_flow_from_descriptor(descriptor: dict[str, Any]) -> dict[str, Any]:
             node["chain"] = nodes[step.next]
         # else: terminal — no chain/chain_map; onComplete attached in step 10.
 
-    # 8. wire-prefills — rewrite {stepId.field} sugar into namespaced keys --
+    # 9. wire-prefills — rewrite {stepId.field} sugar into namespaced keys --
     for step in model.steps:
         if step.id not in reachable:
             continue
@@ -743,7 +1008,7 @@ def build_flow_from_descriptor(descriptor: dict[str, Any]) -> dict[str, Any]:
             node["review_rows"] = _rewrite_in_obj(node["review_rows"], slot_kind)
         # info body copy lives in the ui text; rewritten via the ui pass below.
         node["ui"] = _rewrite_in_obj(node["ui"], slot_kind)
-        # 9. attach-actions — already lowered in assemble; rewrite their refs.
+        # attach-actions — already lowered in assemble; rewrite their refs.
         # (assemble appended action buttons to ui, so the ui rewrite covers them)
 
     # 10. attach-terminal --------------------------------------------------
@@ -855,8 +1120,10 @@ def _validate_graph(model: FlowDescriptor, by_id: dict[str, FlowStep]) -> None:
                         f"option ids {sorted(option_ids)}"
                     )
 
-        # a select step must transition (branch or next) — else it dead-ends
-        if step.kind == "select" and not has_next and not has_branch:
+        # a select step must transition (branch or next) — else it dead-ends.
+        # EXCEPTION: a select the repair pass converted to TERMINAL carries a
+        # `complete` (it is the last step and ends the flow); that is allowed.
+        if step.kind == "select" and not has_next and not has_branch and step.complete is None:
             raise FlowBuildError(
                 f'select step "{step.id}" has no branch/next; it would dead-end after a pick'
             )
@@ -1205,6 +1472,13 @@ def _assemble_node(step: FlowStep, *, is_entry: bool) -> dict[str, Any]:
             oid = str(opt.get("id"))
             olabel = str(opt.get("label") or oid)
             children.append(_select_button(olabel, oid))
+        # A select is normally non-terminal (it branches). When the repair pass
+        # made a dead-ending LAST select terminal, it carries no transition — add
+        # a Finish (flow.submit) so the recorded pick can run the `complete`,
+        # rather than leaving option buttons that emit flow.next with nowhere to
+        # go. The common branching select never reaches this (it has a chain_map).
+        if _is_terminal_step(step):
+            children.append(_submit_button("Finish"))
 
     elif step.kind == "form":
         binds: list[str] = []

--- a/src/pocketpaw/ripple/_flows.py
+++ b/src/pocketpaw/ripple/_flows.py
@@ -1,6 +1,19 @@
 # pocketpaw/ripple/_flows.py — Chain Flow builders (RFC 13 §7.1, M3 → CHAIN FLOW v2).
 #
 # Created: 2026-05-31 (RFC 13 M3, feat/m3-flow-authoring-tool).
+# Updated: 2026-06-15 (feat/chain-flow-v2 — CONTINUATION-NOT-A-BUTTON FIX):
+#   - Mid-flow `StepAction.on_success` / `.on_error` continuation chains are no
+#     longer typed as `list[StepAction]`. `StepAction` is a BUTTON and requires
+#     `id` + `label`; a continuation is NOT a button (design §1.3 / §1.7 write
+#     them as bare `{"verb":"toast","message":…}` / `{"verb":"set","key":…,
+#     "value":…}` with NO id/label). A new `StepContinuation` model carries the
+#     same payload fields + its own nested `on_success`/`on_error` but drops
+#     id/label, so a naturally-authored continuation chain builds instead of
+#     raising FlowBuildError demanding button fields. `_validate_actions` now
+#     recurses the per-verb required-key table INTO continuations (without
+#     requiring id/label), and the on_success/on_error lowering accepts a
+#     `StepContinuation` — output is unchanged (id/label were already discarded
+#     in lowering, so the emitted bare handler dict is byte-identical).
 # Updated: 2026-06-15 (feat/chain-flow-v2 — GENERALIZATION):
 #   - The headline change: the flow primitive is no longer "pick 1 of 2
 #     hardcoded Python templates." A new entry point
@@ -188,6 +201,38 @@ class FlowBuildError(ValueError):
 # ---------------------------------------------------------------------------
 
 
+class StepContinuation(BaseModel):
+    """A continuation in a StepAction's `on_success` / `on_error` chain (§1.3).
+
+    A continuation is NOT a button — it carries no `id` and no `label`. The
+    design authors them bare (`{"verb":"toast","message":…,"variant":…}` /
+    `{"verb":"set","key":…,"value":…}`), so requiring button fields here would
+    reject every naturally-authored chain. It mirrors `StepAction`'s verb +
+    payload fields and nests its OWN `on_success`/`on_error`, validated per-verb
+    by `_validate_actions` (same required-key table, minus id/label).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    verb: str
+    # verb-specific payload (validated per verb in `_validate_actions`)
+    tool: str | None = None
+    args: dict[str, Any] | None = None
+    binding: str | None = None
+    path: str | None = None
+    params: dict[str, Any] | None = None
+    url: str | None = None
+    method: str | None = None
+    body: dict[str, Any] | None = None
+    key: str | None = None
+    value: Any = None
+    message: str | None = None
+    variant: str | None = None
+    # nested continuations — a continuation may itself chain on_success/on_error
+    on_success: list[StepContinuation] | None = None
+    on_error: list[StepContinuation] | None = None
+
+
 class StepAction(BaseModel):
     """A mid-flow button: runs a tool/API/binding without leaving the step (§1.3)."""
 
@@ -209,9 +254,10 @@ class StepAction(BaseModel):
     value: Any = None
     message: str | None = None
     variant: str | None = None
-    # continuations — standard ripple on_success / on_error action chains
-    on_success: list[StepAction] | None = None
-    on_error: list[StepAction] | None = None
+    # continuations — standard ripple on_success / on_error action chains. These
+    # are NOT buttons (no id/label) — see StepContinuation above.
+    on_success: list[StepContinuation] | None = None
+    on_error: list[StepContinuation] | None = None
 
 
 class TerminalAction(BaseModel):
@@ -278,7 +324,9 @@ class FlowDescriptor(BaseModel):
     complete: TerminalAction | None = None
 
 
-# StepAction / TerminalAction are self-referential; rebuild so forward refs bind.
+# StepContinuation / StepAction / TerminalAction are self-referential; rebuild so
+# forward refs bind. StepContinuation first — StepAction references it.
+StepContinuation.model_rebuild()
 StepAction.model_rebuild()
 TerminalAction.model_rebuild()
 
@@ -454,10 +502,12 @@ def _action_button(action: StepAction) -> dict[str, Any]:
     return {"type": "button", "props": {"label": action.label}, "on_click": handler}
 
 
-def _action_handler_only(action: StepAction) -> dict[str, Any]:
-    """Lower a continuation StepAction (on_success/on_error entry) into a bare
-    action handler dict (no surrounding button) — the shape ripple's action
-    chain expects."""
+def _action_handler_only(action: StepContinuation) -> dict[str, Any]:
+    """Lower a continuation (on_success/on_error entry) into a bare action
+    handler dict (no surrounding button) — the shape ripple's action chain
+    expects. A continuation carries no id/label, so the emitted handler is the
+    same bare `{action:<verb>, …payload, on_success?, on_error?}` shape it was
+    before (id/label were never copied into the handler)."""
     handler: dict[str, Any] = {"action": action.verb}
     for key in ("tool", "args", "binding", "path", "params", "url", "method", "body", "key"):
         val = getattr(action, key, None)
@@ -974,7 +1024,20 @@ def _collect_action_refs(action: StepAction, out: list[str]) -> None:
         if payload:
             _collect_ref_strings(payload, out)
     for cont in (action.on_success or []) + (action.on_error or []):
-        _collect_action_refs(cont, out)
+        _collect_continuation_refs(cont, out)
+
+
+def _collect_continuation_refs(cont: StepContinuation, out: list[str]) -> None:
+    """Collect ref-bearing strings from a continuation's payloads (recursively
+    into its own on_success / on_error). Mirrors `_collect_action_refs`; a
+    continuation has the same payload fields, just no id/label."""
+    for payload in (cont.args, cont.params, cont.body):
+        if payload:
+            _collect_ref_strings(payload, out)
+    if cont.value is not None and isinstance(cont.value, str):
+        out.append(cont.value)
+    for nested in (cont.on_success or []) + (cont.on_error or []):
+        _collect_continuation_refs(nested, out)
 
 
 def _branch_membership(model: FlowDescriptor, by_id: dict[str, FlowStep]) -> dict[str, str | None]:
@@ -1048,8 +1111,36 @@ def _validate_step_action(action: StepAction, step_id: str, depth: int = 0) -> N
         raise FlowBuildError(
             f'step "{step_id}" action "{action.id}" nests continuations too deeply'
         )
+    # Continuations are NOT buttons — recurse the SAME per-verb required-key
+    # checks (no id/label demanded). The action's id is carried into the message
+    # so a defective continuation still names the button it hangs off.
     for cont in (action.on_success or []) + (action.on_error or []):
-        _validate_step_action(cont, step_id, depth + 1)
+        _validate_continuation(cont, step_id, action.id, depth + 1)
+
+
+def _validate_continuation(
+    cont: StepContinuation, step_id: str, action_id: str, depth: int = 1
+) -> None:
+    """Validate one `on_success` / `on_error` continuation — same verb-allow-set
+    and per-verb required-key table as a StepAction, but without requiring the
+    button-only `id` / `label`. Recurses into nested continuations."""
+    if cont.verb not in _STEP_ACTION_VERBS:
+        raise FlowBuildError(
+            f'step "{step_id}" action "{action_id}" continuation uses unknown verb '
+            f'"{cont.verb}"; allowed: {sorted(_STEP_ACTION_VERBS)}'
+        )
+    for key in _STEP_VERB_REQUIRED.get(cont.verb, ()):  # required payload keys
+        if getattr(cont, key, None) in (None, ""):
+            raise FlowBuildError(
+                f'step "{step_id}" action "{action_id}" continuation (verb "{cont.verb}") '
+                f'is missing required key "{key}"'
+            )
+    if depth >= _MAX_THEN_DEPTH + 2:
+        raise FlowBuildError(
+            f'step "{step_id}" action "{action_id}" nests continuations too deeply'
+        )
+    for nested in (cont.on_success or []) + (cont.on_error or []):
+        _validate_continuation(nested, step_id, action_id, depth + 1)
 
 
 def _validate_terminal_action(terminal: TerminalAction, step_id: str, depth: int = 1) -> None:
@@ -1538,6 +1629,7 @@ __all__ = [
     "FlowDescriptor",
     "FlowStep",
     "StepAction",
+    "StepContinuation",
     "TerminalAction",
     "build_due_diligence_intake",
     "build_flow",

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -22,6 +22,18 @@
 #   chain_map trees and do NOT fake a flow with a single `set`-stepped spec
 #   — that anti-pattern renders step 1 and never advances. Wired into the
 #   assembled prompt + the final self-check.
+# Modified: 2026-06-15 (feat/chain-flow-v2) — rewrote `_MULTI_STEP_FLOW_RULE`
+#   for CHAIN FLOW v2. The rule now teaches STATE-TRANSITION authoring ("think
+#   in states, not screens"): the agent describes a FLAT step-graph to
+#   `start_flow` (a `flow` id, an `entry`, and a `steps` list where each step
+#   points at the next by id via `next` / `branch`), and the builder owns the
+#   nesting + deep-validation. Dropped the 2-template ceiling and the
+#   "no-template-fit → ask-user-questions" fallback (there is no fixed template
+#   list anymore — describe the graph the request needs). Appended a
+#   state-grammar primitives block and two copy-paste flat-descriptor skeletons
+#   (a branching intake and an action-rich mini-app). `invoke_tool` is marked as
+#   possibly-unavailable until the tool registry ships; call_binding /
+#   create_pocket / api / emit / navigate are the actions that work now.
 
 from pocketpaw.ripple._design import USE_THE_WIDGET_RULE, WIDGET_CATALOG
 
@@ -313,35 +325,108 @@ true), `nextLabel`, `layout` ("inline" | "stacked", default inline).
 
 
 _MULTI_STEP_FLOW_RULE = """\
-# MULTI-STEP FLOWS — CALL start_flow, DO NOT HAND-AUTHOR
+# MULTI-STEP FLOWS & MINI-APPS — DESCRIBE A STEP-GRAPH via start_flow
 
-For ANY multi-step flow — a wizard, an intake form, a survey, an
-onboarding sequence, a step-by-step or collect-then-act flow where the
-user moves through more than one screen before you act — call the
-`start_flow` tool. Pass ONLY a tiny descriptor: a `flow_type` template
-(plus optional `domain` / `config`). The tool returns the ENTIRE nested
-flow as a `{version, ui}` doc; drop that doc VERBATIM into your `ui-spec`
-fence. The flow then advances entirely client-side — no further model
-calls between steps.
+For ANY multi-step flow OR interactive mini-app — a wizard, an intake, a
+survey, an onboarding sequence, a "collect details then DO something"
+flow, or a small app that calls a tool / API and finishes by creating a
+pocket — call `start_flow`. You describe the flow as a FLAT step-graph;
+the tool materializes the nested, validated tree and returns a
+{version, ui} doc. Drop that doc VERBATIM into your `ui-spec` fence. The
+flow then advances entirely client-side — no model calls between steps.
 
-DO NOT hand-author the flow yourself. Specifically, NEVER:
-- write a nested `chain` / `chain_map` step tree by hand — these are
-  recursively nested and fragile to author; a single misplaced key and
-  the flow renders step 1 and silently never advances.
-- fake a multi-step flow with ONE `set`-stepped single spec (a spec that
-  tries to swap its own content via `set` actions). That is the exact
-  anti-pattern `start_flow` exists to prevent: it renders the first step
-  and dead-ends.
+HOW TO AUTHOR (think in states, not screens):
+  steps: a list. Each step has an `id`, a `kind`
+    (select | form | confirm | info), a title, its content
+    (options / fields / review rows), and where it goes next:
+      - `next: "<id>"`        → linear next step
+      - `branch: { "<optId>": "<id>" }` → branch on the picked option
+    A step with neither `next` nor `branch` is the TERMINAL step and
+    carries `complete` (what to do with the answers).
 
-`ask-user-questions` (above) is for a SHORT stepped Q&A that gathers a
-few answers in one bubble. `start_flow` is for a real branching,
-multi-screen flow with its own step tree. When in doubt for anything
-wizard-shaped, reach for `start_flow` — the descriptor is ~3 fields and
-Python owns the tree, so it renders correctly on the first try.
+  Actions make it a real mini-app, not just Q&A:
+    - per-step `actions`: buttons that call a tool/API mid-flow
+      (verb: call_binding | api | invoke_tool) without leaving the step.
+    - terminal `complete.action`:
+        chat        → hand the collected answers back to you (default)
+        call_binding→ write to the backend
+        create_pocket → materialize a permanent pocket from the answers
+        navigate / emit → go somewhere / raise an event
+        invoke_tool → run a tool with the answers
+                      (may be unavailable until the tool registry ships)
 
-If no `flow_type` template fits the request, say so plainly and gather
-the requirements with `ask-user-questions` instead — do NOT fall back to
-hand-authoring a chain tree.
+  Reference earlier answers with `{stepId.field}` (e.g.
+  `{pick_goal.label}`, `{enter_details.company}`) in review rows and
+  action args. The tool rewrites them correctly — you never write the
+  raw `{state.…_selection/_formData}` form.
+
+DO NOT hand-write a nested `chain` / `chain_map` tree, and do NOT fake a
+flow with a single `set`-stepped spec (that anti-pattern renders step 1
+and dead-ends). You describe the FLAT graph; Python owns the nesting and
+DEEP-VALIDATES it (it rejects dead-ends, dangling transitions, missing
+terminals, and unknown verbs with a precise error you can fix and retry).
+A flat graph cannot mis-nest — that is the whole point.
+
+`ask-user-questions` is ONLY for a trivial one-bubble Q&A (one or two
+quick questions, no branching, no actions, no DOING anything with the
+answers beyond reading them). The MOMENT the request has more than one
+screen, branches, an action, or a "then do X" — use `start_flow`.
+There is no longer a fixed template list to fit; describe the graph the
+request needs.
+
+STATE GRAMMAR — the primitives every flow composes from:
+  browse → select → collect → review → complete
+    select  : the user picks one option; branch the next state on it.
+    collect : a form gathers fields into the flow's accumulated answers.
+    review  : a confirm step plays the answers back before the hand-off.
+    complete: the terminal state DOES something with the answers.
+  Never dead-end a state with text: every non-terminal state has a
+  transition, every terminal state has a `complete`. (You can't violate
+  this even if you try — the builder rejects it.)
+
+SKELETON A — branching intake (collect, then hand answers to you):
+```
+{
+  "flow": "intake", "entry": "stage",
+  "steps": [
+    { "id": "stage", "kind": "select", "title": "Pick the stage",
+      "options": [ {"id":"early","label":"Early"}, {"id":"growth","label":"Growth"} ],
+      "branch": { "early": "fin", "growth": "fin" } },
+    { "id": "fin", "kind": "form", "slot": "financials", "title": "Snapshot",
+      "fields": [ {"id":"headline","label":"Headline metric","type":"text","required":true} ],
+      "next": "review" },
+    { "id": "review", "kind": "confirm", "title": "Review",
+      "review": [ {"label":"Stage","value":"{stage.label}"},
+                  {"label":"Metric","value":"{financials.headline}"} ],
+      "complete": { "action": "chat",
+                    "message": "Intake complete — please summarize." } }
+  ]
+}
+```
+
+SKELETON B — action-rich mini-app (validate mid-flow, create a pocket):
+```
+{
+  "flow": "client_setup", "entry": "plan",
+  "steps": [
+    { "id": "plan", "kind": "select", "title": "Plan",
+      "options": [ {"id":"starter","label":"Starter"}, {"id":"pro","label":"Pro"} ],
+      "next": "details" },
+    { "id": "details", "kind": "form", "title": "Company details",
+      "fields": [ {"id":"company","label":"Company","type":"text","required":true},
+                  {"id":"domain","label":"Domain","type":"url","required":true} ],
+      "actions": [ { "id":"verify","label":"Verify domain","verb":"call_binding",
+                     "binding":"dns_check","path":"/dns/check",
+                     "params":{"domain":"{details.domain}"} } ],
+      "next": "review" },
+    { "id": "review", "kind": "confirm", "title": "Confirm",
+      "review": [ {"label":"Company","value":"{details.company}"} ],
+      "complete": { "action": "create_pocket", "name": "{details.company} — Client",
+                    "template": "tracker", "seed_from_flow": true,
+                    "then": { "action": "navigate", "url": "/pockets/{result.id}" } } }
+  ]
+}
+```
 
 ---
 """

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -34,6 +34,17 @@
 #   (a branching intake and an action-rich mini-app). `invoke_tool` is marked as
 #   possibly-unavailable until the tool registry ships; call_binding /
 #   create_pocket / api / emit / navigate are the actions that work now.
+# Modified: 2026-06-15 (feat/chain-flow-v2 — REAL-SCENARIO SKELETONS) — the
+#   genesis "biggest lever": added an ACTION GRAMMAR callout block (a terminal
+#   `complete` uses `action:` not `type:`/`kind:`; approve/reject/fulfill/take-
+#   action means a `call_binding` ACTION BUTTON, never a yes/no select; use
+#   `call_binding` for backend/connector data, not the possibly-unavailable
+#   `invoke_tool`) and three copy-paste skeletons for the captain's real
+#   internal-team scenarios, each ending in a REAL action (not Q&A): APPROVE /
+#   REJECT (call_binding buttons), FULFILL ORDER (collect → confirm with a
+#   call_binding action), and ACT ON CONNECTOR/BACKEND DATA (call_binding
+#   against the pocket's backend, explicitly NOT invoke_tool). Kept the two
+#   existing skeletons (A branching intake, B action-rich mini-app).
 
 from pocketpaw.ripple._design import USE_THE_WIDGET_RULE, WIDGET_CATALOG
 
@@ -382,7 +393,18 @@ STATE GRAMMAR — the primitives every flow composes from:
     complete: the terminal state DOES something with the answers.
   Never dead-end a state with text: every non-terminal state has a
   transition, every terminal state has a `complete`. (You can't violate
-  this even if you try — the builder rejects it.)
+  this even if you try — the builder repairs or rejects it.)
+
+ACTION GRAMMAR — the rules that turn a flow into a real tool, not Q&A:
+  - A terminal `complete` uses `action:` (chat | navigate | emit |
+    call_binding | create_pocket) — NEVER `type:`/`kind:`. (If you slip and
+    write `type:`/`kind:`, the builder coerces it, but author `action:`.)
+  - When the user says approve / reject / fulfill / take action / do X —
+    that is a `call_binding` ACTION BUTTON wired to the verb, NOT a yes/no
+    select. Never leave an action flow as plain Q&A.
+  - To act on backend / connector data, use `call_binding` (works today).
+    `invoke_tool` is only for arbitrary named tools and may be unavailable
+    until the tool registry ships — reach for `call_binding` first.
 
 SKELETON A — branching intake (collect, then hand answers to you):
 ```
@@ -424,6 +446,67 @@ SKELETON B — action-rich mini-app (validate mid-flow, create a pocket):
       "complete": { "action": "create_pocket", "name": "{details.company} — Client",
                     "template": "tracker", "seed_from_flow": true,
                     "then": { "action": "navigate", "url": "/pockets/{result.id}" } } }
+  ]
+}
+```
+
+SKELETON C — APPROVE / REJECT (the buttons ARE the action, not a select):
+```
+{
+  "flow": "approve_request", "entry": "decide",
+  "steps": [
+    { "id": "decide", "kind": "confirm", "title": "Approve this request?",
+      "review": [ {"label":"Request","value":"{flow.payload.title}"} ],
+      "actions": [
+        { "id":"approve","label":"Approve","verb":"call_binding",
+          "binding":"requests","path":"/requests/{flow.payload.id}/approve",
+          "on_success":[{"verb":"toast","message":"Approved","variant":"success"}] },
+        { "id":"reject","label":"Reject","verb":"call_binding",
+          "binding":"requests","path":"/requests/{flow.payload.id}/reject",
+          "on_success":[{"verb":"toast","message":"Rejected","variant":"warning"}] }
+      ],
+      "complete": { "action": "chat", "message": "Decision recorded." } }
+  ]
+}
+```
+
+SKELETON D — FULFILL ORDER (collect → confirm with a call_binding action):
+```
+{
+  "flow": "fulfill_order", "entry": "lookup",
+  "steps": [
+    { "id": "lookup", "kind": "form", "title": "Which order?",
+      "fields": [ {"id":"order_id","label":"Order ID","type":"text","required":true} ],
+      "next": "confirm" },
+    { "id": "confirm", "kind": "confirm", "title": "Fulfill this order?",
+      "review": [ {"label":"Order","value":"{lookup.order_id}"} ],
+      "actions": [
+        { "id":"fulfill","label":"Fulfill order","verb":"call_binding",
+          "binding":"orders","path":"/orders/{lookup.order_id}/fulfill",
+          "on_success":[{"verb":"toast","message":"Order fulfilled","variant":"success"}] }
+      ],
+      "complete": { "action": "chat", "message": "Order fulfillment requested." } }
+  ]
+}
+```
+
+SKELETON E — ACT ON CONNECTOR / BACKEND DATA (call_binding, NOT invoke_tool):
+```
+{
+  "flow": "act_on_item", "entry": "pick",
+  "steps": [
+    { "id": "pick", "kind": "form", "title": "Target record",
+      "fields": [ {"id":"record_id","label":"Record ID","type":"text","required":true} ],
+      "next": "act" },
+    { "id": "act", "kind": "confirm", "title": "Take action on this record",
+      "review": [ {"label":"Record","value":"{pick.record_id}"} ],
+      "actions": [
+        { "id":"archive","label":"Archive","verb":"call_binding",
+          "binding":"crm","path":"/records/{pick.record_id}/archive",
+          "params":{"reason":"flow"},
+          "on_success":[{"verb":"toast","message":"Archived","variant":"success"}] }
+      ],
+      "complete": { "action": "chat", "message": "Action applied to the record." } }
   ]
 }
 ```

--- a/src/pocketpaw/tools/builtin/flow_tool.py
+++ b/src/pocketpaw/tools/builtin/flow_tool.py
@@ -1,17 +1,28 @@
-# pocketpaw/tools/builtin/flow_tool.py — `start_flow` authoring tool (RFC 13 M3).
+# pocketpaw/tools/builtin/flow_tool.py — `start_flow` authoring tool
+# (RFC 13 M3 → CHAIN FLOW v2).
 #
 # Created: 2026-05-31 (RFC 13 M3, feat/m3-flow-authoring-tool).
+# Updated: 2026-06-15 (feat/chain-flow-v2 — GENERALIZATION):
+#   - The tool no longer caps the agent at "pick 1 of 2 hardcoded templates."
+#     The `flow_type` ENUM + `required` flag are GONE. New params let the agent
+#     author an ARBITRARY ephemeral mini-app as a FLAT step-graph:
+#       `flow` (id), `entry` (first step id), `steps` (array of step objects),
+#       optional `title`, optional `complete` (flow-level terminal default).
+#   - `execute` routing: if `steps` is present → `build_flow_from_descriptor`
+#     (the general path); elif `flow_type` is present → `build_flow` (a preset
+#     shorthand the tool STILL accepts for the two known shapes). On a
+#     `FlowBuildError`, the precise, agent-readable message is surfaced verbatim
+#     so the model can fix the flat graph and retry (genesis forgiving-author
+#     loop).
+#   - The description is rewritten to teach the flat-graph shape (states, not
+#     screens), mirroring the inline-prompt rule (`_inline.py`
+#     `_MULTI_STEP_FLOW_RULE`).
 #
-# A `start_flow`-style builtin tool. The contract that makes it reliable:
-#   - the LLM emits a TINY descriptor — `flow_type` (an enum of known
-#     templates), an optional `domain` hint, optional `config` overrides;
-#   - a DETERMINISTIC builder (`pocketpaw.ripple._flows`) expands a hardcoded
-#     template into the full nested chain/chain_map Chain Flow tree and returns
-#     it as a `{version, ui}` inline-Ripple doc.
-#
-# The model never hand-writes the recursively-nested tree — the genesis
-# `preprocessChainStrings` repair code (RFC 13 §2.2) is the evidence that
-# hand-authoring is fragile. The model picks a template; Python owns the tree.
+# A `start_flow`-style builtin tool. The contract that makes it reliable: the
+# agent NEVER hand-writes the recursively-nested chain/chain_map tree — it
+# describes a FLAT graph (impossible to mis-nest), and a DETERMINISTIC builder
+# (`pocketpaw.ripple._flows`) materializes + deep-validates the full nested tree
+# and returns it as a `{version, ui}` inline-Ripple doc.
 #
 # The tool PRODUCES a `{version, ui}` JSON doc (a string the agent drops into a
 # ```ui-spec fenced block — same envelope `_inline.py` mandates and the cloud
@@ -24,16 +35,23 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from pocketpaw.ripple._flows import FLOW_TYPES, build_flow
+from pocketpaw.ripple._flows import (
+    FLOW_TYPES,
+    FlowBuildError,
+    build_flow,
+    build_flow_from_descriptor,
+)
 from pocketpaw.tools.protocol import BaseTool
 
 
 class StartFlowTool(BaseTool):
-    """Scaffold a complete multi-step Chain Flow from a tiny descriptor.
+    """Scaffold a complete multi-step Chain Flow / mini-app from a FLAT graph.
 
-    The agent calls this instead of hand-authoring a nested chain/chain_map
-    tree. It emits ~3 fields; a deterministic builder returns the whole tree
-    as a ``{version, ui}`` doc the agent then renders in a ``ui-spec`` fence.
+    The agent describes a flat step-graph (a `flow` id, an `entry` step id, and
+    a `steps` array where each step points at the next by id string); a
+    deterministic builder owns the nesting and DEEP-VALIDATES it, returning the
+    whole tree as a ``{version, ui}`` doc the agent renders in a ``ui-spec``
+    fence. A flat graph cannot mis-nest — that is the whole point.
     """
 
     @property
@@ -43,23 +61,47 @@ class StartFlowTool(BaseTool):
     @property
     def description(self) -> str:
         return (
-            "Scaffold a complete multi-step flow (wizard / intake / survey) "
-            "from a tiny descriptor. DO NOT hand-author nested chain / "
-            "chain_map step trees — they are fragile to write by hand. Pick a "
-            "`flow_type` template and this tool returns the ENTIRE nested flow "
-            "tree as a {version, ui} doc, ready to drop into a ```ui-spec "
-            "fenced block. The flow then advances entirely client-side with no "
-            "further model calls between steps.\n\n"
-            "Templates (`flow_type`):\n"
-            "- `onboarding_wizard` — pick a goal -> enter workspace details "
-            "(branches on the goal) -> confirm. A new-user setup wizard.\n"
-            "- `due_diligence_intake` — pick a deal stage -> stage-specific "
-            "financials (branches on the stage) -> risk flags -> review. A "
-            "multi-step vertical intake; the same shape works for a survey.\n\n"
-            "Optional `config` tweaks copy without changing the tree's shape "
-            "(e.g. `product_name` for the wizard, `company_name` for the "
-            "intake). When in doubt, pass just `flow_type` — the defaults "
-            "produce a valid, renderable flow.\n\n"
+            "Scaffold a complete multi-step flow OR interactive mini-app (a "
+            "wizard, intake, survey, onboarding sequence, or a 'collect "
+            "details then DO something' flow) from a FLAT step-graph. DO NOT "
+            "hand-author nested chain / chain_map step trees — they are fragile "
+            "to write by hand. You describe a flat list of steps; this tool "
+            "materializes the ENTIRE nested, validated flow tree as a "
+            "{version, ui} doc, ready to drop into a ```ui-spec fence. The flow "
+            "then advances entirely client-side with no further model calls "
+            "between steps.\n\n"
+            "AUTHOR A FLAT GRAPH (think in states, not screens):\n"
+            "- `flow`: a stable id for the flow (e.g. 'vendor_intake').\n"
+            "- `entry`: the id of the first step.\n"
+            "- `steps`: a list. Each step has an `id`, a `kind` "
+            "(select | form | confirm | info), a `title`, its content "
+            "(`options` for select, `fields` for form, `review` for confirm, "
+            "`body` for info), and where it goes next:\n"
+            '    * `next: "<id>"` — linear next step;\n'
+            '    * `branch: { "<optionId>": "<id>" }` — branch on the '
+            "picked option.\n"
+            "  A step with NEITHER `next` nor `branch` is the TERMINAL step and "
+            "carries `complete` (what to do with the answers):\n"
+            "    chat → hand the answers back to you (default); navigate / emit "
+            "→ go somewhere / raise an event; call_binding → write to the "
+            "backend; create_pocket → materialize a permanent pocket; "
+            "invoke_tool → run a tool (may be unavailable until the tool "
+            "registry ships).\n"
+            "- Per-step `actions` (optional) are buttons that call a "
+            "tool/API/binding MID-FLOW without leaving the step (verb: "
+            "call_binding | api | invoke_tool).\n"
+            "- Reference earlier answers with `{stepId.field}` "
+            "(e.g. `{pick_goal.label}`, `{enter_details.company}`) in review "
+            "rows and action args — this tool rewrites them correctly; you "
+            "NEVER write the raw `{state.…_selection/_formData}` form.\n\n"
+            "The builder REJECTS any graph that would dead-end (a select step "
+            "that goes nowhere, a dangling transition, a missing terminal, an "
+            "unknown verb) with a precise error you can fix and retry.\n\n"
+            "PRESET SHORTHAND (optional): instead of `steps`, you may pass a "
+            "`flow_type` for one of the two known shapes — 'onboarding_wizard' "
+            "or 'due_diligence_intake' — plus an optional `config` for copy "
+            "tweaks. The flat `steps` graph is the general path; `flow_type` is "
+            "a convenience for those two exact shapes.\n\n"
             "Returns the JSON doc to emit. Wrap it verbatim in a ```ui-spec "
             "fence in your reply — do not edit the chain / chain_map structure."
         )
@@ -73,65 +115,167 @@ class StartFlowTool(BaseTool):
         return {
             "type": "object",
             "properties": {
+                "flow": {
+                    "type": "string",
+                    "description": (
+                        "A stable id for the flow (e.g. 'vendor_intake'). Seeds "
+                        "each step's flowId namespace. Required when authoring a "
+                        "flat `steps` graph."
+                    ),
+                },
+                "entry": {
+                    "type": "string",
+                    "description": (
+                        "The id of the FIRST step (must exist in `steps`). "
+                        "Required when authoring a flat `steps` graph."
+                    ),
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "The flat step-graph: a list of step objects. Each step "
+                        "has `id`, `kind` (select | form | confirm | info), "
+                        "`title`, its kind-specific content (`options` / "
+                        "`fields` / `review` / `body`), and a transition "
+                        "(`next` or `branch`) — OR `complete` if it is the "
+                        "terminal step. Optional per-step `actions` run a "
+                        "tool/API mid-flow. This is the general authoring path."
+                    ),
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional title shown on the flow frame.",
+                },
+                "complete": {
+                    "type": "object",
+                    "description": (
+                        "Optional flow-level terminal default — the `complete` "
+                        "action a terminal step inherits when it declares none "
+                        "of its own (e.g. {action:'chat', message:'…'})."
+                    ),
+                },
                 "flow_type": {
                     "type": "string",
                     "enum": list(FLOW_TYPES),
                     "description": (
-                        "Which flow template to scaffold. The builder owns the "
-                        "full nested step tree for this template."
+                        "OPTIONAL preset shorthand for the two known shapes "
+                        "('onboarding_wizard' | 'due_diligence_intake') instead "
+                        "of authoring a flat `steps` graph. The builder owns the "
+                        "full nested tree for this preset."
                     ),
                 },
                 "domain": {
                     "type": "string",
                     "description": (
-                        "Optional domain hint (e.g. 'fintech', 'saas'). "
-                        "Reserved for a future data-fresh materialization "
-                        "path; does not change the tree today."
+                        "Optional domain hint (e.g. 'fintech', 'saas') for the "
+                        "preset path. Reserved for a future data-fresh "
+                        "materialization path; does not change the tree today."
                     ),
                 },
                 "config": {
                     "type": "object",
                     "description": (
-                        "Optional per-template copy overrides. Shape-stable: "
-                        "tweaks labels/text, never the chain structure. "
-                        "onboarding_wizard accepts {product_name, goals}; "
-                        "due_diligence_intake accepts {company_name, "
-                        "submit_event}."
+                        "Optional per-preset copy overrides (preset path only). "
+                        "Shape-stable: tweaks labels/text, never the chain "
+                        "structure. onboarding_wizard accepts {product_name, "
+                        "goals, complete_message}; due_diligence_intake accepts "
+                        "{company_name, complete_message}."
                     ),
                 },
             },
-            "required": ["flow_type"],
+            # Nothing is hard-required at the schema level: the general path
+            # needs flow+entry+steps, the preset path needs flow_type. `execute`
+            # validates the combination and returns an agent-readable error when
+            # neither is supplied.
+            "required": [],
         }
 
     async def execute(
         self,
+        flow: str = "",
+        entry: str = "",
+        steps: list[dict[str, Any]] | str | None = None,
+        title: str | None = None,
+        complete: dict[str, Any] | str | None = None,
         flow_type: str = "",
         domain: str | None = None,
-        config: dict[str, Any] | None = None,
+        config: dict[str, Any] | str | None = None,
         **kwargs: Any,
     ) -> str:
-        """Expand the descriptor into a `{version, ui}` flow doc (JSON string)."""
-        if not flow_type:
-            valid = ", ".join(sorted(FLOW_TYPES))
-            return self._error(f"start_flow needs a `flow_type`. Known templates: {valid}.")
+        """Materialize a flat descriptor (or a preset) into a `{version, ui}`
+        flow doc (JSON string)."""
+        # Subprocess / CLI callers can't pass nested objects through a flat
+        # string signature — coerce JSON-string args back to structures.
+        steps = self._coerce_json(steps, "steps")
+        if isinstance(steps, str):  # coercion failed → it returned an Error
+            return steps
+        complete = self._coerce_json(complete, "complete", allow_dict=True)
+        if isinstance(complete, str) and complete.startswith("Error:"):
+            return complete
+        config = self._coerce_json(config, "config", allow_dict=True)
+        if isinstance(config, str) and config.startswith("Error:"):
+            return config
 
-        # `config` may arrive as a JSON string from subprocess/CLI callers that
-        # can't pass a nested object through a flat string signature. Coerce it.
-        if isinstance(config, str):
+        # Route: a flat `steps` graph takes precedence; else a preset shorthand.
+        if steps is not None:
+            if not isinstance(steps, list):
+                return self._error("`steps` must be an array of step objects.")
+            descriptor: dict[str, Any] = {
+                "flow": flow or "flow",
+                "entry": entry,
+                "steps": steps,
+            }
+            if title:
+                descriptor["title"] = title
+            if complete is not None:
+                descriptor["complete"] = complete
             try:
-                config = json.loads(config) if config.strip() else None
-            except json.JSONDecodeError:
-                return self._error("`config` was a string but not valid JSON.")
-        if config is not None and not isinstance(config, dict):
-            return self._error("`config` must be an object (key/value map).")
+                doc = build_flow_from_descriptor(descriptor)
+            except FlowBuildError as exc:
+                # Precise, agent-readable: the model fixes the flat graph and
+                # retries rather than getting a stack trace.
+                return self._error(str(exc))
+            return self._success(self._dump(doc))
 
+        if flow_type:
+            if config is not None and not isinstance(config, dict):
+                return self._error("`config` must be an object (key/value map).")
+            try:
+                doc = build_flow(flow_type, domain=domain, config=config)
+            except (FlowBuildError, ValueError) as exc:
+                return self._error(str(exc))
+            return self._success(self._dump(doc))
+
+        valid = ", ".join(sorted(FLOW_TYPES))
+        return self._error(
+            "start_flow needs either a flat `steps` graph (with `flow` and "
+            "`entry`) or a `flow_type` preset shorthand "
+            f"(one of: {valid})."
+        )
+
+    @staticmethod
+    def _coerce_json(value: Any, name: str, *, allow_dict: bool = False) -> Any:
+        """Coerce a JSON-string arg into a structure; pass through if already
+        one. Returns an ``Error: …`` string on bad JSON so ``execute`` can
+        relay it."""
+        if value is None or not isinstance(value, str):
+            return value
+        s = value.strip()
+        if not s:
+            return None
         try:
-            doc = build_flow(flow_type, domain=domain, config=config)
-        except ValueError as exc:
-            # Unknown flow_type — surface the valid set so the model can retry.
-            return self._error(str(exc))
+            return json.loads(s)
+        except json.JSONDecodeError:
+            return f"Error: `{name}` was a string but not valid JSON."
 
-        return self._success(json.dumps(doc, ensure_ascii=False))
+    @staticmethod
+    def _dump(doc: dict[str, Any]) -> str:
+        """Serialize the doc, dropping the internal `_warnings` key (soft
+        single-branch-reachability notes are for build-time guidance, not part
+        of the rendered spec)."""
+        clean = {k: v for k, v in doc.items() if k != "_warnings"}
+        return json.dumps(clean, ensure_ascii=False)
 
 
 __all__ = ["StartFlowTool"]

--- a/tests/test_flow_authoring.py
+++ b/tests/test_flow_authoring.py
@@ -2,6 +2,17 @@
 # Created: 2026-05-31 (RFC 13 M3, feat/m3-flow-authoring-tool).
 #
 # Changes:
+#   - 2026-06-15 (feat/chain-flow-v2): this file is now the BACK-COMPAT proof
+#     for CHAIN FLOW v2. The two builders (`build_onboarding_wizard` /
+#     `build_due_diligence_intake`) now emit a flat descriptor and delegate to
+#     the generalized `build_flow_from_descriptor`, so every assertion here (one
+#     terminal with onComplete.kind=="chat", flowId on every step, chain_map
+#     keyed on option ids, intermediate Back buttons, deep-validator descent)
+#     proves the preset path still produces the exact pre-v2 tree. The one tool
+#     test that snapshotted the OLD `{flow_type}` schema was updated to assert
+#     the NEW flat-graph descriptor schema (flow/entry/steps + optional
+#     flow_type shorthand) — the only intentional spec-driven change here. The
+#     GENERAL builder's new behavior lives in tests/test_flow_descriptor.py.
 #   - 2026-06-07 (polish/rfc13-flow-nav-validation): added (a) Back-navigation
 #     tests asserting both templates' intermediate (non-first, non-terminal)
 #     steps render a `flow.back` button while root/terminal steps do not, and
@@ -602,15 +613,24 @@ def tool() -> StartFlowTool:
     return StartFlowTool()
 
 
-def test_tool_definition_schema_is_a_tiny_descriptor(tool: StartFlowTool) -> None:
-    """The LLM-facing schema is the descriptor — flow_type (enum) plus optional
-    domain/config — NOT the tree."""
+def test_tool_definition_schema_is_a_flat_graph_descriptor(tool: StartFlowTool) -> None:
+    """CHAIN FLOW v2: the LLM-facing schema describes a FLAT step-graph —
+    `flow` / `entry` / `steps` (+ optional `title` / `complete`) for the general
+    path, plus `flow_type` as OPTIONAL preset shorthand. The `flow_type` enum is
+    no longer required, and `steps` is the general authoring surface (the agent
+    still never emits the nested tree itself)."""
     defn = tool.definition
     assert defn.name == "start_flow"
     props = defn.parameters["properties"]
-    assert set(props) == {"flow_type", "domain", "config"}
-    assert defn.parameters["required"] == ["flow_type"]
+    # the flat-graph params plus the preset-shorthand params
+    assert {"flow", "entry", "steps", "title", "complete"} <= set(props)
+    assert {"flow_type", "domain", "config"} <= set(props)
+    # nothing is hard-required at the schema level — execute() validates the
+    # combination (general needs flow+entry+steps; preset needs flow_type).
+    assert defn.parameters["required"] == []
+    # flow_type stays an enum of the known presets, but as optional shorthand.
     assert props["flow_type"]["enum"] == list(FLOW_TYPES)
+    assert props["steps"]["type"] == "array"
 
 
 async def test_tool_returns_version_ui_doc(tool: StartFlowTool) -> None:

--- a/tests/test_flow_descriptor.py
+++ b/tests/test_flow_descriptor.py
@@ -1,5 +1,21 @@
 # tests/test_flow_descriptor.py
 # Created: 2026-06-15 (feat/chain-flow-v2).
+# Updated: 2026-06-15 (feat/chain-flow-v2 — genesis-style forgiveness):
+#   - Three REJECT tests became REPAIR tests, matching the new forgiveness
+#     passes: `test_repairs_no_terminal_by_making_last_step_terminal`,
+#     `test_repairs_dead_end_select_as_last_step`,
+#     `test_repairs_terminal_with_no_complete_and_no_default` — these sloppy
+#     descriptors now BUILD (repaired) instead of erroring. Added
+#     `test_rejects_dead_end_select_in_the_middle` so the genuine-bug guard (a
+#     select dead-end that ISN'T the last step) stays covered.
+#   - Added a §2.0 forgiveness section: alias coercion (terminal `type:`/`kind:`
+#     → `action:`, action `type:` → `verb:`), explicit-action-wins, no-caller-
+#     mutation, and friendly-parse-error tests (named fix, no Pydantic URL).
+#   - Added skeleton guards: every copy-paste skeleton in the inline prompt
+#     builds clean, and the three action skeletons wire a `call_binding` button.
+#   - The tool-level dead-end test became `test_tool_surfaces_flow_build_error_
+#     for_real_bug` (dangling transition — un-repairable) plus
+#     `test_tool_repairs_dead_end_last_select` (repaired through the tool).
 # Updated: 2026-06-15 (feat/chain-flow-v2 — continuation-not-a-button fix):
 #   - De-papered the two tests that had added dummy `id`/`label` to their
 #     on_success/on_error continuations: `_example_b()` (now verbatim §1.7 with
@@ -194,8 +210,11 @@ def test_rejects_branch_key_not_an_option_id() -> None:
         build_flow_from_descriptor(d)
 
 
-def test_rejects_no_terminal() -> None:
-    # every step transitions onward — the flow never ends.
+def test_repairs_no_terminal_by_making_last_step_terminal() -> None:
+    # GENESIS FORGIVENESS: every step transitions onward (no terminal). The
+    # repair pass makes the LAST-declared step terminal (drops its transition)
+    # and gives it a default complete, so the flow BUILDS instead of erroring.
+    # (Dropping the last transition also breaks the a→b→a cycle.)
     d = {
         "flow": "loopy",
         "entry": "a",
@@ -204,10 +223,10 @@ def test_rejects_no_terminal() -> None:
             {"id": "b", "kind": "info", "title": "B", "next": "a"},
         ],
     }
-    # this also forms a cycle; the no-terminal check fires first in the pipeline.
-    with pytest.raises(FlowBuildError) as exc:
-        build_flow_from_descriptor(d)
-    assert "no terminal step" in str(exc.value) or "cycle detected" in str(exc.value)
+    doc = build_flow_from_descriptor(d)  # must NOT raise
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["flowId"] == "b"  # the last step became the terminal
+    assert term["onComplete"]["kind"] == "chat"  # default complete injected
 
 
 def test_rejects_terminal_with_transition() -> None:
@@ -267,9 +286,10 @@ def test_rejects_cycle() -> None:
         build_flow_from_descriptor(d)
 
 
-def test_rejects_select_with_no_transition() -> None:
-    # THE load-bearing one: a select step that goes nowhere — a hand-authored
-    # dead-end. The whole primitive exists to make this impossible.
+def test_repairs_dead_end_select_as_last_step() -> None:
+    # GENESIS FORGIVENESS: a select that is the LAST step and goes nowhere is no
+    # longer a hard reject — the repair pass converts it to a terminal step with
+    # a default complete (and assemble gives it a Finish button), so it BUILDS.
     d = {
         "flow": "deadend",
         "entry": "pick",
@@ -279,7 +299,38 @@ def test_rejects_select_with_no_transition() -> None:
                 "kind": "select",
                 "title": "Pick (goes nowhere)",
                 "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
-                # NO branch, NO next — dead-end after a pick.
+                # NO branch, NO next — the repair pass ends the flow here.
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)  # must NOT raise
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["flowId"] == "pick"
+    assert term["onComplete"]["kind"] == "chat"
+    # the terminal select carries a Finish (flow.submit) so the pick can complete
+    assert len(_on_clicks(term, "flow.submit")) == 1
+
+
+def test_rejects_dead_end_select_in_the_middle() -> None:
+    # The guard STILL fires for a genuine bug: a select that dead-ends in the
+    # MIDDLE of a flow (not the last step) is unreachable-onward — repair only
+    # rescues a LAST dead-end select, so this is a precise reject.
+    d = {
+        "flow": "middead",
+        "entry": "pick",
+        "steps": [
+            {
+                "id": "pick",
+                "kind": "select",
+                "title": "Pick (goes nowhere)",
+                "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+                # NO branch, NO next — but NOT the last step.
+            },
+            {
+                "id": "tail",
+                "kind": "confirm",
+                "title": "Tail",
+                "complete": {"action": "chat", "message": "ok"},
             },
         ],
     }
@@ -324,6 +375,228 @@ def test_rejects_over_step_cap() -> None:
 def test_rejects_empty_steps() -> None:
     with pytest.raises(FlowBuildError, match=r"flow has no steps"):
         build_flow_from_descriptor({"flow": "x", "entry": "a", "steps": []})
+
+
+# ===========================================================================
+# §2.0 — GENESIS FORGIVENESS: alias normalization + friendly parse errors.
+# A model's instinctive key slips (type:/kind:) are coerced; a shape defect
+# that survives names the fix instead of leaking a Pydantic URL.
+# ===========================================================================
+
+
+def test_terminal_complete_type_alias_coerces_to_action() -> None:
+    # Models write `type:` out of node-authoring habit; the builder coerces a
+    # terminal `complete` written with `type:` → `action:` so it BUILDS.
+    d = {
+        "flow": "f",
+        "entry": "a",
+        "steps": [
+            {
+                "id": "a",
+                "kind": "form",
+                "title": "F",
+                "fields": [{"id": "x", "label": "X", "type": "text"}],
+                "next": "b",
+            },
+            {
+                "id": "b",
+                "kind": "confirm",
+                "title": "Done",
+                "review": [{"label": "X", "value": "{a.x}"}],
+                "complete": {"type": "chat", "message": "done via type slip"},
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)  # must NOT raise on the type: slip
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["onComplete"]["kind"] == "chat"
+    assert term["onComplete"]["message"] == "done via type slip"
+
+
+def test_terminal_complete_kind_alias_coerces_to_action() -> None:
+    d = {
+        "flow": "f",
+        "entry": "b",
+        "steps": [
+            {
+                "id": "b",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {"kind": "navigate", "url": "/somewhere"},
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["onComplete"]["kind"] == "navigate"
+    assert term["onComplete"]["url"] == "/somewhere"
+
+
+def test_step_action_type_alias_coerces_to_verb() -> None:
+    # A mid-flow action written with `type:` instead of `verb:` is coerced.
+    d = {
+        "flow": "f",
+        "entry": "a",
+        "steps": [
+            {
+                "id": "a",
+                "kind": "form",
+                "title": "F",
+                "fields": [{"id": "d", "label": "Domain", "type": "url", "required": True}],
+                "actions": [
+                    {
+                        "id": "verify",
+                        "label": "Verify",
+                        "type": "call_binding",  # should coerce to verb
+                        "binding": "dns",
+                        "path": "/check",
+                    }
+                ],
+                "next": "b",
+            },
+            {
+                "id": "b",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {"action": "chat", "message": "ok"},
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)  # must NOT raise on the action type: slip
+    details = next(s for s in _iter_steps(doc["ui"]) if s["flowId"] == "a")
+    verify = next(
+        n for n in _walk_nodes(details["ui"]) if n.get("props", {}).get("label") == "Verify"
+    )
+    assert verify["on_click"]["action"] == "call_binding"
+    assert verify["on_click"]["binding"] == "dns"
+
+
+def test_explicit_action_wins_over_alias() -> None:
+    # If BOTH `action` and a `type:`/`kind:` alias are present, the explicit
+    # `action` is authoritative — the alias is not allowed to clobber it.
+    d = {
+        "flow": "f",
+        "entry": "b",
+        "steps": [
+            {
+                "id": "b",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {"action": "chat", "type": "navigate", "message": "stay chat"},
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["onComplete"]["kind"] == "chat"
+
+
+def test_does_not_mutate_caller_descriptor() -> None:
+    # Normalization deep-copies — the caller's dict is untouched after a build
+    # (so a retry sees the original input).
+    d = {
+        "flow": "f",
+        "entry": "b",
+        "steps": [
+            {
+                "id": "b",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {"type": "chat", "message": "x"},
+            },
+        ],
+    }
+    build_flow_from_descriptor(d)
+    # the original still carries `type`, not the coerced `action`
+    assert d["steps"][0]["complete"] == {"type": "chat", "message": "x"}
+
+
+def test_friendly_error_for_complete_missing_action() -> None:
+    # A `complete` that is present but missing `action` (and no type:/kind: to
+    # coerce) raises a FRIENDLY error naming the fix — never a Pydantic URL.
+    d = {
+        "flow": "f",
+        "entry": "b",
+        "steps": [
+            {
+                "id": "b",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {"message": "no action key"},
+            },
+        ],
+    }
+    with pytest.raises(FlowBuildError) as exc:
+        build_flow_from_descriptor(d)
+    msg = str(exc.value)
+    assert "action" in msg
+    assert "chat" in msg and "call_binding" in msg  # names the allowed actions
+    assert "errors.pydantic.dev" not in msg  # no leaked Pydantic URL
+
+
+def test_friendly_error_for_bad_kind() -> None:
+    d = {
+        "flow": "f",
+        "entry": "b",
+        "steps": [
+            {
+                "id": "b",
+                "kind": "wizard",  # not a valid kind
+                "title": "Done",
+                "complete": {"action": "chat", "message": "x"},
+            },
+        ],
+    }
+    with pytest.raises(FlowBuildError) as exc:
+        build_flow_from_descriptor(d)
+    msg = str(exc.value)
+    assert "kind" in msg
+    assert "errors.pydantic.dev" not in msg
+
+
+# ===========================================================================
+# The inline-prompt skeletons (the copy-paste examples the model is taught)
+# all BUILD clean — a guard that the prompt never ships an un-buildable example.
+# ===========================================================================
+
+
+def test_inline_prompt_skeletons_build_clean() -> None:
+    import re
+
+    from pocketpaw.ripple._inline import _MULTI_STEP_FLOW_RULE
+
+    blocks = re.findall(r"```\n(\{.*?\})\n```", _MULTI_STEP_FLOW_RULE, re.DOTALL)
+    # Skeletons A + B (existing) + C/D/E (approve, fulfill, act-on-data) = 5.
+    assert len(blocks) == 5, f"expected 5 skeleton blocks in the rule, found {len(blocks)}"
+    for i, raw in enumerate(blocks):
+        descriptor = json.loads(raw)  # must be valid JSON
+        doc = build_flow_from_descriptor(descriptor)  # must BUILD
+        assert doc["version"] == "1.0", f"skeleton {i} ({descriptor.get('flow')}) bad envelope"
+        assert validate_against_catalog(doc, ALLOWED_TYPES) == [], (
+            f"skeleton {i} ({descriptor.get('flow')}) has catalog violations"
+        )
+        assert validate_action_verbs(doc) == [], (
+            f"skeleton {i} ({descriptor.get('flow')}) has verb violations"
+        )
+
+
+def test_action_flow_skeletons_use_call_binding_not_select() -> None:
+    # The genesis lever: an APPROVE/FULFILL/ACT flow is a call_binding ACTION
+    # BUTTON, never a yes/no select. Assert the three action skeletons carry a
+    # call_binding action button (proving the prompt teaches the right pattern).
+    import re
+
+    from pocketpaw.ripple._inline import _MULTI_STEP_FLOW_RULE
+
+    blocks = re.findall(r"```\n(\{.*?\})\n```", _MULTI_STEP_FLOW_RULE, re.DOTALL)
+    by_flow = {json.loads(b)["flow"]: json.loads(b) for b in blocks}
+    for flow_name in ("approve_request", "fulfill_order", "act_on_item"):
+        assert flow_name in by_flow, f"missing action skeleton {flow_name!r}"
+        descriptor = by_flow[flow_name]
+        verbs = {a.get("verb") for step in descriptor["steps"] for a in (step.get("actions") or [])}
+        assert "call_binding" in verbs, (
+            f"action skeleton {flow_name!r} must wire a call_binding action button"
+        )
 
 
 # ===========================================================================
@@ -718,7 +991,10 @@ def test_general_path_allows_multiple_terminals() -> None:
     assert kinds == {"chat", "navigate"}
 
 
-def test_rejects_terminal_with_no_complete_and_no_default() -> None:
+def test_repairs_terminal_with_no_complete_and_no_default() -> None:
+    # GENESIS FORGIVENESS: a terminal step with no `complete` AND no flow-level
+    # default no longer errors — the repair pass injects a default `chat`
+    # complete so the flow BUILDS with a sensible hand-off.
     d = {
         "flow": "nocomplete",
         "entry": "f",
@@ -733,11 +1009,11 @@ def test_rejects_terminal_with_no_complete_and_no_default() -> None:
             {"id": "end", "kind": "confirm", "title": "End"},  # no complete, no default
         ],
     }
-    with pytest.raises(
-        FlowBuildError,
-        match=r'terminal step "end" has no complete action and no flow-level default',
-    ):
-        build_flow_from_descriptor(d)
+    doc = build_flow_from_descriptor(d)  # must NOT raise
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["flowId"] == "end"
+    assert term["onComplete"]["kind"] == "chat"
+    assert term["onComplete"]["message"]  # a non-empty default message
 
 
 # ===========================================================================
@@ -1186,9 +1462,12 @@ async def test_tool_builds_from_flat_steps_graph(tool: StartFlowTool) -> None:
     assert doc == built
 
 
-async def test_tool_surfaces_flow_build_error_for_dead_end(tool: StartFlowTool) -> None:
-    # a select step that goes nowhere — the tool must return the precise reject
-    # message so the model can fix the graph.
+async def test_tool_surfaces_flow_build_error_for_real_bug(tool: StartFlowTool) -> None:
+    # A GENUINE structural bug (a dangling `next` → an undeclared id) is NOT
+    # repairable, so the tool must return the precise reject message verbatim so
+    # the model can fix the graph and retry. (A dead-end LAST select is repaired
+    # now — see test_repairs_dead_end_select_as_last_step — so the un-repairable
+    # dangling-transition case is the right thing to assert the error path on.)
     result = await tool.execute(
         flow="bad",
         entry="pick",
@@ -1196,13 +1475,36 @@ async def test_tool_surfaces_flow_build_error_for_dead_end(tool: StartFlowTool) 
             {
                 "id": "pick",
                 "kind": "select",
-                "title": "Dead end",
+                "title": "Pick",
                 "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+                "branch": {"a": "ghost", "b": "ghost"},  # → undeclared step
             }
         ],
     )
     assert result.startswith("Error:")
-    assert "dead-end after a pick" in result
+    assert "ghost" in result and "not declared" in result
+
+
+async def test_tool_repairs_dead_end_last_select(tool: StartFlowTool) -> None:
+    # The flip side: a dead-end LAST select is REPAIRED by the builder, so the
+    # tool returns a valid doc, not an Error (genesis forgiveness through the
+    # tool boundary).
+    result = await tool.execute(
+        flow="ok",
+        entry="pick",
+        steps=[
+            {
+                "id": "pick",
+                "kind": "select",
+                "title": "Pick",
+                "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+            }
+        ],
+    )
+    assert not result.startswith("Error:")
+    doc = json.loads(result)
+    assert doc["version"] == "1.0"
+    assert doc["ui"]["onComplete"]["kind"] == "chat"
 
 
 async def test_tool_accepts_steps_as_json_string(tool: StartFlowTool) -> None:

--- a/tests/test_flow_descriptor.py
+++ b/tests/test_flow_descriptor.py
@@ -1,5 +1,16 @@
 # tests/test_flow_descriptor.py
 # Created: 2026-06-15 (feat/chain-flow-v2).
+# Updated: 2026-06-15 (feat/chain-flow-v2 — continuation-not-a-button fix):
+#   - De-papered the two tests that had added dummy `id`/`label` to their
+#     on_success/on_error continuations: `_example_b()` (now verbatim §1.7 with
+#     BARE continuations) and `test_step_action_lowers_to_button_with_verb_on_click`.
+#     These now build with the natural `{verb, …payload}` continuation shape.
+#   - Strengthened `test_worked_example_b_builds_clean` to assert the lowered
+#     invoke_tool button carries its bare on_success/on_error handlers and the
+#     terminal onComplete is the create_pocket-with-then.
+#   - Added `test_continuation_actions_need_no_button_id_or_label` — the explicit
+#     regression guard that the §1.3/§1.7 bare-continuation shape builds without
+#     FlowBuildError.
 #
 # Tests for the CHAIN FLOW v2 GENERAL builder — `build_flow_from_descriptor`
 # (`pocketpaw.ripple._flows`). Where `test_flow_authoring.py` proves the two
@@ -441,10 +452,10 @@ def test_step_action_lowers_to_button_with_verb_on_click() -> None:
                         "binding": "dns_check",
                         "path": "/dns/check",
                         "params": {"domain": "{f.domain}"},
+                        # Bare continuations (no id/label) — the §1.3 shape the
+                        # builder accepts after the continuation-not-a-button fix.
                         "on_success": [
                             {
-                                "id": "ok",
-                                "label": "",
                                 "verb": "toast",
                                 "message": "Reachable",
                                 "variant": "success",
@@ -452,8 +463,6 @@ def test_step_action_lowers_to_button_with_verb_on_click() -> None:
                         ],
                         "on_error": [
                             {
-                                "id": "no",
-                                "label": "",
                                 "verb": "toast",
                                 "message": "Unreachable",
                                 "variant": "warning",
@@ -866,6 +875,12 @@ def _example_b() -> dict[str, Any]:
                     {"id": "seats", "label": "Seats", "type": "number", "required": True},
                 ],
                 "actions": [
+                    # Verbatim from design §1.7: the continuations are BARE
+                    # (verb + payload, NO id/label) — they are NOT buttons. This
+                    # is the regression guard for the continuation-not-a-button
+                    # fix; before it, the required id/label on StepAction made
+                    # the build raise FlowBuildError on this naturally-authored
+                    # shape.
                     {
                         "id": "verify_domain",
                         "label": "Verify domain",
@@ -874,15 +889,11 @@ def _example_b() -> dict[str, Any]:
                         "args": {"domain": "{details.domain}"},
                         "on_success": [
                             {
-                                "id": "t1",
-                                "label": "",
                                 "verb": "toast",
                                 "message": "Domain reachable",
                                 "variant": "success",
                             },
                             {
-                                "id": "s1",
-                                "label": "",
                                 "verb": "set",
                                 "key": "details.domain_ok",
                                 "value": True,
@@ -890,8 +901,6 @@ def _example_b() -> dict[str, Any]:
                         ],
                         "on_error": [
                             {
-                                "id": "t2",
-                                "label": "",
                                 "verb": "toast",
                                 "message": "Domain not reachable",
                                 "variant": "warning",
@@ -938,25 +947,87 @@ def test_worked_example_a_builds_clean() -> None:
 
 
 def test_worked_example_b_builds_clean() -> None:
+    # Builds clean — no FlowBuildError — even though the verify_domain action's
+    # on_success/on_error continuations are bare (no id/label). This is the
+    # literal §1.7 example B copied verbatim from the design doc; it is the
+    # regression guard for the continuation-not-a-button fix.
     doc = build_flow_from_descriptor(_example_b())
     assert isinstance(doc["ui"], dict)
     assert validate_against_catalog(doc, ALLOWED_TYPES) == []
     assert validate_action_verbs(doc) == []
-    # terminal create_pocket + then navigate
-    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
-    assert term["onComplete"]["kind"] == "create_pocket"
-    assert term["onComplete"]["then"]["kind"] == "navigate"
-    # the mid-flow verify_domain button is present with the right verb
+
+    # The form step carries the lowered invoke_tool button with its handlers.
     details = next(s for s in _iter_steps(doc["ui"]) if s["flowId"] == "details")
     verify = [
         n for n in _walk_nodes(details["ui"]) if n.get("props", {}).get("label") == "Verify domain"
     ]
     assert len(verify) == 1
-    assert verify[0]["on_click"]["action"] == "invoke_tool"
-    assert verify[0]["on_click"]["tool"] == "dns_domain_check"
+    oc = verify[0]["on_click"]
+    assert oc["action"] == "invoke_tool"
+    assert oc["tool"] == "dns_domain_check"
+    # the {details.domain} arg ref rewrote to the namespaced formData key
+    assert oc["args"]["domain"] == "{state.details_formData.domain}"
+    # on_success / on_error lowered to bare handler dicts (no id/label, no button
+    # wrapper) — exactly two success continuations, one error continuation.
+    assert [h["action"] for h in oc["on_success"]] == ["toast", "set"]
+    assert oc["on_success"][0]["variant"] == "success"
+    assert oc["on_success"][0]["message"] == "Domain reachable"
+    # no id/label leaked into the lowered handler
+    assert "id" not in oc["on_success"][0] and "label" not in oc["on_success"][0]
     # the set continuation preserves its falsy-safe boolean value
-    set_conts = [h for h in verify[0]["on_click"]["on_success"] if h["action"] == "set"]
+    set_conts = [h for h in oc["on_success"] if h["action"] == "set"]
     assert set_conts[0]["value"] is True
+    assert set_conts[0]["key"] == "details.domain_ok"
+    assert [h["action"] for h in oc["on_error"]] == ["toast"]
+    assert oc["on_error"][0]["variant"] == "warning"
+
+    # The terminal onComplete is the create_pocket-with-then.
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["onComplete"]["kind"] == "create_pocket"
+    assert term["onComplete"]["name"] == "{state.details_formData.company} — Client"
+    assert term["onComplete"]["seed_from_flow"] is True
+    assert term["onComplete"]["then"]["kind"] == "navigate"
+    assert term["onComplete"]["then"]["url"] == "/pockets/{result.id}"
+
+
+def test_continuation_actions_need_no_button_id_or_label() -> None:
+    """Regression: the §1.3/§1.7 continuation shape (bare `{verb, …payload}`
+    with NO id/label) must BUILD, not raise.
+
+    Continuations are NOT buttons. Before the fix, `StepAction.on_success` /
+    `.on_error` were typed `list[StepAction]`, and `StepAction` requires
+    `id` + `label`; the real chat agent — following the prompt + design — authors
+    continuations WITHOUT id/label, so every naturally-authored chain hit
+    `FlowBuildError`. This builds the LITERAL §1.7 example B (verbatim, bare
+    continuations) and proves it materializes a clean tree.
+    """
+    # The descriptor's verify_domain continuations carry no id/label at all.
+    desc = _example_b()
+    verify = desc["steps"][1]["actions"][0]
+    for cont in verify["on_success"] + verify["on_error"]:
+        assert "id" not in cont, f"continuation should be authored bare: {cont}"
+        assert "label" not in cont, f"continuation should be authored bare: {cont}"
+
+    # Must build with no FlowBuildError (the bug raised here).
+    doc = build_flow_from_descriptor(desc)
+    assert doc["version"] == "1.0"
+    assert validate_action_verbs(doc) == []
+
+    # The lowered invoke_tool button carries its on_success/on_error handlers,
+    # each a bare action dict (verb + payload, no id/label survived lowering).
+    details = next(s for s in _iter_steps(doc["ui"]) if s["flowId"] == "details")
+    btn = next(
+        n for n in _walk_nodes(details["ui"]) if n.get("props", {}).get("label") == "Verify domain"
+    )
+    handlers = btn["on_click"]["on_success"] + btn["on_click"]["on_error"]
+    assert len(handlers) == 3
+    for h in handlers:
+        assert "action" in h and "id" not in h and "label" not in h
+
+    # And the terminal is the create_pocket-with-then hand-off.
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["onComplete"]["kind"] == "create_pocket"
+    assert term["onComplete"]["then"]["kind"] == "navigate"
 
 
 # ===========================================================================

--- a/tests/test_flow_descriptor.py
+++ b/tests/test_flow_descriptor.py
@@ -1,0 +1,1200 @@
+# tests/test_flow_descriptor.py
+# Created: 2026-06-15 (feat/chain-flow-v2).
+#
+# Tests for the CHAIN FLOW v2 GENERAL builder — `build_flow_from_descriptor`
+# (`pocketpaw.ripple._flows`). Where `test_flow_authoring.py` proves the two
+# PRESETS still emit their exact pre-v2 tree (back-compat), this file proves the
+# generalization: an ARBITRARY flat step-graph descriptor materializes into a
+# valid nested tree, and every graph defect is REJECTED with a precise,
+# agent-readable message.
+#
+# Test philosophy (TDD): the REJECT cases come first — they are the bug-class
+# the primitive exists to prevent ("renders step 1 and silently dead-ends").
+# Each §2.3 graph invariant, the §2.5 prefill-ref rules, the §2.4 action
+# invariants, the §1.5/§2.2 suffix rewrite, the §7 D4 byte-identical button
+# shapes, and the two worked examples (A + B) are exercised.
+#
+# No EE imports — runs in the OSS-only CI scope.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from pocketpaw.ripple._flows import (
+    FlowBuildError,
+    build_flow_from_descriptor,
+)
+from pocketpaw.ripple.manifest import validate_action_verbs, validate_against_catalog
+from pocketpaw.tools.builtin.flow_tool import StartFlowTool
+
+ALLOWED_TYPES = ["container", "heading", "text", "input", "button"]
+
+
+# ---------------------------------------------------------------------------
+# Tree-walk helpers (mirror test_flow_authoring's, kept local so the two files
+# stay independent).
+# ---------------------------------------------------------------------------
+
+
+def _iter_steps(step: dict[str, Any]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    seen: set[int] = set()
+
+    def _visit(node: dict[str, Any]) -> None:
+        if id(node) in seen:
+            return
+        seen.add(id(node))
+        out.append(node)
+        nxt = node.get("chain")
+        if isinstance(nxt, dict):
+            _visit(nxt)
+        cmap = node.get("chain_map")
+        if isinstance(cmap, dict):
+            for branch in cmap.values():
+                if isinstance(branch, dict):
+                    _visit(branch)
+
+    _visit(step)
+    return out
+
+
+def _walk_nodes(node: Any) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    if isinstance(node, dict):
+        out.append(node)
+        for child in node.get("children") or []:
+            out.extend(_walk_nodes(child))
+    return out
+
+
+def _is_terminal(step: dict[str, Any]) -> bool:
+    return "chain" not in step and "chain_map" not in step
+
+
+def _on_clicks(step: dict[str, Any], target: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for node in _walk_nodes(step["ui"]):
+        handler = node.get("on_click")
+        if isinstance(handler, dict) and handler.get("target") == target:
+            out.append(handler)
+    return out
+
+
+def _all_text_blobs(node: Any) -> list[str]:
+    blobs: list[str] = []
+    if isinstance(node, dict):
+        props = node.get("props")
+        if isinstance(props, dict):
+            for key in ("text", "label"):
+                v = props.get(key)
+                if isinstance(v, str):
+                    blobs.append(v)
+        for child in node.get("children") or []:
+            blobs.extend(_all_text_blobs(child))
+    return blobs
+
+
+# A minimal valid 3-step branching flow — the fixture most reject tests mutate.
+def _good_descriptor() -> dict[str, Any]:
+    return {
+        "flow": "demo",
+        "entry": "pick",
+        "title": "Demo",
+        "steps": [
+            {
+                "id": "pick",
+                "kind": "select",
+                "title": "Pick one",
+                "options": [
+                    {"id": "a", "label": "Option A"},
+                    {"id": "b", "label": "Option B"},
+                ],
+                "branch": {"a": "form_a", "b": "form_b"},
+            },
+            {
+                "id": "form_a",
+                "kind": "form",
+                "slot": "details",
+                "title": "Details A",
+                "fields": [{"id": "name", "label": "Name", "type": "text", "required": True}],
+                "next": "done",
+            },
+            {
+                "id": "form_b",
+                "kind": "form",
+                "slot": "details",
+                "title": "Details B",
+                "fields": [{"id": "name", "label": "Name", "type": "text", "required": True}],
+                "next": "done",
+            },
+            {
+                "id": "done",
+                "kind": "confirm",
+                "title": "Confirm",
+                "review": [
+                    {"label": "Choice", "value": "{pick.label}"},
+                    {"label": "Name", "value": "{details.name}"},
+                ],
+                "complete": {"action": "chat", "message": "All set, please proceed."},
+            },
+        ],
+    }
+
+
+# ===========================================================================
+# REJECT CASES (TDD — the bug-class). Each §2.3 invariant rejects with the
+# right message.
+# ===========================================================================
+
+
+def test_rejects_missing_entry() -> None:
+    d = _good_descriptor()
+    d["entry"] = "nonexistent"
+    with pytest.raises(FlowBuildError, match=r'entry "nonexistent" is not a step id'):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_dangling_next() -> None:
+    d = _good_descriptor()
+    d["steps"][1]["next"] = "ghost"
+    with pytest.raises(
+        FlowBuildError, match=r'\.next → "ghost" but "ghost" is not a declared step'
+    ):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_dangling_branch_target() -> None:
+    d = _good_descriptor()
+    d["steps"][0]["branch"]["a"] = "ghost"
+    with pytest.raises(
+        FlowBuildError, match=r'\.branch\["a"\] → "ghost" but "ghost" is not declared'
+    ):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_branch_key_not_an_option_id() -> None:
+    d = _good_descriptor()
+    # add a branch key that is not one of pick's option ids
+    d["steps"][0]["branch"]["c"] = "form_a"
+    with pytest.raises(FlowBuildError, match=r'branch key "c" is not one of pick\'s option ids'):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_no_terminal() -> None:
+    # every step transitions onward — the flow never ends.
+    d = {
+        "flow": "loopy",
+        "entry": "a",
+        "steps": [
+            {"id": "a", "kind": "info", "title": "A", "next": "b"},
+            {"id": "b", "kind": "info", "title": "B", "next": "a"},
+        ],
+    }
+    # this also forms a cycle; the no-terminal check fires first in the pipeline.
+    with pytest.raises(FlowBuildError) as exc:
+        build_flow_from_descriptor(d)
+    assert "no terminal step" in str(exc.value) or "cycle detected" in str(exc.value)
+
+
+def test_rejects_terminal_with_transition() -> None:
+    # a step carrying BOTH a transition and a complete action.
+    d = _good_descriptor()
+    d["steps"][1]["complete"] = {"action": "chat", "message": "early?"}
+    with pytest.raises(
+        FlowBuildError,
+        match=r"has both a transition and a complete action; complete is terminal-only",
+    ):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_orphan_unreachable_step() -> None:
+    d = _good_descriptor()
+    d["steps"].append(
+        {
+            "id": "orphan",
+            "kind": "info",
+            "title": "Orphan",
+            "complete": {"action": "chat", "message": "x"},
+        }
+    )
+    with pytest.raises(FlowBuildError, match=r'step "orphan" is unreachable from entry "pick"'):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_cycle() -> None:
+    # a -> b -> c -> b is a cycle; c is also a select dead-end guard? no, use forms.
+    d = {
+        "flow": "cyc",
+        "entry": "a",
+        "steps": [
+            {"id": "a", "kind": "info", "title": "A", "next": "b"},
+            {"id": "b", "kind": "info", "title": "B", "next": "c"},
+            {"id": "c", "kind": "info", "title": "C", "next": "b"},
+            {
+                "id": "end",
+                "kind": "confirm",
+                "title": "End",
+                "complete": {"action": "chat", "message": "done"},
+            },
+        ],
+    }
+    # 'end' is unreachable; make it reachable so the cycle check is what fires.
+    d["steps"][0]["next"] = "b"
+    d["steps"][2]["next"] = "b"  # c -> b back-edge
+    # add a path to end so 'no terminal' doesn't fire first: branch a
+    d["steps"][0] = {
+        "id": "a",
+        "kind": "select",
+        "title": "A",
+        "options": [{"id": "go", "label": "Go"}, {"id": "fin", "label": "Fin"}],
+        "branch": {"go": "b", "fin": "end"},
+    }
+    with pytest.raises(FlowBuildError, match=r"cycle detected:.*flows must be a DAG"):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_select_with_no_transition() -> None:
+    # THE load-bearing one: a select step that goes nowhere — a hand-authored
+    # dead-end. The whole primitive exists to make this impossible.
+    d = {
+        "flow": "deadend",
+        "entry": "pick",
+        "steps": [
+            {
+                "id": "pick",
+                "kind": "select",
+                "title": "Pick (goes nowhere)",
+                "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+                # NO branch, NO next — dead-end after a pick.
+            },
+        ],
+    }
+    with pytest.raises(
+        FlowBuildError,
+        match=r'select step "pick" has no branch/next; it would dead-end after a pick',
+    ):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_both_next_and_branch() -> None:
+    d = _good_descriptor()
+    d["steps"][0]["next"] = "done"  # already has branch
+    with pytest.raises(FlowBuildError, match=r"has both `next` and `branch`"):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_duplicate_step_id() -> None:
+    d = _good_descriptor()
+    d["steps"].append(dict(d["steps"][1]))  # duplicate form_a id
+    with pytest.raises(FlowBuildError, match=r'duplicate step id "form_a"'):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_over_step_cap() -> None:
+    steps = [
+        {"id": f"s{i}", "kind": "info", "title": f"S{i}", "next": f"s{i + 1}"} for i in range(31)
+    ]
+    steps.append(
+        {
+            "id": "s31",
+            "kind": "confirm",
+            "title": "End",
+            "complete": {"action": "chat", "message": "done"},
+        }
+    )
+    d = {"flow": "huge", "entry": "s0", "steps": steps}
+    with pytest.raises(FlowBuildError, match=r"over the 30-step cap; split the flow"):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_empty_steps() -> None:
+    with pytest.raises(FlowBuildError, match=r"flow has no steps"):
+        build_flow_from_descriptor({"flow": "x", "entry": "a", "steps": []})
+
+
+# ===========================================================================
+# §2.5 prefill-ref validation.
+# ===========================================================================
+
+
+def test_rejects_prefill_ref_to_unknown_step() -> None:
+    d = _good_descriptor()
+    d["steps"][3]["review"][0]["value"] = "{nosuchstep.label}"
+    with pytest.raises(
+        FlowBuildError, match=r"prefill ref \{nosuchstep\.label\} points at unknown step/slot"
+    ):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_prefill_ref_to_undeclared_field() -> None:
+    d = _good_descriptor()
+    # `details` slot form declares `name`, not `salary`.
+    d["steps"][3]["review"][1]["value"] = "{details.salary}"
+    with pytest.raises(
+        FlowBuildError,
+        match=r'prefill ref \{details\.salary\} — step "details" declares no field "salary"',
+    ):
+        build_flow_from_descriptor(d)
+
+
+def test_single_branch_reachability_is_a_warning_not_error() -> None:
+    # A review ref to a per-step-id field reachable on only ONE branch is a
+    # WARNING (renders empty on the other branch), not a hard error. Use
+    # distinct step ids (no shared slot) so the ref is single-branch.
+    d = {
+        "flow": "warn",
+        "entry": "pick",
+        "steps": [
+            {
+                "id": "pick",
+                "kind": "select",
+                "title": "Pick",
+                "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+                "branch": {"a": "fa", "b": "fb"},
+            },
+            {
+                "id": "fa",
+                "kind": "form",
+                "title": "FA",
+                "fields": [{"id": "x", "label": "X", "type": "text"}],
+                "next": "rev",
+            },
+            {
+                "id": "fb",
+                "kind": "form",
+                "title": "FB",
+                "fields": [{"id": "y", "label": "Y", "type": "text"}],
+                "next": "rev",
+            },
+            {
+                "id": "rev",
+                "kind": "confirm",
+                "title": "Rev",
+                "review": [{"label": "X", "value": "{fa.x}"}],  # fa only on branch 'a'
+                "complete": {"action": "chat", "message": "ok"},
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)  # must NOT raise
+    warnings = doc.get("_warnings") or []
+    assert any("only reachable on" in w for w in warnings), (
+        f"expected a single-branch-reachability warning, got: {warnings}"
+    )
+
+
+# ===========================================================================
+# §1.5 / §2.2 — the suffix rewrite is correct (the #1 hand-author bug).
+# ===========================================================================
+
+
+def test_suffix_rewrite_select_becomes_selection() -> None:
+    doc = build_flow_from_descriptor(_good_descriptor())
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    rows = {r["label"]: r["value"] for r in term["review_rows"]}
+    # {pick.label} (a select step) → {state.pick_selection.label}
+    assert rows["Choice"] == "{state.pick_selection.label}"
+
+
+def test_suffix_rewrite_form_becomes_formData_via_slot() -> None:
+    doc = build_flow_from_descriptor(_good_descriptor())
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    rows = {r["label"]: r["value"] for r in term["review_rows"]}
+    # {details.name} (a form slot) → {state.details_formData.name}
+    assert rows["Name"] == "{state.details_formData.name}"
+
+
+def test_passthrough_tokens_not_rewritten() -> None:
+    # {flow.payload} / {state.x} / {result.y} must pass through untouched.
+    d = _good_descriptor()
+    d["steps"][3]["review"][0]["value"] = "{flow.payload}"
+    d["steps"][3]["review"][1]["value"] = "{state.custom_key}"
+    doc = build_flow_from_descriptor(d)
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    values = {r["value"] for r in term["review_rows"]}
+    assert "{flow.payload}" in values
+    assert "{state.custom_key}" in values
+
+
+# ===========================================================================
+# §1.3 / §7 D4 — action lowering emits the right button on_click.
+# ===========================================================================
+
+
+def test_step_action_lowers_to_button_with_verb_on_click() -> None:
+    d = {
+        "flow": "actrich",
+        "entry": "f",
+        "steps": [
+            {
+                "id": "f",
+                "kind": "form",
+                "title": "Form",
+                "fields": [{"id": "domain", "label": "Domain", "type": "url", "required": True}],
+                "actions": [
+                    {
+                        "id": "verify",
+                        "label": "Verify domain",
+                        "verb": "call_binding",
+                        "binding": "dns_check",
+                        "path": "/dns/check",
+                        "params": {"domain": "{f.domain}"},
+                        "on_success": [
+                            {
+                                "id": "ok",
+                                "label": "",
+                                "verb": "toast",
+                                "message": "Reachable",
+                                "variant": "success",
+                            }
+                        ],
+                        "on_error": [
+                            {
+                                "id": "no",
+                                "label": "",
+                                "verb": "toast",
+                                "message": "Unreachable",
+                                "variant": "warning",
+                            }
+                        ],
+                    }
+                ],
+                "next": "done",
+            },
+            {
+                "id": "done",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {"action": "chat", "message": "ok"},
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)
+    form = doc["ui"]
+    # find the action button
+    btns = [
+        n
+        for n in _walk_nodes(form["ui"])
+        if n.get("type") == "button" and n.get("props", {}).get("label") == "Verify domain"
+    ]
+    assert len(btns) == 1
+    oc = btns[0]["on_click"]
+    assert oc["action"] == "call_binding"
+    assert oc["binding"] == "dns_check"
+    assert oc["path"] == "/dns/check"
+    # the {f.domain} ref rewrote to {state.f_formData.domain}
+    assert oc["params"]["domain"] == "{state.f_formData.domain}"
+    # continuations lowered to bare handler dicts
+    assert oc["on_success"][0]["action"] == "toast"
+    assert oc["on_success"][0]["variant"] == "success"
+    assert oc["on_error"][0]["action"] == "toast"
+
+
+def test_rejects_unknown_step_action_verb() -> None:
+    d = {
+        "flow": "bad",
+        "entry": "f",
+        "steps": [
+            {
+                "id": "f",
+                "kind": "form",
+                "title": "F",
+                "fields": [{"id": "a", "label": "A", "type": "text"}],
+                "actions": [{"id": "x", "label": "X", "verb": "teleport"}],
+                "next": "done",
+            },
+            {
+                "id": "done",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {"action": "chat", "message": "ok"},
+            },
+        ],
+    }
+    with pytest.raises(FlowBuildError, match=r'uses unknown verb "teleport"'):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_step_action_missing_required_key() -> None:
+    d = {
+        "flow": "bad",
+        "entry": "f",
+        "steps": [
+            {
+                "id": "f",
+                "kind": "form",
+                "title": "F",
+                "fields": [{"id": "a", "label": "A", "type": "text"}],
+                # invoke_tool requires `tool`
+                "actions": [{"id": "x", "label": "X", "verb": "invoke_tool"}],
+                "next": "done",
+            },
+            {
+                "id": "done",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {"action": "chat", "message": "ok"},
+            },
+        ],
+    }
+    with pytest.raises(FlowBuildError, match=r'is missing required key "tool"'):
+        build_flow_from_descriptor(d)
+
+
+# ===========================================================================
+# §1.4 / §7 D1 — terminal lowering: new kinds + `then`.
+# ===========================================================================
+
+
+def test_terminal_create_pocket_lowers_with_then() -> None:
+    d = {
+        "flow": "setup",
+        "entry": "details",
+        "steps": [
+            {
+                "id": "details",
+                "kind": "form",
+                "title": "Details",
+                "fields": [{"id": "company", "label": "Company", "type": "text", "required": True}],
+                "next": "review",
+            },
+            {
+                "id": "review",
+                "kind": "confirm",
+                "title": "Confirm",
+                "review": [{"label": "Company", "value": "{details.company}"}],
+                "complete": {
+                    "action": "create_pocket",
+                    "name": "{details.company} — Client",
+                    "template": "tracker",
+                    "seed_from_flow": True,
+                    "then": {"action": "navigate", "url": "/pockets/{result.id}"},
+                },
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    oc = term["onComplete"]
+    assert oc["kind"] == "create_pocket"
+    assert oc["name"] == "{state.details_formData.company} — Client"
+    assert oc["template"] == "tracker"
+    assert oc["seed_from_flow"] is True
+    assert oc["then"]["kind"] == "navigate"
+    # {result.id} is a passthrough — not rewritten
+    assert oc["then"]["url"] == "/pockets/{result.id}"
+
+
+def test_terminal_invoke_tool_lowers() -> None:
+    d = {
+        "flow": "tooly",
+        "entry": "f",
+        "steps": [
+            {
+                "id": "f",
+                "kind": "form",
+                "title": "F",
+                "fields": [{"id": "vat", "label": "VAT", "type": "text", "required": True}],
+                "next": "done",
+            },
+            {
+                "id": "done",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {
+                    "action": "invoke_tool",
+                    "tool": "file_vendor",
+                    "args": {"vat": "{f.vat}"},
+                },
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    oc = term["onComplete"]
+    assert oc["kind"] == "invoke_tool"
+    assert oc["tool"] == "file_vendor"
+    assert oc["args"]["vat"] == "{state.f_formData.vat}"
+
+
+def test_rejects_terminal_unknown_action() -> None:
+    d = _good_descriptor()
+    d["steps"][3]["complete"] = {"action": "self_destruct"}
+    with pytest.raises(FlowBuildError, match=r'uses unknown action "self_destruct"'):
+        build_flow_from_descriptor(d)
+
+
+def test_rejects_terminal_then_too_deep() -> None:
+    d = _good_descriptor()
+    d["steps"][3]["complete"] = {
+        "action": "chat",
+        "message": "a",
+        "then": {
+            "action": "chat",
+            "message": "b",
+            "then": {"action": "chat", "message": "c"},
+        },  # depth 3 > cap 2
+    }
+    with pytest.raises(FlowBuildError, match=r"chains `then` deeper than 2"):
+        build_flow_from_descriptor(d)
+
+
+def test_flow_level_default_complete_applies_to_terminal() -> None:
+    # a terminal without its own complete inherits the flow-level default.
+    d = {
+        "flow": "def",
+        "entry": "f",
+        "title": "Def",
+        "steps": [
+            {
+                "id": "f",
+                "kind": "form",
+                "title": "F",
+                "fields": [{"id": "a", "label": "A", "type": "text"}],
+                "next": "end",
+            },
+            {
+                "id": "end",
+                "kind": "confirm",
+                "title": "End",
+                "review": [{"label": "A", "value": "{f.a}"}],
+            },  # no own complete
+        ],
+        "complete": {"action": "chat", "message": "flow default fired"},
+    }
+    doc = build_flow_from_descriptor(d)
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["onComplete"]["kind"] == "chat"
+    assert term["onComplete"]["message"] == "flow default fired"
+
+
+# ===========================================================================
+# §7 D3 — the GENERAL path allows MULTIPLE terminals, each with its own
+# complete (the presets keep exactly one; this is the general allowance).
+# ===========================================================================
+
+
+def test_general_path_allows_multiple_terminals() -> None:
+    d = {
+        "flow": "multi",
+        "entry": "pick",
+        "steps": [
+            {
+                "id": "pick",
+                "kind": "select",
+                "title": "Branch",
+                "options": [{"id": "x", "label": "X"}, {"id": "y", "label": "Y"}],
+                "branch": {"x": "end_x", "y": "end_y"},
+            },
+            {
+                "id": "end_x",
+                "kind": "confirm",
+                "title": "End X",
+                "complete": {"action": "chat", "message": "ended on X"},
+            },
+            {
+                "id": "end_y",
+                "kind": "confirm",
+                "title": "End Y",
+                "complete": {"action": "navigate", "url": "/y"},
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)  # must NOT raise on 2 terminals
+    terminals = [s for s in _iter_steps(doc["ui"]) if _is_terminal(s)]
+    assert len(terminals) == 2
+    kinds = {t["onComplete"]["kind"] for t in terminals}
+    assert kinds == {"chat", "navigate"}
+
+
+def test_rejects_terminal_with_no_complete_and_no_default() -> None:
+    d = {
+        "flow": "nocomplete",
+        "entry": "f",
+        "steps": [
+            {
+                "id": "f",
+                "kind": "form",
+                "title": "F",
+                "fields": [{"id": "a", "label": "A", "type": "text"}],
+                "next": "end",
+            },
+            {"id": "end", "kind": "confirm", "title": "End"},  # no complete, no default
+        ],
+    }
+    with pytest.raises(
+        FlowBuildError,
+        match=r'terminal step "end" has no complete action and no flow-level default',
+    ):
+        build_flow_from_descriptor(d)
+
+
+# ===========================================================================
+# Worked examples A + B build clean (§1.6, §1.7).
+# ===========================================================================
+
+
+def _example_a() -> dict[str, Any]:
+    """The branching due-diligence-style intake from §1.6 (uses a shared slot so
+    the review ref is branch-agnostic — the spec note explains the preset does
+    this; we mirror it here so example A builds without a single-branch warning)."""
+    return {
+        "flow": "diligence_intake",
+        "entry": "stage",
+        "title": "Due-diligence intake",
+        "steps": [
+            {
+                "id": "stage",
+                "kind": "select",
+                "title": "Pick the deal stage",
+                "subtitle": "The next steps adapt to it.",
+                "options": [
+                    {"id": "early", "label": "Early stage (pre-seed / seed)"},
+                    {"id": "growth", "label": "Growth stage (Series A+)"},
+                ],
+                "branch": {"early": "fin_early", "growth": "fin_growth"},
+            },
+            {
+                "id": "fin_early",
+                "kind": "form",
+                "slot": "financials",
+                "title": "Early-stage traction",
+                "fields": [
+                    {
+                        "id": "headline",
+                        "label": "Headline traction metric",
+                        "type": "text",
+                        "placeholder": "1.2k weekly active",
+                        "required": True,
+                    },
+                    {
+                        "id": "raise",
+                        "label": "Round size sought",
+                        "type": "text",
+                        "placeholder": "$2M seed",
+                    },
+                ],
+                "next": "risk",
+            },
+            {
+                "id": "fin_growth",
+                "kind": "form",
+                "slot": "financials",
+                "title": "Growth metrics",
+                "fields": [
+                    {
+                        "id": "headline",
+                        "label": "Headline revenue metric",
+                        "type": "text",
+                        "placeholder": "$4M ARR",
+                        "required": True,
+                    },
+                    {"id": "growth", "label": "YoY growth", "type": "text", "placeholder": "180%"},
+                ],
+                "next": "risk",
+            },
+            {
+                "id": "risk",
+                "kind": "form",
+                "slot": "risk",
+                "title": "Risk & open flags",
+                "fields": [
+                    {
+                        "id": "key_risk",
+                        "label": "Biggest open risk",
+                        "type": "text",
+                        "placeholder": "Customer concentration",
+                        "required": True,
+                    },
+                    {
+                        "id": "mitigation",
+                        "label": "Mitigation (optional)",
+                        "type": "textarea",
+                        "required": False,
+                    },
+                ],
+                "next": "review",
+            },
+            {
+                "id": "review",
+                "kind": "confirm",
+                "title": "Review the intake",
+                "review": [
+                    {"label": "Deal stage", "value": "{stage.label}"},
+                    {"label": "Headline metric", "value": "{financials.headline}"},
+                    {"label": "Key risk", "value": "{risk.key_risk}"},
+                ],
+                "complete": {
+                    "action": "chat",
+                    "message": "Diligence intake complete — please summarize and flag risks.",
+                },
+            },
+        ],
+    }
+
+
+def _example_b() -> dict[str, Any]:
+    """The action-rich 'stand up a client workspace' mini-app from §1.7."""
+    return {
+        "flow": "client_setup",
+        "entry": "plan",
+        "title": "Set up a client workspace",
+        "steps": [
+            {
+                "id": "plan",
+                "kind": "select",
+                "title": "Plan",
+                "options": [{"id": "starter", "label": "Starter"}, {"id": "pro", "label": "Pro"}],
+                "ui": {"layout": "cards", "columns": 2},
+                "next": "details",
+            },
+            {
+                "id": "details",
+                "kind": "form",
+                "title": "Company details",
+                "fields": [
+                    {"id": "company", "label": "Company name", "type": "text", "required": True},
+                    {
+                        "id": "domain",
+                        "label": "Primary domain",
+                        "type": "url",
+                        "required": True,
+                        "placeholder": "acme.com",
+                    },
+                    {"id": "seats", "label": "Seats", "type": "number", "required": True},
+                ],
+                "actions": [
+                    {
+                        "id": "verify_domain",
+                        "label": "Verify domain",
+                        "verb": "invoke_tool",
+                        "tool": "dns_domain_check",
+                        "args": {"domain": "{details.domain}"},
+                        "on_success": [
+                            {
+                                "id": "t1",
+                                "label": "",
+                                "verb": "toast",
+                                "message": "Domain reachable",
+                                "variant": "success",
+                            },
+                            {
+                                "id": "s1",
+                                "label": "",
+                                "verb": "set",
+                                "key": "details.domain_ok",
+                                "value": True,
+                            },
+                        ],
+                        "on_error": [
+                            {
+                                "id": "t2",
+                                "label": "",
+                                "verb": "toast",
+                                "message": "Domain not reachable",
+                                "variant": "warning",
+                            },
+                        ],
+                    }
+                ],
+                "next": "review",
+            },
+            {
+                "id": "review",
+                "kind": "confirm",
+                "title": "Confirm and create the workspace",
+                "review": [
+                    {"label": "Plan", "value": "{plan.label}"},
+                    {"label": "Company", "value": "{details.company}"},
+                    {"label": "Domain", "value": "{details.domain}"},
+                    {"label": "Seats", "value": "{details.seats}"},
+                ],
+                "complete": {
+                    "action": "create_pocket",
+                    "name": "{details.company} — Client",
+                    "template": "tracker",
+                    "seed_from_flow": True,
+                    "then": {"action": "navigate", "url": "/pockets/{result.id}"},
+                },
+            },
+        ],
+    }
+
+
+def test_worked_example_a_builds_clean() -> None:
+    doc = build_flow_from_descriptor(_example_a())
+    assert doc["version"] == "1.0"
+    assert isinstance(doc["ui"], dict)
+    # no single-branch warning (shared slot makes the read branch-agnostic)
+    assert not doc.get("_warnings"), f"example A should build warning-free: {doc.get('_warnings')}"
+    # passes the deep validators
+    assert validate_against_catalog(doc, ALLOWED_TYPES) == []
+    assert validate_action_verbs(doc) == []
+    # 5 logical steps; financials is shared so 6 step objects collapse appropriately
+    flow_ids = {s["flowId"] for s in _iter_steps(doc["ui"])}
+    assert flow_ids == {"stage", "financials", "risk", "review"}
+
+
+def test_worked_example_b_builds_clean() -> None:
+    doc = build_flow_from_descriptor(_example_b())
+    assert isinstance(doc["ui"], dict)
+    assert validate_against_catalog(doc, ALLOWED_TYPES) == []
+    assert validate_action_verbs(doc) == []
+    # terminal create_pocket + then navigate
+    term = next(s for s in _iter_steps(doc["ui"]) if _is_terminal(s))
+    assert term["onComplete"]["kind"] == "create_pocket"
+    assert term["onComplete"]["then"]["kind"] == "navigate"
+    # the mid-flow verify_domain button is present with the right verb
+    details = next(s for s in _iter_steps(doc["ui"]) if s["flowId"] == "details")
+    verify = [
+        n for n in _walk_nodes(details["ui"]) if n.get("props", {}).get("label") == "Verify domain"
+    ]
+    assert len(verify) == 1
+    assert verify[0]["on_click"]["action"] == "invoke_tool"
+    assert verify[0]["on_click"]["tool"] == "dns_domain_check"
+    # the set continuation preserves its falsy-safe boolean value
+    set_conts = [h for h in verify[0]["on_click"]["on_success"] if h["action"] == "set"]
+    assert set_conts[0]["value"] is True
+
+
+# ===========================================================================
+# An arbitrary 6-step branching flow round-trips.
+# ===========================================================================
+
+
+def test_arbitrary_six_step_flow_round_trips() -> None:
+    d = {
+        "flow": "sixstep",
+        "entry": "s1",
+        "title": "Six-step",
+        "steps": [
+            {
+                "id": "s1",
+                "kind": "select",
+                "title": "Start",
+                "options": [{"id": "left", "label": "Left"}, {"id": "right", "label": "Right"}],
+                "branch": {"left": "s2", "right": "s3"},
+            },
+            {
+                "id": "s2",
+                "kind": "form",
+                "slot": "data",
+                "title": "Left form",
+                "fields": [{"id": "v", "label": "Value", "type": "text", "required": True}],
+                "next": "s4",
+            },
+            {
+                "id": "s3",
+                "kind": "form",
+                "slot": "data",
+                "title": "Right form",
+                "fields": [{"id": "v", "label": "Value", "type": "text", "required": True}],
+                "next": "s4",
+            },
+            {
+                "id": "s4",
+                "kind": "info",
+                "title": "Interstitial",
+                "body": "You entered {data.v}.",
+                "next": "s5",
+            },
+            {
+                "id": "s5",
+                "kind": "form",
+                "slot": "extra",
+                "title": "More",
+                "fields": [{"id": "note", "label": "Note", "type": "textarea", "required": False}],
+                "next": "s6",
+            },
+            {
+                "id": "s6",
+                "kind": "confirm",
+                "title": "Done",
+                "review": [
+                    {"label": "Value", "value": "{data.v}"},
+                    {"label": "Note", "value": "{extra.note}"},
+                ],
+                "complete": {"action": "chat", "message": "six steps complete"},
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)
+    steps = _iter_steps(doc["ui"])
+    flow_ids = {s["flowId"] for s in steps}
+    # s2/s3 share slot "data"; s4 info, s5 extra, s6 review
+    assert flow_ids == {"s1", "data", "s4", "extra", "s6"}
+    # diamond: both branches converge on the same s4 object
+    s4_objs = [s for s in steps if s["flowId"] == "s4"]
+    assert len(s4_objs) == 1
+    # the info body ref rewrote
+    info = s4_objs[0]
+    body_blobs = _all_text_blobs(info["ui"])
+    assert any("{state.data_formData.v}" in b for b in body_blobs)
+    # passes deep validators
+    assert validate_against_catalog(doc, ALLOWED_TYPES) == []
+    assert validate_action_verbs(doc) == []
+
+
+# ===========================================================================
+# Diamond-join sharing: a branch-converging step is materialized ONCE.
+# ===========================================================================
+
+
+def test_diamond_join_shares_one_node_instance() -> None:
+    doc = build_flow_from_descriptor(_good_descriptor())
+    root = doc["ui"]
+    a_term = root["chain_map"]["a"]["chain"]
+    b_term = root["chain_map"]["b"]["chain"]
+    # both branches' "done" step must be the SAME object (a materialized diamond)
+    assert a_term is b_term
+
+
+# ===========================================================================
+# Linear (no-branch) flow also builds.
+# ===========================================================================
+
+
+def test_linear_flow_builds() -> None:
+    d = {
+        "flow": "linear",
+        "entry": "a",
+        "steps": [
+            {"id": "a", "kind": "info", "title": "Intro", "body": "Welcome.", "next": "b"},
+            {
+                "id": "b",
+                "kind": "form",
+                "slot": "f",
+                "title": "Fill",
+                "fields": [{"id": "x", "label": "X", "type": "text", "required": True}],
+                "next": "c",
+            },
+            {
+                "id": "c",
+                "kind": "confirm",
+                "title": "Confirm",
+                "review": [{"label": "X", "value": "{f.x}"}],
+                "complete": {"action": "chat", "message": "linear done"},
+            },
+        ],
+    }
+    doc = build_flow_from_descriptor(d)
+    steps = _iter_steps(doc["ui"])
+    assert [s["flowId"] for s in steps] == ["a", "f", "c"]
+    # intermediate form 'b' gets a Back button (not the entry, not terminal)
+    form = steps[1]
+    assert len(_on_clicks(form, "flow.back")) == 1
+    # entry 'a' (info) gets no Back
+    assert len(_on_clicks(steps[0], "flow.back")) == 0
+
+
+# ===========================================================================
+# The `start_flow` tool routes a flat `steps` graph through the general builder
+# and surfaces FlowBuildError verbatim so the model can retry.
+# ===========================================================================
+
+
+@pytest.fixture
+def tool() -> StartFlowTool:
+    return StartFlowTool()
+
+
+async def test_tool_builds_from_flat_steps_graph(tool: StartFlowTool) -> None:
+    d = _good_descriptor()
+    result = await tool.execute(
+        flow=d["flow"], entry=d["entry"], title=d["title"], steps=d["steps"]
+    )
+    assert not result.startswith("Error:")
+    doc = json.loads(result)
+    assert doc["version"] == "1.0"
+    assert isinstance(doc["ui"], dict)
+    # the doc matches the builder's output (minus the internal _warnings key)
+    built = build_flow_from_descriptor(d)
+    built.pop("_warnings", None)
+    assert doc == built
+
+
+async def test_tool_surfaces_flow_build_error_for_dead_end(tool: StartFlowTool) -> None:
+    # a select step that goes nowhere — the tool must return the precise reject
+    # message so the model can fix the graph.
+    result = await tool.execute(
+        flow="bad",
+        entry="pick",
+        steps=[
+            {
+                "id": "pick",
+                "kind": "select",
+                "title": "Dead end",
+                "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+            }
+        ],
+    )
+    assert result.startswith("Error:")
+    assert "dead-end after a pick" in result
+
+
+async def test_tool_accepts_steps_as_json_string(tool: StartFlowTool) -> None:
+    """Subprocess / CLI callers pass `steps` as a JSON string through the flat
+    signature — the tool coerces it."""
+    d = _good_descriptor()
+    result = await tool.execute(flow=d["flow"], entry=d["entry"], steps=json.dumps(d["steps"]))
+    assert not result.startswith("Error:")
+    doc = json.loads(result)
+    assert isinstance(doc["ui"], dict)
+
+
+async def test_tool_preset_shorthand_still_works(tool: StartFlowTool) -> None:
+    """`flow_type` remains an OPTIONAL preset path that returns a valid doc."""
+    result = await tool.execute(flow_type="onboarding_wizard")
+    assert not result.startswith("Error:")
+    doc = json.loads(result)
+    assert isinstance(doc["ui"], dict)
+
+
+async def test_tool_no_steps_no_flow_type_is_agent_readable(tool: StartFlowTool) -> None:
+    result = await tool.execute()
+    assert result.startswith("Error:")
+    assert "steps" in result and "flow_type" in result
+
+
+async def test_tool_does_not_leak_warnings_into_doc(tool: StartFlowTool) -> None:
+    """Single-branch-reachability warnings are build-time guidance, not part of
+    the rendered spec — the tool strips `_warnings` from its output."""
+    # distinct step ids (no shared slot) so a single-branch warning is raised
+    result = await tool.execute(
+        flow="warn",
+        entry="pick",
+        steps=[
+            {
+                "id": "pick",
+                "kind": "select",
+                "title": "Pick",
+                "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+                "branch": {"a": "fa", "b": "fb"},
+            },
+            {
+                "id": "fa",
+                "kind": "form",
+                "title": "FA",
+                "fields": [{"id": "x", "label": "X", "type": "text"}],
+                "next": "rev",
+            },
+            {
+                "id": "fb",
+                "kind": "form",
+                "title": "FB",
+                "fields": [{"id": "y", "label": "Y", "type": "text"}],
+                "next": "rev",
+            },
+            {
+                "id": "rev",
+                "kind": "confirm",
+                "title": "Rev",
+                "review": [{"label": "X", "value": "{fa.x}"}],
+                "complete": {"action": "chat", "message": "ok"},
+            },
+        ],
+    )
+    doc = json.loads(result)
+    assert "_warnings" not in doc

--- a/tests/test_sdk_mcp_inline_help.py
+++ b/tests/test_sdk_mcp_inline_help.py
@@ -8,6 +8,14 @@
 #     prove the MCP handler scaffolds a real {version, ui} flow tree (reusing
 #     the same builder as the runtime StartFlowTool) and returns an
 #     agent-readable error for a bad descriptor.
+#   - 2026-06-15 (feat/chain-flow-v2 — SPLIT-BRAIN FIX): added flat-graph
+#     coverage. The SDK handler was preset-only while the prompt told the model
+#     to author a flat `steps` graph, so flat authoring was rejected at the tool
+#     boundary (the #1 v2 flakiness cause). New tests prove the handler now
+#     routes a flat `steps` descriptor through `build_flow_from_descriptor`
+#     (returning a doc that matches the runtime StartFlowTool byte-for-byte),
+#     coerces a `steps` JSON string, repairs a dead-end last select, and surfaces
+#     a FlowBuildError verbatim for a genuine structural bug.
 
 import pytest
 
@@ -127,3 +135,161 @@ class TestStartFlowHandler:
         # Valid {version, ui} doc still produced with the override applied.
         doc = json.loads(_text_of(out))
         assert set(doc) >= {"version", "ui"}
+
+    # ----- CHAIN FLOW v2 flat-graph routing (the split-brain fix) ----------
+
+    @pytest.mark.asyncio
+    async def test_accepts_flat_steps_graph_and_returns_doc(self):
+        """THE split-brain fix: a FLAT `steps` descriptor (what the prompt tells
+        the model to author) routes through the general builder and returns a
+        {version, ui} doc — NOT the old 'needs a flow_type' error."""
+        import json
+
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+
+        out = await _start_flow_handler(
+            {
+                "flow": "x",
+                "entry": "pick",
+                "title": "Demo",
+                "steps": [
+                    {
+                        "id": "pick",
+                        "kind": "select",
+                        "title": "Pick one",
+                        "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+                        "branch": {"a": "done", "b": "done"},
+                    },
+                    {
+                        "id": "done",
+                        "kind": "confirm",
+                        "title": "Done",
+                        "review": [{"label": "Choice", "value": "{pick.label}"}],
+                        "complete": {"action": "chat", "message": "All set."},
+                    },
+                ],
+            }
+        )
+        assert not out.get("is_error"), "a flat steps graph must NOT error"
+        doc = json.loads(_text_of(out))
+        assert set(doc) >= {"version", "ui"}
+        assert "chain_map" in doc["ui"], "the branching select must materialize a chain_map"
+
+    @pytest.mark.asyncio
+    async def test_flat_graph_matches_runtime_tool_builder(self):
+        """The handler's flat-graph path mirrors StartFlowTool.execute, so an
+        identical flat descriptor yields the identical doc through both."""
+        import json
+
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+        from pocketpaw.tools.builtin.flow_tool import StartFlowTool
+
+        descriptor = {
+            "flow": "demo",
+            "entry": "f",
+            "steps": [
+                {
+                    "id": "f",
+                    "kind": "form",
+                    "title": "F",
+                    "fields": [{"id": "a", "label": "A", "type": "text", "required": True}],
+                    "next": "end",
+                },
+                {
+                    "id": "end",
+                    "kind": "confirm",
+                    "title": "End",
+                    "review": [{"label": "A", "value": "{f.a}"}],
+                    "complete": {"action": "chat", "message": "ok"},
+                },
+            ],
+        }
+        mcp_doc = json.loads(
+            _text_of(
+                await _start_flow_handler(
+                    {
+                        "flow": descriptor["flow"],
+                        "entry": descriptor["entry"],
+                        "steps": descriptor["steps"],
+                    }
+                )
+            )
+        )
+        runtime_doc = json.loads(
+            await StartFlowTool().execute(
+                flow=descriptor["flow"], entry=descriptor["entry"], steps=descriptor["steps"]
+            )
+        )
+        assert mcp_doc == runtime_doc
+
+    @pytest.mark.asyncio
+    async def test_steps_as_json_string_is_coerced(self):
+        """SDK callers may pass `steps` as a JSON string through the flat
+        signature — the handler coerces it (parity with StartFlowTool)."""
+        import json
+
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+
+        steps = [
+            {
+                "id": "only",
+                "kind": "confirm",
+                "title": "Done",
+                "complete": {"action": "chat", "message": "ok"},
+            }
+        ]
+        out = await _start_flow_handler({"flow": "x", "entry": "only", "steps": json.dumps(steps)})
+        assert not out.get("is_error")
+        doc = json.loads(_text_of(out))
+        assert set(doc) >= {"version", "ui"}
+
+    @pytest.mark.asyncio
+    async def test_repairs_dead_end_last_select_through_handler(self):
+        """Genesis forgiveness reaches the SDK boundary: a dead-end LAST select
+        is repaired into a terminal step, so the handler returns a doc, not an
+        error."""
+        import json
+
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+
+        out = await _start_flow_handler(
+            {
+                "flow": "ok",
+                "entry": "pick",
+                "steps": [
+                    {
+                        "id": "pick",
+                        "kind": "select",
+                        "title": "Pick",
+                        "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+                    }
+                ],
+            }
+        )
+        assert not out.get("is_error")
+        doc = json.loads(_text_of(out))
+        assert doc["ui"]["onComplete"]["kind"] == "chat"
+
+    @pytest.mark.asyncio
+    async def test_flat_graph_real_bug_surfaces_error(self):
+        """A genuine structural bug (dangling branch target) is surfaced verbatim
+        so the model can fix the flat graph and retry."""
+        from pocketpaw.agents.sdk_mcp_widgets import _start_flow_handler
+
+        out = await _start_flow_handler(
+            {
+                "flow": "bad",
+                "entry": "pick",
+                "steps": [
+                    {
+                        "id": "pick",
+                        "kind": "select",
+                        "title": "Pick",
+                        "options": [{"id": "a", "label": "A"}, {"id": "b", "label": "B"}],
+                        "branch": {"a": "ghost", "b": "ghost"},
+                    }
+                ],
+            }
+        )
+        assert out.get("is_error") is True
+        assert "ghost" in _text_of(out)


### PR DESCRIPTION
## What this changes

Before this PR, the chat flow primitive let the agent pick one of exactly two hardcoded Python templates (`onboarding_wizard`, `due_diligence_intake`). Anything that didn't fit one of those two shapes got routed to a flat Q&A dead-end. The ripple runtime was already a general flow engine; the cap was on the authoring side.

This adds `build_flow_from_descriptor(descriptor)`: the agent describes a flow as a flat step-graph (a `flow` id, an `entry` step, and a `steps` array where each step points at the next by id via `next` or `branch`), and a Python builder materializes the nested `chain`/`chain_map` tree and validates it. The agent still never emits a nested tree by hand. A flat list with id pointers can't mis-nest, which is what made hand-authoring fragile in the first place.

The two old templates become thin presets that emit a descriptor and call the same builder, so their existing test suite passes unchanged. That suite is now the back-compat proof.

## How the builder works

The pipeline runs in order: parse → index → validate-graph → validate-refs → validate-actions → assemble-nodes → resolve-transitions → wire-prefills → attach-actions → attach-terminal → final deep-validate → envelope.

Every graph defect is a hard reject with a message written for the model to read and retry on:

- `entry` is not a declared step id
- a `next` or `branch` target that doesn't exist
- a `branch` key that isn't one of the select step's option ids
- a select step with no transition (the classic "renders step 1 and goes nowhere")
- a non-terminal step carrying a `complete` action
- an unreachable step
- a cycle (the graph must be a DAG)
- no terminal step at all
- a terminal with no `complete` and no flow-level default

The builder also owns the `{stepId.field}` → `{state.<flowId>_selection|_formData.field}` rewrite, so the author never writes the `_selection`/`_formData` suffix. That suffix mismatch was the single most common hand-author bug, and it's gone structurally. An optional `slot` key lets two branch steps share a flowId so a review row reads the same field regardless of which branch ran.

`assemble_node` reuses the existing `_select_button` / `_continue_button` / `_submit_button` / `_back_button` helpers, so the general path emits byte-identical button `on_click` shapes to the presets. The ChainExecutor and the existing tests depend on those exact shapes; I verified each one matches byte-for-byte (select option, form Continue + Back, terminal Finish).

## New capabilities

- Terminal actions gain `invoke_tool`, `call_binding`, and `create_pocket` on top of the existing `chat`/`navigate`/`emit`, plus an optional `then` post-action (capped at chain length 2). `invoke_tool` points at the existing `/pockets/{id}/tools/run` route but returns `not_allowed` until the tool registry ships, so the prompt marks it accordingly.
- Per-step `actions` lower into buttons that call a tool/API/binding mid-flow without leaving the step.
- The general path allows more than one terminal (branches can end differently, each with its own `complete`). The presets keep exactly one terminal, so their one-terminal test stays green.
- Caps: 30 steps (over that, the build error asks the model to split the flow), and a `then` chain of 2.

## Tool and prompt

`start_flow` drops the `flow_type` enum and the `required` flag. It gains `flow`/`entry`/`steps`/`title`/`complete`. If `steps` is present it builds from the descriptor; if only `flow_type` is present it builds a preset. On a build error it returns the precise message so the model can fix the graph and retry. `flow_type` stays accepted as optional shorthand for the two known shapes.

The inline prompt rule now teaches state-transition authoring instead of template selection, with a state-grammar block and two copy-paste flat-descriptor skeletons (a branching intake and an action-rich mini-app).

## Tests

`tests/test_flow_authoring.py` (46 tests) stays green as the back-compat proof. The one test that snapshotted the old `{flow_type}` tool schema is updated to assert the new flat-graph schema, which is the only intentional change to that file.

`tests/test_flow_descriptor.py` is new (40 tests, reject cases written first). It covers each graph invariant rejecting with the right message, the prefill-ref rules (unknown step/field is a hard error, single-branch reachability is a warning), the suffix rewrite, action lowering, both worked examples building clean, an arbitrary 6-step branching flow round-tripping, a hand-authored dead-end getting rejected, and the tool routing the flat path through the builder.

## Scope

This PR is the pocketpaw core only: builder, tool, prompt, tests. The ripple schema extension for the new `FlowAction` kinds and the paw-enterprise host wiring (chat-adapter `call_binding`/`invoke_tool` branches, terminal `runFlowAction` cases, `runPocketTool` client) ship separately.

Verification: 86 flow tests pass, ruff clean, mypy clean on the builder and tool.

Follow-up: continuation actions don't require id/label (design §1.3/§1.7 shape) — `StepAction.on_success`/`on_error` now type as a non-button `StepContinuation`, so naturally-authored bare `{verb, …payload}` chains build instead of raising `FlowBuildError`. (87 flow tests pass.)


Follow-up (reliability): fixed the split-brain that made v2 flaky. The default `claude_agent_sdk` backend calls the `start_flow` in `agents/sdk_mcp_widgets.py`, and that copy was still preset-only — `flow_type` required, a flat `steps` graph ignored — so every flat-graph attempt the prompt asks for was rejected at the tool boundary with "needs a flow_type." It now mirrors the runtime `flow_tool.py`: flat `steps` → `build_flow_from_descriptor`, bare `flow_type` → preset, JSON-string args coerced, `FlowBuildError` surfaced for retry. Both copies now scaffold the same tree from the same input.

Also added genesis-style forgiveness to the builder so imperfect descriptors build instead of erroring: `type:`/`kind:` slips on a terminal `complete` coerce to `action:` (and `type:` on a mid-flow action coerces to `verb:`); a terminal with no `complete`, a flow with no terminal, and a dead-end last `select`/`info` step are repaired with a sensible default. Repairs stay surgical — a dangling transition, a mid-flow dead-end select, and a duplicate id still reject, now with a friendly message that names the fix instead of leaking a Pydantic URL. The prompt gained an action-grammar callout and three copy-paste skeletons that end in a real action (approve/reject, fulfill order, act on connector data via `call_binding`). 110 flow + SDK-handler tests pass, ruff and mypy clean on the changed files.
