### PR TITLE
feat(sites): stable per-pocket Site identity — fix the stale link + dupes

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -22,6 +22,14 @@
 # a normal (non-editable) site. When set, the generated page carries the gated
 # edit-bridge keyed on it. Persisted so a component-edit republish re-applies it
 # and the site stays editable across edits.
+#
+# Updated 2026-06-18 (feat/sites-stable-identity, PERF-1): a published Paw Site now
+# has a STABLE per-(workspace, pocket_id) identity — its ``_id`` is derived
+# deterministically from the pair (``service._live_object_id``), so a re-publish
+# UPSERTS the SAME Site doc (one canonical row per pocket) instead of inserting a
+# fresh one each time. No schema change: the upsert keys on the primary ``_id``
+# (already unique), so the existing compound (workspace, pocket_id) index — which
+# still serves the per-pocket reads — is sufficient and no new unique key is added.
 
 from __future__ import annotations
 

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -28,6 +28,12 @@
 # This flag (default False, backward-compatible) lets the builder badge "has
 # unpublished edits" without inferring it from the Site doc. ``status``/``is_live``
 # semantics are unchanged in shape; only their derivation moves onto versions.
+# Updated 2026-06-18 (feat/sites-stable-identity, PERF-1): SiteStatusResponse gains
+# ``url`` — the canonical live address of the pocket's deployed site. With stable
+# per-pocket identity (one Site doc per pocket) pocket_status reads the ONE
+# canonical doc and surfaces its non-null url, so the builder/gallery link to the
+# address the latest build actually serves at instead of a stale dupe's url=None.
+# Optional (default None, backward-compatible) — None when no deployed site exists.
 # Updated 2026-06-18 (feat/branch-primitive-revert-history, BP-4): added two DTOs
 # for the Branch-primitive surfaces — SiteVersionResponse + VersionHistoryResponse
 # (the ordered version timeline GET /sites/by-pocket/{pocket_id}/versions returns)
@@ -101,6 +107,9 @@ class SiteStatusResponse(BaseModel):
     is_live: bool
     has_unpublished_changes: bool = False
     site_id: str | None = None
