### PR TITLE
fix(cloud-chat): scope session history query by workspace_id

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -124,6 +124,16 @@ type-gated. The renderer re-sanitizes even though ``summarize_ripple_spec``
 now sanitizes at the source (the get_pocket ``_summary`` path) — it never
 trusts a hand-built dict. Capped lists render honest "+N more" markers
 from the summarizer's new ``*_omitted`` counters.
+Changes: 2026-06-18 (fix/session-history-workspace-scope) —
+``load_history_for_scope``'s pocket/session query now also filters by
+``workspace_id`` (from ``ctx.workspace_id``). Defense-in-depth: pocket/session
+ObjectIds are globally unique so ``session_key`` alone never collides today,
+but the query no longer RELIES on id-uniqueness for tenant isolation — the
+workspace boundary is now an explicit predicate, and the query lands on the
+``(workspace_id, session_key, createdAt)`` compound index. Mirrors the
+existing ``MongoMemoryStore.get_session_in_workspace`` pattern. Normal-path
+behavior (ordering, limit, ``session_key_for`` formula) is unchanged.
+
 Changes: 2026-06-25 (fix/worker-trusts-spec-workspace) — ``resolve_scope_context``
 and the three resolvers gained ``expected_workspace_id``: the authenticated,
 route-validated workspace the run worker threads from ``spec.workspace_id``.
