### PR TITLE
feat(instinct): artifact-change merge gate — review/approve site edits before they deploy

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -197,7 +197,16 @@ rippleSpec persist, via the universal Branch-primitive versions service. The
 existing destructive overwrite + emit are unchanged; the version write is an
 additive, best-effort snapshot (a version-store failure never breaks the merge)
 so every content mutation gains a draft/history without changing the merge
-contract. TODO(BP-3/BP-4): merge gate + revert/history hook onto these rows.
+contract. TODO(BP-4): revert/history hook onto these rows.
+Changes: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) —
+``set_svelte_source_file`` now ALSO records a draft ArtifactVersion
+(scope_type="pocket") after a svelte source edit, via
+``_record_pocket_svelte_draft_version`` (the svelte peer of
+``_record_pocket_draft_version``). BP-1 only versioned the rippleSpec write
+(merge_spec); svelte edits go through ``set_svelte_source_file`` and were not
+versioned. Same additive, best-effort snapshot contract — a version-store
+failure never breaks the edit. The merge gate itself lives in the Instinct
+router (BP-3); these rows are the candidates it reviews.
 """
 
 from __future__ import annotations
@@ -1459,6 +1468,14 @@ async def set_svelte_source_file(
     doc.source = updated
     await doc.save()
     await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+    # Branch primitive (BP-3): a svelte source edit ALSO writes a draft
+    # ArtifactVersion. BP-1 only hooked the rippleSpec write (merge_spec →
+    # _record_pocket_draft_version); svelte edits go through THIS function and
+    # were not versioned. The snapshot is the full svelte ``source`` map (the
+    # version model's ``content`` accepts either a rippleSpec dict OR a svelte
+    # source map). Same best-effort try/except as the rippleSpec hook —
+    # versioning is an additive history layer, never a gate on the edit.
+    await _record_pocket_svelte_draft_version(doc, author=user_id)
     return await _resolved_wire_dict(doc, user_id), previous_source
 
 
@@ -1655,6 +1672,40 @@ async def _record_pocket_draft_version(doc: _PocketDoc, *, author: str | None) -
         logger.warning(
             "versions: failed to record draft version for pocket %s — "
             "merge persisted, version skipped",
+            doc.id,
+            exc_info=True,
+        )
+
+
+async def _record_pocket_svelte_draft_version(doc: _PocketDoc, *, author: str | None) -> None:
+    """Snapshot a svelte pocket's current ``source`` map as a draft ArtifactVersion.
+
+    Branch-primitive hook (BP-3). The svelte analog of
+    ``_record_pocket_draft_version``: BP-1 versioned the rippleSpec write
+    (merge_spec); svelte source edits go through ``set_svelte_source_file`` and
+    were not versioned, so a published svelte site had no draft version to
+    promote. This captures the full ``source`` map (``{path: contents}``) as the
+    version ``content`` — the version model accepts either shape — with
+    ``scope_type="pocket"`` (BP-2 keys site versions on the source pocket).
+
+    Lazy-imports the versions service so the pockets entity takes no hard import
+    on it; failures are logged and swallowed — versioning is an additive
+    history/Branch layer over the edit, never a gate on it.
+    """
+    try:
+        from pocketpaw_ee.versions import service as versions_service
+
+        await versions_service.write_draft(
+            scope_type="pocket",
+            scope_id=str(doc.id),
+            workspace_id=doc.workspace,
+            content=dict(doc.source) if isinstance(doc.source, dict) else {},
+            author=author,
+        )
+    except Exception:  # noqa: BLE001 — versioning must not break the edit
+        logger.warning(
+            "versions: failed to record svelte draft version for pocket %s — "
+            "edit persisted, version skipped",
             doc.id,
             exc_info=True,
         )

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -341,12 +341,34 @@ def _assert_artifact_change_workspace(action: Any, current_workspace: str) -> No
     mutation, on BOTH the approve and the reject side (asymmetric tenant scope is
     no tenant scope — pocketpaw#1183 / #1250). A non-artifact-change Action (no
     blob) is unaffected.
+
+    FAIL-CLOSED on an empty claim — a blob whose workspace resolves to "" (the
+    key absent or null) is a HARD 403 (``instinct.missing_workspace_in_blob``),
+    not a pass-through. An artifact change's tenancy is mandatory; without it the
+    gate cannot verify the caller owns the artifact, so allowing it would let an
+    attacker propose a workspace-less blob targeting a victim's pocket and have
+    any operator approve (publish + DEPLOY) it. There is no legitimate
+    empty-workspace case here.
     """
     blob = _artifact_change_blob(action)
     if blob is None:
         return
     blob_workspace = str(blob.get("workspace") or blob.get("workspace_id") or "")
