### PR TITLE
Make invoke_tool execute: connector reads fire, writes go through Instinct

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -30,6 +30,13 @@ Outcome Metering section: the binding-level `outcome` / `outcome_value` /
 and the new `GET /outcomes/meter` aggregation surface that sums billable
 value by unit per workspace over a since/until window. Invoicing /
 payment / pricing-rules / clawback remain deferred.
+
+Updated: 2026-06-15 (feat/invoke-tool-v1) — documented the now-live
+POST /pockets/{id}/tools/run (was a fail-closed stub) and the new
+owner-only PUT /pockets/{id}/backend/tool-policy. The backend summary now
+carries `allowed_tools` (the per-pocket tool allowlist) alongside
+`allowed_writes`. v1: connector READ tools fire; WRITE tools return
+`code: blocked` (approval lands in v2 via Instinct).
 -->
 
 # Cloud REST API Reference
@@ -68,14 +75,18 @@ Response `200`:
   "base_url": "https://api.example.com",
   "auth_type": "bearer",
   "configured": true,
-  "allowed_writes": []
+  "allowed_writes": [],
+  "allowed_tools": []
 }
 ```
 
 The token is never echoed back. A non-https or internal `base_url` yields
 a `400`. `allowed_writes` is the per-pocket write allowlist (RFC 05 M2a) —
 empty by default, so no write action can fire until an owner sets a policy
-via `PUT /pockets/{id}/backend/write-policy`.
+via `PUT /pockets/{id}/backend/write-policy`. `allowed_tools` is the
+per-pocket tool allowlist (feat/invoke-tool-v1) — also empty by default, so
+no `invoke_tool` can fire until an owner sets a policy via
+`PUT /pockets/{id}/backend/tool-policy`.
 
 For `basic` auth, send `auth_token` as the raw `user:pass` credential —
 the server base64-encodes it into the `Authorization: Basic` header. Do
@@ -94,13 +105,15 @@ Response `200`:
   "base_url": "https://api.example.com",
   "auth_type": "bearer",
   "configured": true,
-  "allowed_writes": [{ "method": "POST", "path_pattern": "/leases/*/renew" }]
+  "allowed_writes": [{ "method": "POST", "path_pattern": "/leases/*/renew" }],
+  "allowed_tools": [{ "tool": "connector:github:list_issues" }]
 }
 ```
 
 Returns `404` when the pocket has no backend configured. The token is
 never included in the response. `allowed_writes` carries the current
-write allowlist (RFC 05 M2a).
+write allowlist (RFC 05 M2a); `allowed_tools` carries the current tool
+allowlist (feat/invoke-tool-v1).
 
 ### `DELETE /pockets/{pocket_id}/backend`
 
@@ -249,6 +262,112 @@ and a write-specific rate limit — 20 writes per `(pocket, user)` per
 minute, a **separate** counter from the read budget. Every run (including
 every rejection) is written to the audit log; the credential token is
 never logged.
+
+## Pockets — Tool Invocations (`invoke_tool`)
+
+feat/invoke-tool-v1. `invoke_tool` is the click-driven tool verb for pocket
+FLOW-BUTTONs. A button fires `{action: "invoke_tool", tool, args}`; Ripple
+resolves the `args` client-side and the host POSTs to the route below. Like
+write actions, it carries a per-pocket allowlist that lives **outside**
+`rippleSpec` — a human authorizes which tools a pocket may run, so a
+compromised or hallucinated spec cannot grant itself a tool.
+
+A grant's `tool` is one of:
+
+- a connector action, `connector:<name>:<action>` (e.g.
+  `connector:github:list_issues`), or
+- a built-in tool name (e.g. `web_fetch`) — reserved; the built-in registry
+  dispatch is a v1.x follow-up, so a built-in grant currently returns
+  `code: unknown_tool`.
+
+**v1 read/write split.** A connector grant is dispatched through the shared
+connector executor (`connectors.service.execute`). A **read** action
+(`trust=auto`) fires immediately and returns its data. A **write** action
+(`trust=confirm`/`restricted`) **never** runs in v1 — it returns
+`code: blocked` with the message "write actions need approval — coming in v2
+(Instinct)". v2 routes writes through the Instinct approval gate (propose →
+human approves → execute-on-approve).
+
+### `PUT /pockets/{pocket_id}/backend/tool-policy`
+
+Set the pocket's tool allowlist. Requires pocket **owner** access.
+
+Request body:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `allowed_tools` | array | List of `{tool}` grants. Replaces the whole list. An empty list is valid — it revokes every tool (fail-closed). |
+
+Each grant: `tool` is a built-in tool name or a connector action
+`connector:<name>:<action>` (`min_length=1`). Omitting a tool means that
+tool can never fire.
+
+Response `200`: the backend summary, including the updated `allowed_tools`.
+
+Returns `400` when the pocket has no backend configured — a tool policy with
+no backend to apply it to is meaningless. The change is audit-logged
+(`pocket.backend.tool_policy`).
+
+### `POST /pockets/{pocket_id}/tools/run`
+
+Invoke a named tool with the resolved args. Access is **owner or explicit
+`shared_with` only** — a tool invocation has the same blast radius as a write
+binding, so a workspace-visible pocket does **not** grant run access.
+
+Request body:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `tool` | string | Required (`min_length=1`). The tool name — a built-in name or `connector:<name>:<action>`. |
+| `args` | object | Optional. The resolved tool arguments (Ripple's `{...}` resolver runs client-side at click time). |
+
+The allowlist is read server-side off the backend-credential row, never from
+the spec. A pocket with no backend, no grants, or a tool not on the list
+returns `code: not_allowed` — fail-closed.
+
+Response `200` (connector read fired):
+
+```json
+{
+  "ok": true,
+  "tool": "connector:github:list_issues",
+  "status": 200,
+  "response": [{ "number": 1, "title": "first issue" }],
+  "on_success": [],
+  "on_error": []
+}
+```
+
+Response `200` (write blocked in v1):
+
+```json
+{
+  "ok": false,
+  "tool": "connector:github:create_issue",
+  "status": 200,
+  "code": "blocked",
+  "error": "write actions need approval — coming in v2 (Instinct)",
+  "response": { "executed": false, "blocked": true }
+}
+```
+
+Other rejection codes (`ok: false`): `not_allowed` (tool not on the
+allowlist / no backend), `not_reachable` (connector not bound to this
+pocket), `unknown_tool` (the connector has no such action, or a built-in
+grant has no registry implementation yet), `bad_grant` (malformed
+`connector:` grant), plus any connector-side `CloudError` code. The result
+is delivered **in this response body** — there is no `pocket_mutation` SSE
+emit; the client applies the `on_success` / `on_error` reconcile handlers.
+
+Returns `403` when the caller is neither the owner nor in `shared_with`;
+`404` when the pocket is not in the caller's scope.
+
+**Security.** A connector grant re-checks the pocket/workspace bind
+(`is_connector_bound_to_pocket`, the tenant boundary) and the action's trust
+level before any call leaves PocketPaw; the connector path's outbound URL is
+bounded by the connector definition, not by a spec-supplied URL. A
+URL-taking built-in tool, when that path lands, must route through the same
+`_http_guard` SSRF boundary the read/write executors use.
 
 ## Pockets — Template Reconcile
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,8 +35,12 @@ Updated: 2026-06-15 (feat/invoke-tool-v1) — documented the now-live
 POST /pockets/{id}/tools/run (was a fail-closed stub) and the new
 owner-only PUT /pockets/{id}/backend/tool-policy. The backend summary now
 carries `allowed_tools` (the per-pocket tool allowlist) alongside
-`allowed_writes`. v1: connector READ tools fire; WRITE tools return
-`code: blocked` (approval lands in v2 via Instinct).
+`allowed_writes`.
+Updated: 2026-06-15 (feat/invoke-tool-v1, v2) — the WRITE path is now live.
+A connector READ tool still fires immediately; a WRITE tool is no longer
+refused with `code: blocked` — it is PROPOSED for human approval through the
+Instinct gate and returns `code: instinct_pending` with a `proposed_action_id`
+(the write fires only when a human approves it in The Tray).
 -->
 
 # Cloud REST API Reference
@@ -280,13 +284,18 @@ A grant's `tool` is one of:
   dispatch is a v1.x follow-up, so a built-in grant currently returns
   `code: unknown_tool`.
 
-**v1 read/write split.** A connector grant is dispatched through the shared
+**Read/write split.** A connector grant is dispatched through the shared
 connector executor (`connectors.service.execute`). A **read** action
 (`trust=auto`) fires immediately and returns its data. A **write** action
-(`trust=confirm`/`restricted`) **never** runs in v1 — it returns
-`code: blocked` with the message "write actions need approval — coming in v2
-(Instinct)". v2 routes writes through the Instinct approval gate (propose →
-human approves → execute-on-approve).
+(`trust=confirm`/`restricted`) **never** runs inline — it is **proposed for
+human approval** through the Instinct gate. The route files a pending Instinct
+Action (via `propose_external_action`) and returns `code: instinct_pending`
+with a `proposed_action_id`; the connector write fires only when a human
+approves the Action in The Tray, at which point the instinct router runs the
+existing execute-on-approve path (`execute_approved_external_action` →
+`connectors.service.execute`, re-validated for workspace + params + idempotency).
+The client's `on_success` handler branches on `code == "instinct_pending"` to
+show a "sent for approval" state and can watch the `proposed_action_id`.
 
 ### `PUT /pockets/{pocket_id}/backend/tool-policy`
 
@@ -338,24 +347,36 @@ Response `200` (connector read fired):
 }
 ```
 
-Response `200` (write blocked in v1):
+Response `202` (write proposed for approval):
 
 ```json
 {
-  "ok": false,
+  "ok": true,
   "tool": "connector:github:create_issue",
-  "status": 200,
-  "code": "blocked",
-  "error": "write actions need approval — coming in v2 (Instinct)",
-  "response": { "executed": false, "blocked": true }
+  "status": 202,
+  "code": "instinct_pending",
+  "proposed_action_id": "act-7f3c…",
+  "response": {
+    "action_id": "act-7f3c…",
+    "proposed_action_id": "act-7f3c…",
+    "status": "pending_approval",
+    "connector": "github",
+    "action": "create_issue"
+  }
 }
 ```
+
+The write does **not** run at this point. The pending Action appears in The
+Tray; on approve, the instinct router fires the connector write through the
+existing execute-on-approve path. On reject, the write never runs.
 
 Other rejection codes (`ok: false`): `not_allowed` (tool not on the
 allowlist / no backend), `not_reachable` (connector not bound to this
 pocket), `unknown_tool` (the connector has no such action, or a built-in
 grant has no registry implementation yet), `bad_grant` (malformed
-`connector:` grant), plus any connector-side `CloudError` code. The result
+`connector:` grant), `propose_failed` (the write could not be filed for
+approval — e.g. the Instinct store was unavailable; the write is **not** run
+inline as a fallback), plus any connector-side `CloudError` code. The result
 is delivered **in this response body** — there is no `pocket_mutation` SSE
 emit; the client applies the `on_success` / `on_error` reconcile handlers.
 

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -108,6 +108,7 @@ CONNECTOR_TOOL_IDS = (
     SENSE_EXECUTE_TOOL_ID,
 )
 
+
 def _error_response(message: str) -> dict[str, Any]:
     """Build an MCP error response in the shape the SDK expects."""
     return {

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -32,22 +32,53 @@
 #   pocket arm matches nothing for a null pocket). Execute uses
 #   ``scope="workspace"`` credentials when unanchored. Trust gate unchanged —
 #   writes still refuse pre-execute.
+# Updated: 2026-06-15 (feat/invoke-tool-v1, v2) — WRITE PATH unlocked via
+#   Instinct, making THIS chat-agent surface SYMMETRIC with the flow-button
+#   surface (``cloud.pockets.tool_executor._propose_connector_write``, same
+#   branch). ``connector_execute``'s Gate 3 no longer refuses a WRITE with the
+#   "coming in v2" stub. A WRITE action (``trust.is_read`` False — confirm /
+#   restricted) is now PROPOSED to a human through the existing external-action
+#   gate: it calls ``external_actions.propose.propose_external_action(...)``
+#   (which files a PENDING Instinct ``Action`` carrying the ``_external_action``
+#   blob: params_hash + idempotency_key, NO connector secret) and returns a
+#   pending-shaped success ``{ok:true, status:"pending_approval", action_id,
+#   message}`` so the agent relays "I've proposed that change — approve it in
+#   your Tray" to the user.
+#   THE load-bearing v2 security rule (identical to tool_executor): a WRITE
+#   STILL never calls ``connectors.service.execute`` INLINE — the human gates
+#   it. The connector write fires only later, when a human approves in The Tray
+#   and the instinct router runs ``execute_approved_external_action`` →
+#   ``connectors.service.execute`` (re-validated: workspace + params_hash +
+#   idempotency). This module adds NOTHING to that approve→execute path; it only
+#   proposes-and-suspends. READS are unchanged (auto-trust still fires execute()
+#   directly). ``list_connector_actions`` now reports write actions as
+#   "needs approval — proposes to your Tray" rather than "blocked".
+#   IMPORT-LINTER: ``propose_external_action`` is lazy-imported inside the WRITE
+#   branch (mirroring how the READ path already lazy-imports ``connectors.service``
+#   function-locally), so the module's import surface is unchanged and the cloud
+#   chokepoint contracts stay 0-broken. (``propose.py`` itself statically imports
+#   no Beanie document class — it lazy-imports ``pocketpaw.stores`` /
+#   ``pocketpaw.instinct.models`` internally.)
 """Agent-side MCP surface for executing a chat's reachable connectors.
 
 Tools registered:
 
   - ``list_connector_actions()`` — for the CURRENT chat, list each reachable
     connector and its READ actions (``trust=auto``) the agent may call, plus
-    its WRITE actions flagged "(needs approval — v2, blocked)". Reachable =
-    enabled pocket-scoped connectors of the chat's pocket (when anchored) plus
-    the workspace-scoped connectors of the tenant (always). No connectors → a
-    clear message rather than a silent empty list.
-  - ``connector_execute(connector_name, action, params)`` — run ONE read action.
-    Gates in order: (a) connector must be enabled for this chat's reach (bound
-    to THIS pocket, or workspace-scoped in THIS workspace); (b) the action's
-    trust level decides read vs write; (c) ``auto`` → call
+    its WRITE actions flagged "(needs approval — proposes to your Tray)".
+    Reachable = enabled pocket-scoped connectors of the chat's pocket (when
+    anchored) plus the workspace-scoped connectors of the tenant (always). No
+    connectors → a clear message rather than a silent empty list.
+  - ``connector_execute(connector_name, action, params)`` — run ONE read action
+    OR propose ONE write. Gates in order: (a) connector must be enabled for this
+    chat's reach (bound to THIS pocket, or workspace-scoped in THIS workspace);
+    (b) the action's trust level decides read vs write; (c) ``auto`` → call
     ``connectors.service.execute`` and return the result; (d) ``confirm`` /
-    ``restricted`` → refuse with the v2 message, never executing the write.
+    ``restricted`` (write) → PROPOSE the call through the Instinct external-
+    action gate (``propose_external_action``) and return a pending result with
+    an ``action_id`` — the write is NEVER executed inline; it fires only when a
+    human approves it in The Tray. This makes the chat-agent surface symmetric
+    with the flow-button surface (``cloud.pockets.tool_executor``).
 
 Identity comes from ``agent_service.current_workspace_id`` /
 ``current_user_id`` / ``current_pocket_id``. Outside an SSE chat stream those
@@ -76,13 +107,6 @@ CONNECTOR_TOOL_IDS = (
     LIST_SENSES_TOOL_ID,
     SENSE_EXECUTE_TOOL_ID,
 )
-
-# The agent-facing refusal for any write/confirm-trust action in v1. Kept as a
-# constant so the test asserts the exact contract and the skills quote it.
-_V2_BLOCK_MESSAGE = (
-    "This action modifies {connector} and needs approval (coming in v2). Not executed."
-)
-
 
 def _error_response(message: str) -> dict[str, Any]:
     """Build an MCP error response in the shape the SDK expects."""
@@ -170,7 +194,7 @@ async def _list_connector_actions_handler(args: dict) -> dict:  # noqa: ARG001 �
             {
                 "action": a.name,
                 "description": a.description,
-                "status": "needs approval — v2, blocked",
+                "status": "needs approval — proposes to your Tray",
             }
             for a in c.actions
             if not a.is_read
@@ -181,7 +205,7 @@ async def _list_connector_actions_handler(args: dict) -> dict:  # noqa: ARG001 �
                 "display_name": c.display_name,
                 "type": c.type,
                 "read_actions": read_actions,
-                "write_actions_blocked": write_actions,
+                "write_actions_need_approval": write_actions,
             }
         )
 
@@ -191,7 +215,10 @@ async def _list_connector_actions_handler(args: dict) -> dict:  # noqa: ARG001 �
             "connectors": out,
             "note": (
                 "Call connector_execute(connector_name, action, params) to run a "
-                "READ action. Write actions are blocked in v1 (need approval)."
+                "READ action (fires immediately) OR to propose a WRITE action. A "
+                "write isn't executed inline — it's sent to the user's Tray for "
+                "approval and runs only once they approve. Tell the user you've "
+                "proposed it and ask them to approve it in their Tray."
             ),
         }
     )
@@ -244,18 +271,26 @@ async def _connector_execute_handler(args: dict) -> dict:
             "Call list_connector_actions for the available actions."
         )
 
-    # Gate 3 — WRITE (confirm/restricted) actions are blocked in v1. Refuse
-    # BEFORE any execute call so a write can never run.
+    # Gate 3 — WRITE (confirm/restricted) actions PROPOSE through Instinct (v2).
+    # THE load-bearing security rule: a WRITE action NEVER calls execute()
+    # INLINE. We route it through the external-action gate (`propose_external_
+    # action`), which files a PENDING Instinct Action carrying the
+    # `_external_action` blob (params_hash + idempotency_key, no connector
+    # secret) and opens the Decision-Graph chain. The connector write fires only
+    # when a human approves in The Tray — the instinct router then runs
+    # `execute_approved_external_action` → `connectors.service.execute` (re-
+    # validated: workspace + params_hash + idempotency). We add NOTHING to that
+    # approve→execute path here; we propose-and-suspend, then STOP. This mirrors
+    # `cloud.pockets.tool_executor._propose_connector_write` EXACTLY so both the
+    # chat-agent surface and the flow-button surface gate writes the same way.
     if not trust.is_read:
