### PR TITLE
Instinct gate foundation: triage classifier, trust ledger, auto-approve, compensation registry

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -803,6 +803,20 @@ class InstinctApprovalRejected(Event):
     EVENT_TYPE: ClassVar[str] = "instinct.approval.rejected"
 
 
+# Layered/learning Instinct gate (2026-06-18 design / T3). Emitted by
+# ``instinct_approvals.service.auto_approve`` when the AUTO lane decides a
+# write WITHOUT a human — a row is created already-decided
+# (status="auto_approved"). Distinct from ``InstinctApprovalApproved``,
+# which fires only on a human's approve action; this one always carries
+# ``actor="system:triager"`` so the UI renders it with a robot icon and the
+# human-pending tray (which filters on status="pending") never shows it.
+# ``data`` carries the approval id + workspace/pocket context plus
+# ``trust_score``, ``triager_reasoning`` and ``lane`` for the audit trail.
+@dataclass
+class InstinctApprovalAutoApproved(Event):
+    EVENT_TYPE: ClassVar[str] = "instinct.approval.auto_approved"
+
+
 # Bulk action dispatch (RFC 03 v2 / Wave 3b). Emitted by
 # ``pockets.service.dispatch_bulk_action`` after a fan-out call resolves —
 # one event per dispatch, regardless of how many rows were processed.

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
@@ -3,6 +3,16 @@
 # writer for the ``InstinctApproval`` collection (RFC 03 v2). Module-
 # level ``async def`` API per EE cloud rule 5. Every state-mutating
 # function:
+#
+# Updated: 2026-06-18 (feat/instinct-gate-foundation, T3) — added
+# ``auto_approve``, the layered/learning gate's AUTO-lane writer. It
+# inserts a row ALREADY-DECIDED (``status="auto_approved"``,
+# ``decided_by="system:triager"``, ``decided_at=now``) in a single write
+# and emits ``InstinctApprovalAutoApproved``. This is how the AUTO lane
+# keeps a complete approval-level audit trail in the SAME Mongo collection
+# as every human decision without ever touching the OSS SQLite store
+# (design MF-1/MF-2). The human queue filters on ``status="pending"``, so
+# an auto-approved row never appears in the human tray.
 #   * validates at entry via ``<Request>.model_validate(body)`` (rule 6)
 #   * filters reads by ``workspace=workspace_id`` (rule 7)
 #   * raises ``CloudError`` subclasses, never ``HTTPException`` (rule 10)
@@ -27,6 +37,7 @@ from pocketpaw_ee.cloud._core.errors import ConflictError, NotFound, ValidationE
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     InstinctApprovalApproved,
+    InstinctApprovalAutoApproved,
     InstinctApprovalCreated,
     InstinctApprovalRejected,
 )
