### PR TITLE
Fix/connectors oauth

### DIFF
--- a/connectors/drive.yaml
+++ b/connectors/drive.yaml
@@ -4,7 +4,7 @@
 # Auth is OAuth 2.0 (bearer token) — either from the credential broker at
 # dispatch time or from GOOGLE_OAUTH_TOKEN for local dev.
 
-name: drive
+name: google_drive
 display_name: Google Drive
 type: knowledge
 icon: cloud

--- a/src/pocketpaw/api/v1/connectors.py
+++ b/src/pocketpaw/api/v1/connectors.py
@@ -128,6 +128,121 @@ class ConnectorStatusResponse(BaseModel):
 # ── Routes ───────────────────────────────────────────────────────────────────
 
 
+# Map OAuth service names to connector names for auto-connect reconciliation.
+_OAUTH_SVC_TO_CONNECTOR: dict[str, str] = {
+    "google_gmail": "gmail",
+    "google_calendar": "gcalendar",
+    "google_drive": "google_drive",
+    "google_docs": "gdocs",
+    "spotify": "spotify",
+}
+
+
+async def _auto_connect_if_oauth(
+    reg: ConnectorRegistry,
+    connector_name: str,
+    pocket_id: str,
+) -> bool:
+    """Check if *connector_name* has valid OAuth tokens and register it.
+
+    Returns True if the connector was newly connected by this call, False
+    if it was already connected or no OAuth tokens exist.
+
+    This bridges the gap between the OAuth TokenStore (used by the Tools
+    tab) and the connector registry's state store (used by the Data Sources
+    tab and agent tools). Existing tokens saved before the auto-connect
+    feature get picked up on the first status query.
+    """
+    # Find the OAuth service name that maps to this connector.
+    svc = None
+    for oauth_svc, conn_name in _OAUTH_SVC_TO_CONNECTOR.items():
+        if conn_name == connector_name:
+            svc = oauth_svc
+            break
+    if svc is None:
+        return False  # Not an OAuth-backed connector
+
+    # Check if registry already has it connected.
+    statuses = reg.status(pocket_id)
+    already = any(
+        s["name"] == connector_name and s["status"] == ConnectorStatus.CONNECTED for s in statuses
+    )
+    if already:
+        return False
+
+    # Check the OAuth token store AND verify the token is actually usable.
+    #
+    # IMPORTANT: We must NOT call reg.connect() with a bad token — the
+    # registry is write-through: connect() saves config, then calls the
+    # adapter's connect(), which tries _get_token() → refresh. If the
+    # refresh fails (400 Bad Request = revoked/expired refresh token),
+    # the adapter returns failure and the registry *deletes* the persisted
+    # row. This creates a fail-delete loop on every status query.
+    #
+    # Instead, we verify the token is valid FIRST by calling
+    # OAuthManager.get_valid_token() (which attempts a refresh). Only
+    # if we get a live token back do we register the connector.
+    try:
+        from pocketpaw.clients.oauth import OAuthManager
+        from pocketpaw.clients.token_store import TokenStore
+        from pocketpaw.config import Settings
+
+        store = TokenStore()
+        tokens = store.load(svc)
+        if not tokens or not tokens.access_token:
+            return False
+        if (
+            tokens.expires_at
+            and tokens.expires_at < __import__("time").time()
+            and not tokens.refresh_token
+        ):
+            return False  # expired with no refresh path
+
+        # Try to get a valid token (triggers refresh if expired). This is
+        # the acid test — if the refresh token is invalid/revoked the
+        # provider returns 400 and we bail without touching the registry.
+        settings = Settings.load()
+        is_google = svc.startswith("google_")
+        provider = "google" if is_google else svc
+        if is_google:
+            client_id = settings.google_oauth_client_id or ""
+            client_secret = settings.google_oauth_client_secret or ""
+        else:
+            client_id = getattr(settings, f"{svc}_client_id", "") or ""
+            client_secret = getattr(settings, f"{svc}_client_secret", "") or ""
+
+        if not client_id or not client_secret:
+            return False  # OAuth not configured
+
+        mgr = OAuthManager(store)
+        live_token = await mgr.get_valid_token(
+            service=svc,
+            client_id=client_id,
+            client_secret=client_secret,
+            provider=provider,
+        )
+        if not live_token:
+            logger.info(
+                "OAuth token for %s is expired and cannot be refreshed — user must re-authorize",
+                svc,
+            )
+            return False  # Token exists but can't be refreshed
+
+        # Token is live — connect the connector in the registry.
+        scope_str = " ".join(tokens.scopes) if tokens.scopes else svc
+        result = await reg.connect(pocket_id, connector_name, {"scope": scope_str})
+        if result and result.success:
+            logger.info(
+                "Auto-connected %s from existing OAuth tokens (%s)",
+                connector_name,
+                svc,
+            )
+            return True
+    except Exception as exc:
+        logger.debug("OAuth auto-connect failed for %s: %s", connector_name, exc)
+    return False
+
+
 # Per-pocket connector status side-table. Kept in memory because the
 # status is an ephemeral snapshot — the adapter instance map in the
 # registry is the source of truth for "connected" and this layer just
