### PR TITLE
feat(sites): edit one svelte component and republish safely

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites.py
@@ -7,6 +7,13 @@
 # ``ee.cloud.chat.agent_service`` the pocket specialist + tasks servers read).
 # Tool ids namespace as ``mcp__pocketpaw_sites_manager__<tool>`` so the Claude
 # Code allowlist machinery matches them.
+#
+# Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2): the
+# ``edit_svelte_component`` tool also registers on this SAME server (built via
+# the factory in sites_create.py). It rewrites ONE file of a published svelte
+# site's source map and republishes — so the create → publish → edit hops sit on
+# one allowlisted server. Its id rides ``SITES_TOOL_IDS``, so the per-surface
+# allowlist (extensions.py + surface/service.py) picks it up automatically.
 """Agent-side MCP surface for publishing a PocketPaw pocket as a Paw Site.
 
 A site is published FROM a pocket: the chat agent identifies the pocket to
@@ -52,8 +59,16 @@ CREATE_LANDING_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_landing_site"
 # The svelte-track create tool also registers on this SAME server (see
 # sites_create.py).
 CREATE_SVELTE_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_svelte_site"
+# The targeted svelte-component edit tool — also registers on this SAME server
+# (see sites_create.py).
+EDIT_SVELTE_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_svelte_component"
 
-SITES_TOOL_IDS = (PUBLISH_TOOL_ID, CREATE_LANDING_SITE_TOOL_ID, CREATE_SVELTE_SITE_TOOL_ID)
+SITES_TOOL_IDS = (
+    PUBLISH_TOOL_ID,
+    CREATE_LANDING_SITE_TOOL_ID,
+    CREATE_SVELTE_SITE_TOOL_ID,
+    EDIT_SVELTE_COMPONENT_TOOL_ID,
+)
 
 
 def _error_response(message: str) -> dict[str, Any]:
@@ -211,17 +226,21 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     from pocketpaw_ee.agent.mcp_servers.sites_create import (
         make_create_landing_site_tool,
         make_create_svelte_site_tool,
+        make_edit_svelte_component_tool,
     )
 
     create_landing_site = make_create_landing_site_tool(tool)
     # The svelte-track create tool — same server, so the author-source-map →
     # create_svelte_site → publish hops sit on one allowlisted server.
     create_svelte_site = make_create_svelte_site_tool(tool)
+    # The targeted svelte-component edit tool — same server, so the
+    # create → publish → edit hops sit on one allowlisted server.
+    edit_svelte_component = make_edit_svelte_component_tool(tool)
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[publish, create_landing_site, create_svelte_site],
+        tools=[publish, create_landing_site, create_svelte_site, edit_svelte_component],
     )
     return SERVER_NAME, server
 
@@ -229,6 +248,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
 __all__ = [
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
+    "EDIT_SVELTE_COMPONENT_TOOL_ID",
     "PUBLISH_TOOL_ID",
     "SERVER_NAME",
     "SITES_TOOL_IDS",

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -15,6 +15,15 @@
 # (the catalog walk only runs on a non-null spec), so the source files pass
 # straight through to persistence and the generator materializes them at publish.
 #
+# Updated: 2026-06-17 (feat/sites-svelte-component-edit, SE-2) — added a THIRD
+# tool ``edit_svelte_component`` for targeted edits of a PUBLISHED svelte site.
+# It takes ``pocket_id`` + ``component_path`` + the FULL ``new_source`` for one
+# file, and delegates to ``sites_service.edit_svelte_component`` (persist the one
+# file via the pockets service, then republish; roll back + leave the prior
+# deploy if the rebuild's smoke gate fails). It registers on the SAME
+# ``pocketpaw_sites_manager`` server as create + publish (see sites.py) so the
+# create → publish → edit hops sit side by side for the chat agent.
+#
 # This is the decisive bypass of the dashboard-built ``pocket_specialist``
 # create machinery. The agent-mode pocket_specialist path (draft kit / plan kit /
 # subagent delegation + the validate-redraft loop) kept downgrading landing
@@ -73,8 +82,16 @@ CREATE_LANDING_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_landing_site"
 # server in sites.py). The skill flow is: author the source map → create_svelte_site
 # → publish.
 CREATE_SVELTE_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_svelte_site"
+# The targeted svelte-component edit tool — rewrites ONE file of a published
+# svelte site's source map and safely republishes. Registers on the SAME server
+# (see sites.py) so the create → publish → edit hops sit side by side.
+EDIT_SVELTE_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_svelte_component"
 
-SITES_CREATE_TOOL_IDS = (CREATE_LANDING_SITE_TOOL_ID, CREATE_SVELTE_SITE_TOOL_ID)
+SITES_CREATE_TOOL_IDS = (
+    CREATE_LANDING_SITE_TOOL_ID,
+    CREATE_SVELTE_SITE_TOOL_ID,
+    EDIT_SVELTE_COMPONENT_TOOL_ID,
+)
 
 
 def _error_response(message: str) -> dict[str, Any]:
@@ -503,13 +520,174 @@ def make_create_svelte_site_tool(tool: Any) -> Any:
     return create_svelte_site
 
 
+async def _edit_svelte_component_handler(args: dict) -> dict:
+    """MCP handler for ``sites_manager__edit_svelte_component``.
+
+    Reads workspace/user identity from the per-stream ContextVars, validates the
+    ``pocket_id`` / ``component_path`` / ``new_source`` inputs, and delegates to
+    ``sites_service.edit_svelte_component`` — which rewrites the one file in the
+    pocket's svelte source map and republishes, rolling the edit back if the
+    republish fails its smoke gate. Returns ``{ok, site, component_path}`` on
+    success; sets ``is_error`` when identity is missing, the inputs are
+    malformed, the pocket / component is not found or not a svelte site, or the
+    rebuild's smoke gate rejects the edit (the live site stays on the prior
+    deploy and the source is rolled back).
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "edit_svelte_component requires workspace and user context (call from "
+            "a cloud chat session)."
+        )
+
+    pocket_id = args.get("pocket_id")
+    if not isinstance(pocket_id, str) or not pocket_id:
+        return _error_response(
+            "edit_svelte_component requires a `pocket_id` — the id of the svelte "
+            "site pocket whose component you are editing."
+        )
+    component_path = args.get("component_path")
+    if not isinstance(component_path, str) or not component_path:
+        return _error_response(
+            "edit_svelte_component requires a `component_path` — the relative path "
+            "of the file to rewrite (e.g. 'src/lib/components/Hero.svelte'). It "
+            "must already exist in the site's source map."
+        )
+    new_source = args.get("new_source")
+    if not isinstance(new_source, str):
+        return _error_response(
+            "edit_svelte_component requires `new_source` — the FULL new contents of "
+            "the file as a string (the tool replaces the whole file, not a patch)."
+        )
+    name_raw = args.get("name")
+    name = name_raw if isinstance(name_raw, str) else ""
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.sites import service as sites_service
+    from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+    try:
+        doc = await sites_service.edit_svelte_component(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            component_path=component_path,
+            new_source=new_source,
+            name=name,
+        )
+    except SmokeGateFailed as exc:
+        # The rebuilt site failed the workerd smoke render — the edit was rolled
+        # back and the live site stays on the prior deploy. Tell the agent so it
+        # can fix the component and retry, NOT report a successful edit.
+        return _error_response(
+            f"the edit did not pass the build smoke test, so the live site was not "
+            f"changed (the previous version is still deployed): {exc}"
+        )
+    except CloudError as exc:
+        # NotFound / ValidationError from the pockets service (missing pocket,
+        # not a svelte site, no such component) — relay the code + message.
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("edit_svelte_component failed", exc_info=True)
+        return _error_response(f"edit failed: {exc}")
+
+    return _success_response(
+        {
+            "ok": True,
+            "component_path": component_path,
+            "site": {
+                "id": str(doc.id),
+                "pocket_id": doc.pocket_id,
+                "name": doc.name,
+                "url": doc.url,
+                "deployed": doc.deployed,
+            },
+        }
+    )
+
+
+def make_edit_svelte_component_tool(tool: Any) -> Any:
+    """Build the ``edit_svelte_component`` SDK tool object using the SDK's
+    ``tool`` decorator (passed in by the caller that already imported it).
+
+    Registered on the SAME ``pocketpaw_sites_manager`` server as publish +
+    create_landing_site + create_svelte_site (see
+    ``make_create_landing_site_tool`` for why one server)."""
+
+    @tool(
+        "edit_svelte_component",
+        (
+            "Rewrite ONE component of an EXISTING svelte Paw Site and republish "
+            "it. Use this when the user asks to change a section of a published "
+            "svelte site — 'make the hero headline bolder', 'change the pricing "
+            "copy', 'restyle the FAQ'. You provide the FULL new file contents for "
+            "ONE file in the site's source map; the tool persists it and "
+            "republishes. Args: `pocket_id` (the svelte site pocket), "
+            "`component_path` (the relative path of the file to rewrite — it must "
+            "already exist in the source map, e.g. "
+            "'src/lib/components/Hero.svelte'), `new_source` (the whole new file "
+            "contents as a string — this REPLACES the file, it is not a patch), "
+            "and optional `name`. CRITICAL authoring rule (same as "
+            "create_svelte_site): the component must render its resting/final "
+            "state in MARKUP — never set it only in onMount — because the page is "
+            "PRERENDERED. Returns {ok, site: {id, name, url, deployed, pocket_id}, "
+            "component_path} — show the user the `url`. ok=false with an error "
+            "means the edit did NOT go live: a smoke-test failure leaves the "
+            "PREVIOUS version deployed (fix the component and retry), and a "
+            "not-found / not-a-svelte-site error means relay the reason. Do NOT "
+            "report a successful edit when ok=false."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Id of the svelte site pocket to edit.",
+                },
+                "component_path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Relative path of the file to rewrite — must already exist "
+                        "in the site's source map (e.g. "
+                        "'src/lib/components/Hero.svelte')."
+                    ),
+                },
+                "new_source": {
+                    "type": "string",
+                    "description": (
+                        "The FULL new contents of the file as a string. This "
+                        "replaces the whole file — it is not a diff/patch."
+                    ),
+                },
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Optional site name override on republish. Defaults to the "
+                        "pocket's own name."
+                    ),
+                },
+            },
+            "required": ["pocket_id", "component_path", "new_source"],
+            "additionalProperties": False,
+        },
+    )
+    async def edit_svelte_component(args):  # type: ignore[no-untyped-def]
+        return await _edit_svelte_component_handler(args)
+
+    return edit_svelte_component
+
+
 __all__ = [
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
+    "EDIT_SVELTE_COMPONENT_TOOL_ID",
     "SERVER_NAME",
     "SITES_CREATE_TOOL_IDS",
     "SVELTE_REQUIRED_EXACT_KEYS",
     "SVELTE_REQUIRED_PREFIXES",
     "make_create_landing_site_tool",
     "make_create_svelte_site_tool",
+    "make_edit_svelte_component_tool",
 ]

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -16,6 +16,12 @@
 # openable address for the cmux smoke. In the real CF path it is left "" in v1
 # (the deployed Worker is reached via its custom domain, surfaced through the
 # domains list) until a canonical workers.dev URL is wired.
