### PR TITLE
Fix stale headless-permission guard tests blocking dev CI

### DIFF
--- a/tests/test_headless_permissions.py
+++ b/tests/test_headless_permissions.py
@@ -6,14 +6,40 @@
 # The bug: commit 24f16e2 gated permission bypass behind a setting that defaults
 #   to false, breaking ALL Bash-based tools (memory, web search, gmail, etc.)
 #   on every messaging channel since v0.3.0.
+#
+# Updated: 2026-06-17 — the option-building (including the unconditional
+#   permission_mode assignment) was extracted from run() into the shared
+#   _build_options() helper (feat/claude-sdk-prewarm). The source-inspection
+#   guards now read both methods via _sdk_options_source() so they follow the
+#   assignment wherever it lives instead of going stale on the refactor.
 
 from __future__ import annotations
 
+import inspect
 import subprocess
 import sys
 from unittest.mock import MagicMock
 
 import pytest
+
+
+def _sdk_options_source() -> str:
+    """Combined source of the SDK backend methods that build agent options.
+
+    The unconditional ``permission_mode = "bypassPermissions"`` assignment was
+    refactored out of ``run()`` into the shared ``_build_options()`` helper
+    (feat/claude-sdk-prewarm), which ``run()`` calls. The invariant these guards
+    protect is "permission_mode is set, and never gated on a setting" — not "set
+    inside run() specifically" — so inspecting both methods keeps the guard valid
+    wherever the assignment lands.
+    """
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+    return (
+        inspect.getsource(ClaudeSDKBackend.run)
+        + "\n"
+        + inspect.getsource(ClaudeSDKBackend._build_options)
+    )
 
 
 class TestHeadlessPermissionMode:
@@ -49,13 +75,12 @@ class TestHeadlessPermissionMode:
         """
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
 
-        backend = ClaudeSDKBackend(self._make_settings(bypass=False))
-
-        # We can't easily run the full .run() method without the SDK installed,
-        # but we can inspect the source to verify the fix is present.
-        import inspect
-
-        source = inspect.getsource(backend.run)
+        # Constructing with bypass=False is the original bug scenario; the fix
+        # must hold regardless of the setting. We can't easily run the full
+        # .run() method without the SDK installed, so we inspect the source of
+        # the option-building methods to verify the fix is present.
+        _ = ClaudeSDKBackend(self._make_settings(bypass=False))
+        source = _sdk_options_source()
 
         # The fix: permission_mode should be set unconditionally (no if statement)
         # Old broken code: 'if self.settings.bypass_permissions:'
@@ -65,28 +90,21 @@ class TestHeadlessPermissionMode:
             "This causes tool calls to hang on messaging channels."
         )
         assert '"bypassPermissions"' in source, (
-            "bypassPermissions not found in run() — permission mode must be set"
+            "bypassPermissions not found in run()/_build_options — permission mode must be set"
         )
 
     def test_permission_mode_set_when_bypass_true(self):
         """Verify bypass_permissions=True also works (should be same behavior now)."""
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
 
-        backend = ClaudeSDKBackend(self._make_settings(bypass=True))
-
-        import inspect
-
-        source = inspect.getsource(backend.run)
+        _ = ClaudeSDKBackend(self._make_settings(bypass=True))
+        source = _sdk_options_source()
         assert '"bypassPermissions"' in source
 
     def test_no_conditional_bypass_in_options_build(self):
         """Verify the options_kwargs assignment is unconditional by checking
-        that 'permission_mode' appears exactly once and not inside an if block."""
-        import inspect
-
-        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-
-        source = inspect.getsource(ClaudeSDKBackend.run)
+        that 'permission_mode' appears and is not inside an if block."""
+        source = _sdk_options_source()
 
         # Count occurrences of permission_mode assignment
         lines = source.split("\n")

--- a/tests/test_integration_headless.py
+++ b/tests/test_integration_headless.py
@@ -14,6 +14,11 @@
 # deps and are skipped in CI by default. Run locally with:
 #   uv run pytest tests/test_integration_headless.py -v
 #   uv run pytest tests/test_integration_headless.py -v -m integration  # integration only
+#
+# Updated: 2026-06-17 — the permission_mode bypass assignment moved from run()
+#   into the shared _build_options() helper (feat/claude-sdk-prewarm); the
+#   source-inspection guards now read both via _sdk_options_source() so they
+#   follow the assignment instead of going stale on the refactor.
 
 from __future__ import annotations
 
@@ -26,6 +31,24 @@ import pytest
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
+
+def _sdk_options_source() -> str:
+    """Combined source of the SDK backend methods that build agent options.
+
+    The unconditional ``permission_mode = "bypassPermissions"`` assignment was
+    refactored out of ``run()`` into the shared ``_build_options()`` helper
+    (feat/claude-sdk-prewarm), which ``run()`` calls. Inspecting both keeps these
+    guards valid wherever the assignment lives — the invariant is "set, and never
+    gated on a setting", not "set inside run() specifically".
+    """
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+
+    return (
+        inspect.getsource(ClaudeSDKBackend.run)
+        + "\n"
+        + inspect.getsource(ClaudeSDKBackend._build_options)
+    )
 
 
 def _make_settings(*, tool_profile: str = "full", bypass: bool = False) -> MagicMock:
@@ -327,9 +350,7 @@ class TestHeadlessChannelToolAccess:
         Complements test_headless_permissions.py::test_no_conditional_bypass_in_options_build
         by also checking that the assignment line is not indented under a settings check.
         """
-        from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-
-        source = inspect.getsource(ClaudeSDKBackend.run)
+        source = _sdk_options_source()
         lines = source.split("\n")
 
         # Find the permission_mode assignment line
@@ -375,9 +396,10 @@ class TestHeadlessChannelToolAccess:
         """
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
 
-        # Construct with bypass=False (the default / the bug scenario)
-        backend = ClaudeSDKBackend(_make_settings(bypass=False))
-        source = inspect.getsource(backend.run)
+        # Construct with bypass=False (the default / the bug scenario) as a smoke
+        # check, then assert on the option-building source (run() + _build_options).
+        _ = ClaudeSDKBackend(_make_settings(bypass=False))
+        source = _sdk_options_source()
 
         # The source must not have the old conditional pattern
         assert "if self.settings.bypass_permissions:" not in source, (


### PR DESCRIPTION
## What's failing

Five guard tests are red on \`dev\` itself (HEAD 5f80cc90), and every open PR targeting \`dev\` inherits the failure:

- \`test_headless_permissions.py::TestHeadlessPermissionMode\` (3 tests)
- \`test_integration_headless.py::TestHeadlessChannelToolAccess\` (2 tests)

PR #1469 (dynamic sites) shows red CI for this reason, not for anything in its own diff.

## Why

These tests read the source of \`ClaudeSDKBackend.run()\` and assert that the permission bypass (\`permission_mode = "bypassPermissions"\`) is set there, unconditionally. The claude-sdk-prewarm refactor moved that assignment out of \`run()\` into the shared \`_build_options()\` helper that \`run()\` calls. The assignment is still unconditional and the behavior never changed, but the tests were looking in the wrong method, so they failed.

## Fix

Both files now read the combined source of \`run()\` plus \`_build_options()\` through a small \`_sdk_options_source()\` helper. The assertions are unchanged: \`permission_mode\` is set, and it is never gated behind a setting. The guard now follows the assignment wherever it lives instead of breaking on a benign refactor.

Test-only change. No source touched.

## Verification

- Reproduced the 5 failures on a clean checkout of \`dev\`.
- After the fix: both files pass (38 passed, 0 failed), \`ruff check\` clean.