### PR TITLE
fix(sites): gate in-process create and publish on the workspace plan

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,16 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated: 2026-06-17 (fix/sites-plan-gate-asymmetry) — both create handlers now
+# call _require_sites_plan_or_error(workspace_id) right after input validation,
+# delegating to the shared sites.service.require_sites_plan gate. Sites is the
+# "fabric" plan feature; these create tools reach agent_create directly and
+# bypassed the REST router's require_plan_feature("fabric") gate, so a team-plan
+# workspace could create + (then publish) a live site that GET /sites 403'd. On a
+# disallowed plan the handler now returns the plan.feature_denied MCP error
+# ("Sites requires the Business plan — upgrade, or switch workspace") so the chat
+# agent surfaces the upgrade message instead of a phantom-created site.
+#
 # Updated: 2026-06-04 (feat/sites-svelte-engine) — added the SECOND deterministic
 # create tool ``create_svelte_site`` for the Paw Sites "Svelte track". It mirrors
 # ``create_landing_site`` (same direct ``agent_create`` persistence, same
@@ -140,6 +150,30 @@ def _identity() -> tuple[str | None, str | None]:
         return None, None
 
 
+async def _require_sites_plan_or_error(workspace_id: str) -> dict | None:
+    """Gate the create on the workspace's plan. Returns an MCP ``_error_response``
+    when the plan lacks the Sites ("fabric") feature (so the agent surfaces the
+    upgrade message instead of a phantom-created site), or ``None`` when the plan
+    is allowed.
+
+    Delegates to the SHARED service gate (``sites.service.require_sites_plan``) so
+    the in-process create path is gated by the SAME plan check + feature table as
+    the publish path and the HTTP ``require_plan_feature("fabric")`` dependency. A
+    team-plan workspace was the bug: create + publish ran in-process and bypassed
+    the router gate, deploying a live site that GET /sites then 403'd."""
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.sites.service import require_sites_plan
+
+    try:
+        await require_sites_plan(workspace_id)
+    except CloudError as exc:
+        # Forbidden('plan.feature_denied') / NotFound('workspace'). Relay the
+        # code + message so the agent tells the user to upgrade / switch
+        # workspace, not "site created".
+        return _error_response(f"{exc.code}: {exc.message}")
+    return None
+
+
 async def _bind_session_and_emit(pocket_id: str, view: dict[str, Any], user_id: str) -> None:
     """Bind the active chat session to the new pocket and push the
     ``pocket_created`` SSE event so the canvas auto-opens — the same atomic
@@ -192,6 +226,11 @@ async def _create_landing_site_handler(args: dict) -> dict:
             "landing page (brand, hero, services, testimonials, tiers, cta_band, "
             "contact, footer). You provide copy only; the tool builds the page."
         )
+
+    # Plan gate (Sites = "fabric"): reject a team-plan workspace here so the
+    # create can't bypass the router's require_plan_feature("fabric") gate.
+    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:
+        return gate
 
     name_raw = args.get("name")
     # Default the pocket name to the brand from the copy when not given.
@@ -379,6 +418,11 @@ async def _create_svelte_site_handler(args: dict) -> dict:
             "+layout.svelte (imports app.css), +page.ts (prerender=true), app.css, "
             "and at least one section component."
         )
+
+    # Plan gate (Sites = "fabric"): reject a team-plan workspace here so the
+    # create can't bypass the router's require_plan_feature("fabric") gate.
+    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:
+        return gate
 
     name_raw = args.get("name")
     name = name_raw.strip() if isinstance(name_raw, str) and name_raw.strip() else "Svelte site"

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,19 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-17 (fix/sites-plan-gate-asymmetry): added require_sites_plan()
+# and call it at the top of publish(). Sites is the "fabric" plan feature; the
+# REST router gates it with require_plan_feature("fabric"), but the chat agent
+# created + published sites IN-PROCESS via the sites_manager MCP tools, which
+# bypass the HTTP router. A team-plan workspace could therefore deploy a live
+# site that GET /sites then 403'd (write path ungated, read path gated). The
+# guard reads the plan from workspace_service.get_workspace_plan against
+# guards.abac.PLAN_FEATURES (same source of truth as the HTTP gate) and raises
+# Forbidden('plan.feature_denied') before any pocket read / generate / deploy.
+# Every publish path (REST + MCP publish + direct callers) funnels through
+# publish(), so this one call covers them all; the create MCP handlers call
+# require_sites_plan() directly (they reach agent_create, not this service).
+#
 # Updated 2026-06-01 (Phase 4 — chat→create-site): added publish_pocket(), the
 # shared "publish a pocket by id" path. It reads the pocket's rippleSpec + theme
 # via pockets_service (logic lifted verbatim from the router) and delegates to
@@ -92,7 +105,7 @@ from typing import Any
 from bson import ObjectId
 from bson.errors import InvalidId
 
-from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
 from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
 from pocketpaw_ee.sites.domain import HostnameStatus
@@ -101,6 +114,16 @@ from pocketpaw_ee.sites.generator_client import GeneratorClient
 
 # The control plane reads the Worker bundle adapter-cloudflare emits here.
 _WORKER_BUNDLE_REL = ".svelte-kit/cloudflare/_worker.js"
+
+# Sites is a plan-gated feature: it unlocks with the "fabric" plan feature
+# (business+). The REST router (sites/router.py) gates every endpoint with
+# require_plan_feature("fabric"), but the chat agent creates + publishes sites
+# IN-PROCESS via the sites_manager MCP tools, which never pass through that HTTP
+# router. Without a service-level gate a team-plan workspace could create and
+# deploy a live site that GET /sites then 403'd — a created-but-invisible
+# resource. _require_sites_plan() closes that asymmetry at the service chokepoint
+# so the in-process write paths are gated identically to HTTP.
+_SITES_PLAN_FEATURE = "fabric"
 
 
 def _default_bundle_reader(project_dir: str) -> bytes:
@@ -188,6 +211,42 @@ def _to_response(doc: _SiteDoc) -> SiteResponse:
     )
 
 
+async def require_sites_plan(workspace_id: str) -> None:
+    """Raise cloud Forbidden('plan.feature_denied') unless the workspace's plan
+    includes the Sites ("fabric") feature.
+
+    The shared plan gate for the in-process site write paths (publish + the
+    create MCP handlers). Reads the plan with the SAME source of truth
+    (``workspace_service.get_workspace_plan``) and the SAME feature table
+    (``guards.abac.PLAN_FEATURES``) as the HTTP ``require_plan_feature("fabric")``
+    dependency, so a team-plan caller is denied identically whether it arrives
+    over REST or through the chat agent. A missing workspace surfaces as NotFound
+    (mirroring the HTTP gate), and the error message names the minimum plan that
+    unlocks Sites. Imports are local to keep the sites service importable without
+    eagerly pulling the cloud workspace/guards modules."""
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+    from pocketpaw_ee.guards.abac import PLAN_FEATURES
+
+    plan = await workspace_service.get_workspace_plan(workspace_id)
+    if plan is None:
+        raise NotFound("workspace", workspace_id)
+    if _SITES_PLAN_FEATURE not in PLAN_FEATURES.get(plan, set()):
+        # Name the minimum plan that unlocks the feature, like the HTTP gate.
+        needed = next(
+            (
+                p
+                for p in ("team", "business", "enterprise")
+                if _SITES_PLAN_FEATURE in PLAN_FEATURES.get(p, set())
+            ),
+            "business",
+        )
+        raise Forbidden(
+            "plan.feature_denied",
+            f"Sites requires the {needed.capitalize()} plan — upgrade, or switch "
+            "to a workspace that has it.",
+        )
+
+
 async def publish(
     *,
     workspace_id: str,
@@ -221,7 +280,15 @@ async def publish(
     respecting entity isolation) and uses its ``name`` field; only when the pocket
     has no name does it fall back to "Untitled site". Callers that pre-resolve the
     name (e.g. ``publish_pocket``, which already holds the wire dict) pass it in,
-    so the common path does not re-fetch."""
+    so the common path does not re-fetch.
+
+    Gated on the workspace's plan: Sites is the "fabric" feature, so a team-plan
+    workspace is rejected with Forbidden('plan.feature_denied') here — BEFORE any
+    pocket read, generation, or deploy. Both ``publish_pocket`` (REST + MCP) and
+    direct service callers funnel through ``publish``, so this one gate covers
+    every in-process publish path."""
+    await require_sites_plan(workspace_id)
+
     generator = _generator or GeneratorClient()
 
     # Default a blank name to the source pocket's own display name so the schema's
@@ -392,6 +459,12 @@ async def publish_pocket(
     straight through to ``publish`` so the shared path is unit-testable without
     Bun / workerd / Cloudflare (the same injection contract ``publish`` exposes).
     """
