### PR TITLE
feat(sites): non-destructive dedupe migration for duplicate Site docs

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -30,6 +30,16 @@
 # fresh one each time. No schema change: the upsert keys on the primary ``_id``
 # (already unique), so the existing compound (workspace, pocket_id) index — which
 # still serves the per-pocket reads — is sufficient and no new unique key is added.
+#
+# Updated 2026-06-18 (feat/sites-dedupe-migration, PERF-2): added ``archived`` — a
+# non-destructive tombstone flag for the duplicate Site docs the pre-PERF-1 minting
+# left behind. PERF-1 made NEW publishes stable (one upserted doc per pocket), but
+# EXISTING data still carries dupes (one pocket had 14 docs). The PERF-2 dedupe
+# migration (``sites.dedupe``) keeps ONE canonical doc per (workspace, pocket_id)
+# active and sets ``archived=True`` on the rest — it NEVER deletes, so the data is
+# recoverable. The gallery read (``service.list_for_workspace`` / listSites) filters
+# ``archived`` so each pocket shows exactly one card. Defaults False, so every
+# existing doc and every fresh publish reads active until the migration archives it.
 
 from __future__ import annotations
 
@@ -63,6 +73,11 @@ class Site(TimestampedDocument):
     # Canonical deployed URL. LOCAL mode: the localhost URL the per-site static
     # server serves. CF mode: "" in v1 (reached via custom domain).
     url: str = ""
+    # PERF-2: a non-destructive tombstone for duplicate Site docs the pre-PERF-1
+    # per-publish ObjectId minting left behind. The dedupe migration keeps ONE
+    # canonical doc per (workspace, pocket_id) active and sets this True on the
+    # rest (never deletes). The gallery read filters it so each pocket shows once.
+    archived: bool = False
     # SE-2b: the builder origin this site was published with, or "" when it was
     # published as a normal (non-editable) site. When set, the generated page
     # carries the gated edit-bridge keyed on this origin. Persisted so a

