### PR TITLE
Wire the layered Instinct gate live (lane routing on the merged foundation)

### DIFF
--- a/ee/pocketpaw_ee/cloud/instinct_approvals/dto.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/dto.py
@@ -38,12 +38,21 @@ class CreateApprovalRequest(BaseModel):
 
 
 class ListApprovalsRequest(BaseModel):
-    """Filter parameters for the list endpoint."""
+    """Filter parameters for the list endpoint.
+
+    ``action_name`` + ``row_id`` are server-side dedup filters (not exposed by
+    the public list route): the gate's BATCH dedup pushes them into the query
+    so a pocket with more pending rows than ``limit`` cannot bury a duplicate
+    match past the page boundary (security-review FIX 3). They default to None
+    so every existing caller is unaffected.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     status: str | None = None
     pocket_id: str | None = None
+    action_name: str | None = None
+    row_id: str | None = None
     limit: int = Field(default=50, ge=1, le=200)
 
 

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
@@ -4,6 +4,13 @@
 # level ``async def`` API per EE cloud rule 5. Every state-mutating
 # function:
 #
+# Updated: 2026-06-19 (feat/instinct-gate-integration, security-review FIX 3) —
+# ``list_approvals`` now honors optional ``action_name`` + ``row_id`` query
+# filters. The gate's BATCH dedup pushes them into the Mongo query so a pocket
+# with more pending rows than the page ``limit`` can no longer bury a duplicate
+# match past the page boundary (the old code listed + matched in Python and
+# could miss the row, stacking a duplicate pending approval).
+#
 # Updated: 2026-06-18 (feat/instinct-gate-foundation, T3) — added
 # ``auto_approve``, the layered/learning gate's AUTO-lane writer. It
 # inserts a row ALREADY-DECIDED (``status="auto_approved"``,
@@ -216,6 +223,13 @@ async def list_approvals(
         query["status"] = body.status
     if body.pocket_id:
         query["pocket_id"] = body.pocket_id
+    # Server-side dedup filters (security-review FIX 3). When the gate's BATCH
+    # dedup passes action_name + row_id, the DB does the matching so a pocket
+    # with more pending rows than ``limit`` can't bury the match past the page.
+    if body.action_name:
+        query["action_name"] = body.action_name
+    if body.row_id:
+        query["row_id"] = body.row_id
     cursor = (
         _ApprovalDoc.find(query).sort(-_ApprovalDoc.createdAt).limit(body.limit)  # type: ignore[operator]
     )

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
@@ -132,18 +132,26 @@ async def auto_approve(
     body: dict | CreateApprovalRequest,
     trust_score: float,
     triager_reasoning: str,
+    lane: str = "AUTO",
 ) -> dict:
     """Create a decided (``auto_approved``) approval row in one write.
 
-    The layered/learning gate's AUTO lane calls this instead of
-    ``create_approval`` when ``classify_lane`` returns ``AUTO``. The row is
-    inserted ALREADY-DECIDED: ``status="auto_approved"``,
-    ``decided_by="system:triager"``, ``decided_at=now`` — there is no
-    intermediate pending state and the OSS SQLite store is never touched
-    (design MF-1). Emits ``InstinctApprovalAutoApproved`` carrying the
-    triager's ``trust_score`` + ``triager_reasoning`` + ``lane="AUTO"`` so
-    the audit trail and Decision-Graph join have a backing row in the same
-    collection as every human decision (design MF-2).
+    The layered/learning gate's AUTO and OPTIMISTIC lanes call this instead
+    of ``create_approval`` when ``classify_lane`` clears the write for an
+    auto decision. The row is inserted ALREADY-DECIDED:
+    ``status="auto_approved"``, ``decided_by="system:triager"``,
+    ``decided_at=now`` — there is no intermediate pending state and the OSS
+    SQLite store is never touched (design MF-1). Emits
+    ``InstinctApprovalAutoApproved`` carrying the triager's ``trust_score``
+    + ``triager_reasoning`` + ``lane`` so the audit trail and Decision-Graph
+    join have a backing row in the same collection as every human decision
+    (design MF-2).
+
+    ``lane`` is the triage lane that produced the decision (``"AUTO"`` or
+    ``"OPTIMISTIC"``) — it rides on the emitted event so the UI can render
+    an optimistic (reversible, fired-now) decision distinctly from a fully
+    auto-approved one. Both share ``status="auto_approved"``; the lane is
+    the discriminator.
 
     ``user_id`` is the human who TRIGGERED the action (recorded as
     ``requested_by``); the DECIDER is the system triager, not the user.
