### PR TITLE
feat(skills): self-improving skills loop (core + scaffold)

### DIFF
--- a/src/pocketpaw/skills_loop/__init__.py
+++ b/src/pocketpaw/skills_loop/__init__.py
@@ -1,0 +1,40 @@
+# skills_loop — the self-improving skills loop (PocketPaw side).
+# Created: 2026-06-16 (feat/self-improving-skills) — a forked WRITE-ONLY reviewer
+#   runs at a workspace agent's session-finalize, reads the transcript, and
+#   writes/refines learned procedures into the WORKSPACE agent's soul procedural
+#   memory under safety machinery:
+#     - whitelist.py  : soul-write-ONLY tool restriction (the reviewer physically
+#                       cannot call any other tool)
+#     - rubric.py     : anti-pattern guard (no env failures, "tool broken"
+#                       claims, or one-off narratives)
+#     - writer.py     : tags procedures AGENT-authored + writes via Soul.note
+#     - reviewer.py   : extract → rubric-filter → write
+#     - trigger.py    : background spawn at session-finalize
+#     - graduation.py : XP → SKILL.md materialization for high-value procedures
+#   An idle curator (soul-protocol's Soul.curate_agent_procedures) consolidates
+#   and archives agent-created procedures separately.
+
+from __future__ import annotations
+
+from pocketpaw.skills_loop.graduation import maybe_graduate_procedure
+from pocketpaw.skills_loop.reviewer import SkillsLoopReviewer
+from pocketpaw.skills_loop.rubric import REVIEWER_SYSTEM_PROMPT, is_rubric_banned
+from pocketpaw.skills_loop.trigger import SkillsLoopTrigger
+from pocketpaw.skills_loop.whitelist import (
+    SOUL_WRITE_TOOL_IDS,
+    assert_write_only,
+    build_reviewer_whitelist,
+)
+from pocketpaw.skills_loop.writer import SoulProcedureWriter
+
+__all__ = [
+    "SOUL_WRITE_TOOL_IDS",
+    "build_reviewer_whitelist",
+    "assert_write_only",
+    "REVIEWER_SYSTEM_PROMPT",
+    "is_rubric_banned",
+    "SoulProcedureWriter",
+    "SkillsLoopReviewer",
+    "SkillsLoopTrigger",
+    "maybe_graduate_procedure",
+]

