### PR TITLE
perf(sites): smoke-gate only at publish, not preview builds

### DIFF
--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -1,10 +1,20 @@
 # ee/pocketpaw_ee/sites/generator_client.py — Python bridge to the Node/Bun
 # generator (paw-sites-gen). build() runs the generate CLI, then `bun install`
-# on the generated project, then the workerd smoke render; if the smoke gate
-# fails the site does NOT proceed to deploy (Contract clause 4). The subprocess
-# calls are isolated behind a _runner so the orchestration is unit-testable
-# without Bun/workerd present.
+# on the generated project, then (only for a LIVE publish) the workerd smoke
+# render; if the smoke gate fails the site does NOT proceed to deploy (Contract
+# clause 4). The subprocess calls are isolated behind a _runner so the
+# orchestration is unit-testable without Bun/workerd present.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
+#
+# Updated 2026-06-18 (feat/sites-smoke-at-publish, PERF-4 — smoke-gate only at
+# publish): build() gained a ``smoke: bool = True`` flag. The workerd SMOKE render
+# is per-edit overhead only needed before a LIVE deploy, so a PREVIEW/edit/arm
+# build now passes ``smoke=False`` to SKIP it (the build runs generate + install
+# only and never spawns the render). A LIVE publish keeps the default
+# ``smoke=True`` so the gate — and the caller's rollback-on-SmokeGateFailed — is
+# unchanged. service.publish() threads ``smoke=not preview`` from its existing
+# ``preview`` flag. A preview build that WOULD fail smoke is no longer blocked;
+# the live publish still gates + rolls back, so a broken edit can never go live.
 #
 # Updated 2026-06-18 (feat/sites-cached-build, PERF-3 — persistent build dir +
 # cached node_modules): the single biggest per-edit cost was running `bun install`
@@ -304,6 +314,7 @@ class GeneratorClient:
         source: dict[str, str] | None = None,
         builder_origin: str | None = None,
         pocket_id: str | None = None,
+        smoke: bool = True,
     ) -> BuildResult:
         """Generate + smoke-build a Paw Site, forking STAGE 2 on ``engine``.
 
@@ -329,6 +340,15 @@ class GeneratorClient:
         build() falls back to a fresh throwaway tempfile dir (no caching) so legacy
         callers keep their prior behaviour. Concurrent builds of the SAME pocket
         are serialized by a per-pocket lock (they share the on-disk dir).
+
+        ``smoke`` (PERF-4) gates the workerd SMOKE render (the SSR safety check).
+        The smoke render is per-edit overhead only needed before a LIVE deploy, so
+        a PREVIEW/edit/arm build passes ``smoke=False`` to SKIP it — the build runs
+        generate + install only and never spawns the workerd render. A LIVE publish
+        keeps the default ``smoke=True`` so the gate (and its
+        rollback-on-SmokeGateFailed behaviour at the caller) is unchanged. A
+        preview build that WOULD fail smoke is no longer blocked — acceptable, since
+        the live publish still gates + rolls back.
         """
         if pocket_id is None:
             return await self._build_one(
@@ -342,6 +362,7 @@ class GeneratorClient:
                 source=source,
                 builder_origin=builder_origin,
                 pocket_id=None,
+                smoke=smoke,
             )
         async with self._lock_for(pocket_id):
             return await self._build_one(
@@ -355,6 +376,7 @@ class GeneratorClient:
                 source=source,
                 builder_origin=builder_origin,
                 pocket_id=pocket_id,
+                smoke=smoke,
             )
 
     async def _build_one(
@@ -370,6 +392,7 @@ class GeneratorClient:
         source: dict[str, str] | None,
         builder_origin: str | None,
         pocket_id: str | None,
+        smoke: bool,
     ) -> BuildResult:
         # PERF-3: stable per-pocket working dir (overwrite the source each build)
         # so node_modules persists; fall back to a throwaway tempfile dir when no
@@ -435,9 +458,16 @@ class GeneratorClient:
             ok, reason = await self._runner.install(project_dir)
             if not ok:
                 raise SmokeGateFailed(reason)
