### PR TITLE
feat(sites): add by-pocket preview and status endpoints

### DIFF
--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -7,8 +7,20 @@
 # per-site static server serves so the caller (and the cmux smoke) can open the
 # published site directly. Empty in the CF path in v1 (reached via custom
 # domain). The frontend Site type mirrors this in Phase 4.
+#
+# Updated 2026-06-17 (pocketpaw#1345 backend half — by-pocket preview + status):
+# added SitePreviewResponse and SiteStatusResponse, the two by-pocket read DTOs
+# the #432 frontend already calls (getSitePreviewByPocket / getSiteStatusByPocket
+# in core/sites/api.ts). Field names/types mirror the frontend types.ts EXACTLY:
+# preview is {pocket_id, engine, content} (content optional — absent when nothing
+# drafted; a rippleSpec for engine="ripple", a {path: contents} source map for
+# engine="svelte"); status is {pocket_id, status, is_live} plus the optional
+# site_id the frontend type also declares. Without these, every Preview-tab fetch
+# 404'd and the builder showed "Nothing to preview yet".
 
 from __future__ import annotations
+
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -25,6 +37,30 @@ class SiteResponse(BaseModel):
     deployed: bool
     signed_key: str
     url: str = ""
+
+
+class SitePreviewResponse(BaseModel):
+    """Draft content to render in the in-app builder Preview tab. ``engine``
+    selects the shape of ``content``: "ripple" → a rippleSpec object; "svelte" →
+    a {path: contents} source map. ``content`` is None when there is nothing
+    drafted yet. Mirrors the frontend SitePreviewResponse (core/sites/types.ts)."""
+
+    pocket_id: str
+    engine: str
+    content: dict[str, Any] | None = None
+
+
+class SiteStatusResponse(BaseModel):
+    """Authoritative draft/published + is_live state for a pocket, so the builder
+    labels accurately even before the site appears in the gallery list. ``status``
+    is "draft" (no published deploy) or "published"; ``is_live`` is the ONLY signal
+    that earns a "Live" badge. ``site_id`` carries the deployed Site's id when one
+    exists. Mirrors the frontend SiteStatusResponse (core/sites/types.ts)."""
+
+    pocket_id: str
+    status: str  # draft | published
+    is_live: bool
+    site_id: str | None = None
 
 
 class DomainRequest(BaseModel):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -21,6 +21,18 @@
 # require_plan_feature("fabric") router gate + require_action_any_workspace
 # scoping as the other authed sites reads) so the Domains tab can rehydrate on
 # reload. A site in another workspace surfaces as a 404 (via the service _load).
+#
+# Updated 2026-06-17 (pocketpaw#1345 backend half — by-pocket preview + status):
+# added GET /sites/by-pocket/{pocket_id}/preview and
+# GET /sites/by-pocket/{pocket_id}/status — the two by-pocket reads the #432
+# frontend already calls (getSitePreviewByPocket / getSiteStatusByPocket). The
+# backend half of #1345 never landed on dev, so every Preview-tab fetch 404'd and
+# the builder showed "Nothing to preview yet". Both are authed fabric.read reads
+# under the router-level fabric plan gate, scoped on ctx.workspace_id /
+# ctx.user_id, matching the other authed sites reads. preview delegates to
+# sites_service.preview_pocket (pockets_service.get raises NotFound → 404 itself);
+# status delegates to sites_service.pocket_status (tenant-scoped Site lookup, no
+# 404 — an unpublished pocket simply reads draft / not live).
 
 from __future__ import annotations
 
