### PR TITLE
fix(sites): re-serve local sites after a backend restart

### DIFF
--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -321,6 +321,28 @@ class CloudLifecycleHook:
         except Exception as exc:  # noqa: BLE001
             logger.warning("xproc consumer start failed: %s", exc)
 
+        # Re-serve locally-deployed Paw Sites. In LOCAL deploy mode the static
+        # server binds an ephemeral port and is only started during publish, so
+        # after this restart every prior site's stored url points at a dead
+        # port even though its files survived on disk. reserve_local_sites()
+        # (re)starts the shared server and rewrites every deployed site's url to
+        # the fresh live base so previously-published local sites are openable
+        # again with no manual re-publish. Unscoped (all workspaces) — this is
+        # the automatic boot path. A no-op when real Cloudflare creds are present
+        # (the CF path owns its own URLs). Guarded so a failure here never blocks
+        # boot. Mirrors this lifecycle hook's other best-effort boot reconcilers
+        # (run sweeper, xproc consumer) rather than mount_cloud's
+        # ``@app.on_event("startup")``, which is silently dropped under
+        # ``FastAPI(lifespan=...)`` (the host's default).
+        try:
+            from pocketpaw_ee.sites.service import reserve_local_sites
+
+            reconciled = await reserve_local_sites()
+            if reconciled:
+                logger.info("Re-served %d local Paw Site(s) after restart", reconciled)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Local Paw Sites re-serve failed (non-fatal): %s", exc)
+
     async def on_shutdown(self) -> None:
         import logging
 

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -33,6 +33,13 @@
 # sites_service.preview_pocket (pockets_service.get raises NotFound → 404 itself);
 # status delegates to sites_service.pocket_status (tenant-scoped Site lookup, no
 # 404 — an unpublished pocket simply reads draft / not live).
+# Updated 2026-06-17 (feat/sites-local-reserve): added POST /sites/reserve — the
+# explicit "re-serve local sites" action. Locally-deployed sites die after a
+# backend restart (the per-process static server binds an ephemeral port and is
+# only started during publish), so this (re)starts the server and rewrites the
+# workspace's site urls to the fresh live base via sites_service
+# .reserve_local_sites(ctx.workspace_id), then returns the reconciled list. Gated
+# like the other authed sites writes (fabric.write). No-op outside local mode.
 
 from __future__ import annotations
 
@@ -73,6 +80,22 @@ async def publish_site(
         pocket_id=body.pocket_id,
     )
     return sites_service._to_response(doc)
