### PR TITLE
Sites: workspace-scope Fabric object types (sovereign discovery foundation)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
@@ -34,8 +34,9 @@
 #     workspace (fix/fabric-stats-workspace-scope: the original instance-wide
 #     stats leaked another tenant's experimental type names into chat on a
 #     shared box). Counts mirror fabric_query's visibility exactly; the type
-#     list holds only types with object rows visible to the workspace (type
-#     DEFINITIONS are global in the schema — see FabricStore.list_types).
+#     list holds only the caller workspace's own types (SZD-2: the
+#     fabric_object_types table now carries a workspace_id; a NULL workspace_id
+#     is a legacy/global type visible to all — see FabricStore.list_types).
 #
 # Read-only: neither tool writes anything. FabricCreateTool is deliberately
 # NOT wrapped — ontology writes from the SDK backend should arrive as gated

--- a/ee/pocketpaw_ee/fabric/router.py
+++ b/ee/pocketpaw_ee/fabric/router.py
@@ -35,6 +35,14 @@
 #   the store's scoped ``list_types()`` / ``stats()`` (own rows + legacy NULL
 #   rows, matching every other scoped read; type list = defined types with at
 #   least one visible object row — definitions stay global in the schema).
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — the
+#   ``POST /fabric/types`` (define_type) endpoint now stamps the caller's
+#   ``current_workspace_id`` onto the new type, so the discovered-type catalog
+#   is private per tenant: a type defined by workspace A is invisible/unusable
+#   from workspace B (``get_type_by_name`` / ``list_types`` / ``stats`` are
+#   scoped on the type's own ``workspace_id`` now). This supersedes the W4a /
+#   fix/fabric-stats note above that called definitions "global in the schema"
+#   — they carry their own workspace column as of SZD-2.
 
 from __future__ import annotations
 
@@ -125,13 +133,18 @@ async def list_types(workspace_id: str = Depends(current_workspace_id)):
     status_code=201,
     dependencies=[Depends(require_action_any_workspace("fabric.write"))],
 )