@@ -33,7 +45,9 @@ from pocketpaw_ee.sites.dto import (
     DomainRequest,
     DomainStatusResponse,
     PublishRequest,
+    SitePreviewResponse,
     SiteResponse,
+    SiteStatusResponse,
 )
 
 router = APIRouter(
@@ -64,6 +78,33 @@ async def publish_site(
 @router.get("/sites", response_model=list[SiteResponse])
 async def list_sites(ctx: RequestContext = Depends(request_context)) -> list[SiteResponse]:
     return await sites_service.list_for_workspace(ctx.workspace_id)
+
+
+@router.get("/sites/by-pocket/{pocket_id}/preview", response_model=SitePreviewResponse)
+async def preview_by_pocket(
+    pocket_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> SitePreviewResponse:
+    """Draft content for the in-app builder Preview tab: {pocket_id, engine,
+    content}. ``content`` is the pocket's rippleSpec for a ripple pocket, or the
+    {path: contents} source map for a svelte pocket. A missing / access-denied
+    pocket surfaces as a 404 (the pockets service raises NotFound itself)."""
+    return await sites_service.preview_pocket(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, pocket_id=pocket_id
+    )
+
+
+@router.get("/sites/by-pocket/{pocket_id}/status", response_model=SiteStatusResponse)
+async def status_by_pocket(
+    pocket_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> SiteStatusResponse:
+    """Authoritative draft/published + is_live state for a pocket: {pocket_id,
+    status, is_live}. Derived from the tenant-scoped Site deployment doc — an
+    unpublished pocket (no Site) reads draft / not live (NOT a 404)."""
+    return await sites_service.pocket_status(workspace_id=ctx.workspace_id, pocket_id=pocket_id)
 
 
 @router.post("/sites/{site_id}/domains", response_model=DomainStatusResponse)

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -81,6 +81,18 @@
 # source-of-truth layer, so sites no longer land unnamed when the caller omits a
 # name. The resolved name flows into BOTH the generated site ``title`` and the
 # stored ``Site.name``.
+#
+# Updated 2026-06-17 (pocketpaw#1345 backend half — by-pocket preview + status):
+# added preview_pocket() and pocket_status(), the two by-pocket reads the #432
+# frontend already calls (the backend half of #1345 never landed on dev, so every
+# Preview-tab fetch 404'd and the builder showed "Nothing to preview yet").
+# preview_pocket() reads the source pocket via the pockets service and returns its
+# DRAFT content — the rippleSpec for a ripple pocket, the {path: contents} source
+# map for a svelte pocket — reusing publish_pocket()'s pocket-read + engine logic
+# so the preview matches what publish would build. pocket_status() derives
+# draft/published + is_live from the Site deployment doc for the pocket
+# (tenant-scoped on ``workspace``, via the model's compound index): no Site doc =
+# draft / not live; a Site doc = published with is_live following ``deployed``.
 
 from __future__ import annotations
 
@@ -96,7 +108,12 @@ from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
 from pocketpaw_ee.sites.domain import HostnameStatus
-from pocketpaw_ee.sites.dto import DomainStatusResponse, SiteResponse
+from pocketpaw_ee.sites.dto import (
+    DomainStatusResponse,
+    SitePreviewResponse,
+    SiteResponse,
+    SiteStatusResponse,
+)
 from pocketpaw_ee.sites.generator_client import GeneratorClient
 
 # The control plane reads the Worker bundle adapter-cloudflare emits here.
@@ -422,6 +439,63 @@ async def publish_pocket(
     )
 
 
+async def preview_pocket(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+) -> SitePreviewResponse:
+    """Read a pocket's DRAFT content for the in-app builder Preview tab.
+
+    Loads the source pocket through the pockets service's PUBLIC ``get`` (the wire
+    dict — no Beanie import, respecting entity isolation; it raises NotFound /
+    Forbidden itself when the pocket is missing or access-denied, which the router
+    maps to 404 / 403). Mirrors ``publish_pocket``'s pocket-read + engine logic so
+    the preview matches what publish would build:
+      * ``engine="ripple"`` (the default) → ``content`` is the pocket's rippleSpec.
+      * ``engine="svelte"`` → ``content`` is the {path: contents} source map.
+    ``content`` is None when the pocket carries nothing to render on that track.
+
+    ``workspace_id`` is unused for the pocket read itself (the pockets service
+    scopes on ``user_id``), but it is required on every Sites service function so
+    the surface stays uniform and tenant-aware as the read paths converge.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    pocket = await pockets_service.get(pocket_id, user_id)
+    engine = pocket.get("engine") or "ripple"
+    if engine == "svelte":
+        source = pocket.get("source")
+        content = source if isinstance(source, dict) else None
+    else:
+        ripple_spec = pocket.get("rippleSpec")
+        content = ripple_spec if isinstance(ripple_spec, dict) else None
+    return SitePreviewResponse(pocket_id=pocket_id, engine=engine, content=content)
+
+
+async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusResponse:
+    """Derive a pocket's draft/published + is_live state from its Site deployment
+    doc, tenant-scoped on ``workspace``.
+
+    Looks up the Site for this (workspace, pocket_id) — the compound index the
+    model declares serves this read directly. With no Site doc the pocket has
+    never been published, so it reads ``draft`` / not live. With a Site doc it
+    reads ``published``; ``is_live`` follows the doc's ``deployed`` flag (the only
+    signal that earns a "Live" badge), and ``site_id`` carries the deployed id.
+    This is the authoritative state the builder uses to label a pocket even before
+    it surfaces in the gallery list. No Cloudflare call — just persisted state.
+    """
+    doc = await _SiteDoc.find_one({"workspace": workspace_id, "pocket_id": pocket_id})
+    if doc is None:
+        return SiteStatusResponse(pocket_id=pocket_id, status="draft", is_live=False)
+    return SiteStatusResponse(
+        pocket_id=pocket_id,
+        status="published",
+        is_live=doc.deployed,
+        site_id=str(doc.id),
+    )
+
+
 async def list_for_workspace(workspace_id: str) -> list[SiteResponse]:
     cursor = _SiteDoc.find({"workspace": workspace_id}).sort(-_SiteDoc.createdAt)  # type: ignore[operator]
     return [_to_response(doc) async for doc in cursor]
@@ -443,6 +517,8 @@ async def site_pocket_ids(workspace_id: str) -> set[str]:
 __all__ = [
     "publish",
     "publish_pocket",
+    "preview_pocket",
+    "pocket_status",
     "add_domain",
     "domain_status",
     "list_domains",

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -144,3 +144,76 @@ async def test_get_domains_cross_tenant_is_404(_seeded_site, monkeypatch):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         resp = await c.get(f"/api/v1/sites/{site.script_name}/domains")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# by-pocket reads (pocketpaw#1345 backend half): the builder Preview tab calls
+# GET /sites/by-pocket/{pocket_id}/preview (draft content to render) and
+# GET /sites/by-pocket/{pocket_id}/status (draft/published + is_live). Both are
+# authed fabric.read reads under the router-level fabric plan gate. The frontend
+# (#432) already ships these calls; this exercises the missing backend half.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_by_pocket_returns_ripple_content(beanie_test_db, monkeypatch):
+    """GET /sites/by-pocket/{id}/preview returns {pocket_id, engine, content} with
+    the pocket's rippleSpec for a ripple pocket."""
+    from unittest.mock import AsyncMock
+
+    spec = {"type": "container", "ui": {"children": []}}
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(return_value={"name": "x", "engine": "ripple", "rippleSpec": spec}),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk1/preview")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {"pocket_id": "pk1", "engine": "ripple", "content": spec}
+
+
+@pytest.mark.asyncio
+async def test_preview_by_pocket_missing_pocket_is_404(beanie_test_db, monkeypatch):
+    """A missing / access-denied pocket surfaces as a 404 (the pockets service's
+    NotFound flows through the standard error handler)."""
+    from unittest.mock import AsyncMock
+
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(side_effect=NotFound("pocket", "pk_missing")),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_missing/preview")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_status_by_pocket_unpublished_is_draft(beanie_test_db, monkeypatch):
+    """An unpublished pocket (no Site doc) reads {status: draft, is_live: false}."""
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_unpublished/status")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["pocket_id"] == "pk_unpublished"
+    assert body["status"] == "draft"
+    assert body["is_live"] is False
+
+
+@pytest.mark.asyncio
+async def test_status_by_pocket_published_is_live(_seeded_site, monkeypatch):
+    """A published pocket (the seeded site is under pk1 / ws_owner) reads
+    {status: published, is_live: true}."""
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk1/status")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["pocket_id"] == "pk1"
+    assert body["status"] == "published"
+    assert body["is_live"] is True

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -605,9 +605,7 @@ async def test_preview_pocket_ripple_returns_ripple_spec():
         "pocketpaw_ee.cloud.pockets.service.get",
         new=AsyncMock(return_value=wire),
     ) as mock_get:
-        res = await sites_service.preview_pocket(
-            workspace_id="ws1", user_id="u1", pocket_id="pk1"
-        )
+        res = await sites_service.preview_pocket(workspace_id="ws1", user_id="u1", pocket_id="pk1")
 
     mock_get.assert_awaited_once_with("pk1", "u1")
     assert res.pocket_id == "pk1"
@@ -626,9 +624,7 @@ async def test_preview_pocket_defaults_engine_to_ripple():
         "pocketpaw_ee.cloud.pockets.service.get",
         new=AsyncMock(return_value=wire),
     ):
-        res = await sites_service.preview_pocket(
-            workspace_id="ws1", user_id="u1", pocket_id="pk1"
-        )
+        res = await sites_service.preview_pocket(workspace_id="ws1", user_id="u1", pocket_id="pk1")
 
     assert res.engine == "ripple"
     assert res.content == spec
@@ -648,9 +644,7 @@ async def test_preview_pocket_svelte_returns_source_map():
         "pocketpaw_ee.cloud.pockets.service.get",
         new=AsyncMock(return_value=wire),
     ):
