### PR TITLE
feat(versions): revert + version history + the request-publish gate entry

### DIFF
--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -28,6 +28,12 @@
 # This flag (default False, backward-compatible) lets the builder badge "has
 # unpublished edits" without inferring it from the Site doc. ``status``/``is_live``
 # semantics are unchanged in shape; only their derivation moves onto versions.
+# Updated 2026-06-18 (feat/branch-primitive-revert-history, BP-4): added two DTOs
+# for the Branch-primitive surfaces — SiteVersionResponse + VersionHistoryResponse
+# (the ordered version timeline GET /sites/by-pocket/{pocket_id}/versions returns)
+# and RequestPublishResponse (the Action created by POST
+# /sites/by-pocket/{pocket_id}/request-publish, the clean entry to the merge gate
+# so the client never hand-builds the Instinct proposal).
 
 from __future__ import annotations
 
@@ -90,6 +96,43 @@ class SiteStatusResponse(BaseModel):
     is_live: bool
     has_unpublished_changes: bool = False
     site_id: str | None = None
+
+
+class SiteVersionResponse(BaseModel):
+    """One row of a pocket's version timeline (BP-4). Mirrors the durable
+    ArtifactVersion row's reading-relevant fields: ``version_no`` (the monotonic
+    ordinal), ``status`` (draft|published|merged|reverted), ``label`` (e.g.
+    "Revert to v2"), ``author`` (who wrote it), ``created_at`` (ISO). ``id`` is
+    the version id a later revert / request-publish targets."""
+
+    id: str
+    version_no: int
+    branch: str
+    status: str
+    label: str | None = None
+    author: str | None = None
+    created_at: str
+
+
+class VersionHistoryResponse(BaseModel):
+    """The ordered version timeline for a pocket (oldest → newest), returned by
+    GET /sites/by-pocket/{pocket_id}/versions. Tenant-scoped."""
+
+    pocket_id: str
+    versions: list[SiteVersionResponse]
+
+
+class RequestPublishResponse(BaseModel):
+    """The review Action created by POST /sites/by-pocket/{pocket_id}/request-
+    publish (BP-4 Part C). Carries the created Action's id + status so the client
+    can show "submitted for review" without re-fetching. ``status`` is "pending"
+    on creation (the gate item awaits operator approval)."""
+
+    action_id: str
+    status: str
+    pocket_id: str
+    to_version_id: str
+    from_version_id: str | None = None
 
 
 class DomainRequest(BaseModel):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -47,10 +47,22 @@
 # resolved in precedence: explicit body ``builder_origin`` > request ``Origin``
 # header > configured PAW_SITES_BUILDER_ORIGIN (env fallback in the service), so
 # the SE-3 editor's call carries the right origin with no extra wiring.