+    # PERF-1: the canonical live url of the pocket's deployed site (the address the
+    # latest build serves at). None when no deployed site exists.
+    url: str | None = None
 
 
 class SiteVersionResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -499,7 +499,19 @@ async def publish(
     # one each call. A PREVIEW build still uses the freshly-minted ObjectId for its
     # transient (never-persisted) doc id and serves at the stable preview path.
     site_id = str(ObjectId()) if preview else str(_live_object_id(workspace_id, pocket_id))
+    # PERF-1 fix (review finding): on a live RE-publish the upsert below preserves
+    # the stored ``doc.signed_key``, so minting a fresh key here would bake a
+    # ``captureSignedKey`` into the built HTML that no longer matches the doc the
+    # capture endpoint verifies against — silently breaking lead capture on every
+    # re-publish. Reuse the existing site's key when one is already stored; mint a
+    # new key only for a first publish or a preview (which never persists a doc).
     signed_key = f"site_key_{secrets.token_urlsafe(24)}"
+    if not preview:
+        _existing = await _SiteDoc.find_one(
+            {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
+        )
+        if _existing is not None and _existing.signed_key:
+            signed_key = _existing.signed_key
 
     build = await generator.build(
         ripple_spec=ripple_spec,

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -176,6 +176,24 @@
 # finding carries a ``fix_prompt`` the UI feeds to the EXISTING edit path
 # (edit_svelte_component / refine) so a fix lands as a reviewable draft in the
 # Tray — BP-7 adds NO apply endpoint.
+#
+# Updated 2026-06-18 (feat/sites-stable-identity, PERF-1): a LIVE publish now has a
+# STABLE per-(workspace, pocket_id) identity instead of minting a fresh ObjectId per
+# call (which inserted a NEW Site doc at a NEW folder/URL every publish — one pocket
+# had 14 docs, the gallery showed dupes, and pocket_status returned an arbitrary
+# stale doc with url=None: the stale-live-link bug). Mirroring the preview path's
+# _preview_id:
+#   * _live_object_id(workspace, pocket) derives a deterministic ObjectId from the
+#     pair, used for the deploy folder/URL, the CF Worker script_name (overwrite the
+#     worker, no orphan), and the Site doc _id. publish()'s preview branch is
+#     unchanged (it already serves at the stable preview-<pocket> path).
+#   * publish() UPSERTS ONE canonical Site doc keyed on the stable _id (find-then-
+#     save/insert) — re-publish refreshes the deploy fields in place and PRESERVES
+#     domain/allowed_origins/signed_key, instead of inserting a second row.
+#   * pocket_status() reads the CANONICAL doc via _canonical_site_doc (the stable-id
+#     doc, else the newest with a real url) and returns its non-null url + is_live,
+#     dropping the arbitrary find_one. PERF-1 does NOT migrate pre-existing dupes
+#     (that is PERF-2) — _canonical_site_doc just resolves the live one among them.
 
 from __future__ import annotations
 
@@ -220,14 +238,43 @@ def _default_bundle_reader(project_dir: str) -> bytes:
 def _preview_id(pocket_id: str) -> str:
     """A STABLE per-pocket id for serving a preview build (the EDIT/arm path).
 
-    A live publish mints a fresh ObjectId per site, but a preview must serve at the
-    SAME URL across repeated builds so the builder iframe can frame it once and just
-    reload — otherwise every edit/arm builds at a new ``/<minted-id>/`` and the user
-    never sees the change (the churn bug). ``local_server.persist_site`` overwrites
-    ``<home>/<id>/`` in place, so a deterministic id derived from the pocket gives
-    the same URL with fresh content on each preview build. Prefixed ``preview-`` so a
-    preview dir never collides with a live site's minted-ObjectId dir."""
+    A live publish derives a stable per-pocket ObjectId (``_live_object_id``); a
+    preview must likewise serve at the SAME URL across repeated builds so the
+    builder iframe can frame it once and just reload — otherwise every edit/arm
+    builds at a new ``/<minted-id>/`` and the user never sees the change (the churn
+    bug). ``local_server.persist_site`` overwrites ``<home>/<id>/`` in place, so a
+    deterministic id derived from the pocket gives the same URL with fresh content
+    on each preview build. Prefixed ``preview-`` so a preview dir never collides
+    with a live site's dir."""
     return f"preview-{pocket_id}"
+
+
+def _live_object_id(workspace_id: str, pocket_id: str) -> ObjectId:
+    """A STABLE per-(workspace, pocket) ObjectId for the LIVE published site (PERF-1).
+
+    Before PERF-1 ``publish`` minted ``ObjectId()`` per call, so every publish
+    inserted a NEW Site doc at a NEW deploy folder / URL — one pocket accumulated 14
+    Site docs, the gallery showed dupes, and ``pocket_status`` did an arbitrary
+    ``find_one`` across them (the stale-live-link bug). Mirroring ``_preview_id``,
+    the live site now has a STABLE identity derived deterministically from
+    ``(workspace_id, pocket_id)``: the SAME 12-byte ObjectId every publish, so:
+
+      * the deploy folder / URL is stable (``local_server.persist_site`` overwrites
+        ``<home>/<id>/`` in place ⇒ same URL, fresh content);
+      * the CF Worker ``script_name`` (== this id) is stable ⇒ ``put_worker``
+        OVERWRITES the worker per pocket instead of orphaning the old one;
+      * the Site doc ``_id`` is stable ⇒ publish UPSERTS ONE canonical doc per
+        ``(workspace, pocket_id)`` rather than inserting a fresh row each time, and
+        ``script_name == str(site.id)`` still holds.
+
+    The id is the first 12 bytes of ``sha1(workspace_id:pocket_id)`` — a pure
+    function of the pair, collision-resistant across the id space the same way a
+    minted ObjectId is, and never colliding with a ``preview-<pocket>`` dir (those
+    are strings, not ObjectId hex)."""
+    import hashlib
+
+    digest = hashlib.sha1(f"{workspace_id}:{pocket_id}".encode()).digest()
+    return ObjectId(digest[:12])
 
 
 def _capture_base() -> str:
@@ -446,7 +493,12 @@ async def publish(
     if not site_name:
         site_name = "Untitled site"
 
-    site_id = str(ObjectId())
+    # PERF-1: the LIVE site has a STABLE per-(workspace, pocket) id (mirroring the
+    # preview path's _preview_id), so re-publishing a pocket overwrites the SAME
+    # deploy folder / URL / CF worker / Site doc in place instead of minting a fresh
+    # one each call. A PREVIEW build still uses the freshly-minted ObjectId for its
+    # transient (never-persisted) doc id and serves at the stable preview path.
+    site_id = str(ObjectId()) if preview else str(_live_object_id(workspace_id, pocket_id))
     signed_key = f"site_key_{secrets.token_urlsafe(24)}"
 
     build = await generator.build(
@@ -528,27 +580,47 @@ async def publish(
         bundle = _bundle_reader(build.project_dir)
         await cf.put_worker(script_name=site_id, bundle=bundle)
 
-    doc = _SiteDoc(
-        id=ObjectId(site_id),
-        workspace=workspace_id,
-        pocket_id=pocket_id,
-        owner=user_id,
-        name=site_name,
-        script_name=site_id,
-        deployed=True,
-        signed_key=signed_key,
-        url=url,
-        # SE-2b: persist the builder origin (or "") so a component-edit republish
-        # can re-apply it and the site stays editable across edits.
-        builder_origin=builder_origin or "",
-        # Seed capture config so a lead lands with no manual Mongo edit: a default
-        # mapping keyed on the form_type the generated endpoint sends, and the
-        # local dev origins so the local smoke works. add_domain() appends the
-        # production hostname when a custom domain is connected.
-        allowed_origins=_default_allowed_origins(),
-        event_mapping=_DEFAULT_EVENT_MAPPING,
-    )
-    await doc.insert()
+    # PERF-1: UPSERT ONE canonical Site doc per (workspace, pocket_id) keyed on the
+    # stable ``_id`` (== site_id), rather than inserting a fresh row every publish.
+    # The stable id means the existing doc (if any) is found by ``_id`` directly; we
+    # refresh the deploy-facing fields in place (a re-publish ships fresh content at
+    # the same URL/worker). Fields a domain connect mutates later (``domains``,
+    # ``allowed_origins``) are PRESERVED on update so connecting a domain survives a
+    # re-publish; only a first insert seeds the defaults. ``signed_key`` is likewise
+    # kept stable across re-publishes (the capture endpoint verifies against it).
+    oid = ObjectId(site_id)
+    doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        doc = _SiteDoc(
+            id=oid,
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            owner=user_id,
+            name=site_name,
+            script_name=site_id,
+            deployed=True,
+            signed_key=signed_key,
+            url=url,
+            # SE-2b: persist the builder origin (or "") so a component-edit republish
+            # can re-apply it and the site stays editable across edits.
+            builder_origin=builder_origin or "",
+            # Seed capture config so a lead lands with no manual Mongo edit: a default
+            # mapping keyed on the form_type the generated endpoint sends, and the
+            # local dev origins so the local smoke works. add_domain() appends the
+            # production hostname when a custom domain is connected.
+            allowed_origins=_default_allowed_origins(),
+            event_mapping=_DEFAULT_EVENT_MAPPING,
+        )
+        await doc.insert()
+    else:
+        doc.pocket_id = pocket_id
+        doc.owner = user_id
+        doc.name = site_name
+        doc.script_name = site_id
+        doc.deployed = True
+        doc.url = url
+        doc.builder_origin = builder_origin or ""
+        await doc.save()
     return doc
 
 
@@ -563,6 +635,41 @@ async def _load(workspace_id: str, site_id: str) -> _SiteDoc:
     if doc is None:
         raise NotFound("site", site_id)
     return doc
+
+
+async def _canonical_site_doc(workspace_id: str, pocket_id: str) -> _SiteDoc | None:
+    """The ONE canonical Site doc for (workspace, pocket_id), or None (PERF-1).
+
+    Stable identity (``_live_object_id``) means a pocket published after PERF-1 has
+    exactly one doc — the stable-id one. But PERF-1 does NOT migrate the dupes the
+    old per-publish minting left behind (PERF-2 does), so a pocket may still have
+    several Site docs, one of which the old arbitrary ``find_one`` could return with
+    a stale ``url`` (the stale-live-link bug). This resolves the canonical doc
+    deterministically:
+
+      1. the STABLE-id doc (``_live_object_id``) when it exists — every post-PERF-1
+         publish writes here, so it is the live one;
+      2. otherwise the newest doc (by ``createdAt``) that actually carries a url —
+         the freshest live build among legacy dupes;
+      3. otherwise the newest doc at all (so a pre-url-era doc still resolves).
+
+    Tenant-scoped on ``workspace``. Returns None when the pocket has no Site doc.
+    """
+    stable = await _SiteDoc.find_one(
+        {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
+    )
+    if stable is not None:
+        return stable
+    docs = (
+        await _SiteDoc.find({"workspace": workspace_id, "pocket_id": pocket_id})
+        .sort(-_SiteDoc.createdAt)  # type: ignore[operator]
+        .to_list()
+    )
+    if not docs:
+        return None
+    # Prefer the newest doc that carries a real url (the freshest live build);
+    # fall back to the newest doc overall when none has one.
+    return next((d for d in docs if d.url), docs[0])
 
 
 async def add_domain(
@@ -1068,8 +1175,16 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
     it). No Cloudflare call — just persisted state. Versioning is an additive
     layer, so a versions read failure degrades to the Site-doc signal rather than
     breaking the status read.
+
+    PERF-1: the read is now the CANONICAL Site doc for (workspace, pocket_id), not
+    an arbitrary ``find_one`` across dupes. With stable identity a pocket has ONE
+    doc; but PERF-1 does NOT migrate the dupes the old minting left behind (that's
+    PERF-2), so to fix the stale-live-link bug today we pick the canonical doc
+    deterministically — the stable-id doc when present, else the newest doc that
+    actually carries a url — and surface its (non-null, latest) ``url`` so the live
+    link no longer points at a stale ``url=None`` row.
     """
-    doc = await _SiteDoc.find_one({"workspace": workspace_id, "pocket_id": pocket_id})
+    doc = await _canonical_site_doc(workspace_id, pocket_id)
 
     published_no: int | None = None
     draft_no: int | None = None
@@ -1122,6 +1237,10 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
         is_live=is_live,
         has_unpublished_changes=has_unpublished_changes,
         site_id=str(doc.id) if doc is not None else None,
+        # PERF-1: surface the canonical doc's live url so the builder/gallery link to
+        # the address the latest build actually serves at, not a stale ``url=None``
+        # dupe. None when the pocket has no deployed site.
+        url=(doc.url or None) if doc is not None else None,
     )
 
 

--- a/tests/ee/sites/test_stable_identity.py
+++ b/tests/ee/sites/test_stable_identity.py
@@ -193,3 +193,50 @@ async def test_cf_republish_uses_stable_script_name_and_one_doc(beanie_test_db):
     docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_cf"}).to_list()
     assert len(docs) == 1
     assert str(first.id) == str(second.id)
+
+
+async def test_republish_reuses_signed_key(beanie_test_db, monkeypatch):
+    """PERF-1 review fix: a live RE-publish must REUSE the stored ``signed_key`` so
+    the built HTML's ``captureSignedKey`` matches the persisted ``doc.signed_key``
+    the capture endpoint verifies against. Before the fix each publish minted a
+    fresh key while the upsert preserved the old one → silent lead-capture breakage
+    on every re-publish."""
+    from unittest.mock import AsyncMock, patch
+
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+
+    keys: list[str] = []
+
+    class _RecordingGen:
+        async def build(self, **kw):
+            from pocketpaw_ee.sites.generator_client import BuildResult
+
+            keys.append(kw.get("capture_signed_key"))
+            return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+    wire = {"name": "AKB", "engine": "ripple", "rippleSpec": {"type": "container"}}
+
+    async def _pub():
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=wire),
+        ):
+            return await sites_service.publish_pocket(
+                workspace_id="ws1",
+                user_id="u1",
+                pocket_id="pk-signedkey",
+                _generator=_RecordingGen(),
+                _bundle_reader=lambda d: b"x",
+                _local_deploy=lambda sid, pd: f"http://127.0.0.1:9999/{sid}/",
+            )
+
+    await _pub()
+    await _pub()
+
+    assert keys[0] is not None
+    assert keys[0] == keys[1], "re-publish must reuse the same signed_key, not mint a new one"
+    doc = await _SiteDoc.find_one(
+        {"_id": sites_service._live_object_id("ws1", "pk-signedkey"), "workspace": "ws1"}
+    )
+    assert doc is not None and doc.signed_key == keys[1], "built key must match the stored doc"

--- a/tests/ee/sites/test_stable_identity.py
+++ b/tests/ee/sites/test_stable_identity.py
@@ -1,0 +1,195 @@
+# tests/ee/sites/test_stable_identity.py — PERF-1 regression guard: a Paw Site
+# has a STABLE per-pocket identity, so re-publishing the SAME pocket overwrites
+# the one site in place (same URL, same single Site doc) instead of minting a
+# fresh site_id / folder / URL / doc on every publish.
+#
+# Created: 2026-06-18 (feat/sites-stable-identity, PERF-1).
+#
+# The bug PERF-1 fixes: publish() minted ``site_id = str(ObjectId())`` per call,
+# so every publish inserted a NEW Site doc at a NEW URL. One pocket accumulated
+# 14 Site docs; the gallery showed dupes and ``pocket_status`` did an arbitrary
+# ``find_one`` across them, returning a stale doc (often ``url=None``) while the
+# freshest build sat at an unreferenced URL ("stale live link"). These tests pin
+# the intended behavior: ONE doc + ONE stable URL per (workspace, pocket_id), and
+# ``pocket_status`` returns that canonical, non-null url.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.sites import service as sites_service
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+    """Stand-in for local_server.deploy_local — returns the served URL for a
+    site_id WITHOUT needing a real built dir on disk. Because the url is derived
+    deterministically from site_id, a STABLE site_id ⇒ a STABLE url, exactly as
+    the real local_server.local_url_for behaves (it overwrites <home>/<id>/ in
+    place)."""
+    return f"http://127.0.0.1:9999/{site_id}/"
+
+
+async def _publish_local(pocket_id: str, *, name: str, deploy):
+    """Publish a pocket through the LIVE path in LOCAL deploy mode (no CF client
+    injected → the local branch), recording the deploy calls via ``deploy``."""
+    from unittest.mock import AsyncMock, patch
+
+    wire = {"name": name, "engine": "ripple", "rippleSpec": {"type": "container"}}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        return await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            _generator=_FakeGenerator(),
+            # NB: no _cloudflare → the LOCAL deploy branch is taken.
+            _bundle_reader=lambda d: b"unused-in-local-mode",
+            _local_deploy=deploy,
+        )
+
+
+async def test_two_publishes_same_pocket_same_url_and_one_doc(beanie_test_db, monkeypatch):
+    """THE REGRESSION GUARD: two consecutive ``publish_pocket`` calls for the SAME
+    pocket must produce the SAME url AND exactly ONE Site doc for that
+    (workspace, pocket_id).
+
+    Before PERF-1 this fails: each publish minted a fresh ObjectId → a new folder,
+    a new url, and a new inserted Site doc (two docs, two urls)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+
+    served_ids: list[str] = []
+
+    def _recording_deploy(site_id: str, project_dir: str) -> str:
+        served_ids.append(site_id)
+        return _fake_local_deploy(site_id, project_dir)
+
+    first = await _publish_local("pk_stable", name="Bright Smile", deploy=_recording_deploy)
+    second = await _publish_local("pk_stable", name="Bright Smile", deploy=_recording_deploy)
+
+    # SAME stable deploy id both times (not a fresh ObjectId per call) ⇒ same folder.
+    assert len(served_ids) == 2
+    assert served_ids[0] == served_ids[1], (
+        "consecutive publishes for one pocket must deploy at the SAME stable id"
+    )
+    # SAME url both times — the live link does not move on re-publish.
+    assert first.url == second.url
+    assert first.url, "the published url must be non-empty"
+
+    # Exactly ONE Site doc for (workspace, pocket_id) — re-publish UPSERTED in place
+    # instead of inserting a second doc.
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_stable"}).to_list()
+    assert len(docs) == 1, f"expected ONE Site doc per pocket, found {len(docs)}"
+    # The upsert reused the SAME doc id (it updated, did not replace with a new _id).
+    assert str(first.id) == str(second.id)
+
+
+async def test_pocket_status_returns_canonical_non_null_url(beanie_test_db, monkeypatch):
+    """``pocket_status`` returns the canonical Site doc's NON-NULL url + is_live —
+    the stale-live-link bug is gone: after two publishes there is one doc whose url
+    is the live, openable address."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+
+    await _publish_local("pk_status", name="x", deploy=_fake_local_deploy)
+    second = await _publish_local("pk_status", name="x", deploy=_fake_local_deploy)
+
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_status")
+    assert res.is_live is True
+    assert res.status == "published"
+    # The canonical url is returned and is the live (non-null) address — the same
+    # one the latest publish deployed at.
+    assert res.url == second.url
+    assert res.url, "pocket_status must return a non-null live url"
+    assert res.site_id == str(second.id)
+
+
+async def test_pocket_status_picks_live_doc_over_stale_dupe(beanie_test_db, monkeypatch):
+    """Robustness against pre-existing dupes (PERF-1 does NOT migrate them — that's
+    PERF-2): if an OLD stale doc (url="" / deployed) already exists for a pocket,
+    ``pocket_status`` must return the canonical doc with a real url, not the stale
+    one an arbitrary find_one might surface."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+
+    # An old, stale dupe with NO url (the shape the bug left behind).
+    stale = _SiteDoc(
+        workspace="ws1",
+        pocket_id="pk_dupe",
+        owner="u1",
+        name="Stale",
+        script_name="stale",
+        deployed=True,
+        url="",
+    )
+    await stale.insert()
+
+    # A real publish lands the canonical doc with a live url.
+    live = await _publish_local("pk_dupe", name="Live", deploy=_fake_local_deploy)
+
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_dupe")
+    assert res.is_live is True
+    assert res.url == live.url
+    assert res.url, "pocket_status must surface the doc that has a real url, not the stale one"
+
+
+class _RecordingCF:
+    """A Cloudflare client that records the script_name each put_worker targets, so
+    a test can prove a re-publish OVERWRITES the SAME worker (stable script_name per
+    pocket) instead of orphaning a new one."""
+
+    def __init__(self):
+        self.put_calls: list[str] = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+async def test_cf_republish_uses_stable_script_name_and_one_doc(beanie_test_db):
+    """PROD consistency: on the real Cloudflare path, two publishes of the same
+    pocket target the SAME worker script_name (overwrite in place, no orphan) and
+    leave exactly ONE Site doc."""
+    from unittest.mock import AsyncMock, patch
+
+    cf = _RecordingCF()
+    wire = {"name": "x", "engine": "ripple", "rippleSpec": {"type": "container"}}
+
+    async def _publish_cf():
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=wire),
+        ):
+            return await sites_service.publish_pocket(
+                workspace_id="ws1",
+                user_id="u1",
+                pocket_id="pk_cf",
+                _generator=_FakeGenerator(),
+                _cloudflare=cf,  # injected CF → the REAL deploy branch
+                _bundle_reader=lambda d: b"export default {}",
+            )
+
+    first = await _publish_cf()
+    second = await _publish_cf()
+
+    # Same worker script_name both times — the worker is overwritten, not orphaned.
+    assert cf.put_calls == [first.script_name, first.script_name]
+    assert first.script_name == second.script_name
+    # script_name is still the str form of the (now stable) doc id.
+    assert first.script_name == str(first.id)
+    # Exactly ONE Site doc — the second publish upserted the first.
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_cf"}).to_list()
+    assert len(docs) == 1
+    assert str(first.id) == str(second.id)


### PR DESCRIPTION
PERF-1 of the sites edit-perf work. Re-publishing a pocket now overwrites ONE Site doc / folder / URL / worker instead of minting a new one each time.

## What ships
- A live publish derives a STABLE per-pocket id (`_live_object_id` = deterministic ObjectId from the workspace+pocket), mirroring the stable preview id shipped today. The deploy folder/URL, the Cloudflare `script_name`, and the Site doc `_id` all key off it.
- `publish()` UPSERTS one Site doc per `(workspace, pocket_id)` (update-in-place, preserving domains/origins/keys) instead of inserting a new one.
- `pocket_status` reads the single canonical doc and returns its non-null, latest URL — fixing the stale-link bug (it previously `find_one`'d across duplicates and could return a stale doc with `url=None`).
- Cloudflare: a stable `script_name` per pocket → publishes overwrite the worker, never orphan it.

## Why
Each publish used to mint a new id → a new folder/URL/Site-doc every time (one pocket had 14). That caused gallery duplication and "the site link shows the old site."

## Tests
Reproduce-first (two publishes → same URL + one doc) red→green; canonical-over-stale-dupe; CF stable script_name. 190 in the sites/versions/gate suites, all green. ruff clean.

## Note
Existing duplicate docs aren't migrated here — that's PERF-2 (this just makes new publishes stable; `_canonical_site_doc` resolves the live one among any legacy dupes meanwhile).