### PR TITLE
fix(livekit): meeting notes not posted for long calls

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -129,23 +129,32 @@ class CallMeetingAgent:
         # Disconnect RTC room first (stops audio streams)
         await self._disconnect_rtc()
 
-        # Cancel monitor task
+        # Cancel monitor task — do NOT await; the task's CancelledError
+        # propagates at its next await point and asyncio.run() handles
+        # cleanup.  Avoiding the await here means _finalize_notes() is
+        # called promptly even when Deepgram/AudioStream cleanup is slow.
         if self._monitor_task:
             self._monitor_task.cancel()
-            try:
-                await self._monitor_task
-            except asyncio.CancelledError:
-                pass
 
-        # Cancel transcribe task
+        # Cancel transcribe task — same rationale: don't block on
+        # AudioStream/Deepgram pipe cleanup, especially for long meetings
+        # with many participants where cleanup can take many seconds.
         if self._transcribe_task:
             self._transcribe_task.cancel()
-            try:
-                await self._transcribe_task
-            except asyncio.CancelledError:
-                pass
 
         await self._finalize_notes()
+
+        # Brief drain for cancelled tasks so they don't leak
+        if self._transcribe_task and not self._transcribe_task.done():
+            try:
+                await asyncio.wait_for(self._transcribe_task, timeout=3)
+            except (asyncio.CancelledError, TimeoutError):
+                pass
+        if self._monitor_task and not self._monitor_task.done():
+            try:
+                await asyncio.wait_for(self._monitor_task, timeout=1)
+            except (asyncio.CancelledError, TimeoutError):
+                pass
 
         logger.info(
             "CallMeetingAgent stopped for room %s (group %s)",

--- a/ee/pocketpaw_ee/cloud/livekit/agent.py
+++ b/ee/pocketpaw_ee/cloud/livekit/agent.py
@@ -626,11 +626,28 @@ class CallMeetingAgent:
 
             transcript_text = "\n".join(transcript_lines)
 
+            # Truncate long transcripts before sending to the LLM so the
+            # API call finishes within the process-grace-period window.
+            # Limit to ~5K chars (~1K tokens) which captures enough context
+            # for a useful summary while keeping latency predictable.
+            # The full transcript is still included in the meeting notes payload.
+            llm_transcript = transcript_text
+            if len(transcript_text) > 5000:
+                logger.info(
+                    "Agent: truncating long transcript for LLM (%d chars → 5000)",
+                    len(transcript_text),
+                )
+                llm_transcript = (
+                    transcript_text[:2500]
+                    + "\n\n[... transcript truncated at 5000 chars ...]\n\n"
+                    + transcript_text[-2500:]
+                )
+
             # Generate AI summary — non-fatal if it fails; notes still post
             # with raw transcript (or a fallback message).
             try:
                 summary, action_items = await self._generate_summary(
-                    transcript_text,
+                    llm_transcript,
                 )
             except Exception:
                 logger.exception("Agent: AI summarization failed — posting notes without summary")
@@ -908,12 +925,17 @@ if __name__ == "__main__":
                 logger.info("Agent: SIGTERM — finalising notes")
                 agent._running = False
                 await agent._disconnect_rtc()
+                # Cancel transcribe task but do NOT await it here —
+                # waiting for cleanup of AudioStreams + Deepgram pipes
+                # can be slow for long meetings. The parent process
+                # waits up to 30s for this process to exit; we want to
+                # spend that time on _finalize_notes, not on teardown.
                 if agent._transcribe_task:
                     agent._transcribe_task.cancel()
-                    try:
-                        await agent._transcribe_task
-                    except asyncio.CancelledError:
-                        pass
+                # Cancel the monitor task so it doesn't block exit with
+                # its 5s sleep interval.
+                if agent._monitor_task:
+                    agent._monitor_task.cancel()
                 await agent._finalize_notes()
                 # Do NOT clean up the room here — the parent process
                 # (end_room) handles room deletion after the agent exits.
@@ -923,14 +945,17 @@ if __name__ == "__main__":
 
             await asyncio.sleep(1)
 
-        # Wait for the monitor task (natural end) to finish its finalise
-        # + cleanup chain before exiting. Without this, asyncio.run()
-        # cancels pending tasks the moment _main() returns, which kills
-        # the monitor task mid-_finalize_notes().
+        # Give cancelled tasks a moment to drain, then let _main()
+        # return so asyncio.run() can clean up.
+        if agent._transcribe_task and not agent._transcribe_task.done():
+            try:
+                await asyncio.wait_for(agent._transcribe_task, timeout=3)
+            except (asyncio.CancelledError, TimeoutError):
+                pass
         if agent._monitor_task and not agent._monitor_task.done():
             try:
-                await agent._monitor_task
-            except asyncio.CancelledError:
+                await asyncio.wait_for(agent._monitor_task, timeout=1)
+            except (asyncio.CancelledError, TimeoutError):
                 pass
 
     asyncio.run(_main())

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -115,16 +115,16 @@ class _SubprocessAgentRef:
         pass
 
     async def stop(self) -> None:
-        """Send SIGTERM and wait up to 10 s for graceful exit."""
+        """Send SIGTERM and wait up to 30 s for graceful exit."""
         if self._process.returncode is not None:
             return  # already terminated
         try:
             self._process.terminate()
             try:
-                await asyncio.wait_for(self._process.wait(), timeout=10)
+                await asyncio.wait_for(self._process.wait(), timeout=30)
             except TimeoutError:
                 logger.warning(
-                    "Agent subprocess for room %s did not exit in 10s, killing",
+                    "Agent subprocess for room %s did not exit in 30s, killing",
                     self.room_name,
                 )
                 self._process.kill()

--- a/tests/ee/test_livekit_service.py
+++ b/tests/ee/test_livekit_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -230,6 +232,44 @@ class TestMeetingNotesAgent:
 
         mock_finalize.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_stop_does_not_block_on_slow_transcribe_task(self):
+        """Regression test: stop() must NOT await a cancelled transcribe task.
+
+        The old code awaited the cancelled transcribe task, which blocked on
+        cleanup of AudioStream/Deepgram pipes for long meetings. The fix
+        cancels the task without awaiting it, letting asyncio.run() clean up.
+        """
+        from pocketpaw_ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="test123",
+            room_name="group-call-test123",
+            bot_token="test-token",
+        )
+
+        # Set up a transcribe task that simulates a long-running cleanup
+        # after cancellation (e.g. draining audio streams).
+        agent._running = True
+        agent._transcribe_task = asyncio.create_task(self._never_ending())
+
+        # This must complete quickly (~0s, not ~10s+).
+        with patch.object(agent, "_finalize_notes", new_callable=AsyncMock) as mock_finalize:
+            await asyncio.wait_for(agent.stop(), timeout=2)
+
+        mock_finalize.assert_called_once()
+
+    @staticmethod
+    async def _never_ending() -> None:
+        """A task that never finishes cleanly after cancellation."""
+        try:
+            while True:
+                await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            # Simulate slow cleanup (old code would await this)
+            await asyncio.sleep(30)
+            raise
+
     def test_add_transcript_segment(self):
         from pocketpaw_ee.cloud.livekit.agent import CallMeetingAgent
 
