### PR TITLE
Stop partial pocket spec updates from wiping instance state

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -115,6 +115,13 @@ Client-sent ``path`` (a row-scoped binding whose stored path holds an unresolved
 ``{item.id}`` template, resolved client-side) still wins — the binding path is
 only the fallback. The server still reads the verb from the binding, so a
 compromised client cannot pick method OR a path the allowlist would reject.
+Updated: 2026-06-19 (feat/typed-ripplespec-phase1) — ``UpdatePocketRequest``
+gains ``reset_state: bool = False``. It is the escape hatch for the clobber-fix:
+by default a partial ``ripple_spec`` body that omits instance-owned regions
+(``state`` / ``selections``) now PRESERVES them (the service does a layer-safe
+merge), so a frontend canvas-only PATCH no longer wipes instance data. A caller
+that genuinely wants to clear instance state sends ``reset_state: true`` to
+restore the old wholesale write. Wire-level ``ripple_spec`` stays ``dict | None``.
 """
 
 from __future__ import annotations
@@ -187,6 +194,20 @@ class UpdatePocketRequest(BaseModel):
     # persisted ``PocketSurfaceProfile`` sub-model (all sub-fields optional,
     # JSON-friendly lists). Wire alias ``surfaceProfile``.
     surface_profile: PocketSurfaceProfile | None = Field(default=None, alias="surfaceProfile")
+    # Escape hatch for the clobber-fix (2026-06-13 bug). By DEFAULT a
+    # ``ripple_spec`` body that omits instance-owned regions (``state`` /
+    # ``selections``) PRESERVES them — the service does a layer-safe merge so a
+    # frontend canvas-only PATCH no longer wipes instance data. A caller that
+    # INTENDS to clear instance state (e.g. "reset this pocket to a clean
+    # slate") must opt in by sending ``reset_state: true``, which restores the
+    # old wholesale write of the incoming spec. Wire-level ``ripple_spec`` stays
+    # ``dict | None`` — this is the only new field on the wire.
+    reset_state: bool = Field(
+        default=False,
+        description="When true, an incoming ripple_spec replaces the pocket "
+        "spec wholesale, clearing instance-owned state/selections it omits. "
+        "Default false preserves existing instance state on a partial update.",
+    )
 
     model_config = {"populate_by_name": True}
 

--- a/ee/pocketpaw_ee/cloud/pockets/reconcile.py
+++ b/ee/pocketpaw_ee/cloud/pockets/reconcile.py
@@ -34,6 +34,18 @@
 # ``PocketUpdated`` bus event — so reconcile rides the same rails as every
 # other pocket mutation and never pokes the Pocket Beanie doc directly
 # (the cloud "Beanie writes only from service.py" import-linter contract).
+#
+# Modified 2026-06-19 (feat/typed-ripplespec-phase1): the template-owned region
+# partition is now DERIVED from ``TemplateLayer.model_fields`` (the typed
+# layer-split model in ``pocketpaw.bundled_templates.schema``) instead of a
+# hand-maintained tuple — single source of truth shared with ``service.update``.
+# ``_build_reconciled_spec`` overlays the template-owned regions via the typed
+# ``RippleSpec.with_template_layer`` merge, which preserves the instance-owned
+# regions (``state`` / ``selections``) structurally rather than by string list.
+# Behaviour is unchanged — the existing reconcile tests stay green; the typed
+# model just makes "reconcile never touches state" a type boundary, not a
+# convention. The reconcile service still exchanges flat dicts at its
+# boundaries (the typed model is used INTERNALLY only).
 """Template Reconcile service — re-apply template-owned regions, preserve
 instance-owned regions.
 
@@ -49,6 +61,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from pocketpaw.bundled_templates.schema import RippleSpec, TemplateLayer
 from pocketpaw_ee.cloud.pockets import service as pockets_service
 from pocketpaw_ee.cloud.pockets.dto import UpdatePocketRequest
 from pocketpaw_ee.cloud.shared.errors import Forbidden, NotFound, ValidationError
@@ -57,10 +70,13 @@ logger = logging.getLogger(__name__)
 
 # The rippleSpec regions the TEMPLATE owns. Reconcile overwrites exactly
 # these keys from the source template and leaves every other key (notably
