### PR TITLE
fix(uploads): accept SVG logos and serve them without an XSS hole

### DIFF
--- a/ee/pocketpaw_ee/cloud/uploads/router.py
+++ b/ee/pocketpaw_ee/cloud/uploads/router.py
@@ -66,9 +66,10 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 
-from pocketpaw.uploads.config import INLINE_MIMES, UploadSettings
+from pocketpaw.uploads.config import INLINE_MIMES, SVG_MIME, UploadSettings
 from pocketpaw.uploads.errors import NotFound
 from pocketpaw.uploads.factory import build_adapter
+from pocketpaw.uploads.svg_safety import svg_response_headers
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import (
     current_user_id,
@@ -577,15 +578,18 @@ async def download(
         rec, it = await _SVC.stream(file_id, user_id, workspace)
     except NotFound as e:
         raise HTTPException(status_code=404, detail="not found") from e
-    disposition = "inline" if rec.mime in INLINE_MIMES else "attachment"
-    return StreamingResponse(
-        it,
-        media_type=rec.mime,
-        headers={
+    # SVG is active content: force a download + a script-blocking CSP so a
+    # direct navigation to this URL can't execute embedded script. The logo
+    # still renders via <img src> (script-safe). See svg_response_headers.
+    if rec.mime == SVG_MIME:
+        headers = svg_response_headers(rec.filename)
+    else:
+        disposition = "inline" if rec.mime in INLINE_MIMES else "attachment"
+        headers = {
             "Content-Disposition": f'{disposition}; filename="{rec.filename}"',
             "X-Content-Type-Options": "nosniff",
-        },
-    )
+        }
+    return StreamingResponse(it, media_type=rec.mime, headers=headers)
 
 
 @router.delete("/{file_id}", status_code=204)

--- a/src/pocketpaw/api/v1/uploads.py
+++ b/src/pocketpaw/api/v1/uploads.py
@@ -22,12 +22,13 @@ from fastapi.responses import StreamingResponse
 
 from pocketpaw.api.deps import require_scope
 from pocketpaw.dashboard_auth import get_access_token
-from pocketpaw.uploads.config import INLINE_MIMES, UploadSettings
+from pocketpaw.uploads.config import INLINE_MIMES, SVG_MIME, UploadSettings
 from pocketpaw.uploads.errors import NotFound
 from pocketpaw.uploads.factory import build_adapter
 from pocketpaw.uploads.file_store import JSONLFileStore
 from pocketpaw.uploads.service import UploadService
 from pocketpaw.uploads.signing import DEFAULT_TTL_SECONDS, sign_grant
+from pocketpaw.uploads.svg_safety import svg_response_headers
 
 _OWNER = "local"  # OSS is single-user; all uploads are "owned" by the local user.
 
@@ -165,15 +166,18 @@ async def download(
         rec, it = await _SVC.stream(file_id, requester_id=_OWNER)
     except NotFound as e:
         raise HTTPException(status_code=404, detail="not found") from e
-    disposition = "inline" if rec.mime in INLINE_MIMES else "attachment"
-    return StreamingResponse(
-        it,
-        media_type=rec.mime,
-        headers={
+    # SVG is active content: force a download + a script-blocking CSP so a
+    # direct navigation to this URL can't execute embedded script. The logo
+    # still renders via <img src> (script-safe). See svg_response_headers.
+    if rec.mime == SVG_MIME:
+        headers = svg_response_headers(rec.filename)
+    else:
+        disposition = "inline" if rec.mime in INLINE_MIMES else "attachment"
+        headers = {
             "Content-Disposition": f'{disposition}; filename="{rec.filename}"',
             "X-Content-Type-Options": "nosniff",
-        },
-    )
+        }
+    return StreamingResponse(it, media_type=rec.mime, headers=headers)
 
 
 @router.delete("/{file_id}", status_code=204)

--- a/src/pocketpaw/uploads/config.py
+++ b/src/pocketpaw/uploads/config.py
@@ -1,3 +1,13 @@
+# config.py — upload size limits, mime allowlist, storage root.
+# Updated: 2026-06-16 — accept SVG logos (image/svg+xml) in the upload
+#   allow-list so the white-label Branding panel's "Upload logo — SVG or
+#   PNG" works. SVG is intentionally kept OUT of ``INLINE_MIMES``: an SVG
+#   is active content (it can carry <script>), so it must be served as a
+#   download (Content-Disposition: attachment) plus a locked-down CSP, never
+#   rendered inline from a direct navigation to the signed URL. The image
+#   <img src> path that actually renders the logo never executes script,
+#   so the panel still works. See ``service.py`` (sniff + sanitize) and the
+#   serving routers (CSP headers) for the matching XSS defenses.
 """Upload configuration — size limits, mime allowlist, storage root."""
 
 from __future__ import annotations
@@ -7,6 +17,8 @@ from pathlib import Path
 
 # Mimes safe to render inline (images, pdf, plain text). Everything else gets
 # Content-Disposition: attachment to avoid in-origin HTML/SVG tricks.
+# NOTE: image/svg+xml is deliberately ABSENT here. SVG is active content and
+# must never be served inline from a same-origin URL — see SVG_MIME below.
 INLINE_MIMES: frozenset[str] = frozenset(
     {
         "image/png",
@@ -20,6 +32,10 @@ INLINE_MIMES: frozenset[str] = frozenset(
     }
 )
 
+# Canonical SVG mime. Centralized so the sniff special-case, the allow-list,
+# the extension map, and the serving routers all agree on one spelling.
+SVG_MIME = "image/svg+xml"
+
 DEFAULT_ALLOWED_MIMES: frozenset[str] = frozenset(
     {
         # Images
@@ -27,6 +43,9 @@ DEFAULT_ALLOWED_MIMES: frozenset[str] = frozenset(
         "image/jpeg",
         "image/gif",
         "image/webp",
+        # SVG — accepted for logos/branding. Served with XSS defenses
+        # (sanitize-on-upload + attachment + locked-down CSP), never inline.
+        SVG_MIME,
         # Documents
         "application/pdf",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
@@ -90,6 +109,7 @@ _MIME_TO_EXT: dict[str, str] = {
     "image/jpeg": ".jpg",
     "image/gif": ".gif",
     "image/webp": ".webp",
+    SVG_MIME: ".svg",
     "application/pdf": ".pdf",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",

--- a/src/pocketpaw/uploads/service.py
+++ b/src/pocketpaw/uploads/service.py
@@ -1,3 +1,12 @@
+# service.py — UploadService: validates, stores, and persists upload metadata.
+# Updated: 2026-06-16 — accept SVG logos (image/svg+xml). The magic-byte
+#   sniff now has a narrow SVG special-case (declared image/svg+xml + .svg
+#   filename + <?xml/<svg signature, via svg_safety.looks_like_svg), since an
+#   SVG is XML text and won't match any binary image signature. SVG uploads
+#   are sanitized in full (svg_safety.sanitize_svg strips <script>, on*
+#   handlers, <foreignObject>, javascript: URLs, DOCTYPE/ENTITY) BEFORE they
+#   hit storage — defense-in-depth alongside the serving routers' attachment
+#   + CSP headers. Non-SVG uploads keep the unchanged streaming path.
 """UploadService — validates, stores, persists metadata, and generates thumbnails."""
 
 from __future__ import annotations
@@ -15,7 +24,7 @@ from typing import Literal
 from fastapi import UploadFile
 
 from pocketpaw.uploads.adapter import StorageAdapter
-from pocketpaw.uploads.config import UploadSettings, extension_for
+from pocketpaw.uploads.config import SVG_MIME, UploadSettings, extension_for
 from pocketpaw.uploads.errors import (
     EmptyFile,
     NotFound,
@@ -26,6 +35,7 @@ from pocketpaw.uploads.errors import (
 )
 from pocketpaw.uploads.file_store import FileRecord, JSONLFileStore
 from pocketpaw.uploads.keys import new_storage_key
+from pocketpaw.uploads.svg_safety import looks_like_svg, sanitize_svg
 
 logger = logging.getLogger(__name__)
 
@@ -155,28 +165,65 @@ class UploadService:
         if len(head) > cap:
             raise TooLarge(f"file exceeds {cap} bytes")
 
-        mime = _sniff_mime(head, file.content_type or "application/octet-stream")
+        declared = file.content_type or "application/octet-stream"
+        mime = _sniff_mime(head, declared)
+
+        # SVG special-case. An SVG is XML text, so _sniff_mime can only return
+        # the declared content-type for it — never a binary image signature.
+        # Accepting that on the client's word alone would let a caller smuggle
+        # arbitrary XML/HTML into the image allow-list, so we re-verify against
+        # a narrow gate (declared image/svg+xml AND .svg filename AND a real
+        # <?xml/<svg signature). A blob that claims image/svg+xml but fails the
+        # gate is rejected as unsupported rather than stored as an image.
+        is_svg = False
+        if mime == SVG_MIME:
+            if looks_like_svg(head, declared, file.filename):
+                is_svg = True
+            else:
+                raise UnsupportedMime(f"mime not allowed: {mime}")
+
         if mime not in self._cfg.allowed_mimes:
             raise UnsupportedMime(f"mime not allowed: {mime}")
 
         ext = extension_for(mime)
         key = new_storage_key("chat", ext)
 
-        first = head
-
-        async def _body() -> AsyncIterator[bytes]:
-            size = len(first)
-            if size > cap:
-                raise TooLarge(f"file exceeds {cap} bytes")
-            yield first
+        if is_svg:
+            # SVGs are small (logos) and need whole-file rewriting, so we buffer
+            # the full body, sanitize it (strip <script>, on* handlers,
+            # <foreignObject>, javascript: URLs, DOCTYPE/ENTITY), then store the
+            # cleaned bytes. This is one of three XSS defenses — the serving
+            # routers also force Content-Disposition: attachment and a
+            # script-blocking CSP so a direct navigation can't execute either.
+            body = head
             while True:
                 chunk = await file.read(64 * 1024)
                 if not chunk:
                     break
-                size += len(chunk)
+                body += chunk
+                if len(body) > cap:
+                    raise TooLarge(f"file exceeds {cap} bytes")
+            cleaned = sanitize_svg(body)
+
+            async def _body() -> AsyncIterator[bytes]:
+                yield cleaned
+
+        else:
+            first = head
+
+            async def _body() -> AsyncIterator[bytes]:
+                size = len(first)
                 if size > cap:
                     raise TooLarge(f"file exceeds {cap} bytes")
-                yield chunk
+                yield first
+                while True:
+                    chunk = await file.read(64 * 1024)
+                    if not chunk:
+                        break
+                    size += len(chunk)
+                    if size > cap:
+                        raise TooLarge(f"file exceeds {cap} bytes")
+                    yield chunk
 
         try:
             obj = await self._adapter.put(key, _body(), mime)

--- a/src/pocketpaw/uploads/svg_safety.py
+++ b/src/pocketpaw/uploads/svg_safety.py
@@ -1,0 +1,140 @@
+# svg_safety.py — SVG detection + XSS sanitization for the upload pipeline.
+# Created: 2026-06-16 — supports accepting image/svg+xml logos in the
+#   white-label Branding panel without opening a stored-XSS hole.
+#
+#   Two helpers:
+#     * looks_like_svg(head, declared_mime, filename) — the narrow gate that
+#       decides whether an uploaded blob may be treated as image/svg+xml.
+#       Requires ALL of: declared content-type image/svg+xml, a .svg
+#       filename, and a real SVG/XML signature in the bytes (optional
+#       BOM/whitespace then <?xml or <svg). We never promote a bare
+#       text/xml or text/plain blob to SVG.
+#     * sanitize_svg(raw) — strips the active-content vectors (script
+#       elements, on* event handlers, javascript: URLs, <foreignObject>,
+#       external entity / DOCTYPE declarations) so the bytes at rest can't
+#       execute. This is ONE layer of defense; the serving routers add the
+#       other two (Content-Disposition: attachment + a locked-down CSP) so
+#       even an unsanitized edge case can't run on a direct navigation.
+"""Dependency-free SVG detection and sanitization for uploads.
+
+Why regex and not a real XML parser: the sanitizer is defense-in-depth, not
+the sole barrier. SVGs are served as ``attachment`` with a ``script-src
+'none'; sandbox`` CSP, so a victim who opens the signed URL directly gets a
+download, not an execution context. The regex pass removes the obvious
+stored-XSS payloads (script tags, inline handlers, ``javascript:`` hrefs,
+``<foreignObject>`` HTML smuggling) so the bytes are inert even in the
+``<img src>`` render path. Pulling in lxml/bleach for this would add a
+supply-chain dependency for a belt-and-suspenders step — not worth it.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Leading bytes we tolerate before the signature: UTF-8 BOM, then any ASCII
+# whitespace. A real SVG written by a design tool starts with either an XML
+# prolog (<?xml ...?>) or the root <svg ...> element.
+_BOM = b"\xef\xbb\xbf"
+_SVG_SIGNATURE = re.compile(
+    rb"^\s*(<\?xml[\s\S]*?\?>\s*)?(<!--[\s\S]*?-->\s*)*<svg\b", re.IGNORECASE
+)
+# A looser check that also accepts a leading <?xml without requiring us to
+# have buffered all the way to the <svg root (the sniff head is only 512 B,
+# and a fat XML prolog + comment can push <svg past that window).
+_XML_OR_SVG_PROLOG = re.compile(rb"^\s*(<\?xml\b|<svg\b)", re.IGNORECASE)
+
+SVG_MIME = "image/svg+xml"
+
+
+def looks_like_svg(head: bytes, declared_mime: str | None, filename: str | None) -> bool:
+    """Return True only when a blob may safely be treated as an SVG.
+
+    Narrow on purpose — all three signals must agree:
+
+    1. the client declared ``image/svg+xml`` (case-insensitive),
+    2. the filename ends ``.svg`` (case-insensitive),
+    3. the bytes begin (after an optional BOM/whitespace) with ``<?xml`` or
+       ``<svg``.
+
+    A blob that sniffs as bare ``text/xml`` / ``text/plain`` or an image that
+    merely *claims* to be an SVG without the signature is rejected, so this
+    cannot be used to smuggle arbitrary XML/HTML into the image allow-list.
+    """
+    if (declared_mime or "").split(";")[0].strip().lower() != SVG_MIME:
+        return False
+    if not filename or not filename.lower().endswith(".svg"):
+        return False
+    probe = head[len(_BOM) :] if head.startswith(_BOM) else head
+    return bool(_XML_OR_SVG_PROLOG.match(probe))
+
+
+# --- Sanitization --------------------------------------------------------
+
+# <script>...</script> (and self-closing / unclosed variants).
+_SCRIPT_BLOCK = re.compile(rb"<script\b[\s\S]*?</script\s*>", re.IGNORECASE)
+_SCRIPT_OPEN = re.compile(rb"<script\b[^>]*/?>", re.IGNORECASE)
+# <foreignObject> lets an SVG embed arbitrary XHTML (a classic bypass).
+_FOREIGN_OBJECT = re.compile(rb"<foreignObject\b[\s\S]*?</foreignObject\s*>", re.IGNORECASE)
+_FOREIGN_OBJECT_OPEN = re.compile(rb"<foreignObject\b[^>]*/?>", re.IGNORECASE)
+# on*="..." / on*='...' / on*=value inline event handlers.
+_EVENT_HANDLER = re.compile(rb"""\son[a-zA-Z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)""", re.IGNORECASE)
+# javascript: (and data: text/html) URLs in href/xlink:href/src/style.
+_JS_URL = re.compile(
+    rb"(href|xlink:href|src)\s*=\s*([\"']?)\s*javascript:[^\"'>\s]*\2", re.IGNORECASE
+)
+# <!DOCTYPE ...> / <!ENTITY ...> — kill XXE / billion-laughs vectors.
+_DOCTYPE = re.compile(rb"<!DOCTYPE[\s\S]*?>", re.IGNORECASE)
+_ENTITY = re.compile(rb"<!ENTITY[\s\S]*?>", re.IGNORECASE)
+
+
+def sanitize_svg(raw: bytes) -> bytes:
+    """Strip active-content vectors from SVG bytes.
+
+    Removes ``<script>`` blocks, ``<foreignObject>`` subtrees, ``on*`` inline
+    event handlers, ``javascript:`` URLs, and ``<!DOCTYPE>``/``<!ENTITY>``
+    declarations. Returns the cleaned bytes. Idempotent and safe to run on
+    any blob (a non-SVG just passes through with the same substitutions, which
+    are no-ops on image binary data).
+    """
+    out = raw
+    out = _SCRIPT_BLOCK.sub(b"", out)
+    out = _SCRIPT_OPEN.sub(b"", out)
+    out = _FOREIGN_OBJECT.sub(b"", out)
+    out = _FOREIGN_OBJECT_OPEN.sub(b"", out)
+    out = _DOCTYPE.sub(b"", out)
+    out = _ENTITY.sub(b"", out)
+    out = _JS_URL.sub(rb"\1=\2\2", out)
+    out = _EVENT_HANDLER.sub(b"", out)
+    return out
+
+
+# --- Safe serving --------------------------------------------------------
+
+# Locked-down CSP for SVG responses: no script execution, no plugins, no
+# network fetches; inline styles only (SVGs legitimately use <style>), and a
+# ``sandbox`` with no allow-tokens so even a direct navigation can't run JS,
+# submit forms, or escape its origin. Belt-and-suspenders with the
+# ``attachment`` disposition below.
+_SVG_CSP = "default-src 'none'; style-src 'unsafe-inline'; sandbox"
+
+
+def svg_response_headers(filename: str) -> dict[str, str]:
+    """Return the XSS-safe response headers for serving an SVG blob.
+
+    Why these and not inline rendering: the logo renders fine through
+    ``<img src>`` (which never executes embedded script), but a victim who
+    opens the signed URL *directly* would be in a script-capable context. So
+    we force a download (``Content-Disposition: attachment``), block sniffing
+    (``X-Content-Type-Options: nosniff``), and clamp execution with a CSP that
+    disables scripts and sandboxes the document. Combined with the
+    sanitize-on-upload pass, that's three independent layers.
+
+    Callers pass the rest (``media_type`` / ``Content-Type``) themselves; this
+    helper only owns the security headers so the two serving routers can't
+    drift apart.
+    """
+    return {
+        "Content-Disposition": f'attachment; filename="{filename}"',
+        "X-Content-Type-Options": "nosniff",
+        "Content-Security-Policy": _SVG_CSP,
+    }

--- a/tests/cloud/uploads/test_router.py
+++ b/tests/cloud/uploads/test_router.py
@@ -38,6 +38,9 @@ def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
 
     app = FastAPI()
     # Override the license + identity dependencies so tests don't need auth plumbing.
+    from types import SimpleNamespace
+
+    from pocketpaw_ee.cloud.auth import current_active_user
     from pocketpaw_ee.cloud.license import require_license
     from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
 
@@ -52,8 +55,25 @@ def ee_client(tmp_path: Path, beanie_upload_db, monkeypatch):
     async def _workspace_dep(x_workspace: str = Header(default="w1")) -> str:
         return x_workspace
 
+    # The POST routes gate on require_action_any_workspace("uploads.write"),
+    # which resolves the caller via current_active_user and checks their role
+    # in the active workspace. Override it with a duck-typed user that owns the
+    # header-named workspace so the RBAC gate passes without real JWT/User
+    # plumbing — the role resolver only reads .id / .active_workspace /
+    # .workspaces[].{workspace,role} (see guards/deps.resolve_workspace_role).
+    async def _active_user_dep(
+        x_user: str = Header(default="u1"),
+        x_workspace: str = Header(default="w1"),
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=x_user,
+            active_workspace=x_workspace,
+            workspaces=[SimpleNamespace(workspace=x_workspace, role="owner")],
+        )
+
     app.dependency_overrides[current_user_id] = _user_dep
     app.dependency_overrides[current_workspace_id] = _workspace_dep
+    app.dependency_overrides[current_active_user] = _active_user_dep
 
     app.include_router(uploads_module.router, prefix="/api/v1")
     return TestClient(app)
@@ -240,11 +260,12 @@ async def test_patch_rejects_bad_hide_type(ee_client: TestClient):
 
 
 def test_bulk_partial_success(ee_client: TestClient):
+    # image/tiff is a real image type that is NOT on the allow-list.
     r = ee_client.post(
         "/api/v1/uploads",
         files=[
             ("files", ("good.png", PNG, "image/png")),
-            ("files", ("bad.svg", b"<svg/>", "image/svg+xml")),
+            ("files", ("bad.tiff", b"II*\x00rest", "image/tiff")),
         ],
         headers={"x-user": "u1", "x-workspace": "w1"},
     )
@@ -253,3 +274,54 @@ def test_bulk_partial_success(ee_client: TestClient):
     assert len(data["uploaded"]) == 1
     assert len(data["failed"]) == 1
     assert data["failed"][0]["code"] == "unsupported_mime"
+
+
+SVG = b'<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>'
+
+
+def test_svg_logo_roundtrip_served_safely(ee_client: TestClient):
+    # The white-label Branding logo upload path: an SVG is accepted, and the
+    # workspace download endpoint serves it with the XSS-safe headers
+    # (attachment + nosniff + script-blocking CSP), never inline.
+    r = ee_client.post(
+        "/api/v1/uploads",
+        files=[("files", ("logo.svg", SVG, "image/svg+xml"))],
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert len(data["uploaded"]) == 1
+    assert data["uploaded"][0]["mime"] == "image/svg+xml"
+    fid = data["uploaded"][0]["id"]
+
+    r2 = ee_client.get(
+        f"/api/v1/uploads/{fid}",
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert r2.status_code == 200
+    assert "attachment" in r2.headers["content-disposition"]
+    assert "inline" not in r2.headers["content-disposition"]
+    assert r2.headers["x-content-type-options"] == "nosniff"
+    csp = r2.headers["content-security-policy"]
+    assert "default-src 'none'" in csp
+    assert "sandbox" in csp
+
+
+def test_svg_with_script_sanitized_on_serve(ee_client: TestClient):
+    dirty = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">'
+        b"<script>alert(document.cookie)</script><rect/></svg>"
+    )
+    r = ee_client.post(
+        "/api/v1/uploads",
+        files=[("files", ("evil.svg", dirty, "image/svg+xml"))],
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    fid = r.json()["uploaded"][0]["id"]
+    r2 = ee_client.get(
+        f"/api/v1/uploads/{fid}",
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    body = r2.content.lower()
+    assert b"<script" not in body
+    assert b"onload" not in body

--- a/tests/uploads/test_router.py
+++ b/tests/uploads/test_router.py
@@ -56,11 +56,12 @@ def test_upload_single_roundtrip(client: TestClient):
 
 
 def test_bulk_upload_partial_success(client: TestClient):
+    # image/tiff is a real image type that is NOT on the allow-list.
     r = client.post(
         "/api/v1/uploads",
         files=[
             ("files", ("good.png", PNG, "image/png")),
-            ("files", ("bad.svg", b"<svg/>", "image/svg+xml")),
+            ("files", ("bad.tiff", b"II*\x00rest", "image/tiff")),
         ],
     )
     assert r.status_code == 200
@@ -68,6 +69,49 @@ def test_bulk_upload_partial_success(client: TestClient):
     assert len(data["uploaded"]) == 1
     assert len(data["failed"]) == 1
     assert data["failed"][0]["code"] == "unsupported_mime"
+
+
+SVG = b'<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>'
+
+
+def test_svg_roundtrip_is_served_safely(client: TestClient):
+    # Upload an SVG logo and confirm it (a) is accepted and (b) comes back
+    # with the XSS-safe headers: a download disposition, no sniffing, and a
+    # script-blocking CSP. An SVG must NEVER be served inline.
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("logo.svg", SVG, "image/svg+xml"))],
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert len(data["uploaded"]) == 1
+    assert data["uploaded"][0]["mime"] == "image/svg+xml"
+    fid = data["uploaded"][0]["id"]
+
+    r2 = client.get(f"/api/v1/uploads/{fid}")
+    assert r2.status_code == 200
+    assert "attachment" in r2.headers["content-disposition"]
+    assert "inline" not in r2.headers["content-disposition"]
+    assert r2.headers["x-content-type-options"] == "nosniff"
+    csp = r2.headers["content-security-policy"]
+    assert "default-src 'none'" in csp
+    assert "sandbox" in csp
+
+
+def test_svg_with_script_is_sanitized_on_serve(client: TestClient):
+    dirty = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">'
+        b"<script>alert(document.cookie)</script><rect/></svg>"
+    )
+    r = client.post(
+        "/api/v1/uploads",
+        files=[("files", ("evil.svg", dirty, "image/svg+xml"))],
+    )
+    fid = r.json()["uploaded"][0]["id"]
+    r2 = client.get(f"/api/v1/uploads/{fid}")
+    body = r2.content.lower()
+    assert b"<script" not in body
+    assert b"onload" not in body
 
 
 def test_delete_then_get_not_found(client: TestClient):

--- a/tests/uploads/test_service.py
+++ b/tests/uploads/test_service.py
@@ -89,7 +89,8 @@ class TestUploadServiceSingle:
 
     async def test_rejects_disallowed_mime(self, service):
         svc, _, _ = service
-        file = _upload(b"<svg/>", "x.svg", "image/svg+xml")
+        # image/tiff is a real image type that is NOT on the allow-list.
+        file = _upload(b"II*\x00rest", "x.tiff", "image/tiff")
         with pytest.raises(UnsupportedMime):
             await svc.upload(file, owner_id="u1", chat_id=None)
 
@@ -113,6 +114,70 @@ class TestUploadServiceSingle:
         assert rec.filename == "evil.png"
 
 
+SVG_PLAIN = b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect/></svg>'
+SVG_WITH_PROLOG = b'<?xml version="1.0"?>\n<svg xmlns="http://www.w3.org/2000/svg"><circle/></svg>'
+SVG_WITH_SCRIPT = (
+    b'<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">'
+    b"<script>alert(document.cookie)</script>"
+    b'<a href="javascript:alert(2)">x</a>'
+    b'<foreignObject><body onclick="evil()">hi</body></foreignObject>'
+    b"<rect/></svg>"
+)
+
+
+class TestSvgUpload:
+    """SVG logos are accepted (with sanitization) but only when genuinely SVG."""
+
+    async def test_plain_svg_accepted(self, service):
+        svc, _, _ = service
+        file = _upload(SVG_PLAIN, "logo.svg", "image/svg+xml")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        assert rec.mime == "image/svg+xml"
+        assert rec.filename == "logo.svg"
+
+    async def test_svg_with_xml_prolog_accepted(self, service):
+        svc, _, _ = service
+        file = _upload(SVG_WITH_PROLOG, "logo.svg", "image/svg+xml")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        assert rec.mime == "image/svg+xml"
+
+    async def test_svg_stored_bytes_are_sanitized(self, service):
+        """The blob written to storage must have no script/handler vectors."""
+        svc, adapter, _ = service
+        file = _upload(SVG_WITH_SCRIPT, "logo.svg", "image/svg+xml")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        # Pull the stored bytes back out of the fake adapter.
+        stored = adapter.blobs[rec.storage_key]
+        lowered = stored.lower()
+        assert b"<script" not in lowered
+        assert b"javascript:" not in lowered
+        assert b"onload" not in lowered
+        assert b"onclick" not in lowered
+        assert b"<foreignobject" not in lowered
+        # The legitimate shape survives.
+        assert b"<rect" in lowered
+
+    async def test_declared_svg_without_signature_rejected(self, service):
+        """A blob that claims image/svg+xml but isn't XML/SVG is rejected."""
+        svc, _, _ = service
+        file = _upload(b"not xml at all", "fake.svg", "image/svg+xml")
+        with pytest.raises(UnsupportedMime):
+            await svc.upload(file, owner_id="u1", chat_id=None)
+
+    async def test_svg_content_with_wrong_extension_rejected(self, service):
+        """Real SVG bytes but a non-.svg name don't sneak through as an image."""
+        svc, _, _ = service
+        file = _upload(SVG_PLAIN, "logo.txt", "image/svg+xml")
+        with pytest.raises(UnsupportedMime):
+            await svc.upload(file, owner_id="u1", chat_id=None)
+
+    async def test_png_still_accepted(self, service):
+        svc, _, _ = service
+        file = _upload(PNG_MAGIC, "logo.png", "image/png")
+        rec = await svc.upload(file, owner_id="u1", chat_id=None)
+        assert rec.mime == "image/png"
+
+
 class TestUploadServiceBulk:
     async def test_all_succeed(self, service):
         svc, _, _ = service
@@ -131,7 +196,7 @@ class TestUploadServiceBulk:
         files = [
             _upload(PNG_MAGIC, "good.png", "image/png"),
             _upload(b"x" * 500, "big.bin", "application/octet-stream"),
-            _upload(b"<svg/>", "bad.svg", "image/svg+xml"),
+            _upload(b"II*\x00rest", "bad.tiff", "image/tiff"),
         ]
         result = await svc.upload_many(files, owner_id="u1", chat_id=None)
         assert len(result.uploaded) == 1

--- a/tests/uploads/test_svg_safety.py
+++ b/tests/uploads/test_svg_safety.py
@@ -1,0 +1,112 @@
+# test_svg_safety.py — unit tests for the SVG detection + sanitization helpers.
+# Created: 2026-06-16 — covers looks_like_svg (the narrow accept gate),
+#   sanitize_svg (strips script/handlers/foreignObject/javascript:/DOCTYPE),
+#   and svg_response_headers (attachment + nosniff + locked-down CSP).
+from __future__ import annotations
+
+from pocketpaw.uploads.svg_safety import (
+    looks_like_svg,
+    sanitize_svg,
+    svg_response_headers,
+)
+
+SVG = b'<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>'
+SVG_PROLOG = b'<?xml version="1.0" encoding="UTF-8"?>\n<svg><circle/></svg>'
+SVG_BOM = b"\xef\xbb\xbf<svg><rect/></svg>"
+
+
+class TestLooksLikeSvg:
+    def test_plain_svg_accepted(self):
+        assert looks_like_svg(SVG, "image/svg+xml", "logo.svg") is True
+
+    def test_xml_prolog_accepted(self):
+        assert looks_like_svg(SVG_PROLOG, "image/svg+xml", "logo.svg") is True
+
+    def test_bom_prefix_accepted(self):
+        assert looks_like_svg(SVG_BOM, "image/svg+xml", "logo.svg") is True
+
+    def test_content_type_with_charset_accepted(self):
+        assert looks_like_svg(SVG, "image/svg+xml; charset=utf-8", "logo.svg") is True
+
+    def test_uppercase_extension_accepted(self):
+        assert looks_like_svg(SVG, "image/svg+xml", "LOGO.SVG") is True
+
+    def test_wrong_content_type_rejected(self):
+        # Bare text/xml must never be promoted to SVG.
+        assert looks_like_svg(SVG, "text/xml", "logo.svg") is False
+        assert looks_like_svg(SVG, "text/plain", "logo.svg") is False
+
+    def test_wrong_extension_rejected(self):
+        assert looks_like_svg(SVG, "image/svg+xml", "logo.txt") is False
+
+    def test_missing_filename_rejected(self):
+        assert looks_like_svg(SVG, "image/svg+xml", None) is False
+
+    def test_non_svg_bytes_rejected(self):
+        assert looks_like_svg(b"GIF89a junk", "image/svg+xml", "logo.svg") is False
+        assert looks_like_svg(b"\x89PNG\r\n", "image/svg+xml", "logo.svg") is False
+
+
+class TestSanitizeSvg:
+    def test_strips_script_block(self):
+        out = sanitize_svg(b"<svg><script>alert(1)</script><rect/></svg>")
+        assert b"<script" not in out.lower()
+        assert b"alert" not in out
+        assert b"<rect" in out.lower()
+
+    def test_strips_self_closing_script(self):
+        out = sanitize_svg(b'<svg><script src="x.js"/><rect/></svg>')
+        assert b"<script" not in out.lower()
+
+    def test_strips_event_handlers(self):
+        out = sanitize_svg(b"<svg onload=\"alert(1)\"><rect onclick='evil()'/></svg>")
+        low = out.lower()
+        assert b"onload" not in low
+        assert b"onclick" not in low
+
+    def test_strips_javascript_urls(self):
+        out = sanitize_svg(b'<svg><a href="javascript:alert(1)">x</a></svg>')
+        assert b"javascript:" not in out.lower()
+
+    def test_strips_foreign_object(self):
+        out = sanitize_svg(b"<svg><foreignObject><body>html</body></foreignObject><rect/></svg>")
+        assert b"<foreignobject" not in out.lower()
+        assert b"<body" not in out.lower()
+
+    def test_strips_doctype_and_entity(self):
+        payload = (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE svg [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
+            b"<svg><rect/></svg>"
+        )
+        out = sanitize_svg(payload)
+        low = out.lower()
+        assert b"<!doctype" not in low
+        assert b"<!entity" not in low
+
+    def test_clean_svg_passes_through(self):
+        out = sanitize_svg(SVG)
+        assert out == SVG
+
+    def test_idempotent(self):
+        dirty = b'<svg onload="x()"><script>y()</script><rect/></svg>'
+        once = sanitize_svg(dirty)
+        twice = sanitize_svg(once)
+        assert once == twice
+
+
+class TestSvgResponseHeaders:
+    def test_forces_attachment(self):
+        h = svg_response_headers("logo.svg")
+        assert h["Content-Disposition"].startswith("attachment")
+        assert "logo.svg" in h["Content-Disposition"]
+
+    def test_blocks_sniffing(self):
+        assert svg_response_headers("logo.svg")["X-Content-Type-Options"] == "nosniff"
+
+    def test_csp_blocks_script_and_sandboxes(self):
+        csp = svg_response_headers("logo.svg")["Content-Security-Policy"]
+        # No script source allowed, and a sandbox with no escape tokens.
+        assert "default-src 'none'" in csp
+        assert "sandbox" in csp
+        assert "script-src" not in csp or "script-src 'none'" in csp


### PR DESCRIPTION
## What's wrong

The white-label Branding panel says "Upload logo — SVG or PNG", but picking an SVG fails with `unsupported_mime`. PNG works fine. The logo upload goes through the generic uploads flow, and the backend decides the type by sniffing magic bytes. An SVG is XML text, so it has no binary image signature — the sniff falls back to the declared content-type, and `image/svg+xml` was never on the image allow-list. So every SVG bounced.

## The fix

Two parts, both needed.

**Accept SVG, narrowly.** An upload is treated as an SVG only when all three agree: it declares `image/svg+xml`, the filename ends `.svg`, and the bytes start (after an optional BOM/whitespace) with `<?xml` or `<svg`. A bare `text/xml`/`text/plain` blob, or a non-SVG file that just claims to be one, is still rejected — this doesn't open the allow-list to arbitrary XML or HTML.

**Serve it safely.** This is the part that needs a careful look. An SVG is active content — it can carry `<script>`, inline `on*` handlers, `javascript:` URLs, or a `<foreignObject>` smuggling HTML. A logo rendered through `<img src>` never runs that script, but a victim who opens the asset's signed URL directly would be in a script-capable context. So uploaded SVGs get three independent defenses:

1. **Sanitized on upload** — `<script>`, `on*` handlers, `<foreignObject>`, `javascript:` URLs, and `<!DOCTYPE>`/`<!ENTITY>` are stripped before the bytes are stored.
2. **Forced download** — SVG stays out of `INLINE_MIMES`, so the response carries `Content-Disposition: attachment` (plus `X-Content-Type-Options: nosniff`).
3. **Locked-down CSP** — SVG responses send `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox`, so even a forced inline render can't execute, fetch, or escape its origin.

Both serving paths (the core download route and the workspace download route) share one helper so they can't drift apart.

## Security review requested

This is security-sensitive — it's stored-XSS territory. Please review the serving defenses specifically:

- Is `Content-Disposition: attachment` + the CSP enough for a direct navigation to the signed URL, given how logos are actually fetched (`<img src>` with cookie auth)? Is there a case where a browser would still render the SVG inline and run script?
- The sanitizer is a dependency-free regex pass (no `bleach`/`lxml`), deliberately treated as defense-in-depth behind the attachment + CSP layers rather than the sole barrier. Any bypass worth closing now versus relying on the serving headers?
- The accept gate keys on declared content-type + extension + signature. Anything that should tighten it further?

I leaned on layered serving defenses over a heavyweight sanitizer on purpose, partly to avoid pulling a fresh dependency past the supply-chain release-age window. Happy to add a vetted sanitizer later if review prefers it.

## Tests

- `tests/uploads/test_svg_safety.py` (new) — the accept gate, the sanitizer, and the response headers in isolation.
- `tests/uploads/test_service.py` — SVG accepted; stored bytes are sanitized; a declared-SVG-without-signature and a real-SVG-with-wrong-extension are both rejected; PNG still works. Updated the two old tests that asserted SVG rejection.
- `tests/uploads/test_router.py` and `tests/cloud/uploads/test_router.py` — SVG round-trips and comes back with attachment + nosniff + CSP, never inline; a script-laden SVG comes back sanitized.

120 tests pass across the touched files (`uv run pytest tests/uploads/ tests/cloud/uploads/test_router.py`).

## Docs

No user-facing upload/mime doc lists the allow-list or the serving rules — the validation logic is the source of truth and is commented inline. Internal change, no doc drift.

## Note on the EE test fixture

The workspace upload router tests gate on an RBAC dependency that wasn't satisfied by the local test fixture, so the whole file 401'd locally (independent of this change). Added a `current_active_user` override to the `ee_client` fixture so the RBAC gate resolves — this un-breaks the pre-existing tests in that file too. Test-only; no production code involved.