+#
+# Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2b): added
+# ``builder_origin`` — the builder origin the site was published with, or "" for
+# a normal (non-editable) site. When set, the generated page carries the gated
+# edit-bridge keyed on it. Persisted so a component-edit republish re-applies it
+# and the site stays editable across edits.
 
 from __future__ import annotations
 
@@ -49,6 +55,11 @@ class Site(TimestampedDocument):
     # Canonical deployed URL. LOCAL mode: the localhost URL the per-site static
     # server serves. CF mode: "" in v1 (reached via custom domain).
     url: str = ""
+    # SE-2b: the builder origin this site was published with, or "" when it was
+    # published as a normal (non-editable) site. When set, the generated page
+    # carries the gated edit-bridge keyed on this origin. Persisted so a
+    # component-edit republish can re-apply it and the site stays editable.
+    builder_origin: str = ""
     # Capture hardening config (mirrors sites_capture.SiteFormConfig fields).
     allowed_origins: list[str] = Field(default_factory=list)
     signed_key: str = ""

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -184,6 +184,13 @@ rippleSpec). Fixes the agent-view misread where ``get_pocket`` returned the
 empty legacy ``widgets: []`` alongside the full rippleSpec and agents
 concluded a fully composed template pocket was "an empty shell". The
 ``widgets`` field itself is NOT removed — other consumers may rely on it.
+
+Changes: 2026-06-17 (feat/sites-svelte-component-edit, SE-2) — added
+``set_svelte_source_file``: rewrite ONE file in a svelte-engine pocket's
+``source`` map (the {path: contents} hand-written SvelteKit files) and persist
+it. The Pocket write stays here (entity isolation); the sites service
+orchestrates the republish. Returns the prior file contents alongside the wire
+dict so the caller can roll the edit back when the downstream smoke gate fails.
 """
 
 from __future__ import annotations
@@ -1394,6 +1401,58 @@ async def update(pocket_id: str, user_id: str, body: UpdatePocketRequest) -> dic
     await doc.save()
     await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
     return await _resolved_wire_dict(doc, user_id)
+
+
+async def set_svelte_source_file(
+    pocket_id: str,
+    user_id: str,
+    *,
+    component_path: str,
+    new_source: str,
+) -> tuple[dict, str]:
+    """Rewrite ONE file in a svelte-engine pocket's ``source`` map and persist it.
+
+    The svelte analog of editing a single component of a Paw Site: ``source`` is
+    a ``{relative_path: file_contents}`` map (the hand-written SvelteKit files),
+    and this replaces the contents at ``component_path`` with ``new_source``. The
+    Pocket Beanie write stays inside the pockets service (entity isolation — the
+    sites service orchestrates the republish but never touches the Pocket model).
+
+    Access mirrors ``update``: explicit ``(pocket_id, user_id)`` with
+    ``_check_domain_edit_access`` (owner / shared_with / workspace-visible). A
+    missing pocket raises ``NotFound``; a non-svelte pocket or a non-existent
+    component path raise the obvious cloud errors rather than silently creating a
+    file or dereferencing ``None``:
+      * not a svelte pocket (``engine != "svelte"`` or no ``source`` map) →
+        ``ValidationError`` (422);
+      * ``component_path`` absent from the map → ``NotFound`` (404) on the
+        component, so a typo'd path is not a silent create.
+
+    Returns ``(resolved_wire_dict, previous_source)`` — the wire dict every other
+    write returns, plus the file's PRIOR contents so the caller can roll the edit
+    back if the downstream republish fails its smoke gate (the sites service does
+    exactly this so a broken edit never leaves stale source on the pocket).
+    """
+    doc = await _fetch_pocket(pocket_id)
+    _check_domain_edit_access(_pocket_to_domain(doc), user_id)
+
+    if getattr(doc, "engine", "ripple") != "svelte" or not isinstance(doc.source, dict):
+        raise ValidationError(
+            "pocket.not_svelte_site",
+            "This pocket is not a svelte Paw Site — it has no component source map to edit.",
+        )
+    if component_path not in doc.source:
+        raise NotFound("site_component", component_path)
+
+    previous_source = doc.source[component_path]
+    # Reassign a fresh dict so Beanie tracks the change (in-place mutation of a
+    # dict field is not always detected as dirty by the ODM).
+    updated = dict(doc.source)
+    updated[component_path] = new_source
+    doc.source = updated
+    await doc.save()
+    await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+    return await _resolved_wire_dict(doc, user_id), previous_source
 
 
 async def merge_spec(
@@ -4408,6 +4467,7 @@ __all__ = [
     "set_pocket_approval_route",
     "set_pocket_backend",
     "set_pocket_write_policy",
+    "set_svelte_source_file",
     "unassign_project_on_pockets",
     "update",
     "update_share_link",

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -17,6 +17,10 @@
 # engine="svelte"); status is {pocket_id, status, is_live} plus the optional
 # site_id the frontend type also declares. Without these, every Preview-tab fetch
 # 404'd and the builder showed "Nothing to preview yet".
+# Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2b): added
+# MakeEditableRequest (the body for POST /sites/by-pocket/{pocket_id}/editable;
+# builder_origin optional) and SiteResponse.builder_origin so the UI can tell
+# whether a published site carries the edit-bridge (non-empty = editable).
 
 from __future__ import annotations
 
@@ -29,6 +33,15 @@ class PublishRequest(BaseModel):
     pocket_id: str
 
 
+class MakeEditableRequest(BaseModel):
+    """Body for POST /sites/by-pocket/{pocket_id}/editable (SE-2b). The builder
+    origin is optional — the service falls back to the configured dashboard
+    origin (PAW_SITES_BUILDER_ORIGIN) when it is omitted, so the body may be
+    empty."""
+
+    builder_origin: str = ""
+
+
 class SiteResponse(BaseModel):
     id: str
     pocket_id: str
@@ -37,6 +50,9 @@ class SiteResponse(BaseModel):
     deployed: bool
     signed_key: str
     url: str = ""
+    # SE-2b: the builder origin the site was published with, or "" for a normal
+    # (non-editable) site. Non-empty means the page carries the edit-bridge.
+    builder_origin: str = ""
 
 
 class SitePreviewResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -6,6 +6,14 @@
 # without Bun/workerd present.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2b): build() takes an
+# optional ``builder_origin`` and, when set, sends it on
+# ``siteConfig.builderOrigin``. The paw-sites generator (SE-1) gates the editable
+# section anchors + the postMessage edit-bridge on that field, so a site is
+# editable only when it carries a builderOrigin. The key is OMITTED when
+# ``builder_origin`` is None, so a normal (non-editable) publish's wire payload is
+# byte-identical to before this change.
+#
 # Updated 2026-06-04 (feat/sites-svelte-engine — Paw Sites "Svelte track"):
 #   * FIX: BuildResult.ripple_version is now optional and build() reads it with
 #     gen.get("rippleVersion") (was gen["rippleVersion"]). The svelte
@@ -202,6 +210,7 @@ class GeneratorClient:
         capture_signed_key: str,
         engine: str = "ripple",
         source: dict[str, str] | None = None,
+        builder_origin: str | None = None,
     ) -> BuildResult:
         """Generate + smoke-build a Paw Site, forking STAGE 2 on ``engine``.
 
