### PR TITLE
feat(sites): draft/published over the version log — fix the Live lie (#1345)

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -36,6 +36,13 @@ Updated: 2026-06-11 (feat/firestore-fabric-ingest) — added
 imports, ``__all__``, and ``get_all_documents()`` so the ingestion worker's
 collections are wired into ``init_beanie``. Only
 ``ee.cloud.fabric_ingest.service`` imports the doc classes directly.
+Updated: 2026-06-18 (feat/branch-primitive-versions, BP-1) — registered the
+``ArtifactVersion`` doc (the universal Branch-primitive version log) in
+``get_all_documents()`` via the lazy ``_ensure_version_docs()`` helper. The doc
+lives in the ``pocketpaw_ee.versions`` package (its own entity), so it is
+imported lazily here — the same out-of-models discipline the belt/mandates docs
+use — to keep ``cloud.models`` from hard-importing the versions package. Only
+``pocketpaw_ee.versions.service`` imports the doc class directly.
 """
 
 from __future__ import annotations
@@ -111,6 +118,11 @@ _EventDoc: type = None  # type: ignore[assignment]
 _MandateDoc: type = None  # type: ignore[assignment]
 _ShiftDoc: type = None  # type: ignore[assignment]
 _SightingDoc: type = None  # type: ignore[assignment]
+# The ArtifactVersion doc lives in pocketpaw_ee.versions (its own Branch-
+# primitive entity, sole importer = its own service). Lazy-loaded here so
+# init_beanie registers it without ee.cloud.models taking a hard import on the
+# versions package (same out-of-models discipline as belt/mandates).
+_ArtifactVersionDoc: type = None  # type: ignore[assignment]
 
 
 def _ensure_file_upload():
@@ -152,6 +164,18 @@ def _ensure_mandate_docs():
         _ShiftDoc = _SD
         _SightingDoc = _SG
     return _MandateDoc, _ShiftDoc, _SightingDoc
+
+
+def _ensure_version_docs():
+    # Why: the versions package is its own Branch-primitive entity whose sole
+    # importer is its own service. Import the doc class directly + deferred so
+    # cloud.models doesn't take a hard import on pocketpaw_ee.versions.
+    global _ArtifactVersionDoc
+    if _ArtifactVersionDoc is None:
+        from pocketpaw_ee.versions.models import ArtifactVersion as _AV
+
+        _ArtifactVersionDoc = _AV
+    return _ArtifactVersionDoc
 
 
 __all__ = [
@@ -229,6 +253,7 @@ def get_all_documents():
     _ensure_file_upload()
     cal_doc, evt_doc = _ensure_calendar_docs()
     mandate_doc, shift_doc, sighting_doc = _ensure_mandate_docs()
+    artifact_version_doc = _ensure_version_docs()
     return [
         User,
         Agent,
@@ -286,6 +311,8 @@ def get_all_documents():
         mandate_doc,
         shift_doc,
         sighting_doc,
+        # Branch primitive — universal artifact version log (BP-1).
+        artifact_version_doc,
     ]
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -191,6 +191,13 @@ Changes: 2026-06-17 (feat/sites-svelte-component-edit, SE-2) — added
 it. The Pocket write stays here (entity isolation); the sites service
 orchestrates the republish. Returns the prior file contents alongside the wire
 dict so the caller can roll the edit back when the downstream smoke gate fails.
+Changes: 2026-06-18 (feat/branch-primitive-versions, BP-1) — ``merge_spec``
+now ALSO records a draft ArtifactVersion (scope_type="pocket") after the
+rippleSpec persist, via the universal Branch-primitive versions service. The
+existing destructive overwrite + emit are unchanged; the version write is an
+additive, best-effort snapshot (a version-store failure never breaks the merge)
+so every content mutation gains a draft/history without changing the merge
+contract. TODO(BP-3/BP-4): merge gate + revert/history hook onto these rows.
 """
 
 from __future__ import annotations
@@ -1604,6 +1611,13 @@ async def merge_spec(
     doc.rippleSpec = normalized
     await doc.save()
     await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+    # Branch primitive (BP-1): record a draft ArtifactVersion snapshot of the
+    # mutated rippleSpec. ADDITIVE — the destructive overwrite above already
+    # happened and stays the source of truth for rendering; this captures a
+    # draft/history snapshot so the artifact can later have draft/published/
+    # rollback (BP-3/BP-4). Best-effort: a version-store failure must NOT break
+    # the merge, so it is wrapped and only logged.
+    await _record_pocket_draft_version(doc, author=user_id)
     resolved = await _resolved_wire_dict(doc, user_id)
     return {
         "ok": True,
@@ -1612,6 +1626,38 @@ async def merge_spec(
         "pocket": resolved,
         "warnings": warnings,
     }
+
+
+async def _record_pocket_draft_version(doc: _PocketDoc, *, author: str | None) -> None:
+    """Snapshot a pocket's current rippleSpec as a draft ArtifactVersion.
+
+    Branch-primitive hook (BP-1). Lazy-imports the versions service so the
+    pockets entity does not take a hard import on the versions package and so
+    a fork without the versions module degrades gracefully. The snapshot is
+    the full ``rippleSpec`` dict (empty dict when None). Failures are logged
+    and swallowed — versioning is an additive audit/history layer over the
+    existing merge, never a gate on it.
+
+    TODO(BP-3): a merge gate may branch this draft for human review before it
+    becomes the published pointer.
+    """
+    try:
+        from pocketpaw_ee.versions import service as versions_service
+
+        await versions_service.write_draft(
+            scope_type="pocket",
+            scope_id=str(doc.id),
+            workspace_id=doc.workspace,
+            content=doc.rippleSpec or {},
+            author=author,
+        )
+    except Exception:  # noqa: BLE001 — versioning must not break the merge
+        logger.warning(
+            "versions: failed to record draft version for pocket %s — "
+            "merge persisted, version skipped",
+            doc.id,
+            exc_info=True,
+        )
 
 
 async def _ensure_project_in_workspace(workspace_id: str, project_id: str) -> None:

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -21,6 +21,13 @@
 # MakeEditableRequest (the body for POST /sites/by-pocket/{pocket_id}/editable;
 # builder_origin optional) and SiteResponse.builder_origin so the UI can tell
 # whether a published site carries the edit-bridge (non-empty = editable).
+# Updated 2026-06-18 (feat/branch-primitive-sites-draft, BP-2 / pocketpaw#1345):
+# SiteStatusResponse gains ``has_unpublished_changes`` — the Branch primitive now
+# derives draft/published from the version pointers (versions.get_draft /
+# get_published), so a pocket can carry a draft NEWER than its published version.
+# This flag (default False, backward-compatible) lets the builder badge "has
+# unpublished edits" without inferring it from the Site doc. ``status``/``is_live``
+# semantics are unchanged in shape; only their derivation moves onto versions.
 
 from __future__ import annotations
 
@@ -69,13 +76,19 @@ class SitePreviewResponse(BaseModel):
 class SiteStatusResponse(BaseModel):
     """Authoritative draft/published + is_live state for a pocket, so the builder
     labels accurately even before the site appears in the gallery list. ``status``
-    is "draft" (no published deploy) or "published"; ``is_live`` is the ONLY signal
-    that earns a "Live" badge. ``site_id`` carries the deployed Site's id when one
-    exists. Mirrors the frontend SiteStatusResponse (core/sites/types.ts)."""
+    is "draft" (no published version) or "published"; ``is_live`` is the ONLY
+    signal that earns a "Live" badge — it requires a published version AND a real
+    successful deploy (the Site doc's ``deployed``), never an optimistic stamp.
+    ``has_unpublished_changes`` is True when a draft version is newer than the
+    published one (edits the publish would ship). ``site_id`` carries the deployed
+    Site's id when one exists. Mirrors the frontend SiteStatusResponse
+    (core/sites/types.ts); ``has_unpublished_changes`` defaults False so the field
+    is backward-compatible for callers that do not yet read it."""
 
     pocket_id: str
     status: str  # draft | published
     is_live: bool
+    has_unpublished_changes: bool = False
     site_id: str | None = None
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -127,9 +127,35 @@
 # and skips sites whose files are not on disk. The cloud boot hook calls it
 # unscoped so a restart auto-re-serves all sites; POST /sites/reserve calls it
 # workspace-scoped for an explicit "re-serve" action.
+#
+# Updated 2026-06-18 (feat/branch-primitive-sites-draft, BP-2 / pocketpaw#1345):
+# sites publish/preview/status are now branch-aware over the BP-1 versions spine,
+# fixing the "Live badge lies" bug — a site was stamped ``deployed`` the instant a
+# Site doc existed, so a never-deployed / draft pocket still read published+live
+# and the builder preview pointed at the live URL instead of the working copy.
+#   * publish() — on a successful build, PROMOTES the pocket's current draft
+#     version to ``published`` via versions.publish() BEFORE deploy (writing a
+#     draft snapshot first if none exists, so a published pointer always lands).
+#     ``deployed``/Live still flips true ONLY after the deploy succeeds (the
+#     smoke gate already runs before deploy). If deploy fails the Site doc is not
+#     persisted (not live) — the published version tag may stand (published !=
+#     live). TODO(BP-3): a merge gate will replace this DIRECT publish.
+#   * preview_pocket() — serves the DRAFT VERSION's content (the unpublished
+#     working copy) via versions.get_draft(), so the Preview tab shows what
+#     publish WOULD build. Falls back to the pocket's current rippleSpec/source
+#     when no draft row exists yet (e.g. a pre-BP-1 pocket, or a svelte pocket
+#     whose source map is not versioned in BP-1).
+#   * pocket_status() — derives draft/published + is_live from the version
+#     pointers AND the real Site deploy state, NOT "a Site doc exists". A
+#     published version (or, for backward compat, a deployed Site doc predating
+#     BP-1) reads published; a draft newer than the published version sets
+#     has_unpublished_changes; is_live requires published AND the Site doc's real
+#     ``deployed``. The artifact is the source pocket: scope_type="pocket",
+#     scope_id=<pocket_id>.
 
 from __future__ import annotations
 
+import logging
 import secrets
 from collections.abc import Callable
 from pathlib import Path
@@ -150,8 +176,15 @@ from pocketpaw_ee.sites.dto import (
 )
 from pocketpaw_ee.sites.generator_client import GeneratorClient
 
+logger = logging.getLogger(__name__)
+
 # The control plane reads the Worker bundle adapter-cloudflare emits here.
 _WORKER_BUNDLE_REL = ".svelte-kit/cloudflare/_worker.js"
+
+# BP-2: the source pocket is the versionable artifact behind a site. The Branch
+# primitive (BP-1) keys every version on (scope_type, scope_id); for a site the
+# scope is the pocket it is published from.
+_VERSION_SCOPE_TYPE = "pocket"
 
 
 def _default_bundle_reader(project_dir: str) -> bytes:
@@ -238,6 +271,56 @@ def _local_mode() -> bool:
     return not os.environ.get("PAW_CF_ACCOUNT_ID")
 
 
+async def _promote_pocket_draft_to_published(
+    *, pocket_id: str, workspace_id: str, author: str | None, content: dict[str, Any]
+) -> None:
+    """Promote a pocket's current draft version to ``published`` (BP-2).
+
+    Called from ``publish`` after the build succeeds and BEFORE deploy: the
+    published version pointer is the durable "this is the version that was
+    published" record, independent of whether the deploy itself lands (published
+    != live). Reads the current draft via the BP-1 versions service and flips it
+    to published; when no draft row exists yet (a pocket published without ever
+    going through ``merge_spec``, or a svelte pocket whose source map BP-1 does
+    not version), it first writes a draft snapshot of ``content`` so a published
+    pointer always lands.
+
+    Lazy-imports the versions service so the sites entity does not take a hard
+    import on the versions package and a fork without it degrades gracefully:
+    versioning is an additive history/Branch layer over publish, never a gate on
+    it, so a failure here is logged and swallowed — the deploy still proceeds.
+
+    TODO(BP-3): the Instinct merge gate will replace this DIRECT promote — a
+    publish will branch the draft for human review and the merge accept (not this
+    call) will move the published pointer.
+    """
+    try:
+        from pocketpaw_ee.versions import service as versions_service
+
+        draft = await versions_service.get_draft(scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id)
+        if draft is None:
+            draft = await versions_service.write_draft(
+                scope_type=_VERSION_SCOPE_TYPE,
+                scope_id=pocket_id,
+                workspace_id=workspace_id,
+                content=content or {},
+                author=author,
+            )
+        await versions_service.publish(
+            scope_type=_VERSION_SCOPE_TYPE,
+            scope_id=pocket_id,
+            workspace_id=workspace_id,
+            version_id=str(draft.id),
+        )
+    except Exception:  # noqa: BLE001 — versioning must not break publish/deploy
+        logger.warning(
+            "versions: failed to promote draft→published for pocket %s — "
+            "deploy proceeds, published version pointer skipped",
+            pocket_id,
+            exc_info=True,
+        )
+
+
 def _to_response(doc: _SiteDoc) -> SiteResponse:
     return SiteResponse(
         id=str(doc.id),
@@ -322,6 +405,22 @@ async def publish(
         engine=engine,
         source=source,
         builder_origin=builder_origin,
+    )
+
+    # BP-2 / #1345: promote the pocket's current draft version to ``published``
+    # BEFORE deploy. The build (which runs the smoke gate) has succeeded, so the
+    # version being published is known-good; the published pointer is the durable
+    # "this is what was published" record even if the deploy below fails
+    # (published != live — a failed deploy just leaves the Site doc un-persisted,
+    # so the pocket reads not-live while the published tag stands). The snapshot
+    # for the promote is the engine's content: the rippleSpec for a ripple site,
+    # the {path: contents} source map for a svelte site.
+    version_content: dict[str, Any] = (source if engine == "svelte" else ripple_spec) or {}
+    await _promote_pocket_draft_to_published(
+        pocket_id=pocket_id,
+        workspace_id=workspace_id,
+        author=user_id,
+        content=version_content,
     )
 
     # Local mode only when the caller did NOT inject a CF client (tests inject a
@@ -649,14 +748,21 @@ async def preview_pocket(
     user_id: str,
     pocket_id: str,
 ) -> SitePreviewResponse:
-    """Read a pocket's DRAFT content for the in-app builder Preview tab.
+    """Read a pocket's DRAFT-version content for the in-app builder Preview tab.
 
     Loads the source pocket through the pockets service's PUBLIC ``get`` (the wire
     dict — no Beanie import, respecting entity isolation; it raises NotFound /
     Forbidden itself when the pocket is missing or access-denied, which the router
-    maps to 404 / 403). Mirrors ``publish_pocket``'s pocket-read + engine logic so
-    the preview matches what publish would build:
-      * ``engine="ripple"`` (the default) → ``content`` is the pocket's rippleSpec.
+    maps to 404 / 403) to resolve the engine + a current-content fallback.
+
+    BP-2 / #1345: the preview serves the DRAFT VERSION's content (the unpublished
+    working copy from the BP-1 versions spine) so the Preview tab shows what
+    publish WOULD build — not the live/published URL. It reads
+    ``versions.get_draft(scope_type="pocket", scope_id=pocket_id)`` and returns
+    that snapshot. It falls back to the pocket's CURRENT content when there is no
+    draft row yet (a pre-BP-1 pocket, or a svelte pocket whose source map BP-1
+    does not version) so the preview is never empty when content exists:
+      * ``engine="ripple"`` (the default) → ``content`` is the rippleSpec.
       * ``engine="svelte"`` → ``content`` is the {path: contents} source map.
     ``content`` is None when the pocket carries nothing to render on that track.
 
@@ -668,35 +774,120 @@ async def preview_pocket(
 
     pocket = await pockets_service.get(pocket_id, user_id)
     engine = pocket.get("engine") or "ripple"
+
+    # The pocket's CURRENT content for the engine — the fallback when the Branch
+    # primitive has no draft row for this pocket yet.
     if engine == "svelte":
         source = pocket.get("source")
-        content = source if isinstance(source, dict) else None
+        current = source if isinstance(source, dict) else None
     else:
         ripple_spec = pocket.get("rippleSpec")
-        content = ripple_spec if isinstance(ripple_spec, dict) else None
+        current = ripple_spec if isinstance(ripple_spec, dict) else None
+
+    # Prefer the DRAFT version's snapshot (the working copy publish would build).
+    # Versioning is an additive layer — a missing module / read failure must not
+    # break the preview, so degrade to the current content on any error.
+    draft_content: dict[str, Any] | None = None
+    try:
+        from pocketpaw_ee.versions import service as versions_service
+
+        draft = await versions_service.get_draft(scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id)
+        if draft is not None:
+            draft_content = draft.content
+    except Exception:  # noqa: BLE001 — versions read is best-effort
+        logger.warning(
+            "versions: failed to read draft for pocket %s preview — "
+            "falling back to current content",
+            pocket_id,
+            exc_info=True,
+        )
+
+    content = draft_content if draft_content is not None else current
     return SitePreviewResponse(pocket_id=pocket_id, engine=engine, content=content)
 
 
 async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusResponse:
-    """Derive a pocket's draft/published + is_live state from its Site deployment
-    doc, tenant-scoped on ``workspace``.
+    """Derive a pocket's draft/published + is_live state from the BRANCH version
+    pointers AND the real Site deploy state — NOT from "a Site doc exists".
 
-    Looks up the Site for this (workspace, pocket_id) — the compound index the
-    model declares serves this read directly. With no Site doc the pocket has
-    never been published, so it reads ``draft`` / not live. With a Site doc it
-    reads ``published``; ``is_live`` follows the doc's ``deployed`` flag (the only
-    signal that earns a "Live" badge), and ``site_id`` carries the deployed id.
-    This is the authoritative state the builder uses to label a pocket even before
-    it surfaces in the gallery list. No Cloudflare call — just persisted state.
+    BP-2 / #1345 fixes the "Live badge lies" bug: before, a Site doc was enough to
+    read published+live, but a Site was stamped ``deployed`` the instant it was
+    created, so a never-deployed / draft pocket reported live and the preview
+    pointed at a dead URL. Now:
+
+      * ``status`` is "published" when a published version pointer exists
+        (``versions.get_published(scope_type="pocket", scope_id=pocket_id)``).
+        Backward compat: a Site doc that was deployed BEFORE BP-1 (so it has no
+        version rows) still reads "published" — the deployed Site is itself the
+        evidence a publish happened. With neither, the pocket reads "draft".
+      * ``has_unpublished_changes`` is True when a draft version is NEWER than the
+        published one (or a draft exists with nothing published yet) — the edits a
+        publish would ship.
+      * ``is_live`` is the ONLY signal that earns a "Live" badge: it requires the
+        pocket to be published AND a real successful deploy, read from the Site
+        doc's ``deployed`` flag (publish only persists the Site doc, with
+        ``deployed=True``, AFTER the deploy succeeds — never optimistically). No
+        published version + a deployed Site (the legacy case) is still live.
+      * ``site_id`` carries the deployed Site's id when one exists.
+
+    Tenant-scoped on ``workspace`` for the Site read (the compound index serves
+    it). No Cloudflare call — just persisted state. Versioning is an additive
+    layer, so a versions read failure degrades to the Site-doc signal rather than
+    breaking the status read.
     """
     doc = await _SiteDoc.find_one({"workspace": workspace_id, "pocket_id": pocket_id})
-    if doc is None:
-        return SiteStatusResponse(pocket_id=pocket_id, status="draft", is_live=False)
+
+    published_no: int | None = None
+    draft_no: int | None = None
+    try:
+        from pocketpaw_ee.versions import service as versions_service
+
+        # The BP-1 pointer reads key only on (scope_type, scope_id) — they are
+        # artifact-generic and do NOT take workspace_id. A pocket_id is globally
+        # unique and belongs to one workspace, so a row's stored ``workspace_id``
+        # is the owner's; we ignore any pointer whose workspace does not match
+        # this caller's so a foreign workspace cannot read another tenant's
+        # published/draft state through a known pocket id (tenant isolation, the
+        # same guarantee the workspace-scoped Site read gives).
+        published = await versions_service.get_published(
+            scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id
+        )
+        draft = await versions_service.get_draft(scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id)
+        if published is not None and published.workspace_id == workspace_id:
+            published_no = published.version_no
+        if draft is not None and draft.workspace_id == workspace_id:
+            draft_no = draft.version_no
+    except Exception:  # noqa: BLE001 — versions read is best-effort
+        logger.warning(
+            "versions: failed to read pointers for pocket %s status — "
+            "falling back to the Site-doc signal",
+            pocket_id,
+            exc_info=True,
+        )
+
+    # Published when a published version pointer exists, OR (backward compat) a
+    # Site doc was already deployed before BP-1 ever recorded a version.
+    has_published = published_no is not None or (doc is not None and doc.deployed)
+    status = "published" if has_published else "draft"
+
+    # Unpublished edits: a draft strictly newer than the published version, or a
+    # draft with nothing published yet.
+    has_unpublished_changes = draft_no is not None and (
+        published_no is None or draft_no > published_no
+    )
+
+    # Live requires published AND a real successful deploy (the Site doc's
+    # ``deployed``). A draft-only pocket, or a published pocket whose deploy
+    # failed (no Site doc), is not live.
+    deployed = bool(doc is not None and doc.deployed)
+    is_live = has_published and deployed
+
     return SiteStatusResponse(
         pocket_id=pocket_id,
-        status="published",
-        is_live=doc.deployed,
-        site_id=str(doc.id),
+        status=status,
+        is_live=is_live,
+        has_unpublished_changes=has_unpublished_changes,
+        site_id=str(doc.id) if doc is not None else None,
     )
 
 

--- a/ee/pocketpaw_ee/versions/__init__.py
+++ b/ee/pocketpaw_ee/versions/__init__.py
@@ -1,0 +1,24 @@
+# ee/pocketpaw_ee/versions/__init__.py
+# Created: 2026-06-18 (feat/branch-primitive-versions, BP-1) — package init
+# for the universal "Branch primitive" versions core: propose → branch →
+# review → merge/publish + diff + revert, for ANY versionable artifact.
+#
+# BP-1 scope (this package today): the version MODEL (ArtifactVersion) and
+# the version SERVICE spine (write_draft / branch / publish + pointer reads).
+# It is EE-cloud-only for now but the model + state machine are kept
+# artifact-generic (NOT sites-specific) so the whole thing can be lifted into
+# an OSS protocol later. ``scope_type`` is the genericity seam — the only
+# wired value today is ``"pocket"`` and other scope types slot in with no
+# model change.
+#
+# What lives elsewhere (later BP tasks — do NOT add here in BP-1):
+#   * BP-3 — the Instinct review/merge gate over a version candidate.
+#   * BP-4 — revert + a Journal read projection (version history view).
+#   * BP-5/6 — the site editor + the review/merge UI.
+#
+# Re-exports are intentionally minimal: the doc class and the service module.
+from __future__ import annotations
+
+from pocketpaw_ee.versions.models import ArtifactVersion
+
+__all__ = ["ArtifactVersion"]

--- a/ee/pocketpaw_ee/versions/models.py
+++ b/ee/pocketpaw_ee/versions/models.py
@@ -1,0 +1,110 @@
+# ee/pocketpaw_ee/versions/models.py
+# Created: 2026-06-18 (feat/branch-primitive-versions, BP-1) — the
+# ArtifactVersion Beanie document: the durable, append-only version log for
+# the universal Branch primitive.
+#
+# Design notes (BP-1):
+#   * GENERIC by ``scope_type``. A version row belongs to one artifact,
+#     identified by (``scope_type``, ``scope_id``). The only wired
+#     ``scope_type`` today is ``"pocket"``; ``"site"`` / ``"dashboard"`` /
+#     anything else slot in later with NO model change — that is the whole
+#     point of keeping this artifact-generic rather than sites-specific.
+#   * FULL SNAPSHOTS. ``content`` is the complete artifact snapshot (a
+#     pocket's rippleSpec dict, OR a svelte source map ``{path: contents}``),
+#     not a diff. Content is small, so full snapshots keep the model dead
+#     simple and make diff/revert (BP-4) a pure function of two rows.
+#   * STATE MACHINE. ``status`` ∈ {draft, published, merged, reverted}. A
+#     write creates a ``draft``; ``publish()`` flips a row to ``published``;
+#     ``merged`` / ``reverted`` are reserved for BP-3 (merge gate) / BP-4
+#     (revert) and are NOT produced in BP-1.
+#   * POINTERS ARE DERIVED, NOT STORED. There is deliberately no separate
+#     ``ArtifactRef`` doc holding draft_version_id / published_version_id.
+#     The "current draft" and "published" pointers are derived from this
+#     collection: latest row by ``version_no`` within (scope, branch)
+#     filtered by status. Reasons:
+#       - A second pointer doc is a second write that can drift from the
+#         versions collection (two-write consistency problem). One source of
+#         truth removes that entire failure class.
+#       - The compound index (scope_type, scope_id, branch, version_no)
+#         makes "latest row of status X" a cheap indexed query.
+#       - Extraction to OSS later is cleaner with a single collection.
+#     The service (service.py) owns the derivation; see ``get_draft`` /
+#     ``get_published`` there.
+#
+# TODO(BP-3): the merge gate sets status="merged" on an accepted candidate.
+# TODO(BP-4): revert reads two snapshots from here + a Journal projection
+#             builds the history view; reverted rows get status="reverted".
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+import pymongo
+from beanie import Document
+from pydantic import Field
+
+__all__ = ["ArtifactVersion", "ArtifactVersionStatus"]
+
+# The version state machine. BP-1 only produces ``draft`` (write_draft /
+# branch) and ``published`` (publish). ``merged`` and ``reverted`` are
+# reserved seams for BP-3 / BP-4 — declared now so the model is stable.
+ArtifactVersionStatus = Literal["draft", "published", "merged", "reverted"]
+
+
+class ArtifactVersion(Document):
+    """One immutable version of a versionable artifact (Branch primitive).
+
+    A row is created once and not mutated except for its ``status`` (the
+    state-machine transition). The (scope_type, scope_id) pair identifies
+    the artifact; ``branch`` separates candidate lineages from ``main``;
+    ``version_no`` is monotonic within (scope, branch).
+    """
+
+    # --- identity / scope (generic) ---
+    # ``scope_type`` is the genericity seam — "pocket" today, others later
+    # with no schema change. ``scope_id`` is the artifact's id within that
+    # scope (e.g. the Pocket _id as a str).
+    scope_type: str
+    scope_id: str
+    workspace_id: str
+
+    # --- branch + ordering ---
+    # ``branch`` defaults to "main" — the published lineage. ``branch()``
+    # opens a named candidate lineage off main. ``version_no`` is monotonic
+    # within (scope_type, scope_id, branch).
+    branch: str = "main"
+    version_no: int
+
+    # --- payload ---
+    # Full snapshot of the artifact at this version. A pocket rippleSpec
+    # dict, OR a svelte source map {path: contents}. NOT a diff.
+    content: dict[str, Any] = Field(default_factory=dict)
+
+    # --- lineage + state ---
+    # The version this one descends from (the row it was branched/derived
+    # from). ``None`` for the very first version of an artifact/branch.
+    parent_version_id: str | None = None
+    status: ArtifactVersionStatus = "draft"
+
+    # --- metadata ---
+    label: str | None = None
+    author: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    class Settings:
+        name = "artifact_versions"
+        indexes = [
+            # The spine index: every "latest row in (scope, branch)" query
+            # and the monotonic version_no assignment ride on this. Ordered
+            # so a prefix scan on (scope_type, scope_id, branch) is cheap and
+            # the trailing descending version_no gives the latest row first.
+            pymongo.IndexModel(
+                [
+                    ("scope_type", pymongo.ASCENDING),
+                    ("scope_id", pymongo.ASCENDING),
+                    ("branch", pymongo.ASCENDING),
+                    ("version_no", pymongo.DESCENDING),
+                ],
+                name="scope_branch_version",
+            ),
+        ]

--- a/ee/pocketpaw_ee/versions/service.py
+++ b/ee/pocketpaw_ee/versions/service.py
@@ -1,0 +1,378 @@
+# ee/pocketpaw_ee/versions/service.py
+# Created: 2026-06-18 (feat/branch-primitive-versions, BP-1) — the version
+# SERVICE spine for the universal Branch primitive. Artifact-GENERIC: it
+# never imports pockets/sites and keys everything off (scope_type, scope_id),
+# so the same spine serves any versionable artifact and can be lifted into an
+# OSS protocol later.
+#
+# Operations (BP-1):
+#   * write_draft(...)   — create the next draft version on a branch.
+#   * branch(...)        — open a candidate lineage off the current head.
+#   * publish(...)       — flip a version to status="published" (the pointer).
+#   * get_draft(...)     — derived pointer: latest draft on a branch.
+#   * get_published(...) — derived pointer: latest published on a branch.
+#   * list_versions(...) — the version log for (scope, branch).
+#   * revert(...)        — STUB. NotImplementedError — TODO(BP-4) owns revert.
+#
+# Pointer storage: DERIVED from the versions collection (no ArtifactRef doc).
+# See models.py header for the why — single source of truth, indexed
+# "latest of status X" query, cleaner OSS extraction.
+#
+# Journal: write_draft and branch each emit a Journal event via the org
+# journal (``pocketpaw.journal_dep.get_journal``) so tests can override the
+# cache. These are NOT Decision-Graph chain events, so we append DIRECTLY
+# (the chain helper ``record_decision_event`` is only for the 4 chain
+# actions). Scope is always stamped non-empty:
+# ``[f"{scope_type}:{scope_id}", f"workspace:{workspace_id}"]``.
+#   * artifact.version.created  — on write_draft
+#   * artifact.version.branched — on branch
+# We do NOT build a read projection here — that is BP-4.
+#
+# TODO(BP-3): a merge gate will set status="merged" on an accepted branch
+#             candidate and may emit artifact.version.merged.
+# TODO(BP-4): revert() reverts to a prior snapshot (status="reverted") and a
+#             Journal VersionProjection folds these events into a history view.
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pymongo
+
+from pocketpaw_ee.versions.models import ArtifactVersion
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "branch",
+    "get_draft",
+    "get_published",
+    "list_versions",
+    "publish",
+    "revert",
+    "write_draft",
+]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — version_no assignment + head lookup (all key off
+# (scope_type, scope_id, branch); they ride the compound index in models.py).
+# ---------------------------------------------------------------------------
+
+
+async def _latest_in_branch(
+    *, scope_type: str, scope_id: str, branch_name: str
+) -> ArtifactVersion | None:
+    """The highest-``version_no`` row in (scope, branch), or None.
+
+    This is the branch head regardless of status — used to assign the next
+    monotonic ``version_no`` and to find the parent for a new row.
+    """
+    return (
+        await ArtifactVersion.find(
+            ArtifactVersion.scope_type == scope_type,
+            ArtifactVersion.scope_id == scope_id,
+            ArtifactVersion.branch == branch_name,
+        )
+        .sort(("version_no", pymongo.DESCENDING))
+        .first_or_none()
+    )
+
+
+def _scope_tags(*, scope_type: str, scope_id: str, workspace_id: str) -> list[str]:
+    """Tenancy/scope tags stamped on every emitted Journal event.
+
+    Always non-empty (the journal enforces min_length=1). The artifact tag
+    comes first so a scope-prefix query can target one artifact.
+    """
+    return [f"{scope_type}:{scope_id}", f"workspace:{workspace_id}"]
+
+
+def _emit_version_event(
+    *,
+    action: str,
+    scope_type: str,
+    scope_id: str,
+    workspace_id: str,
+    author: str | None,
+    payload: dict,
+) -> None:
+    """Append a version Journal event directly (best-effort).
+
+    NOT a Decision-Graph chain event, so we call ``journal.append`` directly
+    rather than ``record_decision_event``. Lazy imports keep the soul-protocol
+    journal types out of module import for static-analysis cleanliness and so
+    a journal-less context (or a fork without the dep) degrades gracefully
+    instead of failing the version write — the ArtifactVersion row is already
+    the durable record; the event is the audit echo.
+    """
+    try:
+        from soul_protocol.spec.journal import Actor, EventEntry
+
+        from pocketpaw.journal_dep import get_journal
+    except Exception:  # noqa: BLE001 — journal dep unavailable on a fork
+        logger.debug("journal dep unavailable — skipping %s event", action)
+        return
+
+    # The actor is the author when known, else the system. ``scope_context``
+    # mirrors the event scope so visibility filters downstream agree.
+    scope = _scope_tags(scope_type=scope_type, scope_id=scope_id, workspace_id=workspace_id)
+    actor = (
+        Actor(kind="user", id=author, scope_context=scope)
+        if author
+        else Actor(kind="system", id="system:versions", scope_context=scope)
+    )
+    event = EventEntry(
+        id=uuid4(),
+        ts=datetime.now(UTC),
+        actor=actor,
+        action=action,
+        scope=scope,
+        payload=payload,
+    )
+    try:
+        get_journal().append(event)
+    except Exception:  # noqa: BLE001 — audit echo must not break the write
+        logger.warning(
+            "versions: failed to append %s for %s:%s — version row still written",
+            action,
+            scope_type,
+            scope_id,
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mutations
+# ---------------------------------------------------------------------------
+
+
+async def write_draft(
+    *,
+    scope_type: str,
+    scope_id: str,
+    workspace_id: str,
+    content: dict,
+    branch: str = "main",  # noqa: A002 — domain term; not the builtin
+    author: str | None = None,
+    label: str | None = None,
+) -> ArtifactVersion:
+    """Create the next draft version on ``branch`` and make it the head.
+
+    The new row gets the next monotonic ``version_no`` within
+    (scope_type, scope_id, branch), ``status="draft"``, and a
+    ``parent_version_id`` pointing at the prior branch head (None for the
+    first version). Becomes the working draft (``get_draft`` returns it).
+
+    Emits ``artifact.version.created``.
+    """
+    head = await _latest_in_branch(scope_type=scope_type, scope_id=scope_id, branch_name=branch)
+    version_no = (head.version_no + 1) if head else 1
+
+    row = ArtifactVersion(
+        scope_type=scope_type,
+        scope_id=scope_id,
+        workspace_id=workspace_id,
+        branch=branch,
+        version_no=version_no,
+        content=content,
+        parent_version_id=str(head.id) if head else None,
+        status="draft",
+        label=label,
+        author=author,
+    )
+    await row.insert()
+
+    _emit_version_event(
+        action="artifact.version.created",
+        scope_type=scope_type,
+        scope_id=scope_id,
+        workspace_id=workspace_id,
+        author=author,
+        payload={
+            "version_id": str(row.id),
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "branch": branch,
+            "version_no": version_no,
+            "parent_version_id": row.parent_version_id,
+            "status": "draft",
+            "label": label,
+        },
+    )
+    return row
+
+
+async def branch(
+    *,
+    scope_type: str,
+    scope_id: str,
+    workspace_id: str,
+    new_branch: str,
+    from_branch: str = "main",
+    author: str | None = None,
+    label: str | None = None,
+) -> ArtifactVersion:
+    """Open a candidate lineage ``new_branch`` off ``from_branch``'s head.
+
+    Snapshots the source branch's current head (published if present, else
+    latest) into a fresh ``version_no=1`` draft row on ``new_branch`` whose
+    ``parent_version_id`` points back at the source head. This is the
+    "propose" step of the Branch primitive: a candidate that BP-3's merge
+    gate later reviews and (BP-3) merges back to ``from_branch``.
+
+    Emits ``artifact.version.branched``.
+    """
+    # Prefer the published head as the branch point so a candidate starts from
+    # what is live; fall back to the latest row when nothing is published yet.
+    source = await get_published(
+        scope_type=scope_type, scope_id=scope_id, branch=from_branch
+    ) or await _latest_in_branch(scope_type=scope_type, scope_id=scope_id, branch_name=from_branch)
+    source_content = source.content if source else {}
+    source_id = str(source.id) if source else None
+
+    row = ArtifactVersion(
+        scope_type=scope_type,
+        scope_id=scope_id,
+        workspace_id=workspace_id,
+        branch=new_branch,
+        version_no=1,
+        content=source_content,
+        parent_version_id=source_id,
+        status="draft",
+        label=label,
+        author=author,
+    )
+    await row.insert()
+
+    _emit_version_event(
+        action="artifact.version.branched",
+        scope_type=scope_type,
+        scope_id=scope_id,
+        workspace_id=workspace_id,
+        author=author,
+        payload={
+            "version_id": str(row.id),
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "branch": new_branch,
+            "from_branch": from_branch,
+            "parent_version_id": source_id,
+            "version_no": 1,
+            "status": "draft",
+            "label": label,
+        },
+    )
+    return row
+
+
+async def publish(
+    *,
+    scope_type: str,
+    scope_id: str,
+    workspace_id: str,
+    version_id: str,
+) -> ArtifactVersion:
+    """Mark ``version_id`` as the published pointer for its artifact.
+
+    Flips the target row's ``status`` to ``"published"``. The published
+    pointer (``get_published``) is derived as the latest ``published`` row,
+    so promoting a newer version simply publishes it; older published rows
+    stay as history. Deploy / Instinct wiring is NOT this function's job
+    (TODO(BP-3)) — this is purely the state transition + pointer move.
+
+    Raises ``ValueError`` if the version does not exist or belongs to a
+    different artifact/workspace (defensive scope check).
+    """
+    row = await ArtifactVersion.get(version_id)
+    if row is None:
+        raise ValueError(f"artifact version not found: {version_id}")
+    if row.scope_type != scope_type or row.scope_id != scope_id or row.workspace_id != workspace_id:
+        raise ValueError(
+            f"version {version_id} does not belong to "
+            f"{scope_type}:{scope_id} in workspace {workspace_id}"
+        )
+
+    row.status = "published"
+    await row.save()
+    return row
+
+
+async def revert(*args, **kwargs):  # pragma: no cover — BP-4 owns this
+    """STUB — revert is owned by BP-4.
+
+    BP-4 will revert an artifact to a prior snapshot (writing a new row with
+    ``status="reverted"`` semantics) and fold the events into a Journal
+    history projection. Intentionally unimplemented in BP-1 so callers fail
+    loud rather than silently no-op.
+    """
+    raise NotImplementedError("revert is implemented in BP-4")
+
+
+# ---------------------------------------------------------------------------
+# Pointer reads (derived from the versions collection)
+# ---------------------------------------------------------------------------
+
+
+async def get_draft(
+    *,
+    scope_type: str,
+    scope_id: str,
+    branch: str = "main",  # noqa: A002
+) -> ArtifactVersion | None:
+    """The current working draft: latest ``draft`` row in (scope, branch)."""
+    return (
+        await ArtifactVersion.find(
+            ArtifactVersion.scope_type == scope_type,
+            ArtifactVersion.scope_id == scope_id,
+            ArtifactVersion.branch == branch,
+            ArtifactVersion.status == "draft",
+        )
+        .sort(("version_no", pymongo.DESCENDING))
+        .first_or_none()
+    )
+
+
+async def get_published(
+    *,
+    scope_type: str,
+    scope_id: str,
+    branch: str = "main",  # noqa: A002
+) -> ArtifactVersion | None:
+    """The published pointer: latest ``published`` row in (scope, branch)."""
+    return (
+        await ArtifactVersion.find(
+            ArtifactVersion.scope_type == scope_type,
+            ArtifactVersion.scope_id == scope_id,
+            ArtifactVersion.branch == branch,
+            ArtifactVersion.status == "published",
+        )
+        .sort(("version_no", pymongo.DESCENDING))
+        .first_or_none()
+    )
+
+
+async def list_versions(
+    *,
+    scope_type: str,
+    scope_id: str,
+    branch: str | None = None,  # noqa: A002
+    limit: int = 100,
+) -> list[ArtifactVersion]:
+    """The version log for an artifact, newest first.
+
+    Scoped to one ``branch`` when given, else all branches of the artifact.
+    """
+    query = [
+        ArtifactVersion.scope_type == scope_type,
+        ArtifactVersion.scope_id == scope_id,
+    ]
+    if branch is not None:
+        query.append(ArtifactVersion.branch == branch)
+    return (
+        await ArtifactVersion.find(*query)
+        .sort(("version_no", pymongo.DESCENDING))
+        .limit(limit)
+        .to_list()
+    )

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -30,6 +30,15 @@
 # "Untitled site" only when the pocket has no name. Also pins the end-to-end
 # publish_pocket path: a pocket named "Flower Shop Landing Page" published with no
 # name lands a Site named "Flower Shop Landing Page".
+# Updated 2026-06-18 (feat/branch-primitive-sites-draft, BP-2 / pocketpaw#1345):
+# branch-aware publish/preview/status coverage over the BP-1 versions spine —
+# (1) a pocket with only a draft version reads draft / not live; (2) is_live is
+# True ONLY after a successful deploy and stays not-live when the deploy fails (the
+# Site doc is not persisted) while the published version tag still stands;
+# (3) preview_pocket serves the DRAFT VERSION's content (and falls back to current
+# content when no draft row exists); (4) publish promotes the current draft to a
+# published version via versions.publish; plus has_unpublished_changes when a draft
+# is newer than the published version.
 from __future__ import annotations
 
 import pytest
@@ -727,3 +736,270 @@ async def test_pocket_status_is_tenant_scoped(beanie_test_db):
     assert res.status == "draft"
     assert res.is_live is False
     assert res.site_id is None
+
+
+# ---------------------------------------------------------------------------
+# BP-2 / #1345 — branch-aware publish/preview/status over the BP-1 versions
+# spine. The bug: a site was stamped ``deployed`` (→ published + live) the
+# instant a Site doc existed, so the "Live" badge lied and the preview pointed
+# at the live URL. These pin the fix: status derives from the version pointers +
+# real deploy state, preview serves the DRAFT version, publish promotes the draft
+# to a published version before deploy.
+# ---------------------------------------------------------------------------
+
+
+class _BoomCF:
+    """A Cloudflare client whose deploy (put_worker) FAILS — used to prove a
+    failed deploy leaves the pocket not-live (no Site doc persisted) while the
+    published version tag may still stand."""
+
+    async def put_worker(self, *, script_name, bundle):
+        raise RuntimeError("cloudflare put_worker failed")
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_draft_version_only_is_draft_not_live(beanie_test_db):
+    """A pocket that has a DRAFT version but was never published reads draft / not
+    live, with has_unpublished_changes True (there is a draft to ship)."""
+    from pocketpaw_ee.versions import service as versions_service
+
+    await versions_service.write_draft(
+        scope_type="pocket",
+        scope_id="pk_draft_only",
+        workspace_id="ws1",
+        content={"type": "container"},
+    )
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_draft_only")
+    assert res.status == "draft"
+    assert res.is_live is False
+    assert res.has_unpublished_changes is True
+    assert res.site_id is None
+
+
+@pytest.mark.asyncio
+async def test_publish_promotes_draft_to_published_version(beanie_test_db):
+    """publish() promotes the pocket's current draft to a PUBLISHED version
+    (versions.publish) before deploy, so a published pointer exists afterwards and
+    the pocket reads published + live with no unpublished changes."""
+    from pocketpaw_ee.versions import service as versions_service
+
+    # A draft exists (as the pocket merge hook would have written).
+    draft = await versions_service.write_draft(
+        scope_type="pocket",
+        scope_id="pk_promote",
+        workspace_id="ws1",
+        content={"type": "container", "v": 1},
+    )
+    assert draft.status == "draft"
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_promote",
+        ripple_spec={"type": "container", "v": 1},
+        theme={},
+        name="x",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    assert site.deployed is True
+
+    # The draft was promoted: a published version pointer now exists, pointing at
+    # the same version row (no NEW draft was created, the existing one flipped).
+    published = await versions_service.get_published(scope_type="pocket", scope_id="pk_promote")
+    assert published is not None
+    assert str(published.id) == str(draft.id)
+    assert published.status == "published"
+
+    # Status derives published + live from the pointer + real deploy state.
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_promote")
+    assert res.status == "published"
+    assert res.is_live is True
+    assert res.has_unpublished_changes is False
+    assert res.site_id == str(site.id)
+
+
+@pytest.mark.asyncio
+async def test_publish_with_no_draft_writes_then_publishes_a_version(beanie_test_db):
+    """A pocket published WITHOUT a pre-existing draft row (never went through
+    merge_spec) still lands a published version: publish() writes a draft snapshot
+    of the engine content, then promotes it."""
+    from pocketpaw_ee.versions import service as versions_service
+
+    assert await versions_service.get_published(scope_type="pocket", scope_id="pk_fresh") is None
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_fresh",
+        ripple_spec={"type": "container", "fresh": True},
+        theme={},
+        name="x",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    published = await versions_service.get_published(scope_type="pocket", scope_id="pk_fresh")
+    assert published is not None
+    assert published.content == {"type": "container", "fresh": True}
+
+
+@pytest.mark.asyncio
+async def test_publish_failed_deploy_leaves_pocket_not_live(beanie_test_db, monkeypatch):
+    """is_live ONLY after a successful deploy: when the deploy raises, no Site doc
+    is persisted (so pocket_status reads not-live), but the published version tag
+    may still stand (published != live)."""
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+    from pocketpaw_ee.versions import service as versions_service
+
+    # Force the REAL deploy branch (injected CF) and make it blow up.
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    gen = _FakeGenerator()
+    boom_cf = _BoomCF()
+
+    with pytest.raises(RuntimeError):
+        await sites_service.publish(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk_fail",
+            ripple_spec={"type": "container"},
+            theme={},
+            name="x",
+            _generator=gen,
+            _cloudflare=boom_cf,
+            _bundle_reader=lambda d: b"x",
+        )
+
+    # No Site doc was persisted — the deploy failed before the insert.
+    assert await _SiteDoc.find_one({"workspace": "ws1", "pocket_id": "pk_fail"}) is None
+
+    # The pocket is NOT live (the only thing that earns a Live badge is a real
+    # successful deploy, which never happened).
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_fail")
+    assert res.is_live is False
+
+    # The published version tag was set BEFORE the deploy, so it may stand:
+    # published is true at the Branch layer even though the site is not live.
+    published = await versions_service.get_published(scope_type="pocket", scope_id="pk_fail")
+    assert published is not None
+    assert res.status == "published"
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_draft_newer_than_published_has_unpublished_changes(beanie_test_db):
+    """After publishing, a NEW draft (a later edit) makes the pocket read published
+    + live AND has_unpublished_changes — the edits a re-publish would ship."""
+    from pocketpaw_ee.versions import service as versions_service
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_edit",
+        ripple_spec={"type": "container", "v": 1},
+        theme={},
+        name="x",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+    # Right after publish: published, live, no unpublished changes.
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_edit")
+    assert res.status == "published"
+    assert res.is_live is True
+    assert res.has_unpublished_changes is False
+
+    # A later edit writes a NEW draft (as the merge hook would) newer than the
+    # published version.
+    await versions_service.write_draft(
+        scope_type="pocket",
+        scope_id="pk_edit",
+        workspace_id="ws1",
+        content={"type": "container", "v": 2},
+    )
+    res2 = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_edit")
+    assert res2.status == "published"  # still live on the published version
+    assert res2.is_live is True
+    assert res2.has_unpublished_changes is True  # but there is a newer draft
+    assert res2.site_id == str(site.id)
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_legacy_deployed_site_without_versions_reads_published(
+    beanie_test_db,
+):
+    """Backward compat: a Site deployed BEFORE BP-1 has a deployed Site doc but no
+    version rows — it must still read published + live, not regress to draft."""
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    legacy = _SiteDoc(
+        workspace="ws1",
+        pocket_id="pk_legacy",
+        owner="u1",
+        name="Legacy",
+        script_name="legacy",
+        deployed=True,
+    )
+    await legacy.insert()
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_legacy")
+    assert res.status == "published"
+    assert res.is_live is True
+    assert res.has_unpublished_changes is False
+    assert res.site_id == str(legacy.id)
+
+
+@pytest.mark.asyncio
+async def test_preview_pocket_serves_draft_version_content(beanie_test_db):
+    """preview_pocket serves the DRAFT VERSION's content (the unpublished working
+    copy), NOT the pocket's currently-stored rippleSpec, so the Preview tab shows
+    what publish WOULD build."""
+    from unittest.mock import AsyncMock, patch
+
+    from pocketpaw_ee.versions import service as versions_service
+
+    # The pocket's CURRENT stored spec (e.g. what was last published / saved).
+    current_spec = {"type": "container", "v": "current"}
+    # A newer DRAFT version — the working copy the preview must serve.
+    draft_spec = {"type": "container", "v": "draft"}
+    await versions_service.write_draft(
+        scope_type="pocket",
+        scope_id="pk_preview",
+        workspace_id="ws1",
+        content=draft_spec,
+    )
+
+    wire = {"name": "x", "engine": "ripple", "rippleSpec": current_spec}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        res = await sites_service.preview_pocket(
+            workspace_id="ws1", user_id="u1", pocket_id="pk_preview"
+        )
+
+    assert res.engine == "ripple"
+    # The draft snapshot wins over the pocket's current stored spec.
+    assert res.content == draft_spec
+
+
+@pytest.mark.asyncio
+async def test_preview_pocket_falls_back_to_current_content_when_no_draft(beanie_test_db):
+    """When no draft version row exists (a pre-BP-1 pocket, or a svelte pocket whose
+    source map BP-1 does not version), preview falls back to the pocket's current
+    content so the preview is never empty when content exists."""
+    from unittest.mock import AsyncMock, patch
+
+    current_spec = {"type": "container", "v": "current"}
+    wire = {"name": "x", "engine": "ripple", "rippleSpec": current_spec}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        res = await sites_service.preview_pocket(
+            workspace_id="ws1", user_id="u1", pocket_id="pk_no_draft"
+        )
+
+    assert res.content == current_spec

--- a/tests/ee/versions/__init__.py
+++ b/tests/ee/versions/__init__.py
@@ -1,0 +1,4 @@
+# tests/ee/versions/__init__.py
+# Created: 2026-06-18 (feat/branch-primitive-versions, BP-1) — test package for
+# the universal Branch-primitive versions core. Makes tests/ee/versions a
+# package so its conftest fixtures resolve.

--- a/tests/ee/versions/conftest.py
+++ b/tests/ee/versions/conftest.py
@@ -1,0 +1,42 @@
+# tests/ee/versions/conftest.py
+# Created: 2026-06-18 (feat/branch-primitive-versions, BP-1) — fixtures for the
+# versions-core tests.
+#
+# The versions service emits Journal events through the process-cached org
+# journal (``pocketpaw.journal_dep.get_journal``). To make those events
+# assertable + isolated, ``versions_journal`` points the cached journal at a
+# per-test tmp file by setting ``SOUL_DATA_DIR`` (which ``journal_dep`` reads
+# when resolving the org data dir) and clearing the lru cache before/after.
+# It yields the opened Journal so a test can ``.query(action=...)`` it.
+#
+# ``beanie_test_db`` (the mongomock-motor + init_beanie fixture that registers
+# ALL_DOCUMENTS, including ArtifactVersion) is inherited from
+# ``tests/ee/conftest.py`` — no need to redeclare it here.
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pocketpaw.journal_dep import get_journal, reset_journal_cache
+
+
+@pytest.fixture()
+def versions_journal(tmp_path: Path) -> Iterator:
+    """Point the cached org journal at a fresh per-test tmp file and yield it.
+
+    Resetting the cache before and after keeps the journal from leaking across
+    tests; setting ``SOUL_DATA_DIR`` makes ``journal_dep._org_data_dir`` resolve
+    to ``tmp_path`` so the service's lazy ``get_journal()`` opens the same file
+    the test reads back.
+    """
+    reset_journal_cache()
+    with patch.dict(os.environ, {"SOUL_DATA_DIR": str(tmp_path)}):
+        journal = get_journal()
+        try:
+            yield journal
+        finally:
+            reset_journal_cache()

--- a/tests/ee/versions/test_pocket_merge_hook.py
+++ b/tests/ee/versions/test_pocket_merge_hook.py
@@ -1,0 +1,170 @@
+# tests/ee/versions/test_pocket_merge_hook.py
+# Created: 2026-06-18 (feat/branch-primitive-versions, BP-1) — proves the
+# pocket-content write path records a draft ArtifactVersion.
+#
+# What this pins:
+#   * Mutating a pocket's rippleSpec via the service-level ``merge_spec`` path
+#     persists a NEW draft ArtifactVersion (scope_type="pocket", scope_id =
+#     the pocket id) carrying the merged spec snapshot.
+#   * The existing merge still works (ok:true, the spec persists) — the version
+#     write is additive, not a replacement.
+#   * A second merge produces a second, monotonically-numbered version.
+#
+# Posture: same collaborator-stubbing as tests/cloud/pockets/test_merge_spec.py
+# (mock the DB-bound + catalog + emit collaborators so merge_spec runs without
+# the full auth/catalog plumbing), BUT against a real ``beanie_test_db`` so the
+# versions.write_draft call inside the hook persists a real ArtifactVersion row
+# we can query back. The fake pocket doc supplies the id + workspace the
+# version write keys off.
+from __future__ import annotations
+
+import copy
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.versions import service as versions
+from pocketpaw_ee.versions.models import ArtifactVersion
+
+pytestmark = pytest.mark.asyncio
+
+POCKET_ID = "pocket-bp1"
+WS_ID = "ws-bp1"
+USER_ID = "user-bp1"
+
+
+class _FakeDoc:
+    """In-memory stand-in for the Pocket doc — only the attributes the
+    merge_spec path (and the BP-1 version hook) read/write."""
+
+    def __init__(self, spec: dict) -> None:
+        self.rippleSpec = spec
+        self.id = POCKET_ID
+        self.workspace = WS_ID
+        self.save_calls = 0
+
+    async def save(self) -> None:
+        self.save_calls += 1
+
+
+def _base_spec() -> dict:
+    return {
+        "version": "1.0",
+        "state": {"draft": ""},
+        "ui": {
+            "id": "n_root0001",
+            "type": "flex",
+            "props": {"direction": "column", "gap": 12},
+            "children": [
+                {
+                    "id": "n_input001",
+                    "type": "input",
+                    "props": {"value": "{{state.draft}}", "label": "Draft"},
+                },
+            ],
+        },
+    }
+
+
+def _wire_stubs(monkeypatch: pytest.MonkeyPatch, fake_doc: _FakeDoc) -> None:
+    """Stub the DB-bound + catalog + emit collaborators so merge_spec runs
+    in-memory against ``fake_doc`` — leaving ONLY the BP-1 version hook to hit
+    the real ``beanie_test_db``."""
+
+    async def _fake_fetch(pocket_id: str):  # type: ignore[no-untyped-def]
+        return fake_doc
+
+    async def _fake_resolved_wire_dict(doc, viewer_user_id):  # type: ignore[no-untyped-def]
+        return {"id": doc.id, "rippleSpec": doc.rippleSpec}
+
+    async def _fake_event_payload(doc):  # type: ignore[no-untyped-def]
+        return {"recipient_ids": [], "pocket": {"id": doc.id}}
+
+    async def _fake_emit(event):  # type: ignore[no-untyped-def]
+        return None
+
+    async def _noop_gate_catalog(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(pockets_service, "_fetch_pocket", _fake_fetch)
+    monkeypatch.setattr(pockets_service, "_pocket_to_domain", lambda doc: object())
+    monkeypatch.setattr(pockets_service, "_check_domain_edit_access", lambda *a, **k: None)
+    monkeypatch.setattr(pockets_service, "_gate_catalog", _noop_gate_catalog)
+    monkeypatch.setattr(pockets_service, "_resolved_wire_dict", _fake_resolved_wire_dict)
+    monkeypatch.setattr(pockets_service, "_pocket_event_payload", _fake_event_payload)
+    monkeypatch.setattr(pockets_service, "emit", _fake_emit)
+
+
+async def test_merge_records_pocket_draft_version(beanie_test_db, monkeypatch: pytest.MonkeyPatch):
+    fake_doc = _FakeDoc(copy.deepcopy(_base_spec()))
+    _wire_stubs(monkeypatch, fake_doc)
+
+    # No version exists for this pocket yet.
+    assert await versions.get_draft(scope_type="pocket", scope_id=POCKET_ID) is None
+
+    body = {"merge": {"state": {"draft": "hello"}}}
+    result = await pockets_service.merge_spec(
+        workspace_id=WS_ID, user_id=USER_ID, pocket_id=POCKET_ID, body=body
+    )
+
+    # The existing merge still works.
+    assert result["ok"] is True, result
+    assert fake_doc.save_calls == 1
+    assert fake_doc.rippleSpec["state"]["draft"] == "hello"
+
+    # A draft ArtifactVersion now exists for the pocket, snapshotting the spec.
+    draft = await versions.get_draft(scope_type="pocket", scope_id=POCKET_ID)
+    assert draft is not None
+    assert draft.scope_type == "pocket"
+    assert draft.scope_id == POCKET_ID
+    assert draft.workspace_id == WS_ID
+    assert draft.author == USER_ID
+    assert draft.status == "draft"
+    assert draft.version_no == 1
+    assert draft.content["state"]["draft"] == "hello"
+
+
+async def test_second_merge_writes_second_version(beanie_test_db, monkeypatch: pytest.MonkeyPatch):
+    fake_doc = _FakeDoc(copy.deepcopy(_base_spec()))
+    _wire_stubs(monkeypatch, fake_doc)
+
+    await pockets_service.merge_spec(
+        workspace_id=WS_ID,
+        user_id=USER_ID,
+        pocket_id=POCKET_ID,
+        body={"merge": {"state": {"draft": "first"}}},
+    )
+    await pockets_service.merge_spec(
+        workspace_id=WS_ID,
+        user_id=USER_ID,
+        pocket_id=POCKET_ID,
+        body={"merge": {"state": {"draft": "second"}}},
+    )
+
+    log = await versions.list_versions(scope_type="pocket", scope_id=POCKET_ID)
+    assert [v.version_no for v in log] == [2, 1]
+    assert log[0].content["state"]["draft"] == "second"
+
+
+async def test_version_hook_failure_does_not_break_merge(
+    beanie_test_db, monkeypatch: pytest.MonkeyPatch
+):
+    """The version write is best-effort — if it raises, the merge still
+    succeeds (the snapshot is an additive audit layer, never a gate)."""
+    fake_doc = _FakeDoc(copy.deepcopy(_base_spec()))
+    _wire_stubs(monkeypatch, fake_doc)
+
+    async def _boom(**kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("version store down")
+
+    monkeypatch.setattr(versions, "write_draft", _boom)
+
+    result = await pockets_service.merge_spec(
+        workspace_id=WS_ID,
+        user_id=USER_ID,
+        pocket_id=POCKET_ID,
+        body={"merge": {"state": {"draft": "still works"}}},
+    )
+    assert result["ok"] is True
+    assert fake_doc.save_calls == 1
+    # No version row was written, but the merge persisted.
+    assert await ArtifactVersion.find().count() == 0

--- a/tests/ee/versions/test_versions_service.py
+++ b/tests/ee/versions/test_versions_service.py
@@ -1,0 +1,263 @@
+# tests/ee/versions/test_versions_service.py
+# Created: 2026-06-18 (feat/branch-primitive-versions, BP-1) — coverage for the
+# universal Branch-primitive versions service spine.
+#
+# Invariants pinned here:
+#   1. write_draft creates monotonic version_no within (scope, branch) and
+#      links parent_version_id to the prior head.
+#   2. get_draft returns the latest draft; get_published returns nothing until
+#      publish(); publish() flips the published pointer (published_version_id
+#      does not change until publish is called).
+#   3. publish() validates the version belongs to the artifact/workspace.
+#   4. branch() opens a candidate lineage off the source head (version_no=1,
+#      parent pointing back at the source).
+#   5. list_versions returns the version log newest-first.
+#   6. write_draft emits artifact.version.created; branch emits
+#      artifact.version.branched — both with a non-empty stamped scope.
+#   7. revert is a BP-4 stub (raises NotImplementedError).
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.versions import service as versions
+
+pytestmark = pytest.mark.asyncio
+
+POCKET = "pocket-abc"
+WS = "ws-1"
+
+
+# ---------------------------------------------------------------------------
+# 1. write_draft — monotonic versions + parent linkage
+# ---------------------------------------------------------------------------
+
+
+async def test_write_draft_monotonic_versions(beanie_test_db):
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"state": {"n": 1}}
+    )
+    v2 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"state": {"n": 2}}
+    )
+    v3 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"state": {"n": 3}}
+    )
+
+    assert [v1.version_no, v2.version_no, v3.version_no] == [1, 2, 3]
+    assert v1.parent_version_id is None
+    assert v2.parent_version_id == str(v1.id)
+    assert v3.parent_version_id == str(v2.id)
+    assert all(v.status == "draft" for v in (v1, v2, v3))
+    assert v3.content == {"state": {"n": 3}}
+
+
+async def test_version_no_is_per_scope(beanie_test_db):
+    # Two different artifacts each start their own monotonic sequence.
+    a1 = await versions.write_draft(
+        scope_type="pocket", scope_id="pocket-A", workspace_id=WS, content={}
+    )
+    b1 = await versions.write_draft(
+        scope_type="pocket", scope_id="pocket-B", workspace_id=WS, content={}
+    )
+    a2 = await versions.write_draft(
+        scope_type="pocket", scope_id="pocket-A", workspace_id=WS, content={}
+    )
+    assert a1.version_no == 1
+    assert b1.version_no == 1
+    assert a2.version_no == 2
+
+
+async def test_generic_scope_type(beanie_test_db):
+    # The model/service are artifact-generic — a non-pocket scope_type works
+    # with no model change (this is the OSS-extraction seam).
+    v = await versions.write_draft(
+        scope_type="dashboard", scope_id="dash-1", workspace_id=WS, content={"x": 1}
+    )
+    assert v.scope_type == "dashboard"
+    assert v.version_no == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. pointer reads — get_draft / get_published + publish flips the pointer
+# ---------------------------------------------------------------------------
+
+
+async def test_get_draft_returns_latest_draft(beanie_test_db):
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    v2 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 2}
+    )
+    draft = await versions.get_draft(scope_type="pocket", scope_id=POCKET)
+    assert draft is not None
+    assert draft.id == v2.id
+    assert draft.content == {"v": 2}
+
+
+async def test_published_pointer_unchanged_until_publish(beanie_test_db):
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    # No published version exists yet.
+    assert await versions.get_published(scope_type="pocket", scope_id=POCKET) is None
+
+    published = await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    assert published.status == "published"
+
+    pub_pointer = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert pub_pointer is not None
+    assert pub_pointer.id == v1.id
+
+
+async def test_publish_promotes_newer_version(beanie_test_db):
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    v2 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 2}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    # Promote v2 — the published pointer follows the higher version_no.
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v2.id)
+    )
+    pub = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert pub is not None
+    assert pub.id == v2.id
+
+
+async def test_publish_rejects_foreign_artifact(beanie_test_db):
+    v = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={}
+    )
+    with pytest.raises(ValueError):
+        await versions.publish(
+            scope_type="pocket",
+            scope_id="some-other-pocket",
+            workspace_id=WS,
+            version_id=str(v.id),
+        )
+
+
+async def test_publish_missing_version_raises(beanie_test_db):
+    from beanie import PydanticObjectId
+
+    with pytest.raises(ValueError):
+        await versions.publish(
+            scope_type="pocket",
+            scope_id=POCKET,
+            workspace_id=WS,
+            version_id=str(PydanticObjectId()),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. branch — candidate lineage off the source head
+# ---------------------------------------------------------------------------
+
+
+async def test_branch_opens_candidate_from_published_head(beanie_test_db):
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"live": True}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    cand = await versions.branch(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, new_branch="candidate-1"
+    )
+    assert cand.branch == "candidate-1"
+    assert cand.version_no == 1
+    assert cand.parent_version_id == str(v1.id)
+    assert cand.content == {"live": True}  # snapshot of the published head
+    # The candidate is its own branch — main's published pointer is unaffected
+    # (still v1) and the candidate row does NOT show up as a main-branch draft.
+    main_pub = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert main_pub is not None
+    assert main_pub.id == v1.id
+    assert await versions.get_draft(scope_type="pocket", scope_id="candidate-never") is None
+    cand_draft = await versions.get_draft(
+        scope_type="pocket", scope_id=POCKET, branch="candidate-1"
+    )
+    assert cand_draft is not None
+    assert cand_draft.id == cand.id
+
+
+async def test_branch_falls_back_to_latest_when_nothing_published(beanie_test_db):
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"draft": 1}
+    )
+    cand = await versions.branch(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, new_branch="candidate-x"
+    )
+    assert cand.parent_version_id == str(v1.id)
+    assert cand.content == {"draft": 1}
+
+
+# ---------------------------------------------------------------------------
+# 5. list_versions — the version log
+# ---------------------------------------------------------------------------
+
+
+async def test_list_versions_newest_first(beanie_test_db):
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 2}
+    )
+    log = await versions.list_versions(scope_type="pocket", scope_id=POCKET, branch="main")
+    assert [v.version_no for v in log] == [2, 1]
+
+
+# ---------------------------------------------------------------------------
+# 6. Journal emission
+# ---------------------------------------------------------------------------
+
+
+async def test_write_draft_emits_version_created(beanie_test_db, versions_journal):
+    v = await versions.write_draft(
+        scope_type="pocket",
+        scope_id=POCKET,
+        workspace_id=WS,
+        content={"v": 1},
+        author="user-7",
+    )
+    events = versions_journal.query(action="artifact.version.created")
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.payload["version_id"] == str(v.id)
+    assert ev.payload["scope_type"] == "pocket"
+    assert ev.payload["version_no"] == 1
+    # Scope MUST be stamped non-empty (journal invariant + downstream filters).
+    assert ev.scope
+    assert f"pocket:{POCKET}" in ev.scope
+    assert f"workspace:{WS}" in ev.scope
+
+
+async def test_branch_emits_version_branched(beanie_test_db, versions_journal):
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    cand = await versions.branch(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, new_branch="cand"
+    )
+    events = versions_journal.query(action="artifact.version.branched")
+    assert len(events) == 1
+    assert events[0].payload["version_id"] == str(cand.id)
+    assert events[0].payload["from_branch"] == "main"
+    assert events[0].scope  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# 7. revert — BP-4 stub
+# ---------------------------------------------------------------------------
+
+
+async def test_revert_is_bp4_stub(beanie_test_db):
+    with pytest.raises(NotImplementedError):
+        await versions.revert()