+
+
+@router.post("/sites/reserve", response_model=list[SiteResponse])
+async def reserve_sites(
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> list[SiteResponse]:
+    """Re-serve this workspace's locally-deployed sites and return the refreshed
+    list. Locally-deployed sites stop responding after a backend restart (the
+    static server binds an ephemeral port and is only started at publish time);
+    this (re)starts the server and rewrites each site's url to the live base, so
+    previously-deployed sites become openable again. A no-op outside local mode
+    (the real Cloudflare path owns its own URLs), in which case the list comes
+    back unchanged."""
+    await sites_service.reserve_local_sites(ctx.workspace_id)
+    return await sites_service.list_for_workspace(ctx.workspace_id)
 
 
 @router.get("/sites", response_model=list[SiteResponse])

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -93,6 +93,18 @@
 # draft/published + is_live from the Site deployment doc for the pocket
 # (tenant-scoped on ``workspace``, via the model's compound index): no Site doc =
 # draft / not live; a Site doc = published with is_live following ``deployed``.
+# Updated 2026-06-17 (feat/sites-local-reserve — local sites die on restart):
+# added reserve_local_sites(). LOCAL deploy mode (Phase 3) serves sites from a
+# per-process static server bound to an EPHEMERAL port that is only started
+# during publish(). After a backend restart the server is gone and every stored
+# ``url`` (http://127.0.0.1:<old-port>/<id>/) is dead, even though the built
+# files survive under sites_home()/<id>/. reserve_local_sites() (re)starts the
+# shared server via local_server.ensure_server() and rewrites every deployed
+# site's ``url`` to the fresh live base, so prior local sites become openable
+# again. It is a no-op outside local mode (the real CF path owns its own URLs)
+# and skips sites whose files are not on disk. The cloud boot hook calls it
+# unscoped so a restart auto-re-serves all sites; POST /sites/reserve calls it
+# workspace-scoped for an explicit "re-serve" action.
 
 from __future__ import annotations
 
@@ -514,6 +526,58 @@ async def site_pocket_ids(workspace_id: str) -> set[str]:
     return {doc.pocket_id async for doc in cursor}
 
 
+async def reserve_local_sites(workspace_id: str | None = None) -> int:
+    """Re-serve locally-deployed Paw Sites after a backend restart.
+
+    In LOCAL deploy mode (Phase 3) a published site is served from a per-process
+    static server on an EPHEMERAL OS-assigned port that is only started inside
+    ``publish``. The built files survive a restart under
+    ``local_server.sites_home()/<site_id>/``, but the server does not — so every
+    stored ``Site.url`` (``http://127.0.0.1:<old-port>/<site_id>/``) is dead and
+    re-publishing one site starts a server on a NEW port, leaving the rest stale.
+
+    This (re)starts the shared static server via ``local_server.ensure_server()``
+    and, for each deployed site whose files exist on disk, rewrites the stored
+    ``url`` to ``f"{base}/{site_id}/"`` against the now-live base, then saves.
+    Returns the count of sites reconciled.
+
+    Scope: ``workspace_id is None`` reconciles ALL workspaces' sites (the boot
+    hook path — a restart re-serves everything); a non-None id is tenant-scoped
+    to that workspace (the manual POST /sites/reserve path).
+
+    No-op outside local mode: the real Cloudflare path owns its own URLs, so when
+    ``_local_mode()`` is False this returns 0 without starting a server. Sites
+    with no persisted dir are skipped (nothing to serve)."""
+    if not _local_mode():
+        return 0
+
+    from pocketpaw_ee.sites import local_server
+
+    base = local_server.ensure_server()
+    home = local_server.sites_home()
+
+    # workspace=None → reconcile every tenant's sites (boot hook). A non-None id
+    # tenant-filters the read. Both paths only touch deployed sites.
+    query: dict[str, Any] = {"deployed": True}
+    if workspace_id is not None:
+        query["workspace"] = workspace_id
+
+    reconciled = 0
+    cursor = _SiteDoc.find(query)
+    async for doc in cursor:
+        site_id = str(doc.id)
+        # Skip sites whose built files are gone — there is nothing to serve, so
+        # rewriting the url to a 404-ing path would be worse than leaving it.
+        if not (home / site_id).is_dir():
+            continue
+        fresh_url = f"{base}/{site_id}/"
+        if doc.url != fresh_url:
+            doc.url = fresh_url
+            await doc.save()  # no-event: local-mode URL reconciliation, not a domain mutation
+        reconciled += 1
+    return reconciled
+
+
 __all__ = [
     "publish",
     "publish_pocket",
@@ -524,4 +588,5 @@ __all__ = [
     "list_domains",
     "list_for_workspace",
     "site_pocket_ids",
+    "reserve_local_sites",
 ]

--- a/tests/ee/sites/test_reserve.py
+++ b/tests/ee/sites/test_reserve.py
@@ -1,0 +1,204 @@
+# tests/ee/sites/test_reserve.py — reproduce-first coverage for re-serving
+# locally-deployed Paw Sites after a backend restart.
+#
+# The bug: site files persist under sites_home()/<site_id>/ across restarts, but
+# the local static server is only started during PUBLISH and binds an ephemeral
+# OS-assigned port. After a restart no server is running, so every stored Site
+# ``url`` (e.g. http://127.0.0.1:56308/<id>/) is dead. reserve_local_sites()
+# (re)starts the shared server and rewrites each deployed site's url to the live
+# base, so prior sites become openable again.
+#
+# Created 2026-06-17 (feat/sites-local-reserve): tests for reserve_local_sites()
+# (service) + POST /sites/reserve (router). Uses PAW_SITES_LOCAL=1 +
+# PAW_SITES_LOCAL_DIR=<tmp> so the local-mode branch is selected and no real
+# ~/.pocketpaw home is touched. The local_server singleton is reset per test so
+# each run gets a fresh ephemeral port (mirrors a fresh process / restart).
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import pytest
+from pocketpaw_ee.sites import local_server
+from pocketpaw_ee.sites import service as sites_service
+
+
+@pytest.fixture(autouse=True)
+def _local_sites_env(tmp_path, monkeypatch):
+    """Select local-deploy mode and root the sites home + server at a temp dir.
+
+    Also resets the local_server singleton before AND after the test so a server
+    bound by a prior test (its own ephemeral port) never leaks into this one —
+    the same reset a fresh backend process would see on restart.
+    """
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+    monkeypatch.delenv("PAW_SITES_LOCAL_PORT", raising=False)
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    _shutdown_local_server()
+    yield
+    _shutdown_local_server()
+
+
+def _shutdown_local_server() -> None:
+    server = local_server._server
+    if server is not None:
+        server.shutdown()
+        server.server_close()
+    local_server._server = None
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+async def _publish_local_site(workspace_id: str, pocket_id: str, name: str):
+    """Publish a site through the LOCAL branch and persist real files under
+    sites_home()/<site_id>/ so reserve_local_sites can find them. The local
+    deploy is faked to just create the per-site dir (no Bun build)."""
+
+    def fake_local_deploy(site_id: str, project_dir: str) -> str:
+        # Create the persisted per-site dir the reconcile step looks for.
+        dest = local_server.sites_home() / site_id
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "index.html").write_text("<html>ok</html>", encoding="utf-8")
+        return local_server.local_url_for(site_id)
+
+    return await sites_service.publish(
+        workspace_id=workspace_id,
+        user_id="u1",
+        pocket_id=pocket_id,
+        ripple_spec={"type": "container"},
+        theme={},
+        name=name,
+        _generator=_FakeGenerator(),
+        _bundle_reader=lambda d: b"unused",
+        _local_deploy=fake_local_deploy,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reserve_restarts_server_and_rewrites_stale_url(beanie_test_db):
+    """A site published in a prior 'process' has its files on disk but its stored
+    url points at a dead ephemeral port (the old server is gone). After a restart
+    (server singleton reset) reserve_local_sites() starts a fresh server and
+    rewrites the url to the live base, so the site is openable again."""
+    site = await _publish_local_site("ws1", "pk1", "Site One")
+    original_url = site.url
+
+    # Simulate the restart: tear down the server that publish started. The Site
+    # row + its files survive (that's the whole point of the bug).
+    _shutdown_local_server()
+
+    count = await sites_service.reserve_local_sites()
+    assert count == 1
+
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    fresh = await _SiteDoc.get(site.id)
+    # The url now ends with /<site_id>/ and points at the fresh live base.
+    assert fresh.url.endswith(f"/{site.id}/")
+    live_base = local_server.ensure_server()
+    assert fresh.url == f"{live_base}/{site.id}/"
+    # The host:port matches the live server, not the dead one.
+    live = urlparse(live_base)
+    got = urlparse(fresh.url)
+    assert (got.hostname, got.port) == (live.hostname, live.port)
+    # And, concretely, the stale port was replaced (publish's server is gone).
+    assert urlparse(original_url).port != got.port
+
+
+@pytest.mark.asyncio
+async def test_reserve_skips_sites_with_no_persisted_dir(beanie_test_db):
+    """A deployed Site row whose files are NOT on disk (e.g. the dir was pruned)
+    is skipped — reserve_local_sites only reconciles sites it can actually serve,
+    and does not count or rewrite the orphan."""
+    served = await _publish_local_site("ws1", "pk_served", "Served")
+    orphan = await _publish_local_site("ws1", "pk_orphan", "Orphan")
+
+    # Remove the orphan's persisted dir so it has no files to serve.
+    import shutil
+
+    shutil.rmtree(local_server.sites_home() / str(orphan.id))
+    orphan_url_before = orphan.url
+
+    _shutdown_local_server()
+    count = await sites_service.reserve_local_sites()
+    assert count == 1  # only the served site was reconciled
+
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    fresh_served = await _SiteDoc.get(served.id)
+    fresh_orphan = await _SiteDoc.get(orphan.id)
+    assert fresh_served.url.endswith(f"/{served.id}/")
+    # The orphan was left untouched.
+    assert fresh_orphan.url == orphan_url_before
+
+
+@pytest.mark.asyncio
+async def test_reserve_is_tenant_scoped(beanie_test_db):
+    """reserve_local_sites(workspace_id) only touches that workspace's sites; an
+    unscoped call (workspace_id=None) reconciles every workspace's sites."""
+    site_a = await _publish_local_site("ws_a", "pk_a", "A")
+    site_b = await _publish_local_site("ws_b", "pk_b", "B")
+    url_b_before = site_b.url
+
+    _shutdown_local_server()
+    count = await sites_service.reserve_local_sites("ws_a")
+    assert count == 1
+
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    fresh_a = await _SiteDoc.get(site_a.id)
+    fresh_b = await _SiteDoc.get(site_b.id)
+    live_base = local_server.ensure_server()
+    assert fresh_a.url == f"{live_base}/{site_a.id}/"
+    # ws_b was NOT in scope — its url is unchanged (still the stale one).
+    assert fresh_b.url == url_b_before
+
+
+@pytest.mark.asyncio
+async def test_reserve_unscoped_reconciles_all_workspaces(beanie_test_db):
+    """The boot hook calls reserve_local_sites() with no workspace so every prior
+    local site across all tenants is re-served on a restart."""
+    site_a = await _publish_local_site("ws_a", "pk_a", "A")
+    site_b = await _publish_local_site("ws_b", "pk_b", "B")
+
+    _shutdown_local_server()
+    count = await sites_service.reserve_local_sites()
+    assert count == 2
+
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    live_base = local_server.ensure_server()
+    fresh_a = await _SiteDoc.get(site_a.id)
+    fresh_b = await _SiteDoc.get(site_b.id)
+    assert fresh_a.url == f"{live_base}/{site_a.id}/"
+    assert fresh_b.url == f"{live_base}/{site_b.id}/"
+
+
+@pytest.mark.asyncio
+async def test_reserve_noop_when_not_local_mode(beanie_test_db, monkeypatch):
+    """With real Cloudflare creds present (PAW_SITES_LOCAL unset), local mode is
+    off and reserve_local_sites is a no-op: it never starts a server and never
+    rewrites a url. Mirrors the existing _is_local()/_local_mode() gate."""
+    # Build a local site first (while local mode is on, via the autouse fixture).
+    site = await _publish_local_site("ws1", "pk1", "Site One")
+    url_before = site.url
+    _shutdown_local_server()
+
+    # Now flip to a configured (CF) environment.
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    monkeypatch.setenv("PAW_CF_ACCOUNT_ID", "acct_123")
+
+    count = await sites_service.reserve_local_sites()
+    assert count == 0
+    assert local_server._server is None  # no server started
+
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    fresh = await _SiteDoc.get(site.id)
+    assert fresh.url == url_before  # untouched

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -11,6 +11,11 @@
 # require_license, and stubs get_workspace_plan -> "business" so the plan gate
 # passes (fabric is a business+ feature). add_error_handler maps the service's
 # NotFound (cross-tenant) to a 404.
+#
+# Updated 2026-06-17 (feat/sites-local-reserve): adds coverage for POST
+# /sites/reserve — the manual "re-serve local sites" endpoint that (re)starts
+# the local static server and returns the workspace's reconciled site list with
+# fresh, valid urls. Gated like the other authed sites writes (fabric.write).
 
 from __future__ import annotations
 
@@ -217,3 +222,62 @@ async def test_status_by_pocket_published_is_live(_seeded_site, monkeypatch):
     assert body["pocket_id"] == "pk1"
     assert body["status"] == "published"
     assert body["is_live"] is True
+@pytest.mark.asyncio
+async def test_post_reserve_returns_reconciled_list(beanie_test_db, monkeypatch):
+    """POST /sites/reserve (re)starts the local server and returns the caller's
+    workspace site list with fresh urls. The handler delegates to
+    reserve_local_sites(ctx.workspace_id) then list_for_workspace, so the response
+    carries every site's refreshed url."""
+    from pocketpaw_ee.sites import local_server
+
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(__import__("tempfile").mkdtemp()))
+    monkeypatch.delenv("PAW_SITES_LOCAL_PORT", raising=False)
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+    # Reset the singleton so this test gets a fresh ephemeral port.
+    if local_server._server is not None:
+        local_server._server.shutdown()
+        local_server._server.server_close()
+        local_server._server = None
+
+    def fake_local_deploy(site_id: str, project_dir: str) -> str:
+        dest = local_server.sites_home() / site_id
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "index.html").write_text("<html>ok</html>", encoding="utf-8")
+        return local_server.local_url_for(site_id)
+
+    site = await sites_service.publish(
+        workspace_id="ws_owner",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Reserve Me",
+        _generator=_FakeGenerator(),
+        _bundle_reader=lambda d: b"x",
+        _local_deploy=fake_local_deploy,
+    )
+
+    # Simulate a restart: the server publish started is gone.
+    if local_server._server is not None:
+        local_server._server.shutdown()
+        local_server._server.server_close()
+        local_server._server = None
+
+    app = _build_app("ws_owner", monkeypatch)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            resp = await c.post("/api/v1/sites/reserve")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["id"] == str(site.id)
+        # The url was re-served against the now-live local server.
+        live_base = local_server.ensure_server()
+        assert body[0]["url"] == f"{live_base}/{site.id}/"
+    finally:
+        if local_server._server is not None:
+            local_server._server.shutdown()
+            local_server._server.server_close()
+            local_server._server = None


