### PR TITLE
Make rippleSpec readers dual-path and promote on read

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/agent_context.py
+++ b/ee/pocketpaw_ee/cloud/pockets/agent_context.py
@@ -54,6 +54,13 @@ on the view under ``_source_merge``) as ``authored_sources`` /
 ``skipped_sources`` so the agent can't report a source that was silently
 dropped. No honesty keys appear when no ``sources`` were supplied — the
 legacy result shape is unchanged.
+Changes: 2026-06-19 (feat/typed-ripplespec-phase2) — DUAL-PATH READER.
+``_validate_ripple_spec`` and ``_resolved_view_for_frontend`` now coerce a
+typed ``RippleSpec`` to its BSON-equivalent flat dict at entry (via
+``to_flat_dict``) before the existing dict-tree walks / resolver run. The
+agent callers still pass the raw wire dict, so this is a no-op for them — the
+guard covers a promoted spec reaching these helpers under the Phase-2
+promote-on-read boundary. No wire / behavior change.
 """
 
 from __future__ import annotations
@@ -61,6 +68,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pocketpaw.bundled_templates.schema import RippleSpec
 from pocketpaw_ee.cloud.pockets import service as pockets_service
 
 logger = logging.getLogger(__name__)
@@ -107,7 +115,9 @@ async def fetch_pocket_for_agent(pocket_id: str) -> dict[str, Any]:
     return {"ok": True, "pocket": view}
 
 
-async def _validate_ripple_spec(ripple_spec: dict[str, Any] | None) -> list[dict[str, Any]]:
+async def _validate_ripple_spec(
+    ripple_spec: RippleSpec | dict[str, Any] | None,
+) -> list[dict[str, Any]]:
     """Pre-persist guard against agent prop-name drift.
 
     Fetches the same manifest the ``get_widget_spec`` MCP tool uses,