@@ -213,20 +222,32 @@ class GeneratorClient:
         carries ``rippleSpec`` and OMITS ``source`` (gaining only the
         ``engine: "ripple"`` tag). ``siteConfig`` + ``theme`` are sent on both
         tracks unchanged. Stages 1, 3-8 (install/smoke/...) are track-agnostic.
+
+        ``builder_origin`` (SE-2b) makes the site EDITABLE: when set, it rides
+        ``siteConfig.builderOrigin`` and the paw-sites generator (SE-1) injects
+        the gated section anchors + the postMessage edit-bridge keyed on it. It
+        is OMITTED from the payload when ``None`` so a normal (non-editable)
+        publish keeps the exact prior wire bytes and the generator does not inject
+        the bridge.
         """
         out_dir = tempfile.mkdtemp(prefix=f"paw-site-{site_id}-")
         # §4.2: ``engine`` is always present; the STAGE-2 payload key forks on
         # it. svelte → ``source`` (no rippleSpec); ripple → ``rippleSpec`` (no
         # source). siteConfig + theme ride both tracks unchanged.
+        site_config: dict[str, Any] = {
+            "siteId": site_id,
+            "title": title,
+            "captureApiBase": capture_api_base,
+            "captureSignedKey": capture_signed_key,
+        }
+        # SE-2b: only present when the site is being published as editable, so a
+        # non-editable publish's payload is byte-identical to before this change.
+        if builder_origin:
+            site_config["builderOrigin"] = builder_origin
         input_json: dict[str, Any] = {
             "engine": engine,
             "theme": theme,
-            "siteConfig": {
-                "siteId": site_id,
-                "title": title,
-                "captureApiBase": capture_api_base,
-                "captureSignedKey": capture_signed_key,
-            },
+            "siteConfig": site_config,
         }
         if engine == "svelte":
             input_json["source"] = source or {}

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -40,10 +40,17 @@
 # workspace's site urls to the fresh live base via sites_service
 # .reserve_local_sites(ctx.workspace_id), then returns the reconciled list. Gated
 # like the other authed sites writes (fabric.write). No-op outside local mode.
+# Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2b): added POST
+# /sites/by-pocket/{pocket_id}/editable — republish the pocket's site as
+# editable (the generated page carries SE-1's gated edit-bridge). Same fabric
+# plan gate + fabric.write action scope as publish. The builder origin is
+# resolved in precedence: explicit body ``builder_origin`` > request ``Origin``
+# header > configured PAW_SITES_BUILDER_ORIGIN (env fallback in the service), so
+# the SE-3 editor's call carries the right origin with no extra wiring.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.deps import require_action_any_workspace, require_plan_feature
@@ -51,6 +58,7 @@ from pocketpaw_ee.sites import service as sites_service
 from pocketpaw_ee.sites.dto import (
     DomainRequest,
     DomainStatusResponse,
+    MakeEditableRequest,
     PublishRequest,
     SitePreviewResponse,
     SiteResponse,
@@ -96,6 +104,38 @@ async def reserve_sites(
     back unchanged."""
     await sites_service.reserve_local_sites(ctx.workspace_id)
     return await sites_service.list_for_workspace(ctx.workspace_id)
+
+
+@router.post("/sites/by-pocket/{pocket_id}/editable", response_model=SiteResponse)
+async def make_site_editable(
+    pocket_id: str,
+    request: Request,
+    body: MakeEditableRequest = MakeEditableRequest(),
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteResponse:
+    """Republish the pocket's site as EDITABLE (SE-2b): the regenerated page
+    carries the gated edit-bridge keyed on a builder origin (the dashboard the
+    page postMessages its section rects to).
+
+    The builder origin is resolved in precedence: an explicit ``builder_origin``
+    in the body (an override the SE-3 editor can pass) wins; otherwise the
+    request's ``Origin`` header (the dashboard origin the call came from); and
+    the service falls back to the configured ``PAW_SITES_BUILDER_ORIGIN`` when
+    neither is present, so the call works with no body and no Origin header.
+
+    The pocket read inside ``publish_pocket`` raises NotFound / Forbidden itself,
+    mapped to 404 / 403 by the error envelope."""
+    # Body override beats the Origin header; the service applies the env fallback
+    # when both are blank. headers.get returns None when absent.
+    builder_origin = (body.builder_origin or "").strip() or (request.headers.get("origin") or "")
+    doc = await sites_service.make_site_editable(
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        pocket_id=pocket_id,
+        builder_origin=builder_origin,
+    )
+    return sites_service._to_response(doc)
 
 
 @router.get("/sites", response_model=list[SiteResponse])

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -70,6 +70,28 @@
 # creds ARE present (or a CF client is injected, e.g. by tests). PROD TODO: local
 # mode is a dev shim — production always takes the CF path.
 #
+# Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2b): thread
+# ``builder_origin`` through the publish path so a svelte Paw Site stays
+# editable. publish()/publish_pocket() forward it to generator.build() (it rides
+# siteConfig.builderOrigin, which SE-1's generator gates the edit-bridge on) and
+# store it on the Site doc. edit_svelte_component() recovers the stored origin
+# from the pocket's current Site (via _latest_site_for_pocket) and re-applies it,
+# so a component edit does not strip the bridge. make_site_editable() republishes
+# a pocket as editable (builder_origin set, defaulting to PAW_SITES_BUILDER_ORIGIN)
+# and backs POST /sites/by-pocket/{pocket_id}/editable.
+#
+# Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2): added
+# edit_svelte_component() — rewrite ONE file of a svelte Paw Site pocket's
+# ``source`` map and safely republish. It delegates the Pocket write to the
+# pockets service (set_svelte_source_file — entity isolation), then calls
+# publish_pocket() to regenerate + smoke-gate + redeploy. publish() smoke-gates
+# BEFORE it deploys, so a broken edit never reaches the live deploy; on
+# SmokeGateFailed this function ALSO rolls the persisted source back to its prior
+# contents and re-raises, so neither the deploy nor the stored source is left
+# broken. This is the chat-agent surface for a targeted component edit, exposed
+# beside create_landing_site / create_svelte_site / publish on the
+# pocketpaw_sites_manager MCP server.
+#
 # Updated 2026-06-03 (Sites backend fixes A+B): (A) added site_pocket_ids() — the
 # set of pocket_ids that have a Site in a workspace, so the /pockets gallery can
 # exclude already-published pockets WITHOUT the pockets service importing the Site
@@ -140,6 +162,17 @@ def _capture_base() -> str:
     import os
 
     return os.environ.get("PAW_CAPTURE_API_BASE", "http://localhost:8888/api/v1")
+
+
+def _builder_origin() -> str:
+    """The dashboard/builder origin an editable Paw Site postMessages its
+    section rects to (SE-2b). The generated edit-bridge only accepts messages
+    from this exact origin. Defaults to the local dashboard; overridable via
+    PAW_SITES_BUILDER_ORIGIN. Used by ``make_site_editable`` when the caller does
+    not pass an explicit origin."""
+    import os
+
+    return os.environ.get("PAW_SITES_BUILDER_ORIGIN", "http://localhost:8888")
 
 
 # The default logical form type. The generated /api/submit endpoint sends this
@@ -214,6 +247,9 @@ def _to_response(doc: _SiteDoc) -> SiteResponse:
         deployed=doc.deployed,
         signed_key=doc.signed_key,
         url=doc.url,
+        # SE-2b: surface whether the site is editable (non-empty = carries the
+        # edit-bridge) so the UI can show/hide the inline-edit affordance.
+        builder_origin=getattr(doc, "builder_origin", ""),
     )
 
 
