### PR TITLE
feat(sites): audit endpoint — deterministic a11y/links/SEO findings with fix prompts

### DIFF
--- a/ee/pocketpaw_ee/sites/audit.py
+++ b/ee/pocketpaw_ee/sites/audit.py
@@ -1,0 +1,451 @@
+# ee/pocketpaw_ee/sites/audit.py — the site-audit engine (BP-7, Branch primitive
+# producer 2). A PURE, deterministic pass over a published site's source that
+# surfaces fixable issues — each finding carries a ``fix_prompt`` the UI feeds to
+# the EXISTING edit path (edit_svelte_component / refine), which lands the fix as
+# a reviewable draft in the Tray. No DB, no network, no LLM in the deterministic
+# core — every check is unit-testable over a sample svelte ``source`` map / HTML.
+#
+# Created: 2026-06-18 (feat/branch-primitive-audit, BP-7 backend half).
+#
+# Scope of the deterministic checks (the tested deliverable):
+#   * a11y  — <img> without alt; <button>/<a> with no accessible text/aria-label;
+#             missing or multiple <h1>; form inputs without an associated label.
+#   * links — empty / placeholder hrefs (href="", href="#"), malformed hrefs.
+#   * seo   — missing <title>; missing meta description; missing Open Graph basics
+#             (og:title / og:image), checked across app.html + page <head>.
+# Each finding: {id, check, tier, severity, location{file,hint}, message,
+# fix_prompt}. ``fix_prompt`` is a concise refine instruction (e.g. "Add
+# descriptive alt text to the hero image in Hero.svelte").
+#
+# The judgment tier (copy quality / SEO wording via a small LLM pass) is DEFERRED
+# — see the TODO near the bottom. The deterministic checks stand alone and must
+# never depend on or be gated by a live model.
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+# ── Finding model ──────────────────────────────────────────────────────────────
+@dataclass
+class Finding:
+    """One audit issue. ``check`` is the short check id (e.g. "a11y.img_alt");
+    ``tier`` is "deterministic" for the rule-based core (or "judgment" for the
+    deferred LLM pass); ``severity`` is "error" | "warning". ``location`` is a
+    {file, hint} pointer the UI can show ("Hero.svelte" + a source snippet).
+    ``fix_prompt`` is the concise refine instruction the UI sends to the existing
+    edit path so the fix lands as a reviewable draft."""
+
+    id: str
+    check: str
+    tier: str
+    severity: str
+    message: str
+    fix_prompt: str
+    location: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ── Source normalization ───────────────────────────────────────────────────────
+# A svelte site is a {path: contents} map; a ripple site renders to a single HTML
+# document. The deterministic checks operate over (path, html) pairs, so both
+# engines normalize to the same list of "documents to scan".
+_SCANNABLE_EXT = (".svelte", ".html", ".htm")
+
+
+def _documents(engine: str, content: Any) -> list[tuple[str, str]]:
+    """Normalize a pocket's content into a list of (file, html) pairs to scan.
+
+    * svelte → every ``.svelte`` / ``.html`` file in the source map (skip .ts /
+      .css / .js — they carry no markup the deterministic checks read).
+    * ripple → a single ("rippleSpec", <rendered-text>) pair. The rippleSpec is a
+      widget tree, not HTML, so we flatten its string values into one blob the
+      text-level checks (links, copy) can still scan. Markup-shape checks (img
+      alt, h1 count) are svelte-only — a ripple site has no hand-written markup.
+    """
+    if engine == "svelte" and isinstance(content, dict):
+        docs: list[tuple[str, str]] = []
+        for path, body in content.items():
+            if isinstance(path, str) and path.lower().endswith(_SCANNABLE_EXT):
+                docs.append((path, body if isinstance(body, str) else ""))
+        return docs
+    if engine == "ripple" and isinstance(content, dict):
+        # Flatten every string leaf of the spec into one scannable blob so the
+        # text-level checks (placeholder hrefs in a button's url, etc.) still run.
+        return [("rippleSpec", _flatten_spec_text(content))]
+    return []
+
+
+def _flatten_spec_text(spec: Any) -> str:
+    """Collect every string value in a rippleSpec tree into one newline-joined
+    blob (depth-first). Used only for the engine-agnostic text-level checks."""
+    out: list[str] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, str):
+            out.append(node)
+        elif isinstance(node, dict):
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(spec)
+    return "\n".join(out)
+
+
+def _short_id(check: str, n: int) -> str:
+    """Stable-ish finding id: ``<check>-<index>``. Deterministic per run so the
+    same audit over the same content yields the same ids (the UI can de-dup)."""
+    return f"{check}-{n}"
+
+
+def _hint(snippet: str, limit: int = 120) -> str:
+    """A trimmed one-line source snippet for the location hint."""
+    flat = " ".join(snippet.split())
+    return flat[:limit] + ("…" if len(flat) > limit else "")
+
+
+# ── Regexes (compiled once) ─────────────────────────────────────────────────────
+_RE_IMG = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+_RE_HAS_ALT = re.compile(r"\balt\s*=", re.IGNORECASE)
+_RE_BUTTON = re.compile(r"<button\b[^>]*>(.*?)</button>", re.IGNORECASE | re.DOTALL)
+_RE_ANCHOR = re.compile(r"<a\b([^>]*)>(.*?)</a>", re.IGNORECASE | re.DOTALL)
+_RE_H1 = re.compile(r"<h1\b[^>]*>", re.IGNORECASE)
+_RE_INPUT = re.compile(r"<input\b[^>]*>", re.IGNORECASE)
+_RE_LABEL = re.compile(r"<label\b", re.IGNORECASE)
+_RE_HREF = re.compile(r"href\s*=\s*(['\"])(.*?)\1", re.IGNORECASE)
+_RE_ARIA_LABEL = re.compile(r"aria-label\s*=\s*(['\"]).*?\1", re.IGNORECASE)
+_RE_TYPE_ATTR = re.compile(r"type\s*=\s*(['\"])(.*?)\1", re.IGNORECASE)
+_RE_TITLE_TAG = re.compile(r"<title\b[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_RE_TITLE_PLACEHOLDER = re.compile(r"%[\w.]+%")  # svelte-kit %sveltekit.head% etc.
+_RE_META_DESC = re.compile(r"<meta\b[^>]*\bname\s*=\s*(['\"])description\1[^>]*>", re.IGNORECASE)
+_RE_META_OG = re.compile(r"<meta\b[^>]*\bproperty\s*=\s*(['\"])og:(title|image)\1", re.IGNORECASE)
+# Strip markup tags + svelte blocks so "accessible text" reflects rendered text.
+_RE_TAGS = re.compile(r"<[^>]+>")
+_RE_SVELTE_EXPR = re.compile(r"\{[^}]*\}", re.DOTALL)
+
+
+def _strip_text(inner: str) -> str:
+    """Approximate the visible text of an element body: drop nested tags and
+    svelte ``{...}`` expressions, collapse whitespace. A non-empty result means
+    the element has accessible text content."""
+    no_tags = _RE_TAGS.sub(" ", inner)
+    no_expr = _RE_SVELTE_EXPR.sub(" ", no_tags)
+    return no_expr.strip()
+
+
+# ── Deterministic a11y checks ───────────────────────────────────────────────────
+def _check_a11y(file: str, html: str, counter: dict[str, int]) -> list[Finding]:
+    findings: list[Finding] = []
+
+    # <img> without alt — every <img> must carry an alt attribute.
+    for m in _RE_IMG.finditer(html):
+        tag = m.group(0)
+        if not _RE_HAS_ALT.search(tag):
+            counter["a11y.img_alt"] = counter.get("a11y.img_alt", 0) + 1
+            findings.append(
+                Finding(
+                    id=_short_id("a11y.img_alt", counter["a11y.img_alt"]),
+                    check="a11y.img_alt",
+                    tier="deterministic",
+                    severity="error",
+                    message="Image is missing an alt attribute (screen readers can't describe it).",
+                    fix_prompt=(
+                        f"Add descriptive alt text to the image in {file} "
+                        f"({_hint(tag, 60)}). Describe what the image shows; "
+                        'use alt="" only if it is purely decorative.'
+                    ),
+                    location={"file": file, "hint": _hint(tag)},
+                )
+            )
+
+    # <button> with no accessible text and no aria-label.
+    for m in _RE_BUTTON.finditer(html):
+        opening = m.group(0).split(">", 1)[0]
+        inner = m.group(1) or ""
+        if not _strip_text(inner) and not _RE_ARIA_LABEL.search(opening):
+            counter["a11y.button_name"] = counter.get("a11y.button_name", 0) + 1
+            findings.append(
+                Finding(
+                    id=_short_id("a11y.button_name", counter["a11y.button_name"]),
+                    check="a11y.button_name",
+                    tier="deterministic",
+                    severity="error",
+                    message="Button has no accessible name (no text and no aria-label).",
+                    fix_prompt=(
+                        f"Give the button in {file} an accessible name: add visible text "
+                        "or an aria-label describing its action "
+                        f"({_hint(m.group(0), 60)})."
+                    ),
+                    location={"file": file, "hint": _hint(m.group(0))},
+                )
+            )
+
+    # <a> with no accessible text and no aria-label (e.g. an icon-only link).
+    for m in _RE_ANCHOR.finditer(html):
+        attrs = m.group(1) or ""
+        inner = m.group(2) or ""
+        if not _strip_text(inner) and not _RE_ARIA_LABEL.search(attrs):
+            counter["a11y.link_name"] = counter.get("a11y.link_name", 0) + 1
+            findings.append(
+                Finding(
+                    id=_short_id("a11y.link_name", counter["a11y.link_name"]),
+                    check="a11y.link_name",
+                    tier="deterministic",
+                    severity="error",
+                    message="Link has no accessible name (no text and no aria-label).",
+                    fix_prompt=(
+                        f"Give the link in {file} an accessible name: add visible text "
+                        "or an aria-label describing where it goes "
+                        f"({_hint(m.group(0), 60)})."
+                    ),
+                    location={"file": file, "hint": _hint(m.group(0))},
+                )
+            )
+
+    # Form <input> without an associated <label> in the same document. Heuristic:
+    # any non-hidden input present while the document has zero <label> elements.
+    inputs = [
+        m
+        for m in _RE_INPUT.finditer(html)
+        if (
+            lambda t: (
+                not (
+                    _RE_TYPE_ATTR.search(t)
+                    and _RE_TYPE_ATTR.search(t).group(2).lower() in {"hidden", "submit", "button"}
+                )
+            )
+        )(m.group(0))
+    ]
+    if inputs and not _RE_LABEL.search(html):
+        counter["a11y.input_label"] = counter.get("a11y.input_label", 0) + 1
+        findings.append(
+            Finding(
+                id=_short_id("a11y.input_label", counter["a11y.input_label"]),
+                check="a11y.input_label",
+                tier="deterministic",
+                severity="warning",
+                message="Form inputs have no associated <label> elements.",
+                fix_prompt=(
+                    f"Add a <label> for each form input in {file} (or an aria-label) "
+                    "so the field's purpose is announced to assistive tech."
+                ),
+                location={"file": file, "hint": _hint(inputs[0].group(0))},
+            )
+        )
+
+    return findings
+
+
+def _check_h1(docs: list[tuple[str, str]], counter: dict[str, int]) -> list[Finding]:
+    """Heading structure is a per-PAGE concern, not per-file (a page is built from
+    many components). Count <h1> across all scannable docs: zero → missing,
+    more than one → too many. Only meaningful for svelte (hand-written markup)."""
+    total = 0
+    first_file = ""
+    for file, html in docs:
+        n = len(_RE_H1.findall(html))
+        if n and not first_file:
+            first_file = file
+        total += n
+
+    findings: list[Finding] = []
+    if total == 0 and docs:
+        counter["a11y.h1_missing"] = counter.get("a11y.h1_missing", 0) + 1
+        findings.append(
+            Finding(
+                id=_short_id("a11y.h1_missing", counter["a11y.h1_missing"]),
+                check="a11y.h1_missing",
+                tier="deterministic",
+                severity="warning",
+                message="Page has no <h1> heading (hurts a11y and SEO).",
+                fix_prompt=(
+                    "Add a single descriptive <h1> to the page's hero / top section "
+                    "so the main heading is clear to readers, screen readers, and search engines."
+                ),
+                location={"file": docs[0][0], "hint": ""},
+            )
+        )
+    elif total > 1:
+        counter["a11y.h1_multiple"] = counter.get("a11y.h1_multiple", 0) + 1
+        findings.append(
+            Finding(
+                id=_short_id("a11y.h1_multiple", counter["a11y.h1_multiple"]),
+                check="a11y.h1_multiple",
+                tier="deterministic",
+                severity="warning",
+                message=f"Page has {total} <h1> headings; it should have exactly one.",
+                fix_prompt=(
+                    f"The page has {total} <h1> headings (first in {first_file}). "
+                    "Keep one <h1> for the main heading and demote the rest to <h2>/<h3>."
+                ),
+                location={"file": first_file, "hint": ""},
+            )
+        )
+    return findings
+
+
+# ── Deterministic link checks ───────────────────────────────────────────────────
+_PLACEHOLDER_HREFS = {"", "#", "javascript:void(0)", "javascript:;"}
+
+
+def _check_links(file: str, html: str, counter: dict[str, int]) -> list[Finding]:
+    findings: list[Finding] = []
+    for m in _RE_HREF.finditer(html):
+        href = (m.group(2) or "").strip()
+        # Skip svelte dynamic hrefs (href={...}) and templated values — those are
+        # resolved at render time, not placeholders.
+        if href.startswith("{") or _RE_TITLE_PLACEHOLDER.search(href):
+            continue
+        bad = href in _PLACEHOLDER_HREFS
+        # Obviously-malformed: a scheme-looking prefix with nothing after it, or a
+        # stray space inside a non-anchor URL.
+        malformed = bool(re.match(r"^[a-z]+:$", href, re.IGNORECASE)) or (
+            " " in href and not href.startswith("#") and "mailto:" not in href
+        )
+        if bad or malformed:
+            counter["links.placeholder"] = counter.get("links.placeholder", 0) + 1
+            findings.append(
+                Finding(
+                    id=_short_id("links.placeholder", counter["links.placeholder"]),
+                    check="links.placeholder",
+                    tier="deterministic",
+                    severity="warning" if bad else "error",
+                    message=(
+                        f'Link has a placeholder href ("{href}") that goes nowhere.'
+                        if bad
+                        else f'Link has a malformed href ("{href}").'
+                    ),
+                    fix_prompt=(
+                        f'Set a real destination for the link with href="{href}" in {file} '
+                        f"({_hint(m.group(0), 50)}) — point it at the correct page, section "
+                        "anchor, or external URL."
+                    ),
+                    location={"file": file, "hint": _hint(m.group(0))},
+                )
+            )
+    return findings
+
+
+# ── Deterministic SEO checks ────────────────────────────────────────────────────
+def _check_seo(docs: list[tuple[str, str]], counter: dict[str, int]) -> list[Finding]:
+    """SEO head tags are page-wide: scan every doc and the app shell together.
+    A site is missing a tag only when NO scanned document carries it."""
+    findings: list[Finding] = []
+    if not docs:
+        return findings
+
+    blob = "\n".join(html for _, html in docs)
+    # Where to point the fix: prefer the app shell (app.html) if present, else the
+    # root page, else the first doc.
+    head_file = next(
+        (f for f, _ in docs if f.lower().endswith("app.html")),
+        next((f for f, _ in docs if "+page.svelte" in f or "+layout.svelte" in f), docs[0][0]),
+    )
+
+    # <title> — present AND non-empty (ignore svelte-kit's %sveltekit.head% which
+    # only RESERVES the slot; the title is set elsewhere via <svelte:head>).
+    title_texts = [t.strip() for t in _RE_TITLE_TAG.findall(blob) if _strip_text(t).strip()]
+    if not title_texts:
+        counter["seo.title"] = counter.get("seo.title", 0) + 1
+        findings.append(
+            Finding(
+                id=_short_id("seo.title", counter["seo.title"]),
+                check="seo.title",
+                tier="deterministic",
+                severity="error",
+                message="Site has no <title> (search results and browser tabs show no name).",
+                fix_prompt=(
+                    f"Add a concise, descriptive <title> in {head_file} (in <svelte:head> for a "
+                    "svelte page, or app.html). Lead with the business / page name."
+                ),
+                location={"file": head_file, "hint": ""},
+            )
+        )
+
+    # meta description.
+    if not _RE_META_DESC.search(blob):
+        counter["seo.meta_description"] = counter.get("seo.meta_description", 0) + 1
+        findings.append(
+            Finding(
+                id=_short_id("seo.meta_description", counter["seo.meta_description"]),
+                check="seo.meta_description",
+                tier="deterministic",
+                severity="warning",
+                message="Site has no meta description (search engines summarize it for you).",
+                fix_prompt=(
+                    f'Add a <meta name="description" content="…"> in {head_file} with a '
+                    "150–160 character summary of what the page offers."
+                ),
+                location={"file": head_file, "hint": ""},
+            )
+        )
+
+    # Open Graph basics — need both og:title and og:image for a rich share card.
+    og_props = {m.group(2).lower() for m in _RE_META_OG.finditer(blob)}
+    missing_og = [p for p in ("title", "image") if p not in og_props]
+    if missing_og:
+        counter["seo.open_graph"] = counter.get("seo.open_graph", 0) + 1
+        findings.append(
+            Finding(
+                id=_short_id("seo.open_graph", counter["seo.open_graph"]),
+                check="seo.open_graph",
+                tier="deterministic",
+                severity="warning",
+                message=(
+                    "Site is missing Open Graph tags ("
+                    + ", ".join(f"og:{p}" for p in missing_og)
+                    + ") so shared links have no preview card."
+                ),
+                fix_prompt=(
+                    f"Add Open Graph meta tags in {head_file}: "
+                    + ", ".join(f'<meta property="og:{p}" content="…">' for p in missing_og)
+                    + " so links shared on social show a title and image."
+                ),
+                location={"file": head_file, "hint": ""},
+            )
+        )
+
+    return findings
+
+
+# ── Public entry point ──────────────────────────────────────────────────────────
+def audit_pocket_site(*, engine: str, content: Any) -> list[dict[str, Any]]:
+    """Run the deterministic audit over a site's content and return findings.
+
+    ``engine`` is "svelte" or "ripple"; ``content`` is the matching content the
+    service read for the pocket (the {path: contents} svelte source map, or the
+    rippleSpec dict). Returns a list of finding dicts (see :class:`Finding`).
+    A clean site returns an empty list. Pure — no I/O, no model — so the whole
+    surface is unit-testable over a sample content map.
+    """
+    docs = _documents(engine, content)
+    counter: dict[str, int] = {}
+    findings: list[Finding] = []
+
+    # Per-document checks (markup-shape a11y + links).
+    for file, html in docs:
+        if engine == "svelte":
+            findings.extend(_check_a11y(file, html, counter))
+        findings.extend(_check_links(file, html, counter))
+
+    # Page-wide checks (heading structure is svelte-only; SEO spans the shell).
+    if engine == "svelte":
+        findings.extend(_check_h1(docs, counter))
+    findings.extend(_check_seo(docs, counter))
+
+    # TODO(BP-7 judgment tier): a small, clearly-separated copy-quality / SEO-
+    # wording pass (e.g. "the hero headline is generic", "the meta description is
+    # keyword-stuffed") via a single LLM call, tier="judgment". DEFERRED for the
+    # backend deliverable: it cannot run without live-LLM flakiness, and the spec
+    # is explicit that it must never gate or flake the deterministic core. When
+    # added it appends tier="judgment" findings here AFTER the deterministic ones,
+    # behind an opt-in flag, so a model outage degrades to the deterministic list.
+
+    return [f.to_dict() for f in findings]

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -34,6 +34,11 @@
 # and RequestPublishResponse (the Action created by POST
 # /sites/by-pocket/{pocket_id}/request-publish, the clean entry to the merge gate
 # so the client never hand-builds the Instinct proposal).
+# Updated 2026-06-18 (feat/branch-primitive-audit, BP-7): added AuditFinding +
+# AuditResponse — the response shape for POST /sites/by-pocket/{pocket_id}/audit
+# (the first non-editor PRODUCER). Each finding carries a ``fix_prompt`` the UI
+# feeds to the EXISTING edit path so the fix lands as a reviewable draft; there is
+# NO new apply endpoint (BP-7 reuses edit_svelte_component / refine).
 
 from __future__ import annotations
 
@@ -133,6 +138,35 @@ class RequestPublishResponse(BaseModel):
     pocket_id: str
     to_version_id: str
     from_version_id: str | None = None
+
+
+class AuditFinding(BaseModel):
+    """One issue surfaced by the site audit (BP-7). ``check`` is the short check id
+    (e.g. "a11y.img_alt"); ``tier`` is "deterministic" for the rule-based core (a
+    later "judgment" tier is deferred); ``severity`` is "error" | "warning".
+    ``location`` is a {file, hint} pointer (the file + a source snippet). The
+    UI feeds ``fix_prompt`` to the EXISTING edit path (edit_svelte_component /
+    refine), which lands the fix as a reviewable draft in the Tray — there is no
+    separate apply endpoint."""
+
+    id: str
+    check: str
+    tier: str
+    severity: str  # error | warning
+    message: str
+    fix_prompt: str
+    location: dict[str, str] = {}
+
+
+class AuditResponse(BaseModel):
+    """The result of POST /sites/by-pocket/{pocket_id}/audit — the findings for a
+    pocket's published-site source. A clean site returns an empty ``findings``
+    list. Tenant-scoped; engine selects how the source was read (svelte source map
+    vs rippleSpec)."""
+
+    pocket_id: str
+    engine: str
+    findings: list[AuditFinding] = []
 
 
 class DomainRequest(BaseModel):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -59,6 +59,13 @@
 #     needs this). Returns the created Action (id/status) so the client shows
 #     "submitted for review". fabric.write — it creates a gate item that, on
 #     approve, publishes + deploys. A 400 when there is no draft to publish.
+# Updated 2026-06-18 (feat/branch-primitive-audit, BP-7 — producer 2): added
+# POST /sites/by-pocket/{pocket_id}/audit — run the deterministic site audit over
+# the pocket's content and return findings, each with a ``fix_prompt`` the UI
+# feeds to the EXISTING edit path so a fix lands as a reviewable draft (no new
+# apply endpoint). It's a read of the pocket's content, so it carries fabric.read
+# (the same gate as preview/status). Tenant-scoped on ctx; the pockets service
+# raises NotFound → 404 itself.
 
 from __future__ import annotations
 
@@ -68,6 +75,7 @@ from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.deps import require_action_any_workspace, require_plan_feature
 from pocketpaw_ee.sites import service as sites_service
 from pocketpaw_ee.sites.dto import (
+    AuditResponse,
     DomainRequest,
     DomainStatusResponse,
     MakeEditableRequest,
@@ -183,6 +191,30 @@ async def status_by_pocket(
     status, is_live}. Derived from the tenant-scoped Site deployment doc — an
     unpublished pocket (no Site) reads draft / not live (NOT a 404)."""
     return await sites_service.pocket_status(workspace_id=ctx.workspace_id, pocket_id=pocket_id)
+
+
+@router.post("/sites/by-pocket/{pocket_id}/audit", response_model=AuditResponse)
+async def audit_by_pocket(
+    pocket_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> AuditResponse:
+    """Audit a pocket's published-site source and return findings (BP-7, the first
+    non-editor producer): a11y (missing alt, unnamed button/link, h1 structure,
+    unlabeled inputs), broken/placeholder links, and SEO head tags (title, meta
+    description, Open Graph). Each finding carries a ``fix_prompt`` the UI sends to
+    the EXISTING edit path (edit_svelte_component / refine) so the fix lands as a
+    reviewable draft in the Tray — there is NO separate apply endpoint.
+
+    A POST because it is an explicit, on-demand pass over the source (potentially
+    a model-backed judgment tier later), not a cheap idempotent read; it still
+    carries fabric.read since it only READS the pocket. A missing / access-denied
+    pocket surfaces as a 404 (the pockets service raises NotFound itself). Reads
+    the same draft-or-current content preview_pocket serves, so the audit matches
+    what publish would build. A clean site returns an empty ``findings`` list."""
+    return await sites_service.audit_pocket(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, pocket_id=pocket_id
+    )
 
 
 @router.get("/sites/by-pocket/{pocket_id}/versions", response_model=VersionHistoryResponse)

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -152,6 +152,13 @@
 #     has_unpublished_changes; is_live requires published AND the Site doc's real
 #     ``deployed``. The artifact is the source pocket: scope_type="pocket",
 #     scope_id=<pocket_id>.
+# Updated 2026-06-18 (feat/branch-primitive-audit, BP-7 — producer 2): added
+# audit_pocket(). It reads the pocket's content the SAME way preview_pocket does
+# (draft-version snapshot, falling back to current rippleSpec/source) and runs the
+# pure deterministic audit engine (sites.audit.audit_pocket_site) over it. Each
+# finding carries a ``fix_prompt`` the UI feeds to the EXISTING edit path
+# (edit_svelte_component / refine) so a fix lands as a reviewable draft in the
+# Tray — BP-7 adds NO apply endpoint.
 
 from __future__ import annotations
 
@@ -169,6 +176,8 @@ from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
 from pocketpaw_ee.sites.domain import HostnameStatus
 from pocketpaw_ee.sites.dto import (
+    AuditFinding,
+    AuditResponse,
     DomainStatusResponse,
     SitePreviewResponse,
     SiteResponse,
@@ -804,6 +813,70 @@ async def preview_pocket(
 
     content = draft_content if draft_content is not None else current
     return SitePreviewResponse(pocket_id=pocket_id, engine=engine, content=content)
+
+
+async def audit_pocket(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+) -> AuditResponse:
+    """Run the deterministic site audit over a pocket's content (BP-7, producer 2).
+
+    Reads the pocket's content the SAME way ``preview_pocket`` does — the BP-1
+    DRAFT-version snapshot (what publish WOULD build), falling back to the pocket's
+    current rippleSpec / source map when there is no draft row — then runs the pure
+    deterministic audit engine (``sites.audit.audit_pocket_site``) over it. The
+    audit itself is side-effect free; this function only resolves the content.
+
+    Each finding carries a ``fix_prompt`` the UI feeds to the EXISTING edit path
+    (``edit_svelte_component`` / refine), which lands the fix as a reviewable draft
+    in the Tray — BP-7 adds NO apply endpoint. A clean site returns an empty
+    ``findings`` list.
+
+    The pockets service's PUBLIC ``get`` raises NotFound / Forbidden itself when
+    the pocket is missing or access-denied (mapped to 404 / 403 by the router), so
+    no extra existence check is needed. ``workspace_id`` keeps the surface uniform
+    and tenant-aware (the pockets read scopes on ``user_id``)."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites.audit import audit_pocket_site
+
+    pocket = await pockets_service.get(pocket_id, user_id)
+    engine = pocket.get("engine") or "ripple"
+
+    # The pocket's CURRENT content for the engine — the fallback when the Branch
+    # primitive has no draft row for this pocket yet (mirrors preview_pocket).
+    if engine == "svelte":
+        source = pocket.get("source")
+        current: dict[str, Any] | None = source if isinstance(source, dict) else None
+    else:
+        ripple_spec = pocket.get("rippleSpec")
+        current = ripple_spec if isinstance(ripple_spec, dict) else None
+
+    # Prefer the DRAFT version's snapshot (the working copy publish would build).
+    # Versioning is an additive layer — a missing module / read failure must not
+    # break the audit, so degrade to the current content on any error.
+    draft_content: dict[str, Any] | None = None
+    try:
+        from pocketpaw_ee.versions import service as versions_service
+
+        draft = await versions_service.get_draft(scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id)
+        if draft is not None:
+            draft_content = draft.content
+    except Exception:  # noqa: BLE001 — versions read is best-effort
+        logger.warning(
+            "versions: failed to read draft for pocket %s audit — falling back to current content",
+            pocket_id,
+            exc_info=True,
+        )
+
+    content = draft_content if draft_content is not None else current
+    findings = audit_pocket_site(engine=engine, content=content)
+    return AuditResponse(
+        pocket_id=pocket_id,
+        engine=engine,
+        findings=[AuditFinding(**f) for f in findings],
+    )
 
 
 async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusResponse:

--- a/tests/ee/sites/test_audit.py
+++ b/tests/ee/sites/test_audit.py
@@ -1,0 +1,273 @@
+# tests/ee/sites/test_audit.py — unit tests for the deterministic site-audit
+# engine (sites.audit.audit_pocket_site), BP-7 backend half (the Branch-primitive
+# producer 2). Created: 2026-06-18 (feat/branch-primitive-audit).
+#
+# The audit engine is a PURE function over a site's content (a {path: contents}
+# svelte source map, or a rippleSpec dict) — no DB, no network, no LLM — so every
+# deterministic check is exercised here over sample content, with a POSITIVE case
+# (issue present → exactly one finding for that check, with a usable fix_prompt)
+# and a NEGATIVE case (clean content → that check produces no finding). A fully
+# clean svelte site returns zero findings.
+#
+# Checks covered:
+#   a11y — img_alt, button_name, link_name, input_label, h1_missing, h1_multiple
+#   links — placeholder/malformed href
+#   seo  — title, meta_description, open_graph
+
+from __future__ import annotations
+
+from pocketpaw_ee.sites.audit import audit_pocket_site
+
+# A clean, §-complete svelte source map: a single <h1>, every <img> has alt, the
+# button/link have accessible text, real hrefs, and a full SEO head (title, meta
+# description, og:title + og:image). Audits to ZERO findings — the baseline every
+# positive case mutates one issue into.
+_CLEAN = {
+    "src/app.html": (
+        "<!doctype html><html><head>"
+        "<title>Bright Smile Dental — Whiter Teeth in 30 Days</title>"
+        "<meta name='description' content='Bright Smile Dental gives you a whiter, "
+        "healthier smile with gentle, modern dentistry. Book a free consult today.'>"
+        "<meta property='og:title' content='Bright Smile Dental'>"
+        "<meta property='og:image' content='https://brightsmile.example/og.png'>"
+        "</head><body>%sveltekit.body%</body></html>"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css'</script><slot/>",
+    "src/routes/+page.ts": "export const prerender = true",
+    "src/app.css": ":root{--brand:#0A84FF}",
+    "src/lib/components/Hero.svelte": (
+        "<section class='hero'>"
+        "<h1>Brighter Smiles, Whiter Teeth</h1>"
+        "<img src='/hero.jpg' alt='A patient smiling after treatment'/>"
+        "<a href='/book'>Book a consult</a>"
+        "<button>Get started</button>"
+        "</section>"
+    ),
+}
+
+
+def _by_check(findings, check):
+    return [f for f in findings if f["check"] == check]
+
+
+def test_clean_site_has_no_findings():
+    findings = audit_pocket_site(engine="svelte", content=_CLEAN)
+    assert findings == [], findings
+
+
+# ── a11y ────────────────────────────────────────────────────────────────────────
+def test_img_without_alt_is_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = "<section><h1>Hi</h1><img src='/hero.jpg'/></section>"
+    findings = audit_pocket_site(engine="svelte", content=src)
+    hits = _by_check(findings, "a11y.img_alt")
+    assert len(hits) == 1
+    f = hits[0]
+    assert f["tier"] == "deterministic"
+    assert f["severity"] == "error"
+    assert f["location"]["file"] == "src/lib/components/Hero.svelte"
+    assert "alt" in f["fix_prompt"].lower()
+    assert "Hero.svelte" in f["fix_prompt"]
+
+
+def test_img_with_alt_is_not_flagged():
+    # The clean baseline's Hero img carries alt — no img_alt finding.
+    findings = audit_pocket_site(engine="svelte", content=_CLEAN)
+    assert _by_check(findings, "a11y.img_alt") == []
+
+
+def test_button_without_accessible_name_is_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = "<section><h1>Hi</h1><button><svg/></button></section>"
+    findings = audit_pocket_site(engine="svelte", content=src)
+    hits = _by_check(findings, "a11y.button_name")
+    assert len(hits) == 1
+    assert hits[0]["severity"] == "error"
+    assert "aria-label" in hits[0]["fix_prompt"]
+
+
+def test_button_with_aria_label_is_not_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = (
+        "<section><h1>Hi</h1><button aria-label='Close'><svg/></button></section>"
+    )
+    findings = audit_pocket_site(engine="svelte", content=src)
+    assert _by_check(findings, "a11y.button_name") == []
+
+
+def test_icon_only_link_without_name_is_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = "<section><h1>Hi</h1><a href='/x'><svg/></a></section>"
+    findings = audit_pocket_site(engine="svelte", content=src)
+    hits = _by_check(findings, "a11y.link_name")
+    assert len(hits) == 1
+    assert hits[0]["severity"] == "error"
+
+
+def test_link_with_text_is_not_flagged():
+    findings = audit_pocket_site(engine="svelte", content=_CLEAN)
+    assert _by_check(findings, "a11y.link_name") == []
+
+
+def test_input_without_label_is_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Form.svelte"] = "<form><input name='email' type='email'/></form>"
+    findings = audit_pocket_site(engine="svelte", content=src)
+    hits = _by_check(findings, "a11y.input_label")
+    assert len(hits) == 1
+    assert hits[0]["severity"] == "warning"
+    assert "label" in hits[0]["fix_prompt"].lower()
+
+
+def test_input_with_label_is_not_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Form.svelte"] = (
+        "<form><label for='email'>Email</label><input id='email' type='email'/></form>"
+    )
+    findings = audit_pocket_site(engine="svelte", content=src)
+    assert _by_check(findings, "a11y.input_label") == []
+
+
+def test_missing_h1_is_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = (
+        "<section><h2>No top heading here</h2>"
+        "<img src='/h.jpg' alt='x'/><a href='/b'>Book</a><button>Go</button></section>"
+    )
+    findings = audit_pocket_site(engine="svelte", content=src)
+    hits = _by_check(findings, "a11y.h1_missing")
+    assert len(hits) == 1
+    assert hits[0]["severity"] == "warning"
+
+
+def test_multiple_h1_is_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = (
+        "<section><h1>One</h1><h1>Two</h1>"
+        "<img src='/h.jpg' alt='x'/><a href='/b'>Book</a><button>Go</button></section>"
+    )
+    findings = audit_pocket_site(engine="svelte", content=src)
+    hits = _by_check(findings, "a11y.h1_multiple")
+    assert len(hits) == 1
+    assert "2" in hits[0]["message"]
+
+
+# ── links ────────────────────────────────────────────────────────────────────────
+def test_empty_href_is_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = "<section><h1>Hi</h1><a href=''>Dead</a></section>"
+    findings = audit_pocket_site(engine="svelte", content=src)
+    hits = _by_check(findings, "links.placeholder")
+    assert len(hits) == 1
+    assert "href" in hits[0]["fix_prompt"].lower()
+
+
+def test_hash_href_is_flagged():
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = "<section><h1>Hi</h1><a href='#'>Top</a></section>"
+    findings = audit_pocket_site(engine="svelte", content=src)
+    assert len(_by_check(findings, "links.placeholder")) == 1
+
+
+def test_real_href_is_not_flagged():
+    findings = audit_pocket_site(engine="svelte", content=_CLEAN)
+    assert _by_check(findings, "links.placeholder") == []
+
+
+def test_svelte_dynamic_href_is_not_flagged():
+    # href={url} is resolved at render — not a placeholder.
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = (
+        "<section><h1>Hi</h1><a href={url}>Dynamic</a></section>"
+    )
+    findings = audit_pocket_site(engine="svelte", content=src)
+    assert _by_check(findings, "links.placeholder") == []
+
+
+# ── SEO ──────────────────────────────────────────────────────────────────────────
+def test_missing_title_is_flagged():
+    src = dict(_CLEAN)
+    src["src/app.html"] = (
+        "<!doctype html><html><head>"
+        "<meta name='description' content='A real description that is present.'>"
+        "<meta property='og:title' content='x'><meta property='og:image' content='y'>"
+        "</head><body></body></html>"
+    )
+    findings = audit_pocket_site(engine="svelte", content=src)
+    hits = _by_check(findings, "seo.title")
+    assert len(hits) == 1
+    assert hits[0]["severity"] == "error"
+
+
+def test_missing_meta_description_is_flagged():
+    src = dict(_CLEAN)
+    src["src/app.html"] = (
+        "<!doctype html><html><head><title>Has a title</title>"
+        "<meta property='og:title' content='x'><meta property='og:image' content='y'>"
+        "</head><body></body></html>"
+    )
+    findings = audit_pocket_site(engine="svelte", content=src)
+    assert len(_by_check(findings, "seo.meta_description")) == 1
+
+
+def test_missing_open_graph_is_flagged():
+    src = dict(_CLEAN)
+    src["src/app.html"] = (
+        "<!doctype html><html><head><title>Has a title</title>"
+        "<meta name='description' content='A real description that is present here.'>"
+        "</head><body></body></html>"
+    )
+    findings = audit_pocket_site(engine="svelte", content=src)
+    hits = _by_check(findings, "seo.open_graph")
+    assert len(hits) == 1
+    # Both og:title and og:image are missing → named in the message.
+    assert "og:title" in hits[0]["message"]
+    assert "og:image" in hits[0]["message"]
+
+
+def test_full_seo_head_is_not_flagged():
+    findings = audit_pocket_site(engine="svelte", content=_CLEAN)
+    assert _by_check(findings, "seo.title") == []
+    assert _by_check(findings, "seo.meta_description") == []
+    assert _by_check(findings, "seo.open_graph") == []
+
+
+# ── engine handling ──────────────────────────────────────────────────────────────
+def test_ripple_engine_scans_flattened_html_for_placeholder_links():
+    # A ripple site has no hand-written component markup, so the markup-SHAPE a11y
+    # checks (img alt, h1, button name) don't run. The text-level link check is
+    # attribute-based: it fires when a ripple node carries literal HTML with an
+    # href= attribute (e.g. an html/embed widget), which the flatten surfaces.
+    spec = {"type": "html", "content": '<a href="#">Click</a>'}
+    findings = audit_pocket_site(engine="ripple", content=spec)
+    assert _by_check(findings, "links.placeholder")
+    # The svelte-only markup-shape a11y checks did NOT fire on a ripple spec.
+    assert _by_check(findings, "a11y.img_alt") == []
+    assert _by_check(findings, "a11y.h1_missing") == []
+
+
+def test_ripple_structured_url_field_is_not_a_link_finding():
+    # A URL stored as a STRUCTURED value ("href": "#"), not as an HTML attribute,
+    # is not markup — the deterministic link check (attribute-based) does not flag
+    # it. Documents the boundary: structured-spec URL validation is out of the
+    # deterministic core's scope (a future judgment/spec-aware tier could add it).
+    spec = {"type": "container", "children": [{"label": "Click", "href": "#"}]}
+    findings = audit_pocket_site(engine="ripple", content=spec)
+    assert _by_check(findings, "links.placeholder") == []
+
+
+def test_none_content_is_safe():
+    assert audit_pocket_site(engine="svelte", content=None) == []
+    assert audit_pocket_site(engine="ripple", content=None) == []
+
+
+def test_finding_ids_are_unique_per_run():
+    # Two imgs without alt → two distinct finding ids.
+    src = dict(_CLEAN)
+    src["src/lib/components/Hero.svelte"] = (
+        "<section><h1>Hi</h1><img src='/a.jpg'/><img src='/b.jpg'/></section>"
+    )
+    findings = audit_pocket_site(engine="svelte", content=src)
+    img_hits = _by_check(findings, "a11y.img_alt")
+    assert len(img_hits) == 2
+    assert len({f["id"] for f in findings}) == len(findings)

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -23,6 +23,13 @@
 # /sites/reserve — the manual "re-serve local sites" endpoint that (re)starts
 # the local static server and returns the workspace's reconciled site list with
 # fresh, valid urls. Gated like the other authed sites writes (fabric.write).
+#
+# Updated 2026-06-18 (feat/branch-primitive-audit, BP-7): adds coverage for POST
+# /sites/by-pocket/{pocket_id}/audit — the deterministic site audit. The handler
+# delegates to sites_service.audit_pocket, which reads the pocket via the pockets
+# service (mocked here, as the preview/status tests do) and runs the pure audit
+# engine. Asserts a site with known issues surfaces findings (each with a
+# fix_prompt), a clean site returns an empty list, and a missing pocket is a 404.
 
 from __future__ import annotations
 
@@ -434,3 +441,96 @@ async def test_make_editable_route_body_beats_origin_header(beanie_test_db, monk
         )
     assert resp.status_code == 200, resp.text
     assert captured["builder_origin"] == "https://explicit.paw.example"
+
+
+# ---------------------------------------------------------------------------
+# audit (BP-7): POST /sites/by-pocket/{pocket_id}/audit runs the deterministic
+# site audit and returns findings, each with a fix_prompt the UI feeds to the
+# existing edit path. fabric.read; tenant-scoped; a missing pocket is a 404.
+# ---------------------------------------------------------------------------
+
+# A svelte source with three known issues: an <img> without alt, an empty href,
+# and a head that lacks <title> / meta description / Open Graph.
+_AUDIT_DIRTY_SOURCE = {
+    "src/app.html": "<!doctype html><html><head></head><body></body></html>",
+    "src/lib/components/Hero.svelte": (
+        "<section><h1>Hi</h1><img src='/hero.jpg'/><a href=''>Dead link</a></section>"
+    ),
+}
+
+
+@pytest.mark.asyncio
+async def test_audit_by_pocket_surfaces_known_issues(beanie_test_db, monkeypatch):
+    """A site with an img-without-alt, an empty href, and a missing title surfaces
+    a finding for each — each carrying a non-empty fix_prompt the UI can feed to
+    the existing edit path."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(return_value={"name": "x", "engine": "svelte", "source": _AUDIT_DIRTY_SOURCE}),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/by-pocket/pk_dirty/audit")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["pocket_id"] == "pk_dirty"
+    assert body["engine"] == "svelte"
+    checks = {f["check"] for f in body["findings"]}
+    assert "a11y.img_alt" in checks
+    assert "links.placeholder" in checks
+    assert "seo.title" in checks
+    # Every finding carries a usable fix_prompt + a location file.
+    for f in body["findings"]:
+        assert f["fix_prompt"].strip()
+        assert f["location"]["file"]
+
+
+@pytest.mark.asyncio
+async def test_audit_by_pocket_clean_site_has_no_findings(beanie_test_db, monkeypatch):
+    """A clean site returns an empty findings list."""
+    from unittest.mock import AsyncMock
+
+    clean = {
+        "src/app.html": (
+            "<!doctype html><html><head>"
+            "<title>Bright Smile Dental</title>"
+            "<meta name='description' content='A whiter, healthier smile with modern dentistry.'>"
+            "<meta property='og:title' content='Bright Smile'>"
+            "<meta property='og:image' content='https://x.example/og.png'>"
+            "</head><body></body></html>"
+        ),
+        "src/lib/components/Hero.svelte": (
+            "<section><h1>Brighter Smiles</h1>"
+            "<img src='/hero.jpg' alt='A patient smiling'/>"
+            "<a href='/book'>Book a consult</a></section>"
+        ),
+    }
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(return_value={"name": "x", "engine": "svelte", "source": clean}),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/by-pocket/pk_clean/audit")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["findings"] == []
+
+
+@pytest.mark.asyncio
+async def test_audit_by_pocket_missing_pocket_is_404(beanie_test_db, monkeypatch):
+    """A missing / access-denied pocket surfaces as a 404 (the pockets service's
+    NotFound flows through the standard error handler)."""
+    from unittest.mock import AsyncMock
+
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(side_effect=NotFound("pocket", "pk_missing")),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/by-pocket/pk_missing/audit")
+    assert resp.status_code == 404


### PR DESCRIPTION
BP-7 (backend) of the Branch primitive — the first non-editor producer. An audit pass over a site's source surfaces issues, each carrying a fix prompt the editor can apply (which lands as a reviewable draft through the existing edit→review path).

## What ships
- A pure, deterministic audit engine (`sites/audit.py`) over the pocket's source: a11y (img alt, button/link names, input labels, h1 missing/multiple), links (empty/placeholder/malformed hrefs), SEO (title, meta description, Open Graph). No LLM — fully testable.
- `POST /sites/by-pocket/{id}/audit` → `AuditResponse {findings}`, tenant-scoped, same auth as the sibling by-pocket reads. Reads the draft snapshot (falls back to current content).
- Each finding carries a concise `fix_prompt` so the UI's one-click fix feeds the existing edit path — no new apply endpoint; fixes become drafts reviewable in the Tray.

## Judgment tier deferred
The copy/SEO-wording (LLM) tier is deliberately deferred (a TODO) to keep the deterministic core solid and flake-free. The engine is structured to append judgment findings behind a flag later.

## Tests
37 tests — each check positive + negative over a sample source map, plus the endpoint (known issues → findings, clean site → none). Full sites suite 134 passed. ruff clean.

## Note
Off merged dev (not stacked). The UI audit panel is a follow-on PR in paw-enterprise.