+    # Plan gate FIRST — before reading the pocket — so a team-plan caller gets
+    # plan.feature_denied regardless of whether the pocket exists, rather than a
+    # misleading pocket.not_found. ``publish`` re-checks for direct callers; the
+    # repeat read is a single cheap workspace lookup.
+    await require_sites_plan(workspace_id)
+
     from pocketpaw_ee.cloud.pockets import service as pockets_service
 
     pocket = await pockets_service.get(pocket_id, user_id)
@@ -443,6 +516,7 @@ async def site_pocket_ids(workspace_id: str) -> set[str]:
 __all__ = [
     "publish",
     "publish_pocket",
+    "require_sites_plan",
     "add_domain",
     "domain_status",
     "list_domains",

--- a/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
@@ -1,4 +1,9 @@
 # tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
+# Updated: 2026-06-17 (fix/sites-plan-gate-asymmetry) — create_svelte_site now
+# calls the shared Sites plan gate (sites.service.require_sites_plan) before
+# agent_create, so an autouse fixture defaults get_workspace_plan to "business"
+# (which unlocks Sites) for the end-to-end create test. Denial is covered in
+# tests/ee/sites/test_plan_gate.py.
 # Created: 2026-06-04 (feat/sites-svelte-engine) — coverage for the Paw Sites
 # "Svelte track" create tool ``create_svelte_site`` on the in-process
 # ``pocketpaw_sites_manager`` server. Three layers:
@@ -17,10 +22,25 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture(autouse=True)
+def _default_sites_plan():
+    """create_svelte_site now calls the shared Sites plan gate
+    (sites.service.require_sites_plan) before agent_create. These tests use
+    synthetic workspace ids with no seeded Workspace doc, so default the plan to
+    one that unlocks Sites ("business") to exercise the create mechanics. Plan-gate
+    denial is covered separately in tests/ee/sites/test_plan_gate.py."""
+    with patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value="business"),
+    ):
+        yield
 
 
 # A representative §4.3-complete source map (paths -> file contents).