-        return _success_response(
-            {
-                "executed": False,
-                "blocked": True,
-                "connector": connector_name,
-                "action": action,
-                "trust_level": trust.trust_level,
-                "reason": _V2_BLOCK_MESSAGE.format(connector=connector_name),
-            }
+        return await _propose_connector_write(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            connector_name=connector_name,
+            action=action,
+            params=params,
         )
 
     # Gate 4 — READ (auto-trust): run via the existing cloud execute path. It
@@ -289,6 +324,85 @@ async def _connector_execute_handler(args: dict) -> dict:
             "error": result.error,
             "records_affected": result.records_affected,
             "execution_mode": result.execution_mode,
+        }
+    )
+
+
+async def _propose_connector_write(
+    *,
+    workspace_id: str,
+    user_id: str | None,
+    pocket_id: str | None,
+    connector_name: str,
+    action: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Gate 3 WRITE path (v2) — propose the connector write to a human, suspend.
+
+    Files a PENDING Instinct ``Action`` via ``propose_external_action`` (the
+    external-action gate, schema 1) and returns a pending-shaped success
+    envelope so the chat agent relays "I've proposed that change — approve it in
+    your Tray" to the user. THE load-bearing security rule: this NEVER calls
+    ``connectors.service.execute``. The connector write fires only when a human
+    approves in The Tray — the instinct router then runs
+    ``execute_approved_external_action`` → ``connectors.service.execute`` (re-
+    validated). We propose-and-suspend, STOP. Mirrors
+    ``cloud.pockets.tool_executor._propose_connector_write`` so the chat-agent
+    surface and the flow-button surface gate writes identically.
+
+    Identity (``workspace_id`` / ``user_id`` / ``pocket_id``) is resolved by the
+    caller from the same per-stream ContextVars the READ path reads. ``scope``
+    follows the pocket: a pocket-anchored chat proposes a ``pocket``-scoped
+    call; an unanchored chat proposes a ``workspace``-scoped one — matching the
+    credentials the eventual approved execute resolves.
+    """
+    # Lazy import — keeps the module's import surface identical to today (the
+    # READ path already lazy-imports ``connectors.service`` function-locally).
+    # ``propose_external_action`` statically imports no Beanie document class, so
+    # the cloud chokepoint contracts stay 0-broken.
+    from pocketpaw_ee.cloud.external_actions.propose import propose_external_action
+
+    scope = "pocket" if pocket_id else "workspace"
+    try:
+        action_id = await propose_external_action(
+            workspace_id=workspace_id,
+            connector_name=connector_name,
+            action=action,
+            params=params,
+            requested_by=user_id or "",
+            scope=scope,
+            pocket_id=pocket_id or None,
+            summary=f"{connector_name}.{action} from chat (pocket {pocket_id or '—'})",
+        )
+    except Exception as exc:  # noqa: BLE001 — surface a clean MCP error, never a 500.
+        logger.warning("connector_execute propose failed", exc_info=True)
+        return _error_response(
+            f"could not send '{action}' on {connector_name!r} for approval: {exc}"
+        )
+
+    logger.info(
+        "connector_execute proposed write: connector=%r action=%r pocket=%r action_id=%s",
+        connector_name,
+        action,
+        pocket_id,
+        action_id,
+    )
+    # Pending-shaped success: the human gates the write. ``status`` is the
+    # string ``"pending_approval"`` (not an HTTP code) so the agent reads it as
+    # "awaiting approval"; ``action_id`` lets the user (and the agent) correlate
+    # the proposal with the pending Action it watches in The Tray. The
+    # ``message`` is phrased for the agent to relay verbatim.
+    return _success_response(
+        {
+            "executed": False,
+            "status": "pending_approval",
+            "action_id": action_id,
+            "connector": connector_name,
+            "action": action,
+            "message": (
+                f"Proposed '{action}' on {connector_name} — it's waiting for your "
+                "approval in the Tray. Approve it there to run it."
+            ),
         }
     )
 
@@ -448,13 +562,15 @@ def build_connectors_context_server() -> tuple[str, Any] | None:
         (
             "List the connectors bound to the CURRENT pocket/room and the "
             "actions you can run on each. Call this FIRST whenever the user "
-            "wants to read from an integration (GitHub issues/PRs, Gmail "
-            "search, etc.) so you know which connector + action to use. "
-            "Returns each connector's READ actions (which you may run directly "
-            "via connector_execute) and its WRITE actions, which are listed but "
-            "BLOCKED in v1 (they need approval). No arguments — the pocket is "
-            "inferred from the active chat. If the chat isn't in a pocket, or "
-            "the pocket has no bound connectors, the result says so."
+            "wants to read from OR change something in an integration (GitHub "
+            "issues/PRs, Gmail search/send, etc.) so you know which connector + "
+            "action to use. Returns each connector's READ actions (which you may "
+            "run directly via connector_execute) and its WRITE actions, which "
+            "you may PROPOSE via connector_execute — a write isn't executed "
+            "inline, it's sent to the user's Tray for approval and runs only "
+            "once they approve. No arguments — the pocket is inferred from the "
+            "active chat. If the chat isn't in a pocket, or the pocket has no "
+            "bound connectors, the result says so."
         ),
         {},
     )
@@ -464,17 +580,22 @@ def build_connectors_context_server() -> tuple[str, Any] | None:
     @tool(
         "connector_execute",
         (
-            "Execute ONE connector action for the current pocket. Use this to "
-            "READ from a bound integration — e.g. list a GitHub repo's issues "
-            "or PRs, search Gmail. Args: `connector_name` (e.g. 'github', "
-            "'gmail'), `action` (an action name from list_connector_actions, "
-            "e.g. 'list_issues', 'gmail_search'), and `params` (an object of "
-            "that action's parameters). Only READ (auto-trust) actions run; "
-            "WRITE actions (create/send/modify/delete) are refused with a "
-            "'needs approval — coming in v2' message and are NEVER executed. "
-            "The connector must be bound to THIS pocket and have a token in its "
-            "config; otherwise you get a clear error. Always call "
-            "list_connector_actions first to pick a valid connector + action."
+            "Run ONE connector action for the current pocket. Use this to READ "
+            "from a bound integration (e.g. list a GitHub repo's issues or PRs, "
+            "search Gmail) OR to make a CHANGE (create an issue, send an email, "
+            "update a record). Args: `connector_name` (e.g. 'github', 'gmail'), "
+            "`action` (an action name from list_connector_actions, e.g. "
+            "'list_issues', 'create_issue', 'gmail_send'), and `params` (an "
+            "object of that action's parameters). READ (auto-trust) actions run "
+            "immediately and return their data. WRITE actions (create/send/"
+            "modify/delete) are NOT executed inline — they are PROPOSED to the "
+            "user for approval: the tool returns status 'pending_approval' with "
+            "an action_id, and the change runs only once the user approves it in "
+            "their Tray. When you get a pending result, tell the user you've "
+            "proposed the change and ask them to approve it in their Tray — do "
+            "NOT claim it's done. The connector must be bound to THIS pocket and "
+            "have a token in its config; otherwise you get a clear error. Always "
+            "call list_connector_actions first to pick a valid connector + action."
         ),
         {
             "type": "object",
@@ -487,7 +608,8 @@ def build_connectors_context_server() -> tuple[str, Any] | None:
                     "type": "string",
                     "description": (
                         "Action name from list_connector_actions, e.g. "
-                        "'list_issues' or 'gmail_search'. Read actions only."
+                        "'list_issues' (read) or 'create_issue' (write — proposed "
+                        "for approval)."
                     ),
                 },
                 "params": {

--- a/ee/pocketpaw_ee/cloud/models/pocket_backend.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket_backend.py
@@ -34,6 +34,15 @@
 #   `"connector"`, `connector_name` names a workspace-bound connector and the
 #   `base_url`/`auth_*` fields are unused — source execution routes each source
 #   through `connectors_service.execute(...)` instead of an HTTP GET.
+# Updated: 2026-06-15 (feat/invoke-tool-v1) — added the per-pocket TOOL
+#   ALLOWLIST. `ToolGrant` is one allowed tool name; `allowed_tools` is the
+#   list a click-driven `invoke_tool` must match before the tool executor
+#   dispatches. Parallel to `allowed_writes`: it lives HERE — outside the
+#   spec, in the same human-configured store as the auth credential — so a
+#   compromised or hallucinated spec cannot grant itself a tool. The default
+#   is an EMPTY list: fail-closed, no tool can fire until a human allow-lists
+#   it via `PUT /pockets/{id}/backend/tool-policy`. A grant's `tool` is either
+#   a built-in tool name or a connector action `connector:<name>:<action>`.
 
 from __future__ import annotations
 
@@ -57,6 +66,28 @@ class AllowedWrite(BaseModel):
 
     method: Literal["POST", "PUT", "PATCH", "DELETE"]
     path_pattern: str
+
+
+class ToolGrant(BaseModel):
+    """One tool-allowlist entry (feat/invoke-tool-v1). Two forms:
+
+    * a built-in / registry tool name, e.g. ``"web_fetch"``
+    * a connector action, ``"connector:<name>:<action>"``, e.g.
+      ``"connector:github:list_issues"``
+
+    The tool executor matches an invoked tool name EXACTLY against the
+    ``tool`` field of every grant. No grant for a name → that name can
+    never fire (fail-closed). A connector grant additionally tells the
+    executor to route through ``connectors.service.execute`` and which
+    ``(connector, action)`` to call.
+
+    A ``connector:`` grant resolves the connector by name (via the bind
+    check) independent of the pocket's ``backend_type`` — the grant names
+    the connector explicitly, so a pocket with an http ``base_url`` backend
+    can still hold connector grants.
+    """
+
+    tool: str = Field(min_length=1)
 
 
 class ApprovalRoute(BaseModel):
@@ -87,8 +118,8 @@ class PocketBackendCredential(TimestampedDocument):
 
     Every read path returns only the non-secret summary (``backend_type`` /
     ``connector_name`` / ``base_url`` / ``auth_type`` / ``configured`` /
-    ``allowed_writes`` / ``approval_route``) — the secret never leaves this
-    collection.
+    ``allowed_writes`` / ``allowed_tools`` / ``approval_route``) — the secret
+    never leaves this collection.
     """
 
     pocket_id: Indexed(str)  # type: ignore[valid-type]
@@ -116,6 +147,12 @@ class PocketBackendCredential(TimestampedDocument):
     # with no policy can fire no write actions. A human widens it via
     # `PUT /pockets/{id}/backend/write-policy`.
     allowed_writes: list[AllowedWrite] = Field(default_factory=list)
+    # feat/invoke-tool-v1 tool allowlist. EMPTY by default — fail-closed: a
+    # pocket with no policy can fire no `invoke_tool` calls. A human widens it
+    # via `PUT /pockets/{id}/backend/tool-policy`. Legacy rows read as `[]`
+    # via this field default, so the fail-closed posture holds with no
+    # migration.
+    allowed_tools: list[ToolGrant] = Field(default_factory=list)
     # RFC 05 M2b.1 approval route. None means the default — `requires_instinct`
     # writes route to the pocket owner. An owner sets a named approver via
     # `PUT /pockets/{id}/backend/approval-route`.

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -605,6 +605,16 @@ class RunToolResponse(BaseModel):
     client runs after — the same shape ``call_binding`` returns, so the
     home grid's ``onEvent`` plumbing handles both with one branch.
 
+    ``proposed_action_id`` carries the pending Instinct Action id when a
+    WRITE grant is invoked (feat/invoke-tool-v1 v2): the WRITE is proposed
+    for human approval rather than fired inline, so ``ok`` is true,
+    ``code`` is ``"instinct_pending"``, and this id lets the client
+    correlate the click with the pending Action it can watch in The Tray.
+    It mirrors :class:`RunActionResponse.proposed_action_id` so a single
+    client branch services gated tool-writes and gated ``call_binding``
+    writes. ``None`` for reads / blocked / not-allowed responses. The id
+    is ALSO echoed inside ``response`` for callers that read it there.
+
     ``extra="forbid"`` matches :class:`RunActionResponse`: any
     executor-internal key the route fails to strip raises on
     construction instead of leaking onto the wire.
@@ -618,6 +628,7 @@ class RunToolResponse(BaseModel):
     response: Any = None
     error: str | None = None
     code: str | None = None
+    proposed_action_id: str | None = None
     on_success: list[dict] = Field(default_factory=list)
     on_error: list[dict] = Field(default_factory=list)
 

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -115,6 +115,15 @@ Client-sent ``path`` (a row-scoped binding whose stored path holds an unresolved
 ``{item.id}`` template, resolved client-side) still wins — the binding path is
 only the fallback. The server still reads the verb from the binding, so a
 compromised client cannot pick method OR a path the allowlist would reject.
+Updated: 2026-06-15 (feat/invoke-tool-v1) — added ``ToolGrantDTO`` and
+``SetToolPolicyRequest`` for the new owner-only ``PUT
+/pockets/{id}/backend/tool-policy`` endpoint (the tool-allowlist analog of
+the write-policy route), and an ``allowed_tools`` field on
+``PocketBackendConfigResponse``. A grant's ``tool`` is a built-in tool name
+or a connector action ``connector:<name>:<action>``. Empty list = fail-closed
+(no ``invoke_tool`` fires until a human allow-lists one). ``RunToolResponse``
+is unchanged — it already carries ``{ok, tool, status, response, error, code,
+on_success, on_error}``.
 """
 
 from __future__ import annotations
@@ -346,6 +355,17 @@ class AllowedWriteDTO(BaseModel):
     path_pattern: str = Field(min_length=1)
 
 
+class ToolGrantDTO(BaseModel):
+    """One tool-allowlist entry on the wire (feat/invoke-tool-v1).
+
+    Mirrors ``models.pocket_backend.ToolGrant``. ``tool`` is either a
+    built-in tool name (``"web_fetch"``) or a connector action
+    (``"connector:<name>:<action>"``, e.g. ``"connector:github:list_issues"``).
+    """
+
+    tool: str = Field(min_length=1)
+
+
 class PocketBackendConfigRequest(BaseModel):
     """Body for ``PUT /pockets/{id}/backend`` — bind a pocket to one backend.
 
@@ -409,6 +429,10 @@ class PocketBackendConfigResponse(BaseModel):
     an owner/editor-facing non-secret. Empty by default (fail-closed: no
     write fires until a human allow-lists it).
 
+    ``allowed_tools`` is the per-pocket tool allowlist (feat/invoke-tool-v1)
+    — the same fail-closed posture: empty by default, no ``invoke_tool``
+    fires until a human allow-lists it.
+
     ``approval_route`` is the per-pocket approver routing for
     ``requires_instinct`` writes (RFC 05 M2b.1). ``None`` means the
     default — the pocket owner approves.
@@ -420,6 +444,7 @@ class PocketBackendConfigResponse(BaseModel):
     auth_type: str
     configured: bool
     allowed_writes: list[AllowedWriteDTO] = Field(default_factory=list)
+    allowed_tools: list[ToolGrantDTO] = Field(default_factory=list)
     approval_route: ApprovalRouteDTO | None = None
 
 
@@ -525,6 +550,17 @@ class SetWritePolicyRequest(BaseModel):
     """
 
     allowed_writes: list[AllowedWriteDTO] = Field(default_factory=list)
+
+
+class SetToolPolicyRequest(BaseModel):
+    """Body for ``PUT /pockets/{id}/backend/tool-policy`` (feat/invoke-tool-v1).
+
+    Replaces the pocket's whole tool allowlist. An empty list is valid
+    and meaningful — it revokes every tool (fail-closed), exactly like the
+    write-policy precedent.
+    """
+
+    allowed_tools: list[ToolGrantDTO] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -1,5 +1,13 @@
 """Pockets domain — FastAPI router.
 
+Updated: 2026-06-15 (feat/invoke-tool-v1) — UNLOCKED ``POST /{id}/tools/run``.
+Added the owner-only ``PUT /{id}/backend/tool-policy`` route (the tool-allowlist
+analog of write-policy) and rewired ``run_pocket_tool`` to read the per-pocket
+``allowed_tools`` off the credential row (via
+``pockets_service.get_pocket_backend_for_executor``, 9th tuple element) and pass
+the tool NAMES to ``tool_executor.run_tool`` by parameter — never from the spec.
+A pocket with no backend / no grants reads as an empty allowlist (fail-closed).
+
 Updated: 2026-06-13 (feat/pocket-template-reconcile, P2.4) — added the
 Template Reconcile REST adapter: ``POST /{id}/reconcile/preview`` (dry-run
 diff) and ``POST /{id}/reconcile/apply`` (re-apply template-owned regions,
@@ -199,6 +207,7 @@ from pocketpaw_ee.cloud.pockets.dto import (
     RunToolRequest,
     RunToolResponse,
     SetApprovalRouteRequest,
+    SetToolPolicyRequest,
     SetWritePolicyRequest,
     ShareLinkRequest,
     UpdatePocketRequest,
@@ -939,6 +948,36 @@ async def set_pocket_write_policy(
 
 
 @router.put(
+    "/{pocket_id}/backend/tool-policy",
+    dependencies=[Depends(require_pocket_owner)],
+)
+async def set_pocket_tool_policy(
+    pocket_id: str,
+    body: SetToolPolicyRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> PocketBackendConfigResponse:
+    """Set this pocket's tool allowlist (feat/invoke-tool-v1). Owner-only.
+
+    Replaces the whole ``allowed_tools`` list — an empty list revokes every
+    tool (fail-closed). The policy lives on the backend-credential row,
+    OUTSIDE the spec, so the agent that authors the spec cannot grant itself
+    a tool (the same blast-radius invariant ``allowed_writes`` enforces). A
+    grant's ``tool`` is a built-in tool name or a connector action
+    ``connector:<name>:<action>``. Returns ``400`` when the pocket has no
+    backend configured — a tool policy with no backend to apply to is
+    meaningless.
+    """
+    result = await pockets_service.set_pocket_tool_policy(
+        workspace_id,
+        user_id,
+        pocket_id,
+        [grant.model_dump() for grant in body.allowed_tools],
+    )
+    return PocketBackendConfigResponse(**result)
+
+
+@router.put(
     "/{pocket_id}/backend/approval-route",
     dependencies=[Depends(require_pocket_owner)],
 )
@@ -1259,7 +1298,7 @@ async def dispatch_bulk_action_route(
 
 
 # ---------------------------------------------------------------------------
-# Pocket tool invocation (#1206 part a — invoke_tool wire)
+# Pocket tool invocation (#1206 — invoke_tool; UNLOCKED in feat/invoke-tool-v1)
 # ---------------------------------------------------------------------------
 
 
@@ -1285,12 +1324,15 @@ async def run_pocket_tool(
     has the same blast radius as a write binding, so a workspace-visible
     pocket does NOT grant run access.
 
-    Part (a) is intentionally fail-closed: the per-pocket allowlist is
-    empty (see :func:`tool_executor.get_pocket_allowed_tools`), so every
-    tool name returns ``ok:false, code:"not_allowed"``. The wire shape +
-    DTOs land here so part (b) (the home-grid ``onEvent`` wiring) has
-    somewhere to POST to. Part (c) adds Composio / WebFetch routing
-    through the real tool registry behind the allowlist.
+    The per-pocket tool allowlist (feat/invoke-tool-v1) lives on the
+    backend-credential row, OUTSIDE the spec — read here via
+    ``get_pocket_backend_for_executor`` and passed to the executor BY
+    PARAMETER, never sourced from ``rippleSpec``. A pocket with no backend
+    (or no grants) reads as an EMPTY allowlist → every tool returns
+    ``ok:false, code:"not_allowed"`` (fail-closed). A ``connector:<name>:
+    <action>`` grant for a READ action fires through
+    ``connectors.service.execute``; a WRITE action returns ``code="blocked"``
+    (approval lands in v2 via Instinct).
 
     The result is delivered in THIS response body — there is no
     ``pocket_mutation`` SSE emit, because the run endpoint is a
@@ -1304,7 +1346,15 @@ async def run_pocket_tool(
 
     from pocketpaw_ee.cloud.pockets import tool_executor
 
-    allowed_tools = await tool_executor.get_pocket_allowed_tools(workspace_id, pocket_id)
+    # Read the allowlist off the per-pocket backend credential row. The 9th
+    # tuple element is `allowed_tools` (a list of `{tool}` wire dicts). A
+    # pocket with no backend configured → `None` → empty allowlist, so the
+    # fail-closed `not_allowed` path holds with no special-casing. The
+    # executor stays Beanie-free — it only ever sees the flat list of names.
+    creds = await pockets_service.get_pocket_backend_for_executor(workspace_id, pocket_id)
+    allowed_tools: list[str] = []
+    if creds is not None:
+        allowed_tools = [grant["tool"] for grant in creds[8]]
 
     # no-event: the tool result is response-body delivery, not persisted.
     result = await tool_executor.run_tool(

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -184,6 +184,15 @@ rippleSpec). Fixes the agent-view misread where ``get_pocket`` returned the
 empty legacy ``widgets: []`` alongside the full rippleSpec and agents
 concluded a fully composed template pocket was "an empty shell". The
 ``widgets`` field itself is NOT removed — other consumers may rely on it.
+Changes: 2026-06-15 (feat/invoke-tool-v1) — added the per-pocket TOOL
+allowlist half (the tool analog of the RFC 05 M2a write allowlist):
+``set_pocket_tool_policy`` (owner-only setter, audit-logged, rejects when no
+backend is configured); ``_allowed_tools_wire`` renders the grants for the
+wire; ``_backend_summary_wire`` / ``get_pocket_backend`` /
+``get_pocket_backend_for_executor`` now carry ``allowed_tools`` so the
+run-tool route can read the allowlist off the credential row.
+``get_pocket_backend_for_executor`` APPENDS ``allowed_tools`` as the 9th tuple
+element (back-compatible — every existing positional destructure uses ``*_``).
 """
 
 from __future__ import annotations
@@ -213,6 +222,7 @@ from pocketpaw_ee.cloud.models.pocket_backend import ApprovalRoute as _ApprovalR
 from pocketpaw_ee.cloud.models.pocket_backend import (
     PocketBackendCredential as _BackendCredentialDoc,
 )
+from pocketpaw_ee.cloud.models.pocket_backend import ToolGrant as _ToolGrantDoc
 from pocketpaw_ee.cloud.pockets import (
     actions_ops,
     backend_crypto,
@@ -3817,6 +3827,17 @@ def _allowed_writes_wire(doc: _BackendCredentialDoc) -> list[dict[str, str]]:
     return out
 
 
+def _allowed_tools_wire(doc: _BackendCredentialDoc) -> list[dict[str, str]]:
+    """Render a backend doc's ``allowed_tools`` as plain wire dicts.
+
+    Each grant is ``{tool}``. A row written before feat/invoke-tool-v1 has no
+    ``allowed_tools`` attribute — ``getattr`` defaults it to an empty list
+    (fail-closed: no ``invoke_tool`` fires). Parallel to ``_allowed_writes_wire``.
+    """
+    grants = getattr(doc, "allowed_tools", None) or []
+    return [{"tool": g.tool} for g in grants]
+
+
 def _approval_route_wire(doc: _BackendCredentialDoc) -> dict[str, str | None] | None:
     """Render a backend doc's ``approval_route`` as a plain wire dict.
 
@@ -3835,9 +3856,10 @@ def _backend_summary_wire(doc: _BackendCredentialDoc) -> dict:
     """Render the full NON-SECRET backend summary for a credential row.
 
     The ONE place the wire summary is shaped so ``get_pocket_backend`` and the
-    write-policy / approval-route setters never drift. NEVER includes the
-    token. ``backend_type`` / ``connector_name`` come via ``getattr`` defaults
-    so a legacy row reads as an http backend — back-compatible.
+    write-policy / tool-policy / approval-route setters never drift. NEVER
+    includes the token. ``backend_type`` / ``connector_name`` / ``allowed_tools``
+    come via ``getattr`` defaults so a legacy row reads as an http backend with
+    no tool grants — back-compatible.
     """
     return {
         "backend_type": getattr(doc, "backend_type", "http"),
@@ -3846,6 +3868,7 @@ def _backend_summary_wire(doc: _BackendCredentialDoc) -> dict:
         "auth_type": doc.auth_type,
         "configured": True,
         "allowed_writes": _allowed_writes_wire(doc),
+        "allowed_tools": _allowed_tools_wire(doc),
         "approval_route": _approval_route_wire(doc),
     }
 
@@ -3855,8 +3878,9 @@ async def get_pocket_backend(workspace_id: str, pocket_id: str) -> dict | None:
 
     NEVER returns the token — only ``backend_type`` / ``connector_name`` /
     ``base_url`` / ``auth_type`` / ``configured`` / ``allowed_writes`` (the
-    write allowlist) / ``approval_route`` (the gated-write approver routing;
-    ``None`` when unset). All owner/editor-facing non-secrets.
+    write allowlist) / ``allowed_tools`` (the tool allowlist) /
+    ``approval_route`` (the gated-write approver routing; ``None`` when unset).
+    All owner/editor-facing non-secrets.
 
     ``backend_type`` / ``connector_name`` come via ``getattr`` defaults so a
     row written before this feature reads as ``backend_type="http"`` /
@@ -3883,23 +3907,29 @@ async def get_pocket_backend_for_executor(
         dict[str, str | None] | None,
         str,
         str | None,
+        list[dict[str, str]],
     ]
     | None
 ):
     """Internal — return ``(base_url, auth_type, auth_header, token,
-    allowed_writes, approval_route, backend_type, connector_name)``.
+    allowed_writes, approval_route, backend_type, connector_name,
+    allowed_tools)``.
 
     Decrypts the stored token (http backends only; a connector backend has no
-    token). Used by the run-sources route handler (which now also reads the
-    trailing ``backend_type`` / ``connector_name`` to route the run), the
-    run-action route handler (it needs ``allowed_writes`` / ``approval_route``),
-    and ``instinct_bridge`` / ``temporal_dispatcher`` / ``bulk_dispatch`` (which
-    ignore the trailing elements). Returns ``None`` when the pocket has no
-    backend configured. The plaintext token must never be logged or returned to
-    a client.
+    token). Used by the run-sources route handler (which reads
+    ``backend_type`` / ``connector_name`` to route the run), the run-action
+    route handler (it needs ``allowed_writes`` / ``approval_route``), the
+    run-tool route handler (it needs ``allowed_tools`` / ``backend_type`` /
+    ``connector_name``), and ``instinct_bridge`` / ``temporal_dispatcher`` /
+    ``bulk_dispatch`` (which ignore the trailing elements via ``*_``). Returns
+    ``None`` when the pocket has no backend configured. The plaintext token
+    must never be logged or returned to a client.
 
-    ``backend_type`` / ``connector_name`` come via ``getattr`` defaults so a
-    legacy row reads as ``"http"`` / ``None`` — back-compatible.
+    ``allowed_tools`` is appended LAST (the 9th element, feat/invoke-tool-v1)
+    so every existing positional destructure that uses ``*_`` / fixed slices
+    is byte-identical — appending a trailing element is back-compatible.
+    ``backend_type`` / ``connector_name`` / ``allowed_tools`` come via
+    ``getattr`` defaults so a legacy row reads as ``"http"`` / ``None`` / ``[]``.
     """
     doc = await _BackendCredentialDoc.find_one(
         _BackendCredentialDoc.pocket_id == pocket_id,
@@ -3920,6 +3950,7 @@ async def get_pocket_backend_for_executor(
         _approval_route_wire(doc),
         getattr(doc, "backend_type", "http"),
         getattr(doc, "connector_name", None),
+        _allowed_tools_wire(doc),
     )
 
 
@@ -3967,6 +3998,56 @@ async def set_pocket_write_policy(
         auth_type=doc.auth_type,
     )
     # no-event: backend credentials (and the write policy on them) are a
+    # separate collection, not pocket state — no downstream handler keys
+    # off a PocketUpdated for them.
+    return _backend_summary_wire(doc)
+
+
+async def set_pocket_tool_policy(
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    allowed_tools: list[dict[str, str]],
+) -> dict:
+    """Replace the pocket's tool allowlist (feat/invoke-tool-v1). Owner-only.
+
+    ``allowed_tools`` is a list of ``{tool}`` grants — each ``tool`` is a
+    built-in tool name or a connector action ``connector:<name>:<action>``.
+    The list lives on the backend-credential row — OUTSIDE the spec — so the
+    agent (which authors the spec) cannot grant itself a tool. An empty list
+    is valid and revokes every tool (fail-closed). Mirrors
+    ``set_pocket_write_policy`` exactly.
+
+    Rejects with ``pocket_backend.not_configured`` if the pocket has no
+    backend configured: a tool policy with no backend to apply it to is
+    meaningless, and silently storing one would mask the misconfiguration.
+    The mutation is audit-logged via the ``_audit_backend_config`` path.
+    """
+    doc = await _BackendCredentialDoc.find_one(
+        _BackendCredentialDoc.pocket_id == pocket_id,
+        _BackendCredentialDoc.workspace_id == workspace_id,
+    )
+    if doc is None:
+        raise ValidationError(
+            "pocket_backend.not_configured",
+            "This pocket has no backend configured — set one before a tool policy",
+        )
+
+    # `model_validate` re-checks each grant at runtime — the router already
+    # validated through `ToolGrantDTO`, but internal callers (bus handlers,
+    # jobs) re-parse here, matching the entry-point validation rule.
+    doc.allowed_tools = [_ToolGrantDoc.model_validate(grant) for grant in allowed_tools]
+    await doc.save()
+
+    _audit_backend_config(
+        actor=user_id,
+        action="pocket.backend.tool_policy",
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        base_url=doc.base_url,
+        auth_type=doc.auth_type,
+    )
+    # no-event: backend credentials (and the tool policy on them) are a
     # separate collection, not pocket state — no downstream handler keys
     # off a PocketUpdated for them.
     return _backend_summary_wire(doc)

--- a/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
@@ -37,6 +37,18 @@
 #   `pocketpaw.instinct.models` internally), so importing it here keeps the
 #   "Pockets — Beanie writes only from service.py" contract 0-broken — verified
 #   with `lint-imports --config ee/pyproject.toml`.
+# Updated: 2026-06-19 (repair/invoke-tool-v1) — close #1472 review HIGH. Every
+#   tool invocation now leaves an APPEND-ONLY forensic trail, not just a
+#   `logger.info` line (which is rotated/sampled and not the security audit
+#   sink the moat pitches). `run_tool` is now a thin wrapper: it calls the
+#   renamed `_run_tool_dispatch` (the unchanged gate logic) and then emits ONE
+#   `AuditEvent` per call covering EVERY outcome — denial, READ, WRITE-proposal,
+#   error — via `_audit_tool_run`. The audit helper mirrors
+#   `action_executor._audit_action_run` (action "pocket.tools.run", category
+#   "pocket_backend_config", wrapped in try/except so audit NEVER breaks the
+#   run). PII (`args`) and connector tokens are NEVER logged — only the tool
+#   name + outcome code. No gate / security logic changed; this is purely
+#   additive observability.
 
 from __future__ import annotations
 
@@ -47,6 +59,97 @@ logger = logging.getLogger(__name__)
 
 
 async def run_tool(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    tool: str,
+    args: dict[str, Any],
+    allowed_tools: list[str],
+) -> dict[str, Any]:
+    """Run a named tool and emit ONE append-only audit event for the outcome.
+
+    Thin wrapper over :func:`_run_tool_dispatch` (the gate logic, unchanged):
+    dispatch produces the wire dict, then :func:`_audit_tool_run` writes a
+    single ``pocket.tools.run`` :class:`~pocketpaw.security.audit.AuditEvent`
+    covering whatever happened — denial, READ, WRITE-proposal, or error. The
+    audit emit is wrapped (in the helper) so it NEVER breaks the run; the
+    result returned to the caller is exactly what dispatch produced.
+
+    See :func:`_run_tool_dispatch` for the gate order. ``args`` (which may carry
+    PII) and any connector token are NEVER logged — only the tool name + the
+    outcome code reach the audit sink (#1472 review HIGH).
+    """
+    result = await _run_tool_dispatch(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        user_id=user_id,
+        tool=tool,
+        args=args,
+        allowed_tools=allowed_tools,
+    )
+    _audit_tool_run(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        user_id=user_id,
+        tool=tool,
+        result=result,
+    )
+    return result
+
+
+def _audit_tool_run(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    tool: str,
+    result: dict[str, Any],
+) -> None:
+    """Write ONE append-only audit-log entry for a ``run_tool`` invocation.
+
+    Mirrors ``action_executor._audit_action_run`` — category
+    ``pocket_backend_config``, action ``pocket.tools.run``, ``target`` the
+    pocket, ``actor`` the clicking user, ``workspace_id`` logged so entries are
+    tenant-filterable. Severity by outcome: a successful READ (``ok`` True and
+    NOT a pending write-proposal) is normal operation → ``INFO``; everything
+    else — a denial, an Instinct write-proposal (still pending a human), or any
+    error code — is noteworthy → ``WARNING``. ``status`` is the outcome code
+    (``result["code"]`` or ``"ok"``). ``args`` (PII) and the connector token are
+    NEVER logged — only ``tool`` and the outcome ``code``. Audit failures must
+    not break the run, so the whole body is wrapped.
+    """
+    try:
+        from pocketpaw.security.audit import (
+            AuditEvent,
+            AuditSeverity,
+            get_audit_logger,
+        )
+
+        code = result.get("code")
+        is_pending = code == "instinct_pending" or "proposed_action_id" in result
+        succeeded_read = result.get("ok") is True and not is_pending
+        severity = AuditSeverity.INFO if succeeded_read else AuditSeverity.WARNING
+        status = code or "ok"
+
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=severity,
+                actor=user_id,
+                action="pocket.tools.run",
+                target=pocket_id,
+                status=status,
+                category="pocket_backend_config",
+                workspace_id=workspace_id,
+                tool=tool,
+                code=code,
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the run
+        logger.warning("pocket tool-run audit-log write failed", exc_info=True)
+
+
+async def _run_tool_dispatch(
     *,
     workspace_id: str,
     pocket_id: str,

--- a/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
@@ -1,20 +1,27 @@
 # tool_executor.py — Server-side executor for pocket tool invocations.
 # Created: 2026-05-24 (#1206 part a — invoke_tool wire).
+# Updated: 2026-06-15 (feat/invoke-tool-v1) — UNLOCKED. The executor now
+#   dispatches a connector-action grant ("connector:<name>:<action>") through
+#   the already-shipped `connectors.service.execute` path (#1376), reusing it
+#   rather than building a second connector engine. v1 is READ-FIRST, mirroring
+#   the chat MCP `connector_execute` gate order EXACTLY:
+#     Gate 1 — the connector must be bound to THIS pocket / workspace
+#              (`is_connector_bound_to_pocket`). execute() is trust-agnostic and
+#              does NOT enforce trust, so the gate order below is load-bearing.
+#     Gate 2 — look up the action's trust (`get_action_trust`); unknown → error.
+#     Gate 3 — READ/WRITE split. A WRITE action (trust.is_read False) NEVER
+#              reaches execute() in v1 — it returns code="blocked" (the
+#              "coming in v2 (Instinct)" message). A v2 seam is marked below.
+#     Gate 4 — a READ action fires execute() and returns its result.
+#   The `get_pocket_allowed_tools` `[]` stub is RETIRED: the router now reads
+#   `allowed_tools` off the credential row (via `get_pocket_backend_for_executor`)
+#   and passes the tool NAMES by parameter. The `not_allowed` gate is unchanged.
 #
-# The click-driven sibling of ``source_executor`` (read-only fetch) and
-# ``action_executor`` (named write binding). This executor receives a tool
-# NAME plus pre-resolved args from the ``invoke_tool`` ripple action verb
-# and runs the named tool against the pocket's tool allowlist.
-#
-# In part (a) the allowlist is intentionally empty — the wire is locked
-# down before any tool can fire. The real tool registry + Composio /
-# WebFetch wiring lands in a follow-up; part (b) adds the home-grid
-# ``onEvent`` plumbing that POSTs to ``/pockets/{id}/tools/run`` and the
-# allowlist storage on the per-pocket backend config.
-#
-# IMPORT-LINTER: must NOT import ``pocketpaw_ee.cloud.models.*``. The
-# executor receives the allowlist by parameter only — the router /
-# service owns Beanie access.
+# IMPORT-LINTER: must NOT import `pocketpaw_ee.cloud.models.*`. The executor
+#   receives the allowlist (a list of tool-name strings) BY PARAMETER only —
+#   the router / service owns Beanie access. Lazy imports of `connectors.service`
+#   / `connectors.dto` / `_core.errors` inside `run_tool` keep the module's
+#   import surface clean (the same pattern the chat MCP handler uses).
 
 from __future__ import annotations
 
@@ -23,21 +30,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-
-async def get_pocket_allowed_tools(workspace_id: str, pocket_id: str) -> list[str]:
-    """Return the list of tool names allowed for this pocket.
-
-    Part (a) intentionally returns ``[]`` for every pocket — the wire is
-    in place but no tool is enabled until the captain explicitly turns
-    one on per pocket (the allowlist storage lives on the per-pocket
-    backend config row in a follow-up). The empty default is fail-closed:
-    every ``invoke_tool`` POST is rejected with ``code="not_allowed"``
-    until that follow-up ships.
-    """
-    # `workspace_id` and `pocket_id` are accepted now so callers don't
-    # have to change shape when the real allowlist is plumbed through.
-    _ = (workspace_id, pocket_id)
-    return []
+# v1 write refusal — kept as a constant so the test pins the exact contract.
+# Mirrors the chat MCP layer's `_V2_BLOCK_MESSAGE` posture so the two surfaces
+# (chat `connector_execute` and click-driven `invoke_tool`) stay consistent.
+_WRITE_BLOCK_MESSAGE = "write actions need approval — coming in v2 (Instinct)"
 
 
 async def run_tool(
@@ -49,25 +45,22 @@ async def run_tool(
     args: dict[str, Any],
     allowed_tools: list[str],
 ) -> dict[str, Any]:
-    """Run a named tool with the resolved args, returning a wire dict
-    shaped like :class:`RunActionResponse`.
+    """Run a named tool with the resolved args, returning a wire dict shaped
+    like :class:`RunToolResponse` (``{ok, tool, status, response, error, code}``).
 
-    Part (a) wires only the gate: an empty allowlist (default) rejects
-    every call with ``code="not_allowed"``; a tool name not on the
-    allowlist gets the same response. Real tool execution (Composio /
-    WebFetch routing through the existing tool registry) lands in a
-    follow-up — the response shape stays the same so the home-grid
-    reconcile handlers don't change.
+    Gate order (mirrors the chat MCP ``connector_execute`` handler):
 
-    ``workspace_id`` and ``user_id`` are accepted now so the future audit
-    log + per-(pocket, user) rate limit can plumb in without touching the
-    route signature.
+    * ``tool not in allowed_tools`` → ``code="not_allowed"`` (fail-closed; the
+      allowlist is read off the per-pocket backend row by the router and passed
+      in by parameter, NEVER from the spec).
+    * a ``connector:<name>:<action>`` grant dispatches through
+      ``connectors.service.execute`` after Gates 1–3 below.
+    * any other (built-in/registry) grant is not wired in v1 →
+      ``code="unknown_tool"``.
+
+    ``workspace_id`` / ``user_id`` are threaded for the audit log + a future
+    per-(pocket, user) rate limit.
     """
-    # The kwargs are part of the public contract — accept and pass-through
-    # even before the real executor lands so the route signature doesn't
-    # have to change later.
-    _ = (workspace_id, user_id, args)
-
     if tool not in allowed_tools:
         logger.info(
             "tool_executor.run_tool denied: tool=%r pocket=%r user=%r reason=not_allowed",
@@ -82,10 +75,23 @@ async def run_tool(
             "code": "not_allowed",
         }
 
-    # The allowlist passed the name through, but no tool registry is
-    # wired up yet in part (a). Surface that as a structured error so
-    # the home-grid reconcile handlers can show a friendly toast; the
-    # follow-up replaces this branch with the real tool dispatch.
+    # --- connector-action grant: "connector:<name>:<action>" ----------------
+    if tool.startswith("connector:"):
+        return await _run_connector_tool(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            tool=tool,
+            args=args,
+        )
+
+    # --- built-in / registry tool grant (web_fetch, etc.) -------------------
+    # v1 scope: connector-action grants ship first. A built-in registry
+    # dispatch (WebFetch / Composio) is a thin follow-up that routes `tool` +
+    # `args` to the existing tool registry and flattens into the SAME wire
+    # dict. A URL-taking built-in (e.g. a future `web_fetch`) MUST route its
+    # outbound fetch through `_http_guard` (the SSRF boundary the source /
+    # action executors use) when that path lands. Until then:
     logger.info(
         "tool_executor.run_tool unknown: tool=%r pocket=%r user=%r — registry not wired",
         tool,
@@ -95,6 +101,151 @@ async def run_tool(
     return {
         "ok": False,
         "tool": tool,
-        "error": f"tool {tool!r} is allowlisted but no registry implementation is wired yet",
+        "error": f"tool {tool!r} has no registry implementation wired yet",
         "code": "unknown_tool",
+    }
+
+
+async def _run_connector_tool(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    tool: str,
+    args: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch a ``connector:<name>:<action>`` grant.
+
+    Reuses ``connectors.service.execute`` (the single CLOUD-path connector
+    executor, #1376) for READ actions. Because ``execute`` is TRUST-AGNOSTIC,
+    this function enforces the three gates the executor does NOT: bind/tenancy
+    (Gate 1), trust lookup (Gate 2), and the READ/WRITE split (Gate 3). A WRITE
+    never reaches ``execute`` in v1.
+    """
+    # Lazy imports — keep the module import-linter-clean (no static
+    # connectors / errors dependency at import time), matching the chat MCP
+    # handler's pattern.
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+
+    try:
+        _, conn_name, action = tool.split(":", 2)
+    except ValueError:
+        return {
+            "ok": False,
+            "tool": tool,
+            "error": f"malformed connector grant {tool!r} — expected connector:<name>:<action>",
+            "code": "bad_grant",
+        }
+    if not conn_name or not action:
+        return {
+            "ok": False,
+            "tool": tool,
+            "error": f"malformed connector grant {tool!r} — empty connector name or action",
+            "code": "bad_grant",
+        }
+
+    # Gate 1 — reachability / tenancy. `connectors.service.execute` re-checks
+    # this internally (service.py is_connector_bound_to_pocket on the pocket
+    # arm), but we ALSO check it here for defense-in-depth: it is the tenant
+    # boundary and the executor must never assume the caller pre-verified it.
+    # An agent in pocket A must not reach a connector bound only to pocket B.
+    bound = await connectors_service.is_connector_bound_to_pocket(
+        workspace_id, pocket_id, conn_name
+    )
+    if not bound:
+        logger.info(
+            "tool_executor.run_tool not_reachable: tool=%r pocket=%r connector=%r",
+            tool,
+            pocket_id,
+            conn_name,
+        )
+        return {
+            "ok": False,
+            "tool": tool,
+            "error": f"connector {conn_name!r} is not reachable from this pocket",
+            "code": "not_reachable",
+        }
+
+    # Gate 2 — trust lookup. Unknown action → clear error (never execute).
+    trust = await connectors_service.get_action_trust(conn_name, action)
+    if trust is None:
+        return {
+            "ok": False,
+            "tool": tool,
+            "error": f"connector {conn_name!r} has no action {action!r}",
+            "code": "unknown_tool",
+        }
+
+    # Gate 3 — READ/WRITE split. THE load-bearing security rule: a WRITE action
+    # NEVER calls execute() in v1. It returns a success-shaped blocked response
+    # so the home-grid `on_success` handler can branch on `code == "blocked"`,
+    # mirroring the chat MCP `_V2_BLOCK_MESSAGE` posture.
+    #
+    # v2 SEAM: replace this refusal with a call to
+    #   pocketpaw_ee.cloud.external_actions.propose.propose_external_action(...)
+    # which files a pending Instinct Action (propose → human approves →
+    # execute_approved_external_action re-enters connectors.service.execute).
+    # Return {ok:true, status:202, code:"instinct_pending",
+    #         response:{proposed_action_id, status:"pending_approval"}}.
+    # DO NOT build v2 here — v1 refuses.
+    if not trust.is_read:
+        logger.info(
+            "tool_executor.run_tool blocked write: tool=%r pocket=%r connector=%r action=%r",
+            tool,
+            pocket_id,
+            conn_name,
+            action,
+        )
+        return {
+            "ok": False,
+            "tool": tool,
+            "status": 200,
+            "code": "blocked",
+            "error": _WRITE_BLOCK_MESSAGE,
+            "response": {
+                "executed": False,
+                "blocked": True,
+                "connector": conn_name,
+                "action": action,
+                "reason": _WRITE_BLOCK_MESSAGE,
+            },
+        }
+
+    # Gate 4 — READ fires now. Build the SAME ExecuteActionRequest the chat MCP
+    # `connector_execute` builds, so both callers converge on one execute path.
+    body = ExecuteActionRequest(
+        action=action,
+        params=args,
+        scope="pocket" if pocket_id else "workspace",
+        pocket_id=pocket_id or None,
+    )
+    try:
+        result = await connectors_service.execute(
+            workspace_id, conn_name, body, user_id=user_id
+        )
+    except CloudError as exc:
+        return {
+            "ok": False,
+            "tool": tool,
+            "status": exc.status_code,
+            "error": exc.message,
+            "code": exc.code,
+        }
+
+    logger.info(
+        "tool_executor.run_tool fired read: tool=%r pocket=%r connector=%r action=%r success=%s",
+        tool,
+        pocket_id,
+        conn_name,
+        action,
+        result.success,
+    )
+    return {
+        "ok": result.success,
+        "tool": tool,
+        "status": 200 if result.success else 502,
+        "response": result.data,
+        "error": result.error,
     }

--- a/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
@@ -9,19 +9,34 @@
 #              (`is_connector_bound_to_pocket`). execute() is trust-agnostic and
 #              does NOT enforce trust, so the gate order below is load-bearing.
 #     Gate 2 — look up the action's trust (`get_action_trust`); unknown → error.
-#     Gate 3 — READ/WRITE split. A WRITE action (trust.is_read False) NEVER
-#              reaches execute() in v1 — it returns code="blocked" (the
-#              "coming in v2 (Instinct)" message). A v2 seam is marked below.
+#     Gate 3 — READ/WRITE split (see below for the v2 write behavior).
 #     Gate 4 — a READ action fires execute() and returns its result.
 #   The `get_pocket_allowed_tools` `[]` stub is RETIRED: the router now reads
 #   `allowed_tools` off the credential row (via `get_pocket_backend_for_executor`)
 #   and passes the tool NAMES by parameter. The `not_allowed` gate is unchanged.
+# Updated: 2026-06-15 (feat/invoke-tool-v1, v2) — WRITE PATH unlocked via Instinct.
+#   Gate 3 no longer refuses a WRITE. A WRITE action (trust.is_read False) is now
+#   PROPOSED to a human through the existing external-action gate: it calls
+#   `external_actions.propose.propose_external_action(...)` (which files a pending
+#   Instinct Action carrying the `_external_action` blob) and returns
+#   `{ok:true, status:202, code:"instinct_pending", response:{action_id, ...}}`.
+#   THE load-bearing v2 security rule: a WRITE STILL never calls
+#   `connectors.service.execute` inline — the human gates it. The connector write
+#   only fires later, when a human approves in The Tray and the instinct router
+#   runs `execute_approved_external_action` → `connectors.service.execute`
+#   (re-validated: workspace + params_hash + idempotency). The executor adds
+#   NOTHING to that approve→execute path; it only proposes-and-suspends.
 #
 # IMPORT-LINTER: must NOT import `pocketpaw_ee.cloud.models.*`. The executor
 #   receives the allowlist (a list of tool-name strings) BY PARAMETER only —
 #   the router / service owns Beanie access. Lazy imports of `connectors.service`
-#   / `connectors.dto` / `_core.errors` inside `run_tool` keep the module's
-#   import surface clean (the same pattern the chat MCP handler uses).
+#   / `connectors.dto` / `_core.errors` / `external_actions.propose` inside
+#   `run_tool` keep the module's import surface clean (the same pattern the chat
+#   MCP handler uses). `external_actions.propose` itself statically imports no
+#   Beanie document class (it lazy-imports `pocketpaw.stores` /
+#   `pocketpaw.instinct.models` internally), so importing it here keeps the
+#   "Pockets — Beanie writes only from service.py" contract 0-broken — verified
+#   with `lint-imports --config ee/pyproject.toml`.
 
 from __future__ import annotations
 
@@ -29,11 +44,6 @@ import logging
 from typing import Any
 
 logger = logging.getLogger(__name__)
-
-# v1 write refusal — kept as a constant so the test pins the exact contract.
-# Mirrors the chat MCP layer's `_V2_BLOCK_MESSAGE` posture so the two surfaces
-# (chat `connector_execute` and click-driven `invoke_tool`) stay consistent.
-_WRITE_BLOCK_MESSAGE = "write actions need approval — coming in v2 (Instinct)"
 
 
 async def run_tool(
@@ -119,8 +129,13 @@ async def _run_connector_tool(
     Reuses ``connectors.service.execute`` (the single CLOUD-path connector
     executor, #1376) for READ actions. Because ``execute`` is TRUST-AGNOSTIC,
     this function enforces the three gates the executor does NOT: bind/tenancy
-    (Gate 1), trust lookup (Gate 2), and the READ/WRITE split (Gate 3). A WRITE
-    never reaches ``execute`` in v1.
+    (Gate 1), trust lookup (Gate 2), and the READ/WRITE split (Gate 3).
+
+    A WRITE never reaches ``execute`` INLINE — Gate 3 proposes it through the
+    Instinct external-action gate (``propose_external_action``) and suspends.
+    The connector write fires only after a human approves (the instinct router
+    then re-enters ``connectors.service.execute`` via
+    ``execute_approved_external_action``).
     """
     # Lazy imports — keep the module import-linter-clean (no static
     # connectors / errors dependency at import time), matching the chat MCP
@@ -179,39 +194,29 @@ async def _run_connector_tool(
         }
 
     # Gate 3 — READ/WRITE split. THE load-bearing security rule: a WRITE action
-    # NEVER calls execute() in v1. It returns a success-shaped blocked response
-    # so the home-grid `on_success` handler can branch on `code == "blocked"`,
-    # mirroring the chat MCP `_V2_BLOCK_MESSAGE` posture.
+    # NEVER calls execute() INLINE. v2 routes it through the Instinct external-
+    # action gate: `propose_external_action` files a PENDING Action carrying the
+    # `_external_action` blob (params_hash + idempotency_key, no connector secret)
+    # and opens the Decision-Graph chain. The connector write only fires when a
+    # human approves in The Tray — the instinct router then runs
+    # `execute_approved_external_action` → `connectors.service.execute` (re-
+    # validated: workspace + params_hash + idempotency). We add NOTHING to that
+    # approve→execute path here; we propose-and-suspend, then STOP.
     #
-    # v2 SEAM: replace this refusal with a call to
-    #   pocketpaw_ee.cloud.external_actions.propose.propose_external_action(...)
-    # which files a pending Instinct Action (propose → human approves →
-    # execute_approved_external_action re-enters connectors.service.execute).
-    # Return {ok:true, status:202, code:"instinct_pending",
-    #         response:{proposed_action_id, status:"pending_approval"}}.
-    # DO NOT build v2 here — v1 refuses.
+    # The return is success-shaped (`ok:true`) with code="instinct_pending" so the
+    # home-grid `on_success` handler can branch on the code and show a "sent for
+    # approval — in your Tray" badge. `propose_external_action` is the gate by
+    # construction; there is no direct-fire path for a connector write.
     if not trust.is_read:
-        logger.info(
-            "tool_executor.run_tool blocked write: tool=%r pocket=%r connector=%r action=%r",
-            tool,
-            pocket_id,
-            conn_name,
-            action,
+        return await _propose_connector_write(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            tool=tool,
+            conn_name=conn_name,
+            action=action,
+            args=args,
         )
-        return {
-            "ok": False,
-            "tool": tool,
-            "status": 200,
-            "code": "blocked",
-            "error": _WRITE_BLOCK_MESSAGE,
-            "response": {
-                "executed": False,
-                "blocked": True,
-                "connector": conn_name,
-                "action": action,
-                "reason": _WRITE_BLOCK_MESSAGE,
-            },
-        }
 
     # Gate 4 — READ fires now. Build the SAME ExecuteActionRequest the chat MCP
     # `connector_execute` builds, so both callers converge on one execute path.
@@ -248,4 +253,88 @@ async def _run_connector_tool(
         "status": 200 if result.success else 502,
         "response": result.data,
         "error": result.error,
+    }
+
+
+async def _propose_connector_write(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    tool: str,
+    conn_name: str,
+    action: str,
+    args: dict[str, Any],
+) -> dict[str, Any]:
+    """Gate 3 WRITE path (v2) — propose the connector write to a human, suspend.
+
+    Files a PENDING Instinct ``Action`` via ``propose_external_action`` (the
+    external-action gate, schema 1) and returns a pending-shaped wire dict. THE
+    load-bearing security rule: this NEVER calls ``connectors.service.execute``.
+    The connector write fires only when a human approves in The Tray — the
+    instinct router then runs ``execute_approved_external_action`` →
+    ``connectors.service.execute`` (re-validated). We propose-and-suspend, STOP.
+
+    The ``assignee`` defaults to ``requested_by`` (the clicking user's queue)
+    inside ``propose_external_action``; routing tool-writes to the pocket's
+    ``approval_route`` is a v2.x polish, not wired here.
+    """
+    # Lazy import — keeps the executor's import surface clean (the same pattern
+    # the READ path uses for `connectors.service`). `propose_external_action`
+    # statically imports no Beanie document class, so the import-linter contract
+    # stays 0-broken.
+    from pocketpaw_ee.cloud.external_actions.propose import propose_external_action
+
+    try:
+        action_id = await propose_external_action(
+            workspace_id=workspace_id,
+            connector_name=conn_name,
+            action=action,
+            params=args,
+            requested_by=user_id,
+            scope="pocket" if pocket_id else "workspace",
+            pocket_id=pocket_id or None,
+            summary=f"{tool} from pocket {pocket_id}",
+        )
+    except Exception:  # noqa: BLE001 — surface a clean wire error, never a 500.
+        logger.exception(
+            "tool_executor.run_tool propose failed: tool=%r pocket=%r connector=%r action=%r",
+            tool,
+            pocket_id,
+            conn_name,
+            action,
+        )
+        return {
+            "ok": False,
+            "tool": tool,
+            "status": 502,
+            "code": "propose_failed",
+            "error": f"could not send {tool!r} for approval",
+        }
+
+    logger.info(
+        "tool_executor.run_tool proposed write: tool=%r pocket=%r connector=%r "
+        "action=%r action_id=%s",
+        tool,
+        pocket_id,
+        conn_name,
+        action,
+        action_id,
+    )
+    # Pending-shaped success: the human gates the write. The home-grid
+    # `on_success` handler branches on code == "instinct_pending" to show a
+    # "sent for approval — in your Tray" badge. `action_id` lets the client
+    # correlate the originating click with the pending Action it can watch.
+    return {
+        "ok": True,
+        "tool": tool,
+        "status": 202,  # Accepted-but-pending.
+        "code": "instinct_pending",
+        "response": {
+            "action_id": action_id,
+            "proposed_action_id": action_id,
+            "status": "pending_approval",
+            "connector": conn_name,
+            "action": action,
+        },
     }

--- a/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
@@ -323,13 +323,16 @@ async def _propose_connector_write(
     )
     # Pending-shaped success: the human gates the write. The home-grid
     # `on_success` handler branches on code == "instinct_pending" to show a
-    # "sent for approval — in your Tray" badge. `action_id` lets the client
-    # correlate the originating click with the pending Action it can watch.
+    # "sent for approval — in your Tray" badge. `proposed_action_id` is surfaced
+    # at the top level (mirroring RunActionResponse) AND echoed inside `response`
+    # so the client can correlate the originating click with the pending Action
+    # it watches in The Tray, however it reads it.
     return {
         "ok": True,
         "tool": tool,
         "status": 202,  # Accepted-but-pending.
         "code": "instinct_pending",
+        "proposed_action_id": action_id,
         "response": {
             "action_id": action_id,
             "proposed_action_id": action_id,

--- a/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/tool_executor.py
@@ -227,9 +227,7 @@ async def _run_connector_tool(
         pocket_id=pocket_id or None,
     )
     try:
-        result = await connectors_service.execute(
-            workspace_id, conn_name, body, user_id=user_id
-        )
+        result = await connectors_service.execute(workspace_id, conn_name, body, user_id=user_id)
     except CloudError as exc:
         return {
             "ok": False,

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -266,6 +266,12 @@ source_modules = [
     "pocketpaw_ee.cloud.pockets._http_guard",
     "pocketpaw_ee.cloud.pockets.action_executor",
     "pocketpaw_ee.cloud.pockets.actions_ops",
+    # feat/invoke-tool-v1 — the click-driven tool executor. It dispatches a
+    # connector-action grant through ``connectors.service.execute`` and
+    # receives the per-pocket allowlist by parameter from the router. It must
+    # NEVER import a Beanie document class directly (no ``models.pocket_backend``):
+    # the router/service own Beanie access.
+    "pocketpaw_ee.cloud.pockets.tool_executor",
     # P2.4 Template Reconcile — the reconcile service resolves the pocket
     # (spec + slug) and writes the reconciled spec entirely through
     # `pockets.service`; it must never import the Pocket Beanie model.

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -52,6 +52,19 @@
 #   approval (it lands in their Instinct Tray and fires on approve) rather than
 #   running inline. `call_binding` remains the first reach for backend/connector
 #   data; `invoke_tool` is for a named tool/connector grant the owner allow-listed.
+# Modified: 2026-06-16 (feat/invoke-tool-v1 — close the in-chat approval loop)
+#   — added `_INSTINCT_TRAY_RULE`: when the agent renders the pending-Instinct-
+#   approvals view (the items `instinct_pending` returns), the Approve / Reject
+#   buttons MUST be bound to the backend Instinct decision routes as `api`
+#   actions — POST /api/v1/instinct/actions/{id}/approve and .../reject — so the
+#   HUMAN's click finalizes the decision directly (the backend re-validates
+#   workspace + params_hash + idempotency and fires the connector write via
+#   execute_approved_external_action). Explicitly NOT an `emit`/`chat.send`
+#   round-trip and NOT an autonomous agent verb — the user's click IS the
+#   approval, which is the whole point of the gate. Also teaches the Tray route:
+#   the pending-approvals list is at /deep-work, surfaced via a `navigate`
+#   button + referenced in the text guidance. Spliced into the assembled prompt
+#   after `_MULTI_STEP_FLOW_RULE` and added to the final self-check.
 
 from pocketpaw.ripple._design import USE_THE_WIDGET_RULE, WIDGET_CATALOG
 
@@ -526,6 +539,67 @@ SKELETON E — ACT ON CONNECTOR / BACKEND DATA (call_binding, NOT invoke_tool):
 """
 
 
+_INSTINCT_TRAY_RULE = """\
+# PENDING INSTINCT APPROVALS — BIND THE APPROVE BUTTON TO THE APPROVE ROUTE
+
+When you render the pending-approvals view (the items `instinct_pending`
+returns — connector writes and other actions awaiting the user's
+decision in the Instinct gate, a.k.a. The Tray), the Approve / Reject
+buttons MUST fire the decision DIRECTLY when the HUMAN clicks them. Do
+NOT wire them to `emit` / `chat.send` — a chat round-trip does not
+finalize anything (it just sends you a message), and there is NO agent
+verb that approves on its own. The user's click IS the approval; that is
+the whole point of the gate. You render the button; the human fires it.
+
+Each pending action has an `id`. Render its buttons as `api` actions to
+the backend Instinct routes (backend-relative paths — the `api` verb
+prepends the host + mints CSRF, so a `/api/v1/...` path is correct and an
+external URL would NOT work):
+
+  - Approve → POST `/api/v1/instinct/actions/{id}/approve`
+  - Reject  → POST `/api/v1/instinct/actions/{id}/reject`
+
+On approve, the backend re-validates the action (workspace + params_hash
++ idempotency) and fires the connector write itself — so a single human
+click finalizes it. Approve button shape (substitute the real action id):
+
+```
+{
+  "type": "button",
+  "props": { "label": "Approve", "variant": "primary" },
+  "on_click": {
+    "action": "api",
+    "url": "/api/v1/instinct/actions/{id}/approve",
+    "method": "POST",
+    "on_success": [
+      { "action": "toast", "message": "Approved — firing now", "variant": "success" }
+    ]
+  }
+}
+```
+
+Reject is the same with `url` ending `/reject` and a `warning` toast
+(e.g. "Rejected"). Render one Approve + one Reject per pending action
+(e.g. a row per item in a `flex`), each carrying that item's own id.
+
+THE TRAY LIVES AT /deep-work. When you offer an "Open Tray" / "see the
+full list" affordance, render it as a navigate button — NOT chat.send —
+and mention the route in your text so the user knows where the queue is:
+
+```
+{ "type": "button", "props": { "label": "Open Tray", "variant": "outline" },
+  "on_click": { "action": "navigate", "url": "/deep-work" } }
+```
+
+So the stance is: render an Approve button bound to the approve route so
+the user clicks to finalize, and point them to the Tray at /deep-work for
+the full list. Never tell the user you "can't approve from chat" and
+never approve on their behalf — bind the button and let them click.
+
+---
+"""
+
+
 _INLINE_RULES = """\
 # RULES
 
@@ -549,6 +623,8 @@ Final self-check before sending:
 ✔ flex/grid `gap` is tight for inline — numeric 2 or 4, not 10/12+
 ✔ Used a core widget, or called `get_inline_widget_help` BEFORE emitting the type
 ✔ Multi-step / wizard / intake flow → called `start_flow`, not a hand-authored or `set`-stepped spec
+✔ Pending Instinct approvals → Approve/Reject buttons `api`-POST the route, NOT chat.send
+✔ Open Tray affordance navigates to /deep-work (not a chat.send)
 ✔ Leads to a clear next step
 ✔ No static lists for open-ended queries
 ✔ Valid JSON, concrete values, one fence
@@ -565,6 +641,8 @@ INLINE_RIPPLE_SYSTEM_PROMPT = (
     + _INLINE_CORE_CATALOG
     + "\n"
     + _MULTI_STEP_FLOW_RULE
+    + "\n"
+    + _INSTINCT_TRAY_RULE
     + "\n"
     + _INLINE_RULES
 )

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -45,6 +45,13 @@
 #   call_binding action), and ACT ON CONNECTOR/BACKEND DATA (call_binding
 #   against the pocket's backend, explicitly NOT invoke_tool). Kept the two
 #   existing skeletons (A branching intake, B action-rich mini-app).
+# Modified: 2026-06-15 (feat/invoke-tool-v1, v2) — refreshed the two
+#   `invoke_tool` notes now that the verb is live. It is no longer
+#   "possibly-unavailable until the tool registry ships": a connector READ
+#   grant fires immediately; a connector WRITE grant is PROPOSED for the user's
+#   approval (it lands in their Instinct Tray and fires on approve) rather than
+#   running inline. `call_binding` remains the first reach for backend/connector
+#   data; `invoke_tool` is for a named tool/connector grant the owner allow-listed.
 
 from pocketpaw.ripple._design import USE_THE_WIDGET_RULE, WIDGET_CATALOG
 
@@ -363,8 +370,9 @@ HOW TO AUTHOR (think in states, not screens):
         call_binding→ write to the backend
         create_pocket → materialize a permanent pocket from the answers
         navigate / emit → go somewhere / raise an event
-        invoke_tool → run a tool with the answers
-                      (may be unavailable until the tool registry ships)
+        invoke_tool → run a named tool with the answers
+                      (connector reads fire; connector writes are
+                       proposed for the user's approval — the Tray)
 
   Reference earlier answers with `{stepId.field}` (e.g.
   `{pick_goal.label}`, `{enter_details.company}`) in review rows and
@@ -403,8 +411,11 @@ ACTION GRAMMAR — the rules that turn a flow into a real tool, not Q&A:
     that is a `call_binding` ACTION BUTTON wired to the verb, NOT a yes/no
     select. Never leave an action flow as plain Q&A.
   - To act on backend / connector data, use `call_binding` (works today).
-    `invoke_tool` is only for arbitrary named tools and may be unavailable
-    until the tool registry ships — reach for `call_binding` first.
+    `invoke_tool` runs a named tool the owner allow-listed on the pocket:
+    a connector READ fires immediately; a connector WRITE is proposed for
+    the user's approval (it lands in their Instinct Tray, fires on approve)
+    rather than running inline. Reach for `call_binding` first; use
+    `invoke_tool` when the action is a named tool/connector grant.
 
 SKELETON A — branching intake (collect, then hand answers to you):
 ```

--- a/tests/cloud/pockets/test_tool_executor.py
+++ b/tests/cloud/pockets/test_tool_executor.py
@@ -6,6 +6,15 @@
 #   `propose_external_action` (right kwargs), does NOT call
 #   `connectors.service.execute` inline, and returns code="instinct_pending"
 #   with a proposed action_id. (risk R1 — the human still gates the write.)
+# Updated: 2026-06-19 (repair/invoke-tool-v1) — close #1472 review HIGH. Every
+#   `run_tool` call now emits ONE append-only `AuditEvent` (action
+#   "pocket.tools.run", category "pocket_backend_config") so agent tool
+#   invocations leave a forensic trail, not just a logger.info line. New tests
+#   pin: (a) a `not_allowed` denial → WARNING audit, (b) an allowed connector
+#   READ → INFO audit, (c) a connector WRITE proposal → WARNING audit. Audit is
+#   captured by patching `pocketpaw.security.audit.get_audit_logger` (the lazy
+#   import target inside `_audit_tool_run`) with a Mock and asserting on the
+#   single emitted event's action / severity / target / status.
 #
 # These tests exercise `run_tool` directly (no FastAPI / Mongo) and spy on the
 # connector service + the external-action propose helper so they pin the
@@ -27,7 +36,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -37,9 +47,37 @@ from pocketpaw_ee.cloud.connectors.domain import ConnectorActionInfo  # noqa: E4
 from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse  # noqa: E402
 from pocketpaw_ee.cloud.pockets import tool_executor  # noqa: E402
 
+from pocketpaw.security.audit import AuditSeverity  # noqa: E402
+
 WS = "ws-alpha"
 POCKET = "pocket-1"
 USER = "user-alice"
+
+
+@contextmanager
+def _capture_audit():
+    """Patch the audit logger `_audit_tool_run` lazy-imports and yield the Mock
+    logger so a test can read the emitted `AuditEvent`(s).
+
+    `_audit_tool_run` does `from pocketpaw.security.audit import ...
+    get_audit_logger`, so the patch target is the source module symbol the lazy
+    import resolves to. The returned logger's `.log(event)` captures the single
+    emitted event for assertion.
+    """
+    fake_logger = Mock()
+    with patch(
+        "pocketpaw.security.audit.get_audit_logger",
+        return_value=fake_logger,
+    ):
+        yield fake_logger
+
+
+def _only_event(fake_logger: Mock):
+    """Assert exactly one audit event was logged and return it."""
+    assert fake_logger.log.call_count == 1, (
+        f"expected exactly one audit event, got {fake_logger.log.call_count}"
+    )
+    return fake_logger.log.call_args.args[0]
 
 
 def _read_trust(action: str = "list_issues") -> ConnectorActionInfo:
@@ -486,3 +524,156 @@ async def test_builtin_tool_grant_is_unknown_tool_in_v1() -> None:
 
     assert result["ok"] is False
     assert result["code"] == "unknown_tool"
+
+
+# ---------------------------------------------------------------------------
+# Audit trail (#1472 review HIGH) — every run_tool call emits ONE AuditEvent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_not_allowed_denial_emits_warning_audit_event() -> None:
+    """A denied tool (not on the allowlist) must leave a forensic audit trail,
+    not just a logger.info line. The emit is a WARNING `pocket.tools.run` event
+    targeting the pocket, with the denied tool + code in the fields."""
+    tool = "connector:github:list_issues"
+    with _capture_audit() as fake_logger:
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={"secret": "do-not-log-me"},
+            allowed_tools=[],  # empty allowlist — fail-closed denial
+        )
+
+    assert result["code"] == "not_allowed"
+    event = _only_event(fake_logger)
+    assert event.action == "pocket.tools.run"
+    assert event.severity == AuditSeverity.WARNING
+    assert event.target == POCKET
+    assert event.actor == USER
+    assert event.status == "not_allowed"
+    assert event.context["workspace_id"] == WS
+    assert event.context["category"] == "pocket_backend_config"
+    assert event.context["tool"] == tool
+    assert event.context["code"] == "not_allowed"
+    # The resolved args carry PII — they must NEVER ride into the audit log.
+    assert "secret" not in str(event.context)
+    assert "do-not-log-me" not in str(event.context)
+
+
+@pytest.mark.asyncio
+async def test_allowed_read_emits_info_audit_event() -> None:
+    """A successful connector READ is normal operation → an INFO audit event."""
+    tool = "connector:github:list_issues"
+    exec_result = ExecuteActionResponse(
+        success=True,
+        data=[{"number": 1, "title": "first issue"}],
+        execution_mode="cloud",
+    )
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(return_value=_read_trust()),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(return_value=exec_result),
+        ),
+        _capture_audit() as fake_logger,
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={"owner": "acme", "repo": "api"},
+            allowed_tools=[tool],
+        )
+
+    assert result["ok"] is True
+    event = _only_event(fake_logger)
+    assert event.action == "pocket.tools.run"
+    assert event.severity == AuditSeverity.INFO
+    assert event.target == POCKET
+    assert event.actor == USER
+    assert event.status == "ok"
+    assert event.context["workspace_id"] == WS
+    assert event.context["category"] == "pocket_backend_config"
+    assert event.context["tool"] == tool
+
+
+@pytest.mark.asyncio
+async def test_write_proposal_emits_warning_audit_event() -> None:
+    """A connector WRITE proposed via Instinct (pending human approval) is a
+    state-changing intent → a WARNING audit event with status="instinct_pending".
+    The proposal is visible in the trail even though the write hasn't fired."""
+    tool = "connector:github:create_issue"
+    proposed_id = "act-pending-123"
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(return_value=_write_trust()),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.external_actions.propose.propose_external_action",
+            new=AsyncMock(return_value=proposed_id),
+        ),
+        _capture_audit() as fake_logger,
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={"title": "needs a human to approve"},
+            allowed_tools=[tool],
+        )
+
+    assert result["code"] == "instinct_pending"
+    event = _only_event(fake_logger)
+    assert event.action == "pocket.tools.run"
+    assert event.severity == AuditSeverity.WARNING
+    assert event.target == POCKET
+    assert event.actor == USER
+    assert event.status == "instinct_pending"
+    assert event.context["workspace_id"] == WS
+    assert event.context["category"] == "pocket_backend_config"
+    assert event.context["tool"] == tool
+    assert event.context["code"] == "instinct_pending"
+
+
+@pytest.mark.asyncio
+async def test_audit_failure_never_breaks_run_tool() -> None:
+    """Audit is observability — a crash inside the audit emit must NEVER fail the
+    run. If `get_audit_logger` raises, `run_tool` still returns its result."""
+    tool = "connector:github:list_issues"
+    with patch(
+        "pocketpaw.security.audit.get_audit_logger",
+        side_effect=RuntimeError("audit backend down"),
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={},
+            allowed_tools=[],  # denial path — simplest to reach
+        )
+
+    # The run still produced its normal wire result despite the audit crash.
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"

--- a/tests/cloud/pockets/test_tool_executor.py
+++ b/tests/cloud/pockets/test_tool_executor.py
@@ -1,0 +1,413 @@
+# tests/cloud/pockets/test_tool_executor.py — feat/invoke-tool-v1.
+# Created: 2026-06-15 — unit coverage for the UNLOCKED `tool_executor.run_tool`.
+#
+# These tests exercise `run_tool` directly (no FastAPI / Mongo) and spy on the
+# connector service so they pin the load-bearing v1 security contract:
+#
+#   * THE security rule — a WRITE-trust connector grant NEVER calls
+#     `connectors.service.execute` and returns code="blocked". (risk R1.)
+#   * a READ-trust grant fires `execute` and returns its data.
+#   * a tool name not on the allowlist → code="not_allowed" (fail-closed).
+#   * Gate 1 (bound), Gate 2 (trust lookup), malformed-grant, and CloudError
+#     mapping are all asserted.
+#
+# `run_tool` lazy-imports `connectors.service` inside `_run_connector_tool`, so
+# the patch target is `pocketpaw_ee.cloud.connectors.service.*` (the canonical
+# module object the import resolves to), matching the MCP server's test layout.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.connectors.domain import ConnectorActionInfo  # noqa: E402
+from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse  # noqa: E402
+from pocketpaw_ee.cloud.pockets import tool_executor  # noqa: E402
+
+WS = "ws-alpha"
+POCKET = "pocket-1"
+USER = "user-alice"
+
+
+def _read_trust(action: str = "list_issues") -> ConnectorActionInfo:
+    return ConnectorActionInfo(
+        name=action,
+        description="List issues",
+        trust_level="auto",
+        execution_mode="cloud",
+        is_read=True,
+    )
+
+
+def _write_trust(action: str = "create_issue") -> ConnectorActionInfo:
+    return ConnectorActionInfo(
+        name=action,
+        description="Create an issue",
+        trust_level="confirm",
+        execution_mode="cloud",
+        is_read=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# THE security rule — a WRITE grant must NEVER reach execute()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_grant_never_calls_execute_and_is_blocked() -> None:
+    """RISK #1 — an unapproved write must be impossible in v1.
+
+    A pocket allow-lists a WRITE connector action and the button fires it.
+    `connectors.service.execute` must be called ZERO times and the response
+    must carry code="blocked". This is the load-bearing invariant: because
+    execute() is trust-agnostic, a missing Gate 3 would silently run the write.
+    """
+    tool = "connector:github:create_issue"
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(return_value=_write_trust()),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(),
+        ) as mock_execute,
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={"title": "should never be created"},
+            allowed_tools=[tool],
+        )
+
+    # THE assertion: execute was never awaited.
+    mock_execute.assert_not_awaited()
+    assert result["ok"] is False
+    assert result["code"] == "blocked"
+    assert result["tool"] == tool
+    assert "v2" in result["error"]
+    # The success-shaped response carries the blocked marker for the
+    # client's on_success handler to branch on.
+    assert result["response"]["blocked"] is True
+    assert result["response"]["executed"] is False
+
+
+# ---------------------------------------------------------------------------
+# A READ grant fires execute() and returns data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_grant_fires_execute_and_returns_data() -> None:
+    """An auto-trust (read) connector grant reaches `connectors.service.execute`
+    and returns its data, mapped to the RunToolResponse wire shape."""
+    tool = "connector:github:list_issues"
+    exec_result = ExecuteActionResponse(
+        success=True,
+        data=[{"number": 1, "title": "first issue"}],
+        execution_mode="cloud",
+    )
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(return_value=_read_trust()),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(return_value=exec_result),
+        ) as mock_execute,
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={"owner": "acme", "repo": "api"},
+            allowed_tools=[tool],
+        )
+
+    assert result["ok"] is True
+    assert result["tool"] == tool
+    assert result["status"] == 200
+    assert result["response"][0]["title"] == "first issue"
+    assert result["error"] is None
+    # The execute call carried the resolved action + pocket scope — the SAME
+    # ExecuteActionRequest the chat MCP `connector_execute` builds.
+    mock_execute.assert_awaited_once()
+    call = mock_execute.await_args
+    assert call.args[0] == WS
+    assert call.args[1] == "github"
+    req = call.args[2]
+    assert req.action == "list_issues"
+    assert req.params == {"owner": "acme", "repo": "api"}
+    assert req.scope == "pocket"
+    assert req.pocket_id == POCKET
+    assert call.kwargs["user_id"] == USER
+
+
+@pytest.mark.asyncio
+async def test_read_grant_failure_maps_to_502() -> None:
+    """A read that runs but the connector reports failure → ok:false, status 502,
+    with the connector's error surfaced (no exception bubbles)."""
+    tool = "connector:github:list_issues"
+    exec_result = ExecuteActionResponse(
+        success=False,
+        data=None,
+        error="upstream 500",
+        execution_mode="cloud",
+    )
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(return_value=_read_trust()),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(return_value=exec_result),
+        ),
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={},
+            allowed_tools=[tool],
+        )
+
+    assert result["ok"] is False
+    assert result["status"] == 502
+    assert result["error"] == "upstream 500"
+
+
+@pytest.mark.asyncio
+async def test_read_grant_cloud_error_maps_to_wire() -> None:
+    """A CloudError from execute (e.g. 503 local-agent-unavailable) is caught
+    and mapped to the wire shape — never raised into the route."""
+    tool = "connector:github:list_issues"
+    from pocketpaw_ee.cloud._core.errors import CloudError
+
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(return_value=_read_trust()),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(
+                side_effect=CloudError(503, "connector.local_agent_unavailable", "open your app")
+            ),
+        ),
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={},
+            allowed_tools=[tool],
+        )
+
+    assert result["ok"] is False
+    assert result["code"] == "connector.local_agent_unavailable"
+    assert result["status"] == 503
+    assert result["error"] == "open your app"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed allowlist gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_grant_returns_not_allowed_and_never_touches_connectors() -> None:
+    """A tool name not on the allowlist is rejected BEFORE any connector call —
+    the fail-closed gate. execute / trust / bind are never touched."""
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(),
+        ) as mock_bound,
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(),
+        ) as mock_trust,
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(),
+        ) as mock_execute,
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool="connector:github:list_issues",
+            args={},
+            allowed_tools=[],  # empty allowlist — fail-closed
+        )
+
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"
+    mock_bound.assert_not_awaited()
+    mock_trust.assert_not_awaited()
+    mock_execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_grant_for_other_tool_does_not_authorize_this_one() -> None:
+    """A grant for tool A must not authorize tool B — the gate matches the
+    invoked name EXACTLY."""
+    with patch(
+        "pocketpaw_ee.cloud.connectors.service.execute",
+        new=AsyncMock(),
+    ) as mock_execute:
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool="connector:github:create_issue",
+            args={},
+            allowed_tools=["connector:github:list_issues"],
+        )
+
+    assert result["code"] == "not_allowed"
+    mock_execute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Gate 1 (bind / tenancy) + Gate 2 (trust lookup) + malformed grant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unbound_connector_is_rejected_before_trust_or_execute() -> None:
+    """Gate 1 — a connector not bound to THIS pocket is rejected before the
+    trust lookup or execute (the tenant boundary, defense-in-depth)."""
+    tool = "connector:github:list_issues"
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(),
+        ) as mock_trust,
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(),
+        ) as mock_execute,
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={},
+            allowed_tools=[tool],
+        )
+
+    assert result["ok"] is False
+    assert result["code"] == "not_reachable"
+    mock_trust.assert_not_awaited()
+    mock_execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_is_unknown_tool_without_execute() -> None:
+    """Gate 2 — an allowlisted connector grant whose action the connector
+    doesn't define → code="unknown_tool", execute never called."""
+    tool = "connector:github:no_such_action"
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(),
+        ) as mock_execute,
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={},
+            allowed_tools=[tool],
+        )
+
+    assert result["ok"] is False
+    assert result["code"] == "unknown_tool"
+    mock_execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_connector_grant_is_bad_grant() -> None:
+    """A grant that starts with `connector:` but lacks an action segment is a
+    structured bad_grant error — not a crash, never an execute."""
+    tool = "connector:github"  # missing :<action>
+    with patch(
+        "pocketpaw_ee.cloud.connectors.service.execute",
+        new=AsyncMock(),
+    ) as mock_execute:
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={},
+            allowed_tools=[tool],
+        )
+
+    assert result["ok"] is False
+    assert result["code"] == "bad_grant"
+    mock_execute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Non-connector (built-in/registry) grant — not wired in v1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_builtin_tool_grant_is_unknown_tool_in_v1() -> None:
+    """A non-connector grant (e.g. a built-in `web_fetch`) is allowlisted but
+    has no registry implementation in v1 → code="unknown_tool"."""
+    result = await tool_executor.run_tool(
+        workspace_id=WS,
+        pocket_id=POCKET,
+        user_id=USER,
+        tool="web_fetch",
+        args={"url": "https://example.com"},
+        allowed_tools=["web_fetch"],
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "unknown_tool"

--- a/tests/cloud/pockets/test_tool_executor.py
+++ b/tests/cloud/pockets/test_tool_executor.py
@@ -1,19 +1,29 @@
 # tests/cloud/pockets/test_tool_executor.py — feat/invoke-tool-v1.
 # Created: 2026-06-15 — unit coverage for the UNLOCKED `tool_executor.run_tool`.
+# Updated: 2026-06-15 (v2) — the WRITE path now PROPOSES via Instinct instead of
+#   refusing. The old "write → code=blocked, execute never called" test is
+#   replaced by the v2 security rule: a WRITE-trust grant calls
+#   `propose_external_action` (right kwargs), does NOT call
+#   `connectors.service.execute` inline, and returns code="instinct_pending"
+#   with a proposed action_id. (risk R1 — the human still gates the write.)
 #
 # These tests exercise `run_tool` directly (no FastAPI / Mongo) and spy on the
-# connector service so they pin the load-bearing v1 security contract:
+# connector service + the external-action propose helper so they pin the
+# load-bearing security contract:
 #
-#   * THE security rule — a WRITE-trust connector grant NEVER calls
-#     `connectors.service.execute` and returns code="blocked". (risk R1.)
+#   * THE v2 security rule — a WRITE-trust connector grant PROPOSES (Instinct)
+#     and NEVER calls `connectors.service.execute` inline. (risk R1.)
 #   * a READ-trust grant fires `execute` and returns its data.
 #   * a tool name not on the allowlist → code="not_allowed" (fail-closed).
 #   * Gate 1 (bound), Gate 2 (trust lookup), malformed-grant, and CloudError
 #     mapping are all asserted.
 #
-# `run_tool` lazy-imports `connectors.service` inside `_run_connector_tool`, so
-# the patch target is `pocketpaw_ee.cloud.connectors.service.*` (the canonical
-# module object the import resolves to), matching the MCP server's test layout.
+# `run_tool` lazy-imports `connectors.service` inside `_run_connector_tool` and
+# `propose_external_action` inside `_propose_connector_write`, so the patch
+# targets are the canonical source modules the imports resolve to
+# (`pocketpaw_ee.cloud.connectors.service.*`,
+# `pocketpaw_ee.cloud.external_actions.propose.propose_external_action`),
+# matching the MCP server's test layout.
 
 from __future__ import annotations
 
@@ -53,19 +63,87 @@ def _write_trust(action: str = "create_issue") -> ConnectorActionInfo:
 
 
 # ---------------------------------------------------------------------------
-# THE security rule — a WRITE grant must NEVER reach execute()
+# THE v2 security rule — a WRITE grant PROPOSES via Instinct, NEVER fires inline
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_write_grant_never_calls_execute_and_is_blocked() -> None:
-    """RISK #1 — an unapproved write must be impossible in v1.
+async def test_write_grant_proposes_via_instinct_and_never_executes_inline() -> None:
+    """RISK #1 (v2) — an unapproved write must be impossible to fire inline.
 
-    A pocket allow-lists a WRITE connector action and the button fires it.
-    `connectors.service.execute` must be called ZERO times and the response
-    must carry code="blocked". This is the load-bearing invariant: because
-    execute() is trust-agnostic, a missing Gate 3 would silently run the write.
+    A pocket allow-lists a WRITE connector action and the button fires it. The
+    executor must:
+      * call `propose_external_action` with the right kwargs (the connector
+        name, the action, the resolved params, the clicking user, the pocket
+        scope) — filing a PENDING Instinct Action;
+      * call `connectors.service.execute` ZERO times (the human gates the write,
+        so it must NOT run inline);
+      * return code="instinct_pending" with the proposed action_id.
+
+    This is the load-bearing v2 invariant: because execute() is trust-agnostic,
+    a WRITE that reached it inline would run WITHOUT approval. Gate 3 routes it
+    to the propose-and-suspend path instead — the write only fires later, when a
+    human approves and the instinct router re-enters execute (covered by the
+    approve→execute integration test below + test_external_action_gate.py).
     """
+    tool = "connector:github:create_issue"
+    proposed_id = "act-pending-123"
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(return_value=_write_trust()),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.execute",
+            new=AsyncMock(),
+        ) as mock_execute,
+        patch(
+            "pocketpaw_ee.cloud.external_actions.propose.propose_external_action",
+            new=AsyncMock(return_value=proposed_id),
+        ) as mock_propose,
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=tool,
+            args={"title": "needs a human to approve"},
+            allowed_tools=[tool],
+        )
+
+    # THE assertion #1: the write was PROPOSED, not fired.
+    mock_propose.assert_awaited_once()
+    kw = mock_propose.await_args.kwargs
+    assert kw["workspace_id"] == WS
+    assert kw["connector_name"] == "github"
+    assert kw["action"] == "create_issue"
+    assert kw["params"] == {"title": "needs a human to approve"}
+    assert kw["requested_by"] == USER
+    assert kw["scope"] == "pocket"
+    assert kw["pocket_id"] == POCKET
+
+    # THE assertion #2: execute was NEVER awaited inline — the human gates it.
+    mock_execute.assert_not_awaited()
+
+    # THE assertion #3: the pending wire shape carries the proposed action_id.
+    assert result["ok"] is True
+    assert result["code"] == "instinct_pending"
+    assert result["status"] == 202
+    assert result["tool"] == tool
+    assert result["proposed_action_id"] == proposed_id
+    assert result["response"]["action_id"] == proposed_id
+    assert result["response"]["status"] == "pending_approval"
+
+
+@pytest.mark.asyncio
+async def test_write_grant_propose_failure_maps_to_clean_wire_error() -> None:
+    """If `propose_external_action` raises (store down, etc.) the executor maps
+    it to a structured wire error (code="propose_failed") and STILL never fires
+    execute — a propose failure must not fall through to an inline write."""
     tool = "connector:github:create_issue"
     with (
         patch(
@@ -80,26 +158,23 @@ async def test_write_grant_never_calls_execute_and_is_blocked() -> None:
             "pocketpaw_ee.cloud.connectors.service.execute",
             new=AsyncMock(),
         ) as mock_execute,
+        patch(
+            "pocketpaw_ee.cloud.external_actions.propose.propose_external_action",
+            new=AsyncMock(side_effect=RuntimeError("instinct store unavailable")),
+        ),
     ):
         result = await tool_executor.run_tool(
             workspace_id=WS,
             pocket_id=POCKET,
             user_id=USER,
             tool=tool,
-            args={"title": "should never be created"},
+            args={"title": "x"},
             allowed_tools=[tool],
         )
 
-    # THE assertion: execute was never awaited.
-    mock_execute.assert_not_awaited()
     assert result["ok"] is False
-    assert result["code"] == "blocked"
-    assert result["tool"] == tool
-    assert "v2" in result["error"]
-    # The success-shaped response carries the blocked marker for the
-    # client's on_success handler to branch on.
-    assert result["response"]["blocked"] is True
-    assert result["response"]["executed"] is False
+    assert result["code"] == "propose_failed"
+    mock_execute.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/pockets/test_tools_run.py
+++ b/tests/cloud/pockets/test_tools_run.py
@@ -1,19 +1,22 @@
-# tests/cloud/pockets/test_tools_run.py — #1206 part a (invoke_tool wire).
-# Created: 2026-05-24 — Integration coverage for the new tool-run route:
+# tests/cloud/pockets/test_tools_run.py — #1206 invoke_tool route coverage.
+# Created: 2026-05-24 — Integration coverage for the tool-run route:
 #
 #   POST /pockets/{id}/tools/run — invoke a named server-side tool with the
-#                                  resolved args from the new invoke_tool
-#                                  Ripple action verb.
+#                                  resolved args from the invoke_tool Ripple
+#                                  action verb.
 #
-# Part (a) intentionally ships an empty allowlist so every tool call is
-# rejected with `code:"not_allowed"`. These tests pin the wire-level
-# contract (auth gate, tenancy scoping, structured error shape) so part
-# (b) — the home-grid `onEvent` plumbing — can rely on a stable surface.
+# Updated: 2026-06-15 (feat/invoke-tool-v1) — the route now reads the
+# per-pocket allowlist off the credential row via
+# `get_pocket_backend_for_executor` (the `get_pocket_allowed_tools` stub was
+# RETIRED), so the tests that used to monkeypatch that stub now stub the
+# backend reader instead. The allowlist lives at the 9th tuple element. The
+# executor's own dispatch/gating is covered in test_tool_executor.py; these
+# tests pin the ROUTE wiring (body parsing, status codes, response shape,
+# allowlist read-and-flatten, auth + tenancy gates).
 #
-# The pocket service + tool executor are monkeypatched, so the tests pin
-# the route wiring (request body parsing, status codes, response shape)
-# without a Mongo connection or real outbound HTTP. Auth + license guards
-# are overridden — same pattern as test_pocket_backend_routes.py.
+# The pocket service + tool executor are monkeypatched, so the tests pin the
+# route wiring without a Mongo connection or real outbound HTTP. Auth +
+# license guards are overridden — same pattern as test_pocket_backend_routes.py.
 
 from __future__ import annotations
 
@@ -34,6 +37,23 @@ from pocketpaw_ee.cloud.shared.deps import (
 
 FAKE_USER = "user-alice"
 FAKE_WORKSPACE = "ws-alpha"
+
+
+def _creds_with_tools(*tool_names: str) -> tuple:
+    """Build the 9-tuple `get_pocket_backend_for_executor` returns, with the
+    given tool names as the `allowed_tools` (9th) element. Mirrors a connector
+    backend with no token; only the trailing allowlist matters to the route."""
+    return (
+        "",  # base_url
+        "none",  # auth_type
+        None,  # auth_header
+        "",  # token
+        [],  # allowed_writes
+        None,  # approval_route
+        "connector",  # backend_type
+        "github",  # connector_name
+        [{"tool": name} for name in tool_names],  # allowed_tools (9th)
+    )
 
 
 @pytest.fixture
@@ -63,15 +83,19 @@ def client(app: FastAPI) -> TestClient:
 # ---------------------------------------------------------------------------
 
 
-def test_run_tool_empty_allowlist_returns_not_allowed(monkeypatch, client):
-    """Part (a) ships with no tools enabled. Every POST returns ok:false
-    with code:not_allowed so the wire is locked down until the captain
-    explicitly enables a tool per pocket."""
+def test_run_tool_no_backend_returns_not_allowed(monkeypatch, client):
+    """A pocket with no backend configured reads as an EMPTY allowlist, so
+    every POST returns ok:false with code:not_allowed — fail-closed, the wire
+    stays locked until an owner sets a tool policy."""
 
     async def _get_pocket(pocket_id, user_id):
         return {"_id": pocket_id}
 
+    async def _no_creds(workspace_id, pocket_id):
+        return None  # no backend configured
+
     monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _no_creds)
 
     res = client.post(
         "/pockets/pocket-1/tools/run",
@@ -89,62 +113,88 @@ def test_run_tool_empty_allowlist_returns_not_allowed(monkeypatch, client):
     assert body["on_error"] == []
 
 
-def test_run_tool_threads_workspace_user_pocket_to_executor(monkeypatch, client):
-    """The route forwards tenancy + caller identity into the executor so
-    a future audit log + per-(pocket, user) rate limit can plumb in
-    without touching the route signature."""
+def test_run_tool_empty_grant_list_returns_not_allowed(monkeypatch, client):
+    """A pocket WITH a backend but an empty tool policy also fails closed —
+    an empty `allowed_tools` revokes every tool."""
 
     async def _get_pocket(pocket_id, user_id):
         return {"_id": pocket_id}
 
+    async def _empty_grants(workspace_id, pocket_id):
+        return _creds_with_tools()  # backend present, zero grants
+
     monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _empty_grants)
+
+    res = client.post(
+        "/pockets/pocket-1/tools/run",
+        json={"tool": "connector:github:list_issues", "args": {}},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is False
+    assert body["code"] == "not_allowed"
+
+
+def test_run_tool_reads_allowlist_off_row_and_threads_identity(monkeypatch, client):
+    """The route reads `allowed_tools` off the credential row (9th tuple
+    element), FLATTENS the wire grants to bare names, and forwards tenancy +
+    caller identity into the executor — so the executor stays Beanie-free and
+    a future audit log / rate limit can plumb in without touching the route."""
+
+    async def _get_pocket(pocket_id, user_id):
+        return {"_id": pocket_id}
 
     captured: dict[str, object] = {}
+
+    async def _creds(workspace_id, pocket_id):
+        captured.setdefault("creds_args", []).append((workspace_id, pocket_id))
+        return _creds_with_tools("connector:gmail:gmail_search", "web_fetch")
 
     async def _run_tool(**kwargs):
         captured.update(kwargs)
         return {"ok": False, "tool": kwargs["tool"], "code": "not_allowed"}
 
-    async def _allowlist(workspace_id, pocket_id):
-        captured.setdefault("allowlist_args", []).append((workspace_id, pocket_id))
-        return []
-
+    monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _creds)
     monkeypatch.setattr(tool_executor, "run_tool", _run_tool)
-    monkeypatch.setattr(tool_executor, "get_pocket_allowed_tools", _allowlist)
 
     res = client.post(
         "/pockets/pocket-1/tools/run",
-        json={"tool": "GMAIL_FETCH_EMAILS", "args": {"label": "INBOX"}},
+        json={"tool": "connector:gmail:gmail_search", "args": {"label": "INBOX"}},
     )
     assert res.status_code == 200, res.text
     assert captured["workspace_id"] == FAKE_WORKSPACE
     assert captured["pocket_id"] == "pocket-1"
     assert captured["user_id"] == FAKE_USER
-    assert captured["tool"] == "GMAIL_FETCH_EMAILS"
+    assert captured["tool"] == "connector:gmail:gmail_search"
     assert captured["args"] == {"label": "INBOX"}
-    assert captured["allowed_tools"] == []
-    # The allowlist lookup is workspace-scoped.
-    assert captured["allowlist_args"] == [(FAKE_WORKSPACE, "pocket-1")]
+    # Flattened to bare names from the `{tool}` wire grants — the executor
+    # never sees the dict form.
+    assert captured["allowed_tools"] == ["connector:gmail:gmail_search", "web_fetch"]
+    # The backend read is workspace + pocket scoped.
+    assert captured["creds_args"] == [(FAKE_WORKSPACE, "pocket-1")]
 
 
 def test_run_tool_returns_unknown_tool_when_allowlisted_but_unregistered(monkeypatch, client):
-    """An allowlist with the tool name but no registry implementation
-    yet returns `code:unknown_tool` — the wire surface is in place so
-    the follow-up that adds Composio / WebFetch routing replaces this
-    branch without changing the response shape."""
+    """A non-connector grant on the allowlist but with no registry
+    implementation yet returns `code:unknown_tool` — the wire surface is
+    stable so the built-in (WebFetch / Composio) follow-up replaces this
+    branch without changing the response shape. Exercises the REAL executor
+    (no executor monkeypatch)."""
 
     async def _get_pocket(pocket_id, user_id):
         return {"_id": pocket_id}
 
-    async def _allowlist(workspace_id, pocket_id):
-        return ["GMAIL_FETCH_EMAILS"]
+    async def _creds(workspace_id, pocket_id):
+        return _creds_with_tools("web_fetch")
 
     monkeypatch.setattr(pockets_service, "get", _get_pocket)
-    monkeypatch.setattr(tool_executor, "get_pocket_allowed_tools", _allowlist)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _creds)
 
     res = client.post(
         "/pockets/pocket-1/tools/run",
-        json={"tool": "GMAIL_FETCH_EMAILS", "args": {}},
+        json={"tool": "web_fetch", "args": {}},
     )
     assert res.status_code == 200, res.text
     body = res.json()
@@ -224,6 +274,9 @@ def test_run_tool_args_default_to_empty_dict(monkeypatch, client):
     async def _get_pocket(pocket_id, user_id):
         return {"_id": pocket_id}
 
+    async def _creds(workspace_id, pocket_id):
+        return _creds_with_tools("WebFetch")
+
     captured: dict[str, object] = {}
 
     async def _run_tool(**kwargs):
@@ -231,6 +284,7 @@ def test_run_tool_args_default_to_empty_dict(monkeypatch, client):
         return {"ok": False, "tool": kwargs["tool"], "code": "not_allowed"}
 
     monkeypatch.setattr(pockets_service, "get", _get_pocket)
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _creds)
     monkeypatch.setattr(tool_executor, "run_tool", _run_tool)
 
     res = client.post("/pockets/pocket-1/tools/run", json={"tool": "WebFetch"})

--- a/tests/cloud/pockets/test_tools_run_v2_instinct.py
+++ b/tests/cloud/pockets/test_tools_run_v2_instinct.py
@@ -1,0 +1,179 @@
+# tests/cloud/pockets/test_tools_run_v2_instinct.py — feat/invoke-tool-v1 (v2).
+# Created: 2026-06-15 — the v2 WRITE-via-Instinct ROUND-TRIP for invoke_tool.
+#
+# This pins the two halves of the v2 contract end-to-end against a REAL
+# InstinctStore (tmp file) — no HTTP router, but the real propose helper and the
+# real approve-side executor, so the propose-produced Action is proven
+# consumable by the approve path:
+#
+#   1. PROPOSE (the security rule): invoke a WRITE connector grant through the
+#      real `tool_executor.run_tool`. The real `propose_external_action` files a
+#      PENDING Instinct Action; `connectors.service.execute` is NEVER called
+#      during the invoke (the human gates the write). `run_tool` returns
+#      code="instinct_pending" + the real proposed action_id, and the stored
+#      Action's `_external_action` blob carries the exact connector/action/params
+#      that were clicked.
+#
+#   2. APPROVE → EXECUTE: approve that SAME Action via the existing
+#      `execute_approved_external_action` path (the path the instinct router runs
+#      on POST /instinct/actions/{id}/approve). With `connectors.service.execute`
+#      spied, assert it IS awaited on approve, with the proposed connector +
+#      action + params (re-validated by the executor). The connector write fires
+#      ONLY on approve — never during the click.
+#
+# The store is patched everywhere the gate reads it (the propose helper + the
+# executor both lazy-import `pocketpaw.stores.get_instinct_store`), mirroring
+# tests/cloud/test_external_action_gate.py. `connectors.service.execute` is the
+# single connector chokepoint both the read path and the approve-side write
+# bottom out at, so spying it proves "fires on approve, not on click".
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.connectors.domain import ConnectorActionInfo  # noqa: E402
+from pocketpaw_ee.cloud.external_actions import executor as ea_executor  # noqa: E402
+from pocketpaw_ee.cloud.pockets import tool_executor  # noqa: E402
+
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+WS = "ws-alpha"
+POCKET = "pocket-1"
+USER = "user-alice"
+TOOL = "connector:github:create_issue"
+
+
+class _FakeExecuteResponse:
+    """Duck-typed ExecuteActionResponse the approve-side executor reads
+    (.success / .data / .error)."""
+
+    def __init__(self, *, success: bool, data: Any = None, error: str | None = None):
+        self.success = success
+        self.data = data
+        self.error = error
+        self.records_affected = 0
+        self.execution_mode = "cloud"
+
+
+class _SpyConnectorService:
+    """Records connector calls + returns a scripted response. Never touches a
+    real connector. Patched onto `connectors.service.execute`."""
+
+    def __init__(self, response: _FakeExecuteResponse | None = None):
+        self.calls: list[dict[str, Any]] = []
+        self._response = response or _FakeExecuteResponse(success=True, data={"number": 42})
+
+    async def execute(self, workspace_id, name, body, *, user_id=None):
+        self.calls.append(
+            {
+                "workspace_id": workspace_id,
+                "name": name,
+                "action": body.action,
+                "params": dict(body.params),
+                "scope": body.scope,
+                "pocket_id": body.pocket_id,
+                "user_id": user_id,
+            }
+        )
+        return self._response
+
+
+def _write_trust(action: str = "create_issue") -> ConnectorActionInfo:
+    return ConnectorActionInfo(
+        name=action,
+        description="Create an issue",
+        trust_level="confirm",
+        execution_mode="cloud",
+        is_read=False,
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired where the propose helper and
+    the executor both read it (`pocketpaw.stores.get_instinct_store`)."""
+    st = InstinctStore(tmp_path / "instinct_tools_run_v2.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+@pytest.mark.asyncio
+async def test_invoke_write_proposes_then_approve_fires_execute(store, monkeypatch):
+    """THE v2 round-trip: a WRITE invoke proposes (execute NOT called); approving
+    the proposed Action fires `connectors.service.execute` with the proposed
+    connector/action/params.
+
+    Proves the whole point of v2: the click NEVER fires the write inline — it
+    files a pending Action a human must approve; the connector write runs ONLY on
+    approve, through the existing external-action executor (re-validated)."""
+    spy = _SpyConnectorService(
+        response=_FakeExecuteResponse(success=True, data={"number": 42, "title": "Bug"})
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.connectors.service.execute", spy.execute)
+
+    # --- Half 1: PROPOSE -----------------------------------------------------
+    # The bind + trust gates resolve to a bound WRITE action; `execute` (the spy)
+    # is the chokepoint we assert never fires during the click.
+    with (
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+            new=AsyncMock(return_value=_write_trust()),
+        ),
+    ):
+        result = await tool_executor.run_tool(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            user_id=USER,
+            tool=TOOL,
+            args={"title": "Bug", "body": "It broke"},
+            allowed_tools=[TOOL],
+        )
+
+    # The click did NOT fire the connector write — it proposed.
+    assert spy.calls == [], "the WRITE must NOT fire inline on click — the human gates it"
+    assert result["ok"] is True
+    assert result["code"] == "instinct_pending"
+    assert result["status"] == 202
+    action_id = result["proposed_action_id"]
+    assert action_id, "the pending response must carry the real proposed action_id"
+
+    # A real PENDING Action was filed, carrying the clicked connector/action/params.
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+    blob = action.parameters["_external_action"]
+    assert blob["connector_name"] == "github"
+    assert blob["action"] == "create_issue"
+    assert blob["params"] == {"title": "Bug", "body": "It broke"}
+    assert blob["requested_by"] == USER
+    assert blob["scope"] == "pocket"
+    assert blob["pocket_id"] == POCKET
+
+    # --- Half 2: APPROVE → EXECUTE ------------------------------------------
+    # Approve through the store (status flip) then run the SAME executor the
+    # instinct router fires on approve. NOW the connector write runs.
+    approved = await store.approve(action_id, approver=USER)
+    await ea_executor.execute_approved_external_action(approved)
+
+    # THE assertion: execute fired ONCE on approve, with the proposed call.
+    assert len(spy.calls) == 1, "the connector write must fire exactly once on approve"
+    call = spy.calls[0]
+    assert call["workspace_id"] == WS
+    assert call["name"] == "github"
+    assert call["action"] == "create_issue"
+    assert call["params"] == {"title": "Bug", "body": "It broke"}
+
+    # The Action is now EXECUTED (the write landed).
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED

--- a/tests/cloud/test_inline_prompt_source_of_truth.py
+++ b/tests/cloud/test_inline_prompt_source_of_truth.py
@@ -1,14 +1,73 @@
 """Regression guard: the cloud chat-inline system prompt must live in one
 place — `ee/ripple/_inline.py`. If a future refactor reintroduces a
-`_RIPPLE_HINT` literal in `agent_service.py`, this test fires."""
+`_RIPPLE_HINT` literal in `agent_service.py`, this test fires.
+
+Also guards the in-chat Instinct approval loop (feat/invoke-tool-v1): the
+pending-approvals guidance must teach the agent to bind the Approve / Reject
+buttons to the backend Instinct decision routes as `api` actions (so the
+HUMAN's click finalizes the decision), point to the Tray at /deep-work, and
+NEVER fall back to an `emit`/`chat.send` round-trip for the decision."""
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 
 import pocketpaw_ee.cloud.chat.agent_service as agent_service
 
 from pocketpaw.ripple import INLINE_RIPPLE_SYSTEM_PROMPT
+
+
+def _fenced_json_blocks(text: str) -> list[dict]:
+    """Parse every ```-fenced block in the prompt that is a single JSON object.
+
+    Mirrors how the flow skeletons are validated elsewhere: pull the fenced
+    examples back out of the prompt and assert on their parsed structure so a
+    future edit that breaks the example JSON (or rewires the button) is caught.
+    Non-JSON fences (and JSON fragments) are skipped.
+    """
+    blocks: list[dict] = []
+    for body in re.findall(r"```(.*?)```", text, flags=re.DOTALL):
+        candidate = body.strip()
+        # Drop an optional language tag on the opening fence line.
+        if candidate and not candidate.lstrip().startswith("{"):
+            candidate = candidate.split("\n", 1)[-1].strip()
+        try:
+            parsed = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, dict):
+            blocks.append(parsed)
+    return blocks
+
+
+def _find_button_by_label(blocks: list[dict], label: str) -> dict | None:
+    """Depth-first search the parsed example blocks for a button node whose
+    ``props.label`` matches (case-insensitive)."""
+
+    def walk(node: object) -> dict | None:
+        if isinstance(node, dict):
+            if node.get("type") == "button":
+                props = node.get("props") or {}
+                if str(props.get("label", "")).strip().lower() == label.lower():
+                    return node
+            for value in node.values():
+                hit = walk(value)
+                if hit is not None:
+                    return hit
+        elif isinstance(node, list):
+            for item in node:
+                hit = walk(item)
+                if hit is not None:
+                    return hit
+        return None
+
+    for block in blocks:
+        hit = walk(block)
+        if hit is not None:
+            return hit
+    return None
 
 
 def test_agent_service_does_not_define_ripple_hint_literal():
@@ -59,3 +118,74 @@ def test_inline_prompt_requires_widget_help_before_emit():
     p = INLINE_RIPPLE_SYSTEM_PROMPT
     assert "get_inline_widget_help" in p
     assert "MUST CALL BEFORE EMIT" in p
+
+
+# ---------------------------------------------------------------------------
+# In-chat Instinct approval loop (feat/invoke-tool-v1)
+# ---------------------------------------------------------------------------
+
+
+def test_inline_prompt_teaches_instinct_approve_route():
+    """The pending-approvals guidance must name the backend Instinct decision
+    routes so the agent binds the Approve / Reject buttons to them."""
+    p = INLINE_RIPPLE_SYSTEM_PROMPT
+    assert "/api/v1/instinct/actions/{id}/approve" in p
+    assert "/api/v1/instinct/actions/{id}/reject" in p
+
+
+def test_inline_prompt_points_to_deep_work_tray():
+    """The Tray route pointer must be present so the agent can offer an
+    'Open Tray' affordance and reference the queue location in its text."""
+    p = INLINE_RIPPLE_SYSTEM_PROMPT
+    assert "/deep-work" in p
+
+
+def test_inline_prompt_approve_button_skeleton_is_api_action():
+    """The embedded Approve button example must round-trip to JSON with an
+    ``api`` on_click POSTing to the approve route — so the HUMAN's click
+    finalizes the decision, not an autonomous agent verb.
+
+    Parses the fenced skeletons back out of the prompt (the same shape the
+    flow-descriptor tests assert on) and inspects the Approve button node.
+    """
+    blocks = _fenced_json_blocks(INLINE_RIPPLE_SYSTEM_PROMPT)
+    approve = _find_button_by_label(blocks, "Approve")
+    assert approve is not None, "Approve button skeleton must be present and valid JSON"
+
+    on_click = approve.get("on_click") or {}
+    assert on_click.get("action") == "api", (
+        "Approve must fire via the `api` verb (human click hits the backend "
+        "approve route), not an emit/chat.send round-trip"
+    )
+    assert on_click.get("method") == "POST"
+    assert on_click.get("url") == "/api/v1/instinct/actions/{id}/approve"
+
+    # The success affordance is a toast, not a further chat round-trip.
+    on_success = on_click.get("on_success") or []
+    assert any(cont.get("action") == "toast" for cont in on_success), (
+        "Approve should confirm with a toast on success"
+    )
+
+
+def test_inline_prompt_approve_button_is_not_chat_send_roundtrip():
+    """Security/UX guard: the Approve button must NOT be wired to
+    emit/chat.send. A chat round-trip does not finalize the decision (it just
+    sends the agent a message); only the backend approve route does."""
+    approve = _find_button_by_label(_fenced_json_blocks(INLINE_RIPPLE_SYSTEM_PROMPT), "Approve")
+    assert approve is not None
+    on_click = approve.get("on_click") or {}
+    assert on_click.get("action") != "emit"
+    assert on_click.get("target") != "chat.send"
+
+
+def test_inline_prompt_does_not_introduce_self_approve_agent_verb():
+    """The fix binds the rendered BUTTON to the approve route; it must NOT
+    teach the agent an autonomous 'approve action' verb it can call on its
+    own. Self-approval would defeat the human-in-the-loop Instinct gate."""
+    p = INLINE_RIPPLE_SYSTEM_PROMPT.lower()
+    # No agent-facing self-approve tool/verb guidance.
+    assert "approve_action" not in p
+    assert "approve_external_action" not in p
+    # The guidance frames approval as a human click, explicitly not an agent
+    # acting on the user's behalf.
+    assert "the user's click is the approval" in p or "the human's click" in p

--- a/tests/cloud/test_pocket_backend_routes.py
+++ b/tests/cloud/test_pocket_backend_routes.py
@@ -30,6 +30,12 @@
 # `pocket_backend.not_configured` error (200) when a runnable source IS
 # authored. The single stale test is replaced by two that pin both arms; the
 # selection + error shape run for real (`selected_source_keys` is not mocked).
+# Updated: 2026-06-15 (feat/invoke-tool-v1) — the backend response now carries
+# `allowed_tools`; the configure assertion updated. Added coverage for the new
+# owner-only route:
+#   PUT /pockets/{id}/backend/tool-policy — set the tool allowlist
+# (owner sets the grants; empty list valid; empty tool name 422'd; non-owner
+# 403 before the service runs).
 
 from __future__ import annotations
 
@@ -135,6 +141,9 @@ def test_put_backend_configures(monkeypatch, client):
         # RFC 05 M2a: the response now carries the write allowlist —
         # empty by default (fail-closed).
         "allowed_writes": [],
+        # feat/invoke-tool-v1: the response carries the tool allowlist —
+        # empty by default (fail-closed).
+        "allowed_tools": [],
         # RFC 05 M2b.1: the response carries the gated-write approval
         # route — None by default (the pocket owner approves).
         "approval_route": None,
@@ -413,6 +422,112 @@ def test_put_write_policy_empty_list_is_valid(monkeypatch, client):
     res = client.put("/pockets/pocket-1/backend/write-policy", json={"allowed_writes": []})
     assert res.status_code == 200, res.text
     assert res.json()["allowed_writes"] == []
+
+
+# ---------------------------------------------------------------------------
+# PUT /pockets/{id}/backend/tool-policy — feat/invoke-tool-v1
+# ---------------------------------------------------------------------------
+
+
+def test_put_tool_policy_sets_allowlist(monkeypatch, client):
+    """An owner sets the tool allowlist; the route forwards the grants to the
+    service and echoes them back. `require_pocket_owner` is overridden to allow
+    (owner)."""
+    captured = {}
+
+    async def _set_policy(workspace_id, user_id, pocket_id, allowed_tools):
+        captured.update(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            allowed_tools=allowed_tools,
+        )
+        return {
+            "base_url": "",
+            "auth_type": "none",
+            "configured": True,
+            "allowed_tools": allowed_tools,
+        }
+
+    monkeypatch.setattr(pockets_service, "set_pocket_tool_policy", _set_policy)
+
+    res = client.put(
+        "/pockets/pocket-1/backend/tool-policy",
+        json={"allowed_tools": [{"tool": "connector:github:list_issues"}, {"tool": "web_fetch"}]},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["allowed_tools"] == [
+        {"tool": "connector:github:list_issues"},
+        {"tool": "web_fetch"},
+    ]
+    # The route forwarded the right identity + grants to the service.
+    assert captured["workspace_id"] == FAKE_WORKSPACE
+    assert captured["user_id"] == FAKE_USER
+    assert captured["pocket_id"] == "pocket-1"
+    assert captured["allowed_tools"] == [
+        {"tool": "connector:github:list_issues"},
+        {"tool": "web_fetch"},
+    ]
+
+
+def test_put_tool_policy_empty_list_is_valid(monkeypatch, client):
+    """An empty allowlist revokes every tool — a valid request (fail-closed)."""
+
+    async def _set_policy(workspace_id, user_id, pocket_id, allowed_tools):
+        return {
+            "base_url": "",
+            "auth_type": "none",
+            "configured": True,
+            "allowed_tools": [],
+        }
+
+    monkeypatch.setattr(pockets_service, "set_pocket_tool_policy", _set_policy)
+    res = client.put("/pockets/pocket-1/backend/tool-policy", json={"allowed_tools": []})
+    assert res.status_code == 200, res.text
+    assert res.json()["allowed_tools"] == []
+
+
+def test_put_tool_policy_rejects_empty_tool_name(client):
+    """`tool` has `min_length=1` — an empty grant is a 422 at parse time, before
+    the service is touched."""
+    res = client.put(
+        "/pockets/pocket-1/backend/tool-policy",
+        json={"allowed_tools": [{"tool": ""}]},
+    )
+    assert res.status_code == 422
+
+
+def test_put_tool_policy_forbidden_for_non_owner(monkeypatch):
+    """The tool-policy route is owner-only — `require_pocket_owner` denies a
+    non-owner with 403 before the service is reached."""
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+
+    a = FastAPI()
+    add_error_handler(a)
+    a.include_router(router)
+    a.dependency_overrides[require_license] = lambda: None
+    a.dependency_overrides[current_user_id] = lambda: FAKE_USER
+    a.dependency_overrides[current_workspace_id] = lambda: FAKE_WORKSPACE
+
+    def _deny():
+        raise Forbidden("pocket.owner_required", "owner access required")
+
+    a.dependency_overrides[require_pocket_owner] = _deny
+
+    # If the guard ever let a non-owner through, the service would be hit — make
+    # that a loud failure rather than a silent pass.
+    async def _should_not_run(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("set_pocket_tool_policy must not run for a non-owner")
+
+    monkeypatch.setattr(pockets_service, "set_pocket_tool_policy", _should_not_run)
+
+    res = TestClient(a).put(
+        "/pockets/pocket-1/backend/tool-policy",
+        json={"allowed_tools": [{"tool": "web_fetch"}]},
+    )
+    assert res.status_code == 403
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_pocket_backend_service.py
+++ b/tests/cloud/test_pocket_backend_service.py
@@ -22,6 +22,13 @@
 # (rejects unknown connector / missing name / bad backend_type); the executor
 # tuple carries them with no token; switching http->connector clears the stale
 # credential; and a legacy row (no backend_type) reads back as http.
+# Updated: 2026-06-15 (feat/invoke-tool-v1) — the summaries now carry
+# `allowed_tools` and the executor tuple is a 9-tuple (trailing tool
+# allowlist). Updated the shape assertions and added set_pocket_tool_policy
+# coverage: grants persist + read back via the executor path, an empty list
+# revokes every tool, the not-configured guard fires, and the mutation is
+# audit-logged (pocket.backend.tool_policy). The legacy-row test now also
+# asserts allowed_tools reads back as [] (back-compat, no migration).
 #
 # What this pins:
 #   - set_pocket_backend then get_pocket_backend returns configured:true
@@ -79,6 +86,9 @@ async def test_set_then_get_backend(mongo_db):
         "auth_type": "bearer",
         "configured": True,
         "allowed_writes": [],
+        # feat/invoke-tool-v1: the summary now carries the tool allowlist —
+        # empty by default (fail-closed).
+        "allowed_tools": [],
         "approval_route": None,
     }
     assert "token" not in summary
@@ -114,8 +124,8 @@ async def test_get_for_executor_decrypts_token(mongo_db):
     )
     creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
     assert creds is not None
-    # connector-as-backend: the executor tuple is now an 8-tuple — trailing
-    # `backend_type` / `connector_name` after the write allowlist + route.
+    # feat/invoke-tool-v1: the executor tuple is now a 9-tuple — trailing
+    # `allowed_tools` after backend_type / connector_name.
     (
         base_url,
         auth_type,
@@ -125,6 +135,7 @@ async def test_get_for_executor_decrypts_token(mongo_db):
         approval_route,
         backend_type,
         connector_name,
+        allowed_tools,
     ) = creds
     assert base_url == "https://api.example.com"
     assert auth_type == "api_key"
@@ -135,6 +146,8 @@ async def test_get_for_executor_decrypts_token(mongo_db):
     assert approval_route is None
     assert backend_type == "http"
     assert connector_name is None
+    # feat/invoke-tool-v1: no tool policy set → empty (fail-closed).
+    assert allowed_tools == []
 
 
 async def test_get_for_executor_none_when_unset(mongo_db):
@@ -152,16 +165,27 @@ async def test_get_for_executor_no_token_for_none_auth(mongo_db):
     )
     creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
     assert creds is not None
-    # connector-as-backend: the executor tuple is now an 8-tuple — trailing
+    # feat/invoke-tool-v1: the executor tuple is now a 9-tuple — trailing
     # elements are write allowlist, approval route, backend_type,
-    # connector_name.
-    _, auth_type, _, token, allowed_writes, approval_route, backend_type, connector_name = creds
+    # connector_name, tool allowlist.
+    (
+        _,
+        auth_type,
+        _,
+        token,
+        allowed_writes,
+        approval_route,
+        backend_type,
+        connector_name,
+        allowed_tools,
+    ) = creds
     assert auth_type == "none"
     assert token == ""
     assert allowed_writes == []
     assert approval_route is None
     assert backend_type == "http"
     assert connector_name is None
+    assert allowed_tools == []
 
 
 async def test_set_backend_upserts(mongo_db):
@@ -263,6 +287,8 @@ async def test_set_connector_backend_summary(mongo_db):
         "auth_type": "none",
         "configured": True,
         "allowed_writes": [],
+        # feat/invoke-tool-v1: the summary carries the tool allowlist too.
+        "allowed_tools": [],
         "approval_route": None,
     }
     assert "token" not in summary
@@ -333,12 +359,16 @@ async def test_connector_backend_for_executor_tuple(mongo_db):
     )
     creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
     assert creds is not None
-    base_url, auth_type, _hdr, token, _aw, _route, backend_type, connector_name = creds
+    # feat/invoke-tool-v1: 9-tuple — trailing allowed_tools.
+    base_url, auth_type, _hdr, token, _aw, _route, backend_type, connector_name, allowed_tools = (
+        creds
+    )
     assert backend_type == "connector"
     assert connector_name == "github"
     assert base_url == ""
     assert auth_type == "none"
     assert token == ""
+    assert allowed_tools == []
 
 
 async def test_switch_http_to_connector_clears_credential(mongo_db):
@@ -404,6 +434,10 @@ async def test_legacy_row_reads_as_http_backend(mongo_db):
     assert creds is not None
     assert creds[6] == "http"  # backend_type
     assert creds[7] is None  # connector_name
+    # feat/invoke-tool-v1: a legacy row (no allowed_tools attr) reads as []
+    # via the getattr default in _allowed_tools_wire — fail-closed, no migration.
+    assert creds[8] == []  # allowed_tools
+    assert summary["allowed_tools"] == []
 
 
 async def test_set_backend_requires_token_for_auth(mongo_db):
@@ -547,3 +581,103 @@ async def test_set_approval_route_rejects_when_no_backend(mongo_db):
         await pockets_service.set_pocket_approval_route(
             "w1", "u1", "missing-pocket", {"mode": "user", "user_id": "x"}
         )
+
+
+# ---------------------------------------------------------------------------
+# feat/invoke-tool-v1 — set_pocket_tool_policy (the tool allowlist)
+# ---------------------------------------------------------------------------
+
+
+async def test_set_tool_policy_persists_and_reads_back_via_executor(mongo_db):
+    """An owner sets a tool policy; the grants persist on the credential row
+    and are read back by get_pocket_backend_for_executor (the 9th element) —
+    the path the run-tool route uses to source the allowlist."""
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+
+    result = await pockets_service.set_pocket_tool_policy(
+        "w1",
+        "u1",
+        "pocket-1",
+        [{"tool": "connector:github:list_issues"}, {"tool": "web_fetch"}],
+    )
+    # The summary echoes the stored grants.
+    assert result["allowed_tools"] == [
+        {"tool": "connector:github:list_issues"},
+        {"tool": "web_fetch"},
+    ]
+
+    # Read back through the executor path — the grants survive the round-trip.
+    creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
+    assert creds is not None
+    assert creds[8] == [
+        {"tool": "connector:github:list_issues"},
+        {"tool": "web_fetch"},
+    ]
+    # And via the owner-facing summary too.
+    summary = await pockets_service.get_pocket_backend("w1", "pocket-1")
+    assert summary["allowed_tools"] == [
+        {"tool": "connector:github:list_issues"},
+        {"tool": "web_fetch"},
+    ]
+
+
+async def test_set_tool_policy_empty_list_revokes_every_tool(mongo_db):
+    """An empty list is valid and revokes every tool — fail-closed, the same
+    semantics as the write policy."""
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    # Grant one, then revoke all.
+    await pockets_service.set_pocket_tool_policy(
+        "w1", "u1", "pocket-1", [{"tool": "connector:github:list_issues"}]
+    )
+    result = await pockets_service.set_pocket_tool_policy("w1", "u1", "pocket-1", [])
+    assert result["allowed_tools"] == []
+
+    creds = await pockets_service.get_pocket_backend_for_executor("w1", "pocket-1")
+    assert creds is not None
+    assert creds[8] == []
+
+
+async def test_set_tool_policy_rejects_when_no_backend(mongo_db):
+    """A tool policy with no backend to apply it to is meaningless — rejected
+    with pocket_backend.not_configured, never silently stored."""
+    with pytest.raises(ValidationError) as excinfo:
+        await pockets_service.set_pocket_tool_policy(
+            "w1", "u1", "missing-pocket", [{"tool": "web_fetch"}]
+        )
+    assert excinfo.value.code == "pocket_backend.not_configured"
+
+
+async def test_set_tool_policy_audit_logs(mongo_db, monkeypatch):
+    """The tool-policy mutation writes an audit-log entry with the
+    pocket.backend.tool_policy action — same audit path as write-policy."""
+    captured: list = []
+
+    def _fake_audit(*, actor, action, workspace_id, pocket_id, base_url, auth_type):
+        captured.append((actor, action, workspace_id, pocket_id))
+
+    monkeypatch.setattr(pockets_service, "_audit_backend_config", _fake_audit)
+
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="none",
+        auth_token="",
+    )
+    await pockets_service.set_pocket_tool_policy("w1", "u1", "pocket-1", [{"tool": "web_fetch"}])
+    assert ("u1", "pocket.backend.tool_policy", "w1", "pocket-1") in captured

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -4,11 +4,21 @@
 #   test_sites_mcp_server layout: registration assertions (server name, tool
 #   ids, build, provider allowlist publication, ambient-not-opt-in) plus
 #   per-handler tests that mock the identity ContextVars + the connectors
-#   service and inspect the MCP envelope the SDK returns. The handler tests
-#   prove the v1 contract: read (auto-trust) actions reach service.execute,
-#   write (confirm-trust) actions are blocked WITHOUT calling execute,
-#   connectors not bound to the pocket are rejected, and a missing pocket /
-#   workspace ContextVar (called off-stream) yields a clear error.
+#   service and inspect the MCP envelope the SDK returns.
+# Updated: 2026-06-15 (feat/invoke-tool-v1, v2) — the WRITE branch of
+#   ``connector_execute`` now PROPOSES through Instinct instead of refusing
+#   ("coming in v2" stub retired), making this chat-agent surface symmetric with
+#   the flow-button surface (``cloud.pockets.tool_executor``). The old "write →
+#   blocked, execute never called" test is replaced by the v2 security rule: a
+#   WRITE-trust action calls ``propose_external_action`` (right kwargs), does
+#   NOT call ``connectors.service.execute`` inline, and returns
+#   status="pending_approval" with an ``action_id``. ``list_connector_actions``
+#   now reports write actions under ``write_actions_need_approval`` flagged
+#   "needs approval — proposes to your Tray". The handler tests prove the
+#   contract: read (auto-trust) actions reach service.execute, write (confirm-
+#   trust) actions PROPOSE without ever calling execute inline, connectors not
+#   bound to the pocket are rejected, and a missing pocket / workspace
+#   ContextVar (called off-stream) yields a clear error.
 """MCP server registration + handler tests for connector execution."""
 
 from __future__ import annotations
@@ -171,10 +181,11 @@ class TestListConnectorActionsHandler:
         assert gh["connector"] == "github"
         # Read action listed as runnable.
         assert [a["action"] for a in gh["read_actions"]] == ["list_issues"]
-        # Write action listed but flagged blocked.
-        assert len(gh["write_actions_blocked"]) == 1
-        assert gh["write_actions_blocked"][0]["action"] == "create_issue"
-        assert "v2" in gh["write_actions_blocked"][0]["status"]
+        # Write action listed but flagged as needing approval (proposes to Tray),
+        # NOT blocked — v2 routes writes through Instinct.
+        assert len(gh["write_actions_need_approval"]) == 1
+        assert gh["write_actions_need_approval"][0]["action"] == "create_issue"
+        assert "approval" in gh["write_actions_need_approval"][0]["status"]
         mock_list.assert_awaited_once_with("ws_1", "pk_1")
 
     @pytest.mark.asyncio
@@ -300,9 +311,135 @@ class TestConnectorExecuteHandler:
         assert req.pocket_id == "pk_1"
 
     @pytest.mark.asyncio
-    async def test_write_action_blocked_without_calling_execute(self) -> None:
-        """A confirm-trust (write) action is refused and service.execute is
-        NEVER called."""
+    async def test_write_action_proposes_via_instinct_and_never_executes_inline(self) -> None:
+        """THE v2 security rule — a confirm-trust (write) action is PROPOSED
+        through Instinct and ``connectors.service.execute`` is NEVER called
+        inline. The human gates the write in The Tray; only their approval (via
+        the instinct router → ``execute_approved_external_action``) fires it.
+
+        This is the chat-agent twin of
+        ``test_tool_executor.test_write_grant_proposes_via_instinct_and_never_executes_inline``
+        — both connector-write surfaces now route through ``propose_external_action``.
+        """
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        write_trust = ConnectorActionInfo(
+            name="create_issue",
+            description="Create an issue",
+            trust_level="confirm",
+            execution_mode="cloud",
+            is_read=False,
+        )
+        proposed_id = "act-pending-777"
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+                new=AsyncMock(return_value=write_trust),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.execute",
+                new=AsyncMock(),
+            ) as mock_execute,
+            patch(
+                "pocketpaw_ee.cloud.external_actions.propose.propose_external_action",
+                new=AsyncMock(return_value=proposed_id),
+            ) as mock_propose,
+        ):
+            out = await connectors_mcp._connector_execute_handler(
+                {
+                    "connector_name": "github",
+                    "action": "create_issue",
+                    "params": {"title": "needs a human"},
+                }
+            )
+
+        # Assertion #1 — the write was PROPOSED with the right kwargs (resolved
+        # from the per-stream ContextVars), not fired.
+        mock_propose.assert_awaited_once()
+        kw = mock_propose.await_args.kwargs
+        assert kw["workspace_id"] == "ws_1"
+        assert kw["connector_name"] == "github"
+        assert kw["action"] == "create_issue"
+        assert kw["params"] == {"title": "needs a human"}
+        assert kw["requested_by"] == "u_1"
+        assert kw["scope"] == "pocket"
+        assert kw["pocket_id"] == "pk_1"
+
+        # Assertion #2 — execute() was NEVER awaited inline. THE security rule.
+        mock_execute.assert_not_awaited()
+
+        # Assertion #3 — pending-shaped success carrying the proposed action_id.
+        assert not out.get("is_error")
+        body = _decode_payload(out)
+        assert body["executed"] is False
+        assert body["status"] == "pending_approval"
+        assert body["action_id"] == proposed_id
+        assert body["connector"] == "github"
+        assert body["action"] == "create_issue"
+        assert "Tray" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_write_action_unanchored_proposes_workspace_scope(self) -> None:
+        """A write proposed from an UNANCHORED chat (pocket_id=None) proposes a
+        ``workspace``-scoped call — matching the credentials the eventual
+        approved execute resolves. Still never fires execute inline."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        write_trust = ConnectorActionInfo(
+            name="gmail_send",
+            description="Send an email",
+            trust_level="confirm",
+            execution_mode="cloud",
+            is_read=False,
+        )
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", None)
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.is_connector_bound_to_pocket",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.get_action_trust",
+                new=AsyncMock(return_value=write_trust),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.connectors.service.execute",
+                new=AsyncMock(),
+            ) as mock_execute,
+            patch(
+                "pocketpaw_ee.cloud.external_actions.propose.propose_external_action",
+                new=AsyncMock(return_value="act-ws-1"),
+            ) as mock_propose,
+        ):
+            out = await connectors_mcp._connector_execute_handler(
+                {"connector_name": "gmail", "action": "gmail_send", "params": {"to": "x@y.z"}}
+            )
+
+        mock_propose.assert_awaited_once()
+        kw = mock_propose.await_args.kwargs
+        assert kw["scope"] == "workspace"
+        assert kw["pocket_id"] is None
+        mock_execute.assert_not_awaited()
+        assert not out.get("is_error")
+
+    @pytest.mark.asyncio
+    async def test_write_action_propose_failure_is_clean_error_not_inline_execute(self) -> None:
+        """If ``propose_external_action`` raises (store down, etc.) the handler
+        returns a clean MCP error envelope and STILL never fires execute — a
+        propose failure must not fall through to an inline write."""
         from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
 
         write_trust = ConnectorActionInfo(
@@ -330,17 +467,17 @@ class TestConnectorExecuteHandler:
                 "pocketpaw_ee.cloud.connectors.service.execute",
                 new=AsyncMock(),
             ) as mock_execute,
+            patch(
+                "pocketpaw_ee.cloud.external_actions.propose.propose_external_action",
+                new=AsyncMock(side_effect=RuntimeError("instinct store unavailable")),
+            ),
         ):
             out = await connectors_mcp._connector_execute_handler(
                 {"connector_name": "github", "action": "create_issue", "params": {}}
             )
 
-        assert not out.get("is_error")
-        body = _decode_payload(out)
-        assert body["executed"] is False
-        assert body["blocked"] is True
-        assert "needs approval" in body["reason"]
-        assert "v2" in body["reason"]
+        assert out.get("is_error") is True
+        assert "for approval" in out["content"][0]["text"]
         mock_execute.assert_not_awaited()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What this does

`POST /pockets/{id}/tools/run` was a fail-closed stub: `get_pocket_allowed_tools` returned `[]` for every pocket and `run_tool` dead-ended at `code: unknown_tool`. This PR makes the route actually work end to end — connector READS fire immediately, connector WRITES are proposed for human approval through Instinct — all behind a per-pocket allowlist a human sets.

`invoke_tool` is the click verb for pocket FLOW-BUTTONs. Ripple already resolves the args and POSTs the event; the backend just refused to do anything with it. Now it does.

## How it's wired

A pocket gets a tool allowlist (`allowed_tools`) stored on the same `PocketBackendCredential` row that already holds `allowed_writes`. Same posture: empty by default, set only by the owner through a PUT route, never read from `rippleSpec`. A hallucinated or shared spec can't widen its own blast radius, because the allowlist doesn't live in the spec.

A grant's `tool` is either a connector action (`connector:<name>:<action>`) or a built-in tool name. When the button fires, `run_tool` resolves the grant and reuses the connector executor from #1376 (`connectors.service.execute`) rather than building a second one. The two callers — chat MCP `connector_execute` and the click-driven route — bottom out at one execution path.

The read/write split is the load-bearing rule. `connectors.service.execute` is trust-agnostic, so `run_tool` enforces three gates in the same order the chat MCP layer proved out:

1. the connector must be bound to this pocket/workspace (the tenant boundary)
2. look up the action's trust level
3. a READ (`trust=auto`) fires `execute`; a WRITE (`confirm`/`restricted`) **never** calls `execute` inline

## Writes go through Instinct (propose → approve → execute)

A WRITE grant doesn't run when you click it. `run_tool` files a pending Instinct Action through the existing external-action gate (`propose_external_action`) and returns `code: instinct_pending` (HTTP 202) with a `proposed_action_id`. The button shows "sent for approval"; the Action lands in the user's Tray.

The connector write fires only when a human approves. That side was already built. The instinct router's approve handler runs `execute_approved_external_action`, which re-validates workspace + params hash + idempotency and then calls the same `connectors.service.execute` the read path uses. This PR adds nothing to the approve side; it only adds the propose-and-suspend interception at gate 3. Read-now and write-on-approve both end at one connector executor.

`propose_external_action` is lazy-imported inside the write path, mirroring the v1 lazy import of `connectors.service`. It statically imports no Beanie model, so the import-linter contract stays clean — the executor still reads its allowlist by parameter and never touches a document class.

## Security

The risk that matters most: a missing trust gate would let `execute` silently run an unapproved write. There's a dedicated test that proves the WRITE path can't fire inline — a pocket grants a WRITE tool, the button fires, and the test asserts `connectors.service.execute` is awaited **zero** times while `propose_external_action` is called with the right kwargs and the response carries `code: instinct_pending`. A second test proves a propose failure (store down) maps to a clean wire error and still doesn't fall through to an inline write.

A round-trip test against a real Instinct store proves the other half: invoking a write files a real pending Action (zero execute calls), and approving that same Action through `execute_approved_external_action` fires `connectors.service.execute` exactly once with the proposed connector, action, and params. So the write only runs after a human approves it, not when the button is clicked.

The connector read path, the bind re-check, the empty-allowlist fail-closed default, and the malformed-grant case are all covered too.

## Scope

Backend only. v1 ships connector grants; a built-in (WebFetch/Composio) registry dispatch is a follow-up, so a built-in grant returns `unknown_tool` for now. The paw-enterprise host branch that calls this route is a separate thin PR against the same response contract. Ripple needs nothing — the `invoke_tool` verb and dispatcher already shipped.

## Both connector-write surfaces now route through Instinct

There are two surfaces that can fire a connector write, and this PR now covers both. They share one rule: a write is never executed inline — it's proposed through the external-action gate (`propose_external_action`) and runs only after a human approves it in their Tray.

- **Flow-button surface** — `cloud.pockets.tool_executor.run_tool` (a button on a pocket fires a tool grant). Covered by the original commits in this PR.
- **Chat-agent surface** — the in-process `pocketpaw_connectors` MCP server's `connector_execute` tool (the chat agent calls an integration directly). This used to refuse writes with a "coming in v2" stub; it now proposes them the same way, returning `status: "pending_approval"` with an `action_id` so the agent relays "I've proposed that change — approve it in your Tray." Reads are unchanged. Added in `feat(connectors): chat-agent connector_execute writes propose via Instinct`.

Both surfaces converge on the same approve→execute path (`execute_approved_external_action` → `connectors.service.execute`), which this PR leaves untouched.

## Tests

- `tests/cloud/pockets/test_tool_executor.py` — the v2 security rule (write proposes via Instinct, never executes inline) plus the gate order, read-fires, fail-closed, CloudError mapping. The old v1 "write returns blocked" test is replaced by the propose-and-suspend contract.
- `tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py` — the same v2 security rule for the chat-agent `connector_execute` surface: a write proposes with the right kwargs and never awaits execute inline, an unanchored chat proposes a workspace-scoped call, and a propose failure returns a clean error without firing execute. The old "write returns blocked" assertion is replaced.
- `tests/cloud/pockets/test_tools_run_v2_instinct.py` (new) — the approve→execute round-trip against a real Instinct store.
- `tests/cloud/pockets/test_tools_run.py` — the route wiring (allowlist read-and-flatten, auth + tenancy gates, body validation).
- `tests/cloud/test_pocket_backend_service.py` / `test_pocket_backend_routes.py` — `set_pocket_tool_policy` persistence + the PUT tool-policy route.

Named scope: 20 passed (executor + route + v2 round-trip). Broader pockets dir: 119 passed. The approve-side gate I depend on (`test_external_action_gate.py`): 13 passed, unchanged. `ruff check` clean on changed files. import-linter: 23 ee contracts kept, 0 broken.

## Docs

`docs/api-reference.md` updated in the same PR: the now-live `tools/run` with the `instinct_pending` write response, the `tool-policy` route, and `allowed_tools` on the backend summary.

## Update — closing the in-chat approval loop

In-chat Approve buttons now fire the approve directly. When the agent renders the pending-approvals view, each action's Approve/Reject button is bound to the backend Instinct route as an `api` action (`POST /api/v1/instinct/actions/{id}/approve` and `.../reject`), so the human's click finalizes the decision and the backend runs the connector write via `execute_approved_external_action`. Previously the rendered buttons fell back to a `chat.send` round-trip that never finalized anything. This is human-clicked, not an agent verb — no self-approve tool was added. The Tray route `/deep-work` is also wired: an "Open Tray" navigate button plus a reference in the agent's text guidance. Guidance lives in the canonical inline prompt (`src/pocketpaw/ripple/_inline.py`); `tests/cloud/test_inline_prompt_source_of_truth.py` parses the embedded Approve skeleton and asserts the binding (10 passed).


