### PR TITLE
Sites: fabric.objects + fabric.query ripple sources (render Fabric in a Pocket)

### DIFF
--- a/ee/pocketpaw_ee/cloud/ripple_sources.py
+++ b/ee/pocketpaw_ee/cloud/ripple_sources.py
@@ -6,6 +6,18 @@ live here, next to the entities they read.
 
 Tenancy rule (from CLAUDE.md ee/cloud rule 7): every Mongo read MUST
 scope by ctx.workspace_id.
+
+Updated 2026-06-19 (SZD-1 — fabric.objects ripple source): added two
+Fabric-backed sources so a rippleSpec can render discovered Fabric data, not
+just pockets/members. ``fabric.objects`` resolves an ``ObjectType`` (by
+``type_id`` and/or ``type_name``) into widget rows; ``fabric.query`` is the
+filtered variant (same args plus a ``filters`` bag). Both are workspace-scoped
+by handing ``ctx.workspace_id`` to ``FabricStore.query`` — the store applies
+its own ``workspace_id = ? OR workspace_id IS NULL`` tenant guard (W4a), so a
+spec in workspace A can never surface workspace B's objects. The store is the
+local SQLite Fabric DB (``~/.pocketpaw/fabric.db`` via ``get_fabric_store``),
+NOT Mongo, so the "every Mongo read scopes by workspace" rule is satisfied here
+by the SQLite tenant scope instead — same invariant, different store.
 """
 
 from __future__ import annotations
@@ -113,3 +125,129 @@ async def _workspace_members(ctx: ResolveCtx, args: dict[str, Any]) -> list[dict
         logger.warning("ripple_resolver: workspace.members called with empty workspace_id")
         return []
     return await _list_workspace_members(ctx.workspace_id)
+
+
+# Hard cap on rows a single Fabric source resolution returns into a spec — a
+# ripple widget renders client-side, so an unbounded type with thousands of
+# objects would bloat the resolved spec and the wire payload. The caller can
+# request fewer via ``limit``; this is the ceiling, mirroring the fabric MCP
+# tool's MAX_QUERY_LIMIT spirit.
+_FABRIC_SOURCE_MAX_ROWS = 500
+
+
+def _fabric_object_to_row(obj: Any) -> dict[str, Any]:
+    """Project a FabricObject into a flat widget row.
+
+    The object's JSON ``properties`` bag is spread to the top level so a
+    column-oriented widget (table, kanban, list) can bind directly to property
+    names, with ``id`` / ``type_id`` / ``type_name`` and provenance kept on
+    reserved keys. A property literally named one of the reserved keys would be
+    shadowed; that's an acceptable, documented edge — reserved keys win so the
+    row always carries a stable id.
+    """
+    row: dict[str, Any] = dict(obj.properties or {})
+    row.update(
+        {
+            "id": obj.id,
+            "type_id": obj.type_id,
+            "type_name": obj.type_name,
+            "source_connector": obj.source_connector,
+            "source_id": obj.source_id,
+        }
+    )
+    return row
+
+
+async def _resolve_fabric_objects(
+    ctx: ResolveCtx, args: dict[str, Any], *, allow_filters: bool
+) -> list[dict[str, Any]]:
+    """Shared resolver for the ``fabric.objects`` / ``fabric.query`` sources.
+
+    Builds a :class:`FabricQuery` from ``args`` and runs it scoped to
+    ``ctx.workspace_id``. Workspace scoping is NOT optional here: a missing
+    workspace returns ``[]`` rather than an unscoped (cross-tenant) read, so a
+    spec resolved without workspace context can never leak the whole instance's
+    objects. ``allow_filters`` gates the property-filter bag — ``fabric.objects``
+    is the simple "all rows of a type" source, ``fabric.query`` adds filters.
+    """
+    if not ctx.workspace_id:
+        logger.warning(
+            "ripple_resolver: fabric source called with empty workspace_id (pocket=%s)",
+            ctx.pocket_id,
+        )
+        return []
+
+    type_id = args.get("type_id")
+    type_name = args.get("type_name")
+    if not type_id and not type_name:
+        logger.warning(
+            "ripple_resolver: fabric source needs a type_id or type_name "
+            "(workspace=%s pocket=%s)",
+            ctx.workspace_id,
+            ctx.pocket_id,
+        )
+        return []
+    # Reject non-string identifiers up front — FabricQuery would coerce/raise,
+    # but a clean empty result keeps a malformed spec from bricking the canvas.
+    if type_id is not None and not isinstance(type_id, str):
+        logger.warning("ripple_resolver: fabric source type_id must be a string")
+        return []
+    if type_name is not None and not isinstance(type_name, str):
+        logger.warning("ripple_resolver: fabric source type_name must be a string")
+        return []
+
+    raw_limit = args.get("limit", _FABRIC_SOURCE_MAX_ROWS)
+    limit = raw_limit if isinstance(raw_limit, int) and raw_limit > 0 else _FABRIC_SOURCE_MAX_ROWS
+    limit = min(limit, _FABRIC_SOURCE_MAX_ROWS)
+    raw_offset = args.get("offset", 0)
+    offset = raw_offset if isinstance(raw_offset, int) and raw_offset >= 0 else 0
+
+    filters = args.get("filters") if allow_filters else None
+    if filters is not None and not isinstance(filters, dict):
+        logger.warning("ripple_resolver: fabric.query filters must be a JSON object")
+        return []
+
+    # Lazy imports keep the resolver free of a hard Fabric dependency at module
+    # import time and mirror the fabric MCP tool's availability guard.
+    from pocketpaw.fabric.models import FabricQuery
+    from pocketpaw.stores import get_fabric_store
+
+    store = get_fabric_store()
+    q = FabricQuery(
+        type_id=type_id,
+        type_name=type_name,
+        filters=filters or {},
+        limit=limit,
+        offset=offset,
+    )
+    # workspace_id is threaded as a PLAIN str from the server-built ctx (never
+    # from the spec), so the store applies its W4a tenant scope: only this
+    # workspace's rows (plus legacy NULL-workspace rows) come back.
+    result = await store.query(q, workspace_id=ctx.workspace_id)
+    return [_fabric_object_to_row(obj) for obj in result.objects]
+
+
+@register("fabric.objects")
+async def _fabric_objects(ctx: ResolveCtx, args: dict[str, Any]) -> list[dict[str, Any]]:
+    """Resolve an ObjectType into widget rows, workspace-scoped (SZD-1).
+
+    Args: ``type_id`` and/or ``type_name`` (at least one required), optional
+    ``limit`` / ``offset``. Returns one row per object of that type in the
+    caller's workspace, the JSON properties spread to the top level (see
+    :func:`_fabric_object_to_row`). This is the source the "sovereign zero-setup
+    discovery" starter-Pocket binds to so it renders discovered Fabric data.
+    """
+    return await _resolve_fabric_objects(ctx, args, allow_filters=False)
+
+
+@register("fabric.query")
+async def _fabric_query(ctx: ResolveCtx, args: dict[str, Any]) -> list[dict[str, Any]]:
+    """Filtered variant of ``fabric.objects`` (SZD-1).
+
+    Same args as ``fabric.objects`` plus a ``filters`` bag (the exact
+    ``FabricQuery.filters`` shape: ``{"status": "active"}`` for equality,
+    ``{"rent": {">": 1000}}`` for comparison). Still workspace-scoped — the
+    store binds every filter value as a parameter, so there is no injection
+    surface from a spec-supplied filter.
+    """
+    return await _resolve_fabric_objects(ctx, args, allow_filters=True)

--- a/tests/cloud/test_fabric_objects_source.py
+++ b/tests/cloud/test_fabric_objects_source.py
@@ -1,0 +1,132 @@
+# tests/cloud/test_fabric_objects_source.py
+# Created: 2026-06-19 (SZD-1 — fabric.objects ripple source).
+#
+# Smoke-proves the SZD-1 invariant for the "sovereign zero-setup discovery"
+# feature: the `fabric.objects` / `fabric.query` ripple sources resolve an
+# ObjectType into widget rows, and they are WORKSPACE-SCOPED — a spec resolved
+# in workspace A sees only workspace A's objects, never workspace B's. The
+# sources are backed by a real (temp) FabricStore so the store's own
+# `workspace_id = ? OR workspace_id IS NULL` tenant guard is exercised end to
+# end, not mocked away.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+# Importing ripple_sources triggers the @register side-effects that put
+# fabric.objects / fabric.query into the resolver registry (the cloud app does
+# this eagerly at startup; tests must import it explicitly).
+import pocketpaw_ee.cloud.ripple_sources  # noqa: F401
+import pytest
+from pocketpaw_ee.cloud.ripple_resolver import ResolveCtx, resolve_ripple_spec
+
+from pocketpaw.fabric.store import FabricStore
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+async def _seed_store(db_path: Path) -> FabricStore:
+    """A FabricStore with a 'Lead' type and objects in two workspaces."""
+    store = FabricStore(db_path)
+    lead_a = await store.define_type(name="Lead", properties=[], workspace_id=WS_A)
+    lead_b = await store.define_type(name="Lead", properties=[], workspace_id=WS_B)
+    await store.create_object(
+        type_id=lead_a.id, properties={"name": "Acme", "status": "hot"}, workspace_id=WS_A
+    )
+    await store.create_object(
+        type_id=lead_a.id, properties={"name": "Globex", "status": "cold"}, workspace_id=WS_A
+    )
+    # Workspace B owns a separate object of its own same-named type — this is
+    # the row that must NOT leak into a workspace-A resolution.
+    await store.create_object(
+        type_id=lead_b.id, properties={"name": "Initech", "status": "hot"}, workspace_id=WS_B
+    )
+    return store
+
+
+@pytest.mark.asyncio
+async def test_fabric_objects_source_resolves_workspace_rows(tmp_path: Path) -> None:
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx = ResolveCtx(workspace_id=WS_A, user_id="u1", pocket_id="p1")
+    spec = {"state": {"leads": {"$source": "fabric.objects", "type_name": "Lead"}}}
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx)
+
+    rows = out["state"]["leads"]
+    names = {r["name"] for r in rows}
+    # Exactly workspace A's two Leads — Globex + Acme — and NOT workspace B's
+    # Initech (the cross-tenant leak this proves is closed).
+    assert names == {"Acme", "Globex"}, f"unexpected rows: {rows!r}"
+    assert "Initech" not in names
+    # Properties are spread to the top level alongside reserved keys.
+    assert all("id" in r and "type_name" in r and "status" in r for r in rows)
+    assert all(r["type_name"] == "Lead" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_fabric_objects_source_other_workspace_sees_only_its_own(tmp_path: Path) -> None:
+    """Cross-workspace proof — the SAME spec resolved as workspace B returns
+    only B's object, demonstrating the scope tracks ctx, not the spec."""
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx_b = ResolveCtx(workspace_id=WS_B, user_id="u2", pocket_id="p2")
+    spec = {"state": {"leads": {"$source": "fabric.objects", "type_name": "Lead"}}}
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx_b)
+
+    names = {r["name"] for r in out["state"]["leads"]}
+    assert names == {"Initech"}, f"workspace B leaked rows: {names!r}"
+    assert "Acme" not in names and "Globex" not in names
+
+
+@pytest.mark.asyncio
+async def test_fabric_query_source_applies_filter_within_workspace(tmp_path: Path) -> None:
+    """fabric.query adds a property filter and stays workspace-scoped."""
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx = ResolveCtx(workspace_id=WS_A, user_id="u1", pocket_id="p1")
+    spec = {
+        "state": {
+            "hot": {
+                "$source": "fabric.query",
+                "type_name": "Lead",
+                "filters": {"status": "hot"},
+            }
+        }
+    }
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx)
+
+    names = {r["name"] for r in out["state"]["hot"]}
+    # Only workspace A's hot lead (Acme). Globex is cold; Initech is workspace B.
+    assert names == {"Acme"}, f"filter/scope mismatch: {names!r}"
+
+
+@pytest.mark.asyncio
+async def test_fabric_objects_source_no_type_returns_empty(tmp_path: Path) -> None:
+    """A spec marker with neither type_id nor type_name resolves to [] (never
+    raises, never returns the whole workspace)."""
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx = ResolveCtx(workspace_id=WS_A, user_id="u1", pocket_id="p1")
+    spec = {"state": {"leads": {"$source": "fabric.objects"}}}
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx)
+
+    assert out["state"]["leads"] == []
+
+
+@pytest.mark.asyncio
+async def test_fabric_objects_source_no_workspace_returns_empty(tmp_path: Path) -> None:
+    """Empty workspace context resolves to [] rather than an unscoped read."""
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx = ResolveCtx(workspace_id="", user_id="u1", pocket_id="p1")
+    spec = {"state": {"leads": {"$source": "fabric.objects", "type_name": "Lead"}}}
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx)
+
+    assert out["state"]["leads"] == []