@@ -1980,9 +1990,16 @@ async def load_history_for_scope(ctx: ScopeContext, *, limit: int = 50) -> list[
 
     try:
         if ctx.kind in (ScopeKind.POCKET, ScopeKind.SESSION):
+            # Scope by workspace_id too (defense-in-depth). Pocket/session
+            # ObjectIds are globally unique, so session_key alone never
+            # collides in practice — but pinning the workspace makes tenant
+            # isolation an explicit predicate rather than an implicit
+            # consequence of id-uniqueness, and hits the
+            # ``(workspace_id, session_key, createdAt)`` compound index.
             query: dict[str, Any] = {
                 "context_type": ctx.kind.value,
                 "session_key": session_key_for(ctx),
+                "workspace_id": ctx.workspace_id,
             }
         else:  # GROUP, DM — both land in a group row
             query = {

--- a/tests/cloud/test_agent_router_history_rehydrate.py
+++ b/tests/cloud/test_agent_router_history_rehydrate.py
@@ -6,6 +6,14 @@ so the POST endpoint must rehydrate history from the persisted ``Message``
 collection and ship it on the ``RunSpec`` to the executor. Before this fix,
 ``history=None`` was passed unconditionally and the agent replied with no
 memory of prior turns after any process restart.
+
+Changes: 2026-06-18 (fix/session-history-workspace-scope) — added
+``test_load_history_for_session_scope_filters_by_workspace_id`` and the
+workspace-aware ``_WorkspaceScopedMessageModel`` stub. The new test proves
+the pocket/session history query scopes by ``workspace_id`` so two rows that
+share a ``session_key`` but live in different workspaces can never bleed
+across the tenant boundary (defense-in-depth — globally-unique ObjectIds make
+a real collision impossible today, but the query no longer relies on that).
 """
 
 from __future__ import annotations
@@ -141,6 +149,7 @@ async def test_load_history_for_session_scope_uses_session_key(monkeypatch):
     assert captured["query"] == {
         "context_type": "session",
         "session_key": session_key_for(ctx),
+        "workspace_id": ctx.workspace_id,
     }
     assert captured["limit"] == 25
     assert result == [
@@ -189,6 +198,105 @@ async def test_load_history_returns_empty_on_mongo_error(monkeypatch):
 
     # Mongo blowing up must NOT kill the stream — degrade to no-context reply.
     assert await load_history_for_scope(_session_ctx()) == []
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth: pocket/session history must scope by workspace_id so two
+# rows sharing a session_key but living in different workspaces never bleed
+# across the tenant boundary. ObjectId global uniqueness makes a real
+# collision impossible today, but the query must not RELY on that.
+# ---------------------------------------------------------------------------
+
+
+class _WorkspaceStubMsg:
+    """Stub Message carrying the workspace_id the real adapter stamps."""
+
+    def __init__(self, *, role=None, sender_type="user", content="", workspace_id=None):
+        self.role = role
+        self.sender_type = sender_type
+        self.content = content
+        self.workspace_id = workspace_id
+
+
+class _WorkspaceScopedFindChain:
+    """find().sort().limit().to_list() chain that filters like Mongo would.
+
+    Applies the captured query's ``workspace_id`` (and ``session_key``)
+    predicates to the in-memory docs, so a query that OMITS ``workspace_id``
+    leaks every workspace's rows — exactly the seam under test.
+    """
+
+    def __init__(self, query: dict, docs: list[_WorkspaceStubMsg]):
+        self._query = query
+        self._docs = docs
+
+    def sort(self, *args, **kwargs):  # noqa: ARG002
+        return self
+
+    def limit(self, n):  # noqa: ARG002
+        return self
+
+    async def to_list(self):
+        out = []
+        for d in self._docs:
+            if "session_key" in self._query and self._query["session_key"] is not None:
+                # The stub doesn't model session_key per-doc; assume all docs
+                # share the key under test (the test constructs them that way).
+                pass
+            if "workspace_id" in self._query:
+                if getattr(d, "workspace_id", None) != self._query["workspace_id"]:
+                    continue
+            out.append(d)
+        return out
+
+
+class _WorkspaceScopedMessageModel:
+    _captured: dict = {}
+    _docs: list[_WorkspaceStubMsg] = []
+
+    @classmethod
+    def configure(cls, docs: list[_WorkspaceStubMsg]) -> dict:
+        cls._captured = {}
+        cls._docs = docs
+        return cls._captured
+
+    @classmethod
+    def find(cls, query):
+        cls._captured["query"] = query
+        return _WorkspaceScopedFindChain(query, cls._docs)
+
+
+@pytest.mark.asyncio
+async def test_load_history_for_session_scope_filters_by_workspace_id(monkeypatch):
+    """Two rows share a session_key but live in different workspaces.
+
+    ``load_history_for_scope`` for ``ctx.workspace_id == "w1"`` must return
+    ONLY the ``w1`` row. Without a ``workspace_id`` predicate in the query the
+    stub (modeling Mongo's filter) returns both rows and this assertion fails,
+    proving the unscoped query is the seam.
+    """
+    captured = _WorkspaceScopedMessageModel.configure(
+        [
+            _WorkspaceStubMsg(role="user", content="mine", workspace_id="w1"),
+            _WorkspaceStubMsg(role="user", content="not mine", workspace_id="w2"),
+        ]
+    )
+    import pocketpaw_ee.cloud.models.message as message_mod
+
+    monkeypatch.setattr(message_mod, "Message", _WorkspaceScopedMessageModel)
+
+    ctx = _session_ctx()  # workspace_id == "w1"
+    result = await load_history_for_scope(ctx)
+
+    # The query itself must carry the workspace predicate.
+    assert captured["query"].get("workspace_id") == "w1", (
+        f"pocket/session history query must filter by workspace_id; got query={captured['query']!r}"
+    )
+    # And only this workspace's row may come back.
+    assert result == [{"role": "user", "content": "mine"}], (
+        "history must not include rows from another workspace that happen to "
+        f"share the session_key; got {result!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`load_history_for_scope` in the cloud chat service rehydrates a pocket/session thread's prior turns from Mongo so the agent keeps context across backend restarts and pool evictions. For pocket and session scopes it built the query from two fields:

```python
{ "context_type": ctx.kind.value, "session_key": session_key_for(ctx) }
```

This PR adds `workspace_id` to that query.

## Why this was safe but worth hardening

`session_key` is `cloud:{kind}:{scope_id}:{target_agent_id}`, and `scope_id` is a pocket or session Mongo ObjectId. Those ids are globally unique, so two tenants can't end up sharing a `session_key` — isolation held in practice and there's no known cross-tenant leak.

The catch is that isolation was a *side effect* of id-uniqueness rather than something the query stated. If a future change ever reused or weakened that id space, the read would silently widen. Messages already store `workspace_id` (the persist helpers stamp it on every row), and there's even a `(workspace_id, session_key, createdAt)` compound index waiting for exactly this predicate. So the boundary should be explicit.

## The fix

Add `workspace_id: ctx.workspace_id` to the pocket/session branch of the query. `ScopeContext` already carries `workspace_id` as a required field — every resolver (`_resolve_pocket`, `_resolve_session`, `_resolve_group_like`) populates it from the underlying document's workspace — so nothing had to be threaded through. The change mirrors the pattern `MongoMemoryStore.get_session_in_workspace` already uses ("a leaked or guessed key cannot expose a tenant's messages").

Normal-path behavior is unchanged: same ordering (`createdAt`), same limit, same `session_key_for` formula. The group/DM branch is untouched.

## Test

Added `test_load_history_for_session_scope_filters_by_workspace_id`. It seeds two message rows that share a `session_key` but live in different workspaces, runs the loader for `workspace_id="w1"`, and asserts:

- the query carries `workspace_id`, and
- only the `w1` row comes back.

The stub models Mongo's filter, so the test fails against the old query (it returned both rows) and passes with the fix. Written failing-first. The existing `test_load_history_for_session_scope_uses_session_key` assertion was updated to expect the new field.

## Scope note

`ee/pocketpaw_ee/cloud/memory/mongo_store.py` has unscoped `get_session` / `get_session_with_messages` methods on the `MemoryStoreProtocol` surface, but it already exposes tenant-scoped variants (`get_session_in_workspace`) that ee callers are directed to prefer — that's a separate abstraction with its own protocol signature, so it's intentionally left alone here.

## Verification

```
uv run pytest tests/cloud/test_agent_router_history_rehydrate.py -q
# 5 passed

uv run pytest tests/cloud --ignore=tests/cloud/extraction -k "session or history or agent_router" -q
# 184 passed, 1 xfailed
```

Two failures in that broader run (`test_session_history_empty_envelope_shape`, `test_envelope_field_parity`) are pre-existing and unrelated — they fail identically on the base branch (a password-breach guard rejecting a test fixture, and a stale envelope-keys assertion). The `tests/cloud/extraction` dir is excluded for a missing optional `pypdf` dependency, also unrelated.