-async def define_type(req: DefineTypeRequest):
+async def define_type(
+    req: DefineTypeRequest,
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Define an object type stamped with the caller's active workspace (SZD-2)."""
     return await _store().define_type(
         name=req.name,
         properties=req.properties,
         description=req.description,
         icon=req.icon,
         color=req.color,
+        workspace_id=workspace_id,
     )
 
 

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -12,6 +12,15 @@
 #   existing ObjectType by id (the EE Firestore→Fabric worker's per-workspace
 #   mapping) ride this same canonical upsert loop instead of hand-rolling a
 #   parallel one. Additive; name-based callers are unchanged.
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ensure_type() now
+#   threads ``workspace_id`` into both the get_type_by_name() resolve and the
+#   define_type() create, so the type catalog stays per-tenant: a connector
+#   ingesting into workspace A resolves/defines its ObjectType inside A, and the
+#   same logical type name in workspace B resolves to B's own type (or is
+#   defined fresh for B) rather than silently reusing A's. ``ingest_records``
+#   already carried ``workspace_id`` for the object writes; it now forwards it to
+#   ensure_type so the TYPE mint is scoped too. ``None`` (OSS / single-tenant
+#   callers) keeps the prior unscoped behavior.
 #
 # WHY THIS EXISTS
 # ---------------
@@ -117,22 +126,30 @@ class IngestResult:
         return self.created + self.updated
 
 
-async def ensure_type(store: FabricStore, mapping: FabricMapping) -> str:
+async def ensure_type(
+    store: FabricStore, mapping: FabricMapping, workspace_id: str | None = None
+) -> str:
     """Ensure the mapping's ObjectType exists; return its ``type_id``.
 
     When the mapping carries an explicit ``type_id`` (the caller's config
     references an existing type by id), return it directly — no name lookup,
     no implicit define.
 
-    Otherwise, define-once-by-name: if a type with this name already exists (a
-    prior sync, a manually-defined ontology type, the EE fabric registry),
-    reuse it rather than creating a second type that would split the same
-    logical objects across two ``type_id``s. Name match is case-insensitive
-    (see get_type_by_name).
+    Otherwise, define-once-by-name: if a type with this name already exists in
+    the caller's workspace (a prior sync, a manually-defined ontology type, the
+    EE fabric registry), reuse it rather than creating a second type that would
+    split the same logical objects across two ``type_id``s. Name match is
+    case-insensitive (see get_type_by_name).
+
+    SZD-2: ``workspace_id`` scopes both the resolve and the define so the type
+    catalog is per-tenant — workspace A's "CalendarEvent" type is neither found
+    nor reused when ingesting into workspace B, and a fresh define for B is
+    stamped with B's workspace. ``None`` keeps the unscoped behavior for OSS /
+    single-tenant callers.
     """
     if mapping.type_id:
         return mapping.type_id
-    existing = await store.get_type_by_name(mapping.type_name)
+    existing = await store.get_type_by_name(mapping.type_name, workspace_id=workspace_id)
     if existing is not None:
         return existing.id
     created = await store.define_type(
@@ -141,6 +158,7 @@ async def ensure_type(store: FabricStore, mapping: FabricMapping) -> str:
         description=mapping.type_description,
         icon=mapping.type_icon,
         color=mapping.type_color,
+        workspace_id=workspace_id,
     )
     return created.id
 
@@ -172,7 +190,7 @@ async def ingest_records(
     lacking a usable source_id are skipped (counted) — without a stable key they
     cannot be deduplicated and would silently duplicate on every sync.
     """
-    type_id = await ensure_type(store, mapping)
+    type_id = await ensure_type(store, mapping, workspace_id=workspace_id)
     result = IngestResult(type_name=mapping.type_name)
 
     for record in records:

--- a/src/pocketpaw/fabric/models.py
+++ b/src/pocketpaw/fabric/models.py
@@ -19,6 +19,15 @@
 #   latency / infinite-loop risk); PathHop.link_type carries Field(max_length=200)
 #   as a sanity bound on an LLM-facing string (values are already bound params,
 #   so this is hygiene, not injection defense).
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ObjectType gains an
+#   optional ``workspace_id`` so the discovered-type catalog is per-tenant. This
+#   reverses the earlier W4a choice (object_types deliberately had NO workspace
+#   column then); the "sovereign zero-setup discovery" feature requires each
+#   tenant's discovered object TYPES to stay private, so a type defined in
+#   workspace A must be invisible/unusable from workspace B. ``None`` = a
+#   legacy/global type predating tenancy (or an OSS / single-tenant caller),
+#   which a scoped read still sees — exactly the NULL-as-legacy boundary the
+#   W4a object/link scoping already uses.
 
 from __future__ import annotations
 
@@ -66,6 +75,10 @@ class ObjectType(BaseModel):
     icon: str = "box"
     color: str = "#0A84FF"
     properties: list[PropertyDef] = Field(default_factory=list)
+    # Tenancy (SZD-2): the owning workspace of this object TYPE. ``None`` =
+    # legacy/global type written before per-type tenancy or by an OSS /
+    # single-tenant caller; a scoped read still sees it (own rows + NULL).
+    workspace_id: str | None = None
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
 

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -99,6 +99,42 @@
 #   tenant-scoped per hop, so this changes no result, it just makes the last read
 #   self-guarding. Walk is iterative, fixed-depth, no cross-hop cycle re-visit
 #   (see the note in _query_path).
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — closes the LAST
+#   cross-tenant leak in the Fabric store: the object-TYPE catalog was GLOBAL.
+#   W4a deliberately left ``fabric_object_types`` without a ``workspace_id``
+#   column ("definitions are not per-tenant data"), and ``list_types`` / ``stats``
+#   only hid type NAMES indirectly by joining to a visible object row. But the
+#   "sovereign zero-setup discovery" feature requires the DISCOVERED type catalog
+#   to be private per workspace, and ``define_type`` / ``get_type_by_name`` took
+#   no workspace — so a type defined in workspace A was directly visible and
+#   reusable from workspace B (``get_type_by_name`` returned it, ``ensure_type``
+#   reused its id). This change:
+#     1. Adds a ``workspace_id TEXT`` column to ``fabric_object_types`` via the
+#        same additive ALTER migration the W4a object/link columns use (idempotent
+#        — the duplicate-column OperationalError is swallowed on every boot). A
+#        pre-existing row keeps NULL ``workspace_id`` = legacy/global; the backfill
+#        below attributes a row to a workspace ONLY when every object of that type
+#        unambiguously shares one workspace (otherwise it stays NULL = global, the
+#        documented sentinel — a type cannot be safely attributed after the fact
+#        when its objects span tenants or predate tenancy).
+#     2. ``define_type`` stamps the caller's ``workspace_id``; ``get_type_by_name``
+#        and ``get_type`` take an optional ``workspace_id`` and apply the same
+#        ``(workspace_id = ? OR workspace_id IS NULL)`` scope as every other W4a
+#        read. A scoped read for workspace B can therefore neither see nor reuse
+#        workspace A's type. ``workspace_id=None`` = unscoped (OSS / agent-tool /
+#        single-tenant callers), full backward compatibility.
+#     3. ``list_types`` / ``stats`` now scope on the TYPE's OWN ``workspace_id``
+#        (own rows + legacy NULL) instead of joining through a visible object row,
+#        so a tenant's empty (object-less) type is visible to its owner and an
+#        owned-but-empty type no longer disappears — the type catalog is now first
+#        -class tenant data, not metadata inferred from object rows.
+#     4. The unique-name index becomes UNIQUE on ``(workspace_id, LOWER(name))``
+#        (was a global UNIQUE on ``LOWER(name)``) so two workspaces may each define
+#        their own "Customer" type; the concurrent-``ensure_type`` race guard now
+#        holds PER workspace. The de-dup pass keys on ``(workspace_id, name)`` to
+#        match. ``ensure_type`` / ``ingest_records`` (connectors/fabric_ingest.py)
+#        thread ``workspace_id`` so existing ingestion keeps working and minted
+#        types land in the caller's tenant.
 
 
 from __future__ import annotations
@@ -141,6 +177,11 @@ CREATE TABLE IF NOT EXISTS fabric_object_types (
     icon TEXT DEFAULT 'box',
     color TEXT DEFAULT '#0A84FF',
     properties_schema TEXT DEFAULT '[]',
+    -- Tenancy (SZD-2): the owning workspace of this object TYPE. NULL =
+    -- legacy/global type written before per-type tenancy or by an OSS caller;
+    -- a scoped read still sees it (own rows + NULL). On a pre-SZD-2 DB this
+    -- column is added by the ALTER migration in _ensure_schema, NOT here.
+    workspace_id TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -187,19 +228,34 @@ CREATE INDEX IF NOT EXISTS idx_links_type ON fabric_links(link_type);
 _WORKSPACE_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_objects_workspace ON fabric_objects(workspace_id)",
     "CREATE INDEX IF NOT EXISTS idx_links_workspace ON fabric_links(workspace_id)",
+    # SZD-2: a plain (non-unique) index on the type's workspace for scoped
+    # list_types / stats reads. The UNIQUE (workspace_id, LOWER(name)) index is
+    # created separately (_TYPE_NAME_UNIQUE_INDEX_SQL) after the de-dup pass.
+    "CREATE INDEX IF NOT EXISTS idx_object_types_workspace ON fabric_object_types(workspace_id)",
 )
 
-# A UNIQUE index on the (case-folded) type name closes a concurrent
+# A UNIQUE index on (workspace_id, case-folded type name) closes a concurrent
 # ``ensure_type`` race: two callers both miss ``get_type_by_name`` and both run
 # ``define_type``, leaving two type rows with the SAME name but different ids —
 # objects of "the same logical type" then split across two ``type_id``s. Created
 # AFTER SCHEMA_SQL (same reason as _WORKSPACE_INDEX_SQL): a pre-existing DB may
 # already hold duplicate-name rows, so _ensure_schema de-dups defensively before
 # creating the index. ``get_type_by_name`` matches case-insensitively, so the
-# uniqueness key is LOWER(name) to match.
+# name key is LOWER(name).
+#
+# SZD-2: the uniqueness key now includes ``workspace_id`` so two DIFFERENT
+# workspaces may each define their own "Customer" type — the race guard is
+# per-workspace. SQLite treats NULLs as DISTINCT in a UNIQUE index, so legacy
+# NULL-workspace rows are NOT collapsed by this index (multiple NULL-workspace
+# "Customer" rows can coexist); the de-dup pass that runs first keys on
+# (workspace_id, name) and still collapses true within-workspace duplicates
+# (including NULL/NULL pairs) up front. The old global index on LOWER(name)
+# (``idx_object_types_name_unique``) is DROPPED in the migration first, because
+# it would otherwise reject a second workspace defining a name the first used.
+_OLD_GLOBAL_TYPE_NAME_INDEX = "idx_object_types_name_unique"
 _TYPE_NAME_UNIQUE_INDEX_SQL = (
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_object_types_name_unique"
-    " ON fabric_object_types(LOWER(name))"
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_object_types_ws_name_unique"
+    " ON fabric_object_types(workspace_id, LOWER(name))"
 )
 
 # Whitelist of filter operators -> SQL operator. User input never reaches the
@@ -318,28 +374,45 @@ class FabricStore:
             return
         async with aiosqlite.connect(self._db_path) as db:
             await db.executescript(SCHEMA_SQL)
-            # Additive migration (W4a): tenancy columns on a pre-existing DB.
-            # CREATE TABLE IF NOT EXISTS won't add a column to a table that
+            # Additive migration (W4a + SZD-2): tenancy columns on a pre-existing
+            # DB. CREATE TABLE IF NOT EXISTS won't add a column to a table that
             # already exists, so ALTER and swallow the duplicate-column error
             # that fires on every subsequent boot — same pattern as the W2b
             # instinct hash-chain / assignee migrations. Pre-existing rows keep
-            # NULL workspace_id (legacy/global; see the module header).
-            for _tbl in ("fabric_objects", "fabric_links"):
+            # NULL workspace_id (legacy/global; see the module header). SZD-2
+            # extends the same ALTER to fabric_object_types so the type catalog
+            # is per-tenant too.
+            for _tbl in ("fabric_objects", "fabric_links", "fabric_object_types"):
                 try:
                     await db.execute(f"ALTER TABLE {_tbl} ADD COLUMN workspace_id TEXT")
                 except aiosqlite.OperationalError:
                     pass
+            # SZD-2: drop the pre-SZD-2 GLOBAL unique index on LOWER(name) if it
+            # exists. It enforced one type name per WHOLE DB; under per-workspace
+            # tenancy two tenants must be able to use the same name, so it would
+            # otherwise reject the second tenant's define_type. The replacement
+            # (workspace_id, LOWER(name)) index is created below. DROP IF EXISTS
+            # is a no-op on a fresh / already-migrated DB.
+            await db.execute(f"DROP INDEX IF EXISTS {_OLD_GLOBAL_TYPE_NAME_INDEX}")
             # Create the tenancy indexes only after the column is guaranteed to
             # exist (fresh DB via CREATE TABLE, or pre-existing DB via the ALTER
             # above). Doing this inside SCHEMA_SQL would fail on a pre-W4a DB.
             for _idx in _WORKSPACE_INDEX_SQL:
                 await db.execute(_idx)
-            # Unique-name index on fabric_object_types. A pre-existing DB may
-            # already hold duplicate-name rows (the ensure_type race this index
-            # prevents could have fired before this code shipped), so de-dup
-            # FIRST, then create the index. Both steps are wrapped so a residual
-            # duplicate can never crash _ensure_schema — a metering/ontology
-            # nicety must not take the store down on boot.
+            # SZD-2 backfill: attribute a NULL-workspace type to a tenant ONLY
+            # when every object of that type unambiguously shares one workspace.
+            # A type whose objects span tenants (or that has no objects, or whose
+            # objects are themselves legacy NULL) stays NULL = global, the
+            # documented sentinel — it cannot be safely attributed after the
+            # fact. Idempotent: a second run finds nothing left to attribute.
+            await self._backfill_object_type_workspaces(db)
+            # Unique (workspace_id, name) index on fabric_object_types. A
+            # pre-existing DB may already hold duplicate (workspace, name) rows
+            # (the ensure_type race this index prevents could have fired before
+            # this code shipped), so de-dup FIRST, then create the index. Both
+            # steps are wrapped so a residual duplicate can never crash
+            # _ensure_schema — a metering/ontology nicety must not take the store
+            # down on boot.
             await self._dedup_object_types(db)
             try:
                 await db.execute(_TYPE_NAME_UNIQUE_INDEX_SQL)
@@ -350,37 +423,88 @@ class FabricStore:
                 # is a race guard, not a correctness invariant the store needs
                 # to function.
                 logger.warning(
-                    "could not create unique index on fabric_object_types(name) — "
-                    "duplicate type names may remain; ensure_type race guard is off",
+                    "could not create unique index on "
+                    "fabric_object_types(workspace_id, name) — duplicate type "
+                    "names may remain; ensure_type race guard is off",
                     exc_info=True,
                 )
             await db.commit()
         self._initialized = True
 
     @staticmethod
-    async def _dedup_object_types(db: aiosqlite.Connection) -> None:
-        """Collapse duplicate-name object types before the UNIQUE index is built.
+    async def _backfill_object_type_workspaces(db: aiosqlite.Connection) -> None:
+        """Attribute NULL-workspace object types to a tenant where unambiguous (SZD-2).
 
-        Two type rows can share a name (case-insensitively) only on a DB that
-        predates the unique index — the concurrent ``ensure_type`` race. Keep the
-        LOWEST rowid per case-folded name (the first-defined survivor), re-point
-        any objects bound to a losing type id at the survivor's id so no object is
-        orphaned, then delete the loser type rows. Best-effort: a failure here is
-        swallowed (logged) so it can never crash ``_ensure_schema``; the index
-        creation that follows is itself try/except-guarded as the final backstop.
+        A pre-SZD-2 row has NULL ``workspace_id``. We can sometimes recover the
+        owning tenant from its objects: if EVERY non-NULL object of the type
+        carries the SAME ``workspace_id`` and there is exactly one such workspace,
+        the type clearly belongs to that tenant and we stamp it. Otherwise — the
+        type has no objects, or its objects span multiple workspaces, or its
+        objects are themselves all legacy NULL — the row stays NULL = global (the
+        documented sentinel), because it cannot be safely attributed after the
+        fact. Only NULL-workspace type rows are touched, so this never re-homes a
+        type a caller already stamped. Idempotent: a second run re-derives the
+        same single-workspace attributions and finds nothing new to change.
+        Best-effort: any failure is swallowed (logged) so it can never crash
+        ``_ensure_schema``.
+        """
+        try:
+            db.row_factory = aiosqlite.Row
+            # For each NULL-workspace type, the DISTINCT non-NULL workspaces of
+            # its objects. A HAVING COUNT(DISTINCT ...) = 1 keeps only the
+            # types whose objects unambiguously live in a single tenant.
+            async with db.execute(
+                "SELECT o.type_id AS type_id, MIN(o.workspace_id) AS ws "
+                "FROM fabric_objects o "
+                "JOIN fabric_object_types t ON t.id = o.type_id "
+                "WHERE t.workspace_id IS NULL AND o.workspace_id IS NOT NULL "
+                "GROUP BY o.type_id "
+                "HAVING COUNT(DISTINCT o.workspace_id) = 1"
+            ) as cur:
+                rows = await cur.fetchall()
+            for row in rows:
+                await db.execute(
+                    "UPDATE fabric_object_types SET workspace_id = ? "
+                    "WHERE id = ? AND workspace_id IS NULL",
+                    (row["ws"], row["type_id"]),
+                )
+        except aiosqlite.Error:
+            logger.warning(
+                "fabric_object_types workspace backfill failed — leaving rows NULL",
+                exc_info=True,
+            )
+        finally:
+            db.row_factory = None
+
+    @staticmethod
+    async def _dedup_object_types(db: aiosqlite.Connection) -> None:
+        """Collapse duplicate (workspace, name) object types before the UNIQUE index.
+
+        Two type rows can share a (workspace_id, case-folded name) only on a DB
+        that predates the unique index — the concurrent ``ensure_type`` race.
+        Keep the LOWEST rowid per (workspace, case-folded name) (the
+        first-defined survivor), re-point any objects bound to a losing type id
+        at the survivor's id so no object is orphaned, then delete the loser type
+        rows. SZD-2: the de-dup key now includes ``workspace_id`` so two tenants'
+        same-named types are NOT collapsed into one — only true within-workspace
+        duplicates are (legacy NULL/NULL pairs included, so the survivor of a pair
+        of global "Customer" rows is kept and the index can be created). Best
+        -effort: a failure here is swallowed (logged) so it can never crash
+        ``_ensure_schema``; the index creation that follows is itself try/except
+        -guarded as the final backstop.
         """
         try:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT rowid, id, name FROM fabric_object_types ORDER BY rowid ASC"
+                "SELECT rowid, id, name, workspace_id FROM fabric_object_types ORDER BY rowid ASC"
             ) as cur:
                 rows = await cur.fetchall()
-            survivor_by_name: dict[str, str] = {}
+            survivor_by_key: dict[tuple[str | None, str], str] = {}
             for row in rows:
-                key = (row["name"] or "").strip().lower()
-                survivor_id = survivor_by_name.get(key)
+                key = (row["workspace_id"], (row["name"] or "").strip().lower())
+                survivor_id = survivor_by_key.get(key)
                 if survivor_id is None:
-                    survivor_by_name[key] = row["id"]
+                    survivor_by_key[key] = row["id"]
                     continue
                 loser_id = row["id"]
                 if loser_id == survivor_id:
@@ -416,20 +540,30 @@ class FabricStore:
         description: str = "",
         icon: str = "box",
         color: str = "#0A84FF",
+        workspace_id: str | None = None,
     ) -> ObjectType:
+        """Define a new object type, optionally scoped to a tenant (SZD-2).
+
+        ``workspace_id`` stamps the owning workspace on the type row so the
+        discovered-type catalog stays private per tenant: a type defined here
+        for workspace A is invisible/unusable from workspace B (see
+        :meth:`get_type_by_name`). ``None`` writes a legacy/global type (OSS /
+        agent-tool / single-tenant callers), visible to every scoped read.
+        """
         obj_type = ObjectType(
             name=name,
             description=description,
             icon=icon,
             color=color,
             properties=properties,
+            workspace_id=workspace_id,
         )
         await self._ensure_schema()
         async with self._conn() as db:
             await db.execute(
                 "INSERT INTO fabric_object_types"
-                " (id, name, description, icon, color, properties_schema)"
-                " VALUES (?, ?, ?, ?, ?, ?)",
+                " (id, name, description, icon, color, properties_schema, workspace_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     obj_type.id,
                     obj_type.name,
@@ -437,64 +571,91 @@ class FabricStore:
                     obj_type.icon,
                     obj_type.color,
                     json.dumps([p.model_dump() for p in properties]),
+                    workspace_id,
                 ),
             )
             await db.commit()
         return obj_type
 
-    async def get_type(self, type_id: str) -> ObjectType | None:
+    async def get_type(self, type_id: str, workspace_id: str | None = None) -> ObjectType | None:
+        """Fetch one object type by id, optionally scoped to ``workspace_id`` (SZD-2).
+
+        When ``workspace_id`` is supplied, a type owned by another tenant returns
+        ``None`` (legacy NULL-workspace types stay visible). ``None`` leaves the
+        read unscoped (OSS / agent-tool / single-tenant callers). Note that
+        :meth:`create_object` calls this UNSCOPED on purpose — it only needs the
+        type's name to denormalize onto the object row, and the object write
+        itself carries the tenancy guard.
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_object_types WHERE id = ?"
+        params: list[Any] = [type_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM fabric_object_types WHERE id = ?", (type_id,)
-            ) as cur:
+            async with db.execute(sql, params) as cur:
                 row = await cur.fetchone()
                 if not row:
                     return None
                 return self._row_to_type(row)
 
-    async def get_type_by_name(self, name: str) -> ObjectType | None:
+    async def get_type_by_name(
+        self, name: str, workspace_id: str | None = None
+    ) -> ObjectType | None:
+        """Resolve an object type by (case-insensitive) name, scoped to a tenant (SZD-2).
+
+        This is the read ``ensure_type`` uses to decide "reuse the existing type
+        or define a new one". Scoping it is the core of SZD-2: a type defined in
+        workspace A must be invisible AND non-reusable from workspace B, so a
+        scoped lookup returns only the caller's own type (or a legacy NULL-
+        workspace type). With ``workspace_id`` set, two tenants that both have a
+        "Customer" type each resolve to THEIR OWN id; ``None`` is unscoped and
+        returns the first match by rowid (OSS / single-tenant callers).
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_object_types WHERE LOWER(name) = LOWER(?)"
+        params: list[Any] = [name]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        # When scoped, the caller's OWN type wins over a legacy NULL-workspace
+        # type of the same name: order own-rows-first (workspace_id NOT NULL),
+        # then by rowid for a stable pick.
+        sql += " ORDER BY (workspace_id IS NULL), rowid LIMIT 1"
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM fabric_object_types WHERE LOWER(name) = LOWER(?)", (name,)
-            ) as cur:
+            async with db.execute(sql, params) as cur:
                 row = await cur.fetchone()
                 if not row:
                     return None
                 return self._row_to_type(row)
 
     async def list_types(self, workspace_id: str | None = None) -> list[ObjectType]:
-        """List object types, optionally scoped to a tenant (W4a follow-up).
+        """List object types, optionally scoped to a tenant (SZD-2).
 
-        Type DEFINITIONS are global — ``fabric_object_types`` has no
-        ``workspace_id`` column (a deliberate W4a choice: the shared schema is
-        not per-tenant data). But the type NAMES a tenant can see are tenant
-        metadata: on a shared deployment, listing every defined type leaks what
-        other tenants are modeling. So a scoped call returns only the types
-        with at least one object row VISIBLE to that workspace — the same
-        visibility ``query()`` applies (own rows plus legacy NULL-workspace
-        rows, via ``_workspace_scope``). A defined type with no visible rows
-        (including the caller's own empty types) is omitted; it reappears the
-        moment a visible object exists. ``workspace_id=None`` keeps the
-        original unscoped behavior (all defined types) for OSS / single-tenant
-        callers.
+        SZD-2: type definitions are now first-class TENANT data —
+        ``fabric_object_types`` carries its own ``workspace_id``. A scoped call
+        returns the caller's OWN types plus legacy NULL-workspace types (the
+        same ``_workspace_scope`` visibility every other W4a read uses), scoped
+        on the TYPE's column directly. This supersedes the earlier
+        join-through-a-visible-object-row approach (fix/fabric-stats-workspace-
+        scope): a tenant's empty (object-less) type is now correctly listed for
+        its owner and is invisible to other tenants. ``workspace_id=None`` keeps
+        the original unscoped behavior (all defined types) for OSS / single-
+        tenant callers.
         """
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            if workspace_id is None:
+            ws_cond, params = _workspace_scope(workspace_id)
+            if ws_cond is None:
                 sql = "SELECT * FROM fabric_object_types ORDER BY name"
-                params: list[Any] = []
             else:
-                ws_cond, params = _workspace_scope(workspace_id, column="o.workspace_id")
-                sql = (
-                    "SELECT DISTINCT t.* FROM fabric_object_types t"
-                    " JOIN fabric_objects o ON o.type_id = t.id"
-                    f" WHERE {ws_cond} ORDER BY t.name"
-                )
+                sql = f"SELECT * FROM fabric_object_types WHERE {ws_cond} ORDER BY name"
             async with db.execute(sql, params) as cur:
                 return [self._row_to_type(row) async for row in cur]
 
@@ -1083,12 +1244,11 @@ class FabricStore:
         legacy NULL-workspace rows, via ``_workspace_scope``) so stats and
         query always agree: ``stats(workspace_id=w)["objects"]`` equals the
         ``total`` of an unfiltered scoped query. ``links`` applies the same
-        scope to ``fabric_links``. ``types`` counts the DEFINED types with at
-        least one visible object row — matching ``list_types(workspace_id=w)``
-        — because type definitions are global but which types a tenant sees is
-        tenant metadata (the cross-tenant type-name leak this closes).
-        ``workspace_id=None`` keeps the original unscoped, instance-wide
-        behavior for OSS / single-tenant callers.
+        scope to ``fabric_links``. SZD-2: ``types`` now counts types scoped on
+        the TYPE's OWN ``workspace_id`` (own rows + legacy NULL) so it matches
+        ``list_types(workspace_id=w)`` exactly — including the caller's empty,
+        object-less types. ``workspace_id=None`` keeps the original unscoped,
+        instance-wide behavior for OSS / single-tenant callers.
         """
         await self._ensure_schema()
         async with self._conn() as db:
@@ -1103,11 +1263,9 @@ class FabricStore:
                 }
             obj_cond, obj_params = _workspace_scope(workspace_id)
             link_cond, link_params = _workspace_scope(workspace_id)
-            type_cond, type_params = _workspace_scope(workspace_id, column="o.workspace_id")
+            type_cond, type_params = _workspace_scope(workspace_id)
             types = await db.execute_fetchall(
-                "SELECT COUNT(DISTINCT t.id) FROM fabric_object_types t"
-                " JOIN fabric_objects o ON o.type_id = t.id"
-                f" WHERE {type_cond}",
+                f"SELECT COUNT(*) FROM fabric_object_types WHERE {type_cond}",
                 type_params,
             )
             objects = await db.execute_fetchall(
@@ -1126,6 +1284,11 @@ class FabricStore:
 
     def _row_to_type(self, row: Any) -> ObjectType:
         props_raw = json.loads(row["properties_schema"]) if row["properties_schema"] else []
+        # SZD-2: surface the type's owning workspace. ``keys()`` guard keeps the
+        # helper resilient to any legacy SELECT projection that omitted the
+        # column (defensive — current callers all SELECT *).
+        keys = row.keys() if hasattr(row, "keys") else ()
+        workspace_id = row["workspace_id"] if "workspace_id" in keys else None
         return ObjectType(
             id=row["id"],
             name=row["name"],
@@ -1133,6 +1296,7 @@ class FabricStore:
             icon=row["icon"] or "box",
             color=row["color"] or "#0A84FF",
             properties=[PropertyDef(**p) for p in props_raw],
+            workspace_id=workspace_id,
         )
 
     def _row_to_object(self, row: Any) -> FabricObject:

--- a/tests/cloud/test_ee_fabric.py
+++ b/tests/cloud/test_ee_fabric.py
@@ -43,6 +43,17 @@
 #   result, NOT an error), a single-hop fan-out exceeding MAX_FRONTIER (clean
 #   ValueError, never a SQLite bound-variable crash), and a path deeper than
 #   MAX_HOPS rejected at FabricQuery construction.
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — reworked
+#   TestStatsWorkspaceScoping and TestTypeNameUniqueIndex for the new per-type
+#   tenancy. fabric_object_types now carries its OWN workspace_id, so scoped
+#   list_types / stats filter on the type's column (own rows + legacy NULL)
+#   instead of inferring visibility from object rows. Concretely: define_type
+#   takes a workspace_id and a type stamped for ws-b is invisible to ws-a;
+#   an owner's EMPTY (object-less) type IS now visible to its owner (the old
+#   "omit empty types" rule was an artifact of the join-through-objects
+#   approach and is inverted here); the unique index is now
+#   (workspace_id, LOWER(name)) named idx_object_types_ws_name_unique, and the
+#   race guard is exercised within a single workspace.
 
 from __future__ import annotations
 
@@ -416,19 +427,20 @@ class TestWorkspaceScoping:
 
 
 class TestStatsWorkspaceScoping:
-    """fix/fabric-stats-workspace-scope — scoped stats() and list_types().
+    """Scoped stats() and list_types() (fix/fabric-stats-workspace-scope, SZD-2).
 
-    The last two W4a reads were left instance-wide. On a shared ``fabric.db``
-    that leaked: a tenant's chat called fabric_stats and got back another
-    context's experimental type names (``Lease`` / ``Lease2``), and the global
-    object count (13) disagreed with what the workspace-scoped query actually
-    saw (11). These tests pin both: scoped counts mirror ``query()`` exactly,
-    and a scoped type list never names a type only another tenant has rows for.
+    On a shared ``fabric.db`` an unscoped read leaked across tenants: a tenant's
+    chat called fabric_stats and got back another context's experimental type
+    names (``Lease`` / ``Lease2``), and the global object count disagreed with
+    what the workspace-scoped query actually saw. These tests pin both: scoped
+    counts mirror ``query()`` exactly, and a scoped type list never names
+    another tenant's type.
 
-    Subtlety being guarded: ``fabric_object_types`` has NO workspace column —
-    type DEFINITIONS are global. So a scoped type list cannot come from the
-    type table; it must be derived from types with at least one object row
-    VISIBLE to the workspace.
+    SZD-2 changed the mechanism: ``fabric_object_types`` now carries its OWN
+    ``workspace_id``, so a scoped type list filters on the type table directly
+    (own rows + legacy NULL), not by inferring visibility from object rows. A
+    type is therefore isolated by who DEFINED it, not by who has rows of it —
+    and an owner's empty type is visible to its owner.
     """
 
     @pytest.mark.asyncio
@@ -460,15 +472,13 @@ class TestStatsWorkspaceScoping:
     async def test_scoped_type_list_excludes_other_tenant_type_names(
         self, store: FabricStore
     ) -> None:
-        # The exact live leak: ws-b defines "Lease" / "Lease2" and only B has
-        # rows of them. ws-a, which only models "Customer", must NOT see those
-        # type names — even though the type DEFINITIONS are global.
-        customer = await store.define_type(name="Customer", properties=[])
-        lease = await store.define_type(name="Lease", properties=[])
-        lease2 = await store.define_type(name="Lease2", properties=[])
-        await store.create_object(customer.id, {"name": "A1"}, workspace_id="ws-a")
-        await store.create_object(lease.id, {"tenant": "B-co"}, workspace_id="ws-b")
-        await store.create_object(lease2.id, {"tenant": "B-co"}, workspace_id="ws-b")
+        # The exact live leak: ws-b defines "Lease" / "Lease2". ws-a, which only
+        # models "Customer", must NOT see those type names. SZD-2 — isolation is
+        # by who DEFINED the type (its own workspace_id), so types are stamped on
+        # define_type.
+        await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+        await store.define_type(name="Lease", properties=[], workspace_id="ws-b")
+        await store.define_type(name="Lease2", properties=[], workspace_id="ws-b")
 
         a_types = {t.name for t in await store.list_types(workspace_id="ws-a")}
         assert a_types == {"Customer"}
@@ -482,10 +492,8 @@ class TestStatsWorkspaceScoping:
     async def test_stats_types_count_matches_scoped_type_list(self, store: FabricStore) -> None:
         # stats["types"] is the count of types VISIBLE to the workspace — it
         # must equal len(list_types(workspace_id)), not the global type count.
-        customer = await store.define_type(name="Customer", properties=[])
-        lease = await store.define_type(name="Lease", properties=[])
-        await store.create_object(customer.id, {"name": "A1"}, workspace_id="ws-a")
-        await store.create_object(lease.id, {"tenant": "B-co"}, workspace_id="ws-b")
+        await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+        await store.define_type(name="Lease", properties=[], workspace_id="ws-b")
 
         a_stats = await store.stats(workspace_id="ws-a")
         a_types = await store.list_types(workspace_id="ws-a")
@@ -533,35 +541,48 @@ class TestStatsWorkspaceScoping:
         assert names == {"Customer", "Lease"}
 
     @pytest.mark.asyncio
-    async def test_scoped_type_with_no_visible_rows_is_omitted(self, store: FabricStore) -> None:
-        # A defined type with zero visible rows (even the caller's own empty
-        # type) is omitted, and reappears the moment a visible object exists.
-        empty = await store.define_type(name="Empty", properties=[])
-        assert {t.name for t in await store.list_types(workspace_id="ws-a")} == set()
-
-        await store.create_object(empty.id, {"k": "v"}, workspace_id="ws-a")
+    async def test_owner_sees_own_empty_type(self, store: FabricStore) -> None:
+        # SZD-2: an owner's EMPTY (object-less) type IS visible to its owner —
+        # type definitions are first-class tenant data now, not inferred from
+        # object rows (this inverts the pre-SZD-2 "omit empty types" rule). A
+        # type owned by ws-a remains invisible to ws-b regardless of objects.
+        await store.define_type(name="Empty", properties=[], workspace_id="ws-a")
         assert {t.name for t in await store.list_types(workspace_id="ws-a")} == {"Empty"}
+        assert (await store.stats(workspace_id="ws-a"))["types"] == 1
+        # ws-b never defined it -> does not see it.
+        assert {t.name for t in await store.list_types(workspace_id="ws-b")} == set()
+        assert (await store.stats(workspace_id="ws-b"))["types"] == 0
 
 
 class TestTypeNameUniqueIndex:
-    """A UNIQUE index on fabric_object_types(name) closes the ensure_type race."""
+    """A UNIQUE index on fabric_object_types(workspace_id, name) closes the
+    ensure_type race PER workspace (SZD-2 — was a global LOWER(name) index)."""
 
     @pytest.mark.asyncio
     async def test_concurrent_same_name_defines_one_type(self, store: FabricStore) -> None:
-        # Two concurrent define_type calls for the same name must not leave two
-        # type rows. The UNIQUE index makes the second INSERT fail rather than
-        # silently splitting the same logical type across two ids.
+        # Two concurrent define_type calls for the same name WITHIN one workspace
+        # must not leave two type rows. The UNIQUE (workspace_id, name) index
+        # makes the second INSERT fail rather than silently splitting the same
+        # logical type across two ids.
         results = await asyncio.gather(
-            store.define_type(name="Customer", properties=[]),
-            store.define_type(name="Customer", properties=[]),
+            store.define_type(name="Customer", properties=[], workspace_id="ws-a"),
+            store.define_type(name="Customer", properties=[], workspace_id="ws-a"),
             return_exceptions=True,
         )
         # At least one succeeded; any second one either errored or was rejected.
         ok = [r for r in results if not isinstance(r, Exception)]
         assert ok, "at least one define_type must succeed"
 
-        types = [t for t in await store.list_types() if t.name == "Customer"]
+        types = [t for t in await store.list_types(workspace_id="ws-a") if t.name == "Customer"]
         assert len(types) == 1, "the unique index must prevent a duplicate type row"
+
+    @pytest.mark.asyncio
+    async def test_two_workspaces_may_define_same_name(self, store: FabricStore) -> None:
+        # SZD-2: the uniqueness key includes workspace_id, so the SAME name in
+        # two different workspaces is allowed — each tenant gets its own type.
+        a = await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+        b = await store.define_type(name="Customer", properties=[], workspace_id="ws-b")
+        assert a.id != b.id
 
     @pytest.mark.asyncio
     async def test_unique_index_exists(self, store: FabricStore) -> None:
@@ -573,7 +594,9 @@ class TestTypeNameUniqueIndex:
                 " AND tbl_name='fabric_object_types'"
             ) as cur:
                 names = {row["name"] async for row in cur}
-        assert "idx_object_types_name_unique" in names
+        assert "idx_object_types_ws_name_unique" in names
+        # The old global index must NOT exist (it was dropped in the migration).
+        assert "idx_object_types_name_unique" not in names
 
     @pytest.mark.asyncio
     async def test_preexisting_duplicate_names_are_deduped(self, tmp_path: Path) -> None:

--- a/tests/cloud/test_fabric_mcp.py
+++ b/tests/cloud/test_fabric_mcp.py
@@ -226,12 +226,13 @@ async def test_stats_does_not_leak_other_tenant_type_names(store):
     """The live leak, pinned at the MCP boundary.
 
     w2 alone models "Lease" / "Lease2"; w1 models "Customer". A w1-scoped
-    fabric_stats must NOT name w2's experimental types — even though the type
-    DEFINITIONS are global in the schema.
+    fabric_stats must NOT name w2's experimental types. SZD-2 — type isolation
+    is by who DEFINED the type (its own workspace_id), so w2's experimental
+    types are stamped with workspace="w2".
     """
     await _seed_customers(store)  # Customer rows in w1 (+ one in w2)
-    lease = await store.define_type(name="Lease", properties=[])
-    lease2 = await store.define_type(name="Lease2", properties=[])
+    lease = await store.define_type(name="Lease", properties=[], workspace_id="w2")
+    lease2 = await store.define_type(name="Lease2", properties=[], workspace_id="w2")
     await store.create_object(lease.id, {"tenant": "X"}, workspace_id="w2")
     await store.create_object(lease2.id, {"tenant": "Y"}, workspace_id="w2")
 

--- a/tests/test_fabric_type_scoping.py
+++ b/tests/test_fabric_type_scoping.py
@@ -1,0 +1,314 @@
+# tests/test_fabric_type_scoping.py
+# Created: 2026-06-19 (SZD-2 — workspace-scope object TYPES).
+#
+# Proves the SZD-2 invariant for the "sovereign zero-setup discovery" feature:
+# the Fabric object-TYPE catalog is private per workspace. A type defined in
+# workspace A must be invisible AND non-reusable from workspace B —
+# get_type_by_name / get_type / list_types / stats all scope on the type's own
+# workspace_id (own rows + legacy NULL), and ensure_type / ingest_records thread
+# the workspace through so connector ingestion stays inside its tenant.
+#
+# Also covers:
+#   * legacy NULL-workspace types stay globally visible (back-compat),
+#   * two workspaces may each define a same-named type (the unique index is now
+#     (workspace_id, LOWER(name)), not a global LOWER(name)),
+#   * the additive migration runs idempotently on a pre-SZD-2 DB (twice, no
+#     error), including dropping the old global unique index, and
+#   * the SZD-2 backfill attributes a NULL-workspace type to a tenant only when
+#     its objects unambiguously share one workspace.
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
+from pocketpaw.fabric.models import PropertyDef
+from pocketpaw.fabric.store import SCHEMA_SQL, FabricStore
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+# ---------------------------------------------------------------------------
+# Core SZD-2 invariant: A cannot read/reuse B's types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_type_defined_in_a_is_invisible_to_b(tmp_path: Path) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type(name="Customer", properties=[], workspace_id=WS_A)
+
+    # B asks for the same name by its own scope -> not found (cannot read A's).
+    assert await store.get_type_by_name("Customer", workspace_id=WS_B) is None
+    # A sees its own type.
+    a_type = await store.get_type_by_name("Customer", workspace_id=WS_A)
+    assert a_type is not None
+    assert a_type.workspace_id == WS_A
+
+    # list_types is scoped: A sees Customer, B sees nothing.
+    a_names = {t.name for t in await store.list_types(workspace_id=WS_A)}
+    b_names = {t.name for t in await store.list_types(workspace_id=WS_B)}
+    assert a_names == {"Customer"}
+    assert b_names == set()
+
+    # get_type by id is scoped too: B cannot fetch A's type by id.
+    assert await store.get_type(a_type.id, workspace_id=WS_B) is None
+    assert (await store.get_type(a_type.id, workspace_id=WS_A)).id == a_type.id
+
+
+@pytest.mark.asyncio
+async def test_ensure_type_does_not_reuse_other_workspaces_type(tmp_path: Path) -> None:
+    """ensure_type for B must NOT return A's type id — it mints B's own."""
+    store = FabricStore(tmp_path / "fabric.db")
+    mapping = FabricMapping(
+        type_name="CalendarEvent",
+        source_id_field="id",
+        field_map={"summary": "summary"},
+        properties=[PropertyDef(name="summary", type="string")],
+    )
+
+    # A ingests one record -> defines A's CalendarEvent type.
+    await ingest_records(
+        store,
+        connector="gcal",
+        records=[{"id": "a1", "summary": "A standup"}],
+        mapping=mapping,
+        workspace_id=WS_A,
+    )
+    # B ingests -> must define B's OWN CalendarEvent, distinct id.
+    await ingest_records(
+        store,
+        connector="gcal",
+        records=[{"id": "b1", "summary": "B standup"}],
+        mapping=mapping,
+        workspace_id=WS_B,
+    )
+
+    a_type = await store.get_type_by_name("CalendarEvent", workspace_id=WS_A)
+    b_type = await store.get_type_by_name("CalendarEvent", workspace_id=WS_B)
+    assert a_type is not None and b_type is not None
+    # The whole point: two distinct, workspace-owned types with the same name.
+    assert a_type.id != b_type.id
+    assert a_type.workspace_id == WS_A
+    assert b_type.workspace_id == WS_B
+
+    # Each workspace lists only its own type.
+    assert [t.workspace_id for t in await store.list_types(workspace_id=WS_A)] == [WS_A]
+    assert [t.workspace_id for t in await store.list_types(workspace_id=WS_B)] == [WS_B]
+
+    # stats counts only the tenant's own type.
+    assert (await store.stats(workspace_id=WS_A))["types"] == 1
+    assert (await store.stats(workspace_id=WS_B))["types"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reingest_same_workspace_reuses_type(tmp_path: Path) -> None:
+    """Within ONE workspace, ensure_type still reuses (define-once-by-name)."""
+    store = FabricStore(tmp_path / "fabric.db")
+    mapping = FabricMapping(type_name="Ticket", source_id_field="tid", field_map={"title": "title"})
+    r1 = await ingest_records(
+        store,
+        connector="hd",
+        records=[{"tid": "t1", "title": "x"}],
+        mapping=mapping,
+        workspace_id=WS_A,
+    )
+    r2 = await ingest_records(
+        store,
+        connector="hd",
+        records=[{"tid": "t2", "title": "y"}],
+        mapping=mapping,
+        workspace_id=WS_A,
+    )
+    assert r1.created == 1 and r2.created == 1
+    a_types = [t for t in await store.list_types(workspace_id=WS_A) if t.name == "Ticket"]
+    assert len(a_types) == 1  # one type, reused — not duplicated
+
+
+# ---------------------------------------------------------------------------
+# Legacy NULL-workspace types stay globally visible (back-compat)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_null_workspace_type_visible_to_all(tmp_path: Path) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    # No workspace_id -> legacy/global type.
+    await store.define_type(name="GlobalThing", properties=[])
+
+    # Both tenants see it; the unscoped read sees it; B can reuse it via name.
+    assert (await store.get_type_by_name("GlobalThing", workspace_id=WS_A)) is not None
+    assert (await store.get_type_by_name("GlobalThing", workspace_id=WS_B)) is not None
+    assert (await store.get_type_by_name("GlobalThing")) is not None
+    assert {t.name for t in await store.list_types(workspace_id=WS_A)} == {"GlobalThing"}
+    assert {t.name for t in await store.list_types()} == {"GlobalThing"}
+
+
+@pytest.mark.asyncio
+async def test_own_type_wins_over_legacy_same_name(tmp_path: Path) -> None:
+    """When both a legacy NULL type and the caller's own type share a name, the
+    scoped lookup resolves to the caller's OWN type (own-rows-first ordering)."""
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type(name="Customer", properties=[])  # legacy/global
+    own = await store.define_type(name="Customer", properties=[], workspace_id=WS_A)
+
+    resolved = await store.get_type_by_name("Customer", workspace_id=WS_A)
+    assert resolved is not None
+    assert resolved.id == own.id
+    assert resolved.workspace_id == WS_A
+
+
+@pytest.mark.asyncio
+async def test_unscoped_callers_see_everything(tmp_path: Path) -> None:
+    """workspace_id=None is fully backward-compatible: sees all defined types."""
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type(name="A", properties=[], workspace_id=WS_A)
+    await store.define_type(name="B", properties=[], workspace_id=WS_B)
+    await store.define_type(name="G", properties=[])
+    names = {t.name for t in await store.list_types()}
+    assert names == {"A", "B", "G"}
+    assert (await store.stats())["types"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Migration idempotency on a pre-SZD-2 DB
+# ---------------------------------------------------------------------------
+
+
+# The faithful pre-SZD-2 schema: fabric_object_types had NO workspace_id column,
+# fabric_objects / fabric_links already had one (from W4a), and the type-name
+# unique index was GLOBAL on LOWER(name). Written out literally rather than
+# regex-stripping the live SCHEMA_SQL so the test pins the exact historic shape
+# the migration must upgrade from.
+_PRE_SZD2_SCHEMA = """
+CREATE TABLE fabric_object_types (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    icon TEXT DEFAULT 'box',
+    color TEXT DEFAULT '#0A84FF',
+    properties_schema TEXT DEFAULT '[]',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE fabric_objects (
+    id TEXT PRIMARY KEY,
+    type_id TEXT NOT NULL REFERENCES fabric_object_types(id),
+    type_name TEXT DEFAULT '',
+    properties TEXT NOT NULL DEFAULT '{}',
+    source_connector TEXT,
+    source_id TEXT,
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE fabric_links (
+    id TEXT PRIMARY KEY,
+    from_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    to_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    link_type TEXT NOT NULL,
+    properties TEXT DEFAULT '{}',
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX idx_object_types_name_unique ON fabric_object_types(LOWER(name));
+"""
+
+
+def _make_pre_szd2_db(path: Path) -> None:
+    """Materialize a DB whose fabric_object_types has NO workspace_id column and
+    carries the OLD global unique index on LOWER(name) — the faithful pre-SZD-2
+    state a deployment would be upgrading from."""
+    # Sanity: confirm SCHEMA_SQL (the current schema) does carry the column we
+    # are deliberately omitting here, so this stays a true "before" snapshot.
+    types_block = SCHEMA_SQL.split("CREATE TABLE IF NOT EXISTS fabric_objects")[0]
+    assert "workspace_id" in types_block, "current object_types should have workspace_id"
+    conn = sqlite3.connect(path)
+    conn.executescript(_PRE_SZD2_SCHEMA)
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent_on_pre_szd2_db(tmp_path: Path) -> None:
+    db = tmp_path / "fabric.db"
+    _make_pre_szd2_db(db)
+
+    # First open: runs the migration (ALTER + drop old index + new index).
+    store1 = FabricStore(db)
+    assert await store1.list_types() == []  # opens cleanly, no OperationalError
+    # After migration two workspaces can define the same name (old global
+    # unique index would have rejected the second).
+    await store1.define_type(name="Customer", properties=[], workspace_id=WS_A)
+    await store1.define_type(name="Customer", properties=[], workspace_id=WS_B)
+
+    # Second open on the SAME file re-runs _ensure_schema end to end. The ALTER's
+    # duplicate-column error and the DROP/CREATE INDEX must all be no-ops.
+    store2 = FabricStore(db)
+    a = await store2.get_type_by_name("Customer", workspace_id=WS_A)
+    b = await store2.get_type_by_name("Customer", workspace_id=WS_B)
+    assert a is not None and b is not None and a.id != b.id
+
+
+@pytest.mark.asyncio
+async def test_backfill_attributes_unambiguous_type(tmp_path: Path) -> None:
+    """A pre-SZD-2 NULL-workspace type whose objects all live in one workspace is
+    attributed to that workspace on migration; an ambiguous one stays NULL."""
+    db = tmp_path / "fabric.db"
+    _make_pre_szd2_db(db)
+
+    # Seed pre-SZD-2 state directly: types have no workspace_id column yet, but
+    # objects (which predate SZD-2 and DO have workspace_id from W4a) carry one.
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO fabric_object_types (id, name, properties_schema) VALUES (?, ?, '[]')",
+        ("ot-solo", "Solo"),
+    )
+    conn.execute(
+        "INSERT INTO fabric_object_types (id, name, properties_schema) VALUES (?, ?, '[]')",
+        ("ot-mixed", "Mixed"),
+    )
+    # Solo: all objects in WS_A -> backfill attributes Solo to WS_A.
+    conn.execute(
+        "INSERT INTO fabric_objects (id, type_id, properties, workspace_id)"
+        " VALUES ('o1', 'ot-solo', '{}', ?)",
+        (WS_A,),
+    )
+    conn.execute(
+        "INSERT INTO fabric_objects (id, type_id, properties, workspace_id)"
+        " VALUES ('o2', 'ot-solo', '{}', ?)",
+        (WS_A,),
+    )
+    # Mixed: objects span WS_A and WS_B -> cannot attribute, stays NULL/global.
+    conn.execute(
+        "INSERT INTO fabric_objects (id, type_id, properties, workspace_id)"
+        " VALUES ('o3', 'ot-mixed', '{}', ?)",
+        (WS_A,),
+    )
+    conn.execute(
+        "INSERT INTO fabric_objects (id, type_id, properties, workspace_id)"
+        " VALUES ('o4', 'ot-mixed', '{}', ?)",
+        (WS_B,),
+    )
+    conn.commit()
+    conn.close()
+
+    store = FabricStore(db)
+    await store.list_types()  # triggers migration + backfill
+
+    solo = await store.get_type("ot-solo")
+    mixed = await store.get_type("ot-mixed")
+    assert solo is not None and mixed is not None
+    assert solo.workspace_id == WS_A  # unambiguous -> attributed
+    assert mixed.workspace_id is None  # ambiguous -> stays global
+
+    # Consequence: WS_A sees Solo (attributed) + Mixed (global); WS_B sees only
+    # Mixed (global), NOT Solo.
+    a_names = {t.name for t in await store.list_types(workspace_id=WS_A)}
+    b_names = {t.name for t in await store.list_types(workspace_id=WS_B)}
+    assert a_names == {"Solo", "Mixed"}
+    assert b_names == {"Mixed"}


### PR DESCRIPTION
First foundational slice of sovereign zero-setup discovery (SZD-2). Fabric object *types* were a global catalog — `define_type` had no `workspace_id` and `fabric_object_types` had no `workspace_id` column — so a type defined in one tenant's workspace was visible to all. For the discovery feature (and tenant sovereignty generally), discovered types must stay private to the workspace that owns them.

## What changed
- `workspace_id` on `define_type` + the `ObjectType` model + the `fabric_object_types` table (idempotent additive migration; legacy rows keep `workspace_id = NULL` = global, for backward compatibility).
- Every object-type read is workspace-scoped: `get_type_by_name`, `list_types`, `stats`, dedup, and the unique index (now `(workspace_id, LOWER(name))`, replacing the global name index).
- `workspace_id` threaded through `ingest_records` / `ensure_type` so connector ingestion mints types in the right workspace.

## Verified
- New `tests/test_fabric_type_scoping.py` (8 tests): workspace A can't read/reuse workspace B's types; legacy NULL stays global; same-name types coexist across workspaces; migration idempotency; backfill.
- 6 existing fabric tests updated to the scoped semantics (they encoded the old global-catalog behavior); reviewed and confirmed legitimate.
- Re-ran the touched suites: 179 fabric tests pass; the migration runs twice cleanly.

## Notes
- Reverses the earlier W4a choice to leave types unscoped — superseded by the 2026-06-19 decision to scope types per workspace.
- Behavior change: an owner's empty (object-less) type is now visible to its owner — it's first-class tenant data now, not derived from object rows.
- Two non-blocking review follow-ups: a test helper (`_seed_customers`) still defines an unscoped type, so one stats assertion passes for the wrong reason; and a one-line comment on the backfill/dedup row-factory ordering. Neither affects correctness.

Foundation for SZD-5a (the `_fabric_objects` proposal type). Part of the sovereign zero-setup discovery slice — design/PRD/tasks in `docs/design/drafts/2026-06-19-sovereign-zero-setup-discovery*`.