--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -1,0 +1,40 @@
+# tests/ee/sites/conftest.py
+# Created: 2026-06-17 (fix/sites-plan-gate-asymmetry) — Sites is now plan-gated at
+# the service chokepoint: sites.service.publish()/publish_pocket() and the create
+# MCP handlers call require_sites_plan(), which reads the workspace plan via
+# workspace_service.get_workspace_plan and raises Forbidden('plan.feature_denied')
+# (or NotFound when the workspace is missing). The existing mechanics tests in
+# this directory call publish/create with SYNTHETIC workspace ids that have no
+# seeded Workspace doc, so the gate would now raise NotFound and mask what they
+# actually exercise. This autouse fixture patches get_workspace_plan to return a
+# plan that INCLUDES Sites ("business") by default, so the happy-path mechanics
+# tests pass the gate. The dedicated gate test (test_plan_gate.py) overrides the
+# plan per-test with its own patch (an inner patch of the same target wins while
+# active), so the team-plan denial cases still assert correctly.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture(autouse=True)
+def _default_sites_plan(request: pytest.FixtureRequest):
+    """Default the workspace plan to one that unlocks Sites ('business') for the
+    sites mechanics tests, so the new service-level plan gate doesn't reject their
+    synthetic workspace ids. test_plan_gate.py patches the same target per-test to
+    exercise the denial paths."""
+    # The gate test owns the plan itself — don't double-patch under it.
+    if request.module.__name__.endswith("test_plan_gate"):
+        yield
+        return
+    from unittest.mock import patch
+
+    with patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value="business"),
+    ):
+        yield