@@ -118,7 +128,13 @@ async def _validate_ripple_spec(ripple_spec: dict[str, Any] | None) -> list[dict
     Returns the issues list so callers can surface them to the agent.
     Best-effort — if the manifest is unavailable, returns ``[]``. Mutates
     ``ripple_spec`` in place when aliases apply.
+
+    Phase-2 dual-path: a typed ``RippleSpec`` is flattened to its
+    BSON-equivalent dict at entry (the in-place alias walk then operates on
+    that flat dict); the agent callers pass the raw wire dict, unchanged.
     """
+    if isinstance(ripple_spec, RippleSpec):
+        ripple_spec = ripple_spec.to_flat_dict()
     if not isinstance(ripple_spec, dict):
         return []
     try:
@@ -201,6 +217,12 @@ async def _resolved_view_for_frontend(pocket_view: dict[str, Any]) -> dict[str, 
     spec = pocket_view.get("rippleSpec")
     if not spec:
         return pocket_view
+    # Phase-2 dual-path: a promoted ``RippleSpec`` is flattened back to its
+    # BSON-equivalent dict before resolution, so the ``$source``-marker tree
+    # walk (and the resolved wire payload) stay flat dicts. Agent callers pass
+    # the wire dict, so this is a no-op for them.
+    if isinstance(spec, RippleSpec):
+        spec = spec.to_flat_dict()
     try:
         from pocketpaw_ee.cloud.chat.agent_service import current_user_id, current_workspace_id
 

--- a/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/pockets/bulk_dispatch.py
@@ -49,6 +49,15 @@
 # a Beanie document class. The ee/pyproject.toml import-linter contract
 # adds this module to the ``pockets`` source_modules list to lock the
 # invariant.
+#
+# Updated: 2026-06-19 (feat/typed-ripplespec-phase2) — DUAL-PATH READER. The
+# spec-level actions read in ``_fire_executions`` now goes through the new
+# ``_action_binding_for`` helper, which promotes the pocket's (legacy flat
+# dict) ``rippleSpec`` to a typed ``RippleSpec`` via ``from_flat_dict`` and
+# reads ``spec.actions[name]`` — or reads a typed spec directly. A corrupt /
+# unpromotable spec yields ``None`` (the same ``action_not_found`` per-row
+# error as before), so a bad doc never crashes the fan-out. Promote-on-read:
+# the pocket document shape is unchanged, no migration.
 
 """Bulk action dispatch — fan-out across N rows with ONE batch approval."""
 
@@ -59,7 +68,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from pocketpaw.bundled_templates import PocketTemplate
+from pocketpaw.bundled_templates import PocketTemplate, RippleSpec
 from pocketpaw.bundled_templates.bulk_executor import (
     BulkExecutionError,
     plan_bulk_execution,
@@ -67,6 +76,32 @@ from pocketpaw.bundled_templates.bulk_executor import (
 from pocketpaw.bundled_templates.identifier_resolver import IdentifierResolver
 from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
 from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+
+
+def _action_binding_for(
+    ripple_spec: RippleSpec | dict | None, action_name: str
+) -> dict[str, Any] | None:
+    """Return the named write-binding dict from a pocket's rippleSpec.
+
+    Phase-2 dual-path: promotes a legacy flat dict to ``RippleSpec`` via
+    ``from_flat_dict`` (returns ``None`` on a corrupt/unpromotable spec, so the
+    bulk path fails the row cleanly rather than crashing), then reads
+    ``spec.actions[action_name]``. An already-typed ``RippleSpec`` is read
+    directly. Returns ``None`` when there is no actions block or the named
+    binding is absent / not a dict — the caller turns that into a per-row
+    ``action_not_found`` error.
+    """
+    spec = (
+        ripple_spec
+        if isinstance(ripple_spec, RippleSpec)
+        else RippleSpec.from_flat_dict(ripple_spec)
+    )
+    if spec is None:
+        return None
+    actions = spec.actions if isinstance(spec.actions, dict) else {}
+    raw_action = actions.get(action_name)
+    return raw_action if isinstance(raw_action, dict) else None
+
 
 # ---------------------------------------------------------------------------
 # Result models — frozen so the caller (service / router) cannot mutate
@@ -359,9 +394,11 @@ async def _fire_executions(
     if not plan.executions:
         return []
 
-    spec = pocket.get("rippleSpec") or {}
-    actions = spec.get("actions") if isinstance(spec.get("actions"), dict) else {}
-    raw_action = actions.get(plan.action_name) if isinstance(actions, dict) else None
+    # Phase-2 dual-path: ``pocket["rippleSpec"]`` is a legacy flat dict today;
+    # ``_action_binding_for`` promotes it to ``RippleSpec`` (or reads a typed
+    # spec directly) and pulls the named write binding. A corrupt spec yields
+    # ``None`` → the same per-row ``action_not_found`` error below.
+    raw_action = _action_binding_for(pocket.get("rippleSpec"), plan.action_name)
 
     if not isinstance(raw_action, dict):
         # The action is declared on the template but not in the pocket's

--- a/ee/pocketpaw_ee/cloud/pockets/domain.py
+++ b/ee/pocketpaw_ee/cloud/pockets/domain.py
@@ -24,6 +24,12 @@ chunk ②) — added optional ``Pocket.surface_profile`` (the JSON-shaped
 per-entity surface-profile override dict, or ``None``) so the wire layer +
 the entity-aware resolve_profile (chunk ①) can read an entity pocket's
 ripple_mode / tools / skills override. ``None`` for legacy pockets.
+Updated: 2026-06-19 (feat/typed-ripplespec-phase2) — widened
+``Pocket.ripple_spec`` to ``RippleSpec | dict[str, Any] | None`` during the
+typed-rippleSpec transition. ``service._pocket_to_domain`` promotes the stored
+flat dict to a typed ``RippleSpec`` on read (promote-on-read; the Beanie field
+stays ``dict``, no document migration), falling back to the raw value on a
+corrupt/unpromotable spec. Every reader downstream is dual-path.
 """
 
 from __future__ import annotations
@@ -31,6 +37,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
+
+from pocketpaw.bundled_templates.schema import RippleSpec
 
 
 @dataclass(frozen=True)
@@ -100,7 +108,14 @@ class Pocket:
     team: tuple[str, ...]
     agents: tuple[str, ...]
     widgets: tuple[Widget, ...]
-    ripple_spec: dict[str, Any] | None
+    # Phase-2 (feat/typed-ripplespec-phase2): widened to ``RippleSpec | dict``
+    # during the transition. ``service._pocket_to_domain`` PROMOTES the stored
+    # flat dict to a typed ``RippleSpec`` on read (promote-on-read — the Beanie
+    # ``Pocket.rippleSpec`` field stays ``dict``, no document migration). A
+    # corrupt/unpromotable spec falls back to the raw stored value, so a bad
+    # doc never breaks pocket load. Every downstream reader is dual-path, so it
+    # accepts whichever shape it gets.
+    ripple_spec: RippleSpec | dict[str, Any] | None
     share_link_token: str | None
     share_link_access: str  # view | comment | edit
     shared_with: tuple[str, ...]

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -242,6 +242,7 @@ from beanie import PydanticObjectId
 from bson.errors import InvalidId
 from pydantic import ValidationError as PydanticValidationError
 
+from pocketpaw.bundled_templates.schema import RippleSpec
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     PocketCreated,
@@ -420,6 +421,26 @@ async def apply_derived_surface_profile(
     await doc.save()
 
 
+def _promote_ripple_spec(raw: Any) -> RippleSpec | dict[str, Any] | None:
+    """Promote a stored flat ``rippleSpec`` dict to a typed ``RippleSpec``.
+
+    Phase-2 domain-boundary promotion. The Beanie field stays a raw dict;
+    promotion happens here on read. The byte-equivalence invariant is
+    preserved at the edges:
+
+    * A falsy spec (``None`` or ``{}``) is returned VERBATIM — an empty dict
+      must stay ``{}`` and ``None`` must stay ``None``, so the wire serializer
+      (``pocket_to_wire_dict``) produces the same shape it did before Phase 2.
+    * A non-empty dict is promoted via ``from_flat_dict`` (which NEVER raises).
+    * A corrupt / unpromotable spec — ``from_flat_dict`` returns ``None`` —
+      falls back to the raw stored value, so a bad doc never breaks pocket
+      load. Every downstream reader is dual-path and accepts either shape.
+    """
+    if not raw:
+        return raw
+    return RippleSpec.from_flat_dict(raw) or raw
+
+
 def _pocket_to_domain(doc: _PocketDoc) -> Pocket:
     return Pocket(
         id=str(doc.id),
@@ -434,7 +455,14 @@ def _pocket_to_domain(doc: _PocketDoc) -> Pocket:
         team=tuple(str(t) for t in doc.team),
         agents=tuple(str(a) for a in doc.agents),
         widgets=tuple(_widget_to_domain(w) for w in doc.widgets),
-        ripple_spec=doc.rippleSpec,
+        # Phase-2 (feat/typed-ripplespec-phase2) — PROMOTE-ON-READ at the
+        # domain boundary (see ``_promote_ripple_spec``). The Beanie
+        # ``Pocket.rippleSpec`` field stays a raw ``dict`` (no migration); a
+        # NON-EMPTY spec becomes a typed ``RippleSpec`` so every downstream
+        # reader can use the typed fields. A falsy spec (``None`` / ``{}``) and
+        # a corrupt/unpromotable spec are carried through verbatim so the wire
+        # stays byte-equivalent and a bad doc never breaks pocket load.
+        ripple_spec=_promote_ripple_spec(doc.rippleSpec),
         share_link_token=doc.share_link_token,
         share_link_access=doc.share_link_access,
         shared_with=tuple(doc.shared_with),
@@ -542,9 +570,20 @@ async def _resolved_wire_dict(doc: _PocketDoc, viewer_user_id: str) -> dict:
         from pocketpaw_ee.cloud import ripple_sources  # noqa: F401  — register sources
         from pocketpaw_ee.cloud.ripple_resolver import ResolveCtx, resolve_ripple_spec
 
+        # Phase-2: ``pocket.ripple_spec`` is now a promoted ``RippleSpec`` (or a
+        # raw dict for an unpromotable doc). ``resolve_ripple_spec`` walks the
+        # flat ``$source``-marker tree, so flatten a typed spec back to its
+        # BSON-equivalent dict before resolving. ``resolved`` (a dict) is then
+        # stored on the domain object — the resolved view goes straight to the
+        # wire, so a dict here keeps the wire shape unchanged.
+        spec_for_resolve = (
+            pocket.ripple_spec.to_flat_dict()
+            if isinstance(pocket.ripple_spec, RippleSpec)
+            else pocket.ripple_spec
+        )
         try:
             resolved = await resolve_ripple_spec(
-                pocket.ripple_spec,
+                spec_for_resolve,
                 ResolveCtx(
                     workspace_id=doc.workspace,
                     user_id=viewer_user_id,

--- a/ee/pocketpaw_ee/cloud/pockets/source_executor.py
+++ b/ee/pocketpaw_ee/cloud/pockets/source_executor.py
@@ -83,6 +83,14 @@
 # `_source_transform` helper is pure (no imports beyond typing); the connectors
 # service is imported LAZILY inside `_run_connector_binding` (same pattern as
 # the sense resolver import) so the static graph stays clean and cycle-free.
+# Updated: 2026-06-19 (feat/typed-ripplespec-phase2) — DUAL-PATH READER. The
+#   spec-reading entry points (`_parse_bindings`, `selected_source_keys`,
+#   `run_sources`) now accept `RippleSpec | dict | None`. A new `_sources_block`
+#   helper reads `spec.sources` from a typed RippleSpec or `.get("sources")`
+#   from a legacy flat dict — so a stored legacy dict and a promoted typed spec
+#   both run identically (no migration, promote-on-read). The OSS-only
+#   `pocketpaw.bundled_templates.schema` import keeps the import-linter contract
+#   clean (no `models.*` dependency).
 
 from __future__ import annotations
 
@@ -90,11 +98,12 @@ import asyncio
 import logging
 import time
 import urllib.parse
-from typing import Literal
+from typing import Any, Literal
 
 import httpx
 from pydantic import BaseModel, Field, ValidationError
 
+from pocketpaw.bundled_templates.schema import RippleSpec
 from pocketpaw.security.url_validators import validate_external_url_strict
 from pocketpaw_ee.cloud.pockets._http_guard import (
     _HTTP_TIMEOUT,
@@ -285,8 +294,25 @@ def _select_sources(
     return dict(bindings)
 
 
+def _sources_block(ripple_spec: RippleSpec | dict | None) -> dict[str, Any]:
+    """Return the ``sources`` block from a ``RippleSpec | dict | None`` reader input.
+
+    Phase-2 dual-path: when handed a typed ``RippleSpec`` read its ``sources``
+    field; when handed a legacy flat dict use the existing ``.get("sources")``
+    path. ``None`` / a non-dict ``sources`` value yields an empty dict, exactly
+    as the prior ``(ripple_spec or {}).get("sources") or {}`` expression did.
+    """
+    if isinstance(ripple_spec, RippleSpec):
+        raw = ripple_spec.sources
+    elif isinstance(ripple_spec, dict):
+        raw = ripple_spec.get("sources")
+    else:
+        raw = None
+    return raw if isinstance(raw, dict) else {}
+
+
 def selected_source_keys(
-    ripple_spec: dict,
+    ripple_spec: RippleSpec | dict | None,
     *,
     trigger: str | None = None,
     only_source: str | None = None,
@@ -299,6 +325,8 @@ def selected_source_keys(
     entries (which ``_parse_bindings`` turns into parse errors, not bindings)
     are correctly excluded — they are never runnable.
 
+    Accepts a typed ``RippleSpec`` or a legacy flat dict (Phase-2 dual-path).
+
     Used by the ``sources/run`` route to decide, when no backend is
     configured, whether the request is a benign no-op (nothing selected →
     empty result) or a real misconfiguration (a runnable source was authored
@@ -309,13 +337,19 @@ def selected_source_keys(
     return list(selected.keys())
 
 
-def _parse_bindings(ripple_spec: dict) -> tuple[dict[str, SourceBinding], list[dict]]:
+def _parse_bindings(
+    ripple_spec: RippleSpec | dict | None,
+) -> tuple[dict[str, SourceBinding], list[dict]]:
     """Parse ``rippleSpec.sources`` into SourceBinding objects.
 
     Returns ``(valid_bindings, parse_errors)``. A malformed entry becomes a
     parse error rather than aborting the whole run.
+
+    Phase-2 dual-path: accepts a typed ``RippleSpec`` (reads ``spec.sources``)
+    or a legacy flat dict (the existing ``.get("sources")`` path). Either way a
+    malformed / absent ``sources`` block yields no bindings.
     """
-    raw = (ripple_spec or {}).get("sources") or {}
+    raw = _sources_block(ripple_spec)
     bindings: dict[str, SourceBinding] = {}
     errors: list[dict] = []
     if not isinstance(raw, dict):
@@ -565,7 +599,7 @@ async def run_sources(
     *,
     pocket_id: str,
     user_id: str,
-    ripple_spec: dict,
+    ripple_spec: RippleSpec | dict | None,
     base_url: str,
     auth_type: str,
     auth_header: str | None,

--- a/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
+++ b/ee/pocketpaw_ee/cloud/pockets/temporal_dispatcher.py
@@ -7,6 +7,13 @@
 # ``temporal_sweeps`` entity's job; per-row Instinct branching is
 # Wave 3a's; this module is the orchestration glue.
 #
+# Updated: 2026-06-19 (feat/typed-ripplespec-phase2) — DUAL-PATH READER. The
+# action-binding lookup in ``_dispatch_action_for_row`` now promotes the
+# pocket's rippleSpec through ``RippleSpec.from_flat_dict`` (accepts a legacy
+# flat dict OR a typed RippleSpec, never raises) before reading
+# ``spec.actions[name]``. A corrupt spec yields the same ``action_not_found``
+# soft failure. Promote-on-read; no document migration.
+#
 # Wave 3d scope (locked by the architect brief):
 #
 #   1. Load the prior sweep state via ``temporal_sweeps.service.load_last_seen``.
@@ -69,7 +76,7 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 
-from pocketpaw.bundled_templates import PocketTemplate
+from pocketpaw.bundled_templates import PocketTemplate, RippleSpec
 from pocketpaw.bundled_templates.identifier_resolver import IdentifierResolver
 from pocketpaw.bundled_templates.temporal_sweeper import (
     SweepResult,
@@ -290,7 +297,13 @@ async def _invoke_executor(
     base_url, auth_type, auth_header, token, allowed_writes, _approval_route, *_ = creds
 
     ripple_spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
-    actions = (ripple_spec or {}).get("actions")
+    # Phase-2 dual-path: ``get_pocket_ripple_spec`` returns a legacy flat dict
+    # today, but promote-on-read at the domain boundary means a typed
+    # ``RippleSpec`` is also a valid shape. ``RippleSpec.from_flat_dict``
+    # accepts either (idempotent on a RippleSpec) and never raises — a corrupt
+    # spec yields ``None`` → the ``action_not_found`` path below.
+    spec = RippleSpec.from_flat_dict(ripple_spec)
+    actions = spec.actions if spec is not None and isinstance(spec.actions, dict) else None
     raw_action = actions.get(action_name) if isinstance(actions, dict) else None
     if not isinstance(raw_action, dict):
         return {

--- a/ee/pocketpaw_ee/cloud/ripple_normalizer.py
+++ b/ee/pocketpaw_ee/cloud/ripple_normalizer.py
@@ -39,6 +39,14 @@ under any of several invented keys (``interval`` / ``interval_seconds``
 to a positive int, writes it as ``refresh_interval_seconds`` on the
 lifted source, and appends ``"interval"`` to its refresh policy. The
 interval scheduler floors a sub-minimum value at run time.
+
+Changes: 2026-06-19 (feat/typed-ripplespec-phase2) — DUAL-PATH READER.
+``normalize_ripple_spec`` now accepts ``RippleSpec | dict | None``. A typed
+``RippleSpec`` is flattened to its BSON-equivalent dict via ``to_flat_dict``
+at entry; the function ALWAYS returns a flat dict (never a ``RippleSpec``) so
+the persisted document and the wire stay ``Record<string, any>`` — the
+no-migration / byte-equivalent invariant. All existing tree repairs operate
+on the flat dict, unchanged.
 """
 
 from __future__ import annotations
@@ -47,6 +55,8 @@ import logging
 import secrets
 import urllib.parse
 from typing import Any
+
+from pocketpaw.bundled_templates.schema import RippleSpec
 
 log = logging.getLogger(__name__)
 
@@ -628,13 +638,24 @@ def _walk_and_fix(node: Any) -> Any:
     return node
 
 
-def normalize_ripple_spec(spec: dict[str, Any] | None) -> dict[str, Any] | None:
+def normalize_ripple_spec(
+    spec: RippleSpec | dict[str, Any] | None,
+) -> dict[str, Any] | None:
     """Normalize AI-generated rippleSpec before persistence.
 
     Ensures envelope fields (version, intent, lifecycle.id).
     Passes through UISpec and multi-pane specs with minimal changes.
     Generates widget IDs if missing for flat widget specs.
+
+    Phase-2 dual-path: accepts a typed ``RippleSpec`` or a legacy flat dict.
+    A ``RippleSpec`` is flattened to its BSON-equivalent dict via
+    ``to_flat_dict`` BEFORE normalization, and the result is ALWAYS a flat
+    dict (never a ``RippleSpec``) — the persisted document and the wire shape
+    stay ``Record<string, any>`` (no migration, byte-equivalent). The
+    normalizer's tree repairs operate on the flat dict exactly as before.
     """
+    if isinstance(spec, RippleSpec):
+        spec = spec.to_flat_dict()
     if not spec or not isinstance(spec, dict):
         return None
 

--- a/ee/pocketpaw_ee/cloud/ripple_validator.py
+++ b/ee/pocketpaw_ee/cloud/ripple_validator.py
@@ -23,6 +23,14 @@ new token / method added to the resolver should be added here too — the
 two files together are the contract.
 
 Changes:
+  - 2026-06-19 (feat/typed-ripplespec-phase2): DUAL-PATH READER. Every public
+    spec reader (``validate_ripple_spec`` + ``_logged`` / ``_strict``,
+    ``validate_against_catalog_*``, ``validate_action_wiring_*``,
+    ``validate_required_props_*``, ``find_unreferenced_state_keys``) now accepts
+    ``RippleSpec | dict | None``. A new ``_as_flat_dict`` helper flattens a
+    typed ``RippleSpec`` to its BSON-equivalent dict so the existing whole-spec
+    tree walks run unchanged; a legacy dict passes through. Promote-on-read,
+    no migration.
   - 2026-05-31 (constraint-zone enforcer): added the required-prop gate —
     ``MissingRequiredPropError`` plus ``validate_required_props_strict``
     (agent-generation path, RAISES) and ``..._logged`` (human/import path,
@@ -56,6 +64,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
+from pocketpaw.bundled_templates.schema import RippleSpec
 from pocketpaw.ripple.manifest import (
     check_embed_nodes_in_spec,
     find_unwired_live_buttons,
@@ -65,6 +74,20 @@ from pocketpaw.ripple.manifest import (
 )
 
 log = logging.getLogger(__name__)
+
+
+def _as_flat_dict(spec: RippleSpec | dict[str, Any] | None) -> dict[str, Any] | None:
+    """Coerce a ``RippleSpec | dict | None`` reader input to a flat dict.
+
+    Phase-2 dual-path: a typed ``RippleSpec`` is flattened to its
+    BSON-equivalent dict (``to_flat_dict``) so the existing whole-spec tree
+    walks (expression grammar, catalog, action wiring, required props, orphan
+    state) run UNCHANGED on the flat shape. A legacy dict passes through; any
+    other value becomes ``None`` (the walkers already no-op on a non-dict).
+    """
+    if isinstance(spec, RippleSpec):
+        return spec.to_flat_dict()
+    return spec if isinstance(spec, dict) else None
 
 
 # Mirrors the whitelist in ``expression-resolver.ts:applyMethod``.
@@ -255,12 +278,15 @@ def _validate_one(path: str, expression: str) -> list[ExpressionWarning]:
 # ---------------------------------------------------------------------------
 
 
-def validate_ripple_spec(spec: dict[str, Any] | None) -> list[ExpressionWarning]:
+def validate_ripple_spec(spec: RippleSpec | dict[str, Any] | None) -> list[ExpressionWarning]:
     """Walk the spec and return one warning per offending expression.
 
     Empty list means the spec's expression grammar is fully supported by
     the current resolver. Does not block; never raises.
+
+    Accepts a typed ``RippleSpec`` or a legacy flat dict (Phase-2 dual-path).
     """
+    spec = _as_flat_dict(spec)
     if not isinstance(spec, dict):
         return []
     out: list[ExpressionWarning] = []
@@ -272,7 +298,7 @@ def validate_ripple_spec(spec: dict[str, Any] | None) -> list[ExpressionWarning]
 
 
 def validate_ripple_spec_logged(
-    spec: dict[str, Any] | None,
+    spec: RippleSpec | dict[str, Any] | None,
     *,
     pocket_id: str | None = None,
     workspace_id: str | None = None,
@@ -323,7 +349,7 @@ class RippleSpecGrammarError(Exception):
 
 
 def validate_ripple_spec_strict(
-    spec: dict[str, Any] | None,
+    spec: RippleSpec | dict[str, Any] | None,
     *,
     pocket_id: str | None = None,
     workspace_id: str | None = None,
@@ -408,13 +434,14 @@ class CatalogViolationError(Exception):
 
 
 def _collect_catalog_violations(
-    spec: dict[str, Any] | None,
+    spec: RippleSpec | dict[str, Any] | None,
     allowed_types: list[str] | set[str],
     embed_allowed_hosts: list[str] | set[str],
 ) -> list[dict[str, Any]]:
     """Run both the catalog-type walk and the embed URL/host walk, return
     the combined violations list (unknown-type issues first, then embed
     policy issues)."""
+    spec = _as_flat_dict(spec)
     violations: list[dict[str, Any]] = []
     violations.extend(validate_against_catalog(spec, allowed_types))
     violations.extend(check_embed_nodes_in_spec(spec, embed_allowed_hosts))
@@ -448,7 +475,7 @@ def format_violations_for_agent(violations: list[dict[str, Any]]) -> str:
 
 
 def validate_against_catalog_logged(
-    spec: dict[str, Any] | None,
+    spec: RippleSpec | dict[str, Any] | None,
     allowed_types: list[str] | set[str],
     *,
     embed_allowed_hosts: list[str] | set[str],
@@ -490,7 +517,7 @@ def validate_against_catalog_logged(
 
 
 def validate_against_catalog_strict(
-    spec: dict[str, Any] | None,
+    spec: RippleSpec | dict[str, Any] | None,
     allowed_types: list[str] | set[str],
     *,
     embed_allowed_hosts: list[str] | set[str],
@@ -563,7 +590,9 @@ class ActionWiringViolationError(Exception):
         return "\n".join(lines)
 
 
-def _collect_action_wiring_violations(spec: dict[str, Any] | None) -> list[dict[str, Any]]:
+def _collect_action_wiring_violations(
+    spec: RippleSpec | dict[str, Any] | None,
+) -> list[dict[str, Any]]:
     """Run both action-wiring walks, return the combined list.
 
     Unknown-verb issues first (cheaper to fix, also catch the inert
@@ -572,6 +601,7 @@ def _collect_action_wiring_violations(spec: dict[str, Any] | None) -> list[dict[
     handler that also fails the live-button check isn't reported
     twice.
     """
+    spec = _as_flat_dict(spec)
     violations: list[dict[str, Any]] = []
     violations.extend(validate_action_verbs(spec))
     seen_paths = {v["path"] for v in violations}
@@ -614,7 +644,7 @@ def format_action_violations_for_agent(violations: list[dict[str, Any]]) -> str:
 
 
 def validate_action_wiring_logged(
-    spec: dict[str, Any] | None,
+    spec: RippleSpec | dict[str, Any] | None,
     *,
     pocket_id: str | None = None,
     workspace_id: str | None = None,
@@ -654,7 +684,7 @@ def validate_action_wiring_logged(
 
 
 def validate_action_wiring_strict(
-    spec: dict[str, Any] | None,
+    spec: RippleSpec | dict[str, Any] | None,
     *,
     pocket_id: str | None = None,
     workspace_id: str | None = None,
@@ -746,7 +776,7 @@ def format_required_prop_violations_for_agent(violations: list[dict[str, Any]]) 
 
 
 def validate_required_props_logged(
-    spec: dict[str, Any] | None,
+    spec: RippleSpec | dict[str, Any] | None,
     manifest_or_required: dict[str, Any],
     *,
     pocket_id: str | None = None,
@@ -759,7 +789,7 @@ def validate_required_props_logged(
     but does NOT block the write (an older imported spec may predate a prop
     becoming required).
     """
-    violations = validate_required_props(spec, manifest_or_required)
+    violations = validate_required_props(_as_flat_dict(spec), manifest_or_required)
     for v in violations:
         log.warning(
             "ripple_spec.missing_required_prop",
@@ -775,7 +805,7 @@ def validate_required_props_logged(
 
 
 def validate_required_props_strict(
-    spec: dict[str, Any] | None,
+    spec: RippleSpec | dict[str, Any] | None,
     manifest_or_required: dict[str, Any],
     *,
     pocket_id: str | None = None,
@@ -900,7 +930,7 @@ def _collect_referenced_state(
         referenced.update(_state_keys_in_expression(node))
 
 
-def find_unreferenced_state_keys(spec: dict[str, Any] | None) -> list[str]:
+def find_unreferenced_state_keys(spec: RippleSpec | dict[str, Any] | None) -> list[str]:
     """Return top-level ``state`` keys that no ui node references.
 
     Walks ``spec["ui"]`` collecting every state reference (template
@@ -912,8 +942,11 @@ def find_unreferenced_state_keys(spec: dict[str, Any] | None) -> list[str]:
     Pure / side-effect-free — mirrors ``find_unwired_live_buttons``. The
     caller decides what to do with the result; this never blocks.
 
-    Returns ``[]`` when ``spec`` is not a dict or has no ``state`` dict.
+    Accepts a typed ``RippleSpec`` or a legacy flat dict (Phase-2 dual-path).
+    Returns ``[]`` when ``spec`` is not a dict / RippleSpec or has no
+    ``state`` dict.
     """
+    spec = _as_flat_dict(spec)
     if not isinstance(spec, dict):
         return []
     state = spec.get("state")

--- a/tests/ee/pockets/test_reader_dual_path.py
+++ b/tests/ee/pockets/test_reader_dual_path.py
@@ -1,0 +1,325 @@
+# tests/ee/pockets/test_reader_dual_path.py
+# Created: 2026-06-19 (feat/typed-ripplespec-phase2) — TDD coverage for the
+# Phase 2 executor/reader dual-path + domain-boundary promotion. Phase 1
+# (#1503) shipped the typed RippleSpec model and used it INTERNALLY in
+# service.update + reconcile; Phase 2 makes the reader layer accept
+# ``RippleSpec | dict`` and promotes dict -> RippleSpec at the domain
+# boundary (``_pocket_to_domain``).
+#
+# THE MIGRATION INVARIANT under test (non-negotiable — the hot read path):
+#   * Dual-path / back-compat: EVERY touched reader works given EITHER a raw
+#     legacy dict OR a typed RippleSpec. A reader that breaks on a legacy dict
+#     is a FAILURE.
+#   * No migration: ``to_flat_dict`` is byte-equivalent; nothing rewrites
+#     stored documents — promotion happens on read only.
+#   * No data loss: unknown/passthrough keys survive a read->write round-trip
+#     (RippleSpec has ``extra="allow"``).
+#   * A corrupt/unpromotable spec must NOT break a reader (falls back to the
+#     dict path).
+#
+# These tests are unit-level (no Mongo): they call each reader directly with
+# both shapes. The route-level suites (test_sources_run_endpoint,
+# test_template_reconcile_route, ...) remain the integration gate.
+"""Phase-2 dual-path reader tests for the typed RippleSpec."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw.bundled_templates import RippleSpec  # noqa: E402
+
+# A realistic seeded-shape rippleSpec: a UISpec tree + instance state +
+# read sources + write actions + a passthrough key the readers never touch
+# but which MUST survive a round-trip.
+_SEEDED_FLAT: dict = {
+    "ui": {
+        "type": "stack",
+        "id": "n_root",
+        "children": [{"type": "text", "id": "n_t", "props": {"text": "{state.title}"}}],
+    },
+    "state": {"title": "Hello", "rows": [{"id": "r1"}, {"id": "r2"}]},
+    "selections": {"row": "r1"},
+    "sources": {
+        "feed": {"method": "GET", "path": "/feed", "bind": "state.rows", "refresh": ["pocket_open"]}
+    },
+    "actions": {
+        "save": {
+            "kind": "write_binding",
+            "method": "POST",
+            "path": "/save",
+            "params": {},
+            "instinct_exempt": True,
+            "requires_instinct": False,
+        }
+    },
+    # Passthrough / unknown keys — must round-trip untouched.
+    "kb_scope": "pocket",
+    "schema_version": "2",
+    "triggers": [{"type": "manual"}],
+    "some_future_key": {"nested": [1, 2, 3]},
+}
+
+
+def _typed() -> RippleSpec:
+    """The seeded spec promoted to a typed RippleSpec."""
+    spec = RippleSpec.from_flat_dict(_SEEDED_FLAT)
+    assert spec is not None
+    return spec
+
+
+def _strip_ids(node):
+    """Drop minted ``id`` keys recursively.
+
+    ``normalize_ripple_spec`` re-mints a random ``n_<hex>`` id on every node on
+    every call (pre-existing ``ensure_ids`` behavior, orthogonal to Phase 2).
+    Comparing two separate normalize calls therefore needs the ids stripped —
+    the dual-path contract is about the STRUCTURE being identical, not the
+    randomized ids.
+    """
+    if isinstance(node, dict):
+        return {k: _strip_ids(v) for k, v in node.items() if k != "id"}
+    if isinstance(node, list):
+        return [_strip_ids(c) for c in node]
+    return node
+
+
+# ---------------------------------------------------------------------------
+# source_executor._parse_bindings — dual-path
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bindings_legacy_dict() -> None:
+    from pocketpaw_ee.cloud.pockets.source_executor import _parse_bindings
+
+    bindings, errors = _parse_bindings(_SEEDED_FLAT)
+    assert errors == []
+    assert "feed" in bindings
+    assert bindings["feed"].path == "/feed"
+
+
+def test_parse_bindings_typed_spec() -> None:
+    from pocketpaw_ee.cloud.pockets.source_executor import _parse_bindings
+
+    bindings, errors = _parse_bindings(_typed())
+    assert errors == []
+    assert "feed" in bindings
+    assert bindings["feed"].path == "/feed"
+
+
+def test_parse_bindings_none_and_empty() -> None:
+    from pocketpaw_ee.cloud.pockets.source_executor import _parse_bindings
+
+    assert _parse_bindings(None) == ({}, [])
+    assert _parse_bindings(RippleSpec()) == ({}, [])
+
+
+def test_selected_source_keys_dual_path() -> None:
+    from pocketpaw_ee.cloud.pockets.source_executor import selected_source_keys
+
+    assert selected_source_keys(_SEEDED_FLAT, trigger="pocket_open") == ["feed"]
+    assert selected_source_keys(_typed(), trigger="pocket_open") == ["feed"]
+
+
+# ---------------------------------------------------------------------------
+# bulk_dispatch — actions read via from_flat_dict
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_dispatch_reads_actions_from_legacy_dict() -> None:
+    # The helper extracts the named action binding off the (legacy) wire dict.
+    from pocketpaw_ee.cloud.pockets.bulk_dispatch import _action_binding_for
+
+    raw = _action_binding_for(_SEEDED_FLAT, "save")
+    assert isinstance(raw, dict)
+    assert raw["method"] == "POST"
+
+
+def test_bulk_dispatch_reads_actions_from_typed_spec() -> None:
+    from pocketpaw_ee.cloud.pockets.bulk_dispatch import _action_binding_for
+
+    raw = _action_binding_for(_typed(), "save")
+    assert isinstance(raw, dict)
+    assert raw["method"] == "POST"
+
+
+def test_bulk_dispatch_missing_action_returns_none() -> None:
+    from pocketpaw_ee.cloud.pockets.bulk_dispatch import _action_binding_for
+
+    assert _action_binding_for(_SEEDED_FLAT, "nope") is None
+    assert _action_binding_for(_typed(), "nope") is None
+    assert _action_binding_for(None, "save") is None
+    assert _action_binding_for("corrupt", "save") is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# ripple_normalizer.normalize_ripple_spec — dual-path; returns the flat wire
+# dict in BOTH cases (the wire stays Record<string, any>) and preserves the
+# passthrough/unknown keys.
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_legacy_dict_unchanged_wire_shape() -> None:
+    from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
+
+    out = normalize_ripple_spec(_SEEDED_FLAT)
+    assert isinstance(out, dict)
+    # State + passthrough survive.
+    assert out["state"]["rows"] == [{"id": "r1"}, {"id": "r2"}]
+    assert out["kb_scope"] == "pocket"
+    assert out["some_future_key"] == {"nested": [1, 2, 3]}
+
+
+def test_normalize_typed_spec_returns_equivalent_wire_dict() -> None:
+    from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
+
+    from_dict = normalize_ripple_spec(_SEEDED_FLAT)
+    from_typed = normalize_ripple_spec(_typed())
+    assert isinstance(from_typed, dict)
+    # Same logical wire shape regardless of input type (byte-equivalent
+    # invariant: a promoted spec normalizes to the same stored document).
+    # Node ids are randomized per-call, so compare structure id-stripped.
+    assert _strip_ids(from_typed["ui"]) == _strip_ids(from_dict["ui"])
+    assert from_typed["state"] == from_dict["state"]
+    assert from_typed["kb_scope"] == "pocket"
+    assert from_typed["some_future_key"] == {"nested": [1, 2, 3]}
+
+
+def test_normalize_none_returns_none() -> None:
+    from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
+
+    assert normalize_ripple_spec(None) is None
+
+
+# ---------------------------------------------------------------------------
+# ripple_validator — dual-path on every public spec reader.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_ripple_spec_dual_path() -> None:
+    from pocketpaw_ee.cloud.ripple_validator import validate_ripple_spec
+
+    # A clean spec yields no warnings either way.
+    assert validate_ripple_spec(_SEEDED_FLAT) == []
+    assert validate_ripple_spec(_typed()) == []
+
+
+def test_validate_ripple_spec_flags_bad_expression_dual_path() -> None:
+    from pocketpaw_ee.cloud.ripple_validator import validate_ripple_spec
+
+    bad_flat = {
+        "ui": {"type": "text", "id": "n", "props": {"text": "{state.x.map(=> y)}"}},
+        "state": {},
+    }
+    dict_warnings = validate_ripple_spec(bad_flat)
+    typed_warnings = validate_ripple_spec(RippleSpec.from_flat_dict(bad_flat))
+    assert dict_warnings, "expected a grammar warning on the dict path"
+    # The typed path must surface the SAME finding (same ui tree walk).
+    assert {w.code for w in typed_warnings} == {w.code for w in dict_warnings}
+
+
+def test_find_unreferenced_state_keys_dual_path() -> None:
+    from pocketpaw_ee.cloud.ripple_validator import find_unreferenced_state_keys
+
+    flat = {
+        "ui": {"type": "text", "id": "n", "props": {"text": "{state.title}"}},
+        "state": {"title": "x", "orphan": "y"},
+    }
+    assert find_unreferenced_state_keys(flat) == ["orphan"]
+    assert find_unreferenced_state_keys(RippleSpec.from_flat_dict(flat)) == ["orphan"]
+
+
+# ---------------------------------------------------------------------------
+# Domain-boundary promotion — _pocket_to_domain promotes dict -> RippleSpec,
+# but a corrupt spec falls back to the raw value and never breaks the load.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDoc:
+    """Minimal stand-in for the Beanie Pocket doc the converter reads."""
+
+    def __init__(self, ripple_spec):
+        self.id = "pid"
+        self.workspace = "ws"
+        self.name = "n"
+        self.description = "d"
+        self.type = "custom"
+        self.icon = ""
+        self.color = ""
+        self.owner = "owner"
+        self.visibility = "private"
+        self.team = []
+        self.agents = []
+        self.widgets = []
+        self.rippleSpec = ripple_spec
+        self.share_link_token = None
+        self.share_link_access = "view"
+        self.shared_with = []
+        self.tool_specs = []
+
+
+def test_pocket_to_domain_promotes_dict_to_ripplespec() -> None:
+    from pocketpaw_ee.cloud.pockets import service as svc
+
+    pocket = svc._pocket_to_domain(_FakeDoc(_SEEDED_FLAT))
+    assert isinstance(pocket.ripple_spec, RippleSpec)
+    assert pocket.ripple_spec.instance_layer.state["title"] == "Hello"
+    # Passthrough keys survive promotion + round-trip.
+    assert pocket.ripple_spec.to_flat_dict()["some_future_key"] == {"nested": [1, 2, 3]}
+
+
+def test_pocket_to_domain_none_stays_none() -> None:
+    from pocketpaw_ee.cloud.pockets import service as svc
+
+    pocket = svc._pocket_to_domain(_FakeDoc(None))
+    assert pocket.ripple_spec is None
+
+
+def test_pocket_to_domain_empty_dict_stays_empty_dict() -> None:
+    # Byte-equivalence: a stored ``rippleSpec: {}`` must stay ``{}`` (NOT
+    # promote to a truthy RippleSpec that would later normalize away to None
+    # on the wire). The wire serializer keys off truthiness.
+    from pocketpaw_ee.cloud.pockets import service as svc
+
+    pocket = svc._pocket_to_domain(_FakeDoc({}))
+    assert pocket.ripple_spec == {}
+    assert not isinstance(pocket.ripple_spec, RippleSpec)
+
+
+def test_pocket_to_domain_corrupt_spec_falls_back_to_raw() -> None:
+    # A non-dict / unpromotable rippleSpec must NOT break pocket load: the
+    # converter falls back to the raw stored value.
+    from pocketpaw_ee.cloud.pockets import service as svc
+
+    corrupt = "this is not a spec"
+    pocket = svc._pocket_to_domain(_FakeDoc(corrupt))
+    assert pocket.ripple_spec == corrupt
+
+
+# ---------------------------------------------------------------------------
+# Wire byte-equivalence — a promoted Pocket serializes to the SAME wire dict
+# a legacy (dict) Pocket would. This is the no-document-migration invariant
+# expressed at the serializer boundary.
+# ---------------------------------------------------------------------------
+
+
+def test_wire_serialization_is_equivalent_for_dict_and_typed() -> None:
+    import dataclasses
+
+    from pocketpaw_ee.cloud.pockets import service as svc
+    from pocketpaw_ee.cloud.pockets.dto import pocket_to_wire_dict
+
+    legacy = svc._pocket_to_domain(_FakeDoc(_SEEDED_FLAT))
+    # Force the dict path for the comparison baseline.
+    legacy_dict = dataclasses.replace(legacy, ripple_spec=dict(_SEEDED_FLAT))
+
+    wire_typed = pocket_to_wire_dict(legacy)
+    wire_dict = pocket_to_wire_dict(legacy_dict)
+
+    assert _strip_ids(wire_typed["rippleSpec"]["ui"]) == _strip_ids(wire_dict["rippleSpec"]["ui"])
+    assert wire_typed["rippleSpec"]["state"] == wire_dict["rippleSpec"]["state"]
+    assert wire_typed["rippleSpec"]["some_future_key"] == {"nested": [1, 2, 3]}
+    # The wire rippleSpec is a plain dict, never a RippleSpec object.
+    assert isinstance(wire_typed["rippleSpec"], dict)
+    assert not isinstance(wire_typed["rippleSpec"], RippleSpec)


### PR DESCRIPTION
## What this does

Second slice of the typed rippleSpec work. The first slice (#1503) added the `RippleSpec` / `TemplateLayer` / `InstanceLayer` model and used it inside `service.update` and reconcile, but every reader still received a plain dict. This change makes the executor and reader layer typed — without rewriting a single stored document.

Every rippleSpec reader now accepts a `RippleSpec` or a dict and behaves identically with either:

- `source_executor` — `_parse_bindings` / `selected_source_keys` / `run_sources` read `spec.sources` from a typed spec or `.get("sources")` from a legacy dict (via a small `_sources_block` helper)
- `bulk_dispatch` — a new `_action_binding_for` helper promotes the pocket's stored dict to a `RippleSpec` and reads `spec.actions[name]`
- `temporal_dispatcher` — same promote-then-read for the per-row action lookup
- `ripple_normalizer` — `normalize_ripple_spec` flattens a typed spec to its dict at entry and always returns a dict, so the persisted document and the wire stay `Record<string, any>`
- `ripple_validator` — every public spec reader flattens a typed spec before its existing whole-spec tree walk (a shared `_as_flat_dict` helper)
- `agent_context` — coerces a typed spec to a dict at entry on the two spec-reading helpers

The promotion itself happens at the domain boundary: `_pocket_to_domain` turns a non-empty stored dict into a `RippleSpec`, and `domain.Pocket.ripple_spec` widens to `RippleSpec | dict | None` for the transition.

## The migration invariant

This is the hot read path, and every pocket on disk today is a live dict. The change holds the invariant end to end:

- **Dual-path / back-compat** — every reader works given either a raw legacy dict or a typed `RippleSpec`. Tests cover both shapes for each reader.
- **Beanie stays dict; promote on read** — the `Pocket.rippleSpec` Beanie field is untouched. Promotion happens only when a doc is read.
- **No document migration** — `to_flat_dict` is byte-equivalent, so nothing rewrites stored documents. An empty `{}` stays `{}` so the wire shape is unchanged.
- **No data loss** — unknown and passthrough keys survive a read/write round-trip (`extra="allow"`).
- **Corrupt specs don't break load** — `from_flat_dict` never raises; an unpromotable spec falls back to the raw stored value.

## Tests

New `tests/ee/pockets/test_reader_dual_path.py` exercises each reader with both a legacy dict and a typed spec, plus the round-trip-preserves-unknown-keys, corrupt-spec-falls-back, empty-dict-stays-empty, and wire-byte-equivalence cases. The clobber-fix, reconcile, bulk, temporal, source-run, normalizer/validator, agent-context and the #1506 instinct-dispatch gate suites all stay green.

## Scope notes

- `action_executor.run_action` needs no change — it already takes the single resolved action binding, not the whole spec. The spec-level actions read lives in `bulk_dispatch` and `temporal_dispatcher`, which are the ones updated here.
- `get_pocket_ripple_spec` / `get_pocket_spec_and_slug` keep returning a dict. Their consumers (the webhook route, reconcile, the refresh scheduler) do dict reads or feed the now-dual-path executors, so returning a dict is correct and lower-risk than rippling a return-type change through the live reconcile path. The authoritative promotion is at `_pocket_to_domain`.