-    if blob_workspace and blob_workspace != current_workspace:
+    # SECURITY — an absent/empty workspace claim is a HARD 403, never a
+    # pass-through. The old ``if blob_workspace and ...`` short-circuited: a blob
+    # whose workspace resolved to "" skipped the tenancy check entirely, so an
+    # attacker could propose an artifact change with workspace="" and
+    # scope_id=<victim pocket> and have ANY operator in ANY workspace approve
+    # (publish + DEPLOY) or reject (discard) it. There is no legitimate
+    # empty-workspace case for an artifact change — its tenancy is mandatory —
+    # so we fail closed before the equality check on both the approve and reject
+    # side.
+    if not blob_workspace:
+        raise Forbidden(
+            "instinct.missing_workspace_in_blob",
+            "This artifact change has no workspace claim — cannot verify tenancy",
+        )
+    if blob_workspace != current_workspace:
         raise Forbidden(
             "instinct.cross_workspace_approval",
             "This artifact change belongs to a different workspace",

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,25 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — added the
+#   FIFTH gated proposal kind: the Branch-primitive artifact-change MERGE GATE.
+#   ``_artifact_change_blob`` + ``_assert_artifact_change_workspace`` are the
+#   peers of the four existing blob accessors + tenancy guards. The blob
+#   (``Action.parameters._artifact_change``) carries {scope_type, scope_id,
+#   branch, from_version_id, to_version_id, workspace, user_id}. On APPROVE the
+#   router emits ``human.corrected`` then fires
+#   ``versions.instinct_executor.execute_approved_change`` (MERGE = publish the
+#   candidate version via versions.publish + mark it merged + deploy via BP-2's
+#   sites.publish_pocket for pocket/site scope; the executor owns the
+#   executed/failed terminal). On REJECT the router emits ``human.corrected`` +
+#   ``decision.completed(rejected)`` itself then fires
+#   ``versions.instinct_executor.discard_rejected_change`` (DISCARD = flip the
+#   candidate to reverted; the PUBLISHED pointer is left untouched). The
+#   ``_assert_artifact_change_workspace`` 403 runs in ALL FOUR locations
+#   (approve / bulk-approve / reject / bulk-reject) BEFORE any mutation —
+#   asymmetric tenant scope is no tenant scope (pocketpaw#1183 / #1250). Part A
+#   of BP-3 also added an additive ``scope_type`` to ``ProposeRequest`` /
+#   ``propose_action`` so an Action can be scoped to a generic artifact.
+#   TODO(BP-4): revert/discard semantics deepen in the executor + a history view.
 # Updated: 2026-06-11 (feat/external-action-proposal) — added the THIRD gated
 #   proposal kind: a gated external-action connector call. ``_external_action_blob``
 #   + ``_assert_external_action_workspace`` are the peers of the ``_code_change``
@@ -289,6 +309,50 @@ def _external_action_blob(action: Any) -> dict[str, Any] | None:
     return blob if isinstance(blob, dict) else None
 
 
+def _artifact_change_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_artifact_change`` blob on an Action, or ``None``.
+
+    The blob is the Branch-primitive merge-gate payload a producer stores under
+    ``Action.parameters._artifact_change``:
+    ``{scope_type, scope_id, branch, from_version_id, to_version_id, workspace,
+    user_id}``. This is the FIFTH gated proposal kind (BP-3) — the peer of
+    ``_pocket_write`` / ``_code_change`` / ``_external_action`` / ``_belt_plan``.
+    On APPROVE the router dispatches the merge executor (publish the target
+    version + deploy); on REJECT it dispatches the discard. Anything not a dict
+    is treated as "no artifact change".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_artifact_change")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_artifact_change_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting an artifact change from another workspace.
+
+    SECURITY (BP-3) — the merge gate is the human REVIEW/MERGE gate over a
+    version candidate; approving it MOVES THE PUBLISHED POINTER and triggers a
+    DEPLOY. ``require_action_any_workspace("instinct.approve")`` only proves the
+    caller holds the role SOMEWHERE; this binds the artifact-change Action to the
+    caller's active workspace. The artifact's tenancy lives on the blob's
+    ``workspace`` (with ``workspace_id`` accepted as an alias). A blob whose
+    workspace differs from the caller's active workspace → 403, BEFORE any state
+    mutation, on BOTH the approve and the reject side (asymmetric tenant scope is
+    no tenant scope — pocketpaw#1183 / #1250). A non-artifact-change Action (no
+    blob) is unaffected.
+    """
+    blob = _artifact_change_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace") or blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This artifact change belongs to a different workspace",
+        )
+
+
 def _belt_plan_blob(action: Any) -> dict[str, Any] | None:
     """Return the ``_belt_plan`` blob on an Action, or ``None``.
 
@@ -461,6 +525,10 @@ def _store():
 
 class ProposeRequest(BaseModel):
     pocket_id: str
+    # BP-3 — optional generic scope. ``None`` (the default) is the legacy
+    # pocket scope; set it (e.g. "site") to scope the Action to another
+    # artifact type, with ``pocket_id`` carrying the scope id within it.
+    scope_type: str | None = None
     title: str
     description: str = ""
     recommendation: str = ""
@@ -620,6 +688,7 @@ async def propose_action(
         reasoning_trace=req.reasoning_trace,
         fabric_snapshots=list(req.fabric_snapshots) if req.fabric_snapshots else None,
         workspace_id=workspace_id,
+        scope_type=req.scope_type,
     )
 
 
@@ -728,6 +797,7 @@ async def bulk_approve_actions(
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
+            _assert_artifact_change_workspace(action, workspace_id)
 
     approved, missing, bulk_id = await store.bulk_approve(
         list(req.ids), approver=approver_id, note=req.note
@@ -842,6 +912,35 @@ async def bulk_approve_actions(
                 )
             continue
 
+        # BP-3 — a bulk-approved ``_artifact_change`` Action MERGES its candidate
+        # (publish + deploy), exactly like the single-approve hook. Disposition
+        # is always ``accepted`` (bulk-approve has no edit surface). The executor
+        # marks the Action executed/failed; matched BEFORE the pocket-write
+        # fallthrough and ``continue``d so the kinds never cross.
+        artifact_change_blob = _artifact_change_blob(action)
+        if artifact_change_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=artifact_change_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(artifact_change_blob),
+            )
+            try:
+                from pocketpaw_ee.versions import instinct_executor as artifact_executor
+
+                await artifact_executor.execute_approved_change(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve artifact-change merge failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
         action_blob = _pocket_write_blob(action)
         if action_blob is None:
             continue
@@ -919,6 +1018,7 @@ async def bulk_reject_actions(
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
+            _assert_artifact_change_workspace(action, workspace_id)
 
     rejected, missing, bulk_id = await store.bulk_reject(
         list(req.ids), reason=req.reason, rejector=rejector_id
@@ -1027,6 +1127,40 @@ async def bulk_reject_actions(
                 causation_override=human_event_id,
             )
             await _mark_plan_rejected_safe(action, req.reason)
+            continue
+
+        # BP-3 — a bulk-rejected ``_artifact_change`` Action DISCARDS its
+        # candidate and closes its chain HERE (the merge executor never runs on
+        # reject). The published pointer is left untouched. Mirrors the
+        # code-change reject branch.
+        artifact_change_blob = _artifact_change_blob(action)
+        if artifact_change_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=artifact_change_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(artifact_change_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=artifact_change_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            try:
+                from pocketpaw_ee.versions import instinct_executor as artifact_executor
+
+                await artifact_executor.discard_rejected_change(action)
+            except Exception:
+                logger.exception(
+                    "bulk-reject artifact-change discard failed for %s (non-fatal)",
+                    action.id,
+                )
 
     return BulkActionResponse(bulk_id=bulk_id, affected=rejected, missing=missing)
 
@@ -1073,6 +1207,10 @@ async def approve_action(
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
+    # BP-3 — same tenancy gate for an artifact-change merge (its
+    # ``_artifact_change`` blob carries the workspace). Approving it moves the
+    # published pointer + deploys, so the cross-workspace gate is mandatory here.
+    _assert_artifact_change_workspace(before, workspace_id)
 
     req = req or ApproveRequest()
     # SHOULD-FIX 1 — the audit actor is the authenticated identity, not
@@ -1258,6 +1396,34 @@ async def approve_action(
         except Exception:
             logger.exception("belt_plan execution after approval failed (non-fatal)")
 
+    # BP-3 — when the approved Action carries an ``_artifact_change`` blob, MERGE
+    # the branch: promote the candidate version to published + (for pocket/site
+    # scope) trigger the deploy. The executor owns the merge state transitions +
+    # marks the Action executed/failed; the router owns the ``human.corrected``
+    # emit (citing ``agent.proposed`` as causation, same as the code-change /
+    # external-action paths — a merge proposal IS the chain origin). Same
+    # best-effort, lazy-import, never-break-the-approve-response shape as the
+    # hooks above. A non-artifact-change Action skips this.
+    artifact_change_blob = _artifact_change_blob(approved)
+    if artifact_change_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=artifact_change_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(artifact_change_blob),
+        )
+        try:
+            from pocketpaw_ee.versions import instinct_executor as artifact_executor
+
+            await artifact_executor.execute_approved_change(approved, human_event_id=human_event_id)
+        except Exception:
+            logger.exception("artifact-change merge after approval failed (non-fatal)")
+
     # gap2 — when the approved Action carries a ``_customer_reply`` blob (a
     # paw-print customer event awaiting a decision), deliver the owner's reply
     # back to the customer surface. Same best-effort, lazy-import,
@@ -1339,6 +1505,11 @@ async def reject_action(
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
+    # BP-3 — same tenancy gate for an artifact-change merge on the REJECT side.
+    # Asymmetric tenant scope is no tenant scope: a cross-workspace reject (which
+    # would discard another tenant's candidate) must 403 before any mutation,
+    # exactly like the approve side (pocketpaw#1183 / #1250).
+    _assert_artifact_change_workspace(before, workspace_id)
 
     reason = req.reason if req else ""
     rejector_id = str(user.id)
@@ -1451,6 +1622,39 @@ async def reject_action(
             causation_override=human_event_id,
         )
         await _mark_plan_rejected_safe(action, reason)
+
+    # BP-3 — a rejected ``_artifact_change`` Action DISCARDS its candidate (flips
+    # the candidate version to reverted) and closes its chain HERE (the merge
+    # executor never runs on reject — the router owns the close, mirroring the
+    # code-change reject path). The PUBLISHED pointer is left untouched: a
+    # rejection must never move what is live. ``human.corrected(rejected)`` cites
+    # ``agent.proposed``; the terminal cites the human event. The discard is a
+    # best-effort store nudge.
+    artifact_change_blob = _artifact_change_blob(action)
+    if artifact_change_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=artifact_change_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(artifact_change_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=artifact_change_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
+        try:
+            from pocketpaw_ee.versions import instinct_executor as artifact_executor
+
+            await artifact_executor.discard_rejected_change(action)
+        except Exception:
+            logger.exception("artifact-change discard after rejection failed (non-fatal)")
 
     # gap2 — a rejected ``_customer_reply`` Action delivers a DECLINED decision
     # (carrying the rejection reason) back to the customer surface. Same

--- a/ee/pocketpaw_ee/versions/__init__.py
+++ b/ee/pocketpaw_ee/versions/__init__.py
@@ -11,8 +11,15 @@
 # wired value today is ``"pocket"`` and other scope types slot in with no
 # model change.
 #
-# What lives elsewhere (later BP tasks — do NOT add here in BP-1):
-#   * BP-3 — the Instinct review/merge gate over a version candidate.
+# BP-3 additions (feat/branch-primitive-instinct-gate):
+#   * service.mark_merged / service.discard — the merge-gate state transitions
+#     (accept → status="merged", reject → status="reverted") the executor calls.
+#   * instinct_executor — the apply-on-approve (MERGE = publish + deploy) /
+#     discard-on-reject executor the Instinct router dispatches to for an
+#     ``_artifact_change`` Action. Kept in this package (not the router) so the
+#     versions spine owns its merge logic; the router only gates (403) + emits.
+#
+# What lives elsewhere (later BP tasks — do NOT add here):
 #   * BP-4 — revert + a Journal read projection (version history view).
 #   * BP-5/6 — the site editor + the review/merge UI.
 #

--- a/ee/pocketpaw_ee/versions/instinct_executor.py
+++ b/ee/pocketpaw_ee/versions/instinct_executor.py
@@ -1,0 +1,221 @@
+# ee/pocketpaw_ee/versions/instinct_executor.py
+# Created: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — the
+# apply-on-approve / discard-on-reject executor for the Branch primitive's
+# artifact-change merge gate.
+#
+# This is the executor the Instinct router dispatches to when an approved /
+# rejected Action carries an ``_artifact_change`` blob (the peer of the
+# pocket-write bridge, the belt code-change executor, and the external-action
+# executor). It is artifact-GENERIC over (scope_type, scope_id) and keeps the
+# router thin — the router owns the tenant gate (``_assert_artifact_change_
+# workspace``, a 403 before any mutation) + the Decision-Graph chain emits; this
+# module owns the actual MERGE / DISCARD state transitions + the deploy trigger.
+#
+# Contract (mirrors the belt executor):
+#   * execute_approved_change(action, human_event_id=None) — APPROVE = MERGE:
+#       1. publish the reviewed candidate (``to_version_id``) → moves the
+#          published pointer via versions.publish(). This IS the merge. In the
+#          single-row derived-pointer model (versions/models.py) published/merged
+#          are mutually exclusive, so we do NOT also mark this row "merged" — that
+#          would erase the published pointer. ``service.mark_merged`` exists for a
+#          branch-based flow where the published row lives separately on main
+#          (BP-4 / a producer path), not for this in-place promote.
+#       2. for pocket/site scope, trigger the deploy via BP-2's
+#          ``sites.service.publish_pocket(...)`` so Live reflects the new
+#          published version;
+#       3. mark the Action ``executed`` (success) or ``failed`` (any error) on
+#          the Instinct store, so The Tray shows the outcome.
+#   * discard_rejected_change(action) — REJECT = DISCARD: flip the candidate
+#       (``to_version_id``) status="reverted" so it leaves the draft pointer; the
+#       PUBLISHED pointer is left UNTOUCHED (a rejection never moves what is
+#       live). No deploy. Best-effort store nudge — the router already closed the
+#       chain on the reject path.
+#
+# Both lazy-import the versions + sites services so the instinct package keeps no
+# module-top dependency on either (same discipline as the other executors), and
+# the deploy trigger is itself wrapped so a deploy failure marks the Action
+# failed rather than crashing the approve response (the router's call is also
+# best-effort).
+#
+# TODO(BP-4): revert/discard semantics deepen — BP-4 owns reverting the published
+# pointer to a prior snapshot + the Journal history projection. BP-3 only
+# promotes the candidate on approve and abandons it on reject.
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Scope types whose merge also triggers a site deploy. A "pocket" artifact is the
+# source pocket behind a Paw Site (BP-2 keys site versions on scope_type="pocket"),
+# and a "site" scope is treated the same — both publish the pocket as a site so
+# Live reflects the newly published version. Other scope types (e.g. a future
+# "dashboard") merge the version pointer but do NOT deploy.
+_DEPLOYABLE_SCOPES = {"pocket", "site"}
+
+
+def artifact_change_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_artifact_change`` blob on an Action, or ``None``.
+
+    The blob is the merge-gate payload a Branch-primitive producer stores under
+    ``Action.parameters._artifact_change``:
+    ``{scope_type, scope_id, branch, from_version_id, to_version_id, workspace,
+    user_id}``. The router has its own ``_artifact_change_blob`` accessor (it
+    mirrors the other blob accessors there); this one lets the executor read the
+    blob without importing the router. Anything not a dict is "no artifact
+    change".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_artifact_change")
+    return blob if isinstance(blob, dict) else None
+
+
+async def execute_approved_change(action: Any, *, human_event_id: Any | None = None) -> None:
+    """MERGE an approved artifact-change Action (BP-3).
+
+    Promotes the candidate draft (``to_version_id``) to published, marks it
+    merged, and — for a deployable scope — triggers the site deploy. Marks the
+    Action ``executed`` on success or ``failed`` on any error. Never raises: the
+    router's call site is best-effort and a failure must not break the approve
+    response. The Action's outcome carries what happened so The Tray can show it.
+
+    ``human_event_id`` is accepted for parity with the other executors (the
+    chain causation handle); BP-3 does not yet thread it into a terminal chain
+    event of its own (the router owns the chain emits for this blob), so it is
+    currently unused beyond the signature contract.
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    blob = artifact_change_blob(action)
+    if blob is None:
+        # Defensive — the router only calls this when the blob is present.
+        return
+
+    scope_type = str(blob.get("scope_type") or "")
+    scope_id = str(blob.get("scope_id") or "")
+    workspace_id = str(blob.get("workspace") or blob.get("workspace_id") or "")
+    to_version_id = str(blob.get("to_version_id") or "")
+    author = blob.get("user_id")
+
+    if not (scope_type and scope_id and workspace_id and to_version_id):
+        await store.mark_failed(
+            action.id,
+            "artifact-change merge: blob missing scope_type/scope_id/workspace/to_version_id",
+        )
+        return
+
+    try:
+        from pocketpaw_ee.versions import service as versions_service
+
+        # Promote the reviewed candidate (to_version_id) to published — this IS
+        # the merge: it moves the published pointer (``get_published`` derives the
+        # pointer as the latest status=="published" row) to the version the human
+        # accepted. The service re-asserts the version belongs to (scope,
+        # workspace) (belt-and-braces under the router 403).
+        #
+        # NB: we deliberately do NOT also ``mark_merged`` THIS row. In the
+        # single-row derived-pointer model (versions/models.py) ``published`` and
+        # ``merged`` are mutually exclusive states, so flipping the just-published
+        # row to ``merged`` would erase the published pointer. ``mark_merged`` is
+        # for a branch-based flow where the published row lives separately on main
+        # (a producer path / BP-4 may use it); the BP-3 executor's job is the
+        # promote. TODO(BP-4): when revert/branch-merge semantics deepen, record
+        # the accepted branch candidate as ``merged`` separately from the
+        # published row.
+        await versions_service.publish(
+            scope_type=scope_type,
+            scope_id=scope_id,
+            workspace_id=workspace_id,
+            version_id=to_version_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as a failed Action, never raise
+        logger.exception(
+            "artifact-change merge: publish failed for %s:%s version %s",
+            scope_type,
+            scope_id,
+            to_version_id,
+        )
+        await store.mark_failed(action.id, f"artifact-change merge failed: {exc}")
+        return
+
+    # 3. Deploy for a deployable scope so Live reflects the newly published
+    #    version. The source pocket is ``scope_id`` (BP-2 keys site versions on
+    #    the pocket). A deploy failure marks the Action failed — the version is
+    #    already published (published != live, the same invariant BP-2 documents).
+    deploy_note = ""
+    if scope_type in _DEPLOYABLE_SCOPES:
+        try:
+            from pocketpaw_ee.sites import service as sites_service
+
+            await sites_service.publish_pocket(
+                workspace_id=workspace_id,
+                user_id=str(author or "system"),
+                pocket_id=scope_id,
+            )
+            deploy_note = " + deploy triggered"
+        except Exception as exc:  # noqa: BLE001 — failed Action, never raise
+            logger.exception(
+                "artifact-change merge: deploy failed for %s:%s (version published)",
+                scope_type,
+                scope_id,
+            )
+            await store.mark_failed(
+                action.id,
+                f"artifact-change merged (version {to_version_id} published) "
+                f"but deploy failed: {exc}",
+            )
+            return
+
+    await store.mark_executed(
+        action.id,
+        f"merged {scope_type}:{scope_id} — published version {to_version_id}{deploy_note}",
+    )
+
+
+async def discard_rejected_change(action: Any) -> None:
+    """DISCARD a rejected artifact-change Action (BP-3).
+
+    Flips the candidate draft (``to_version_id``) to ``status="reverted"`` so it
+    leaves the working-draft pointer; the PUBLISHED pointer is left untouched (a
+    rejection must never move what is live). No deploy. Best-effort: the router
+    already flipped the Action to ``rejected`` and closed the Decision-Graph
+    chain on the reject path, so a discard failure here is logged and swallowed —
+    it must not break the reject response.
+
+    TODO(BP-4): deeper discard/revert semantics (reverting the published pointer
+    to a prior snapshot, history projection) land in BP-4.
+    """
+    blob = artifact_change_blob(action)
+    if blob is None:
+        return
+
+    scope_type = str(blob.get("scope_type") or "")
+    scope_id = str(blob.get("scope_id") or "")
+    workspace_id = str(blob.get("workspace") or blob.get("workspace_id") or "")
+    to_version_id = str(blob.get("to_version_id") or "")
+    if not (scope_type and scope_id and workspace_id and to_version_id):
+        logger.debug("artifact-change discard: blob missing fields — nothing to discard")
+        return
+
+    try:
+        from pocketpaw_ee.versions import service as versions_service
+
+        await versions_service.discard(
+            scope_type=scope_type,
+            scope_id=scope_id,
+            workspace_id=workspace_id,
+            version_id=to_version_id,
+        )
+    except Exception:  # noqa: BLE001 — discard nudge must never break the reject
+        logger.warning(
+            "artifact-change discard: failed to revert candidate %s for %s:%s "
+            "(published pointer untouched)",
+            to_version_id,
+            scope_type,
+            scope_id,
+            exc_info=True,
+        )

--- a/ee/pocketpaw_ee/versions/service.py
+++ b/ee/pocketpaw_ee/versions/service.py
@@ -28,8 +28,18 @@
 #   * artifact.version.branched — on branch
 # We do NOT build a read projection here — that is BP-4.
 #
-# TODO(BP-3): a merge gate will set status="merged" on an accepted branch
-#             candidate and may emit artifact.version.merged.
+# Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — the merge
+# gate state transitions land here so the Instinct executor stays thin:
+#   * mark_merged(version_id)  — flip an ACCEPTED candidate to status="merged"
+#                                (the merge gate's approve path calls publish()
+#                                on the target first, then marks the candidate
+#                                merged). Emits artifact.version.merged.
+#   * discard(version_id)      — flip a REJECTED candidate to status="reverted"
+#                                so it leaves the draft pointer; the published
+#                                pointer is untouched. Emits artifact.version.
+#                                discarded.
+# Both are minimal + idempotent-friendly (a missing row raises ValueError, same
+# defensive contract as publish()). TODO(BP-4) still owns full revert()/history.
 # TODO(BP-4): revert() reverts to a prior snapshot (status="reverted") and a
 #             Journal VersionProjection folds these events into a history view.
 from __future__ import annotations
@@ -46,9 +56,11 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "branch",
+    "discard",
     "get_draft",
     "get_published",
     "list_versions",
+    "mark_merged",
     "publish",
     "revert",
     "write_draft",
@@ -285,6 +297,26 @@ async def publish(
     Raises ``ValueError`` if the version does not exist or belongs to a
     different artifact/workspace (defensive scope check).
     """
+    row = await _scoped_row(
+        scope_type=scope_type, scope_id=scope_id, workspace_id=workspace_id, version_id=version_id
+    )
+    row.status = "published"
+    await row.save()
+    return row
+
+
+async def _scoped_row(
+    *, scope_type: str, scope_id: str, workspace_id: str, version_id: str
+) -> ArtifactVersion:
+    """Load a version by id and assert it belongs to (scope, workspace).
+
+    The shared defensive scope check used by ``publish`` / ``mark_merged`` /
+    ``discard``: a version mutation must never cross to another artifact or
+    tenant. Raises ``ValueError`` on a missing row or a scope/workspace
+    mismatch (the caller surfaces it). This is a SERVICE-level belt-and-braces
+    check; the Instinct router's ``_assert_artifact_change_workspace`` is the
+    primary tenant gate (it 403s before any state mutation).
+    """
     row = await ArtifactVersion.get(version_id)
     if row is None:
         raise ValueError(f"artifact version not found: {version_id}")
@@ -293,9 +325,95 @@ async def publish(
             f"version {version_id} does not belong to "
             f"{scope_type}:{scope_id} in workspace {workspace_id}"
         )
+    return row
 
-    row.status = "published"
+
+async def mark_merged(
+    *,
+    scope_type: str,
+    scope_id: str,
+    workspace_id: str,
+    version_id: str,
+) -> ArtifactVersion:
+    """Flip an ACCEPTED branch candidate to ``status="merged"`` (BP-3).
+
+    The merge gate's APPROVE path calls :func:`publish` on the merge target
+    first (that moves the published pointer), then marks the candidate row
+    ``merged`` so the version log records that this candidate was accepted into
+    the published lineage. Pure state transition + audit echo — it does NOT move
+    the published pointer (publish already did).
+
+    Raises ``ValueError`` if the version does not exist or belongs to a
+    different artifact/workspace (same defensive scope check as ``publish``).
+
+    Emits ``artifact.version.merged``.
+    """
+    row = await _scoped_row(
+        scope_type=scope_type, scope_id=scope_id, workspace_id=workspace_id, version_id=version_id
+    )
+    row.status = "merged"
     await row.save()
+    _emit_version_event(
+        action="artifact.version.merged",
+        scope_type=scope_type,
+        scope_id=scope_id,
+        workspace_id=workspace_id,
+        author=row.author,
+        payload={
+            "version_id": str(row.id),
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "branch": row.branch,
+            "version_no": row.version_no,
+            "status": "merged",
+        },
+    )
+    return row
+
+
+async def discard(
+    *,
+    scope_type: str,
+    scope_id: str,
+    workspace_id: str,
+    version_id: str,
+) -> ArtifactVersion:
+    """Discard a REJECTED branch candidate (BP-3).
+
+    The merge gate's REJECT path calls this: it flips the candidate row to
+    ``status="reverted"`` so it no longer reads as the working draft, and leaves
+    the PUBLISHED pointer entirely untouched (a rejection must never move what is
+    live). This is the minimal, correct discard for BP-3.
+
+    TODO(BP-4): revert/discard semantics deepen here — BP-4 owns reverting the
+    published pointer to a prior snapshot and the Journal history projection.
+    BP-3 only abandons the candidate draft.
+
+    Raises ``ValueError`` if the version does not exist or belongs to a
+    different artifact/workspace (same defensive scope check as ``publish``).
+
+    Emits ``artifact.version.discarded``.
+    """
+    row = await _scoped_row(
+        scope_type=scope_type, scope_id=scope_id, workspace_id=workspace_id, version_id=version_id
+    )
+    row.status = "reverted"
+    await row.save()
+    _emit_version_event(
+        action="artifact.version.discarded",
+        scope_type=scope_type,
+        scope_id=scope_id,
+        workspace_id=workspace_id,
+        author=row.author,
+        payload={
+            "version_id": str(row.id),
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "branch": row.branch,
+            "version_no": row.version_no,
+            "status": "reverted",
+        },
+    )
     return row
 
 

--- a/src/pocketpaw/instinct/models.py
+++ b/src/pocketpaw/instinct/models.py
@@ -1,5 +1,14 @@
 # Instinct data models — decision pipeline types.
 # Created: 2026-03-28
+# Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — added an
+#   ADDITIVE, nullable ``Action.scope_type`` so an Action can be scoped to a
+#   GENERIC artifact (pocket / site / dashboard / …) instead of being implicitly
+#   pocket-scoped. ``scope_type=None`` reads as the legacy "pocket" scope: every
+#   pre-BP-3 row (and every caller that does not set it) keeps working unchanged,
+#   with ``pocket_id`` reused as the pocket-scope id. When ``scope_type`` is set,
+#   ``pocket_id`` carries the scope id within that scope_type. Nothing was
+#   renamed — this is purely additive so the existing pocket-scoped pipeline is
+#   untouched.
 # Updated: 2026-05-21 (feat/instinct-outcome-verification) — issue #1162:
 #   Action.outcome can now hold a structured OutcomeVerdict (status +
 #   per-criterion results) instead of only a free-text "what happened"
@@ -117,6 +126,13 @@ class Action(BaseModel):
     """A proposed action from the agent, waiting for approval."""
 
     id: str = Field(default_factory=lambda: _gen_id("act"))
+    # ``scope_type`` (BP-3) makes the Action artifact-GENERIC. ``None`` is the
+    # legacy default and reads as "pocket": pre-BP-3 rows and every caller that
+    # does not set it stay pocket-scoped with ``pocket_id`` as the pocket-scope
+    # id. When set (e.g. "site"), ``pocket_id`` carries the scope id within that
+    # scope_type. Purely additive — nothing was renamed, so the pocket pipeline
+    # is unchanged.
+    scope_type: str | None = None
     pocket_id: str
     title: str
     description: str

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,18 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — ADDITIVE
+#   generic scope on the actions table. ``instinct_actions`` now carries a
+#   nullable ``scope_type`` column (additive ALTER, mirrors the assignee /
+#   workspace_id migrations). ``propose`` accepts an optional ``scope_type`` and
+#   stamps it; ``_row_to_action`` reads it back. The per-pocket READS
+#   (``_query_actions`` → ``list_actions`` / ``for_pocket`` / ``pending`` and
+#   ``pending_count``) are now SCOPE-AWARE: a caller that passes ``scope_type``
+#   filters on ``(scope_type, scope_id)`` — the ``scope_id`` reuses the
+#   ``pocket_id`` argument/column — while a caller that omits it keeps the legacy
+#   pocket_id path EXACTLY. Legacy rows (scope_type NULL) are unaffected by a
+#   non-scoped read and still match the plain pocket_id filter. ``scope_type`` is
+#   a READ FILTER + a write column only — it is NOT folded into the W2b audit
+#   hash (the chain stays content-bound + global).
 # Updated: 2026-06-10 (sov/r2a review fixes) — two store-level fixes:
 #   FIX 1 — added ``get_audit_entry(audit_id, workspace_id=None)``: a direct
 #     single-row SELECT by id with the same ``workspace_id = ? OR workspace_id
@@ -255,6 +268,11 @@ CREATE TABLE IF NOT EXISTS instinct_actions (
     approved_at TEXT,
     rejected_reason TEXT,
     assignee TEXT,
+    -- Generic scope (BP-3): the artifact scope_type this Action belongs to
+    -- ("pocket" / "site" / "dashboard" / …). NULL = legacy pocket-scoped row;
+    -- a non-scoped read still matches it via the plain pocket_id filter. When
+    -- set, the read filters on (scope_type, scope_id) with scope_id == pocket_id.
+    scope_type TEXT,
     -- Tenancy (W4a): the owning workspace. NULL = legacy/global row written
     -- before tenancy or by a non-cloud OSS caller; a scoped read still sees it.
     workspace_id TEXT,
@@ -326,6 +344,14 @@ _WORKSPACE_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_audit_workspace ON instinct_audit(workspace_id)",
 )
 
+# Generic-scope index (BP-3). Created AFTER the ALTER that adds scope_type for
+# the same reason the workspace indexes are — on a pre-BP-3 DB the column does
+# not exist until the ALTER lands. The compound (scope_type, pocket_id) index
+# serves the scope-aware (scope_type, scope_id) read; scope_id reuses pocket_id.
+_SCOPE_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_actions_scope ON instinct_actions(scope_type, pocket_id)",
+)
+
 
 class InstinctStore:
     """Async SQLite store for the decision pipeline."""
@@ -374,10 +400,18 @@ class InstinctStore:
                     await db.execute(f"ALTER TABLE {_tbl} ADD COLUMN workspace_id TEXT")
                 except aiosqlite.OperationalError:
                     pass
+            # Additive migration (BP-3): the generic ``scope_type`` column on a
+            # pre-existing actions table. Same swallow-the-duplicate pattern.
+            # Pre-existing rows keep NULL scope_type (legacy pocket-scoped; a
+            # non-scoped read still matches them via the plain pocket_id filter).
+            try:
+                await db.execute("ALTER TABLE instinct_actions ADD COLUMN scope_type TEXT")
+            except aiosqlite.OperationalError:
+                pass
             # Tenancy indexes created only after the column is guaranteed to
             # exist — see _WORKSPACE_INDEX_SQL note above. Inside SCHEMA_SQL this
-            # would fail on a pre-W4a DB.
-            for _idx in _WORKSPACE_INDEX_SQL:
+            # would fail on a pre-W4a DB. The scope index follows the same rule.
+            for _idx in (*_WORKSPACE_INDEX_SQL, *_SCOPE_INDEX_SQL):
                 await db.execute(_idx)
             await db.commit()
         self._initialized = True
@@ -403,8 +437,10 @@ class InstinctStore:
         fabric_snapshots: list[FabricObjectSnapshot] | None = None,
         assignee: str | None = None,
         workspace_id: str | None = None,
+        scope_type: str | None = None,
     ) -> Action:
         action = Action(
+            scope_type=scope_type,
             pocket_id=pocket_id,
             title=title,
             description=description,
@@ -422,8 +458,9 @@ class InstinctStore:
                 "INSERT INTO instinct_actions"
                 " (id, pocket_id, title, description,"
                 " category, status, priority, trigger,"
-                " recommendation, parameters, context, assignee, workspace_id)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " recommendation, parameters, context, assignee, workspace_id,"
+                " scope_type)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     action.id,
                     pocket_id,
@@ -438,6 +475,7 @@ class InstinctStore:
                     action.context.model_dump_json(),
                     assignee,
                     workspace_id,
+                    scope_type,
                 ),
             )
             await db.commit()
@@ -698,20 +736,34 @@ class InstinctStore:
         pocket_id: str | None = None,
         assignee: str | None = None,
         workspace_id: str | None = None,
+        scope_type: str | None = None,
     ) -> list[Action]:
         return await self._query_actions(
             status=ActionStatus.PENDING,
             pocket_id=pocket_id,
             assignee=assignee,
             workspace_id=workspace_id,
+            scope_type=scope_type,
         )
 
     async def pending_count(
-        self, pocket_id: str | None = None, workspace_id: str | None = None
+        self,
+        pocket_id: str | None = None,
+        workspace_id: str | None = None,
+        scope_type: str | None = None,
     ) -> int:
         cond = "WHERE status = 'pending'"
         params: list[Any] = []
-        if pocket_id:
+        # BP-3 — scope-aware count, mirroring ``_query_actions``: a scope_type
+        # selects (scope_type, scope_id) with scope_id == pocket_id; omitting it
+        # keeps the legacy pocket_id-only path so legacy rows still count.
+        if scope_type is not None:
+            cond += " AND scope_type = ?"
+            params.append(scope_type)
+            if pocket_id:
+                cond += " AND pocket_id = ?"
+                params.append(pocket_id)
+        elif pocket_id:
             cond += " AND pocket_id = ?"
             params.append(pocket_id)
         # W4a — scope the count to the caller's workspace (plus legacy NULL rows)
@@ -735,10 +787,20 @@ class InstinctStore:
         status: ActionStatus | None = None,
         limit: int = 50,
         workspace_id: str | None = None,
+        scope_type: str | None = None,
     ) -> list[Action]:
-        """Public method — list actions with optional filters and limit."""
+        """Public method — list actions with optional filters and limit.
+
+        BP-3 — ``scope_type`` makes the listing scope-aware: with it, the
+        ``pocket_id`` filter is read as the generic scope id within
+        ``scope_type``; without it, the legacy pocket_id-only path runs.
+        """
         return await self._query_actions(
-            status=status, pocket_id=pocket_id, limit=limit, workspace_id=workspace_id
+            status=status,
+            pocket_id=pocket_id,
+            limit=limit,
+            workspace_id=workspace_id,
+            scope_type=scope_type,
         )
 
     async def _query_actions(
@@ -748,13 +810,25 @@ class InstinctStore:
         limit: int = 500,
         assignee: str | None = None,
         workspace_id: str | None = None,
+        scope_type: str | None = None,
     ) -> list[Action]:
         conditions: list[str] = []
         params: list[Any] = []
         if status:
             conditions.append("status = ?")
             params.append(status.value)
-        if pocket_id:
+        # BP-3 — scope-aware artifact filter. When ``scope_type`` is given the
+        # caller is selecting a GENERIC artifact: filter on (scope_type,
+        # scope_id) where ``scope_id`` reuses the ``pocket_id`` column. When
+        # ``scope_type`` is omitted the legacy pocket_id-only path runs EXACTLY
+        # as before, so pre-BP-3 rows (scope_type NULL) keep matching unchanged.
+        if scope_type is not None:
+            conditions.append("scope_type = ?")
+            params.append(scope_type)
+            if pocket_id:
+                conditions.append("pocket_id = ?")
+                params.append(pocket_id)
+        elif pocket_id:
             conditions.append("pocket_id = ?")
             params.append(pocket_id)
         if assignee:
@@ -1270,6 +1344,10 @@ class InstinctStore:
         # ``_ensure_schema`` — use a key check so ``aiosqlite.Row`` (which
         # raises IndexError on unknown keys) doesn't break the read.
         assignee = row["assignee"] if "assignee" in row.keys() else None
+        # BP-3 — read the generic scope_type back. Key-checked like ``assignee``
+        # so a pre-migration row missing the column doesn't raise. NULL/absent
+        # stays None (legacy pocket scope).
+        scope_type = row["scope_type"] if "scope_type" in row.keys() else None
         # The SQLite layer stamps created_at/updated_at as ISO strings.
         # Forward them on the rebuilt Action so consumers (outcome window
         # filters, age sorting) see real history instead of "now". Old
@@ -1278,6 +1356,7 @@ class InstinctStore:
         updated_at = _parse_iso(row["updated_at"]) if "updated_at" in row.keys() else None
         return Action(
             id=row["id"],
+            scope_type=scope_type,
             pocket_id=row["pocket_id"],
             title=row["title"],
             description=row["description"] or "",

--- a/tests/cloud/test_artifact_change_gate.py
+++ b/tests/cloud/test_artifact_change_gate.py
@@ -1,0 +1,288 @@
+# tests/cloud/test_artifact_change_gate.py
+# Created: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — security +
+# behaviour coverage for the Branch-primitive artifact-change MERGE GATE on the
+# Instinct router (Part B + Part C).
+#
+# What this pins (router level, sync TestClient over HTTP — mirrors
+# test_instinct_approval_security.py):
+#   SECURITY (Part C) — a cross-workspace caller gets 403 BEFORE any state
+#     mutation, on BOTH approve and reject (single + bulk), with the same
+#     ``instinct.cross_workspace_approval`` error code. Asymmetric tenant scope
+#     is no tenant scope (pocketpaw#1183 / #1250).
+#   MERGE (Part B) — an approved ``_artifact_change`` Action dispatches the merge
+#     executor (publish + deploy); a same-tenant approve reaches it.
+#   DISCARD (Part B) — a rejected ``_artifact_change`` Action dispatches the
+#     discard executor; the published pointer is untouched.
+#
+# The executor itself is patched off here (its real publish/mark_merged/discard
+# behaviour against beanie is covered in tests/ee/versions/test_merge_gate_service.py
+# + the executor behaviour test below). These tests pin the GATE: who is allowed
+# through, and that the right executor branch fires.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+TRIGGER = {"type": "agent", "source": "claude", "reason": "artifact-change gate test"}
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "user-A", workspace_id: str = "ws-A") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _artifact_change_params(workspace_id: str) -> dict:
+    """An Action ``parameters`` payload carrying an ``_artifact_change`` blob —
+    the merge-gate candidate shape. Tenancy lives on the blob's ``workspace``.
+    ``correlation_id`` is set so the (best-effort) chain emits have an id to
+    chain off; the gate tests don't assert chain semantics."""
+    return {
+        "_artifact_change": {
+            "schema": 1,
+            "scope_type": "pocket",
+            "scope_id": "pocket-art",
+            "branch": "cand",
+            "from_version_id": "ver-from",
+            "to_version_id": "ver-to",
+            "workspace": workspace_id,
+            "user_id": "requester-9",
+            "correlation_id": None,
+            "proposed_event_id": None,
+        }
+    }
+
+
+@pytest.fixture
+def router_store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "artifact_gate.db")
+
+
+def _make_client(router_store: InstinctStore, user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _propose(client: TestClient, *, pocket_id: str, title: str, parameters: dict | None = None):
+    payload: dict = {"pocket_id": pocket_id, "title": title, "trigger": TRIGGER}
+    if parameters is not None:
+        payload["parameters"] = parameters
+    resp = client.post("/instinct/actions", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _status_of(client: TestClient, action_id: str) -> str:
+    resp = client.get("/instinct/actions", params={"limit": 500})
+    assert resp.status_code == 200, resp.text
+    for action in resp.json()["actions"]:
+        if action["id"] == action_id:
+            return action["status"]
+    raise AssertionError(f"action {action_id} not found")
+
+
+# ---------------------------------------------------------------------------
+# Part C — cross-workspace 403 on BOTH approve and reject (single + bulk)
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactChangeCrossWorkspace:
+    def test_single_approve_of_foreign_workspace_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-B merge",
+                parameters=_artifact_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            # No mutation — still pending.
+            assert _status_of(client, action_id) == "pending"
+
+    def test_single_reject_of_foreign_workspace_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """The reject side MUST 403 too — a cross-workspace reject would discard
+        another tenant's candidate. Asymmetric scope is no scope."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-B merge",
+                parameters=_artifact_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "nope"})
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_bulk_approve_of_foreign_workspace_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-A merge",
+                parameters=_artifact_change_params(workspace_id="ws-A"),
+            )
+            foreign = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-B merge",
+                parameters=_artifact_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post("/instinct/actions/bulk-approve", json={"ids": [own, foreign]})
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            # Whole batch rejected — nothing flips.
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+    def test_bulk_reject_of_foreign_workspace_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-A merge",
+                parameters=_artifact_change_params(workspace_id="ws-A"),
+            )
+            foreign = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-B merge",
+                parameters=_artifact_change_params(workspace_id="ws-B"),
+            )
+            resp = client.post(
+                "/instinct/actions/bulk-reject",
+                json={"ids": [own, foreign], "reason": "batch nope"},
+            )
+            assert resp.status_code == 403
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Part B — same-tenant approve MERGES, same-tenant reject DISCARDS
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactChangeDispatch:
+    def test_same_workspace_approve_dispatches_merge(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A same-tenant approve passes the gate and reaches the MERGE executor
+        (patched off — the real publish/deploy is covered against beanie)."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        calls: dict = {}
+
+        async def _fake_merge(action, *, human_event_id=None):
+            calls["merge"] = action.id
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.versions.instinct_executor.execute_approved_change", _fake_merge
+        )
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-A merge",
+                parameters=_artifact_change_params(workspace_id="ws-A"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["action"]["status"] == "approved"
+            # The MERGE executor fired for this action.
+            assert calls.get("merge") == action_id
+
+    def test_same_workspace_reject_dispatches_discard(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A same-tenant reject passes the gate and reaches the DISCARD
+        executor; the action transitions to rejected."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        calls: dict = {}
+
+        async def _fake_discard(action):
+            calls["discard"] = action.id
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.versions.instinct_executor.discard_rejected_change", _fake_discard
+        )
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-A merge",
+                parameters=_artifact_change_params(workspace_id="ws-A"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not yet"})
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "rejected"
+            # The DISCARD executor fired.
+            assert calls.get("discard") == action_id
+
+    def test_merge_executor_failure_does_not_break_approve(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """A crash inside the merge executor is swallowed — the approve still
+        returns 200 (best-effort, like every other blob hook)."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+
+        async def _boom(action, *, human_event_id=None):
+            raise RuntimeError("merge blew up")
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.versions.instinct_executor.execute_approved_change", _boom
+        )
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-A merge",
+                parameters=_artifact_change_params(workspace_id="ws-A"),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["action"]["status"] == "approved"

--- a/tests/cloud/test_artifact_change_gate.py
+++ b/tests/cloud/test_artifact_change_gate.py
@@ -286,3 +286,142 @@ class TestArtifactChangeDispatch:
             resp = client.post(f"/instinct/actions/{action_id}/approve")
             assert resp.status_code == 200, resp.text
             assert resp.json()["action"]["status"] == "approved"
+
+
+# ---------------------------------------------------------------------------
+# Part C (security fix) — empty/missing workspace claim MUST 403, never pass
+# ---------------------------------------------------------------------------
+
+
+def _empty_workspace_params() -> dict:
+    """An ``_artifact_change`` blob with NO workspace claim (empty string + the
+    alias key absent). There is no legitimate empty-workspace case — the gate
+    must hard-403 rather than skip the tenancy check (the null-workspace bypass:
+    a blob with workspace="" and scope_id=<victim pocket> would otherwise be
+    approvable + DEPLOYABLE by any operator in any workspace)."""
+    return {
+        "_artifact_change": {
+            "schema": 1,
+            "scope_type": "pocket",
+            "scope_id": "victim-pocket",
+            "branch": "cand",
+            "from_version_id": "ver-from",
+            "to_version_id": "ver-to",
+            "workspace": "",  # empty claim — and ``workspace_id`` alias absent
+            "user_id": "attacker-1",
+            "correlation_id": None,
+            "proposed_event_id": None,
+        }
+    }
+
+
+class TestArtifactChangeEmptyWorkspaceBypass:
+    """Regression for the null/empty-workspace bypass. An attacker proposing an
+    ``_artifact_change`` blob with no workspace claim must NOT be able to get a
+    different-workspace operator to approve (publish + DEPLOY) or reject
+    (discard) it. Empty workspace = unverifiable tenancy = hard 403 on BOTH
+    sides, with NO executor side-effect."""
+
+    def _no_side_effect_spies(self, monkeypatch) -> dict:
+        """Patch BOTH executor entrypoints to record if they ever run. The 403
+        must fire before any of them — if a spy is recorded, the bypass is
+        live."""
+        ran: dict = {}
+
+        async def _merge_spy(action, *, human_event_id=None):
+            ran["merge"] = action.id
+
+        async def _discard_spy(action):
+            ran["discard"] = action.id
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.versions.instinct_executor.execute_approved_change", _merge_spy
+        )
+        monkeypatch.setattr(
+            "pocketpaw_ee.versions.instinct_executor.discard_rejected_change", _discard_spy
+        )
+        return ran
+
+    def test_approve_of_empty_workspace_blob_is_403_no_merge(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        ran = self._no_side_effect_spies(monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="victim-pocket",
+                title="no-workspace merge",
+                parameters=_empty_workspace_params(),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.missing_workspace_in_blob"
+            # No state mutation, no merge/deploy side-effect.
+            assert _status_of(client, action_id) == "pending"
+            assert ran == {}
+
+    def test_reject_of_empty_workspace_blob_is_403_no_discard(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        ran = self._no_side_effect_spies(monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="victim-pocket",
+                title="no-workspace merge",
+                parameters=_empty_workspace_params(),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "nope"})
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.missing_workspace_in_blob"
+            assert _status_of(client, action_id) == "pending"
+            assert ran == {}
+
+    def test_empty_workspace_blob_403_even_from_matching_empty_caller(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """There is no legitimate empty-workspace case: even a caller whose own
+        active workspace resolves empty cannot approve an empty-workspace blob —
+        empty must ALWAYS 403, never match-through."""
+        client = _make_client(router_store, _FakeUser("user-X", ""), monkeypatch)
+        ran = self._no_side_effect_spies(monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose(
+                client,
+                pocket_id="victim-pocket",
+                title="no-workspace merge",
+                parameters=_empty_workspace_params(),
+            )
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.missing_workspace_in_blob"
+            assert ran == {}
+
+    def test_bulk_approve_with_empty_workspace_blob_is_403_no_merge(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        """The bulk path runs the same up-front guard — an empty-workspace item
+        fails the whole batch with 403 and nothing flips or merges."""
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        ran = self._no_side_effect_spies(monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose(
+                client,
+                pocket_id="pocket-art",
+                title="ws-A merge",
+                parameters=_artifact_change_params(workspace_id="ws-A"),
+            )
+            empty = _propose(
+                client,
+                pocket_id="victim-pocket",
+                title="no-workspace merge",
+                parameters=_empty_workspace_params(),
+            )
+            resp = client.post("/instinct/actions/bulk-approve", json={"ids": [own, empty]})
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.missing_workspace_in_blob"
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, empty) == "pending"
+            assert ran == {}

--- a/tests/ee/versions/test_instinct_executor.py
+++ b/tests/ee/versions/test_instinct_executor.py
@@ -1,0 +1,169 @@
+# tests/ee/versions/test_instinct_executor.py
+# Created: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — behaviour
+# coverage for the artifact-change merge/discard EXECUTOR against real
+# ArtifactVersion rows (beanie), with the Instinct store + site deploy mocked.
+#
+# What this pins (the BP-3 done-when behaviour):
+#   * execute_approved_change MERGES: the candidate draft (to_version_id) is
+#     promoted to published, marked merged, and — for pocket/site scope — the
+#     site deploy is triggered; the Action is marked executed.
+#   * execute_approved_change marks the Action FAILED if the deploy raises (the
+#     version is still published — published != live).
+#   * discard_rejected_change DISCARDS: the candidate is flipped to reverted and
+#     the published pointer is left UNTOUCHED (a rejection never moves Live).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pocketpaw_ee.versions import instinct_executor as executor
+from pocketpaw_ee.versions import service as versions
+
+pytestmark = pytest.mark.asyncio
+
+WS = "ws-exec"
+POCKET = "pocket-exec"
+USER = "user-exec"
+
+
+class _FakeStore:
+    """Captures mark_executed / mark_failed so the test can assert the terminal
+    the executor wrote on the Action."""
+
+    def __init__(self) -> None:
+        self.executed: dict[str, Any] = {}
+        self.failed: dict[str, Any] = {}
+
+    async def mark_executed(self, action_id: str, outcome: Any = None) -> None:
+        self.executed[action_id] = outcome
+
+    async def mark_failed(self, action_id: str, error: str) -> None:
+        self.failed[action_id] = error
+
+
+def _action(to_version_id: str) -> SimpleNamespace:
+    """A minimal Action stand-in carrying an ``_artifact_change`` blob."""
+    return SimpleNamespace(
+        id="act-1",
+        pocket_id=POCKET,
+        parameters={
+            "_artifact_change": {
+                "scope_type": "pocket",
+                "scope_id": POCKET,
+                "branch": "cand",
+                "from_version_id": "ver-from",
+                "to_version_id": to_version_id,
+                "workspace": WS,
+                "user_id": USER,
+            }
+        },
+    )
+
+
+async def test_approve_merges_publishes_and_deploys(
+    beanie_test_db, versions_journal, monkeypatch
+) -> None:
+    """APPROVE = MERGE: the candidate is promoted to published, the site deploy
+    fires, and the Action is marked executed."""
+    store = _FakeStore()
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+
+    deploys: list[dict] = []
+
+    async def _fake_publish_pocket(**kwargs):
+        deploys.append(kwargs)
+        return SimpleNamespace(id="site-1")
+
+    monkeypatch.setattr("pocketpaw_ee.sites.service.publish_pocket", _fake_publish_pocket)
+
+    # A candidate draft is the merge target.
+    cand = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "candidate"}
+    )
+
+    await executor.execute_approved_change(_action(str(cand.id)))
+
+    # The candidate is now the published pointer (the merge = promote). In the
+    # single-row model published IS the merge result; we deliberately do NOT also
+    # flip it to "merged" (that would erase the pointer).
+    refreshed = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert refreshed is not None
+    assert str(refreshed.id) == str(cand.id)
+    from pocketpaw_ee.versions.models import ArtifactVersion
+
+    row = await ArtifactVersion.get(str(cand.id))
+    assert row.status == "published"
+
+    # The site deploy was triggered for the pocket scope.
+    assert len(deploys) == 1
+    assert deploys[0]["pocket_id"] == POCKET
+    assert deploys[0]["workspace_id"] == WS
+
+    # The Action was marked executed (not failed).
+    assert "act-1" in store.executed
+    assert "act-1" not in store.failed
+
+
+async def test_approve_merge_marks_failed_when_deploy_raises(
+    beanie_test_db, versions_journal, monkeypatch
+) -> None:
+    """If the deploy raises, the Action is marked FAILED — the version is still
+    published (published != live, the BP-2 invariant)."""
+    store = _FakeStore()
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+
+    async def _boom_deploy(**kwargs):
+        raise RuntimeError("workerd smoke gate failed")
+
+    monkeypatch.setattr("pocketpaw_ee.sites.service.publish_pocket", _boom_deploy)
+
+    cand = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "candidate"}
+    )
+
+    await executor.execute_approved_change(_action(str(cand.id)))
+
+    # The version IS published despite the deploy failing.
+    published = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert published is not None
+    assert str(published.id) == str(cand.id)
+
+    # The Action is marked failed (deploy failed).
+    assert "act-1" in store.failed
+    assert "deploy failed" in store.failed["act-1"]
+    assert "act-1" not in store.executed
+
+
+async def test_reject_discards_candidate_and_leaves_published(
+    beanie_test_db, versions_journal, monkeypatch
+) -> None:
+    """REJECT = DISCARD: the candidate is reverted, the published pointer is
+    untouched."""
+    store = _FakeStore()
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+
+    # A live published version, plus a candidate draft.
+    live = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "live"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(live.id)
+    )
+    cand = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "candidate"}
+    )
+
+    await executor.discard_rejected_change(_action(str(cand.id)))
+
+    # The candidate is reverted.
+    from pocketpaw_ee.versions.models import ArtifactVersion
+
+    row = await ArtifactVersion.get(str(cand.id))
+    assert row.status == "reverted"
+
+    # The published pointer is still the live version — untouched.
+    published = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert published is not None
+    assert str(published.id) == str(live.id)
+    assert published.content == {"v": "live"}