@@ -227,6 +263,7 @@ async def publish(
     name: str = "",
     engine: str = "ripple",
     source: dict[str, str] | None = None,
+    builder_origin: str | None = None,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
@@ -250,7 +287,13 @@ async def publish(
     respecting entity isolation) and uses its ``name`` field; only when the pocket
     has no name does it fall back to "Untitled site". Callers that pre-resolve the
     name (e.g. ``publish_pocket``, which already holds the wire dict) pass it in,
-    so the common path does not re-fetch."""
+    so the common path does not re-fetch.
+
+    ``builder_origin`` (SE-2b) makes the site EDITABLE: when set, it rides
+    ``siteConfig.builderOrigin`` so the paw-sites generator injects the gated
+    edit-bridge, and it is persisted on the Site doc so a later component-edit
+    republish can re-apply it. ``None`` (the default) publishes a normal,
+    non-editable site (empty ``builder_origin`` on the doc, no bridge)."""
     generator = _generator or GeneratorClient()
 
     # Default a blank name to the source pocket's own display name so the schema's
@@ -278,6 +321,7 @@ async def publish(
         capture_signed_key=signed_key,
         engine=engine,
         source=source,
+        builder_origin=builder_origin,
     )
 
     # Local mode only when the caller did NOT inject a CF client (tests inject a
@@ -304,6 +348,9 @@ async def publish(
         deployed=True,
         signed_key=signed_key,
         url=url,
+        # SE-2b: persist the builder origin (or "") so a component-edit republish
+        # can re-apply it and the site stays editable across edits.
+        builder_origin=builder_origin or "",
         # Seed capture config so a lead lands with no manual Mongo edit: a default
         # mapping keyed on the form_type the generated endpoint sends, and the
         # local dev origins so the local smoke works. add_domain() appends the
@@ -398,6 +445,7 @@ async def publish_pocket(
     user_id: str,
     pocket_id: str,
     name: str = "",
+    builder_origin: str | None = None,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
@@ -416,6 +464,10 @@ async def publish_pocket(
     wire dict this function already holds, so ``publish`` does not re-fetch the
     pocket on this path. (``publish`` carries the same fallback as a safety net for
     direct callers who pass a blank name.)
+
+    ``builder_origin`` (SE-2b) is forwarded straight through so a publish via this
+    shared path can request an editable site (the edit-bridge gates on it). It
+    defaults to ``None`` (a normal, non-editable publish).
 
     The generator / Cloudflare / bundle-reader / local-deploy seams are forwarded
     straight through to ``publish`` so the shared path is unit-testable without
@@ -444,6 +496,146 @@ async def publish_pocket(
         engine=engine,
         source=source,
         name=name or pocket.get("name", ""),
+        builder_origin=builder_origin,
+        _generator=_generator,
+        _cloudflare=_cloudflare,
+        _bundle_reader=_bundle_reader,
+        _local_deploy=_local_deploy,
+    )
+
+
+async def edit_svelte_component(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    component_path: str,
+    new_source: str,
+    name: str = "",
+    _generator: GeneratorClient | None = None,
+    _cloudflare: Any | None = None,
+    _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
+    _local_deploy: Callable[[str, str], str] | None = None,
+) -> _SiteDoc:
+    """Rewrite ONE component of a svelte Paw Site pocket and safely republish.
+
+    The chat-agent entry point for a targeted component edit: it replaces the
+    file at ``component_path`` in the pocket's svelte ``source`` map with
+    ``new_source`` and republishes the site. The Pocket write is owned by the
+    pockets service (``set_svelte_source_file`` — entity isolation); this
+    function only orchestrates persist → republish.
+
+    Safety contract — a broken edit must leave NEITHER a broken deploy NOR stale
+    source on the pocket:
+      1. persist the new component source (the pockets service validates the
+         pocket is a svelte site and that ``component_path`` exists, raising
+         ValidationError / NotFound otherwise — propagated to the caller);
+      2. republish via ``publish_pocket`` (regenerate + smoke-gate + redeploy);
+      3. if the republish raises ``SmokeGateFailed`` (the workerd smoke render
+         rejects the edited site), ROLL BACK the persisted source to its prior
+         contents and re-raise. ``publish`` smoke-gates BEFORE it deploys, so the
+         prior live deploy is already untouched; the rollback keeps the stored
+         source matching that last-good deploy so a later publish is not broken.
+
+    SE-2b: the republish recovers the ``builder_origin`` stored on the pocket's
+    current Site doc and re-applies it, so an EDITABLE site stays editable after
+    an edit (and a non-editable one stays non-editable — there is no origin to
+    re-apply). Without this, a republish would publish a fresh non-editable site
+    and strip the edit-bridge SE-1 gates on ``builderOrigin``.
+
+    The generator / Cloudflare / bundle-reader / local-deploy seams forward
+    straight to ``publish_pocket`` so the path is unit-testable without
+    Bun / workerd / Cloudflare.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+    # SE-2b: recover the builder origin the site is currently published with so
+    # the republish keeps the edit-bridge. "" (or no prior site) republishes
+    # non-editable, exactly as before.
+    prior = await _latest_site_for_pocket(workspace_id, pocket_id)
+    builder_origin = prior.builder_origin if prior else ""
+
+    # 1. Persist the edit (pockets service owns the Pocket write + validation).
+    #    ``previous_source`` is the file's prior contents, held for rollback.
+    _wire, previous_source = await pockets_service.set_svelte_source_file(
+        pocket_id,
+        user_id,
+        component_path=component_path,
+        new_source=new_source,
+    )
+
+    # 2. Republish. 3. On a smoke-gate failure, restore the prior source so the
+    #    pocket never carries a component the renderer rejects — then re-raise so
+    #    the caller surfaces the reason. The prior deploy is untouched because the
+    #    gate fires before publish deploys.
+    try:
+        return await publish_pocket(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            name=name,
+            builder_origin=builder_origin or None,
+            _generator=_generator,
+            _cloudflare=_cloudflare,
+            _bundle_reader=_bundle_reader,
+            _local_deploy=_local_deploy,
+        )
+    except SmokeGateFailed:
+        await pockets_service.set_svelte_source_file(
+            pocket_id,
+            user_id,
+            component_path=component_path,
+            new_source=previous_source,
+        )
+        raise
+
+
+async def _latest_site_for_pocket(workspace_id: str, pocket_id: str) -> _SiteDoc | None:
+    """Return the most recently published Site doc for ``pocket_id`` in this
+    workspace, or ``None`` if the pocket was never published.
+
+    ``publish`` inserts a fresh Site doc per publish, so a pocket can have more
+    than one Site row; the newest (by ``createdAt``) is the live one. SE-2b uses
+    this to recover the ``builder_origin`` a republish must re-apply. Tenant-
+    scoped on ``workspace``."""
+    return await (
+        _SiteDoc.find({"workspace": workspace_id, "pocket_id": pocket_id})
+        .sort(-_SiteDoc.createdAt)  # type: ignore[operator]
+        .first_or_none()
+    )
+
+
+async def make_site_editable(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    builder_origin: str | None = None,
+    _generator: GeneratorClient | None = None,
+    _cloudflare: Any | None = None,
+    _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
+    _local_deploy: Callable[[str, str], str] | None = None,
+) -> _SiteDoc:
+    """Republish a pocket's site as EDITABLE (SE-2b).
+
+    Backs ``POST /sites/by-pocket/{pocket_id}/editable``: it republishes the
+    pocket with ``builder_origin`` set so the generated page carries the gated
+    edit-bridge, and persists that origin on the Site doc. ``builder_origin``
+    defaults to the configured dashboard origin (``PAW_SITES_BUILDER_ORIGIN``)
+    when the caller does not pass one, so the endpoint works with no body.
+
+    Delegates to ``publish_pocket`` (reads the pocket, regenerates, smoke-gates,
+    redeploys), so it inherits the same NotFound / Forbidden propagation and the
+    smoke gate — a build that fails the gate raises ``SmokeGateFailed`` and the
+    prior deploy is untouched.
+    """
+    origin = (builder_origin or "").strip() or _builder_origin()
+    return await publish_pocket(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        builder_origin=origin,
         _generator=_generator,
         _cloudflare=_cloudflare,
         _bundle_reader=_bundle_reader,
@@ -583,6 +775,8 @@ __all__ = [
     "publish_pocket",
     "preview_pocket",
     "pocket_status",
+    "edit_svelte_component",
+    "make_site_editable",
     "add_domain",
     "domain_status",
     "list_domains",

--- a/tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py
@@ -1,0 +1,214 @@
+# tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py
+# Created: 2026-06-17 (feat/sites-svelte-component-edit, SE-2) — coverage for the
+# targeted svelte-component edit tool ``edit_svelte_component`` on the in-process
+# ``pocketpaw_sites_manager`` server. Two layers:
+#   1. Registration — the tool id rides the SAME server allowlist as publish +
+#      create_landing_site + create_svelte_site, and the provider advertises it.
+#   2. Handler wiring — identity gating, input validation, the success response
+#      shape, and error MAPPING: a SmokeGateFailed from the service becomes an
+#      is_error telling the agent the live site is unchanged; a CloudError
+#      (NotFound / not-a-svelte-site) is relayed by code. The service-level
+#      persist + republish + rollback logic is covered by
+#      tests/ee/sites/test_component_edit.py; here we pin the agent surface.
+"""Tests for the targeted svelte-component edit tool (edit_svelte_component)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+def _identity(workspace_id: str | None, user_id: str | None):
+    """Context managers patching the per-stream identity ContextVar accessors."""
+    return (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            return_value=workspace_id,
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            return_value=user_id,
+        ),
+    )
+
+
+class _FakeSiteDoc:
+    """Stand-in for the Site Beanie doc the service returns — only the fields the
+    handler reads onto the response."""
+
+    def __init__(self) -> None:
+        from bson import ObjectId
+
+        self.id = ObjectId()
+        self.pocket_id = "pk1"
+        self.name = "Bright Smile"
+        self.url = "http://127.0.0.1:9999/site/"
+        self.deployed = True
+
+
+# ---------------------------------------------------------------------------
+# Registration — the tool rides the shared sites_manager allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_tool_id_on_shared_server_allowlist(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import (
+            EDIT_SVELTE_COMPONENT_TOOL_ID,
+            SITES_TOOL_IDS,
+        )
+
+        assert (
+            EDIT_SVELTE_COMPONENT_TOOL_ID == "mcp__pocketpaw_sites_manager__edit_svelte_component"
+        )
+        assert EDIT_SVELTE_COMPONENT_TOOL_ID in SITES_TOOL_IDS
+
+    def test_provider_advertises_edit_tool_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import EDIT_SVELTE_COMPONENT_TOOL_ID
+        from pocketpaw_ee.extensions import CloudSitesMcpProvider
+
+        assert EDIT_SVELTE_COMPONENT_TOOL_ID in CloudSitesMcpProvider().tool_ids()
+
+
+# ---------------------------------------------------------------------------
+# Handler wiring — identity, validation, response shape, error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestEditHandler:
+    @pytest.mark.asyncio
+    async def test_success_returns_site_and_component_path(self) -> None:
+        """A successful edit returns {ok, component_path, site:{...}} and forwards
+        the agent's identity + inputs to the service."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        ws_patch, user_patch = _identity("ws1", "u1")
+        fake = AsyncMock(return_value=_FakeSiteDoc())
+        with (
+            ws_patch,
+            user_patch,
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_svelte_component",
+                new=fake,
+            ),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                    "new_source": "<section/>",
+                }
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        assert body["component_path"] == "src/lib/components/Hero.svelte"
+        assert body["site"]["pocket_id"] == "pk1"
+        assert body["site"]["deployed"] is True
+        # The service got the agent identity + the edit inputs.
+        fake.assert_awaited_once()
+        kwargs = fake.await_args.kwargs
+        assert kwargs["workspace_id"] == "ws1"
+        assert kwargs["user_id"] == "u1"
+        assert kwargs["component_path"] == "src/lib/components/Hero.svelte"
+        assert kwargs["new_source"] == "<section/>"
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=(None, None)):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                    "new_source": "<section/>",
+                }
+            )
+        assert out.get("is_error") is True
+        assert "workspace and user context" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_component_path_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_svelte_component_handler(
+                {"pocket_id": "pk1", "new_source": "<section/>"}
+            )
+        assert out.get("is_error") is True
+        assert "`component_path`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_non_string_new_source_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                    "new_source": {"not": "a string"},
+                }
+            )
+        assert out.get("is_error") is True
+        assert "`new_source`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_smoke_gate_failure_maps_to_unchanged_site_error(self) -> None:
+        """A SmokeGateFailed from the service becomes a clear is_error: the live
+        site is unchanged (prior version still deployed). The agent must NOT
+        report a successful edit."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+        from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_svelte_component",
+                new=AsyncMock(side_effect=SmokeGateFailed("workerd SSR failure")),
+            ),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                    "new_source": "<broken/>",
+                }
+            )
+        assert out.get("is_error") is True
+        text = out["content"][0]["text"]
+        assert "smoke test" in text
+        assert "previous version is still deployed" in text
+
+    @pytest.mark.asyncio
+    async def test_cloud_error_is_relayed_by_code(self) -> None:
+        """A CloudError (e.g. NotFound on the component) is relayed by code +
+        message so the agent can tell the user what was wrong."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+        from pocketpaw_ee.cloud._core.errors import NotFound
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_svelte_component",
+                new=AsyncMock(
+                    side_effect=NotFound("site_component", "src/lib/components/X.svelte")
+                ),
+            ),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/X.svelte",
+                    "new_source": "<section/>",
+                }
+            )
+        assert out.get("is_error") is True
+        assert "site_component.not_found" in out["content"][0]["text"]

--- a/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
@@ -27,6 +27,7 @@ class TestSitesMcpServerRegistration:
         from pocketpaw_ee.agent.mcp_servers.sites import (
             CREATE_LANDING_SITE_TOOL_ID,
             CREATE_SVELTE_SITE_TOOL_ID,
+            EDIT_SVELTE_COMPONENT_TOOL_ID,
             PUBLISH_TOOL_ID,
             SERVER_NAME,
             SITES_TOOL_IDS,
@@ -35,16 +36,21 @@ class TestSitesMcpServerRegistration:
         assert SERVER_NAME == "pocketpaw_sites_manager"
         # Allowlist entries must use the exact ``mcp__<server>__<tool>`` form.
         assert PUBLISH_TOOL_ID == "mcp__pocketpaw_sites_manager__publish"
-        # The deterministic create tools register on the SAME server (two
-        # create_sdk_mcp_server calls under one name would clobber each other),
-        # so all ids ride the one ``pocketpaw_sites_manager`` server: the ripple
-        # landing tool + the svelte-track tool sit beside publish.
+        # The deterministic create tools + the targeted edit tool register on the
+        # SAME server (two create_sdk_mcp_server calls under one name would clobber
+        # each other), so all ids ride the one ``pocketpaw_sites_manager`` server:
+        # the ripple landing tool, the svelte-track tool, and the component-edit
+        # tool sit beside publish.
         assert CREATE_LANDING_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_landing_site"
         assert CREATE_SVELTE_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_svelte_site"
+        assert (
+            EDIT_SVELTE_COMPONENT_TOOL_ID == "mcp__pocketpaw_sites_manager__edit_svelte_component"
+        )
         assert PUBLISH_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_LANDING_SITE_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_SVELTE_SITE_TOOL_ID in SITES_TOOL_IDS
-        assert len(SITES_TOOL_IDS) == 3
+        assert EDIT_SVELTE_COMPONENT_TOOL_ID in SITES_TOOL_IDS
+        assert len(SITES_TOOL_IDS) == 4
 
     def test_extension_provider_advertises_tool_id(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk

--- a/tests/ee/sites/test_builder_origin.py
+++ b/tests/ee/sites/test_builder_origin.py
@@ -1,0 +1,272 @@
+# tests/ee/sites/test_builder_origin.py — exercises threading builderOrigin
+# through the publish path so a svelte Paw Site stays editable across republish.
+# Created: 2026-06-17 (feat/sites-svelte-component-edit, SE-2b).
+#
+# Background: SE-1 (paw-sites generator) gates the editable section anchors + the
+# postMessage edit-bridge on ``SiteConfig.builderOrigin``. The publish path never
+# set it, so (a) a site was never editable and (b) an edit-republish would strip
+# the bridge. These tests pin the pocketpaw side: publish/publish_pocket thread a
+# ``builder_origin`` to the generator AND store it on the Site doc;
+# edit_svelte_component reuses the STORED value so an editable site stays editable
+# after a component edit; and make_site_editable republishes a site as editable.
+#
+# Fakes inject the generator + CF client so no Bun/workerd/Cloudflare is touched.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+
+_HERO_V1 = "<section class='hero'><h1>Bright Smile</h1></section>"
+_HERO_V2 = "<section class='hero'><h1>Brighter Smiles</h1></section>"
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css'</script><slot/>",
+    "src/routes/+page.ts": "export const prerender = true",
+    "src/app.css": ":root{--brand:#0A84FF}",
+    "src/lib/components/Hero.svelte": _HERO_V1,
+}
+
+
+class _FakeGenerator:
+    def __init__(self):
+        self.built = None
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version=None)
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Install a recording EventBus so pockets-service emits don't raise."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    return pocket_id
+
+
+@pytest.mark.asyncio
+async def test_publish_stores_builder_origin_and_forwards_to_generator(beanie_test_db):
+    """publish(builder_origin=...) hands it to the generator AND persists it on
+    the Site doc, so a later republish can recover it."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        builder_origin="https://app.paw.example",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    assert gen.built["builder_origin"] == "https://app.paw.example"
+    assert site.builder_origin == "https://app.paw.example"
+    fresh = await _SiteDoc.get(site.id)
+    assert fresh.builder_origin == "https://app.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_publish_default_builder_origin_is_empty(beanie_test_db):
+    """A publish with no builder_origin stores "" and does NOT forward an origin
+    to the generator — the site is not editable (no bridge)."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    assert site.builder_origin == ""
+    # build() got no origin (None), so the generator omits builderOrigin.
+    assert gen.built.get("builder_origin") in (None, "")
+
+
+@pytest.mark.asyncio
+async def test_publish_pocket_threads_builder_origin(beanie_test_db):
+    """publish_pocket(builder_origin=...) forwards it through to publish + the
+    generator."""
+    from unittest.mock import AsyncMock, patch
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    wire = {"name": "Bright Smile", "rippleSpec": {"type": "container"}}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        site = await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk1",
+            builder_origin="https://app.paw.example",
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"x",
+        )
+    assert gen.built["builder_origin"] == "https://app.paw.example"
+    assert site.builder_origin == "https://app.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_edit_component_preserves_stored_builder_origin(beanie_test_db):
+    """The key SE-2b guarantee: editing a component of an EDITABLE site keeps it
+    editable. The component-edit republish recovers the builder_origin stored on
+    the prior Site doc and re-sends it to the generator, so the bridge survives."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    # First publish the site as EDITABLE (builder_origin set).
+    first = await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://app.paw.example",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+    assert first.builder_origin == "https://app.paw.example"
+
+    # Now edit a component. The republish must re-apply the stored origin.
+    gen = _FakeGenerator()
+    site = await sites_service.edit_svelte_component(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/lib/components/Hero.svelte",
+        new_source=_HERO_V2,
+        _generator=gen,
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+    # The edited site is STILL editable — builder_origin carried through.
+    assert gen.built["builder_origin"] == "https://app.paw.example"
+    assert site.builder_origin == "https://app.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_edit_component_on_non_editable_site_stays_non_editable(beanie_test_db):
+    """A site published WITHOUT a builder_origin stays non-editable after an
+    edit — the republish does not invent an origin."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+    gen = _FakeGenerator()
+    site = await sites_service.edit_svelte_component(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/lib/components/Hero.svelte",
+        new_source=_HERO_V2,
+        _generator=gen,
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+    assert site.builder_origin == ""
+    assert gen.built.get("builder_origin") in (None, "")
+
+
+@pytest.mark.asyncio
+async def test_make_site_editable_republishes_with_origin(beanie_test_db):
+    """make_site_editable republishes the pocket's site WITH a builder_origin so
+    the generator injects the edit-bridge. Backs POST
+    /sites/by-pocket/{pocket_id}/editable."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    # Start non-editable.
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+    gen = _FakeGenerator()
+    site = await sites_service.make_site_editable(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://app.paw.example",
+        _generator=gen,
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+    assert site.builder_origin == "https://app.paw.example"
+    assert gen.built["builder_origin"] == "https://app.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_make_site_editable_defaults_builder_origin_from_config(beanie_test_db, monkeypatch):
+    """When no builder_origin is passed, make_site_editable falls back to the
+    configured PAW_SITES_BUILDER_ORIGIN so the endpoint works with no arg."""
+    monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "https://configured.paw.example")
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen = _FakeGenerator()
+    site = await sites_service.make_site_editable(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=gen,
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+    assert site.builder_origin == "https://configured.paw.example"
+    assert gen.built["builder_origin"] == "https://configured.paw.example"

--- a/tests/ee/sites/test_component_edit.py
+++ b/tests/ee/sites/test_component_edit.py
@@ -1,0 +1,245 @@
+# tests/ee/sites/test_component_edit.py — exercises the targeted svelte-component
+# edit + republish path (sites_service.edit_svelte_component). Created:
+# 2026-06-17 (feat/sites-svelte-component-edit, SE-2).
+#
+# The flow under test: one component file of a svelte Paw Site pocket is
+# rewritten and the site is safely republished. These tests use the shared
+# ``beanie_test_db`` fixture (an in-memory Mongo) so the pockets service persists
+# a real svelte Pocket doc, and inject a fake generator + CF client so no
+# Bun/workerd/Cloudflare is touched. They prove:
+#   (a) a component edit reaches the regenerated build (the new source is what
+#       the generator materializes) and persists on the pocket;
+#   (b) a deliberately-broken edit fails the smoke gate (SmokeGateFailed
+#       propagates), the live deploy is unchanged, and the persisted source is
+#       rolled back to the last good contents so the next publish is not broken;
+#   (c) the standard not-found / wrong-engine / unknown-component guards.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+# A minimal but §4.3-complete svelte source map — enough to stand in for a real
+# Paw Site pocket. The component under edit is Hero.svelte.
+_HERO_V1 = "<section class='hero'><h1>Bright Smile</h1></section>"
+_HERO_V2 = "<section class='hero'><h1>Brighter Smiles, Whiter Teeth</h1></section>"
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css'</script><slot/>",
+    "src/routes/+page.ts": "export const prerender = true",
+    "src/app.css": ":root{--brand:#0A84FF}",
+    "src/lib/components/Hero.svelte": _HERO_V1,
+}
+
+
+class _FakeGenerator:
+    """Records the source map it was asked to build so a test can assert the
+    edited component reached the regenerated build."""
+
+    def __init__(self):
+        self.built = None
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version=None)
+
+
+class _SmokeFailGenerator:
+    """Stands in for a generator whose workerd smoke render fails — exactly how
+    ``GeneratorClient.build`` signals a broken site (it raises SmokeGateFailed
+    BEFORE any deploy)."""
+
+    def __init__(self):
+        self.built = None
+
+    async def build(self, **kw):
+        self.built = kw
+        raise SmokeGateFailed("workerd SSR failure: document is not defined")
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Install a recording EventBus so the pockets service's ``emit`` calls
+    (PocketCreated on create, PocketUpdated on the component edit) don't raise —
+    the real bus is only wired by ``init_realtime()`` at boot. Mirrors the same
+    fixture in tests/cloud/conftest.py / the sites-MCP tests."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    """Persist a real svelte-engine Pocket via the pockets service and return its
+    id. Mirrors how ``create_svelte_site`` lands a pocket: type='site',
+    pattern='landing', engine='svelte', source=<map>, trusted=True."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+@pytest.mark.asyncio
+async def test_edit_component_republishes_with_new_source(beanie_test_db):
+    """A component edit is persisted on the pocket AND reaches the regenerated
+    build: the generator materializes the NEW Hero source, not the old one."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen, cf = _FakeGenerator(), _FakeCF()
+
+    site = await sites_service.edit_svelte_component(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/lib/components/Hero.svelte",
+        new_source=_HERO_V2,
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+    )
+
+    assert site.deployed is True
+    assert site.pocket_id == pocket_id
+    # The regenerated build materialized the EDITED component, not the original.
+    assert gen.built is not None
+    assert gen.built["engine"] == "svelte"
+    assert gen.built["source"]["src/lib/components/Hero.svelte"] == _HERO_V2
+    # Untouched files came through verbatim.
+    assert gen.built["source"]["src/routes/+page.ts"] == "export const prerender = true"
+
+    # The edit persisted on the pocket — a re-read shows the new source.
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == _HERO_V2
+
+
+@pytest.mark.asyncio
+async def test_broken_edit_propagates_smoke_gate_and_rolls_back(beanie_test_db):
+    """A deliberately-broken edit fails the smoke gate: SmokeGateFailed
+    propagates, NO worker is deployed (the prior deploy stays), and the persisted
+    source is ROLLED BACK to the last good contents so the next publish is not
+    broken."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen, cf = _SmokeFailGenerator(), _FakeCF()
+
+    broken = "<script>onMount(() => { throw new Error('boom') })</script>"
+    with pytest.raises(SmokeGateFailed):
+        await sites_service.edit_svelte_component(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/lib/components/Hero.svelte",
+            new_source=broken,
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"export default {}",
+        )
+
+    # The smoke gate fired BEFORE any deploy — no worker was put.
+    assert cf.put_calls == []
+    # The broken edit WAS handed to the generator (so the gate saw it) ...
+    assert gen.built["source"]["src/lib/components/Hero.svelte"] == broken
+    # ... but the persisted source was rolled back to the last good contents, so a
+    # later publish would not rebuild the broken page.
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_edit_unknown_component_raises_not_found(beanie_test_db):
+    """Editing a component path that does not exist in the pocket's source map
+    raises NotFound (404) — the agent gets a clear 'no such component', not a
+    silent create or a 500."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    with pytest.raises(NotFound):
+        await sites_service.edit_svelte_component(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/lib/components/DoesNotExist.svelte",
+            new_source="<section/>",
+            _generator=_FakeGenerator(),
+            _cloudflare=_FakeCF(),
+            _bundle_reader=lambda d: b"x",
+        )
+
+
+@pytest.mark.asyncio
+async def test_edit_missing_pocket_raises_not_found(beanie_test_db):
+    """A missing pocket id raises NotFound, mapped by callers to a 404 / is_error."""
+    with pytest.raises(NotFound):
+        await sites_service.edit_svelte_component(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="0123456789abcdef01234567",
+            component_path="src/lib/components/Hero.svelte",
+            new_source="<section/>",
+            _generator=_FakeGenerator(),
+            _cloudflare=_FakeCF(),
+            _bundle_reader=lambda d: b"x",
+        )
+
+
+@pytest.mark.asyncio
+async def test_edit_ripple_pocket_rejected(beanie_test_db):
+    """A ripple-engine pocket has no svelte ``source`` map — editing a component
+    on it is a clear CloudError, not a None-deref or a 500."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Ripple Pocket",
+        type_="site",
+        pattern="landing",
+        ripple_spec={"type": "container"},
+        # engine defaults to "ripple", source stays None
+    )
+    assert err is None, err
+    with pytest.raises(CloudError):
+        await sites_service.edit_svelte_component(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/lib/components/Hero.svelte",
+            new_source="<section/>",
+            _generator=_FakeGenerator(),
+            _cloudflare=_FakeCF(),
+            _bundle_reader=lambda d: b"x",
+        )