--- a/src/pocketpaw/skills_loop/graduation.py
+++ b/src/pocketpaw/skills_loop/graduation.py
@@ -1,0 +1,104 @@
+# skills_loop/graduation.py — XP → SKILL.md graduation for learned procedures.
+# Created: 2026-06-16 (feat/self-improving-skills) — grants XP to the skill that
+#   tracks a learned procedure each time the procedure is used (via the soul
+#   SkillRegistry.grant_xp_for_procedure_use helper). When a grant crosses a
+#   level boundary the procedure GRADUATES: it is materialized as a SKILL.md
+#   under ~/.pocketpaw/skills, reusing the write precedent established by
+#   skills/api_skill_builder.install_api_skill (mkdir parents + write_text +
+#   INFO audit log). Below threshold nothing is written.
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _slugify(text: str) -> str:
+    """Lowercase slug safe for a directory name.
+
+    Pathological ids (all-punctuation, empty) would otherwise all collapse to
+    the literal ``"procedure"`` and collide on the same directory — clobbering
+    each other's SKILL.md. When the slug degenerates we disambiguate with a
+    short stable suffix derived from the raw text: its alphanumerics if it has
+    any, else a short hash so even two distinct all-punctuation ids
+    (``"@@@"`` vs ``"###"``) get distinct directories.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    if slug:
+        return slug[:48]
+    raw_alnum = re.sub(r"[^A-Za-z0-9]+", "", text)[:8].lower()
+    if raw_alnum:
+        return f"procedure-{raw_alnum}"
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+    return f"procedure-{digest}"
+
+
+def _render_skill_md(procedure_id: str, procedure_text: str) -> str:
+    """Render a minimal SKILL.md for a graduated procedure."""
+    name = f"learned-{_slugify(procedure_id)}"
+    summary = procedure_text.strip().split("\n", 1)[0][:120]
+    return (
+        f"---\n"
+        f"name: {name}\n"
+        f"description: >-\n"
+        f"  Learned procedure graduated from the workspace agent's soul "
+        f"(self-improving skills loop). {summary}\n"
+        f"---\n\n"
+        f"# {name}\n\n"
+        f"This skill was graduated from a procedure the workspace agent learned "
+        f"and used repeatedly. It originated in soul procedural memory "
+        f"`{procedure_id}` and crossed the XP/use graduation threshold.\n\n"
+        f"## Procedure\n\n"
+        f"{procedure_text.strip()}\n"
+    )
+
+
+def maybe_graduate_procedure(
+    skill_registry: Any,
+    *,
+    procedure_id: str,
+    procedure_text: str,
+    amount: int = 10,
+    skills_root: Path | None = None,
+) -> Path | None:
+    """Grant XP for a procedure use and materialize a SKILL.md on graduation.
+
+    Args:
+        skill_registry: a soul ``SkillRegistry`` (or compatible) exposing
+            ``grant_xp_for_procedure_use(skill_id, amount) -> bool``.
+        procedure_id: the soul procedural-memory id backing the procedure. The
+            tracking skill id is ``proc:<procedure_id>``.
+        procedure_text: the procedure content (rendered into the SKILL.md).
+        amount: XP granted for this use (default 10).
+        skills_root: override the skills root (for tests). Defaults to
+            ``~/.pocketpaw/skills`` — the same root install_api_skill writes to.
+
+    Returns:
+        The path to the written SKILL.md when the grant crosses a level
+        boundary (graduation), otherwise ``None``.
+    """
+    skill_id = f"proc:{procedure_id}"
+    graduated = skill_registry.grant_xp_for_procedure_use(skill_id, amount)
+    if not graduated:
+        return None
+
+    root = skills_root if skills_root is not None else (Path.home() / ".pocketpaw" / "skills")
+    skill_dir = root / f"learned-{_slugify(procedure_id)}"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(_render_skill_md(procedure_id, procedure_text), encoding="utf-8")
+
+    logger.info(
+        "skills_loop: graduated procedure %s → materialized SKILL.md at %s",
+        procedure_id,
+        skill_md,
+    )
+    return skill_md
+
+
+__all__ = ["maybe_graduate_procedure"]

--- a/src/pocketpaw/skills_loop/reviewer.py
+++ b/src/pocketpaw/skills_loop/reviewer.py
@@ -1,0 +1,101 @@
+# skills_loop/reviewer.py — the forked write-only session reviewer.
+# Created: 2026-06-16 (feat/self-improving-skills) — runs at an agent's
+#   session-finalize. It replays the session transcript, asks an extractor (the
+#   LLM, faked in tests) for candidate procedures, filters them through the
+#   anti-pattern rubric, and writes the survivors into the WORKSPACE agent's
+#   soul via SoulProcedureWriter. The reviewer EXPOSES a soul-write-ONLY tool
+#   whitelist (whitelist.build_reviewer_whitelist) as ``tool_whitelist``. That
+#   set is the CONTRACT the SDK caller MUST forward as ``allow_sdk_tools`` (with
+#   a deny-everything base policy) when it spawns the forked reviewer — that is
+#   what makes the reviewer physically unable to call any tool but soul-write.
+#   This PR does NOT yet spawn the reviewer through the SDK, so the runtime
+#   restriction is NOT enforced here; the whitelist + assert_write_only only
+#   guarantee the CONTRACT is well-formed. Wiring the spawn (forwarding
+#   allow_sdk_tools + the rubric system prompt) is the follow-up runtime-hookup
+#   PR tracked alongside the soul-protocol dep bump.
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from pocketpaw.skills_loop.whitelist import assert_write_only, build_reviewer_whitelist
+from pocketpaw.skills_loop.writer import SoulProcedureWriter
+
+logger = logging.getLogger(__name__)
+
+
+class ProcedureExtractor(Protocol):
+    """The LLM-backed step that reads a transcript and proposes procedures.
+
+    Faked in tests; in production this is the forked Claude SDK run launched
+    with the write-only whitelist + the rubric system prompt.
+    """
+
+    async def extract(self, transcript: str) -> list[str]: ...
+
+
+class SkillsLoopReviewer:
+    """Replays a session and writes learned procedures into the workspace soul.
+
+    Args:
+        soul: the WORKSPACE agent's soul (the single default agent carrying the
+            workspace soul). The reviewer never resolves a per-pocket soul.
+        extractor: proposes candidate procedures from the transcript.
+        importance: importance score stamped on written procedures.
+    """
+
+    def __init__(
+        self,
+        *,
+        soul: Any,
+        extractor: ProcedureExtractor,
+        importance: int = 6,
+    ) -> None:
+        self._writer = SoulProcedureWriter(soul)
+        self._extractor = extractor
+        self._importance = importance
+        # The soul-write-ONLY CONTRACT the SDK caller must forward as
+        # ``allow_sdk_tools`` when spawning the forked reviewer. Asserted here
+        # so a mis-constructed whitelist fails loudly. NOTE: this object does
+        # not itself spawn an SDK run, so the restriction is not enforced at
+        # this layer — the caller wiring (the follow-up runtime-hookup PR) is
+        # responsible for actually forwarding ``tool_whitelist`` to the spawn.
+        # TODO(skills-loop runtime-hookup PR): forward ``tool_whitelist`` to the
+        #   Claude SDK backend as ``allow_sdk_tools`` (+ rubric system prompt)
+        #   at session-finalize spawn so the enforcement this contract describes
+        #   becomes real. Lands with the soul-protocol dep bump.
+        self.tool_whitelist = build_reviewer_whitelist()
+        assert_write_only(self.tool_whitelist)
+
+    async def review_session(self, transcript: str) -> dict:
+        """Extract, rubric-filter, and write procedures. Returns a report.
+
+        ``{"candidates": int, "written": int, "rejected": int, "ids": list[str]}``
+        """
+        candidates = await self._extractor.extract(transcript)
+        written_ids: list[str] = []
+        rejected = 0
+        for proc in candidates:
+            result = await self._writer.write(proc, importance=self._importance)
+            if result["written"]:
+                written_ids.append(result["id"])
+            else:
+                rejected += 1
+
+        report = {
+            "candidates": len(candidates),
+            "written": len(written_ids),
+            "rejected": rejected,
+            "ids": written_ids,
+        }
+        logger.info(
+            "skills_loop reviewer: %d candidates → %d written, %d rejected",
+            report["candidates"],
+            report["written"],
+            report["rejected"],
+        )
+        return report
+
+
+__all__ = ["SkillsLoopReviewer", "ProcedureExtractor"]

--- a/src/pocketpaw/skills_loop/rubric.py
+++ b/src/pocketpaw/skills_loop/rubric.py
@@ -1,0 +1,92 @@
+# skills_loop/rubric.py — anti-pattern rubric for the session reviewer.
+# Created: 2026-06-16 (feat/self-improving-skills) — ports the spirit of
+#   Hermes's reviewer rubric. Captures the prompt the forked reviewer runs under
+#   AND a deterministic code-side guard (``is_rubric_banned``) that blocks the
+#   worst failure modes BEFORE a write, so a misbehaving LLM can't harden a
+#   self-cited refusal into the soul. The three banned classes:
+#     1. environment / infrastructure failures ("the network was down")
+#     2. "tool X is broken" claims (they become self-cited refusals)
+#     3. one-off task narratives (per-customer / per-date / per-bug stories)
+
+from __future__ import annotations
+
+import re
+
+# The system prompt the forked write-only reviewer runs under. It frames the
+# job (learn a REUSABLE procedure, not a story) and enumerates the bans.
+REVIEWER_SYSTEM_PROMPT = """\
+You are a write-only session reviewer for a workspace AI agent. You have read
+the agent's session transcript. Your ONLY capability is writing a learned
+procedure into the agent's persistent procedural memory (the soul-write tool).
+You cannot run commands, read files, or call any other tool.
+
+Capture at most a few GENERALIZABLE, REUSABLE procedures — durable how-tos the
+agent should apply in future sessions. A good procedure is phrased as a
+repeatable instruction ("To do X, run Y", "When Z happens, check W").
+
+Do NOT capture any of the following — they poison future sessions:
+  1. Environment or infrastructure failures (network down, disk full,
+     permission denied, service unavailable, rate-limited). These are
+     transient, not learnings.
+  2. "Tool X is broken / always fails / don't use it" claims. These harden
+     into self-cited refusals where the agent stops using a working tool.
+  3. One-off task narratives — anything tied to a specific customer, date,
+     ticket, or bug fix ("On <date> we fixed <bug> for <customer>"). These are
+     episodic events, not procedures.
+
+If nothing in the session is worth durably remembering, write nothing.
+"""
+
+# Banned-pattern detectors. Each returns a short reason when it matches.
+_ENV_FAILURE_RE = re.compile(
+    r"\b("
+    r"network (was )?(down|unavailable)|"
+    r"disk (is )?full|"
+    r"permission denied|"
+    r"environment (is )?(misconfigured|broken)|"
+    r"service (is )?(down|unavailable)|"
+    r"rate.?limit|"
+    r"timed? out|timeout|"
+    r"connection (refused|reset|failed)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+_TOOL_BROKEN_RE = re.compile(
+    r"\btool\b.{0,40}\b(broken|is broken|always (errors|fails)|doesn'?t work|never works)\b"
+    r"|\b\w+ tool is broken\b"
+    r"|\b(do not|don'?t|never|avoid) (use|call)(ing)?\b.{0,30}\btool\b",
+    re.IGNORECASE,
+)
+
+# One-off narrative markers: explicit dates, customer/ticket references, or
+# past-tense "we fixed/resolved <thing>" stories.
+_ONE_OFF_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}\b"  # an ISO date → episodic
+    r"|\b(we|i) (fixed|resolved|debugged|patched) (the |a )?\w+ (bug|issue|ticket)\b"
+    r"|\bfor (customer|client|account|tenant) [A-Z]\w+\b"
+    r"|\bticket #?\d+\b",
+    re.IGNORECASE,
+)
+
+
+def is_rubric_banned(procedure_text: str) -> tuple[bool, str | None]:
+    """Return ``(True, reason)`` if ``procedure_text`` violates the rubric.
+
+    Deterministic belt-and-suspenders guard applied to every candidate
+    procedure BEFORE it is written, regardless of what the LLM proposed. A
+    clean procedure returns ``(False, None)``.
+    """
+    text = (procedure_text or "").strip()
+    if not text:
+        return True, "empty procedure"
+    if _TOOL_BROKEN_RE.search(text):
+        return True, "tool-broken claim (becomes a self-cited refusal)"
+    if _ENV_FAILURE_RE.search(text):
+        return True, "environment/infrastructure failure (transient, not a learning)"
+    if _ONE_OFF_RE.search(text):
+        return True, "one-off task narrative (episodic, not a reusable procedure)"
+    return False, None
+
+
+__all__ = ["REVIEWER_SYSTEM_PROMPT", "is_rubric_banned"]

--- a/src/pocketpaw/skills_loop/trigger.py
+++ b/src/pocketpaw/skills_loop/trigger.py
@@ -1,0 +1,73 @@
+# skills_loop/trigger.py — session-finalize trigger for the skills-loop reviewer.
+# Created: 2026-06-16 (feat/self-improving-skills) — fires the forked write-only
+#   reviewer in the BACKGROUND when a workspace agent's session finalizes. Mirrors
+#   the fire-and-return background-spawn pattern of
+#   MCTaskExecutor.execute_task_background (mission_control/executor.py): create
+#   an asyncio task, track it so it can't be GC'd mid-flight or double-dispatched,
+#   and return immediately so session teardown never blocks on the review. The
+#   reviewer itself runs under the soul-write-only whitelist (see whitelist.py).
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from pocketpaw.skills_loop.reviewer import ProcedureExtractor, SkillsLoopReviewer
+
+logger = logging.getLogger(__name__)
+
+
+class SkillsLoopTrigger:
+    """Spawns background reviewer runs at session-finalize.
+
+    Holds strong references to in-flight review tasks (asyncio does not keep a
+    task alive on its own) and guards against double-dispatch for the same
+    session key — the same discipline ``execute_task_background`` applies.
+    """
+
+    def __init__(self) -> None:
+        self._running: dict[str, asyncio.Task] = {}
+
+    def on_session_finalize(
+        self,
+        session_key: str,
+        *,
+        soul: Any,
+        extractor: ProcedureExtractor,
+        transcript: str,
+        importance: int = 6,
+    ) -> bool:
+        """Launch a background review for ``session_key``. Returns immediately.
+
+        MUST be called from within a running asyncio event loop — it schedules
+        the review via ``asyncio.create_task`` (the same requirement
+        ``execute_task_background`` has). Calling it from synchronous,
+        loop-less code raises ``RuntimeError: no running event loop``.
+
+        Returns True if a review was launched, False if one is already in
+        flight for this session (double-dispatch guard).
+        """
+        if session_key in self._running and not self._running[session_key].done():
+            logger.warning("skills_loop: review already running for %s, skipping", session_key)
+            return False
+
+        reviewer = SkillsLoopReviewer(soul=soul, extractor=extractor, importance=importance)
+
+        async def _run() -> None:
+            try:
+                await reviewer.review_session(transcript)
+            except Exception:  # noqa: BLE001 — a failed review must never crash teardown
+                logger.exception("skills_loop: background review failed for %s", session_key)
+            finally:
+                self._running.pop(session_key, None)
+
+        self._running[session_key] = asyncio.create_task(_run())
+        return True
+
+    def is_running(self, session_key: str) -> bool:
+        task = self._running.get(session_key)
+        return task is not None and not task.done()
+
+
+__all__ = ["SkillsLoopTrigger"]

--- a/src/pocketpaw/skills_loop/whitelist.py
+++ b/src/pocketpaw/skills_loop/whitelist.py
@@ -1,0 +1,52 @@
+# skills_loop/whitelist.py — the write-only tool whitelist for the reviewer.
+# Created: 2026-06-16 (feat/self-improving-skills) — the safety machinery that
+#   restricts the forked session reviewer to soul-write ONLY.
+# Updated: 2026-06-16 (review) — the set is the CONTRACT a caller MUST forward to
+#   the Claude SDK backend's per-run tool allowlist (agents/backend.py
+#   ``allow_sdk_tools`` / the ``allowed_tools`` assembly in claude_sdk) so the
+#   reviewer cannot call Bash/Read/Write/Edit/any MCP tool — only write learned
+#   procedures into the soul. NOTE: this PR does NOT spawn the SDK run, so that
+#   runtime restriction is not enforced here; the session-finalize spawn that
+#   forwards this set lands with the runtime-hookup follow-up (see reviewer.py).
+#   ``assert_write_only`` is the invariant guard a caller runs before launching.
+
+from __future__ import annotations
+
+# The ONLY tool the reviewer may use: the soul-write tool
+# (``SoulRememberTool.name`` in ``pocketpaw.paw.tools``). Kept as a frozenset so
+# it is immutable and hashes into the SDK client cache key cleanly.
+SOUL_WRITE_TOOL_IDS: frozenset[str] = frozenset({"soul_remember"})
+
+
+def build_reviewer_whitelist() -> frozenset[str]:
+    """Return the write-only tool whitelist for the session reviewer.
+
+    The reviewer is granted exactly the soul-write tool and nothing else. This
+    is the additive allowlist passed to the Claude SDK backend; combined with a
+    deny-everything base policy it leaves soul-write as the only callable tool.
+    """
+    return SOUL_WRITE_TOOL_IDS
+
+
+def assert_write_only(whitelist: frozenset[str]) -> None:
+    """Assert ``whitelist`` grants soul-write tools ONLY.
+
+    Raises ``ValueError`` if the set contains any id outside
+    :data:`SOUL_WRITE_TOOL_IDS` (e.g. Bash, Read, Write, Edit, or any MCP
+    tool). Run this immediately before spawning the reviewer so a
+    mis-assembled allowlist can never let the reviewer reach a non-write tool.
+    """
+    extra = set(whitelist) - SOUL_WRITE_TOOL_IDS
+    if extra:
+        raise ValueError(
+            "Skills-loop reviewer must be write-only: "
+            f"whitelist carries non-soul-write tools {sorted(extra)}"
+        )
+    if not whitelist:
+        raise ValueError(
+            "Skills-loop reviewer must be write-only: whitelist is empty "
+            "(the reviewer would be unable to write any learned procedure)"
+        )
+
+
+__all__ = ["SOUL_WRITE_TOOL_IDS", "build_reviewer_whitelist", "assert_write_only"]

--- a/src/pocketpaw/skills_loop/writer.py
+++ b/src/pocketpaw/skills_loop/writer.py
@@ -1,0 +1,88 @@
+# skills_loop/writer.py — writes a learned procedure into the workspace soul.
+# Created: 2026-06-16 (feat/self-improving-skills) — the single write path the
+#   reviewer uses. Runs the rubric guard, then writes the procedure as a
+#   PROCEDURAL memory tagged AGENT-authored. Provenance is carried two ways so
+#   the slice ships independently of the soul-protocol PR:
+#     - always on the ``entities`` list (the ``provenance:agent`` tag) — present
+#       in every soul-protocol version, so agent-created procedures are always
+#       distinguishable from human-authored ones;
+#     - additionally via the ``provenance=`` kwarg when the installed
+#       soul-protocol exposes ``MemoryProvenance`` (the matching soul PR), so the
+#       curator's native provenance field is populated once both land.
+#   Writes go through ``Soul.note`` when available (dedup via reconcile_fact),
+#   falling back to ``Soul.remember`` on older soul-protocol builds.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from soul_protocol.runtime.types import MemoryType
+
+from pocketpaw.skills_loop.rubric import is_rubric_banned
+
+logger = logging.getLogger(__name__)
+
+# Entities tag marking a procedure as agent-authored. Stable across every
+# soul-protocol version (``entities`` is a long-standing field), so the curator
+# and any consumer can distinguish loop-learned procedures from human ones even
+# before the native ``provenance`` field exists.
+AGENT_PROVENANCE_TAG = "provenance:agent"
+SKILLS_LOOP_TAG = "skills-loop"
+
+# Resolve the native provenance enum if the installed soul-protocol carries it.
+try:  # pragma: no cover - import-time capability probe
+    from soul_protocol.runtime.types import MemoryProvenance
+
+    _AGENT_PROVENANCE: Any | None = MemoryProvenance.AGENT
+except ImportError:  # pragma: no cover - older soul-protocol, kwarg unsupported
+    _AGENT_PROVENANCE = None
+
+
+class SoulProcedureWriter:
+    """Writes rubric-clean, agent-tagged procedures into a workspace soul.
+
+    The soul passed in is the WORKSPACE agent's soul — the writer never resolves
+    a per-pocket soul. It only knows how to write to whatever soul it is handed.
+    """
+
+    def __init__(self, soul: Any) -> None:
+        self._soul = soul
+
+    async def write(self, procedure_text: str, *, importance: int = 6) -> dict:
+        """Write one learned procedure. Returns a result dict.
+
+        ``{"written": bool, "id": str | None, "reason": str | None}`` —
+        ``written`` is False (with a ``reason``) when the rubric guard rejects
+        the candidate, so nothing banned ever reaches the soul.
+        """
+        banned, reason = is_rubric_banned(procedure_text)
+        if banned:
+            logger.info("skills_loop: rejected procedure (%s)", reason)
+            return {"written": False, "id": None, "reason": reason}
+
+        entities = [AGENT_PROVENANCE_TAG, SKILLS_LOOP_TAG]
+        kwargs: dict[str, Any] = {
+            "type": MemoryType.PROCEDURAL,
+            "importance": importance,
+            "entities": entities,
+        }
+        if _AGENT_PROVENANCE is not None:
+            kwargs["provenance"] = _AGENT_PROVENANCE
+
+        result = await self._write_via_soul(procedure_text, kwargs)
+        mem_id = result.get("id") if isinstance(result, dict) else result
+        logger.info("skills_loop: wrote agent procedure id=%s", mem_id)
+        return {"written": True, "id": mem_id, "reason": None}
+
+    async def _write_via_soul(self, content: str, kwargs: dict[str, Any]) -> Any:
+        """Prefer ``Soul.note`` (dedup); fall back to ``Soul.remember``."""
+        note = getattr(self._soul, "note", None)
+        if note is not None:
+            return await note(content, **kwargs)
+        # Older soul-protocol: no note(), no provenance kwarg.
+        kwargs.pop("provenance", None)
+        return await self._soul.remember(content, **kwargs)
+
+
+__all__ = ["SoulProcedureWriter", "AGENT_PROVENANCE_TAG", "SKILLS_LOOP_TAG"]

--- a/tests/test_skills_loop.py
+++ b/tests/test_skills_loop.py
@@ -1,0 +1,337 @@
+# test_skills_loop.py — Self-improving skills loop (PocketPaw side).
+# Created: 2026-06-16 (feat/self-improving-skills) — TDD coverage for the forked
+#   write-only reviewer that learns procedures into the WORKSPACE agent's soul:
+#     - the reviewer whitelist resolves to soul-write ONLY (it physically cannot
+#       call any other tool),
+#     - rubric-banned items (env failures / "tool broken" / one-off narratives)
+#       are NOT written,
+#     - agent-created procedures are provenance-tagged (distinguishable from
+#       human-authored ones),
+#     - writes target the workspace agent's soul (no per-pocket soul),
+#     - XP graduation materializes a SKILL.md.
+#   LLM extraction + the background spawn are faked — no real model calls.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pocketpaw.skills_loop.graduation import maybe_graduate_procedure
+from pocketpaw.skills_loop.reviewer import SkillsLoopReviewer
+from pocketpaw.skills_loop.rubric import is_rubric_banned
+from pocketpaw.skills_loop.whitelist import (
+    SOUL_WRITE_TOOL_IDS,
+    assert_write_only,
+    build_reviewer_whitelist,
+)
+from pocketpaw.skills_loop.writer import AGENT_PROVENANCE_TAG, SoulProcedureWriter
+
+
+# --------------------------------------------------------------------------- #
+# Fakes (no real LLM, no real background spawn, in-memory soul)                #
+# --------------------------------------------------------------------------- #
+class FakeSoul:
+    """Records note()/remember() calls so tests can assert what got written."""
+
+    def __init__(self) -> None:
+        self.writes: list[dict] = []
+
+    async def note(self, content, **kwargs):
+        record = {"content": content, **kwargs}
+        record["_id"] = f"m{len(self.writes)}"
+        self.writes.append(record)
+        return {"action": "CREATE", "id": record["_id"]}
+
+
+class FakeOldSoul:
+    """Older soul-protocol stand-in: NO note(), only remember().
+
+    Models the interim window before pocketpaw's soul-protocol dep is bumped —
+    the writer must fall back to remember() and still tag provenance.
+    """
+
+    def __init__(self) -> None:
+        self.writes: list[dict] = []
+
+    async def remember(self, content, **kwargs):
+        record = {"content": content, **kwargs}
+        record["_id"] = f"m{len(self.writes)}"
+        self.writes.append(record)
+        return record["_id"]
+
+
+class FakeExtractor:
+    """Stand-in for the LLM that reads a transcript and proposes procedures."""
+
+    def __init__(self, procedures: list[str]) -> None:
+        self._procedures = procedures
+
+    async def extract(self, transcript: str) -> list[str]:  # noqa: ARG002
+        return list(self._procedures)
+
+
+# --------------------------------------------------------------------------- #
+# (1) Whitelist — soul-write ONLY                                             #
+# --------------------------------------------------------------------------- #
+class TestWhitelist:
+    def test_whitelist_is_soul_write_only(self):
+        wl = build_reviewer_whitelist()
+        assert wl == SOUL_WRITE_TOOL_IDS
+        # The core safety assertion: nothing but soul-write may be present.
+        assert wl == frozenset({"soul_remember"})
+
+    def test_assert_write_only_passes_for_soul_write(self):
+        # Must not raise.
+        assert_write_only(build_reviewer_whitelist())
+
+    @pytest.mark.parametrize(
+        "forbidden",
+        [
+            frozenset({"soul_remember", "Bash"}),
+            frozenset({"soul_remember", "Write"}),
+            frozenset({"soul_remember", "Read"}),
+            frozenset({"soul_remember", "Edit"}),
+            frozenset({"soul_remember", "mcp__pocketpaw_pocket__add_widget"}),
+            frozenset({"Bash"}),
+        ],
+    )
+    def test_assert_write_only_rejects_any_other_tool(self, forbidden):
+        with pytest.raises(ValueError, match="write-only"):
+            assert_write_only(forbidden)
+
+
+# --------------------------------------------------------------------------- #
+# (2) Rubric — banned items are not captured                                  #
+# --------------------------------------------------------------------------- #
+class TestRubric:
+    @pytest.mark.parametrize(
+        "banned",
+        [
+            "The network was down so the deploy failed — wait and retry later.",
+            "Tool Bash is broken and always errors, do not use it.",
+            "The Read tool is broken, avoid calling it.",
+            "On 2026-06-14 we fixed the login bug for customer Acme by editing line 42.",
+            "Permission denied when running git push, the environment is misconfigured.",
+        ],
+    )
+    def test_banned_items_are_rejected(self, banned):
+        is_banned, reason = is_rubric_banned(banned)
+        assert is_banned is True
+        assert reason
+
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "To regenerate C4 diagrams, run make c4-pp from the docs directory.",
+            "When a pytest-asyncio test hangs, check for an unawaited coroutine.",
+            "Prefer uv run ruff format over manual formatting before committing.",
+        ],
+    )
+    def test_legitimate_procedures_pass(self, good):
+        is_banned, _ = is_rubric_banned(good)
+        assert is_banned is False
+
+
+# --------------------------------------------------------------------------- #
+# (3)+(4) Writer — provenance tagging + workspace soul                        #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+class TestWriter:
+    async def test_write_tags_agent_provenance(self):
+        soul = FakeSoul()
+        writer = SoulProcedureWriter(soul)
+        result = await writer.write("To run e2e tests use uv run pytest tests e2e")
+        assert result["written"] is True
+        assert len(soul.writes) == 1
+        rec = soul.writes[0]
+        # Provenance is carried on the entities tag (works on every
+        # soul-protocol version) — distinguishable from human-authored.
+        assert AGENT_PROVENANCE_TAG in rec["entities"]
+        # And as PROCEDURAL memory.
+        assert str(rec["type"]).endswith("procedural")
+
+    async def test_write_rejects_rubric_banned(self):
+        soul = FakeSoul()
+        writer = SoulProcedureWriter(soul)
+        result = await writer.write("Tool Bash is broken, never use it.")
+        assert result["written"] is False
+        assert result["reason"]
+        assert soul.writes == []
+
+    async def test_write_falls_back_to_remember_on_old_soul(self, monkeypatch):
+        # Interim window: soul-protocol has no note() and no MemoryProvenance.
+        # The writer must fall back to remember(), drop the unsupported
+        # provenance kwarg, and STILL land the agent provenance tag on entities.
+        import pocketpaw.skills_loop.writer as writer_mod
+
+        monkeypatch.setattr(writer_mod, "_AGENT_PROVENANCE", None)
+        soul = FakeOldSoul()
+        writer = SoulProcedureWriter(soul)
+        result = await writer.write("To run e2e tests use uv run pytest tests e2e")
+        assert result["written"] is True
+        assert len(soul.writes) == 1
+        rec = soul.writes[0]
+        # Fallback path: provenance tag still present on the entities list.
+        assert AGENT_PROVENANCE_TAG in rec["entities"]
+        # The unsupported native kwarg must NOT be forwarded to remember().
+        assert "provenance" not in rec
+        assert str(rec["type"]).endswith("procedural")
+
+
+# --------------------------------------------------------------------------- #
+# (3)+(4) Reviewer end-to-end — workspace soul, provenance, rubric            #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+class TestReviewer:
+    async def test_reviewer_writes_only_legitimate_procedures(self):
+        soul = FakeSoul()
+        extractor = FakeExtractor(
+            [
+                "To regenerate C4 run make c4-pp from docs",  # good
+                "Tool Bash is broken and always fails",  # banned
+                "The network was down so the build failed",  # banned
+            ]
+        )
+        reviewer = SkillsLoopReviewer(soul=soul, extractor=extractor)
+        report = await reviewer.review_session("...transcript...")
+
+        # Only the legitimate procedure was written.
+        assert len(soul.writes) == 1
+        assert "c4-pp" in soul.writes[0]["content"]
+        assert report["written"] == 1
+        assert report["rejected"] == 2
+
+    async def test_reviewer_targets_workspace_soul(self):
+        # The reviewer must write to the soul it is given (the workspace
+        # agent's soul) — it never resolves a per-pocket soul itself.
+        workspace_soul = FakeSoul()
+        extractor = FakeExtractor(["To deploy run make ship from the repo root"])
+        reviewer = SkillsLoopReviewer(soul=workspace_soul, extractor=extractor)
+        await reviewer.review_session("...transcript...")
+        assert len(workspace_soul.writes) == 1
+        assert AGENT_PROVENANCE_TAG in workspace_soul.writes[0]["entities"]
+
+    async def test_reviewer_uses_write_only_whitelist(self):
+        # The reviewer exposes a soul-write-only whitelist — the CONTRACT the
+        # SDK caller must forward as allow_sdk_tools. (This object does not spawn
+        # the SDK run itself; the runtime hookup is a follow-up PR.)
+        reviewer = SkillsLoopReviewer(soul=FakeSoul(), extractor=FakeExtractor([]))
+        assert_write_only(reviewer.tool_whitelist)
+        assert reviewer.tool_whitelist == frozenset({"soul_remember"})
+
+
+# --------------------------------------------------------------------------- #
+# (5) Graduation — XP threshold materializes a SKILL.md                       #
+# --------------------------------------------------------------------------- #
+class FakeSkillRegistry:
+    """Minimal SkillRegistry stand-in for graduation tests."""
+
+    def __init__(self, *, graduate: bool) -> None:
+        self._graduate = graduate
+        self.granted: list[tuple[str, int]] = []
+
+    def grant_xp_for_procedure_use(self, skill_id: str, amount: int = 10) -> bool:
+        self.granted.append((skill_id, amount))
+        return self._graduate
+
+
+class TestGraduation:
+    def test_graduation_materializes_skill_md(self, tmp_path):
+        registry = FakeSkillRegistry(graduate=True)
+        path = maybe_graduate_procedure(
+            registry,
+            procedure_id="abc123",
+            procedure_text="To regenerate C4 run make c4-pp from docs",
+            skills_root=tmp_path,
+        )
+        assert path is not None
+        assert path.exists()
+        body = path.read_text()
+        assert "make c4-pp" in body
+        assert registry.granted == [("proc:abc123", 10)]
+
+    def test_no_graduation_below_threshold(self, tmp_path):
+        registry = FakeSkillRegistry(graduate=False)
+        path = maybe_graduate_procedure(
+            registry,
+            procedure_id="abc123",
+            procedure_text="To regenerate C4 run make c4-pp from docs",
+            skills_root=tmp_path,
+        )
+        assert path is None
+        # No SKILL.md written.
+        assert list(tmp_path.glob("**/SKILL.md")) == []
+
+    def test_pathological_ids_do_not_collide(self, tmp_path):
+        # Two distinct all-punctuation ids must not collapse to the same
+        # "learned-procedure" directory (and clobber each other's SKILL.md).
+        p1 = maybe_graduate_procedure(
+            FakeSkillRegistry(graduate=True),
+            procedure_id="@@@",
+            procedure_text="First procedure body alpha",
+            skills_root=tmp_path,
+        )
+        p2 = maybe_graduate_procedure(
+            FakeSkillRegistry(graduate=True),
+            procedure_id="###",
+            procedure_text="Second procedure body beta",
+            skills_root=tmp_path,
+        )
+        assert p1 is not None and p2 is not None
+        # The two SKILL.md paths must be distinct (no clobber).
+        assert p1 != p2
+        assert "alpha" in p1.read_text()
+        assert "beta" in p2.read_text()
+
+
+# --------------------------------------------------------------------------- #
+# Trigger — background fire-and-return at session-finalize                     #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+class TestTrigger:
+    async def test_finalize_launches_background_review(self):
+        from pocketpaw.skills_loop.trigger import SkillsLoopTrigger
+
+        soul = FakeSoul()
+        trigger = SkillsLoopTrigger()
+        launched = trigger.on_session_finalize(
+            "sess-1",
+            soul=soul,
+            extractor=FakeExtractor(["To deploy run make ship from the repo root"]),
+            transcript="...",
+        )
+        assert launched is True
+        # Let the background task run to completion.
+        await asyncio.sleep(0.05)
+        assert len(soul.writes) == 1
+        assert not trigger.is_running("sess-1")
+
+    async def test_double_dispatch_is_guarded(self):
+        from pocketpaw.skills_loop.trigger import SkillsLoopTrigger
+
+        soul = FakeSoul()
+        trigger = SkillsLoopTrigger()
+        slow = SlowExtractor(["To deploy run make ship from the repo root"])
+        first = trigger.on_session_finalize("sess-1", soul=soul, extractor=slow, transcript="...")
+        second = trigger.on_session_finalize("sess-1", soul=soul, extractor=slow, transcript="...")
+        assert first is True
+        assert second is False  # already in flight
+        slow.release()
+        await asyncio.sleep(0.05)
+        assert len(soul.writes) == 1
+
+
+class SlowExtractor:
+    """Extractor that blocks until released — exercises the in-flight guard."""
+
+    def __init__(self, procedures: list[str]) -> None:
+        self._procedures = procedures
+        self._gate = asyncio.Event()
+
+    def release(self) -> None:
+        self._gate.set()
+
+    async def extract(self, transcript: str) -> list[str]:  # noqa: ARG002
+        await self._gate.wait()
+        return list(self._procedures)


### PR DESCRIPTION
Second half of the self-improving skills loop — the pocketpaw side. Depends on soul-protocol PR (agent provenance + curator); merge this after that lands and bump the soul-protocol dep.

## What

After a workspace agent's session, a forked review pass reads the transcript and writes a learned procedure into the workspace agent's soul (procedural memory), governed by safety machinery:

- **Write-only whitelist** (`skills_loop/whitelist.py`) — the contract that restricts the reviewer to the soul-write tool and nothing else, with `assert_write_only` as the construction-time guard.
- **Anti-pattern rubric** (`rubric.py`) — both a reviewer prompt and a deterministic pre-write filter that rejects the things you must never learn: environment failures, "tool X is broken" claims, one-off task narratives (they harden into refusals the agent later cites against itself).
- **Writer** (`writer.py`) — provenance-tags each procedure and writes via `Soul.note` (the dedup path), degrading gracefully on the old soul-protocol version until the dep bump.
- **XP → SKILL.md graduation** (`graduation.py`) — proven procedures materialize to a SKILL.md under `~/.pocketpaw/skills`, reusing the `install_api_skill` write precedent.

## Honest scope — read before merging

This PR ships the **safety machinery and the loop logic, tested with fakes**. It does **not** wire the session-finalize trigger into the live dispatch path — the whitelist is the *contract the SDK caller must forward* as `allow_sdk_tools`, not yet an enforced runtime restriction (the comments and a TODO say so plainly). The runtime hookup — spawning the reviewer at session-finalize with the whitelist forwarded — lands with a follow-up, alongside the soul-protocol dep bump. So this is the proven core, not a live loop yet.

## Tests

`uv run pytest tests/test_skills_loop.py -q` → 27 passed. Covers: the write-only whitelist + assert guard; rubric rejects banned items; provenance tagging; the old-soul-protocol fallback path; pathological-id slug collisions; XP graduation. ruff check + format clean.

Captain reviews; not merging.