--- a/tests/ee/versions/test_merge_gate_service.py
+++ b/tests/ee/versions/test_merge_gate_service.py
@@ -1,0 +1,205 @@
+# tests/ee/versions/test_merge_gate_service.py
+# Created: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — coverage for
+# the merge-gate state transitions on the versions service (mark_merged /
+# discard) and the svelte-edit draft-version hook (Part D).
+#
+# What this pins:
+#   * mark_merged flips an accepted candidate to status="merged" and emits
+#     artifact.version.merged; it does NOT move the published pointer (publish
+#     already did) and is scope-checked.
+#   * discard flips a rejected candidate to status="reverted" and leaves the
+#     PUBLISHED pointer untouched (a rejection never moves what is live).
+#   * Both raise on a scope/workspace mismatch (the defensive service check).
+#   * A svelte set_svelte_source_file edit records a draft ArtifactVersion
+#     (scope_type="pocket") snapshotting the source map (Part D).
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.versions import service as versions
+
+pytestmark = pytest.mark.asyncio
+
+WS = "ws-merge"
+POCKET = "pocket-merge"
+USER = "user-merge"
+
+
+# ---------------------------------------------------------------------------
+# mark_merged / discard — the merge-gate state transitions
+# ---------------------------------------------------------------------------
+
+
+async def test_mark_merged_flips_candidate_and_keeps_published(
+    beanie_test_db, versions_journal
+) -> None:
+    """mark_merged sets status='merged' on the candidate. It does not change the
+    published pointer (publish moved it first in the real flow)."""
+    # A published version already lives on main.
+    pub = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(pub.id)
+    )
+
+    # A candidate on a branch is published (the merge target), then marked merged.
+    cand = await versions.branch(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, new_branch="cand"
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(cand.id)
+    )
+    merged = await versions.mark_merged(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(cand.id)
+    )
+    assert merged.status == "merged"
+
+    # The merge event landed on the journal.
+    events = versions_journal.query(action="artifact.version.merged")
+    assert len(events) == 1
+    assert events[0].payload["version_id"] == str(cand.id)
+
+
+async def test_discard_reverts_candidate_and_leaves_published_untouched(
+    beanie_test_db, versions_journal
+) -> None:
+    """discard flips the candidate to reverted; the published pointer on main is
+    untouched (rejection must never move what is live)."""
+    pub = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "live"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(pub.id)
+    )
+
+    cand = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "candidate"}
+    )
+    discarded = await versions.discard(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(cand.id)
+    )
+    assert discarded.status == "reverted"
+
+    # The published pointer is still the original live version — untouched.
+    live = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert live is not None
+    assert str(live.id) == str(pub.id)
+    assert live.content == {"v": "live"}
+
+    events = versions_journal.query(action="artifact.version.discarded")
+    assert len(events) == 1
+
+
+async def test_mark_merged_rejects_cross_workspace(beanie_test_db) -> None:
+    """A version mutation must not cross to another workspace — the service-level
+    defensive scope check raises ValueError."""
+    row = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={}
+    )
+    with pytest.raises(ValueError):
+        await versions.mark_merged(
+            scope_type="pocket", scope_id=POCKET, workspace_id="ws-OTHER", version_id=str(row.id)
+        )
+
+
+async def test_discard_rejects_cross_workspace(beanie_test_db) -> None:
+    row = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={}
+    )
+    with pytest.raises(ValueError):
+        await versions.discard(
+            scope_type="pocket", scope_id=POCKET, workspace_id="ws-OTHER", version_id=str(row.id)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Part D — svelte source edit writes a draft version
+# ---------------------------------------------------------------------------
+
+
+class _FakeSvelteDoc:
+    """In-memory Pocket doc carrying a svelte source map — only the attributes
+    set_svelte_source_file + the BP-3 version hook read/write."""
+
+    def __init__(self, source: dict) -> None:
+        self.id = POCKET
+        self.workspace = WS
+        self.engine = "svelte"
+        self.source = source
+        self.save_calls = 0
+
+    async def save(self) -> None:
+        self.save_calls += 1
+
+
+def _wire_stubs(monkeypatch: pytest.MonkeyPatch, fake_doc: _FakeSvelteDoc) -> None:
+    async def _fake_fetch(pocket_id: str):  # type: ignore[no-untyped-def]
+        return fake_doc
+
+    async def _fake_resolved_wire_dict(doc, viewer_user_id):  # type: ignore[no-untyped-def]
+        return {"id": doc.id, "source": doc.source}
+
+    async def _fake_event_payload(doc):  # type: ignore[no-untyped-def]
+        return {"recipient_ids": [], "pocket": {"id": doc.id}}
+
+    async def _fake_emit(event):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(pockets_service, "_fetch_pocket", _fake_fetch)
+    monkeypatch.setattr(pockets_service, "_pocket_to_domain", lambda doc: object())
+    monkeypatch.setattr(pockets_service, "_check_domain_edit_access", lambda *a, **k: None)
+    monkeypatch.setattr(pockets_service, "_resolved_wire_dict", _fake_resolved_wire_dict)
+    monkeypatch.setattr(pockets_service, "_pocket_event_payload", _fake_event_payload)
+    monkeypatch.setattr(pockets_service, "emit", _fake_emit)
+
+
+async def test_svelte_edit_records_draft_version(
+    beanie_test_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A set_svelte_source_file edit writes a draft ArtifactVersion snapshotting
+    the source map (BP-3 Part D — BP-1 only versioned the rippleSpec write)."""
+    fake_doc = _FakeSvelteDoc({"src/Hero.svelte": "<h1>old</h1>"})
+    _wire_stubs(monkeypatch, fake_doc)
+
+    # No version exists for this pocket yet.
+    assert await versions.get_draft(scope_type="pocket", scope_id=POCKET) is None
+
+    wire, previous = await pockets_service.set_svelte_source_file(
+        POCKET, USER, component_path="src/Hero.svelte", new_source="<h1>new</h1>"
+    )
+
+    # The edit persisted + returned the prior contents.
+    assert fake_doc.save_calls == 1
+    assert previous == "<h1>old</h1>"
+    assert fake_doc.source["src/Hero.svelte"] == "<h1>new</h1>"
+
+    # A draft ArtifactVersion now snapshots the full source map.
+    draft = await versions.get_draft(scope_type="pocket", scope_id=POCKET)
+    assert draft is not None
+    assert draft.scope_type == "pocket"
+    assert draft.scope_id == POCKET
+    assert draft.workspace_id == WS
+    assert draft.author == USER
+    assert draft.status == "draft"
+    assert draft.content == {"src/Hero.svelte": "<h1>new</h1>"}
+
+
+async def test_svelte_edit_version_failure_does_not_break_edit(
+    beanie_test_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The version write is best-effort — if it raises, the edit still
+    succeeds (additive history layer, never a gate)."""
+    fake_doc = _FakeSvelteDoc({"src/Hero.svelte": "<h1>old</h1>"})
+    _wire_stubs(monkeypatch, fake_doc)
+
+    async def _boom(**kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("version store down")
+
+    monkeypatch.setattr(versions, "write_draft", _boom)
+
+    wire, previous = await pockets_service.set_svelte_source_file(
+        POCKET, USER, component_path="src/Hero.svelte", new_source="<h1>still works</h1>"
+    )
+    assert fake_doc.save_calls == 1
+    assert fake_doc.source["src/Hero.svelte"] == "<h1>still works</h1>"

--- a/tests/instinct/test_scope_aware_actions.py
+++ b/tests/instinct/test_scope_aware_actions.py
@@ -1,0 +1,140 @@
+# tests/instinct/test_scope_aware_actions.py
+# Created: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — coverage for
+# the ADDITIVE generic scope on the Instinct store (Part A). Pins that:
+#   1. A legacy Action (no scope_type) round-trips with scope_type=None and the
+#      legacy pocket_id-only read still finds it.
+#   2. A scoped Action (scope_type set) round-trips and a scope-aware read
+#      filtering on (scope_type, scope_id) returns it.
+#   3. A scope-aware read does NOT return a legacy row that shares the same
+#      pocket_id/scope_id (scope_type discriminates), and a legacy read is
+#      unaffected by scoped rows existing.
+#   4. pending() is scope-aware the same way.
+# These are OSS store tests — no cloud extras, no beanie, just a tmp SQLite db.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.instinct.models import ActionStatus, ActionTrigger
+from pocketpaw.instinct.store import InstinctStore
+
+pytestmark = pytest.mark.asyncio
+
+TRIGGER = ActionTrigger(type="agent", source="claude", reason="scope test")
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "scope.db")
+
+
+async def test_legacy_action_roundtrips_with_none_scope(store: InstinctStore) -> None:
+    """A propose with no scope_type stores scope_type=None and is readable via
+    the legacy pocket_id-only path — the pre-BP-3 behaviour, unchanged."""
+    action = await store.propose(
+        pocket_id="pocket-1",
+        title="legacy",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+    )
+    assert action.scope_type is None
+
+    # Read back via get_action — scope_type comes back None.
+    fetched = await store.get_action(action.id)
+    assert fetched is not None
+    assert fetched.scope_type is None
+    assert fetched.pocket_id == "pocket-1"
+
+    # Legacy pocket_id-only listing finds it.
+    rows = await store.list_actions(pocket_id="pocket-1")
+    assert [r.id for r in rows] == [action.id]
+
+
+async def test_scoped_action_roundtrips_and_scope_aware_read_finds_it(
+    store: InstinctStore,
+) -> None:
+    """A propose with scope_type='site' round-trips, and a scope-aware read
+    filtering on (scope_type, scope_id) returns it."""
+    action = await store.propose(
+        pocket_id="pocket-9",  # reused as the scope id within scope_type="site"
+        title="scoped",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+        scope_type="site",
+    )
+    assert action.scope_type == "site"
+
+    fetched = await store.get_action(action.id)
+    assert fetched is not None
+    assert fetched.scope_type == "site"
+
+    # Scope-aware read returns it.
+    rows = await store.list_actions(pocket_id="pocket-9", scope_type="site")
+    assert [r.id for r in rows] == [action.id]
+
+
+async def test_scope_aware_read_discriminates_legacy_from_scoped(
+    store: InstinctStore,
+) -> None:
+    """A legacy row and a scoped row that share the same id value must NOT be
+    confused: a scope-aware read returns only the scoped row, and a legacy
+    pocket_id-only read returns only the legacy row."""
+    legacy = await store.propose(
+        pocket_id="shared-id",
+        title="legacy row",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+    )
+    scoped = await store.propose(
+        pocket_id="shared-id",
+        title="scoped row",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+        scope_type="site",
+    )
+
+    # Scope-aware read on (site, shared-id) returns ONLY the scoped row.
+    scoped_rows = await store.list_actions(pocket_id="shared-id", scope_type="site")
+    assert [r.id for r in scoped_rows] == [scoped.id]
+
+    # Legacy pocket_id-only read returns BOTH rows that carry pocket_id ==
+    # shared-id (the legacy path is scope-type-agnostic — it never narrowed by
+    # scope_type, so it is unchanged from pre-BP-3 and sees every row with that
+    # pocket_id). The important guarantee is that a SCOPED read does not leak
+    # the legacy row; the legacy read staying broad is the backward-compat path.
+    legacy_ids = {r.id for r in await store.list_actions(pocket_id="shared-id")}
+    assert legacy.id in legacy_ids
+    assert scoped.id in legacy_ids
+
+
+async def test_pending_is_scope_aware(store: InstinctStore) -> None:
+    """pending() filters on (scope_type, scope_id) when scope_type is given."""
+    legacy = await store.propose(
+        pocket_id="p",
+        title="legacy pending",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+    )
+    scoped = await store.propose(
+        pocket_id="p",
+        title="scoped pending",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+        scope_type="dashboard",
+    )
+
+    scoped_pending = await store.pending(pocket_id="p", scope_type="dashboard")
+    assert [a.id for a in scoped_pending] == [scoped.id]
+    assert all(a.status == ActionStatus.PENDING for a in scoped_pending)
+
+    # The legacy pending read (no scope_type) still sees both.
+    all_pending_ids = {a.id for a in await store.pending(pocket_id="p")}
+    assert legacy.id in all_pending_ids
+    assert scoped.id in all_pending_ids


### PR DESCRIPTION
BP-3 of the Branch primitive, stacked on #1490. Wires the human review/merge gate using the existing Instinct pipeline, so a site edit becomes a reviewable proposal instead of a live mutation.

## What ships
- **Generic scope, additive.** `Action.scope_type` (nullable, default None = legacy "pocket") plus scope-aware store queries. Nothing renamed; every existing Instinct path keeps working.
- **The artifact-change gate.** A new `_artifact_change` proposal kind mirroring the existing blob/executor pattern (`_code_change`, `_pocket_write`, …). Approve → promote the draft to published (`versions.publish`) and deploy via the sites publish path. Reject → discard the candidate, published untouched. Wired into approve / reject / bulk-approve / bulk-reject.
- **Svelte edits version too.** `set_svelte_source_file` now snapshots a draft version (BP-1 only hooked rippleSpec via merge); the editor path needs this.

## Security
The tenant guard `_assert_artifact_change_workspace` runs before any mutation on all four paths (approve, reject, bulk-approve, bulk-reject) — asymmetric protection is no protection (pocketpaw#1183/#1250). An independent audit caught a null-workspace bypass (an empty/missing workspace claim skipped the check); fixed to fail closed with a hard 403, with reproduction-first regression tests on both approve and reject.

## Heads-up (separate finding, not in this PR)
The audit found the *same* null-workspace pattern in the pre-existing guards (`_code_change`, `_external_action`, `_belt_plan`, `_pocket_write`) on dev. Scoped this PR to the new guard only; the pre-existing ones deserve a dedicated security PR.

## Tests
20 BP-3 tests + 4 bypass-regression tests + the existing instinct/versions/sites suites — 76 in the focused security run, 430+ across the broader sweep, all green. ruff clean.

## Stacking
Base is the BP-2 branch (#1490). Merge order: #1489 → #1490 → this, each with --rebase.