### PR TITLE
fix(tests): unbreak the headless permission meta-tests (pre-existing dev red)

### DIFF
--- a/tests/test_headless_permissions.py
+++ b/tests/test_headless_permissions.py
@@ -52,10 +52,12 @@ class TestHeadlessPermissionMode:
         backend = ClaudeSDKBackend(self._make_settings(bypass=False))
 
         # We can't easily run the full .run() method without the SDK installed,
-        # but we can inspect the source to verify the fix is present.
+        # but we can inspect the source to verify the fix is present. The
+        # unconditional assignment lives in ``_build_options`` (the options
+        # builder ``run`` delegates to) since the #1461 prewarm refactor.
         import inspect
 
-        source = inspect.getsource(backend.run)
+        source = inspect.getsource(backend._build_options)
 
         # The fix: permission_mode should be set unconditionally (no if statement)
         # Old broken code: 'if self.settings.bypass_permissions:'
@@ -76,7 +78,7 @@ class TestHeadlessPermissionMode:
 
         import inspect
 
-        source = inspect.getsource(backend.run)
+        source = inspect.getsource(backend._build_options)
         assert '"bypassPermissions"' in source
 
     def test_no_conditional_bypass_in_options_build(self):
@@ -86,7 +88,8 @@ class TestHeadlessPermissionMode:
 
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
 
-        source = inspect.getsource(ClaudeSDKBackend.run)
+        # Assignment lives in _build_options (run delegates to it) since #1461.
+        source = inspect.getsource(ClaudeSDKBackend._build_options)
 
         # Count occurrences of permission_mode assignment
         lines = source.split("\n")

--- a/tests/test_integration_headless.py
+++ b/tests/test_integration_headless.py
@@ -329,7 +329,8 @@ class TestHeadlessChannelToolAccess:
         """
         from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
 
-        source = inspect.getsource(ClaudeSDKBackend.run)
+        # Assignment lives in _build_options (run delegates to it) since #1461.
+        source = inspect.getsource(ClaudeSDKBackend._build_options)
         lines = source.split("\n")
 
         # Find the permission_mode assignment line
@@ -377,7 +378,8 @@ class TestHeadlessChannelToolAccess:
 
         # Construct with bypass=False (the default / the bug scenario)
         backend = ClaudeSDKBackend(_make_settings(bypass=False))
-        source = inspect.getsource(backend.run)
+        # Assignment lives in _build_options (run delegates to it) since #1461.
+        source = inspect.getsource(backend._build_options)
 
         # The source must not have the old conditional pattern
         assert "if self.settings.bypass_permissions:" not in source, (


### PR DESCRIPTION
## What

Five tests have been red on `dev` itself — `test_headless_permissions.py` (3) and `test_integration_headless.py` (2) — failing every open PR's Test job for a reason that has nothing to do with the PR. This repoints them and they go green.

## Why they broke

They're source-asserting meta-tests: they `inspect.getsource(backend.run)` and grep for the unconditional `permission_mode = "bypassPermissions"` assignment. The #1461 prewarm refactor moved that assignment out of `run()` into `_build_options` (the options builder `run` delegates to). The greps stopped finding the literal in `run()`'s source and the tests failed — even though the behavior is intact.

## The behavior is correct (this is a test fix, not a code fix)

Verified: `_build_options` sets `permission_mode = "bypassPermissions"` unconditionally, with no `if bypass_permissions` gate. The fix only points the five `getsource` calls at the method that now holds the assignment. No production code changed. One of the tests is even named `test_no_conditional_bypass_in_options_build`, so `_build_options` is plainly the intended target.

## Tests

`uv run pytest tests/test_headless_permissions.py tests/test_integration_headless.py -q` → 38 passed (was 5 failing). ruff clean.

Worth merging promptly — it's gating clean CI on every other open PR. Follow-up worth considering: these source-string assertions are brittle (any `run()` refactor re-breaks them); converting to behavior assertions would be sturdier, but needs the SDK installed, which the tests avoid by design.

Captain reviews; not merging.