### PR TITLE
feat(terminal): SSE-backed PTY shell for /code 

### DIFF
--- a/src/pocketpaw/api/v1/__init__.py
+++ b/src/pocketpaw/api/v1/__init__.py
@@ -69,6 +69,7 @@ _V1_ROUTERS: list[tuple[str, str, str]] = [
     ("pocketpaw.api.v1.tools", "router", "Tools"),
     ("pocketpaw.api.v1.oauth_integrations", "router", "OAuth Integrations"),
     ("pocketpaw.api.v1.uploads", "router", "Uploads"),
+    ("pocketpaw.api.v1.terminal", "router", "Terminal"),
     ("pocketpaw.audit.router", "router", "Audit"),
     # Cluster C / PR4 — canonical runtime audit surface. `/audit` stays as
     # a deprecated alias in audit.router and `/instinct/audit` stays in

--- a/src/pocketpaw/api/v1/terminal.py
+++ b/src/pocketpaw/api/v1/terminal.py
@@ -1,0 +1,394 @@
+"""Terminal router — SSE-backed PTY shell for the /code IDE.
+
+Exposes three endpoints:
+  • GET  /api/v1/terminal/sse    — SSE stream of terminal output (stdout + stderr)
+  • POST /api/v1/terminal/input   — send keystrokes / input to the shell
+  • POST /api/v1/terminal/resize  — resize the terminal (cols, rows)
+
+A single background shell process (bash) is created on first SSE connect and
+persists for the lifetime of the server. Keystrokes are written to its stdin;
+output is read from its PTY and broadcast to all connected SSE clients via
+an in-memory publish/subscribe pattern.
+
+Created: 2026-06-16
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fcntl
+import logging
+import os
+import pty
+import select
+import signal
+import struct
+import termios
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Terminal"])
+
+# ---------------------------------------------------------------------------
+# Singleton shell process — one PTY-backed bash per server lifetime.
+# ---------------------------------------------------------------------------
+
+
+class ShellProcess:
+    """Manages a single PTY-backed bash process.
+
+    Output from the PTY is continuously read and pushed to all connected
+    SSE clients via an in-memory async broadcast queue.
+    """
+
+    def __init__(self) -> None:
+        self._proc: asyncio.subprocess.Process | None = None
+        self._master_fd: int | None = None  # PTY master file descriptor
+        self._subscribers: list[asyncio.Queue[bytes]] = []
+        self._lock = asyncio.Lock()
+        self._task: asyncio.Task[None] | None = None
+        self._started = False
+        # Circular buffer of recent output — replayed to new subscribers so
+        # they always see the current prompt and terminal state. Capped at
+        # ~256 KB (256 × 1024 byte chunks).
+        self._buf: list[bytes] = []
+        self._buf_max = 256
+        self._buf_size = 0
+
+    async def ensure_running(self) -> None:
+        """Start the shell if not already running."""
+        if self._started and self._proc is not None and self._proc.returncode is None:
+            return
+        async with self._lock:
+            if self._started:
+                return
+            self._started = True
+
+        # Create a PTY pair.
+        master_fd, slave_fd = pty.openpty()
+
+        # Set the initial window size.
+        s = struct.pack("HHHH", 24, 80, 0, 0)
+        fcntl.ioctl(master_fd, termios.TIOCSWINSZ, s)
+
+        # Set the slave to raw mode.
+        attrs = termios.tcgetattr(slave_fd)
+        # Enable OPOST + ONLCR so the kernel converts \n to \r\n on output.
+        attrs[1] = attrs[1] | (termios.OPOST | termios.ONLCR)
+        # Disable ICANON so bash receives each keystroke immediately.
+        # ECHO is OFF — the frontend handles local echo for instant feedback.
+        # ISIG stays on so Ctrl+C/Ctrl+Z work.
+        attrs[3] = attrs[3] & ~(
+            termios.ICANON | termios.ECHO | termios.ECHOE | termios.ECHOK | termios.ECHONL
+        )
+        attrs[3] = attrs[3] | termios.ISIG
+        termios.tcsetattr(slave_fd, termios.TCSANOW, attrs)
+
+        # Set the master to non-blocking.
+        fl = fcntl.fcntl(master_fd, fcntl.F_GETFL)
+        fcntl.fcntl(master_fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+
+        self._master_fd = master_fd
+
+        # Build env with TERM set so programs (vim, htop, etc.) work properly.
+        env = os.environ.copy()
+        env["TERM"] = "xterm-256color"
+        env["SHELL"] = "/bin/bash"
+        env["LANG"] = "C.UTF-8"
+
+        # Start bash with the slave as its stdin/stdout/stderr.
+        self._proc = await asyncio.create_subprocess_exec(
+            "bash",
+            "--login",
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+            preexec_fn=lambda: os.setsid(),
+            env=env,
+        )
+
+        # Close the slave end in the parent — only the child needs it.
+        os.close(slave_fd)
+
+        logger.info("Terminal shell started (pid=%s)", self._proc.pid)
+
+        # Start the reader task that pumps PTY output to subscribers.
+        self._task = asyncio.create_task(self._reader_loop())
+
+    async def _reader_loop(self) -> None:
+        """Read from the PTY master and broadcast to all subscribers."""
+        loop = asyncio.get_event_loop()
+        fd = self._master_fd
+        buf = b""
+
+        try:
+            while True:
+                # Use asyncio to wait for the fd to be readable.
+                await loop.run_in_executor(None, select.select, [fd], [], [fd])
+
+                try:
+                    data = os.read(fd, 4096)
+                except BlockingIOError:
+                    await asyncio.sleep(0.01)
+                    continue
+                except OSError as e:
+                    logger.warning("Terminal read error: %s", e)
+                    break
+
+                if not data:
+                    # EOF — shell exited.
+                    logger.info(
+                        "Terminal shell exited (pid=%s)", self._proc.pid if self._proc else "?"
+                    )
+                    break
+
+                # Accumulate and try to decode as UTF-8.
+                buf += data
+                try:
+                    text = buf.decode("utf-8")
+                    buf = b""
+                except UnicodeDecodeError:
+                    # Partial UTF-8 character — wait for more data.
+                    if len(buf) > 4:
+                        # Force-decode with replacement if buffer is too large.
+                        text = buf.decode("utf-8", errors="replace")
+                        buf = b""
+                    else:
+                        text = None
+
+                if text:
+                    self._broadcast(text.encode("utf-8"))
+
+        except asyncio.CancelledError:
+            pass
+        finally:
+            await self._cleanup()
+
+    def _broadcast(self, data: bytes) -> None:
+        """Push data to all subscriber queues and buffer for replay."""
+        # Maintain a bounded circular buffer (max _buf_max chunks).
+        self._buf.append(data)
+        self._buf_size += len(data)
+        while len(self._buf) > self._buf_max:
+            evicted = self._buf.pop(0)
+            self._buf_size -= len(evicted)
+
+        dead: list[asyncio.Queue[bytes]] = []
+        for q in self._subscribers:
+            try:
+                q.put_nowait(data)
+            except asyncio.QueueFull:
+                dead.append(q)
+        for q in dead:
+            self._subscribers.remove(q)
+
+    async def write(self, data: str | bytes) -> None:
+        """Write data to the PTY master (the shell's stdin)."""
+        if self._master_fd is None or (self._proc and self._proc.returncode is not None):
+            self._started = False
+            await self.ensure_running()
+
+        if self._master_fd is not None:
+            if isinstance(data, str):
+                data = data.encode("utf-8", errors="replace")
+            try:
+                os.write(self._master_fd, data)
+            except OSError as e:
+                logger.warning("Terminal write error: %s", e)
+
+    async def resize(self, cols: int, rows: int) -> None:
+        """Resize the terminal window."""
+        if self._master_fd is not None:
+            try:
+                s = struct.pack("HHHH", rows, cols, 0, 0)
+                fcntl.ioctl(self._master_fd, termios.TIOCSWINSZ, s)
+            except (OSError, struct.error) as e:
+                logger.warning("Terminal resize error: %s", e)
+
+    async def subscribe(self) -> asyncio.Queue[bytes]:
+        """Register a subscriber queue and return it, replaying buffered
+        output so the new subscriber sees the current terminal state."""
+        q: asyncio.Queue[bytes] = asyncio.Queue(maxsize=512)
+        # Replay buffered output so the subscriber sees the current prompt.
+        for chunk in self._buf:
+            try:
+                q.put_nowait(chunk)
+            except asyncio.QueueFull:
+                break
+        self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue[bytes]) -> None:
+        """Remove a subscriber queue."""
+        if q in self._subscribers:
+            self._subscribers.remove(q)
+
+    async def _cleanup(self) -> None:
+        """Kill the shell and close the PTY."""
+        if self._proc and self._proc.returncode is None:
+            try:
+                # Try SIGTERM first for a clean shutdown.
+                self._proc.send_signal(signal.SIGTERM)
+                try:
+                    await asyncio.wait_for(self._proc.wait(), timeout=2.0)
+                except TimeoutError:
+                    self._proc.send_signal(signal.SIGKILL)
+                    await self._proc.wait()
+            except ProcessLookupError:
+                pass
+        if self._master_fd is not None:
+            try:
+                os.close(self._master_fd)
+            except OSError:
+                pass
+        self._master_fd = None
+        self._proc = None
+        self._task = None
+
+
+# Singleton instance.
+_shell = ShellProcess()
+
+
+# ---------------------------------------------------------------------------
+# Helper: register a shutdown handler so the shell is cleaned up when the
+# server stops.
+# ---------------------------------------------------------------------------
+
+
+def _register_shutdown(app: object) -> None:
+    """Register the shell cleanup as a FastAPI shutdown event."""
+    try:
+        from fastapi import FastAPI
+
+        if isinstance(app, FastAPI):
+
+            async def _shutdown_shell() -> None:
+                logger.info("Shutting down terminal shell...")
+                await _shell._cleanup()
+
+            app.add_event_handler("shutdown", _shutdown_shell)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# SSE endpoint
+# ---------------------------------------------------------------------------
+
+
+async def _sse_generator():
+    """Generator that yields SSE events from the terminal output."""
+    await _shell.ensure_running()
+    queue = await _shell.subscribe()
+
+    try:
+        # Send an initial "connected" event so the client knows the stream
+        # is live. The shell's prompt will follow as data events.
+        yield "event: connected\ndata: {}\n\n"
+
+        while True:
+            try:
+                data = await asyncio.wait_for(queue.get(), timeout=30.0)
+            except TimeoutError:
+                # Send a keepalive comment to prevent proxies from closing
+                # idle connections.
+                yield ": keepalive\n\n"
+                continue
+
+            if not data:
+                break
+
+            # Decode to text. Errors already handled in the reader loop,
+            # but guard here too.
+            try:
+                text = data.decode("utf-8")
+            except UnicodeDecodeError:
+                text = data.decode("utf-8", errors="replace")
+
+            # Send the raw data as a single SSE event so ANSI sequences and
+            # cursor positioning arrive intact. Do NOT split on newlines —
+            # xterm.js reassembles partial writes correctly.
+            #
+            # Escape the data field per the SSE spec: replace \n with
+            # \ndata: so multi-line output is valid SSE.
+            for line in text.split("\n"):
+                if line:
+                    yield f"data: {line}\n"
+                else:
+                    yield "data: \n"
+            yield "\n"
+
+            # Small yield to let other coroutines run.
+            await asyncio.sleep(0)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        _shell.unsubscribe(queue)
+
+
+@router.get("/terminal/sse")
+async def terminal_sse():
+    """SSE endpoint: streams terminal output to the client.
+
+    The client opens an EventSource to this URL and receives ``data`` events
+    containing the raw terminal output (stdout + stderr combined). ANSI escape
+    sequences are preserved — xterm.js on the client renders them.
+    """
+    return StreamingResponse(
+        _sse_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Input endpoint
+# ---------------------------------------------------------------------------
+
+
+class TerminalInput(BaseModel):
+    data: str
+
+
+@router.post("/terminal/input")
+async def terminal_input(body: TerminalInput):
+    """POST endpoint: send keystrokes/input to the terminal.
+
+    The body should be a JSON object with a ``data`` field containing the
+    characters to send (e.g. ``{"data": "ls -la\\n"}``). Backslash escapes
+    in the JSON string are handled automatically by the JSON parser.
+    """
+    await _shell.ensure_running()
+    await _shell.write(body.data)
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Resize endpoint
+# ---------------------------------------------------------------------------
+
+
+class TerminalResize(BaseModel):
+    cols: int
+    rows: int
+
+
+@router.post("/terminal/resize")
+async def terminal_resize(body: TerminalResize):
+    """POST endpoint: resize the terminal window.
+
+    The body should be a JSON object with ``cols`` and ``rows`` fields
+    (e.g. ``{"cols": 80, "rows": 24}``).
+    """
+    await _shell.resize(body.cols, body.rows)
+    return {"ok": True}

--- a/src/pocketpaw/api/v1/terminal.py
+++ b/src/pocketpaw/api/v1/terminal.py
@@ -17,12 +17,15 @@ from __future__ import annotations
 
 import asyncio
 import fcntl
+import json
 import logging
 import os
 import pty
+import re
 import select
 import signal
 import struct
+import subprocess
 import termios
 
 from fastapi import APIRouter
@@ -58,6 +61,9 @@ class ShellProcess:
         self._buf: list[bytes] = []
         self._buf_max = 256
         self._buf_size = 0
+        # Current working directory of the shell, tracked via PROMPT_COMMAND.
+        # Updated every prompt so the frontend can sync the file tree on cd.
+        self._cwd: str | None = None
 
     async def ensure_running(self) -> None:
         """Start the shell if not already running."""
@@ -117,6 +123,30 @@ class ShellProcess:
 
         logger.info("Terminal shell started (pid=%s)", self._proc.pid)
 
+        # Seed the initial CWD by reading /proc/<pid>/cwd (Linux) or
+        # using lsof (macOS). Fall back to $HOME.
+        try:
+            result = subprocess.run(
+                ["lsof", "-p", str(self._proc.pid), "-d", "cwd", "-Fn"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            for line in result.stdout.split("\n"):
+                if line.startswith("fcwd") and line[5:].strip():
+                    self._cwd = line[5:].strip()
+                    break
+        except Exception:
+            pass
+        if not self._cwd:
+            self._cwd = os.environ.get("HOME", "/")
+
+        # Set PROMPT_COMMAND so every prompt outputs the CWD wrapped in
+        # \x1e (Record Separator, ASCII 30) markers. These are invisible
+        # in the terminal and stripped by _reader_loop before broadcast.
+        prompt_cmd = b'PROMPT_COMMAND=\'printf "\\x1ePAW_CWD:%s\\x1e" "$PWD"\'\n'
+        os.write(self._master_fd, prompt_cmd)
+
         # Start the reader task that pumps PTY output to subscribers.
         self._task = asyncio.create_task(self._reader_loop())
 
@@ -162,7 +192,22 @@ class ShellProcess:
                         text = None
 
                 if text:
-                    self._broadcast(text.encode("utf-8"))
+                    # Scan for CWD markers: \x1ePAW_CWD:/path\x1e
+                    # These are emitted by PROMPT_COMMAND on every prompt.
+                    # Strip them from output and update self._cwd.
+                    cwd_pattern = re.compile(r"\x1ePAW_CWD:([^\x1e]+)\x1e")
+                    cleaned_parts = []
+                    pos = 0
+                    for m in cwd_pattern.finditer(text):
+                        path = m.group(1)
+                        self._cwd = path
+                        self._broadcast_cwd(path)
+                        cleaned_parts.append(text[pos : m.start()])
+                        pos = m.end()
+                    cleaned_parts.append(text[pos:])
+                    cleaned = "".join(cleaned_parts)
+                    if cleaned:
+                        self._broadcast(cleaned.encode("utf-8"))
 
         except asyncio.CancelledError:
             pass
@@ -186,6 +231,21 @@ class ShellProcess:
                 dead.append(q)
         for q in dead:
             self._subscribers.remove(q)
+
+    def _broadcast_cwd(self, path: str) -> None:
+        """Push a CWD-change notification to all subscriber queues.
+
+        Uses a \x00 sentinel that the SSE generator detects and converts
+        to an ``event: cwd`` SSE frame. Sentinels are NOT buffered for
+        replay since they would be stale; the current ``_cwd`` is sent
+        to new subscribers on subscribe instead.
+        """
+        sentinel = f"\x00CWD:{path}\x00".encode()
+        for q in self._subscribers:
+            try:
+                q.put_nowait(sentinel)
+            except asyncio.QueueFull:
+                pass
 
     async def write(self, data: str | bytes) -> None:
         """Write data to the PTY master (the shell's stdin)."""
@@ -292,6 +352,15 @@ async def _sse_generator():
         # is live. The shell's prompt will follow as data events.
         yield "event: connected\ndata: {}\n\n"
 
+        # If the shell already has a CWD (previous session or initialised
+        # after bash started), send it immediately so the frontend can
+        # set the file tree root without waiting for the first prompt.
+        if _shell._cwd:
+            yield f"event: cwd\ndata: {json.dumps({'path': _shell._cwd})}\n\n"
+
+        # Pre-compile the CWD sentinel pattern for fast matching.
+        cwd_pattern = re.compile(r"\x00CWD:([^\x00]+)\x00")
+
         while True:
             try:
                 data = await asyncio.wait_for(queue.get(), timeout=30.0)
@@ -304,19 +373,15 @@ async def _sse_generator():
             if not data:
                 break
 
-            # Decode to text. Errors already handled in the reader loop,
-            # but guard here too.
-            try:
-                text = data.decode("utf-8")
-            except UnicodeDecodeError:
-                text = data.decode("utf-8", errors="replace")
+            # Check for CWD sentinel: \x00CWD:/path\x00
+            text = data.decode("utf-8", errors="replace")
+            cwd_match = cwd_pattern.match(text)
+            if cwd_match:
+                path = cwd_match.group(1)
+                yield f"event: cwd\ndata: {json.dumps({'path': path})}\n\n"
+                continue
 
-            # Send the raw data as a single SSE event so ANSI sequences and
-            # cursor positioning arrive intact. Do NOT split on newlines —
-            # xterm.js reassembles partial writes correctly.
-            #
-            # Escape the data field per the SSE spec: replace \n with
-            # \ndata: so multi-line output is valid SSE.
+            # Regular terminal output — send as unnamed data events.
             for line in text.split("\n"):
                 if line:
                     yield f"data: {line}\n"


### PR DESCRIPTION
## Summary

Adds a backend terminal router (`terminal.py`) that creates a single PTY-backed bash process per server lifetime and streams output to the `/code` IDE frontend via Server-Sent Events (SSE). The second commit adds Current Working Directory (CWD) tracking so the file tree automatically follows `cd` commands.

---

## Commits

| SHA | Message |
| :--- | :--- |
| `30cc7639` | feat(terminal): add SSE-backed PTY shell for /code IDE |
| `c79156ac` | feat(terminal): track CWD and sync file tree via SSE |

---

## Changes

### Commit 1 — PTY shell + SSE endpoints (`terminal.py`)

A new `ShellProcess` class manages a single PTY-backed bash process with the following behavior:
* **Process Spawning:** On the first SSE connection, it spawns `bash --login` with `xterm-256color` as the `TERM` environment variable via `asyncio.create_subprocess_exec` on a pty pair.
* **PTY Configuration:** The PTY slave is configured to raw mode (`ICANON` off, `ISIG` on for `Ctrl+C/Z` handling, and `ECHO` off since the frontend handles local echo).
* **Reader Loop:** A background loop continuously reads PTY master output via `select.select` in an executor, decodes it as UTF-8, and broadcasts the stream to subscriber queues.
* **Output Replay:** A bounded circular buffer (capped at 256 chunks) replays recent output history to any new subscribers joining mid-session.

Three new API endpoints are registered:
* `GET /api/v1/terminal/sse` – An SSE stream emitting unnamed `data:` events containing raw ANSI output, an `event: connected` message on initial handshake, and a `: keepalive` comment every 30 seconds of idle time.
* `POST /api/v1/terminal/input` – Accepts `{"data": "ls -la\n"}` payload and writes those bytes directly to the PTY stdin.
* `POST /api/v1/terminal/resize` – Accepts `{"cols": 80, "rows": 24}` window boundary updates and issues a `TIOCSWINSZ` ioctl call.

> **Note:** A server shutdown handler is registered via a FastAPI event lifecycle hook to cleanly send a `SIGTERM` to the shell background process when the application stops.

### Commit 2 — CWD tracking → file tree sync

* **CWD Initialization:** The `ShellProcess` introduces a `_cwd` field initialized on startup by checking `lsof -p <pid> -d cwd -Fn` (optimized for macOS) with a fallback to `$HOME`.
* **Prompt Injection:** On startup, it writes `PROMPT_COMMAND='printf "\x1ePAW_CWD:%s\x1e" "$PWD"'` to the PTY. This forces bash to emit an invisible CWD marker string alongside every prompt.
* **Sentinel Detection:** The reader loop scans incoming bytes for `\x1ePAW_CWD:/path\x1e` matchers, strips them entirely from the visible terminal output, updates the underlying `_cwd` state, and pushes a internal `\x00CWD:/path\x00` sentinel frame to active queues.
* **Frontend Sync:** The SSE generator catches these internal sentinel frames and formats them into an `event: cwd\ndata: {"path": "..."}` network message. The initial path is also instantly pushed upon connecting so the frontend file tree maps its root directory right away.

---

## Files Changed

* `src/pocketpaw/api/v1/terminal.py` *(New, 459 lines)*
* `src/pocketpaw/api/v1/__init__.py` *(Wired terminal router)*

---

## Testing Matrix

- [x] Shell successfully spawns on first SSE connect and persists across requests
- [x] Combined stdout + stderr output streams cleanly to connected SSE clients
- [x] Text input sent via POST successfully reaches the backend shell stdin
- [x] Resize POST payloads properly adjust PTY window dimensions
- [x] CWD markers are emitted by the shell prompt and completely stripped from visible terminal output
- [x] `event: cwd` SSE frame is triggered and sent down on directory shifts
- [x] Initial CWD maps correctly on immediate SSE connection
- [x] Reconnection handling functions; new subscribers get historical buffered output caught up
- [x] Server lifecycle teardown successfully sends a `SIGTERM` signal to stop the background shell process