--- a/tests/ee/sites/test_plan_gate.py
+++ b/tests/ee/sites/test_plan_gate.py
@@ -1,0 +1,257 @@
+# tests/ee/sites/test_plan_gate.py
+# Created: 2026-06-17 (fix/sites-plan-gate-asymmetry) — reproduce-first coverage
+# for the Sites plan-gate asymmetry bug. Sites is a fabric-gated feature: the REST
+# router gates every endpoint with require_plan_feature("fabric"), but the chat
+# agent creates + publishes sites IN-PROCESS (the sites_manager MCP tools call the
+# create handlers + publish_pocket directly), bypassing the HTTP router. Net bug:
+# on a `team`-plan workspace the agent happily created and deployed a live site,
+# but GET /sites 403'd — a created-but-invisible resource (write path ungated,
+# read path gated). This suite asserts the in-process write paths are now gated at
+# the SERVICE chokepoint, identically to HTTP:
+#   1. publish_pocket() / publish() raise Forbidden("plan.feature_denied") on a
+#      team plan, and succeed on business/enterprise.
+#   2. The create MCP handlers (landing / svelte) surface the same
+#      plan.feature_denied as an MCP error on a team plan, and create on business.
+# (origin/dev ships the landing + svelte create tools; the dynamic create tool is
+# not yet on dev, so it is out of scope for this PR.)
+# The plan is controlled by patching workspace_service.get_workspace_plan (same
+# technique as tests/cloud/test_plan_feature_gate.py) so no plan-seeding is needed.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+# A minimal landing copy object — enough for assemble_landing_spec on the
+# business-plan success path. The team-plan path is rejected before assembly.
+def _landing_content() -> dict:
+    return {
+        "brand": "Acme",
+        "hero": {"title": "Get paid faster", "subtitle": "Invoicing for freelancers"},
+        "footer": {"copyright": "Acme"},
+    }
+
+
+def _patch_plan(plan: str):
+    """Patch workspace_service.get_workspace_plan to return a fixed plan tier for
+    BOTH the sites service and the create MCP handlers (they both read the plan
+    via workspace_service.get_workspace_plan). Returns the patch context manager."""
+    return patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value=plan),
+    )
+
+
+def _patch_identity(workspace_id: str, user_id: str):
+    """Patch the per-stream identity ContextVars the create MCP handlers read."""
+    return (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            return_value=workspace_id,
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            return_value=user_id,
+        ),
+    )
+
+
+@pytest.fixture()
+def recording_bus():
+    """Install a recording EventBus so agent_create's emit(PocketCreated) doesn't
+    raise (the real bus is only wired by init_realtime() at boot). Mirrors
+    tests/ee/agent/test_sites_mcp_server/test_create_dynamic_site.py."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# publish() / publish_pocket() — the shared publish chokepoint (REST + MCP)
+# ---------------------------------------------------------------------------
+
+
+class TestPublishPlanGate:
+    @pytest.mark.asyncio
+    async def test_publish_pocket_on_team_plan_is_forbidden(self) -> None:
+        """The shared publish path must reject a team-plan workspace with
+        plan.feature_denied, BEFORE reading the pocket or invoking the generator
+        (so this proves the gate, not an incidental missing-pocket error)."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud._core.errors import Forbidden
+        from pocketpaw_ee.sites import service as sites_service
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+
+        with _patch_plan("team"):
+            with pytest.raises(Forbidden) as ei:
+                await sites_service.publish_pocket(
+                    workspace_id=workspace_id,
+                    user_id=user_id,
+                    pocket_id=str(ObjectId()),
+                )
+        assert ei.value.code == "plan.feature_denied"
+        assert ei.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_publish_on_team_plan_is_forbidden(self) -> None:
+        """publish() (the inner funnel the REST endpoint also reaches) is gated
+        too, so a direct service caller can't slip past the publish_pocket guard."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud._core.errors import Forbidden
+        from pocketpaw_ee.sites import service as sites_service
+
+        with _patch_plan("team"):
+            with pytest.raises(Forbidden) as ei:
+                await sites_service.publish(
+                    workspace_id=str(ObjectId()),
+                    user_id=str(ObjectId()),
+                    pocket_id=str(ObjectId()),
+                    ripple_spec={"version": 1, "state": {}, "ui": {"type": "container"}},
+                    theme={},
+                )
+        assert ei.value.code == "plan.feature_denied"
+
+    @pytest.mark.asyncio
+    async def test_publish_pocket_on_business_plan_passes_the_gate(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """A business-plan workspace passes the gate and publishes. The generator
+        + Cloudflare client are faked so this runs without Bun/workerd/CF; the
+        assertion is that the gate did NOT fire (the publish proceeds and persists
+        a Site), not the deploy mechanics."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud.pockets.service import agent_create
+        from pocketpaw_ee.sites import service as sites_service
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+
+        # Seed a real source pocket to publish (a minimal landing site spec).
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        ripple_spec = assemble_landing_spec(_landing_content())
+        view, pocket_id, err = await agent_create(
+            workspace_id=workspace_id,
+            owner_id=user_id,
+            name="Acme",
+            type_="site",
+            pattern="landing",
+            ripple_spec=ripple_spec,
+            trusted=True,
+        )
+        assert err is None and pocket_id is not None, err
+
+        class _FakeBuild:
+            project_dir = "/tmp/does-not-matter"
+
+        class _FakeGenerator:
+            async def build(self, **_kwargs):  # noqa: ANN003
+                return _FakeBuild()
+
+        class _FakeCloudflare:
+            async def put_worker(self, **_kwargs):  # noqa: ANN003
+                return None
+
+        with _patch_plan("business"):
+            doc = await sites_service.publish_pocket(
+                workspace_id=workspace_id,
+                user_id=user_id,
+                pocket_id=pocket_id,
+                _generator=_FakeGenerator(),
+                _cloudflare=_FakeCloudflare(),
+                _bundle_reader=lambda _d: b"worker-bundle",
+            )
+        assert doc is not None
+        assert doc.workspace == workspace_id
+        assert doc.pocket_id == pocket_id
+
+
+# ---------------------------------------------------------------------------
+# create MCP handlers — the in-process create bypass (landing / svelte / dynamic)
+# ---------------------------------------------------------------------------
+
+
+def _svelte_source() -> dict:
+    return {
+        "src/routes/+page.svelte": (
+            "<script>import Hero from '$lib/components/Hero.svelte';</script><Hero />"
+        ),
+        "src/routes/+layout.svelte": "<script>import '../app.css';</script>",
+        "src/routes/+page.ts": "export const prerender = true;",
+        "src/app.css": ":root{}",
+        "src/lib/components/Hero.svelte": "<section><h1>Hi</h1></section>",
+    }
+
+
+class TestCreateHandlersPlanGate:
+    @pytest.mark.asyncio
+    async def test_create_landing_site_on_team_plan_is_error(self, recording_bus) -> None:
+        # recording_bus is installed so that, on the BUGGY (pre-fix) code, the
+        # handler proceeds past the absent gate and into agent_create instead of
+        # raising "EventBus not initialized" — making the failure a clean
+        # "missing plan.feature_denied" rather than a noisy crash. After the fix
+        # the guard fires before agent_create, so the bus is never reached.
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        workspace_id, user_id = "ws_team", "u_1"
+        pw, pu = _patch_identity(workspace_id, user_id)
+        with _patch_plan("team"), pw, pu:
+            out = await mcp._create_landing_site_handler({"content": _landing_content()})
+        assert out.get("is_error") is True
+        assert "plan.feature_denied" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_create_svelte_site_on_team_plan_is_error(self, recording_bus) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        pw, pu = _patch_identity("ws_team", "u_1")
+        with _patch_plan("team"), pw, pu:
+            out = await mcp._create_svelte_site_handler({"source": _svelte_source()})
+        assert out.get("is_error") is True
+        assert "plan.feature_denied" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_create_landing_site_on_business_plan_creates(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """Business plan passes the gate and the landing site is created (ground
+        truth: a pocket lands and the handler returns ok)."""
+        from bson import ObjectId
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+        pw, pu = _patch_identity(workspace_id, user_id)
+        with _patch_plan("business"), pw, pu:
+            out = await mcp._create_landing_site_handler(
+                {"content": _landing_content(), "name": "Acme"}
+            )
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        doc = await _PocketDoc.get(ObjectId(body["pocket_id"]))
+        assert doc is not None
+        assert doc.type == "site"


### PR DESCRIPTION
## What was broken

Sites is the \`fabric\` plan feature (business and enterprise only). The REST router gates every \`/sites\` endpoint with \`require_plan_feature("fabric")\`, but the chat agent creates and publishes sites **in-process** through the \`sites_manager\` MCP tools, which never pass through that router.

The result on a \`team\`-plan workspace: the agent happily created and deployed a live site (the URL worked), but \`GET /sites\` returned 403 \`plan.feature_denied\`, so the gallery showed "No sites yet". A created-but-invisible resource — write path ungated, read path gated.

Verified live: workspace "OCEAN" is on the \`team\` plan; a site deployed there but did not list.

## The fix

Close the asymmetry at the service chokepoint instead of the HTTP edge, so in-process callers are gated identically to HTTP.

\`sites.service\` gains \`require_sites_plan(workspace_id)\`. It reads the plan from \`workspace_service.get_workspace_plan\` against \`guards.abac.PLAN_FEATURES\` — the same source of truth and feature table the HTTP \`require_plan_feature("fabric")\` dependency uses — and raises \`Forbidden("plan.feature_denied")\` when the plan lacks \`fabric\` (or \`NotFound\` when the workspace is missing, mirroring the HTTP gate).

- \`publish()\` and \`publish_pocket()\` call it before any pocket read, generation, or deploy. Every publish path (REST, MCP, direct service callers) funnels through these, so one check covers them all, and a team-plan caller gets \`plan.feature_denied\` rather than a misleading \`pocket.not_found\`.
- The create MCP handlers (\`create_landing_site\`, \`create_svelte_site\`) reach \`agent_create\` directly, so each calls the shared gate after input validation and returns \`plan.feature_denied\` as the MCP error. The chat agent relays the upgrade message ("Sites requires the Business plan — upgrade, or switch to a workspace that has it") instead of reporting a phantom-created site.

The dynamic-site create tool is not on \`dev\` yet, so it is out of scope here; when it lands it should call the same shared gate.

## Tests

Reproduce-first. \`tests/ee/sites/test_plan_gate.py\`:

**Before the fix** (failing):
- \`test_create_landing_site_on_team_plan_is_error\` and \`test_create_svelte_site_on_team_plan_is_error\` returned \`{"ok":true,...}\` — the agent created a site on a team plan (the bypass).
- \`test_publish_pocket_on_team_plan_is_forbidden\` and \`test_publish_on_team_plan_is_forbidden\` had no gate to fire.

**After the fix** (passing): the four team-plan cases are rejected with \`plan.feature_denied\`; the two business-plan cases still create and publish.

A new \`tests/ee/sites/conftest.py\` defaults the plan to \`business\` for the existing sites mechanics tests so they keep exercising the happy path (the gate test overrides per-test). One existing MCP create test gets the same default.

Verification (targeted):
- \`tests/ee/sites/ tests/ee/agent/test_sites_mcp_server/ tests/cloud/test_plan_feature_gate.py tests/cloud/surface/test_sites_handler.py\` — 109 passed, 1 skipped.
- \`pytest tests/ -k "site"\` — 101 passed, 2 skipped.
- \`ruff check\` and \`mypy\` clean on the changed source files.

## Files changed
- \`ee/pocketpaw_ee/sites/service.py\` — \`require_sites_plan()\` + calls in \`publish()\` / \`publish_pocket()\`.
- \`ee/pocketpaw_ee/agent/mcp_servers/sites_create.py\` — shared \`_require_sites_plan_or_error()\` + calls in both create handlers.
- \`tests/ee/sites/test_plan_gate.py\` (new), \`tests/ee/sites/conftest.py\` (new), \`tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py\` (plan default).

The frontend counterpart (the gallery rendering a distinct plan-gate message instead of "No sites yet" on a 403) ships in a separate paw-enterprise PR.