### PR TITLE
Sites editing pipeline — perf rearchitecture + the root-cause fix sprint

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -33,6 +33,19 @@
 # "Submit for review" to publish. The tool docstring the agent reads was reworded to
 # match. The create + publish tools are unchanged (publish is a real live deploy).
 #
+# Updated: 2026-06-18 (feat/sites-diff-edit, P3) — ``edit_svelte_component`` now
+# accepts a TARGETED diff: ``edits=[{old_string, new_string}, ...]`` (search/replace
+# blocks like the built-in Edit tool) as an ALTERNATIVE to the full ``new_source``,
+# so the agent emits ONLY the change for a small edit instead of regenerating the
+# whole file (the dominant edit-latency cost). Exactly one of ``edits`` /
+# ``new_source`` is required (``new_source`` dropped from the schema's ``required``).
+# The handler validates the diff SHAPE (a non-empty list of string {old_string,
+# new_string} dicts) and forwards both fields to ``sites_service.edit_svelte_component``,
+# which applies the blocks to the pocket's CURRENT source (apply_edits) — a 0/>1
+# match raises ValidationError, relayed to the agent by code so it can retry. The
+# tool description steers the agent to PREFER ``edits`` for small changes and reserve
+# ``new_source`` for large rewrites.
+#
 # This is the decisive bypass of the dashboard-built ``pocket_specialist``
 # create machinery. The agent-mode pocket_specialist path (draft kit / plan kit /
 # subagent delegation + the validate-redraft loop) kept downgrading landing
@@ -562,12 +575,45 @@ async def _edit_svelte_component_handler(args: dict) -> dict:
             "of the file to rewrite (e.g. 'src/lib/components/Hero.svelte'). It "
             "must already exist in the site's source map."
         )
+    # P3 — the edit can be a TARGETED diff (``edits``) OR a full rewrite
+    # (``new_source``); exactly one is required. ``edits`` is preferred for small
+    # changes so the agent emits only the diff, not the whole file.
+    edits = args.get("edits")
     new_source = args.get("new_source")
-    if not isinstance(new_source, str):
+    has_edits = edits is not None
+    has_new_source = new_source is not None
+    if has_edits == has_new_source:
         return _error_response(
-            "edit_svelte_component requires `new_source` — the FULL new contents of "
-            "the file as a string (the tool replaces the whole file, not a patch)."
+            "edit_svelte_component requires exactly one of `edits` (a targeted "
+            "search/replace diff — PREFERRED for small changes) or `new_source` "
+            "(the FULL new file contents — for large rewrites). Provide one, not "
+            "both and not neither."
         )
+    if has_new_source and not isinstance(new_source, str):
+        return _error_response(
+            "edit_svelte_component `new_source` must be the FULL new contents of the "
+            "file as a string (the tool replaces the whole file, not a patch)."
+        )
+    if has_edits:
+        # Validate the diff SHAPE at the surface (a list of {old_string,
+        # new_string} string dicts) so a malformed payload gets a clear error
+        # before the service runs. The MATCH-uniqueness contract is enforced by the
+        # service's apply_edits (relayed below as a ValidationError).
+        if not isinstance(edits, list) or not edits:
+            return _error_response(
+                "edit_svelte_component `edits` must be a non-empty list of "
+                "{old_string, new_string} blocks (like the built-in Edit tool)."
+            )
+        for i, block in enumerate(edits):
+            if (
+                not isinstance(block, dict)
+                or not isinstance(block.get("old_string"), str)
+                or not isinstance(block.get("new_string"), str)
+            ):
+                return _error_response(
+                    f"edit_svelte_component `edits` block {i} must be an object with "
+                    "string `old_string` and `new_string`."
+                )
     name_raw = args.get("name")
     name = name_raw if isinstance(name_raw, str) else ""
 
@@ -581,7 +627,8 @@ async def _edit_svelte_component_handler(args: dict) -> dict:
             user_id=user_id,
             pocket_id=pocket_id,
             component_path=component_path,
-            new_source=new_source,
+            new_source=new_source if has_new_source else None,
+            edits=edits if has_edits else None,
             name=name,
         )
     except SmokeGateFailed as exc:
@@ -641,30 +688,39 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
     @tool(
         "edit_svelte_component",
         (
-            "Rewrite ONE component of an EXISTING svelte Paw Site and stage it as a "
+            "Edit ONE component of an EXISTING svelte Paw Site and stage it as a "
             "DRAFT PREVIEW. Use this when the user asks to change a section of a "
-            "svelte site — 'make the hero headline bolder', 'change the pricing "
-            "copy', 'restyle the FAQ'. You provide the FULL new file contents for "
-            "ONE file in the site's source map; the tool persists it as a draft and "
-            "builds a preview. The edit is NOT published and does NOT go live — it "
-            "is staged for review. Args: `pocket_id` (the svelte site pocket), "
-            "`component_path` (the relative path of the file to rewrite — it must "
-            "already exist in the source map, e.g. "
-            "'src/lib/components/Hero.svelte'), `new_source` (the whole new file "
-            "contents as a string — this REPLACES the file, it is not a patch), "
-            "and optional `name`. CRITICAL authoring rule (same as "
-            "create_svelte_site): the component must render its resting/final "
-            "state in MARKUP — never set it only in onMount — because the page is "
-            "PRERENDERED. Returns {ok, status:'draft', is_live:false, site: {id, "
-            "name, preview_url, deployed:false, pocket_id}, component_path, "
-            "message}. Relay the `message` to the user: the change is a DRAFT "
-            "PREVIEW (not live), `preview_url` is a PREVIEW (not the published "
-            "site), and to publish it the user clicks 'Submit for review'. Do NOT "
-            "tell the user the change is published or live. ok=false with an error "
-            "means the edit was NOT staged: a smoke-test failure leaves the "
-            "previous version unchanged (fix the component and retry), and a "
-            "not-found / not-a-svelte-site error means relay the reason. Do NOT "
-            "report a successful edit when ok=false."
+            "svelte site — 'add a background color to the nav', 'make the hero "
+            "headline bolder', 'change the pricing copy', 'restyle the FAQ'. The "
+            "edit is NOT published and does NOT go live — it is staged for review. "
+            "Give the edit ONE of two ways (exactly one, not both):\n"
+            "  * `edits` — PREFER THIS for small/targeted changes. A list of "
+            "search/replace blocks [{old_string, new_string}, ...], exactly like "
+            "the built-in Edit tool: each `old_string` is copied VERBATIM from the "
+            "current file and must match EXACTLY ONCE (include enough surrounding "
+            "context to be unique), and `new_string` is what it becomes. You send "
+            "ONLY the change, not the whole file — far fewer tokens and faster. If "
+            "you have not read the file this turn, read it first so old_string "
+            "matches.\n"
+            "  * `new_source` — the FULL new file contents as a string (REPLACES "
+            "the whole file, not a patch). Reserve this for LARGE rewrites where "
+            "most of the file changes; for a small tweak use `edits`.\n"
+            "Other args: `pocket_id` (the svelte site pocket), `component_path` (the "
+            "relative path of the file to edit — it must already exist in the source "
+            "map, e.g. 'src/lib/components/Hero.svelte'), optional `name`. CRITICAL "
+            "authoring rule (same as create_svelte_site): the component must render "
+            "its resting/final state in MARKUP — never set it only in onMount — "
+            "because the page is PRERENDERED. Returns {ok, status:'draft', "
+            "is_live:false, site: {id, name, preview_url, deployed:false, "
+            "pocket_id}, component_path, message}. Relay the `message` to the user: "
+            "the change is a DRAFT PREVIEW (not live), `preview_url` is a PREVIEW "
+            "(not the published site), and to publish it the user clicks 'Submit for "
+            "review'. Do NOT tell the user the change is published or live. ok=false "
+            "with an error means the edit was NOT staged: an `edits` old_string that "
+            "matched 0 or >1 times means make it more specific and retry, a "
+            "smoke-test failure leaves the previous version unchanged (fix the "
+            "component and retry), and a not-found / not-a-svelte-site error means "
+            "relay the reason. Do NOT report a successful edit when ok=false."
         ),
         {
             "type": "object",
@@ -678,16 +734,44 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
                     "type": "string",
                     "minLength": 1,
                     "description": (
-                        "Relative path of the file to rewrite — must already exist "
+                        "Relative path of the file to edit — must already exist "
                         "in the site's source map (e.g. "
                         "'src/lib/components/Hero.svelte')."
                     ),
                 },
+                "edits": {
+                    "type": "array",
+                    "description": (
+                        "PREFERRED for small changes: a list of search/replace "
+                        "blocks applied to the file's CURRENT contents. Each "
+                        "`old_string` must match exactly once. Send this INSTEAD of "
+                        "`new_source` so you emit only the diff."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "old_string": {
+                                "type": "string",
+                                "description": (
+                                    "Exact text to replace, copied verbatim from the "
+                                    "current file; must match exactly once."
+                                ),
+                            },
+                            "new_string": {
+                                "type": "string",
+                                "description": "Replacement text (may be empty to delete).",
+                            },
+                        },
+                        "required": ["old_string", "new_string"],
+                        "additionalProperties": False,
+                    },
+                },
                 "new_source": {
                     "type": "string",
                     "description": (
-                        "The FULL new contents of the file as a string. This "
-                        "replaces the whole file — it is not a diff/patch."
+                        "The FULL new contents of the file as a string (REPLACES the "
+                        "whole file — not a diff). Use for large rewrites; for small "
+                        "changes prefer `edits`."
                     ),
                 },
                 "name": {
@@ -698,7 +782,7 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
                     ),
                 },
             },
-            "required": ["pocket_id", "component_path", "new_source"],
+            "required": ["pocket_id", "component_path"],
             "additionalProperties": False,
         },
     )

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,16 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated: 2026-06-17 (fix/sites-plan-gate-asymmetry) — both create handlers now
+# call _require_sites_plan_or_error(workspace_id) right after input validation,
+# delegating to the shared sites.service.require_sites_plan gate. Sites is the
+# "fabric" plan feature; these create tools reach agent_create directly and
+# bypassed the REST router's require_plan_feature("fabric") gate, so a team-plan
+# workspace could create + (then publish) a live site that GET /sites 403'd. On a
+# disallowed plan the handler now returns the plan.feature_denied MCP error
+# ("Sites requires the Business plan — upgrade, or switch workspace") so the chat
+# agent surfaces the upgrade message instead of a phantom-created site.
+#
 # Updated: 2026-06-04 (feat/sites-svelte-engine) — added the SECOND deterministic
 # create tool ``create_svelte_site`` for the Paw Sites "Svelte track". It mirrors
 # ``create_landing_site`` (same direct ``agent_create`` persistence, same
@@ -140,6 +150,30 @@ def _identity() -> tuple[str | None, str | None]:
         return None, None
 
 
+async def _require_sites_plan_or_error(workspace_id: str) -> dict | None:
+    """Gate the create on the workspace's plan. Returns an MCP ``_error_response``
+    when the plan lacks the Sites ("fabric") feature (so the agent surfaces the
+    upgrade message instead of a phantom-created site), or ``None`` when the plan
+    is allowed.
+
+    Delegates to the SHARED service gate (``sites.service.require_sites_plan``) so
+    the in-process create path is gated by the SAME plan check + feature table as
+    the publish path and the HTTP ``require_plan_feature("fabric")`` dependency. A
+    team-plan workspace was the bug: create + publish ran in-process and bypassed
+    the router gate, deploying a live site that GET /sites then 403'd."""
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.sites.service import require_sites_plan
+
+    try:
+        await require_sites_plan(workspace_id)
+    except CloudError as exc:
+        # Forbidden('plan.feature_denied') / NotFound('workspace'). Relay the
+        # code + message so the agent tells the user to upgrade / switch
+        # workspace, not "site created".
+        return _error_response(f"{exc.code}: {exc.message}")
+    return None
+
+
 async def _bind_session_and_emit(pocket_id: str, view: dict[str, Any], user_id: str) -> None:
     """Bind the active chat session to the new pocket and push the
     ``pocket_created`` SSE event so the canvas auto-opens — the same atomic
@@ -192,6 +226,11 @@ async def _create_landing_site_handler(args: dict) -> dict:
             "landing page (brand, hero, services, testimonials, tiers, cta_band, "
             "contact, footer). You provide copy only; the tool builds the page."
         )
+
+    # Plan gate (Sites = "fabric"): reject a team-plan workspace here so the
+    # create can't bypass the router's require_plan_feature("fabric") gate.
+    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:
+        return gate
 
     name_raw = args.get("name")
     # Default the pocket name to the brand from the copy when not given.
@@ -379,6 +418,11 @@ async def _create_svelte_site_handler(args: dict) -> dict:
             "+layout.svelte (imports app.css), +page.ts (prerender=true), app.css, "
             "and at least one section component."
         )
+
+    # Plan gate (Sites = "fabric"): reject a team-plan workspace here so the
+    # create can't bypass the router's require_plan_feature("fabric") gate.
+    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:
+        return gate
 
     name_raw = args.get("name")
     name = name_raw.strip() if isinstance(name_raw, str) and name_raw.strip() else "Svelte site"

--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -4,6 +4,22 @@ Streams a typed SSE sequence in the response body while persisting the user
 message, submitting a ``Run`` to the configured executor, and tailing the
 run's Redis Stream so durability sits underneath the wire shape the
 frontend already speaks.
+
+Changes: 2026-06-18 (PERF-6, feat/sites-minimal-context) — window the history
+fed to the agent on the SITES EDIT/REFINE surface only. The sites builder got
+progressively slower per edit because ``load_history_for_scope`` loads the FULL
+accumulating scope history every turn, so the LLM re-processed ever-more context
+per refine. ``_window_history_for_surface`` now caps the loaded history to the
+last ``SITES_REFINE_HISTORY_TURNS`` turns (kept for pronoun referents like "make
+it bigger") when ``_is_sites_refine_surface`` matches (kind=sites + a refine
+``pocket_id`` in the surface meta — the same discriminator the sites preamble /
+profile resolver use). Every other surface (general pocket/dm/group chat, the
+sites-create gallery, legacy clients with no surface hint) keeps the FULL
+history — the windowing is a strict no-op off the sites-refine surface. The
+``<pocket-summary>`` block already carries the pocket's current state to the
+agent, so injecting the raw component source is intentionally left out of this
+change (it would add a build/DB read on the shared chat path); the windowing is
+the core latency win.
 """
 
 from __future__ import annotations