@@ -112,6 +123,73 @@ async def create_approval(
     domain = _to_domain(doc)
     wire = approval_to_wire_dict(domain)
     await emit(InstinctApprovalCreated(data=dict(wire)))
+    return wire
+
+
+async def auto_approve(
+    workspace_id: str,
+    user_id: str,
+    body: dict | CreateApprovalRequest,
+    trust_score: float,
+    triager_reasoning: str,
+) -> dict:
+    """Create a decided (``auto_approved``) approval row in one write.
+
+    The layered/learning gate's AUTO lane calls this instead of
+    ``create_approval`` when ``classify_lane`` returns ``AUTO``. The row is
+    inserted ALREADY-DECIDED: ``status="auto_approved"``,
+    ``decided_by="system:triager"``, ``decided_at=now`` — there is no
+    intermediate pending state and the OSS SQLite store is never touched
+    (design MF-1). Emits ``InstinctApprovalAutoApproved`` carrying the
+    triager's ``trust_score`` + ``triager_reasoning`` + ``lane="AUTO"`` so
+    the audit trail and Decision-Graph join have a backing row in the same
+    collection as every human decision (design MF-2).
+
+    ``user_id`` is the human who TRIGGERED the action (recorded as
+    ``requested_by``); the DECIDER is the system triager, not the user.
+    """
+    body = CreateApprovalRequest.model_validate(body)
+
+    if not workspace_id:
+        raise ValidationError(
+            "instinct_approval.workspace_required",
+            "workspace_id is required to auto-approve an approval row",
+        )
+    if not user_id:
+        raise ValidationError(
+            "instinct_approval.user_required",
+            "user_id is required to auto-approve an approval row",
+        )
+
+    now = datetime.now(UTC)
+    doc = _ApprovalDoc(
+        workspace=workspace_id,
+        pocket_id=body.pocket_id,
+        action_name=body.action_name,
+        row_id=body.row_id,
+        row_data=body.row_data,
+        verdict=body.verdict,
+        reason=body.reason,
+        matched_rules=body.matched_rules,
+        requested_at=now,
+        requested_by=user_id,
+        status="auto_approved",
+        decided_at=now,
+        decided_by="system:triager",
+        park=body.park,
+    )
+    await doc.insert()
+    domain = _to_domain(doc)
+    wire = approval_to_wire_dict(domain)
+    # The event payload carries the triager rationale alongside the wire
+    # row. ``actor`` is the system triager (UI renders system: with a robot
+    # icon, not in the human-pending queue).
+    payload = dict(wire)
+    payload["actor"] = "system:triager"
+    payload["trust_score"] = trust_score
+    payload["triager_reasoning"] = triager_reasoning
+    payload["lane"] = "AUTO"
+    await emit(InstinctApprovalAutoApproved(data=payload))
     return wire
 
 
@@ -244,6 +322,7 @@ async def _decide(
 
 __all__ = [
     "approve",
+    "auto_approve",
     "create_approval",
     "get_approval",
     "list_approvals",

--- a/ee/pocketpaw_ee/cloud/models/instinct_approval.py
+++ b/ee/pocketpaw_ee/cloud/models/instinct_approval.py
@@ -18,6 +18,14 @@
 # M2b.1 ``_park`` field on ``pocketpaw.instinct.models.Action`` is
 # scoped to the RFC 03 v2 template flow only — the M2b.1 binding-level
 # park remains for backward compatibility.
+#
+# Updated: 2026-06-18 (feat/instinct-gate-foundation, T3) — added the
+# additive ``"auto_approved"`` status value to ``ApprovalStatusT``. The
+# layered/learning gate's AUTO lane writes a row already-decided with this
+# status (via ``instinct_approvals.service.auto_approve``,
+# ``decided_by="system:triager"``) in a single write. The human queue UI
+# filters on ``status="pending"``, so an auto-approved row never appears in
+# the human tray. No migration: the literal is additive only.
 
 """Beanie document for the Instinct approval queue (RFC 03 v2)."""
 
@@ -31,7 +39,7 @@ from pydantic import Field
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
-ApprovalStatusT = Literal["pending", "approved", "rejected", "expired"]
+ApprovalStatusT = Literal["pending", "approved", "rejected", "expired", "auto_approved"]
 
 
 class InstinctApproval(TimestampedDocument):

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_compensation_registry.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_compensation_registry.py
@@ -1,0 +1,201 @@
+# ee/pocketpaw_ee/cloud/pockets/instinct_compensation_registry.py
+# Created: 2026-06-18 (feat/instinct-gate-foundation, T4) — the in-memory
+# registry that holds an OPTIMISTIC-lane write's compensation handle until
+# the client either triggers rollback or the TTL expires (2026-06-18
+# gate-layered-learning design). The OPTIMISTIC lane fires a write before a
+# human has reviewed it, on the bet that it's reversible; this registry is
+# the safety net that guarantees the bet is bounded in time.
+#
+# On the import-linter "Pockets" allowlist (no Beanie writes). It imports
+# ``CompensateSpec`` from action_executor (import-linter-pure) and the OSS
+# audit logger.
+#
+# TTL expiry is the security-critical path (design MF-8): if a compensation
+# is never rolled back AND never expires loudly, an un-reviewed write sits
+# committed with no human ever told. So expiry FIRES AN ALERT-severity
+# audit event and PERSISTS the expired handle to
+# ~/.pocketpaw/instinct/expired_compensations/<workspace_id>.jsonl (0700/
+# 0600) before purging the entry. The persist is best-effort: if it fails
+# we log a warning but STILL purge from memory so a write-failure can't leak
+# the registry (MF-8). Hard expiry only — no heartbeat extension (design
+# open-question #2, defaulted pending captain).
+#
+# Time is INJECTED (``now=...``) on register / sweep so the TTL is
+# deterministic and testable; callers pass the real clock in production.
+
+"""In-memory optimistic-compensation registry with TTL expiry."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+from pocketpaw_ee.cloud.pockets.action_executor import CompensateSpec
+
+logger = logging.getLogger(__name__)
+
+_EXPIRED_SUBDIR = ("instinct", "expired_compensations")
+_DIR_MODE = 0o700
+_FILE_MODE = 0o600
+
+
+@dataclass(frozen=True)
+class CompensationHandle:
+    """One live optimistic compensation awaiting rollback or expiry.
+
+    Frozen so a holder cannot mutate the rollback target after the
+    registry hands it back. ``compensate`` is the inverse write the saga
+    runtime fires to undo the optimistic forward write.
+    """
+
+    compensation_id: str
+    workspace_id: str
+    pocket_id: str
+    action: str
+    compensate: CompensateSpec
+    registered_at: datetime
+    expires_at: datetime
+
+
+class OptimisticCompensationRegistry:
+    """Holds optimistic compensation handles until rollback or TTL expiry.
+
+    Single-process, in-memory (a dict). A future multi-process deployment
+    would back this with a shared store, but the optimistic window is short
+    (default 300s) and the registry is consulted only by the same process
+    that minted the handle, so in-memory is correct for the foundation.
+    """
+
+    def __init__(self, ttl_seconds: int = 300) -> None:
+        self._ttl = timedelta(seconds=ttl_seconds)
+        self._handles: dict[str, CompensationHandle] = {}
+
+    def register(
+        self,
+        *,
+        workspace_id: str,
+        pocket_id: str,
+        action: str,
+        compensate: CompensateSpec,
+        now: datetime | None = None,
+    ) -> str:
+        """Register a compensation handle; return its id (a UUID).
+
+        The id keys the rollback endpoint the client receives on an
+        ``optimistic_proceed`` response.
+        """
+        ts = now or datetime.now(UTC)
+        cid = str(uuid.uuid4())
+        self._handles[cid] = CompensationHandle(
+            compensation_id=cid,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            action=action,
+            compensate=compensate,
+            registered_at=ts,
+            expires_at=ts + self._ttl,
+        )
+        return cid
+
+    def get(self, compensation_id: str) -> CompensationHandle | None:
+        """Return the live handle, or ``None`` if unknown / already gone."""
+        return self._handles.get(compensation_id)
+
+    def pop(self, compensation_id: str) -> CompensationHandle | None:
+        """Remove and return a handle (the rollback / consume path)."""
+        return self._handles.pop(compensation_id, None)
+
+    def sweep_expired(self, *, now: datetime | None = None) -> list[CompensationHandle]:
+        """Expire every handle past its TTL; return the expired handles.
+
+        For each expired handle: fire an ALERT audit event, persist it to
+        the expired-compensations JSONL, then purge it from memory. The
+        purge happens even if the persist raises (MF-8) so a disk error
+        cannot leak the registry.
+        """
+        ts = now or datetime.now(UTC)
+        expired = [h for h in self._handles.values() if h.expires_at <= ts]
+        for handle in expired:
+            self._on_expiry(handle)
+            # purge unconditionally — even if _on_expiry's persist failed.
+            self._handles.pop(handle.compensation_id, None)
+        return expired
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _on_expiry(self, handle: CompensationHandle) -> None:
+        """Fire the ALERT audit event + persist the expired handle.
+
+        Audit first (it's the loud signal an operator must see), then
+        persist. Both are wrapped so a failure in one does not prevent the
+        purge in ``sweep_expired``.
+        """
+        try:
+            get_audit_logger().log(
+                AuditEvent.create(
+                    severity=AuditSeverity.ALERT,
+                    actor="system:triager",
+                    action="instinct_optimistic_expired",
+                    target=f"compensation:{handle.compensation_id}",
+                    status="error",
+                    workspace_id=handle.workspace_id,
+                    pocket_id=handle.pocket_id,
+                    action_name=handle.action,
+                    compensation_id=handle.compensation_id,
+                    registered_at=handle.registered_at.isoformat(),
+                    expires_at=handle.expires_at.isoformat(),
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - audit must never block purge
+            logger.warning(
+                "optimistic-compensation: audit emit failed for %s (%s)",
+                handle.compensation_id,
+                exc,
+            )
+        try:
+            self._persist_expired(handle)
+        except Exception as exc:  # noqa: BLE001 - persist is best-effort (MF-8)
+            logger.warning(
+                "optimistic-compensation: expired-JSONL persist failed for %s (%s)",
+                handle.compensation_id,
+                exc,
+            )
+
+    def _persist_expired(self, handle: CompensationHandle) -> None:
+        """Append the expired handle to the workspace JSONL at 0700/0600."""
+        d = Path.home().joinpath(".pocketpaw", *_EXPIRED_SUBDIR)
+        d.mkdir(parents=True, exist_ok=True, mode=_DIR_MODE)
+        try:
+            os.chmod(d, _DIR_MODE)
+        except OSError:  # pragma: no cover - platform-dependent
+            pass
+        path = d / f"{handle.workspace_id}.jsonl"
+        row = {
+            "compensation_id": handle.compensation_id,
+            "workspace_id": handle.workspace_id,
+            "pocket_id": handle.pocket_id,
+            "action": handle.action,
+            "compensate": handle.compensate.model_dump(),
+            "registered_at": handle.registered_at.isoformat(),
+            "expires_at": handle.expires_at.isoformat(),
+        }
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, _FILE_MODE)
+        try:
+            with os.fdopen(fd, "a", encoding="utf-8") as f:
+                f.write(json.dumps(row) + "\n")
+        finally:
+            try:
+                os.chmod(path, _FILE_MODE)
+            except OSError:  # pragma: no cover
+                pass
+
+
+__all__ = ["CompensationHandle", "OptimisticCompensationRegistry"]

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_triage.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_triage.py
@@ -1,0 +1,207 @@
+# ee/pocketpaw_ee/cloud/pockets/instinct_triage.py
+# Created: 2026-06-18 (feat/instinct-gate-foundation, T1) — the pure,
+# synchronous lane classifier for the layered/learning Instinct gate
+# (2026-06-18 gate-layered-learning design). Turns a binary
+# escalate/execute gate into a 4-lane router (DRY_RUN / AUTO / OPTIMISTIC /
+# BATCH / ESCALATE) using three signals: reversibility (CompensateSpec
+# presence), blast radius (DELETE + financial keyword heuristic), and the
+# per-(pocket, action) trust score + proposed_count from trust_ledger.
+#
+# PURE: no I/O, no DB, no clock. ``classify_lane`` is a total function of
+# its ``TriageProposal`` + the ``dry_run_mode`` flag. This module is on the
+# import-linter "Pockets" allowlist (no Beanie writes) — it only imports
+# ``CompensateSpec`` from action_executor (itself import-linter-pure).
+#
+# DEFAULT-SAFE: every uncertain branch returns ESCALATE. The classifier is
+# DORMANT until the integration layer (separate gated PR) passes a non-ASK
+# ``approval_level`` — under the default ApprovalLevel.ASK rule 2 forces
+# ESCALATE for every proposal, so this module changes zero behavior on its
+# own. A high-blast action (DELETE or financial path) can reach OPTIMISTIC
+# at best, never AUTO — a CompensateSpec is not proof of reversibility for
+# money/DELETE.
+
+"""Pure lane classifier for the layered/learning Instinct gate."""
+
+from __future__ import annotations
+
+from enum import IntEnum, StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from pocketpaw_ee.cloud.pockets.action_executor import CompensateSpec
+
+# Financial-action keywords. A write whose path contains any of these is
+# treated as high-blast regardless of HTTP method — a CompensateSpec may
+# move it to OPTIMISTIC but never to AUTO. Hardcoded here as the moat (see
+# design open-question #3 — defaulted, pending captain; a per-workspace
+# override list is a possible future change). Matching is case-insensitive
+# substring on the path.
+_FINANCIAL_KEYWORDS: tuple[str, ...] = (
+    "charge",
+    "refund",
+    "cancel",
+    "payment",
+    "invoice",
+    "withdraw",
+    "subscription",
+    "billing",
+)
+
+# The trust bar mirrors the config default ``instinct_auto_approve_threshold``
+# (0.9). It lives here as a module constant so the pure classifier has no
+# config dependency; the integration layer asserts the two stay in sync.
+_THRESHOLD: float = 0.9
+
+
+class TriageLane(IntEnum):
+    """The lane a proposal routes to.
+
+    Ordering is by escalation severity (0 = most-governed dry run … 4 =
+    fully-escalated human queue). ``IntEnum`` so audit rows can store the
+    int and dashboards can sort, while the name stays the wire/audit label.
+    """
+
+    DRY_RUN = 0
+    AUTO = 1
+    OPTIMISTIC = 2
+    BATCH = 3
+    ESCALATE = 4
+
+
+class ApprovalLevel(StrEnum):
+    """Per-workspace triager activation level.
+
+    * ``ASK`` — triager dormant. Every escalate goes to a human. This is
+      the global default; under it ``classify_lane`` always returns
+      ESCALATE (rule 2), so shipping the classifier changes nothing.
+    * ``TRIAGE`` — triager active; lanes 0-4 all live.
+    * ``TRUSTED`` — reserved. In this foundation it is treated IDENTICALLY
+      to ``TRIAGE`` (no behavior difference yet — design open-question #1,
+      defaulted pending captain).
+    """
+
+    ASK = "ASK"
+    TRIAGE = "TRIAGE"
+    TRUSTED = "TRUSTED"
+
+
+class TriageProposal(BaseModel):
+    """The immutable input to ``classify_lane`` for one (action, row).
+
+    Frozen so a caller cannot mutate the signals after construction. The
+    classifier reads only these fields plus the ``dry_run_mode`` flag — it
+    is a pure function of this object.
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    action: str
+    method: Literal["POST", "PUT", "PATCH", "DELETE"]
+    path: str
+    compensate: CompensateSpec | None
+    trust_score: float
+    proposed_count: int
+    instinct_verdict: str
+    approval_level: ApprovalLevel
+
+
+def _is_high_blast(method: str, path: str) -> bool:
+    """True for irreversible / money-moving writes.
+
+    A high-blast action cannot reach AUTO even with a CompensateSpec — the
+    compensate signal can only lift it to OPTIMISTIC. Two triggers:
+
+    * ``DELETE`` method — a destructive verb. A compensate (undelete) is
+      rarely a true inverse, so DELETE never auto-fires.
+    * a financial keyword anywhere in the path (case-insensitive). Money
+      movement is the canonical "review before it fires" surface.
+    """
+    if method == "DELETE":
+        return True
+    low = path.lower()
+    return any(kw in low for kw in _FINANCIAL_KEYWORDS)
+
+
+def classify_lane(proposal: TriageProposal, *, dry_run_mode: bool = False) -> TriageLane:
+    """Route one proposal to a lane. Pure; default-safe (ESCALATE on doubt).
+
+    Rules are evaluated in priority order — the first match wins:
+
+    1. ``instinct_verdict == "BLOCK"`` → ESCALATE (hard floor, no override).
+    2. ``approval_level == ASK`` → ESCALATE (triager dormant).
+    3. ``dry_run_mode`` → DRY_RUN (governance rehearsal).
+    4. ``proposed_count == 0`` → ESCALATE (cold-start floor; warmup of >=1
+       human-approved execution required before any auto/optimistic route).
+    5. high-blast AND no compensate → ESCALATE.
+    6. high-blast AND compensate present → OPTIMISTIC if trust clears the
+       implicit bar, else ESCALATE (never AUTO — blast-radius floor).
+    7. trust >= threshold AND compensate present (low-blast) → AUTO.
+    8. trust >= threshold AND no compensate AND low-blast → OPTIMISTIC.
+    9. trust < threshold AND compensate present (low-blast) → OPTIMISTIC.
+    10. else → ESCALATE.
+
+    "Trusted" means ``trust_score >= _THRESHOLD`` (the module constant that
+    mirrors the config ``instinct_auto_approve_threshold`` default of 0.9).
+    The bar is a module constant rather than a parameter so the classifier
+    stays a pure, config-free total function; the integration layer asserts
+    the constant and the config default stay in sync.
+    """
+    # Rule 1 — BLOCK is the absolute safety floor.
+    if proposal.instinct_verdict == "BLOCK":
+        return TriageLane.ESCALATE
+
+    # Rule 2 — triager dormant.
+    if proposal.approval_level == ApprovalLevel.ASK:
+        return TriageLane.ESCALATE
+
+    # Rule 3 — dry-run rehearsal mode (only after BLOCK/ASK floors).
+    if dry_run_mode:
+        return TriageLane.DRY_RUN
+
+    # Rule 4 — cold-start floor: no prior human-approved data → escalate.
+    if proposal.proposed_count == 0:
+        return TriageLane.ESCALATE
+
+    trusted = proposal.trust_score >= _THRESHOLD
+    has_compensate = proposal.compensate is not None
+
+    # DELETE is the hardest blast-radius floor: a delete is irreversible in
+    # a way a compensate (undelete) cannot truthfully repair, so it NEVER
+    # reaches AUTO *or* OPTIMISTIC — it always escalates to a human (T-01,
+    # T-09). This is stricter than the financial-keyword floor below, which
+    # a CompensateSpec CAN lift to OPTIMISTIC.
+    if proposal.method == "DELETE":
+        return TriageLane.ESCALATE
+
+    # Rules 5-6 — financial-keyword high-blast floor. Compensate can lift to
+    # OPTIMISTIC at best; without it, escalate. Never AUTO.
+    if _is_high_blast(proposal.method, proposal.path):
+        if not has_compensate:
+            return TriageLane.ESCALATE
+        # compensate present on a high-blast (financial) action → OPTIMISTIC
+        # when trusted, else ESCALATE.
+        return TriageLane.OPTIMISTIC if trusted else TriageLane.ESCALATE
+
+    # Rule 7 — low-blast, trusted, reversible → AUTO.
+    if trusted and has_compensate:
+        return TriageLane.AUTO
+
+    # Rule 8 — low-blast, trusted, no compensate → OPTIMISTIC.
+    if trusted and not has_compensate:
+        return TriageLane.OPTIMISTIC
+
+    # Rule 9 — low-blast, below threshold, reversible → OPTIMISTIC.
+    if not trusted and has_compensate:
+        return TriageLane.OPTIMISTIC
+
+    # Rule 10 — everything else escalates.
+    return TriageLane.ESCALATE
+
+
+__all__ = [
+    "ApprovalLevel",
+    "TriageLane",
+    "TriageProposal",
+    "classify_lane",
+]

--- a/ee/pocketpaw_ee/cloud/pockets/trust_ledger.py
+++ b/ee/pocketpaw_ee/cloud/pockets/trust_ledger.py
@@ -1,0 +1,236 @@
+# ee/pocketpaw_ee/cloud/pockets/trust_ledger.py
+# Created: 2026-06-18 (feat/instinct-gate-foundation, T2) — the per-
+# (workspace, pocket, action) trust score that feeds the layered/learning
+# Instinct gate's lane classifier (2026-06-18 gate-layered-learning
+# design). File-based, NOT Beanie: one append-only JSONL sidecar per
+# workspace at ~/.pocketpaw/instinct/trust/<workspace_id>.jsonl, dir 0700 /
+# file 0600 (same permission model as the internal-token + audit-log
+# secrets). On the import-linter "Pockets" allowlist (no Beanie writes).
+#
+# Score model: each executed gated write appends one row tagged
+# ``was_auto_approved`` (True when the system triager decided it, False
+# when a human did — see instinct_bridge T8). ``get_trust_score`` returns
+# (auto_count / total, total) over a rolling ``window_days`` window, where
+# total is ``proposed_count`` — the warmup signal the classifier's
+# cold-start floor reads (count==0 → ESCALATE).
+#
+# Reset: a backend-credential change invalidates accumulated trust for a
+# pocket (anti-gaming — see design M-5). ``reset_pocket_trust`` appends a
+# reset MARKER row; ``get_trust_score`` then counts only rows written
+# AFTER the latest marker for that pocket.
+#
+# No cache: ``cachetools`` is not a current EE dependency (design M-7
+# open-question #5), so this module reads the sidecar on every call. The
+# files are small (one short line per executed write) and reads are
+# infrequent relative to writes; a TTLCache can be layered later without
+# changing the public surface.
+
+"""File-based per-(workspace, pocket, action) trust ledger."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_TRUST_SUBDIR = ("instinct", "trust")
+_DIR_MODE = 0o700
+_FILE_MODE = 0o600
+
+
+def _trust_dir() -> Path:
+    """The per-host trust directory: ~/.pocketpaw/instinct/trust."""
+    return Path.home().joinpath(".pocketpaw", *_TRUST_SUBDIR)
+
+
+def _sidecar_path(workspace_id: str) -> Path:
+    return _trust_dir() / f"{workspace_id}.jsonl"
+
+
+def _ensure_trust_dir() -> Path:
+    """Create the trust dir tree with 0700 perms and return it.
+
+    ``mkdir(mode=0o700)`` is honored only for the leaf when the parents
+    already exist with a wider mode; we ``chmod`` the leaf explicitly so a
+    pre-existing ~/.pocketpaw at a wider mode cannot leave the trust dir
+    group/other-readable.
+    """
+    d = _trust_dir()
+    d.mkdir(parents=True, exist_ok=True, mode=_DIR_MODE)
+    try:
+        os.chmod(d, _DIR_MODE)
+    except OSError as exc:  # pragma: no cover - platform-dependent
+        logger.warning("trust_ledger: could not chmod %s (%s)", d, exc)
+    return d
+
+
+def _append_row(workspace_id: str, row: dict) -> None:
+    """Append one JSON row to the workspace sidecar at 0600.
+
+    Best-effort durability: the row is the trust feedback signal, not the
+    write itself, so a failed append degrades trust accuracy but never
+    blocks the (already-executed) write. The caller treats this as
+    best-effort (see instinct_bridge T8).
+    """
+    _ensure_trust_dir()
+    path = _sidecar_path(workspace_id)
+    # Pin 0600 at create time so the file never exists at the default 0644
+    # even briefly; chmod again after in case it pre-existed wider.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, _FILE_MODE)
+    try:
+        with os.fdopen(fd, "a", encoding="utf-8") as f:
+            f.write(json.dumps(row) + "\n")
+    finally:
+        try:
+            os.chmod(path, _FILE_MODE)
+        except OSError as exc:  # pragma: no cover
+            logger.warning("trust_ledger: could not chmod %s (%s)", path, exc)
+
+
+def _read_rows(workspace_id: str) -> list[dict]:
+    """Return every parsed row in the sidecar, oldest first.
+
+    Malformed lines are skipped (forward-compat: a newer writer may add a
+    row shape this reader doesn't recognize). Missing file → empty list.
+    """
+    path = _sidecar_path(workspace_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    except OSError as exc:  # pragma: no cover
+        logger.warning("trust_ledger: could not read %s (%s)", path, exc)
+        return []
+    rows: list[dict] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            rows.append(obj)
+    return rows
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    # Treat naive timestamps as UTC so comparisons never raise.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+async def get_trust_score(
+    workspace_id: str,
+    pocket_id: str,
+    action: str,
+    window_days: int = 30,
+) -> tuple[float, int]:
+    """Return ``(score, proposed_count)`` for one (pocket, action) pair.
+
+    * ``score`` — fraction of in-window executions that were
+      auto-approved (``was_auto_approved=True``). ``0.0`` when there are no
+      in-window rows.
+    * ``proposed_count`` — total in-window executions for the pair. This is
+      the warmup signal: ``0`` forces the classifier's cold-start ESCALATE.
+
+    Rows older than ``window_days`` are excluded. Rows written before the
+    latest ``reset_pocket_trust`` marker for this pocket are excluded
+    (backend-change anti-gaming, design M-5).
+    """
+    rows = _read_rows(workspace_id)
+    if not rows:
+        return (0.0, 0)
+
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(days=window_days)
+
+    # Find the latest reset marker for this pocket; rows at/before it don't
+    # count.
+    reset_ts: datetime | None = None
+    for r in rows:
+        if r.get("reset") and r.get("pocket_id") == pocket_id:
+            ts = _parse_ts(r.get("ts"))
+            if ts is not None and (reset_ts is None or ts > reset_ts):
+                reset_ts = ts
+
+    auto = 0
+    total = 0
+    for r in rows:
+        if r.get("reset"):
+            continue
+        if r.get("pocket_id") != pocket_id or r.get("action") != action:
+            continue
+        ts = _parse_ts(r.get("ts"))
+        if ts is None or ts < cutoff:
+            continue
+        if reset_ts is not None and ts <= reset_ts:
+            continue
+        total += 1
+        if r.get("was_auto_approved") is True:
+            auto += 1
+
+    if total == 0:
+        return (0.0, 0)
+    return (auto / total, total)
+
+
+async def record_correction(
+    workspace_id: str,
+    pocket_id: str,
+    action: str,
+    was_auto_approved: bool,
+) -> None:
+    """Append one trust-feedback row after an executed gated write.
+
+    Called from EXACTLY ONE site — ``instinct_bridge.execute_approved_write``
+    after ``mark_executed`` succeeds (design MF-3; ``outcomes/service.py``
+    must NOT call this). ``was_auto_approved`` is ``True`` when the system
+    triager decided the write, ``False`` when a human approver did.
+    """
+    _append_row(
+        workspace_id,
+        {
+            "pocket_id": pocket_id,
+            "action": action,
+            "was_auto_approved": bool(was_auto_approved),
+            "ts": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
+async def reset_pocket_trust(workspace_id: str, pocket_id: str) -> None:
+    """Invalidate accumulated trust for every action on one pocket.
+
+    Appends a reset MARKER row; subsequent ``get_trust_score`` calls count
+    only rows written after this marker. Called by the pocket backend
+    update path when a new base_url / credential is saved (design M-5) so a
+    swapped backend cannot inherit the prior backend's earned trust.
+    """
+    _append_row(
+        workspace_id,
+        {
+            "reset": True,
+            "pocket_id": pocket_id,
+            "ts": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
+__all__ = [
+    "get_trust_score",
+    "record_correction",
+    "reset_pocket_trust",
+]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -308,6 +308,16 @@ source_modules = [
     # ``outcomes.service``. Receives backend creds + bindings by
     # parameter — never imports a Beanie document class directly.
     "pocketpaw_ee.cloud.pockets.saga",
+    # Layered/learning Instinct gate foundation (2026-06-18 design). Three
+    # pure helper modules for the 4-lane triage router. None writes a
+    # Beanie document: ``instinct_triage`` is a pure classifier (no I/O),
+    # ``trust_ledger`` reads/writes a JSONL sidecar under ~/.pocketpaw, and
+    # ``instinct_compensation_registry`` is an in-memory TTL registry that
+    # persists expired handles to a JSONL sidecar. The gate's Beanie writes
+    # still go exclusively through ``instinct_approvals.service``.
+    "pocketpaw_ee.cloud.pockets.instinct_triage",
+    "pocketpaw_ee.cloud.pockets.trust_ledger",
+    "pocketpaw_ee.cloud.pockets.instinct_compensation_registry",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.pocket",

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,13 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-18: Added the four layered/learning Instinct gate defaults —
+    ``instinct_approval_level`` (default "ASK", dormant),
+    ``instinct_auto_approve_threshold`` (0.9), ``instinct_dry_run_mode``
+    (False), ``instinct_optimistic_ttl_seconds`` (300). Global host-wide
+    defaults for the 4-lane triage router; per-workspace overrides land
+    with the gate integration layer. Dormant on ship (ASK escalates
+    everything). Env: POCKETPAW_INSTINCT_* .
   - 2026-06-10: Added ``belt_repo_allowlist`` — the security boundary for the
     Belt & Pulley code-change gate (BS-3). A ``belt_propose_change`` proposal's
     repo path must resolve inside one of these roots; empty defaults to the
@@ -1327,6 +1334,54 @@ class Settings(BaseSettings):
             "then loopback / private / link-local / cloud-metadata hosts stay "
             "hard-blocked. Defaults to a curated set of sandbox-friendly "
             "embed providers."
+        ),
+    )
+
+    # Layered/learning Instinct gate — GLOBAL DEFAULTS (2026-06-18 design).
+    # These are the host-wide defaults for the 4-lane triage router that
+    # turns the binary escalate/execute Instinct gate into a learning gate.
+    # They are DORMANT by default: `instinct_approval_level="ASK"` makes the
+    # lane classifier always escalate, so shipping these changes zero
+    # behavior. A per-workspace override (a field on the workspace document)
+    # lands with the integration layer; until an admin opts a workspace into
+    # "TRIAGE", the global default governs and every escalate goes to a
+    # human. A support engineer setting the env var changes the default for
+    # NEW workspaces only — it cannot silently upgrade existing tenants.
+    instinct_approval_level: str = Field(
+        default="ASK",
+        description=(
+            "Global default triager activation level for the layered Instinct "
+            "gate: 'ASK' (dormant — every escalate goes to a human), 'TRIAGE' "
+            "(triager active — auto/optimistic/batch lanes live), or 'TRUSTED' "
+            "(reserved; treated as TRIAGE today). Per-workspace overrides live "
+            "on the workspace document. Set via POCKETPAW_INSTINCT_APPROVAL_LEVEL."
+        ),
+    )
+    instinct_auto_approve_threshold: float = Field(
+        default=0.9,
+        description=(
+            "Trust-score bar (0.0-1.0) a (pocket, action) pair must reach for "
+            "the AUTO/OPTIMISTIC lanes. A score below this escalates. Money- "
+            "moving and DELETE actions never AUTO regardless of score (a hard "
+            "blast-radius floor). Set via POCKETPAW_INSTINCT_AUTO_APPROVE_THRESHOLD."
+        ),
+    )
+    instinct_dry_run_mode: bool = Field(
+        default=False,
+        description=(
+            "When true, the Instinct gate routes escalating writes to the "
+            "DRY_RUN lane: the write is resolved and audited but never sent to "
+            "the backend (a governance rehearsal). BLOCK verdicts still block. "
+            "Set via POCKETPAW_INSTINCT_DRY_RUN_MODE."
+        ),
+    )
+    instinct_optimistic_ttl_seconds: int = Field(
+        default=300,
+        description=(
+            "Seconds an OPTIMISTIC-lane compensation handle stays live before "
+            "hard expiry. On expiry the registry fires an ALERT audit event and "
+            "persists the expired handle (no heartbeat extension). Set via "
+            "POCKETPAW_INSTINCT_OPTIMISTIC_TTL_SECONDS."
         ),
     )
 

--- a/tests/cloud/test_instinct_approvals_service.py
+++ b/tests/cloud/test_instinct_approvals_service.py
@@ -16,6 +16,7 @@ from pocketpaw_ee.cloud._core.errors import (
 )
 from pocketpaw_ee.cloud._core.realtime.events import (
     InstinctApprovalApproved,
+    InstinctApprovalAutoApproved,
     InstinctApprovalCreated,
     InstinctApprovalRejected,
 )
@@ -159,3 +160,72 @@ async def test_decide_requires_user_id() -> None:
     created = await approvals_service.create_approval("w1", "u1", _create_body())
     with pytest.raises(ValidationError):
         await approvals_service.approve("w1", "", created["id"], None)
+
+
+# ---------------------------------------------------------------------------
+# auto_approve — the AUTO-lane single-write decided row (T3 / design MF-1,
+# MF-2). Creates a row already-decided (status="auto_approved",
+# decided_by="system:triager") so the AUTO lane never calls the OSS store
+# and the human queue (which filters on status="pending") never sees it.
+# ---------------------------------------------------------------------------
+
+
+async def test_auto_approve_creates_decided_row(recording_bus) -> None:
+    out = await approvals_service.auto_approve(
+        "w1",
+        "u1",
+        _create_body(),
+        trust_score=0.95,
+        triager_reasoning="trust 0.95 >= 0.9, reversible POST",
+    )
+    assert out["status"] == "auto_approved"
+    assert out["decided_by"] == "system:triager"
+    assert out["decided_at"] is not None
+    # the requester is still recorded (who triggered the action)
+    assert out["requested_by"] == "u1"
+
+
+async def test_auto_approve_emits_auto_approved_event(recording_bus) -> None:
+    out = await approvals_service.auto_approve(
+        "w1",
+        "u1",
+        _create_body(),
+        trust_score=0.95,
+        triager_reasoning="reasoning",
+    )
+    events = [e for e in recording_bus.events if isinstance(e, InstinctApprovalAutoApproved)]
+    assert len(events) == 1
+    assert events[0].data["id"] == out["id"]
+    # the actor on the event is the system triager, not the human
+    assert events[0].data.get("actor") == "system:triager"
+    assert events[0].data.get("trust_score") == 0.95
+    assert events[0].data.get("lane") == "AUTO"
+
+
+async def test_auto_approved_row_excluded_from_pending_list() -> None:
+    # one pending (human queue) + one auto-approved (never in human tray)
+    await approvals_service.create_approval("w1", "u1", _create_body(pocket_id="p_pending"))
+    await approvals_service.auto_approve(
+        "w1",
+        "u1",
+        _create_body(pocket_id="p_auto"),
+        trust_score=0.95,
+        triager_reasoning="r",
+    )
+
+    pending = await approvals_service.list_approvals("w1", "u1", {"status": "pending"})
+    assert [r["pocket_id"] for r in pending] == ["p_pending"]
+
+    auto = await approvals_service.list_approvals("w1", "u1", {"status": "auto_approved"})
+    assert [r["pocket_id"] for r in auto] == ["p_auto"]
+
+
+async def test_auto_approve_requires_workspace_and_user() -> None:
+    with pytest.raises(ValidationError):
+        await approvals_service.auto_approve(
+            "", "u1", _create_body(), trust_score=0.95, triager_reasoning="r"
+        )
+    with pytest.raises(ValidationError):
+        await approvals_service.auto_approve(
+            "w1", "", _create_body(), trust_score=0.95, triager_reasoning="r"
+        )

--- a/tests/cloud/test_instinct_compensation_registry.py
+++ b/tests/cloud/test_instinct_compensation_registry.py
@@ -1,0 +1,172 @@
+# tests/cloud/test_instinct_compensation_registry.py
+# Created: 2026-06-18 (feat/instinct-gate-foundation, T4) — tests for the
+# in-memory OptimisticCompensationRegistry that backs the OPTIMISTIC lane's
+# rollback safety net (2026-06-18 gate-layered-learning design). No DB.
+# Time is injected (now=...) so TTL expiry is deterministic. Audit + home
+# dir are redirected to test doubles / tmp_path so the real ~/.pocketpaw
+# and audit log are never touched. Pins case T-36: TTL expiry fires an
+# ALERT audit event, persists the expired handle to the expired-
+# compensations JSONL, and purges the registry entry.
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud.pockets import instinct_compensation_registry as reg_mod
+from pocketpaw_ee.cloud.pockets.action_executor import CompensateSpec
+from pocketpaw_ee.cloud.pockets.instinct_compensation_registry import (
+    OptimisticCompensationRegistry,
+)
+
+from pocketpaw.security.audit import AuditSeverity
+
+
+class _FakeAuditLogger:
+    """Captures logged events instead of writing the real audit JSONL."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def log(self, event) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture
+def fake_audit(monkeypatch):
+    logger = _FakeAuditLogger()
+    monkeypatch.setattr(reg_mod, "get_audit_logger", lambda: logger)
+    return logger
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    monkeypatch.setattr(reg_mod.Path, "home", classmethod(lambda cls: tmp_path))
+    return tmp_path
+
+
+def _compensate() -> CompensateSpec:
+    return CompensateSpec(method="POST", path="/refund", params={"id": "x"})
+
+
+def _expired_path(home, workspace_id: str):
+    return home / ".pocketpaw" / "instinct" / "expired_compensations" / f"{workspace_id}.jsonl"
+
+
+def test_register_returns_id_and_is_retrievable() -> None:
+    r = OptimisticCompensationRegistry(ttl_seconds=300)
+    now = datetime.now(UTC)
+    cid = r.register(
+        workspace_id="w1",
+        pocket_id="p1",
+        action="charge",
+        compensate=_compensate(),
+        now=now,
+    )
+    assert isinstance(cid, str) and cid
+    handle = r.get(cid)
+    assert handle is not None
+    assert handle.workspace_id == "w1"
+    assert handle.action == "charge"
+
+
+def test_rollback_removes_entry() -> None:
+    r = OptimisticCompensationRegistry(ttl_seconds=300)
+    now = datetime.now(UTC)
+    cid = r.register(
+        workspace_id="w1",
+        pocket_id="p1",
+        action="charge",
+        compensate=_compensate(),
+        now=now,
+    )
+    popped = r.pop(cid)
+    assert popped is not None
+    assert r.get(cid) is None
+
+
+# T-36: TTL expiry fires ALERT audit event + writes expired JSONL + purges.
+def test_t36_ttl_expiry_alerts_persists_and_purges(fake_audit, _tmp_home) -> None:
+    r = OptimisticCompensationRegistry(ttl_seconds=300)
+    t0 = datetime.now(UTC)
+    cid = r.register(
+        workspace_id="w1",
+        pocket_id="p1",
+        action="charge",
+        compensate=_compensate(),
+        now=t0,
+    )
+
+    # Before TTL: sweep finds nothing expired.
+    expired_early = r.sweep_expired(now=t0 + timedelta(seconds=299))
+    assert expired_early == []
+    assert r.get(cid) is not None
+    assert fake_audit.events == []
+
+    # After TTL: sweep expires the entry.
+    expired = r.sweep_expired(now=t0 + timedelta(seconds=301))
+    assert len(expired) == 1
+    assert expired[0].compensation_id == cid
+
+    # registry entry purged
+    assert r.get(cid) is None
+
+    # ALERT audit event fired
+    assert len(fake_audit.events) == 1
+    evt = fake_audit.events[0]
+    assert evt.severity == AuditSeverity.ALERT
+    assert "w1" in (evt.context.get("workspace_id"), evt.target)
+
+    # expired-compensation JSONL written
+    path = _expired_path(_tmp_home, "w1")
+    assert path.exists()
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    row = json.loads(lines[0])
+    assert row["compensation_id"] == cid
+    assert row["pocket_id"] == "p1"
+    assert row["action"] == "charge"
+
+
+def test_expiry_jsonl_permissions(fake_audit, _tmp_home) -> None:
+    import stat
+
+    r = OptimisticCompensationRegistry(ttl_seconds=10)
+    t0 = datetime.now(UTC)
+    r.register(
+        workspace_id="w1",
+        pocket_id="p1",
+        action="charge",
+        compensate=_compensate(),
+        now=t0,
+    )
+    r.sweep_expired(now=t0 + timedelta(seconds=11))
+
+    path = _expired_path(_tmp_home, "w1")
+    dir_mode = stat.S_IMODE(path.parent.stat().st_mode)
+    file_mode = stat.S_IMODE(path.stat().st_mode)
+    assert dir_mode == 0o700
+    assert file_mode == 0o600
+
+
+def test_sweep_purges_even_if_jsonl_write_fails(fake_audit, monkeypatch) -> None:
+    # design MF-8: if the JSONL persist fails, log + still purge to avoid a
+    # memory leak. Force the persist to raise and assert the entry is gone.
+    r = OptimisticCompensationRegistry(ttl_seconds=10)
+    t0 = datetime.now(UTC)
+    cid = r.register(
+        workspace_id="w1",
+        pocket_id="p1",
+        action="charge",
+        compensate=_compensate(),
+        now=t0,
+    )
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(r, "_persist_expired", _boom)
+    expired = r.sweep_expired(now=t0 + timedelta(seconds=11))
+    assert len(expired) == 1
+    assert r.get(cid) is None  # purged despite persist failure

--- a/tests/cloud/test_instinct_gate_config.py
+++ b/tests/cloud/test_instinct_gate_config.py
@@ -1,0 +1,50 @@
+# tests/cloud/test_instinct_gate_config.py
+# Created: 2026-06-18 (feat/instinct-gate-foundation, T5) — config-default
+# tests for the layered/learning Instinct gate's four global settings
+# (2026-06-18 gate-layered-learning design). These are GLOBAL DEFAULTS;
+# the per-workspace override path (the full T-25 workspace-document field)
+# lands with the integration layer (T6, separate gated PR). Here we pin:
+#   * the four fields exist with the design's default values
+#   * the default approval level is "ASK" (triager dormant — zero
+#     behavioral change on ship)
+#   * env vars override the defaults via the POCKETPAW_ prefix
+
+from __future__ import annotations
+
+from pocketpaw.config import Settings
+
+
+def test_instinct_gate_defaults() -> None:
+    """The four gate settings default to the design's safe values."""
+    s = Settings()
+    assert s.instinct_approval_level == "ASK"
+    assert s.instinct_auto_approve_threshold == 0.9
+    assert s.instinct_dry_run_mode is False
+    assert s.instinct_optimistic_ttl_seconds == 300
+
+
+def test_default_approval_level_is_dormant() -> None:
+    """ASK is the dormant level — nothing auto-approves until an admin
+    opts a workspace into TRIAGE. This is the zero-behavioral-change
+    guarantee for shipping the foundation."""
+    assert Settings().instinct_approval_level == "ASK"
+
+
+def test_env_overrides_approval_level(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_INSTINCT_APPROVAL_LEVEL", "TRIAGE")
+    assert Settings().instinct_approval_level == "TRIAGE"
+
+
+def test_env_overrides_threshold(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_INSTINCT_AUTO_APPROVE_THRESHOLD", "0.75")
+    assert Settings().instinct_auto_approve_threshold == 0.75
+
+
+def test_env_overrides_dry_run_mode(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_INSTINCT_DRY_RUN_MODE", "true")
+    assert Settings().instinct_dry_run_mode is True
+
+
+def test_env_overrides_optimistic_ttl(monkeypatch) -> None:
+    monkeypatch.setenv("POCKETPAW_INSTINCT_OPTIMISTIC_TTL_SECONDS", "600")
+    assert Settings().instinct_optimistic_ttl_seconds == 600

--- a/tests/cloud/test_instinct_triage.py
+++ b/tests/cloud/test_instinct_triage.py
@@ -1,0 +1,190 @@
+# tests/cloud/test_instinct_triage.py
+# Created: 2026-06-18 (feat/instinct-gate-foundation, T1) — pure unit tests
+# for the layered/learning Instinct gate's lane classifier. No DB, no I/O.
+# Pins the 10 priority-ordered lane rules + the _is_high_blast floor from
+# the 2026-06-18 gate-layered-learning design's Contracts section. Cases
+# T-01..T-09 from the design's Test plan. The classifier is DORMANT by
+# default: ApprovalLevel.ASK forces ESCALATE so nothing auto-approves until
+# the integration layer (separate PR) sets a non-ASK level.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.pockets.action_executor import CompensateSpec
+from pocketpaw_ee.cloud.pockets.instinct_triage import (
+    ApprovalLevel,
+    TriageLane,
+    TriageProposal,
+    classify_lane,
+)
+
+
+def _compensate() -> CompensateSpec:
+    return CompensateSpec(method="POST", path="/refund", params={})
+
+
+def _proposal(**overrides) -> TriageProposal:
+    """Build a TriageProposal with sensible TRIAGE-mode defaults.
+
+    Defaults describe a low-blast, reversible, warm (proposed_count>=1),
+    high-trust POST that an EXECUTE-floor verdict escalated — i.e. the
+    happy AUTO case — so each test overrides only the signal it pins.
+    """
+    base: dict = {
+        "action": "do_thing",
+        "method": "POST",
+        "path": "/items",
+        "compensate": _compensate(),
+        "trust_score": 0.95,
+        "proposed_count": 5,
+        "instinct_verdict": "ESCALATE_APPROVAL",
+        "approval_level": ApprovalLevel.TRIAGE,
+    }
+    base.update(overrides)
+    return TriageProposal(**base)
+
+
+# T-01: irreversible high-blast always escalates regardless of trust.
+def test_t01_delete_no_compensate_high_trust_escalates() -> None:
+    p = _proposal(
+        method="DELETE",
+        path="/items/42",
+        compensate=None,
+        trust_score=1.0,
+        proposed_count=99,
+    )
+    assert classify_lane(p) == TriageLane.ESCALATE
+
+
+# T-02: reversible POST, high trust, warm, TRIAGE → AUTO.
+def test_t02_post_compensate_high_trust_warm_auto() -> None:
+    p = _proposal(
+        method="POST",
+        path="/items",
+        trust_score=0.95,
+        proposed_count=5,
+    )
+    assert classify_lane(p) == TriageLane.AUTO
+
+
+# T-03: reversible POST, below threshold, warm → OPTIMISTIC.
+def test_t03_post_compensate_low_trust_optimistic() -> None:
+    p = _proposal(
+        method="POST",
+        path="/items",
+        trust_score=0.4,
+        proposed_count=3,
+    )
+    assert classify_lane(p) == TriageLane.OPTIMISTIC
+
+
+# T-04: ASK level forces ESCALATE for any proposal (any trust, any method).
+def test_t04_ask_level_always_escalates() -> None:
+    p = _proposal(
+        approval_level=ApprovalLevel.ASK,
+        method="POST",
+        trust_score=1.0,
+        proposed_count=99,
+    )
+    assert classify_lane(p) == TriageLane.ESCALATE
+
+
+# T-05: BLOCK verdict → ESCALATE regardless of trust, level, compensate.
+def test_t05_block_verdict_escalates_even_at_trusted() -> None:
+    p = _proposal(
+        instinct_verdict="BLOCK",
+        approval_level=ApprovalLevel.TRUSTED,
+        trust_score=1.0,
+        proposed_count=99,
+    )
+    assert classify_lane(p) == TriageLane.ESCALATE
+
+
+# T-06: cold-start floor — proposed_count=0 forces ESCALATE even with high
+# trust + compensate at TRIAGE.
+def test_t06_cold_start_zero_count_escalates() -> None:
+    p = _proposal(
+        proposed_count=0,
+        trust_score=0.99,
+    )
+    assert classify_lane(p) == TriageLane.ESCALATE
+
+
+# T-07: financial path + PATCH + compensate + high trust → OPTIMISTIC (not
+# AUTO — blast-radius floor for financial paths).
+def test_t07_financial_path_high_trust_optimistic_not_auto() -> None:
+    p = _proposal(
+        method="PATCH",
+        path="/subscriptions/cancel",
+        trust_score=0.95,
+        proposed_count=5,
+    )
+    assert classify_lane(p) == TriageLane.OPTIMISTIC
+
+
+# T-08: dry_run_mode=True → DRY_RUN regardless of lane (but BLOCK/ASK still
+# take priority — see T-29; here verdict is the escalate floor).
+def test_t08_dry_run_mode_returns_dry_run() -> None:
+    p = _proposal()
+    assert classify_lane(p, dry_run_mode=True) == TriageLane.DRY_RUN
+
+
+# T-09: DELETE is high-blast; a CompensateSpec cannot promote DELETE to AUTO
+# or OPTIMISTIC.
+def test_t09_delete_with_compensate_high_trust_still_escalates() -> None:
+    p = _proposal(
+        method="DELETE",
+        path="/items/42",
+        compensate=_compensate(),
+        trust_score=1.0,
+        proposed_count=20,
+    )
+    assert classify_lane(p) == TriageLane.ESCALATE
+
+
+# --- extra coverage for the remaining rules (rule 8: optimistic when
+# reversible+nothing else fires; AUTO requires compensate) ---
+
+
+def test_high_trust_no_compensate_low_blast_optimistic() -> None:
+    # rule 8: trust>=threshold AND compensate is None AND not high-blast
+    p = _proposal(
+        method="POST",
+        path="/items",
+        compensate=None,
+        trust_score=0.95,
+        proposed_count=5,
+    )
+    assert classify_lane(p) == TriageLane.OPTIMISTIC
+
+
+def test_low_trust_no_compensate_low_blast_escalates() -> None:
+    # rule 10 (else): low trust, no compensate, not high-blast → ESCALATE
+    p = _proposal(
+        method="POST",
+        path="/items",
+        compensate=None,
+        trust_score=0.3,
+        proposed_count=5,
+    )
+    assert classify_lane(p) == TriageLane.ESCALATE
+
+
+def test_dry_run_mode_does_not_override_block() -> None:
+    # BLOCK is the hard floor (rule 1) — even dry_run_mode cannot move it.
+    p = _proposal(instinct_verdict="BLOCK")
+    assert classify_lane(p, dry_run_mode=True) == TriageLane.ESCALATE
+
+
+def test_dry_run_mode_does_not_override_ask() -> None:
+    # ASK (rule 2) takes priority over dry_run_mode (rule 3).
+    p = _proposal(approval_level=ApprovalLevel.ASK)
+    assert classify_lane(p, dry_run_mode=True) == TriageLane.ESCALATE
+
+
+def test_proposal_is_frozen() -> None:
+    import pytest
+    from pydantic import ValidationError
+
+    p = _proposal()
+    with pytest.raises(ValidationError):
+        p.trust_score = 0.1  # type: ignore[misc]

--- a/tests/cloud/test_trust_ledger.py
+++ b/tests/cloud/test_trust_ledger.py
@@ -1,0 +1,170 @@
+# tests/cloud/test_trust_ledger.py
+# Created: 2026-06-18 (feat/instinct-gate-foundation, T2) — file-I/O tests
+# for the per-(workspace, pocket, action) trust ledger that feeds the
+# layered/learning Instinct gate. No DB. Each test points the ledger at a
+# tmp_path home via monkeypatch so the real ~/.pocketpaw is never touched.
+# Pins cases T-10..T-17 + T-37 from the 2026-06-18 gate-layered-learning
+# design's Test plan: empty→(0.0,0), score = auto/total, per-workspace
+# isolation, window filtering, append semantics, 0700/0600 permissions,
+# warmup floor, and backend-change reset.
+
+from __future__ import annotations
+
+import json
+import stat
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.cloud.pockets import trust_ledger
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(monkeypatch, tmp_path):
+    """Redirect the ledger's home dir to a tmp path for every test."""
+    monkeypatch.setattr(trust_ledger.Path, "home", classmethod(lambda cls: tmp_path))
+    return tmp_path
+
+
+def _sidecar(home, workspace_id: str):
+    return home / ".pocketpaw" / "instinct" / "trust" / f"{workspace_id}.jsonl"
+
+
+def _write_rows(home, workspace_id: str, rows: list[dict]) -> None:
+    """Write raw ledger rows directly (bypassing record_correction) so a
+    test can seed a specific approved/corrected mix + timestamps."""
+    path = _sidecar(home, workspace_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def _row(pocket_id: str, action: str, *, auto: bool, ts: datetime) -> dict:
+    return {
+        "pocket_id": pocket_id,
+        "action": action,
+        "was_auto_approved": auto,
+        "ts": ts.isoformat(),
+    }
+
+
+# T-10: fresh sidecar, 0 rows → (0.0, 0).
+async def test_t10_empty_returns_zero() -> None:
+    score, count = await trust_ledger.get_trust_score("w1", "pocket-a", "charge")
+    assert score == 0.0
+    assert count == 0
+
+
+# T-11: 8 auto + 2 human-corrected over 30 days → score 0.8, count 10.
+async def test_t11_score_is_auto_over_total(_tmp_home) -> None:
+    now = datetime.now(UTC)
+    rows = [_row("pocket-a", "charge", auto=True, ts=now) for _ in range(8)]
+    rows += [_row("pocket-a", "charge", auto=False, ts=now) for _ in range(2)]
+    _write_rows(_tmp_home, "w1", rows)
+
+    score, count = await trust_ledger.get_trust_score("w1", "pocket-a", "charge")
+    assert score == pytest.approx(0.8)
+    assert count == 10
+
+
+# T-12: per-workspace isolation — w2's rows don't affect w1.
+async def test_t12_workspace_isolation(_tmp_home) -> None:
+    now = datetime.now(UTC)
+    _write_rows(_tmp_home, "w2", [_row("pocket-a", "charge", auto=True, ts=now) for _ in range(5)])
+    score_w1, count_w1 = await trust_ledger.get_trust_score("w1", "pocket-a", "charge")
+    assert (score_w1, count_w1) == (0.0, 0)
+
+    score_w2, count_w2 = await trust_ledger.get_trust_score("w2", "pocket-a", "charge")
+    assert count_w2 == 5
+
+
+# T-13: window_days filters older rows.
+async def test_t13_window_filters_old_rows(_tmp_home) -> None:
+    now = datetime.now(UTC)
+    old = now - timedelta(days=20)
+    rows = [_row("pocket-a", "charge", auto=True, ts=now) for _ in range(3)]
+    rows += [_row("pocket-a", "charge", auto=False, ts=old) for _ in range(5)]
+    _write_rows(_tmp_home, "w1", rows)
+
+    # window of 7 days keeps only the 3 recent auto rows.
+    score, count = await trust_ledger.get_trust_score("w1", "pocket-a", "charge", window_days=7)
+    assert count == 3
+    assert score == pytest.approx(1.0)
+
+
+# T-14: record_correction appends; get_trust_score reflects it next call.
+async def test_t14_record_correction_appends_and_reflects() -> None:
+    s0, c0 = await trust_ledger.get_trust_score("w1", "pocket-a", "charge")
+    assert (s0, c0) == (0.0, 0)
+
+    await trust_ledger.record_correction("w1", "pocket-a", "charge", was_auto_approved=True)
+
+    s1, c1 = await trust_ledger.get_trust_score("w1", "pocket-a", "charge")
+    assert c1 == 1
+    assert s1 == pytest.approx(1.0)
+
+
+# T-15: two corrections in the same second → two distinct rows (no dedup).
+async def test_t15_no_dedup_same_second(_tmp_home) -> None:
+    await trust_ledger.record_correction("w1", "p", "a", was_auto_approved=True)
+    await trust_ledger.record_correction("w1", "p", "a", was_auto_approved=False)
+
+    _, count = await trust_ledger.get_trust_score("w1", "p", "a")
+    assert count == 2
+
+    # confirm both lines physically present on disk
+    lines = _sidecar(_tmp_home, "w1").read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+
+
+# T-16: directory 0700, file 0600.
+async def test_t16_permissions(_tmp_home) -> None:
+    await trust_ledger.record_correction("w1", "p", "a", was_auto_approved=True)
+
+    path = _sidecar(_tmp_home, "w1")
+    dir_mode = stat.S_IMODE(path.parent.stat().st_mode)
+    file_mode = stat.S_IMODE(path.stat().st_mode)
+    assert dir_mode == 0o700, f"dir mode was {oct(dir_mode)}"
+    assert file_mode == 0o600, f"file mode was {oct(file_mode)}"
+
+
+# T-17: warmup floor — exactly one human-approved row yields proposed_count=1.
+async def test_t17_warmup_floor_count_one() -> None:
+    # a single human decision (was_auto_approved=False) still counts toward
+    # proposed_count, so the classifier's cold-start floor (count==0) is
+    # cleared after one execution.
+    await trust_ledger.record_correction("w1", "p", "a", was_auto_approved=False)
+    score, count = await trust_ledger.get_trust_score("w1", "p", "a")
+    assert count == 1
+    assert score == pytest.approx(0.0)
+
+
+# T-37: backend credential change resets trust for the affected pocket.
+async def test_t37_reset_pocket_trust(_tmp_home) -> None:
+    now = datetime.now(UTC)
+    _write_rows(
+        _tmp_home,
+        "w1",
+        [_row("pocket-a", "charge", auto=True, ts=now) for _ in range(5)]
+        + [_row("pocket-b", "charge", auto=True, ts=now) for _ in range(3)],
+    )
+    # sanity: both pockets have history
+    assert (await trust_ledger.get_trust_score("w1", "pocket-a", "charge"))[1] == 5
+    assert (await trust_ledger.get_trust_score("w1", "pocket-b", "charge"))[1] == 3
+
+    await trust_ledger.reset_pocket_trust("w1", "pocket-a")
+
+    # pocket-a is reset to cold-start; pocket-b is untouched.
+    assert await trust_ledger.get_trust_score("w1", "pocket-a", "charge") == (0.0, 0)
+    assert (await trust_ledger.get_trust_score("w1", "pocket-b", "charge"))[1] == 3
+
+
+# Action isolation — distinct actions on the same pocket score independently.
+async def test_action_isolation() -> None:
+    await trust_ledger.record_correction("w1", "p", "charge", was_auto_approved=True)
+    await trust_ledger.record_correction("w1", "p", "refund", was_auto_approved=False)
+
+    s_charge, c_charge = await trust_ledger.get_trust_score("w1", "p", "charge")
+    s_refund, c_refund = await trust_ledger.get_trust_score("w1", "p", "refund")
+    assert (c_charge, s_charge) == (1, pytest.approx(1.0))
+    assert (c_refund, s_refund) == (1, pytest.approx(0.0))


### PR DESCRIPTION
## What this is

The foundation for turning the Instinct gate from a binary fork (escalate to a human, or execute) into a layered gate that learns which writes are routine. This PR ships only the foundation: pure new modules, four config defaults, and the auto-approve write path. The piece that wires it into the live gate (`gate_action` / `run_action`) is a separate PR, gated on the open questions below.

**Nothing here is behavior-live.** The default approval level is `ASK`, which makes the lane classifier always return ESCALATE. Every write still goes to the human queue exactly as it does today, for every tenant, until an admin opts a workspace into TRIAGE through the integration layer. The new modules are not imported by any live code path yet.

## The five tasks

- **T1 `instinct_triage.py`** — a pure `classify_lane()` with the ten priority-ordered lane rules. BLOCK and the dormant `ASK` level both force ESCALATE. A cold-start pair (no prior approvals) escalates. DELETE never leaves the ESCALATE lane even with a compensation declared; a financial-keyword path can reach OPTIMISTIC at best, never AUTO. No I/O, no clock, no config import.
- **T2 `trust_ledger.py`** — the per-(workspace, pocket, action) trust score over a JSONL sidecar at `~/.pocketpaw/instinct/trust/<workspace_id>.jsonl` (dir 0700, file 0600). Score is the auto-approved fraction over a rolling window; `proposed_count` is the warmup signal the cold-start floor reads. A backend-credential change writes a reset marker so a swapped backend cannot inherit earned trust. No cache, since `cachetools` is not a dependency here.
- **T3 `approvals_service.auto_approve`** — the AUTO lane's writer. It inserts one row already decided (`status="auto_approved"`, `decided_by="system:triager"`) in a single write and emits `InstinctApprovalAutoApproved`. The OSS SQLite store is never touched from this path. The human queue filters on `status="pending"`, so auto-approved rows never reach the human tray. Added `"auto_approved"` to the approval status literal (additive, no migration).
- **T4 `instinct_compensation_registry.py`** — an in-memory TTL registry for the OPTIMISTIC lane's rollback handles. On expiry it fires an ALERT-severity audit event, persists the expired handle to `~/.pocketpaw/instinct/expired_compensations/<workspace_id>.jsonl`, and purges the entry even if that persist fails (so a disk error cannot leak the registry).
- **T5 `config.py`** — four global defaults: `instinct_approval_level` ("ASK"), `instinct_auto_approve_threshold` (0.9), `instinct_dry_run_mode` (False), `instinct_optimistic_ttl_seconds` (300). Per-workspace overrides land with the integration layer.

The three new pure modules are added to the import-linter Pockets allowlist in `ee/pyproject.toml`, per the touch-time rule.

## Three defaults that need your call

These are built to the safe default and flagged for you to confirm or override at review:

1. **TRUSTED mode** is defined in the enum but treated identically to TRIAGE for now (no behavior difference yet).
2. **The financial keyword list** (`charge`, `refund`, `cancel`, `payment`, `invoice`, `withdraw`, `subscription`, `billing`) is hardcoded in `_is_high_blast`, not per-workspace configurable.
3. **Optimistic TTL** is hard expiry plus an ALERT on timeout, with no heartbeat extension.

## Scope

Foundation only. The integration layer (T6 through T12) that wires `gate_action` and `run_action` live is a separate gated PR. Nothing in this PR changes runtime behavior: the default `ASK` level keeps the classifier escalating everything, and no live code imports the new modules.

## Tests

```
uv run pytest tests/cloud/test_instinct_triage.py tests/cloud/test_trust_ledger.py \
  tests/cloud/test_instinct_gate_config.py tests/cloud/test_instinct_compensation_registry.py \
  tests/cloud/test_instinct_approvals_service.py -q
```

53 passed (14 triage, 10 trust ledger, 6 config, 5 compensation registry, 18 approvals service including the 14 pre-existing approve/reject tests that stay green). A wider regression of the instinct dispatch, bridge, saga, and bulk suites is also green (209 passed). Both import-linter configs pass (root: 1 contract; `ee/pyproject.toml`: 23 contracts, including the Pockets allowlist).