--- a/tests/ee/sites/test_generator_client_svelte.py
+++ b/tests/ee/sites/test_generator_client_svelte.py
@@ -10,6 +10,14 @@
 # generator would parse, without spawning bun/node/workerd. siteConfig + theme
 # ride both tracks unchanged; install + smoke stay track-agnostic.
 #
+# Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2b): added coverage
+# that build() threads an optional ``builder_origin`` into
+# ``siteConfig.builderOrigin``. The paw-sites generator (SE-1) gates the
+# editable section anchors + the postMessage edit-bridge on this field, so a
+# site is only editable when it carries a builderOrigin. It is OMITTED from the
+# payload when not set, so non-editable publishes keep the exact prior wire
+# bytes.
+#
 # Updated 2026-06-04: added test_svelte_result_shape_no_ripple_version, a
 # regression for an integration KeyError. A's real generator returns
 # ``{"projectDir", "engine"}`` for svelte (NO ``rippleVersion`` — types.ts §4.2),
@@ -127,6 +135,52 @@ async def test_engine_defaults_to_ripple_when_unspecified() -> None:
     assert sent["engine"] == "ripple"
     assert "rippleSpec" in sent
     assert "source" not in sent
+
+
+@pytest.mark.asyncio
+async def test_builder_origin_is_threaded_into_site_config() -> None:
+    """SE-2b: build(builder_origin=...) puts it on siteConfig.builderOrigin so
+    the paw-sites generator injects the gated edit-bridge. A site is only
+    editable when this field is present."""
+    runner = _CapturingRunner()
+    client = GeneratorClient(_runner=runner)
+    await client.build(
+        engine="svelte",
+        source=_SOURCE_MAP,
+        ripple_spec=None,
+        theme={},
+        site_id="site_sv",
+        title="Tally",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+        builder_origin="https://app.paw.example",
+    )
+    sent = runner.input_json
+    assert sent is not None
+    assert sent["siteConfig"]["builderOrigin"] == "https://app.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_builder_origin_omitted_when_not_set() -> None:
+    """A normal (non-editable) publish carries NO builderOrigin key — the wire
+    payload is byte-identical to before SE-2b, so the generator does not inject
+    the bridge."""
+    runner = _CapturingRunner()
+    client = GeneratorClient(_runner=runner)
+    await client.build(
+        engine="svelte",
+        source=_SOURCE_MAP,
+        ripple_spec=None,
+        theme={},
+        site_id="site_sv",
+        title="Tally",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+        # builder_origin omitted
+    )
+    sent = runner.input_json
+    assert sent is not None
+    assert "builderOrigin" not in sent["siteConfig"]
 
 
 class _SvelteShapeRunner:

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -3,6 +3,13 @@
 # covers GET /sites/{site_id}/domains end-to-end through a FastAPI app — the new
 # tenant-scoped domains read backing the Domains tab's reload rehydration.
 #
+# Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2b): covers POST
+# /sites/by-pocket/{pocket_id}/editable — the route republishes the pocket as
+# editable. The handler delegates to the service, so the tests patch
+# publish_pocket (the real generator would spawn bun) and assert the route
+# resolves the builder origin in precedence (explicit body > Origin header >
+# configured env fallback) and returns the editable SiteResponse.
+#
 # Auth wiring mirrors tests/cloud/test_ee_fabric_list_endpoints.py: the sites
 # router gates on require_plan_feature("fabric") (router level) +
 # require_action_any_workspace("fabric.read"), both of which resolve the caller
@@ -283,3 +290,147 @@ async def test_post_reserve_returns_reconciled_list(beanie_test_db, monkeypatch)
             local_server._server.shutdown()
             local_server._server.server_close()
             local_server._server = None
+
+
+@pytest.mark.asyncio
+async def test_make_editable_route_republishes_with_builder_origin(beanie_test_db, monkeypatch):
+    """POST /sites/by-pocket/{pocket_id}/editable republishes the pocket as
+    editable and returns the editable SiteResponse (builder_origin set). The real
+    generator would spawn bun, so publish_pocket is patched to record the
+    forwarded builder_origin."""
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_publish_pocket(*, builder_origin=None, **kw):
+        captured["builder_origin"] = builder_origin
+        return _SiteDoc(
+            id=ObjectId(),
+            workspace="ws_owner",
+            pocket_id="pk1",
+            owner="user-test-1",
+            name="Owner Site",
+            script_name="site1",
+            deployed=True,
+            signed_key="k",
+            builder_origin=builder_origin or "",
+        )
+
+    monkeypatch.setattr(sites_service, "publish_pocket", _fake_publish_pocket)
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/by-pocket/pk1/editable",
+            json={"builder_origin": "https://app.paw.example"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert captured["builder_origin"] == "https://app.paw.example"
+    body = resp.json()
+    assert body["pocket_id"] == "pk1"
+    assert body["builder_origin"] == "https://app.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_make_editable_route_empty_body_falls_back_to_config(beanie_test_db, monkeypatch):
+    """An empty body works — the service falls back to the configured dashboard
+    origin (PAW_SITES_BUILDER_ORIGIN)."""
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    monkeypatch.setenv("PAW_SITES_BUILDER_ORIGIN", "https://configured.paw.example")
+
+    async def _fake_publish_pocket(*, builder_origin=None, **kw):
+        return _SiteDoc(
+            id=ObjectId(),
+            workspace="ws_owner",
+            pocket_id="pk1",
+            owner="user-test-1",
+            name="Owner Site",
+            script_name="site1",
+            deployed=True,
+            signed_key="k",
+            builder_origin=builder_origin or "",
+        )
+
+    # make_site_editable computes the origin (the PAW_SITES_BUILDER_ORIGIN
+    # fallback) BEFORE it calls publish_pocket, so patching publish_pocket still
+    # exercises the genuine fallback and the resolved origin reaches the response.
+    monkeypatch.setattr(sites_service, "publish_pocket", _fake_publish_pocket)
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        # No Origin header and no body field -> the configured env fallback fires.
+        resp = await c.post("/api/v1/sites/by-pocket/pk1/editable", json={})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["builder_origin"] == "https://configured.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_make_editable_route_uses_origin_header(beanie_test_db, monkeypatch):
+    """When the body carries no builder_origin, the route derives it from the
+    request's Origin header — the dashboard origin the SE-3 editor calls from."""
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_publish_pocket(*, builder_origin=None, **kw):
+        captured["builder_origin"] = builder_origin
+        return _SiteDoc(
+            id=ObjectId(),
+            workspace="ws_owner",
+            pocket_id="pk1",
+            owner="user-test-1",
+            name="Owner Site",
+            script_name="site1",
+            deployed=True,
+            signed_key="k",
+            builder_origin=builder_origin or "",
+        )
+
+    monkeypatch.setattr(sites_service, "publish_pocket", _fake_publish_pocket)
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/by-pocket/pk1/editable",
+            json={},
+            headers={"Origin": "https://dash.paw.example"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert captured["builder_origin"] == "https://dash.paw.example"
+    assert resp.json()["builder_origin"] == "https://dash.paw.example"
+
+
+@pytest.mark.asyncio
+async def test_make_editable_route_body_beats_origin_header(beanie_test_db, monkeypatch):
+    """An explicit builder_origin in the body wins over the Origin header — it's
+    an override the editor can pass to publish against a different dashboard."""
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_publish_pocket(*, builder_origin=None, **kw):
+        captured["builder_origin"] = builder_origin
+        return _SiteDoc(
+            id=ObjectId(),
+            workspace="ws_owner",
+            pocket_id="pk1",
+            owner="user-test-1",
+            name="Owner Site",
+            script_name="site1",
+            deployed=True,
+            signed_key="k",
+            builder_origin=builder_origin or "",
+        )
+
+    monkeypatch.setattr(sites_service, "publish_pocket", _fake_publish_pocket)
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/sites/by-pocket/pk1/editable",
+            json={"builder_origin": "https://explicit.paw.example"},
+            headers={"Origin": "https://dash.paw.example"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert captured["builder_origin"] == "https://explicit.paw.example"


### PR DESCRIPTION
## What this does

Adds the pocketpaw backend so the chat agent can rewrite one component of a published svelte Paw Site and republish it, without ever leaving the live site broken. This is one part of a 3-repo feature; this PR is the backend slice only (the UI click-to-edit and inline copy edit land separately).

A svelte site pocket stores its `source` as a `{path: contents}` map (e.g. `src/lib/components/Hero.svelte`). Today that map can only be written at create time. This adds a targeted edit path: replace one file, republish, and roll back if the rebuild fails.

## How it works

- **pockets service** gains `set_svelte_source_file(pocket_id, user_id, component_path, new_source)`. It loads the pocket with the same access check `update` uses, confirms the pocket is a svelte site and that the component path already exists, rewrites that one entry in the source map, and persists it. It returns the file's prior contents so the caller can roll back. The Pocket write stays inside the pockets service, so entity isolation holds.
- **sites service** gains `edit_svelte_component(...)`. It persists the edit, then republishes through `publish_pocket`. `publish` runs the workerd smoke gate before it deploys, so a broken edit never reaches the live site. On `SmokeGateFailed` the stored source is rolled back to its last good contents and the error is re-raised, so neither the deploy nor the persisted source is left broken.
- **MCP surface**: a new `edit_svelte_component` tool registers beside `publish` and the two create tools on the `pocketpaw_sites_manager` server. Its id rides `SITES_TOOL_IDS`, so the per-surface allowlist in `extensions.py` and `surface/service.py` picks it up with no extra wiring.

## Persistence and tool location (for the inline-edit task)

- `pocket.source` is persisted via the new `pockets.service.set_svelte_source_file`, which reassigns a fresh dict onto `doc.source` and calls `doc.save()` (in-place dict mutation is not reliably tracked by the ODM).
- The edit tool is registered in `ee/pocketpaw_ee/agent/mcp_servers/sites.py` (`build_sites_manager_server`), built from the factory `make_edit_svelte_component_tool` in `sites_create.py`, beside `create_landing_site` / `create_svelte_site` / `publish`.

## Tests (reproduce-first)

Service layer (`tests/ee/sites/test_component_edit.py`):
- an edit reaches the regenerated build and persists on the pocket
- a broken edit propagates `SmokeGateFailed`, no worker is deployed, and the source is rolled back to the last good contents
- unknown component path, missing pocket, and ripple-engine pocket all raise the right error

MCP surface (`tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py`):
- registration on the shared allowlist, identity gating, input validation, success response shape, and error mapping (smoke-gate failure to "site unchanged", CloudError relayed by code)

The existing `test_mcp_tool.py` registration test was updated for the fourth tool on the server.

## Verification

```
uv run pytest tests/ee/sites/ tests/ee/agent/test_sites_mcp_server/ -p no:cacheprovider
# 94 passed, 1 skipped (pre-existing unrelated skip)

uv run pytest tests/cloud/pockets/ tests/cloud/surface/ -p no:cacheprovider
# 179 passed
```

`ruff check` clean on all changed files. `mypy` on the two service modules adds zero new errors (the 41 pre-existing errors in `pockets/service.py` are unchanged by this PR).


---

## SE-2b: keep svelte sites editable across republish (builderOrigin)

SE-1 (paw-sites generator) gates the editable section anchors and the postMessage edit-bridge on `siteConfig.builderOrigin`. The publish path never set it, so a site was never editable, and worse, the SE-2 component-edit republish would strip the bridge. This change threads `builder_origin` through the whole publish path and persists it so an editable site stays editable.

### How it works

- `generator_client.build` takes an optional `builder_origin` and, when set, sends it on `siteConfig.builderOrigin`. It is omitted from the payload when unset, so a normal (non-editable) publish keeps the exact prior wire bytes and the generator does not inject the bridge.
- `publish` and `publish_pocket` thread `builder_origin` through to the generator and store it on the Site doc (`Site.builder_origin`).
- `edit_svelte_component` recovers the `builder_origin` from the pocket's current Site (`_latest_site_for_pocket`, newest by `createdAt`) and re-applies it on republish. So an editable site stays editable after a component edit; a non-editable one stays non-editable (there is no origin to re-apply).
- `make_site_editable` republishes a pocket as editable. It backs `POST /api/v1/sites/by-pocket/{pocket_id}/editable` (same `fabric` plan gate + `fabric.write` action scope as publish). The route resolves the builder origin in precedence: an explicit `builder_origin` in the body wins, otherwise the request `Origin` header (the dashboard the call came from), and the service falls back to the configured `PAW_SITES_BUILDER_ORIGIN` when neither is present. This matches the contract the SE-3 editor calls, so it does not have to send its own origin.
- `SiteResponse.builder_origin` is surfaced so the UI can tell whether a site is editable (non-empty = carries the bridge).

### Tests (reproduce-first)

- `tests/ee/sites/test_generator_client_svelte.py`: `builder_origin` rides `siteConfig.builderOrigin`; omitted when unset (wire payload unchanged).
- `tests/ee/sites/test_builder_origin.py`: `publish`/`publish_pocket` thread and store it; `edit_svelte_component` preserves the stored origin across an edit; a non-editable site stays non-editable; `make_site_editable` sets it and falls back to the configured origin.
- `tests/ee/sites/test_router.py`: `POST /sites/by-pocket/{pocket_id}/editable` forwards the body origin, derives it from the `Origin` header when the body is blank, lets the body override the header, and falls back to the configured origin when neither is present.

### Verification (SE-2b)

```
uv run pytest tests/ee/sites/ tests/ee/agent/test_sites_mcp_server/
# 105 passed, 1 skipped

uv run pytest tests/cloud/pockets/ tests/cloud/surface/ tests/cloud/leads/ tests/sites_capture/
# all green
```

`ruff` clean. `mypy` adds zero new errors on the changed modules; `router.py` carries 1 more `ctx.workspace_id: str | None` arg-type warning that follows the pre-existing pattern shared by every other route in that file (the base has 5 identical ones).