### PR DESCRIPTION
BP-2 of the Branch primitive, stacked on #1489. Puts the sites publish/preview/status flow on top of BP-1's version log and fixes pocketpaw#1345 along the way.

## What ships
- `pocket_status` now derives draft-vs-published and `is_live` from the version pointers plus real deploy state — not from "a Site doc exists." A pocket reads `published` only when it has a published version (or a legacy pre-versions deploy), and `is_live` only when published AND the deploy actually succeeded. Adds `has_unpublished_changes` (a draft newer than the published version).
- `publish` promotes the current draft to published (`versions.publish`) before deploying, then flips Live true only after a successful deploy. A failed deploy leaves the site not-live; the published tag still stands.
- `preview_pocket` serves the draft version's content, so the builder previews what publish would build instead of a dead/published URL.

## Fixes #1345
"Live" no longer lies (no optimistic deployed stamp), and preview renders the draft.

## Tenant isolation
BP-1's pointer reads are artifact-generic (not workspace-scoped by design), so the sites layer guards by matching `workspace_id` on each version row before trusting it. pocket_id is a globally-unique ObjectId, so this holds.

## Known gap (tracked for the editor slice)
BP-1's merge hook snapshots rippleSpec; svelte source maps aren't draft-versioned by the merge path yet (svelte edits go through a different write). For svelte pockets, publish writes the source as the published snapshot and preview falls back to current source. The editor slice will wire svelte-source draft versioning.

## Tests
9 new + existing sites/versions suites — 117 passing locally, no regressions. ruff clean.

## Stacking
Base is the BP-1 branch (#1489), not dev. Merge #1489 first (rebase), then this.