-        res = await sites_service.preview_pocket(
-            workspace_id="ws1", user_id="u1", pocket_id="pk1"
-        )
+        res = await sites_service.preview_pocket(workspace_id="ws1", user_id="u1", pocket_id="pk1")
 
     assert res.engine == "svelte"
     assert res.content == source

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -582,3 +582,154 @@ async def test_publish_pocket_no_name_lands_site_with_pocket_name(beanie_test_db
         )
 
     assert site.name == "Flower Shop Landing Page"
+
+
+# ---------------------------------------------------------------------------
+# preview_pocket — the DRAFT-content reader backing
+# GET /sites/by-pocket/{pocket_id}/preview. Reads the source pocket via the
+# pockets service (the wire-dict reader, which raises NotFound itself) and
+# returns {pocket_id, engine, content}: the rippleSpec for a ripple pocket, or
+# the {path: contents} source map for a svelte pocket. Mirrors publish_pocket's
+# pocket-read + engine logic so the preview matches what publish would build.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_pocket_ripple_returns_ripple_spec():
+    """A ripple pocket previews its rippleSpec verbatim, with engine='ripple'."""
+    from unittest.mock import AsyncMock, patch
+
+    spec = {"type": "container", "ui": {"children": []}, "theme": {"primary": "#0A84FF"}}
+    wire = {"name": "Bright Smile", "engine": "ripple", "rippleSpec": spec}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ) as mock_get:
+        res = await sites_service.preview_pocket(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+
+    mock_get.assert_awaited_once_with("pk1", "u1")
+    assert res.pocket_id == "pk1"
+    assert res.engine == "ripple"
+    assert res.content == spec
+
+
+@pytest.mark.asyncio
+async def test_preview_pocket_defaults_engine_to_ripple():
+    """A pocket with no explicit engine previews as ripple (the default track)."""
+    from unittest.mock import AsyncMock, patch
+
+    spec = {"type": "container"}
+    wire = {"name": "x", "rippleSpec": spec}  # no engine key
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        res = await sites_service.preview_pocket(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+
+    assert res.engine == "ripple"
+    assert res.content == spec
+
+
+@pytest.mark.asyncio
+async def test_preview_pocket_svelte_returns_source_map():
+    """A svelte pocket previews its {path: contents} source map, engine='svelte'."""
+    from unittest.mock import AsyncMock, patch
+
+    source = {
+        "src/routes/+page.svelte": "<h1>Hello</h1>",
+        "src/lib/Hero.svelte": "<section>hero</section>",
+    }
+    wire = {"name": "x", "engine": "svelte", "source": source, "rippleSpec": {}}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        res = await sites_service.preview_pocket(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+
+    assert res.engine == "svelte"
+    assert res.content == source
+
+
+@pytest.mark.asyncio
+async def test_preview_pocket_propagates_not_found():
+    """A missing / access-denied pocket surfaces NotFound (router → 404), not a
+    swallowed empty preview."""
+    from unittest.mock import AsyncMock, patch
+
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(side_effect=NotFound("pocket", "pk_missing")),
+    ):
+        with pytest.raises(NotFound):
+            await sites_service.preview_pocket(
+                workspace_id="ws1", user_id="u1", pocket_id="pk_missing"
+            )
+
+
+# ---------------------------------------------------------------------------
+# pocket_status — the draft/published + is_live reader backing
+# GET /sites/by-pocket/{pocket_id}/status. Derives the lifecycle from the Site
+# deployment doc for the pocket (tenant-scoped on workspace): a Site doc means
+# published (is_live == doc.deployed); no Site doc means draft / not live.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_no_site_is_draft_not_live(beanie_test_db):
+    """A pocket that has never been published has no Site doc → draft, not live."""
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_unpublished")
+    assert res.pocket_id == "pk_unpublished"
+    assert res.status == "draft"
+    assert res.is_live is False
+    assert res.site_id is None
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_published_site_is_live(beanie_test_db):
+    """A pocket with a deployed Site doc reads published + live, and carries the
+    site id."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_live",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_live")
+    assert res.pocket_id == "pk_live"
+    assert res.status == "published"
+    assert res.is_live is True
+    assert res.site_id == str(site.id)
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_is_tenant_scoped(beanie_test_db):
+    """A Site published in another workspace does not leak into this workspace's
+    status read — a different workspace sees the pocket as draft / not live."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    await sites_service.publish(
+        workspace_id="ws_owner",
+        user_id="u1",
+        pocket_id="pk_x",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    res = await sites_service.pocket_status(workspace_id="ws_intruder", pocket_id="pk_x")
+    assert res.status == "draft"
+    assert res.is_live is False
+    assert res.site_id is None


### PR DESCRIPTION
## What's missing

The Sites builder Preview tab is blank. It fetches two backend reads that never landed on `dev`:

- `GET /api/v1/sites/by-pocket/{pocket_id}/preview` — draft content to render in-app
- `GET /api/v1/sites/by-pocket/{pocket_id}/status` — draft/published + is_live state

The #432 frontend already ships these calls (`getSitePreviewByPocket` / `getSiteStatusByPocket` in `core/sites/api.ts`, attributed to #1345), but only the frontend half of #1345 merged. The backend half was never added, so every preview fetch returns 404. The frontend's catch swallows it and the builder shows "Nothing to preview yet" even though the pocket carries a healthy spec. This PR is the missing backend half of #1345.

## Why preview was blank

`git show origin/dev:ee/pocketpaw_ee/sites/router.py` has only `/sites/publish`, `/sites`, and the domain routes. There is no by-pocket route and no `SitePreviewResponse` anywhere in the backend. The data is fine; the endpoints just don't exist.

## What this adds

In `ee/pocketpaw_ee/sites/`:

- **`dto.py`** — `SitePreviewResponse {pocket_id, engine, content}` and `SiteStatusResponse {pocket_id, status, is_live, site_id?}`. Field names and types match the frontend `types.ts` exactly.
- **`service.py`**:
  - `preview_pocket` reads the source pocket via `pockets_service.get` and returns its draft content: the `rippleSpec` for a ripple pocket, the `{path: contents}` source map for a svelte pocket. It reuses `publish_pocket`'s pocket-read and engine logic so the preview matches what publish would build. A missing or access-denied pocket raises `NotFound`, which the router maps to 404.
  - `pocket_status` derives `status` and `is_live` from the Site deployment doc for the pocket, scoped on `workspace`. No Site doc means `draft` / not live; a Site doc means `published` with `is_live` following the doc's `deployed` flag, plus the site id.
- **`router.py`** — `GET /sites/by-pocket/{pocket_id}/preview` and `GET /sites/by-pocket/{pocket_id}/status`, both authed `fabric.read` reads under the existing router-level `fabric` plan gate, scoped on `ctx.workspace_id` / `ctx.user_id`, matching the other authed sites reads.

## How I derived is_live

The `Site` model has no explicit lifecycle or version fields, so status is derived from deployment state: a Site doc for `(workspace, pocket_id)` means published and `is_live = doc.deployed`; no Site doc means draft and not live. The model's compound `(workspace, pocket_id)` index serves this lookup directly. This lines up with the frontend's `siteBadgeState` rule.

## Verification

Reproduce-first: the new tests fail on current code (routes 404 / service functions absent) and pass after the change.

```
tests/ee/sites/test_service.py: preview_pocket (ripple, default engine, svelte source map, NotFound),
                                pocket_status (no site = draft, published site = live, tenant scoped)
tests/ee/sites/test_router.py:  preview by-pocket (ripple content, missing pocket = 404),
                                status by-pocket (unpublished = draft, published = live)

uv run pytest tests/ -k "site"  ->  106 passed, 2 skipped
```

The previously-flagged 5 headless guard test failures are already fixed on `dev` by #1482 (merged), so this branch inherits a clean suite: `tests/test_headless_permissions.py` + `tests/test_integration_headless.py` -> 38 passed.

## Known follow-up (out of scope)

The frontend's bare catch in the preview fetch swallows errors silently. With these endpoints in place the preview now renders, but a separate paw-enterprise robustness fix should surface fetch failures instead of degrading to a blank "Nothing to preview yet". Not touched here.