### PR TITLE
chore(format): ruff format sites test_router

### DIFF
--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -222,6 +222,8 @@ async def test_status_by_pocket_published_is_live(_seeded_site, monkeypatch):
     assert body["pocket_id"] == "pk1"
     assert body["status"] == "published"
     assert body["is_live"] is True
+
+
 @pytest.mark.asyncio
 async def test_post_reserve_returns_reconciled_list(beanie_test_db, monkeypatch):
     """POST /sites/reserve (re)starts the local server and returns the caller's


### PR DESCRIPTION
One-file ruff format fix. The #1486 rebase left `tests/ee/sites/test_router.py` unformatted and it landed on dev, so `ruff format --check` (the Lint job) fails for dev and every open PR. This restores green Lint. No logic change.