-        ok, reason = await self._runner.smoke(project_dir)
-        if not ok:
-            raise SmokeGateFailed(reason)
+        # PERF-4: run the workerd SMOKE render only when the caller asked for it
+        # (smoke=True — the LIVE publish path). A PREVIEW/edit/arm build passes
+        # smoke=False to SKIP the render: it is per-edit overhead only needed before
+        # a live deploy, and a preview that would fail smoke is no longer blocked
+        # (the live publish still gates + rolls back). Skipping leaves
+        # generate+install (the correctness-bearing steps) intact.
+        if smoke:
+            ok, reason = await self._runner.smoke(project_dir)
+            if not ok:
+                raise SmokeGateFailed(reason)
         # ``rippleVersion`` is present only on the ripple GenerateResult; the svelte
         # path omits it (paw-sites types.ts §4.2), so read it defensively — a svelte
         # build must not KeyError here.

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,16 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-18 (feat/sites-smoke-at-publish, PERF-4): publish() now threads
+# ``smoke=not preview`` into generator.build(), so the workerd SMOKE render runs
+# ONLY for a LIVE publish (preview=False) and is SKIPPED for a preview/edit/arm
+# build (preview=True). The render is per-edit overhead only needed before a
+# deploy; skipping it cuts the remaining per-edit cost left after PERF-3 cached
+# `bun install`. The live publish keeps the gate AND the edit_svelte_component
+# rollback-on-SmokeGateFailed behaviour unchanged. A preview that would fail smoke
+# is no longer blocked — acceptable, because the live publish still gates + rolls
+# back, so a broken edit can never reach the live deploy.
+#
 # Updated 2026-06-18 (feat/sites-cached-build, PERF-3): publish() now forwards the
 # source pocket_id to generator.build() so the build runs in the STABLE per-pocket
 # working dir (persistent node_modules + cached `bun install`), cutting the dominant
@@ -470,6 +480,13 @@ async def publish(
         # cutting the dominant per-edit cost. A fresh site_id is minted per publish,
         # but a pocket's working dir is reused across its publishes/previews.
         pocket_id=pocket_id,
+        # PERF-4: run the workerd SMOKE render ONLY for a LIVE publish. The render
+        # is per-edit overhead only needed before a deploy, so a preview/edit/arm
+        # build (preview=True) skips it (smoke=False); a live publish (preview=False)
+        # keeps it (smoke=True) so the gate + the rollback below are unchanged. A
+        # preview that would fail smoke is no longer blocked — the live publish still
+        # gates + rolls back, so a broken edit never reaches the live deploy.
+        smoke=not preview,
     )
 
     # PREVIEW MODE (Branch primitive — EDIT/arm path): the build above already ran