@@ -186,6 +301,16 @@ async def get_connector_status(
 
         raise HTTPException(status_code=404, detail=f"Connector '{connector_name}' not found")
 
+    # Sync: if this connector is backed by OAuth tokens, check whether
+    # valid tokens exist in the TokenStore and auto-register them with
+    # the connector registry. This bridges the gap between the OAuth
+    # token store and the registry state store so existing tokens (saved
+    # before the auto-connect fix) show as "connected" here too.
+    try:
+        await _auto_connect_if_oauth(reg, connector_name, pocket_id)
+    except Exception:
+        pass  # Best-effort — don't break status reporting
+
     # Derive "connected" from the registry's durable state (definition +
     # persisted config), not from the in-process adapter map — a configured
     # connector stays connected across restarts (CS-6).
@@ -217,8 +342,18 @@ async def list_connectors(pocket_id: str = "default"):
     durable state, so the list is truthful after a restart. Orphaned state
     rows (config persisted but the YAML definition is gone) are appended
     with status ``definition_missing`` rather than silently dropped.
+
+    Before building the response, known OAuth-backed connectors are synced
+    from the TokenStore so any connector with valid OAuth tokens reports
+    as "connected" even without a prior /connectors/connect call.
     """
     reg = _get_registry()
+    # Sync all OAuth-backed connectors from the token store.
+    for conn_name in set(_OAUTH_SVC_TO_CONNECTOR.values()):
+        try:
+            await _auto_connect_if_oauth(reg, conn_name, pocket_id)
+        except Exception:
+            continue
     reg_status = reg.status(pocket_id)
     status_map = {s["name"]: s["status"].value for s in reg_status}
 
@@ -288,6 +423,36 @@ async def get_connector_detail(connector_name: str, pocket_id: str = "default"):
         actions=actions,
         credentials=credentials,
     )
+
+
+@router.get("/connectors/{connector_name}/actions")
+async def get_connector_actions(connector_name: str):
+    """List available actions for a connector.
+
+    The agent uses this path to discover what actions a connector supports.
+    Returns a flat list of actions (same shape as inside ConnectorDetailResponse)
+    without the rest of the detail payload.
+    """
+    reg = _get_registry()
+    defn = reg.get_definition(connector_name)
+    if not defn:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=404, detail=f"Connector '{connector_name}' not found")
+
+    actions = []
+    for act in defn.actions:
+        actions.append(
+            {
+                "name": act["name"],
+                "description": act.get("description", ""),
+                "method": act.get("method", "GET"),
+                "params": list(act.get("params", {}).keys()) + list(act.get("body", {}).keys()),
+                "trust_level": act.get("trust_level", "confirm"),
+            }
+        )
+
+    return {"connector": connector_name, "actions": actions}
 
 
 @router.post("/connectors/connect", response_model=ConnectResponse)

--- a/src/pocketpaw/api/v1/oauth_integrations.py
+++ b/src/pocketpaw/api/v1/oauth_integrations.py
@@ -5,6 +5,9 @@
 #   ``state`` (provider:service:user_id); the callback parses it back out and
 #   stores tokens in that user's bucket (VIP Onboarding Phase B). Omitting
 #   user_id keeps the shared single-user flow (state stays provider:service).
+# 2026-06-16: callback now auto-connects the corresponding connector in the
+#   registry so the connector shows up as "connected" after OAuth completes.
+#   Also added OAUTH_TO_CONNECTOR mapping so the correct connector_name is used.
 
 from __future__ import annotations
 
@@ -33,6 +36,17 @@ OAUTH_SCOPES: dict[str, list[str]] = {
         "playlist-modify-public",
         "playlist-modify-private",
     ],
+}
+
+# Map OAuth service names to connector names in the registry.
+# When OAuth completes for a service, the corresponding connector is
+# auto-connected so the registry knows it's active.
+OAUTH_TO_CONNECTOR: dict[str, str] = {
+    "google_gmail": "gmail",
+    "google_calendar": "gcalendar",
+    "google_drive": "google_drive",
+    "google_docs": "gdocs",
+    "spotify": "spotify",
 }
 
 
@@ -99,7 +113,12 @@ async def oauth_callback(
     state: str = Query(""),
     error: str = Query(""),
 ):
-    """OAuth callback — exchanges auth code for tokens."""
+    """OAuth callback — exchanges auth code for tokens and auto-connects the connector.
+
+    After saving tokens, the corresponding connector is registered in the
+    connector registry (via ``registry.connect()``) so it shows as "connected"
+    in the UI and the agent can use it without a separate connect step.
+    """
     from fastapi.responses import HTMLResponse
 
     if error:
@@ -142,6 +161,25 @@ async def oauth_callback(
             scopes=scopes,
             user_id=user_id,
         )
+
+        # Auto-connect the corresponding connector in the registry so the
+        # connector shows as "connected" without a separate /connectors/connect
+        # call. This bridges the gap between the OAuth token store and the
+        # connector registry's state store.
+        connector_name = OAUTH_TO_CONNECTOR.get(service)
+        if connector_name:
+            try:
+                from pocketpaw.api.v1.connectors import _get_registry
+
+                reg = _get_registry()
+                await reg.connect("default", connector_name, {"scope": " ".join(scopes)})
+            except Exception as exc:
+                logger.warning(
+                    "Auto-connect failed for %s (connector %s): %s",
+                    service,
+                    connector_name,
+                    exc,
+                )
 
         return HTMLResponse(
             "<h2>Authorization Successful</h2>"

--- a/src/pocketpaw/api/v1/oauth_integrations.py
+++ b/src/pocketpaw/api/v1/oauth_integrations.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -190,3 +191,48 @@ async def oauth_callback(
     except Exception as e:
         logger.error("OAuth callback error: %s", e)
         return HTMLResponse(f"<h2>OAuth Error</h2><p>{e}</p>")
+
+
+class OAuthDisconnectRequest(BaseModel):
+    """Request to disconnect an OAuth service."""
+
+    service: str
+    pocket_id: str = "default"
+
+
+@router.post("/oauth/integrations/disconnect")
+async def oauth_disconnect(req: OAuthDisconnectRequest):
+    """Disconnect an OAuth service — delete tokens + disconnect the connector.
+
+    Returns the oauth_status dict so the frontend can update immediately.
+    """
+    if req.service not in OAUTH_SCOPES:
+        raise HTTPException(status_code=400, detail=f"Unknown service: {req.service}")
+
+    try:
+        from pocketpaw.clients.token_store import TokenStore
+
+        # Delete OAuth tokens.
+        store = TokenStore()
+        store.delete(req.service)
+
+        # Disconnect the corresponding connector from the registry.
+        connector_name = OAUTH_TO_CONNECTOR.get(req.service)
+        if connector_name:
+            try:
+                from pocketpaw.api.v1.connectors import _get_registry
+
+                reg = _get_registry()
+                await reg.disconnect(req.pocket_id, connector_name)
+            except Exception as exc:
+                logger.warning(
+                    "OAuth disconnect: failed to disconnect connector %s: %s",
+                    connector_name,
+                    exc,
+                )
+
+        logger.info("Disconnected OAuth service %s", req.service)
+        return {"success": True, "service": req.service}
+    except Exception as e:
+        logger.error("OAuth disconnect error: %s", e)
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/src/pocketpaw/api/v1/tools.py
+++ b/src/pocketpaw/api/v1/tools.py
@@ -58,9 +58,14 @@ async def list_tools():
     except Exception:
         logger.debug("MCP manager not available for tools listing", exc_info=True)
 
-    # OAuth connection status — check which services have saved tokens.
+    # OAuth connection status — check which services have saved tokens
+    # and whether they are still valid (not expired without a refresh path).
+    # Also sync valid tokens into the connector registry so the Data Sources
+    # tab and agent tools see the same "connected" status.
     oauth_status: dict[str, str] = {}
     try:
+        import time as _time
+
         from pocketpaw.clients.token_store import TokenStore
         from pocketpaw.config import Settings
 
@@ -68,10 +73,55 @@ async def list_tools():
         store = TokenStore()
         has_google_creds = bool(settings.google_oauth_client_id)
 
+        # Map OAuth service names to connector names — used to sync the
+        # connector registry whenever we find valid tokens.
+        _OAUTH_SVC_TO_CONNECTOR: dict[str, str] = {
+            "google_gmail": "gmail",
+            "google_calendar": "gcalendar",
+            "google_drive": "google_drive",
+            "google_docs": "gdocs",
+            "spotify": "spotify",
+        }
+
         for svc in ("google_gmail", "google_calendar", "google_drive", "google_docs", "spotify"):
             tokens = store.load(svc)
             if tokens and tokens.access_token:
-                oauth_status[svc] = "connected"
+                # If the token has an expires_at that is past due AND there
+                # is no refresh_token to auto-renew, report it as "expired".
+                # A valid refresh_token means auto-refresh will handle it
+                # on next use, so we still show "connected".
+                if (
+                    tokens.expires_at
+                    and tokens.expires_at < _time.time()
+                    and not tokens.refresh_token
+                ):
+                    oauth_status[svc] = "expired"
+                else:
+                    oauth_status[svc] = "connected"
+                    # Sync: ensure the connector registry also knows this
+                    # connector is connected. This bridges the gap between
+                    # the OAuth token store (checked by this endpoint) and
+                    # the connector registry state store (checked by the
+                    # Data Sources tab and agent tools).
+                    try:
+                        connector_name = _OAUTH_SVC_TO_CONNECTOR.get(svc)
+                        if connector_name:
+                            from pocketpaw.api.v1.connectors import (
+                                _get_registry as _get_connector_registry,
+                            )
+
+                            reg = _get_connector_registry()
+                            # Only auto-connect if the registry doesn't already
+                            # have it — avoids redundant writes.
+                            is_connected = any(
+                                s["name"] == connector_name and s["status"].value == "connected"
+                                for s in reg.status("default")
+                            )
+                            if not is_connected:
+                                scopes = " ".join(tokens.scopes) if tokens.scopes else svc
+                                await reg.connect("default", connector_name, {"scope": scopes})
+                    except Exception as sync_exc:
+                        logger.debug("OAuth→registry sync failed for %s: %s", svc, sync_exc)
             elif svc.startswith("google_") and not has_google_creds:
                 oauth_status[svc] = "not_configured"
             else:

--- a/src/pocketpaw/connectors/adapters/gdrive.py
+++ b/src/pocketpaw/connectors/adapters/gdrive.py
@@ -35,7 +35,7 @@ class GoogleDriveConnector:
 
     @property
     def name(self) -> str:
-        return "drive"
+        return "google_drive"
 
     @property
     def display_name(self) -> str:

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -204,6 +204,12 @@ def _provider_state_store() -> ConnectorStateStore | None:
         return None
 
 
+# Connectors that were renamed on disk. An existing user's persisted state row
+# is keyed by the OLD name, so without a migration a rename silently orphans
+# their connection (it surfaces as ``definition_missing``). Map old -> new.
+_RENAMED_CONNECTORS: dict[str, str] = {"drive": "google_drive"}
+
+
 class ConnectorRegistry:
     """Discovers available connectors and manages instances per pocket."""
 
@@ -224,6 +230,7 @@ class ConnectorRegistry:
         # Per-key locks serializing the connect paths — see _lock_for().
         self._connect_locks: dict[str, asyncio.Lock] = {}
         self._scan()
+        self._migrate_renamed_connectors()
 
     def _lock_for(self, key: str) -> asyncio.Lock:
         """Per-(pocket, connector) lock for connect()/ensure_connected().
@@ -255,6 +262,47 @@ class ConnectorRegistry:
                     self._definitions[defn.name] = defn
                 except Exception:
                     pass  # Skip malformed YAMLs
+
+    def _migrate_renamed_connectors(self) -> None:
+        """One-time, idempotent migration of state rows for renamed connectors.
+
+        A rename (e.g. ``drive`` -> ``google_drive``) would otherwise orphan an
+        existing user's persisted state, which is keyed by the old name. For each
+        ``(old, scope)`` row whose new name is a known definition and has no row
+        yet, copy the config across and delete the old row. After it runs once no
+        legacy row remains, so re-running is a no-op.
+
+        Sync-only: the OSS ``FileConnectorStateStore`` is synchronous. If an
+        async state provider returns awaitables we skip — a multi-tenant cloud
+        provider scopes/handles its own rows separately.
+        """
+        try:
+            rows = self._state_store.list()
+        except Exception:
+            return
+        if inspect.isawaitable(rows):
+            return  # async state provider — not migrated here
+        for name, scope in list(rows):
+            new_name = _RENAMED_CONNECTORS.get(name)
+            if not new_name or new_name not in self._definitions:
+                continue
+            try:
+                existing = self._state_store.get(new_name, scope)
+                if inspect.isawaitable(existing):
+                    return
+                if existing is not None:
+                    # New row already present — drop the stale legacy row.
+                    self._state_store.delete(name, scope)
+                    continue
+                config = self._state_store.get(name, scope)
+                if config is not None:
+                    self._state_store.set(new_name, scope, config)
+                    self._state_store.delete(name, scope)
+                    logger.info(
+                        "Migrated connector state %s -> %s (scope %s)", name, new_name, scope
+                    )
+            except Exception as exc:
+                logger.debug("rename migration failed for %s (scope %s): %s", name, scope, exc)
 
     @property
     def available(self) -> list[dict[str, str]]:

--- a/src/pocketpaw/connectors/registry.py
+++ b/src/pocketpaw/connectors/registry.py
@@ -109,7 +109,7 @@ _NATIVE_COMM_CONNECTORS: set[str] = {
     "gmail",
     "gcalendar",
     "gdocs",
-    "drive",
+    "google_drive",
     "reddit",
     "spotify",
 }  # PR-3..7
@@ -156,7 +156,7 @@ def _create_native_adapter(connector_name: str) -> AnyAdapter | None:
                 from pocketpaw.connectors.adapters.gdocs import GoogleDocsConnector
 
                 return GoogleDocsConnector()
-            if connector_name == "drive":
+            if connector_name == "google_drive":
                 from pocketpaw.connectors.adapters.gdrive import GoogleDriveConnector
 
                 return GoogleDriveConnector()

--- a/tests/connectors/test_gdrive_connector.py
+++ b/tests/connectors/test_gdrive_connector.py
@@ -16,7 +16,7 @@ from pocketpaw.connectors.protocol import (
 
 def test_metadata():
     c = GoogleDriveConnector()
-    assert c.name == "drive"
+    assert c.name == "google_drive"
     assert c.display_name == "Google Drive"
     assert c.type == "knowledge"
 
@@ -84,5 +84,5 @@ def test_registry_returns_drive_connector():
     """Native adapter wins over the YAML-only DirectRESTAdapter."""
     from pocketpaw.connectors.registry import _create_native_adapter
 
-    adapter = _create_native_adapter("drive")
+    adapter = _create_native_adapter("google_drive")
     assert isinstance(adapter, GoogleDriveConnector)

--- a/tests/connectors/test_pr1481_oauth_reconcile.py
+++ b/tests/connectors/test_pr1481_oauth_reconcile.py
@@ -1,0 +1,112 @@
+# tests/connectors/test_pr1481_oauth_reconcile.py
+# Created during review of PR #1481 (connectors-oauth reconciliation) to verify
+# the new behaviour with running code: (1) the auto-connect happy path works,
+# (2) it avoids the fail-delete loop on a revoked token, and (3) the
+# drive->google_drive rename ORPHANS an existing 'drive' connection (migration
+# gap). Tests 1-2 are expected to PASS (prove the fix); test 3 documents the gap.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.connectors.protocol import ConnectorStatus
+from pocketpaw.connectors.registry import ConnectorRegistry
+from pocketpaw.connectors.state_store import FileConnectorStateStore
+
+REPO_CONNECTORS = Path(__file__).resolve().parents[2] / "connectors"
+
+
+@pytest.fixture
+def store(tmp_path) -> FileConnectorStateStore:
+    return FileConnectorStateStore(base_dir=tmp_path / "state")
+
+
+@pytest.fixture
+def reg(tmp_path, store) -> ConnectorRegistry:
+    return ConnectorRegistry(
+        REPO_CONNECTORS, state_store=store, home_connectors_dir=tmp_path / "home"
+    )
+
+
+class _FakeToken:
+    def __init__(self, *, access="acc", expires_at=None, refresh="ref", scopes=("a",)):
+        self.access_token = access
+        self.expires_at = expires_at
+        self.refresh_token = refresh
+        self.scopes = list(scopes)
+
+
+def _patch_oauth(monkeypatch, *, token, live_token):
+    """Patch the lazy imports inside _auto_connect_if_oauth."""
+
+    class _FakeStore:
+        def load(self, svc):
+            return token
+
+        def delete(self, svc):  # pragma: no cover - not used here
+            pass
+
+    class _FakeMgr:
+        def __init__(self, store):
+            self._store = store
+
+        async def get_valid_token(self, **kwargs):
+            return live_token
+
+    class _FakeSettings:
+        google_oauth_client_id = "cid"
+        google_oauth_client_secret = "csec"
+
+        @classmethod
+        def load(cls):
+            return cls()
+
+    monkeypatch.setattr("pocketpaw.clients.token_store.TokenStore", _FakeStore)
+    monkeypatch.setattr("pocketpaw.clients.oauth.OAuthManager", _FakeMgr)
+    monkeypatch.setattr("pocketpaw.config.Settings", _FakeSettings)
+
+
+async def test_auto_connect_registers_google_drive_with_valid_token(reg, store, monkeypatch):
+    """Happy path: a live OAuth token reconciles into the registry as connected."""
+    from pocketpaw.api.v1.connectors import _auto_connect_if_oauth
+
+    _patch_oauth(monkeypatch, token=_FakeToken(), live_token="live-access-token")
+    newly = await _auto_connect_if_oauth(reg, "google_drive", "default")
+
+    assert newly is True
+    statuses = {s["name"]: s["status"] for s in reg.status("default")}
+    assert statuses.get("google_drive") == ConnectorStatus.CONNECTED
+
+
+async def test_auto_connect_no_fail_delete_on_revoked_token(reg, store, monkeypatch):
+    """A present-but-revoked token must NOT create-then-delete state (the old loop)."""
+    from pocketpaw.api.v1.connectors import _auto_connect_if_oauth
+
+    # Token exists with a refresh_token, but the refresh fails -> get_valid_token None.
+    _patch_oauth(monkeypatch, token=_FakeToken(refresh="dead"), live_token=None)
+    newly = await _auto_connect_if_oauth(reg, "google_drive", "default")
+
+    assert newly is False
+    # No state row was written for google_drive (no fail-delete churn).
+    assert store.get("google_drive", "default") is None
+    statuses = {s["name"]: s["status"] for s in reg.status("default")}
+    assert statuses.get("google_drive") == ConnectorStatus.DISCONNECTED
+
+
+def test_rename_orphans_existing_drive_connection(reg, store):
+    """GAP: a user connected as 'drive' before the rename is now orphaned, not migrated.
+
+    Documents the migration gap — there is no rename of existing state rows, so the
+    pre-rename connection surfaces as definition_missing and google_drive shows
+    disconnected until the user re-authorises.
+    """
+    # Simulate an existing connection persisted under the OLD name.
+    store.set("drive", "default", {"scope": "https://www.googleapis.com/auth/drive"})
+
+    statuses = {s["name"]: s["status"] for s in reg.status("default")}
+
+    # The old connection is orphaned (definition gone after the rename)...
+    assert statuses.get("drive") == ConnectorStatus.DEFINITION_MISSING
+    # ...and the renamed connector has no state -> appears disconnected.
+    assert statuses.get("google_drive") == ConnectorStatus.DISCONNECTED

--- a/tests/connectors/test_pr1481_oauth_reconcile.py
+++ b/tests/connectors/test_pr1481_oauth_reconcile.py
@@ -2,8 +2,8 @@
 # Created during review of PR #1481 (connectors-oauth reconciliation) to verify
 # the new behaviour with running code: (1) the auto-connect happy path works,
 # (2) it avoids the fail-delete loop on a revoked token, and (3) the
-# drive->google_drive rename ORPHANS an existing 'drive' connection (migration
-# gap). Tests 1-2 are expected to PASS (prove the fix); test 3 documents the gap.
+# drive->google_drive rename MIGRATES an existing 'drive' connection instead of
+# orphaning it (the registry runs a one-time rename migration on construction).
 from __future__ import annotations
 
 from pathlib import Path
@@ -68,10 +68,25 @@ def _patch_oauth(monkeypatch, *, token, live_token):
 
 
 async def test_auto_connect_registers_google_drive_with_valid_token(reg, store, monkeypatch):
-    """Happy path: a live OAuth token reconciles into the registry as connected."""
+    """Happy path: a live OAuth token reconciles into the registry as connected.
+
+    The adapter's own ``connect()`` (a real token/network handshake) is tested
+    elsewhere and is env-dependent; here we verify the reconciliation LOGIC, so
+    ``reg.connect`` is stubbed to the success it returns once the token is live.
+    """
     from pocketpaw.api.v1.connectors import _auto_connect_if_oauth
 
     _patch_oauth(monkeypatch, token=_FakeToken(), live_token="live-access-token")
+
+    class _Result:
+        success = True
+
+    async def _fake_connect(pocket_id, name, config):
+        store.set(name, pocket_id, config)  # mirror what a real connect persists
+        return _Result()
+
+    monkeypatch.setattr(reg, "connect", _fake_connect)
+
     newly = await _auto_connect_if_oauth(reg, "google_drive", "default")
 
     assert newly is True
@@ -94,19 +109,27 @@ async def test_auto_connect_no_fail_delete_on_revoked_token(reg, store, monkeypa
     assert statuses.get("google_drive") == ConnectorStatus.DISCONNECTED
 
 
-def test_rename_orphans_existing_drive_connection(reg, store):
-    """GAP: a user connected as 'drive' before the rename is now orphaned, not migrated.
+def test_rename_migrates_existing_drive_connection(tmp_path, store):
+    """A user connected as 'drive' before the rename is MIGRATED, not orphaned.
 
-    Documents the migration gap — there is no rename of existing state rows, so the
-    pre-rename connection surfaces as definition_missing and google_drive shows
-    disconnected until the user re-authorises.
+    The registry runs a one-time, idempotent rename migration on construction:
+    an existing ``drive`` state row is moved to ``google_drive`` so the
+    connection survives the rename instead of surfacing as definition_missing.
     """
-    # Simulate an existing connection persisted under the OLD name.
+    # Simulate an existing connection persisted under the OLD name, BEFORE the
+    # registry is built (mirrors a real on-disk row from a prior release).
     store.set("drive", "default", {"scope": "https://www.googleapis.com/auth/drive"})
+
+    # Building the registry triggers the migration.
+    reg = ConnectorRegistry(
+        REPO_CONNECTORS, state_store=store, home_connectors_dir=tmp_path / "home"
+    )
 
     statuses = {s["name"]: s["status"] for s in reg.status("default")}
 
-    # The old connection is orphaned (definition gone after the rename)...
-    assert statuses.get("drive") == ConnectorStatus.DEFINITION_MISSING
-    # ...and the renamed connector has no state -> appears disconnected.
-    assert statuses.get("google_drive") == ConnectorStatus.DISCONNECTED
+    # The connection survived the rename, carried over to the new name...
+    assert statuses.get("google_drive") == ConnectorStatus.CONNECTED
+    # ...and the legacy 'drive' row is gone (no orphan, no definition_missing).
+    assert "drive" not in statuses
+    assert store.get("drive", "default") is None
+    assert store.get("google_drive", "default") is not None


### PR DESCRIPTION

### The Problem
Three disconnected state systems were causing conflicting connection statuses between the **Tools tab**, **Data Sources tab**, and the **Agent**:
1. **OAuth TokenStore** — Had valid tokens 
2. **Connector Registry StateStore** — Had no configuration 
3. **Naming Mismatch** — The backend expected `"drive"` while the frontend sent `"google_drive"` 

The OAuth flow successfully saved tokens to the `TokenStore` but never registered them with the `ConnectorRegistry`. As a result, both the Agent and the Data Sources tab reported *"no connectors connected"* despite valid tokens existing. Additionally, expired or revoked refresh tokens triggered a fail-delete loop during status queries.

---

### Changes

#### 1. Backend Changes (`pocketpaw`)

* **Connector Naming Alignment:** * Renamed `drive` ➡️ `google_drive` in the YAML definition, registry native adapter set, and adapter dispatch logic to unify naming conventions across the frontend and OAuth systems.
* **OAuth ➡️ Registry Reconciliation:**
    * Introduced `_auto_connect_if_oauth()` to automatically sync valid OAuth tokens into the connector registry during status queries. 
    * It safely invokes `get_valid_token()` (handling refresh attempts) before updating the registry, preventing the fail-delete loop when refresh tokens are dead or revoked.
* **Endpoint Synchronization:**
    * `GET /connectors` and `GET /connectors/{name}/status` now both trigger the auto-reconciliation routine.
    * `GET /tools` syncs tokens and accurately identifies expired states (yielding `"expired"` if no refresh path remains).
    * The OAuth callback routine now explicitly auto-connects the registry immediately after saving tokens.
* **New Endpoints Added:**
    * `GET /connectors/{name}/actions` — Fixed a `404` error the agent encountered when requesting the action list.
    * `POST /oauth/integrations/disconnect` — Securely deletes tokens and cleanses the corresponding connector from the registry.

#### 2. Frontend Changes (`paw-enterprise`)

* **State Alignment:** Integrated UI handling for the new `"expired"` status badge, updating state mappings inside the Data Panel layout.
* **Toggle Synchronization:** Synchronized status badges with toggle logic, preventing `"connected"` badges from displaying if a category toggle is explicitly turned off.
* **Component Cleanup:** Added an explicit disconnect action calling the new backend endpoint to safely remove active individual OAuth connections.
* **Onboarding Fault Tolerance:** Gracefully handles instances where the cloud connectors endpoint might be missing (e.g., local or OSS mode).

---

### Files Changed

* `connectors/drive.yaml`
* `connectors/registry.py`
* `connectors/adapters/gdrive.py`
* `api/v1/connectors.py`
* `api/v1/tools.py`
* `api/v1/oauth_integrations.py`
* `src/lib/components/os/PocketDataPanel.svelte`
* `src/lib/core/pockets/api.ts`
* `src/lib/core/runtime/api.ts`
* `tests/`