### PR TITLE
fix(sites): edits stay a draft + a stable preview URL (not a live publish)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -24,6 +24,15 @@
 # ``pocketpaw_sites_manager`` server as create + publish (see sites.py) so the
 # create → publish → edit hops sit side by side for the chat agent.
 #
+# Updated: 2026-06-18 (fix/sites-edit-draft-not-publish, BUG 2) — an edit now
+# stages a DRAFT PREVIEW, not a live publish, so the success result no longer
+# narrates "published"/"republished"/"live at". ``_edit_svelte_component_handler``
+# returns ``{ok, status:"draft", is_live:false, site:{..., preview_url, deployed},
+# component_path, message}`` with a message that says the change is a draft preview
+# (not live), the url is a PREVIEW (not the published site), and the user must click
+# "Submit for review" to publish. The tool docstring the agent reads was reworded to
+# match. The create + publish tools are unchanged (publish is a real live deploy).
+#
 # This is the decisive bypass of the dashboard-built ``pocket_specialist``
 # create machinery. The agent-mode pocket_specialist path (draft kit / plan kit /
 # subagent delegation + the validate-redraft loop) kept downgrading landing
@@ -580,8 +589,8 @@ async def _edit_svelte_component_handler(args: dict) -> dict:
         # back and the live site stays on the prior deploy. Tell the agent so it
         # can fix the component and retry, NOT report a successful edit.
         return _error_response(
-            f"the edit did not pass the build smoke test, so the live site was not "
-            f"changed (the previous version is still deployed): {exc}"
+            f"the edit did not pass the build smoke test, so it was not staged "
+            f"(the previous version is unchanged): {exc}"
         )
     except CloudError as exc:
         # NotFound / ValidationError from the pockets service (missing pocket,
@@ -591,17 +600,32 @@ async def _edit_svelte_component_handler(args: dict) -> dict:
         logger.warning("edit_svelte_component failed", exc_info=True)
         return _error_response(f"edit failed: {exc}")
 
+    # An edit stages a DRAFT PREVIEW — it does NOT publish or go live. The chat
+    # agent narrates this payload, so it must make the draft-not-live state
+    # unambiguous: ``status="draft"`` / ``is_live=False``, the url is a PREVIEW (not
+    # the live site), and the user must Submit for review to publish. The wording
+    # deliberately avoids "published"/"republished"/"live at" so the agent does not
+    # tell the user the change is live.
     return _success_response(
         {
             "ok": True,
+            "status": "draft",
+            "is_live": False,
             "component_path": component_path,
             "site": {
                 "id": str(doc.id),
                 "pocket_id": doc.pocket_id,
                 "name": doc.name,
-                "url": doc.url,
+                # The preview URL — a draft preview of the edit, NOT the live site.
+                "preview_url": doc.url,
                 "deployed": doc.deployed,
             },
+            "message": (
+                "Your change is staged as a draft preview — it is NOT live yet. "
+                "The preview_url shows a preview of the edit, not the live site. "
+                "To take it live, the user clicks 'Submit for review' (which sends "
+                "the draft for approval)."
+            ),
         }
     )
 