--- a/ee/pocketpaw_ee/sites/dedupe.py
+++ b/ee/pocketpaw_ee/sites/dedupe.py
@@ -1,0 +1,279 @@
+# ee/pocketpaw_ee/sites/dedupe.py — PERF-2: non-destructive dedupe migration for
+# duplicate Site docs.
+#
+# Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+#
+# Why this exists: PERF-1 (feat/sites-stable-identity) made NEW publishes stable —
+# ``publish`` now UPSERTS ONE Site doc per (workspace, pocket_id) keyed on a
+# deterministic ``_live_object_id``. But the pre-PERF-1 code minted a fresh
+# ``ObjectId()`` per publish, so EXISTING data carries a pile of duplicate Site docs
+# per pocket (the "AKB" pocket had 14). ``service._canonical_site_doc`` (PERF-1)
+# resolves the live one among dupes at READ time, but the dupes still clutter the
+# gallery list. This migration COLLAPSES each pocket's dupes to ONE canonical doc,
+# non-destructively.
+#
+# Contract:
+#   * NON-DESTRUCTIVE — it sets ``archived=True`` on the non-canonical dupes; it
+#     NEVER deletes, so the data is fully recoverable. ``list_for_workspace`` /
+#     ``site_pocket_ids`` filter ``archived`` so the gallery shows one card per
+#     pocket.
+#   * IDEMPOTENT — re-running is safe: a pocket already collapsed to one ACTIVE doc
+#     has nothing to archive on the second pass (the picker only ever considers the
+#     active docs, so the canonical it already picked stays, and there is nothing
+#     left to archive).
+#   * DRY-RUN by default — ``dedupe_workspace`` / ``dedupe_all`` default to
+#     ``apply=False``: they REPORT what they would archive and write nothing.
+#     ``apply=True`` is the explicit flag that actually flips ``archived``.
+#   * RUNNABLE + UNIT-TESTABLE — the canonical-pick rule is a PURE function
+#     (``pick_canonical``) a test feeds in-memory docs to; the async
+#     ``dedupe_workspace`` / ``dedupe_all`` drive it over the DB. The module is also
+#     runnable as a management command: ``python -m pocketpaw_ee.sites.dedupe``
+#     (dry-run) / ``--apply`` / ``--workspace <id>``.
+#
+# Canonical-pick rule (``pick_canonical``), highest priority first:
+#   1. the PERF-1 stable-id doc (``_live_object_id(workspace, pocket_id)``) — every
+#      post-PERF-1 publish writes here, so it IS the live identity;
+#   2. otherwise the newest (by ``createdAt``) doc that is DEPLOYED and carries a
+#      real ``url`` — the freshest real live build among legacy dupes;
+#   3. otherwise the newest doc that carries a real ``url`` (deployed flag aside);
+#   4. otherwise the newest doc overall (a pre-url-era doc still resolves).
+# This mirrors ``service._canonical_site_doc`` so the migration converges on the
+# SAME doc the read path already treats as live.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.sites.service import _live_object_id
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PocketDedupeResult:
+    """What the dedupe decided for ONE (workspace, pocket_id) group."""
+
+    workspace_id: str
+    pocket_id: str
+    canonical_id: str
+    archived_ids: list[str] = field(default_factory=list)
+
+    @property
+    def docs_archived(self) -> int:
+        return len(self.archived_ids)
+
+
+@dataclass
+class DedupeReport:
+    """Aggregate accounting for a dedupe run (one workspace or all)."""
+
+    applied: bool
+    pockets_scanned: int = 0
+    docs_archived: int = 0
+    groups: list[PocketDedupeResult] = field(default_factory=list)
+
+    def add(self, result: PocketDedupeResult) -> None:
+        self.groups.append(result)
+        self.pockets_scanned += 1
+        self.docs_archived += result.docs_archived
+
+
+def _created_at(doc: _SiteDoc) -> datetime:
+    """The doc's createdAt as a sortable value. ``TimestampedDocument`` always sets
+    it, but guard a None (a hand-built in-memory doc in a test) with the epoch so
+    the sort is total and never raises."""
+    ts = getattr(doc, "createdAt", None)
+    return ts if isinstance(ts, datetime) else datetime.min
+
+
+def pick_canonical(docs: list[_SiteDoc]) -> tuple[_SiteDoc, list[_SiteDoc]]:
+    """Pick the ONE canonical Site doc among a pocket's docs (PURE — no DB).
+
+    ``docs`` are the Site docs for a SINGLE (workspace, pocket_id) — the caller
+    groups them. Returns ``(canonical, [docs_to_archive])`` where the archive list
+    is every other doc. The rule (highest priority first):
+
+      1. the PERF-1 stable-id doc — derived from the group's own
+         ``(workspace, pocket_id)`` via ``_live_object_id``; every post-PERF-1
+         publish writes here, so it is the live identity;
+      2. else the newest deployed doc that carries a real ``url`` (the freshest
+         real live build among legacy dupes);
+      3. else the newest doc that carries a real ``url``;
+      4. else the newest doc overall.
+
+    Mirrors ``service._canonical_site_doc`` so the migration converges on the same
+    doc the read path treats as live. Raises ``ValueError`` on an empty list (the
+    caller never groups an empty set)."""
+    if not docs:
+        raise ValueError("pick_canonical requires at least one doc")
+
+    # Derive the stable id from the group itself (all docs share workspace +
+    # pocket_id). Rule 1: the stable-id doc wins outright when present.
+    stable_id = _live_object_id(docs[0].workspace, docs[0].pocket_id)
+    stable = next((d for d in docs if d.id == stable_id), None)
+    if stable is not None:
+        canonical = stable
+    else:
+        newest_first = sorted(docs, key=_created_at, reverse=True)
+        # Rule 2: newest deployed doc with a real url.
+        canonical = next(
+            (d for d in newest_first if d.deployed and d.url),
+            # Rule 3: newest doc with a real url (deployed flag aside).
+            next(
+                (d for d in newest_first if d.url),
+                # Rule 4: newest doc overall.
+                newest_first[0],
+            ),
+        )
+
+    to_archive = [d for d in docs if d.id != canonical.id]
+    return canonical, to_archive
+
+
+def _group_by_pocket(docs: list[_SiteDoc]) -> dict[tuple[str, str], list[_SiteDoc]]:
+    """Group ACTIVE Site docs by (workspace, pocket_id)."""
+    groups: dict[tuple[str, str], list[_SiteDoc]] = defaultdict(list)
+    for doc in docs:
+        groups[(doc.workspace, doc.pocket_id)].append(doc)
+    return groups
+
+
+async def _dedupe(query: dict, *, apply: bool) -> DedupeReport:
+    """Core async dedupe over the Site docs matching ``query``.
+
+    Reads only ACTIVE docs (``archived: {"$ne": True}``), groups them per pocket,
+    picks the canonical, and archives the rest. A pocket already collapsed to one
+    active doc archives nothing — so a second run over the same data is a no-op
+    (idempotent). With ``apply=False`` (dry-run) it computes the FULL report but
+    writes nothing.
+    """
+    report = DedupeReport(applied=apply)
+
+    # Only consider ACTIVE docs. A doc already archived by a prior run is invisible
+    # here, so the second pass sees one active doc per already-deduped pocket and
+    # archives nothing (idempotent). ``$ne: True`` so docs predating the field
+    # (no ``archived`` key) still read active.
+    active_query = {**query, "archived": {"$ne": True}}
+    docs = await _SiteDoc.find(active_query).to_list()
+
+    for (workspace_id, pocket_id), group in _group_by_pocket(docs).items():
+        canonical, to_archive = pick_canonical(group)
+        if not to_archive:
+            # One active doc already — nothing to do (the idempotent steady state).
+            continue
+        result = PocketDedupeResult(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            canonical_id=str(canonical.id),
+            archived_ids=[str(d.id) for d in to_archive],
+        )
+        report.add(result)
+        if apply:
+            for doc in to_archive:
+                doc.archived = True
+                # save(): a tombstone flip, not a domain mutation — no event fired.
+                await doc.save()
+
+    return report
+
+
+async def dedupe_workspace(workspace_id: str, *, apply: bool = False) -> DedupeReport:
+    """Dedupe the Site docs of ONE workspace, non-destructively.
+
+    For each (workspace, pocket_id) with multiple ACTIVE docs, keeps the canonical
+    (``pick_canonical``) active and sets ``archived=True`` on the rest. DRY-RUN by
+    default (``apply=False`` reports what it WOULD archive, writes nothing);
+    ``apply=True`` actually archives. Idempotent — re-running archives nothing new.
+    """
+    return await _dedupe({"workspace": workspace_id}, apply=apply)
+
+
+async def dedupe_all(*, apply: bool = False) -> DedupeReport:
+    """Dedupe EVERY workspace's Site docs in one sweep (the boot / CLI unscoped
+    path). Same non-destructive, idempotent, dry-run-by-default contract as
+    ``dedupe_workspace`` — it just does not tenant-filter the read, so every
+    (workspace, pocket_id) group is reconciled. The per-pocket grouping keys on
+    BOTH fields, so pockets never bleed across workspaces."""
+    return await _dedupe({}, apply=apply)
+
+
+# ---------------------------------------------------------------------------
+# Runnable management command.
+#   python -m pocketpaw_ee.sites.dedupe                  # dry-run, all workspaces
+#   python -m pocketpaw_ee.sites.dedupe --apply          # apply, all workspaces
+#   python -m pocketpaw_ee.sites.dedupe --workspace ws1  # dry-run, one workspace
+#   python -m pocketpaw_ee.sites.dedupe --workspace ws1 --apply
+# Dry-run is the DEFAULT — ``--apply`` is the explicit flag that writes.
+# ---------------------------------------------------------------------------
+
+
+def _format_report(report: DedupeReport, *, workspace_id: str | None) -> str:
+    scope = f"workspace {workspace_id}" if workspace_id else "ALL workspaces"
+    mode = "APPLIED" if report.applied else "DRY-RUN (no writes)"
+    lines = [
+        f"Site dedupe — {scope} — {mode}",
+        f"  pockets with dupes : {report.pockets_scanned}",
+        f"  docs archived      : {report.docs_archived}",
+    ]
+    for g in report.groups:
+        lines.append(
+            f"  - {g.workspace_id}/{g.pocket_id}: keep {g.canonical_id}, "
+            f"archive {g.docs_archived} ({', '.join(g.archived_ids)})"
+        )
+    if not report.applied and report.docs_archived:
+        lines.append("  (dry-run — re-run with --apply to archive the above)")
+    return "\n".join(lines)
+
+
+async def _run_cli(workspace_id: str | None, apply: bool) -> DedupeReport:
+    """Init the EE cloud DB connection, run the dedupe, print the report."""
+    # Lazy import: the DB bootstrap is only needed for the runnable path, not for
+    # the unit-tested pure / async functions (tests init Beanie via the fixture).
+    # ``init_cloud_db`` reads PAW_MONGO_URI when set, else the local default — the
+    # same Beanie init the cloud app boots with, so the migration sees the real
+    # ``sites`` collection.
+    import os
+
+    from pocketpaw_ee.cloud.db import init_cloud_db
+
+    mongo_uri = os.environ.get("PAW_MONGO_URI", "mongodb://localhost:27017/paw-enterprise")
+    await init_cloud_db(mongo_uri)
+    if workspace_id:
+        report = await dedupe_workspace(workspace_id, apply=apply)
+    else:
+        report = await dedupe_all(apply=apply)
+    print(_format_report(report, workspace_id=workspace_id))
+    return report
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m pocketpaw_ee.sites.dedupe",
+        description=(
+            "Non-destructively collapse each pocket's duplicate Site docs to one "
+            "canonical (PERF-2). DRY-RUN by default; pass --apply to write."
+        ),
+    )
+    parser.add_argument(
+        "--workspace",
+        dest="workspace_id",
+        default=None,
+        help="Limit to ONE workspace id. Omit to sweep all workspaces.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually archive the dupes. Without it the run is a dry-run.",
+    )
+    args = parser.parse_args(argv)
+    asyncio.run(_run_cli(args.workspace_id, args.apply))
+
+
+if __name__ == "__main__":
+    main()

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1347,7 +1347,20 @@ async def request_publish_pocket(
 
 
 async def list_for_workspace(workspace_id: str) -> list[SiteResponse]:
-    cursor = _SiteDoc.find({"workspace": workspace_id}).sort(-_SiteDoc.createdAt)  # type: ignore[operator]
+    """The gallery / listSites read: the workspace's Site cards, newest first.
+
+    PERF-2: filters out ARCHIVED docs so each pocket shows exactly one card. The
+    pre-PERF-1 minting left a pile of duplicate Site docs per pocket (one pocket
+    had 14), all of which this read listed → the gallery duplicated. The dedupe
+    migration (``sites.dedupe``) keeps ONE canonical doc per pocket active and
+    tombstones the rest with ``archived=True``; excluding them here collapses the
+    gallery to one card per pocket. ``archived: {"$ne": True}`` (not ``False``)
+    so docs predating the field — which have no ``archived`` key in Mongo — still
+    count as active.
+    """
+    cursor = _SiteDoc.find({"workspace": workspace_id, "archived": {"$ne": True}}).sort(
+        -_SiteDoc.createdAt
+    )  # type: ignore[operator]
     return [_to_response(doc) async for doc in cursor]
 
 
@@ -1359,8 +1372,13 @@ async def site_pocket_ids(workspace_id: str) -> set[str]:
     (they show under /sites instead) WITHOUT the pockets service importing the
     Site Beanie model — the Site read stays in this service, which is the sole
     owner of Site reads (entity isolation). Tenant-scoped on ``workspace``.
+
+    PERF-2: excludes ARCHIVED dupes (``archived: {"$ne": True}``) so the set is
+    keyed on pockets that still have an ACTIVE Site — a fully-archived pocket
+    would be wrong to hide from the /pockets gallery. Pre-field docs (no
+    ``archived`` key) still count as active.
     """
-    cursor = _SiteDoc.find({"workspace": workspace_id})
+    cursor = _SiteDoc.find({"workspace": workspace_id, "archived": {"$ne": True}})
     return {doc.pocket_id async for doc in cursor}
 
 

--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -1,0 +1,46 @@
+# tests/ee/sites/conftest.py
+# Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+#
+# PERF-2's ``test_dedupe.py`` has PURE picker tests (``pick_canonical``) that build
+# in-memory ``Site`` docs WITHOUT the function-scoped ``beanie_test_db`` DB fixture
+# — the picker never touches the DB. But Beanie's ``Document.__init__`` resolves the
+# document's collection settings, which raises ``CollectionWasNotInitialized`` until
+# ``init_beanie`` has run at least once in the process. The async tests in the same
+# file DO take ``beanie_test_db``, but it is function-scoped (its mongomock client
+# goes out of scope on teardown), so a pure test that runs in isolation — or after
+# that teardown — has no initialised settings and cannot even CONSTRUCT a ``Site``.
+#
+# This session-scoped autouse fixture runs ``init_beanie`` ONCE against a throwaway
+# mongomock database so model CONSTRUCTION works everywhere in ``tests/ee/sites/``.
+# It does NOT replace ``beanie_test_db``: the per-test fixture still re-inits against
+# its own fresh DB for the async tests' DB isolation (Beanie re-init just repoints
+# the settings at the new client). This fixture only guarantees the settings exist
+# so a fixtureless pure test can build a doc.
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def _sites_beanie_settings() -> Any:
+    """Initialise Beanie once for the sites test module so in-memory ``Site``
+    construction works in the pure (fixtureless) picker tests."""
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+    from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
+    from pocketpaw_ee.cloud.models import ALL_DOCUMENTS
+
+    client = AsyncMongoMockClient()
+    db = client["test_ee_sites_settings"]
+
+    original = db.list_collection_names
+
+    async def _safe_list_collection_names(*_args: Any, **_kwargs: Any) -> list[str]:
+        return await original()
+
+    db.list_collection_names = _safe_list_collection_names  # type: ignore[method-assign]
+
+    await init_beanie(database=db, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
+    yield

--- a/tests/ee/sites/test_dedupe.py
+++ b/tests/ee/sites/test_dedupe.py
@@ -1,0 +1,247 @@
+# tests/ee/sites/test_dedupe.py — PERF-2 regression + unit guard: a
+# non-destructive migration collapses each pocket's duplicate Site docs down to
+# ONE active (non-archived) canonical, archiving the rest, and ``listSites``
+# (``list_for_workspace``) then returns one card per pocket.
+#
+# Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+#
+# The state PERF-2 fixes: PERF-1 made NEW publishes stable (one upserted Site doc
+# per pocket), but EXISTING data still carries the dupes the old per-publish
+# ObjectId minting left behind — e.g. the "AKB" pocket had 14 Site docs. The
+# gallery (``list_for_workspace``) listed every one, so a single pocket showed up
+# as many cards. This file pins PERF-2's contract:
+#   * the PURE picker ``pick_canonical`` chooses the right canonical (stable-id >
+#     deployed-with-url > newest) and returns the set to archive — no DB needed;
+#   * the async ``dedupe_workspace`` archives the non-canonical dupes
+#     non-destructively (sets ``archived=True``, never deletes), is IDEMPOTENT
+#     (a second run archives nothing new), and a DRY-RUN writes nothing;
+#   * ``list_for_workspace`` excludes archived docs ⇒ exactly one doc per pocket.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from bson import ObjectId
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.sites import dedupe as dedupe_mod
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.service import _live_object_id
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Pure picker — no DB. ``pick_canonical`` takes the Site docs for ONE pocket and
+# returns (canonical_doc, [docs_to_archive]). These exercise the rule directly.
+# ---------------------------------------------------------------------------
+
+
+def _doc(
+    *,
+    workspace: str = "ws1",
+    pocket_id: str = "pk",
+    oid: ObjectId | None = None,
+    deployed: bool = True,
+    url: str = "",
+    created: datetime | None = None,
+) -> _SiteDoc:
+    """Build an in-memory Site doc (never inserted) for the pure picker tests."""
+    doc = _SiteDoc(
+        id=oid or ObjectId(),
+        workspace=workspace,
+        pocket_id=pocket_id,
+        owner="u1",
+        name="x",
+        script_name="x",
+        deployed=deployed,
+        url=url,
+    )
+    if created is not None:
+        doc.createdAt = created
+    return doc
+
+
+def test_pick_canonical_prefers_stable_id_doc():
+    """Rule 1: the PERF-1 stable-id doc wins outright — it is the live identity
+    every post-PERF-1 publish writes to, even if an older dupe is 'newer' by some
+    other field."""
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    stable_oid = _live_object_id("ws1", "pk")
+    stable = _doc(oid=stable_oid, deployed=True, url="http://x/stable/", created=base)
+    # A newer dupe with a url — but NOT the stable id.
+    newer = _doc(deployed=True, url="http://x/newer/", created=base + timedelta(days=5))
+
+    canonical, to_archive = dedupe_mod.pick_canonical([newer, stable])
+
+    assert canonical.id == stable_oid
+    assert [d.id for d in to_archive] == [newer.id]
+
+
+def test_pick_canonical_prefers_deployed_with_url_then_newest():
+    """Rule 2/3/4 (no stable-id doc present): among legacy dupes, prefer a
+    deployed doc that carries a real url, breaking ties by newest createdAt."""
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    # Oldest: deployed but no url (the stale shape the bug left behind).
+    stale = _doc(deployed=True, url="", created=base)
+    # Middle: deployed WITH a url — the freshest real live build among these two.
+    live_old = _doc(deployed=True, url="http://x/old/", created=base + timedelta(days=1))
+    # Newest: deployed WITH a url — should win the tie-break.
+    live_new = _doc(deployed=True, url="http://x/new/", created=base + timedelta(days=2))
+
+    canonical, to_archive = dedupe_mod.pick_canonical([stale, live_old, live_new])
+
+    assert canonical.id == live_new.id
+    assert {d.id for d in to_archive} == {stale.id, live_old.id}
+
+
+def test_pick_canonical_single_doc_archives_nothing():
+    """A pocket with ONE doc has nothing to archive (the idempotent steady state)."""
+    only = _doc(deployed=True, url="http://x/only/")
+    canonical, to_archive = dedupe_mod.pick_canonical([only])
+    assert canonical.id == only.id
+    assert to_archive == []
+
+
+# ---------------------------------------------------------------------------
+# Async migration over a real (mongomock) DB.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_dupes(workspace: str, pocket_id: str, n: int) -> list[_SiteDoc]:
+    """Insert ``n`` Site docs for one pocket with ascending createdAt and real
+    urls — the AKB-style dupe pile the old per-publish minting produced."""
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    docs: list[_SiteDoc] = []
+    for i in range(n):
+        d = _SiteDoc(
+            workspace=workspace,
+            pocket_id=pocket_id,
+            owner="u1",
+            name=f"AKB {i}",
+            script_name=f"s{i}",
+            deployed=True,
+            url=f"http://127.0.0.1:9999/legacy-{i}/",
+        )
+        d.createdAt = base + timedelta(minutes=i)
+        await d.insert()
+        docs.append(d)
+    return docs
+
+
+async def test_dedupe_apply_archives_all_but_one(beanie_test_db):
+    """The core migration: a pocket with 14 dupes ends with exactly ONE active
+    (non-archived) doc; the other 13 are archived (NOT deleted)."""
+    await _seed_dupes("ws1", "akb", 14)
+
+    report = await dedupe_mod.dedupe_workspace("ws1", apply=True)
+
+    # Report accounting: one group, 13 archived, 1 kept active.
+    assert report.pockets_scanned == 1
+    assert report.docs_archived == 13
+    assert report.applied is True
+
+    all_docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "akb"}).to_list()
+    assert len(all_docs) == 14, "non-destructive: every doc still exists"
+    active = [d for d in all_docs if not getattr(d, "archived", False)]
+    archived = [d for d in all_docs if getattr(d, "archived", False)]
+    assert len(active) == 1, "exactly one active doc per pocket after dedupe"
+    assert len(archived) == 13
+
+
+async def test_dedupe_dry_run_writes_nothing(beanie_test_db):
+    """DRY-RUN (the default): report what WOULD be archived, but write nothing."""
+    await _seed_dupes("ws1", "akb", 5)
+
+    report = await dedupe_mod.dedupe_workspace("ws1", apply=False)
+
+    assert report.applied is False
+    assert report.docs_archived == 4  # what it WOULD archive
+
+    all_docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "akb"}).to_list()
+    assert all(not getattr(d, "archived", False) for d in all_docs), (
+        "dry-run must not flip archived on any doc"
+    )
+
+
+async def test_dedupe_is_idempotent(beanie_test_db):
+    """Running the migration twice is safe: the second run finds one active doc
+    already and archives nothing new."""
+    await _seed_dupes("ws1", "akb", 6)
+
+    first = await dedupe_mod.dedupe_workspace("ws1", apply=True)
+    assert first.docs_archived == 5
+
+    second = await dedupe_mod.dedupe_workspace("ws1", apply=True)
+    assert second.docs_archived == 0, "second run must archive nothing new"
+
+    active = [
+        d
+        for d in await _SiteDoc.find({"workspace": "ws1", "pocket_id": "akb"}).to_list()
+        if not getattr(d, "archived", False)
+    ]
+    assert len(active) == 1
+
+
+async def test_list_for_workspace_excludes_archived(beanie_test_db):
+    """``list_for_workspace`` (the gallery / listSites read) returns ONE card per
+    pocket after the dedupe — archived dupes are filtered out."""
+    await _seed_dupes("ws1", "akb", 8)
+    # A second pocket with its own single doc — both pockets should show once.
+    other = _SiteDoc(
+        workspace="ws1",
+        pocket_id="other",
+        owner="u1",
+        name="Other",
+        script_name="o",
+        deployed=True,
+        url="http://x/other/",
+    )
+    await other.insert()
+
+    # Before dedupe: the gallery shows all 8 AKB dupes + 1 other = 9 cards.
+    before = await sites_service.list_for_workspace("ws1")
+    assert len(before) == 9
+
+    await dedupe_mod.dedupe_workspace("ws1", apply=True)
+
+    after = await sites_service.list_for_workspace("ws1")
+    pocket_ids = sorted(r.pocket_id for r in after)
+    assert pocket_ids == ["akb", "other"], "one card per pocket after dedupe"
+
+
+async def test_dedupe_multiple_pockets_independent(beanie_test_db):
+    """Each (workspace, pocket_id) group is deduped independently — pockets don't
+    bleed into each other's canonical pick."""
+    await _seed_dupes("ws1", "akb", 4)
+    await _seed_dupes("ws1", "second", 3)
+
+    report = await dedupe_mod.dedupe_workspace("ws1", apply=True)
+
+    assert report.pockets_scanned == 2
+    assert report.docs_archived == 3 + 2  # (4-1) + (3-1)
+    for pid in ("akb", "second"):
+        active = [
+            d
+            for d in await _SiteDoc.find({"workspace": "ws1", "pocket_id": pid}).to_list()
+            if not getattr(d, "archived", False)
+        ]
+        assert len(active) == 1
+
+
+async def test_dedupe_all_workspaces(beanie_test_db):
+    """``dedupe_all`` (the boot/CLI unscoped path) reconciles every workspace's
+    pockets in one sweep."""
+    await _seed_dupes("wsA", "p1", 3)
+    await _seed_dupes("wsB", "p2", 4)
+
+    report = await dedupe_mod.dedupe_all(apply=True)
+
+    assert report.docs_archived == 2 + 3
+    for ws, pid in (("wsA", "p1"), ("wsB", "p2")):
+        active = [
+            d
+            for d in await _SiteDoc.find({"workspace": ws, "pocket_id": pid}).to_list()
+            if not getattr(d, "archived", False)
+        ]
+        assert len(active) == 1


### PR DESCRIPTION
PERF-2, stacked on #1497. Collapses each pocket's duplicate Site docs (e.g. AKB's 14) to one canonical, non-destructively, so the gallery shows one card per site.

## What ships
- `sites.dedupe` — `pick_canonical` / `dedupe_workspace` / `dedupe_all` + a `python -m pocketpaw_ee.sites.dedupe [--workspace <id>] [--apply]` CLI.
- Canonical pick (mirrors PERF-1): the stable-id doc wins; else newest deployed with a real url; else newest with a url; else newest. The rest get `archived=True` — **never deleted** (fully recoverable).
- `list_for_workspace` / `site_pocket_ids` filter `archived` (`$ne True` so pre-field docs still read active) → one card per pocket.
- **Dry-run by default** (reports what it would archive, writes nothing); `--apply` flips it. Idempotent.

## Tests
9 dedupe tests (canonical-pick, archive set, idempotent, dry-run writes nothing, list excludes archived) + 151 sites suite, green. ruff clean.

## Stacking
Base is PERF-1 (#1497). Merge #1497 first, then this.