+# Updated 2026-06-18 (feat/branch-primitive-revert-history, BP-4): added two
+# Branch-primitive surfaces over the BP-1 versions spine.
+#   * GET /sites/by-pocket/{pocket_id}/versions — the ordered version timeline
+#     for the pocket (the source pocket is the versionable artifact; scope_type=
+#     "pocket"), tenant-scoped (fabric.read). Reads the durable ArtifactVersion
+#     rows (list_versions) — the exact, current log — not a journal replay.
+#   * POST /sites/by-pocket/{pocket_id}/request-publish — the CLEAN entry to the
+#     Instinct merge gate (BP-3): the server builds the ``_artifact_change``
+#     review proposal so the CLIENT never hand-builds the Instinct propose (BP-5
+#     needs this). Returns the created Action (id/status) so the client shows
+#     "submitted for review". fabric.write — it creates a gate item that, on
+#     approve, publishes + deploys. A 400 when there is no draft to publish.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.deps import require_action_any_workspace, require_plan_feature
@@ -60,9 +72,12 @@ from pocketpaw_ee.sites.dto import (
     DomainStatusResponse,
     MakeEditableRequest,
     PublishRequest,
+    RequestPublishResponse,
     SitePreviewResponse,
     SiteResponse,
     SiteStatusResponse,
+    SiteVersionResponse,
+    VersionHistoryResponse,
 )
 
 router = APIRouter(
@@ -168,6 +183,69 @@ async def status_by_pocket(
     status, is_live}. Derived from the tenant-scoped Site deployment doc — an
     unpublished pocket (no Site) reads draft / not live (NOT a 404)."""
     return await sites_service.pocket_status(workspace_id=ctx.workspace_id, pocket_id=pocket_id)
+
+
+@router.get("/sites/by-pocket/{pocket_id}/versions", response_model=VersionHistoryResponse)
+async def versions_by_pocket(
+    pocket_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> VersionHistoryResponse:
+    """The ordered version timeline for a pocket (BP-4): every ArtifactVersion of
+    the source pocket (scope_type="pocket"), oldest → newest, tenant-scoped on
+    ctx.workspace_id. An unversioned pocket reads an empty list (not a 404)."""
+    rows = await sites_service.version_history(workspace_id=ctx.workspace_id, pocket_id=pocket_id)
+    return VersionHistoryResponse(
+        pocket_id=pocket_id,
+        versions=[
+            SiteVersionResponse(
+                id=str(r.id),
+                version_no=r.version_no,
+                branch=r.branch,
+                status=r.status,
+                label=r.label,
+                author=r.author,
+                created_at=r.created_at.isoformat(),
+            )
+            for r in rows
+        ],
+    )
+
+
+@router.post("/sites/by-pocket/{pocket_id}/request-publish", response_model=RequestPublishResponse)
+async def request_publish_by_pocket(
+    pocket_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> RequestPublishResponse:
+    """Submit the pocket's current draft for review (BP-4 Part C) — the clean
+    entry to the Instinct merge gate.
+
+    The SERVER builds the ``_artifact_change`` review proposal (the client must
+    NOT hand-build the Instinct propose) and returns the created Action so the
+    client can show "submitted for review". Approving that Action in The Tray
+    dispatches BP-3's merge executor (publish the reviewed version + deploy).
+
+    The blob's ``workspace`` is stamped with ctx.workspace_id (never empty —
+    BP-3's guard hard-403s an empty workspace claim). When the pocket has no
+    current draft to publish, the service raises ValueError → 400 (nothing to
+    review)."""
+    try:
+        action = await sites_service.request_publish_pocket(
+            workspace_id=ctx.workspace_id, user_id=ctx.user_id, pocket_id=pocket_id
+        )
+    except ValueError as exc:
+        # No draft to publish → 400 (nothing to submit for review).
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    blob = (action.parameters or {}).get("_artifact_change", {})
+    return RequestPublishResponse(
+        action_id=str(action.id),
+        status=action.status.value if hasattr(action.status, "value") else str(action.status),
+        pocket_id=pocket_id,
+        to_version_id=str(blob.get("to_version_id") or ""),
+        from_version_id=blob.get("from_version_id"),
+    )
 
 
 @router.post("/sites/{site_id}/domains", response_model=DomainStatusResponse)

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -891,6 +891,108 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
     )
 
 
+async def request_publish_pocket(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+) -> Any:
+    """Submit a pocket's current draft for human review (BP-4 Part C).
+
+    The clean entry to the Branch-primitive MERGE GATE: instead of a client
+    hand-building the Instinct ``_artifact_change`` proposal (and getting the
+    blob shape / tenancy wrong), it POSTs here and the SERVER constructs the
+    review Action via the Instinct store. The created Action is the gate item an
+    operator approves in The Tray; approving it dispatches BP-3's merge executor
+    (publish the candidate version + deploy), so this is the request-publish →
+    review → approve → published round-trip's first step.
+
+    The versionable artifact behind a Paw Site is the source pocket
+    (scope_type="pocket", scope_id=pocket_id — the same scope BP-2 keys site
+    versions on). The proposal's ``_artifact_change`` blob carries:
+      * ``from_version_id`` — the currently published version id (or None when
+        nothing is live yet — a first publish);
+      * ``to_version_id``   — the current DRAFT version id (the working copy the
+        operator is being asked to take live).
+
+    Tenancy: the blob's ``workspace`` is stamped with ``workspace_id`` (NEVER
+    empty — BP-3's ``_assert_artifact_change_workspace`` hard-403s an empty
+    workspace claim, so a real workspace MUST be set here for the gate to ever
+    approve). The caller passes its ``ctx.workspace_id``.
+
+    Raises ``ValueError`` when there is NO current draft to publish (the router
+    maps it to a 4xx — there is nothing to submit for review). A missing /
+    access-denied pocket surfaces via the pockets service (NotFound → 404) only
+    when no draft row exists; the common path (a draft was written by an edit)
+    reads the draft directly off the versions spine.
+    """
+    from pocketpaw.instinct.models import (
+        ActionCategory,
+        ActionPriority,
+        ActionTrigger,
+    )
+    from pocketpaw.stores import get_instinct_store
+    from pocketpaw_ee.versions import service as versions_service
+
+    draft = await versions_service.get_draft(scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id)
+    if draft is None or draft.workspace_id != workspace_id:
+        # Nothing drafted for this pocket in this workspace — nothing to review.
+        # (A foreign-workspace draft is also "nothing here" for this caller —
+        # tenant isolation, the same guard pocket_status applies.)
+        raise ValueError(f"no draft version to publish for pocket {pocket_id} — nothing to review")
+
+    published = await versions_service.get_published(
+        scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id
+    )
+    from_version_id = (
+        str(published.id)
+        if published is not None and published.workspace_id == workspace_id
+        else None
+    )
+    to_version_id = str(draft.id)
+
+    # The merge-gate blob. Shape MUST match BP-3's ``_artifact_change_blob``
+    # (instinct/router.py) + the executor's reader exactly: the executor pulls
+    # scope_type/scope_id/workspace/to_version_id off it on approve. ``branch``
+    # is "main" (the published lineage — this is a publish, not a candidate
+    # branch). ``workspace`` is the canonical key; the executor also accepts
+    # ``workspace_id`` as an alias.
+    blob = {
+        "schema": 1,
+        "scope_type": _VERSION_SCOPE_TYPE,
+        "scope_id": pocket_id,
+        "branch": "main",
+        "from_version_id": from_version_id,
+        "to_version_id": to_version_id,
+        "workspace": workspace_id,
+        "user_id": user_id,
+        "correlation_id": None,
+        "proposed_event_id": None,
+    }
+
+    store = get_instinct_store()
+    action = await store.propose(
+        pocket_id=pocket_id,
+        title="Publish site changes",
+        description=(
+            "Take the current draft of this site live. Approving merges the "
+            "reviewed version and deploys it."
+        ),
+        recommendation="Review the draft, then approve to publish.",
+        trigger=ActionTrigger(
+            type="user",
+            source="request-publish",
+            reason="Operator requested the pocket's draft be published for review",
+        ),
+        category=ActionCategory.WORKFLOW,
+        priority=ActionPriority.MEDIUM,
+        parameters={"_artifact_change": blob},
+        workspace_id=workspace_id,
+        scope_type=_VERSION_SCOPE_TYPE,
+    )
+    return action
+
+
 async def list_for_workspace(workspace_id: str) -> list[SiteResponse]:
     cursor = _SiteDoc.find({"workspace": workspace_id}).sort(-_SiteDoc.createdAt)  # type: ignore[operator]
     return [_to_response(doc) async for doc in cursor]
@@ -961,11 +1063,42 @@ async def reserve_local_sites(workspace_id: str | None = None) -> int:
     return reconciled
 
 
+async def version_history(*, workspace_id: str, pocket_id: str) -> list[Any]:
+    """The ordered version timeline for a pocket (BP-4 Part B).
+
+    Backs ``GET /sites/by-pocket/{pocket_id}/versions``: the version log for the
+    source pocket (scope_type="pocket"), oldest → newest, tenant-scoped on
+    ``workspace_id``. Reads the ArtifactVersion rows directly via
+    ``versions.list_versions`` — the rows ARE the ordered log (monotonic
+    ``version_no``), so the timeline is exact and current with no projection
+    replay. (The VersionProjection is the BP-4 deliverable for the EVENT history
+    view — what happened, in order; this endpoint shows the VERSION timeline,
+    which the rows serve directly and correctly.)
+
+    Tenant isolation: the BP-1 pointer/log reads key only on
+    (scope_type, scope_id) — artifact-generic, no workspace param — so we filter
+    the returned rows on the caller's ``workspace_id`` here, exactly as
+    ``pocket_status`` does, so a foreign workspace cannot read another tenant's
+    history through a known pocket id. Returned oldest → newest (the natural
+    reading order for a history view; list_versions returns newest-first).
+    """
+    from pocketpaw_ee.versions import service as versions_service
+
+    rows = await versions_service.list_versions(
+        scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id, branch="main"
+    )
+    scoped = [r for r in rows if r.workspace_id == workspace_id]
+    # list_versions returns newest-first; a timeline reads oldest → newest.
+    return list(reversed(scoped))
+
+
 __all__ = [
     "publish",
     "publish_pocket",
     "preview_pocket",
     "pocket_status",
+    "request_publish_pocket",
+    "version_history",
     "edit_svelte_component",
     "make_site_editable",
     "add_domain",

--- a/ee/pocketpaw_ee/versions/__init__.py
+++ b/ee/pocketpaw_ee/versions/__init__.py
@@ -19,8 +19,16 @@
 #     ``_artifact_change`` Action. Kept in this package (not the router) so the
 #     versions spine owns its merge logic; the router only gates (403) + emits.
 #
+# BP-4 additions (feat/branch-primitive-revert-history):
+#   * service.revert — revert an artifact to a prior snapshot by writing a NEW
+#     draft from the target version's content (revert moves forward; history is
+#     never mutated). service.publish now also emits artifact.version.published.
+#   * projection.VersionProjection — the READ projection that replays the
+#     journal's artifact.version.* events into a per-artifact EVENT history
+#     timeline (created / branched / merged / discarded / reverted / published),
+#     mirroring the Decision/Fabric projection contract.
+#
 # What lives elsewhere (later BP tasks — do NOT add here):
-#   * BP-4 — revert + a Journal read projection (version history view).
 #   * BP-5/6 — the site editor + the review/merge UI.
 #
 # Re-exports are intentionally minimal: the doc class and the service module.

--- a/ee/pocketpaw_ee/versions/projection.py
+++ b/ee/pocketpaw_ee/versions/projection.py
@@ -1,0 +1,242 @@
+# ee/pocketpaw_ee/versions/projection.py
+# Created: 2026-06-18 (feat/branch-primitive-revert-history, BP-4) — the READ
+# projection for the universal Branch primitive: it replays the append-only
+# Journal's ``artifact.version.*`` events into a per-artifact history timeline.
+#
+# Why a projection (vs. just reading the ArtifactVersion rows): the rows are the
+# durable source of truth for the *current* version log (list_versions serves
+# the ordered timeline an endpoint shows), but they only carry STATE, not the
+# sequence of lifecycle ACTIONS. The journal records every event —
+# created / branched / merged / discarded / reverted / published — so the
+# projection yields an EVENT history (what happened, in what order, by whom),
+# which is what an audit / "history" view needs (BP-6's review UI, BP-7's audit
+# agent). The rows answer "what versions exist now"; this answers "what happened
+# to this artifact over time".
+#
+# Contract MIRRORS the Decision/Fabric projections (cloud/decisions/projection.py,
+# src/pocketpaw/fabric/projection.py) so the read pattern is uniform:
+#   * rebuild(journal_iter, since_seq=0) — full / incremental replay; resets the
+#     in-memory state on a full rebuild.
+#   * apply(entry) — fold one EventEntry (used inline + by rebuild).
+#   * cursor — the latest seq seen, for restart catch-up.
+#   * history(scope_type, scope_id, workspace_id=None) — the per-artifact,
+#     scope-filtered ordered timeline (oldest → newest by seq, then ts).
+#
+# It is artifact-GENERIC over (scope_type, scope_id), tenant-aware (every
+# ``artifact.version.*`` event stamps ``workspace:<id>`` in its scope, so a read
+# can filter on workspace), and process-local (in-memory — one instance per
+# org/process, same as the other projections). No SQLite store: the version log
+# itself lives in Mongo (the rows), so the projection only needs the lightweight
+# event history; rebuilding from the journal on demand is cheap for the bounded
+# per-artifact event count.
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from soul_protocol.spec.journal import Actor, EventEntry
+
+logger = logging.getLogger(__name__)
+
+# The lifecycle actions the version projection folds. Anything else on the
+# journal is dropped (the projection is concerned only with the Branch
+# primitive's version events). Mirrors the Decision projection's tracked-action
+# allowlist.
+_VERSION_ACTIONS = frozenset(
+    {
+        "artifact.version.created",
+        "artifact.version.branched",
+        "artifact.version.merged",
+        "artifact.version.discarded",
+        "artifact.version.reverted",
+        "artifact.version.published",
+    }
+)
+
+
+@dataclass
+class VersionEvent:
+    """One folded version-lifecycle event — a row in the history timeline.
+
+    ``action`` is the short verb ("created" / "branched" / "merged" /
+    "discarded" / "reverted" / "published"), stripped of the
+    ``artifact.version.`` prefix so a UI/audit reader gets a clean label.
+    ``version_id`` / ``branch`` / ``version_no`` identify the version the event
+    acted on; ``actor_id`` is who did it (the journal actor); ``payload`` keeps
+    the full event payload (e.g. ``reverted_from`` on a revert) for a detail
+    view. ``seq`` / ``ts`` are the ordering keys.
+    """
+
+    action: str
+    scope_type: str
+    scope_id: str
+    workspace_id: str
+    version_id: str | None
+    branch: str | None
+    version_no: int | None
+    actor_id: str | None
+    ts: datetime
+    seq: int
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+def _scope_value(scope: list[str], prefix: str) -> str | None:
+    """Pull the value of the first ``<prefix>:<value>`` tag in an event scope.
+
+    The versions service stamps every event with
+    ``[f"{scope_type}:{scope_id}", f"workspace:{workspace_id}"]`` (see
+    service._scope_tags), so the artifact tag carries the scope_type as its
+    prefix and the ``workspace:`` tag carries the tenant. Returns None when no
+    matching tag is present.
+    """
+    needle = f"{prefix}:"
+    for tag in scope:
+        if tag.startswith(needle):
+            return tag[len(needle) :]
+    return None
+
+
+class VersionProjection:
+    """Replay ``artifact.version.*`` Journal events into a per-artifact history.
+
+    Wire contract matches the Decision/Fabric projections:
+      * one instance per process (per org)
+      * ``rebuild(journal_iter, since_seq=0)`` for full / incremental replay
+      * ``apply(entry)`` for inline per-event update
+      * ``cursor`` surfaces the latest seen seq for restart catch-up
+
+    State is an in-memory dict keyed by ``(scope_type, scope_id)`` → ordered list
+    of :class:`VersionEvent`. ``history()`` reads it back, scope- and (optionally)
+    workspace-filtered.
+    """
+
+    def __init__(self) -> None:
+        # (scope_type, scope_id) → events in apply order. We keep them sorted by
+        # seq on read rather than insert so an out-of-order replay still yields a
+        # correctly ordered timeline.
+        self._by_artifact: dict[tuple[str, str], list[VersionEvent]] = {}
+        self._cursor: int = 0
+
+    @property
+    def cursor(self) -> int:
+        return self._cursor
+
+    # --- rebuild / apply ----------------------------------------------------
+
+    def rebuild(self, journal_iter: Iterable[EventEntry], *, since_seq: int = 0) -> int:
+        """Replay events. Returns the count applied.
+
+        On a full rebuild (``since_seq == 0``) the in-memory state is reset
+        first; on an incremental replay (``since_seq > 0``) events at or below
+        the cursor are skipped (they were already folded). Idempotent: a folded
+        event is keyed on its ``version_id`` + ``action`` so re-applying the same
+        entry does not duplicate the timeline row. Mirrors the Decision
+        projection's rebuild contract.
+        """
+        if since_seq == 0:
+            self._by_artifact = {}
+            self._cursor = 0
+
+        applied = 0
+        for entry in journal_iter:
+            entry_seq = getattr(entry, "seq", None)
+            if since_seq > 0 and entry_seq is not None and entry_seq <= since_seq:
+                continue
+            self.apply(entry)
+            applied += 1
+        return applied
+
+    def apply(self, entry: EventEntry) -> VersionEvent | None:
+        """Fold one event into the per-artifact history.
+
+        Returns the folded :class:`VersionEvent` (for callers wiring inline
+        update side-effects), or ``None`` when the event is not a tracked
+        version action or lacks the scope tag needed to key it.
+        """
+        if entry.action not in _VERSION_ACTIONS:
+            return None
+
+        seq = getattr(entry, "seq", None) or 0
+        if seq > self._cursor:
+            self._cursor = seq
+
+        payload = entry.payload or {}
+        # Prefer the payload's explicit scope (the service always sets it); fall
+        # back to the scope tags so an externally-produced event still folds.
+        scope_type = str(payload.get("scope_type") or "")
+        scope_id = str(payload.get("scope_id") or "")
+        workspace_id = _scope_value(list(entry.scope), "workspace") or ""
+        if not scope_type:
+            # Recover scope_type/scope_id from the artifact tag (the FIRST tag,
+            # ``<scope_type>:<scope_id>``) when the payload omits them.
+            for tag in entry.scope:
+                if tag.startswith("workspace:"):
+                    continue
+                head, _, tail = tag.partition(":")
+                if head and tail:
+                    scope_type, scope_id = head, tail
+                    break
+        if not (scope_type and scope_id):
+            logger.debug(
+                "version projection: %s without a resolvable scope — dropped", entry.action
+            )
+            return None
+
+        actor: Actor | None = getattr(entry, "actor", None)
+        event = VersionEvent(
+            action=entry.action.removeprefix("artifact.version."),
+            scope_type=scope_type,
+            scope_id=scope_id,
+            workspace_id=workspace_id,
+            version_id=payload.get("version_id"),
+            branch=payload.get("branch"),
+            version_no=payload.get("version_no"),
+            actor_id=getattr(actor, "id", None) if actor is not None else None,
+            ts=entry.ts,
+            seq=seq,
+            payload=dict(payload),
+        )
+
+        bucket = self._by_artifact.setdefault((scope_type, scope_id), [])
+        # Idempotence — drop a re-applied duplicate (same version_id + action +
+        # seq). A rebuild from seq=0 after an incremental replay must converge.
+        for existing in bucket:
+            if (
+                existing.version_id == event.version_id
+                and existing.action == event.action
+                and existing.seq == event.seq
+            ):
+                return existing
+        bucket.append(event)
+        return event
+
+    # --- reads --------------------------------------------------------------
+
+    def history(
+        self,
+        *,
+        scope_type: str,
+        scope_id: str,
+        workspace_id: str | None = None,
+    ) -> list[VersionEvent]:
+        """The per-artifact event history, oldest → newest.
+
+        Ordered by ``seq`` then ``ts`` (a stable timeline even when seqs tie or
+        are absent on an older journal wheel). When ``workspace_id`` is given the
+        result is tenant-filtered — a foreign workspace cannot read another
+        tenant's version history through a known scope_id (the same isolation the
+        version pointer reads enforce).
+        """
+        bucket = self._by_artifact.get((scope_type, scope_id), [])
+        rows = [
+            e
+            for e in bucket
+            if workspace_id is None or e.workspace_id == workspace_id or e.workspace_id == ""
+        ]
+        return sorted(rows, key=lambda e: (e.seq, e.ts))
+
+
+__all__ = ["VersionEvent", "VersionProjection"]

--- a/ee/pocketpaw_ee/versions/service.py
+++ b/ee/pocketpaw_ee/versions/service.py
@@ -39,9 +39,23 @@
 #                                pointer is untouched. Emits artifact.version.
 #                                discarded.
 # Both are minimal + idempotent-friendly (a missing row raises ValueError, same
-# defensive contract as publish()). TODO(BP-4) still owns full revert()/history.
-# TODO(BP-4): revert() reverts to a prior snapshot (status="reverted") and a
-#             Journal VersionProjection folds these events into a history view.
+# defensive contract as publish()).
+#
+# Updated: 2026-06-18 (feat/branch-primitive-revert-history, BP-4) — revert +
+# the publish event so the history view sees the full lifecycle:
+#   * revert(version_id)  — revert an artifact to a prior snapshot by writing a
+#                           NEW draft whose content == the target version's
+#                           content (revert moves FORWARD; history is never
+#                           mutated). A follow-up publish() then takes the
+#                           reverted content live. Emits artifact.version.reverted
+#                           (carrying ``reverted_from`` = the target version id).
+#   * publish() now also emits artifact.version.published so the BP-4
+#     VersionProjection (versions/projection.py) can fold the published-pointer
+#     move into the per-artifact history timeline alongside created / branched /
+#     merged / discarded / reverted. The projection is the event-history read; the
+#     ordered version timeline an endpoint shows is served by list_versions (the
+#     ArtifactVersion rows ARE the ordered log — see sites/router.py
+#     /history).
 from __future__ import annotations
 
 import logging
@@ -296,12 +310,30 @@ async def publish(
 
     Raises ``ValueError`` if the version does not exist or belongs to a
     different artifact/workspace (defensive scope check).
+
+    Emits ``artifact.version.published`` (BP-4) so the VersionProjection can
+    fold the published-pointer move into the per-artifact history timeline.
     """
     row = await _scoped_row(
         scope_type=scope_type, scope_id=scope_id, workspace_id=workspace_id, version_id=version_id
     )
     row.status = "published"
     await row.save()