### PR DESCRIPTION
SZD-1, stacked on #1509. A Pocket couldn't render Fabric data — only `workspace.pockets` and `workspace.members` ripple sources existed; nothing resolved a Fabric ObjectType into widget rows. The sovereign zero-setup discovery starter-Pocket needs that.

## What changed
- `fabric.objects` source — resolves an ObjectType (by `type_id` and/or `type_name`) → widget rows, optional `limit`/`offset`. Properties spread to the top level for column-oriented widgets; id/type/provenance on reserved keys.
- `fabric.query` source — the filtered variant (adds a `FabricQuery` filters bag). Trivial given FabricQuery already supports filters, so included rather than deferred.
- Both workspace-scoped: `workspace_id` comes from the server-built resolve context (never the spec), threaded to `FabricStore.query`, which applies its W4a tenant guard. A missing workspace returns `[]` — never an unscoped read. Rows capped at 500 to keep resolved specs lean.
- Auto-registered (the `@register` decorators live in `ripple_sources.py`, already eager-imported at startup) — no wiring change.

## Verified
- New `tests/cloud/test_fabric_objects_source.py` (5 tests): workspace A resolves only A's objects, never B's (and the mirror from B). Re-ran with the resolver regression suite: 19 pass.

## Notes
- No paw-enterprise change needed: the resolver replaces source markers with plain row lists before the spec reaches the frontend, so these render like any other widget data.
- Follow-up (SZD-6, the starter-Pocket slice): teach the pocket-authoring skill that `fabric.objects`/`fabric.query` are bindable sources so the author emits them.

Stacks on #1509. Part of sovereign zero-setup discovery.