@@ -32,7 +48,11 @@ from pocketpaw_ee.cloud.chat.runs.executor import get_executor
 from pocketpaw_ee.cloud.chat.runs.transport import get_stream_transport
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
-from pocketpaw_ee.cloud.surface import resolve_surface_context
+from pocketpaw_ee.cloud.surface import (
+    SurfaceContext,
+    SurfaceKind,
+    resolve_surface_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +60,55 @@ router = APIRouter(tags=["Cloud Agent Chat"], dependencies=[Depends(require_lice
 
 
 Scope = Literal["dm", "group", "pocket", "session"]
+
+# PERF-6: how many trailing TURNS of history to keep on the sites EDIT/REFINE
+# surface. A "turn" is one user request plus its assistant reply (2 stored
+# ``Message`` rows), so the window keeps the last
+# ``2 * SITES_REFINE_HISTORY_TURNS`` rows — enough to resolve a pronoun referent
+# ("make IT bigger", "now the SAME for the footer") without re-feeding the whole
+# accumulating edit log to the LLM every refine. Kept as a module constant so
+# the window size is tunable in one place.
+SITES_REFINE_HISTORY_TURNS = 2
+_SITES_REFINE_HISTORY_ROWS = 2 * SITES_REFINE_HISTORY_TURNS
+
+
+def _is_sites_refine_surface(surface_context: SurfaceContext | None) -> bool:
+    """True only for the /sites EDIT/REFINE chat surface.
+
+    The refine surface is identified the SAME way the sites preamble
+    (``surface/handlers/sites.py``) and the profile resolver
+    (``surface/service.resolve_profile``) identify it: ``kind == SITES`` AND the
+    surface meta carries a ``pocket_id`` (the source pocket being edited). The
+    /sites gallery CREATE surface is ``kind == SITES`` with NO ``pocket_id``, and
+    a general pocket chat is ``kind == POCKET`` — both return ``False`` so the
+    windowing never touches general chat. A ``None`` surface context (legacy
+    client that sent no surface hint) is never refine.
+    """
+    if surface_context is None:
+        return False
+    return surface_context.kind == SurfaceKind.SITES and bool(
+        getattr(surface_context.meta, "pocket_id", None)
+    )
+
+
+def _window_history_for_surface(
+    history: list[dict[str, str]], surface_context: SurfaceContext | None
+) -> list[dict[str, str]]:
+    """Cap ``history`` to the last ``SITES_REFINE_HISTORY_TURNS`` turns on the
+    sites-refine surface; return it unchanged everywhere else.
+
+    This is the PERF-6 fix: on the sites builder each refine fed the FULL
+    growing scope history to the agent, so the LLM re-processed ever-more context
+    per edit. For the refine surface we keep only the trailing turns (enough for
+    pronoun referents); for EVERY other surface — general pocket/dm/group chat,
+    the sites-create gallery, legacy no-surface clients — the history passes
+    through untouched, so general chat behavior is byte-identical.
+    """
+    if not _is_sites_refine_surface(surface_context):
+        return history
+    if len(history) <= _SITES_REFINE_HISTORY_ROWS:
+        return history
+    return history[-_SITES_REFINE_HISTORY_ROWS:]
 
 
 def _sse(event: str, data: dict[str, Any], *, entry_id: str | None = None) -> bytes:
@@ -90,6 +159,11 @@ async def post_agent_chat(
 
     # Load history BEFORE persisting the new user message so it excludes this turn.
     history = await load_history_for_scope(ctx)
+    # PERF-6: on the sites EDIT/REFINE surface, window the loaded history to the
+    # last few turns so the LLM stops re-processing the whole accumulating edit
+    # log on every refine (the progressive-slowdown cause). No-op for general
+    # chat — see ``_window_history_for_surface`` / ``_is_sites_refine_surface``.
+    history = _window_history_for_surface(history, ctx.surface_context)
     user_message_id = await _persist_user_message(ctx, body)
 
     # Resolve the sidebar Session up-front so ``message.persisted`` carries

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -30,6 +30,16 @@
 # fresh one each time. No schema change: the upsert keys on the primary ``_id``
 # (already unique), so the existing compound (workspace, pocket_id) index — which
 # still serves the per-pocket reads — is sufficient and no new unique key is added.
+#
+# Updated 2026-06-18 (feat/sites-dedupe-migration, PERF-2): added ``archived`` — a
+# non-destructive tombstone flag for the duplicate Site docs the pre-PERF-1 minting
+# left behind. PERF-1 made NEW publishes stable (one upserted doc per pocket), but
+# EXISTING data still carries dupes (one pocket had 14 docs). The PERF-2 dedupe
+# migration (``sites.dedupe``) keeps ONE canonical doc per (workspace, pocket_id)
+# active and sets ``archived=True`` on the rest — it NEVER deletes, so the data is
+# recoverable. The gallery read (``service.list_for_workspace`` / listSites) filters
+# ``archived`` so each pocket shows exactly one card. Defaults False, so every
+# existing doc and every fresh publish reads active until the migration archives it.
 
 from __future__ import annotations
 
@@ -63,6 +73,11 @@ class Site(TimestampedDocument):
     # Canonical deployed URL. LOCAL mode: the localhost URL the per-site static
     # server serves. CF mode: "" in v1 (reached via custom domain).
     url: str = ""
+    # PERF-2: a non-destructive tombstone for duplicate Site docs the pre-PERF-1
+    # per-publish ObjectId minting left behind. The dedupe migration keeps ONE
+    # canonical doc per (workspace, pocket_id) active and sets this True on the
+    # rest (never deletes). The gallery read filters it so each pocket shows once.
+    archived: bool = False
     # SE-2b: the builder origin this site was published with, or "" when it was
     # published as a normal (non-editable) site. When set, the generated page
     # carries the gated edit-bridge keyed on this origin. Persisted so a

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -40,9 +40,17 @@
 # recoverable. The gallery read (``service.list_for_workspace`` / listSites) filters
 # ``archived`` so each pocket shows exactly one card. Defaults False, so every
 # existing doc and every fresh publish reads active until the migration archives it.
+#
+# Updated 2026-06-19 (P2b-backend — "Last Deployed"): added ``deployed_at`` — the UTC
+# timestamp of the most recent SUCCESSFUL live deploy. ``service.publish`` stamps it
+# (``datetime.now(UTC)``) ONLY when a non-preview deploy succeeds and ``deployed``
+# flips True — NOT on a preview/edit/arm build and NOT on every ``updatedAt`` bump,
+# so it is a true "last shipped" marker, not a "last touched" one. Defaults None;
+# backfill is not required (pre-P2b rows read null, exposed as None on the DTOs).
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from beanie import Indexed
@@ -70,6 +78,11 @@ class Site(TimestampedDocument):
     # Workers-for-Platforms script name (== site id) once deployed.
     script_name: str = ""
     deployed: bool = False
+    # P2b: UTC timestamp of the most recent SUCCESSFUL live deploy. Stamped by
+    # service.publish ONLY when a non-preview deploy succeeds (when ``deployed``
+    # flips True) — never on a preview/edit build, never on a plain updatedAt bump.
+    # None until the pocket has been deployed at least once (old rows read null).
+    deployed_at: datetime | None = None
     # Canonical deployed URL. LOCAL mode: the localhost URL the per-site static
     # server serves. CF mode: "" in v1 (reached via custom domain).
     url: str = ""

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -22,6 +22,14 @@
 # a normal (non-editable) site. When set, the generated page carries the gated
 # edit-bridge keyed on it. Persisted so a component-edit republish re-applies it
 # and the site stays editable across edits.
+#
+# Updated 2026-06-18 (feat/sites-stable-identity, PERF-1): a published Paw Site now
+# has a STABLE per-(workspace, pocket_id) identity — its ``_id`` is derived
+# deterministically from the pair (``service._live_object_id``), so a re-publish
+# UPSERTS the SAME Site doc (one canonical row per pocket) instead of inserting a
+# fresh one each time. No schema change: the upsert keys on the primary ``_id``
+# (already unique), so the existing compound (workspace, pocket_id) index — which
+# still serves the per-pocket reads — is sufficient and no new unique key is added.
 
 from __future__ import annotations
 

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -343,6 +343,20 @@ class CloudLifecycleHook:
         except Exception as exc:  # noqa: BLE001
             logger.warning("Local Paw Sites re-serve failed (non-fatal): %s", exc)
 
+        # Paw Sites live Vite dev-server reaper (Phase 2 / P2a). The DevServerManager
+        # runs one long-lived `vite dev` per pocket being edited (HMR preview); the
+        # idle reaper stops servers idle past DEV_SERVER_IDLE_SECONDS so editor
+        # sessions that walk away never leak processes. Best-effort, like the other
+        # boot reconcilers — a failure here must not block boot. The manager itself
+        # is lazily created on the first dev-preview call; starting the reaper here
+        # just ensures the idle sweep is ticking. on_shutdown stops it + every server.
+        try:
+            from pocketpaw_ee.sites.dev_server import start_dev_server_reaper
+
+            await start_dev_server_reaper()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Paw Sites dev-server reaper start failed (non-fatal): %s", exc)
+
     async def on_shutdown(self) -> None:
         import logging
 
@@ -387,6 +401,15 @@ class CloudLifecycleHook:
             await stop_xproc_consumer()
         except Exception as exc:  # noqa: BLE001
             logger.warning("xproc consumer stop failed: %s", exc)
+
+        # Stop the Paw Sites dev-server reaper AND terminate every running `vite dev`
+        # so no editor preview process outlives the web process (P2a resource safety).
+        try:
+            from pocketpaw_ee.sites.dev_server import stop_dev_servers
+
+            await stop_dev_servers()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Paw Sites dev-server stop failed: %s", exc)
 
         # Close the arq enqueuer pool if this web process ever built one
         # (POCKETPAW_CLOUD_RUN_EXECUTOR=arq). No-op otherwise.

--- a/ee/pocketpaw_ee/sites/dedupe.py
+++ b/ee/pocketpaw_ee/sites/dedupe.py
@@ -1,0 +1,279 @@
+# ee/pocketpaw_ee/sites/dedupe.py — PERF-2: non-destructive dedupe migration for
+# duplicate Site docs.
+#
+# Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+#
+# Why this exists: PERF-1 (feat/sites-stable-identity) made NEW publishes stable —
+# ``publish`` now UPSERTS ONE Site doc per (workspace, pocket_id) keyed on a
+# deterministic ``_live_object_id``. But the pre-PERF-1 code minted a fresh
+# ``ObjectId()`` per publish, so EXISTING data carries a pile of duplicate Site docs
+# per pocket (the "AKB" pocket had 14). ``service._canonical_site_doc`` (PERF-1)
+# resolves the live one among dupes at READ time, but the dupes still clutter the
+# gallery list. This migration COLLAPSES each pocket's dupes to ONE canonical doc,
+# non-destructively.
+#
+# Contract:
+#   * NON-DESTRUCTIVE — it sets ``archived=True`` on the non-canonical dupes; it
+#     NEVER deletes, so the data is fully recoverable. ``list_for_workspace`` /
+#     ``site_pocket_ids`` filter ``archived`` so the gallery shows one card per
+#     pocket.
+#   * IDEMPOTENT — re-running is safe: a pocket already collapsed to one ACTIVE doc
+#     has nothing to archive on the second pass (the picker only ever considers the
+#     active docs, so the canonical it already picked stays, and there is nothing
+#     left to archive).
+#   * DRY-RUN by default — ``dedupe_workspace`` / ``dedupe_all`` default to
+#     ``apply=False``: they REPORT what they would archive and write nothing.
+#     ``apply=True`` is the explicit flag that actually flips ``archived``.
+#   * RUNNABLE + UNIT-TESTABLE — the canonical-pick rule is a PURE function
+#     (``pick_canonical``) a test feeds in-memory docs to; the async
+#     ``dedupe_workspace`` / ``dedupe_all`` drive it over the DB. The module is also
+#     runnable as a management command: ``python -m pocketpaw_ee.sites.dedupe``
+#     (dry-run) / ``--apply`` / ``--workspace <id>``.
+#
+# Canonical-pick rule (``pick_canonical``), highest priority first:
+#   1. the PERF-1 stable-id doc (``_live_object_id(workspace, pocket_id)``) — every
+#      post-PERF-1 publish writes here, so it IS the live identity;
+#   2. otherwise the newest (by ``createdAt``) doc that is DEPLOYED and carries a
+#      real ``url`` — the freshest real live build among legacy dupes;
+#   3. otherwise the newest doc that carries a real ``url`` (deployed flag aside);
+#   4. otherwise the newest doc overall (a pre-url-era doc still resolves).
+# This mirrors ``service._canonical_site_doc`` so the migration converges on the
+# SAME doc the read path already treats as live.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.sites.service import _live_object_id
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PocketDedupeResult:
+    """What the dedupe decided for ONE (workspace, pocket_id) group."""
+
+    workspace_id: str
+    pocket_id: str
+    canonical_id: str
+    archived_ids: list[str] = field(default_factory=list)
+
+    @property
+    def docs_archived(self) -> int:
+        return len(self.archived_ids)
+
+
+@dataclass
+class DedupeReport:
+    """Aggregate accounting for a dedupe run (one workspace or all)."""
+
+    applied: bool
+    pockets_scanned: int = 0
+    docs_archived: int = 0
+    groups: list[PocketDedupeResult] = field(default_factory=list)
+
+    def add(self, result: PocketDedupeResult) -> None:
+        self.groups.append(result)
+        self.pockets_scanned += 1
+        self.docs_archived += result.docs_archived
+
+
+def _created_at(doc: _SiteDoc) -> datetime:
+    """The doc's createdAt as a sortable value. ``TimestampedDocument`` always sets
+    it, but guard a None (a hand-built in-memory doc in a test) with the epoch so
+    the sort is total and never raises."""
+    ts = getattr(doc, "createdAt", None)
+    return ts if isinstance(ts, datetime) else datetime.min
+
+
+def pick_canonical(docs: list[_SiteDoc]) -> tuple[_SiteDoc, list[_SiteDoc]]:
+    """Pick the ONE canonical Site doc among a pocket's docs (PURE — no DB).
+
+    ``docs`` are the Site docs for a SINGLE (workspace, pocket_id) — the caller
+    groups them. Returns ``(canonical, [docs_to_archive])`` where the archive list
+    is every other doc. The rule (highest priority first):
+
+      1. the PERF-1 stable-id doc — derived from the group's own
+         ``(workspace, pocket_id)`` via ``_live_object_id``; every post-PERF-1
+         publish writes here, so it is the live identity;
+      2. else the newest deployed doc that carries a real ``url`` (the freshest
+         real live build among legacy dupes);
+      3. else the newest doc that carries a real ``url``;
+      4. else the newest doc overall.
+
+    Mirrors ``service._canonical_site_doc`` so the migration converges on the same
+    doc the read path treats as live. Raises ``ValueError`` on an empty list (the
+    caller never groups an empty set)."""
+    if not docs:
+        raise ValueError("pick_canonical requires at least one doc")
+
+    # Derive the stable id from the group itself (all docs share workspace +
+    # pocket_id). Rule 1: the stable-id doc wins outright when present.
+    stable_id = _live_object_id(docs[0].workspace, docs[0].pocket_id)
+    stable = next((d for d in docs if d.id == stable_id), None)
+    if stable is not None:
+        canonical = stable
+    else:
+        newest_first = sorted(docs, key=_created_at, reverse=True)
+        # Rule 2: newest deployed doc with a real url.
+        canonical = next(
+            (d for d in newest_first if d.deployed and d.url),
+            # Rule 3: newest doc with a real url (deployed flag aside).
+            next(
+                (d for d in newest_first if d.url),
+                # Rule 4: newest doc overall.
+                newest_first[0],
+            ),
+        )
+
+    to_archive = [d for d in docs if d.id != canonical.id]
+    return canonical, to_archive
+
+
+def _group_by_pocket(docs: list[_SiteDoc]) -> dict[tuple[str, str], list[_SiteDoc]]:
+    """Group ACTIVE Site docs by (workspace, pocket_id)."""
+    groups: dict[tuple[str, str], list[_SiteDoc]] = defaultdict(list)
+    for doc in docs:
+        groups[(doc.workspace, doc.pocket_id)].append(doc)
+    return groups
+
+
+async def _dedupe(query: dict, *, apply: bool) -> DedupeReport:
+    """Core async dedupe over the Site docs matching ``query``.
+
+    Reads only ACTIVE docs (``archived: {"$ne": True}``), groups them per pocket,
+    picks the canonical, and archives the rest. A pocket already collapsed to one
+    active doc archives nothing — so a second run over the same data is a no-op
+    (idempotent). With ``apply=False`` (dry-run) it computes the FULL report but
+    writes nothing.
+    """
+    report = DedupeReport(applied=apply)
+
+    # Only consider ACTIVE docs. A doc already archived by a prior run is invisible
+    # here, so the second pass sees one active doc per already-deduped pocket and
+    # archives nothing (idempotent). ``$ne: True`` so docs predating the field
+    # (no ``archived`` key) still read active.
+    active_query = {**query, "archived": {"$ne": True}}
+    docs = await _SiteDoc.find(active_query).to_list()
+
+    for (workspace_id, pocket_id), group in _group_by_pocket(docs).items():
+        canonical, to_archive = pick_canonical(group)
+        if not to_archive:
+            # One active doc already — nothing to do (the idempotent steady state).
+            continue
+        result = PocketDedupeResult(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            canonical_id=str(canonical.id),
+            archived_ids=[str(d.id) for d in to_archive],
+        )
+        report.add(result)
+        if apply:
+            for doc in to_archive:
+                doc.archived = True
+                # save(): a tombstone flip, not a domain mutation — no event fired.
+                await doc.save()
+
+    return report
+
+
+async def dedupe_workspace(workspace_id: str, *, apply: bool = False) -> DedupeReport:
+    """Dedupe the Site docs of ONE workspace, non-destructively.
+
+    For each (workspace, pocket_id) with multiple ACTIVE docs, keeps the canonical
+    (``pick_canonical``) active and sets ``archived=True`` on the rest. DRY-RUN by
+    default (``apply=False`` reports what it WOULD archive, writes nothing);
+    ``apply=True`` actually archives. Idempotent — re-running archives nothing new.
+    """
+    return await _dedupe({"workspace": workspace_id}, apply=apply)
+
+
+async def dedupe_all(*, apply: bool = False) -> DedupeReport:
+    """Dedupe EVERY workspace's Site docs in one sweep (the boot / CLI unscoped
+    path). Same non-destructive, idempotent, dry-run-by-default contract as
+    ``dedupe_workspace`` — it just does not tenant-filter the read, so every
+    (workspace, pocket_id) group is reconciled. The per-pocket grouping keys on
+    BOTH fields, so pockets never bleed across workspaces."""
+    return await _dedupe({}, apply=apply)
+
+
+# ---------------------------------------------------------------------------
+# Runnable management command.
+#   python -m pocketpaw_ee.sites.dedupe                  # dry-run, all workspaces
+#   python -m pocketpaw_ee.sites.dedupe --apply          # apply, all workspaces
+#   python -m pocketpaw_ee.sites.dedupe --workspace ws1  # dry-run, one workspace
+#   python -m pocketpaw_ee.sites.dedupe --workspace ws1 --apply
+# Dry-run is the DEFAULT — ``--apply`` is the explicit flag that writes.
+# ---------------------------------------------------------------------------
+
+
+def _format_report(report: DedupeReport, *, workspace_id: str | None) -> str:
+    scope = f"workspace {workspace_id}" if workspace_id else "ALL workspaces"
+    mode = "APPLIED" if report.applied else "DRY-RUN (no writes)"
+    lines = [
+        f"Site dedupe — {scope} — {mode}",
+        f"  pockets with dupes : {report.pockets_scanned}",
+        f"  docs archived      : {report.docs_archived}",
+    ]
+    for g in report.groups:
+        lines.append(
+            f"  - {g.workspace_id}/{g.pocket_id}: keep {g.canonical_id}, "
+            f"archive {g.docs_archived} ({', '.join(g.archived_ids)})"
+        )
+    if not report.applied and report.docs_archived:
+        lines.append("  (dry-run — re-run with --apply to archive the above)")
+    return "\n".join(lines)
+
+
+async def _run_cli(workspace_id: str | None, apply: bool) -> DedupeReport:
+    """Init the EE cloud DB connection, run the dedupe, print the report."""
+    # Lazy import: the DB bootstrap is only needed for the runnable path, not for
+    # the unit-tested pure / async functions (tests init Beanie via the fixture).
+    # ``init_cloud_db`` reads PAW_MONGO_URI when set, else the local default — the
+    # same Beanie init the cloud app boots with, so the migration sees the real
+    # ``sites`` collection.
+    import os
+
+    from pocketpaw_ee.cloud.db import init_cloud_db
+
+    mongo_uri = os.environ.get("PAW_MONGO_URI", "mongodb://localhost:27017/paw-enterprise")
+    await init_cloud_db(mongo_uri)
+    if workspace_id:
+        report = await dedupe_workspace(workspace_id, apply=apply)
+    else:
+        report = await dedupe_all(apply=apply)
+    print(_format_report(report, workspace_id=workspace_id))
+    return report
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m pocketpaw_ee.sites.dedupe",
+        description=(
+            "Non-destructively collapse each pocket's duplicate Site docs to one "
+            "canonical (PERF-2). DRY-RUN by default; pass --apply to write."
+        ),
+    )
+    parser.add_argument(
+        "--workspace",
+        dest="workspace_id",
+        default=None,
+        help="Limit to ONE workspace id. Omit to sweep all workspaces.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually archive the dupes. Without it the run is a dry-run.",
+    )
+    args = parser.parse_args(argv)
+    asyncio.run(_run_cli(args.workspace_id, args.apply))
+
+
+if __name__ == "__main__":
+    main()

--- a/ee/pocketpaw_ee/sites/dev_server.py
+++ b/ee/pocketpaw_ee/sites/dev_server.py
@@ -1,0 +1,429 @@
+# ee/pocketpaw_ee/sites/dev_server.py — Phase 2 / P2a: live Vite dev-server
+# preview manager for the Paw Sites EDITING surface.
+#
+# Created: 2026-06-18 (feat/sites-devserver, Phase 2 / P2a).
+#
+# WHY: today editing a site rebuilds the whole SvelteKit app per edit (generate +
+# install + render). Phase 1 (PERF-3/PERF-4) cut that to a cached install + no
+# smoke, but a full `vite build` still runs per edit. P2a replaces the EDITING
+# preview with a long-lived `vite dev` server per pocket: the first edit
+# materializes the pocket's source into the PERSISTENT per-pocket dir (PERF-3 —
+# node_modules already cached) and starts `vite dev` on an ephemeral port;
+# subsequent edits hot-reload in ~ms over Vite HMR. PUBLISH is unchanged — it still
+# runs the full prod build + workerd smoke (PERF-4). The dev server is the editing
+# preview ONLY, never a deploy.
+#
+# DESIGN (this file: DevServerManager):
+#   * Async singleton (get_manager()). Tracks {pocket_id -> _DevServer} in an
+#     OrderedDict so the registry doubles as the LRU order (move_to_end on touch).
+#   * ensure_dev_server(workspace_id, user_id, pocket_id) -> dev URL: live server
+#     for the pocket → touch + return its url; else enforce the LRU cap, materialize
+#     the source, allocate a free port, spawn `vite dev`, register, return the url.
+#   * Per-pocket asyncio lock so two concurrent ensure calls never double-spawn; a
+#     global lock guards registry mutations (cap eviction, reaper sweep).
+#   * Idle reaper: a background task (start_reaper/stop_reaper, mirroring
+#     extensions.start_run_sweeper) that stops servers idle > idle_seconds.
+#   * LRU cap (max_servers): when starting would exceed the cap, the
+#     least-recently-used server is stopped first. Tenant-box reality: a handful of
+#     concurrent editors, so a small cap + a reaper keeps the process bounded.
+#   * INJECTABLE seams so the lifecycle is unit-testable WITHOUT real vite/bun:
+#       - _spawn(cmd, cwd, port) -> process   (default: asyncio subprocess)
+#       - _free_port() -> int                 (default: bind a socket to port 0)
+#       - _materialize(workspace_id, user_id, pocket_id) -> project_dir
+#                                             (default: GeneratorClient.build →
+#                                              the persistent per-pocket project dir)
+#
+# EDIT-BRIDGE NOTE (P2a scope decision): the hover-edit overlay needs the
+# `data-paw-section` anchors + the gated postMessage edit-bridge (SE-1/SE-2b) to be
+# present in the SOURCE the dev server serves. As of this change that bridge is NOT
+# in the ACTIVE generator (paw-workspace/paw-sites @ feat/dynamic-sites-authoring,
+# the one PAW_SITES_GEN_CMD invokes) — it lives only in an unmerged intg-paw-sites
+# worktree. So P2a ships INSTANT VISUAL feedback (Vite HMR) — the core win — and the
+# overlay-in-dev is a documented follow-up: merge the SE-1/SE-2b bridge into the
+# active generator's source templates (app.html / component scaffolds) so a
+# dev-served page carries it. No deploy/publish path changes here.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import time
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+# Defaults — all env-overridable so a tenant box can tune them without a redeploy.
+_DEFAULT_IDLE_SECONDS = 600.0  # stop a dev server idle longer than this
+_DEFAULT_MAX_SERVERS = 3  # LRU cap on concurrently running dev servers
+_DEFAULT_HOST = "127.0.0.1"  # dev servers bind loopback only
+_DEFAULT_REAP_INTERVAL = 60.0  # how often the reaper sweeps for idle servers
+
+
+def _idle_seconds() -> float:
+    raw = os.environ.get("DEV_SERVER_IDLE_SECONDS")
+    try:
+        return float(raw) if raw else _DEFAULT_IDLE_SECONDS
+    except ValueError:
+        return _DEFAULT_IDLE_SECONDS
+
+
+def _max_servers() -> int:
+    raw = os.environ.get("DEV_SERVER_MAX")
+    try:
+        return max(1, int(raw)) if raw else _DEFAULT_MAX_SERVERS
+    except ValueError:
+        return _DEFAULT_MAX_SERVERS
+
+
+def _dev_host() -> str:
+    return os.environ.get("DEV_SERVER_HOST", _DEFAULT_HOST)
+
+
+def _dev_cmd_argv(port: int, host: str) -> list[str]:
+    """The `vite dev` invocation, tokenised. Default runs the generated app's own
+    ``dev`` script via bun (the template declares ``"dev": "vite dev"``), pinned to
+    the chosen host + ephemeral port and ``--strictPort`` so vite fails loudly
+    rather than silently hopping to another port we don't know about. Override the
+    whole command with PAW_SITES_DEV_CMD (shell-tokenised) for a different runtime
+    (e.g. ``npm run dev``); the host/port/strictPort flags are always appended after
+    a ``--`` separator so they reach vite, not the package-manager wrapper."""
+    import shlex
+
+    base = shlex.split(os.environ.get("PAW_SITES_DEV_CMD", "bun run dev"))
+    # `--` ends the package-manager's own args so the flags pass through to vite.
+    return [*base, "--", "--host", host, "--port", str(port), "--strictPort"]
+
+
+class _Process(Protocol):
+    """The subset of an async subprocess the manager drives. Both
+    asyncio.subprocess.Process and the test's _FakeProc satisfy it."""
+
+    def terminate(self) -> None: ...
+    def kill(self) -> None: ...
+    async def wait(self) -> int: ...
+
+
+@dataclass
+class _DevServer:
+    """One running `vite dev` server for a pocket."""
+
+    pocket_id: str
+    workspace_id: str
+    port: int
+    url: str
+    process: _Process
+    last_activity: float = field(default_factory=time.monotonic)
+
+
+async def _default_spawn(cmd: list[str], cwd: str, port: int) -> _Process:
+    """Default spawner: start `vite dev` as an async subprocess in the project dir.
+    Output is discarded (DEVNULL) so a long-lived server never fills a pipe buffer
+    and blocks. Replaced wholesale in tests by an injected fake."""
+    return await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=cwd,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+
+
+def _default_free_port() -> int:
+    """Default port allocator: bind a socket to port 0, read the OS-assigned port,
+    release it, and hand it to vite. There is a tiny TOCTOU window between release
+    and vite binding; ``--strictPort`` makes vite fail loudly if it ever loses the
+    race, rather than silently serving on a different port. Replaced in tests."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind((_dev_host(), 0))
+        return int(s.getsockname()[1])
+    finally:
+        s.close()
+
+
+async def _default_materialize(*, workspace_id: str, user_id: str, pocket_id: str) -> str:
+    """Default source-materialize: run the generator into the PERSISTENT per-pocket
+    dir (PERF-3 — node_modules already cached there) and return the SvelteKit
+    project dir `vite dev` runs in. We reuse the same build path the preview/edit
+    flow uses with ``smoke=False`` (the workerd render is a publish-only gate,
+    PERF-4) — generate + cached install is all the dev server needs before it can
+    serve + HMR. Reads the pocket's draft content via the sites service the same way
+    a preview build does. Replaced in tests by an injected fake."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+    pocket = await pockets_service.get(pocket_id, user_id)
+    ripple_spec = pocket.get("rippleSpec") or {}
+    theme = (ripple_spec.get("theme") if isinstance(ripple_spec, dict) else {}) or {}
+    engine = pocket.get("engine") or "ripple"
+    source = pocket.get("source") if isinstance(pocket.get("source"), dict) else None
+    title = (pocket.get("name") or "").strip() or "Untitled site"
+
+    build = await GeneratorClient().build(
+        ripple_spec=ripple_spec,
+        theme=theme,
+        # A dev-only id namespace so the dev build dir never collides with the
+        # publish/preview build dirs for the same pocket.
+        site_id=f"dev-{pocket_id}",
+        title=title,
+        capture_api_base=os.environ.get("PAW_CAPTURE_API_BASE", "http://localhost:8888/api/v1"),
+        capture_signed_key="dev-preview",
+        engine=engine,
+        source=source,
+        # PERF-3: build into the stable per-pocket working dir (cached node_modules).
+        pocket_id=f"dev-{pocket_id}",
+        # PERF-4: the dev server never needs the workerd smoke render.
+        smoke=False,
+    )
+    return build.project_dir
+
+
+class DevServerManager:
+    """Async singleton that owns the live `vite dev` servers (one per pocket).
+
+    Resource safety is the priority: the idle reaper + LRU cap together bound the
+    number of running servers, and a per-pocket lock prevents two concurrent ensure
+    calls from double-spawning. All subprocess/IO is behind injectable seams so the
+    full lifecycle is unit-testable without a real vite/bun."""
+
+    def __init__(
+        self,
+        *,
+        idle_seconds: float | None = None,
+        max_servers: int | None = None,
+        host: str | None = None,
+        _spawn: Callable[[list[str], str, int], Awaitable[_Process]] | None = None,
+        _free_port: Callable[[], int] | None = None,
+        _materialize: Callable[..., Awaitable[str]] | None = None,
+    ) -> None:
+        self.idle_seconds = idle_seconds if idle_seconds is not None else _idle_seconds()
+        self.max_servers = max_servers if max_servers is not None else _max_servers()
+        self.host = host or _dev_host()
+        self._spawn = _spawn or _default_spawn
+        self._free_port = _free_port or _default_free_port
+        self._materialize = _materialize or _default_materialize
+
+        # OrderedDict so the registry itself encodes LRU order (front = least
+        # recently used). Mutated only under _global_lock.
+        self._servers: OrderedDict[str, _DevServer] = OrderedDict()
+        self._global_lock = asyncio.Lock()
+        # One lock per pocket so concurrent ensure calls for the SAME pocket
+        # serialize (no double-spawn) while DIFFERENT pockets proceed in parallel.
+        self._pocket_locks: dict[str, asyncio.Lock] = {}
+        self._reaper_task: asyncio.Task[None] | None = None
+
+    # --- public API --------------------------------------------------------
+
+    async def ensure_dev_server(self, *, workspace_id: str, user_id: str, pocket_id: str) -> str:
+        """Return the dev URL for the pocket's live `vite dev` server, starting it
+        if needed. A second call for a running pocket touches it (LRU bump) and
+        returns the same URL without respawning."""
+        lock = self._lock_for(pocket_id)
+        async with lock:
+            existing = self._servers.get(pocket_id)
+            if existing is not None and self._is_running(existing):
+                self.touch(pocket_id)
+                return existing.url
+
+            # A dead/exited process left a stale entry — drop it before respawning.
+            if existing is not None:
+                async with self._global_lock:
+                    self._servers.pop(pocket_id, None)
+
+            # Enforce the LRU cap BEFORE spawning so we never momentarily exceed it.
+            await self._enforce_cap()
+
+            project_dir = await self._materialize(
+                workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+            )
+            port = self._free_port()
+            cmd = _dev_cmd_argv(port, self.host)
+            process = await self._spawn(cmd, project_dir, port)
+            url = f"http://{self.host}:{port}/"
+            server = _DevServer(
+                pocket_id=pocket_id,
+                workspace_id=workspace_id,
+                port=port,
+                url=url,
+                process=process,
+            )
+            async with self._global_lock:
+                self._servers[pocket_id] = server
+                self._servers.move_to_end(pocket_id)  # most-recently-used = back
+            logger.info(
+                "dev-server: started for pocket %s on %s (cwd=%s)", pocket_id, url, project_dir
+            )
+            return url
+
+    def touch(self, pocket_id: str) -> None:
+        """Bump a server's last_activity and mark it most-recently-used. No-op for
+        an unknown pocket."""
+        server = self._servers.get(pocket_id)
+        if server is None:
+            return
+        server.last_activity = time.monotonic()
+        self._servers.move_to_end(pocket_id)
+
+    async def stop(self, pocket_id: str) -> None:
+        """Stop one pocket's dev server (terminate the process, drop the entry).
+        Idempotent — stopping an unknown/already-stopped pocket is a no-op."""
+        async with self._global_lock:
+            server = self._servers.pop(pocket_id, None)
+        if server is not None:
+            await self._terminate(server)
+
+    async def stop_all(self) -> None:
+        """Stop every running dev server. Called on shutdown so no `vite dev`
+        outlives the process."""
+        async with self._global_lock:
+            servers = list(self._servers.values())
+            self._servers.clear()
+        for server in servers:
+            await self._terminate(server)
+
+    async def reap_idle(self) -> list[str]:
+        """Stop every server idle longer than ``idle_seconds`` and return the list
+        of reaped pocket ids. One reaper tick — driven directly in tests, and on a
+        timer by the background loop."""
+        now = time.monotonic()
+        async with self._global_lock:
+            stale = [s for s in self._servers.values() if now - s.last_activity > self.idle_seconds]
+            for s in stale:
+                self._servers.pop(s.pocket_id, None)
+        for s in stale:
+            await self._terminate(s)
+        if stale:
+            logger.info("dev-server: reaped %d idle server(s)", len(stale))
+        return [s.pocket_id for s in stale]
+
+    def live_pocket_ids(self) -> list[str]:
+        """Pocket ids with a live server, LRU order (least → most recent)."""
+        return list(self._servers.keys())
+
+    # --- reaper lifecycle (mirrors extensions.start_run_sweeper) -----------
+
+    async def start_reaper(self, *, interval: float | None = None) -> None:
+        """Start the background idle-reaper loop (idempotent). Cancelled by
+        stop_reaper on shutdown."""
+        if self._reaper_task is not None:
+            return
+        tick = interval if interval is not None else _DEFAULT_REAP_INTERVAL
+        self._reaper_task = asyncio.create_task(self._reaper_loop(tick))
+
+    async def stop_reaper(self) -> None:
+        """Cancel the reaper loop and wait for it to unwind."""
+        from contextlib import suppress
+
+        task = self._reaper_task
+        self._reaper_task = None
+        if task is not None:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+    async def _reaper_loop(self, interval: float) -> None:
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                await self.reap_idle()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("dev-server: reaper tick failed")
+
+    # --- internals ---------------------------------------------------------
+
+    def _lock_for(self, pocket_id: str) -> asyncio.Lock:
+        lock = self._pocket_locks.get(pocket_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._pocket_locks[pocket_id] = lock
+        return lock
+
+    @staticmethod
+    def _is_running(server: _DevServer) -> bool:
+        """Whether the server's process is still alive. asyncio.subprocess.Process
+        exposes ``returncode`` (None == running); the fake proc does too."""
+        returncode = getattr(server.process, "returncode", None)
+        return returncode is None
+
+    async def _enforce_cap(self) -> None:
+        """Stop least-recently-used servers until there is room for one more under
+        the cap. Front of the OrderedDict is the LRU. Runs before a spawn so the
+        cap is never momentarily exceeded."""
+        while True:
+            async with self._global_lock:
+                if len(self._servers) < self.max_servers:
+                    return
+                # Pop the least-recently-used (front of the OrderedDict).
+                _, victim = self._servers.popitem(last=False)
+            await self._terminate(victim)
+            logger.info("dev-server: LRU cap reached — stopped pocket %s", victim.pocket_id)
+
+    async def _terminate(self, server: _DevServer) -> None:
+        """Terminate a server's process, escalating to kill if it ignores SIGTERM.
+        Never raises — a teardown failure must not break the caller (cap eviction,
+        reaper, shutdown)."""
+        proc = server.process
+        try:
+            if getattr(proc, "returncode", None) is None:
+                proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except TimeoutError:
+                proc.kill()
+                await proc.wait()
+        except ProcessLookupError:
+            # Already gone — fine.
+            pass
+        except Exception:
+            logger.exception("dev-server: error stopping pocket %s", server.pocket_id)
+
+
+# --- module singleton ------------------------------------------------------
+
+_MANAGER: DevServerManager | None = None
+
+
+def get_manager() -> DevServerManager:
+    """The process-wide DevServerManager singleton. Lazily constructed with the
+    default (real-subprocess) seams; tests build their own DevServerManager with
+    fakes instead of going through here."""
+    global _MANAGER
+    if _MANAGER is None:
+        _MANAGER = DevServerManager()
+    return _MANAGER
+
+
+async def ensure_dev_server(*, workspace_id: str, user_id: str, pocket_id: str) -> str:
+    """Module-level convenience over the singleton — the endpoint calls this."""
+    return await get_manager().ensure_dev_server(
+        workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+    )
+
+
+async def start_dev_server_reaper() -> None:
+    """Start the singleton's idle reaper (called from the cloud boot hook)."""
+    await get_manager().start_reaper()
+
+
+async def stop_dev_servers() -> None:
+    """Stop the reaper AND every running dev server (called from cloud shutdown) so
+    no `vite dev` process outlives the web process."""
+    if _MANAGER is None:
+        return
+    await _MANAGER.stop_reaper()
+    await _MANAGER.stop_all()
+
+
+__all__ = [
+    "DevServerManager",
+    "get_manager",
+    "ensure_dev_server",
+    "start_dev_server_reaper",
+    "stop_dev_servers",
+]

--- a/ee/pocketpaw_ee/sites/dev_server.py
+++ b/ee/pocketpaw_ee/sites/dev_server.py
@@ -3,6 +3,15 @@
 #
 # Created: 2026-06-18 (feat/sites-devserver, Phase 2 / P2a).
 #
+# Updated 2026-06-19 (fix/sites-preview-fresh-build, P0a): the P0a fix makes
+# generator.build()'s ``bun run build`` static-output step ALWAYS run by default
+# (so the served preview/publish is fresh + anchored — the #1 bug). The dev server
+# serves from SOURCE via ``vite dev`` and never goes through deploy_local, so it
+# needs no ``.svelte-kit/cloudflare/`` static output; ``_default_materialize`` now
+# passes ``static_build=False`` to SKIP the prod build (generate + cached install
+# is all ``vite dev`` needs). Without this the dev path would run a wasted full prod
+# build before every dev-server start.
+#
 # WHY: today editing a site rebuilds the whole SvelteKit app per edit (generate +
 # install + render). Phase 1 (PERF-3/PERF-4) cut that to a cached install + no
 # smoke, but a full `vite build` still runs per edit. P2a replaces the EDITING
@@ -178,6 +187,13 @@ async def _default_materialize(*, workspace_id: str, user_id: str, pocket_id: st
         pocket_id=f"dev-{pocket_id}",
         # PERF-4: the dev server never needs the workerd smoke render.
         smoke=False,
+        # P0a: the dev server serves from SOURCE via `vite dev` (never deploy_local),
+        # so it needs NO `.svelte-kit/cloudflare/` static output — skip `bun run
+        # build` entirely (generate + cached install is all it needs before `vite
+        # dev`). Forcing the static build here would add a wasted full prod build
+        # before every dev-server start. (The static build is REQUIRED only on the
+        # served preview/publish path — that is where the #1 stale-build bug lived.)
+        static_build=False,
     )
     return build.project_dir
 

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -90,6 +90,17 @@ class SitePreviewResponse(BaseModel):
     content: dict[str, Any] | None = None
 
 
+class DevPreviewResponse(BaseModel):
+    """The live Vite dev-server URL for a pocket's EDITING preview (Phase 2 / P2a).
+    ``url`` is a localhost address (http://127.0.0.1:<port>/) the builder iframe
+    frames so edits hot-reload over Vite HMR in ~ms, instead of a full per-edit
+    rebuild. This is the editing preview only — publish still does the full prod
+    build + workerd smoke."""
+
+    pocket_id: str
+    url: str
+
+
 class SiteStatusResponse(BaseModel):
     """Authoritative draft/published + is_live state for a pocket, so the builder
     labels accurately even before the site appears in the gallery list. ``status``

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -28,6 +28,12 @@
 # This flag (default False, backward-compatible) lets the builder badge "has
 # unpublished edits" without inferring it from the Site doc. ``status``/``is_live``
 # semantics are unchanged in shape; only their derivation moves onto versions.
+# Updated 2026-06-18 (feat/sites-stable-identity, PERF-1): SiteStatusResponse gains
+# ``url`` — the canonical live address of the pocket's deployed site. With stable
+# per-pocket identity (one Site doc per pocket) pocket_status reads the ONE
+# canonical doc and surfaces its non-null url, so the builder/gallery link to the
+# address the latest build actually serves at instead of a stale dupe's url=None.
+# Optional (default None, backward-compatible) — None when no deployed site exists.
 # Updated 2026-06-18 (feat/branch-primitive-revert-history, BP-4): added two DTOs
 # for the Branch-primitive surfaces — SiteVersionResponse + VersionHistoryResponse
 # (the ordered version timeline GET /sites/by-pocket/{pocket_id}/versions returns)
@@ -101,6 +107,9 @@ class SiteStatusResponse(BaseModel):
     is_live: bool
     has_unpublished_changes: bool = False
     site_id: str | None = None
+    # PERF-1: the canonical live url of the pocket's deployed site (the address the
+    # latest build serves at). None when no deployed site exists.
+    url: str | None = None
 
 
 class SiteVersionResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -45,6 +45,11 @@
 # (the first non-editor PRODUCER). Each finding carries a ``fix_prompt`` the UI
 # feeds to the EXISTING edit path so the fix lands as a reviewable draft; there is
 # NO new apply endpoint (BP-7 reuses edit_svelte_component / refine).
+# Updated 2026-06-19 (P2b-backend — "Last Deployed"): SiteResponse and
+# SiteStatusResponse gain ``deployed_at`` — the ISO-8601 string of the pocket's most
+# recent successful live deploy (the Site doc's ``deployed_at``), or None before the
+# first deploy. The builder/gallery surface a "Last deployed <time>" label without a
+# second fetch. Optional (default None) so the field is backward-compatible.
 
 from __future__ import annotations
 
@@ -77,6 +82,9 @@ class SiteResponse(BaseModel):
     # SE-2b: the builder origin the site was published with, or "" for a normal
     # (non-editable) site. Non-empty means the page carries the edit-bridge.
     builder_origin: str = ""
+    # P2b: ISO-8601 timestamp of the most recent successful live deploy, or None
+    # before the first deploy (a preview-only / never-deployed pocket reads None).
+    deployed_at: str | None = None
 
 
 class SitePreviewResponse(BaseModel):
@@ -121,6 +129,10 @@ class SiteStatusResponse(BaseModel):
     # PERF-1: the canonical live url of the pocket's deployed site (the address the
     # latest build serves at). None when no deployed site exists.
     url: str | None = None
+    # P2b: ISO-8601 timestamp of the pocket's most recent successful live deploy,
+    # read from the canonical Site doc's ``deployed_at``. None when the pocket has
+    # never been deployed (no Site doc, or a pre-P2b row that predates the field).
+    deployed_at: str | None = None
 
 
 class SiteVersionResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -1,10 +1,20 @@
 # ee/pocketpaw_ee/sites/generator_client.py — Python bridge to the Node/Bun
 # generator (paw-sites-gen). build() runs the generate CLI, then `bun install`
-# on the generated project, then the workerd smoke render; if the smoke gate
-# fails the site does NOT proceed to deploy (Contract clause 4). The subprocess
-# calls are isolated behind a _runner so the orchestration is unit-testable
-# without Bun/workerd present.
+# on the generated project, then (only for a LIVE publish) the workerd smoke
+# render; if the smoke gate fails the site does NOT proceed to deploy (Contract
+# clause 4). The subprocess calls are isolated behind a _runner so the
+# orchestration is unit-testable without Bun/workerd present.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
+#
+# Updated 2026-06-18 (feat/sites-smoke-at-publish, PERF-4 — smoke-gate only at
+# publish): build() gained a ``smoke: bool = True`` flag. The workerd SMOKE render
+# is per-edit overhead only needed before a LIVE deploy, so a PREVIEW/edit/arm
+# build now passes ``smoke=False`` to SKIP it (the build runs generate + install
+# only and never spawns the render). A LIVE publish keeps the default
+# ``smoke=True`` so the gate — and the caller's rollback-on-SmokeGateFailed — is
+# unchanged. service.publish() threads ``smoke=not preview`` from its existing
+# ``preview`` flag. A preview build that WOULD fail smoke is no longer blocked;
+# the live publish still gates + rolls back, so a broken edit can never go live.
 #
 # Updated 2026-06-18 (feat/sites-cached-build, PERF-3 — persistent build dir +
 # cached node_modules): the single biggest per-edit cost was running `bun install`
@@ -304,6 +314,7 @@ class GeneratorClient:
         source: dict[str, str] | None = None,
         builder_origin: str | None = None,
         pocket_id: str | None = None,
+        smoke: bool = True,
     ) -> BuildResult:
         """Generate + smoke-build a Paw Site, forking STAGE 2 on ``engine``.
 
@@ -329,6 +340,15 @@ class GeneratorClient:
         build() falls back to a fresh throwaway tempfile dir (no caching) so legacy
         callers keep their prior behaviour. Concurrent builds of the SAME pocket
         are serialized by a per-pocket lock (they share the on-disk dir).
+
+        ``smoke`` (PERF-4) gates the workerd SMOKE render (the SSR safety check).
+        The smoke render is per-edit overhead only needed before a LIVE deploy, so
+        a PREVIEW/edit/arm build passes ``smoke=False`` to SKIP it — the build runs
+        generate + install only and never spawns the workerd render. A LIVE publish
+        keeps the default ``smoke=True`` so the gate (and its
+        rollback-on-SmokeGateFailed behaviour at the caller) is unchanged. A
+        preview build that WOULD fail smoke is no longer blocked — acceptable, since
+        the live publish still gates + rolls back.
         """
         if pocket_id is None:
             return await self._build_one(
@@ -342,6 +362,7 @@ class GeneratorClient:
                 source=source,
                 builder_origin=builder_origin,
                 pocket_id=None,
+                smoke=smoke,
             )
         async with self._lock_for(pocket_id):
             return await self._build_one(
@@ -355,6 +376,7 @@ class GeneratorClient:
                 source=source,
                 builder_origin=builder_origin,
                 pocket_id=pocket_id,
+                smoke=smoke,
             )
 
     async def _build_one(
@@ -370,6 +392,7 @@ class GeneratorClient:
         source: dict[str, str] | None,
         builder_origin: str | None,
         pocket_id: str | None,
+        smoke: bool,
     ) -> BuildResult:
         # PERF-3: stable per-pocket working dir (overwrite the source each build)
         # so node_modules persists; fall back to a throwaway tempfile dir when no
@@ -435,9 +458,16 @@ class GeneratorClient:
             ok, reason = await self._runner.install(project_dir)
             if not ok:
                 raise SmokeGateFailed(reason)
-        ok, reason = await self._runner.smoke(project_dir)
-        if not ok:
-            raise SmokeGateFailed(reason)
+        # PERF-4: run the workerd SMOKE render only when the caller asked for it
+        # (smoke=True — the LIVE publish path). A PREVIEW/edit/arm build passes
+        # smoke=False to SKIP the render: it is per-edit overhead only needed before
+        # a live deploy, and a preview that would fail smoke is no longer blocked
+        # (the live publish still gates + rolls back). Skipping leaves
+        # generate+install (the correctness-bearing steps) intact.
+        if smoke:
+            ok, reason = await self._runner.smoke(project_dir)
+            if not ok:
+                raise SmokeGateFailed(reason)
         # ``rippleVersion`` is present only on the ripple GenerateResult; the svelte
         # path omits it (paw-sites types.ts §4.2), so read it defensively — a svelte
         # build must not KeyError here.

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -1,10 +1,46 @@
 # ee/pocketpaw_ee/sites/generator_client.py — Python bridge to the Node/Bun
 # generator (paw-sites-gen). build() runs the generate CLI, then `bun install`
-# on the generated project, then (only for a LIVE publish) the workerd smoke
-# render; if the smoke gate fails the site does NOT proceed to deploy (Contract
-# clause 4). The subprocess calls are isolated behind a _runner so the
-# orchestration is unit-testable without Bun/workerd present.
+# on the generated project, then `bun run build` to emit the deployable
+# `.svelte-kit/cloudflare/` static output (with the data-paw-section anchors +
+# the injected edit-bridge for an editable site); a LIVE publish additionally
+# fail-gates on the workerd SSR render markers. If the gate fails the site does
+# NOT proceed to deploy (Contract clause 4). The subprocess calls are isolated
+# behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
+#
+# Updated 2026-06-19 (fix/sites-preview-fresh-build, P0a + P1a — the #1 Paw Sites
+# bug: the editable PREVIEW served STALE anchorless HTML so the hover edit-pill
+# never appeared). ROOT CAUSE: PERF-4 overloaded the ``smoke`` flag — it gated
+# ``_runner.smoke()``, the ONLY step that ran ``bun run build`` (the step that
+# emits ``.svelte-kit/cloudflare/index.html`` with the section anchors + the
+# injected ``id="paw-edit-bridge"``). A preview build (``smoke=False``) re-stamped
+# the SOURCE with anchors but SKIPPED ``bun run build``, so ``persist_site`` copied
+# whatever the LAST build left on disk — the stale, non-anchored LIVE build.
+#   * P0a: SPLIT the two concerns the ``smoke`` flag conflated. ``bun run build``
+#     (the static-output step — REQUIRED on any path that is served locally, i.e.
+#     every preview that goes through deploy_local) now ALWAYS runs; the SSR
+#     FAIL-gate (the actual "smoke" safety check) is the only thing the flag
+#     toggles. The runner gained ``build_static(project_dir, gate)``: it always
+#     runs ``bun run build`` (a non-zero exit always fails — a build that can't
+#     produce output is never servable), and applies the workerd SSR-marker
+#     fail-check ONLY when ``gate=True`` (the LIVE publish path). ``_build_one``
+#     now ALWAYS calls it (``gate=smoke``) instead of calling ``smoke()`` only on
+#     publish, so the preview/editable path produces FRESH anchored output and
+#     ``persist_site`` copies it. Reintroduces per-edit build time — acceptable +
+#     correct for now (instant-HMR via dev_server is a separate future change).
+#   * P1a: REAP the build-path workerd. ``adapter-cloudflare`` prerenders by
+#     booting a workerd that the bun build process never reaps (it reparents to
+#     PID 1 and lives on), so they pile up and progressively slow the box (~60
+#     observed). ``reap_build_workerd(project_dir)`` runs AFTER every static build
+#     and terminates any workerd whose executable lives under this build's
+#     ``project_dir`` (scoped so it never touches another build's / the dev
+#     server's processes). The leak is independent of the smoke flag, so the reap
+#     runs on BOTH the gated and ungated static build.
+#   * The legacy ``smoke()`` runner method is preserved for the fake runners in the
+#     existing generator/cache/smoke-gate unit tests (those fakes do not define
+#     ``build_static``); ``_build_one`` falls back to the OLD behaviour (call
+#     ``smoke()`` only when ``smoke=True``) for a runner without ``build_static``.
+#     The REAL runner defines ``build_static`` and is always on the new path.
 #
 # Updated 2026-06-18 (feat/sites-smoke-at-publish, PERF-4 — smoke-gate only at
 # publish): build() gained a ``smoke: bool = True`` flag. The workerd SMOKE render
@@ -92,12 +128,15 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import os
 import shlex
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
 
 # Sentinel file (in the per-pocket build dir) recording the install-input
 # fingerprint of the last SUCCESSFUL `bun install`. build() skips install when the
@@ -108,6 +147,77 @@ _INSTALL_HASH_FILE = ".paw-install-hash"
 # stale and must be reinstalled. The lockfile names cover bun's text + binary
 # lockfiles and the npm fallback.
 _INSTALL_INPUT_FILES = ("package.json", "bun.lock", "bun.lockb", "package-lock.json")
+
+# Known workerd SSR-render failure markers (mirrors paw-sites/src/smoke.ts). A
+# LIVE publish fail-gates on these; a preview build tolerates them (the live
+# publish still gates + rolls back, so a broken edit can never go live).
+_WORKERD_SSR_MARKERS = ("window is not defined", "document is not defined", "No such module")
+
+
+def reap_build_workerd(project_dir: str) -> int:
+    """Terminate any orphaned ``workerd`` process spawned by THIS build's
+    ``bun run build`` (P1a). Returns the count reaped.
+
+    ``adapter-cloudflare`` prerenders by booting a workerd that ``bun run build``
+    does NOT reap: when the build process exits the workerd reparents to PID 1 and
+    lives on, so on a per-edit rebuild loop they pile up and progressively slow the
+    box (the reaper that already exists only covers ``dev_server``'s ``vite dev``).
+
+    The reap is SCOPED to this build's ``project_dir``: each generated project
+    installs its own ``@cloudflare/workerd-*`` binary under
+    ``<project_dir>/node_modules/...``, and a prerender workerd runs THAT binary, so
+    a process whose executable path is under ``project_dir`` is a leftover from this
+    build — never another build's, never the dev server's. We match on the resolved
+    project dir so the same pocket's persistent build dir (PERF-3) is handled too.
+
+    Best-effort + never raises: a reap failure must not fail the build. If
+    ``psutil`` is unavailable the reap is a logged no-op (the build still succeeds;
+    the leak just isn't swept on that box)."""
+    try:
+        import psutil
+    except Exception:  # noqa: BLE001 — reaping is best-effort; never fail the build
+        logger.debug("sites: psutil unavailable, skipping build-workerd reap")
+        return 0
+
+    try:
+        root = str(Path(project_dir).resolve())
+    except Exception:  # noqa: BLE001
+        root = project_dir
+    victims = []
+    for proc in psutil.process_iter(["name", "exe"]):
+        try:
+            name = (proc.info.get("name") or "").lower()
+            exe = proc.info.get("exe") or ""
+            # A prerender workerd for this build runs the workerd binary that lives
+            # under this build's node_modules — match on the resolved project dir.
+            if "workerd" in name and exe and root in exe:
+                victims.append(proc)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        except Exception:  # noqa: BLE001 — never let one bad proc abort the sweep
+            continue
+    for proc in victims:
+        try:
+            proc.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        except Exception:  # noqa: BLE001
+            continue
+    if victims:
+        # Give SIGTERM a moment, then SIGKILL any survivor so the leak is real-swept.
+        try:
+            _gone, alive = psutil.wait_procs(victims, timeout=3)
+            for proc in alive:
+                try:
+                    proc.kill()
+                except Exception:  # noqa: BLE001
+                    continue
+        except Exception:  # noqa: BLE001
+            pass
+        logger.info(
+            "sites: reaped %d build-path workerd process(es) under %s", len(victims), root
+        )
+    return len(victims)
 
 
 class SmokeGateFailed(RuntimeError):
@@ -202,6 +312,14 @@ def _rewrite_ripple_dep(project_dir: str, source: str) -> None:
 class _Runner(Protocol):
     async def generate(self, input_json: dict[str, Any], out_dir: str) -> dict[str, Any]: ...
     async def install(self, project_dir: str) -> tuple[bool, str]: ...
+    # P0a: the static-output step — runs `bun run build` (emits
+    # `.svelte-kit/cloudflare/` with the section anchors + injected edit-bridge),
+    # reaps the build-path workerd, and applies the SSR fail-gate ONLY when
+    # ``gate=True``. ALWAYS runs (preview + publish) so the served file is fresh.
+    async def build_static(self, project_dir: str, *, gate: bool) -> tuple[bool, str]: ...
+    # Legacy SSR fail-gate (== the old combined `bun run build` + marker check).
+    # Kept for fake runners that predate build_static; the real runner routes the
+    # gate through build_static. build() falls back to it when build_static is absent.
     async def smoke(self, project_dir: str) -> tuple[bool, str]: ...
     # PERF-3: fingerprint of the install inputs (package.json + lockfile). build()
     # uses it to decide whether `bun install` can be skipped. Optional on a runner —
@@ -261,9 +379,18 @@ class _SubprocessRunner:
             return False, f"bun install failed (exit {proc.returncode}): {stderr.decode()[-500:]}"
         return True, "ok"
 
-    async def smoke(self, project_dir: str) -> tuple[bool, str]:
-        # Build the generated project; a non-zero exit OR a known workerd marker
-        # in the output fails the gate. Mirrors paw-sites/src/smoke.ts markers.
+    async def build_static(self, project_dir: str, *, gate: bool) -> tuple[bool, str]:
+        # P0a: run `bun run build` — the step that emits the deployable
+        # `.svelte-kit/cloudflare/` static output (the data-paw-section anchors + the
+        # injected edit-bridge for an editable site). This ALWAYS runs (preview +
+        # publish): persist_site copies whatever this leaves on disk, so skipping it
+        # is exactly what served the stale anchorless build (the #1 bug).
+        #   * A non-zero exit ALWAYS fails — a build that can't produce output is
+        #     never servable, on any path.
+        #   * A known workerd SSR marker fails the gate ONLY when ``gate=True`` (the
+        #     LIVE publish path). A preview build tolerates a would-fail SSR render
+        #     (the live publish still gates + rolls back, so a broken edit can't go
+        #     live) but still BUILDS so the served preview is fresh + anchored.
         proc = await asyncio.create_subprocess_exec(
             "bun",
             "run",
@@ -273,13 +400,23 @@ class _SubprocessRunner:
             stderr=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await proc.communicate()
+        # P1a: reap the prerender-spawned workerd after EVERY build (the leak is
+        # independent of the gate), scoped to this build's project dir.
+        reap_build_workerd(project_dir)
         haystack = stdout.decode() + "\n" + stderr.decode()
-        for marker in ("window is not defined", "document is not defined", "No such module"):
-            if marker in haystack:
-                return False, f"workerd SSR failure: {marker}"
         if proc.returncode != 0:
             return False, f"build failed (exit {proc.returncode})"
+        if gate:
+            for marker in _WORKERD_SSR_MARKERS:
+                if marker in haystack:
+                    return False, f"workerd SSR failure: {marker}"
         return True, "ok"
+
+    async def smoke(self, project_dir: str) -> tuple[bool, str]:
+        # Legacy entry point (== the old combined `bun run build` + SSR fail-gate).
+        # The real path now routes through build_static; this delegates to it with
+        # the gate ON so any direct/legacy caller keeps the publish-time semantics.
+        return await self.build_static(project_dir, gate=True)
 
 
 class GeneratorClient:
@@ -315,6 +452,7 @@ class GeneratorClient:
         builder_origin: str | None = None,
         pocket_id: str | None = None,
         smoke: bool = True,
+        static_build: bool = True,
     ) -> BuildResult:
         """Generate + smoke-build a Paw Site, forking STAGE 2 on ``engine``.
 
@@ -341,14 +479,23 @@ class GeneratorClient:
         callers keep their prior behaviour. Concurrent builds of the SAME pocket
         are serialized by a per-pocket lock (they share the on-disk dir).
 
-        ``smoke`` (PERF-4) gates the workerd SMOKE render (the SSR safety check).
-        The smoke render is per-edit overhead only needed before a LIVE deploy, so
-        a PREVIEW/edit/arm build passes ``smoke=False`` to SKIP it — the build runs
-        generate + install only and never spawns the workerd render. A LIVE publish
-        keeps the default ``smoke=True`` so the gate (and its
-        rollback-on-SmokeGateFailed behaviour at the caller) is unchanged. A
-        preview build that WOULD fail smoke is no longer blocked — acceptable, since
-        the live publish still gates + rolls back.
+        ``static_build`` (P0a) controls whether ``bun run build`` runs to emit the
+        deployable ``.svelte-kit/cloudflare/`` static output. It defaults to ``True``
+        and MUST stay ``True`` on any path whose result is SERVED via deploy_local
+        (every preview / publish — ``persist_site`` copies whatever this leaves on
+        disk, so skipping it serves a stale build, the #1 bug). The dev server
+        (``vite dev`` serves from source, never deploy_local) passes
+        ``static_build=False`` so it only runs generate + cached install — the static
+        build is wasted work there.
+
+        ``smoke`` (P0a — was PERF-4) now gates ONLY the workerd SSR FAIL-check, NOT
+        whether ``bun run build`` runs. A PREVIEW/edit/arm build passes ``smoke=False``
+        to SKIP the SSR fail-gate (a preview that would fail SSR is no longer blocked
+        — the live publish still gates + rolls back) but the static build STILL runs
+        so the served preview is fresh + anchored. A LIVE publish keeps the default
+        ``smoke=True`` so the SSR gate (and its rollback-on-SmokeGateFailed behaviour
+        at the caller) is unchanged. Before this fix ``smoke`` ALSO gated the build
+        itself, so a preview skipped ``bun run build`` and served the stale build.
         """
         if pocket_id is None:
             return await self._build_one(
@@ -363,6 +510,7 @@ class GeneratorClient:
                 builder_origin=builder_origin,
                 pocket_id=None,
                 smoke=smoke,
+                static_build=static_build,
             )
         async with self._lock_for(pocket_id):
             return await self._build_one(
@@ -377,6 +525,7 @@ class GeneratorClient:
                 builder_origin=builder_origin,
                 pocket_id=pocket_id,
                 smoke=smoke,
+                static_build=static_build,
             )
 
     async def _build_one(
@@ -393,6 +542,7 @@ class GeneratorClient:
         builder_origin: str | None,
         pocket_id: str | None,
         smoke: bool,
+        static_build: bool = True,
     ) -> BuildResult:
         # PERF-3: stable per-pocket working dir (overwrite the source each build)
         # so node_modules persists; fall back to a throwaway tempfile dir when no
@@ -458,16 +608,32 @@ class GeneratorClient:
             ok, reason = await self._runner.install(project_dir)
             if not ok:
                 raise SmokeGateFailed(reason)
-        # PERF-4: run the workerd SMOKE render only when the caller asked for it
-        # (smoke=True — the LIVE publish path). A PREVIEW/edit/arm build passes
-        # smoke=False to SKIP the render: it is per-edit overhead only needed before
-        # a live deploy, and a preview that would fail smoke is no longer blocked
-        # (the live publish still gates + rolls back). Skipping leaves
-        # generate+install (the correctness-bearing steps) intact.
-        if smoke:
-            ok, reason = await self._runner.smoke(project_dir)
-            if not ok:
-                raise SmokeGateFailed(reason)
+        # P0a: run the static-output step (`bun run build`) so the served file is
+        # FRESH + anchored. The fix splits the two concerns PERF-4's ``smoke`` flag
+        # conflated: ``bun run build`` (REQUIRED on any locally-served path —
+        # persist_site copies whatever it leaves on disk) vs the workerd SSR
+        # FAIL-gate (the actual "smoke" safety check). ``build_static(gate=smoke)``
+        # builds; the SSR-marker fail-check applies only on a LIVE publish
+        # (smoke=True). A non-zero build exit fails on EITHER path (a build that
+        # can't produce output is never servable). This reintroduces per-edit build
+        # time — acceptable + correct for now; instant-HMR via dev_server is separate
+        # (the dev server passes ``static_build=False`` — it serves from source via
+        # ``vite dev`` and never goes through deploy_local, so it needs no static
+        # output and skips this whole step).
+        if static_build:
+            builder = getattr(self._runner, "build_static", None)
+            if builder is not None:
+                ok, reason = await builder(project_dir, gate=smoke)
+                if not ok:
+                    raise SmokeGateFailed(reason)
+            elif smoke:
+                # Legacy fakes without build_static: keep the old
+                # smoke()-only-on-publish contract so the existing
+                # generator/cache/smoke-gate unit tests (which fake the subprocess and
+                # never produce real files) are unaffected.
+                ok, reason = await self._runner.smoke(project_dir)
+                if not ok:
+                    raise SmokeGateFailed(reason)
         # ``rippleVersion`` is present only on the ripple GenerateResult; the svelte
         # path omits it (paw-sites types.ts §4.2), so read it defensively — a svelte
         # build must not KeyError here.

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -6,6 +6,33 @@
 # without Bun/workerd present.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-06-18 (feat/sites-cached-build, PERF-3 — persistent build dir +
+# cached node_modules): the single biggest per-edit cost was running `bun install`
+# on a FRESH throwaway tempfile dir on EVERY build (preview AND publish). build()
+# now materializes the generated source into a STABLE per-pocket working dir under
+# build_home() (``<build_home>/<pocket_id>/``, configurable via PAW_SITES_BUILD_DIR
+# — mirrors local_server.sites_home()), so node_modules persists across builds.
+#   * `bun install` runs ONLY when the dependency set changed: build() fingerprints
+#     the install inputs (the rewritten package.json + any lockfile) and compares
+#     it to a sentinel (``.paw-install-hash``) recorded after the last successful
+#     install in that dir. Hash match → SKIP install (reuse cached node_modules);
+#     mismatch (or first build) → install, then record the new hash. This keeps
+#     correctness: a stale node_modules can never serve old deps because the
+#     dep-hash guard forces a reinstall whenever the inputs change.
+#   * ``_rewrite_ripple_dep`` is preserved but now applied in build() (before the
+#     hash is computed) so the fingerprint reflects the FINAL install inputs; the
+#     runner's install() just runs `bun install` on the prepared dir.
+#   * The real runner gained install_inputs_hash(project_dir). Fakes that don't
+#     define it fall back to ALWAYS installing (legacy behaviour), so existing
+#     generator/svelte tests are unaffected.
+#   * Concurrent builds of the SAME pocket are serialized by a per-pocket asyncio
+#     lock (last-writer wins on the shared dir). Per-process only; per-tenant few
+#     editors makes cross-process contention a non-issue in practice. When no
+#     pocket_id is passed, build() falls back to the old throwaway tempfile dir
+#     (no caching) so legacy callers keep their prior behaviour.
+#
+# The smoke render stays as-is (PERF-4 gates it to publish-only — NOT here).
+#
 # Updated 2026-06-17 (feat/sites-svelte-component-edit, SE-2b): build() takes an
 # optional ``builder_origin`` and, when set, sends it on
 # ``siteConfig.builderOrigin``. The paw-sites generator (SE-1) gates the editable
@@ -53,6 +80,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import shlex
@@ -60,6 +88,16 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
+
+# Sentinel file (in the per-pocket build dir) recording the install-input
+# fingerprint of the last SUCCESSFUL `bun install`. build() skips install when the
+# current fingerprint matches this; mismatch forces a reinstall (PERF-3).
+_INSTALL_HASH_FILE = ".paw-install-hash"
+
+# Files whose contents define the dependency set. If any change, node_modules is
+# stale and must be reinstalled. The lockfile names cover bun's text + binary
+# lockfiles and the npm fallback.
+_INSTALL_INPUT_FILES = ("package.json", "bun.lock", "bun.lockb", "package-lock.json")
 
 
 class SmokeGateFailed(RuntimeError):
@@ -75,6 +113,36 @@ class BuildResult:
     # this is ``None`` on the svelte path. Optional so reading the svelte result
     # does not KeyError.
     ripple_version: str | None = None
+
+
+def build_home() -> Path:
+    """Root dir for the persistent per-pocket build working dirs (PERF-3). Each
+    pocket builds into ``build_home()/<pocket_id>/`` so node_modules persists
+    across builds and `bun install` can be cached. ~/.pocketpaw/site-builds by
+    default; override with PAW_SITES_BUILD_DIR (tests use a temp dir so they never
+    write the real home). Mirrors local_server.sites_home()'s convention."""
+    raw = os.environ.get("PAW_SITES_BUILD_DIR")
+    base = Path(raw) if raw else Path.home() / ".pocketpaw" / "site-builds"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _install_inputs_hash(project_dir: str) -> str:
+    """Fingerprint the install inputs (package.json + any lockfile) in a project
+    dir. A stable hash for an unchanged dependency set; it changes the moment a dep
+    or lockfile changes, which is exactly when node_modules goes stale and a
+    reinstall is required (PERF-3 correctness guard). Computed AFTER
+    ``_rewrite_ripple_dep`` so the @ripple-ui/svelte / motion rewrites are part of
+    the fingerprint."""
+    h = hashlib.sha256()
+    for name in _INSTALL_INPUT_FILES:
+        p = Path(project_dir, name)
+        if p.is_file():
+            h.update(name.encode())
+            h.update(b"\0")
+            h.update(p.read_bytes())
+            h.update(b"\0")
+    return h.hexdigest()
 
 
 def _gen_cmd_argv() -> list[str]:
@@ -125,6 +193,10 @@ class _Runner(Protocol):
     async def generate(self, input_json: dict[str, Any], out_dir: str) -> dict[str, Any]: ...
     async def install(self, project_dir: str) -> tuple[bool, str]: ...
     async def smoke(self, project_dir: str) -> tuple[bool, str]: ...
+    # PERF-3: fingerprint of the install inputs (package.json + lockfile). build()
+    # uses it to decide whether `bun install` can be skipped. Optional on a runner —
+    # build() falls back to always-install when a runner does not provide it.
+    def install_inputs_hash(self, project_dir: str) -> str: ...
 
 
 class _SubprocessRunner:
@@ -156,11 +228,16 @@ class _SubprocessRunner:
         finally:
             os.unlink(input_path)
 
+    def install_inputs_hash(self, project_dir: str) -> str:
+        # PERF-3: fingerprint of package.json + lockfile, computed on the real
+        # files in the prepared project dir (build() runs _rewrite_ripple_dep
+        # first, so the rewrite is included).
+        return _install_inputs_hash(project_dir)
+
     async def install(self, project_dir: str) -> tuple[bool, str]:
-        # Make the generated project's deps resolvable, then install. Without
-        # this the generated package.json pins an unpublished @ripple-ui/svelte
-        # and `bun run build` can't resolve it in a fresh environment.
-        _rewrite_ripple_dep(project_dir, _ripple_dep_source())
+        # The deps are already made resolvable by build() (_rewrite_ripple_dep runs
+        # before the install decision so the dep-hash reflects the final inputs).
+        # This just runs `bun install` on the prepared dir.
         proc = await asyncio.create_subprocess_exec(
             "bun",
             "install",
@@ -196,8 +273,23 @@ class _SubprocessRunner:
 
 
 class GeneratorClient:
+    # PERF-3: per-pocket async locks serialize concurrent builds of the SAME pocket
+    # (they share one on-disk working dir, so an interleaved generate/install would
+    # corrupt it). Class-level so all clients in a process share the same lock per
+    # pocket. Last-writer wins. Per-process only — per-tenant few editors makes
+    # cross-process contention a non-issue (noted in PERF-3 scope).
+    _pocket_locks: dict[str, asyncio.Lock] = {}
+
     def __init__(self, _runner: _Runner | None = None) -> None:
         self._runner = _runner or _SubprocessRunner()
+
+    @classmethod
+    def _lock_for(cls, pocket_id: str) -> asyncio.Lock:
+        lock = cls._pocket_locks.get(pocket_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            cls._pocket_locks[pocket_id] = lock
+        return lock
 
     async def build(
         self,
@@ -211,6 +303,7 @@ class GeneratorClient:
         engine: str = "ripple",
         source: dict[str, str] | None = None,
         builder_origin: str | None = None,
+        pocket_id: str | None = None,
     ) -> BuildResult:
         """Generate + smoke-build a Paw Site, forking STAGE 2 on ``engine``.
 
@@ -229,8 +322,63 @@ class GeneratorClient:
         is OMITTED from the payload when ``None`` so a normal (non-editable)
         publish keeps the exact prior wire bytes and the generator does not inject
         the bridge.
+
+        ``pocket_id`` (PERF-3) builds into a STABLE per-pocket working dir under
+        build_home() (``<build_home>/<pocket_id>/``) so node_modules persists and
+        `bun install` is cached across builds (preview AND publish). When None,
+        build() falls back to a fresh throwaway tempfile dir (no caching) so legacy
+        callers keep their prior behaviour. Concurrent builds of the SAME pocket
+        are serialized by a per-pocket lock (they share the on-disk dir).
         """
-        out_dir = tempfile.mkdtemp(prefix=f"paw-site-{site_id}-")
+        if pocket_id is None:
+            return await self._build_one(
+                ripple_spec=ripple_spec,
+                theme=theme,
+                site_id=site_id,
+                title=title,
+                capture_api_base=capture_api_base,
+                capture_signed_key=capture_signed_key,
+                engine=engine,
+                source=source,
+                builder_origin=builder_origin,
+                pocket_id=None,
+            )
+        async with self._lock_for(pocket_id):
+            return await self._build_one(
+                ripple_spec=ripple_spec,
+                theme=theme,
+                site_id=site_id,
+                title=title,
+                capture_api_base=capture_api_base,
+                capture_signed_key=capture_signed_key,
+                engine=engine,
+                source=source,
+                builder_origin=builder_origin,
+                pocket_id=pocket_id,
+            )
+
+    async def _build_one(
+        self,
+        *,
+        ripple_spec: dict[str, Any] | None,
+        theme: dict[str, Any],
+        site_id: str,
+        title: str,
+        capture_api_base: str,
+        capture_signed_key: str,
+        engine: str,
+        source: dict[str, str] | None,
+        builder_origin: str | None,
+        pocket_id: str | None,
+    ) -> BuildResult:
+        # PERF-3: stable per-pocket working dir (overwrite the source each build)
+        # so node_modules persists; fall back to a throwaway tempfile dir when no
+        # pocket_id is given (legacy callers — no caching).
+        if pocket_id is not None:
+            out_dir = str(build_home() / pocket_id)
+            Path(out_dir).mkdir(parents=True, exist_ok=True)
+        else:
+            out_dir = tempfile.mkdtemp(prefix=f"paw-site-{site_id}-")
         # §4.2: ``engine`` is always present; the STAGE-2 payload key forks on
         # it. svelte → ``source`` (no rippleSpec); ripple → ``rippleSpec`` (no
         # source). siteConfig + theme ride both tracks unchanged.
@@ -254,17 +402,43 @@ class GeneratorClient:
         else:
             input_json["rippleSpec"] = ripple_spec
         gen = await self._runner.generate(input_json, out_dir)
-        # Install the generated project's deps (rewriting the @ripple-ui/svelte
-        # pin to a resolvable source) BEFORE the smoke build, or `bun run build`
-        # can't resolve them in a fresh environment. A failed install fails the
-        # gate closed — the site does NOT proceed to deploy.
-        ok, reason = await self._runner.install(gen["projectDir"])
-        if not ok:
-            raise SmokeGateFailed(reason)
-        ok, reason = await self._runner.smoke(gen["projectDir"])
+        project_dir = gen["projectDir"]
+        # Make the generated project's deps resolvable BEFORE install (and before
+        # the dep-hash is computed, so the rewrite is part of the fingerprint).
+        # The template pins an unpublished @ripple-ui/svelte; the rewrite swaps it
+        # for a resolvable source and adds motion. No-op on the svelte track (no
+        # @ripple-ui/svelte dep). Guarded so the fake-runner tests (whose projectDir
+        # is not a real dir) don't fail on a missing package.json.
+        if Path(project_dir, "package.json").is_file():
+            _rewrite_ripple_dep(project_dir, _ripple_dep_source())
+        # PERF-3 install cache: run `bun install` ONLY when the dependency set
+        # changed. Fingerprint the install inputs and compare to the sentinel from
+        # the last successful install in this dir. Match → skip (reuse the cached
+        # node_modules). Mismatch / first build → install, then record the new
+        # fingerprint. A runner without install_inputs_hash() always installs
+        # (legacy fakes), so existing tests are unaffected.
+        hasher = getattr(self._runner, "install_inputs_hash", None)
+        if hasher is not None:
+            new_hash = hasher(project_dir)
+            sentinel = Path(project_dir, _INSTALL_HASH_FILE)
+            prior_hash = sentinel.read_text().strip() if sentinel.is_file() else None
+            if new_hash != prior_hash:
+                ok, reason = await self._runner.install(project_dir)
+                if not ok:
+                    raise SmokeGateFailed(reason)
+                # Record AFTER a successful install so a failed install never
+                # poisons the cache (next build retries the install).
+                if Path(project_dir).is_dir():
+                    sentinel.write_text(new_hash)
+            # else: deps unchanged — reuse cached node_modules, skip install.
+        else:
+            ok, reason = await self._runner.install(project_dir)
+            if not ok:
+                raise SmokeGateFailed(reason)
+        ok, reason = await self._runner.smoke(project_dir)
         if not ok:
             raise SmokeGateFailed(reason)
         # ``rippleVersion`` is present only on the ripple GenerateResult; the svelte
         # path omits it (paw-sites types.ts §4.2), so read it defensively — a svelte
         # build must not KeyError here.
-        return BuildResult(project_dir=gen["projectDir"], ripple_version=gen.get("rippleVersion"))
+        return BuildResult(project_dir=project_dir, ripple_version=gen.get("rippleVersion"))

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -214,9 +214,7 @@ def reap_build_workerd(project_dir: str) -> int:
                     continue
         except Exception:  # noqa: BLE001
             pass
-        logger.info(
-            "sites: reaped %d build-path workerd process(es) under %s", len(victims), root
-        )
+        logger.info("sites: reaped %d build-path workerd process(es) under %s", len(victims), root)
     return len(victims)
 
 

--- a/ee/pocketpaw_ee/sites/local_server.py
+++ b/ee/pocketpaw_ee/sites/local_server.py
@@ -5,6 +5,16 @@
 # that tree over HTTP so the published site has a real openable localhost URL
 # (what the cmux smoke + Phase 5 open).
 #
+# Updated 2026-06-19 (fix/sites-preview-fresh-build, P1a — fail soft on a missing
+# build dir): ``deploy_local`` no longer lets a missing ``.svelte-kit/cloudflare/``
+# escape as a bare FileNotFoundError → 500. If the build dir is absent but a PRIOR
+# deploy of the same site is still on disk, it keeps the prior deploy and returns
+# its URL plus a logged warning (the caller serves the last-good site instead of
+# erroring). Only when there is no prior deploy either does it raise
+# ``MissingBuildOutput`` (a clear, typed error the caller can surface). With the
+# P0a fix ``bun run build`` always runs, so a missing build dir should no longer
+# happen on the normal path — this is a defensive backstop, not the happy path.
+#
 # Design:
 #   * One server per process, rooted at the sites home (~/.pocketpaw/sites by
 #     default, override with PAW_SITES_LOCAL_DIR). A request for /<site_id>/
@@ -24,6 +34,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import threading
@@ -31,9 +42,17 @@ from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
+
 # The control plane reads the deployable static site adapter-cloudflare emits
 # here (same dir the real path reads _worker.js from).
 _CLOUDFLARE_BUILD_REL = ".svelte-kit/cloudflare"
+
+
+class MissingBuildOutput(RuntimeError):
+    """Raised by deploy_local when there is no built static site to serve AND no
+    prior deploy to fall back to. A clear, typed error the caller can surface as a
+    meaningful message instead of a bare 500 (P1a)."""
 
 
 def sites_home() -> Path:
@@ -100,9 +119,40 @@ def local_url_for(site_id: str) -> str:
 
 def deploy_local(site_id: str, project_dir: str) -> str:
     """Persist the built site and return its served localhost URL. The one call
-    the service makes in local mode in place of cf.put_worker()."""
+    the service makes in local mode in place of cf.put_worker().
+
+    Fails SOFT on a missing build dir (P1a): if ``.svelte-kit/cloudflare/`` is not
+    present (a build that produced no output), this does NOT raise a bare
+    FileNotFoundError → 500. When a PRIOR deploy of the same site is still on disk
+    it keeps that deploy and returns its URL with a logged warning (serve the
+    last-good site rather than break the page); only when there is no prior deploy
+    EITHER does it raise ``MissingBuildOutput`` — a clear, typed error the caller
+    can surface. With the P0a fix ``bun run build`` always runs, so a missing build
+    dir should not happen on the normal path; this is a defensive backstop."""
+    src = Path(project_dir, _CLOUDFLARE_BUILD_REL)
+    if not src.is_dir():
+        dest = sites_home() / site_id
+        if dest.is_dir():
+            logger.warning(
+                "sites: no fresh build at %s — serving the PRIOR deploy at %s "
+                "(the build produced no static output)",
+                src,
+                dest,
+            )
+            return local_url_for(site_id)
+        raise MissingBuildOutput(
+            f"no built static site at {src} and no prior deploy for {site_id} — "
+            "the build produced no static output to serve."
+        )
     persist_site(site_id, project_dir)
     return local_url_for(site_id)
 
 
-__all__ = ["sites_home", "persist_site", "ensure_server", "local_url_for", "deploy_local"]
+__all__ = [
+    "sites_home",
+    "persist_site",
+    "ensure_server",
+    "local_url_for",
+    "deploy_local",
+    "MissingBuildOutput",
+]

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -66,6 +66,13 @@
 # apply endpoint). It's a read of the pocket's content, so it carries fabric.read
 # (the same gate as preview/status). Tenant-scoped on ctx; the pockets service
 # raises NotFound → 404 itself.
+# Updated 2026-06-18 (feat/sites-devserver, Phase 2 / P2a): added POST
+# /sites/by-pocket/{pocket_id}/dev-preview — start (or reuse) a live Vite dev-server
+# for the pocket's EDITING preview and return its localhost url. Delegates to
+# sites_service.dev_preview_pocket → the DevServerManager singleton (long-lived
+# `vite dev` per pocket, HMR in ~ms vs a per-edit rebuild). Carries fabric.write (it
+# spawns a process / mutates server state); a missing pocket is a 404 (the pockets
+# service raises NotFound during materialize). Publish/editable are unchanged.
 
 from __future__ import annotations
 
@@ -76,6 +83,7 @@ from pocketpaw_ee.cloud._core.deps import require_action_any_workspace, require_
 from pocketpaw_ee.sites import service as sites_service
 from pocketpaw_ee.sites.dto import (
     AuditResponse,
+    DevPreviewResponse,
     DomainRequest,
     DomainStatusResponse,
     MakeEditableRequest,
@@ -177,6 +185,29 @@ async def preview_by_pocket(
     {path: contents} source map for a svelte pocket. A missing / access-denied
     pocket surfaces as a 404 (the pockets service raises NotFound itself)."""
     return await sites_service.preview_pocket(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, pocket_id=pocket_id
+    )
+
+
+@router.post("/sites/by-pocket/{pocket_id}/dev-preview", response_model=DevPreviewResponse)
+async def dev_preview_by_pocket(
+    pocket_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> DevPreviewResponse:
+    """Start (or reuse) a live Vite dev-server for the pocket's EDITING preview and
+    return its localhost URL (Phase 2 / P2a): {pocket_id, url}.
+
+    The editor frames this URL so edits hot-reload over Vite HMR in ~ms instead of
+    rebuilding the whole site per edit. A running server for the pocket is reused
+    (touched); otherwise one is materialized from the pocket's current source
+    (PERF-3 persistent dir, cached node_modules) and started on an ephemeral port.
+    Publish / make_site_editable are unchanged — this is the editing preview only.
+
+    Carries fabric.write (it spawns a process / mutates server state), matching the
+    other by-pocket write actions. A missing / access-denied pocket surfaces as a
+    404 (the pockets service raises NotFound itself during materialize)."""
+    return await sites_service.dev_preview_pocket(
         workspace_id=ctx.workspace_id, user_id=ctx.user_id, pocket_id=pocket_id
     )
 

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -73,6 +73,15 @@
 # `vite dev` per pocket, HMR in ~ms vs a per-edit rebuild). Carries fabric.write (it
 # spawns a process / mutates server state); a missing pocket is a 404 (the pockets
 # service raises NotFound during materialize). Publish/editable are unchanged.
+# Updated 2026-06-19 (P2b-backend — revert endpoint): added POST
+# /sites/by-pocket/{pocket_id}/versions/{version_no}/revert — revert a pocket's site
+# to a prior version by ordinal. Delegates to sites_service.revert_pocket_version,
+# which resolves version_no → the durable ArtifactVersion row (tenant-scoped, main
+# branch) and writes a NEW forward-moving draft snapshot of that version's content;
+# the normal review/publish flow then applies (request-publish → merge gate). Returns
+# the new draft as a SiteVersionResponse (the same row shape the versions timeline
+# uses). fabric.write (it creates a draft); an unknown version_no is a 404 (the
+# service raises ValueError).
 
 from __future__ import annotations
 
@@ -308,6 +317,48 @@ async def request_publish_by_pocket(
         pocket_id=pocket_id,
         to_version_id=str(blob.get("to_version_id") or ""),
         from_version_id=blob.get("from_version_id"),
+    )
+
+
+@router.post(
+    "/sites/by-pocket/{pocket_id}/versions/{version_no}/revert",
+    response_model=SiteVersionResponse,
+)
+async def revert_version_by_pocket(
+    pocket_id: str,
+    version_no: int,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SiteVersionResponse:
+    """Revert a pocket's site to a prior version by ordinal (P2b-backend).
+
+    Revert is FORWARD-MOVING: it writes a NEW draft on the main branch whose
+    content snapshots the target version, then the normal review/publish flow
+    applies — the operator request-publishes the new draft and the merge gate
+    takes the reverted content live. History is never rewritten; the revert is its
+    own auditable lineage step. Tenant-scoped on ctx.workspace_id; a version_no the
+    pocket does not have (or one under another workspace) raises ValueError → 404.
+    Carries fabric.write — it creates a draft. Returns the new draft row so the UI
+    can show the freshly-created version (and feed it to request-publish)."""
+    try:
+        draft = await sites_service.revert_pocket_version(
+            workspace_id=ctx.workspace_id,
+            user_id=ctx.user_id,
+            pocket_id=pocket_id,
+            version_no=version_no,
+        )
+    except ValueError as exc:
+        # Unknown / cross-tenant version_no → 404 (nothing to revert to).
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return SiteVersionResponse(
+        id=str(draft.id),
+        version_no=draft.version_no,
+        branch=draft.branch,
+        status=draft.status,
+        label=draft.label,
+        author=draft.author,
+        created_at=draft.created_at.isoformat(),
     )
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,16 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-19 (P2b-backend — "Last Deployed" + revert endpoint): publish()
+# now stamps the Site doc's ``deployed_at`` (UTC) ONLY when a non-preview deploy
+# succeeds (when ``deployed`` flips True) — the true "last shipped" marker, not a
+# "last touched" one. ``_to_response``/``pocket_status`` surface it as an ISO
+# string|None on the DTOs. Added ``revert_pocket_version`` — resolves a pocket's
+# version_no → its ArtifactVersion row (tenant-scoped, main branch) and calls
+# ``versions.revert`` to write a NEW forward-moving draft from that version's
+# content (the normal review/publish flow then applies); backs the new
+# POST /sites/by-pocket/{pocket_id}/versions/{version_no}/revert endpoint.
+#
 # Updated 2026-06-19 (P0b — review-400 self-heal): ``request_publish_pocket`` no
 # longer 400s a LEGACY site (one published before BP-1, so it has ZERO
 # ``artifact_versions`` rows and no draft). When ``get_draft`` is None it now
@@ -255,6 +265,7 @@ from __future__ import annotations
 import logging
 import secrets
 from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -474,6 +485,7 @@ async def _promote_pocket_draft_to_published(
 
 
 def _to_response(doc: _SiteDoc) -> SiteResponse:
+    deployed_at = getattr(doc, "deployed_at", None)
     return SiteResponse(
         id=str(doc.id),
         pocket_id=doc.pocket_id,
@@ -485,6 +497,9 @@ def _to_response(doc: _SiteDoc) -> SiteResponse:
         # SE-2b: surface whether the site is editable (non-empty = carries the
         # edit-bridge) so the UI can show/hide the inline-edit affordance.
         builder_origin=getattr(doc, "builder_origin", ""),
+        # P2b: ISO string of the last successful live deploy, or None before the
+        # first deploy (pre-P2b rows read null via the getattr default).
+        deployed_at=deployed_at.isoformat() if deployed_at is not None else None,
     )
 
 
@@ -732,6 +747,12 @@ async def publish(
     # re-publish; only a first insert seeds the defaults. ``signed_key`` is likewise
     # kept stable across re-publishes (the capture endpoint verifies against it).
     oid = ObjectId(site_id)
+    # P2b: this branch runs ONLY on a successful non-preview deploy (a preview
+    # returned earlier), so ``deployed`` flips True HERE — stamp the live-deploy
+    # time alongside it. A re-publish refreshes it (it is "last shipped", not
+    # "first shipped"). It is NOT set on a preview/edit build and NOT a plain
+    # updatedAt bump, so it stays a true "last deployed" marker.
+    now = datetime.now(UTC)
     doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
     if doc is None:
         doc = _SiteDoc(
@@ -742,6 +763,7 @@ async def publish(
             name=site_name,
             script_name=site_id,
             deployed=True,
+            deployed_at=now,
             signed_key=signed_key,
             url=url,
             # SE-2b: persist the builder origin (or "") so a component-edit republish
@@ -761,6 +783,7 @@ async def publish(
         doc.name = site_name
         doc.script_name = site_id
         doc.deployed = True
+        doc.deployed_at = now
         doc.url = url
         doc.builder_origin = builder_origin or ""
         await doc.save()
@@ -1522,6 +1545,11 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
     deployed = bool(doc is not None and doc.deployed)
     is_live = has_published and deployed
 
+    # P2b: surface the canonical doc's last-deploy time so the builder/gallery can
+    # render "Last deployed <time>" without a second fetch. None when the pocket has
+    # no deployed site or the doc predates the field (a pre-P2b row).
+    deployed_at = getattr(doc, "deployed_at", None) if doc is not None else None
+
     return SiteStatusResponse(
         pocket_id=pocket_id,
         status=status,
@@ -1532,6 +1560,7 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
         # the address the latest build actually serves at, not a stale ``url=None``
         # dupe. None when the pocket has no deployed site.
         url=(doc.url or None) if doc is not None else None,
+        deployed_at=deployed_at.isoformat() if deployed_at is not None else None,
     )
 
 
@@ -1775,6 +1804,50 @@ async def version_history(*, workspace_id: str, pocket_id: str) -> list[Any]:
     return list(reversed(scoped))
 
 
+async def revert_pocket_version(
+    *, workspace_id: str, user_id: str, pocket_id: str, version_no: int
+) -> Any:
+    """Revert a pocket's site to a prior version by ordinal (P2b-backend).
+
+    Backs ``POST /sites/by-pocket/{pocket_id}/versions/{version_no}/revert``.
+    Revert is FORWARD-MOVING: it writes a NEW draft (on the main branch) whose
+    content is a snapshot of the target version's content, then the normal
+    review/publish flow applies (the operator can request-publish that draft and
+    take the reverted content live through the merge gate). It never mutates
+    history — the version log stays append-only and the revert is its own
+    auditable lineage step.
+
+    The router carries the human-friendly ``version_no`` (the timeline ordinal the
+    UI shows); the versions ``revert`` keys on the durable ``version_id``, so this
+    resolves the ordinal → the row via the SAME tenant-scoped, main-branch log
+    ``version_history`` reads. A version_no the pocket does not have (or one under
+    another workspace — the rows are pre-filtered on ``workspace_id``) raises
+    ``ValueError`` (the router maps it to a 404). Returns the new draft
+    ``ArtifactVersion``.
+    """
+    from pocketpaw_ee.versions import service as versions_service
+
+    rows = await versions_service.list_versions(
+        scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id, branch="main"
+    )
+    target = next(
+        (r for r in rows if r.version_no == version_no and r.workspace_id == workspace_id),
+        None,
+    )
+    if target is None:
+        raise ValueError(
+            f"no version v{version_no} for pocket {pocket_id} — cannot revert"
+        )
+
+    return await versions_service.revert(
+        scope_type=_VERSION_SCOPE_TYPE,
+        scope_id=pocket_id,
+        workspace_id=workspace_id,
+        version_id=str(target.id),
+        author=user_id,
+    )
+
+
 __all__ = [
     "apply_edits",
     "publish",
@@ -1783,6 +1856,7 @@ __all__ = [
     "pocket_status",
     "request_publish_pocket",
     "version_history",
+    "revert_pocket_version",
     "edit_svelte_component",
     "make_site_editable",
     "require_sites_plan",

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,12 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-18 (feat/sites-cached-build, PERF-3): publish() now forwards the
+# source pocket_id to generator.build() so the build runs in the STABLE per-pocket
+# working dir (persistent node_modules + cached `bun install`), cutting the dominant
+# per-edit cost across both preview and live publishes. A site_id is still minted
+# fresh per publish — only the on-disk build dir is reused per pocket.
+#
 # Updated 2026-06-01 (Phase 4 — chat→create-site): added publish_pocket(), the
 # shared "publish a pocket by id" path. It reads the pocket's rippleSpec + theme
 # via pockets_service (logic lifted verbatim from the router) and delegates to
@@ -459,6 +465,11 @@ async def publish(
         engine=engine,
         source=source,
         builder_origin=builder_origin,
+        # PERF-3: build into the STABLE per-pocket working dir so node_modules
+        # persists and `bun install` is cached across builds (preview AND publish),
+        # cutting the dominant per-edit cost. A fresh site_id is minted per publish,
+        # but a pocket's working dir is reused across its publishes/previews.
+        pocket_id=pocket_id,
     )
 
     # PREVIEW MODE (Branch primitive — EDIT/arm path): the build above already ran

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -499,7 +499,19 @@ async def publish(
     # one each call. A PREVIEW build still uses the freshly-minted ObjectId for its
     # transient (never-persisted) doc id and serves at the stable preview path.
     site_id = str(ObjectId()) if preview else str(_live_object_id(workspace_id, pocket_id))
+    # PERF-1 fix (review finding): on a live RE-publish the upsert below preserves
+    # the stored ``doc.signed_key``, so minting a fresh key here would bake a
+    # ``captureSignedKey`` into the built HTML that no longer matches the doc the
+    # capture endpoint verifies against — silently breaking lead capture on every
+    # re-publish. Reuse the existing site's key when one is already stored; mint a
+    # new key only for a first publish or a preview (which never persists a doc).
     signed_key = f"site_key_{secrets.token_urlsafe(24)}"
+    if not preview:
+        _existing = await _SiteDoc.find_one(
+            {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
+        )
+        if _existing is not None and _existing.signed_key:
+            signed_key = _existing.signed_key
 
     build = await generator.build(
         ripple_spec=ripple_spec,

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,19 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-17 (fix/sites-plan-gate-asymmetry): added require_sites_plan()
+# and call it at the top of publish(). Sites is the "fabric" plan feature; the
+# REST router gates it with require_plan_feature("fabric"), but the chat agent
+# created + published sites IN-PROCESS via the sites_manager MCP tools, which
+# bypass the HTTP router. A team-plan workspace could therefore deploy a live
+# site that GET /sites then 403'd (write path ungated, read path gated). The
+# guard reads the plan from workspace_service.get_workspace_plan against
+# guards.abac.PLAN_FEATURES (same source of truth as the HTTP gate) and raises
+# Forbidden('plan.feature_denied') before any pocket read / generate / deploy.
+# Every publish path (REST + MCP publish + direct callers) funnels through
+# publish(), so this one call covers them all; the create MCP handlers call
+# require_sites_plan() directly (they reach agent_create, not this service).
+#
 # Updated 2026-06-01 (Phase 4 — chat→create-site): added publish_pocket(), the
 # shared "publish a pocket by id" path. It reads the pocket's rippleSpec + theme
 # via pockets_service (logic lifted verbatim from the router) and delegates to
@@ -92,7 +105,7 @@ from typing import Any
 from bson import ObjectId
 from bson.errors import InvalidId
 
-from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound
 from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
 from pocketpaw_ee.sites.domain import HostnameStatus
@@ -101,6 +114,16 @@ from pocketpaw_ee.sites.generator_client import GeneratorClient
 
 # The control plane reads the Worker bundle adapter-cloudflare emits here.
 _WORKER_BUNDLE_REL = ".svelte-kit/cloudflare/_worker.js"
+
+# Sites is a plan-gated feature: it unlocks with the "fabric" plan feature
+# (business+). The REST router (sites/router.py) gates every endpoint with
+# require_plan_feature("fabric"), but the chat agent creates + publishes sites
+# IN-PROCESS via the sites_manager MCP tools, which never pass through that HTTP
+# router. Without a service-level gate a team-plan workspace could create and
+# deploy a live site that GET /sites then 403'd — a created-but-invisible
+# resource. _require_sites_plan() closes that asymmetry at the service chokepoint
+# so the in-process write paths are gated identically to HTTP.
+_SITES_PLAN_FEATURE = "fabric"
 
 
 def _default_bundle_reader(project_dir: str) -> bytes:
@@ -188,6 +211,42 @@ def _to_response(doc: _SiteDoc) -> SiteResponse:
     )
 
 
+async def require_sites_plan(workspace_id: str) -> None:
+    """Raise cloud Forbidden('plan.feature_denied') unless the workspace's plan
+    includes the Sites ("fabric") feature.
+
+    The shared plan gate for the in-process site write paths (publish + the
+    create MCP handlers). Reads the plan with the SAME source of truth
+    (``workspace_service.get_workspace_plan``) and the SAME feature table
+    (``guards.abac.PLAN_FEATURES``) as the HTTP ``require_plan_feature("fabric")``
+    dependency, so a team-plan caller is denied identically whether it arrives
+    over REST or through the chat agent. A missing workspace surfaces as NotFound
+    (mirroring the HTTP gate), and the error message names the minimum plan that
+    unlocks Sites. Imports are local to keep the sites service importable without
+    eagerly pulling the cloud workspace/guards modules."""
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+    from pocketpaw_ee.guards.abac import PLAN_FEATURES
+
+    plan = await workspace_service.get_workspace_plan(workspace_id)
+    if plan is None:
+        raise NotFound("workspace", workspace_id)
+    if _SITES_PLAN_FEATURE not in PLAN_FEATURES.get(plan, set()):
+        # Name the minimum plan that unlocks the feature, like the HTTP gate.
+        needed = next(
+            (
+                p
+                for p in ("team", "business", "enterprise")
+                if _SITES_PLAN_FEATURE in PLAN_FEATURES.get(p, set())
+            ),
+            "business",
+        )
+        raise Forbidden(
+            "plan.feature_denied",
+            f"Sites requires the {needed.capitalize()} plan — upgrade, or switch "
+            "to a workspace that has it.",
+        )
+
+
 async def publish(
     *,
     workspace_id: str,
@@ -221,7 +280,15 @@ async def publish(
     respecting entity isolation) and uses its ``name`` field; only when the pocket
     has no name does it fall back to "Untitled site". Callers that pre-resolve the
     name (e.g. ``publish_pocket``, which already holds the wire dict) pass it in,
-    so the common path does not re-fetch."""
+    so the common path does not re-fetch.
+
+    Gated on the workspace's plan: Sites is the "fabric" feature, so a team-plan
+    workspace is rejected with Forbidden('plan.feature_denied') here — BEFORE any
+    pocket read, generation, or deploy. Both ``publish_pocket`` (REST + MCP) and
+    direct service callers funnel through ``publish``, so this one gate covers
+    every in-process publish path."""
+    await require_sites_plan(workspace_id)
+
     generator = _generator or GeneratorClient()
 
     # Default a blank name to the source pocket's own display name so the schema's
@@ -392,6 +459,12 @@ async def publish_pocket(
     straight through to ``publish`` so the shared path is unit-testable without
     Bun / workerd / Cloudflare (the same injection contract ``publish`` exposes).
     """
+    # Plan gate FIRST — before reading the pocket — so a team-plan caller gets
+    # plan.feature_denied regardless of whether the pocket exists, rather than a
+    # misleading pocket.not_found. ``publish`` re-checks for direct callers; the
+    # repeat read is a single cheap workspace lookup.
+    await require_sites_plan(workspace_id)
+
     from pocketpaw_ee.cloud.pockets import service as pockets_service
 
     pocket = await pockets_service.get(pocket_id, user_id)
@@ -443,6 +516,7 @@ async def site_pocket_ids(workspace_id: str) -> set[str]:
 __all__ = [
     "publish",
     "publish_pocket",
+    "require_sites_plan",
     "add_domain",
     "domain_status",
     "list_domains",

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,16 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-18 (feat/sites-smoke-at-publish, PERF-4): publish() now threads
+# ``smoke=not preview`` into generator.build(), so the workerd SMOKE render runs
+# ONLY for a LIVE publish (preview=False) and is SKIPPED for a preview/edit/arm
+# build (preview=True). The render is per-edit overhead only needed before a
+# deploy; skipping it cuts the remaining per-edit cost left after PERF-3 cached
+# `bun install`. The live publish keeps the gate AND the edit_svelte_component
+# rollback-on-SmokeGateFailed behaviour unchanged. A preview that would fail smoke
+# is no longer blocked — acceptable, because the live publish still gates + rolls
+# back, so a broken edit can never reach the live deploy.
+#
 # Updated 2026-06-18 (feat/sites-cached-build, PERF-3): publish() now forwards the
 # source pocket_id to generator.build() so the build runs in the STABLE per-pocket
 # working dir (persistent node_modules + cached `bun install`), cutting the dominant
@@ -470,6 +480,13 @@ async def publish(
         # cutting the dominant per-edit cost. A fresh site_id is minted per publish,
         # but a pocket's working dir is reused across its publishes/previews.
         pocket_id=pocket_id,
+        # PERF-4: run the workerd SMOKE render ONLY for a LIVE publish. The render
+        # is per-edit overhead only needed before a deploy, so a preview/edit/arm
+        # build (preview=True) skips it (smoke=False); a live publish (preview=False)
+        # keeps it (smoke=True) so the gate + the rollback below are unchanged. A
+        # preview that would fail smoke is no longer blocked — the live publish still
+        # gates + rolls back, so a broken edit never reaches the live deploy.
+        smoke=not preview,
     )
 
     # PREVIEW MODE (Branch primitive — EDIT/arm path): the build above already ran

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -229,6 +229,7 @@ from pocketpaw_ee.sites.domain import HostnameStatus
 from pocketpaw_ee.sites.dto import (
     AuditFinding,
     AuditResponse,
+    DevPreviewResponse,
     DomainStatusResponse,
     SitePreviewResponse,
     SiteResponse,
@@ -1109,6 +1110,36 @@ async def preview_pocket(
 
     content = draft_content if draft_content is not None else current
     return SitePreviewResponse(pocket_id=pocket_id, engine=engine, content=content)
+
+
+async def dev_preview_pocket(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+) -> DevPreviewResponse:
+    """Ensure a live Vite dev-server is running for the pocket and return its URL
+    (Phase 2 / P2a — the EDITING preview).
+
+    Delegates to the DevServerManager singleton: a running server for the pocket is
+    touched + reused (its URL returned); otherwise the manager materializes the
+    pocket's current source into the persistent per-pocket build dir (PERF-3 —
+    cached node_modules) and starts ``vite dev`` on an ephemeral port, so subsequent
+    edits hot-reload over Vite HMR in ~ms instead of rebuilding the whole site. The
+    workerd smoke render is NOT run for the dev server (it is a publish-only gate,
+    PERF-4); publish() is unchanged and still does the full prod build + smoke.
+
+    ``user_id`` is threaded through so the manager reads the pocket via the pockets
+    service under the caller's scope (it raises NotFound / Forbidden itself, mapped
+    by the router to 404 / 403). ``workspace_id`` keeps the surface uniform and
+    tenant-aware with the other by-pocket reads.
+    """
+    from pocketpaw_ee.sites.dev_server import get_manager
+
+    url = await get_manager().ensure_dev_server(
+        workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+    )
+    return DevPreviewResponse(pocket_id=pocket_id, url=url)
 
 
 async def audit_pocket(

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1347,7 +1347,20 @@ async def request_publish_pocket(
 
 
 async def list_for_workspace(workspace_id: str) -> list[SiteResponse]:
-    cursor = _SiteDoc.find({"workspace": workspace_id}).sort(-_SiteDoc.createdAt)  # type: ignore[operator]
+    """The gallery / listSites read: the workspace's Site cards, newest first.
+
+    PERF-2: filters out ARCHIVED docs so each pocket shows exactly one card. The
+    pre-PERF-1 minting left a pile of duplicate Site docs per pocket (one pocket
+    had 14), all of which this read listed → the gallery duplicated. The dedupe
+    migration (``sites.dedupe``) keeps ONE canonical doc per pocket active and
+    tombstones the rest with ``archived=True``; excluding them here collapses the
+    gallery to one card per pocket. ``archived: {"$ne": True}`` (not ``False``)
+    so docs predating the field — which have no ``archived`` key in Mongo — still
+    count as active.
+    """
+    cursor = _SiteDoc.find({"workspace": workspace_id, "archived": {"$ne": True}}).sort(
+        -_SiteDoc.createdAt
+    )  # type: ignore[operator]
     return [_to_response(doc) async for doc in cursor]
 
 
@@ -1359,8 +1372,13 @@ async def site_pocket_ids(workspace_id: str) -> set[str]:
     (they show under /sites instead) WITHOUT the pockets service importing the
     Site Beanie model — the Site read stays in this service, which is the sole
     owner of Site reads (entity isolation). Tenant-scoped on ``workspace``.
+
+    PERF-2: excludes ARCHIVED dupes (``archived: {"$ne": True}``) so the set is
+    keyed on pockets that still have an ACTIVE Site — a fully-archived pocket
+    would be wrong to hide from the /pockets gallery. Pre-field docs (no
+    ``archived`` key) still count as active.
     """
-    cursor = _SiteDoc.find({"workspace": workspace_id})
+    cursor = _SiteDoc.find({"workspace": workspace_id, "archived": {"$ne": True}})
     return {doc.pocket_id async for doc in cursor}
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -176,6 +176,24 @@
 # finding carries a ``fix_prompt`` the UI feeds to the EXISTING edit path
 # (edit_svelte_component / refine) so a fix lands as a reviewable draft in the
 # Tray — BP-7 adds NO apply endpoint.
+#
+# Updated 2026-06-18 (feat/sites-stable-identity, PERF-1): a LIVE publish now has a
+# STABLE per-(workspace, pocket_id) identity instead of minting a fresh ObjectId per
+# call (which inserted a NEW Site doc at a NEW folder/URL every publish — one pocket
+# had 14 docs, the gallery showed dupes, and pocket_status returned an arbitrary
+# stale doc with url=None: the stale-live-link bug). Mirroring the preview path's
+# _preview_id:
+#   * _live_object_id(workspace, pocket) derives a deterministic ObjectId from the
+#     pair, used for the deploy folder/URL, the CF Worker script_name (overwrite the
+#     worker, no orphan), and the Site doc _id. publish()'s preview branch is
+#     unchanged (it already serves at the stable preview-<pocket> path).
+#   * publish() UPSERTS ONE canonical Site doc keyed on the stable _id (find-then-
+#     save/insert) — re-publish refreshes the deploy fields in place and PRESERVES
+#     domain/allowed_origins/signed_key, instead of inserting a second row.
+#   * pocket_status() reads the CANONICAL doc via _canonical_site_doc (the stable-id
+#     doc, else the newest with a real url) and returns its non-null url + is_live,
+#     dropping the arbitrary find_one. PERF-1 does NOT migrate pre-existing dupes
+#     (that is PERF-2) — _canonical_site_doc just resolves the live one among them.
 
 from __future__ import annotations
 
@@ -220,14 +238,43 @@ def _default_bundle_reader(project_dir: str) -> bytes:
 def _preview_id(pocket_id: str) -> str:
     """A STABLE per-pocket id for serving a preview build (the EDIT/arm path).
 
-    A live publish mints a fresh ObjectId per site, but a preview must serve at the
-    SAME URL across repeated builds so the builder iframe can frame it once and just
-    reload — otherwise every edit/arm builds at a new ``/<minted-id>/`` and the user
-    never sees the change (the churn bug). ``local_server.persist_site`` overwrites
-    ``<home>/<id>/`` in place, so a deterministic id derived from the pocket gives
-    the same URL with fresh content on each preview build. Prefixed ``preview-`` so a
-    preview dir never collides with a live site's minted-ObjectId dir."""
+    A live publish derives a stable per-pocket ObjectId (``_live_object_id``); a
+    preview must likewise serve at the SAME URL across repeated builds so the
+    builder iframe can frame it once and just reload — otherwise every edit/arm
+    builds at a new ``/<minted-id>/`` and the user never sees the change (the churn
+    bug). ``local_server.persist_site`` overwrites ``<home>/<id>/`` in place, so a
+    deterministic id derived from the pocket gives the same URL with fresh content
+    on each preview build. Prefixed ``preview-`` so a preview dir never collides
+    with a live site's dir."""
     return f"preview-{pocket_id}"
+
+
+def _live_object_id(workspace_id: str, pocket_id: str) -> ObjectId:
+    """A STABLE per-(workspace, pocket) ObjectId for the LIVE published site (PERF-1).
+
+    Before PERF-1 ``publish`` minted ``ObjectId()`` per call, so every publish
+    inserted a NEW Site doc at a NEW deploy folder / URL — one pocket accumulated 14
+    Site docs, the gallery showed dupes, and ``pocket_status`` did an arbitrary
+    ``find_one`` across them (the stale-live-link bug). Mirroring ``_preview_id``,
+    the live site now has a STABLE identity derived deterministically from
+    ``(workspace_id, pocket_id)``: the SAME 12-byte ObjectId every publish, so:
+
+      * the deploy folder / URL is stable (``local_server.persist_site`` overwrites
+        ``<home>/<id>/`` in place ⇒ same URL, fresh content);
+      * the CF Worker ``script_name`` (== this id) is stable ⇒ ``put_worker``
+        OVERWRITES the worker per pocket instead of orphaning the old one;
+      * the Site doc ``_id`` is stable ⇒ publish UPSERTS ONE canonical doc per
+        ``(workspace, pocket_id)`` rather than inserting a fresh row each time, and
+        ``script_name == str(site.id)`` still holds.
+
+    The id is the first 12 bytes of ``sha1(workspace_id:pocket_id)`` — a pure
+    function of the pair, collision-resistant across the id space the same way a
+    minted ObjectId is, and never colliding with a ``preview-<pocket>`` dir (those
+    are strings, not ObjectId hex)."""
+    import hashlib
+
+    digest = hashlib.sha1(f"{workspace_id}:{pocket_id}".encode()).digest()
+    return ObjectId(digest[:12])
 
 
 def _capture_base() -> str:
@@ -446,7 +493,12 @@ async def publish(
     if not site_name:
         site_name = "Untitled site"
 
-    site_id = str(ObjectId())
+    # PERF-1: the LIVE site has a STABLE per-(workspace, pocket) id (mirroring the
+    # preview path's _preview_id), so re-publishing a pocket overwrites the SAME
+    # deploy folder / URL / CF worker / Site doc in place instead of minting a fresh
+    # one each call. A PREVIEW build still uses the freshly-minted ObjectId for its
+    # transient (never-persisted) doc id and serves at the stable preview path.
+    site_id = str(ObjectId()) if preview else str(_live_object_id(workspace_id, pocket_id))
     signed_key = f"site_key_{secrets.token_urlsafe(24)}"
 
     build = await generator.build(
@@ -528,27 +580,47 @@ async def publish(
         bundle = _bundle_reader(build.project_dir)
         await cf.put_worker(script_name=site_id, bundle=bundle)
 
-    doc = _SiteDoc(
-        id=ObjectId(site_id),
-        workspace=workspace_id,
-        pocket_id=pocket_id,
-        owner=user_id,
-        name=site_name,
-        script_name=site_id,
-        deployed=True,
-        signed_key=signed_key,
-        url=url,
-        # SE-2b: persist the builder origin (or "") so a component-edit republish
-        # can re-apply it and the site stays editable across edits.
-        builder_origin=builder_origin or "",
-        # Seed capture config so a lead lands with no manual Mongo edit: a default
-        # mapping keyed on the form_type the generated endpoint sends, and the
-        # local dev origins so the local smoke works. add_domain() appends the
-        # production hostname when a custom domain is connected.
-        allowed_origins=_default_allowed_origins(),
-        event_mapping=_DEFAULT_EVENT_MAPPING,
-    )
-    await doc.insert()
+    # PERF-1: UPSERT ONE canonical Site doc per (workspace, pocket_id) keyed on the
+    # stable ``_id`` (== site_id), rather than inserting a fresh row every publish.
+    # The stable id means the existing doc (if any) is found by ``_id`` directly; we
+    # refresh the deploy-facing fields in place (a re-publish ships fresh content at
+    # the same URL/worker). Fields a domain connect mutates later (``domains``,
+    # ``allowed_origins``) are PRESERVED on update so connecting a domain survives a
+    # re-publish; only a first insert seeds the defaults. ``signed_key`` is likewise
+    # kept stable across re-publishes (the capture endpoint verifies against it).
+    oid = ObjectId(site_id)
+    doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        doc = _SiteDoc(
+            id=oid,
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            owner=user_id,
+            name=site_name,
+            script_name=site_id,
+            deployed=True,
+            signed_key=signed_key,
+            url=url,
+            # SE-2b: persist the builder origin (or "") so a component-edit republish
+            # can re-apply it and the site stays editable across edits.
+            builder_origin=builder_origin or "",
+            # Seed capture config so a lead lands with no manual Mongo edit: a default
+            # mapping keyed on the form_type the generated endpoint sends, and the
+            # local dev origins so the local smoke works. add_domain() appends the
+            # production hostname when a custom domain is connected.
+            allowed_origins=_default_allowed_origins(),
+            event_mapping=_DEFAULT_EVENT_MAPPING,
+        )
+        await doc.insert()
+    else:
+        doc.pocket_id = pocket_id
+        doc.owner = user_id
+        doc.name = site_name
+        doc.script_name = site_id
+        doc.deployed = True
+        doc.url = url
+        doc.builder_origin = builder_origin or ""
+        await doc.save()
     return doc
 
 
@@ -563,6 +635,41 @@ async def _load(workspace_id: str, site_id: str) -> _SiteDoc:
     if doc is None:
         raise NotFound("site", site_id)
     return doc
+
+
+async def _canonical_site_doc(workspace_id: str, pocket_id: str) -> _SiteDoc | None:
+    """The ONE canonical Site doc for (workspace, pocket_id), or None (PERF-1).
+
+    Stable identity (``_live_object_id``) means a pocket published after PERF-1 has
+    exactly one doc — the stable-id one. But PERF-1 does NOT migrate the dupes the
+    old per-publish minting left behind (PERF-2 does), so a pocket may still have
+    several Site docs, one of which the old arbitrary ``find_one`` could return with
+    a stale ``url`` (the stale-live-link bug). This resolves the canonical doc
+    deterministically:
+
+      1. the STABLE-id doc (``_live_object_id``) when it exists — every post-PERF-1
+         publish writes here, so it is the live one;
+      2. otherwise the newest doc (by ``createdAt``) that actually carries a url —
+         the freshest live build among legacy dupes;
+      3. otherwise the newest doc at all (so a pre-url-era doc still resolves).
+
+    Tenant-scoped on ``workspace``. Returns None when the pocket has no Site doc.
+    """
+    stable = await _SiteDoc.find_one(
+        {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
+    )
+    if stable is not None:
+        return stable
+    docs = (
+        await _SiteDoc.find({"workspace": workspace_id, "pocket_id": pocket_id})
+        .sort(-_SiteDoc.createdAt)  # type: ignore[operator]
+        .to_list()
+    )
+    if not docs:
+        return None
+    # Prefer the newest doc that carries a real url (the freshest live build);
+    # fall back to the newest doc overall when none has one.
+    return next((d for d in docs if d.url), docs[0])
 
 
 async def add_domain(
@@ -1068,8 +1175,16 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
     it). No Cloudflare call — just persisted state. Versioning is an additive
     layer, so a versions read failure degrades to the Site-doc signal rather than
     breaking the status read.
+
+    PERF-1: the read is now the CANONICAL Site doc for (workspace, pocket_id), not
+    an arbitrary ``find_one`` across dupes. With stable identity a pocket has ONE
+    doc; but PERF-1 does NOT migrate the dupes the old minting left behind (that's
+    PERF-2), so to fix the stale-live-link bug today we pick the canonical doc
+    deterministically — the stable-id doc when present, else the newest doc that
+    actually carries a url — and surface its (non-null, latest) ``url`` so the live
+    link no longer points at a stale ``url=None`` row.
     """
-    doc = await _SiteDoc.find_one({"workspace": workspace_id, "pocket_id": pocket_id})
+    doc = await _canonical_site_doc(workspace_id, pocket_id)
 
     published_no: int | None = None
     draft_no: int | None = None
@@ -1122,6 +1237,10 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
         is_live=is_live,
         has_unpublished_changes=has_unpublished_changes,
         site_id=str(doc.id) if doc is not None else None,
+        # PERF-1: surface the canonical doc's live url so the builder/gallery link to
+        # the address the latest build actually serves at, not a stale ``url=None``
+        # dupe. None when the pocket has no deployed site.
+        url=(doc.url or None) if doc is not None else None,
     )
 
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,15 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-19 (P0b — review-400 self-heal): ``request_publish_pocket`` no
+# longer 400s a LEGACY site (one published before BP-1, so it has ZERO
+# ``artifact_versions`` rows and no draft). When ``get_draft`` is None it now
+# BACKFILLS a draft snapshot of the pocket's current content via the existing
+# ``_ensure_pocket_draft`` helper, then re-reads; the 400 is kept ONLY for a
+# genuinely empty / nonexistent pocket or a foreign-workspace draft. This fixes
+# the "Submit for review → 400 (and edits seem to go live)" bug — both symptoms
+# were the same missing-draft-lineage gap.
+#
 # Updated 2026-06-18 (feat/sites-smoke-at-publish, PERF-4): publish() now threads
 # ``smoke=not preview`` into generator.build(), so the workerd SMOKE render runs
 # ONLY for a LIVE publish (preview=False) and is SKIPPED for a preview/edit/arm
@@ -1555,11 +1564,17 @@ async def request_publish_pocket(
     workspace claim, so a real workspace MUST be set here for the gate to ever
     approve). The caller passes its ``ctx.workspace_id``.
 
-    Raises ``ValueError`` when there is NO current draft to publish (the router
-    maps it to a 4xx — there is nothing to submit for review). A missing /
-    access-denied pocket surfaces via the pockets service (NotFound → 404) only
-    when no draft row exists; the common path (a draft was written by an edit)
-    reads the draft directly off the versions spine.
+    P0b — SELF-HEAL legacy sites: a site published before BP-1 has ZERO
+    ``artifact_versions`` rows, so ``get_draft`` returns None even though the
+    pocket has live content. Rather than 400, this BACKFILLS a draft snapshot of
+    the pocket's current content (via ``_ensure_pocket_draft``) and proceeds. The
+    400 is kept ONLY for a genuinely empty / nonexistent pocket (nothing to
+    snapshot) or a foreign-workspace draft (tenant isolation).
+
+    Raises ``ValueError`` when there is NO current draft to publish AND none can
+    be backfilled (the router maps it to a 4xx — there is nothing to submit for
+    review). A missing / access-denied pocket surfaces via the pockets service
+    (NotFound, swallowed by the best-effort backfill) → still no draft → 400.
     """
     from pocketpaw.instinct.models import (
         ActionCategory,
@@ -1571,9 +1586,24 @@ async def request_publish_pocket(
 
     draft = await versions_service.get_draft(scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id)
     if draft is None or draft.workspace_id != workspace_id:
-        # Nothing drafted for this pocket in this workspace — nothing to review.
-        # (A foreign-workspace draft is also "nothing here" for this caller —
-        # tenant isolation, the same guard pocket_status applies.)
+        # P0b — a site PUBLISHED before BP-1 has ZERO artifact_versions rows, so it
+        # has no draft lineage at all. That is NOT "nothing to review": the pocket
+        # still has live content the operator wants to submit. BACKFILL a draft
+        # snapshot of the pocket's CURRENT content (reusing ``_ensure_pocket_draft``,
+        # which reads the engine + content via the pockets service and writes a draft
+        # only when none exists), then re-read. This self-heals the legacy site so
+        # Submit-for-review works on the first click instead of 400'ing — and the
+        # edits no longer leak to live, because they land on a draft the merge gate
+        # must approve. A genuinely empty / nonexistent pocket still has nothing to
+        # snapshot (``_ensure_pocket_draft`` swallows the pockets-service NotFound),
+        # so ``get_draft`` stays None below and we keep the 400.
+        await _ensure_pocket_draft(workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id)
+        draft = await versions_service.get_draft(scope_type=_VERSION_SCOPE_TYPE, scope_id=pocket_id)
+
+    if draft is None or draft.workspace_id != workspace_id:
+        # Still nothing after the backfill attempt — a genuinely empty / nonexistent
+        # pocket, or a foreign-workspace draft (tenant isolation, the same guard
+        # ``pocket_status`` applies). Nothing to review.
         raise ValueError(f"no draft version to publish for pocket {pocket_id} — nothing to review")
 
     published = await versions_service.get_published(

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -633,12 +633,17 @@ async def publish(
         # cutting the dominant per-edit cost. A fresh site_id is minted per publish,
         # but a pocket's working dir is reused across its publishes/previews.
         pocket_id=pocket_id,
-        # PERF-4: run the workerd SMOKE render ONLY for a LIVE publish. The render
-        # is per-edit overhead only needed before a deploy, so a preview/edit/arm
-        # build (preview=True) skips it (smoke=False); a live publish (preview=False)
-        # keeps it (smoke=True) so the gate + the rollback below are unchanged. A
-        # preview that would fail smoke is no longer blocked — the live publish still
-        # gates + rolls back, so a broken edit never reaches the live deploy.
+        # P0a (was PERF-4): ``smoke`` now toggles ONLY the workerd SSR FAIL-gate,
+        # NOT whether ``bun run build`` runs. ``bun run build`` (the static-output
+        # step) runs on BOTH preview and publish (``static_build`` defaults to True),
+        # because this site is SERVED via deploy_local and persist_site copies
+        # whatever the build leaves on disk — skipping it served a STALE anchorless
+        # build (the #1 bug: no hover edit-pill). A preview/edit/arm build
+        # (preview=True) skips only the SSR fail-gate (smoke=False) — it still BUILDS
+        # fresh + anchored output; a live publish (preview=False) keeps the SSR gate
+        # (smoke=True) so the gate + the rollback below are unchanged. A preview that
+        # would fail the SSR render is not blocked — the live publish still gates +
+        # rolls back, so a broken edit never reaches the live deploy.
         smoke=not preview,
     )
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -210,6 +210,23 @@
 #     doc, else the newest with a real url) and returns its non-null url + is_live,
 #     dropping the arbitrary find_one. PERF-1 does NOT migrate pre-existing dupes
 #     (that is PERF-2) — _canonical_site_doc just resolves the live one among them.
+#
+# Updated 2026-06-18 (feat/sites-diff-edit, P3 — TARGETED / DIFF edit): a svelte
+# component edit can now be expressed as a list of search/replace blocks
+# (``edits=[{old_string, new_string}, ...]``, like the built-in Edit tool) INSTEAD
+# of the FULL ``new_source``, so the agent emits ONLY the change for a small edit
+# ("add a bg color to the nav") rather than reading + regenerating the whole file
+# — far fewer tokens in and out, the dominant edit-latency cost. New pieces:
+#   * apply_edits(source, edits) — a PURE, I/O-free function that applies the
+#     blocks sequentially; each ``old_string`` must match EXACTLY ONCE (0 or >1
+#     raises ValidationError with a clear, retry-able message), so it is the same
+#     uniqueness contract the built-in Edit tool enforces.
+#   * edit_svelte_component() gained an ``edits`` param (alternative to
+#     ``new_source``). When ``edits`` is given it reads the pocket's CURRENT
+#     component source via the pockets service, computes the new source with
+#     apply_edits, and hands that to the UNCHANGED SE-2 persist + preview/republish
+#     + smoke-gate-rollback path. ``new_source`` (full rewrite) is unchanged and
+#     stays the fallback for large rewrites; exactly one of the two must be given.
 
 from __future__ import annotations
 
@@ -222,7 +239,7 @@ from typing import Any
 from bson import ObjectId
 from bson.errors import InvalidId
 
-from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
 from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
 from pocketpaw_ee.sites.domain import HostnameStatus
@@ -838,13 +855,84 @@ async def publish_pocket(
     )
 
 
+def apply_edits(source: str, edits: list[dict[str, str]]) -> str:
+    """Apply a list of search/replace blocks to ``source`` and return the result
+    (P3 — the TARGETED / DIFF edit primitive). PURE + I/O-free, so it is directly
+    unit-testable; ``edit_svelte_component`` calls it to turn the agent's minimal
+    diff into the new file contents before reusing the unchanged persist path.
+
+    Each block is ``{"old_string": <str>, "new_string": <str>}``. The contract
+    mirrors the built-in Edit tool so the agent's existing instinct transfers:
+
+      * ``old_string`` must match the CURRENT working text EXACTLY ONCE. 0 matches
+        or >1 matches raise ``ValidationError`` with a clear, retry-able message
+        (the agent makes ``old_string`` more specific and retries) — never a silent
+        no-op or a partial/ambiguous replace.
+      * blocks apply SEQUENTIALLY against the running result, so a later block can
+        target text an earlier block produced.
+      * ``new_string`` may be empty (a deletion); ``old_string == new_string`` is a
+        no-op the agent did not intend and is rejected.
+
+    Raises ``ValidationError`` on an empty list, a malformed block (missing/non-str
+    keys), or any match-count violation — so a bad diff fails closed BEFORE
+    anything is persisted or rebuilt.
+    """
+    if not isinstance(edits, list) or not edits:
+        raise ValidationError(
+            "site_edit.empty_edits",
+            "edits must be a non-empty list of {old_string, new_string} blocks.",
+        )
+    result = source
+    for i, block in enumerate(edits):
+        if not isinstance(block, dict):
+            raise ValidationError(
+                "site_edit.malformed_block",
+                f"edit block {i} is not an object with old_string/new_string.",
+            )
+        old = block.get("old_string")
+        new = block.get("new_string")
+        if not isinstance(old, str) or not isinstance(new, str):
+            raise ValidationError(
+                "site_edit.malformed_block",
+                f"edit block {i} must have string `old_string` and `new_string`.",
+            )
+        if old == "":
+            raise ValidationError(
+                "site_edit.empty_old_string",
+                f"edit block {i} has an empty `old_string` — provide the exact text to replace.",
+            )
+        if old == new:
+            raise ValidationError(
+                "site_edit.noop_block",
+                f"edit block {i} has identical old_string and new_string (no-op) — "
+                "the change would do nothing.",
+            )
+        count = result.count(old)
+        if count == 0:
+            raise ValidationError(
+                "site_edit.no_match",
+                f"edit block {i}: old_string was not found (0 times) in the current "
+                "source — it must match the file exactly. Re-read the component and "
+                "copy the text verbatim.",
+            )
+        if count > 1:
+            raise ValidationError(
+                "site_edit.ambiguous_match",
+                f"edit block {i}: old_string matches {count} times — it must be "
+                "unique. Include more surrounding context so it matches exactly once.",
+            )
+        result = result.replace(old, new, 1)
+    return result
+
+
 async def edit_svelte_component(
     *,
     workspace_id: str,
     user_id: str,
     pocket_id: str,
     component_path: str,
-    new_source: str,
+    new_source: str | None = None,
+    edits: list[dict[str, str]] | None = None,
     name: str = "",
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
@@ -853,11 +941,22 @@ async def edit_svelte_component(
 ) -> _SiteDoc:
     """Rewrite ONE component of a svelte Paw Site pocket and safely republish.
 
-    The chat-agent entry point for a targeted component edit: it replaces the
-    file at ``component_path`` in the pocket's svelte ``source`` map with
-    ``new_source`` and republishes the site. The Pocket write is owned by the
-    pockets service (``set_svelte_source_file`` — entity isolation); this
-    function only orchestrates persist → republish.
+    The chat-agent entry point for a targeted component edit. The edit can be
+    expressed two ways (exactly one is required):
+
+      * ``edits`` (PREFERRED for small changes, P3) — a list of search/replace
+        blocks ``[{old_string, new_string}, ...]`` the agent emits INSTEAD of the
+        whole file. This reads the pocket's CURRENT ``component_path`` source,
+        applies the blocks via ``apply_edits`` (each ``old_string`` must match
+        exactly once), and uses the COMPUTED new source. The agent sends only the
+        diff — the dominant token / latency saving over a full rewrite.
+      * ``new_source`` (full rewrite, the SE-2 fallback) — the whole new file
+        contents; used as-is. Reserve this for large rewrites.
+
+    Either way the resolved new source replaces the file at ``component_path`` in
+    the pocket's svelte ``source`` map and the site is republished. The Pocket
+    write is owned by the pockets service (``set_svelte_source_file`` — entity
+    isolation); this function only orchestrates resolve → persist → republish.
 
     Safety contract — a broken edit must leave NEITHER a broken deploy NOR stale
     source on the pocket:
@@ -883,6 +982,36 @@ async def edit_svelte_component(
     """
     from pocketpaw_ee.cloud.pockets import service as pockets_service
     from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+    # P3 — resolve the edit shape to a single ``new_source`` string. Exactly one of
+    # ``edits`` (targeted diff) / ``new_source`` (full rewrite) must be supplied.
+    if (edits is None) == (new_source is None):
+        raise ValidationError(
+            "site_edit.invalid_args",
+            "edit_svelte_component requires exactly one of `edits` (a targeted "
+            "search/replace diff) or `new_source` (a full file rewrite).",
+        )
+    if edits is not None:
+        # Targeted/diff edit: read the pocket's CURRENT component source and apply
+        # the blocks to compute the new source. The read goes through the pockets
+        # service's PUBLIC ``get`` (wire dict — entity isolation; it raises
+        # NotFound/Forbidden itself) so the apply runs against the source of truth.
+        # A missing component path is a NotFound (same contract as the full-rewrite
+        # path, where set_svelte_source_file raises it) — not a silent create.
+        pocket = await pockets_service.get(pocket_id, user_id)
+        if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(
+            pocket.get("source"), dict
+        ):
+            raise ValidationError(
+                "pocket.not_svelte_site",
+                "This pocket is not a svelte Paw Site — it has no component source map to edit.",
+            )
+        source_map = pocket["source"]
+        if component_path not in source_map:
+            raise NotFound("site_component", component_path)
+        # apply_edits raises ValidationError (clear, retry-able) on any match-count
+        # violation, BEFORE anything is persisted or rebuilt.
+        new_source = apply_edits(source_map[component_path], edits)
 
     # SE-2b: recover the builder origin the site is currently published with so
     # the republish keeps the edit-bridge. "" (or no prior site) republishes
@@ -1523,6 +1652,7 @@ async def version_history(*, workspace_id: str, pocket_id: str) -> list[Any]:
 
 
 __all__ = [
+    "apply_edits",
     "publish",
     "publish_pocket",
     "preview_pocket",

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1835,9 +1835,7 @@ async def revert_pocket_version(
         None,
     )
     if target is None:
-        raise ValueError(
-            f"no version v{version_no} for pocket {pocket_id} — cannot revert"
-        )
+        raise ValueError(f"no version v{version_no} for pocket {pocket_id} — cannot revert")
 
     return await versions_service.revert(
         scope_type=_VERSION_SCOPE_TYPE,

--- a/ee/pocketpaw_ee/versions/instinct_executor.py
+++ b/ee/pocketpaw_ee/versions/instinct_executor.py
@@ -3,6 +3,15 @@
 # apply-on-approve / discard-on-reject executor for the Branch primitive's
 # artifact-change merge gate.
 #
+# Updated 2026-06-19 (P2a — discard-all-drafts): discard_rejected_change now
+# clears ALL drafts above the published pointer in one pass via
+# versions_service.discard_all_drafts (passing the blob's branch), instead of
+# reverting only the single candidate ``to_version_id``. Fixes "discard needs N
+# clicks": a pocket edited N times accumulated N draft rows, and reverting only
+# the latest left the others standing so the unpublished-changes bar never
+# cleared. The published pointer is still left untouched (a reject never moves
+# Live).
+#
 # This is the executor the Instinct router dispatches to when an approved /
 # rejected Action carries an ``_artifact_change`` blob (the peer of the
 # pocket-write bridge, the belt code-change executor, and the external-action
@@ -177,17 +186,23 @@ async def execute_approved_change(action: Any, *, human_event_id: Any | None = N
 
 
 async def discard_rejected_change(action: Any) -> None:
-    """DISCARD a rejected artifact-change Action (BP-3).
+    """DISCARD a rejected artifact-change Action (BP-3 + P2a).
 
-    Flips the candidate draft (``to_version_id``) to ``status="reverted"`` so it
-    leaves the working-draft pointer; the PUBLISHED pointer is left untouched (a
-    rejection must never move what is live). No deploy. Best-effort: the router
-    already flipped the Action to ``rejected`` and closed the Decision-Graph
-    chain on the reject path, so a discard failure here is logged and swallowed —
-    it must not break the reject response.
+    P2a — clears ALL drafts above the published pointer in ONE pass via
+    ``versions_service.discard_all_drafts`` instead of reverting only the single
+    candidate the Action names. A pocket edited N times accumulated N draft rows
+    (one per edit); the old single-row discard reverted only ``to_version_id``, so
+    ``get_draft`` stayed non-None and the unpublished-changes bar never cleared →
+    "discard needs N clicks". One ``discard_all_drafts`` flips every draft above
+    published to ``status="reverted"`` so the bar clears on click 1, and it
+    back-handles pockets already carrying a pile of accumulated drafts.
 
-    TODO(BP-4): deeper discard/revert semantics (reverting the published pointer
-    to a prior snapshot, history projection) land in BP-4.
+    The PUBLISHED pointer is left untouched (a rejection must never move what is
+    live). No deploy. Tenant-scoped on the blob's ``workspace`` (the same scope
+    the merge gate enforces). Best-effort: the router already flipped the Action
+    to ``rejected`` and closed the Decision-Graph chain on the reject path, so a
+    discard failure here is logged and swallowed — it must not break the reject
+    response.
     """
     blob = artifact_change_blob(action)
     if blob is None:
@@ -197,6 +212,7 @@ async def discard_rejected_change(action: Any) -> None:
     scope_id = str(blob.get("scope_id") or "")
     workspace_id = str(blob.get("workspace") or blob.get("workspace_id") or "")
     to_version_id = str(blob.get("to_version_id") or "")
+    branch = str(blob.get("branch") or "main")
     if not (scope_type and scope_id and workspace_id and to_version_id):
         logger.debug("artifact-change discard: blob missing fields — nothing to discard")
         return
@@ -204,17 +220,18 @@ async def discard_rejected_change(action: Any) -> None:
     try:
         from pocketpaw_ee.versions import service as versions_service
 
-        await versions_service.discard(
+        # Clear EVERY draft above the published pointer in one pass (P2a), not just
+        # the candidate the Action names — so one discard clears the bar.
+        await versions_service.discard_all_drafts(
             scope_type=scope_type,
             scope_id=scope_id,
             workspace_id=workspace_id,
-            version_id=to_version_id,
+            branch=branch,
         )
     except Exception:  # noqa: BLE001 — discard nudge must never break the reject
         logger.warning(
-            "artifact-change discard: failed to revert candidate %s for %s:%s "
+            "artifact-change discard: failed to clear drafts for %s:%s "
             "(published pointer untouched)",
-            to_version_id,
             scope_type,
             scope_id,
             exc_info=True,

--- a/ee/pocketpaw_ee/versions/service.py
+++ b/ee/pocketpaw_ee/versions/service.py
@@ -41,6 +41,19 @@
 # Both are minimal + idempotent-friendly (a missing row raises ValueError, same
 # defensive contract as publish()).
 #
+# Updated: 2026-06-19 (P2a — discard-all-drafts) — two changes that stop the
+# draft pile accumulating so ONE discard clears the unpublished-changes bar:
+#   * write_draft now SUPERSEDES the prior draft head: when the current branch
+#     head is already status="draft" it is flipped to "reverted" before the new
+#     row is inserted, so at most ONE live draft exists per (scope, branch). The
+#     monotonic version_no is preserved (the superseded row stays as history).
+#     A published/merged/reverted head is never superseded.
+#   * discard_all_drafts(scope, workspace, branch) reverts EVERY status="draft"
+#     row above the published pointer in one pass (tenant-scoped), back-handling
+#     pockets that already carry a pile of drafts. The Instinct reject path
+#     (instinct_executor.discard_rejected_change) now calls it instead of the
+#     single-row discard, so has_unpublished_changes goes false on click 1.
+#
 # Updated: 2026-06-18 (feat/branch-primitive-revert-history, BP-4) — revert +
 # the publish event so the history view sees the full lifecycle:
 #   * revert(version_id)  — revert an artifact to a prior snapshot by writing a
@@ -71,6 +84,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "branch",
     "discard",
+    "discard_all_drafts",
     "get_draft",
     "get_published",
     "list_versions",
@@ -191,10 +205,26 @@ async def write_draft(
     ``parent_version_id`` pointing at the prior branch head (None for the
     first version). Becomes the working draft (``get_draft`` returns it).
 
+    P2a (B) — SUPERSEDE the prior draft head: if the current branch head is
+    already ``status="draft"``, it is flipped to ``"reverted"`` BEFORE the new
+    row is inserted, so AT MOST ONE live draft exists per (scope, branch). This
+    stops the draft pile from accumulating (the cause of "discard needs N
+    clicks"): a pocket edited N times leaves one live draft, not N. The
+    monotonic ``version_no`` counter is NOT reused — the superseded row stays on
+    the append-only log as history, and the new row still gets head.version_no+1
+    so list_versions / lineage are unchanged. A PUBLISHED (or merged/reverted)
+    head is never superseded — a new draft on top of a published version is a
+    reviewable change that must keep the published pointer live.
+
     Emits ``artifact.version.created``.
     """
     head = await _latest_in_branch(scope_type=scope_type, scope_id=scope_id, branch_name=branch)
     version_no = (head.version_no + 1) if head else 1
+
+    # Supersede the prior DRAFT head so only one live draft survives (P2a B).
+    if head is not None and head.status == "draft":
+        head.status = "reverted"
+        await head.save()
 
     row = ArtifactVersion(
         scope_type=scope_type,
@@ -447,6 +477,72 @@ async def discard(
         },
     )
     return row
+
+
+async def discard_all_drafts(
+    *,
+    scope_type: str,
+    scope_id: str,
+    workspace_id: str,
+    branch: str = "main",  # noqa: A002 — domain term; not the builtin
+) -> int:
+    """Discard EVERY draft above the published pointer in one pass (P2a A).
+
+    The single-row :func:`discard` only abandons the candidate the merge gate
+    names. A pocket edited N times before this fix accumulated N ``status="draft"``
+    rows (write_draft always inserted a new one), so a single discard left the
+    other drafts standing → ``get_draft`` stayed non-None → the unpublished-changes
+    bar never cleared → "discard needs N clicks". This flips every
+    ``status="draft"`` row with ``version_no`` strictly greater than the published
+    pointer's ``version_no`` (or ALL drafts when nothing is published yet) to
+    ``"reverted"`` in a single call, so ONE discard makes ``has_unpublished_changes``
+    false. It also back-handles pockets already carrying a pile of drafts on disk.
+
+    The PUBLISHED pointer is left entirely untouched (a discard must never move
+    what is live), and the scan is tenant-scoped on ``workspace_id`` (a same-id
+    draft in another workspace is never reverted). Returns the number of drafts
+    reverted (0 when there is nothing above the published pointer — idempotent).
+
+    Emits ``artifact.version.discarded`` per reverted row so the history
+    projection records each abandonment.
+    """
+    published = await get_published(scope_type=scope_type, scope_id=scope_id, branch=branch)
+    floor = published.version_no if published is not None else 0
+
+    drafts = await ArtifactVersion.find(
+        ArtifactVersion.scope_type == scope_type,
+        ArtifactVersion.scope_id == scope_id,
+        ArtifactVersion.workspace_id == workspace_id,
+        ArtifactVersion.branch == branch,
+        ArtifactVersion.status == "draft",
+    ).to_list()
+
+    reverted = 0
+    for row in drafts:
+        if row.version_no <= floor:
+            # A draft at/below the published pointer is not an unpublished change
+            # (defensive — drafts are normally above; never touch live history).
+            continue
+        row.status = "reverted"
+        await row.save()
+        reverted += 1
+        _emit_version_event(
+            action="artifact.version.discarded",
+            scope_type=scope_type,
+            scope_id=scope_id,
+            workspace_id=workspace_id,
+            author=row.author,
+            payload={
+                "version_id": str(row.id),
+                "scope_type": scope_type,
+                "scope_id": scope_id,
+                "branch": row.branch,
+                "version_no": row.version_no,
+                "status": "reverted",
+                "discard_all": True,
+            },
+        )
+    return reverted
 
 
 async def revert(

--- a/src/pocketpaw/dashboard_auth.py
+++ b/src/pocketpaw/dashboard_auth.py
@@ -477,19 +477,33 @@ async def _auth_dispatch(request: Request) -> Response | None:
 
     is_auth_optional = any(path.startswith(p) for p in auth_optional_prefixes)
 
-    # Rate limiting — pick tier based on path
+    # Rate limiting.
+    #
+    # /api/auth/session is a master-token-exchange endpoint — keep its per-IP
+    # auth_limiter guard HERE, before auth, alongside the login / qr brute-force
+    # buckets above. An attacker hitting it has no valid token yet, so a per-IP
+    # cap is exactly right.
+    #
+    # The GENERAL per-IP api_limiter is deferred until AFTER the auth cascade
+    # below (P1b). It used to fire here, keyed solely on client_ip, which meant
+    # the paw-enterprise desktop editor — every /api/v1/* call coming from the
+    # single localhost IP (127.0.0.1) — shared ONE 30-token bucket and tripped
+    # 429 "Too many requests" under moderate editing. Authenticated full-access
+    # traffic is already trusted; api-key traffic has its own per-key bucket;
+    # only UNauthenticated /api callers still need the per-IP cap. So we run the
+    # api_limiter once full_access / is_valid are known. See the deferred block
+    # after step 6 below.
     client_ip = request.client.host if request.client else "unknown"
-    is_auth_path = request.url.path == "/api/auth/session"
-    limiter = auth_limiter if is_auth_path else api_limiter
-    rl_info = limiter.check(client_ip)
-    if not rl_info.allowed:
-        return JSONResponse(
-            status_code=429,
-            content={"detail": "Too many requests"},
-            headers=rl_info.headers(),
-        )
-    # Stash rate limit info to add response headers later
-    request.state.rate_limit_headers = rl_info.headers()
+    if request.url.path == "/api/auth/session":
+        rl_info = auth_limiter.check(client_ip)
+        if not rl_info.allowed:
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Too many requests"},
+                headers=rl_info.headers(),
+            )
+        # Stash rate limit info to add response headers later
+        request.state.rate_limit_headers = rl_info.headers()
 
     # Check for token in query or header
     token = request.query_params.get("token")
@@ -617,6 +631,30 @@ async def _auth_dispatch(request: Request) -> Response | None:
         or request.url.path.startswith("/uploads/")
     ):
         return None  # allow through
+
+    # Deferred general per-IP api_limiter (P1b).
+    #
+    # Runs now that the auth cascade above has set is_valid / full_access.
+    # Authenticated callers are EXEMPT from this per-IP bucket:
+    #   - full_access (master token / dashboard session / genuine localhost) is
+    #     already fully trusted — and is the bug we're fixing: the desktop
+    #     editor fans many /api/v1/* calls out of the single localhost IP, which
+    #     used to drain one shared 30-token bucket and 429.
+    #   - api-key callers already passed their own per-key limiter above
+    #     (apikey:<id>); the per-IP bucket would only double-limit them.
+    #   - oauth callers authenticated by token, not by IP.
+    # UNauthenticated /api (and any other non-exempt) traffic still hits the
+    # per-IP api_limiter, so the brute-force / abuse cap is preserved. The
+    # separate login / auth-session / qr buckets are untouched.
+    if not is_valid:
+        rl_info = api_limiter.check(client_ip)
+        if not rl_info.allowed:
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Too many requests"},
+                headers=rl_info.headers(),
+            )
+        request.state.rate_limit_headers = rl_info.headers()
 
     # Require auth for ALL remaining paths — not only /api* and /ws*.
     # Previously only API/WS paths were gated here, meaning any non-exempt

--- a/tests/cloud/test_agent_router_sites_window.py
+++ b/tests/cloud/test_agent_router_sites_window.py
@@ -1,0 +1,261 @@
+# test_agent_router_sites_window.py — PERF-6 regression suite.
+#
+# Created: 2026-06-18 (PERF-6, feat/sites-minimal-context) — proves the
+# sites-edit/refine surface ships a WINDOWED history to the executor (last N
+# turns only) instead of the full accumulating scope history, while every
+# non-sites surface keeps shipping the FULL history unchanged. The progressive
+# slowdown on the sites builder came from feeding the whole growing chat to the
+# LLM on every refine; windowing the refine surface fixes it without touching
+# general pocket/dm/group chat.
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from pocketpaw_ee.cloud.chat import agent_router as router_mod
+from pocketpaw_ee.cloud.chat import agent_service
+from pocketpaw_ee.cloud.chat.agent_router import (
+    SITES_REFINE_HISTORY_TURNS,
+    _is_sites_refine_surface,
+    _window_history_for_surface,
+)
+from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceKind, SurfaceMeta
+
+
+class _StubTransport:
+    """Yields one ``stream_end`` so the SSE generator finishes immediately."""
+
+    async def request_cancel(self, run_id: str) -> None:  # noqa: ARG002
+        return None
+
+    def read_events(self, run_id: str, *, after: str = "0", block_ms: int = 15000) -> AsyncIterator:  # noqa: ARG002
+        async def _gen() -> AsyncIterator:
+            from pocketpaw_ee.cloud.chat.runs.transport import StreamEvent
+
+            yield StreamEvent(
+                entry_id="1-0",
+                event="stream_end",
+                data={"assistant_message_id": None, "usage": {}, "cancelled": False},
+            )
+
+        return _gen()
+
+
+def _sites_refine_surface() -> SurfaceContext:
+    """A /sites/[siteId] refine surface: kind=SITES + meta.pocket_id set."""
+    return SurfaceContext(
+        workspace_id="w1",
+        user_id="u1",
+        kind=SurfaceKind.SITES,
+        meta=SurfaceMeta(pocket_id="pkt-1", site_id="site-1"),
+        preamble='<surface kind="sites" mode="refine" />',
+    )
+
+
+def _sites_create_surface() -> SurfaceContext:
+    """A /sites gallery create surface: kind=SITES but NO pocket_id."""
+    return SurfaceContext(
+        workspace_id="w1",
+        user_id="u1",
+        kind=SurfaceKind.SITES,
+        meta=SurfaceMeta(),
+        preamble='<surface kind="sites" />',
+    )
+
+
+def _pocket_surface() -> SurfaceContext:
+    """A general pocket chat surface (anchored to a pocket, NOT a site)."""
+    return SurfaceContext(
+        workspace_id="w1",
+        user_id="u1",
+        kind=SurfaceKind.POCKET,
+        meta=SurfaceMeta(pocket_id="pkt-1"),
+        preamble='<surface kind="pocket" />',
+    )
+
+
+def _long_history(turns: int) -> list[dict[str, str]]:
+    """A long accumulating history: ``turns`` user+assistant pairs."""
+    out: list[dict[str, str]] = []
+    for i in range(turns):
+        out.append({"role": "user", "content": f"edit request {i}"})
+        out.append({"role": "assistant", "content": f"applied edit {i}"})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Unit: the surface detector
+# ---------------------------------------------------------------------------
+
+
+def test_is_sites_refine_surface_true_only_for_sites_with_pocket_id():
+    assert _is_sites_refine_surface(_sites_refine_surface()) is True
+    # create-mode sites (no pocket_id) is NOT refine — full history.
+    assert _is_sites_refine_surface(_sites_create_surface()) is False
+    # a general pocket chat is NOT a sites refine even WITH a pocket_id.
+    assert _is_sites_refine_surface(_pocket_surface()) is False
+    # no surface context at all (legacy client) — never refine.
+    assert _is_sites_refine_surface(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Unit: the windowing helper
+# ---------------------------------------------------------------------------
+
+
+def test_window_history_caps_sites_refine_to_last_n_turns():
+    history = _long_history(20)  # 40 messages
+    windowed = _window_history_for_surface(history, _sites_refine_surface())
+    # ≤ N turns ⇒ ≤ 2*N messages, taken from the TAIL (most recent).
+    assert len(windowed) <= 2 * SITES_REFINE_HISTORY_TURNS
+    assert windowed == history[-2 * SITES_REFINE_HISTORY_TURNS :]
+    # the most recent turn must be present for pronoun referents.
+    assert windowed[-1] == history[-1]
+
+
+def test_window_history_unchanged_for_general_pocket_surface():
+    history = _long_history(20)
+    assert _window_history_for_surface(history, _pocket_surface()) == history
+
+
+def test_window_history_unchanged_for_sites_create_surface():
+    history = _long_history(20)
+    assert _window_history_for_surface(history, _sites_create_surface()) == history
+
+
+def test_window_history_unchanged_when_no_surface_context():
+    history = _long_history(20)
+    assert _window_history_for_surface(history, None) == history
+
+
+def test_window_history_short_history_is_passed_through():
+    history = _long_history(1)  # 2 messages, under the cap
+    assert _window_history_for_surface(history, _sites_refine_surface()) == history
+
+
+# ---------------------------------------------------------------------------
+# Integration: post_agent_chat ships the WINDOWED history on the RunSpec for
+# a sites-refine surface, and the FULL history for a non-sites surface.
+# ---------------------------------------------------------------------------
+
+
+async def _drive_post_agent_chat(
+    cloud_app_client: AsyncClient,
+    *,
+    surface: str | None,
+    surface_meta: dict | None,
+    history: list[dict[str, str]],
+) -> list:
+    """POST one agent-chat turn with a stubbed loader returning ``history`` and
+    capture the RunSpec handed to the executor. Returns ``captured_specs``."""
+    captured_specs: list = []
+
+    # A fake scope ctx so the test never depends on a real session in Mongo.
+    # ``surface_context`` starts None; the router sets it from the REAL
+    # ``resolve_surface_context`` using the request's surface / surface_meta —
+    # exactly the production path that decides whether windowing kicks in.
+    fake_ctx = SimpleNamespace(
+        kind=SimpleNamespace(value="session"),
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        pocket_tool_specs=[],
+        session_id=None,
+        pocket_id=None,
+        intent=None,
+        surface_context=None,
+    )
+
+    class _RecordingExecutor:
+        async def submit(self, spec):
+            captured_specs.append(spec)
+
+    async def fake_resolver(**_):
+        return fake_ctx
+
+    async def fake_persist(_ctx, _body):
+        return "user_msg_id_1"
+
+    async def fake_ensure_session(_ctx):
+        return None
+
+    async def fake_loader(ctx, *, limit=50):  # noqa: ARG001
+        return list(history)
+
+    body: dict = {"content": "make the hero bigger", "client_message_id": "c-window"}
+    if surface is not None:
+        body["surface"] = surface
+    if surface_meta is not None:
+        body["surface_meta"] = surface_meta
+
+    with (
+        patch.object(router_mod, "resolve_scope_context", fake_resolver),
+        patch.object(router_mod, "load_history_for_scope", fake_loader),
+        patch.object(agent_service, "load_history_for_scope", fake_loader),
+        patch.object(router_mod, "_persist_user_message", fake_persist),
+        patch.object(router_mod, "_ensure_scope_session", fake_ensure_session),
+        patch.object(router_mod, "get_executor", lambda: _RecordingExecutor()),
+        patch.object(router_mod, "get_stream_transport", lambda: _StubTransport()),
+    ):
+        resp = await cloud_app_client.post(
+            "/cloud/chat/session/s1/agent",
+            json=body,
+        )
+
+    assert resp.status_code == 200, resp.text
+    return captured_specs
+
+
+@pytest.mark.asyncio
+async def test_post_agent_chat_windows_history_for_sites_refine(
+    cloud_app_client: AsyncClient,
+    mongo_db,  # noqa: ARG001 — Beanie init for create_run
+):
+    """A sites-refine surface (kind=sites + pocket_id) must ship a WINDOWED
+    history (≤ N turns from the tail), even when the stored scope history is long."""
+    history = _long_history(20)  # 40 messages
+
+    specs = await _drive_post_agent_chat(
+        cloud_app_client,
+        surface="sites",
+        surface_meta={"pocket_id": "pkt-1", "site_id": "site-1"},
+        history=history,
+    )
+
+    assert len(specs) == 1
+    shipped = specs[0].history
+    assert len(shipped) <= 2 * SITES_REFINE_HISTORY_TURNS, (
+        "sites refine must window the history so the LLM stops re-processing the "
+        "whole accumulating chat on every edit (the progressive-slowdown cause)."
+    )
+    assert shipped == history[-2 * SITES_REFINE_HISTORY_TURNS :]
+
+
+@pytest.mark.asyncio
+async def test_post_agent_chat_keeps_full_history_for_general_chat(
+    cloud_app_client: AsyncClient,
+    mongo_db,  # noqa: ARG001 — Beanie init for create_run
+):
+    """A non-sites surface (a plain session chat with no surface hint) must ship
+    the FULL history — windowing is a no-op off the sites-refine surface."""
+    history = _long_history(20)
+
+    specs = await _drive_post_agent_chat(
+        cloud_app_client,
+        surface=None,
+        surface_meta=None,
+        history=history,
+    )
+
+    assert len(specs) == 1
+    assert specs[0].history == history, (
+        "general chat history must be unchanged — windowing only applies to the "
+        "sites-refine surface."
+    )

--- a/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
@@ -1,4 +1,9 @@
 # tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
+# Updated: 2026-06-17 (fix/sites-plan-gate-asymmetry) — create_svelte_site now
+# calls the shared Sites plan gate (sites.service.require_sites_plan) before
+# agent_create, so an autouse fixture defaults get_workspace_plan to "business"
+# (which unlocks Sites) for the end-to-end create test. Denial is covered in
+# tests/ee/sites/test_plan_gate.py.
 # Created: 2026-06-04 (feat/sites-svelte-engine) — coverage for the Paw Sites
 # "Svelte track" create tool ``create_svelte_site`` on the in-process
 # ``pocketpaw_sites_manager`` server. Three layers:
@@ -17,10 +22,25 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture(autouse=True)
+def _default_sites_plan():
+    """create_svelte_site now calls the shared Sites plan gate
+    (sites.service.require_sites_plan) before agent_create. These tests use
+    synthetic workspace ids with no seeded Workspace doc, so default the plan to
+    one that unlocks Sites ("business") to exercise the create mechanics. Plan-gate
+    denial is covered separately in tests/ee/sites/test_plan_gate.py."""
+    with patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value="business"),
+    ):
+        yield
 
 
 # A representative §4.3-complete source map (paths -> file contents).

--- a/tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_edit_svelte_component.py
@@ -178,6 +178,97 @@ class TestEditHandler:
         assert "is live" not in text
 
     @pytest.mark.asyncio
+    async def test_edits_input_forwarded_to_service(self) -> None:
+        """P3: the agent can send a targeted ``edits`` list INSTEAD of the whole
+        ``new_source``; the handler forwards the blocks to the service and does NOT
+        require ``new_source``."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_FakeSiteDoc())
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_svelte_component", new=fake),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                    "edits": [{"old_string": "Bright", "new_string": "Brighter"}],
+                }
+            )
+
+        assert not out.get("is_error"), out
+        fake.assert_awaited_once()
+        kwargs = fake.await_args.kwargs
+        assert kwargs["edits"] == [{"old_string": "Bright", "new_string": "Brighter"}]
+        # No full-file rewrite was forced on the diff path.
+        assert kwargs.get("new_source") is None
+
+    @pytest.mark.asyncio
+    async def test_neither_edits_nor_new_source_is_error(self) -> None:
+        """P3: a call with neither ``edits`` nor ``new_source`` is rejected with a
+        clear is_error before the service is touched."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                }
+            )
+        assert out.get("is_error") is True
+        text = out["content"][0]["text"]
+        assert "edits" in text and "new_source" in text
+
+    @pytest.mark.asyncio
+    async def test_malformed_edits_is_error(self) -> None:
+        """P3: ``edits`` must be a list of {old_string, new_string} dicts — a
+        malformed shape is caught at the handler with a clear is_error."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                    "edits": [{"old_string": "only-old"}],
+                }
+            )
+        assert out.get("is_error") is True
+        assert "`edits`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_validation_error_from_apply_relayed(self) -> None:
+        """P3: when the service's apply step rejects the edit (e.g. old_string does
+        not match uniquely) the ValidationError is relayed by code + message so the
+        agent can retry with a more specific old_string."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+        from pocketpaw_ee.cloud._core.errors import ValidationError
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_svelte_component",
+                new=AsyncMock(
+                    side_effect=ValidationError(
+                        "site_edit.no_match",
+                        "old_string did not match (0 times)",
+                    )
+                ),
+            ),
+        ):
+            out = await mcp._edit_svelte_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/lib/components/Hero.svelte",
+                    "edits": [{"old_string": "nope", "new_string": "x"}],
+                }
+            )
+        assert out.get("is_error") is True
+        assert "site_edit.no_match" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
     async def test_missing_identity_is_error(self) -> None:
         from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
 

--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -1,0 +1,46 @@
+# tests/ee/sites/conftest.py
+# Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+#
+# PERF-2's ``test_dedupe.py`` has PURE picker tests (``pick_canonical``) that build
+# in-memory ``Site`` docs WITHOUT the function-scoped ``beanie_test_db`` DB fixture
+# — the picker never touches the DB. But Beanie's ``Document.__init__`` resolves the
+# document's collection settings, which raises ``CollectionWasNotInitialized`` until
+# ``init_beanie`` has run at least once in the process. The async tests in the same
+# file DO take ``beanie_test_db``, but it is function-scoped (its mongomock client
+# goes out of scope on teardown), so a pure test that runs in isolation — or after
+# that teardown — has no initialised settings and cannot even CONSTRUCT a ``Site``.
+#
+# This session-scoped autouse fixture runs ``init_beanie`` ONCE against a throwaway
+# mongomock database so model CONSTRUCTION works everywhere in ``tests/ee/sites/``.
+# It does NOT replace ``beanie_test_db``: the per-test fixture still re-inits against
+# its own fresh DB for the async tests' DB isolation (Beanie re-init just repoints
+# the settings at the new client). This fixture only guarantees the settings exist
+# so a fixtureless pure test can build a doc.
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+async def _sites_beanie_settings() -> Any:
+    """Initialise Beanie once for the sites test module so in-memory ``Site``
+    construction works in the pure (fixtureless) picker tests."""
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+    from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
+    from pocketpaw_ee.cloud.models import ALL_DOCUMENTS
+
+    client = AsyncMongoMockClient()
+    db = client["test_ee_sites_settings"]
+
+    original = db.list_collection_names
+
+    async def _safe_list_collection_names(*_args: Any, **_kwargs: Any) -> list[str]:
+        return await original()
+
+    db.list_collection_names = _safe_list_collection_names  # type: ignore[method-assign]
+
+    await init_beanie(database=db, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
+    yield

--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -1,0 +1,40 @@
+# tests/ee/sites/conftest.py
+# Created: 2026-06-17 (fix/sites-plan-gate-asymmetry) — Sites is now plan-gated at
+# the service chokepoint: sites.service.publish()/publish_pocket() and the create
+# MCP handlers call require_sites_plan(), which reads the workspace plan via
+# workspace_service.get_workspace_plan and raises Forbidden('plan.feature_denied')
+# (or NotFound when the workspace is missing). The existing mechanics tests in
+# this directory call publish/create with SYNTHETIC workspace ids that have no
+# seeded Workspace doc, so the gate would now raise NotFound and mask what they
+# actually exercise. This autouse fixture patches get_workspace_plan to return a
+# plan that INCLUDES Sites ("business") by default, so the happy-path mechanics
+# tests pass the gate. The dedicated gate test (test_plan_gate.py) overrides the
+# plan per-test with its own patch (an inner patch of the same target wins while
+# active), so the team-plan denial cases still assert correctly.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture(autouse=True)
+def _default_sites_plan(request: pytest.FixtureRequest):
+    """Default the workspace plan to one that unlocks Sites ('business') for the
+    sites mechanics tests, so the new service-level plan gate doesn't reject their
+    synthetic workspace ids. test_plan_gate.py patches the same target per-test to
+    exercise the denial paths."""
+    # The gate test owns the plan itself — don't double-patch under it.
+    if request.module.__name__.endswith("test_plan_gate"):
+        yield
+        return
+    from unittest.mock import patch
+
+    with patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value="business"),
+    ):
+        yield

--- a/tests/ee/sites/test_dedupe.py
+++ b/tests/ee/sites/test_dedupe.py
@@ -1,0 +1,247 @@
+# tests/ee/sites/test_dedupe.py — PERF-2 regression + unit guard: a
+# non-destructive migration collapses each pocket's duplicate Site docs down to
+# ONE active (non-archived) canonical, archiving the rest, and ``listSites``
+# (``list_for_workspace``) then returns one card per pocket.
+#
+# Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+#
+# The state PERF-2 fixes: PERF-1 made NEW publishes stable (one upserted Site doc
+# per pocket), but EXISTING data still carries the dupes the old per-publish
+# ObjectId minting left behind — e.g. the "AKB" pocket had 14 Site docs. The
+# gallery (``list_for_workspace``) listed every one, so a single pocket showed up
+# as many cards. This file pins PERF-2's contract:
+#   * the PURE picker ``pick_canonical`` chooses the right canonical (stable-id >
+#     deployed-with-url > newest) and returns the set to archive — no DB needed;
+#   * the async ``dedupe_workspace`` archives the non-canonical dupes
+#     non-destructively (sets ``archived=True``, never deletes), is IDEMPOTENT
+#     (a second run archives nothing new), and a DRY-RUN writes nothing;
+#   * ``list_for_workspace`` excludes archived docs ⇒ exactly one doc per pocket.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from bson import ObjectId
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.sites import dedupe as dedupe_mod
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.service import _live_object_id
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Pure picker — no DB. ``pick_canonical`` takes the Site docs for ONE pocket and
+# returns (canonical_doc, [docs_to_archive]). These exercise the rule directly.
+# ---------------------------------------------------------------------------
+
+
+def _doc(
+    *,
+    workspace: str = "ws1",
+    pocket_id: str = "pk",
+    oid: ObjectId | None = None,
+    deployed: bool = True,
+    url: str = "",
+    created: datetime | None = None,
+) -> _SiteDoc:
+    """Build an in-memory Site doc (never inserted) for the pure picker tests."""
+    doc = _SiteDoc(
+        id=oid or ObjectId(),
+        workspace=workspace,
+        pocket_id=pocket_id,
+        owner="u1",
+        name="x",
+        script_name="x",
+        deployed=deployed,
+        url=url,
+    )
+    if created is not None:
+        doc.createdAt = created
+    return doc
+
+
+def test_pick_canonical_prefers_stable_id_doc():
+    """Rule 1: the PERF-1 stable-id doc wins outright — it is the live identity
+    every post-PERF-1 publish writes to, even if an older dupe is 'newer' by some
+    other field."""
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    stable_oid = _live_object_id("ws1", "pk")
+    stable = _doc(oid=stable_oid, deployed=True, url="http://x/stable/", created=base)
+    # A newer dupe with a url — but NOT the stable id.
+    newer = _doc(deployed=True, url="http://x/newer/", created=base + timedelta(days=5))
+
+    canonical, to_archive = dedupe_mod.pick_canonical([newer, stable])
+
+    assert canonical.id == stable_oid
+    assert [d.id for d in to_archive] == [newer.id]
+
+
+def test_pick_canonical_prefers_deployed_with_url_then_newest():
+    """Rule 2/3/4 (no stable-id doc present): among legacy dupes, prefer a
+    deployed doc that carries a real url, breaking ties by newest createdAt."""
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    # Oldest: deployed but no url (the stale shape the bug left behind).
+    stale = _doc(deployed=True, url="", created=base)
+    # Middle: deployed WITH a url — the freshest real live build among these two.
+    live_old = _doc(deployed=True, url="http://x/old/", created=base + timedelta(days=1))
+    # Newest: deployed WITH a url — should win the tie-break.
+    live_new = _doc(deployed=True, url="http://x/new/", created=base + timedelta(days=2))
+
+    canonical, to_archive = dedupe_mod.pick_canonical([stale, live_old, live_new])
+
+    assert canonical.id == live_new.id
+    assert {d.id for d in to_archive} == {stale.id, live_old.id}
+
+
+def test_pick_canonical_single_doc_archives_nothing():
+    """A pocket with ONE doc has nothing to archive (the idempotent steady state)."""
+    only = _doc(deployed=True, url="http://x/only/")
+    canonical, to_archive = dedupe_mod.pick_canonical([only])
+    assert canonical.id == only.id
+    assert to_archive == []
+
+
+# ---------------------------------------------------------------------------
+# Async migration over a real (mongomock) DB.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_dupes(workspace: str, pocket_id: str, n: int) -> list[_SiteDoc]:
+    """Insert ``n`` Site docs for one pocket with ascending createdAt and real
+    urls — the AKB-style dupe pile the old per-publish minting produced."""
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    docs: list[_SiteDoc] = []
+    for i in range(n):
+        d = _SiteDoc(
+            workspace=workspace,
+            pocket_id=pocket_id,
+            owner="u1",
+            name=f"AKB {i}",
+            script_name=f"s{i}",
+            deployed=True,
+            url=f"http://127.0.0.1:9999/legacy-{i}/",
+        )
+        d.createdAt = base + timedelta(minutes=i)
+        await d.insert()
+        docs.append(d)
+    return docs
+
+
+async def test_dedupe_apply_archives_all_but_one(beanie_test_db):
+    """The core migration: a pocket with 14 dupes ends with exactly ONE active
+    (non-archived) doc; the other 13 are archived (NOT deleted)."""
+    await _seed_dupes("ws1", "akb", 14)
+
+    report = await dedupe_mod.dedupe_workspace("ws1", apply=True)
+
+    # Report accounting: one group, 13 archived, 1 kept active.
+    assert report.pockets_scanned == 1
+    assert report.docs_archived == 13
+    assert report.applied is True
+
+    all_docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "akb"}).to_list()
+    assert len(all_docs) == 14, "non-destructive: every doc still exists"
+    active = [d for d in all_docs if not getattr(d, "archived", False)]
+    archived = [d for d in all_docs if getattr(d, "archived", False)]
+    assert len(active) == 1, "exactly one active doc per pocket after dedupe"
+    assert len(archived) == 13
+
+
+async def test_dedupe_dry_run_writes_nothing(beanie_test_db):
+    """DRY-RUN (the default): report what WOULD be archived, but write nothing."""
+    await _seed_dupes("ws1", "akb", 5)
+
+    report = await dedupe_mod.dedupe_workspace("ws1", apply=False)
+
+    assert report.applied is False
+    assert report.docs_archived == 4  # what it WOULD archive
+
+    all_docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "akb"}).to_list()
+    assert all(not getattr(d, "archived", False) for d in all_docs), (
+        "dry-run must not flip archived on any doc"
+    )
+
+
+async def test_dedupe_is_idempotent(beanie_test_db):
+    """Running the migration twice is safe: the second run finds one active doc
+    already and archives nothing new."""
+    await _seed_dupes("ws1", "akb", 6)
+
+    first = await dedupe_mod.dedupe_workspace("ws1", apply=True)
+    assert first.docs_archived == 5
+
+    second = await dedupe_mod.dedupe_workspace("ws1", apply=True)
+    assert second.docs_archived == 0, "second run must archive nothing new"
+
+    active = [
+        d
+        for d in await _SiteDoc.find({"workspace": "ws1", "pocket_id": "akb"}).to_list()
+        if not getattr(d, "archived", False)
+    ]
+    assert len(active) == 1
+
+
+async def test_list_for_workspace_excludes_archived(beanie_test_db):
+    """``list_for_workspace`` (the gallery / listSites read) returns ONE card per
+    pocket after the dedupe — archived dupes are filtered out."""
+    await _seed_dupes("ws1", "akb", 8)
+    # A second pocket with its own single doc — both pockets should show once.
+    other = _SiteDoc(
+        workspace="ws1",
+        pocket_id="other",
+        owner="u1",
+        name="Other",
+        script_name="o",
+        deployed=True,
+        url="http://x/other/",
+    )
+    await other.insert()
+
+    # Before dedupe: the gallery shows all 8 AKB dupes + 1 other = 9 cards.
+    before = await sites_service.list_for_workspace("ws1")
+    assert len(before) == 9
+
+    await dedupe_mod.dedupe_workspace("ws1", apply=True)
+
+    after = await sites_service.list_for_workspace("ws1")
+    pocket_ids = sorted(r.pocket_id for r in after)
+    assert pocket_ids == ["akb", "other"], "one card per pocket after dedupe"
+
+
+async def test_dedupe_multiple_pockets_independent(beanie_test_db):
+    """Each (workspace, pocket_id) group is deduped independently — pockets don't
+    bleed into each other's canonical pick."""
+    await _seed_dupes("ws1", "akb", 4)
+    await _seed_dupes("ws1", "second", 3)
+
+    report = await dedupe_mod.dedupe_workspace("ws1", apply=True)
+
+    assert report.pockets_scanned == 2
+    assert report.docs_archived == 3 + 2  # (4-1) + (3-1)
+    for pid in ("akb", "second"):
+        active = [
+            d
+            for d in await _SiteDoc.find({"workspace": "ws1", "pocket_id": pid}).to_list()
+            if not getattr(d, "archived", False)
+        ]
+        assert len(active) == 1
+
+
+async def test_dedupe_all_workspaces(beanie_test_db):
+    """``dedupe_all`` (the boot/CLI unscoped path) reconciles every workspace's
+    pockets in one sweep."""
+    await _seed_dupes("wsA", "p1", 3)
+    await _seed_dupes("wsB", "p2", 4)
+
+    report = await dedupe_mod.dedupe_all(apply=True)
+
+    assert report.docs_archived == 2 + 3
+    for ws, pid in (("wsA", "p1"), ("wsB", "p2")):
+        active = [
+            d
+            for d in await _SiteDoc.find({"workspace": ws, "pocket_id": pid}).to_list()
+            if not getattr(d, "archived", False)
+        ]
+        assert len(active) == 1

--- a/tests/ee/sites/test_deployed_at_and_revert.py
+++ b/tests/ee/sites/test_deployed_at_and_revert.py
@@ -1,0 +1,216 @@
+# tests/ee/sites/test_deployed_at_and_revert.py
+# Created: 2026-06-19 (P2b-backend — "Last Deployed" + revert endpoint).
+# Reproduce-first cover for the two P2b-backend deliverables:
+#   1. ``deployed_at`` — the Site model now carries a ``deployed_at`` (UTC) stamped
+#      ONLY on a successful non-preview deploy (when ``deployed`` flips True), and
+#      both SiteResponse and SiteStatusResponse expose it as an ISO string|None.
+#      Asserted: publish stamps it; a PREVIEW build does NOT; pocket_status reads
+#      None before any deploy and the ISO string after.
+#   2. revert — ``revert_pocket_version`` resolves a pocket's version_no → the
+#      durable ArtifactVersion row (tenant-scoped, main branch) and writes a NEW
+#      forward-moving DRAFT snapshot of that version's content. Asserted: a revert
+#      creates a draft whose content == the target version; an unknown version_no
+#      raises ValueError (the router maps it to 404).
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.versions import service as versions
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# P2b — deployed_at stamping + DTO exposure
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_stamps_deployed_at(beanie_test_db):
+    """A successful live publish stamps the Site doc's ``deployed_at`` (UTC) when
+    ``deployed`` flips True — the 'last shipped' marker. Before the field existed,
+    a deployed Site carried no deploy time at all."""
+    from datetime import datetime
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk-da",
+        ripple_spec={"type": "container"},
+        theme={"primary": "#0A84FF"},
+        name="Bright Smile",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+    )
+    assert site.deployed is True
+    assert site.deployed_at is not None, "a successful deploy must stamp deployed_at"
+    assert isinstance(site.deployed_at, datetime)
+
+
+async def test_site_response_exposes_deployed_at_iso(beanie_test_db):
+    """``_to_response`` surfaces ``deployed_at`` as an ISO-8601 string on
+    SiteResponse after a deploy (the FE renders 'Last deployed <time>')."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    doc = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk-da2",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Bright Smile",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+    )
+    resp = sites_service._to_response(doc)
+    assert resp.deployed_at is not None
+    # An ISO-8601 string the FE can parse round-trips back to the stamped datetime.
+    from datetime import datetime
+
+    assert datetime.fromisoformat(resp.deployed_at) == doc.deployed_at
+
+
+async def test_status_deployed_at_none_before_deploy_then_iso_after(beanie_test_db):
+    """pocket_status reads ``deployed_at`` None before any deploy (no Site doc) and
+    the ISO string after a deploy — the DTO exposes None before the first deploy."""
+    # No Site doc yet → status reads deployed_at None (and not live).
+    before = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk-da3")
+    assert before.deployed_at is None
+    assert before.is_live is False
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk-da3",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Bright Smile",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+    )
+
+    after = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk-da3")
+    assert after.deployed_at is not None
+    from datetime import datetime
+
+    # Parses as a real ISO timestamp.
+    datetime.fromisoformat(after.deployed_at)
+
+
+async def test_preview_does_not_stamp_deployed_at(beanie_test_db, monkeypatch, tmp_path):
+    """A PREVIEW/edit build returns a transient, NON-persisted Site doc with
+    ``deployed=False`` and NO ``deployed_at`` — the stamp is reserved for a real
+    live deploy, so an edit preview never marks the pocket as 'just deployed'."""
+    from unittest.mock import AsyncMock, patch
+
+    # Local mode so the preview path serves from disk (no CF).
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+    gen = _FakeGenerator()
+    wire = {"name": "Preview Site", "rippleSpec": {"type": "container"}}
+
+    def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+        return f"http://127.0.0.1:9999/{site_id}/"
+
+    with patch("pocketpaw_ee.cloud.pockets.service.get", new=AsyncMock(return_value=wire)):
+        site = await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk-da4",
+            preview=True,
+            _generator=gen,
+            _local_deploy=_fake_local_deploy,
+        )
+
+    assert site.deployed is False, "a preview is not a live deploy"
+    assert site.deployed_at is None, "a preview must NOT stamp deployed_at"
+
+    # And no canonical deployed Site doc was persisted, so status reads no deploy time.
+    status = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk-da4")
+    assert status.deployed_at is None
+
+
+# ---------------------------------------------------------------------------
+# P2b — revert endpoint (service half)
+# ---------------------------------------------------------------------------
+
+WS = "ws-rev"
+POCKET = "pocket-rev"
+USER = "user-rev"
+
+
+async def test_revert_creates_draft_from_prior_version(beanie_test_db):
+    """``revert_pocket_version`` writes a NEW forward-moving DRAFT whose content is a
+    snapshot of the target version — the normal review/publish flow then applies."""
+    # v1 (published live), v2 (a later edit). We revert back to v1.
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "one"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(v1.id)
+    )
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "two"}
+    )
+
+    new_draft = await sites_service.revert_pocket_version(
+        workspace_id=WS, user_id=USER, pocket_id=POCKET, version_no=v1.version_no
+    )
+
+    # A NEW draft, forward of the head, carrying v1's content (revert never mutates
+    # history — it is a fresh snapshot the operator can then publish).
+    assert new_draft.status == "draft"
+    assert new_draft.content == {"v": "one"}
+    assert new_draft.version_no > v1.version_no
+    assert new_draft.author == USER
+    assert new_draft.label == f"Revert to v{v1.version_no}"
+
+    # It is the current draft for the pocket (request-publish would pick it up).
+    head_draft = await versions.get_draft(scope_type="pocket", scope_id=POCKET)
+    assert head_draft is not None
+    assert head_draft.id == new_draft.id
+
+
+async def test_revert_unknown_version_no_raises(beanie_test_db):
+    """An unknown version_no → ValueError (the router maps it to a 404)."""
+    await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": 1}
+    )
+    with pytest.raises(ValueError):
+        await sites_service.revert_pocket_version(
+            workspace_id=WS, user_id=USER, pocket_id=POCKET, version_no=999
+        )
+
+
+async def test_revert_is_tenant_scoped(beanie_test_db):
+    """A version_no that exists only under ANOTHER workspace is 'not found' for this
+    caller — the tenant guard treats it as no such version → ValueError."""
+    foreign = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id="ws-OTHER", content={"v": 1}
+    )
+    with pytest.raises(ValueError):
+        await sites_service.revert_pocket_version(
+            workspace_id=WS, user_id=USER, pocket_id=POCKET, version_no=foreign.version_no
+        )

--- a/tests/ee/sites/test_dev_server.py
+++ b/tests/ee/sites/test_dev_server.py
@@ -1,0 +1,212 @@
+# tests/ee/sites/test_dev_server.py
+# Created: 2026-06-18 (feat/sites-devserver, Phase 2 / P2a) — unit tests for the
+# live Vite dev-server preview manager (ee/pocketpaw_ee/sites/dev_server.py).
+#
+# The manager spawns a long-lived `vite dev` per pocket so edits hot-reload in ~ms
+# instead of rebuilding the whole site per edit. These tests exercise the FULL
+# lifecycle WITHOUT a real vite/bun: the spawner, the free-port allocator, and the
+# source-materialize step are all injected fakes (the manager exposes _spawn,
+# _free_port, and _materialize seams for exactly this). So they assert the
+# resource-safety logic the captain cares about — start-once, LRU cap, idle reaper,
+# stop/stop_all, per-pocket no-double-spawn — deterministically and offline.
+#
+# Live verification (real vite spawn + HMR) is a manual captain step documented in
+# the branch report; it cannot run in CI without bun + the generator on PATH.
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.sites.dev_server import DevServerManager
+
+
+class _FakeProc:
+    """Stands in for an asyncio subprocess running `vite dev`. Tracks whether it
+    is still 'running' so the manager's stop() (terminate + wait) is observable."""
+
+    def __init__(self, port: int) -> None:
+        self.port = port
+        self.terminated = False
+        self.killed = False
+        self.returncode: int | None = None
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        # Terminating a fake proc resolves immediately.
+        self.returncode = self.returncode if self.returncode is not None else 0
+        return self.returncode
+
+
+def _make_manager(
+    *, idle_seconds: float = 600.0, max_servers: int = 3
+) -> tuple[DevServerManager, dict]:
+    """Build a manager with all three subprocess/IO seams faked. Returns the
+    manager plus a ``probe`` dict the test reads to assert spawn behaviour."""
+    probe: dict = {"spawned": [], "ports": iter(range(40000, 40100)), "materialized": []}
+
+    def _free_port() -> int:
+        return next(probe["ports"])
+
+    async def _materialize(*, workspace_id: str, user_id: str, pocket_id: str) -> str:
+        # The real seam runs GeneratorClient.build(preview) and returns the
+        # persistent per-pocket project dir; the fake just records the call and
+        # returns a deterministic path so the spawn cwd is observable.
+        probe["materialized"].append(pocket_id)
+        return f"/tmp/site-builds/{pocket_id}"
+
+    async def _spawn(cmd: list[str], cwd: str, port: int) -> _FakeProc:
+        proc = _FakeProc(port)
+        probe["spawned"].append({"cmd": cmd, "cwd": cwd, "port": port, "proc": proc})
+        return proc
+
+    mgr = DevServerManager(
+        idle_seconds=idle_seconds,
+        max_servers=max_servers,
+        _spawn=_spawn,
+        _free_port=_free_port,
+        _materialize=_materialize,
+    )
+    return mgr, probe
+
+
+@pytest.mark.asyncio
+async def test_ensure_starts_once_and_reuses_on_second_call():
+    """P2a CORE: the first ensure_dev_server spawns one server; a second call for
+    the SAME pocket returns the SAME url WITHOUT spawning again (it touches the
+    existing server). This is the whole point — a long-lived dev server, not a
+    per-edit rebuild."""
+    mgr, probe = _make_manager()
+
+    url1 = await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk1")
+    url2 = await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk1")
+
+    assert url1 == url2
+    assert url1.startswith("http://127.0.0.1:")
+    assert url1.endswith("/")
+    # Exactly ONE spawn + ONE materialize across both calls.
+    assert len(probe["spawned"]) == 1
+    assert probe["materialized"] == ["pk1"]
+
+
+@pytest.mark.asyncio
+async def test_distinct_pockets_get_distinct_servers():
+    mgr, probe = _make_manager()
+    url_a = await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk_a")
+    url_b = await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk_b")
+    assert url_a != url_b
+    assert len(probe["spawned"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_lru_cap_stops_oldest_when_exceeded():
+    """The cap must prevent unbounded servers: starting a server when the cap is
+    full stops the LEAST-recently-used one first (resource safety)."""
+    mgr, probe = _make_manager(max_servers=2)
+
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk1")
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk2")
+    # Touch pk1 so pk2 becomes the least-recently-used.
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk1")
+    # Third distinct pocket exceeds the cap of 2 → the LRU (pk2) is stopped.
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk3")
+
+    assert set(mgr.live_pocket_ids()) == {"pk1", "pk3"}
+    # pk2's process was terminated.
+    pk2_proc = probe["spawned"][1]["proc"]
+    assert pk2_proc.terminated is True
+
+
+@pytest.mark.asyncio
+async def test_idle_reaper_stops_idle_servers():
+    """The reaper stops servers idle longer than idle_seconds and leaves fresh
+    ones alone. We drive one tick directly (no real timer) with a tiny idle bound
+    and a back-dated last_activity so the test is deterministic."""
+    mgr, probe = _make_manager(idle_seconds=0.05)
+
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="stale")
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="fresh")
+    # Back-date the stale one's activity well past the idle bound.
+    mgr._servers["stale"].last_activity -= 10.0
+
+    reaped = await mgr.reap_idle()
+
+    assert reaped == ["stale"]
+    assert mgr.live_pocket_ids() == ["fresh"]
+    assert probe["spawned"][0]["proc"].terminated is True
+    assert probe["spawned"][1]["proc"].terminated is False
+
+
+@pytest.mark.asyncio
+async def test_touch_bumps_activity():
+    mgr, _ = _make_manager()
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk1")
+    before = mgr._servers["pk1"].last_activity
+    await asyncio.sleep(0.01)
+    mgr.touch("pk1")
+    assert mgr._servers["pk1"].last_activity > before
+
+
+@pytest.mark.asyncio
+async def test_stop_and_stop_all():
+    mgr, probe = _make_manager()
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk1")
+    await mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk2")
+
+    await mgr.stop("pk1")
+    assert mgr.live_pocket_ids() == ["pk2"]
+    assert probe["spawned"][0]["proc"].terminated is True
+    # stop() of an unknown pocket is a no-op (idempotent).
+    await mgr.stop("pk1")
+
+    await mgr.stop_all()
+    assert mgr.live_pocket_ids() == []
+    assert probe["spawned"][1]["proc"].terminated is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ensure_spawns_only_once():
+    """Two concurrent ensure calls for the same pocket must not double-spawn — the
+    per-pocket lock serializes them so the second sees the first's server."""
+    # A materialize that yields control mid-flight so the two coroutines actually
+    # interleave at the await point (where a naive impl would double-spawn).
+    probe: dict = {"spawned": [], "ports": iter(range(40000, 40100))}
+
+    def _free_port() -> int:
+        return next(probe["ports"])
+
+    async def _materialize(*, workspace_id: str, user_id: str, pocket_id: str) -> str:
+        await asyncio.sleep(0.02)  # force interleave
+        return f"/tmp/site-builds/{pocket_id}"
+
+    async def _spawn(cmd: list[str], cwd: str, port: int) -> _FakeProc:
+        proc = _FakeProc(port)
+        probe["spawned"].append(proc)
+        return proc
+
+    mgr = DevServerManager(_spawn=_spawn, _free_port=_free_port, _materialize=_materialize)
+
+    urls = await asyncio.gather(
+        mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk1"),
+        mgr.ensure_dev_server(workspace_id="ws1", user_id="u1", pocket_id="pk1"),
+    )
+    assert urls[0] == urls[1]
+    assert len(probe["spawned"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_reaper_loop_start_stop_is_clean():
+    """The background reaper task starts and cancels cleanly (mirrors the run
+    sweeper lifecycle so on_shutdown can cancel it without a hang)."""
+    mgr, _ = _make_manager(idle_seconds=600.0)
+    await mgr.start_reaper(interval=0.01)
+    assert mgr._reaper_task is not None
+    await asyncio.sleep(0.03)  # let it tick at least once
+    await mgr.stop_reaper()
+    assert mgr._reaper_task is None

--- a/tests/ee/sites/test_diff_edit.py
+++ b/tests/ee/sites/test_diff_edit.py
@@ -1,0 +1,295 @@
+# tests/ee/sites/test_diff_edit.py — exercises the TARGETED / DIFF edit path for a
+# svelte Paw Site component (P3 — sites edit-perf). Created: 2026-06-18
+# (feat/sites-diff-edit, P3).
+#
+# Motivation (the latency cause P3 addresses): the SE-2 edit tool takes the FULL
+# ``new_source`` for a file, so for a one-line change ("add a bg color to the
+# nav") the agent must read AND regenerate the whole component — lots of tokens in
+# and out, slow, error-prone. P3 adds an ALTERNATIVE ``edits`` surface: a list of
+# search/replace blocks ``[{old_string, new_string}, ...]`` (like the built-in
+# Edit tool) the agent emits INSTEAD of the whole file. The blocks are applied to
+# the pocket's CURRENT component source to produce the new source, which then
+# reuses the unchanged SE-2 persist + preview/republish + rollback path.
+#
+# Two layers under test:
+#   1. ``apply_edits`` — the PURE, I/O-free search/replace function. A block whose
+#      ``old_string`` matches exactly once is applied; 0 matches or >1 matches
+#      error with a clear, retry-able message; blocks apply sequentially so a
+#      later block can target text an earlier block produced.
+#   2. ``edit_svelte_component(..., edits=[...])`` — the diff path end to end:
+#      it reads the pocket's current Hero source, applies the blocks, persists the
+#      computed new source, and reaches the regenerated PREVIEW build with the
+#      edited component (same downstream contract as the full-``new_source`` path).
+#      The full-``new_source`` path is re-asserted here to prove it still works.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+
+# A minimal but §4.3-complete svelte source map (mirrors test_component_edit.py).
+# The component under edit is Hero.svelte.
+_HERO_V1 = "<section class='hero'><h1>Bright Smile</h1></section>"
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css'</script><slot/>",
+    "src/routes/+page.ts": "export const prerender = true",
+    "src/app.css": ":root{--brand:#0A84FF}",
+    "src/lib/components/Hero.svelte": _HERO_V1,
+}
+
+
+class _FakeGenerator:
+    """Records the source map it was asked to build so a test can assert the
+    diff-edited component reached the regenerated build."""
+
+    def __init__(self):
+        self.built = None
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version=None)
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+    return f"http://127.0.0.1:9999/{site_id}/"
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Install a recording EventBus so the pockets service's ``emit`` calls don't
+    raise (the real bus is only wired at boot). Mirrors test_component_edit.py."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+# ---------------------------------------------------------------------------
+# 1. apply_edits — the PURE search/replace function
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEdits:
+    def test_single_block_applies_unique_match(self):
+        out = sites_service.apply_edits(
+            "<section class='hero'><h1>Bright Smile</h1></section>",
+            [{"old_string": "Bright Smile", "new_string": "Brighter Smiles"}],
+        )
+        assert out == "<section class='hero'><h1>Brighter Smiles</h1></section>"
+
+    def test_multiple_blocks_apply_in_order(self):
+        """Blocks apply sequentially; a later block can target text an earlier
+        block produced."""
+        out = sites_service.apply_edits(
+            "<section class='hero'><h1>Bright Smile</h1></section>",
+            [
+                # First add the class hook ...
+                {
+                    "old_string": "<section class='hero'>",
+                    "new_string": "<section class='hero' style='background:#000'>",
+                },
+                # ... then a block that matches text the first block just wrote.
+                {
+                    "old_string": "background:#000",
+                    "new_string": "background:#0A84FF",
+                },
+            ],
+        )
+        assert out == (
+            "<section class='hero' style='background:#0A84FF'><h1>Bright Smile</h1></section>"
+        )
+
+    def test_zero_match_raises_clear_error(self):
+        with pytest.raises(ValidationError) as ei:
+            sites_service.apply_edits(
+                "<section class='hero'><h1>Bright Smile</h1></section>",
+                [{"old_string": "Not Present", "new_string": "x"}],
+            )
+        msg = ei.value.message.lower()
+        assert "not found" in msg or "0 time" in msg or "did not match" in msg
+
+    def test_multiple_match_raises_clear_error(self):
+        """An ``old_string`` that matches more than once errors so the agent makes
+        it unique (same contract as the built-in Edit tool)."""
+        with pytest.raises(ValidationError) as ei:
+            sites_service.apply_edits(
+                "<div>x</div><div>x</div>",
+                [{"old_string": "<div>x</div>", "new_string": "<div>y</div>"}],
+            )
+        msg = ei.value.message.lower()
+        assert "2 time" in msg or "more than once" in msg or "unique" in msg
+
+    def test_empty_edits_list_raises(self):
+        with pytest.raises(ValidationError):
+            sites_service.apply_edits("abc", [])
+
+    def test_malformed_block_missing_keys_raises(self):
+        with pytest.raises(ValidationError):
+            sites_service.apply_edits("abc", [{"old_string": "a"}])
+
+    def test_noop_block_old_equals_new_raises(self):
+        """old_string == new_string is a no-op the agent did not intend — reject it
+        with a clear message rather than silently doing nothing."""
+        with pytest.raises(ValidationError):
+            sites_service.apply_edits("abc", [{"old_string": "a", "new_string": "a"}])
+
+
+# ---------------------------------------------------------------------------
+# 2. edit_svelte_component(..., edits=[...]) — the diff path end to end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_targeted_edit_applies_and_reaches_build(beanie_test_db):
+    """A targeted edit ([{old_string, new_string}]) is applied to the pocket's
+    CURRENT Hero source, the computed new source persists, and the regenerated
+    PREVIEW build materializes the edited component — without the agent ever
+    sending the whole file."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen, cf = _FakeGenerator(), _FakeCF()
+
+    site = await sites_service.edit_svelte_component(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/lib/components/Hero.svelte",
+        edits=[{"old_string": "Bright Smile", "new_string": "Brighter Smiles, Whiter Teeth"}],
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    # Same preview contract as the full-new_source path: no live deploy.
+    assert cf.put_calls == []
+    assert site.deployed is False
+    assert site.url.endswith(f"/preview-{pocket_id}/")
+
+    expected = "<section class='hero'><h1>Brighter Smiles, Whiter Teeth</h1></section>"
+    # The build materialized the diff-edited component.
+    assert gen.built is not None
+    assert gen.built["source"]["src/lib/components/Hero.svelte"] == expected
+    # Untouched files came through verbatim.
+    assert gen.built["source"]["src/routes/+page.ts"] == "export const prerender = true"
+
+    # The computed new source persisted on the pocket.
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == expected
+
+
+@pytest.mark.asyncio
+async def test_targeted_edit_non_unique_match_errors_without_persisting(beanie_test_db):
+    """A targeted edit whose old_string does not match uniquely raises a clear
+    ValidationError and does NOT mutate the pocket (the agent retries with a more
+    specific old_string)."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen, cf = _FakeGenerator(), _FakeCF()
+
+    with pytest.raises(ValidationError):
+        await sites_service.edit_svelte_component(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/lib/components/Hero.svelte",
+            edits=[{"old_string": "NOT IN THE FILE", "new_string": "x"}],
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"x",
+            _local_deploy=_fake_local_deploy,
+        )
+
+    # The bad edit never reached the generator and never mutated the pocket.
+    assert gen.built is None
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_full_new_source_path_still_works(beanie_test_db):
+    """Compat: the full-file ``new_source`` path is unchanged — it still rewrites
+    the whole component and reaches the build."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen, cf = _FakeGenerator(), _FakeCF()
+    whole = "<section class='hero'><h1>Totally Rewritten</h1></section>"
+
+    site = await sites_service.edit_svelte_component(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/lib/components/Hero.svelte",
+        new_source=whole,
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    assert site.deployed is False
+    assert gen.built["source"]["src/lib/components/Hero.svelte"] == whole
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == whole
+
+
+@pytest.mark.asyncio
+async def test_neither_edits_nor_new_source_raises(beanie_test_db):
+    """Calling the edit with neither ``edits`` nor ``new_source`` is a programming
+    error — raise a clear ValidationError, not a None-deref."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    with pytest.raises(ValidationError):
+        await sites_service.edit_svelte_component(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/lib/components/Hero.svelte",
+            _generator=_FakeGenerator(),
+            _cloudflare=_FakeCF(),
+            _bundle_reader=lambda d: b"x",
+            _local_deploy=_fake_local_deploy,
+        )

--- a/tests/ee/sites/test_generator_client_cache.py
+++ b/tests/ee/sites/test_generator_client_cache.py
@@ -1,0 +1,166 @@
+# tests/ee/sites/test_generator_client_cache.py
+# Created: 2026-06-18 (feat/sites-cached-build, PERF-3) — covers the persistent
+# per-pocket build dir + cached node_modules behaviour:
+#   * Building the SAME pocket twice with an UNCHANGED dep-hash runs `bun install`
+#     only ONCE (the second build reuses the cached node_modules). Asserted via the
+#     fake runner's install() call count.
+#   * Changing the dep-hash (a new install-input fingerprint) triggers a reinstall.
+#   * The build dir is STABLE per pocket: the same pocket builds into the same dir
+#     across builds (so node_modules persists), under a configurable build_home().
+#   * Correctness: a build still produces a BuildResult with the project dir.
+# The gen/install/smoke/hash subprocess calls are faked behind the injected
+# _runner seam, so no real bun/workerd is spawned. The dep-hash itself is supplied
+# by the runner's install_inputs_hash() so a test can flip it deterministically.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites.generator_client import (
+    GeneratorClient,
+    SmokeGateFailed,
+    build_home,
+)
+
+
+class _CountingRunner:
+    """Fake runner that records call order + counts and serves a controllable
+    install-input hash, so the cache decision can be asserted without bun.
+
+    ``hash_value`` is what install_inputs_hash() returns; flip it between builds
+    to simulate a changed dependency set (which must force a reinstall)."""
+
+    def __init__(self, *, hash_value: str = "h1") -> None:
+        self.hash_value = hash_value
+        self.calls: list[str] = []
+        self.install_count = 0
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.calls.append("generate")
+        # The real generator writes into out_dir and reports the project dir; the
+        # persistent-dir contract is that projectDir == the stable build dir.
+        return {"projectDir": out_dir, "rippleVersion": "0.2.0"}
+
+    def install_inputs_hash(self, project_dir: str) -> str:
+        return self.hash_value
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("install")
+        self.install_count += 1
+        return True, "ok"
+
+    async def smoke(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("smoke")
+        return True, "ok"
+
+
+def _build_kwargs():
+    return dict(
+        ripple_spec={"type": "container"},
+        theme={"primary": "#0A84FF"},
+        site_id="site_1",
+        title="Bright Smile",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+        pocket_id="pocket_abc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_second_build_unchanged_deps_skips_install(tmp_path, monkeypatch):
+    """PERF-3 core: two builds of the same pocket with an UNCHANGED dep-hash run
+    `bun install` exactly ONCE. The second build reuses the cached node_modules."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(hash_value="h1")
+    client = GeneratorClient(_runner=runner)
+
+    first = await client.build(**_build_kwargs())
+    second = await client.build(**_build_kwargs())
+
+    # Install ran on the first build, was SKIPPED on the second (hash unchanged).
+    assert runner.install_count == 1
+    # Both builds still generate + smoke; only install is cached.
+    assert runner.calls == ["generate", "install", "smoke", "generate", "smoke"]
+    # Both builds produced a BuildResult at the SAME stable per-pocket dir.
+    assert first.project_dir == second.project_dir
+
+
+@pytest.mark.asyncio
+async def test_changed_dep_hash_triggers_reinstall(tmp_path, monkeypatch):
+    """A changed install-input fingerprint (new deps / lockfile) forces a reinstall
+    so a stale node_modules never serves old deps."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(hash_value="h1")
+    client = GeneratorClient(_runner=runner)
+
+    await client.build(**_build_kwargs())
+    assert runner.install_count == 1
+
+    # Dependency set changed → new hash → must reinstall.
+    runner.hash_value = "h2-changed"
+    await client.build(**_build_kwargs())
+    assert runner.install_count == 2
+
+
+@pytest.mark.asyncio
+async def test_build_dir_is_stable_per_pocket(tmp_path, monkeypatch):
+    """The build dir is derived from pocket_id under build_home(), so the same
+    pocket always materializes into the same dir (node_modules persists there)."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner()
+    client = GeneratorClient(_runner=runner)
+
+    result = await client.build(**_build_kwargs())
+    expected = build_home() / "pocket_abc"
+    assert result.project_dir == str(expected)
+
+
+@pytest.mark.asyncio
+async def test_different_pockets_get_different_dirs(tmp_path, monkeypatch):
+    """Two distinct pockets must not share a build dir (their node_modules and
+    sources are independent)."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner()
+    client = GeneratorClient(_runner=runner)
+
+    a = await client.build(**{**_build_kwargs(), "pocket_id": "pocket_a"})
+    b = await client.build(**{**_build_kwargs(), "pocket_id": "pocket_b"})
+    assert a.project_dir != b.project_dir
+
+
+def test_build_home_is_env_overridable(tmp_path, monkeypatch):
+    """build_home() mirrors sites_home(): a configurable base dir, env-overridable
+    via PAW_SITES_BUILD_DIR, created on demand."""
+    target = tmp_path / "custom-build-home"
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(target))
+    home = build_home()
+    assert home == target
+    assert home.is_dir()
+
+
+class _FailingInstallRunner(_CountingRunner):
+    """A runner whose install() fails — exercises the cache fail-closed path."""
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("install")
+        self.install_count += 1
+        return False, "bun install failed (exit 1): could not resolve @ripple-ui/svelte"
+
+
+@pytest.mark.asyncio
+async def test_failed_install_does_not_poison_cache(tmp_path, monkeypatch):
+    """A failed install must (a) fail the gate closed (SmokeGateFailed, smoke never
+    runs) and (b) NOT record the hash sentinel, so the NEXT build retries the
+    install rather than skipping it on a never-installed dir."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _FailingInstallRunner(hash_value="h1")
+    client = GeneratorClient(_runner=runner)
+
+    with pytest.raises(SmokeGateFailed):
+        await client.build(**_build_kwargs())
+    # Install ran and failed; smoke must NOT have run.
+    assert runner.calls == ["generate", "install"]
+
+    # Same deps, but because the prior install failed (no sentinel recorded), the
+    # next build retries the install instead of treating it as cached.
+    with pytest.raises(SmokeGateFailed):
+        await client.build(**_build_kwargs())
+    assert runner.install_count == 2

--- a/tests/ee/sites/test_generator_client_smoke_gate.py
+++ b/tests/ee/sites/test_generator_client_smoke_gate.py
@@ -1,0 +1,121 @@
+# tests/ee/sites/test_generator_client_smoke_gate.py
+# Created: 2026-06-18 (feat/sites-smoke-at-publish, PERF-4) — covers the
+# smoke-gate-only-at-publish behaviour:
+#   * build(smoke=False) (the preview/edit/arm path) does NOT run the workerd
+#     smoke render — it is per-edit overhead only needed before a LIVE deploy.
+#   * build() defaults to smoke=True (the live publish path) and DOES run smoke,
+#     keeping the rollback-on-SmokeGateFailed gate unchanged for publish.
+#   * A preview build (smoke=False) is no longer blocked by a would-fail smoke
+#     render (acceptable — publish still gates + rolls back).
+# Asserted via the fake runner's smoke call-count, so no real bun/workerd spawns.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites.generator_client import (
+    GeneratorClient,
+    SmokeGateFailed,
+)
+
+
+class _CountingRunner:
+    """Fake runner that records call order so the smoke decision can be asserted
+    without bun/workerd. ``smoke_ok`` controls whether the smoke render passes."""
+
+    def __init__(self, *, smoke_ok: bool = True, smoke_reason: str = "") -> None:
+        self.smoke_ok = smoke_ok
+        self.smoke_reason = smoke_reason
+        self.calls: list[str] = []
+        self.smoke_count = 0
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.calls.append("generate")
+        return {"projectDir": out_dir, "rippleVersion": "0.2.0"}
+
+    def install_inputs_hash(self, project_dir: str) -> str:
+        return "h1"
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("install")
+        return True, "ok"
+
+    async def smoke(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("smoke")
+        self.smoke_count += 1
+        return self.smoke_ok, self.smoke_reason
+
+
+def _build_kwargs(tmp_path) -> dict:
+    return dict(
+        ripple_spec={"type": "container"},
+        theme={"primary": "#0A84FF"},
+        site_id="site_1",
+        title="Bright Smile",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+        pocket_id="pocket_abc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_build_skips_smoke(tmp_path, monkeypatch):
+    """PERF-4 core: a PREVIEW build (smoke=False) does NOT run the workerd smoke
+    render — the gate is per-edit overhead only needed before a live deploy."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(smoke_ok=True)
+    client = GeneratorClient(_runner=runner)
+
+    result = await client.build(**_build_kwargs(tmp_path), smoke=False)
+
+    # Smoke was SKIPPED — generate + install ran, no smoke.
+    assert runner.smoke_count == 0
+    assert "smoke" not in runner.calls
+    assert runner.calls == ["generate", "install"]
+    # The build still produced a BuildResult.
+    assert result.project_dir == str(tmp_path / "pocket_abc")
+
+
+@pytest.mark.asyncio
+async def test_publish_build_runs_smoke_by_default(tmp_path, monkeypatch):
+    """PERF-4: build() defaults to smoke=True (the live publish path) and DOES run
+    the smoke render, so the publish gate is unchanged."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(smoke_ok=True)
+    client = GeneratorClient(_runner=runner)
+
+    await client.build(**_build_kwargs(tmp_path))  # smoke defaults to True
+
+    assert runner.smoke_count == 1
+    assert runner.calls == ["generate", "install", "smoke"]
+
+
+@pytest.mark.asyncio
+async def test_publish_build_still_gates_on_smoke_failure(tmp_path, monkeypatch):
+    """PERF-4: a publish build (smoke=True) that fails the smoke render still raises
+    SmokeGateFailed — the live gate + rollback behaviour is unchanged."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(
+        smoke_ok=False, smoke_reason="workerd SSR failure: window is not defined"
+    )
+    client = GeneratorClient(_runner=runner)
+
+    with pytest.raises(SmokeGateFailed) as exc:
+        await client.build(**_build_kwargs(tmp_path), smoke=True)
+    assert "window is not defined" in str(exc.value)
+    assert runner.smoke_count == 1
+
+
+@pytest.mark.asyncio
+async def test_preview_build_not_blocked_by_would_fail_smoke(tmp_path, monkeypatch):
+    """PERF-4: a preview build (smoke=False) is NOT blocked even when the smoke
+    render WOULD fail — smoke never runs, so no SmokeGateFailed is raised
+    (acceptable; the live publish still gates + rolls back)."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _CountingRunner(
+        smoke_ok=False, smoke_reason="workerd SSR failure: window is not defined"
+    )
+    client = GeneratorClient(_runner=runner)
+
+    # No raise — the preview build completes despite a would-fail smoke render.
+    result = await client.build(**_build_kwargs(tmp_path), smoke=False)
+    assert result.project_dir == str(tmp_path / "pocket_abc")
+    assert runner.smoke_count == 0

--- a/tests/ee/sites/test_pipeline_regression_gate.py
+++ b/tests/ee/sites/test_pipeline_regression_gate.py
@@ -1,0 +1,216 @@
+# tests/ee/sites/test_pipeline_regression_gate.py
+# Created: 2026-06-19 (P2c — the cross-repo E2E regression gate).
+#
+# THE PIPELINE REGRESSION GATE. This is the ONE consolidated end-to-end test that
+# would have caught F1 + F2 + F4 TOGETHER — the three Paw Sites pipeline failures
+# that each shipped because no single test exercised the real build → deploy_local
+# → serve path AND the request-publish entry AND the build-path workerd reap in one
+# place. Each prior failure had its own narrow unit test; this gate asserts the
+# whole pipeline so a regression in any leg fails here, loudly, before it ships.
+#
+# It asserts, end-to-end on the REAL build+deploy_local path (the build itself is
+# faked behind the GeneratorClient ``_runner`` seam — no real bun/node/workerd):
+#   (a) F1 — arming a svelte pocket: the SERVED preview index.html (the DEPLOYED
+#       file, NOT the source) contains BOTH ``data-paw-section`` AND
+#       ``id="paw-edit-bridge"`` (the overlay contract the hover edit-pill needs).
+#   (b) F2 — request-publish succeeds on a FRESH pocket AND on a LEGACY-shaped
+#       pocket (zero artifact_versions). Both must SELF-HEAL a backfilled draft and
+#       return a review Action, never 400.
+#   (c) F4 — the build-path workerd nets ZERO across a build: the reaper fires once,
+#       scoped to the build's project dir, after the static build. Reuses the exact
+#       reap assertion from test_preview_serves_fresh_anchored_build.py rather than
+#       duplicating it — it drives the REAL runner's build_static with a faked
+#       subprocess and spies reap_build_workerd.
+#
+# Reuse, don't re-implement: the served-anchored-build fake runner comes from Agent
+# A's test module (``_StaticBuildRunner``); the request-publish self-heal contract
+# is the same one Agent B's test_request_publish.py pins; the reap leg reuses the
+# generator_client reap wiring. This file CONSOLIDATES those into one gate.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Reuse Agent A's fake runner (the one that drops a STALE anchorless build on
+# ``generate`` and overwrites it with the FRESH ANCHORED build on the static-build
+# step) so the served-file contract is asserted on the exact same mechanics, not a
+# re-implementation.
+from tests.ee.sites.test_preview_serves_fresh_anchored_build import (
+    _FRESH_ANCHORED_HTML,
+    _StaticBuildRunner,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _recording_bus():
+    """Install a recording EventBus so the pockets service's ``emit`` calls don't
+    raise (the real bus is only wired by ``init_realtime()`` at boot). Mirrors the
+    fixture in test_preview_serves_fresh_anchored_build.py — autouse fixtures are
+    module-scoped, so the gate needs its own copy."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+async def _make_svelte_pocket(name: str) -> str:
+    """Create a real svelte pocket (zero artifact_versions — agent_create does not
+    record a draft on create) and return its id. This is BOTH the fresh-pocket and
+    the legacy-shaped case: a pocket with live content but no version rows."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws-gate",
+        owner_id="u-gate",
+        name=name,
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source={"src/routes/+page.svelte": "<h1>hi</h1>"},
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+async def test_sites_pipeline_regression_gate(beanie_test_db, tmp_path, monkeypatch):
+    """THE PIPELINE REGRESSION GATE (P2c) — the consolidated F1+F2+F4 cover.
+
+    One test, the whole pipeline. A regression in ANY of the three legs fails here.
+    """
+    from pocketpaw_ee.sites import local_server
+    from pocketpaw_ee.sites import service as sites_service
+
+    # Build + serve under throwaway dirs so the real home is never touched.
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path / "builds"))
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+    # ---- (a) F1: arming a svelte pocket SERVES a fresh anchored+bridged build ----
+    fresh_pocket = await _make_svelte_pocket("Gate Fresh")
+
+    runner = _StaticBuildRunner()
+    gen = sites_service.GeneratorClient(_runner=runner)
+
+    # The EDITABLE preview / arm path (preview=True + builder_origin) — the real
+    # make_site_editable / edit flow. REAL local deploy (persist + serve).
+    site = await sites_service.publish_pocket(
+        workspace_id="ws-gate",
+        user_id="u-gate",
+        pocket_id=fresh_pocket,
+        preview=True,
+        builder_origin="http://localhost:8888",
+        _generator=gen,
+    )
+
+    served = local_server.sites_home() / f"preview-{fresh_pocket}" / "index.html"
+    assert served.is_file(), f"the arm/preview path served no index.html at {served}"
+    html = served.read_text()
+    assert "data-paw-section" in html, (
+        "F1 REGRESSION: the SERVED preview HTML has no section anchors — the hover "
+        "edit-pill can never bind (a stale, anchorless build was served)"
+    )
+    assert 'id="paw-edit-bridge"' in html, (
+        "F1 REGRESSION: the SERVED preview HTML has no edit-bridge — the iframe "
+        "can't postMessage section rects (a stale build with no bridge was served)"
+    )
+    # It is the FRESH build the static-build step emitted, not the stale on-disk one.
+    assert _FRESH_ANCHORED_HTML == html
+    assert runner.static_build_count == 1, "the arm path must run `bun run build`"
+    assert site.url.endswith(f"/preview-{fresh_pocket}/")
+    # An arm/preview is NOT a live deploy → no deployed_at stamp leaks onto it (P2b).
+    assert site.deployed is False
+    assert site.deployed_at is None
+
+    # ---- (b) F2: request-publish self-heals on FRESH and LEGACY-shaped pockets ----
+    # A throwaway InstinctStore wired where both the sites service and the BP-3
+    # executor read it, so request-publish can create the review Action.
+    from pocketpaw.instinct.store import InstinctStore
+
+    store = InstinctStore(tmp_path / "gate_instinct.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+
+    from pocketpaw_ee.versions import service as versions
+
+    # FRESH pocket: zero artifact_versions (agent_create records none). Submit for
+    # review must BACKFILL a draft from the pocket's current content, not 400.
+    assert await versions.get_draft(scope_type="pocket", scope_id=fresh_pocket) is None
+    action_fresh = await sites_service.request_publish_pocket(
+        workspace_id="ws-gate", user_id="u-gate", pocket_id=fresh_pocket
+    )
+    assert action_fresh is not None, "F2 REGRESSION: request-publish 400'd on a fresh pocket"
+    healed_fresh = await versions.get_draft(scope_type="pocket", scope_id=fresh_pocket)
+    assert healed_fresh is not None, "request-publish must self-heal a draft for a fresh pocket"
+    assert action_fresh.parameters["_artifact_change"]["to_version_id"] == str(healed_fresh.id)
+
+    # LEGACY-shaped pocket: same zero-versions shape (a site published before BP-1).
+    # The self-heal path is identical — a second independent pocket proves it is not
+    # the first call that happened to seed state.
+    legacy_pocket = await _make_svelte_pocket("Gate Legacy")
+    assert await versions.get_draft(scope_type="pocket", scope_id=legacy_pocket) is None
+    action_legacy = await sites_service.request_publish_pocket(
+        workspace_id="ws-gate", user_id="u-gate", pocket_id=legacy_pocket
+    )
+    assert action_legacy is not None, (
+        "F2 REGRESSION: request-publish 400'd on a legacy-shaped pocket"
+    )
+    healed_legacy = await versions.get_draft(scope_type="pocket", scope_id=legacy_pocket)
+    assert healed_legacy is not None, "request-publish must self-heal a legacy-shaped pocket"
+    # First publish for each — nothing was ever published, so from is None.
+    assert action_legacy.parameters["_artifact_change"]["from_version_id"] is None
+
+    # ---- (c) F4: the build-path workerd nets ZERO across a build ----
+    # Reuse the reap wiring assertion (the same contract Agent A's
+    # test_build_reaps_workerd_after_static_build pins): drive the REAL runner's
+    # build_static with a faked subprocess and spy the reaper — it must fire once,
+    # scoped to THIS build's project dir, so no workerd is left behind (net zero).
+    from pocketpaw_ee.sites import generator_client
+
+    reaped: list[str] = []
+    monkeypatch.setattr(
+        generator_client,
+        "reap_build_workerd",
+        lambda project_dir: reaped.append(project_dir),
+    )
+
+    async def _fake_exec(*args, **kwargs):
+        class _P:
+            returncode = 0
+
+            async def communicate(self):
+                return b"built ok", b""
+
+        return _P()
+
+    monkeypatch.setattr(generator_client.asyncio, "create_subprocess_exec", _fake_exec)
+
+    real_runner = generator_client._SubprocessRunner()
+    build_dir = str(tmp_path / "reap-proj")
+    Path(build_dir).mkdir(parents=True, exist_ok=True)
+    ok, reason = await real_runner.build_static(build_dir, gate=True)
+
+    assert ok, reason
+    assert reaped == [build_dir], (
+        "F4 REGRESSION: the build-path workerd was not reaped after the static "
+        "build — orphaned workerd processes pile up and slow the box (net != zero)"
+    )

--- a/tests/ee/sites/test_plan_gate.py
+++ b/tests/ee/sites/test_plan_gate.py
@@ -1,0 +1,257 @@
+# tests/ee/sites/test_plan_gate.py
+# Created: 2026-06-17 (fix/sites-plan-gate-asymmetry) — reproduce-first coverage
+# for the Sites plan-gate asymmetry bug. Sites is a fabric-gated feature: the REST
+# router gates every endpoint with require_plan_feature("fabric"), but the chat
+# agent creates + publishes sites IN-PROCESS (the sites_manager MCP tools call the
+# create handlers + publish_pocket directly), bypassing the HTTP router. Net bug:
+# on a `team`-plan workspace the agent happily created and deployed a live site,
+# but GET /sites 403'd — a created-but-invisible resource (write path ungated,
+# read path gated). This suite asserts the in-process write paths are now gated at
+# the SERVICE chokepoint, identically to HTTP:
+#   1. publish_pocket() / publish() raise Forbidden("plan.feature_denied") on a
+#      team plan, and succeed on business/enterprise.
+#   2. The create MCP handlers (landing / svelte) surface the same
+#      plan.feature_denied as an MCP error on a team plan, and create on business.
+# (origin/dev ships the landing + svelte create tools; the dynamic create tool is
+# not yet on dev, so it is out of scope for this PR.)
+# The plan is controlled by patching workspace_service.get_workspace_plan (same
+# technique as tests/cloud/test_plan_feature_gate.py) so no plan-seeding is needed.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+# A minimal landing copy object — enough for assemble_landing_spec on the
+# business-plan success path. The team-plan path is rejected before assembly.
+def _landing_content() -> dict:
+    return {
+        "brand": "Acme",
+        "hero": {"title": "Get paid faster", "subtitle": "Invoicing for freelancers"},
+        "footer": {"copyright": "Acme"},
+    }
+
+
+def _patch_plan(plan: str):
+    """Patch workspace_service.get_workspace_plan to return a fixed plan tier for
+    BOTH the sites service and the create MCP handlers (they both read the plan
+    via workspace_service.get_workspace_plan). Returns the patch context manager."""
+    return patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value=plan),
+    )
+
+
+def _patch_identity(workspace_id: str, user_id: str):
+    """Patch the per-stream identity ContextVars the create MCP handlers read."""
+    return (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            return_value=workspace_id,
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            return_value=user_id,
+        ),
+    )
+
+
+@pytest.fixture()
+def recording_bus():
+    """Install a recording EventBus so agent_create's emit(PocketCreated) doesn't
+    raise (the real bus is only wired by init_realtime() at boot). Mirrors
+    tests/ee/agent/test_sites_mcp_server/test_create_dynamic_site.py."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# publish() / publish_pocket() — the shared publish chokepoint (REST + MCP)
+# ---------------------------------------------------------------------------
+
+
+class TestPublishPlanGate:
+    @pytest.mark.asyncio
+    async def test_publish_pocket_on_team_plan_is_forbidden(self) -> None:
+        """The shared publish path must reject a team-plan workspace with
+        plan.feature_denied, BEFORE reading the pocket or invoking the generator
+        (so this proves the gate, not an incidental missing-pocket error)."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud._core.errors import Forbidden
+        from pocketpaw_ee.sites import service as sites_service
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+
+        with _patch_plan("team"):
+            with pytest.raises(Forbidden) as ei:
+                await sites_service.publish_pocket(
+                    workspace_id=workspace_id,
+                    user_id=user_id,
+                    pocket_id=str(ObjectId()),
+                )
+        assert ei.value.code == "plan.feature_denied"
+        assert ei.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_publish_on_team_plan_is_forbidden(self) -> None:
+        """publish() (the inner funnel the REST endpoint also reaches) is gated
+        too, so a direct service caller can't slip past the publish_pocket guard."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud._core.errors import Forbidden
+        from pocketpaw_ee.sites import service as sites_service
+
+        with _patch_plan("team"):
+            with pytest.raises(Forbidden) as ei:
+                await sites_service.publish(
+                    workspace_id=str(ObjectId()),
+                    user_id=str(ObjectId()),
+                    pocket_id=str(ObjectId()),
+                    ripple_spec={"version": 1, "state": {}, "ui": {"type": "container"}},
+                    theme={},
+                )
+        assert ei.value.code == "plan.feature_denied"
+
+    @pytest.mark.asyncio
+    async def test_publish_pocket_on_business_plan_passes_the_gate(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """A business-plan workspace passes the gate and publishes. The generator
+        + Cloudflare client are faked so this runs without Bun/workerd/CF; the
+        assertion is that the gate did NOT fire (the publish proceeds and persists
+        a Site), not the deploy mechanics."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud.pockets.service import agent_create
+        from pocketpaw_ee.sites import service as sites_service
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+
+        # Seed a real source pocket to publish (a minimal landing site spec).
+        from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+
+        ripple_spec = assemble_landing_spec(_landing_content())
+        view, pocket_id, err = await agent_create(
+            workspace_id=workspace_id,
+            owner_id=user_id,
+            name="Acme",
+            type_="site",
+            pattern="landing",
+            ripple_spec=ripple_spec,
+            trusted=True,
+        )
+        assert err is None and pocket_id is not None, err
+
+        class _FakeBuild:
+            project_dir = "/tmp/does-not-matter"
+
+        class _FakeGenerator:
+            async def build(self, **_kwargs):  # noqa: ANN003
+                return _FakeBuild()
+
+        class _FakeCloudflare:
+            async def put_worker(self, **_kwargs):  # noqa: ANN003
+                return None
+
+        with _patch_plan("business"):
+            doc = await sites_service.publish_pocket(
+                workspace_id=workspace_id,
+                user_id=user_id,
+                pocket_id=pocket_id,
+                _generator=_FakeGenerator(),
+                _cloudflare=_FakeCloudflare(),
+                _bundle_reader=lambda _d: b"worker-bundle",
+            )
+        assert doc is not None
+        assert doc.workspace == workspace_id
+        assert doc.pocket_id == pocket_id
+
+
+# ---------------------------------------------------------------------------
+# create MCP handlers — the in-process create bypass (landing / svelte / dynamic)
+# ---------------------------------------------------------------------------
+
+
+def _svelte_source() -> dict:
+    return {
+        "src/routes/+page.svelte": (
+            "<script>import Hero from '$lib/components/Hero.svelte';</script><Hero />"
+        ),
+        "src/routes/+layout.svelte": "<script>import '../app.css';</script>",
+        "src/routes/+page.ts": "export const prerender = true;",
+        "src/app.css": ":root{}",
+        "src/lib/components/Hero.svelte": "<section><h1>Hi</h1></section>",
+    }
+
+
+class TestCreateHandlersPlanGate:
+    @pytest.mark.asyncio
+    async def test_create_landing_site_on_team_plan_is_error(self, recording_bus) -> None:
+        # recording_bus is installed so that, on the BUGGY (pre-fix) code, the
+        # handler proceeds past the absent gate and into agent_create instead of
+        # raising "EventBus not initialized" — making the failure a clean
+        # "missing plan.feature_denied" rather than a noisy crash. After the fix
+        # the guard fires before agent_create, so the bus is never reached.
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        workspace_id, user_id = "ws_team", "u_1"
+        pw, pu = _patch_identity(workspace_id, user_id)
+        with _patch_plan("team"), pw, pu:
+            out = await mcp._create_landing_site_handler({"content": _landing_content()})
+        assert out.get("is_error") is True
+        assert "plan.feature_denied" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_create_svelte_site_on_team_plan_is_error(self, recording_bus) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        pw, pu = _patch_identity("ws_team", "u_1")
+        with _patch_plan("team"), pw, pu:
+            out = await mcp._create_svelte_site_handler({"source": _svelte_source()})
+        assert out.get("is_error") is True
+        assert "plan.feature_denied" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_create_landing_site_on_business_plan_creates(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """Business plan passes the gate and the landing site is created (ground
+        truth: a pocket lands and the handler returns ok)."""
+        from bson import ObjectId
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+        pw, pu = _patch_identity(workspace_id, user_id)
+        with _patch_plan("business"), pw, pu:
+            out = await mcp._create_landing_site_handler(
+                {"content": _landing_content(), "name": "Acme"}
+            )
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        doc = await _PocketDoc.get(ObjectId(body["pocket_id"]))
+        assert doc is not None
+        assert doc.type == "site"

--- a/tests/ee/sites/test_preview_serves_fresh_anchored_build.py
+++ b/tests/ee/sites/test_preview_serves_fresh_anchored_build.py
@@ -1,0 +1,359 @@
+# tests/ee/sites/test_preview_serves_fresh_anchored_build.py
+# Created: 2026-06-19 (fix/sites-preview-fresh-build, P0a + P1a) — reproduce-first
+# cover for the #1 Paw Sites bug: the hover edit-pill never appears because the
+# editable PREVIEW build SERVED STALE HTML without the data-paw-section anchors.
+#
+# ROOT CAUSE (PERF-4 overloaded the ``smoke`` flag): the ``smoke`` flag gated
+# ``_runner.smoke()``, the ONLY step that ran ``bun run build`` — the step that
+# emits the deployable ``.svelte-kit/cloudflare/`` static output (with the section
+# anchors + the injected ``id="paw-edit-bridge"``). ``service.publish()`` passes
+# ``smoke = not preview``, so the preview/editable path re-stamped the SOURCE with
+# anchors but SKIPPED ``bun run build``; ``persist_site`` then copied whatever the
+# LAST build left on disk — the stale, non-anchored LIVE build. So the SERVED
+# preview had 0 anchors → no pill.
+#
+# These tests assert on the SERVED (deployed) ``index.html`` — NOT the source — so
+# they prove the file the iframe actually loads carries the anchors + bridge:
+#   * test_preview_serves_fresh_anchored_build — FAILS on the pre-fix code (the
+#     served file is the stale non-anchored build) and PASSES after the fix
+#     (``bun run build`` always runs on the preview/local-served path, so the
+#     served file is the FRESH anchored build).
+#   * test_build_reaps_workerd_after_static_build — P1a: the build-path workerd
+#     leak is reaped after each ``bun run build`` (the reap function is invoked).
+#
+# The build is faked behind the GeneratorClient ``_runner`` seam: ``generate``
+# writes a STALE (anchorless) ``.svelte-kit/cloudflare/index.html`` to simulate a
+# prior LIVE build sitting on disk; the static-build step (``bun run build``)
+# overwrites it with the FRESH ANCHORED build. No real bun/node/workerd spawns.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.sites import local_server
+
+pytestmark = pytest.mark.asyncio
+
+# What the prior LIVE build left on disk: NO anchors, NO bridge — the stale HTML
+# the bug serves on a preview.
+_STALE_HTML = "<html><body><h1>old live build</h1></body></html>"
+# What a FRESH `bun run build` of an EDITABLE site emits: section anchors + the
+# injected edit-bridge. The exact tokens the hover edit-pill overlay needs.
+_FRESH_ANCHORED_HTML = (
+    '<html><head><script id="paw-edit-bridge">/* bridge */</script></head>'
+    '<body><section data-paw-section="hero"><h1>fresh editable build</h1></section>'
+    "</body></html>"
+)
+
+_CLOUDFLARE_BUILD_REL = ".svelte-kit/cloudflare"
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Install a recording EventBus so the pockets service's ``emit`` calls don't
+    raise (the real bus is only wired by ``init_realtime()`` at boot)."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+class _StaticBuildRunner:
+    """Fake runner that models the on-disk build output: ``generate`` drops a
+    STALE anchorless build (a prior live build), and the static-build step
+    (``build_static`` — the real runner's ``bun run build``) overwrites it with
+    the FRESH ANCHORED build. This is how the SERVED file ends up stale when the
+    static build is skipped on the preview path (the bug)."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.static_build_count = 0
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.calls.append("generate")
+        # Simulate a stale prior LIVE build already on disk (anchorless HTML).
+        cf = Path(out_dir, _CLOUDFLARE_BUILD_REL)
+        cf.mkdir(parents=True, exist_ok=True)
+        (cf / "index.html").write_text(_STALE_HTML)
+        return {"projectDir": out_dir, "rippleVersion": "0.2.0"}
+
+    def install_inputs_hash(self, project_dir: str) -> str:
+        return "h1"
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("install")
+        return True, "ok"
+
+    async def build_static(self, project_dir: str, *, gate: bool) -> tuple[bool, str]:
+        """The static-output step (== the real runner's ``bun run build``). Always
+        emits the FRESH ANCHORED build; ``gate`` toggles only the SSR fail-check."""
+        self.calls.append("build_static")
+        self.static_build_count += 1
+        cf = Path(project_dir, _CLOUDFLARE_BUILD_REL)
+        cf.mkdir(parents=True, exist_ok=True)
+        (cf / "index.html").write_text(_FRESH_ANCHORED_HTML)
+        return True, "ok"
+
+
+async def test_preview_serves_fresh_anchored_build(beanie_test_db, tmp_path, monkeypatch):
+    """The #1 bug, reproduce-first: the SERVED preview index.html (the DEPLOYED
+    file, not the source) must contain BOTH ``data-paw-section`` AND
+    ``id="paw-edit-bridge"``. On the pre-fix code the preview path skipped
+    ``bun run build`` and ``persist_site`` copied the stale anchorless build, so
+    this FAILS; with the fix the static build always runs on the preview path so
+    the served file is fresh + anchored."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites import service as sites_service
+
+    # Build + serve under throwaway dirs so the real home is never touched.
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path / "builds"))
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+    # A real svelte pocket so publish_pocket reads engine/source from the wire.
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source={"src/routes/+page.svelte": "<h1>hi</h1>"},
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+
+    runner = _StaticBuildRunner()
+    gen = sites_service.GeneratorClient(_runner=runner)
+
+    # The EDITABLE preview path (preview=True + builder_origin) — exactly the
+    # make_site_editable / edit flow. Real local deploy (persist + serve).
+    site = await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        preview=True,
+        builder_origin="http://localhost:8888",
+        _generator=gen,
+    )
+
+    # Read the SERVED (deployed) file — the one the iframe loads — NOT the source.
+    served = local_server.sites_home() / f"preview-{pocket_id}" / "index.html"
+    assert served.is_file(), f"no served preview index.html at {served}"
+    html = served.read_text()
+
+    assert "data-paw-section" in html, (
+        "the SERVED preview HTML has no section anchors — the hover edit-pill can "
+        "never bind (the bug: a stale, anchorless build was served)"
+    )
+    assert 'id="paw-edit-bridge"' in html, (
+        "the SERVED preview HTML has no edit-bridge — the iframe can't postMessage "
+        "section rects (the bug: a stale build with no injected bridge was served)"
+    )
+    # And it is the FRESH build, not the stale one left on disk by `generate`.
+    assert "fresh editable build" in html
+    assert "old live build" not in html
+    # The static build (`bun run build`) actually ran on the preview path.
+    assert runner.static_build_count == 1
+    # The site URL points at the stable preview path the served file lives under.
+    assert site.url.endswith(f"/preview-{pocket_id}/")
+
+
+async def test_build_reaps_workerd_after_static_build(tmp_path, monkeypatch):
+    """P1a: each static build (``bun run build``) reaps the prerender-spawned
+    workerd so they don't pile up. Asserted by spying the reap function — it is
+    invoked once per static build, scoped to the build's project dir."""
+    from pocketpaw_ee.sites import generator_client
+
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+
+    reaped: list[str] = []
+    monkeypatch.setattr(
+        generator_client,
+        "reap_build_workerd",
+        lambda project_dir: reaped.append(project_dir),
+    )
+
+    runner = generator_client._SubprocessRunner()
+
+    # Drive only the static-build step with a fake `bun run build` that succeeds
+    # without spawning a real process, so we isolate the reap-after-build wiring.
+    async def _fake_exec(*args, **kwargs):
+        class _P:
+            returncode = 0
+
+            async def communicate(self):
+                return b"built ok", b""
+
+        return _P()
+
+    monkeypatch.setattr(generator_client.asyncio, "create_subprocess_exec", _fake_exec)
+
+    project_dir = str(tmp_path / "proj")
+    Path(project_dir).mkdir(parents=True, exist_ok=True)
+    ok, reason = await runner.build_static(project_dir, gate=True)
+
+    assert ok, reason
+    # The reaper ran exactly once, scoped to THIS build's project dir.
+    assert reaped == [project_dir]
+
+
+# --- the split semantics: bun run build vs the SSR fail-gate --------------------
+
+
+class _SplitCountingRunner:
+    """A runner with ``build_static`` that records the call sequence + the ``gate``
+    flag, so the split (always-build vs gate-only-on-publish) can be asserted
+    without bun/workerd. ``ssr_fail`` makes the build report an SSR marker."""
+
+    def __init__(self, *, ssr_fail: bool = False) -> None:
+        self.calls: list[str] = []
+        self.build_static_count = 0
+        self.last_gate: bool | None = None
+        self.ssr_fail = ssr_fail
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.calls.append("generate")
+        return {"projectDir": out_dir, "rippleVersion": "0.2.0"}
+
+    def install_inputs_hash(self, project_dir: str) -> str:
+        return "h1"
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("install")
+        return True, "ok"
+
+    async def build_static(self, project_dir: str, *, gate: bool) -> tuple[bool, str]:
+        self.calls.append("build_static")
+        self.build_static_count += 1
+        self.last_gate = gate
+        if self.ssr_fail and gate:
+            return False, "workerd SSR failure: window is not defined"
+        return True, "ok"
+
+
+def _kwargs(tmp_path):
+    return dict(
+        ripple_spec={"type": "container"},
+        theme={"primary": "#0A84FF"},
+        site_id="site_1",
+        title="Bright Smile",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+        pocket_id="pocket_abc",
+    )
+
+
+async def test_preview_build_still_runs_static_build_gate_off(tmp_path, monkeypatch):
+    """P0a core: a PREVIEW build (smoke=False) STILL runs `bun run build`
+    (build_static) — only the SSR fail-gate is off. Before the fix smoke=False
+    skipped the build entirely, which served the stale anchorless output."""
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _SplitCountingRunner()
+    client = GeneratorClient(_runner=runner)
+
+    await client.build(**_kwargs(tmp_path), smoke=False)
+
+    assert runner.build_static_count == 1, "the preview path must still BUILD"
+    assert runner.last_gate is False, "the SSR fail-gate is OFF on a preview build"
+    assert runner.calls == ["generate", "install", "build_static"]
+
+
+async def test_publish_build_runs_static_build_with_gate_on(tmp_path, monkeypatch):
+    """A LIVE publish (smoke=True default) builds AND turns the SSR fail-gate ON."""
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _SplitCountingRunner()
+    client = GeneratorClient(_runner=runner)
+
+    await client.build(**_kwargs(tmp_path))  # smoke defaults to True
+
+    assert runner.build_static_count == 1
+    assert runner.last_gate is True, "the SSR fail-gate is ON for a live publish"
+
+
+async def test_publish_still_gates_on_ssr_failure(tmp_path, monkeypatch):
+    """The split keeps the publish gate: a live build whose SSR render fails still
+    raises SmokeGateFailed."""
+    from pocketpaw_ee.sites.generator_client import GeneratorClient, SmokeGateFailed
+
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _SplitCountingRunner(ssr_fail=True)
+    client = GeneratorClient(_runner=runner)
+
+    with pytest.raises(SmokeGateFailed) as exc:
+        await client.build(**_kwargs(tmp_path), smoke=True)
+    assert "window is not defined" in str(exc.value)
+
+
+async def test_preview_not_blocked_by_would_fail_ssr(tmp_path, monkeypatch):
+    """A preview build (smoke=False) is NOT blocked by a would-fail SSR render — it
+    builds + serves fresh; the live publish still gates + rolls back."""
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _SplitCountingRunner(ssr_fail=True)
+    client = GeneratorClient(_runner=runner)
+
+    # No raise — the preview builds despite a would-fail SSR render.
+    result = await client.build(**_kwargs(tmp_path), smoke=False)
+    assert result.project_dir == str(tmp_path / "pocket_abc")
+    assert runner.build_static_count == 1
+
+
+async def test_static_build_false_skips_build(tmp_path, monkeypatch):
+    """The dev-server path (static_build=False, serves from `vite dev`) skips the
+    static build entirely — only generate + install run."""
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    runner = _SplitCountingRunner()
+    client = GeneratorClient(_runner=runner)
+
+    await client.build(**_kwargs(tmp_path), smoke=False, static_build=False)
+
+    assert runner.build_static_count == 0, "the dev path must NOT run `bun run build`"
+    assert runner.calls == ["generate", "install"]
+
+
+async def test_deploy_local_fails_soft_on_missing_build(tmp_path, monkeypatch):
+    """P1a: deploy_local returns the PRIOR deploy's URL (not a 500) when a fresh
+    build produced no static output but a prior deploy is on disk; with no prior
+    deploy it raises a clear MissingBuildOutput instead of a bare FileNotFoundError."""
+    from pocketpaw_ee.sites import local_server
+
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+
+    # No build output AND no prior deploy → clear typed error (not a bare 500).
+    empty_proj = tmp_path / "empty-proj"
+    empty_proj.mkdir()
+    with pytest.raises(local_server.MissingBuildOutput):
+        local_server.deploy_local("site_x", str(empty_proj))
+
+    # Seed a prior deploy, then deploy a project with NO fresh build → fail soft to
+    # the prior URL.
+    prior = local_server.sites_home() / "site_x"
+    prior.mkdir(parents=True, exist_ok=True)
+    (prior / "index.html").write_text("<html>prior good build</html>")
+    url = local_server.deploy_local("site_x", str(empty_proj))
+    assert url.endswith("/site_x/")

--- a/tests/ee/sites/test_request_publish.py
+++ b/tests/ee/sites/test_request_publish.py
@@ -137,6 +137,75 @@ async def test_request_publish_ignores_foreign_workspace_draft(beanie_test_db, i
 
 
 # ---------------------------------------------------------------------------
+# P0b — a LEGACY site (published before BP-1) has ZERO artifact_versions rows,
+# so it has no draft. Submit-for-review must BACKFILL a draft snapshot of the
+# pocket's current content and succeed — not 400. Only a genuinely empty /
+# nonexistent pocket keeps the 400.
+# ---------------------------------------------------------------------------
+
+
+async def test_request_publish_backfills_draft_for_legacy_site(
+    beanie_test_db, instinct_store, monkeypatch
+):
+    """THE BUG (P0b): a site published before BP-1 has ZERO artifact_versions rows,
+    so ``get_draft`` is None and (pre-fix) ``request_publish_pocket`` raised
+    ValueError → the Submit-for-review UI 400'd. The fix backfills a draft snapshot
+    of the pocket's CURRENT content via ``_ensure_pocket_draft`` and then proceeds
+    to create the review Action.
+
+    Before the fix this fails: zero versions → get_draft None → ValueError.
+    """
+    # No artifact_versions exist for this pocket at all (the legacy-site state).
+    assert await versions.get_draft(scope_type="pocket", scope_id=POCKET) is None
+
+    # The pocket itself still has its current (ripple) content — the legacy live
+    # site. ``_ensure_pocket_draft`` reads it through the pockets service.
+    current_spec = {"widgets": [{"type": "hero", "props": {"title": "PawPlace"}}]}
+
+    async def _fake_get(pocket_id: str, user_id: str) -> dict:
+        assert pocket_id == POCKET
+        return {"id": POCKET, "engine": "ripple", "rippleSpec": current_spec}
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.service.get", _fake_get)
+
+    action = await sites_service.request_publish_pocket(
+        workspace_id=WS, user_id=USER, pocket_id=POCKET
+    )
+
+    # A draft was backfilled from the pocket's current content.
+    draft = await versions.get_draft(scope_type="pocket", scope_id=POCKET)
+    assert draft is not None, "a legacy site with no versions must get a backfilled draft"
+    assert draft.workspace_id == WS
+    assert draft.content == current_spec
+
+    # And the review Action was created over that backfilled draft (no 400).
+    assert action is not None
+    blob = action.parameters["_artifact_change"]
+    assert blob["to_version_id"] == str(draft.id)
+    # Nothing was published before — a first publish.
+    assert blob["from_version_id"] is None
+
+
+async def test_request_publish_genuinely_empty_pocket_still_raises(
+    beanie_test_db, instinct_store, monkeypatch
+):
+    """A pocket with no versions AND no current content (genuinely empty) keeps the
+    400: there is nothing to snapshot, so the backfill writes an empty draft only if
+    content exists — an empty pocket has nothing to review."""
+    from pocketpaw_ee.cloud.shared.errors import NotFound
+
+    async def _fake_get_missing(pocket_id: str, user_id: str) -> dict:
+        raise NotFound("pocket", pocket_id)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.service.get", _fake_get_missing)
+
+    with pytest.raises(ValueError):
+        await sites_service.request_publish_pocket(
+            workspace_id=WS, user_id=USER, pocket_id="ghost-pocket"
+        )
+
+
+# ---------------------------------------------------------------------------
 # The round-trip — request-publish → approve (real gate + real merge executor)
 # → the reviewed draft version is published.
 # ---------------------------------------------------------------------------

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -239,6 +239,74 @@ async def test_status_by_pocket_published_is_live(_seeded_site, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_dev_preview_by_pocket_returns_url(beanie_test_db, monkeypatch):
+    """POST /sites/by-pocket/{id}/dev-preview returns {pocket_id, url} — the live
+    Vite dev-server URL for the editing preview (P2a). The route delegates to
+    sites_service.dev_preview_pocket → the DevServerManager singleton; we inject a
+    manager built with fake spawn/port/materialize seams so no real vite is spawned,
+    exercising the real service→manager→endpoint path end to end."""
+    import pocketpaw_ee.sites.dev_server as dev_server_mod
+    from pocketpaw_ee.sites.dev_server import DevServerManager
+
+    async def _fake_materialize(*, workspace_id, user_id, pocket_id):
+        return f"/tmp/site-builds/{pocket_id}"
+
+    async def _fake_spawn(cmd, cwd, port):
+        class _P:
+            returncode = None
+
+            def terminate(self):
+                pass
+
+            def kill(self):
+                pass
+
+            async def wait(self):
+                return 0
+
+        return _P()
+
+    mgr = DevServerManager(
+        _spawn=_fake_spawn, _free_port=lambda: 41234, _materialize=_fake_materialize
+    )
+    monkeypatch.setattr(dev_server_mod, "_MANAGER", mgr)
+
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/by-pocket/pk1/dev-preview")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {"pocket_id": "pk1", "url": "http://127.0.0.1:41234/"}
+    # The endpoint actually started a server in the singleton.
+    assert mgr.live_pocket_ids() == ["pk1"]
+    await mgr.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_dev_preview_by_pocket_missing_pocket_is_404(beanie_test_db, monkeypatch):
+    """A missing / access-denied pocket surfaces as a 404: the DEFAULT materialize
+    reads the pocket via the pockets service, whose NotFound flows through the
+    standard error handler."""
+    from unittest.mock import AsyncMock
+
+    import pocketpaw_ee.sites.dev_server as dev_server_mod
+    from pocketpaw_ee.cloud._core.errors import NotFound
+    from pocketpaw_ee.sites.dev_server import DevServerManager
+
+    # Fresh singleton with the REAL materialize so it hits the pockets service.
+    monkeypatch.setattr(dev_server_mod, "_MANAGER", DevServerManager())
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(side_effect=NotFound("pocket", "pk_missing")),
+    )
+
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/by-pocket/pk_missing/dev-preview")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_post_reserve_returns_reconciled_list(beanie_test_db, monkeypatch):
     """POST /sites/reserve (re)starts the local server and returns the caller's
     workspace site list with fresh urls. The handler delegates to

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -30,6 +30,13 @@
 # service (mocked here, as the preview/status tests do) and runs the pure audit
 # engine. Asserts a site with known issues surfaces findings (each with a
 # fix_prompt), a clean site returns an empty list, and a missing pocket is a 404.
+#
+# Updated 2026-06-19 (P2b-backend): adds coverage for POST
+# /sites/by-pocket/{pocket_id}/versions/{version_no}/revert — revert to a prior
+# version by ordinal. The handler delegates to sites_service.revert_pocket_version
+# (over the real versions spine) and returns the new draft as a SiteVersionResponse;
+# an unknown version_no is a 404. Also asserts the seeded-site status response now
+# carries a ``deployed_at`` ISO string (None before any deploy).
 
 from __future__ import annotations
 
@@ -227,7 +234,7 @@ async def test_status_by_pocket_unpublished_is_draft(beanie_test_db, monkeypatch
 @pytest.mark.asyncio
 async def test_status_by_pocket_published_is_live(_seeded_site, monkeypatch):
     """A published pocket (the seeded site is under pk1 / ws_owner) reads
-    {status: published, is_live: true}."""
+    {status: published, is_live: true} and carries a deployed_at ISO string (P2b)."""
     app = _build_app("ws_owner", monkeypatch)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         resp = await c.get("/api/v1/sites/by-pocket/pk1/status")
@@ -236,6 +243,22 @@ async def test_status_by_pocket_published_is_live(_seeded_site, monkeypatch):
     assert body["pocket_id"] == "pk1"
     assert body["status"] == "published"
     assert body["is_live"] is True
+    # P2b: the deployed site carries a last-deploy ISO timestamp.
+    assert body["deployed_at"] is not None
+    from datetime import datetime
+
+    datetime.fromisoformat(body["deployed_at"])
+
+
+@pytest.mark.asyncio
+async def test_status_by_pocket_unpublished_deployed_at_is_none(beanie_test_db, monkeypatch):
+    """P2b: an unpublished pocket (no Site doc) reads deployed_at None — the DTO
+    exposes None before the first deploy."""
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_never_deployed/status")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["deployed_at"] is None
 
 
 @pytest.mark.asyncio
@@ -601,4 +624,74 @@ async def test_audit_by_pocket_missing_pocket_is_404(beanie_test_db, monkeypatch
     app = _build_app("ws_owner", monkeypatch)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         resp = await c.post("/api/v1/sites/by-pocket/pk_missing/audit")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# revert (P2b-backend): POST /sites/by-pocket/{pocket_id}/versions/{version_no}/revert
+# reverts a pocket's site to a prior version by ordinal — it writes a NEW
+# forward-moving draft snapshot of the target version and returns it as a
+# SiteVersionResponse. fabric.write; tenant-scoped; an unknown version_no is a 404.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revert_by_pocket_creates_draft(beanie_test_db, monkeypatch):
+    """POST .../versions/{n}/revert returns 200 with a NEW draft whose content is a
+    snapshot of version n — the normal review/publish flow then applies."""
+    from pocketpaw_ee.versions import service as versions
+
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id="pk_rev", workspace_id="ws_owner", content={"v": "one"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id="pk_rev", workspace_id="ws_owner", version_id=str(v1.id)
+    )
+    await versions.write_draft(
+        scope_type="pocket", scope_id="pk_rev", workspace_id="ws_owner", content={"v": "two"}
+    )
+
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(f"/api/v1/sites/by-pocket/pk_rev/versions/{v1.version_no}/revert")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # A new draft row, forward of v1, labelled as a revert.
+    assert body["status"] == "draft"
+    assert body["version_no"] > v1.version_no
+    assert body["label"] == f"Revert to v{v1.version_no}"
+
+    # The new draft carries v1's content (verified through the versions spine).
+    draft = await versions.get_draft(scope_type="pocket", scope_id="pk_rev")
+    assert draft is not None
+    assert str(draft.id) == body["id"]
+    assert draft.content == {"v": "one"}
+
+
+@pytest.mark.asyncio
+async def test_revert_by_pocket_unknown_version_is_404(beanie_test_db, monkeypatch):
+    """An unknown version_no → 404 (the service ValueError maps to a 404)."""
+    from pocketpaw_ee.versions import service as versions
+
+    await versions.write_draft(
+        scope_type="pocket", scope_id="pk_rev2", workspace_id="ws_owner", content={"v": 1}
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post("/api/v1/sites/by-pocket/pk_rev2/versions/999/revert")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_revert_by_pocket_cross_tenant_is_404(beanie_test_db, monkeypatch):
+    """A version that exists only under ANOTHER workspace is a 404 for this caller —
+    the service's tenant filter treats it as no such version."""
+    from pocketpaw_ee.versions import service as versions
+
+    foreign = await versions.write_draft(
+        scope_type="pocket", scope_id="pk_rev3", workspace_id="ws_other", content={"v": 1}
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(f"/api/v1/sites/by-pocket/pk_rev3/versions/{foreign.version_no}/revert")
     assert resp.status_code == 404

--- a/tests/ee/sites/test_smoke_at_publish.py
+++ b/tests/ee/sites/test_smoke_at_publish.py
@@ -1,0 +1,183 @@
+# tests/ee/sites/test_smoke_at_publish.py
+# Created: 2026-06-18 (feat/sites-smoke-at-publish, PERF-4) — service-level cover
+# for "smoke-gate only at publish, not preview builds":
+#   * service.publish(preview=True) (the EDIT/arm path) tells generator.build() to
+#     SKIP smoke (smoke=False) — the workerd render is per-edit overhead only needed
+#     before a live deploy.
+#   * service.publish(preview=False) (the live publish path) runs smoke (smoke=True)
+#     AND still rolls back on SmokeGateFailed (edit_svelte_component restores the
+#     prior source) — the publish gate is unchanged.
+# The generator is faked behind the injected _generator seam (it records the
+# build() kwargs / raises SmokeGateFailed), so no real bun/workerd spawns.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.generator_client import BuildResult, SmokeGateFailed
+
+pytestmark = pytest.mark.asyncio
+
+_HERO_V1 = "<section class='hero'><h1>Bright Smile</h1></section>"
+_HERO_V2 = "<section class='hero'><h1>Brighter Smiles, Whiter Teeth</h1></section>"
+_SVELTE_SOURCE = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte'</script><Hero/>"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css'</script><slot/>",
+    "src/routes/+page.ts": "export const prerender = true",
+    "src/app.css": ":root{--brand:#0A84FF}",
+    "src/lib/components/Hero.svelte": _HERO_V1,
+}
+
+
+class _RecordingGenerator:
+    """Records the ``smoke`` flag (and other kwargs) each build() was called with so
+    a test can assert preview builds skip smoke and publish builds run it."""
+
+    def __init__(self):
+        self.builds: list[dict] = []
+
+    async def build(self, **kw):
+        self.builds.append(kw)
+        return BuildResult(project_dir="/tmp/site", ripple_version=None)
+
+
+class _SmokeFailGenerator:
+    """A generator whose build() ALWAYS fails the smoke gate — exercises the
+    publish rollback path (the gate must still bite on a live publish)."""
+
+    def __init__(self):
+        self.builds: list[dict] = []
+
+    async def build(self, **kw):
+        self.builds.append(kw)
+        raise SmokeGateFailed("workerd SSR failure: window is not defined")
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+    return f"http://127.0.0.1:9999/{site_id}/"
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Install a recording EventBus so the pockets service's ``emit`` calls don't
+    raise (the real bus is only wired by ``init_realtime()`` at boot)."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+async def _make_svelte_pocket(workspace_id: str, user_id: str) -> str:
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source=dict(_SVELTE_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+async def test_preview_publish_skips_smoke(beanie_test_db):
+    """PERF-4: a PREVIEW publish (preview=True — the EDIT/arm path) tells
+    generator.build() to SKIP smoke (smoke=False)."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen = _RecordingGenerator()
+
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        preview=True,
+        _generator=gen,
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    assert len(gen.builds) == 1
+    assert gen.builds[0]["smoke"] is False, "a preview build must SKIP the smoke gate"
+
+
+async def test_live_publish_runs_smoke(beanie_test_db):
+    """PERF-4: a LIVE publish (preview=False — the default chat-create / approve
+    path) tells generator.build() to RUN smoke (smoke=True)."""
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+    gen = _RecordingGenerator()
+
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        # preview defaults to False — the live publish path
+        _generator=gen,
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"export default {}",
+        _local_deploy=_fake_local_deploy,
+    )
+
+    assert len(gen.builds) == 1
+    assert gen.builds[0]["smoke"] is True, "a live publish must RUN the smoke gate"
+
+
+async def test_live_publish_still_rolls_back_on_smoke_failure(beanie_test_db):
+    """PERF-4 guard: a LIVE publish whose build fails the smoke gate still raises
+    SmokeGateFailed, and edit_svelte_component still ROLLS BACK the persisted source
+    to its prior contents — the publish gate + rollback are unchanged.
+
+    edit_svelte_component publishes a PREVIEW (preview=True) by design, so to prove
+    the publish gate still bites we drive the rollback via a generator that always
+    fails the gate: the edit persists V2, the build fails, and the source must be
+    restored to V1.
+    """
+    pocket_id = await _make_svelte_pocket("ws1", "u1")
+
+    with pytest.raises(SmokeGateFailed):
+        await sites_service.edit_svelte_component(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/lib/components/Hero.svelte",
+            new_source=_HERO_V2,
+            _generator=_SmokeFailGenerator(),
+            _cloudflare=_FakeCF(),
+            _bundle_reader=lambda d: b"export default {}",
+            _local_deploy=_fake_local_deploy,
+        )
+
+    # Rollback: the persisted source is back to V1, not the rejected V2.
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["source"]["src/lib/components/Hero.svelte"] == _HERO_V1, (
+        "a smoke-gate failure must roll the persisted source back to its prior contents"
+    )

--- a/tests/ee/sites/test_stable_identity.py
+++ b/tests/ee/sites/test_stable_identity.py
@@ -193,3 +193,50 @@ async def test_cf_republish_uses_stable_script_name_and_one_doc(beanie_test_db):
     docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_cf"}).to_list()
     assert len(docs) == 1
     assert str(first.id) == str(second.id)
+
+
+async def test_republish_reuses_signed_key(beanie_test_db, monkeypatch):
+    """PERF-1 review fix: a live RE-publish must REUSE the stored ``signed_key`` so
+    the built HTML's ``captureSignedKey`` matches the persisted ``doc.signed_key``
+    the capture endpoint verifies against. Before the fix each publish minted a
+    fresh key while the upsert preserved the old one → silent lead-capture breakage
+    on every re-publish."""
+    from unittest.mock import AsyncMock, patch
+
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+
+    keys: list[str] = []
+
+    class _RecordingGen:
+        async def build(self, **kw):
+            from pocketpaw_ee.sites.generator_client import BuildResult
+
+            keys.append(kw.get("capture_signed_key"))
+            return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+    wire = {"name": "AKB", "engine": "ripple", "rippleSpec": {"type": "container"}}
+
+    async def _pub():
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=wire),
+        ):
+            return await sites_service.publish_pocket(
+                workspace_id="ws1",
+                user_id="u1",
+                pocket_id="pk-signedkey",
+                _generator=_RecordingGen(),
+                _bundle_reader=lambda d: b"x",
+                _local_deploy=lambda sid, pd: f"http://127.0.0.1:9999/{sid}/",
+            )
+
+    await _pub()
+    await _pub()
+
+    assert keys[0] is not None
+    assert keys[0] == keys[1], "re-publish must reuse the same signed_key, not mint a new one"
+    doc = await _SiteDoc.find_one(
+        {"_id": sites_service._live_object_id("ws1", "pk-signedkey"), "workspace": "ws1"}
+    )
+    assert doc is not None and doc.signed_key == keys[1], "built key must match the stored doc"

--- a/tests/ee/sites/test_stable_identity.py
+++ b/tests/ee/sites/test_stable_identity.py
@@ -1,0 +1,195 @@
+# tests/ee/sites/test_stable_identity.py — PERF-1 regression guard: a Paw Site
+# has a STABLE per-pocket identity, so re-publishing the SAME pocket overwrites
+# the one site in place (same URL, same single Site doc) instead of minting a
+# fresh site_id / folder / URL / doc on every publish.
+#
+# Created: 2026-06-18 (feat/sites-stable-identity, PERF-1).
+#
+# The bug PERF-1 fixes: publish() minted ``site_id = str(ObjectId())`` per call,
+# so every publish inserted a NEW Site doc at a NEW URL. One pocket accumulated
+# 14 Site docs; the gallery showed dupes and ``pocket_status`` did an arbitrary
+# ``find_one`` across them, returning a stale doc (often ``url=None``) while the
+# freshest build sat at an unreferenced URL ("stale live link"). These tests pin
+# the intended behavior: ONE doc + ONE stable URL per (workspace, pocket_id), and
+# ``pocket_status`` returns that canonical, non-null url.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.sites import service as sites_service
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+def _fake_local_deploy(site_id: str, project_dir: str) -> str:
+    """Stand-in for local_server.deploy_local — returns the served URL for a
+    site_id WITHOUT needing a real built dir on disk. Because the url is derived
+    deterministically from site_id, a STABLE site_id ⇒ a STABLE url, exactly as
+    the real local_server.local_url_for behaves (it overwrites <home>/<id>/ in
+    place)."""
+    return f"http://127.0.0.1:9999/{site_id}/"
+
+
+async def _publish_local(pocket_id: str, *, name: str, deploy):
+    """Publish a pocket through the LIVE path in LOCAL deploy mode (no CF client
+    injected → the local branch), recording the deploy calls via ``deploy``."""
+    from unittest.mock import AsyncMock, patch
+
+    wire = {"name": name, "engine": "ripple", "rippleSpec": {"type": "container"}}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        return await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            _generator=_FakeGenerator(),
+            # NB: no _cloudflare → the LOCAL deploy branch is taken.
+            _bundle_reader=lambda d: b"unused-in-local-mode",
+            _local_deploy=deploy,
+        )
+
+
+async def test_two_publishes_same_pocket_same_url_and_one_doc(beanie_test_db, monkeypatch):
+    """THE REGRESSION GUARD: two consecutive ``publish_pocket`` calls for the SAME
+    pocket must produce the SAME url AND exactly ONE Site doc for that
+    (workspace, pocket_id).
+
+    Before PERF-1 this fails: each publish minted a fresh ObjectId → a new folder,
+    a new url, and a new inserted Site doc (two docs, two urls)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+
+    served_ids: list[str] = []
+
+    def _recording_deploy(site_id: str, project_dir: str) -> str:
+        served_ids.append(site_id)
+        return _fake_local_deploy(site_id, project_dir)
+
+    first = await _publish_local("pk_stable", name="Bright Smile", deploy=_recording_deploy)
+    second = await _publish_local("pk_stable", name="Bright Smile", deploy=_recording_deploy)
+
+    # SAME stable deploy id both times (not a fresh ObjectId per call) ⇒ same folder.
+    assert len(served_ids) == 2
+    assert served_ids[0] == served_ids[1], (
+        "consecutive publishes for one pocket must deploy at the SAME stable id"
+    )
+    # SAME url both times — the live link does not move on re-publish.
+    assert first.url == second.url
+    assert first.url, "the published url must be non-empty"
+
+    # Exactly ONE Site doc for (workspace, pocket_id) — re-publish UPSERTED in place
+    # instead of inserting a second doc.
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_stable"}).to_list()
+    assert len(docs) == 1, f"expected ONE Site doc per pocket, found {len(docs)}"
+    # The upsert reused the SAME doc id (it updated, did not replace with a new _id).
+    assert str(first.id) == str(second.id)
+
+
+async def test_pocket_status_returns_canonical_non_null_url(beanie_test_db, monkeypatch):
+    """``pocket_status`` returns the canonical Site doc's NON-NULL url + is_live —
+    the stale-live-link bug is gone: after two publishes there is one doc whose url
+    is the live, openable address."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+
+    await _publish_local("pk_status", name="x", deploy=_fake_local_deploy)
+    second = await _publish_local("pk_status", name="x", deploy=_fake_local_deploy)
+
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_status")
+    assert res.is_live is True
+    assert res.status == "published"
+    # The canonical url is returned and is the live (non-null) address — the same
+    # one the latest publish deployed at.
+    assert res.url == second.url
+    assert res.url, "pocket_status must return a non-null live url"
+    assert res.site_id == str(second.id)
+
+
+async def test_pocket_status_picks_live_doc_over_stale_dupe(beanie_test_db, monkeypatch):
+    """Robustness against pre-existing dupes (PERF-1 does NOT migrate them — that's
+    PERF-2): if an OLD stale doc (url="" / deployed) already exists for a pocket,
+    ``pocket_status`` must return the canonical doc with a real url, not the stale
+    one an arbitrary find_one might surface."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+
+    # An old, stale dupe with NO url (the shape the bug left behind).
+    stale = _SiteDoc(
+        workspace="ws1",
+        pocket_id="pk_dupe",
+        owner="u1",
+        name="Stale",
+        script_name="stale",
+        deployed=True,
+        url="",
+    )
+    await stale.insert()
+
+    # A real publish lands the canonical doc with a live url.
+    live = await _publish_local("pk_dupe", name="Live", deploy=_fake_local_deploy)
+
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk_dupe")
+    assert res.is_live is True
+    assert res.url == live.url
+    assert res.url, "pocket_status must surface the doc that has a real url, not the stale one"
+
+
+class _RecordingCF:
+    """A Cloudflare client that records the script_name each put_worker targets, so
+    a test can prove a re-publish OVERWRITES the SAME worker (stable script_name per
+    pocket) instead of orphaning a new one."""
+
+    def __init__(self):
+        self.put_calls: list[str] = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+async def test_cf_republish_uses_stable_script_name_and_one_doc(beanie_test_db):
+    """PROD consistency: on the real Cloudflare path, two publishes of the same
+    pocket target the SAME worker script_name (overwrite in place, no orphan) and
+    leave exactly ONE Site doc."""
+    from unittest.mock import AsyncMock, patch
+
+    cf = _RecordingCF()
+    wire = {"name": "x", "engine": "ripple", "rippleSpec": {"type": "container"}}
+
+    async def _publish_cf():
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=wire),
+        ):
+            return await sites_service.publish_pocket(
+                workspace_id="ws1",
+                user_id="u1",
+                pocket_id="pk_cf",
+                _generator=_FakeGenerator(),
+                _cloudflare=cf,  # injected CF → the REAL deploy branch
+                _bundle_reader=lambda d: b"export default {}",
+            )
+
+    first = await _publish_cf()
+    second = await _publish_cf()
+
+    # Same worker script_name both times — the worker is overwritten, not orphaned.
+    assert cf.put_calls == [first.script_name, first.script_name]
+    assert first.script_name == second.script_name
+    # script_name is still the str form of the (now stable) doc id.
+    assert first.script_name == str(first.id)
+    # Exactly ONE Site doc — the second publish upserted the first.
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_cf"}).to_list()
+    assert len(docs) == 1
+    assert str(first.id) == str(second.id)

--- a/tests/ee/versions/test_instinct_executor.py
+++ b/tests/ee/versions/test_instinct_executor.py
@@ -43,7 +43,13 @@ class _FakeStore:
 
 
 def _action(to_version_id: str) -> SimpleNamespace:
-    """A minimal Action stand-in carrying an ``_artifact_change`` blob."""
+    """A minimal Action stand-in carrying an ``_artifact_change`` blob.
+
+    ``branch`` is "main" to match the real request_publish_pocket flow (it stamps
+    branch="main") AND the branch the candidate drafts below are written on
+    (write_draft defaults to "main"). The P2a discard_all_drafts is branch-scoped,
+    so the blob branch must match where the draft actually lives — exactly as it
+    does in production."""
     return SimpleNamespace(
         id="act-1",
         pocket_id=POCKET,
@@ -51,7 +57,7 @@ def _action(to_version_id: str) -> SimpleNamespace:
             "_artifact_change": {
                 "scope_type": "pocket",
                 "scope_id": POCKET,
-                "branch": "cand",
+                "branch": "main",
                 "from_version_id": "ver-from",
                 "to_version_id": to_version_id,
                 "workspace": WS,
@@ -167,3 +173,79 @@ async def test_reject_discards_candidate_and_leaves_published(
     assert published is not None
     assert str(published.id) == str(live.id)
     assert published.content == {"v": "live"}
+
+
+async def test_reject_clears_all_accumulated_drafts(
+    beanie_test_db, versions_journal, monkeypatch
+) -> None:
+    """P2a: ONE reject (discard_rejected_change) must clear ALL drafts above the
+    published pointer — not just the candidate the Action names — so
+    has_unpublished_changes goes false on the first click instead of after N.
+
+    The action's ``to_version_id`` names the latest draft, but a pocket edited N
+    times (back-handling the pre-fix accumulated state) has N draft rows above
+    published. After the fix the discard reverts every one in a single pass.
+
+    Reproduce-first: pre-fix discard_rejected_change reverts only to_version_id,
+    so the other accumulated drafts remain → get_draft is non-None → fails.
+    """
+    store = _FakeStore()
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: store)
+
+    # A live published version.
+    live = await versions.write_draft(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, content={"v": "live"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=POCKET, workspace_id=WS, version_id=str(live.id)
+    )
+
+    # Force three raw draft rows above published (the already-accumulated state a
+    # pre-fix pocket is in on disk), independent of the supersede behaviour.
+    from pocketpaw_ee.versions.models import ArtifactVersion
+
+    head = await versions._latest_in_branch(
+        scope_type="pocket", scope_id=POCKET, branch_name="main"
+    )
+    next_no = head.version_no + 1
+    cands = []
+    for j in range(3):
+        row = ArtifactVersion(
+            scope_type="pocket",
+            scope_id=POCKET,
+            workspace_id=WS,
+            branch="main",
+            version_no=next_no + j,
+            content={"raw": j},
+            status="draft",
+        )
+        await row.insert()
+        cands.append(row)
+
+    # The Action names only the LATEST draft as to_version_id. The publish flow's
+    # blob is on the "main" lineage (request_publish_pocket stamps branch="main"),
+    # so build a main-branch action here.
+    main_action = SimpleNamespace(
+        id="act-discard-all",
+        pocket_id=POCKET,
+        parameters={
+            "_artifact_change": {
+                "scope_type": "pocket",
+                "scope_id": POCKET,
+                "branch": "main",
+                "from_version_id": str(live.id),
+                "to_version_id": str(cands[-1].id),
+                "workspace": WS,
+                "user_id": USER,
+            }
+        },
+    )
+    await executor.discard_rejected_change(main_action)
+
+    # ALL drafts above published are gone → get_draft is None on click 1.
+    assert await versions.get_draft(scope_type="pocket", scope_id=POCKET) is None
+
+    # The published pointer is untouched.
+    published = await versions.get_published(scope_type="pocket", scope_id=POCKET)
+    assert published is not None
+    assert str(published.id) == str(live.id)

--- a/tests/ee/versions/test_merge_gate_service.py
+++ b/tests/ee/versions/test_merge_gate_service.py
@@ -114,6 +114,185 @@ async def test_discard_rejects_cross_workspace(beanie_test_db) -> None:
 
 
 # ---------------------------------------------------------------------------
+# P2a — discard must clear ALL accumulated drafts in one pass, and write_draft
+# must supersede the prior draft head so at most ONE live draft exists.
+# ---------------------------------------------------------------------------
+
+
+async def _draft_rows_above_published(scope_id: str) -> list:
+    """All status='draft' rows above the published pointer (the rows that keep
+    has_unpublished_changes true)."""
+    from pocketpaw_ee.versions.models import ArtifactVersion
+
+    published = await versions.get_published(scope_type="pocket", scope_id=scope_id)
+    floor = published.version_no if published is not None else 0
+    rows = await ArtifactVersion.find(
+        ArtifactVersion.scope_type == "pocket",
+        ArtifactVersion.scope_id == scope_id,
+        ArtifactVersion.branch == "main",
+        ArtifactVersion.status == "draft",
+    ).to_list()
+    return [r for r in rows if r.version_no > floor]
+
+
+async def test_discard_all_drafts_clears_every_draft_in_one_pass(
+    beanie_test_db, versions_journal
+) -> None:
+    """P2a (A): after N edits a pocket has N draft rows above the published
+    pointer (write_draft inserts a fresh draft each time). ONE discard_all_drafts
+    must flip EVERY draft above published to 'reverted' so get_draft() is None and
+    has_unpublished_changes becomes false on the FIRST discard — not after N clicks.
+
+    Reproduce-first: pre-fix discard_all_drafts does not exist (AttributeError).
+    """
+    scope = "pocket-discard-all"
+    # A published baseline so we can prove discard leaves it untouched.
+    pub = await versions.write_draft(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, content={"v": "live"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, version_id=str(pub.id)
+    )
+
+    # Three edits. Whether or not write_draft supersedes, this must end with at
+    # least one draft above published; the back-handling case (already-accumulated
+    # drafts) is exercised by inserting raw rows below.
+    for i in range(3):
+        await versions.write_draft(
+            scope_type="pocket", scope_id=scope, workspace_id=WS, content={"v": i}
+        )
+
+    # Back-handle the already-accumulated case: force three raw draft rows above
+    # published (the state a pre-fix pocket is already in on disk), so the test
+    # proves discard_all_drafts clears a PILE, not just the head.
+    from pocketpaw_ee.versions.models import ArtifactVersion
+
+    head = await versions._latest_in_branch(scope_type="pocket", scope_id=scope, branch_name="main")
+    next_no = head.version_no + 1
+    for j in range(3):
+        await ArtifactVersion(
+            scope_type="pocket",
+            scope_id=scope,
+            workspace_id=WS,
+            branch="main",
+            version_no=next_no + j,
+            content={"raw": j},
+            status="draft",
+        ).insert()
+
+    # Multiple drafts above published exist now (the bug's accumulated state).
+    before = await _draft_rows_above_published(scope)
+    assert len(before) >= 2, "precondition: a pile of drafts above published"
+
+    # ONE discard_all_drafts clears them all.
+    n = await versions.discard_all_drafts(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, branch="main"
+    )
+    assert n >= 2
+
+    # Zero drafts above published → has_unpublished_changes is false on click 1.
+    after = await _draft_rows_above_published(scope)
+    assert after == []
+    assert await versions.get_draft(scope_type="pocket", scope_id=scope) is None
+
+    # The published pointer is untouched (a discard must never move what is live).
+    live = await versions.get_published(scope_type="pocket", scope_id=scope)
+    assert live is not None
+    assert live.id == pub.id
+    assert live.content == {"v": "live"}
+
+
+async def test_discard_all_drafts_is_tenant_scoped(beanie_test_db) -> None:
+    """discard_all_drafts must only touch THIS workspace's drafts — a same-id draft
+    under another workspace is never reverted."""
+    scope = "pocket-discard-tenant"
+    await versions.write_draft(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, content={"mine": 1}
+    )
+    foreign = await versions.write_draft(
+        scope_type="pocket", scope_id=scope, workspace_id="ws-OTHER", content={"theirs": 1}
+    )
+
+    await versions.discard_all_drafts(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, branch="main"
+    )
+
+    from pocketpaw_ee.versions.models import ArtifactVersion
+
+    foreign_row = await ArtifactVersion.get(str(foreign.id))
+    assert foreign_row is not None
+    assert foreign_row.status == "draft", "another workspace's draft must be untouched"
+
+
+async def test_write_draft_supersedes_prior_draft_head(beanie_test_db) -> None:
+    """P2a (B): three sequential write_drafts must leave EXACTLY ONE live draft —
+    each new write supersedes the prior draft head (flips it to 'reverted') so the
+    draft pile never accumulates again.
+
+    Reproduce-first: pre-fix write_draft always inserts a new status='draft' row,
+    so three writes leave THREE live drafts → this assertion fails (count == 3).
+    """
+    scope = "pocket-supersede"
+    v1 = await versions.write_draft(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, content={"v": 1}
+    )
+    v2 = await versions.write_draft(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, content={"v": 2}
+    )
+    v3 = await versions.write_draft(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, content={"v": 3}
+    )
+
+    from pocketpaw_ee.versions.models import ArtifactVersion
+
+    live_drafts = await ArtifactVersion.find(
+        ArtifactVersion.scope_type == "pocket",
+        ArtifactVersion.scope_id == scope,
+        ArtifactVersion.branch == "main",
+        ArtifactVersion.status == "draft",
+    ).to_list()
+    assert len(live_drafts) == 1, "at most one live draft per (scope, branch)"
+    assert live_drafts[0].id == v3.id
+
+    # The current draft pointer is the newest write; monotonic version_no preserved.
+    draft = await versions.get_draft(scope_type="pocket", scope_id=scope)
+    assert draft is not None
+    assert draft.id == v3.id
+    assert draft.version_no == 3
+    # The superseded heads are still on the log as reverted (history is append-only).
+    superseded = await ArtifactVersion.find(
+        ArtifactVersion.scope_type == "pocket",
+        ArtifactVersion.scope_id == scope,
+        ArtifactVersion.branch == "main",
+        ArtifactVersion.status == "reverted",
+    ).to_list()
+    assert {r.id for r in superseded} == {v1.id, v2.id}
+
+
+async def test_write_draft_does_not_supersede_published_head(beanie_test_db) -> None:
+    """write_draft must only supersede a DRAFT head — a published head stays live so
+    the new draft is a reviewable change ON TOP of what is published."""
+    scope = "pocket-supersede-pub"
+    pub = await versions.write_draft(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, content={"v": "live"}
+    )
+    await versions.publish(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, version_id=str(pub.id)
+    )
+    # A new edit on top of the published version.
+    draft = await versions.write_draft(
+        scope_type="pocket", scope_id=scope, workspace_id=WS, content={"v": "edit"}
+    )
+
+    from pocketpaw_ee.versions.models import ArtifactVersion
+
+    pub_row = await ArtifactVersion.get(str(pub.id))
+    assert pub_row.status == "published", "a published head must NOT be superseded"
+    assert (await versions.get_draft(scope_type="pocket", scope_id=scope)).id == draft.id
+    assert (await versions.get_published(scope_type="pocket", scope_id=scope)).id == pub.id
+
+
+# ---------------------------------------------------------------------------
 # Part D — svelte source edit writes a draft version
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -674,3 +674,112 @@ class TestWebSocketMiddlewareAuth:
 
         await middleware(scope, None, None)
         assert downstream_called
+
+
+# ---------------------------------------------------------------------------
+# P1b — authenticated full-access editing must not trip the per-IP api_limiter
+#
+# The desktop editor (paw-enterprise) talks to localhost:8888, so every
+# /api/v1/* control-plane call shares ONE client_ip (127.0.0.1) and therefore
+# ONE 30-token api_limiter bucket. During editing the FE fans out many
+# /api/v1/* calls (/editable, /preview, /status, /audit, /cloud/chat refine),
+# draining 30 tokens faster than the 10/s refill -> HTTP 429 "Too many
+# requests". These requests are authenticated full-access and already trusted,
+# so the per-IP api_limiter must NOT apply to them. Unauthenticated /api
+# traffic must STILL be limited (no open hole), and the separate login / auth /
+# qr brute-force buckets are untouched.
+# ---------------------------------------------------------------------------
+
+
+class TestFullAccessApiLimiterExemption:
+    """Authenticated full-access /api/v1 traffic must bypass the per-IP api_limiter."""
+
+    _MASTER = "test-master-token-1234567890"
+
+    def _make_request(
+        self,
+        path: str = "/api/v1/sites/editable",
+        method: str = "GET",
+        client_ip: str = "127.0.0.1",
+        authorized: bool = True,
+    ):
+        from types import SimpleNamespace
+
+        req = MagicMock()
+        req.method = method
+        req.url.path = path
+        req.client = MagicMock()
+        req.client.host = client_ip
+        req.query_params = {}
+        # A valid master token in the Authorization header sets is_valid +
+        # full_access via the bearer branch of _auth_dispatch.
+        req.headers = {"Authorization": f"Bearer {self._MASTER}"} if authorized else {}
+        req.cookies = {}
+        # Use a real namespace so request.state.full_access is a real bool,
+        # not a truthy MagicMock attribute.
+        req.state = SimpleNamespace()
+        return req
+
+    async def test_full_access_flood_not_rate_limited(self):
+        """>30 rapid authenticated full-access /api/v1 requests from one IP: no 429."""
+        from pocketpaw.dashboard_auth import _auth_dispatch
+        from pocketpaw.security.rate_limiter import RateLimiter
+
+        # Fresh limiter (capacity 30, like the real api_limiter) so prior test
+        # state doesn't pollute, and so a flood would deterministically drain it
+        # if the exemption were missing.
+        fresh = RateLimiter(rate=10.0, capacity=30)
+        with (
+            patch("pocketpaw.dashboard_auth.api_limiter", fresh),
+            patch("pocketpaw.dashboard_auth.get_access_token", return_value=self._MASTER),
+        ):
+            for i in range(60):
+                req = self._make_request()
+                resp = await _auth_dispatch(req)
+                # Allow-through is None; any 429 is a failure.
+                assert resp is None or resp.status_code != 429, (
+                    f"request {i} got 429 despite full_access"
+                )
+                assert getattr(req.state, "full_access", False) is True
+
+    async def test_unauthenticated_flood_still_limited(self):
+        """Unauthenticated remote /api/v1 flood from one IP still gets a 429 (no open hole).
+
+        A *remote* (non-localhost, non-tunnel-trusted) caller with no token does
+        not get full_access, so the per-IP api_limiter must still cap it. We
+        patch _is_genuine_localhost to False so the request is treated as the
+        untrusted remote client the per-IP bucket exists to defend against.
+        """
+        from pocketpaw.dashboard_auth import _auth_dispatch
+        from pocketpaw.security.rate_limiter import RateLimiter
+
+        fresh = RateLimiter(rate=10.0, capacity=30)
+        saw_429 = False
+        with (
+            patch("pocketpaw.dashboard_auth.api_limiter", fresh),
+            patch("pocketpaw.dashboard_auth.get_access_token", return_value=self._MASTER),
+            patch("pocketpaw.dashboard_auth._is_genuine_localhost", return_value=False),
+        ):
+            # /api/v1/* is auth-optional (no 401), but the per-IP api_limiter
+            # must still cap unauthenticated callers. 40 > capacity 30.
+            for _ in range(40):
+                req = self._make_request(authorized=False, client_ip="203.0.113.7")
+                resp = await _auth_dispatch(req)
+                if resp is not None and resp.status_code == 429:
+                    saw_429 = True
+                    break
+        assert saw_429, "unauthenticated flood was not rate-limited — security hole"
+
+    async def test_auth_session_brute_force_bucket_untouched(self):
+        """/api/auth/session keeps its per-IP auth_limiter (brute-force guard)."""
+        from pocketpaw.dashboard_auth import _auth_dispatch
+        from pocketpaw.security.rate_limiter import RateLimitInfo
+
+        denied = RateLimitInfo(allowed=False, limit=5, remaining=0, reset_after=1.0)
+        with patch("pocketpaw.dashboard_auth.auth_limiter") as mock_auth_limiter:
+            mock_auth_limiter.check.return_value = denied
+            req = self._make_request(path="/api/auth/session", method="POST")
+            resp = await _auth_dispatch(req)
+            assert resp is not None
+            assert resp.status_code == 429
+            mock_auth_limiter.check.assert_called_once_with("127.0.0.1")


### PR DESCRIPTION
Brings the whole sites edit/preview/publish rearchitecture plus the follow-up root-cause fixes onto dev. It ran as one bundle on the live per-tenant stack and was tested end to end before this PR.

## What's in it
- **Stable per-pocket Site identity** — one Site doc / folder / URL per pocket (kills the stale-link bug + gallery dupes), with the signed_key reuse fix so lead capture survives a re-publish, plus a non-destructive dedupe migration for existing dupes.
- **Faster, flatter builds** — persistent per-pocket build dir + cached node_modules (no repeat bun install), windowed refine context so edits stop getting slower each turn.
- **Live dev-server preview** (Phase 2) and **diff/targeted edit** (Phase 3).
- **Plan-gate on create/publish** — the in-process (chat) paths now match the HTTP fabric gate.
- **The pipeline root-cause fixes** (from the orientation pass):
  - Editable preview now actually runs the static build (split the workerd smoke gate from vite build), so the hover-edit overlay anchors reach the served HTML — the recurring 'edit pill missing' bug.
  - Reap the prerender workerd after each build + fail-soft preview — stops the progressive slowdown and the missing-build 500s.
  - Self-heal review on legacy sites (backfill a draft instead of 400).
  - One-click discard (clears all drafts; write_draft supersedes the prior head).
  - Authenticated / localhost editing exempt from the per-IP rate bucket — no more 429 under normal editing.
  - deployed_at marker + a versions revert endpoint.
- **A cross-repo E2E regression gate** that asserts on the *served* HTML (data-paw-section + the edit-bridge), runs submit-for-review on a fresh and a legacy-shaped pocket, and checks the build workerd count nets zero. This is the test that would have caught the overlay regression.

## Testing
Ran live on the per-tenant stack; targeted pytest green across the touched suites (sites / versions / instinct / dashboard-auth); the regression gate passes.

## Rolls up (close after merge)
Supersedes #1497, #1499, #1500, #1501, #1502, #1484 — their commits are all in this branch. #1469 (dynamic-sites authoring) stays separate; it was deferred.