+    _emit_version_event(
+        action="artifact.version.published",
+        scope_type=scope_type,
+        scope_id=scope_id,
+        workspace_id=workspace_id,
+        author=row.author,
+        payload={
+            "version_id": str(row.id),
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "branch": row.branch,
+            "version_no": row.version_no,
+            "status": "published",
+        },
+    )
     return row
 
 
@@ -417,15 +449,85 @@ async def discard(
     return row
 
 
-async def revert(*args, **kwargs):  # pragma: no cover — BP-4 owns this
-    """STUB — revert is owned by BP-4.
+async def revert(
+    *,
+    scope_type: str,
+    scope_id: str,
+    workspace_id: str,
+    version_id: str,
+    author: str | None = None,
+    label: str | None = None,
+) -> ArtifactVersion:
+    """Revert an artifact to a prior version (BP-4).
 
-    BP-4 will revert an artifact to a prior snapshot (writing a new row with
-    ``status="reverted"`` semantics) and fold the events into a Journal
-    history projection. Intentionally unimplemented in BP-1 so callers fail
-    loud rather than silently no-op.
+    Reverting writes a NEW draft on the target version's branch whose
+    ``content`` is a copy of the target version's content, and makes it the
+    head. Revert moves FORWARD — it never mutates history. The user can then
+    ``publish()`` the new draft to take the reverted content live, exactly as
+    they would publish any other draft. This keeps the version log append-only
+    and makes "revert" a first-class, auditable lineage step rather than a
+    destructive rewrite.
+
+    ``label`` defaults to a human-readable "Revert to v<n>" so the history view
+    reads cleanly; callers can override it.
+
+    Raises ``ValueError`` if the target version does not exist or belongs to a
+    different artifact/workspace (the shared ``_scoped_row`` defensive check —
+    a revert must never cross tenants or artifacts).
+
+    Emits ``artifact.version.reverted`` (carrying ``reverted_from`` = the target
+    version id + the new draft's id) so the VersionProjection records the revert
+    as its own lifecycle event in the history timeline.
     """
-    raise NotImplementedError("revert is implemented in BP-4")
+    target = await _scoped_row(
+        scope_type=scope_type, scope_id=scope_id, workspace_id=workspace_id, version_id=version_id
+    )
+
+    revert_label = label or f"Revert to v{target.version_no}"
+
+    # Write the new draft on the SAME branch as the target so the revert lands
+    # on the lineage it is reverting (typically "main"). Snapshot the target's
+    # content (a shallow dict copy so a later mutation of one row never bleeds
+    # into the other — content is a small full snapshot, not a diff).
+    head = await _latest_in_branch(
+        scope_type=scope_type, scope_id=scope_id, branch_name=target.branch
+    )
+    version_no = (head.version_no + 1) if head else 1
+
+    new_draft = ArtifactVersion(
+        scope_type=scope_type,
+        scope_id=scope_id,
+        workspace_id=workspace_id,
+        branch=target.branch,
+        version_no=version_no,
+        content=dict(target.content),
+        parent_version_id=str(head.id) if head else None,
+        status="draft",
+        label=revert_label,
+        author=author,
+    )
+    await new_draft.insert()
+
+    _emit_version_event(
+        action="artifact.version.reverted",
+        scope_type=scope_type,
+        scope_id=scope_id,
+        workspace_id=workspace_id,
+        author=author,
+        payload={
+            "version_id": str(new_draft.id),
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "branch": target.branch,
+            "version_no": version_no,
+            "parent_version_id": new_draft.parent_version_id,
+            "reverted_from": str(target.id),
+            "reverted_from_version_no": target.version_no,
+            "status": "draft",
+            "label": revert_label,
+        },
+    )
+    return new_draft
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ee/sites/test_request_publish.py
+++ b/tests/ee/sites/test_request_publish.py
@@ -1,0 +1,231 @@
+# tests/ee/sites/test_request_publish.py
+# Created: 2026-06-18 (feat/branch-primitive-revert-history, BP-4) — coverage for
+# the two Branch-primitive Sites surfaces over the BP-1 versions spine:
+#   Part B — version_history() / GET /sites/by-pocket/{id}/versions returns the
+#            ordered (oldest → newest) version timeline for a pocket, tenant-scoped.
+#   Part C — request_publish_pocket() / POST /sites/by-pocket/{id}/request-publish
+#            builds a WELL-FORMED _artifact_change review proposal server-side (the
+#            client never hand-builds the Instinct propose), stamps a real
+#            workspace, and returns the created Action; a pocket with no draft → 400.
+#
+# The headline test is the ROUND-TRIP: request-publish creates the gate Action,
+# approving it (through the REAL Instinct router + the REAL BP-3 merge executor,
+# with only the site DEPLOY faked) publishes the reviewed draft version. This pins
+# that request-publish → approve → published works end to end through the gate.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.versions import service as versions
+
+from pocketpaw.instinct.store import InstinctStore
+
+pytestmark = pytest.mark.asyncio
+
+WS = "ws-rp"
+POCKET = "pocket-rp"
+USER = "user-rp"
+
+
+@pytest.fixture
+def instinct_store(tmp_path, monkeypatch):
+    """A throwaway InstinctStore wired into BOTH places the code reads it from:
+    the sites service (``pocketpaw.stores.get_instinct_store``) and the BP-3
+    executor (same accessor). Returns the store so a test can read the Action
+    back."""
+    store = InstinctStore(tmp_path / "rp_instinct.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Part B — version_history (ordered timeline, tenant-scoped)
+# ---------------------------------------------------------------------------
+
+
+async def test_version_history_oldest_to_newest(beanie_test_db):
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 2}
+    )
+    rows = await sites_service.version_history(workspace_id=WS, pocket_id=POCKET)
+    assert [r.version_no for r in rows] == [1, 2]  # oldest → newest
+
+
+async def test_version_history_is_tenant_scoped(beanie_test_db):
+    await versions.write_draft(scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={})
+    # A version of the SAME pocket id stamped under another workspace must not leak.
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id="ws-OTHER", content={}
+    )
+    rows = await sites_service.version_history(workspace_id=WS, pocket_id=POCKET)
+    assert all(r.workspace_id == WS for r in rows)
+    assert len(rows) == 1
+
+
+async def test_version_history_empty_for_unversioned_pocket(beanie_test_db):
+    rows = await sites_service.version_history(workspace_id=WS, pocket_id="never-versioned")
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Part C — request_publish_pocket builds a well-formed proposal
+# ---------------------------------------------------------------------------
+
+
+async def test_request_publish_builds_well_formed_proposal(beanie_test_db, instinct_store):
+    """The created Action carries an _artifact_change blob with the exact shape
+    BP-3's gate + executor read: scope_type/scope_id/branch/from/to/workspace."""
+    # A published version is live; a newer draft is the working copy to review.
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "live"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    v2 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "draft"}
+    )
+
+    action = await sites_service.request_publish_pocket(
+        workspace_id=WS, user_id=USER, pocket_id=POCKET
+    )
+
+    assert action.status.value == "pending"
+    assert action.scope_type == "pocket"
+    blob = action.parameters["_artifact_change"]
+    assert blob["scope_type"] == "pocket"
+    assert blob["scope_id"] == POCKET
+    assert blob["branch"] == "main"
+    assert blob["from_version_id"] == str(v1.id)  # the currently-published version
+    assert blob["to_version_id"] == str(v2.id)  # the current draft
+    assert blob["workspace"] == WS  # real workspace, never empty (BP-3 hard-403s "")
+    assert blob["user_id"] == USER
+
+
+async def test_request_publish_first_publish_has_null_from(beanie_test_db, instinct_store):
+    """Nothing published yet → from_version_id is None (a first publish)."""
+    draft = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "draft"}
+    )
+    action = await sites_service.request_publish_pocket(
+        workspace_id=WS, user_id=USER, pocket_id=POCKET
+    )
+    blob = action.parameters["_artifact_change"]
+    assert blob["from_version_id"] is None
+    assert blob["to_version_id"] == str(draft.id)
+
+
+async def test_request_publish_no_draft_raises(beanie_test_db, instinct_store):
+    """A pocket with no draft version → ValueError (the router maps it to 400)."""
+    with pytest.raises(ValueError):
+        await sites_service.request_publish_pocket(
+            workspace_id=WS, user_id=USER, pocket_id="no-draft-here"
+        )
+
+
+async def test_request_publish_ignores_foreign_workspace_draft(beanie_test_db, instinct_store):
+    """A draft under another workspace is 'nothing here' for this caller — the
+    tenant guard treats it as no draft → ValueError."""
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id="ws-OTHER", content={"v": 1}
+    )
+    with pytest.raises(ValueError):
+        await sites_service.request_publish_pocket(workspace_id=WS, user_id=USER, pocket_id=POCKET)
+
+
+# ---------------------------------------------------------------------------
+# The round-trip — request-publish → approve (real gate + real merge executor)
+# → the reviewed draft version is published.
+# ---------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str, workspace_id: str) -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+async def test_request_publish_approve_publishes_the_draft(
+    beanie_test_db, instinct_store, monkeypatch
+):
+    """End to end: request-publish creates the gate Action; approving it through
+    the REAL Instinct router + the REAL BP-3 merge executor publishes the reviewed
+    draft version (only the site DEPLOY is faked). Pins request-publish → approve
+    → published."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.instinct.router import router as instinct_router
+
+    # A published v1 is live; a newer draft v2 is the working copy to review.
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "live"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    v2 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "draft"}
+    )
+
+    # 1. request-publish — the server builds the gate proposal.
+    action = await sites_service.request_publish_pocket(
+        workspace_id=WS, user_id=USER, pocket_id=POCKET
+    )
+    assert action.parameters["_artifact_change"]["to_version_id"] == str(v2.id)
+
+    # The merge executor triggers a site DEPLOY for a pocket scope — fake just the
+    # deploy so no Bun/workerd/CF is touched; the version publish below is REAL.
+    deploy_calls: dict = {}
+
+    async def _fake_deploy(*, workspace_id, user_id, pocket_id):
+        deploy_calls["pocket_id"] = pocket_id
+
+    monkeypatch.setattr(sites_service, "publish_pocket", _fake_deploy)
+
+    # 2. approve the Action through the REAL Instinct router. The gate's
+    # cross-workspace check passes (caller's active workspace == blob workspace),
+    # then it dispatches the real BP-3 merge executor (publish v2 + deploy).
+    from unittest.mock import AsyncMock
+
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    user = _FakeUser(USER, WS)
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(instinct_router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+
+    from unittest.mock import patch
+
+    with patch("pocketpaw_ee.instinct.router._store", return_value=instinct_store):
+        client = TestClient(app)
+        resp = client.post(f"/instinct/actions/{action.id}/approve")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["action"]["status"] == "approved"
+
+    # 3. The reviewed draft (v2) is now the published version — request-publish →
+    # approve → published worked through the gate.
+    live = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert live is not None
+    assert live.id == v2.id
+    assert live.content == {"v": "draft"}
+    # The deploy fired for this pocket.
+    assert deploy_calls.get("pocket_id") == POCKET

--- a/tests/ee/versions/test_version_projection.py
+++ b/tests/ee/versions/test_version_projection.py
@@ -1,0 +1,162 @@
+# tests/ee/versions/test_version_projection.py
+# Created: 2026-06-18 (feat/branch-primitive-revert-history, BP-4) — coverage for
+# the VersionProjection: the read projection that replays the journal's
+# artifact.version.* events into a per-artifact EVENT history timeline.
+#
+# What this pins:
+#   * The projection folds created / branched / merged / discarded / reverted /
+#     published events and yields them oldest → newest for one artifact.
+#   * It is scope-keyed: two artifacts' histories never bleed into each other.
+#   * history(workspace_id=...) is tenant-filtered.
+#   * apply() is idempotent (a re-applied entry does not duplicate the timeline).
+#   * Non-version events on the journal are dropped.
+#
+# It drives the REAL versions service (which emits the events) against a tmp
+# journal, then rebuilds the projection from that journal — an end-to-end check
+# that the emitted event shape and the projection's fold agree.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.versions import service as versions
+from pocketpaw_ee.versions.projection import VersionProjection
+
+pytestmark = pytest.mark.asyncio
+
+WS = "ws-proj"
+POCKET = "pocket-proj"
+
+
+def _rebuild(journal) -> VersionProjection:
+    proj = VersionProjection()
+    proj.rebuild(journal.replay_from(0))
+    return proj
+
+
+async def test_projection_folds_full_lifecycle_in_order(beanie_test_db, versions_journal):
+    """A create → publish → revert sequence lands as an ordered event timeline."""
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}, author="u-1"
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    new_draft = await versions.revert(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id), author="u-2"
+    )
+
+    proj = _rebuild(versions_journal)
+    history = proj.history(scope_type="pocket", scope_id=POCKET)
+
+    # Oldest → newest: created, published, reverted.
+    assert [e.action for e in history] == ["created", "published", "reverted"]
+    # The created event carries v1; the reverted event carries the new draft +
+    # the reverted_from pointer.
+    created, published, reverted = history
+    assert created.version_id == str(v1.id)
+    assert created.actor_id == "u-1"
+    assert published.version_id == str(v1.id)
+    assert reverted.version_id == str(new_draft.id)
+    assert reverted.payload["reverted_from"] == str(v1.id)
+    assert reverted.workspace_id == WS
+
+
+async def test_projection_folds_branch_merge_discard(beanie_test_db, versions_journal):
+    """branch / merged / discarded events fold into the history with their verbs."""
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    cand = await versions.branch(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, new_branch="cand"
+    )
+    await versions.mark_merged(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(cand.id)
+    )
+
+    other = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 2}
+    )
+    await versions.discard(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(other.id)
+    )
+
+    proj = _rebuild(versions_journal)
+    actions = [e.action for e in proj.history(scope_type="pocket", scope_id=POCKET)]
+    assert actions == ["created", "branched", "merged", "created", "discarded"]
+
+
+async def test_projection_is_scope_keyed(beanie_test_db, versions_journal):
+    """Two artifacts keep separate histories — no cross-bleed."""
+    await versions.write_draft(
+        scope_type="pocket", scope_id="pocket-A", workspace_id=WS, content={}
+    )
+    await versions.write_draft(
+        scope_type="pocket", scope_id="pocket-B", workspace_id=WS, content={}
+    )
+    await versions.write_draft(
+        scope_type="pocket", scope_id="pocket-A", workspace_id=WS, content={}
+    )
+
+    proj = _rebuild(versions_journal)
+    a = proj.history(scope_type="pocket", scope_id="pocket-A")
+    b = proj.history(scope_type="pocket", scope_id="pocket-B")
+    assert len(a) == 2
+    assert len(b) == 1
+    assert all(e.scope_id == "pocket-A" for e in a)
+
+
+async def test_projection_history_is_tenant_filtered(beanie_test_db, versions_journal):
+    """history(workspace_id=...) only returns the caller's tenant's events."""
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id="ws-1", content={}
+    )
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id="ws-2", content={}
+    )
+
+    proj = _rebuild(versions_journal)
+    # Unfiltered sees both; tenant-filtered sees only its own.
+    assert len(proj.history(scope_type="pocket", scope_id=POCKET)) == 2
+    ws1 = proj.history(scope_type="pocket", scope_id=POCKET, workspace_id="ws-1")
+    assert len(ws1) == 1
+    assert ws1[0].workspace_id == "ws-1"
+
+
+async def test_projection_apply_is_idempotent(beanie_test_db, versions_journal):
+    """Replaying the same journal twice does not duplicate the timeline."""
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+
+    proj = VersionProjection()
+    proj.rebuild(versions_journal.replay_from(0))
+    first = len(proj.history(scope_type="pocket", scope_id=POCKET))
+    # Re-apply the same events (incremental from 0, which re-folds) — dedup keeps
+    # the count stable.
+    for entry in versions_journal.replay_from(0):
+        proj.apply(entry)
+    second = len(proj.history(scope_type="pocket", scope_id=POCKET))
+    assert first == second == 2
+
+
+async def test_projection_drops_non_version_events(versions_journal):
+    """A non-artifact.version.* event on the journal is ignored by the fold."""
+    from datetime import UTC, datetime
+    from uuid import uuid4
+
+    from soul_protocol.spec.journal import Actor, EventEntry
+
+    versions_journal.append(
+        EventEntry(
+            id=uuid4(),
+            ts=datetime.now(UTC),
+            actor=Actor(kind="system", id="x", scope_context=["pocket:p"]),
+            action="fabric.object.created",
+            scope=["pocket:p", "workspace:ws-1"],
+            payload={"object_id": "o1"},
+        )
+    )
+    proj = _rebuild(versions_journal)
+    assert proj.history(scope_type="pocket", scope_id="p") == []

--- a/tests/ee/versions/test_versions_service.py
+++ b/tests/ee/versions/test_versions_service.py
@@ -14,7 +14,13 @@
 #   5. list_versions returns the version log newest-first.
 #   6. write_draft emits artifact.version.created; branch emits
 #      artifact.version.branched — both with a non-empty stamped scope.
-#   7. revert is a BP-4 stub (raises NotImplementedError).
+#
+# Updated 2026-06-18 (feat/branch-primitive-revert-history, BP-4):
+#   7. revert(version_id) writes a NEW draft from the target version's content
+#      (revert moves forward; history is never mutated), emits
+#      artifact.version.reverted, and a follow-up publish takes the reverted
+#      content live. It is scope/workspace-checked. (Replaces the BP-1 stub test.)
+#   8. publish() now emits artifact.version.published.
 from __future__ import annotations
 
 import pytest
@@ -254,10 +260,131 @@ async def test_branch_emits_version_branched(beanie_test_db, versions_journal):
 
 
 # ---------------------------------------------------------------------------
-# 7. revert — BP-4 stub
+# 7. revert — BP-4: writes a new draft from a prior snapshot, moves forward
 # ---------------------------------------------------------------------------
 
 
-async def test_revert_is_bp4_stub(beanie_test_db):
-    with pytest.raises(NotImplementedError):
-        await versions.revert()
+async def test_revert_writes_new_draft_from_target_content(beanie_test_db):
+    """revert(v1) writes a NEW draft whose content == v1's content, on the same
+    branch, with the next version_no. History is not mutated — v1/v2 stand."""
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    v2 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 2}
+    )
+
+    reverted = await versions.revert(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    # A NEW row (not v1/v2), next version_no, draft status, v1's content.
+    assert reverted.id not in (v1.id, v2.id)
+    assert reverted.version_no == 3
+    assert reverted.status == "draft"
+    assert reverted.content == {"v": 1}
+    assert reverted.branch == "main"
+    assert reverted.label == "Revert to v1"
+    # The new draft is the head (parent == v2).
+    assert reverted.parent_version_id == str(v2.id)
+    # History intact — v1/v2 unchanged, the log now has 3 rows.
+    log = await versions.list_versions(scope_type="pocket", scope_id=POCKET)
+    assert [v.version_no for v in log] == [3, 2, 1]
+
+
+async def test_revert_then_publish_goes_live_with_reverted_content(beanie_test_db):
+    """The full revert flow: revert(old) → publish(new draft) takes the reverted
+    content live."""
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "good"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    # A bad edit is published.
+    v2 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "bad"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v2.id)
+    )
+    assert (await versions.get_published(scope_type="pocket", scope_id=POCKET)).content == {
+        "v": "bad"
+    }
+
+    # Revert to the good version, then publish the resulting draft.
+    new_draft = await versions.revert(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(new_draft.id)
+    )
+
+    live = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert live is not None
+    assert live.id == new_draft.id
+    assert live.content == {"v": "good"}
+
+
+async def test_revert_emits_reverted_event(beanie_test_db, versions_journal):
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}, author="u-1"
+    )
+    new_draft = await versions.revert(
+        scope_type="pocket",
+        scope_id=POCKET,
+        workspace_id=WS,
+        version_id=str(v1.id),
+        author="u-2",
+    )
+    events = versions_journal.query(action="artifact.version.reverted")
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.payload["version_id"] == str(new_draft.id)
+    assert ev.payload["reverted_from"] == str(v1.id)
+    assert ev.payload["reverted_from_version_no"] == 1
+    assert ev.scope  # non-empty
+    assert f"workspace:{WS}" in ev.scope
+
+
+async def test_revert_rejects_cross_workspace(beanie_test_db):
+    v = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={}
+    )
+    with pytest.raises(ValueError):
+        await versions.revert(
+            scope_type="pocket",
+            scope_id=POCKET,
+            workspace_id="ws-OTHER",
+            version_id=str(v.id),
+        )
+
+
+async def test_revert_missing_version_raises(beanie_test_db):
+    from beanie import PydanticObjectId
+
+    with pytest.raises(ValueError):
+        await versions.revert(
+            scope_type="pocket",
+            scope_id=POCKET,
+            workspace_id=WS,
+            version_id=str(PydanticObjectId()),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. publish emits artifact.version.published (BP-4)
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_emits_published_event(beanie_test_db, versions_journal):
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    events = versions_journal.query(action="artifact.version.published")
+    assert len(events) == 1
+    assert events[0].payload["version_id"] == str(v1.id)
+    assert events[0].payload["status"] == "published"
+    assert f"workspace:{WS}" in events[0].scope


### PR DESCRIPTION
BP-4 of the Branch primitive, stacked on #1491. Completes the backend: revert, history, and the clean endpoint the editor uses to send a publish through review.

## What ships
- **Revert.** `versions.revert(version_id)` writes a new draft from a prior version's snapshot (history moves forward, never mutates the past) and emits `artifact.version.reverted`. Publish that draft to go live with the reverted content.
- **History.** A `VersionProjection` replays the `artifact.version.*` events into a per-artifact event timeline (who/what/when) for the review UI and the audit agent. The version-timeline read endpoint (`GET /sites/by-pocket/{id}/versions`) serves the durable version rows directly — they're the exact ordered log, never lossy — while the projection covers the event-history view.
- **The gate entry.** `POST /sites/by-pocket/{id}/request-publish` builds the `_artifact_change` review proposal server-side (correct scope, version ids, and a real workspace claim — never empty, which BP-3 hard-403s) so the client submits one call instead of hand-assembling an Instinct propose. Returns the created review Action. Approving it (the BP-3 executor) publishes the pocket.

## Why this matters for the next slices
BP-5 (editor) and BP-6 (review UI) build against these endpoints — request-publish is the seam that keeps the client out of Instinct internals.

## Tests
revert, history ordering, and a full request-publish→approve→published round-trip through the real Instinct router + BP-3 executor — 156 in the broad run, 56 in the focused set, all green. request-publish with no draft → 400. ruff clean.

## Stacking
Base is the BP-3 branch (#1491). Merge order: #1489 → #1490 → #1491 → this, each --rebase.