### PR TITLE
Sites: _fabric_objects Instinct proposal type (gated ontology writes)

### DIFF
--- a/ee/pocketpaw_ee/cloud/fabric_proposals/__init__.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/__init__.py
@@ -1,0 +1,33 @@
+# ee/cloud/fabric_proposals/__init__.py — the gated Fabric-ontology Instinct
+# proposal type (a peer of ``_pocket_write`` / ``_code_change`` /
+# ``_external_action`` / ``_belt_plan`` / ``_artifact_change``).
+# Created: 2026-06-19 (SZD-5a — _fabric_objects proposal type) — a proposed
+#   Fabric ontology (object types + objects + links) staged for human review
+#   through the Instinct gate. "Sovereign zero-setup discovery" infers a tenant's
+#   ontology from connector data and proposes "create these Fabric objects"; a
+#   human approves or rejects in The Tray; on approve the executor materialises
+#   the ontology in Fabric via the canonical, workspace-scoped, idempotent
+#   ``connectors.fabric_ingest.ingest_records`` upsert loop. Fully generic — no
+#   domain-specific logic.
+#
+# Re-exports the propose helper + the apply-on-approve executor so callers (the
+# discovery surface, the instinct router) import from the package root, mirroring
+# how the external-action gate is imported.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.fabric_proposals.executor import execute_approved_fabric_objects
+from pocketpaw_ee.cloud.fabric_proposals.propose import (
+    FABRIC_OBJECTS_KIND,
+    FABRIC_OBJECTS_PARAM_KEY,
+    FABRIC_OBJECTS_SCHEMA,
+    propose_fabric_objects,
+)
+
+__all__ = [
+    "FABRIC_OBJECTS_KIND",
+    "FABRIC_OBJECTS_PARAM_KEY",
+    "FABRIC_OBJECTS_SCHEMA",
+    "execute_approved_fabric_objects",
+    "propose_fabric_objects",
+]