@@ -188,7 +196,7 @@ async def auto_approve(
     payload["actor"] = "system:triager"
     payload["trust_score"] = trust_score
     payload["triager_reasoning"] = triager_reasoning
-    payload["lane"] = "AUTO"
+    payload["lane"] = lane
     await emit(InstinctApprovalAutoApproved(data=payload))
     return wire
 

--- a/ee/pocketpaw_ee/cloud/models/workspace.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace.py
@@ -1,5 +1,16 @@
 """Workspace document — one per deployment/org.
 
+2026-06-19 (layered/learning gate, T6): added
+``Workspace.instinct_approval_level`` — the PER-WORKSPACE override for the
+layered Instinct gate's triager activation level ("ASK" | "TRIAGE" |
+"TRUSTED"). ``None`` (the default) means "use the global config default"
+(``Settings.instinct_approval_level``, itself "ASK"). A workspace must
+explicitly set this to a non-ASK value to activate auto/optimistic/dry-run
+lanes for its writes — a global env var changes the default for NEW
+workspaces only and can never silently upgrade an existing tenant (design
+MF-9). The cloud router reads this field and passes the resolved level to
+``run_action`` → ``gate_action``.
+
 2026-06-14 (WB-1): added the ``Branding`` sub-model and a top-level
 ``Workspace.branding`` field for white-label theming (logo, display name,
 tab title, accent color, favicon, paw-mark toggle). Branding is a per-tenant
@@ -85,6 +96,13 @@ class Workspace(TimestampedDocument):
     sso_config: SsoConfig | None = None
     verified_domains: list[VerifiedDomain] = Field(default_factory=list)
     deleted_at: datetime | None = None
+    # Layered/learning Instinct gate (T6) — per-workspace triager activation
+    # level. None = use the global config default (Settings.
+    # instinct_approval_level, "ASK"). A workspace owner opts in to "TRIAGE"
+    # (or future "TRUSTED") to activate the auto/optimistic lanes for THIS
+    # workspace's writes; nothing else changes the default for an existing
+    # tenant (design MF-9 — global config cannot silently upgrade tenants).
+    instinct_approval_level: str | None = None
 
     class Settings:
         name = "workspaces"

--- a/ee/pocketpaw_ee/cloud/pockets/action_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/action_executor.py
@@ -199,6 +199,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# The dormant, fail-safe triager level. When a caller threads no
+# `approval_level` into `run_action`, gate 1.5 passes this string and
+# `gate_action._coerce_approval_level` maps it onto ApprovalLevel.ASK — the
+# triager stays dormant and every escalate goes to a human (zero behavior
+# change). Kept as a bare string so this module does not import the
+# `instinct_triage` enum at module load (instinct_triage imports
+# `CompensateSpec` from HERE, so a top-level back-import would risk a cycle).
+_DEFAULT_APPROVAL_LEVEL = "ASK"
+
 # --- limits / policy --------------------------------------------------------
 _PER_ACTION_TIMEOUT_S = 10.0
 # Write budget per (pocket, user) per window. Separate from the read
@@ -210,6 +219,40 @@ _ACTION_RATE_LIMIT_WINDOW_S = 60.0
 # Per-(pocket, user) write timestamps. SEPARATE dict from
 # source_executor._run_log so reads and writes never share a budget.
 _action_log: dict[tuple[str, str], list[float]] = {}
+
+# --- optimistic compensation registry (layered/learning gate, T10) ----------
+# The OPTIMISTIC lane fires a reversible write BEFORE a human reviews it, on
+# the bet that it can be undone. The registry holds the inverse-write handle
+# until the client rolls it back OR the TTL hard-expires it (firing an ALERT
+# audit). A single process-wide instance keyed by config TTL; consulted only
+# by the same process that minted the handle (in-memory is correct for the
+# foundation — see instinct_compensation_registry).
+_optimistic_registry: Any = None
+
+
+def get_optimistic_registry():
+    """Return the process-wide ``OptimisticCompensationRegistry`` (lazy).
+
+    Lazily constructed so importing this module never reads config at import
+    time and so a test can swap the instance. The TTL comes from
+    ``instinct_optimistic_ttl_seconds`` (default 300s, hard-expiry, no
+    heartbeat — design Q2).
+    """
+    global _optimistic_registry
+    if _optimistic_registry is None:
+        from pocketpaw.config import get_settings
+        from pocketpaw_ee.cloud.pockets.instinct_compensation_registry import (
+            OptimisticCompensationRegistry,
+        )
+
+        ttl = 300
+        try:
+            ttl = int(get_settings().instinct_optimistic_ttl_seconds)
+        except Exception:  # noqa: BLE001 — fall back to the documented default
+            logger.warning("could not read instinct_optimistic_ttl_seconds; using 300s")
+        _optimistic_registry = OptimisticCompensationRegistry(ttl_seconds=ttl)
+    return _optimistic_registry
+
 
 # Guards the check-and-record on ``_action_log``. The read-filter-write is a
 # TOCTOU race under ``asyncio.gather``; the lock makes it atomic — the same
@@ -671,6 +714,10 @@ async def run_action(
     workspace_context: dict[str, Any] | None = None,
     row_id: str = "",
     correlation_id: UUID | None = None,
+    optimistic_execute: bool = False,
+    dry_run: bool = False,
+    approval_level: Any = None,
+    dry_run_mode: bool = False,
 ) -> dict:
     """Run ONE pocket write action against its configured backend.
 
@@ -697,6 +744,24 @@ async def run_action(
     Action's schema-2 ``_pocket_write`` blob). On the parked path the
     minted / supplied id rides on the ``_park`` dict so the bridge can
     stash it on the Instinct Action.
+
+    ``dry_run`` and ``optimistic_execute`` (the layered/learning gate
+    integration, T7) are NEW dedicated flags — neither reuses
+    ``from_instinct``:
+
+    * ``dry_run=True`` — a GOVERNANCE REHEARSAL. The executor runs every
+      security gate (2-6) as VALIDATION, then intercepts at gate 7 and
+      returns the ``instinct_dry_run`` sentinel carrying the resolved write
+      under ``_park`` — server-side only, NO HTTP call, NO approval row. An
+      off-policy write (allowlist miss, bad base-url) is still REJECTED by
+      the gates that run first; the dry-run intercept never runs for it
+      (the safety-critical ordering, T-30).
+    * ``optimistic_execute=True`` — a TRUSTED, REVERSIBLE write the triager
+      cleared for OPTIMISTIC execution. It sets ``optimistic_gate_cleared``
+      so gate 7's deny-by-default park does NOT fire; the write executes
+      NOW. ``from_instinct`` stays ``False`` (MF-4 — no semantic lie: this
+      is not a post-human-approval re-entry). The caller registers a bounded
+      compensation handle so the optimistic bet is time-limited.
 
     The result shape on a fired success::
 
@@ -812,6 +877,10 @@ async def run_action(
             "outcome_value": binding.outcome_value,
             "outcome_unit": binding.outcome_unit,
         }
+        # The binding's declared inverse rides on `park` so the triage
+        # router (classify_lane) can read reversibility for the lane decision.
+        if binding.compensate is not None:
+            park["compensate"] = binding.compensate.model_dump()
         gate = await instinct_dispatch.gate_action(
             workspace_id=workspace_id,
             user_id=user_id,
@@ -822,6 +891,15 @@ async def run_action(
             workspace_context=workspace_context,
             row_id=row_id,
             park=park,
+            # Layered/learning gate (T6). When the caller passes no
+            # `approval_level` (every legacy caller), `gate_action`'s own
+            # default ApprovalLevel.ASK applies — the triager stays dormant
+            # and every escalate becomes a human-pending row (zero behavior
+            # change). The router passes the workspace's level to activate it.
+            approval_level=approval_level
+            if approval_level is not None
+            else _DEFAULT_APPROVAL_LEVEL,
+            dry_run_mode=dry_run_mode,
         )
         if gate.next_step == "blocked":
             _audit_action_run(
@@ -859,15 +937,38 @@ async def run_action(
                 "on_success": [],
                 "on_error": [],
             }
-        # gate.next_step == "proceed" — fall through into the existing
-        # gate stack. Notify rules are dropped on the floor here; Wave
-        # 3c wires the side-effect dispatcher.
-        #
-        # W2a — the template gate EXPLICITLY adjudicated this write and said
-        # proceed. Mark it so gate 7's deny-by-default park does not double-
-        # gate it (see the `template_gate_cleared` definition above and the
-        # gate-7 condition below).
-        template_gate_cleared = True
+        if gate.next_step == "dry_run":
+            # The triager routed this escalate to the DRY_RUN lane. Set the
+            # local dry-run flag so gate 7a returns the `instinct_dry_run`
+            # sentinel AFTER the security gates validate the write. No
+            # approval row was persisted (the gate's DRY_RUN branch persists
+            # nothing). template_gate_cleared so gate 7's park does not also
+            # fire.
+            dry_run = True
+            template_gate_cleared = True
+        elif gate.next_step == "auto_approved":
+            # AUTO lane — the gate already wrote a DECIDED (auto_approved)
+            # approval row; the write now FIRES. template_gate_cleared
+            # suppresses gate 7's deny-by-default park so the HTTP call runs.
+            template_gate_cleared = True
+        elif gate.next_step == "optimistic_proceed":
+            # OPTIMISTIC lane — the gate wrote a decided row; the write fires
+            # NOW and registers a bounded compensation handle (gate 8 success
+            # path). `optimistic_execute` clears gate 7's park and triggers
+            # the handle registration.
+            optimistic_execute = True
+            template_gate_cleared = True
+        else:
+            # gate.next_step == "proceed" — EXECUTE / NOTIFY_AND_EXECUTE.
+            # Fall through into the existing gate stack. Notify rules are
+            # dropped on the floor here; Wave 3c wires the side-effect
+            # dispatcher.
+            #
+            # W2a — the template gate EXPLICITLY adjudicated this write and
+            # said proceed. Mark it so gate 7's deny-by-default park does not
+            # double-gate it (see the `template_gate_cleared` definition above
+            # and the gate-7 condition below).
+            template_gate_cleared = True
 
     # ── 2. write rate limit ─────────────────────────────────────────────
     if await _action_rate_limited(pocket_id, user_id):
@@ -1009,9 +1110,58 @@ async def run_action(
         )
         return _error(action, exc.message, exc.code, on_error)
 
+    # The resolved-write blob — built once so the dry-run sentinel and the
+    # gate-7 park return BYTE-IDENTICAL `_park` dicts. The router strips
+    # `_park` from both sentinels the same way (it must never reach the
+    # wire), so the two shapes must match exactly (T-31).
+    park_blob = {
+        "action": action,
+        "method": method,
+        "path": path,
+        "params": params,
+        "idempotency_key": idempotency_key,
+        "outcome": binding.outcome,
+        # gap-3 — billable value/unit ride on _park so the bridge stashes
+        # them on the persisted parked-write blob and the post-approval
+        # emit threads them to the ledger row.
+        "outcome_value": binding.outcome_value,
+        "outcome_unit": binding.outcome_unit,
+        # RFC 09 Slice 2 — correlation_id rides on _park so the bridge can
+        # stash it on the parked Action's schema-2 _pocket_write blob.
+        "correlation_id": str(correlation_id),
+    }
+
+    # ── 7a. DRY-RUN intercept (layered/learning gate, T7) ───────────────
+    # Placed AFTER the security gates (2-6) so they run as VALIDATION first:
+    # an off-policy write (allowlist miss, SSRF, bad base-url) was ALREADY
+    # rejected above and never reaches this point (T-30). A dry-run is a
+    # governance REHEARSAL — the write is resolved + auditable but NEVER
+    # sent to the backend and NEVER persisted as an approval row. The
+    # `instinct_dry_run` sentinel stays server-side: the router strips
+    # `_park` exactly as it does for `instinct_pending`, so the resolved
+    # write never reaches the client wire (T-31). dry_run never overrides a
+    # BLOCK — a BLOCK short-circuited at gate 1.5 before reaching here.
+    if dry_run:
+        _audit_action_run(
+            actor=user_id,
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            action=action,
+            status="instinct-dry-run",
+            base_url=base_url,
+        )
+        return {
+            "ok": True,
+            "code": "instinct_dry_run",
+            "action": action,
+            "_park": park_blob,
+            "on_success": [],
+            "on_error": [],
+        }
+
     # ── 7. instinct park ────────────────────────────────────────────────
     # W2a — DENY-BY-DEFAULT. `binding.requires_instinct` now defaults True
-    # (see ActionBinding), so EVERY write parks here unless one of THREE
+    # (see ActionBinding), so EVERY write parks here unless one of FOUR
     # explicit, auditable conditions holds:
     #   * `binding.instinct_exempt` — the author declared (in the persisted
     #     spec) that this binding is deliberately allowed to fire without
@@ -1029,21 +1179,32 @@ async def run_action(
     #     writes the template already cleared. The template gate is the
     #     governance for template-bound pockets; the binding-level gate is
     #     the deny-by-default backstop for everything else.
+    #   * `optimistic_execute` — the layered/learning gate (T7) cleared this
+    #     write for OPTIMISTIC execution: trusted + reversible, the triager
+    #     bet the write can be undone if wrong. It fires NOW instead of
+    #     parking, and the caller registers a bounded compensation handle so
+    #     the bet is time-limited. A DEDICATED flag, not `from_instinct`
+    #     (MF-4): this is NOT a post-human-approval re-entry, so reusing
+    #     `from_instinct` would be a semantic lie that also wrongly
+    #     suppresses the direct-path chain close. The optimistic write OWNS
+    #     its chain close like any other direct fire.
     #
     # A binding that requires instinct, on a direct (not post-approval, not
-    # exempt, not template-cleared) run, is PARKED — not fired. Gates 2-6
-    # already ran as VALIDATION, so a write the allowlist would reject was
-    # rejected above, NOT parked: an off-policy write must never reach the
-    # approval surface looking legitimate. The executor stays pure — it just
-    # returns the resolved write under `_park` and signals
-    # `instinct_pending`. The router hands `_park` to
+    # exempt, not template-cleared, not optimistic) run, is PARKED — not
+    # fired. Gates 2-6 already ran as VALIDATION, so a write the allowlist
+    # would reject was rejected above, NOT parked: an off-policy write must
+    # never reach the approval surface looking legitimate. The executor
+    # stays pure — it just returns the resolved write under `_park` and
+    # signals `instinct_pending`. The router hands `_park` to
     # `instinct_bridge.propose_pocket_write`, which builds the Instinct
     # Action. NO HTTP call is made here.
+    optimistic_gate_cleared = optimistic_execute
     if (
         binding.requires_instinct
         and not binding.instinct_exempt
         and not from_instinct
         and not template_gate_cleared
+        and not optimistic_gate_cleared
     ):
         _audit_action_run(
             actor=user_id,
@@ -1057,26 +1218,7 @@ async def run_action(
             "ok": True,
             "code": "instinct_pending",
             "action": action,
-            "_park": {
-                "action": action,
-                "method": method,
-                "path": path,
-                "params": params,
-                "idempotency_key": idempotency_key,
-                "outcome": binding.outcome,
-                # gap-3 — billable value/unit ride on _park so the bridge
-                # stashes them on the persisted parked-write blob and the
-                # post-approval emit threads them to the ledger row.
-                "outcome_value": binding.outcome_value,
-                "outcome_unit": binding.outcome_unit,
-                # RFC 09 Slice 2 — correlation_id rides on _park so the
-                # bridge can stash it on the parked Action's schema-2
-                # _pocket_write blob. The Instinct router reads it back
-                # at approve/reject time to chain policy.evaluated +
-                # human.corrected + decision.completed under the same
-                # correlation as the agent.proposed we already emitted.
-                "correlation_id": str(correlation_id),
-            },
+            "_park": park_blob,
             "on_success": [],
             "on_error": [],
         }
@@ -1267,7 +1409,7 @@ async def run_action(
             causation_id=policy_event_id,
         )
 
-    return {
+    success = {
         "ok": True,
         "action": action,
         "status": result["status"],
@@ -1284,6 +1426,34 @@ async def run_action(
         "on_success": binding.on_success,
         "on_error": on_error,
     }
+
+    # ── OPTIMISTIC compensation registration (layered/learning gate, T10) ─
+    # An OPTIMISTIC write fired BEFORE a human reviewed it, on the bet it's
+    # reversible. If the binding declares a `compensate` inverse, register a
+    # bounded handle so (a) the client can roll it back via the optimistic
+    # rollback endpoint and (b) the TTL sweeper hard-expires the bet with an
+    # ALERT if it's never rolled back. No `compensate` → no handle (nothing
+    # to undo). Best-effort: a registry hiccup must never break the write
+    # that already succeeded. The id rides back on `_optimistic_compensation_id`
+    # which the router passes to the client and strips from the wire model.
+    if optimistic_execute and binding.compensate is not None:
+        try:
+            cid = get_optimistic_registry().register(
+                workspace_id=workspace_id,
+                pocket_id=pocket_id,
+                action=action,
+                compensate=binding.compensate,
+            )
+            success["_optimistic_compensation_id"] = cid
+        except Exception:  # noqa: BLE001 — registration must never break the write
+            logger.warning(
+                "optimistic compensation registration failed for action=%s pocket=%s",
+                action,
+                pocket_id,
+                exc_info=True,
+            )
+
+    return success
 
 
 def _emit_direct_path_failure(
@@ -1395,4 +1565,9 @@ async def _do_request(
     return {"status": resp.status_code, "response": response}
 
 
-__all__ = ["ActionBinding", "CompensateSpec", "run_action"]
+__all__ = [
+    "ActionBinding",
+    "CompensateSpec",
+    "get_optimistic_registry",
+    "run_action",
+]

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -559,6 +559,12 @@ class RunActionResponse(BaseModel):
     error: str | None = None
     code: str | None = None
     proposed_action_id: str | None = None
+    # Layered/learning gate (T6/T10) — set only on an OPTIMISTIC-lane write:
+    # the id of the bounded compensation handle the client can roll back via
+    # the optimistic rollback endpoint. None on every other path. The
+    # executor returns it as ``_optimistic_compensation_id`` (internal key);
+    # the router maps it onto this public field.
+    optimistic_compensation_id: str | None = None
     on_success: list[dict] = Field(default_factory=list)
     on_error: list[dict] = Field(default_factory=list)
 

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
@@ -601,6 +601,32 @@ async def execute_approved_write(action) -> None:  # type: ignore[no-untyped-def
         f"write '{action_name}' executed — HTTP {result.get('status')}",
     )
 
+    # T8 (layered/learning gate) — the SINGLE trust-feedback write site.
+    # After a gated write actually LANDS, append one trust-ledger row for
+    # the (workspace, pocket, action) pair. ``was_auto_approved`` is True
+    # when the system triager decided the write (``approver ==
+    # "system:triager"`` — the AUTO/OPTIMISTIC lanes' decider) and False
+    # when a human approved it. This is the ONLY place trust is recorded
+    # (MF-3): ``outcomes/service.py`` must NOT call it, so the trust loop
+    # can never self-poison by double-counting one executed write. Best-
+    # effort: a sidecar write failure degrades trust accuracy but must
+    # never fail the approve response (the write already succeeded).
+    try:
+        from pocketpaw_ee.cloud.pockets import trust_ledger
+
+        await trust_ledger.record_correction(
+            workspace_id,
+            pocket_id,
+            action_name,
+            was_auto_approved=(approver == "system:triager"),
+        )
+    except Exception:  # noqa: BLE001 — trust feedback is best-effort
+        logger.warning(
+            "approved action %s: trust feedback write failed (write succeeded)",
+            action.id,
+            exc_info=True,
+        )
+
     # RFC 09 Slice 2 — chain close on the bridge-side success path
     # (audit Producer 4 site (b)). Emit BEFORE ``emit_pocket_outcome``
     # so the outcomes-side ``decision.outcome_attached`` (RFC 07 Slice 2

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
@@ -1,4 +1,11 @@
 # ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+# Updated: 2026-06-19 (feat/instinct-gate-integration, security-review FIX 3) —
+# `_find_existing_pending_id` now pushes the (action_name, row_id) match INTO
+# the approvals query (limit=1) instead of paging a default list and matching
+# in Python. A pocket with more pending rows than the page limit could bury the
+# target row, the scan would miss it, and the BATCH lane would stack a
+# DUPLICATE pending row. The DB-side filter makes dedup correct at any volume.
+#
 # Updated: 2026-06-19 (feat/instinct-gate-integration, T6/T11) — wired the
 # layered/learning gate LIVE. `gate_action` now takes `approval_level`
 # (default ASK = dormant) and `dry_run_mode` (default False), and after an
@@ -240,20 +247,35 @@ async def _find_existing_pending_id(
 
     Two escalating gate calls for the SAME row (a flapping rule, a retried
     dispatch, a bulk fan-out hitting the same row twice) must not stack N
-    pending rows in the human tray — the human decides the row ONCE. We scope
-    by ``(pocket_id, status="pending")`` and match the action + row in
-    Python (the list query has no row_id filter today). An empty ``row_id``
-    is NOT deduped — a row-less escalate has no stable identity to group on,
-    so it falls through to a fresh row (the conservative choice).
+    pending rows in the human tray — the human decides the row ONCE.
+
+    Security-review FIX 3: the match is now pushed INTO the query
+    (``action_name`` + ``row_id`` filters) with ``limit=1``, instead of listing
+    a default page of pending rows and matching in Python. A pocket with more
+    pending rows than the list page (default 50) could otherwise bury the
+    target row past the page boundary, the Python scan would miss it, and the
+    gate would stack a DUPLICATE pending row — exactly the dedup the lane is
+    meant to prevent. Letting Mongo do the match makes dedup correct regardless
+    of how many other pending rows the pocket carries.
+
+    An empty ``row_id`` is NOT deduped — a row-less escalate has no stable
+    identity to group on, so it falls through to a fresh row (conservative).
     """
     if not row_id:
         return None
     existing = await approvals_service.list_approvals(
-        workspace_id, user_id, {"pocket_id": pocket_id, "status": "pending"}
+        workspace_id,
+        user_id,
+        {
+            "pocket_id": pocket_id,
+            "status": "pending",
+            "action_name": action_name,
+            "row_id": row_id,
+            "limit": 1,
+        },
     )
-    for row in existing:
-        if row.get("action_name") == action_name and row.get("row_id") == row_id:
-            return row.get("id")
+    if existing:
+        return existing[0].get("id")
     return None
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
@@ -1,4 +1,29 @@
 # ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py
+# Updated: 2026-06-19 (feat/instinct-gate-integration, T6/T11) — wired the
+# layered/learning gate LIVE. `gate_action` now takes `approval_level`
+# (default ASK = dormant) and `dry_run_mode` (default False), and after an
+# `ESCALATE_APPROVAL` verdict it calls `instinct_triage.classify_lane` and
+# branches by lane:
+#   * AUTO       → `approvals_service.auto_approve(...)` (a DECIDED row, no
+#                  pending) and `next_step="auto_approved"`.
+#   * OPTIMISTIC → an auto_approved row tagged lane=OPTIMISTIC and
+#                  `next_step="optimistic_proceed"`.
+#   * DRY_RUN    → `next_step="dry_run"` (no row; the executor resolves the
+#                  write and audits it but never fires).
+#   * ESCALATE   → the EXISTING human-pending path, UNCHANGED, with BATCH
+#                  dedup (T11): a second escalate for the same
+#                  (pocket, action, row) returns the existing pending id.
+#   * BLOCK      → unchanged.
+# The triage decision is audited (`category="instinct_triage"`) at every
+# TRIAGE call. trust_score + proposed_count come from the trust ledger.
+#
+# THE SAFETY INVARIANT: default `approval_level=ASK` makes `classify_lane`
+# return ESCALATE for every proposal (rule 2), so a caller that passes no
+# new args is byte-identical to the pre-integration behavior — every
+# escalate becomes a human-pending row. Auto-approval activates ONLY when a
+# workspace explicitly opts into a non-ASK level; uncertainty always
+# escalates to the human, never silently approves.
+#
 # Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — single entry
 # point from the runtime into the RFC 03 v2 template-level Instinct.
 # Wraps the OSS-side ``resolve_instinct`` pure function with the EE-
@@ -39,27 +64,48 @@ from pocketpaw.bundled_templates import (
 from pocketpaw.bundled_templates.identifier_resolver import IdentifierResolver
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+from pocketpaw_ee.cloud.pockets import trust_ledger
+from pocketpaw_ee.cloud.pockets.action_executor import CompensateSpec
+from pocketpaw_ee.cloud.pockets.instinct_triage import (
+    ApprovalLevel,
+    TriageLane,
+    TriageProposal,
+    classify_lane,
+)
 
 logger = logging.getLogger(__name__)
 
-NextStepT = Literal["proceed", "blocked", "pending_approval"]
+# Two new literals join the original three: ``dry_run`` (the write is
+# resolved + audited but never fired) and ``optimistic_proceed`` (the write
+# fires now, with a registered compensation handle for bounded rollback).
+NextStepT = Literal[
+    "proceed",
+    "blocked",
+    "pending_approval",
+    "auto_approved",
+    "dry_run",
+    "optimistic_proceed",
+]
 
 
 class InstinctGateResult(BaseModel):
     """Outcome of a single ``gate_action`` call.
 
-    Frozen so the executor cannot mutate it. The four-fielded shape
-    matches what the runtime needs to dispatch:
+    Frozen so the executor cannot mutate it. The shape matches what the
+    runtime needs to dispatch:
 
     * ``decision`` — the pure OSS composer's verdict + audit data.
     * ``next_step`` — collapsed branch for the executor (proceed /
-      blocked / pending_approval).
-    * ``approval_id`` — set only when ``next_step == "pending_approval"``;
-      the action_executor returns it on the ``instinct_pending``
-      sentinel response.
+      blocked / pending_approval / auto_approved / dry_run /
+      optimistic_proceed).
+    * ``approval_id`` — set when ``next_step`` is ``pending_approval``
+      (the new human-pending row), ``auto_approved`` (the decided AUTO/
+      OPTIMISTIC row), and stays ``None`` for proceed / blocked / dry_run.
     * ``notify_rules`` — top-level ``notify`` rules whose ``when``
-      matched the row. Carried through for the future notify side-
-      effect dispatcher (Wave 3c). Empty on BLOCK.
+      matched the row. Empty on BLOCK.
+    * ``lane`` — the triage lane ``classify_lane`` selected. Defaults to
+      ``ESCALATE`` (the safe lane) so a result built on a non-triage path
+      (EXECUTE / BLOCK) reports the most-governed lane.
     """
 
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
@@ -68,6 +114,7 @@ class InstinctGateResult(BaseModel):
     next_step: NextStepT
     approval_id: str | None = None
     notify_rules: list[InstinctRule] = []
+    lane: TriageLane = TriageLane.ESCALATE
 
 
 def _matched_rules_payload(decision: InstinctDecision) -> list[dict[str, Any]]:
@@ -75,6 +122,139 @@ def _matched_rules_payload(decision: InstinctDecision) -> list[dict[str, Any]]:
     Beanie ``list[dict]`` field. ``InstinctRule.model_dump`` is the
     canonical serializer."""
     return [r.model_dump() for r in decision.matched_rules]
+
+
+def _coerce_approval_level(level: ApprovalLevel | str | None) -> ApprovalLevel:
+    """Map a raw (possibly stringy / unknown) level onto the enum, default-safe.
+
+    The cloud router reads the per-workspace field (a plain string) or the
+    global config default; both may arrive as a bare string. An unknown /
+    malformed value falls back to ``ASK`` — the dormant, fail-safe level —
+    so a typo on a workspace document can never silently activate the
+    triager.
+    """
+    if isinstance(level, ApprovalLevel):
+        return level
+    if isinstance(level, str):
+        try:
+            return ApprovalLevel(level)
+        except ValueError:
+            logger.warning("unknown instinct approval_level %r — falling back to ASK", level)
+    return ApprovalLevel.ASK
+
+
+def _compensate_from_park(park: dict[str, Any] | None) -> CompensateSpec | None:
+    """Pull the binding's ``compensate`` spec off the ``_park`` blob, if any.
+
+    The executor threads the binding's declared ``compensate`` into ``park``
+    (gap-3 path); a write with a declared inverse is the reversibility
+    signal ``classify_lane`` reads. A malformed compensate blob is treated
+    as ABSENT (no compensate) — the safe reading, since a write with no
+    trustworthy inverse must never be promoted to AUTO.
+    """
+    if not park:
+        return None
+    raw = park.get("compensate")
+    if raw is None:
+        return None
+    if isinstance(raw, CompensateSpec):
+        return raw
+    if isinstance(raw, dict):
+        try:
+            return CompensateSpec.model_validate(raw)
+        except Exception:  # noqa: BLE001 — a bad inverse is no inverse (safe)
+            logger.warning("malformed compensate spec on park blob — treating as no compensate")
+            return None
+    return None
+
+
+def _audit_triage_decision(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    action: str,
+    lane: TriageLane,
+    trust_score: float,
+    proposed_count: int,
+    approval_level: ApprovalLevel,
+) -> None:
+    """Write the classify_lane decision to the append-only audit log.
+
+    Category ``instinct_triage``, severity INFO. Every TRIAGE-level
+    classify decision is logged so the triager's reasoning is auditable —
+    which lane it chose, the trust score + warmup count it read, and the
+    activation level in force. Audit failures must never break the gate, so
+    the whole call is wrapped (mirrors ``action_executor._audit_action_run``).
+    """
+    try:
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=AuditSeverity.INFO,
+                actor="system:triager",
+                action="instinct.triage.classify",
+                target=pocket_id,
+                status=lane.name.lower(),
+                category="instinct_triage",
+                workspace_id=workspace_id,
+                pocket_action=action,
+                lane=lane.name,
+                trust_score=trust_score,
+                proposed_count=proposed_count,
+                approval_level=approval_level.value,
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the gate
+        logger.warning("instinct triage-decision audit-log write failed", exc_info=True)
+
+
+def _escalate_body(
+    *,
+    pocket_id: str,
+    action_name: str,
+    row_id: str,
+    row_context: dict[str, Any],
+    decision: InstinctDecision,
+    park: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the CreateApprovalRequest body shared by the pending + decided
+    write paths. One shape so the audit trail is uniform across lanes."""
+    return {
+        "pocket_id": pocket_id,
+        "action_name": action_name,
+        "row_id": row_id,
+        "row_data": row_context,
+        "verdict": decision.verdict,
+        "reason": decision.reason,
+        "matched_rules": _matched_rules_payload(decision),
+        "park": park,
+    }
+
+
+async def _find_existing_pending_id(
+    *, workspace_id: str, user_id: str, pocket_id: str, action_name: str, row_id: str
+) -> str | None:
+    """T11 — BATCH-lane dedup: return an existing pending approval id for the
+    same (pocket, action, row), or ``None``.
+
+    Two escalating gate calls for the SAME row (a flapping rule, a retried
+    dispatch, a bulk fan-out hitting the same row twice) must not stack N
+    pending rows in the human tray — the human decides the row ONCE. We scope
+    by ``(pocket_id, status="pending")`` and match the action + row in
+    Python (the list query has no row_id filter today). An empty ``row_id``
+    is NOT deduped — a row-less escalate has no stable identity to group on,
+    so it falls through to a fresh row (the conservative choice).
+    """
+    if not row_id:
+        return None
+    existing = await approvals_service.list_approvals(
+        workspace_id, user_id, {"pocket_id": pocket_id, "status": "pending"}
+    )
+    for row in existing:
+        if row.get("action_name") == action_name and row.get("row_id") == row_id:
+            return row.get("id")
+    return None
 
 
 async def gate_action(
@@ -90,6 +270,8 @@ async def gate_action(
     park: dict[str, Any] | None = None,
     resolver: IdentifierResolver | None = None,
     now: datetime | None = None,
+    approval_level: ApprovalLevel | str | None = ApprovalLevel.ASK,
+    dry_run_mode: bool = False,
 ) -> InstinctGateResult:
     """Resolve the template-level Instinct verdict for one action+row.
 
@@ -97,22 +279,43 @@ async def gate_action(
     branches:
 
     * ``BLOCK`` → persist nothing. Return ``next_step="blocked"``.
-    * ``ESCALATE_APPROVAL`` → persist one ``InstinctApproval`` row via
-      ``instinct_approvals.service.create_approval``. Return
-      ``next_step="pending_approval"`` with the new approval id.
-    * ``EXECUTE`` → no persistence. Return ``next_step="proceed"``.
-    * ``NOTIFY_AND_EXECUTE`` → no persistence. Return
+    * ``EXECUTE`` / ``NOTIFY_AND_EXECUTE`` → no persistence. Return
       ``next_step="proceed"`` with ``notify_rules`` populated for the
       side-effect dispatcher.
+    * ``ESCALATE_APPROVAL`` → run the layered triage router. Read the
+      (pocket, action) trust score from the trust ledger, build a
+      ``TriageProposal`` from the verdict + the parked write's method/path/
+      compensate, call ``classify_lane`` and branch by lane:
+
+        - AUTO → ``approvals_service.auto_approve`` writes a DECIDED row;
+          ``next_step="auto_approved"``.
+        - OPTIMISTIC → an auto_approved row tagged lane=OPTIMISTIC;
+          ``next_step="optimistic_proceed"`` (the executor fires the write
+          and registers a bounded compensation handle).
+        - DRY_RUN → ``next_step="dry_run"`` (no row; the executor resolves
+          and audits the write but never fires it).
+        - ESCALATE → the human-pending path (unchanged), with BATCH dedup.
+
+    ``approval_level`` defaults to ``ASK`` — the dormant level under which
+    ``classify_lane`` always returns ESCALATE, so EVERY existing caller
+    (none pass the new args) is byte-identical to the pre-integration gate.
+    A workspace must explicitly opt into ``TRIAGE``/``TRUSTED`` for any
+    lane other than ESCALATE to fire. The cloud router reads the
+    workspace's level (falling back to the global config default) and
+    passes it here.
+
+    ``dry_run_mode`` (from config / the workspace) routes escalating writes
+    to DRY_RUN — but only AFTER the BLOCK and ASK floors, so a BLOCK row is
+    still blocked and a dormant workspace still escalates to a human even
+    when dry-run is globally on.
 
     Errors:
         ``InstinctResolutionError`` from the composer (unknown action
         on the template, or a CEL eval failure on a rule) is mapped to
-        ``NotFound("instinct_action", action_name)``. The brief locks
-        ``NotFound`` for unknown action; an eval failure is structurally
-        the same shape (an undeclared identifier or a malformed rule is
-        a programming/authoring error, not a permissions issue).
+        ``NotFound("instinct_action", action_name)``.
     """
+    level = _coerce_approval_level(approval_level)
+
     try:
         decision = resolve_instinct(
             template,
@@ -123,11 +326,6 @@ async def gate_action(
             now=now,
         )
     except InstinctResolutionError as exc:
-        # The runtime cannot dispatch an action the template does not
-        # declare, and it cannot continue past a rule that does not
-        # evaluate cleanly. Either is a 404 on "the action the caller
-        # asked for is not (currently) runnable" — never echo the
-        # internal exception text to the wire.
         logger.warning(
             "instinct gate failed for action=%s pocket=%s: %s",
             action_name,
@@ -142,38 +340,211 @@ async def gate_action(
             next_step="blocked",
             approval_id=None,
             notify_rules=[],
+            lane=TriageLane.ESCALATE,
         )
 
     if decision.verdict == "ESCALATE_APPROVAL":
-        # Persist + tag the approval id back onto the result. The
-        # executor returns this on the ``instinct_pending`` sentinel
-        # so the caller (and the eventual approver UI) can address
-        # the row.
-        body = {
-            "pocket_id": pocket_id,
-            "action_name": action_name,
-            "row_id": row_id,
-            "row_data": row_context,
-            "verdict": decision.verdict,
-            "reason": decision.reason,
-            "matched_rules": _matched_rules_payload(decision),
-            "park": park,
-        }
-        wire = await approvals_service.create_approval(workspace_id, user_id, body)
-        return InstinctGateResult(
+        return await _route_escalation(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            action_name=action_name,
+            row_id=row_id,
+            row_context=row_context,
             decision=decision,
-            next_step="pending_approval",
-            approval_id=wire["id"],
-            notify_rules=list(decision.notify_rules),
+            park=park,
+            level=level,
+            dry_run_mode=dry_run_mode,
         )
 
-    # EXECUTE / NOTIFY_AND_EXECUTE — proceed. Notify rules carry
-    # through (top-level notify can fire alongside an auto execute).
+    # EXECUTE / NOTIFY_AND_EXECUTE — proceed. Notify rules carry through.
     return InstinctGateResult(
         decision=decision,
         next_step="proceed",
         approval_id=None,
         notify_rules=list(decision.notify_rules),
+        lane=TriageLane.ESCALATE,
+    )
+
+
+async def _route_escalation(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    action_name: str,
+    row_id: str,
+    row_context: dict[str, Any],
+    decision: InstinctDecision,
+    park: dict[str, Any] | None,
+    level: ApprovalLevel,
+    dry_run_mode: bool,
+) -> InstinctGateResult:
+    """Run the layered triage router for an ESCALATE_APPROVAL verdict.
+
+    Reads trust, classifies the lane, audits the decision (at TRIAGE+), and
+    dispatches per lane. ASK short-circuits to the unchanged human-pending
+    path WITHOUT a trust read or audit (zero behavior change + zero new
+    I/O on the dormant path).
+    """
+    # Fast path: dormant triager. classify_lane would return ESCALATE under
+    # ASK anyway, but short-circuiting here means the dormant default does
+    # not even read the trust ledger or emit a triage audit row — it is
+    # byte-identical to the pre-integration escalate path.
+    if level == ApprovalLevel.ASK:
+        return await _escalate_to_human(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            action_name=action_name,
+            row_id=row_id,
+            row_context=row_context,
+            decision=decision,
+            park=park,
+        )
+
+    # Active triager — read trust, classify, audit.
+    compensate = _compensate_from_park(park)
+    method = str((park or {}).get("method") or "POST")
+    path = str((park or {}).get("path") or "")
+    trust_score, proposed_count = await trust_ledger.get_trust_score(
+        workspace_id, pocket_id, action_name
+    )
+
+    proposal = TriageProposal(
+        action=action_name,
+        method=method,  # type: ignore[arg-type]
+        path=path,
+        compensate=compensate,
+        trust_score=trust_score,
+        proposed_count=proposed_count,
+        instinct_verdict=decision.verdict,
+        approval_level=level,
+    )
+    lane = classify_lane(proposal, dry_run_mode=dry_run_mode)
+
+    _audit_triage_decision(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        action=action_name,
+        lane=lane,
+        trust_score=trust_score,
+        proposed_count=proposed_count,
+        approval_level=level,
+    )
+
+    if lane == TriageLane.DRY_RUN:
+        # No persistence — the executor resolves + audits the write but
+        # never fires it. The dry-run sentinel stays server-side.
+        return InstinctGateResult(
+            decision=decision,
+            next_step="dry_run",
+            approval_id=None,
+            notify_rules=list(decision.notify_rules),
+            lane=lane,
+        )
+
+    if lane in (TriageLane.AUTO, TriageLane.OPTIMISTIC):
+        body = _escalate_body(
+            pocket_id=pocket_id,
+            action_name=action_name,
+            row_id=row_id,
+            row_context=row_context,
+            decision=decision,
+            park=park,
+        )
+        reasoning = (
+            f"triager lane={lane.name} trust={trust_score:.2f} "
+            f"count={proposed_count} verdict={decision.verdict}"
+        )
+        wire = await approvals_service.auto_approve(
+            workspace_id,
+            user_id,
+            body,
+            trust_score=trust_score,
+            triager_reasoning=reasoning,
+            lane=lane.name,
+        )
+        next_step: NextStepT = "auto_approved" if lane == TriageLane.AUTO else "optimistic_proceed"
+        return InstinctGateResult(
+            decision=decision,
+            next_step=next_step,
+            approval_id=wire["id"],
+            notify_rules=list(decision.notify_rules),
+            lane=lane,
+        )
+
+    # BATCH / ESCALATE → human-pending (BATCH is dedup-then-escalate today;
+    # the lane is recorded but routes to the same human queue).
+    result = await _escalate_to_human(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        action_name=action_name,
+        row_id=row_id,
+        row_context=row_context,
+        decision=decision,
+        park=park,
+    )
+    # Stamp the classified lane onto the result (the human path defaults the
+    # lane field to ESCALATE; record what the triager actually decided).
+    return result.model_copy(update={"lane": lane})
+
+
+async def _escalate_to_human(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    action_name: str,
+    row_id: str,
+    row_context: dict[str, Any],
+    decision: InstinctDecision,
+    park: dict[str, Any] | None,
+) -> InstinctGateResult:
+    """Persist (or dedup to) a pending approval row — the unchanged human path.
+
+    T11 — BATCH dedup: a second escalate for the same (pocket, action, row)
+    returns the existing pending row's id instead of creating a duplicate.
+    """
+    existing_id = await _find_existing_pending_id(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        action_name=action_name,
+        row_id=row_id,
+    )
+    if existing_id is not None:
+        logger.info(
+            "instinct gate: dedup pending approval for pocket=%s action=%s row=%s → %s",
+            pocket_id,
+            action_name,
+            row_id,
+            existing_id,
+        )
+        return InstinctGateResult(
+            decision=decision,
+            next_step="pending_approval",
+            approval_id=existing_id,
+            notify_rules=list(decision.notify_rules),
+            lane=TriageLane.ESCALATE,
+        )
+
+    body = _escalate_body(
+        pocket_id=pocket_id,
+        action_name=action_name,
+        row_id=row_id,
+        row_context=row_context,
+        decision=decision,
+        park=park,
+    )
+    wire = await approvals_service.create_approval(workspace_id, user_id, body)
+    return InstinctGateResult(
+        decision=decision,
+        next_step="pending_approval",
+        approval_id=wire["id"],
+        notify_rules=list(decision.notify_rules),
+        lane=TriageLane.ESCALATE,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -1114,6 +1114,21 @@ async def run_pocket_action(
     if template is not None and not any(a.name == body.action for a in template.actions):
         template = None
 
+    # Layered/learning gate (T6) — resolve the workspace's triager activation
+    # level (per-workspace field → global config default → "ASK") and the
+    # global dry-run flag, and thread them into the executor's gate 1.5. When
+    # the workspace has not opted in, the level is "ASK" and the gate behaves
+    # exactly as before — every escalate parks for a human. The level is only
+    # read when a template actually governs this action (otherwise the gate
+    # never runs), so a non-template write is byte-identical to before.
+    approval_level = "ASK"
+    dry_run_mode = False
+    if template is not None:
+        approval_level = await pockets_service.resolve_workspace_approval_level(workspace_id)
+        from pocketpaw.config import get_settings
+
+        dry_run_mode = bool(get_settings().instinct_dry_run_mode)
+
     # no-event: the write result is response-body delivery, not persisted.
     result = await action_executor.run_action(
         workspace_id=workspace_id,
@@ -1130,6 +1145,8 @@ async def run_pocket_action(
         allowed_writes=allowed_writes,
         idempotency_key=body.idempotency_key,
         template=template,
+        approval_level=approval_level,
+        dry_run_mode=dry_run_mode,
     )
 
     # W2a — a template-level CEL rule BLOCKED this write (gate 1.5). It
@@ -1144,6 +1161,19 @@ async def run_pocket_action(
             action=body.action,
             code="instinct_blocked",
             error="action blocked by an Instinct rule",
+        )
+
+    # Layered/learning gate (T7/T-31) — a DRY_RUN write. The executor
+    # resolved + audited the write but made NO backend call and persisted no
+    # approval row. It carries the resolved write under `_park`, which MUST
+    # NOT reach the client wire (the same constraint as `instinct_pending`).
+    # Surface a clean dry-run acknowledgement; the resolved write is visible
+    # only in the audit log, never the response.
+    if result.get("code") == "instinct_dry_run":
+        return RunActionResponse(
+            ok=True,
+            action=body.action,
+            code="instinct_dry_run",
         )
 
     # M2b.1 / W2a — a write was PARKED, not fired. There are TWO park
@@ -1215,16 +1245,33 @@ async def run_pocket_action(
     # assertion below catches a strip that drifts out of sync with the
     # executor's result keys; `RunActionResponse` is also `extra="forbid"`
     # so a missed key fails construction rather than leaking.
+    # Layered/learning gate (T10) — map the executor-internal optimistic
+    # handle id onto the PUBLIC wire field before the strip below removes the
+    # underscored key. Only set on an OPTIMISTIC-lane write that declared a
+    # compensate; absent otherwise.
+    optimistic_id = result.get("_optimistic_compensation_id")
+
     wire = {
         k: v
         for k, v in result.items()
         # gap-3 — strip the metering keys too: `outcome_value`/`outcome_unit`
         # join `outcome` as executor-internal fields the wire model
         # (`extra="forbid"`) does not carry. They were already consumed by
-        # the `emit_pocket_outcome` call above.
-        if k not in ("_park", "outcome", "outcome_value", "outcome_unit")
+        # the `emit_pocket_outcome` call above. `_optimistic_compensation_id`
+        # is the executor-internal key for the optimistic handle — re-exposed
+        # below as the public `optimistic_compensation_id` field.
+        if k
+        not in (
+            "_park",
+            "outcome",
+            "outcome_value",
+            "outcome_unit",
+            "_optimistic_compensation_id",
+        )
     }
     assert "_park" not in wire, "executor `_park` blob must be stripped before the wire response"
+    if optimistic_id:
+        wire["optimistic_compensation_id"] = optimistic_id
     return RunActionResponse(**wire)
 
 

--- a/ee/pocketpaw_ee/cloud/pockets/saga.py
+++ b/ee/pocketpaw_ee/cloud/pockets/saga.py
@@ -198,9 +198,21 @@ class SagaResult(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+# Result codes that mean a forward step did NOT commit a backend write even
+# though it returned ``ok:True``. Both are "the write was governed away":
+#   * ``instinct_pending`` — parked for human approval (it never fired).
+#   * ``instinct_dry_run`` — a governance rehearsal (resolved + audited but
+#     deliberately not sent to the backend; T10).
+# A step that returns either is a sequence non-commit: the steps BEFORE it
+# are committed and must roll back, exactly like an ``ok:false`` failure.
+_NON_COMMIT_CODES = frozenset({"instinct_pending", "instinct_dry_run"})
+
+
 def _is_parked(result: dict[str, Any]) -> bool:
-    """A forward step that routed to Instinct instead of firing."""
-    return result.get("code") == "instinct_pending"
+    """A forward step that routed to Instinct (parked OR dry-run) instead of
+    firing. Either way no backend write committed, so the sequence cannot
+    advance past it and the prior committed steps must roll back."""
+    return result.get("code") in _NON_COMMIT_CODES
 
 
 def _compensation_idempotency_key(step_key: str | None) -> str | None:

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -1185,6 +1185,48 @@ async def resolve_pocket_template(
         return None
 
 
+async def resolve_workspace_approval_level(workspace_id: str) -> str:
+    """Return the effective layered-gate triager level for a workspace (T6).
+
+    Resolution order (design MF-9):
+      1. The workspace document's ``instinct_approval_level`` field, when set
+         to a non-empty value — the PER-WORKSPACE opt-in.
+      2. Otherwise the GLOBAL config default
+         (``Settings.instinct_approval_level``, itself "ASK").
+
+    A global env var therefore changes the default for workspaces that have
+    NOT set their own field — it can never silently upgrade a workspace that
+    relies on the default away from "ASK" once that workspace sets its own
+    value. Any read failure falls back to the global default (and ultimately
+    "ASK"), so a DB hiccup can never accidentally activate the triager.
+
+    Returns a bare string ("ASK" | "TRIAGE" | "TRUSTED"); ``gate_action``
+    coerces it onto the enum and treats an unknown value as ASK.
+    """
+    from pocketpaw.config import get_settings
+
+    try:
+        global_default = str(get_settings().instinct_approval_level or "ASK")
+    except Exception:  # noqa: BLE001 — config read failure → dormant
+        global_default = "ASK"
+
+    if not workspace_id:
+        return global_default
+
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    try:
+        ws = await Workspace.get(PydanticObjectId(workspace_id))
+    except Exception:  # noqa: BLE001 — malformed id / read failure → global default
+        return global_default
+    if ws is None:
+        return global_default
+    field = getattr(ws, "instinct_approval_level", None)
+    if isinstance(field, str) and field:
+        return field
+    return global_default
+
+
 # ---------------------------------------------------------------------------
 # CRUD
 # ---------------------------------------------------------------------------
@@ -4017,7 +4059,25 @@ async def set_pocket_backend(
         _BackendCredentialDoc.pocket_id == pocket_id,
         _BackendCredentialDoc.workspace_id == workspace_id,
     )
+    # T12 (layered/learning gate, design M-5) — detect a backend IDENTITY
+    # change so the trust ledger can be invalidated below. The identity is
+    # (backend_type, base_url, connector_name): a pocket that swaps which
+    # backend it points at must NOT inherit the prior backend's earned
+    # auto-approve trust (anti-gaming — a low-trust backend can't borrow a
+    # trusted one's score by re-pointing the URL). Compared on the EXISTING
+    # row BEFORE the overwrite. A first-time config (no existing row) earned
+    # nothing, so it never resets. A token rotation that keeps the same URL
+    # is NOT an identity change and does not reset.
+    backend_changed = False
     if existing is not None:
+        old_identity = (
+            getattr(existing, "backend_type", "http"),
+            existing.base_url,
+            getattr(existing, "connector_name", None),
+        )
+        new_identity = (backend_type, base_url, connector_name)
+        backend_changed = old_identity != new_identity
+
         existing.backend_type = backend_type
         existing.connector_name = connector_name
         existing.base_url = base_url
@@ -4040,6 +4100,22 @@ async def set_pocket_backend(
             nonce=nonce,
             salt=salt,
         ).insert()
+
+    # T12 — invalidate earned trust when the backend identity changed. Done
+    # AFTER the credential save so a save failure never leaves a reset marker
+    # for a backend that did not actually change. Best-effort: a trust-ledger
+    # write failure must not fail backend configuration (the more important
+    # operation succeeded). The lazy import keeps this module's static import
+    # graph free of the pure ledger helper.
+    if backend_changed:
+        try:
+            from pocketpaw_ee.cloud.pockets import trust_ledger
+
+            await trust_ledger.reset_pocket_trust(workspace_id, pocket_id)
+        except Exception:  # noqa: BLE001 — trust reset is best-effort
+            logger.warning(
+                "trust reset failed after backend change for pocket %s", pocket_id, exc_info=True
+            )
 
     _audit_backend_config(
         actor=user_id,

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -14,6 +14,9 @@ UI can check a slug live; ``validate_slug`` now reuses ``SLUG_RE``.
 format validation) + ``BrandingOut`` (response), an optional ``branding``
 field on ``UpdateWorkspaceRequest``, a ``branding`` field on ``WorkspaceOut``,
 and the ``Branding`` -> ``BrandingOut`` mapping in ``workspace_to_dto``.
+2026-06-19 (feat/instinct-gate-integration, security-review FIX 1): added
+``SetApprovalLevelRequest`` — the closed-enum body for the OWNER-only route
+that activates the layered Instinct gate's triager for a workspace.
 """
 
 from __future__ import annotations
@@ -21,7 +24,7 @@ from __future__ import annotations
 import re
 from typing import Literal
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.workspace.domain import (
@@ -110,6 +113,23 @@ class CreateInviteRequest(BaseModel):
 
 class UpdateMemberRoleRequest(BaseModel):
     role: str = Field(pattern="^(owner|admin|member)$")
+
+
+class SetApprovalLevelRequest(BaseModel):
+    """PATCH /workspaces/{id}/instinct/approval-level request (security FIX 1).
+
+    The body for the OWNER-only switch that activates the layered Instinct
+    gate's triager for a workspace. ``level`` is a closed enum
+    (``ASK`` | ``TRIAGE`` | ``TRUSTED``) so the route boundary 422s on any
+    other value — a typo can never silently land a junk level on the workspace
+    document (which the gate would then read and route ASK on, masking the
+    misconfiguration). ``extra="forbid"`` rejects stray fields. The service
+    re-validates against the canonical ``ApprovalLevel`` enum (defense in
+    depth, and so direct service callers get the same guarantee)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    level: Literal["ASK", "TRIAGE", "TRUSTED"]
 
 
 class BulkInviteRequest(BaseModel):

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -3,6 +3,12 @@
 Authorization is declared at the route level via ``require_action(...)``.
 Service module functions take ``RequestContext`` and return domain
 entities; the router maps to DTOs at the boundary.
+
+2026-06-19 (feat/instinct-gate-integration, security-review FIX 1): added
+``PATCH /{workspace_id}/instinct/approval-level`` — the OWNER-only
+(``instinct.activate``) switch that activates the layered Instinct gate's
+triager for a workspace. Kept off the general PATCH route because a non-ASK
+level enables auto-approval of agent WRITE actions workspace-wide.
 """
 
 from __future__ import annotations
@@ -36,6 +42,7 @@ from pocketpaw_ee.cloud.workspace.dto import (
     InviteOut,
     InvitePreviewResponse,
     MemberOut,
+    SetApprovalLevelRequest,
     SlugAvailabilityOut,
     UpdateDomainRequest,
     UpdateMemberRoleRequest,
@@ -126,6 +133,29 @@ async def delete_workspace(
 ) -> Response:
     await workspace_service.delete(ctx, workspace_id)
     return Response(status_code=204)
+
+
+@router.patch("/{workspace_id}/instinct/approval-level", response_model=WorkspaceOut)
+async def set_instinct_approval_level(
+    workspace_id: str,
+    body: SetApprovalLevelRequest,
+    ctx: RequestContext = Depends(request_context),
+    user: User = Depends(require_action("instinct.activate")),
+) -> WorkspaceOut:
+    """Activate (or stand down) the layered Instinct gate's triager for a
+    workspace — security-review FIX 1.
+
+    A non-ASK level turns ON auto-approval of agent WRITE actions for the whole
+    workspace, so this is the most security-sensitive workspace write in the
+    gate. It is a DEDICATED route — NOT folded into the general PATCH/
+    ``UpdateWorkspaceRequest`` path — guarded by the OWNER-only
+    ``instinct.activate`` action (the strongest workspace tier). The body is a
+    closed enum (422 on anything else); the service re-validates against the
+    ``ApprovalLevel`` enum and emits a WARNING audit event with the old→new
+    level.
+    """
+    ws = await workspace_service.set_instinct_approval_level(ctx, workspace_id, body.level)
+    return workspace_to_dto(ws)
 
 
 @router.get(

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -47,6 +47,14 @@ workspace-scoped lookup) — a cross-workspace or unknown asset ref raises
 Forbidden (workspace.branding_asset_not_owned). accent_color format is
 validated upstream by BrandingPatch (422). _workspace_to_domain now carries
 branding through to the domain object so it serializes onto WorkspaceOut.
+2026-06-19 (feat/instinct-gate-integration, security-review FIX 1): added
+set_instinct_approval_level() — the dedicated, OWNER-gated writer for a
+workspace's layered-Instinct-gate triager level. Validates against the
+ApprovalLevel enum (422 on a bad value, nothing written), kept off the
+general update() path on purpose (a non-ASK level enables auto-approval of
+agent writes), and emits a WARNING-severity append-only audit event with the
+old→new level. The write goes through this service per the import-linter
+Beanie-writes-only-from-service contract.
 """
 
 from __future__ import annotations
@@ -65,6 +73,7 @@ from pocketpaw_ee.cloud._core.errors import (
     Forbidden,
     NotFound,
     SeatLimitError,
+    ValidationError,
 )
 from pocketpaw_ee.cloud._core.realtime.bus import get_resolver
 from pocketpaw_ee.cloud._core.realtime.emit import emit
@@ -427,6 +436,98 @@ async def update(
         target_type="workspace",
         target_id=workspace_id,
         metadata={"patched": patched},
+    )
+
+    count = await _count_members(workspace_id)
+    return _workspace_to_domain(doc, member_count=count)
+
+
+def _audit_approval_level_change(
+    *, actor: str, workspace_id: str, old_level: str, new_level: str
+) -> None:
+    """Append-only audit of the layered-gate activation switch (security FIX 1).
+
+    Setting a non-ASK ``instinct_approval_level`` turns ON auto-approval of
+    agent WRITE actions for the workspace — the single most security-sensitive
+    governance switch in the gate. Emitted at WARNING severity (a
+    state-changing, potentially-dangerous op, mirroring ``action_executor.
+    _audit_action_run``) carrying actor + workspace_id + old→new level so the
+    flip is loud and attributable. Audit failure must never break the write, so
+    the whole call is wrapped.
+    """
+    try:
+        from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=AuditSeverity.WARNING,
+                actor=actor,
+                action="instinct.approval_level.set",
+                target=workspace_id,
+                status="changed" if old_level != new_level else "unchanged",
+                category="instinct_activation",
+                workspace_id=workspace_id,
+                old_level=old_level,
+                new_level=new_level,
+            )
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the activation write
+        logger.warning("instinct approval-level audit-log write failed", exc_info=True)
+
+
+async def set_instinct_approval_level(
+    ctx: RequestContext,
+    workspace_id: str,
+    level: str,
+) -> Workspace:
+    """Set a workspace's layered-Instinct-gate triager activation level.
+
+    The DEDICATED writer for the activation switch (security-review FIX 1).
+    Kept off the general ``UpdateWorkspaceRequest``/PATCH path on purpose: a
+    non-ASK level enables AUTO-APPROVAL of agent WRITE actions workspace-wide,
+    so it gets its own OWNER-only route (``instinct.activate``) and its own
+    loud WARNING audit trail, never folded into the routine workspace patch.
+
+    ``level`` is validated against the canonical ``ApprovalLevel`` enum here
+    (defense in depth — the DTO already constrains it at the route boundary).
+    An out-of-enum value raises ``ValidationError`` (422) and NOTHING is
+    written: the level must fail loudly, never be coerced to a fallback that
+    silently parks a typo on the document (the gate would then read it and
+    route ASK, masking the misconfiguration). The write goes through this
+    service per the import-linter contract (Beanie writes only from
+    ``service.py``). Emits a WARNING audit event carrying old→new level.
+    """
+    from pocketpaw_ee.cloud.pockets.instinct_triage import ApprovalLevel
+
+    valid = {lvl.value for lvl in ApprovalLevel}
+    if level not in valid:
+        raise ValidationError(
+            "workspace.invalid_approval_level",
+            f"approval level {level!r} must be one of {sorted(valid)}",
+        )
+
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        raise NotFound("workspace", workspace_id)
+
+    old_level = doc.instinct_approval_level or "ASK"
+    doc.instinct_approval_level = level
+    await doc.save()
+
+    _audit_approval_level_change(
+        actor=ctx.user_id,
+        workspace_id=workspace_id,
+        old_level=old_level,
+        new_level=level,
+    )
+
+    await audit_service.record(
+        workspace_id,
+        ctx.user_id,
+        "workspace.instinct_approval_level_set",
+        target_type="workspace",
+        target_id=workspace_id,
+        metadata={"old_level": old_level, "new_level": level},
     )
 
     count = await _count_members(workspace_id)
@@ -1550,6 +1651,7 @@ __all__ = [
     "resend_invite",
     "revoke_invite",
     "seed_default_workspace",
+    "set_instinct_approval_level",
     "update",
     "update_member_role",
     "validate_invite",

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -30,6 +30,12 @@
 # the pocket-outcomes count router (ee.cloud.outcomes) can guard
 # ``GET /api/v1/outcomes``.
 #
+# Updated: 2026-06-19 (feat/instinct-gate-integration, security-review FIX 1) —
+# added ``instinct.activate`` (OWNER) gating the workspace route that sets a
+# workspace's ``instinct_approval_level``. A non-ASK level turns on
+# auto-approval of agent WRITE actions workspace-wide, so the switch is
+# OWNER-only — the most restrictive workspace tier.
+#
 # Updated: 2026-06-10 (feat/belt-console-backend, SC-1) — added ``belt.read``
 # (MEMBER) and ``belt.manage`` (ADMIN) so the Belt console router
 # (ee.cloud.belt.router) can guard its read routes (repos list, runs list, run
@@ -176,6 +182,13 @@ ACTIONS: dict[str, ActionRule] = {
     "instinct.propose": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
     "instinct.approve": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     "instinct.audit": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Activating the layered Instinct gate's triager (setting a workspace's
+    # ``instinct_approval_level`` to a non-ASK value) turns ON AUTO-APPROVAL of
+    # agent WRITE actions for the whole workspace — the single most sensitive
+    # governance switch in the gate. OWNER-only, the most restrictive workspace
+    # tier (mirrors workspace.delete / billing.manage): a mere admin must not
+    # be able to disable the human-in-the-loop for everyone.
+    "instinct.activate": ActionRule(WorkspaceRole.OWNER, "workspace.insufficient_role"),
     # Connector — workspace-level connector lifecycle.
     # execute is MEMBER so any team member can run actions against enabled connectors.
     # manage (enable/disable/config) is ADMIN because it changes workspace-wide state

--- a/tests/cloud/test_dry_run_lane.py
+++ b/tests/cloud/test_dry_run_lane.py
@@ -1,0 +1,350 @@
+# tests/cloud/test_dry_run_lane.py
+# Created: 2026-06-19 (feat/instinct-gate-integration, T7) — coverage for the
+# DRY_RUN and OPTIMISTIC executor paths added to
+# ``action_executor.run_action`` by the layered/learning gate integration.
+#
+# DRY_RUN (governance rehearsal): when ``dry_run=True`` the executor runs the
+# security gates (rate-limit, base-URL, SSRF, allowlist, DNS) AS VALIDATION,
+# then intercepts at gate 7 and returns an ``instinct_dry_run`` sentinel —
+# the resolved write under ``_park`` (server-side only), NO HTTP call, NO
+# approval row. The sentinel is structurally identical to ``instinct_pending``
+# so the router strips ``_park`` the same way and the write never leaks to the
+# wire (T-31, pinned against the router's strip logic in
+# test_pocket_action_executor flow assumptions).
+#
+# OPTIMISTIC: ``optimistic_execute=True`` is a NEW dedicated flag (never
+# reuses ``from_instinct``) — it clears the gate-7 park so a trusted,
+# reversible write fires NOW, and the caller registers a bounded compensation
+# handle.
+#
+# THE SAFETY-CRITICAL ORDERING (T-30): the dry-run intercept sits AFTER the
+# security gates, so an allowlist miss on a ``dry_run=True`` call still returns
+# ``not_allowed`` — a rehearsal of an off-policy write is still rejected.
+#
+# Test plan cases: T-27, T-28, T-30. (T-29 config→gate routing lives in the
+# dispatch lanes / triage tests; T-31 router strip is asserted via the
+# existing router strip + extra="forbid" model; T-32 saga lives in
+# test_pocket_saga.)
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud.pockets import action_executor, source_executor, trust_ledger
+from pocketpaw_ee.cloud.pockets.instinct_triage import ApprovalLevel
+
+from pocketpaw.bundled_templates import PocketTemplate
+
+BASE = "https://api.example.com"
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limits():
+    action_executor._action_log.clear()
+    source_executor._run_log.clear()
+    yield
+    action_executor._action_log.clear()
+    source_executor._run_log.clear()
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    """Make every hostname resolve to a public IP so the DNS guard passes."""
+
+    def _fake_getaddrinfo(host, *_args, **_kwargs):
+        return [(2, 1, 6, "", ("8.8.8.8", 0))]
+
+    monkeypatch.setattr("socket.getaddrinfo", _fake_getaddrinfo)
+
+
+class _Recorder:
+    """Records every HTTP request the executor makes; replies 200 {}."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.calls.append((request.method, request.url.path))
+        return httpx.Response(200, json={"ok": True})
+
+
+def _patch_transport(monkeypatch, recorder: _Recorder) -> None:
+    real_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(recorder.handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(action_executor.httpx, "AsyncClient", _factory)
+
+
+_ALLOW = [{"method": "POST", "path_pattern": "/items"}]
+
+
+def _raw_action(**over) -> dict:
+    raw = {"kind": "write_binding", "method": "POST", "path": "/items"}
+    raw.update(over)
+    return raw
+
+
+async def _run(monkeypatch, recorder, **over):
+    _patch_transport(monkeypatch, recorder)
+    kwargs = dict(
+        workspace_id="w1",
+        pocket_id="p1",
+        user_id="u1",
+        action="do_thing",
+        raw_action=_raw_action(),
+        path="/items",
+        params={"x": 1},
+        base_url=BASE,
+        auth_type="none",
+        auth_header=None,
+        token="",
+        allowed_writes=_ALLOW,
+    )
+    kwargs.update(over)
+    return await action_executor.run_action(**kwargs)
+
+
+# ===========================================================================
+# T-27 / T-28 — dry_run returns the sentinel, makes no call, persists nothing.
+# ===========================================================================
+
+
+async def test_dry_run_returns_sentinel_no_http(monkeypatch) -> None:
+    """T-27/T-28: dry_run=True → instinct_dry_run sentinel, NO HTTP call, the
+    _park dict carries the resolved write (identical fields to a live park)."""
+    recorder = _Recorder()
+    result = await _run(monkeypatch, recorder, dry_run=True)
+
+    assert result["ok"] is True
+    assert result["code"] == "instinct_dry_run"
+    assert result["action"] == "do_thing"
+    # No HTTP call fired.
+    assert recorder.calls == []
+    # _park carries the resolved write, same shape as instinct_pending.
+    park = result["_park"]
+    assert park["method"] == "POST"
+    assert park["path"] == "/items"
+    assert park["params"] == {"x": 1}
+    # The sentinel does not carry an approval_id (dry-run persists nothing).
+    assert "approval_id" not in result or result.get("approval_id") is None
+
+
+async def test_dry_run_park_matches_pending_shape(monkeypatch) -> None:
+    """The dry-run _park dict has the same key set as the live instinct_pending
+    park, so the router's existing strip handles it identically (T-31 basis)."""
+    recorder = _Recorder()
+    # A binding that requires instinct so the live path would park at gate 7.
+    pending = await _run(monkeypatch, recorder, raw_action=_raw_action(requires_instinct=True))
+    assert pending["code"] == "instinct_pending"
+
+    dry = await _run(monkeypatch, recorder, dry_run=True)
+    assert dry["code"] == "instinct_dry_run"
+
+    # Same _park key set (correlation_id may differ in value, not presence).
+    assert set(dry["_park"].keys()) == set(pending["_park"].keys())
+
+
+# ===========================================================================
+# T-30 — security gates run BEFORE the dry-run intercept.
+# ===========================================================================
+
+
+async def test_dry_run_allowlist_miss_still_rejected(monkeypatch) -> None:
+    """T-30 (the safety-critical ordering): an allowlist miss on a dry_run=True
+    call returns not_allowed, NOT instinct_dry_run — the rehearsal of an
+    off-policy write is still rejected by the security gates that run first."""
+    recorder = _Recorder()
+    result = await _run(
+        monkeypatch,
+        recorder,
+        dry_run=True,
+        path="/forbidden",
+        raw_action=_raw_action(path="/forbidden"),
+        allowed_writes=[{"method": "POST", "path_pattern": "/items"}],
+    )
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"
+    assert recorder.calls == []
+
+
+async def test_dry_run_bad_base_url_still_rejected(monkeypatch) -> None:
+    """A base-URL gate failure precedes the dry-run intercept too."""
+    recorder = _Recorder()
+    result = await _run(monkeypatch, recorder, dry_run=True, base_url="http://169.254.169.254")
+    assert result["ok"] is False
+    assert result["code"] in ("bad_base_url", "rejected")
+    assert recorder.calls == []
+
+
+# ===========================================================================
+# OPTIMISTIC — optimistic_execute fires the write, clears the park.
+# ===========================================================================
+
+
+async def test_optimistic_execute_fires_and_clears_park(monkeypatch) -> None:
+    """optimistic_execute=True on a requires_instinct binding FIRES the write
+    (clears gate 7's park) and returns a normal success — not instinct_pending."""
+    recorder = _Recorder()
+    result = await _run(
+        monkeypatch,
+        recorder,
+        optimistic_execute=True,
+        raw_action=_raw_action(requires_instinct=True),
+    )
+    assert result["ok"] is True
+    assert result.get("code") not in ("instinct_pending", "instinct_dry_run")
+    assert result["status"] == 200
+    # The HTTP call actually fired.
+    assert recorder.calls == [("POST", "/items")]
+
+
+async def test_optimistic_with_compensate_registers_handle(monkeypatch) -> None:
+    """T10: an optimistic write whose binding declares a `compensate` spec
+    registers a bounded compensation handle and returns its id under
+    `_optimistic_compensation_id`, so the caller can expose a rollback and the
+    TTL sweeper can hard-expire the bet if it's never rolled back."""
+    recorder = _Recorder()
+    result = await _run(
+        monkeypatch,
+        recorder,
+        optimistic_execute=True,
+        raw_action=_raw_action(
+            requires_instinct=True,
+            compensate={"method": "DELETE", "path": "/items/1"},
+        ),
+        allowed_writes=[
+            {"method": "POST", "path_pattern": "/items"},
+            {"method": "DELETE", "path_pattern": "/items/*"},
+        ],
+    )
+    assert result["ok"] is True
+    assert result["status"] == 200
+    cid = result.get("_optimistic_compensation_id")
+    assert cid, "optimistic write with a compensate must return a handle id"
+    # The handle is live in the registry until rollback or TTL expiry.
+    handle = action_executor.get_optimistic_registry().get(cid)
+    assert handle is not None
+    assert handle.action == "do_thing"
+    assert handle.compensate.method == "DELETE"
+
+
+async def test_optimistic_without_compensate_no_handle(monkeypatch) -> None:
+    """An optimistic write with NO declared compensate fires but registers no
+    handle — there is nothing to roll back, so no id is returned."""
+    recorder = _Recorder()
+    result = await _run(
+        monkeypatch,
+        recorder,
+        optimistic_execute=True,
+        raw_action=_raw_action(requires_instinct=True),
+    )
+    assert result["ok"] is True
+    assert result.get("_optimistic_compensation_id") is None
+
+
+async def test_optimistic_does_not_reuse_from_instinct(monkeypatch) -> None:
+    """optimistic_execute is a DEDICATED flag — default from_instinct stays
+    False on the optimistic path (MF-4: no semantic lie)."""
+    recorder = _Recorder()
+    # An allowlist miss on the optimistic path is still rejected — the
+    # security gates run; optimistic only clears the PARK, not the gates.
+    result = await _run(
+        monkeypatch,
+        recorder,
+        optimistic_execute=True,
+        path="/forbidden",
+        raw_action=_raw_action(path="/forbidden", requires_instinct=True),
+        allowed_writes=[{"method": "POST", "path_pattern": "/items"}],
+    )
+    assert result["ok"] is False
+    assert result["code"] == "not_allowed"
+    assert recorder.calls == []
+
+
+# ===========================================================================
+# END-TO-END through run_action: a template-gated escalate, with the
+# workspace opted into TRIAGE and trust seeded, fires the write via the AUTO
+# lane (the full T6 vertical slice) — and the SAME call under default ASK
+# parks for a human (the safety invariant, end-to-end).
+# ===========================================================================
+
+
+def _escalate_template() -> PocketTemplate:
+    return PocketTemplate.model_validate(
+        {
+            "schema_version": "2",
+            "name": "t",
+            "version": "1.0.0",
+            "pattern": "app",
+            "vertical": "test",
+            "description": "x",
+            "shape": "data-grid",
+            "state": {"entity_type": "Thing", "columns": [{"field": "value", "widget": "number"}]},
+            "actions": [
+                {"name": "do_thing", "label": "Do", "kind": "single-row", "instinct_policy": "auto"}
+            ],
+            "instinct_rules": {"rules": [{"when": "value > 0", "action": "require_approval"}]},
+        }
+    )
+
+
+@pytest.fixture
+def _isolated_trust(monkeypatch, tmp_path):
+    monkeypatch.setattr(trust_ledger, "_trust_dir", lambda: tmp_path / "trust")
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_e2e_triage_auto_fires_write(monkeypatch, _isolated_trust) -> None:
+    """approval_level=TRIAGE + seeded trust + reversible POST → the executor
+    FIRES the write via the AUTO lane (no park)."""
+    # Seed trust so the (pocket, action) pair clears the threshold.
+    for _ in range(10):
+        await trust_ledger.record_correction("w1", "p1", "do_thing", was_auto_approved=True)
+
+    recorder = _Recorder()
+    result = await _run(
+        monkeypatch,
+        recorder,
+        template=_escalate_template(),
+        row_context={"value": 5},
+        raw_action=_raw_action(compensate={"method": "DELETE", "path": "/items/1"}),
+        allowed_writes=[
+            {"method": "POST", "path_pattern": "/items"},
+            {"method": "DELETE", "path_pattern": "/items/*"},
+        ],
+        approval_level=ApprovalLevel.TRIAGE,
+    )
+    assert result["ok"] is True
+    assert result.get("code") not in ("instinct_pending", "instinct_dry_run")
+    assert result["status"] == 200
+    assert recorder.calls == [("POST", "/items")]
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_e2e_default_ask_parks_same_call(monkeypatch, _isolated_trust) -> None:
+    """The SAME call as above, but with NO approval_level (default ASK), PARKS
+    for a human — the safety invariant proven end-to-end through run_action."""
+    for _ in range(10):
+        await trust_ledger.record_correction("w1", "p1", "do_thing", was_auto_approved=True)
+
+    recorder = _Recorder()
+    result = await _run(
+        monkeypatch,
+        recorder,
+        template=_escalate_template(),
+        row_context={"value": 5},
+        raw_action=_raw_action(compensate={"method": "DELETE", "path": "/items/1"}),
+        allowed_writes=[
+            {"method": "POST", "path_pattern": "/items"},
+            {"method": "DELETE", "path_pattern": "/items/*"},
+        ],
+        # NO approval_level — dormant ASK.
+    )
+    assert result["ok"] is True
+    assert result["code"] == "instinct_pending"
+    assert result["approval_id"]
+    # The write never fired — it parked for a human.
+    assert recorder.calls == []

--- a/tests/cloud/test_instinct_dispatch_lanes.py
+++ b/tests/cloud/test_instinct_dispatch_lanes.py
@@ -411,6 +411,68 @@ async def test_batch_dedup_returns_existing_pending(recording_bus) -> None:
 
 
 # ===========================================================================
+# T-26b / FIX 3 — BATCH dedup must survive a pocket with MANY pending rows.
+# `_find_existing_pending_id` previously listed pending rows (default limit
+# 50) and matched in Python; a pocket with >50 pending rows could push the
+# target row past the limit, so the second escalate for the SAME row would
+# miss it and stack a duplicate. The fix pushes action_name + row_id into the
+# query filter so the DB finds the row regardless of how many others exist.
+# ===========================================================================
+
+
+async def test_batch_dedup_survives_many_pending_rows(recording_bus) -> None:
+    """FIX 3: with 60 OTHER pending rows already on the pocket (more than the
+    list default limit of 50), a re-escalate of the same (pocket, action, row)
+    still finds the existing pending row and returns its id — no duplicate."""
+    template = _escalate_template()
+
+    # First: the row we care about — creates ONE pending row.
+    target = dict(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        row_id="row-target",
+        park={"action": "do_thing", "method": "POST", "path": "/items"},
+        now=FROZEN_NOW,
+    )
+    first = await instinct_dispatch.gate_action(**target)
+    assert first.next_step == "pending_approval"
+
+    # Now flood the SAME pocket with 60 other distinct pending rows so the
+    # target row is no longer in the first page of a limit-50 list query.
+    for i in range(60):
+        await instinct_dispatch.gate_action(
+            workspace_id="w1",
+            user_id="u1",
+            pocket_id="p1",
+            template=template,
+            action_name="do_thing",
+            row_context={"value": 1},
+            row_id=f"row-noise-{i}",
+            park={"action": "do_thing", "method": "POST", "path": "/items"},
+            now=FROZEN_NOW,
+        )
+
+    # Re-escalate the ORIGINAL row. It must dedup to the first row's id even
+    # though 60 newer pending rows would otherwise bury it past the limit.
+    second = await instinct_dispatch.gate_action(**target)
+    assert second.next_step == "pending_approval"
+    assert second.approval_id == first.approval_id, (
+        "dedup missed the target row because it fell past the list limit"
+    )
+
+    # Exactly 61 distinct pending rows total — the target deduped, not stacked.
+    all_pending = await approvals_service.list_approvals(
+        "w1", "u1", {"status": "pending", "limit": 200}
+    )
+    target_rows = [r for r in all_pending if r.get("row_id") == "row-target"]
+    assert len(target_rows) == 1, "the target row was duplicated, not deduped"
+
+
+# ===========================================================================
 # T-35 / T9 — outcomes/service must NOT call trust_ledger (correctness guard).
 # The trust loop is written at EXACTLY ONE site (instinct_bridge, T8); a
 # second write from the outcomes path would self-poison the score by

--- a/tests/cloud/test_instinct_dispatch_lanes.py
+++ b/tests/cloud/test_instinct_dispatch_lanes.py
@@ -1,0 +1,439 @@
+# tests/cloud/test_instinct_dispatch_lanes.py
+# Created: 2026-06-19 (feat/instinct-gate-integration, T6/T11) — integration
+# coverage for the layered/learning gate wired LIVE into
+# ``instinct_dispatch.gate_action``. The foundation (T1-T5) shipped the pure
+# classifier, the trust ledger, the auto-approve writer and the config
+# defaults; this file pins the gate ROUTING that calls ``classify_lane`` and
+# branches per lane (AUTO → decided row, OPTIMISTIC → optimistic_proceed,
+# DRY_RUN → dry_run, ESCALATE → the unchanged human-pending path, BLOCK →
+# blocked).
+#
+# THE SAFETY INVARIANT (T-18 + test_default_ask_is_zero_behavior_change):
+# a ``gate_action`` call that passes NO ``approval_level`` arg behaves EXACTLY
+# as it did before this PR — every escalate goes to a human-pending row. The
+# triager only ever activates when a workspace explicitly opts into a non-ASK
+# level. These tests are the proof.
+#
+# Test plan cases pinned here: T-18, T-20, T-21, T-22, T-23, T-24, T-25, T-26.
+# (T-19 dry_run-at-gate routing lives in test_dry_run_lane.py.)
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import (
+    InstinctApprovalAutoApproved,
+    InstinctApprovalCreated,
+)
+from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+from pocketpaw_ee.cloud.pockets import instinct_dispatch, trust_ledger
+from pocketpaw_ee.cloud.pockets.instinct_triage import ApprovalLevel, TriageLane
+
+from pocketpaw.bundled_templates import PocketTemplate
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+FROZEN_NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Template fixture — a data-grid template with a single configurable action.
+# ---------------------------------------------------------------------------
+
+
+def _template(
+    *,
+    instinct_policy: str = "auto",
+    rules: list[dict] | None = None,
+    action_name: str = "do_thing",
+) -> PocketTemplate:
+    raw: dict = {
+        "schema_version": "2",
+        "name": "test-template",
+        "version": "1.0.0",
+        "pattern": "app",
+        "vertical": "test",
+        "description": "test fixture",
+        "shape": "data-grid",
+        "state": {
+            "entity_type": "Thing",
+            "columns": [{"field": "value", "widget": "number"}],
+        },
+        "actions": [
+            {
+                "name": action_name,
+                "label": "Do Thing",
+                "kind": "single-row",
+                "instinct_policy": instinct_policy,
+            }
+        ],
+    }
+    if rules is not None:
+        raw["instinct_rules"] = {"rules": rules}
+    return PocketTemplate.model_validate(raw)
+
+
+def _escalate_template() -> PocketTemplate:
+    """A template whose rule escalates the row to human approval."""
+    return _template(rules=[{"when": "value > 0", "action": "require_approval"}])
+
+
+@pytest.fixture(autouse=True)
+def _isolated_trust(monkeypatch, tmp_path):
+    """Point the trust ledger at a temp dir so the per-test sidecar is clean."""
+
+    def _dir() -> object:
+        return tmp_path / "trust"
+
+    monkeypatch.setattr(trust_ledger, "_trust_dir", _dir)
+
+
+async def _seed_trust(workspace_id: str, pocket_id: str, action: str, *, n_auto: int, n_human: int):
+    """Append n_auto auto-approved + n_human human rows so the (pocket, action)
+    pair reaches a known score / proposed_count."""
+    for _ in range(n_auto):
+        await trust_ledger.record_correction(
+            workspace_id, pocket_id, action, was_auto_approved=True
+        )
+    for _ in range(n_human):
+        await trust_ledger.record_correction(
+            workspace_id, pocket_id, action, was_auto_approved=False
+        )
+
+
+# ===========================================================================
+# THE SAFETY INVARIANT — default approval_level=ASK is zero behavior change.
+# ===========================================================================
+
+
+async def test_default_ask_is_zero_behavior_change(recording_bus) -> None:
+    """T-18 / safety invariant: a gate_action call with NO approval_level arg
+    produces the SAME result as before this PR — a human-pending row, never an
+    auto-approval. Even with high trust seeded, the dormant triager escalates.
+    """
+    # Seed maximum trust for the pair — if the triager were active this would
+    # AUTO-approve. Under default ASK it must NOT.
+    await _seed_trust("w1", "p1", "do_thing", n_auto=10, n_human=0)
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=_escalate_template(),
+        action_name="do_thing",
+        row_context={"value": 1},
+        row_id="r1",
+        park={"action": "do_thing", "method": "POST", "path": "/items", "params": {}},
+        now=FROZEN_NOW,
+        # NO approval_level passed — default ASK.
+    )
+
+    assert result.next_step == "pending_approval"
+    assert result.lane == TriageLane.ESCALATE
+    assert result.approval_id is not None
+
+    # The persisted row is PENDING (human queue), not auto_approved.
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+    assert approvals[0]["status"] == "pending"
+
+    # The created event is the human-pending one; NO auto-approved event.
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    auto = [e for e in recording_bus.events if isinstance(e, InstinctApprovalAutoApproved)]
+    assert len(created) == 1
+    assert auto == []
+
+
+async def test_default_ask_high_trust_delete_still_pending(recording_bus) -> None:
+    """Belt-and-braces: even a DELETE with high trust under default ASK stays
+    pending. ASK short-circuits before any blast-radius reasoning."""
+    await _seed_trust("w1", "p1", "do_thing", n_auto=10, n_human=0)
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=_escalate_template(),
+        action_name="do_thing",
+        row_context={"value": 1},
+        park={"action": "do_thing", "method": "DELETE", "path": "/items/1", "params": {}},
+        now=FROZEN_NOW,
+    )
+    assert result.next_step == "pending_approval"
+    assert result.lane == TriageLane.ESCALATE
+
+
+# ===========================================================================
+# T-18 — ESCALATE verdict + ASK level → unchanged pending path.
+# ===========================================================================
+
+
+async def test_escalate_ask_level_is_pending(recording_bus) -> None:
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=_escalate_template(),
+        action_name="do_thing",
+        row_context={"value": 1},
+        approval_level=ApprovalLevel.ASK,
+        park={"action": "do_thing", "method": "POST", "path": "/items", "params": {}},
+        now=FROZEN_NOW,
+    )
+    assert result.next_step == "pending_approval"
+    assert result.lane == TriageLane.ESCALATE
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert approvals[0]["status"] == "pending"
+
+
+# ===========================================================================
+# T-20 — AUTO lane writes a decided row, no pending.
+# ===========================================================================
+
+
+async def test_triage_auto_lane_writes_decided_row(recording_bus) -> None:
+    """ESCALATE verdict + TRIAGE + trust≥threshold + proposed_count≥1 + POST +
+    CompensateSpec → AUTO. A decided (auto_approved) row, no pending row, the
+    auto-approved event fires."""
+    await _seed_trust("w1", "p1", "do_thing", n_auto=10, n_human=0)  # score 1.0, count 10
+
+    park = {
+        "action": "do_thing",
+        "method": "POST",
+        "path": "/items",
+        "params": {"x": 1},
+        "compensate": {"method": "DELETE", "path": "/items/1"},
+    }
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=_escalate_template(),
+        action_name="do_thing",
+        row_context={"value": 1},
+        row_id="r1",
+        approval_level=ApprovalLevel.TRIAGE,
+        park=park,
+        now=FROZEN_NOW,
+    )
+
+    assert result.lane == TriageLane.AUTO
+    assert result.next_step == "auto_approved"
+    assert result.approval_id is not None
+
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+    assert approvals[0]["status"] == "auto_approved"
+    assert approvals[0]["decided_by"] == "system:triager"
+
+    # No pending rows exist.
+    pending = await approvals_service.list_approvals("w1", "u1", {"status": "pending"})
+    assert pending == []
+
+    auto = [e for e in recording_bus.events if isinstance(e, InstinctApprovalAutoApproved)]
+    assert len(auto) == 1
+    assert auto[0].data["lane"] == "AUTO"
+    assert auto[0].data["actor"] == "system:triager"
+
+
+# ===========================================================================
+# T-21 / T-22 — EXECUTE proceeds, BLOCK blocks (even at TRUSTED).
+# ===========================================================================
+
+
+async def test_execute_verdict_proceeds() -> None:
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=_template(instinct_policy="auto"),
+        action_name="do_thing",
+        row_context={"value": 1},
+        approval_level=ApprovalLevel.TRIAGE,
+        now=FROZEN_NOW,
+    )
+    assert result.next_step == "proceed"
+    assert result.decision.verdict == "EXECUTE"
+
+
+async def test_block_verdict_blocks_even_at_trusted() -> None:
+    """T-22: a BLOCK rule blocks regardless of approval_level — the safety
+    hard gate bypasses triage entirely."""
+    await _seed_trust("w1", "p1", "do_thing", n_auto=10, n_human=0)
+    template = _template(rules=[{"when": "value > 100", "action": "block"}])
+
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 999},
+        approval_level=ApprovalLevel.TRUSTED,
+        park={"action": "do_thing", "method": "POST", "path": "/items"},
+        now=FROZEN_NOW,
+    )
+    assert result.next_step == "blocked"
+    assert result.lane == TriageLane.ESCALATE  # default-safe lane on a block
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert approvals == []
+
+
+# ===========================================================================
+# T-23 — OPTIMISTIC lane → optimistic_proceed + auto_approved row.
+# ===========================================================================
+
+
+async def test_triage_optimistic_lane(recording_bus) -> None:
+    """A reversible low-blast write with trust below threshold but ≥1 prior
+    execution routes OPTIMISTIC → next_step=optimistic_proceed, an
+    auto_approved row tagged lane=OPTIMISTIC."""
+    # score 0.5 (below 0.9 threshold), proposed_count 2 → OPTIMISTIC (rule 9)
+    await _seed_trust("w1", "p1", "do_thing", n_auto=1, n_human=1)
+
+    park = {
+        "action": "do_thing",
+        "method": "POST",
+        "path": "/items",
+        "params": {},
+        "compensate": {"method": "DELETE", "path": "/items/1"},
+    }
+    result = await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=_escalate_template(),
+        action_name="do_thing",
+        row_context={"value": 1},
+        approval_level=ApprovalLevel.TRIAGE,
+        park=park,
+        now=FROZEN_NOW,
+    )
+
+    assert result.lane == TriageLane.OPTIMISTIC
+    assert result.next_step == "optimistic_proceed"
+
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1
+    assert approvals[0]["status"] == "auto_approved"
+
+    auto = [e for e in recording_bus.events if isinstance(e, InstinctApprovalAutoApproved)]
+    assert len(auto) == 1
+    assert auto[0].data["lane"] == "OPTIMISTIC"
+
+
+# ===========================================================================
+# T-24 — every TRIAGE classify decision is audited.
+# ===========================================================================
+
+
+async def test_triage_decision_is_audited(monkeypatch) -> None:
+    """T-24: gate_action logs the classify_lane decision (lane, trust_score,
+    proposed_count, approval_level) to the audit log at every TRIAGE call."""
+    captured: list[dict] = []
+
+    from pocketpaw.security import audit as audit_mod
+
+    class _FakeLogger:
+        def log(self, event):
+            captured.append(event.to_dict() if hasattr(event, "to_dict") else event.__dict__)
+
+    monkeypatch.setattr(audit_mod, "get_audit_logger", lambda: _FakeLogger())
+    # gate_action imports get_audit_logger lazily inside its audit helper, so
+    # patching the source module is enough.
+
+    await _seed_trust("w1", "p1", "do_thing", n_auto=10, n_human=0)
+    await instinct_dispatch.gate_action(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=_escalate_template(),
+        action_name="do_thing",
+        row_context={"value": 1},
+        approval_level=ApprovalLevel.TRIAGE,
+        park={
+            "action": "do_thing",
+            "method": "POST",
+            "path": "/items",
+            "compensate": {"method": "DELETE", "path": "/items/1"},
+        },
+        now=FROZEN_NOW,
+    )
+
+    # AuditEvent.to_dict nests the custom fields under ``context``.
+    def _ctx(e: dict) -> dict:
+        return e.get("context") or {}
+
+    triage_events = [e for e in captured if str(_ctx(e).get("category", "")) == "instinct_triage"]
+    assert triage_events, f"no instinct_triage audit event found in {captured}"
+    blob = _ctx(triage_events[0])
+    assert blob.get("lane") == "AUTO"
+    assert "trust_score" in blob
+    assert "proposed_count" in blob
+
+
+# ===========================================================================
+# T-26 — BATCH-lane dedup (T11). A second escalate for the same
+# (pocket, action, row) returns the existing pending row's id.
+# ===========================================================================
+
+
+async def test_batch_dedup_returns_existing_pending(recording_bus) -> None:
+    """T-26 / T11: two escalating gate_action calls for the same
+    (pocket_id, action_name, row_id) produce ONE pending row — the second
+    finds the first and returns its id."""
+    template = _escalate_template()
+    common = dict(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="p1",
+        template=template,
+        action_name="do_thing",
+        row_context={"value": 1},
+        row_id="row-dup",
+        park={"action": "do_thing", "method": "POST", "path": "/items"},
+        now=FROZEN_NOW,
+    )
+
+    first = await instinct_dispatch.gate_action(**common)
+    second = await instinct_dispatch.gate_action(**common)
+
+    assert first.next_step == "pending_approval"
+    assert second.next_step == "pending_approval"
+    assert second.approval_id == first.approval_id
+
+    approvals = await approvals_service.list_approvals("w1", "u1", {})
+    assert len(approvals) == 1, "dedup must not create a second pending row"
+
+    created = [e for e in recording_bus.events if isinstance(e, InstinctApprovalCreated)]
+    assert len(created) == 1
+
+
+# ===========================================================================
+# T-35 / T9 — outcomes/service must NOT call trust_ledger (correctness guard).
+# The trust loop is written at EXACTLY ONE site (instinct_bridge, T8); a
+# second write from the outcomes path would self-poison the score by
+# double-counting one executed write (design MF-3).
+# ===========================================================================
+
+
+def test_outcomes_service_does_not_import_trust_ledger() -> None:
+    """T-35: the outcomes service neither imports nor references trust_ledger.
+
+    A source-level assertion (not a behavioral mock) — the invariant is
+    'this module is structurally incapable of moving the trust score', so we
+    assert the absence of the symbol entirely, the way the design specifies.
+    """
+    import inspect
+
+    from pocketpaw_ee.cloud.outcomes import service as outcomes_service
+
+    src = inspect.getsource(outcomes_service)
+    assert "trust_ledger" not in src, (
+        "outcomes/service.py must not reference trust_ledger — trust feedback "
+        "is written at exactly one site (instinct_bridge.execute_approved_write)"
+    )
+    assert "record_correction" not in src
+    # And the module object carries no such attribute (catches a re-export).
+    assert not hasattr(outcomes_service, "trust_ledger")

--- a/tests/cloud/test_instinct_gate_config.py
+++ b/tests/cloud/test_instinct_gate_config.py
@@ -1,15 +1,24 @@
 # tests/cloud/test_instinct_gate_config.py
 # Created: 2026-06-18 (feat/instinct-gate-foundation, T5) — config-default
 # tests for the layered/learning Instinct gate's four global settings
-# (2026-06-18 gate-layered-learning design). These are GLOBAL DEFAULTS;
-# the per-workspace override path (the full T-25 workspace-document field)
-# lands with the integration layer (T6, separate gated PR). Here we pin:
+# (2026-06-18 gate-layered-learning design).
+# Updated: 2026-06-19 (feat/instinct-gate-integration, T6) — added the
+# per-workspace override resolution (T-25): a Workspace document's
+# `instinct_approval_level` field overrides the global default, an unset
+# field falls back to the global default, and a global env var changes the
+# default for workspaces that have NOT opted in (MF-9 — never a silent
+# upgrade of an existing tenant that set its own value).
+# Here we pin:
 #   * the four fields exist with the design's default values
 #   * the default approval level is "ASK" (triager dormant — zero
 #     behavioral change on ship)
 #   * env vars override the defaults via the POCKETPAW_ prefix
+#   * resolve_workspace_approval_level honors the workspace field, falls back
+#     to the global default, and degrades safe on a read failure.
 
 from __future__ import annotations
+
+import pytest
 
 from pocketpaw.config import Settings
 
@@ -48,3 +57,51 @@ def test_env_overrides_dry_run_mode(monkeypatch) -> None:
 def test_env_overrides_optimistic_ttl(monkeypatch) -> None:
     monkeypatch.setenv("POCKETPAW_INSTINCT_OPTIMISTIC_TTL_SECONDS", "600")
     assert Settings().instinct_optimistic_ttl_seconds == 600
+
+
+# ---------------------------------------------------------------------------
+# T-25 / T6 — per-workspace override resolution.
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("pocketpaw_ee")
+
+
+async def _make_workspace(level: str | None) -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(name="W", slug=f"w-{level or 'none'}", owner="u1")
+    if level is not None:
+        ws.instinct_approval_level = level
+    await ws.insert()
+    return str(ws.id)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_workspace_field_overrides_global_default() -> None:
+    """T-25: a workspace that set TRIAGE resolves to TRIAGE even though the
+    global default is ASK — the per-workspace opt-in."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    ws_id = await _make_workspace("TRIAGE")
+    level = await pockets_service.resolve_workspace_approval_level(ws_id)
+    assert level == "TRIAGE"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_workspace_unset_falls_back_to_global_default() -> None:
+    """A workspace with no field set uses the global default (ASK)."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    ws_id = await _make_workspace(None)
+    level = await pockets_service.resolve_workspace_approval_level(ws_id)
+    assert level == "ASK"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_resolution_degrades_safe_on_bad_id() -> None:
+    """A malformed / unknown workspace id resolves to the global default, never
+    a non-ASK level (a read failure must never activate the triager)."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    level = await pockets_service.resolve_workspace_approval_level("not-an-objectid")
+    assert level == "ASK"

--- a/tests/cloud/test_instinct_triage.py
+++ b/tests/cloud/test_instinct_triage.py
@@ -188,3 +188,45 @@ def test_proposal_is_frozen() -> None:
     p = _proposal()
     with pytest.raises(ValidationError):
         p.trust_score = 0.1  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# DELETE-floor guard (security-review FIX 2). The explicit DELETE check in
+# classify_lane is the hardest blast-radius floor: a DELETE must NEVER reach
+# OPTIMISTIC or AUTO — not even with a CompensateSpec AND perfect trust AND a
+# warm history. A future refactor that "simplifies" the DELETE check into
+# _is_high_blast would silently let a compensate lift a DELETE to OPTIMISTIC
+# (the financial-keyword floor permits that). This test pins the floor so that
+# refactor fails loudly. Do NOT delete or weaken it.
+# ---------------------------------------------------------------------------
+
+
+def test_delete_floor_compensate_perfect_trust_triage_still_escalates() -> None:
+    """DELETE + CompensateSpec + trust_score=1.0 + TRIAGE + proposed_count=5
+    → ESCALATE. The delete floor overrides every promotion signal: an
+    "undelete" compensate is not a truthful inverse, so a DELETE always goes
+    to a human regardless of trust or warmup. Pins design rule that the
+    DELETE branch stays SEPARATE from _is_high_blast (the financial floor)."""
+    p = _proposal(
+        method="DELETE",
+        path="/items/42",
+        compensate=_compensate(),
+        trust_score=1.0,
+        proposed_count=5,
+        approval_level=ApprovalLevel.TRIAGE,
+    )
+    assert classify_lane(p) == TriageLane.ESCALATE
+
+
+def test_delete_floor_holds_at_trusted_level() -> None:
+    """Even at the (reserved) TRUSTED level, DELETE + compensate + max trust
+    escalates — the floor is independent of activation level."""
+    p = _proposal(
+        method="DELETE",
+        path="/items/42",
+        compensate=_compensate(),
+        trust_score=1.0,
+        proposed_count=99,
+        approval_level=ApprovalLevel.TRUSTED,
+    )
+    assert classify_lane(p) == TriageLane.ESCALATE

--- a/tests/cloud/test_pocket_backend_service.py
+++ b/tests/cloud/test_pocket_backend_service.py
@@ -217,6 +217,77 @@ async def test_set_backend_upserts(mongo_db):
     assert creds[3] == "new-token"
 
 
+# ---------------------------------------------------------------------------
+# T12 / T-37 — a backend credential change invalidates earned trust.
+# A pocket that swapped its backend must not inherit the prior backend's
+# auto-approve trust (anti-gaming, design M-5). The reset fires only when an
+# EXISTING row's base_url actually changes — not on first-time configuration
+# (nothing earned yet) and not on an unchanged re-save.
+# ---------------------------------------------------------------------------
+
+
+def _capture_trust_reset(monkeypatch):
+    calls: list[tuple[str, str]] = []
+
+    async def _reset(workspace_id, pocket_id):
+        calls.append((workspace_id, pocket_id))
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.trust_ledger.reset_pocket_trust", _reset)
+    return calls
+
+
+async def test_backend_url_change_resets_trust(mongo_db, monkeypatch):
+    """T-37: changing the base_url on an existing backend resets the pocket's
+    trust ledger (the new backend earns its own trust from zero)."""
+    calls = _capture_trust_reset(monkeypatch)
+
+    # First-time set — NO reset (no prior trust to invalidate).
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://old.example.com",
+        auth_type="bearer",
+        auth_token="old-token",
+    )
+    assert calls == [], "first-time backend config must not reset trust"
+
+    # Swap the base_url — this is the credential change that invalidates trust.
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://new.example.com",
+        auth_type="bearer",
+        auth_token="new-token",
+    )
+    assert calls == [("w1", "pocket-1")]
+
+
+async def test_backend_unchanged_resave_does_not_reset_trust(mongo_db, monkeypatch):
+    """Re-saving the SAME base_url (e.g. a token rotation that keeps the URL)
+    must not reset trust — the backend identity (the URL) did not change."""
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="bearer",
+        auth_token="token-1",
+    )
+    calls = _capture_trust_reset(monkeypatch)
+    # Same URL, different token.
+    await pockets_service.set_pocket_backend(
+        workspace_id="w1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        base_url="https://api.example.com",
+        auth_type="bearer",
+        auth_token="token-2",
+    )
+    assert calls == [], "an unchanged base_url must not reset trust"
+
+
 async def test_set_backend_rejects_http_url(mongo_db):
     with pytest.raises(ValidationError):
         await pockets_service.set_pocket_backend(

--- a/tests/cloud/test_pocket_instinct_bridge.py
+++ b/tests/cloud/test_pocket_instinct_bridge.py
@@ -304,3 +304,116 @@ async def test_execute_approved_write_no_outcome_emits_nothing(store, monkeypatc
     await instinct_bridge.execute_approved_write(approved)
 
     assert emitted == []
+
+
+# ---------------------------------------------------------------------------
+# T8 — trust feedback at the SINGLE write site (execute_approved_write).
+# ---------------------------------------------------------------------------
+
+
+def _capture_trust(monkeypatch):
+    """Patch trust_ledger.record_correction on its import target and capture
+    every call. The bridge calls it best-effort after mark_executed."""
+    calls: list[dict] = []
+
+    async def _record(workspace_id, pocket_id, action, was_auto_approved):
+        calls.append(
+            {
+                "workspace_id": workspace_id,
+                "pocket_id": pocket_id,
+                "action": action,
+                "was_auto_approved": was_auto_approved,
+            }
+        )
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.trust_ledger.record_correction", _record)
+    return calls
+
+
+async def test_trust_feedback_human_approver_records_false(store, monkeypatch):
+    """T-34: a human approver → record_correction(was_auto_approved=False),
+    exactly ONE row written, after a successful execution."""
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+    async def _run_action(**kwargs):
+        return {"ok": True, "action": kwargs["action"], "status": 200}
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor", _get_creds
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
+    calls = _capture_trust(monkeypatch)
+
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    approved = await store.approve(action_id, approver="user:alice")
+    await instinct_bridge.execute_approved_write(approved)
+
+    assert len(calls) == 1, "trust feedback must be written exactly ONCE"
+    assert calls[0]["was_auto_approved"] is False
+    assert calls[0]["workspace_id"] == "w1"
+    assert calls[0]["pocket_id"] == "pocket-1"
+    assert calls[0]["action"] == "mark_renewed"
+
+
+async def test_trust_feedback_system_triager_records_true(store, monkeypatch):
+    """T-33: a system:triager approver → record_correction(
+    was_auto_approved=True), exactly ONE row."""
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+    async def _run_action(**kwargs):
+        return {"ok": True, "action": kwargs["action"], "status": 200}
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor", _get_creds
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
+    calls = _capture_trust(monkeypatch)
+
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    approved = await store.approve(action_id, approver="system:triager")
+    await instinct_bridge.execute_approved_write(approved)
+
+    assert len(calls) == 1
+    assert calls[0]["was_auto_approved"] is True
+
+
+async def test_trust_feedback_not_written_on_failed_execution(store, monkeypatch):
+    """A rejected post-approval write (allowlist miss) → NO trust feedback.
+    The write never landed, so it must not move the trust score."""
+
+    async def _get_creds(workspace_id, pocket_id):
+        return ("https://api.example.com", "bearer", None, "tok", [], None)
+
+    async def _run_action(**kwargs):
+        return {"ok": False, "code": "not_allowed", "error": "nope"}
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get_pocket_backend_for_executor", _get_creds
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.action_executor.run_action", _run_action)
+    calls = _capture_trust(monkeypatch)
+
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write=_park(),
+        requested_by="requester-9",
+    )
+    approved = await store.approve(action_id, approver="user:alice")
+    await instinct_bridge.execute_approved_write(approved)
+
+    assert calls == []

--- a/tests/cloud/test_pocket_saga.py
+++ b/tests/cloud/test_pocket_saga.py
@@ -444,6 +444,57 @@ async def test_parked_forward_step_rolls_back_prior_steps(monkeypatch, _capture_
 
 
 # ---------------------------------------------------------------------------
+# T10 — a dry-run step is treated as not-committed → prior steps roll back.
+# A `instinct_dry_run` result has ok:True but the write never fired, so the
+# saga must treat it like a park (a sequence failure that rolls back the
+# already-committed steps) — never advance past it as if it had landed.
+# ---------------------------------------------------------------------------
+
+
+async def test_dry_run_step_rolls_back_prior_steps(monkeypatch, _capture_outcomes):
+    """T-32 / T10: a forward step that comes back `instinct_dry_run` is a
+    non-commit — the saga rolls back the prior committed step and records the
+    dry-run as the failure."""
+    rec = _Recorder({("POST", "/refund"): 200})
+
+    # Wrap run_action so the second step ("charge") returns the dry-run
+    # sentinel (ok:True, code:instinct_dry_run) — the shape the executor
+    # returns when dry_run=True. The first step ("reserve") fires normally.
+    real_run_action = action_executor.run_action
+
+    async def _maybe_dry_run(**kwargs):
+        if kwargs.get("action") == "charge":
+            return {
+                "ok": True,
+                "code": "instinct_dry_run",
+                "action": "charge",
+                "_park": {"action": "charge", "method": "POST", "path": "/charge"},
+                "on_success": [],
+                "on_error": [],
+            }
+        return await real_run_action(**kwargs)
+
+    monkeypatch.setattr(action_executor, "run_action", _maybe_dry_run)
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.saga.run_action", _maybe_dry_run)
+
+    steps = [
+        _step("reserve", "POST", "/reserve", compensate={"method": "POST", "path": "/refund"}),
+        _step("charge", "POST", "/charge", compensate={"method": "POST", "path": "/refund"}),
+    ]
+    result = await _run(steps, monkeypatch, rec)
+
+    assert result.ok is False
+    assert result.failed_action == "charge"
+    assert result.failure["code"] == "instinct_dry_run"
+    assert result.completed == ["reserve"]
+    # reserve rolled back.
+    assert [c.action for c in result.compensations] == ["reserve"]
+    assert result.compensations[0].status == "compensated"
+    # /charge never hit the backend (it was a dry run).
+    assert ("POST", "/charge") not in rec.calls
+
+
+# ---------------------------------------------------------------------------
 # Edge: first step fails → nothing committed, nothing to compensate
 # ---------------------------------------------------------------------------
 

--- a/tests/cloud/workspace/test_instinct_approval_level.py
+++ b/tests/cloud/workspace/test_instinct_approval_level.py
@@ -1,0 +1,185 @@
+# tests/cloud/workspace/test_instinct_approval_level.py
+# Created: 2026-06-19 (feat/instinct-gate-integration, security-review FIX 1) —
+# coverage for the OWNER-ONLY activation route that turns the layered Instinct
+# gate's triager on for a workspace (`PATCH /workspaces/{id}/instinct/
+# approval-level`). Enabling a non-ASK level activates AUTO-APPROVAL of agent
+# WRITE actions, so this is the single most security-sensitive write in the
+# gate: it MUST be the most-restrictive guard, validate the level against the
+# `ApprovalLevel` enum, audit the change at WARNING severity, and round-trip
+# through `resolve_workspace_approval_level`.
+#
+# Pinned here (service-level — the Beanie writer):
+#   * owner CAN set a valid level → persisted, audited (WARNING, old→new),
+#     and read back by `resolve_workspace_approval_level`
+#   * an invalid level (not ASK/TRIAGE/TRUSTED) → ValidationError (422)
+#   * the route is registered at the OWNER-only RBAC action `instinct.activate`
+#     (the strongest workspace guard) — a non-owner is denied
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.workspace import service as workspace_service
+from pocketpaw_ee.cloud.workspace.dto import CreateWorkspaceRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+@pytest.fixture(autouse=True)
+def _resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stub the realtime resolver so create()/save() don't need init_realtime."""
+    mock = MagicMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.get_resolver", lambda: mock)
+    return mock
+
+
+async def _seed_user(email: str = "owner@x.c") -> _UserDoc:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="Owner",
+        workspaces=[],
+    )
+    await doc.insert()
+    return doc
+
+
+def _ctx(user_id: str) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=None,
+        request_id="test",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _make_workspace() -> tuple[str, str]:
+    """Seed an owner User + a workspace. Returns (workspace_id, owner_user_id)."""
+    owner = await _seed_user()
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="Acme", slug="acme")
+    )
+    return ws.id, str(owner.id)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — owner sets a valid level, it is audited + read back.
+# ---------------------------------------------------------------------------
+
+
+async def test_owner_sets_valid_level_persists_and_reads_back() -> None:
+    """A valid level is written through the service and resolves on read."""
+    ws_id, owner_id = await _make_workspace()
+
+    # Default before any set — global "ASK".
+    assert await pockets_service.resolve_workspace_approval_level(ws_id) == "ASK"
+
+    await workspace_service.set_instinct_approval_level(_ctx(owner_id), ws_id, "TRIAGE")
+
+    # Read back via the canonical resolver the gate uses.
+    assert await pockets_service.resolve_workspace_approval_level(ws_id) == "TRIAGE"
+
+
+async def test_set_level_emits_warning_audit_old_to_new(monkeypatch) -> None:
+    """The activation switch emits an append-only WARNING audit event carrying
+    actor, workspace_id, and the old→new level — this is the switch that
+    enables auto-approval of agent writes, so it must be loud and attributable."""
+    captured: list[object] = []
+
+    from pocketpaw.security import audit as audit_mod
+
+    class _FakeLogger:
+        def log(self, event):
+            captured.append(event)
+
+    monkeypatch.setattr(audit_mod, "get_audit_logger", lambda: _FakeLogger())
+
+    ws_id, owner_id = await _make_workspace()
+    await workspace_service.set_instinct_approval_level(_ctx(owner_id), ws_id, "TRIAGE")
+
+    activation = [e for e in captured if getattr(e, "action", "") == "instinct.approval_level.set"]
+    assert activation, f"no activation audit event found in {captured}"
+    ev = activation[0]
+    assert str(getattr(ev, "severity", "")).lower().endswith("warning")
+    ctx = getattr(ev, "context", {}) or {}
+    assert ctx.get("workspace_id") == ws_id
+    assert ctx.get("old_level") == "ASK"
+    assert ctx.get("new_level") == "TRIAGE"
+    assert getattr(ev, "actor", "") == owner_id
+
+
+@pytest.mark.parametrize("level", ["TRUSTED", "ASK"])
+async def test_owner_sets_other_valid_levels(level: str) -> None:
+    """All three enum values are accepted by the service."""
+    ws_id, owner_id = await _make_workspace()
+    await workspace_service.set_instinct_approval_level(_ctx(owner_id), ws_id, level)
+    assert await pockets_service.resolve_workspace_approval_level(ws_id) == level
+
+
+# ---------------------------------------------------------------------------
+# Validation — an out-of-enum value is rejected (maps to 422 at the boundary).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["ask", "YOLO", "", "auto", "trusted "])
+async def test_invalid_level_rejected(bad: str) -> None:
+    """A value not in the ApprovalLevel enum raises ValidationError (422).
+
+    The level must NEVER be coerced to a fallback here — an invalid set must
+    fail loudly, not silently park a typo on the document (which the gate
+    would then read and route ASK on, masking the misconfiguration)."""
+    ws_id, owner_id = await _make_workspace()
+    with pytest.raises(ValidationError):
+        await workspace_service.set_instinct_approval_level(_ctx(owner_id), ws_id, bad)
+    # And the stored value is unchanged (still the ASK default).
+    assert await pockets_service.resolve_workspace_approval_level(ws_id) == "ASK"
+
+
+async def test_unknown_workspace_raises_not_found() -> None:
+    """Setting the level on a missing workspace is a 404, not a silent no-op."""
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    with pytest.raises(NotFound):
+        await workspace_service.set_instinct_approval_level(
+            _ctx("000000000000000000000001"), "000000000000000000000000", "TRIAGE"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Authz — the route is registered at the OWNER-only RBAC action.
+# ---------------------------------------------------------------------------
+
+
+def test_activation_action_is_owner_only() -> None:
+    """The dedicated RBAC action gating the route is OWNER-level — the most
+    restrictive workspace guard. Auto-approval of agent writes must never be
+    flippable by a mere admin or member."""
+    from pocketpaw_ee.guards.actions import ACTIONS
+    from pocketpaw_ee.guards.rbac import WorkspaceRole
+
+    rule = ACTIONS["instinct.activate"]
+    assert rule.minimum == WorkspaceRole.OWNER
+
+
+def test_activation_route_uses_owner_guard() -> None:
+    """The PATCH approval-level route on the workspace router is guarded by
+    `require_action('instinct.activate')` — pinned structurally so a future
+    refactor can't silently downgrade the guard to a weaker action."""
+    from pocketpaw_ee.cloud.workspace import router as ws_router
+
+    route = next(
+        r
+        for r in ws_router.router.routes
+        if getattr(r, "path", "").endswith("/instinct/approval-level")
+        and "PATCH" in getattr(r, "methods", set())
+    )
+    guard_names = [getattr(d.call, "__name__", "") for d in route.dependant.dependencies]
+    assert any("instinct_activate" in n for n in guard_names), guard_names


### PR DESCRIPTION
## What this does

The foundation (#1495) shipped the pieces of the layered Instinct gate — the lane classifier, the trust ledger, the auto-approve writer, the compensation registry — but none of them were called by the live gate yet. They sat dormant. This PR wires them in.

`gate_action` now runs the triage router after an escalate verdict: it reads the (pocket, action) trust score, classifies the write into a lane, audits the decision, and branches. AUTO and OPTIMISTIC write an already-decided approval row and let the write through; DRY_RUN resolves and audits the write without firing it; ESCALATE is the same human-pending path as before, now with dedup so the same row never stacks twice in the tray.

**Default `approval_level=ASK` means zero behavior change.** Under ASK the classifier returns ESCALATE for everything, so every existing caller — none of which pass the new args — behaves exactly as it does today: every escalate parks for a human. Auto-approval only ever activates when a workspace explicitly sets a non-ASK level on its own document. Uncertainty always escalates to the human; nothing gets silently approved. There is a test that pins this end-to-end: the same gated call fires the write under TRIAGE and parks under default ASK.

## Tasks done (T6–T12 from the design)

- **T6** — `gate_action` lane routing + triage audit; the router reads the workspace's `instinct_approval_level` (per-workspace field, falling back to the global config default) and threads it through `run_action`.
- **T7** — `run_action` gains dedicated `dry_run` and `optimistic_execute` flags. The dry-run intercept sits *after* the security gates, so an off-policy write is still rejected rather than rehearsed. Optimistic clears the gate-7 park and never reuses `from_instinct`.
- **T8** — trust feedback is written at exactly one site, in the bridge after a gated write lands. A system-triager decision counts as auto-approved, a human as not.
- **T9** — the outcomes service stays free of any trust-ledger call (a source-level guard test pins this), so the trust loop can't self-poison.
- **T10** — the saga treats `instinct_dry_run` as a non-commit and rolls back the prior steps; an optimistic write registers a bounded compensation handle.
- **T11** — BATCH-lane dedup: a second escalate for the same pocket/action/row returns the existing pending id.
- **T12** — changing a pocket's backend credential resets its earned trust, so a swapped backend can't inherit the old one's auto-approve score.

## Safety notes

This activates auto-approval of writes, so the whole change is default-safe: the dormant ASK path takes a fast lane that doesn't even read the ledger, every uncertain branch escalates, money-moving and DELETE actions never reach AUTO, and a cold-start (no prior approvals) always escalates. The optimistic compensation handle hard-expires with an alert if it's never rolled back.

## Tests

New: `tests/cloud/test_instinct_dispatch_lanes.py`, `tests/cloud/test_dry_run_lane.py`. Extended: the bridge, saga, backend-service, and gate-config suites. The full instinct/pockets/gate/backend set is green; every existing caller (bulk, temporal, direct route) stays green, which is the zero-change-by-default proof.

Docs follow-up for the per-workspace setting and the rollout playbook is a separate pass — this PR is the runtime wiring.


## Security-review fixes (follow-up commit)

Three findings from the review, fixed here since this PR is what turns auto-approval on.

- **Owner-only activation route.** The workspace document already had `instinct_approval_level` and a resolver read it, but there was no way to set it, so the gate couldn't be turned on safely. Added `PATCH /api/v1/workspaces/{id}/instinct/approval-level`, guarded by a new OWNER-only RBAC action (`instinct.activate`). It's deliberately separate from the general workspace PATCH route. The value is validated against the `ApprovalLevel` enum (422 on anything else), the write goes through the workspace service per the import-linter contract, and the flip emits a WARNING audit event with the old and new level.
- **DELETE floor hardened.** The explicit `if method == "DELETE": return ESCALATE` in the triage classifier stays separate from the financial `_is_high_blast` check on purpose: a DELETE must never reach OPTIMISTIC or AUTO, even with a CompensateSpec and a perfect trust score. Added a named test pinning that so the floor can't be quietly folded into the blast-radius helper later.
- **Batch-dedup query fix.** `_find_existing_pending_id` listed pending rows and matched in Python. A pocket with more pending rows than the list page could bury the match and stack a duplicate pending row. The `action_name` and `row_id` now go into the query, so dedup holds regardless of how many other rows the pocket has.

### Not in scope

HIGH-3 (the optimistic rollback endpoint's `workspace_id` ownership check) is **not** addressed here because that endpoint doesn't exist in this PR yet. When it's built, it must verify `handle.workspace_id == requester` and return 404 on a mismatch, so a caller can't roll back another tenant's optimistic write.