@@ -305,6 +345,41 @@ class TestMeetingNotesAgent:
 
         assert "Line 1" in summary
         assert items == []
+
+    @pytest.mark.asyncio
+    async def test_finalize_notes_truncates_long_transcript_for_llm(self):
+        """Long transcripts should be truncated before the LLM call.
+
+        The full transcript is still saved in the payload, but the LLM
+        should only receive ~5000 chars so the API call completes within
+        the process-grace-period window.
+        """
+        from pocketpaw_ee.cloud.livekit.agent import CallMeetingAgent
+
+        agent = CallMeetingAgent(
+            group_id="test123",
+            room_name="group-call-test123",
+            bot_token="test-token",
+        )
+        agent._call_start_time = time.time()
+
+        # Add transcript segments totalling well over 5000 chars
+        long_text = "Hello world. " * 1000  # ~14K chars
+        agent.add_transcript_segment("Alice", long_text)
+        agent.add_transcript_segment("Bob", "Short reply.")
+
+        with patch.object(agent, "_generate_summary", AsyncMock()) as mock_gen:
+            mock_gen.return_value = ("summary", ["action"])
+            await agent._finalize_notes()
+
+        # Verify the LLM got a truncated version (head + tail + ellipsis
+        # is ~5048 chars with the speaker prefix; assert it's well under
+        # the original ~14K length and contains the truncation marker).
+        called_with = mock_gen.call_args[0][0]
+        assert len(called_with) < 14000, (
+            f"LLM got full {len(called_with)}-char transcript, expected truncation"
+        )
+        assert "[... transcript truncated at 5000 chars ...]" in called_with
 
 
 class TestMeetingNotesPosting:


### PR DESCRIPTION
## Problem

Meeting notes were silently dropped for long meetings. The agent subprocess was being **SIGKILL'd** (exit code -9) by the parent before `_finalize_notes()` could write the payload to stdout and exit cleanly.

Logs from prod showed:
```
Agent subprocess for room group-call-... did not exit in 10s, killing
Agent subprocess exited (code -9)
```

The meeting notes payload was never posted, and the transcript was never stored.

## Root Cause

Three compounding issues:

1. **`await agent._transcribe_task` after cancel()** — blocked on cleanup of AudioStream + Deepgram pipes. For long meetings with many participants, this takes multiple seconds, burning grace-period time *before* `_finalize_notes()` is even called.

2. **`await agent._monitor_task` after finalize** — blocked up to 5 seconds (the poll interval) after notes were already generated, pushing the process past the 10s parent grace window.

3. **No transcript truncation** — DeepSeek API call on 18K+ char transcripts takes longer, eating further into the grace period.

## Fixes

- **Don't await cancelled transcribe task** in SIGTERM path; cancel and let `asyncio.run()` clean up in the background.
- **Cancel monitor task immediately** instead of awaiting its full sleep.
- **Truncate transcript to 5K chars** before LLM call (head + tail). Full transcript still saved in the meeting notes payload — only the LLM summary input is truncated.
- **Bump parent `stop()` timeout** from 10s → 30s, giving the agent ample time for DeepSeek even on long calls.