### PR TITLE
fix(chat): reply pong to client WS heartbeat pings

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/router.py
+++ b/ee/pocketpaw_ee/cloud/chat/router.py
@@ -676,6 +676,12 @@ async def websocket_endpoint(websocket: WebSocket, token: str | None = Query(Non
             raw = await websocket.receive_text()
             try:
                 data = json.loads(raw)
+                # Heartbeat: clients ping to keep the socket warm through idle-
+                # closing edge proxies (e.g. Cloudflare drops idle WebSockets
+                # after ~100s). Reply pong and skip the message-handling path.
+                if isinstance(data, dict) and data.get("type") == "ping":
+                    await websocket.send_json({"type": "pong"})
+                    continue
                 msg = WsInbound.model_validate(_normalize_ws_inbound(data))
             except Exception:
                 await websocket.send_json(


### PR DESCRIPTION
The web client now sends a `{"type":"ping"}` heartbeat on `/ws/cloud` every 25s to keep the socket warm through idle-closing edge proxies — Cloudflare drops idle WebSockets after ~100s, which was leaving the GCP demo's UI stale until a reload (see qbtrix/paw-enterprise#436).

The server didn't know the `ping` frame, so it replied with `invalid_message` every time. The client ignores that, so it works today — but it's noise on the wire. This teaches the receive loop to answer `ping` with `pong` and skip the message path; it sits before `WsInbound` validation so it never hits the error branch.

Verified live (through Cloudflare) that a pinged socket stays open past 118s, well past the idle close.

Follow-up: the cloud suite has no full `/ws/cloud` `websocket_connect` harness (existing WS tests unit-test `_handle_ws_message` or the ticket mint/consume helpers). A connect-level ping/pong integration test should land with that harness rather than bolting a one-off onto this small change.