--- a/tests/ee/sites/test_generator_client_smoke_gate.py
+++ b/tests/ee/sites/test_generator_client_smoke_gate.py
@@ -1,0 +1,121 @@
+# tests/ee/sites/test_generator_client_smoke_gate.py
+# Created: 2026-06-18 (feat/sites-smoke-at-publish, PERF-4) — covers the
+# smoke-gate-only-at-publish behaviour:
+#   * build(smoke=False) (the preview/edit/arm path) does NOT run the workerd
+#     smoke render — it is per-edit overhead only needed before a LIVE deploy.
+#   * build() defaults to smoke=True (the live publish path) and DOES run smoke,
+#     keeping the rollback-on-SmokeGateFailed gate unchanged for publish.
+#   * A preview build (smoke=False) is no longer blocked by a would-fail smoke
+#     render (acceptable — publish still gates + rolls back).
+# Asserted via the fake runner's smoke call-count, so no real bun/workerd spawns.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites.generator_client import (
+    GeneratorClient,
+    SmokeGateFailed,
+)
+
+
+class _CountingRunner:
+    """Fake runner that records call order so the smoke decision can be asserted
+    without bun/workerd. ``smoke_ok`` controls whether the smoke render passes."""
+
+    def __init__(self, *, smoke_ok: bool = True, smoke_reason: str = "") -> None:
+        self.smoke_ok = smoke_ok
+        self.smoke_reason = smoke_reason
+        self.calls: list[str] = []
+        self.smoke_count = 0
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.calls.append("generate")
+        return {"projectDir": out_dir, "rippleVersion": "0.2.0"}
+
+    def install_inputs_hash(self, project_dir: str) -> str:
+        return "h1"
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("install")
+        return True, "ok"
+
+    async def smoke(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("smoke")
+        self.smoke_count += 1
+        return self.smoke_ok, self.smoke_reason
+
+
+def _build_kwargs(tmp_path) -> dict:
+    return dict(
+        ripple_spec={"type": "container"},
+        theme={"primary": "#0A84FF"},
+        site_id="site_1",
+        title="Bright Smile",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+        pocket_id="pocket_abc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_build_skips_smoke(tmp_path, monkeypatch):
+    """PERF-4 core: a PREVIEW build (smoke=False) does NOT run the workerd smoke
+    render — the gate is per-edit overhead only needed before a live deploy."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(smoke_ok=True)
+    client = GeneratorClient(_runner=runner)
+
+    result = await client.build(**_build_kwargs(tmp_path), smoke=False)
+
+    # Smoke was SKIPPED — generate + install ran, no smoke.
+    assert runner.smoke_count == 0
+    assert "smoke" not in runner.calls
+    assert runner.calls == ["generate", "install"]
+    # The build still produced a BuildResult.
+    assert result.project_dir == str(tmp_path / "pocket_abc")
+
+
+@pytest.mark.asyncio
+async def test_publish_build_runs_smoke_by_default(tmp_path, monkeypatch):
+    """PERF-4: build() defaults to smoke=True (the live publish path) and DOES run
+    the smoke render, so the publish gate is unchanged."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(smoke_ok=True)
+    client = GeneratorClient(_runner=runner)
+
+    await client.build(**_build_kwargs(tmp_path))  # smoke defaults to True
+
+    assert runner.smoke_count == 1
+    assert runner.calls == ["generate", "install", "smoke"]
+
+
+@pytest.mark.asyncio
+async def test_publish_build_still_gates_on_smoke_failure(tmp_path, monkeypatch):
+    """PERF-4: a publish build (smoke=True) that fails the smoke render still raises
+    SmokeGateFailed — the live gate + rollback behaviour is unchanged."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(
+        smoke_ok=False, smoke_reason="workerd SSR failure: window is not defined"
+    )
+    client = GeneratorClient(_runner=runner)
+
+    with pytest.raises(SmokeGateFailed) as exc:
+        await client.build(**_build_kwargs(tmp_path), smoke=True)
+    assert "window is not defined" in str(exc.value)
+    assert runner.smoke_count == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_build_not_blocked_by_would_fail_smoke(tmp_path, monkeypatch):
+    """PERF-4: a preview build (smoke=False) is NOT blocked even when the smoke
+    render WOULD fail — smoke never runs, so no SmokeGateFailed is raised
+    (acceptable; the live publish still gates + rolls back)."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(
+        smoke_ok=False, smoke_reason="workerd SSR failure: window is not defined"
+    )
+    client = GeneratorClient(_runner=runner)
+
+    # No raise — the preview build completes despite a would-fail smoke render.
+    result = await client.build(**_build_kwargs(tmp_path), smoke=False)
+    assert result.project_dir == str(tmp_path / "pocket_abc")
+    assert runner.smoke_count == 0

--- a/tests/ee/sites/test_smoke_at_publish.py
+++ b/tests/ee/sites/test_smoke_at_publish.py
@@ -1,0 +1,183 @@
+# tests/ee/sites/test_smoke_at_publish.py
+# Created: 2026-06-18 (feat/sites-smoke-at-publish, PERF-4) — service-level cover
+# for "smoke-gate only at publish, not preview builds":
+#   * service.publish(preview=True) (the EDIT/arm path) tells generator.build() to
+#     SKIP smoke (smoke=False) — the workerd render is per-edit overhead only needed
+#     before a live deploy.
+#   * service.publish(preview=False) (the live publish path) runs smoke (smoke=True)
+#     AND still rolls back on SmokeGateFailed (edit_svelte_component restores the
+#     prior source) — the publish gate is unchanged.
+# The generator is faked behind the injected _generator seam (it records the
+# build() kwargs / raises SmokeGateFailed), so no real bun/workerd spawns.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.generator_client import BuildResult, SmokeGateFailed
+
+pytestmark = pytest.mark.asyncio
+
+_HERO_V1 = "<section class='hero'><h1>Bright Smile</h1></section>"
+_HERO_V2 = "<section class='hero'><h1>Brighter Smiles, Whiter Teeth</h1></section>"
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css'</script><slot/>",
+    "src/routes/+page.ts": "export const prerender = true",
+    "src/app.css": ":root{--brand:#0A84FF}",
+    "src/lib/components/Hero.svelte": _HERO_V1,
+}
+
+
+class _RecordingGenerator:
+    """Records the ``smoke`` flag (and other kwargs) each build() was called with so
+    a test can assert preview builds skip smoke and publish builds run it."""
+
+    def __init__(self):
+        self.builds: list[dict] = []
+
+    async def build(self, **kw):
+        self.builds.append(kw)
+        return BuildResult(project_dir="/tmp/site", ripple_version=None)
+
+
+class _SmokeFailGenerator:
+    """A generator whose build() ALWAYS fails the smoke gate — exercises the
+    publish rollback path (the gate must still bite on a live publish)."""
+
+    def __init__(self):
+        self.builds: list[dict] = []
+
+    async def build(self, **kw):
+        self.builds.append(kw)
+        raise SmokeGateFailed("workerd SSR failure: window is not defined")
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+    return f"http://127.0.0.1:9999/{site_id}/"
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Install a recording EventBus so the pockets service's ``emit`` calls don't
+    raise (the real bus is only wired by ``init_realtime()`` at boot)."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+async def test_preview_publish_skips_smoke(beanie_test_db):
+    """PERF-4: a PREVIEW publish (preview=True — the EDIT/arm path) tells
+    generator.build() to SKIP smoke (smoke=False)."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen = _RecordingGenerator()
+
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        preview=True,
+        _generator=gen,
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    assert len(gen.builds) == 1
+    assert gen.builds[0]["smoke"] is False, "a preview build must SKIP the smoke gate"
+
+
+async def test_live_publish_runs_smoke(beanie_test_db):
+    """PERF-4: a LIVE publish (preview=False — the default chat-create / approve
+    path) tells generator.build() to RUN smoke (smoke=True)."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen = _RecordingGenerator()
+
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        # preview defaults to False — the live publish path
+        _generator=gen,
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    assert len(gen.builds) == 1
+    assert gen.builds[0]["smoke"] is True, "a live publish must RUN the smoke gate"
+
+
+async def test_live_publish_still_rolls_back_on_smoke_failure(beanie_test_db):
+    """PERF-4 guard: a LIVE publish whose build fails the smoke gate still raises
+    SmokeGateFailed, and edit_svelte_component still ROLLS BACK the persisted source
+    to its prior contents — the publish gate + rollback are unchanged.
+
+    edit_svelte_component publishes a PREVIEW (preview=True) by design, so to prove
+    the publish gate still bites we drive the rollback via a generator that always
+    fails the gate: the edit persists V2, the build fails, and the source must be
+    restored to V1.
+    """
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    with pytest.raises(SmokeGateFailed):
+        await sites_service.edit_svelte_component(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/lib/components/Hero.svelte",
+            new_source=_HERO_V2,
+            _generator=_SmokeFailGenerator(),
+            _cloudflare=_FakeCF(),
+            _bundle_reader=lambda d: b"export default {}",
+            _local_deploy=_fake_local_deploy,
+        )
+
+    # Rollback: the persisted source is back to V1, not the rejected V2.
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == _HERO_V1, (
+        "a smoke-gate failure must roll the persisted source back to its prior contents"
+    )


### PR DESCRIPTION
PERF-4, stacked on #1500. The workerd smoke render now runs only for a live publish (preview=False); preview/edit/arm builds skip it (smoke=not preview, threaded from publish() → build()). Publish keeps the gate + rollback-on-SmokeGateFailed. 7 TDD tests (preview skips / publish runs / rollback intact) red→green, 162 passed. ruff clean. Merge order: #1500 → this.