### PR DESCRIPTION
## What

Locally-deployed Paw Sites (the static/custom track served from `ee/pocketpaw_ee/sites/local_server.py`) go dead after the backend restarts. This adds a way to bring them back, both automatically on boot and through an explicit endpoint.

## Why

In local deploy mode a published site is served from a per-process static server that binds an ephemeral, OS-assigned port. That server is only started during publish. The site files themselves persist across restarts under `~/.pocketpaw/sites/<site_id>/`, but the server does not, so once the process exits every stored site `url` (e.g. `http://127.0.0.1:56308/<id>/`) points at a port nothing is listening on. Re-publishing a single site spins up a server on a fresh port and leaves all the other sites' URLs stale. The net effect: after a restart, none of your previously-deployed local sites open.

This is local-mode only. When real Cloudflare creds are present the production path owns its own URLs and none of this runs.

## What changed

- **Service** `reserve_local_sites(workspace_id=None)` in `sites/service.py`. In local mode it restarts the shared static server via `local_server.ensure_server()`, then for each deployed site whose files exist on disk it rewrites the stored `url` to `f"{base}/{site_id}/"` and saves. Returns the count reconciled. `workspace_id=None` covers all workspaces (the boot path); a workspace id scopes it to one tenant. Sites with no persisted directory are skipped. No-op outside local mode.
- **Boot hook** in the cloud lifecycle `on_startup` (`extensions.py`). Calls `reserve_local_sites()` unscoped on startup so a restart automatically re-serves every prior local site with fresh URLs. Guarded so a failure never blocks boot. It lives in the lifecycle hook, not `mount_cloud`'s `@app.on_event("startup")`, because the latter is silently dropped under `FastAPI(lifespan=...)` (the host's default) and so would never fire.
- **Endpoint** `POST /sites/reserve` in `sites/router.py`, gated like the other authed sites writes (`require_plan_feature("fabric")` at the router level + `require_action_any_workspace("fabric.write")`). Runs `reserve_local_sites(ctx.workspace_id)` and returns the refreshed `list[SiteResponse]` for the workspace. This backs a future "Re-serve sites" button.

## Tests

Reproduce-first: the new tests failed against `dev` before the implementation (the service function and endpoint did not exist), then passed after.

- `tests/ee/sites/test_reserve.py` — stale-url rewrite to the live base, skip-when-no-files, tenant scoping, unscoped reconciles all workspaces, and the not-local no-op.
- `tests/ee/sites/test_router.py::test_post_reserve_returns_reconciled_list` — the endpoint returns the reconciled list with refreshed URLs.

Verified locally:

```
uv run pytest tests/ee/sites/ -k "reserve or local"   # 7 passed, 1 skipped
uv run pytest tests/ee/sites/                          # 63 passed, 1 skipped
uv run pytest tests/ee/                                # 1193 passed, 2 skipped
```

Ruff and format are clean on the changed files. mypy shows the pre-existing `ctx.workspace_id: str | None` arg-type warnings that already exist on every sites endpoint on `dev`; this change adds one more of the same shape and does not introduce a new class of error.