-# ``state``) exactly as the instance has it. Order is the canonical display
-# order used in the diff. Keep in sync with the design doc's P2.4 partition
-# and RFC 03's template schema.
-_TEMPLATE_OWNED_REGIONS: tuple[str, ...] = ("ui", "actions", "sources", "shape")
+# ``state``) exactly as the instance has it. DERIVED from the typed
+# ``TemplateLayer`` so there is ONE source of truth for the partition shared
+# with ``service.update``'s clobber-fix — a field added to ``TemplateLayer``
+# automatically becomes template-owned here (and a test pins the invariant).
+# ``model_fields`` is insertion-ordered, which is the canonical display order
+# used in the diff: ("ui", "actions", "sources", "shape").
+_TEMPLATE_OWNED_REGIONS: tuple[str, ...] = tuple(TemplateLayer.model_fields)
 
 
 def _resolve_template_owned(
@@ -113,7 +129,26 @@ def _build_reconciled_spec(
     are preserved verbatim. No input is mutated. This is intentionally a
     region-level overwrite, NOT the node-id-keyed ``merge_ripple_spec`` walk
     — reconcile owns whole regions, not individual UI nodes.
+
+    Implemented via the typed ``RippleSpec.with_template_layer`` merge: it
+    overlays exactly the template-owned regions ``template_owned`` provides
+    and preserves every instance-owned + passthrough key on the existing spec.
+    ``template_owned`` carries ONLY keys from ``_TEMPLATE_OWNED_REGIONS`` (built
+    by ``_resolve_template_owned``), so promoting it to a ``TemplateLayer`` is
+    safe even under the layer's ``extra="forbid"``. Falls back to the prior
+    deepcopy-overlay if the existing spec cannot be promoted (corrupt spec),
+    so reconcile never drops the template refresh.
     """
+    spec = RippleSpec.from_flat_dict(existing_spec)
+    if spec is not None:
+        # Only the regions the template actually provides — an absent region is
+        # NOT cleared (matches the prior "if region in template_owned" guard).
+        layer = TemplateLayer.model_validate(
+            {k: v for k, v in template_owned.items() if k in _TEMPLATE_OWNED_REGIONS}
+        )
+        return spec.with_template_layer(layer).to_flat_dict()
+
+    # Fallback: existing spec unpromotable — preserve the historical behaviour.
     out: dict[str, Any] = copy.deepcopy(existing_spec) if isinstance(existing_spec, dict) else {}
     for region in _TEMPLATE_OWNED_REGIONS:
         if region in template_owned:

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -207,6 +207,16 @@ Changes: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) —
 versioned. Same additive, best-effort snapshot contract — a version-store
 failure never breaks the edit. The merge gate itself lives in the Instinct
 router (BP-3); these rows are the candidates it reviews.
+Changes: 2026-06-19 (feat/typed-ripplespec-phase1) — fixed the 2026-06-13
+rippleSpec clobber bug in ``update``. A partial ``ripple_spec`` body that
+OMITS instance-owned regions (``state`` / ``selections``) no longer wipes
+them: ``update`` now routes through ``_layer_safe_update_spec`` (a per-key
+overlay expressed via the typed ``RippleSpec`` layer split) unless the new
+``UpdatePocketRequest.reset_state`` flag is set or a ``template_slug``
+recompile is in play. The typed model is used INTERNALLY only — Beanie
+``Pocket.rippleSpec`` and ``domain.Pocket.ripple_spec`` stay ``dict``, and
+every reader still receives a flat dict (executor dual-path readers deferred
+to a Phase 2 gated on PR #1472).
 """
 
 from __future__ import annotations
@@ -996,6 +1006,72 @@ def _merge_compile_into_ripple_spec(
     return out
 
 
+def _layer_safe_update_spec(
+    existing_raw: dict[str, Any] | None,
+    incoming_raw: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge an incoming (partial) rippleSpec onto the existing one WITHOUT
+    clobbering instance-owned regions the incoming spec omits.
+
+    This is the fix for the 2026-06-13 clobber bug. The bug: ``update()`` did a
+    wholesale ``doc.rippleSpec = normalized_spec``, so a frontend ``PATCH`` that
+    sent only the template canvas (``ui`` / ``actions`` / ``sources``) WIPED the
+    instance's ``state`` / ``selections`` — and, symmetrically, a state-only
+    write would have wiped the canvas.
+
+    The merge is a per-key overlay expressed through the typed layer split:
+    the result is the EXISTING spec with every key the INCOMING spec actually
+    SET overlaid on top. A key the incoming spec omits is preserved from the
+    existing spec — whichever layer it belongs to. Concretely:
+
+      * incoming carries ``ui`` but no ``state`` (the clobber case) →
+        new ``ui``, existing ``state`` preserved.
+      * incoming carries ``state`` but no ``ui`` (a state-only edit, e.g.
+        reconcile's instance-preserve path) → new ``state``, existing ``ui``
+        preserved.
+
+    Implementation uses ``RippleSpec`` for the type boundary: we promote both
+    sides, overlay the incoming TEMPLATE layer and the incoming INSTANCE layer
+    onto the existing spec (each carries only the keys that side set, via
+    ``exclude_unset``), then overlay any remaining incoming keys (the
+    compile_template passthrough envelope — ``name`` / ``version`` / ``lifecycle``
+    / ``metadata`` / etc. the normalizer stamps) so a partial write still
+    refreshes those. ``to_flat_dict`` returns the same BSON-shaped flat dict the
+    DB already stores — no migration.
+
+    Falls back to the legacy wholesale-incoming behaviour only if the incoming
+    spec cannot be promoted (corrupt) — never silently drops the write.
+    """
+    from pocketpaw.bundled_templates import InstanceLayer, RippleSpec, TemplateLayer
+
+    existing = RippleSpec.from_flat_dict(existing_raw)
+    incoming = RippleSpec.from_flat_dict(incoming_raw)
+    if incoming is None:
+        # Incoming is unpromotable (should not happen post-normalize) — keep the
+        # historical behaviour rather than drop the caller's write.
+        return incoming_raw
+    if existing is None:
+        # No existing spec to protect (fresh pocket / unpromotable existing) —
+        # the incoming spec is authoritative.
+        return incoming.to_flat_dict()
+
+    # Overlay the incoming layers onto the existing spec. ``with_*_layer`` only
+    # applies the keys the incoming side actually set, so an omitted region is
+    # preserved from ``existing`` verbatim.
+    merged = existing.with_template_layer(incoming.template_layer)
+    merged = merged.with_instance_layer(incoming.instance_layer)
+
+    # Overlay the remaining incoming keys (passthrough + envelope the normalizer
+    # stamps: name/version/lifecycle/title/color/metadata/...). The layer fields
+    # are already handled above, so skip them to avoid re-applying.
+    layer_fields = set(TemplateLayer.model_fields) | set(InstanceLayer.model_fields)
+    flat = merged.to_flat_dict()
+    for key, value in incoming.to_flat_dict().items():
+        if key not in layer_fields:
+            flat[key] = value
+    return flat
+
+
 async def _check_template_needs(loaded: dict[str, Any] | None, workspace_id: str) -> list[str]:
     """Return the template's declared Sense ids that NO enabled connector fills.
 
@@ -1393,7 +1469,22 @@ async def update(pocket_id: str, user_id: str, body: UpdatePocketRequest) -> dic
     if body.visibility is not None:
         doc.visibility = body.visibility
     if normalized_spec is not None:
-        doc.rippleSpec = normalized_spec
+        # Clobber-fix (2026-06-13 bug): a partial ``ripple_spec`` body that
+        # OMITS instance-owned regions (state / selections) must NOT wipe them.
+        # Three branches, in priority order:
+        #   1. ``reset_state`` — explicit caller intent to clear instance state.
+        #      Wholesale write (the legacy behaviour, now opt-in).
+        #   2. ``template_slug`` — the recompile path already ran ownership-aware
+        #      ``_merge_compile_into_ripple_spec`` against ``doc.rippleSpec``,
+        #      so the merged result is authoritative — write it wholesale.
+        #   3. default (user / frontend partial PATCH) — layer-safe merge that
+        #      preserves the existing instance layer for any region the incoming
+        #      spec omits (and, symmetrically, the template layer on a
+        #      state-only write).
+        if body.reset_state or body.template_slug is not None:
+            doc.rippleSpec = normalized_spec
+        else:
+            doc.rippleSpec = _layer_safe_update_spec(doc.rippleSpec, normalized_spec)
     if body.template_slug is not None:
         doc.template_slug = body.template_slug
     if body.project_id is not None:

--- a/src/pocketpaw/bundled_templates/__init__.py
+++ b/src/pocketpaw/bundled_templates/__init__.py
@@ -43,6 +43,13 @@
 # template lint --registry <path>``. Wave 4c will replace it with the
 # live EE FabricRegistry; until then, this is the developer-facing mock
 # for ``tier: registered`` lint workflows.
+# Modified 2026-06-19 (feat/typed-ripplespec-phase1): re-exports the
+# RFC-03-v2 runtime layer-split models ``RippleSpec``, ``TemplateLayer`` and
+# ``InstanceLayer`` so the EE cloud service (service.update + reconcile) and
+# any future non-EE consumer (CLI lint, registry validator) can import the
+# typed rippleSpec at the package root. ``RippleSpec.to_flat_dict`` is
+# BSON-byte-equivalent to the stored flat dict — a TYPE boundary, not a
+# storage change.
 """Built-in pocket templates bundled and auto-installed by PocketPaw.
 
 Third sibling to ``pocketpaw.bundled_skills`` and ``pocketpaw.bundled_kb``.
@@ -142,13 +149,16 @@ from pocketpaw.bundled_templates.schema import (
     ColumnDef,
     ConfirmDef,
     DataSourceDef,
+    InstanceLayer,
     InstinctRule,
     InstinctRulesDef,
     JoinedEntity,
     PermissionsDef,
     PocketTemplate,
+    RippleSpec,
     SavedView,
     StateBinding,
+    TemplateLayer,
     TriggerDef,
 )
 from pocketpaw.bundled_templates.temporal_sweeper import (
@@ -176,6 +186,7 @@ __all__ = [
     "FabricValidationError",
     "IdentifierResolver",
     "InstallResult",
+    "InstanceLayer",
     "InstinctDecision",
     "InstinctResolutionError",
     "InstinctRule",
@@ -187,6 +198,7 @@ __all__ = [
     "NullFabricRegistry",
     "PermissionsDef",
     "PocketTemplate",
+    "RippleSpec",
     "RowExecution",
     "SavedView",
     "StateBinding",
@@ -194,6 +206,7 @@ __all__ = [
     "TemplateDiff",
     "TemplateIdentifierResolver",
     "TemplateInstallResult",
+    "TemplateLayer",
     "TemplateValidationError",
     "TemporalRisingEdge",
     "TemporalSweepError",

--- a/src/pocketpaw/bundled_templates/schema.py
+++ b/src/pocketpaw/bundled_templates/schema.py
@@ -25,6 +25,19 @@
 # path-required-for-http and sense_id+action-required-for-sense, and validates
 # sense_id via senses.validate_sense_id. The resolved Sense value binds into
 # state like any HTTP source, so Ripple needs no changes.
+# Modified: 2026-06-19 (feat/typed-ripplespec-phase1) — added the RFC-03-v2
+# RUNTIME layer-split models ``TemplateLayer``, ``InstanceLayer`` and
+# ``RippleSpec`` (distinct from the design-time ``PocketTemplate`` above).
+# ``RippleSpec`` is a TYPE boundary over the flat rippleSpec dict MongoDB
+# already stores — ``to_flat_dict`` is BSON-byte-equivalent (no migration).
+# The split lets the cloud ``service.update`` + ``reconcile`` paths overwrite
+# template-owned regions (ui/actions/sources/shape) WITHOUT clobbering the
+# instance-owned regions (state/selections), the 2026-06-13 production bug.
+# Phase 1 wires these models INTERNALLY in service.update + reconcile only;
+# Beanie ``Pocket.rippleSpec`` and ``domain.Pocket.ripple_spec`` stay ``dict``
+# and every reader still receives a flat dict (executor dual-path readers are
+# deferred to a #1472-gated Phase 2). All compile_template passthrough keys are
+# explicit typed fields so no ``.get("agents")`` reader silently breaks.
 """Pydantic v2 model for the RFC 03 v2 Pocket Template Schema.
 
 This module is the **schema chokepoint** — every bundled template, every
@@ -54,6 +67,7 @@ Out of scope (separate PRs):
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Literal
 
 from pydantic import (
@@ -65,6 +79,8 @@ from pydantic import (
 )
 
 from pocketpaw.bundled_templates.expressions import CelExpression
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Enumerations (kept as Literal aliases so Pydantic generates clean
@@ -534,18 +550,203 @@ class PocketTemplate(BaseModel):
         return self
 
 
+# ---------------------------------------------------------------------------
+# RFC 03 v2 RUNTIME layer split — TemplateLayer / InstanceLayer / RippleSpec
+# ---------------------------------------------------------------------------
+#
+# These are the RUNTIME models (distinct from the design-time ``PocketTemplate``
+# above). ``compile_template`` turns a ``PocketTemplate`` into a flat rippleSpec
+# dict; ``RippleSpec`` is the typed view OVER that flat dict. The split is a
+# TYPE boundary, not a storage boundary: ``to_flat_dict`` produces the exact
+# flat dict MongoDB already stores, so there is NO migration and revert is a
+# one-line change at every call site.
+#
+# Ownership partition (the load-bearing contract — see reconcile.py):
+#   * TEMPLATE-OWNED (reconcile overwrites from the source template):
+#       ui, actions, sources, shape  → ``TemplateLayer``
+#   * INSTANCE-OWNED (reconcile NEVER touches; agents read/write via state_ops):
+#       state, selections            → ``InstanceLayer``
+#   * Everything else (agents, triggers, kb_scope, schema_version, …) is a
+#     compile_template PASSTHROUGH field — explicit on ``RippleSpec`` so a
+#     ``.get("agents")`` reader never silently breaks (adversarial must-fix #2).
+
+
+class TemplateLayer(BaseModel):
+    """Template-owned rippleSpec regions.
+
+    Reconcile owns these — it overwrites them from the freshly-loaded source
+    template. Instance edits to these regions survive only until the user runs
+    reconcile. NEVER write instance/runtime data into this layer.
+
+    ``actions`` is typed ``dict | list`` because ``compile_template`` emits a
+    list from ``PocketTemplate.actions`` while the runtime ``rippleSpec.actions``
+    block (post-normalizer write-binding lift) is a dict; both shapes are valid
+    on a stored doc.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    ui: dict[str, Any] | None = None
+    actions: dict[str, Any] | list[Any] | None = None
+    sources: dict[str, Any] | None = None
+    shape: str | None = None
+
+
+class InstanceLayer(BaseModel):
+    """Instance-owned rippleSpec regions.
+
+    Reconcile NEVER touches these. Agents read/write ``state`` via state_ops.
+    The clobber-fix preserves this layer when a partial ``update`` omits it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    state: dict[str, Any] = Field(default_factory=dict)
+    selections: dict[str, Any] = Field(default_factory=dict)
+
+
+class RippleSpec(BaseModel):
+    """Typed, layer-split rippleSpec — the RFC-03-v2 runtime model.
+
+    The layer split is a TYPE boundary, not a storage boundary. ``to_flat_dict``
+    is byte-equivalent to the flat dict MongoDB already stores, so no document
+    migration is required and any phase is independently revertable.
+
+    Design notes embedded in the contract:
+
+    * **Every ``compile_template`` passthrough key is an explicit field**
+      (adversarial must-fix #2). No key silently disappears into
+      ``__pydantic_extra__`` where a ``.get("agents")`` reader would miss it.
+      Truly-unknown future keys still land in ``__pydantic_extra__`` (extra is
+      allowed) and survive a round-trip — additive-safe.
+    * **``to_flat_dict`` uses ``exclude_unset=True``** (must-fix #1) so a key
+      absent from the original dict is never re-emitted as a null, while a key
+      explicitly set to ``None`` (a deliberate clear) is preserved.
+    * **``from_flat_dict`` is the sole promotion entry point** and NEVER raises
+      — a corrupted spec must not break pocket load (returns ``None``).
+    * **``with_template_layer`` / ``with_instance_layer`` return NEW objects.**
+      No mutation — the ownership boundary is explicit at the call site.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    # Template layer (explicit — IDE autocomplete + grep + reconcile derives
+    # _TEMPLATE_OWNED_REGIONS from TemplateLayer.model_fields, not from here).
+    ui: dict[str, Any] | None = None
+    actions: dict[str, Any] | list[Any] | None = None
+    sources: dict[str, Any] | None = None
+    shape: str | None = None
+
+    # Instance layer.
+    state: dict[str, Any] = Field(default_factory=dict)
+    selections: dict[str, Any] = Field(default_factory=dict)
+
+    # compile_template passthrough fields (explicit to prevent .get() breakage).
+    schema_version: str | None = None
+    name: str | None = None
+    version: str | None = None
+    agents: list[Any] | None = None
+    triggers: list[Any] | None = None
+    outcomes: list[str] | None = None
+    kb_scope: str | None = None
+    skill_refs: list[str] | None = None
+    permissions: dict[str, Any] | None = None
+    instinct_rules: dict[str, Any] | None = None
+
+    # Any remaining keys land in __pydantic_extra__ — additive safe.
+
+    @property
+    def template_layer(self) -> TemplateLayer:
+        """The template-owned regions as a typed ``TemplateLayer``.
+
+        Only fields the spec actually SET are carried onto the layer, so a
+        downstream ``model_dump(exclude_unset=True)`` does not resurrect a key
+        the spec omitted (keeps the layer-merge faithful to the partial input).
+        """
+        return TemplateLayer.model_validate(
+            {k: getattr(self, k) for k in TemplateLayer.model_fields if k in self.model_fields_set}
+        )
+
+    @property
+    def instance_layer(self) -> InstanceLayer:
+        """The instance-owned regions as a typed ``InstanceLayer``.
+
+        Mirrors :attr:`template_layer`: only fields the spec SET are carried,
+        so an absent ``selections`` is not re-introduced as ``{}`` on merge.
+        """
+        return InstanceLayer.model_validate(
+            {k: getattr(self, k) for k in InstanceLayer.model_fields if k in self.model_fields_set}
+        )
+
+    @classmethod
+    def from_flat_dict(cls, d: dict[str, Any] | None) -> RippleSpec | None:
+        """Promote a legacy flat dict to ``RippleSpec``.
+
+        Returns ``None`` on ``None``/non-dict input or any validation failure —
+        NEVER raises, because a corrupted stored spec must not break pocket
+        load. An already-constructed ``RippleSpec`` is returned unchanged
+        (idempotent promotion).
+        """
+        if d is None:
+            return None
+        if isinstance(d, RippleSpec):
+            return d
+        if not isinstance(d, dict):
+            return None
+        try:
+            return cls.model_validate(d)
+        except Exception:  # noqa: BLE001 — promotion must never break load.
+            logger.warning("RippleSpec.from_flat_dict: validation failed, returning None")
+            return None
+
+    def to_flat_dict(self) -> dict[str, Any]:
+        """Serialize to a BSON-compatible flat dict.
+
+        Byte-equivalent to the current MongoDB documents — no migration needed.
+        ``exclude_unset=True`` avoids injecting null keys absent from the
+        original document while preserving keys explicitly set to ``None``
+        (tracked via ``model_fields_set``). See adversarial must-fix #1.
+        """
+        return self.model_dump(exclude_unset=True, mode="python")
+
+    def with_template_layer(self, layer: TemplateLayer) -> RippleSpec:
+        """Return a NEW ``RippleSpec`` with template-owned fields from ``layer``.
+
+        Instance-owned fields (state, selections) and passthrough/extra keys
+        are preserved verbatim. Only the fields ``layer`` actually SET are
+        overlaid, so an empty ``TemplateLayer()`` is a no-op on the template
+        regions (it never clears an existing ui).
+        """
+        flat = self.to_flat_dict()
+        flat.update(layer.model_dump(exclude_unset=True))
+        return RippleSpec.model_validate(flat)
+
+    def with_instance_layer(self, layer: InstanceLayer) -> RippleSpec:
+        """Return a NEW ``RippleSpec`` with instance-owned fields from ``layer``.
+
+        Template-owned fields and passthrough/extra keys are preserved verbatim.
+        Only the fields ``layer`` actually SET are overlaid.
+        """
+        flat = self.to_flat_dict()
+        flat.update(layer.model_dump(exclude_unset=True))
+        return RippleSpec.model_validate(flat)
+
+
 __all__ = [
     "ActionDef",
     "AgentDef",
     "ColumnDef",
     "ConfirmDef",
     "DataSourceDef",
+    "InstanceLayer",
     "InstinctRule",
     "InstinctRulesDef",
     "JoinedEntity",
     "PermissionsDef",
     "PocketTemplate",
+    "RippleSpec",
     "SavedView",
     "StateBinding",
+    "TemplateLayer",
     "TriggerDef",
 ]

--- a/tests/cloud/pockets/test_update_clobber.py
+++ b/tests/cloud/pockets/test_update_clobber.py
@@ -1,0 +1,184 @@
+# tests/cloud/pockets/test_update_clobber.py
+# Created: 2026-06-19 (feat/typed-ripplespec-phase1) — regression tests for the
+# 2026-06-13 rippleSpec clobber bug. The bug: pockets_service.update() did a
+# wholesale `doc.rippleSpec = normalized_spec`, so a partial PATCH that omitted
+# instance-owned regions (state / selections) WIPED them — the frontend's
+# canvas-only persistMutation silently erased operator data.
+#
+# These tests drive the public service API (create / update / get) against the
+# real mongomock-motor + RecordingBus fixtures (same shape as
+# test_template_reconcile.py). They prove:
+#   * a ui-only update PRESERVES existing state (the clobber, now fixed),
+#   * a state-only update PRESERVES existing ui (the symmetric direction),
+#   * reset_state=True restores the wholesale clear (the escape hatch),
+#   * a template_slug recompile path is unaffected,
+#   * passthrough/envelope keys are refreshed on a partial write.
+"""Clobber-bug regression for pockets_service.update (layer-safe spec write)."""
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest, UpdatePocketRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws_clobber"
+_USER = "user_clobber"
+
+
+async def _make_pocket() -> str:
+    """Create a pocket carrying both a template-owned ui and instance state."""
+    wire = await pockets_service.create(
+        _WS,
+        _USER,
+        CreatePocketRequest(
+            name="Clobber Probe",
+            ripple_spec={
+                "ui": {"type": "stack", "children": [{"type": "text", "props": {"text": "hi"}}]},
+                "actions": [{"name": "approve"}],
+                "sources": {"items": {"method": "GET", "path": "/items", "bind": "state.items"}},
+                "state": {
+                    "items": [{"id": "row_1", "label": "Original Row"}],
+                    "selected_id": "row_1",
+                },
+            },
+        ),
+    )
+    return wire["_id"]
+
+
+# ---------------------------------------------------------------------------
+# The clobber bug + its fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ui_only_update_preserves_state() -> None:
+    """REPRODUCES the 2026-06-13 clobber: a PATCH whose ripple_spec omits
+    `state` must NOT wipe it. This FAILS before the layer-safe fix (the old
+    wholesale write dropped state) and PASSES after.
+    """
+    pocket_id = await _make_pocket()
+    before = await pockets_service.get(pocket_id, _USER)
+    assert before["rippleSpec"]["state"]["items"] == [{"id": "row_1", "label": "Original Row"}]
+
+    # The frontend persistMutation after a canvas edit: sends the new ui (and
+    # the template machinery) but NOT state.
+    await pockets_service.update(
+        pocket_id,
+        _USER,
+        UpdatePocketRequest(
+            ripple_spec={
+                "ui": {
+                    "type": "stack",
+                    "children": [{"type": "text", "props": {"text": "edited"}}],
+                },
+            }
+        ),
+    )
+
+    after = await pockets_service.get(pocket_id, _USER)
+    spec = after["rippleSpec"]
+    # The bug fixed: instance state survived the ui-only write.
+    assert spec["state"]["items"] == [{"id": "row_1", "label": "Original Row"}]
+    assert spec["state"]["selected_id"] == "row_1"
+    # The intended change still landed.
+    assert spec["ui"]["children"][0]["props"]["text"] == "edited"
+    # Other template-owned regions the patch omitted are also preserved.
+    assert "items" in spec["sources"]
+
+
+@pytest.mark.asyncio
+async def test_state_only_update_preserves_ui() -> None:
+    """The symmetric direction: a state-only PATCH must NOT wipe the template
+    canvas / actions / sources. (This is the path reconcile's instance-preserve
+    uses and the frontend's state-sync uses.)"""
+    pocket_id = await _make_pocket()
+
+    await pockets_service.update(
+        pocket_id,
+        _USER,
+        UpdatePocketRequest(
+            ripple_spec={
+                "state": {
+                    "items": [{"id": "row_2", "label": "New Row"}],
+                    "selected_id": "row_2",
+                }
+            }
+        ),
+    )
+
+    spec = (await pockets_service.get(pocket_id, _USER))["rippleSpec"]
+    # New state landed.
+    assert spec["state"]["items"] == [{"id": "row_2", "label": "New Row"}]
+    assert spec["state"]["selected_id"] == "row_2"
+    # Template-owned regions survived the state-only write.
+    assert spec["ui"]["children"][0]["props"]["text"] == "hi"
+    assert "items" in spec["sources"]
+
+
+@pytest.mark.asyncio
+async def test_reset_state_clears_omitted_state() -> None:
+    """The escape hatch: reset_state=True restores the wholesale write, so a
+    caller that INTENDS to clear instance state can. A ui-only body with
+    reset_state=True drops the existing state entirely."""
+    pocket_id = await _make_pocket()
+
+    await pockets_service.update(
+        pocket_id,
+        _USER,
+        UpdatePocketRequest(
+            ripple_spec={
+                "ui": {"type": "stack", "children": []},
+            },
+            reset_state=True,
+        ),
+    )
+
+    spec = (await pockets_service.get(pocket_id, _USER))["rippleSpec"]
+    # reset_state wiped the omitted instance regions — the wholesale write
+    # dropped `state` entirely (the incoming body carried none), so neither the
+    # original rows nor the selection survive.
+    state = spec.get("state") or {}
+    assert state.get("items") in (None, [])
+    assert "selected_id" not in state
+
+
+@pytest.mark.asyncio
+async def test_partial_update_refreshes_passthrough_keys() -> None:
+    """A partial write still refreshes the compile_template passthrough /
+    envelope keys the normalizer stamps (name, version, lifecycle) — the
+    layer-safe merge overlays incoming non-layer keys too."""
+    pocket_id = await _make_pocket()
+
+    await pockets_service.update(
+        pocket_id,
+        _USER,
+        UpdatePocketRequest(
+            ripple_spec={
+                "name": "Renamed Spec",
+                "ui": {"type": "stack", "children": []},
+            }
+        ),
+    )
+
+    spec = (await pockets_service.get(pocket_id, _USER))["rippleSpec"]
+    # Envelope/passthrough refreshed.
+    assert spec.get("name") == "Renamed Spec"
+    # State still preserved (the clobber-fix holds even with passthrough keys).
+    assert spec["state"]["items"] == [{"id": "row_1", "label": "Original Row"}]
+
+
+@pytest.mark.asyncio
+async def test_update_without_ripple_spec_leaves_spec_untouched() -> None:
+    """A metadata-only update (no ripple_spec) must not touch the spec at all —
+    confirms the clobber-fix branch only runs when a spec is actually sent."""
+    pocket_id = await _make_pocket()
+    before = (await pockets_service.get(pocket_id, _USER))["rippleSpec"]
+
+    await pockets_service.update(pocket_id, _USER, UpdatePocketRequest(name="Just A Rename"))
+
+    after = (await pockets_service.get(pocket_id, _USER))["rippleSpec"]
+    assert after["state"] == before["state"]
+    assert after["ui"] == before["ui"]

--- a/tests/ee/pockets/__init__.py
+++ b/tests/ee/pockets/__init__.py
@@ -1,0 +1,4 @@
+# tests/ee/pockets/__init__.py
+# Created: 2026-06-19 (feat/typed-ripplespec-phase1) — package marker for
+# the pockets test sub-tree under tests/ee. Hosts the pure-model unit tests
+# for the typed RippleSpec / TemplateLayer / InstanceLayer (Phase 1).

--- a/tests/ee/pockets/test_ripple_spec_model.py
+++ b/tests/ee/pockets/test_ripple_spec_model.py
@@ -1,0 +1,186 @@
+# tests/ee/pockets/test_ripple_spec_model.py
+# Created: 2026-06-19 (feat/typed-ripplespec-phase1) — TDD unit tests for the
+# typed RippleSpec / TemplateLayer / InstanceLayer models (RFC-03-v2 runtime
+# layer split). These are PURE model tests — no Mongo, no FastAPI. They pin
+# the five adversarial-review must-fix contracts:
+#   #1 to_flat_dict uses exclude_unset → never injects null keys absent from
+#      the original, and round-trips extra/passthrough keys.
+#   #2 every compile_template passthrough key is an explicit typed field
+#      (no silent fall-through to __pydantic_extra__).
+#   #3/#4 the layer split is the type boundary the clobber-fix is built on:
+#      with_template_layer preserves state, with_instance_layer preserves ui.
+# The model lives in pocketpaw.bundled_templates.schema (OSS core) so a future
+# non-EE consumer (CLI lint, registry validator) can use it without an EE dep.
+"""Unit tests for the typed, layer-split RippleSpec."""
+
+from __future__ import annotations
+
+from pocketpaw.bundled_templates import InstanceLayer, RippleSpec, TemplateLayer
+
+# ---------------------------------------------------------------------------
+# from_flat_dict — promotion entry point
+# ---------------------------------------------------------------------------
+
+
+def test_from_flat_dict_promotes_legacy_spec() -> None:
+    spec = RippleSpec.from_flat_dict(
+        {"ui": {"type": "stack", "id": "n_abc"}, "state": {"items": []}, "sources": {}}
+    )
+    assert isinstance(spec, RippleSpec)
+    assert spec.template_layer.ui == {"type": "stack", "id": "n_abc"}
+    assert spec.instance_layer.state == {"items": []}
+
+
+def test_from_flat_dict_returns_none_on_none_input() -> None:
+    assert RippleSpec.from_flat_dict(None) is None
+
+
+def test_from_flat_dict_returns_none_on_non_dict() -> None:
+    # Must NOT raise — a corrupted spec value must not break pocket load.
+    assert RippleSpec.from_flat_dict("not a dict") is None  # type: ignore[arg-type]
+    assert RippleSpec.from_flat_dict(42) is None  # type: ignore[arg-type]
+
+
+def test_from_flat_dict_idempotent_on_ripplespec() -> None:
+    original = RippleSpec(ui={"type": "stack"})
+    assert RippleSpec.from_flat_dict(original) is original
+
+
+# ---------------------------------------------------------------------------
+# to_flat_dict — BSON-equivalence + must-fix #1 (no null injection)
+# ---------------------------------------------------------------------------
+
+
+def test_to_flat_dict_round_trips_extra_keys() -> None:
+    flat = {
+        "ui": {"type": "stack"},
+        "state": {"rows": [1, 2]},
+        "kb_scope": "pocket",
+        "schema_version": "2",
+    }
+    spec = RippleSpec.from_flat_dict(flat)
+    assert spec is not None
+    out = spec.to_flat_dict()
+    assert out["kb_scope"] == "pocket"
+    assert out["schema_version"] == "2"
+
+
+def test_to_flat_dict_round_trips_unknown_extra_keys() -> None:
+    # A key NOT declared as a typed field must survive a round-trip via
+    # __pydantic_extra__ (extra="allow"), so an unknown future field on a
+    # stored doc is never silently dropped on the next write.
+    flat = {"ui": {"type": "stack"}, "some_future_field": {"nested": True}}
+    spec = RippleSpec.from_flat_dict(flat)
+    assert spec is not None
+    out = spec.to_flat_dict()
+    assert out["some_future_field"] == {"nested": True}
+
+
+def test_to_flat_dict_does_not_inject_null_keys() -> None:
+    # "actions" was absent in the input — it must NOT appear as a null key
+    # in the serialized dict (must-fix #1). Injecting nulls would pollute
+    # documents that originally omitted the key and break .get() readers
+    # that distinguish "absent" from "null".
+    spec = RippleSpec.from_flat_dict({"ui": {"type": "stack"}, "state": {}})
+    assert spec is not None
+    out = spec.to_flat_dict()
+    assert "actions" not in out
+    assert "sources" not in out
+    assert "agents" not in out
+
+
+def test_to_flat_dict_preserves_explicit_null() -> None:
+    # A key explicitly set to None in the original (a deliberate clear) IS
+    # part of model_fields_set, so exclude_unset keeps it.
+    spec = RippleSpec.from_flat_dict({"ui": None, "state": {"x": 1}})
+    assert spec is not None
+    out = spec.to_flat_dict()
+    assert "ui" in out
+    assert out["ui"] is None
+
+
+# ---------------------------------------------------------------------------
+# layer split — must-fix #3/#4 (the clobber-fix type boundary)
+# ---------------------------------------------------------------------------
+
+
+def test_with_template_layer_preserves_state() -> None:
+    spec = RippleSpec.from_flat_dict({"ui": {"type": "old"}, "state": {"items": ["a", "b"]}})
+    assert spec is not None
+    new_layer = TemplateLayer(ui={"type": "new"}, actions={"act_1": {"kind": "write_binding"}})
+    merged = spec.with_template_layer(new_layer)
+    # Instance-owned state is preserved verbatim; template UI is refreshed.
+    assert merged.instance_layer.state == {"items": ["a", "b"]}
+    assert merged.template_layer.ui == {"type": "new"}
+    assert merged.template_layer.actions == {"act_1": {"kind": "write_binding"}}
+    # Original is not mutated (with_* returns a NEW object).
+    assert spec.template_layer.ui == {"type": "old"}
+
+
+def test_with_instance_layer_preserves_ui() -> None:
+    spec = RippleSpec.from_flat_dict({"ui": {"type": "stack"}, "state": {"old": True}})
+    assert spec is not None
+    merged = spec.with_instance_layer(InstanceLayer(state={"items": []}))
+    assert merged.template_layer.ui == {"type": "stack"}
+    assert merged.instance_layer.state == {"items": []}
+    # Original is not mutated.
+    assert spec.instance_layer.state == {"old": True}
+
+
+def test_template_layer_property_excludes_instance_keys() -> None:
+    spec = RippleSpec.from_flat_dict(
+        {"ui": {"type": "stack"}, "state": {"rows": []}, "selections": {"sel": 1}}
+    )
+    assert spec is not None
+    layer = spec.template_layer
+    dumped = layer.model_dump(exclude_unset=True)
+    assert "state" not in dumped
+    assert "selections" not in dumped
+
+
+# ---------------------------------------------------------------------------
+# passthrough fields — must-fix #2 (no silent __pydantic_extra__ fall-through)
+# ---------------------------------------------------------------------------
+
+
+def test_compile_template_passthrough_fields_accessible() -> None:
+    spec = RippleSpec.from_flat_dict(
+        {"agents": [{"name": "helper"}], "triggers": [], "kb_scope": "global"}
+    )
+    assert spec is not None
+    # These would FAIL (return None / KeyError) if the keys landed in
+    # __pydantic_extra__ instead of being explicit typed fields.
+    assert spec.agents == [{"name": "helper"}]
+    assert spec.kb_scope == "global"
+    assert spec.triggers == []
+
+
+def test_all_compile_passthrough_keys_are_declared_fields() -> None:
+    # Pin must-fix #2: every key compile_template can emit that a downstream
+    # `.get("<key>")` reader depends on must be a declared field, NOT an extra.
+    declared = set(RippleSpec.model_fields.keys())
+    passthrough = {
+        "schema_version",
+        "name",
+        "version",
+        "agents",
+        "triggers",
+        "outcomes",
+        "kb_scope",
+        "skill_refs",
+        "permissions",
+        "instinct_rules",
+    }
+    missing = passthrough - declared
+    assert not missing, f"compile_template passthrough keys not declared as fields: {missing}"
+
+
+def test_template_layer_fields_are_template_owned_set() -> None:
+    # The TemplateLayer field set is the single source of truth reconcile
+    # derives _TEMPLATE_OWNED_REGIONS from. Pin the contract so a field add
+    # there is a deliberate, test-visible change.
+    assert set(TemplateLayer.model_fields.keys()) == {"ui", "actions", "sources", "shape"}
+
+
+def test_instance_layer_fields_are_instance_owned_set() -> None:
+    assert set(InstanceLayer.model_fields.keys()) == {"state", "selections"}


### PR DESCRIPTION
## What this fixes

A frontend canvas edit saved through `PATCH /pockets/{id}` sent a `rippleSpec` body carrying only the template canvas — `ui`, `actions`, `sources` — and no `state`. `update()` did a wholesale `doc.rippleSpec = normalized_spec`, so the instance's `state` and `selections` were dropped on every such save. That's the 2026-06-13 clobber bug (a wiped detail panel after a canvas edit). The symmetric case was just as broken: a state-only write would have flattened the canvas.

The root cause is structural — there was no type boundary keeping a template-region write from touching instance-owned keys.

## Phase 1 scope (deliberately narrow)

This is the first, collision-safe slice of the typed rippleSpec + layer split. It is behaviour-safe everywhere except the bug it fixes.

What landed:

1. **Typed runtime model** (OSS core, additive) — `TemplateLayer`, `InstanceLayer`, and `RippleSpec` in `bundled_templates/schema.py`, exported from the package root. `RippleSpec` declares every `compile_template` passthrough key (`agents`, `triggers`, `outcomes`, `kb_scope`, `skill_refs`, `permissions`, `instinct_rules`, `schema_version`, `name`, `version`) as an explicit field so no `.get("agents")` reader silently breaks. `to_flat_dict()` uses `exclude_unset=True` so it never injects null keys absent from the original doc, and unknown keys survive a round-trip. It is byte-equivalent to the stored document — no migration.

2. **The clobber fix** — `service.update()` now routes a `ripple_spec` write through `_layer_safe_update_spec`, a per-key overlay built on the typed layers: keep the existing spec, write only the regions the incoming body actually set. State survives a canvas-only edit; the canvas survives a state-only edit.

3. **`reset_state` escape hatch** — `UpdatePocketRequest` gains `reset_state: bool = False`. Set it to clear instance state intentionally (restores the old wholesale write). Wire-level `ripple_spec` stays `dict | None`.

4. **Reconcile, typed internally** — `_TEMPLATE_OWNED_REGIONS` is now derived from `TemplateLayer.model_fields` (one source of truth, shared with the update fix), and `_build_reconciled_spec` runs its overlay through the typed merge. Behaviour is unchanged; the existing reconcile tests stay green.

## Dormant by design

The typed model is used **internally only** by `service.update` and `reconcile` in this phase. `Pocket.rippleSpec` stays a `dict` in Beanie, `domain.Pocket.ripple_spec` stays a `dict`, and every reader still receives a flat dict. The executor dual-path readers (`action_executor`, `source_executor`, `bulk_dispatch`, `ripple_normalizer`, `ripple_validator`, `agent_context`) and the domain-boundary promotion are deferred to a Phase 2 gated on PR #1472, which collides on `action_executor.py` / `source_executor.py`. Every phase is independently revertable because `to_flat_dict()` always emits the stored shape.

## Files

- `src/pocketpaw/bundled_templates/schema.py` — the three models
- `src/pocketpaw/bundled_templates/__init__.py` — exports
- `ee/pocketpaw_ee/cloud/pockets/service.py` — `_layer_safe_update_spec` + the three-branch write in `update()`
- `ee/pocketpaw_ee/cloud/pockets/dto.py` — `reset_state` on `UpdatePocketRequest`
- `ee/pocketpaw_ee/cloud/pockets/reconcile.py` — derived region set + typed overlay
- `tests/ee/pockets/test_ripple_spec_model.py` — model unit tests (new)
- `tests/cloud/pockets/test_update_clobber.py` — clobber regression (new)

## Proof the bug is fixed

The clobber regression tests were run against the old wholesale-write code and **failed** (`KeyError: 'state'` on the ui-only write, `KeyError: 'ui'` on the state-only write), then **pass** with the layer-safe write. The reconcile suite stays green.

```
uv run pytest tests/ee/pockets/test_ripple_spec_model.py \
  tests/cloud/pockets/test_template_reconcile.py \
  tests/cloud/pockets/test_update_clobber.py -q
# 32 passed
```

`lint-imports` (root + `ee/pyproject.toml`) clean, `ruff format`/`ruff check` clean. No new modules needed an allowlist entry — `reconcile.py` was already allowlisted and the new `schema.py` import is OSS-core (an allowed direction).