--- a/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
@@ -1,0 +1,544 @@
+# ee/cloud/fabric_proposals/executor.py — apply an approved Fabric-ontology write.
+# Created: 2026-06-19 (SZD-5a — _fabric_objects Instinct proposal type).
+#
+# What this module does (the apply-on-approve half of the Fabric-objects gate):
+# the propose helper (``fabric_proposals.propose.propose_fabric_objects``) files
+# an Instinct Action carrying a ``_fabric_objects`` blob THROUGH Instinct (the
+# human approve/reject layer). After a human approves the Action, the ee instinct
+# router's ``approve_action`` fires ``execute_approved_fabric_objects`` here —
+# exactly mirroring how ``external_actions.executor.
+# execute_approved_external_action`` is fired for a gated connector call. This
+# function:
+#
+#   1. Reads the ``_fabric_objects`` blob from ``action.parameters``. A missing
+#      blob → return (no chain was opened, nothing to close). A schema-mismatched
+#      blob → mark_failed + close the chain, return.
+#   2. Idempotency guard — if the Action is already terminal (executed / failed)
+#      or the blob already carries an ``outcome``, the write is NOT re-run.
+#      Re-approve / retry never double-applies. The ingest loop itself is ALSO
+#      idempotent (dedup by ``(source_connector, source_id)``), so even a
+#      double-fire that slips past this guard creates N stable objects, not N*records.
+#   3. Materialises the ontology via the canonical
+#      ``connectors.fabric_ingest.ingest_records`` upsert loop, WORKSPACE-SCOPED
+#      by the blob's ``workspace_id`` (SZD-2 per-tenant types). Objects are grouped
+#      by type so each group rides one FabricMapping. Links are created with
+#      ``(from, to, link_type)`` dedup against the existing links.
+#   4. Back-writes the outcome ``{status, created, updated, links_created, executed_at}``
+#      onto the persisted blob via the direct-SQL pattern.
+#   5. Records the result on the Action (``mark_executed`` / ``mark_failed``) and
+#      CLOSES the Decision-Graph chain exactly once.
+#
+# EXACTLY-ONE-TERMINAL discipline (critical): on APPROVE the EXECUTOR owns the
+# ``decision.completed`` chain close — the router does NOT emit it (mirrors the
+# external-action executor). On REJECT the ROUTER owns the close and the executor
+# never runs. Every terminal path here goes through the single ``_fail``
+# chokepoint (failure) or the one success emit at the end — never both.
+#
+# Never raises — a failure here must not break the approve response. The router
+# wraps the call too; this is belt-and-braces. A Fabric write error is captured
+# as ``status=failed`` with a ``failed`` terminal, NOT re-raised.
+#
+# Security (this code writes typed objects into a tenant's Fabric on approval):
+#   * tenancy: every Fabric write is scoped by the blob's ``workspace_id``; an
+#     empty workspace_id is refused (a tenancy hole). The router's
+#     ``_assert_fabric_objects_workspace`` is the primary gate; this is
+#     belt-and-braces.
+#   * the write primitive is the SHIPPED ``ingest_records`` — this module does
+#     NOT call raw ``define_type`` / ``create_object`` / ``link``, so it inherits
+#     the proven workspace-scoped, provenance-stamped, idempotent upsert.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.fabric_proposals.propose import (
+    FABRIC_OBJECTS_PARAM_KEY,
+    FABRIC_OBJECTS_SCHEMA,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    summary: dict[str, Any],
+    executed_at: str,
+) -> None:
+    """Back-write the write outcome onto the persisted ``_fabric_objects`` blob.
+
+    Direct SQL update — the same pattern the external-action executor's
+    ``_persist_outcome`` uses. The blob's ``outcome`` carries the counts +
+    timestamp so a reader (audit, a re-invocation idempotency check) sees the
+    result structurally. Best-effort: a write failure leaves the blob without the
+    structured outcome but the free-text ``mark_executed`` / ``mark_failed``
+    outcome still records it.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(FABRIC_OBJECTS_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {"status": status, "executed_at": executed_at, **summary}
+        params[FABRIC_OBJECTS_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "fabric_objects: failed to persist outcome onto action %s — the "
+            "structured outcome is unavailable (free-text outcome still recorded)",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a Fabric-objects write.
+
+    Mirrors ``external_actions.executor._emit_chain_close`` — the executor owns
+    the chain close on the approve path. ``correlation_id`` is read off the blob;
+    ``causation_id`` is the ``human.corrected`` event the router emitted just
+    before approval so the terminal chains back to the human approval.
+
+    Returns early when ``correlation_id`` is None (a blob with a malformed /
+    missing id): there is no chain to close. Best-effort: a Decision-Graph wiring
+    failure must never break the approve response — the journal write is the
+    source of truth; the Slice 4 reconciler is the safety net.
+    """
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if summary:
+        payload["summary"] = summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "fabric_objects decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this Fabric write already ran.
+
+    Two signals, either is sufficient:
+      * the blob already carries an ``outcome`` (a prior run back-wrote it), or
+      * the Action is already in a terminal state (executed / failed).
+
+    Re-invocation (bulk re-approve, retry) must never re-run the write. The
+    Action's ``status`` is the authoritative gate, and the back-written outcome
+    is the belt-and-braces signal in case status reads are stale. (The ingest
+    loop is itself idempotent, so even a slip is harmless — this guard avoids the
+    redundant work + the duplicate terminal.)
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+# The reserved record key carrying the object's source id. It is prefixed +
+# suffixed so it can't collide with a real property name, and it is excluded from
+# the projected field_map so it never lands in the object's properties.
+_SOURCE_ID_KEY = "__fabric_proposal_source_id__"
+
+
+def _build_ingest_batches(
+    object_types: list[dict[str, Any]],
+    objects: list[dict[str, Any]],
+) -> list[tuple[Any, str, list[dict[str, Any]]]]:
+    """Group objects by (type_name, source_connector) into ingest batches.
+
+    Returns a list of ``(FabricMapping, source_connector, [records])`` — one
+    batch per (type, connector) so each ``ingest_records`` call stamps the right
+    ``source_connector`` provenance. Each record is a FLAT dict: the object's
+    properties at the top level, plus the object's ``source_id`` under the
+    reserved key. The mapping's ``field_map`` is an IDENTITY projection over the
+    union of property keys in the batch (so ``ingest_records`` stores each
+    property verbatim), and ``source_id_field`` reads the reserved key. The type's
+    declared properties (from ``object_types``) ride on the mapping so
+    ``ensure_type`` defines the type with the proposed schema; a type referenced
+    by an object but absent from ``object_types`` is ensured with empty
+    properties (the upsert still stamps provenance).
+    """
+    from pocketpaw.connectors.fabric_ingest import FabricMapping
+    from pocketpaw.fabric.models import PropertyDef
+
+    # Index the declared type schemas by name (case-insensitive) for lookup.
+    type_schemas: dict[str, dict[str, Any]] = {}
+    for t in object_types:
+        name = str(t.get("type_name") or "").strip()
+        if name:
+            type_schemas[name.lower()] = t
+
+    # Group objects by (type_name, source_connector), preserving insertion order.
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for obj in objects:
+        type_name = str(obj.get("type_name") or "").strip()
+        connector = str(obj.get("source_connector") or "").strip()
+        if not type_name or not connector:
+            continue
+        grouped.setdefault((type_name, connector), []).append(obj)
+
+    batches: list[tuple[Any, str, list[dict[str, Any]]]] = []
+    for (type_name, connector), objs in grouped.items():
+        decl = type_schemas.get(type_name.lower(), {})
+        prop_defs = [
+            PropertyDef(**p)
+            for p in (decl.get("properties") or [])
+            if isinstance(p, dict) and p.get("name")
+        ]
+        records: list[dict[str, Any]] = []
+        prop_keys: set[str] = set()
+        for obj in objs:
+            props = dict(obj.get("properties") or {})
+            prop_keys.update(props.keys())
+            record = dict(props)
+            record[_SOURCE_ID_KEY] = obj["source_id"]
+            records.append(record)
+        field_map: dict[str, Any] = {k: k for k in prop_keys}
+        mapping = FabricMapping(
+            type_name=type_name,
+            source_id_field=_SOURCE_ID_KEY,
+            field_map=field_map,
+            properties=prop_defs,
+            type_description=str(decl.get("description") or ""),
+            type_icon=str(decl.get("icon") or "box"),
+            type_color=str(decl.get("color") or "#0A84FF"),
+        )
+        batches.append((mapping, connector, records))
+    return batches
+
+
+async def _create_links_deduped(
+    *,
+    store: Any,
+    links: list[dict[str, Any]],
+    workspace_id: str,
+) -> int:
+    """Create the proposed links, WORKSPACE-SCOPED, deduped by (from, to, link_type).
+
+    Each link references its endpoints by ``(source_connector, source_id)`` — the
+    natural key the objects were upserted under — so we resolve them to the
+    materialised object ids via ``get_object_by_source`` (the same workspace-scoped
+    read the ingest loop uses). A link whose endpoint can't be resolved (the object
+    wasn't in this proposal and doesn't already exist) is skipped. An EXISTING link
+    with the same ``(from_id, to_id, link_type)`` is NOT recreated — re-approve (or
+    two proposals asserting the same link) does not duplicate. Returns the count of
+    NEW links created.
+
+    ``store.link`` is not idempotent on its own, so the dedup lives here: we check
+    ``list_links(from_id, to_id, link_type, workspace_id)`` before each create.
+    """
+    created = 0
+    for link in links:
+        from_ref = link.get("from") or {}
+        to_ref = link.get("to") or {}
+        link_type = str(link.get("link_type") or "").strip()
+        if not link_type:
+            continue
+
+        from_obj = await store.get_object_by_source(
+            source_connector=str(from_ref.get("source_connector") or ""),
+            source_id=str(from_ref.get("source_id") or ""),
+            workspace_id=workspace_id,
+        )
+        to_obj = await store.get_object_by_source(
+            source_connector=str(to_ref.get("source_connector") or ""),
+            source_id=str(to_ref.get("source_id") or ""),
+            workspace_id=workspace_id,
+        )
+        if from_obj is None or to_obj is None:
+            logger.info(
+                "fabric_objects: skipping link %s — endpoint not resolvable in "
+                "workspace %s",
+                link_type,
+                workspace_id,
+            )
+            continue
+
+        # Dedup by (from, to, link_type) within the tenant — skip if it exists.
+        existing, total = await store.list_links(
+            from_id=from_obj.id,
+            to_id=to_obj.id,
+            link_type=link_type,
+            workspace_id=workspace_id,
+        )
+        if total > 0:
+            continue
+
+        await store.link(
+            from_id=from_obj.id,
+            to_id=to_obj.id,
+            link_type=link_type,
+            workspace_id=workspace_id,
+        )
+        created += 1
+    return created
+
+
+async def execute_approved_fabric_objects(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """Materialise the Fabric ontology carried by a freshly-approved Action.
+
+    Called best-effort from the instinct router's ``approve_action`` /
+    ``bulk_approve_actions`` after ``store.approve()`` succeeds — the same hook
+    shape the external-action executor uses. ``action`` is the approved Action.
+
+    ``human_event_id`` is the id of the ``human.corrected`` event the router
+    emitted just before calling this — threaded through so the terminal
+    ``decision.completed`` event can chain its ``causation_id`` back to the
+    approval, completing the causal walk ``agent.proposed → human.corrected →
+    decision.completed``. ``None`` is tolerated (the chain still folds via the
+    shared ``correlation_id``).
+
+    Never raises — a failure here must not break the approve response. The router
+    wraps the call too; this is belt-and-braces. The Action is marked executed on
+    a successful write or failed with a clear outcome on any error, and the
+    Decision-Graph chain is closed exactly once (success → landed, failure →
+    failed).
+    """
+    from pocketpaw.stores import get_fabric_store, get_instinct_store
+
+    store = get_instinct_store()
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(FABRIC_OBJECTS_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not a fabric-objects Action at all — no chain was opened for it, so
+        # there is nothing to close. Return without a terminal emit.
+        logger.warning("approved action %s carries no _fabric_objects blob", action.id)
+        return
+
+    # Read the chain ids off the blob up front so EVERY terminal path can close
+    # the chain it opened. A malformed / missing id → None and the close no-ops
+    # (the Slice 4 abandon-sweeper closes any chain left open).
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    requested_by = str(blob.get("requested_by") or "")
+    approver = str(getattr(action, "approved_by", "") or "") or requested_by or "system"
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Mark the Action failed AND close the chain with one terminal — the
+        single failure-path chokepoint so a path can never both fail and
+        double-fire the terminal."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            summary={"reason": reason},
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=approver,
+            causation_id=causation,
+            summary=reason,
+        )
+
+    # Schema guard — a stale blob from an incompatible build fails loud rather
+    # than writing a misinterpreted ontology.
+    if blob.get("schema") != FABRIC_OBJECTS_SCHEMA:
+        await _fail(
+            "fabric-objects schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    # Tenancy — a Fabric write with no workspace is a tenancy hole. The Fabric
+    # writes are scoped by workspace_id; fail loud so a malformed blob is
+    # recorded, not silently written unscoped.
+    if not workspace_id:
+        await _fail(
+            "fabric-objects blob carries no workspace_id — cannot scope the write",
+            error_class="MissingWorkspace",
+        )
+        return
+
+    # Idempotency — never re-run the write on a re-invocation.
+    if _already_executed(action, blob):
+        logger.info(
+            "fabric_objects: action %s already executed (idempotency guard) — "
+            "skipping the Fabric write",
+            action.id,
+        )
+        return
+
+    objects = blob.get("objects")
+    if not isinstance(objects, list) or not objects:
+        await _fail(
+            "fabric-objects blob carries no objects to materialise",
+            error_class="MalformedBlob",
+        )
+        return
+    object_types = blob.get("object_types") if isinstance(blob.get("object_types"), list) else []
+    links = blob.get("links") if isinstance(blob.get("links"), list) else []
+
+    # Materialise the ontology. Any failure (bad property, store error) is
+    # captured as a failed outcome — NEVER re-raised into the router.
+    try:
+        from pocketpaw.connectors.fabric_ingest import ingest_records
+
+        fabric = get_fabric_store()
+        batches = _build_ingest_batches(object_types, objects)
+
+        total_created = 0
+        total_updated = 0
+        for mapping, connector, records in batches:
+            # REUSE the shipped, workspace-scoped, idempotent upsert loop — one
+            # call per (type, connector) batch so the right provenance is stamped.
+            ingest_result = await ingest_records(
+                fabric,
+                connector,
+                records,
+                mapping,
+                workspace_id=workspace_id,
+            )
+            total_created += ingest_result.created
+            total_updated += ingest_result.updated
+
+        links_created = await _create_links_deduped(
+            store=fabric,
+            links=links,
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — never let a Fabric write break approve
+        logger.warning(
+            "fabric_objects: write crashed for action %s (workspace=%s)",
+            action.id,
+            workspace_id,
+            exc_info=True,
+        )
+        await _fail(
+            f"fabric write failed: {exc}",
+            error_class=type(exc).__name__,
+        )
+        return
+
+    summary = {
+        "created": total_created,
+        "updated": total_updated,
+        "links_created": links_created,
+    }
+
+    # Success — mark executed, back-write the structured outcome, close the chain.
+    await store.mark_executed(
+        action.id,
+        f"fabric ontology materialised: {total_created} created, "
+        f"{total_updated} updated, {links_created} link(s) created",
+    )
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        summary=summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    # Close the chain on the SUCCESS path. This is the ONLY terminal on the happy
+    # path (every failure path above closed via ``_fail`` and returned), so
+    # exactly one ``decision.completed`` lands per write.
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=approver,
+        causation_id=causation,
+        summary=(
+            f"{total_created} created, {total_updated} updated, "
+            f"{links_created} link(s) created"
+        ),
+    )
+    logger.info(
+        "fabric_objects: executed action %s → %d created / %d updated / %d links (ok)",
+        action.id,
+        total_created,
+        total_updated,
+        links_created,
+    )
+
+
+__all__ = ["execute_approved_fabric_objects"]

--- a/ee/pocketpaw_ee/cloud/fabric_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/propose.py
@@ -1,0 +1,445 @@
+# ee/cloud/fabric_proposals/propose.py — propose a gated Fabric-ontology write.
+# Created: 2026-06-19 (SZD-5a — _fabric_objects Instinct proposal type).
+#
+# What this module does (the propose half of the Fabric-objects gate): "sovereign
+# zero-setup discovery" stages a PROPOSED Fabric ontology — a set of object types,
+# objects, and links it inferred from a tenant's connector data — for a human to
+# review through the Instinct gate before any of it is written to Fabric. This
+# files an Instinct ``Action`` carrying a ``_fabric_objects`` blob (schema 1)
+# under ``Action.parameters``. A human approves it in The Tray; the
+# apply-on-approve executor (``fabric_proposals.executor.
+# execute_approved_fabric_objects``) then materialises the ontology in Fabric via
+# the canonical ``connectors.fabric_ingest.ingest_records`` upsert loop. This
+# module does NOT write Fabric — it only gates.
+#
+# The blob is the gated Fabric-ontology kind, sitting alongside the pocket-write
+# bridge's ``_pocket_write``, the Belt develop-station's ``_code_change``, the
+# external-action gate's ``_external_action``, the mandate foreman's
+# ``_belt_plan``, and the Branch-primitive merge gate's ``_artifact_change``. The
+# router + executor dispatch on the presence of the ``_fabric_objects``
+# parameters key (the Action model has no literal ``kind`` column; the blob also
+# carries ``kind="fabric_objects"`` for readers that introspect it).
+#
+# Schema 1 (this is the first version — the schema-version pattern is replicated
+# from ``external_actions.propose.EXTERNAL_ACTION_SCHEMA`` /
+# ``instinct_bridge._POCKET_WRITE_SCHEMA`` / belt's ``CODE_CHANGE_SCHEMA``,
+# starting at 1). The blob carries:
+#   * ``schema`` / ``kind`` — version + discriminator;
+#   * ``workspace_id`` — the originating tenant (the executor's tenancy gate
+#     reads it HERE; a Fabric ontology isn't bound to a pocket the way a parked
+#     write is, so tenancy lives entirely on the blob — and the Fabric writes are
+#     workspace-scoped via this id, building on SZD-2's per-tenant type catalog);
+#   * ``object_types`` — the ObjectTypes to ensure-exist: each
+#     ``{type_name, description?, icon?, color?, properties[]}``;
+#   * ``objects`` — the objects to upsert: each
+#     ``{type_name, properties, source_connector, source_id}``. ``source_id`` is
+#     the idempotency key — re-approving (or two proposals asserting the same
+#     ``(source_connector, source_id)``) updates rather than duplicates;
+#   * ``links`` — the links to create: each ``{from, to, link_type}``, deduped by
+#     ``(from, to, link_type)`` at execution;
+#   * ``summary`` — a human-readable one-liner for the gate UI (The Tray);
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids,
+#     minted here at propose time (``agent.proposed`` opens the chain). The
+#     router's approve / reject paths and the executor close the SAME chain.
+#
+# Security:
+#   * NO Fabric mutation happens here — the ontology is staged as DATA on the
+#     blob and only materialised after a human approves.
+#   * Tenancy is bound on the router's approve / reject paths via
+#     ``_assert_fabric_objects_workspace`` and re-validated at execution (the
+#     Fabric writes are scoped by the blob's ``workspace_id``). A
+#     cross-workspace approve OR reject is refused — asymmetric tenant scope is
+#     no tenant scope (pocketpaw#1183 / #1250).
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator for a Fabric-objects proposal. The
+# router + executor dispatch on the presence of the parameters key below; the
+# blob also carries ``kind="fabric_objects"`` for readers that introspect it.
+FABRIC_OBJECTS_KIND = "fabric_objects"
+
+# The parameters key under which the Fabric-objects blob rides — peer of the
+# pocket-write bridge's ``_pocket_write``, belt's ``_code_change``, and the
+# external-action gate's ``_external_action``. The router + executor dispatch on
+# this key being present.
+FABRIC_OBJECTS_PARAM_KEY = "_fabric_objects"
+
+# Schema version stamped on the ``_fabric_objects`` blob. Bump when the blob
+# shape changes so a stale pending Action approved after a deploy fails loud
+# instead of writing a misinterpreted ontology (same discipline as the
+# external-action gate's ``EXTERNAL_ACTION_SCHEMA``). Starts at 1 — first version.
+FABRIC_OBJECTS_SCHEMA = 1
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    workspace_id: str,
+    user_id: str,
+    type_count: int,
+    object_count: int,
+    link_count: int,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a Fabric-objects write.
+
+    Mirrors ``external_actions.propose._emit_agent_proposed``: the proposing
+    caller is the actor (``kind="agent"`` with the requesting user on its id, the
+    workspace on its scope_context). A Fabric ontology isn't bound to a pocket —
+    its tenancy is the workspace — so ``pocket_id`` on the chain carries the
+    workspace id (matching how the Action's ``pocket_id`` field carries the
+    workspace).
+
+    Returns the emitted event id so the caller can persist it on the blob's
+    ``proposed_event_id`` field for the ``human.corrected`` causation chain, or
+    ``None`` when the emit raised — best-effort per RFC 09; the Slice 4
+    reconciler picks up any orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = (
+        f"create {object_count} Fabric object(s) across {type_count} type(s) "
+        f"and {link_count} link(s)"
+    )
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "fabric_objects",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator.
+        "proposal_kind": "fabric_objects",
+        "proposal": {
+            "type_count": type_count,
+            "object_count": object_count,
+            "link_count": link_count,
+        },
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "fabric_objects agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._fabric_objects`` blob after ``agent.proposed`` fired.
+
+    The blob is built with ``correlation_id`` already set (minted before build);
+    ``proposed_event_id`` is the field this back-write fills in. Direct SQL
+    update — the same pattern the external-action gate's ``_persist_chain_ids``
+    uses. Best-effort: a write failure leaves ``proposed_event_id`` None and the
+    eventual ``human.corrected`` emits without a causation_id (the chain still
+    folds; causation_id is optional on EventEntry).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(FABRIC_OBJECTS_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[FABRIC_OBJECTS_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "fabric_objects: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _normalize_object_types(object_types: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Coerce the proposed object types into a stable, JSON-safe blob shape.
+
+    Each entry keeps ``type_name`` + the optional presentation/properties fields
+    the executor's FabricMapping consumes. ``properties`` is a list of
+    PropertyDef-shaped dicts (``{name, type, required, description, ...}``);
+    anything not a dict is dropped (a malformed property can't be materialised).
+    """
+    out: list[dict[str, Any]] = []
+    for entry in object_types or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("type_name") or "").strip()
+        if not name:
+            continue
+        props = [p for p in (entry.get("properties") or []) if isinstance(p, dict)]
+        out.append(
+            {
+                "type_name": name,
+                "description": str(entry.get("description") or ""),
+                "icon": str(entry.get("icon") or "box"),
+                "color": str(entry.get("color") or "#0A84FF"),
+                "properties": props,
+            }
+        )
+    return out
+
+
+def _normalize_objects(objects: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Coerce the proposed objects into a stable, JSON-safe blob shape.
+
+    Each entry MUST carry ``type_name`` + ``source_connector`` + ``source_id``
+    (the idempotency key) and a ``properties`` dict. Entries missing any of those
+    are dropped — without a stable ``(source_connector, source_id)`` an object
+    cannot be deduplicated and would silently duplicate on re-approve.
+    """
+    out: list[dict[str, Any]] = []
+    for entry in objects or []:
+        if not isinstance(entry, dict):
+            continue
+        type_name = str(entry.get("type_name") or "").strip()
+        source_connector = str(entry.get("source_connector") or "").strip()
+        source_id = str(entry.get("source_id") or "").strip()
+        props = entry.get("properties")
+        if not type_name or not source_connector or not source_id or not isinstance(props, dict):
+            continue
+        out.append(
+            {
+                "type_name": type_name,
+                "properties": dict(props),
+                "source_connector": source_connector,
+                "source_id": source_id,
+            }
+        )
+    return out
+
+
+def _normalize_links(links: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Coerce the proposed links into a stable, JSON-safe blob shape.
+
+    Each entry MUST carry ``from`` + ``to`` + ``link_type``. ``from`` / ``to``
+    reference an object by its ``(source_connector, source_id)`` natural key so
+    the executor can resolve them to the materialised object ids AFTER the
+    upsert (the Fabric object ids don't exist yet at propose time). Entries
+    missing any field are dropped.
+    """
+    out: list[dict[str, Any]] = []
+    for entry in links or []:
+        if not isinstance(entry, dict):
+            continue
+        from_ref = entry.get("from")
+        to_ref = entry.get("to")
+        link_type = str(entry.get("link_type") or "").strip()
+        if not isinstance(from_ref, dict) or not isinstance(to_ref, dict) or not link_type:
+            continue
+        out.append(
+            {
+                "from": {
+                    "source_connector": str(from_ref.get("source_connector") or "").strip(),
+                    "source_id": str(from_ref.get("source_id") or "").strip(),
+                },
+                "to": {
+                    "source_connector": str(to_ref.get("source_connector") or "").strip(),
+                    "source_id": str(to_ref.get("source_id") or "").strip(),
+                },
+                "link_type": link_type,
+            }
+        )
+    return out
+
+
+async def propose_fabric_objects(
+    *,
+    workspace_id: str,
+    objects: list[dict[str, Any]],
+    object_types: list[dict[str, Any]] | None = None,
+    links: list[dict[str, Any]] | None = None,
+    requested_by: str,
+    summary: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+) -> str:
+    """Build + store an Instinct ``Action`` for a gated Fabric-ontology write.
+
+    Files an Action carrying the ``_fabric_objects`` blob (schema 1) and opens
+    the Decision-Graph chain (``agent.proposed``). Returns the proposed Action
+    id. NO Fabric mutation happens here — the ontology is staged as DATA and only
+    materialised after a human approves.
+
+    Args:
+        workspace_id: the originating tenant. Bound on the router's approve /
+            reject paths and re-validated at execution; the Fabric writes are
+            scoped by it. Required — a Fabric write with no tenant to scope it to
+            is a tenancy hole.
+        objects: the objects to upsert. Each carries
+            ``{type_name, properties, source_connector, source_id}``. ``source_id``
+            is the idempotency key. Required + non-empty — a proposal with no
+            objects has nothing to materialise.
+        object_types: the ObjectTypes to ensure-exist. Each carries
+            ``{type_name, description?, icon?, color?, properties[]}``. Optional —
+            when omitted, the executor ensures each object's type by name with
+            empty properties.
+        links: the links to create. Each carries ``{from, to, link_type}`` where
+            ``from`` / ``to`` reference objects by ``(source_connector,
+            source_id)``. Deduped by ``(from, to, link_type)`` at execution.
+        requested_by: the user id that proposed the write (chain actor + audit).
+        summary: a human-readable one-liner for the gate UI. A sensible default
+            is built from the counts when omitted.
+        correlation_id: an optional pre-minted chain id. When omitted a fresh one
+            is minted here (the common case).
+        assignee: the workspace member who should approve. Defaults to
+            ``requested_by`` so the proposer's queue carries it.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_fabric_objects requires a non-empty workspace_id")
+
+    norm_types = _normalize_object_types(object_types)
+    norm_objects = _normalize_objects(objects)
+    norm_links = _normalize_links(links)
+    if not norm_objects:
+        raise ValueError(
+            "propose_fabric_objects requires at least one object with a "
+            "type_name, source_connector, source_id, and properties"
+        )
+
+    # Mint the chain correlation_id BEFORE building the blob so the stored Action
+    # carries it from the first write. The same id threads through approve /
+    # reject (router) and execute (executor) so the whole write folds into ONE
+    # Decision chain.
+    corr = correlation_id or str(uuid4())
+
+    human_summary = summary or (
+        f"Create {len(norm_objects)} Fabric object(s) across "
+        f"{len(norm_types)} type(s) and {len(norm_links)} link(s)."
+    )
+
+    blob: dict[str, Any] = {
+        "kind": FABRIC_OBJECTS_KIND,
+        "schema": FABRIC_OBJECTS_SCHEMA,
+        "workspace_id": workspace_id,
+        "object_types": norm_types,
+        "objects": norm_objects,
+        "links": norm_links,
+        "requested_by": requested_by,
+        "summary": human_summary,
+        # RFC 09 chain-correlation fields (schema 1 carries them from the start).
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    title = (
+        f"Fabric ontology — {len(norm_objects)} object(s), "
+        f"{len(norm_types)} type(s), {len(norm_links)} link(s)"
+    )
+    recommendation = f"Approve to create the proposed Fabric ontology. {human_summary}"
+    trigger = ActionTrigger(
+        type="agent",
+        source=requested_by or "fabric_objects",
+        reason="proposed Fabric ontology requires approval",
+    )
+
+    store = get_instinct_store()
+    action_obj = await store.propose(
+        # ``pocket_id`` carries the workspace for Fabric-objects writes — they
+        # aren't bound to a pocket the way Mission Control items are (mirrors the
+        # external-action gate). The workspace also rides on the blob (the
+        # executor's tenancy gate reads it there); pocket_id mirrors it so the
+        # existing per-pocket queries still surface the row.
+        pocket_id=workspace_id,
+        title=title,
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.WORKFLOW,
+        priority=ActionPriority.MEDIUM,
+        parameters={FABRIC_OBJECTS_PARAM_KEY: blob},
+        assignee=assignee or requested_by or None,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "fabric_objects: proposed %d object(s) / %d type(s) / %d link(s) → "
+        "Instinct action %s (workspace=%s, correlation_id=%s)",
+        len(norm_objects),
+        len(norm_types),
+        len(norm_links),
+        action_obj.id,
+        workspace_id,
+        corr,
+    )
+
+    # Open the Decision-Graph chain now that the Action is stored. ``agent.
+    # proposed`` is the chain origin; its event id is back-written onto the blob
+    # so the router's ``human.corrected`` can cite it as causation. Best-effort:
+    # a Decision-Graph wiring failure must NOT fail the propose response.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        workspace_id=workspace_id,
+        user_id=requested_by,
+        type_count=len(norm_types),
+        object_count=len(norm_objects),
+        link_count=len(norm_links),
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+__all__ = [
+    "FABRIC_OBJECTS_KIND",
+    "FABRIC_OBJECTS_PARAM_KEY",
+    "FABRIC_OBJECTS_SCHEMA",
+    "propose_fabric_objects",
+]

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,20 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-19 (SZD-5a — _fabric_objects proposal type) — added a gated
+#   Fabric-ontology proposal kind. ``_fabric_objects_blob`` +
+#   ``_assert_fabric_objects_workspace`` are the peers of the existing blob
+#   accessors + tenancy guards. The blob (``Action.parameters._fabric_objects``)
+#   carries {object_types[], objects[], links[], workspace_id}. On APPROVE the
+#   router emits ``human.corrected`` then fires
+#   ``fabric_proposals.executor.execute_approved_fabric_objects`` (which
+#   materialises the ontology via the workspace-scoped, idempotent
+#   ``connectors.fabric_ingest.ingest_records`` upsert loop and OWNS the chain
+#   close). On REJECT the router emits ``human.corrected`` +
+#   ``decision.completed(rejected)`` itself (the executor never runs on reject —
+#   no Fabric write happens). The ``_assert_fabric_objects_workspace`` 403 runs
+#   in ALL FOUR locations (approve / bulk-approve / reject / bulk-reject) BEFORE
+#   any mutation — asymmetric tenant scope is no tenant scope (pocketpaw#1183 /
+#   #1250). Same exactly-one-terminal discipline as the external-action gate.
 # Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — added the
 #   FIFTH gated proposal kind: the Branch-primitive artifact-change MERGE GATE.
 #   ``_artifact_change_blob`` + ``_assert_artifact_change_workspace`` are the
@@ -498,6 +513,48 @@ def _assert_external_action_workspace(action: Any, current_workspace: str) -> No
         )
 
 
+def _fabric_objects_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_fabric_objects`` blob on an Action, or ``None``.
+
+    The blob is the gated Fabric-ontology payload
+    ``ee.cloud.fabric_proposals.propose`` stores under
+    ``Action.parameters._fabric_objects`` (object_types / objects / links + the
+    originating ``workspace_id``). This is a peer gated proposal kind — the
+    approve path dispatches the apply-on-approve executor on its presence,
+    exactly as it dispatches the external-action executor on ``_external_action``.
+    Anything that is not a dict is treated as "no fabric objects".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_fabric_objects")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_fabric_objects_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting a Fabric-ontology write from another workspace.
+
+    Mirror of ``_assert_external_action_workspace`` for the ``_fabric_objects``
+    blob. ``require_action_any_workspace("instinct.approve")`` only proves the
+    caller holds the role SOMEWHERE; this binds the Fabric-objects Action to the
+    caller's active workspace. A Fabric write carries no pocket the way a parked
+    write does, so its tenancy lives entirely on the blob's ``workspace_id``. A
+    blob whose ``workspace_id`` differs from the caller's active workspace → 403,
+    on BOTH the approve and reject side (asymmetric tenant scope is no tenant
+    scope — pocketpaw#1183 / #1250). A non-fabric-objects Action (no blob) is
+    unaffected.
+    """
+    blob = _fabric_objects_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This fabric-objects write belongs to a different workspace",
+        )
+
+
 def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
     """Reject approving a parked pocket write from another workspace.
 
@@ -818,6 +875,7 @@ async def bulk_approve_actions(
             _assert_pocket_write_workspace(action, workspace_id)
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
+            _assert_fabric_objects_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -904,6 +962,39 @@ async def bulk_approve_actions(
             except Exception:
                 logger.exception(
                     "bulk-approve external-action execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
+        # A bulk-approved gated ``_fabric_objects`` Action materialises its
+        # proposed ontology in Fabric. Mirrors the external-action branch above:
+        # per-item ``human.corrected(accepted)`` (bulk-approve has no edit
+        # surface), the ``agent.proposed`` event id (off the blob's
+        # ``proposed_event_id``) as causation, then the executor (which owns the
+        # chain close). Matched BEFORE the pocket-write fallthrough and
+        # ``continue``d so the kinds never cross.
+        fabric_objects_blob = _fabric_objects_blob(action)
+        if fabric_objects_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=fabric_objects_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(fabric_objects_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.fabric_proposals import (
+                    executor as fabric_objects_executor,
+                )
+
+                await fabric_objects_executor.execute_approved_fabric_objects(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve fabric-objects execution failed for %s (non-fatal)",
                     action.id,
                 )
             continue
@@ -1039,6 +1130,7 @@ async def bulk_reject_actions(
             _assert_pocket_write_workspace(action, workspace_id)
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
+            _assert_fabric_objects_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -1118,6 +1210,32 @@ async def bulk_reject_actions(
             )
             _emit_decision_completed_rejected(
                 blob=external_action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            continue
+
+        # A bulk-rejected gated ``_fabric_objects`` Action closes its chain HERE
+        # (the executor never runs on reject — the router owns the close). NO
+        # Fabric write happens. Mirrors the external-action reject branch.
+        # Matched AFTER pocket-write + code-change + external-action and
+        # ``continue``d so the kinds never cross.
+        fabric_objects_blob = _fabric_objects_blob(action)
+        if fabric_objects_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=fabric_objects_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(fabric_objects_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=fabric_objects_blob,
                 action=action,
                 user_id=rejector_id,
                 workspace_id=workspace_id,
@@ -1226,6 +1344,11 @@ async def approve_action(
     # Same tenancy gate for a gated external-action Action — its
     # ``_external_action`` blob carries the workspace, not a pocket.
     _assert_external_action_workspace(before, workspace_id)
+    # Same tenancy gate for a gated Fabric-objects Action — its
+    # ``_fabric_objects`` blob carries the workspace, not a pocket. Approving it
+    # writes typed objects into the tenant's Fabric, so the cross-workspace gate
+    # is mandatory here.
+    _assert_fabric_objects_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -1392,6 +1515,45 @@ async def approve_action(
         except Exception:
             logger.exception("external-action execution after approval failed (non-fatal)")
 
+    # When the approved Action carries a gated ``_fabric_objects`` blob,
+    # materialise the proposed ontology in Fabric (workspace-scoped, idempotent
+    # ingest). Same best-effort, lazy-import, never-break-the-approve-response
+    # shape as the external-action hook above; the executor records success /
+    # failure on the Action itself. A non-fabric-objects Action skips this.
+    #
+    # The Fabric-objects write is part of its own Decision-Graph chain (the
+    # propose helper minted the ``correlation_id`` + emitted ``agent.proposed``).
+    # Emit the ``human.corrected`` event for the approval HERE (the router owns
+    # the human-action emit on every approve path), citing the ``agent.proposed``
+    # event id (stored on the blob as ``proposed_event_id`` — the same field the
+    # external-action path reads, so ``_code_change_proposed_event_id`` resolves
+    # it) as causation, then thread its event id into the executor so the terminal
+    # ``decision.completed`` chains back to the approval. The executor owns the
+    # chain CLOSE (success or failure) — the router does NOT emit
+    # ``decision.completed`` here, mirroring the external-action executor. No
+    # double terminal.
+    fabric_objects_blob = _fabric_objects_blob(approved)
+    if fabric_objects_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=fabric_objects_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(fabric_objects_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.fabric_proposals import executor as fabric_objects_executor
+
+            await fabric_objects_executor.execute_approved_fabric_objects(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("fabric-objects execution after approval failed (non-fatal)")
+
     # MANDATES — when the approved Action carries a ``_belt_plan`` blob (the
     # mandate foreman's shift plan), dispatch the plan executor. Same shape as
     # the code-change hook: the router owns the ``human.corrected`` emit, the
@@ -1524,6 +1686,10 @@ async def reject_action(
     _assert_pocket_write_workspace(before, workspace_id)
     _assert_code_change_workspace(before, workspace_id)
     _assert_external_action_workspace(before, workspace_id)
+    # Same tenancy gate for a gated Fabric-objects Action on the REJECT side —
+    # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
+    # 403 before any mutation, exactly like the approve side.
+    _assert_fabric_objects_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -1613,6 +1779,33 @@ async def reject_action(
         )
         _emit_decision_completed_rejected(
             blob=external_action_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
+
+    # A rejected gated ``_fabric_objects`` Action closes its chain HERE (the
+    # executor never runs on reject — the router owns the close, mirroring the
+    # external-action reject path). NO Fabric write happens.
+    # ``human.corrected(rejected)`` cites the ``agent.proposed`` event (off the
+    # blob's ``proposed_event_id``); ``decision.completed(rejected)`` cites the
+    # human event so the chain reads ``agent.proposed → human.corrected →
+    # decision.completed``.
+    fabric_objects_blob = _fabric_objects_blob(action)
+    if fabric_objects_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=fabric_objects_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(fabric_objects_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=fabric_objects_blob,
             action=action,
             user_id=rejector_id,
             workspace_id=workspace_id,

--- a/tests/cloud/test_fabric_objects_gate.py
+++ b/tests/cloud/test_fabric_objects_gate.py
@@ -1,0 +1,533 @@
+# tests/cloud/test_fabric_objects_gate.py — the gated _fabric_objects proposal
+# type (SZD-5a), a tenancy gate over a proposed Fabric ontology.
+#
+# Created: 2026-06-19 (SZD-5a — _fabric_objects Instinct proposal type).
+#
+# What this pins:
+#   * propose_fabric_objects — blob shape (schema 1, object_types, objects,
+#     links, workspace_id, correlation_id, summary), tenancy (workspace
+#     required), object-count requirement.
+#   * execute_approved_fabric_objects against a REAL tmp FabricStore:
+#       - happy path: objects materialised via ingest_records, types defined,
+#         links created, action EXECUTED, structured outcome back-written.
+#       - dedup: re-approve (or two proposals asserting the same
+#         (source_connector, source_id)) does NOT duplicate objects OR links.
+#       - schema mismatch: a stale schema blob → FAILED, no Fabric write.
+#   * the 4-PATH cross-workspace tenancy gate through the REAL router:
+#       - approve / reject (single) AND bulk-approve / bulk-reject all 403 a
+#         cross-workspace caller — a missing guard on ANY of the four is a leak.
+#   * the MANDATORY production-path chain test: propose → approve via the REAL
+#     router → executor materialises objects → walk the decision chain and assert
+#     EXACTLY agent.proposed → human.corrected → decision.completed (one
+#     terminal), and the reject path's router-owned close (executor never runs).
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The instinct store is
+# patched to a tmp-file InstinctStore; the FABRIC store is patched to a tmp-file
+# FabricStore so the writes are real but isolated. The integration tests wire a
+# fresh on-disk journal + DecisionGraph (same fixture shape as
+# tests/cloud/test_external_action_gate.py) and drive the router over a
+# TestClient with stubbed auth deps.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.fabric_proposals import executor as fo_executor  # noqa: E402
+from pocketpaw_ee.cloud.fabric_proposals import propose as fo_propose  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired everywhere the gate reads it
+    (the propose helper + the executor both lazy-import
+    ``pocketpaw.stores.get_instinct_store``)."""
+    st = InstinctStore(tmp_path / "instinct_fabric_objects_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+@pytest.fixture
+def fabric(tmp_path: Path, monkeypatch) -> FabricStore:
+    """Isolated FabricStore on a tmp file, wired into ``get_fabric_store`` so the
+    executor writes real (but isolated) typed objects + links."""
+    fs = FabricStore(tmp_path / "fabric_objects_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda: fs)
+    return fs
+
+
+# A canonical proposal payload reused across tests.
+_OBJECT_TYPES = [
+    {
+        "type_name": "Customer",
+        "description": "A discovered customer",
+        "properties": [
+            {"name": "name", "type": "string"},
+            {"name": "email", "type": "string"},
+        ],
+    },
+    {
+        "type_name": "Order",
+        "properties": [{"name": "total", "type": "number"}],
+    },
+]
+_OBJECTS = [
+    {
+        "type_name": "Customer",
+        "properties": {"name": "Acme Inc", "email": "ops@acme.test"},
+        "source_connector": "crm",
+        "source_id": "cust-1",
+    },
+    {
+        "type_name": "Order",
+        "properties": {"total": 42},
+        "source_connector": "billing",
+        "source_id": "ord-9",
+    },
+]
+_LINKS = [
+    {
+        "from": {"source_connector": "billing", "source_id": "ord-9"},
+        "to": {"source_connector": "crm", "source_id": "cust-1"},
+        "link_type": "placed_by",
+    }
+]
+
+
+async def _propose(store, **overrides) -> str:
+    kwargs: dict[str, Any] = dict(
+        workspace_id="w1",
+        objects=_OBJECTS,
+        object_types=_OBJECT_TYPES,
+        links=_LINKS,
+        requested_by="u1",
+    )
+    kwargs.update(overrides)
+    return await fo_propose.propose_fabric_objects(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# propose — blob shape + tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_builds_fabric_objects_blob(store):
+    """propose_fabric_objects files an Action carrying a well-formed schema-1
+    ``_fabric_objects`` blob — object_types, objects, links, workspace_id,
+    correlation_id, summary."""
+    action_id = await _propose(store)
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+
+    blob = action.parameters["_fabric_objects"]
+    assert blob["kind"] == "fabric_objects"
+    assert blob["schema"] == 1
+    assert blob["workspace_id"] == "w1"
+    assert len(blob["object_types"]) == 2
+    assert len(blob["objects"]) == 2
+    assert len(blob["links"]) == 1
+    assert blob["objects"][0]["source_connector"] == "crm"
+    assert blob["objects"][0]["source_id"] == "cust-1"
+    assert blob["requested_by"] == "u1"
+    assert blob["correlation_id"]
+    assert blob["summary"]
+
+
+async def test_propose_requires_workspace(store):
+    """A propose with no workspace_id is rejected — a Fabric write with no tenant
+    to scope it to is a tenancy hole."""
+    with pytest.raises(ValueError, match="workspace_id"):
+        await fo_propose.propose_fabric_objects(
+            workspace_id="",
+            objects=_OBJECTS,
+            requested_by="u1",
+        )
+
+
+async def test_propose_requires_objects(store):
+    """A propose with no usable objects is rejected — nothing to materialise."""
+    with pytest.raises(ValueError, match="object"):
+        await fo_propose.propose_fabric_objects(
+            workspace_id="w1",
+            objects=[],
+            requested_by="u1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# executor — happy path, dedup, schema
+# ---------------------------------------------------------------------------
+
+
+async def _propose_and_approve(store, **overrides) -> Any:
+    action_id = await _propose(store, **overrides)
+    return await store.approve(action_id, approver="u1")
+
+
+async def test_executor_happy_path_materialises_objects(store, fabric):
+    """On approve the executor materialises the proposed objects via
+    ingest_records (workspace-scoped), defines the types, creates the link, marks
+    EXECUTED, and back-writes the structured outcome."""
+    approved = await _propose_and_approve(store)
+    await fo_executor.execute_approved_fabric_objects(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED
+    outcome = final.parameters["_fabric_objects"]["outcome"]
+    assert outcome["status"] == "executed"
+    assert outcome["created"] == 2
+    assert outcome["updated"] == 0
+    assert outcome["links_created"] == 1
+    assert "executed_at" in outcome
+
+    # The objects exist in Fabric, workspace-scoped, with provenance.
+    cust = await fabric.get_object_by_source(
+        source_connector="crm", source_id="cust-1", workspace_id="w1"
+    )
+    assert cust is not None
+    assert cust.properties["name"] == "Acme Inc"
+    assert cust.properties["email"] == "ops@acme.test"
+    ord_obj = await fabric.get_object_by_source(
+        source_connector="billing", source_id="ord-9", workspace_id="w1"
+    )
+    assert ord_obj is not None
+    assert ord_obj.properties["total"] == 42
+
+    # The types were defined in w1.
+    types = await fabric.list_types(workspace_id="w1")
+    type_names = {t.name for t in types}
+    assert {"Customer", "Order"} <= type_names
+
+    # The link exists, workspace-scoped.
+    links, total = await fabric.list_links(
+        from_id=ord_obj.id, to_id=cust.id, link_type="placed_by", workspace_id="w1"
+    )
+    assert total == 1
+
+
+async def test_executor_reapprove_does_not_duplicate(store, fabric):
+    """Re-running the executor (idempotency-guard bypassed by re-proposing the
+    SAME objects in a SECOND action) does NOT duplicate objects OR links — the
+    ingest dedup keys on (source_connector, source_id) and the link dedup on
+    (from, to, link_type)."""
+    # First proposal — materialise.
+    approved1 = await _propose_and_approve(store)
+    await fo_executor.execute_approved_fabric_objects(approved1)
+
+    # Second proposal asserting the SAME objects + link.
+    approved2 = await _propose_and_approve(store)
+    await fo_executor.execute_approved_fabric_objects(approved2)
+
+    final2 = await store.get_action(approved2.id)
+    out2 = final2.parameters["_fabric_objects"]["outcome"]
+    # Second run UPDATES the existing objects (no new create) and creates NO new
+    # link (the (from,to,link_type) already exists).
+    assert out2["created"] == 0
+    assert out2["updated"] == 2
+    assert out2["links_created"] == 0
+
+    # Exactly ONE object per type — no duplicates split across two type_ids or
+    # two rows.
+    from pocketpaw.fabric.models import FabricQuery
+
+    cust_result = await fabric.query(FabricQuery(type_name="Customer"), workspace_id="w1")
+    ord_result = await fabric.query(FabricQuery(type_name="Order"), workspace_id="w1")
+    assert len(cust_result.objects) == 1
+    assert len(ord_result.objects) == 1
+
+    ord_obj = await fabric.get_object_by_source(
+        source_connector="billing", source_id="ord-9", workspace_id="w1"
+    )
+    cust = await fabric.get_object_by_source(
+        source_connector="crm", source_id="cust-1", workspace_id="w1"
+    )
+    _links, total = await fabric.list_links(
+        from_id=ord_obj.id, to_id=cust.id, link_type="placed_by", workspace_id="w1"
+    )
+    assert total == 1  # still ONE link
+
+
+async def test_executor_idempotent_never_reruns(store, fabric):
+    """Re-invoking the executor on an already-EXECUTED Action short-circuits
+    before any Fabric write (the idempotency guard)."""
+    approved = await _propose_and_approve(store)
+    await fo_executor.execute_approved_fabric_objects(approved)
+    types_after_first = await fabric.list_types(workspace_id="w1")
+
+    reloaded = await store.get_action(approved.id)
+    await fo_executor.execute_approved_fabric_objects(reloaded)
+    types_after_second = await fabric.list_types(workspace_id="w1")
+    # No additional type rows — the guard skipped the re-run.
+    assert len(types_after_second) == len(types_after_first)
+
+
+async def test_executor_schema_mismatch_refuses(store, fabric):
+    """A stale blob with an incompatible schema version → FAILED, no Fabric
+    write."""
+    approved = await _propose_and_approve(store)
+    approved.parameters["_fabric_objects"]["schema"] = 999  # incompatible
+
+    await fo_executor.execute_approved_fabric_objects(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "schema" in str(final.error).lower()
+    # Nothing was written.
+    types = await fabric.list_types(workspace_id="w1")
+    assert types == []
+
+
+async def test_executor_no_blob_is_noop(store, fabric):
+    """An Action with no ``_fabric_objects`` blob is a clean no-op."""
+    from pocketpaw.instinct.models import ActionTrigger
+
+    action = await store.propose(
+        pocket_id="w1",
+        title="not fabric",
+        description="",
+        recommendation="",
+        trigger=ActionTrigger(type="agent", source="x", reason="y"),
+    )
+    approved = await store.approve(action.id, approver="u1")
+    await fo_executor.execute_approved_fabric_objects(approved)
+    types = await fabric.list_types(workspace_id="w1")
+    assert types == []
+
+
+# ---------------------------------------------------------------------------
+# Integration fixtures — journal + decision graph + router client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "u1", workspace_id: str = "w1") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _make_client(user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _events_by_correlation(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+# ---------------------------------------------------------------------------
+# MANDATORY production-path chain tests
+# ---------------------------------------------------------------------------
+
+
+async def test_production_path_approve_runs_executor_one_terminal(
+    store, fabric, journal, graph, monkeypatch
+):
+    """propose → approve through the REAL router → the executor materialises the
+    objects → walk the decision chain and assert EXACTLY agent.proposed →
+    human.corrected → decision.completed (ONE terminal, executor owns the close)."""
+    action_id = await _propose(store)
+    blob = (await store.get_action(action_id)).parameters["_fabric_objects"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED
+    # The objects landed in Fabric.
+    assert (
+        await fabric.get_object_by_source(
+            source_connector="crm", source_id="cust-1", workspace_id="w1"
+        )
+    ) is not None
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is True
+    assert (terminal.payload or {})["action_outcome"] == "landed"
+    hc = chain[1]
+    assert terminal.causation_id == hc.id
+
+
+async def test_production_path_reject_router_closes_executor_never_runs(
+    store, fabric, journal, graph, monkeypatch
+):
+    """Reject path: the ROUTER emits human.corrected + decision.completed
+    (rejected); the executor NEVER runs (no Fabric write)."""
+    action_id = await _propose(store)
+    blob = (await store.get_action(action_id)).parameters["_fabric_objects"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED
+    # NO Fabric write happened on reject.
+    assert (
+        await fabric.get_object_by_source(
+            source_connector="crm", source_id="cust-1", workspace_id="w1"
+        )
+    ) is None
+    types = await fabric.list_types(workspace_id="w1")
+    assert types == []
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is False
+    assert (terminal.payload or {})["action_outcome"] == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# 4-PATH cross-workspace tenancy gate — a missing guard on ANY path is a leak.
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_workspace_single_approve_forbidden(store, fabric, journal, graph, monkeypatch):
+    """PATH 1/4 — single approve: a caller in w1 cannot approve a w-OTHER
+    Fabric-objects Action."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+    # Nothing written.
+    assert await fabric.list_types(workspace_id="w-OTHER") == []
+
+
+async def test_cross_workspace_single_reject_forbidden(store, fabric, journal, graph, monkeypatch):
+    """PATH 2/4 — single reject: a caller in w1 cannot reject a w-OTHER
+    Fabric-objects Action (asymmetric tenant scope is no tenant scope)."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+
+
+async def test_cross_workspace_bulk_approve_forbidden(store, fabric, journal, graph, monkeypatch):
+    """PATH 3/4 — bulk approve: a single cross-workspace item 403s the whole
+    batch before any mutation."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+    assert await fabric.list_types(workspace_id="w-OTHER") == []
+
+
+async def test_cross_workspace_bulk_reject_forbidden(store, fabric, journal, graph, monkeypatch):
+    """PATH 4/4 — bulk reject: a single cross-workspace item 403s the whole
+    batch before any mutation."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post("/instinct/actions/bulk-reject", json={"ids": [action_id], "reason": "no"})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING


### PR DESCRIPTION
SZD-5a, stacked on #1509. The Instinct gate had no way to propose "create these Fabric objects" — it was sealed to `_pocket_write` / `_code_change` / `_external_action` / `_belt_plan`. Sovereign zero-setup discovery needs to stage a proposed Fabric ontology for human review and only write on approve. This adds that proposal type, mirroring the shipped `_external_action` pattern exactly.

## What changed
- New `ee/pocketpaw_ee/cloud/fabric_proposals/` — `propose_fabric_objects` (schema-1 blob: object_types + objects + links + the tenancy `workspace_id`; anchors `pocket_id=workspace_id`; opens the `agent.proposed` chain) + `execute_approved_fabric_objects` (reuses the idempotent, workspace-scoped `ingest_records`; links deduped on `(from,to,link_type)`; single `_fail` chokepoint; owns `decision.completed` on approve).
- `router.py` — `_assert_fabric_objects_workspace` guard, called in all four paths (approve / reject / bulk-approve / bulk-reject) before any mutation; approve→executor, reject→router-owned chain close.

## Verified
- New `tests/cloud/test_fabric_objects_gate.py` (14 tests): all four cross-workspace paths reject (403, no write); re-approve doesn't duplicate (created=0 / updated=2 / links=0); chain is `[agent.proposed, human.corrected, decision.completed]`, one terminal per path; a schema-999 blob is refused. Regression: external_action_gate (27) + fabric_ingest + instinct_decision_events (12) green.
- Independently re-ran the 14 tests + confirmed the guard is invoked in all four router dispatch functions; distrust review returned SPEC_PASS, no cross-tenant path.

## Notes
- Links reference endpoints by `(source_connector, source_id)` natural key (Fabric ids don't exist at propose time); resolved post-ingest, a link to a missing endpoint is skipped (logged), not failed — the right default for a self-contained ontology proposal.
- No caller wires `propose_fabric_objects` yet — that's the discovery surface (SZD-6). The helper is exported, ready.

Stacks on #1509. Pairs with `_pocket_create` (SZD-5b, next). Part of sovereign zero-setup discovery.