@@ -617,12 +641,13 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
     @tool(
         "edit_svelte_component",
         (
-            "Rewrite ONE component of an EXISTING svelte Paw Site and republish "
-            "it. Use this when the user asks to change a section of a published "
+            "Rewrite ONE component of an EXISTING svelte Paw Site and stage it as a "
+            "DRAFT PREVIEW. Use this when the user asks to change a section of a "
             "svelte site — 'make the hero headline bolder', 'change the pricing "
             "copy', 'restyle the FAQ'. You provide the FULL new file contents for "
-            "ONE file in the site's source map; the tool persists it and "
-            "republishes. Args: `pocket_id` (the svelte site pocket), "
+            "ONE file in the site's source map; the tool persists it as a draft and "
+            "builds a preview. The edit is NOT published and does NOT go live — it "
+            "is staged for review. Args: `pocket_id` (the svelte site pocket), "
             "`component_path` (the relative path of the file to rewrite — it must "
             "already exist in the source map, e.g. "
             "'src/lib/components/Hero.svelte'), `new_source` (the whole new file "
@@ -630,10 +655,14 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
             "and optional `name`. CRITICAL authoring rule (same as "
             "create_svelte_site): the component must render its resting/final "
             "state in MARKUP — never set it only in onMount — because the page is "
-            "PRERENDERED. Returns {ok, site: {id, name, url, deployed, pocket_id}, "
-            "component_path} — show the user the `url`. ok=false with an error "
-            "means the edit did NOT go live: a smoke-test failure leaves the "
-            "PREVIOUS version deployed (fix the component and retry), and a "
+            "PRERENDERED. Returns {ok, status:'draft', is_live:false, site: {id, "
+            "name, preview_url, deployed:false, pocket_id}, component_path, "
+            "message}. Relay the `message` to the user: the change is a DRAFT "
+            "PREVIEW (not live), `preview_url` is a PREVIEW (not the published "
+            "site), and to publish it the user clicks 'Submit for review'. Do NOT "
+            "tell the user the change is published or live. ok=false with an error "
+            "means the edit was NOT staged: a smoke-test failure leaves the "
+            "previous version unchanged (fix the component and retry), and a "
             "not-found / not-a-svelte-site error means relay the reason. Do NOT "
             "report a successful edit when ok=false."
         ),

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -128,6 +128,23 @@
 # unscoped so a restart auto-re-serves all sites; POST /sites/reserve calls it
 # workspace-scoped for an explicit "re-serve" action.
 #
+# Updated 2026-06-18 (fix/sites-edit-draft-not-publish): EDITING a site no longer
+# auto-publishes it. ``publish()`` gained a ``preview`` flag (forwarded through
+# ``publish_pocket``); ``edit_svelte_component`` and ``make_site_editable`` now
+# call it with ``preview=True``. A preview build still smoke-gates + locally serves
+# the working copy (so a broken edit is caught), but it does NOT promote the
+# pocket's draft to ``published`` and does NOT overwrite the canonical live Site
+# doc/url — it returns a TRANSIENT preview Site (``deployed=False``). Before this
+# fix both edit-path callers routed through ``publish`` → promote+deploy, so after
+# any edit the pocket had only published versions and NO draft; ``get_draft``
+# returned None and ``request_publish_pocket`` (Submit-for-review) raised → the UI
+# got a 400. Now the draft survives, the published pointer is unchanged, and only
+# an approved review (the real ``publish``, ``preview=False``) deploys live +
+# promotes. ``make_site_editable`` also ensures a draft snapshot exists on arm
+# (``_ensure_pocket_draft``) so a never-edited armed site still has a working copy
+# to frame + submit. The chat-CREATE publish and the approve→publish executor are
+# unchanged (they stay ``preview=False`` real publishes).
+#
 # Updated 2026-06-18 (feat/branch-primitive-sites-draft, BP-2 / pocketpaw#1345):
 # sites publish/preview/status are now branch-aware over the BP-1 versions spine,
 # fixing the "Live badge lies" bug — a site was stamped ``deployed`` the instant a
@@ -347,6 +364,7 @@ async def publish(
     engine: str = "ripple",
     source: dict[str, str] | None = None,
     builder_origin: str | None = None,
+    preview: bool = False,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
@@ -355,6 +373,20 @@ async def publish(
     """Generate, smoke-gate, deploy, and persist a site. Raises SmokeGateFailed
     (from generator_client) if the workerd smoke render fails — the site is not
     deployed and not persisted as deployed.
+
+    PREVIEW MODE (Branch primitive — the EDIT/arm path). When ``preview=True``,
+    this builds + smoke-gates + locally serves a DRAFT preview but does NOT take
+    the edit live: it does NOT promote the pocket's draft version to ``published``
+    and it does NOT claim/overwrite the canonical live Site doc. It returns a
+    transient Site-shaped object whose ``url`` is the preview URL (with
+    ``deployed=False``) so the builder iframe can frame the working copy, while the
+    pocket's draft survives for review (``get_draft`` stays non-None, the
+    ``published`` pointer is unchanged) and ``request_publish_pocket`` can submit
+    it. Only an approved review (the real ``publish``, ``preview=False``) deploys
+    live + promotes. ``preview=True`` requires ``_local_mode()`` / no injected CF
+    deploy claim — the preview build is served from localhost (never the CF live
+    deploy); a CF-only preview build is still generated and smoke-gated but is not
+    PUT into the dispatch namespace.
 
     Deploy has two branches:
       * REAL Cloudflare (default when creds are present, or when a CF client is
@@ -406,6 +438,37 @@ async def publish(
         source=source,
         builder_origin=builder_origin,
     )
+
+    # PREVIEW MODE (Branch primitive — EDIT/arm path): the build above already ran
+    # the smoke gate (a broken edit is still caught BEFORE it can be served), but a
+    # preview must NOT take the edit live. Serve the built dir from localhost so the
+    # builder iframe can frame the working copy, then return a TRANSIENT Site-shaped
+    # object (NOT persisted, ``deployed=False``) carrying that preview URL. The
+    # pocket's draft version is left untouched (no promote → ``get_draft`` stays
+    # non-None, the ``published`` pointer does not move), so the draft is reviewable
+    # and ``request_publish_pocket`` can submit it. The canonical live Site doc and
+    # its URL are not claimed or overwritten — only an approved review (the real
+    # ``publish``, ``preview=False``) deploys live + promotes.
+    if preview:
+        from pocketpaw_ee.sites import local_server
+
+        deploy = _local_deploy or local_server.deploy_local
+        preview_url = deploy(site_id, build.project_dir)
+        return _SiteDoc(
+            id=ObjectId(site_id),
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            owner=user_id,
+            name=site_name,
+            script_name=site_id,
+            deployed=False,  # a preview is NOT a live deploy
+            signed_key=signed_key,
+            url=preview_url,
+            # Editable preview carries the bridge origin so the iframe can edit it.
+            builder_origin=builder_origin or "",
+            allowed_origins=_default_allowed_origins(),
+            event_mapping=_DEFAULT_EVENT_MAPPING,
+        )
 
     # BP-2 / #1345: promote the pocket's current draft version to ``published``
     # BEFORE deploy. The build (which runs the smoke gate) has succeeded, so the
@@ -545,6 +608,7 @@ async def publish_pocket(
     pocket_id: str,
     name: str = "",
     builder_origin: str | None = None,
+    preview: bool = False,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
@@ -552,6 +616,12 @@ async def publish_pocket(
 ) -> _SiteDoc:
     """Publish a pocket as a site by id — the shared path for the REST router
     and the in-process MCP tool.
+
+    ``preview`` (Branch primitive — EDIT/arm path) is forwarded straight to
+    ``publish``: ``True`` builds + smoke-gates + locally serves a DRAFT preview
+    WITHOUT promoting the draft to published or claiming the live deploy (it
+    returns a transient preview Site doc); ``False`` (the default) is a real live
+    publish + promote.
 
     Reads the pocket's rippleSpec + theme via the pockets service (the source of
     truth, which returns the resolved wire dict and raises NotFound / Forbidden
@@ -596,6 +666,7 @@ async def publish_pocket(
         source=source,
         name=name or pocket.get("name", ""),
         builder_origin=builder_origin,
+        preview=preview,
         _generator=_generator,
         _cloudflare=_cloudflare,
         _bundle_reader=_bundle_reader,
@@ -664,10 +735,17 @@ async def edit_svelte_component(
         new_source=new_source,
     )
 
-    # 2. Republish. 3. On a smoke-gate failure, restore the prior source so the
-    #    pocket never carries a component the renderer rejects — then re-raise so
-    #    the caller surfaces the reason. The prior deploy is untouched because the
-    #    gate fires before publish deploys.
+    # 2. Build a PREVIEW of the edit (Branch primitive). The persist above already
+    #    wrote a fresh DRAFT ArtifactVersion (set_svelte_source_file hooks it); the
+    #    preview build smoke-gates + locally serves the working copy but does NOT
+    #    promote that draft to published and does NOT overwrite the canonical live
+    #    deploy. So an edit stays a reviewable draft (the prior live URL is
+    #    untouched, get_draft is non-None, request_publish_pocket can submit it) —
+    #    only an approved review (the real publish) takes the edit live.
+    # 3. On a smoke-gate failure, restore the prior source so the pocket never
+    #    carries a component the renderer rejects — then re-raise so the caller
+    #    surfaces the reason. The prior deploy is untouched because the gate fires
+    #    before publish deploys.
     try:
         return await publish_pocket(
             workspace_id=workspace_id,
@@ -675,6 +753,7 @@ async def edit_svelte_component(
             pocket_id=pocket_id,
             name=name,
             builder_origin=builder_origin or None,
+            preview=True,
             _generator=_generator,
             _cloudflare=_cloudflare,
             _bundle_reader=_bundle_reader,
@@ -716,30 +795,93 @@ async def make_site_editable(
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
     _local_deploy: Callable[[str, str], str] | None = None,
 ) -> _SiteDoc:
-    """Republish a pocket's site as EDITABLE (SE-2b).
+    """Arm a pocket's site for editing — build an editable PREVIEW (SE-2b + the
+    Branch primitive).
 
-    Backs ``POST /sites/by-pocket/{pocket_id}/editable``: it republishes the
-    pocket with ``builder_origin`` set so the generated page carries the gated
-    edit-bridge, and persists that origin on the Site doc. ``builder_origin``
-    defaults to the configured dashboard origin (``PAW_SITES_BUILDER_ORIGIN``)
-    when the caller does not pass one, so the endpoint works with no body.
+    Backs ``POST /sites/by-pocket/{pocket_id}/editable``: it builds the pocket with
+    ``builder_origin`` set so the generated page carries the gated edit-bridge, and
+    returns the PREVIEW url the iframe frames. ``builder_origin`` defaults to the
+    configured dashboard origin (``PAW_SITES_BUILDER_ORIGIN``) when the caller does
+    not pass one, so the endpoint works with no body.
 
-    Delegates to ``publish_pocket`` (reads the pocket, regenerates, smoke-gates,
-    redeploys), so it inherits the same NotFound / Forbidden propagation and the
-    smoke gate — a build that fails the gate raises ``SmokeGateFailed`` and the
-    prior deploy is untouched.
+    Branch primitive: arming for editing is a PREVIEW, NOT a live publish. It
+    delegates to ``publish_pocket`` with ``preview=True``, so it builds +
+    smoke-gates + locally serves the working copy but does NOT promote the draft to
+    published and does NOT overwrite the canonical live deploy/url. The pocket's
+    draft survives (so a subsequent edit + ``request_publish_pocket`` works); only
+    an approved review takes the edit live. It first ensures a draft snapshot
+    exists (a pocket armed for editing that has never been edited would otherwise
+    have no draft for the builder to frame / submit) via the same best-effort
+    versions hook publish uses.
+
+    It inherits ``publish``'s NotFound / Forbidden propagation and the smoke gate —
+    a build that fails the gate raises ``SmokeGateFailed`` and the prior live
+    deploy is untouched.
     """
     origin = (builder_origin or "").strip() or _builder_origin()
+
+    # Ensure a draft snapshot exists so the armed-for-editing pocket has a working
+    # copy to frame and submit, even before the first component edit. Snapshots the
+    # pocket's current engine content (rippleSpec / svelte source map). Best-effort
+    # — versioning is an additive layer, never a gate on arming.
+    await _ensure_pocket_draft(workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id)
+
     return await publish_pocket(
         workspace_id=workspace_id,
         user_id=user_id,
         pocket_id=pocket_id,
         builder_origin=origin,
+        preview=True,
         _generator=_generator,
         _cloudflare=_cloudflare,
         _bundle_reader=_bundle_reader,
         _local_deploy=_local_deploy,
     )
+
+
+async def _ensure_pocket_draft(*, workspace_id: str, user_id: str, pocket_id: str) -> None:
+    """Ensure the pocket has a current DRAFT version (Branch primitive).
+
+    Arming a site for editing must leave a draft for the builder to frame and for
+    ``request_publish_pocket`` to submit. A pocket that was published but never
+    edited has only a ``published`` version (no draft), so this writes a draft
+    snapshot of the pocket's current engine content when none exists. It is a
+    no-op when a draft is already present (the common path — an edit already wrote
+    one). Reads the pocket through the pockets service (wire dict — entity
+    isolation) to resolve the engine + content.
+
+    Best-effort: versioning is an additive history/Branch layer, never a gate on
+    arming, so a missing module / read failure is logged and swallowed.
+    """
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+        from pocketpaw_ee.versions import service as versions_service
+
+        existing = await versions_service.get_draft(
+            scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id
+        )
+        if existing is not None:
+            return
+        pocket = await pockets_service.get(pocket_id, user_id)
+        engine = pocket.get("engine") or "ripple"
+        if engine == "svelte":
+            content = pocket.get("source") if isinstance(pocket.get("source"), dict) else {}
+        else:
+            content = pocket.get("rippleSpec") if isinstance(pocket.get("rippleSpec"), dict) else {}
+        await versions_service.write_draft(
+            scope_type=_VERSION_SCOPE_TYPE,
+            scope_id=pocket_id,
+            workspace_id=workspace_id,
+            content=content or {},
+            author=user_id,
+        )
+    except Exception:  # noqa: BLE001 — versioning must not break arming for edit
+        logger.warning(
+            "versions: failed to ensure a draft for pocket %s on arm-for-edit — "
+            "preview proceeds, draft snapshot skipped",
+            pocket_id,
+            exc_info=True,
+        )
 
 
 async def preview_pocket(

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -208,6 +208,19 @@ def _default_bundle_reader(project_dir: str) -> bytes:
     return Path(project_dir, _WORKER_BUNDLE_REL).read_bytes()
 
 
+def _preview_id(pocket_id: str) -> str:
+    """A STABLE per-pocket id for serving a preview build (the EDIT/arm path).
+
+    A live publish mints a fresh ObjectId per site, but a preview must serve at the
+    SAME URL across repeated builds so the builder iframe can frame it once and just
+    reload — otherwise every edit/arm builds at a new ``/<minted-id>/`` and the user
+    never sees the change (the churn bug). ``local_server.persist_site`` overwrites
+    ``<home>/<id>/`` in place, so a deterministic id derived from the pocket gives
+    the same URL with fresh content on each preview build. Prefixed ``preview-`` so a
+    preview dir never collides with a live site's minted-ObjectId dir."""
+    return f"preview-{pocket_id}"
+
+
 def _capture_base() -> str:
     import os
 
@@ -452,8 +465,14 @@ async def publish(
     if preview:
         from pocketpaw_ee.sites import local_server
 
+        # Serve at a STABLE per-pocket preview id (NOT the freshly-minted ObjectId)
+        # so repeated preview builds overwrite the same dir and serve at the SAME
+        # url — the builder iframe frames it once and just reloads. The transient
+        # doc still carries the minted ObjectId in its ``id``/``script_name`` (it is
+        # never persisted), but the served path + url use the stable preview id.
+        preview_id = _preview_id(pocket_id)
         deploy = _local_deploy or local_server.deploy_local
-        preview_url = deploy(site_id, build.project_dir)
+        preview_url = deploy(preview_id, build.project_dir)
         return _SiteDoc(
             id=ObjectId(site_id),
             workspace=workspace_id,

--- a/tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py
@@ -6,10 +6,17 @@
 #      create_landing_site + create_svelte_site, and the provider advertises it.
 #   2. Handler wiring — identity gating, input validation, the success response
 #      shape, and error MAPPING: a SmokeGateFailed from the service becomes an
-#      is_error telling the agent the live site is unchanged; a CloudError
+#      is_error telling the agent the edit was not staged; a CloudError
 #      (NotFound / not-a-svelte-site) is relayed by code. The service-level
 #      persist + republish + rollback logic is covered by
 #      tests/ee/sites/test_component_edit.py; here we pin the agent surface.
+#
+# Updated: 2026-06-18 (fix/sites-edit-draft-not-publish, BUG 2) — an edit now stages
+# a DRAFT PREVIEW, not a live publish. The handler returns deployed=False +
+# status="draft" + is_live=False + a preview_url + a message that says draft/preview
+# and "Submit for review"; it must NOT narrate published/republished/live. The
+# success-shape test asserts the draft/preview framing; the smoke-gate test asserts
+# the "previous version is unchanged" (not "...still deployed") wording.
 """Tests for the targeted svelte-component edit tool (edit_svelte_component)."""
 
 from __future__ import annotations
@@ -37,8 +44,9 @@ def _identity(workspace_id: str | None, user_id: str | None):
 
 
 class _FakeSiteDoc:
-    """Stand-in for the Site Beanie doc the service returns — only the fields the
-    handler reads onto the response."""
+    """Stand-in for the Site doc the service returns — only the fields the handler
+    reads onto the response. The edit path returns a PREVIEW (deployed=False) since
+    an edit is now staged as a draft, not deployed live."""
 
     def __init__(self) -> None:
         from bson import ObjectId
@@ -46,8 +54,9 @@ class _FakeSiteDoc:
         self.id = ObjectId()
         self.pocket_id = "pk1"
         self.name = "Bright Smile"
-        self.url = "http://127.0.0.1:9999/site/"
-        self.deployed = True
+        self.url = "http://127.0.0.1:9999/preview-pk1/"
+        # An edit builds a PREVIEW, not a live deploy.
+        self.deployed = False
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +119,8 @@ class TestEditHandler:
         assert body["ok"] is True
         assert body["component_path"] == "src/lib/components/Hero.svelte"
         assert body["site"]["pocket_id"] == "pk1"
-        assert body["site"]["deployed"] is True
+        # The edit returns a PREVIEW, not a live deploy.
+        assert body["site"]["deployed"] is False
         # The service got the agent identity + the edit inputs.
         fake.assert_awaited_once()
         kwargs = fake.await_args.kwargs
@@ -118,6 +128,54 @@ class TestEditHandler:
         assert kwargs["user_id"] == "u1"
         assert kwargs["component_path"] == "src/lib/components/Hero.svelte"
         assert kwargs["new_source"] == "<section/>"
+
+    @pytest.mark.asyncio
+    async def test_success_payload_says_draft_preview_not_published(self) -> None:
+        """BUG 2: the edit success result must tell the agent the change is staged
+        as a DRAFT PREVIEW (NOT live/published) and that the user must Submit for
+        review to publish. The agent narrates this payload, so it must not claim
+        'published'/'live'/'republished'."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_svelte_component",
+                new=AsyncMock(return_value=_FakeSiteDoc()),
+            ),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                    "new_source": "<section/>",
+                }
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+
+        # The payload carries a draft/preview framing the agent relays.
+        assert body["status"] == "draft"
+        assert body["is_live"] is False
+        assert "preview_url" in body["site"]
+        # A human-readable message that says preview/draft + Submit for review.
+        message = (body.get("message") or "").lower()
+        assert "preview" in message or "draft" in message
+        assert "submit for review" in message
+
+        # And it does NOT CLAIM the edit is published / republished / live. The
+        # word "publish" may appear as an instruction ("to take it live, click
+        # Submit for review") but never as a completed-state claim about THIS edit.
+        text = out["content"][0]["text"].lower()
+        assert "republished" not in text
+        # No "published"/"is published"/"now published" completed-state claim.
+        assert "published" not in text
+        # No "live at <url>" / "now live" / "is live" publish claim. (is_live is a
+        # JSON key with an underscore, so the bare phrase "is live" must be absent.)
+        assert "live at" not in text
+        assert "now live" not in text
+        assert "is live" not in text
 
     @pytest.mark.asyncio
     async def test_missing_identity_is_error(self) -> None:
@@ -185,7 +243,9 @@ class TestEditHandler:
         assert out.get("is_error") is True
         text = out["content"][0]["text"]
         assert "smoke test" in text
-        assert "previous version is still deployed" in text
+        # The edit stages a draft preview, so a smoke failure means it was NOT
+        # staged and the previous version is unchanged (no deploy to roll back to).
+        assert "previous version is unchanged" in text
 
     @pytest.mark.asyncio
     async def test_cloud_error_is_relayed_by_code(self) -> None:

--- a/tests/ee/sites/test_builder_origin.py
+++ b/tests/ee/sites/test_builder_origin.py
@@ -11,6 +11,12 @@
 # after a component edit; and make_site_editable republishes a site as editable.
 #
 # Fakes inject the generator + CF client so no Bun/workerd/Cloudflare is touched.
+#
+# Updated 2026-06-18 (fix/sites-edit-draft-not-publish): edit_svelte_component /
+# make_site_editable now take the PREVIEW branch (local serve, no live promote), so
+# the edit/arm-path tests inject a fake ``_local_deploy`` instead of relying on the
+# CF deploy. The builder_origin threading these tests pin is unchanged — a preview
+# still forwards the origin to the generator and carries it on the returned Site.
 
 from __future__ import annotations
 
@@ -50,6 +56,12 @@ class _FakeCF:
     async def put_worker(self, *, script_name, bundle):
         self.put_calls.append(script_name)
         return True
+
+
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+    """Stand in for local_server.deploy_local so the PREVIEW serve (the edit/arm
+    path) does not need a real built dir on disk — returns the localhost URL."""
+    return f"http://127.0.0.1:9999/{site_id}/"
 
 
 @pytest.fixture(autouse=True)
@@ -190,6 +202,7 @@ async def test_edit_component_preserves_stored_builder_origin(beanie_test_db):
         _generator=gen,
         _cloudflare=_FakeCF(),
         _bundle_reader=lambda d: b"x",
+        _local_deploy=_fake_local_deploy,
     )
     # The edited site is STILL editable — builder_origin carried through.
     assert gen.built["builder_origin"] == "https://app.paw.example"
@@ -219,6 +232,7 @@ async def test_edit_component_on_non_editable_site_stays_non_editable(beanie_tes
         _generator=gen,
         _cloudflare=_FakeCF(),
         _bundle_reader=lambda d: b"x",
+        _local_deploy=_fake_local_deploy,
     )
     assert site.builder_origin == ""
     assert gen.built.get("builder_origin") in (None, "")
@@ -248,6 +262,7 @@ async def test_make_site_editable_republishes_with_origin(beanie_test_db):
         _generator=gen,
         _cloudflare=_FakeCF(),
         _bundle_reader=lambda d: b"x",
+        _local_deploy=_fake_local_deploy,
     )
     assert site.builder_origin == "https://app.paw.example"
     assert gen.built["builder_origin"] == "https://app.paw.example"
@@ -267,6 +282,7 @@ async def test_make_site_editable_defaults_builder_origin_from_config(beanie_tes
         _generator=gen,
         _cloudflare=_FakeCF(),
         _bundle_reader=lambda d: b"x",
+        _local_deploy=_fake_local_deploy,
     )
     assert site.builder_origin == "https://configured.paw.example"
     assert gen.built["builder_origin"] == "https://configured.paw.example"

--- a/tests/ee/sites/test_component_edit.py
+++ b/tests/ee/sites/test_component_edit.py
@@ -2,6 +2,13 @@
 # edit + republish path (sites_service.edit_svelte_component). Created:
 # 2026-06-17 (feat/sites-svelte-component-edit, SE-2).
 #
+# Updated 2026-06-18 (fix/sites-edit-draft-not-publish): a component edit now
+# builds a PREVIEW (local serve, draft kept) instead of a live CF deploy +
+# promote-to-published. test_edit_component_republishes_with_new_source asserts the
+# new contract: preview built (deployed=False, no CF put, preview URL returned), the
+# pocket source persisted, and a reviewable draft left behind. The smoke-gate
+# rollback test is unchanged (the gate fires before any deploy, preview or live).
+#
 # The flow under test: one component file of a svelte Paw Site pocket is
 # rewritten and the site is safely republished. These tests use the shared
 # ``beanie_test_db`` fixture (an in-memory Mongo) so the pockets service persists
@@ -73,6 +80,12 @@ class _FakeCF:
         return True
 
 
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+    """Stand in for local_server.deploy_local so the PREVIEW serve (the edit path)
+    does not need a real built dir on disk — returns the localhost preview URL."""
+    return f"http://127.0.0.1:9999/{site_id}/"
+
+
 @pytest.fixture(autouse=True)
 def recording_bus():
     """Install a recording EventBus so the pockets service's ``emit`` calls
@@ -122,7 +135,11 @@ async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
 @pytest.mark.asyncio
 async def test_edit_component_republishes_with_new_source(beanie_test_db):
     """A component edit is persisted on the pocket AND reaches the regenerated
-    build: the generator materializes the NEW Hero source, not the old one."""
+    PREVIEW build: the generator materializes the NEW Hero source, not the old one.
+
+    Branch primitive (fix/sites-edit-draft-not-publish): an edit now builds a
+    PREVIEW (local serve) — it is NOT a live deploy, so ``deployed`` is False and no
+    CF worker is put. The live deploy only happens on an approved review."""
     pocket_id = await _make_svelte_pocket("ws1", "u1")
     gen, cf = _FakeGenerator(), _FakeCF()
 
@@ -135,9 +152,14 @@ async def test_edit_component_republishes_with_new_source(beanie_test_db):
         _generator=gen,
         _cloudflare=cf,
         _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
     )
 
-    assert site.deployed is True
+    # An edit is a PREVIEW, not a live deploy: no CF worker put, not deployed,
+    # but it returns the preview URL the builder iframe frames.
+    assert cf.put_calls == []
+    assert site.deployed is False
+    assert site.url.endswith(f"/{site.script_name}/")
     assert site.pocket_id == pocket_id
     # The regenerated build materialized the EDITED component, not the original.
     assert gen.built is not None
@@ -149,6 +171,13 @@ async def test_edit_component_republishes_with_new_source(beanie_test_db):
     # The edit persisted on the pocket — a re-read shows the new source.
     wire = await pockets_service.get(pocket_id, "u1")
     assert wire["source"]["src/lib/components/Hero.svelte"] == _HERO_V2
+
+    # And it left a reviewable DRAFT — not promoted to published (the bug).
+    from pocketpaw_ee.versions import service as versions
+
+    draft = await versions.get_draft(scope_type="pocket", scope_id=pocket_id)
+    assert draft is not None
+    assert draft.content["src/lib/components/Hero.svelte"] == _HERO_V2
 
 
 @pytest.mark.asyncio

--- a/tests/ee/sites/test_component_edit.py
+++ b/tests/ee/sites/test_component_edit.py
@@ -156,10 +156,12 @@ async def test_edit_component_republishes_with_new_source(beanie_test_db):
     )
 
     # An edit is a PREVIEW, not a live deploy: no CF worker put, not deployed,
-    # but it returns the preview URL the builder iframe frames.
+    # but it returns the STABLE per-pocket preview URL the builder iframe frames
+    # (preview-<pocket_id>, NOT the minted site id — so repeated builds don't churn
+    # the url).
     assert cf.put_calls == []
     assert site.deployed is False
-    assert site.url.endswith(f"/{site.script_name}/")
+    assert site.url.endswith(f"/preview-{pocket_id}/")
     assert site.pocket_id == pocket_id
     # The regenerated build materialized the EDITED component, not the original.
     assert gen.built is not None

--- a/tests/ee/sites/test_edit_draft_not_publish.py
+++ b/tests/ee/sites/test_edit_draft_not_publish.py
@@ -1,0 +1,263 @@
+# tests/ee/sites/test_edit_draft_not_publish.py — reproduces + locks the
+# Branch-primitive bug where editing a site AUTO-PUBLISHED it instead of leaving a
+# reviewable draft. Created: 2026-06-18 (fix/sites-edit-draft-not-publish).
+#
+# The bug: make_site_editable() and edit_svelte_component() both routed through
+# publish_pocket → publish, and publish() PROMOTED the pocket's draft version to
+# ``published`` AND claimed the canonical live deploy. So after arming + editing a
+# site, get_draft(...) returned None (the draft was promoted away) and the
+# ``published`` pointer had moved — which made request_publish_pocket() raise
+# ("no draft version to publish") and the Submit-for-review UI 400.
+#
+# These tests assert the INTENDED Branch model: arming + editing a site builds a
+# PREVIEW (draft) — it must NOT promote to published and must NOT move the live
+# pointer — so the draft survives, the published pointer is unchanged, and
+# request_publish_pocket() succeeds (creates the review Action). The live publish
+# path (chat-create + approve→publish) is covered by test_component_edit.py /
+# test_request_publish.py and must stay a real deploy.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.versions import service as versions
+
+from pocketpaw.instinct.store import InstinctStore
+
+pytestmark = pytest.mark.asyncio
+
+_HERO_V1 = "<section class='hero'><h1>Bright Smile</h1></section>"
+_HERO_V2 = "<section class='hero'><h1>Brighter Smiles, Whiter Teeth</h1></section>"
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css'</script><slot/>",
+    "src/routes/+page.ts": "export const prerender = true",
+    "src/app.css": ":root{--brand:#0A84FF}",
+    "src/lib/components/Hero.svelte": _HERO_V1,
+}
+
+
+class _FakeGenerator:
+    """Records the source map + builder_origin it was asked to build so a test can
+    assert the preview build still ran the smoke gate (a broken edit is caught)."""
+
+    def __init__(self):
+        self.built = None
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version=None)
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+    """Stand in for local_server.deploy_local so the PREVIEW serve does not need a
+    real built dir on disk — returns the localhost URL the preview would be served
+    at (what the builder iframe frames)."""
+    return f"http://127.0.0.1:9999/{site_id}/"
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Install a recording EventBus so the pockets service's ``emit`` calls don't
+    raise (the real bus is only wired by ``init_realtime()`` at boot)."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def instinct_store(tmp_path, monkeypatch):
+    """A throwaway InstinctStore wired into the accessor the sites service reads so
+    request_publish_pocket() can actually create the review Action."""
+    store = InstinctStore(tmp_path / "edit_draft_instinct.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+    return store
+
+
+async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    """Persist a real svelte-engine Pocket via the pockets service and return its
+    id — mirrors how create_svelte_site lands a pocket."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+async def test_arm_then_edit_leaves_a_reviewable_draft(beanie_test_db, instinct_store):
+    """THE BUG: arm a svelte site editable → edit a component → the edit must leave
+    a DRAFT (not promote it to published) and must NOT move the published pointer,
+    so request_publish_pocket() succeeds (creates the review Action) instead of
+    raising "no draft to publish".
+
+    Before the fix this fails: make_site_editable() / edit_svelte_component() route
+    through publish(), which promotes the draft → published, so get_draft() is None
+    and request_publish_pocket() raises ValueError → the UI 400.
+    """
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    # Establish a published baseline so we can prove the EDIT does not move it.
+    # (A real site has a live/published version; the edit must leave it alone.)
+    # Snapshot the pocket's current source as the live version, the way a prior
+    # publish would have — agent_create does not itself version the source.
+    baseline = await versions.write_draft(
+        scope_type="pocket",
+        scope_id=pocket_id,
+        workspace_id="ws1",
+        content=dict(_SVELTE_SOURCE),
+        author="u1",
+    )
+    await versions.publish(
+        scope_type="pocket",
+        scope_id=pocket_id,
+        workspace_id="ws1",
+        version_id=str(baseline.id),
+    )
+    published_before = await versions.get_published(scope_type="pocket", scope_id=pocket_id)
+    assert published_before is not None
+    assert published_before.id == baseline.id
+
+    # 1. Arm the site for editing — must be a PREVIEW, not a live publish/promote.
+    await sites_service.make_site_editable(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    # 2. Edit a component — must persist a DRAFT + PREVIEW, not auto-publish.
+    edit_gen, edit_cf = _FakeGenerator(), _FakeCF()
+    await sites_service.edit_svelte_component(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/lib/components/Hero.svelte",
+        new_source=_HERO_V2,
+        _generator=edit_gen,
+        _cloudflare=edit_cf,
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    # The preview build still ran (smoke-gate safety) and saw the edited source.
+    assert edit_gen.built is not None
+    assert edit_gen.built["source"]["src/lib/components/Hero.svelte"] == _HERO_V2
+
+    # CORE ASSERTION 1 — the edit left a DRAFT (it was NOT promoted to published).
+    draft = await versions.get_draft(scope_type="pocket", scope_id=pocket_id)
+    assert draft is not None, "editing a site must leave a reviewable DRAFT, not auto-publish it"
+    assert draft.content["src/lib/components/Hero.svelte"] == _HERO_V2
+
+    # CORE ASSERTION 2 — the published pointer is UNCHANGED (the edit is not live).
+    published_after = await versions.get_published(scope_type="pocket", scope_id=pocket_id)
+    assert published_after is not None
+    assert published_after.id == published_before.id, (
+        "an edit must NOT move the published pointer — only an approved review does"
+    )
+
+    # CORE ASSERTION 3 — Submit-for-review now works (the bug's 400 is gone).
+    action = await sites_service.request_publish_pocket(
+        workspace_id="ws1", user_id="u1", pocket_id=pocket_id
+    )
+    assert action is not None
+    blob = action.parameters["_artifact_change"]
+    assert blob["to_version_id"] == str(draft.id)  # the draft is what we review
+    assert blob["from_version_id"] == str(published_before.id)  # current live
+
+
+async def test_make_editable_does_not_promote_or_go_live(beanie_test_db):
+    """Arming a fresh (never-published) site for editing must build a PREVIEW only:
+    it must NOT create a published version pointer and must NOT stamp a live Site
+    deploy. The pocket stays a draft awaiting review."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    cf = _FakeCF()
+
+    preview = await sites_service.make_site_editable(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=_FakeGenerator(),
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    # No published pointer — arming for edit is not a publish.
+    published = await versions.get_published(scope_type="pocket", scope_id=pocket_id)
+    assert published is None, "arming a site for editing must NOT promote to published"
+
+    # A draft still exists (the working copy to review).
+    draft = await versions.get_draft(scope_type="pocket", scope_id=pocket_id)
+    assert draft is not None
+
+    # The preview still returns a url the iframe can frame (builder_origin set so
+    # the edit-bridge is injected), but it is a PREVIEW, not the canonical live
+    # deploy: ``deployed`` is False (it is not live yet).
+    assert preview.builder_origin  # editable → carries the bridge origin
+    assert preview.deployed is False, "a preview must not claim a live deploy"
+
+
+async def test_chat_create_publish_still_goes_live(beanie_test_db):
+    """Backward-compat guard: a normal publish (no builder_origin — the chat-create
+    / approve path) MUST still deploy live and promote the draft to published. The
+    fix only changes the EDIT/arm path, never the live-publish path."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    cf = _FakeCF()
+
+    site = await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=_FakeGenerator(),
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    # A real live publish: the worker was deployed and the Site doc is live.
+    assert cf.put_calls == [site.script_name]
+    assert site.deployed is True
+    # The draft was promoted to published (this is what going live means).
+    published = await versions.get_published(scope_type="pocket", scope_id=pocket_id)
+    assert published is not None

--- a/tests/ee/sites/test_edit_draft_not_publish.py
+++ b/tests/ee/sites/test_edit_draft_not_publish.py
@@ -238,6 +238,59 @@ async def test_make_editable_does_not_promote_or_go_live(beanie_test_db):
     assert preview.deployed is False, "a preview must not claim a live deploy"
 
 
+async def test_consecutive_previews_serve_at_a_stable_url(beanie_test_db):
+    """BUG 1: a preview must serve at a STABLE per-pocket URL so repeated builds
+    overwrite in place and the FE can frame it once and just reload.
+
+    Before the fix each preview build (arm, then edit, then a second edit) served
+    at ``deploy_local(<freshly-minted-ObjectId>, ...)`` → a NEW url every time, so
+    the iframe (framing the first url) never showed the change. This asserts the
+    two consecutive preview builds for the SAME pocket serve at the SAME url.
+    """
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    # Record the site_id each preview serve is asked to deploy at; the returned
+    # url is f"<base>/{site_id}/" (matching local_server.local_url_for), so a
+    # stable site_id ⇒ a stable url.
+    served_ids: list[str] = []
+
+    def _recording_local_deploy(site_id: str, project_dir: str) -> str:
+        served_ids.append(site_id)
+        return f"http://127.0.0.1:9999/{site_id}/"
+
+    arm = await sites_service.make_site_editable(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_recording_local_deploy,
+    )
+    edit = await sites_service.edit_svelte_component(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/lib/components/Hero.svelte",
+        new_source=_HERO_V2,
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_recording_local_deploy,
+    )
+
+    # Both preview builds served at the SAME stable per-pocket id (NOT a minted
+    # ObjectId per call), so the preview URL does not churn.
+    assert len(served_ids) == 2
+    assert served_ids[0] == served_ids[1], (
+        "consecutive preview builds for one pocket must serve at the SAME url"
+    )
+    # The returned preview urls match (so the iframe can frame once + reload).
+    assert arm.url == edit.url
+    # The stable id is derived from the pocket, not a random ObjectId.
+    assert pocket_id in served_ids[0]
+
+
 async def test_chat_create_publish_still_goes_live(beanie_test_db):
     """Backward-compat guard: a normal publish (no builder_origin — the chat-create
     / approve path) MUST still deploy live and promote the draft to published. The


### PR DESCRIPTION
Found and fixed live while testing the Branch-primitive editor. Two related fixes (reproduce-first, 193 tests).

## What ships
- **Edit = draft, not a live publish.** Editing a site (and arming it editable) now builds a draft + a local preview — it does NOT deploy live or promote to published. Only an approved review deploys. Fixes the "Submit for review → 400 (no draft)" bug: the edit path was still auto-publishing, so no draft survived.
- **Stable per-pocket preview URL** (`preview-<pocket>`, overwrite in place) instead of a new URL per build — so the editor iframe can actually show the change.
- **Draft wording** in the edit tool: it tells the user the change is staged as a draft to review, not "published / live."

## Tests
Reproduce-first (the bug's exact scenario fails before, passes after) + the existing sites/versions/gate suites — 193 passing. ruff clean.