### PR TITLE
Sites: _pocket_create Instinct proposal type (gated Pocket creation)

### DIFF
--- a/ee/pocketpaw_ee/cloud/pocket_proposals/__init__.py
+++ b/ee/pocketpaw_ee/cloud/pocket_proposals/__init__.py
@@ -1,0 +1,32 @@
+# ee/cloud/pocket_proposals/__init__.py — the gated starter-Pocket-create Instinct
+# proposal type (a peer of ``_fabric_objects`` / ``_pocket_write`` /
+# ``_code_change`` / ``_external_action`` / ``_belt_plan`` / ``_artifact_change``).
+# Created: 2026-06-19 (SZD-5b — _pocket_create proposal type) — a proposed starter
+#   Pocket (a rippleSpec + name, optional template slug) staged for human review
+#   through the Instinct gate. "Sovereign zero-setup discovery" infers a starter
+#   Pocket for a tenant and proposes "create this Pocket"; a human approves or
+#   rejects in The Tray; on approve the executor creates the Pocket via the
+#   canonical, workspace-scoped ``pockets.service.create`` write path. Fully
+#   generic — no domain-specific logic.
+#
+# Re-exports the propose helper + the apply-on-approve executor so callers (the
+# discovery surface, the instinct router) import from the package root, mirroring
+# how the Fabric-objects gate is imported.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.pocket_proposals.executor import execute_approved_pocket_create
+from pocketpaw_ee.cloud.pocket_proposals.propose import (
+    POCKET_CREATE_KIND,
+    POCKET_CREATE_PARAM_KEY,
+    POCKET_CREATE_SCHEMA,
+    propose_pocket,
+)
+
+__all__ = [
+    "POCKET_CREATE_KIND",
+    "POCKET_CREATE_PARAM_KEY",
+    "POCKET_CREATE_SCHEMA",
+    "execute_approved_pocket_create",
+    "propose_pocket",
+]

--- a/ee/pocketpaw_ee/cloud/pocket_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/pocket_proposals/executor.py
@@ -1,0 +1,406 @@
+# ee/cloud/pocket_proposals/executor.py — apply an approved starter-Pocket create.
+# Created: 2026-06-19 (SZD-5b — _pocket_create Instinct proposal type).
+#
+# What this module does (the apply-on-approve half of the Pocket-create gate): the
+# propose helper (``pocket_proposals.propose.propose_pocket``) files an Instinct
+# Action carrying a ``_pocket_create`` blob THROUGH Instinct (the human
+# approve/reject layer). After a human approves the Action, the ee instinct
+# router's ``approve_action`` fires ``execute_approved_pocket_create`` here —
+# exactly mirroring how ``fabric_proposals.executor.execute_approved_fabric_objects``
+# is fired for a gated Fabric write. This function:
+#
+#   1. Reads the ``_pocket_create`` blob from ``action.parameters``. A missing blob
+#      → return (no chain was opened, nothing to close). A schema-mismatched blob →
+#      mark_failed + close the chain, return.
+#   2. Workspace guard — an empty ``workspace_id`` on the blob → mark_failed +
+#      close (a Pocket create with no tenant to scope it to is a tenancy hole).
+#   3. Idempotency guard — if the Action is already terminal (executed / failed) or
+#      the blob already carries an ``outcome``, the create is NOT re-run.
+#      Re-approve / retry never double-creates.
+#   4. Validates the staged spec at the entry to the create path:
+#      ``body = CreatePocketRequest.model_validate(blob["pocket_spec"])`` — a
+#      structurally invalid spec fails CLEANLY (mark_failed + close), not silently.
+#      Then ``await pockets.service.create(workspace_id, user_id, body)``, scoped
+#      by the blob's top-level ``workspace_id`` / owned by its top-level
+#      ``user_id`` (NOT anything inside ``pocket_spec`` — tenancy/owner are
+#      un-editable).
+#   5. Back-writes the outcome ``{status, pocket_id, name, executed_at}`` onto the
+#      persisted blob via the direct-SQL pattern.
+#   6. Records the result on the Action (``mark_executed`` / ``mark_failed``) and
+#      CLOSES the Decision-Graph chain exactly once.
+#
+# EXACTLY-ONE-TERMINAL discipline (critical): on APPROVE the EXECUTOR owns the
+# ``decision.completed`` chain close — the router does NOT emit it (mirrors the
+# Fabric-objects executor). On REJECT the ROUTER owns the close and the executor
+# never runs. Every terminal path here goes through the single ``_fail`` chokepoint
+# (failure) or the one success emit at the end — never both.
+#
+# Never raises — a failure here must not break the approve response. The router
+# wraps the call too; this is belt-and-braces. A create error is captured as
+# ``status=failed`` with a ``failed`` terminal, NOT re-raised.
+#
+# Security (this code creates a Pocket in a tenant's workspace on approval):
+#   * tenancy + owner are read off the blob's SEPARATE top-level ``workspace_id`` /
+#     ``user_id`` fields — NEVER off ``pocket_spec`` (which the correction flow can
+#     edit). An empty workspace_id is refused (a tenancy hole). The router's
+#     ``_assert_pocket_create_workspace`` is the primary gate; this is
+#     belt-and-braces.
+#   * the write primitive is the SHIPPED ``pockets.service.create`` — this module
+#     does NOT touch the Beanie document directly, so it inherits the proven
+#     workspace-scoped, validate-at-entry create path.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.pocket_proposals.propose import (
+    POCKET_CREATE_PARAM_KEY,
+    POCKET_CREATE_SCHEMA,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    summary: dict[str, Any],
+    executed_at: str,
+) -> None:
+    """Back-write the create outcome onto the persisted ``_pocket_create`` blob.
+
+    Direct SQL update — the same pattern the Fabric-objects executor's
+    ``_persist_outcome`` uses. The blob's ``outcome`` carries the created pocket id
+    + name + timestamp so a reader (audit, a re-invocation idempotency check) sees
+    the result structurally. Best-effort: a write failure leaves the blob without
+    the structured outcome but the free-text ``mark_executed`` / ``mark_failed``
+    outcome still records it.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(POCKET_CREATE_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {"status": status, "executed_at": executed_at, **summary}
+        params[POCKET_CREATE_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "pocket_create: failed to persist outcome onto action %s — the "
+            "structured outcome is unavailable (free-text outcome still recorded)",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a Pocket create.
+
+    Mirrors ``fabric_proposals.executor._emit_chain_close`` — the executor owns the
+    chain close on the approve path. ``correlation_id`` is read off the blob;
+    ``causation_id`` is the ``human.corrected`` event the router emitted just
+    before approval so the terminal chains back to the human approval.
+
+    Returns early when ``correlation_id`` is None (a blob with a malformed /
+    missing id): there is no chain to close. Best-effort: a Decision-Graph wiring
+    failure must never break the approve response — the journal write is the source
+    of truth; the Slice 4 reconciler is the safety net.
+    """
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if summary:
+        payload["summary"] = summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "pocket_create decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this Pocket create already ran.
+
+    Two signals, either is sufficient:
+      * the blob already carries an ``outcome`` (a prior run back-wrote it), or
+      * the Action is already in a terminal state (executed / failed).
+
+    Re-invocation (bulk re-approve, retry) must never re-run the create — a Pocket
+    create has no natural idempotency key (each call mints a fresh pocket id), so
+    the Action's terminal ``status`` + the back-written outcome are the ONLY guard
+    against a double-create. The Action's ``status`` is the authoritative gate, and
+    the back-written outcome is the belt-and-braces signal in case status reads are
+    stale.
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+async def execute_approved_pocket_create(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """Create the starter Pocket carried by a freshly-approved Action.
+
+    Called best-effort from the instinct router's ``approve_action`` /
+    ``bulk_approve_actions`` after ``store.approve()`` succeeds — the same hook
+    shape the Fabric-objects executor uses. ``action`` is the approved Action.
+
+    ``human_event_id`` is the id of the ``human.corrected`` event the router
+    emitted just before calling this — threaded through so the terminal
+    ``decision.completed`` event can chain its ``causation_id`` back to the
+    approval, completing the causal walk ``agent.proposed → human.corrected →
+    decision.completed``. ``None`` is tolerated (the chain still folds via the
+    shared ``correlation_id``).
+
+    Never raises — a failure here must not break the approve response. The router
+    wraps the call too; this is belt-and-braces. The Action is marked executed on a
+    successful create or failed with a clear outcome on any error, and the
+    Decision-Graph chain is closed exactly once (success → landed, failure →
+    failed).
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(POCKET_CREATE_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not a pocket-create Action at all — no chain was opened for it, so there
+        # is nothing to close. Return without a terminal emit.
+        logger.warning("approved action %s carries no _pocket_create blob", action.id)
+        return
+
+    # Read the chain ids + tenancy/owner off the blob up front so EVERY terminal
+    # path can close the chain it opened. Tenancy/owner come from the SEPARATE
+    # top-level fields — NEVER from ``pocket_spec`` (which the correction flow can
+    # edit). A malformed / missing correlation id → None and the close no-ops (the
+    # Slice 4 abandon-sweeper closes any chain left open).
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    owner_user_id = str(blob.get("user_id") or "")
+    approver = str(getattr(action, "approved_by", "") or "") or owner_user_id or "system"
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Mark the Action failed AND close the chain with one terminal — the
+        single failure-path chokepoint so a path can never both fail and
+        double-fire the terminal."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            summary={"reason": reason},
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=approver,
+            causation_id=causation,
+            summary=reason,
+        )
+
+    # Schema guard — a stale blob from an incompatible build fails loud rather than
+    # creating a misinterpreted Pocket.
+    if blob.get("schema") != POCKET_CREATE_SCHEMA:
+        await _fail(
+            "pocket-create schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    # Tenancy — a Pocket create with no workspace is a tenancy hole. The Pocket is
+    # created scoped by workspace_id; fail loud so a malformed blob is recorded, not
+    # silently created unscoped.
+    if not workspace_id:
+        await _fail(
+            "pocket-create blob carries no workspace_id — cannot scope the create",
+            error_class="MissingWorkspace",
+        )
+        return
+    if not owner_user_id:
+        await _fail(
+            "pocket-create blob carries no user_id — cannot assign an owner",
+            error_class="MissingOwner",
+        )
+        return
+
+    # Idempotency — never re-run the create on a re-invocation.
+    if _already_executed(action, blob):
+        logger.info(
+            "pocket_create: action %s already executed (idempotency guard) — "
+            "skipping the Pocket create",
+            action.id,
+        )
+        return
+
+    pocket_spec = blob.get("pocket_spec")
+    if not isinstance(pocket_spec, dict):
+        await _fail(
+            "pocket-create blob carries no pocket_spec to create",
+            error_class="MalformedBlob",
+        )
+        return
+
+    # Validate the staged spec at the entry to the create path — a structurally
+    # invalid spec (e.g. a missing/blank name) fails CLEANLY here rather than
+    # blowing up inside the service. ``CreatePocketRequest`` carries the camelCase
+    # aliases (``rippleSpec`` / ``templateSlug``) with populate_by_name=True, so a
+    # spec authored with either spelling resolves.
+    try:
+        from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+        body = CreatePocketRequest.model_validate(pocket_spec)
+    except Exception as exc:  # noqa: BLE001 — a bad spec is a failed outcome, not a crash
+        await _fail(
+            f"pocket-create spec is invalid: {exc}",
+            error_class=type(exc).__name__,
+        )
+        return
+
+    # Create the Pocket through the SHIPPED service, scoped by the blob's top-level
+    # workspace_id / owned by its top-level user_id. Any failure (validation inside
+    # the service, store error) is captured as a failed outcome — NEVER re-raised
+    # into the router.
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        created = await pockets_service.create(workspace_id, owner_user_id, body)
+    except Exception as exc:  # noqa: BLE001 — never let a create break approve
+        logger.warning(
+            "pocket_create: create crashed for action %s (workspace=%s)",
+            action.id,
+            workspace_id,
+            exc_info=True,
+        )
+        await _fail(
+            f"pocket create failed: {exc}",
+            error_class=type(exc).__name__,
+        )
+        return
+
+    # The pockets wire dict carries the id under the legacy ``_id`` key (with
+    # ``id`` accepted as a fallback for any future wire-shape change) and the
+    # tenant under ``workspace``.
+    created_dict = created or {}
+    pocket_id = str(created_dict.get("_id") or created_dict.get("id") or "")
+    pocket_name = str(created_dict.get("name") or body.name)
+    summary = {"pocket_id": pocket_id, "name": pocket_name}
+
+    # Success — mark executed, back-write the structured outcome, close the chain.
+    await store.mark_executed(
+        action.id,
+        f"starter Pocket created: {pocket_name!r} (id={pocket_id})",
+    )
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        summary=summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    # Close the chain on the SUCCESS path. This is the ONLY terminal on the happy
+    # path (every failure path above closed via ``_fail`` and returned), so exactly
+    # one ``decision.completed`` lands per create.
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=approver,
+        causation_id=causation,
+        summary=f"created Pocket {pocket_name!r} (id={pocket_id})",
+    )
+    logger.info(
+        "pocket_create: executed action %s → created Pocket %s (%r) (ok)",
+        action.id,
+        pocket_id,
+        pocket_name,
+    )
+
+
+__all__ = ["execute_approved_pocket_create"]

--- a/ee/pocketpaw_ee/cloud/pocket_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/pocket_proposals/propose.py
@@ -1,0 +1,386 @@
+# ee/cloud/pocket_proposals/propose.py — propose a gated starter-Pocket create.
+# Created: 2026-06-19 (SZD-5b — _pocket_create Instinct proposal type).
+#
+# What this module does (the propose half of the Pocket-create gate): "sovereign
+# zero-setup discovery" stages a PROPOSED starter Pocket — a rippleSpec + name (an
+# optional template slug) it inferred for a tenant — for a human to review through
+# the Instinct gate before any Pocket is created. This files an Instinct ``Action``
+# carrying a ``_pocket_create`` blob (schema 1) under ``Action.parameters``. A
+# human approves it in The Tray; the apply-on-approve executor
+# (``pocket_proposals.executor.execute_approved_pocket_create``) then creates the
+# Pocket via the canonical ``pockets.service.create`` write path. This module does
+# NOT create a Pocket — it only gates.
+#
+# The blob is the gated Pocket-create kind, sitting alongside the Fabric-objects
+# gate's ``_fabric_objects`` (SZD-5a), the pocket-write bridge's ``_pocket_write``,
+# the Belt develop-station's ``_code_change``, the external-action gate's
+# ``_external_action``, the mandate foreman's ``_belt_plan``, and the
+# Branch-primitive merge gate's ``_artifact_change``. The router + executor
+# dispatch on the presence of the ``_pocket_create`` parameters key (the Action
+# model has no literal ``kind`` column; the blob also carries
+# ``kind="pocket_create"`` for readers that introspect it).
+#
+# Schema 1 (this is the first version — the schema-version pattern is replicated
+# from ``fabric_proposals.propose.FABRIC_OBJECTS_SCHEMA`` /
+# ``external_actions.propose.EXTERNAL_ACTION_SCHEMA``, starting at 1). The blob
+# carries:
+#   * ``schema`` / ``kind`` — version + discriminator;
+#   * ``workspace_id`` — the originating tenant. The executor's tenancy gate reads
+#     it HERE; a proposed Pocket isn't bound to an EXISTING pocket the way a parked
+#     write is, so tenancy lives entirely on the blob — and the new Pocket is
+#     created scoped to this workspace. SECURITY: this is a SEPARATE top-level
+#     blob field, NOT nested inside ``pocket_spec`` — the correction/edit flow
+#     diffs the proposal's editable shape, so keeping tenancy out of the editable
+#     spec means a tenant editing the proposal cannot move it to another
+#     workspace.
+#   * ``user_id`` — the approver/owner the Pocket is created under. Also a SEPARATE
+#     top-level blob field for the same reason: the owner cannot be edited via the
+#     correction flow (a tenant can't reassign ownership of the staged Pocket).
+#   * ``pocket_spec`` — the staged ``CreatePocketRequest`` body the executor
+#     model_validates: ``{ripple_spec, name, template_slug?}`` plus any other
+#     CreatePocketRequest-shaped fields (description, type, icon, color, ...). This
+#     is the ONLY part of the blob that a correction edit may legitimately touch.
+#   * ``summary`` — a human-readable one-liner for the gate UI (The Tray);
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids,
+#     minted here at propose time (``agent.proposed`` opens the chain). The
+#     router's approve / reject paths and the executor close the SAME chain.
+#
+# Security:
+#   * NO Pocket is created here — the spec is staged as DATA on the blob and only
+#     materialised after a human approves.
+#   * Tenancy + owner are bound on SEPARATE top-level blob fields (NOT in the
+#     editable ``pocket_spec``) so the correction flow cannot move ownership /
+#     workspace. They are bound on the router's approve / reject paths via
+#     ``_assert_pocket_create_workspace`` and re-validated at execution (the Pocket
+#     is created scoped by the blob's ``workspace_id`` / owned by ``user_id``). A
+#     cross-workspace approve OR reject is refused — asymmetric tenant scope is no
+#     tenant scope (pocketpaw#1183 / #1250).
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator for a Pocket-create proposal. The router
+# + executor dispatch on the presence of the parameters key below; the blob also
+# carries ``kind="pocket_create"`` for readers that introspect it.
+POCKET_CREATE_KIND = "pocket_create"
+
+# The parameters key under which the Pocket-create blob rides — peer of the
+# Fabric-objects gate's ``_fabric_objects``, the pocket-write bridge's
+# ``_pocket_write``, belt's ``_code_change``, and the external-action gate's
+# ``_external_action``. The router + executor dispatch on this key being present.
+POCKET_CREATE_PARAM_KEY = "_pocket_create"
+
+# Schema version stamped on the ``_pocket_create`` blob. Bump when the blob shape
+# changes so a stale pending Action approved after a deploy fails loud instead of
+# creating a misinterpreted Pocket (same discipline as the Fabric-objects gate's
+# ``FABRIC_OBJECTS_SCHEMA``). Starts at 1 — first version.
+POCKET_CREATE_SCHEMA = 1
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    workspace_id: str,
+    user_id: str,
+    name: str,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a Pocket create.
+
+    Mirrors ``fabric_proposals.propose._emit_agent_proposed``: the proposing
+    caller is the actor (``kind="agent"`` with the requesting user on its id, the
+    workspace on its scope_context). A proposed Pocket isn't bound to an EXISTING
+    pocket — its tenancy is the workspace — so ``pocket_id`` on the chain carries
+    the workspace id (matching how the Action's ``pocket_id`` field carries the
+    workspace).
+
+    Returns the emitted event id so the caller can persist it on the blob's
+    ``proposed_event_id`` field for the ``human.corrected`` causation chain, or
+    ``None`` when the emit raised — best-effort per RFC 09; the Slice 4 reconciler
+    picks up any orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"create the starter Pocket {name!r}"
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "pocket_create",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator.
+        "proposal_kind": "pocket_create",
+        "proposal": {"name": name},
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "pocket_create agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._pocket_create`` blob after ``agent.proposed`` fired.
+
+    The blob is built with ``correlation_id`` already set (minted before build);
+    ``proposed_event_id`` is the field this back-write fills in. Direct SQL update
+    — the same pattern the Fabric-objects gate's ``_persist_chain_ids`` uses.
+    Best-effort: a write failure leaves ``proposed_event_id`` None and the eventual
+    ``human.corrected`` emits without a causation_id (the chain still folds;
+    causation_id is optional on EventEntry).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(POCKET_CREATE_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[POCKET_CREATE_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "pocket_create: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _normalize_pocket_spec(
+    *,
+    ripple_spec: dict[str, Any] | None,
+    name: str,
+    template_slug: str | None,
+    extra: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the staged ``pocket_spec`` — the editable ``CreatePocketRequest``
+    body the executor model_validates.
+
+    Carries ``name`` (required), ``rippleSpec`` (camelCase alias — kept as-is so
+    ``CreatePocketRequest.model_validate`` resolves it via the alias), and the
+    optional ``templateSlug``. Any ``extra`` keys (description, type, icon, color,
+    visibility, ...) are merged in so a richer starter Pocket can be staged — but
+    ``workspace_id`` / ``user_id`` are NEVER placed here (they ride as separate
+    top-level blob fields so the correction flow can't edit tenancy/owner).
+
+    SECURITY: tenancy keys are stripped from ``extra`` defensively — even if a
+    caller passes ``workspace``/``workspace_id``/``owner``/``user_id`` in extra,
+    they never reach the editable spec.
+    """
+    spec: dict[str, Any] = {}
+    for k, v in (extra or {}).items():
+        # Never let a tenancy/owner key sneak into the editable spec.
+        if k in {"workspace", "workspace_id", "owner", "user_id"}:
+            continue
+        spec[k] = v
+    spec["name"] = name
+    if ripple_spec is not None:
+        # Use the camelCase alias so model_validate resolves it; the DTO sets
+        # populate_by_name=True so either spelling works, but the alias is the
+        # canonical wire shape.
+        spec["rippleSpec"] = ripple_spec
+    if template_slug:
+        spec["templateSlug"] = template_slug
+    return spec
+
+
+async def propose_pocket(
+    *,
+    workspace_id: str,
+    user_id: str,
+    ripple_spec: dict[str, Any] | None = None,
+    name: str,
+    template_slug: str | None = None,
+    extra: dict[str, Any] | None = None,
+    summary: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+) -> str:
+    """Build + store an Instinct ``Action`` for a gated starter-Pocket create.
+
+    Files an Action carrying the ``_pocket_create`` blob (schema 1) and opens the
+    Decision-Graph chain (``agent.proposed``). Returns the proposed Action id. NO
+    Pocket is created here — the spec is staged as DATA and only materialised after
+    a human approves.
+
+    Args:
+        workspace_id: the originating tenant. Bound on the router's approve /
+            reject paths and re-validated at execution; the Pocket is created
+            scoped to it. Required — a Pocket create with no tenant is a tenancy
+            hole. Rides as a SEPARATE top-level blob field (NOT in ``pocket_spec``)
+            so the correction flow can't move it.
+        user_id: the approver/owner the Pocket is created under. Required. Also a
+            SEPARATE top-level blob field — the owner can't be edited via the
+            correction flow.
+        ripple_spec: the staged rippleSpec for the new Pocket. Optional — a
+            template-only proposal can omit it (the template compiles into the spec
+            at create time). Stored under the ``rippleSpec`` camelCase alias inside
+            ``pocket_spec``.
+        name: the new Pocket's name. Required + non-empty.
+        template_slug: an optional bundled-template slug to compile-on-install.
+        extra: optional additional ``CreatePocketRequest`` fields (description,
+            type, icon, color, visibility, ...) merged into the staged spec.
+            Tenancy/owner keys are stripped defensively.
+        summary: a human-readable one-liner for the gate UI. Defaults to a sensible
+            one built from the name.
+        correlation_id: an optional pre-minted chain id. When omitted a fresh one
+            is minted here (the common case).
+        assignee: the workspace member who should approve. Defaults to ``user_id``
+            so the proposer's queue carries it.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_pocket requires a non-empty workspace_id")
+    user_id = str(user_id or "")
+    if not user_id:
+        raise ValueError("propose_pocket requires a non-empty user_id (the owner)")
+    name = str(name or "").strip()
+    if not name:
+        raise ValueError("propose_pocket requires a non-empty name")
+
+    pocket_spec = _normalize_pocket_spec(
+        ripple_spec=ripple_spec,
+        name=name,
+        template_slug=template_slug,
+        extra=extra,
+    )
+
+    # Mint the chain correlation_id BEFORE building the blob so the stored Action
+    # carries it from the first write. The same id threads through approve / reject
+    # (router) and execute (executor) so the whole create folds into ONE Decision
+    # chain.
+    corr = correlation_id or str(uuid4())
+
+    human_summary = summary or f"Create the starter Pocket {name!r}."
+
+    blob: dict[str, Any] = {
+        "kind": POCKET_CREATE_KIND,
+        "schema": POCKET_CREATE_SCHEMA,
+        # Tenancy + owner are SEPARATE top-level fields (NOT in pocket_spec) so the
+        # correction/edit flow can never change them.
+        "workspace_id": workspace_id,
+        "user_id": user_id,
+        # The editable staged CreatePocketRequest body.
+        "pocket_spec": pocket_spec,
+        "summary": human_summary,
+        # RFC 09 chain-correlation fields (schema 1 carries them from the start).
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    title = f"Starter Pocket — {name}"
+    recommendation = f"Approve to create the proposed starter Pocket. {human_summary}"
+    trigger = ActionTrigger(
+        type="agent",
+        source=user_id or "pocket_create",
+        reason="proposed starter Pocket requires approval",
+    )
+
+    store = get_instinct_store()
+    action_obj = await store.propose(
+        # ``pocket_id`` carries the workspace for Pocket-create proposals — they
+        # aren't bound to an EXISTING pocket the way Mission Control items are
+        # (mirrors the Fabric-objects gate). The workspace also rides on the blob
+        # (the executor's tenancy gate reads it there); pocket_id mirrors it so the
+        # existing per-pocket queries still surface the row.
+        pocket_id=workspace_id,
+        title=title,
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.WORKFLOW,
+        priority=ActionPriority.MEDIUM,
+        parameters={POCKET_CREATE_PARAM_KEY: blob},
+        assignee=assignee or user_id or None,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "pocket_create: proposed starter Pocket %r → Instinct action %s "
+        "(workspace=%s, owner=%s, correlation_id=%s)",
+        name,
+        action_obj.id,
+        workspace_id,
+        user_id,
+        corr,
+    )
+
+    # Open the Decision-Graph chain now that the Action is stored. ``agent.
+    # proposed`` is the chain origin; its event id is back-written onto the blob so
+    # the router's ``human.corrected`` can cite it as causation. Best-effort: a
+    # Decision-Graph wiring failure must NOT fail the propose response.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=name,
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+__all__ = [
+    "POCKET_CREATE_KIND",
+    "POCKET_CREATE_PARAM_KEY",
+    "POCKET_CREATE_SCHEMA",
+    "propose_pocket",
+]

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,22 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-19 (SZD-5b — _pocket_create proposal type) — added a gated
+#   starter-Pocket-create proposal kind (TENANCY GATE). ``_pocket_create_blob`` +
+#   ``_assert_pocket_create_workspace`` are the peers of the existing blob
+#   accessors + tenancy guards. The blob (``Action.parameters._pocket_create``)
+#   carries the staged ``pocket_spec`` plus, as SEPARATE top-level fields, the
+#   originating ``workspace_id`` and the owner ``user_id`` (kept OUT of the
+#   editable spec so the correction flow can't move tenancy/owner). On APPROVE the
+#   router emits ``human.corrected`` then fires
+#   ``pocket_proposals.executor.execute_approved_pocket_create`` (which creates the
+#   Pocket via the workspace-scoped ``pockets.service.create`` after a
+#   ``CreatePocketRequest.model_validate`` at entry, and OWNS the chain close). On
+#   REJECT the router emits ``human.corrected`` + ``decision.completed(rejected)``
+#   itself (the executor never runs on reject — no Pocket is created). The
+#   ``_assert_pocket_create_workspace`` 403 runs in ALL FOUR locations (approve /
+#   bulk-approve / reject / bulk-reject) BEFORE any mutation — asymmetric tenant
+#   scope is no tenant scope (pocketpaw#1183 / #1250). Same exactly-one-terminal
+#   discipline as the Fabric-objects gate.
 # Updated: 2026-06-19 (SZD-5a — _fabric_objects proposal type) — added a gated
 #   Fabric-ontology proposal kind. ``_fabric_objects_blob`` +
 #   ``_assert_fabric_objects_workspace`` are the peers of the existing blob
@@ -555,6 +572,49 @@ def _assert_fabric_objects_workspace(action: Any, current_workspace: str) -> Non
         )
 
 
+def _pocket_create_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_pocket_create`` blob on an Action, or ``None``.
+
+    The blob is the gated starter-Pocket-create payload
+    ``ee.cloud.pocket_proposals.propose`` stores under
+    ``Action.parameters._pocket_create`` (the staged ``pocket_spec`` +, as SEPARATE
+    top-level fields, the originating ``workspace_id`` and the owner ``user_id``).
+    This is a peer gated proposal kind — the approve path dispatches the
+    apply-on-approve executor on its presence, exactly as it dispatches the
+    Fabric-objects executor on ``_fabric_objects``. Anything that is not a dict is
+    treated as "no pocket create".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_pocket_create")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_pocket_create_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting a starter-Pocket create from another workspace.
+
+    Mirror of ``_assert_fabric_objects_workspace`` for the ``_pocket_create`` blob.
+    ``require_action_any_workspace("instinct.approve")`` only proves the caller
+    holds the role SOMEWHERE; this binds the Pocket-create Action to the caller's
+    active workspace. A proposed Pocket carries no EXISTING pocket the way a parked
+    write does, so its tenancy lives entirely on the blob's top-level
+    ``workspace_id`` (NEVER inside the editable ``pocket_spec``). A blob whose
+    ``workspace_id`` differs from the caller's active workspace → 403, on BOTH the
+    approve and reject side (asymmetric tenant scope is no tenant scope —
+    pocketpaw#1183 / #1250). A non-pocket-create Action (no blob) is unaffected.
+    """
+    blob = _pocket_create_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This pocket create belongs to a different workspace",
+        )
+
+
 def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
     """Reject approving a parked pocket write from another workspace.
 
@@ -876,6 +936,7 @@ async def bulk_approve_actions(
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
             _assert_fabric_objects_workspace(action, workspace_id)
+            _assert_pocket_create_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -995,6 +1056,38 @@ async def bulk_approve_actions(
             except Exception:
                 logger.exception(
                     "bulk-approve fabric-objects execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
+        # A bulk-approved gated ``_pocket_create`` Action creates its proposed
+        # starter Pocket. Mirrors the Fabric-objects branch above: per-item
+        # ``human.corrected(accepted)`` (bulk-approve has no edit surface), the
+        # ``agent.proposed`` event id (off the blob's ``proposed_event_id``) as
+        # causation, then the executor (which owns the chain close). Matched BEFORE
+        # the pocket-write fallthrough and ``continue``d so the kinds never cross.
+        pocket_create_blob = _pocket_create_blob(action)
+        if pocket_create_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=pocket_create_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(pocket_create_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.pocket_proposals import (
+                    executor as pocket_create_executor,
+                )
+
+                await pocket_create_executor.execute_approved_pocket_create(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve pocket-create execution failed for %s (non-fatal)",
                     action.id,
                 )
             continue
@@ -1131,6 +1224,7 @@ async def bulk_reject_actions(
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
             _assert_fabric_objects_workspace(action, workspace_id)
+            _assert_pocket_create_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -1244,6 +1338,32 @@ async def bulk_reject_actions(
             )
             continue
 
+        # A bulk-rejected gated ``_pocket_create`` Action closes its chain HERE
+        # (the executor never runs on reject — the router owns the close). NO
+        # Pocket is created. Mirrors the Fabric-objects reject branch. Matched
+        # AFTER pocket-write + code-change + external-action + fabric-objects and
+        # ``continue``d so the kinds never cross.
+        pocket_create_blob = _pocket_create_blob(action)
+        if pocket_create_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=pocket_create_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(pocket_create_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=pocket_create_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            continue
+
         # MANDATES — a bulk-rejected ``_belt_plan`` Action closes its chain
         # here (the plan executor never runs on reject), mirroring the
         # code-change branch above.
@@ -1349,6 +1469,11 @@ async def approve_action(
     # writes typed objects into the tenant's Fabric, so the cross-workspace gate
     # is mandatory here.
     _assert_fabric_objects_workspace(before, workspace_id)
+    # Same tenancy gate for a gated Pocket-create Action — its ``_pocket_create``
+    # blob carries the workspace (and owner) on SEPARATE top-level fields, not a
+    # pocket. Approving it creates a Pocket in the tenant's workspace, so the
+    # cross-workspace gate is mandatory here.
+    _assert_pocket_create_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -1554,6 +1679,46 @@ async def approve_action(
         except Exception:
             logger.exception("fabric-objects execution after approval failed (non-fatal)")
 
+    # When the approved Action carries a gated ``_pocket_create`` blob, create the
+    # proposed starter Pocket via ``pockets.service.create`` (workspace-scoped,
+    # owned by the blob's top-level ``user_id``). Same best-effort, lazy-import,
+    # never-break-the-approve-response shape as the Fabric-objects hook above; the
+    # executor records success / failure on the Action itself. A non-pocket-create
+    # Action skips this.
+    #
+    # The Pocket create is part of its own Decision-Graph chain (the propose helper
+    # minted the ``correlation_id`` + emitted ``agent.proposed``). Emit the
+    # ``human.corrected`` event for the approval HERE (the router owns the
+    # human-action emit on every approve path), citing the ``agent.proposed`` event
+    # id (stored on the blob as ``proposed_event_id`` — the same field the
+    # Fabric-objects path reads, so ``_code_change_proposed_event_id`` resolves it)
+    # as causation, then thread its event id into the executor so the terminal
+    # ``decision.completed`` chains back to the approval. The executor owns the
+    # chain CLOSE (success or failure) — the router does NOT emit
+    # ``decision.completed`` here, mirroring the Fabric-objects executor. No double
+    # terminal.
+    pocket_create_blob = _pocket_create_blob(approved)
+    if pocket_create_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=pocket_create_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(pocket_create_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.pocket_proposals import executor as pocket_create_executor
+
+            await pocket_create_executor.execute_approved_pocket_create(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("pocket-create execution after approval failed (non-fatal)")
+
     # MANDATES — when the approved Action carries a ``_belt_plan`` blob (the
     # mandate foreman's shift plan), dispatch the plan executor. Same shape as
     # the code-change hook: the router owns the ``human.corrected`` emit, the
@@ -1690,6 +1855,10 @@ async def reject_action(
     # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
     # 403 before any mutation, exactly like the approve side.
     _assert_fabric_objects_workspace(before, workspace_id)
+    # Same tenancy gate for a gated Pocket-create Action on the REJECT side —
+    # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
+    # 403 before any mutation, exactly like the approve side.
+    _assert_pocket_create_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -1806,6 +1975,33 @@ async def reject_action(
         )
         _emit_decision_completed_rejected(
             blob=fabric_objects_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
+
+    # A rejected gated ``_pocket_create`` Action closes its chain HERE (the
+    # executor never runs on reject — the router owns the close, mirroring the
+    # Fabric-objects reject path). NO Pocket is created.
+    # ``human.corrected(rejected)`` cites the ``agent.proposed`` event (off the
+    # blob's ``proposed_event_id``); ``decision.completed(rejected)`` cites the
+    # human event so the chain reads ``agent.proposed → human.corrected →
+    # decision.completed``.
+    pocket_create_blob = _pocket_create_blob(action)
+    if pocket_create_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=pocket_create_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(pocket_create_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=pocket_create_blob,
             action=action,
             user_id=rejector_id,
             workspace_id=workspace_id,

--- a/tests/cloud/test_pocket_create_gate.py
+++ b/tests/cloud/test_pocket_create_gate.py
@@ -1,0 +1,520 @@
+# tests/cloud/test_pocket_create_gate.py — the gated _pocket_create proposal type
+# (SZD-5b), a tenancy gate over a proposed starter Pocket.
+#
+# Created: 2026-06-19 (SZD-5b — _pocket_create Instinct proposal type).
+#
+# What this pins:
+#   * propose_pocket — blob shape (schema 1, pocket_spec, SEPARATE top-level
+#     workspace_id + user_id, correlation_id, summary), tenancy (workspace + owner
+#     required), name requirement, AND the security invariant: tenancy/owner are
+#     NOT inside the editable pocket_spec.
+#   * execute_approved_pocket_create against the REAL pockets.service.create
+#     (mongomock Beanie):
+#       - happy path: a Pocket is created in the workspace, owned correctly, action
+#         EXECUTED, structured outcome (pocket_id/name) back-written.
+#       - model_validate is enforced: a rippleSpec camelCase-alias spec resolves; a
+#         structurally invalid spec (blank name) FAILS cleanly (no Pocket created),
+#         not silently.
+#       - schema mismatch: a stale schema blob → FAILED, no Pocket created.
+#       - idempotency: re-approve / re-invoke does NOT double-create.
+#   * the 4-PATH cross-workspace tenancy gate through the REAL router:
+#       - approve / reject (single) AND bulk-approve / bulk-reject all 403 a
+#         cross-workspace caller — a missing guard on ANY of the four is a leak.
+#   * the MANDATORY production-path chain test: propose → approve via the REAL
+#     router → executor creates the Pocket → walk the decision chain and assert
+#     EXACTLY agent.proposed → human.corrected → decision.completed (one terminal),
+#     and the reject path's router-owned close (executor never runs).
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The instinct store is
+# patched to a tmp-file InstinctStore; the Pocket create runs against the shared
+# mongomock Beanie ``mongo_db`` fixture so the create is real but isolated. The
+# integration tests wire a fresh on-disk journal + DecisionGraph (same fixture
+# shape as tests/cloud/test_fabric_objects_gate.py) and drive the router over a
+# TestClient with stubbed auth deps.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.pocket_proposals import executor as pc_executor  # noqa: E402
+from pocketpaw_ee.cloud.pocket_proposals import propose as pc_propose  # noqa: E402
+from pocketpaw_ee.cloud.pockets import service as pockets_service  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    """Stable AUTH_SECRET so the pockets create path's token machinery is quiet."""
+    monkeypatch.setenv("AUTH_SECRET", "pocket-create-gate-test-secret")
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired everywhere the gate reads it
+    (the propose helper + the executor both lazy-import
+    ``pocketpaw.stores.get_instinct_store``)."""
+    st = InstinctStore(tmp_path / "instinct_pocket_create_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+# A canonical rippleSpec staged on the proposal. The camelCase alias ``rippleSpec``
+# is exercised by the model_validate test.
+_RIPPLE_SPEC = {
+    "version": "1.0",
+    "root": {"id": "root", "type": "container", "children": []},
+}
+
+
+async def _propose(store, **overrides) -> str:
+    kwargs: dict[str, Any] = dict(
+        workspace_id="w1",
+        user_id="u1",
+        ripple_spec=_RIPPLE_SPEC,
+        name="Starter dashboard",
+    )
+    kwargs.update(overrides)
+    return await pc_propose.propose_pocket(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# propose — blob shape + tenancy + the un-editable-tenancy security invariant
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_builds_pocket_create_blob(store):
+    """propose_pocket files an Action carrying a well-formed schema-1
+    ``_pocket_create`` blob — pocket_spec, SEPARATE top-level workspace_id +
+    user_id, correlation_id, summary."""
+    action_id = await _propose(store)
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+
+    blob = action.parameters["_pocket_create"]
+    assert blob["kind"] == "pocket_create"
+    assert blob["schema"] == 1
+    # Tenancy + owner are SEPARATE top-level blob fields.
+    assert blob["workspace_id"] == "w1"
+    assert blob["user_id"] == "u1"
+    # The staged spec carries name + the camelCase rippleSpec alias.
+    spec = blob["pocket_spec"]
+    assert spec["name"] == "Starter dashboard"
+    assert spec["rippleSpec"] == _RIPPLE_SPEC
+    assert blob["correlation_id"]
+    assert blob["summary"]
+
+
+async def test_propose_tenancy_not_in_editable_spec(store):
+    """SECURITY — workspace_id / user_id are NEVER inside the editable pocket_spec
+    (the correction flow can edit pocket_spec; it must not be able to move tenancy
+    or owner). Even a caller passing them via ``extra`` cannot smuggle them in."""
+    action_id = await _propose(
+        store,
+        extra={"workspace_id": "w-EVIL", "user_id": "u-EVIL", "description": "ok"},
+    )
+    blob = (await store.get_action(action_id)).parameters["_pocket_create"]
+    spec = blob["pocket_spec"]
+    assert "workspace_id" not in spec
+    assert "user_id" not in spec
+    assert "workspace" not in spec
+    assert "owner" not in spec
+    # The legitimate extra field rode through.
+    assert spec["description"] == "ok"
+    # The real tenancy/owner are unchanged on the top-level fields.
+    assert blob["workspace_id"] == "w1"
+    assert blob["user_id"] == "u1"
+
+
+async def test_propose_requires_workspace(store):
+    """A propose with no workspace_id is rejected — a Pocket create with no tenant
+    to scope it to is a tenancy hole."""
+    with pytest.raises(ValueError, match="workspace_id"):
+        await pc_propose.propose_pocket(
+            workspace_id="", user_id="u1", name="x", ripple_spec=_RIPPLE_SPEC
+        )
+
+
+async def test_propose_requires_owner(store):
+    """A propose with no user_id (owner) is rejected."""
+    with pytest.raises(ValueError, match="user_id"):
+        await pc_propose.propose_pocket(
+            workspace_id="w1", user_id="", name="x", ripple_spec=_RIPPLE_SPEC
+        )
+
+
+async def test_propose_requires_name(store):
+    """A propose with a blank name is rejected — nothing to create."""
+    with pytest.raises(ValueError, match="name"):
+        await pc_propose.propose_pocket(
+            workspace_id="w1", user_id="u1", name="  ", ripple_spec=_RIPPLE_SPEC
+        )
+
+
+# ---------------------------------------------------------------------------
+# executor — happy path, model_validate, schema, idempotency (real Beanie create)
+# ---------------------------------------------------------------------------
+
+
+async def _propose_and_approve(store, **overrides) -> Any:
+    action_id = await _propose(store, **overrides)
+    return await store.approve(action_id, approver="u1")
+
+
+async def test_executor_happy_path_creates_pocket(store, mongo_db):
+    """On approve the executor creates the Pocket via pockets.service.create
+    (workspace-scoped, owned by the blob's top-level user_id), marks EXECUTED, and
+    back-writes the structured outcome carrying the created pocket id + name."""
+    approved = await _propose_and_approve(store)
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED
+    outcome = final.parameters["_pocket_create"]["outcome"]
+    assert outcome["status"] == "executed"
+    assert outcome["name"] == "Starter dashboard"
+    assert outcome["pocket_id"]
+    assert "executed_at" in outcome
+
+    # The Pocket exists in w1, owned by u1.
+    wire = await pockets_service.get(outcome["pocket_id"], "u1")
+    assert wire["name"] == "Starter dashboard"
+    assert wire["workspace"] == "w1"
+    assert wire["owner"] == "u1"
+
+
+async def test_executor_model_validate_resolves_camelcase_alias(store, mongo_db):
+    """The staged spec uses the camelCase ``rippleSpec`` alias; model_validate at
+    the entry to the create path resolves it (populate_by_name=True) so the spec
+    materialises with the rippleSpec attached."""
+    approved = await _propose_and_approve(store)
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED
+    pocket_id = final.parameters["_pocket_create"]["outcome"]["pocket_id"]
+    wire = await pockets_service.get(pocket_id, "u1")
+    # The rippleSpec round-tripped onto the created pocket (normalized).
+    assert wire.get("rippleSpec") is not None
+
+
+async def test_executor_invalid_spec_fails_cleanly(store, mongo_db, monkeypatch):
+    """A structurally invalid staged spec (blank name violates the DTO's
+    min_length=1) FAILS the action cleanly at model_validate — NOT a silent
+    skip, NOT a crash — and no Pocket is created."""
+    approved = await _propose_and_approve(store)
+    # Corrupt the staged spec to an invalid CreatePocketRequest (name too short).
+    # The propose helper rejects a blank name, so we tamper the persisted blob
+    # directly to simulate a malformed/edited spec reaching the executor.
+    approved.parameters["_pocket_create"]["pocket_spec"]["name"] = ""
+
+    before_count = await _count_pockets("w1")
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "invalid" in str(final.error).lower()
+    # Nothing was created.
+    assert await _count_pockets("w1") == before_count
+
+
+async def test_executor_schema_mismatch_refuses(store, mongo_db):
+    """A stale blob with an incompatible schema version → FAILED, no Pocket
+    created."""
+    approved = await _propose_and_approve(store)
+    approved.parameters["_pocket_create"]["schema"] = 999  # incompatible
+
+    before_count = await _count_pockets("w1")
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "schema" in str(final.error).lower()
+    assert await _count_pockets("w1") == before_count
+
+
+async def test_executor_missing_workspace_refuses(store, mongo_db):
+    """A blob whose top-level workspace_id is empty → FAILED, no Pocket created
+    (belt-and-braces behind the router gate)."""
+    approved = await _propose_and_approve(store)
+    approved.parameters["_pocket_create"]["workspace_id"] = ""
+
+    before_count = await _count_pockets("w1")
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "workspace" in str(final.error).lower()
+    assert await _count_pockets("w1") == before_count
+
+
+async def test_executor_idempotent_never_reruns(store, mongo_db):
+    """Re-invoking the executor on an already-EXECUTED Action short-circuits before
+    any create (the idempotency guard) — re-approve / retry never double-creates."""
+    approved = await _propose_and_approve(store)
+    await pc_executor.execute_approved_pocket_create(approved)
+    count_after_first = await _count_pockets("w1")
+    assert count_after_first == 1
+
+    reloaded = await store.get_action(approved.id)
+    await pc_executor.execute_approved_pocket_create(reloaded)
+    # No additional pocket — the guard skipped the re-run.
+    assert await _count_pockets("w1") == count_after_first
+
+
+async def test_executor_no_blob_is_noop(store, mongo_db):
+    """An Action with no ``_pocket_create`` blob is a clean no-op."""
+    from pocketpaw.instinct.models import ActionTrigger
+
+    action = await store.propose(
+        pocket_id="w1",
+        title="not pocket-create",
+        description="",
+        recommendation="",
+        trigger=ActionTrigger(type="agent", source="x", reason="y"),
+    )
+    approved = await store.approve(action.id, approver="u1")
+    before_count = await _count_pockets("w1")
+    await pc_executor.execute_approved_pocket_create(approved)
+    assert await _count_pockets("w1") == before_count
+
+
+async def _count_pockets(workspace_id: str) -> int:
+    """Count the pockets in a workspace via the service list path."""
+    wires = await pockets_service.list_pockets(workspace_id, "u1")
+    return len(wires)
+
+
+# ---------------------------------------------------------------------------
+# Integration fixtures — journal + decision graph + router client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "u1", workspace_id: str = "w1") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _make_client(user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _events_by_correlation(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+# ---------------------------------------------------------------------------
+# MANDATORY production-path chain tests
+# ---------------------------------------------------------------------------
+
+
+async def test_production_path_approve_runs_executor_one_terminal(
+    store, mongo_db, journal, graph, monkeypatch
+):
+    """propose → approve through the REAL router → the executor creates the Pocket
+    → walk the decision chain and assert EXACTLY agent.proposed → human.corrected →
+    decision.completed (ONE terminal, executor owns the close)."""
+    action_id = await _propose(store)
+    blob = (await store.get_action(action_id)).parameters["_pocket_create"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED
+    # The Pocket landed in w1, owned by u1.
+    pocket_id = final.parameters["_pocket_create"]["outcome"]["pocket_id"]
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["workspace"] == "w1"
+    assert wire["owner"] == "u1"
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is True
+    assert (terminal.payload or {})["action_outcome"] == "landed"
+    hc = chain[1]
+    assert terminal.causation_id == hc.id
+
+
+async def test_production_path_reject_router_closes_executor_never_runs(
+    store, mongo_db, journal, graph, monkeypatch
+):
+    """Reject path: the ROUTER emits human.corrected + decision.completed
+    (rejected); the executor NEVER runs (no Pocket created)."""
+    action_id = await _propose(store)
+    blob = (await store.get_action(action_id)).parameters["_pocket_create"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED
+    # NO Pocket was created on reject.
+    assert await _count_pockets("w1") == 0
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is False
+    assert (terminal.payload or {})["action_outcome"] == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# 4-PATH cross-workspace tenancy gate — a missing guard on ANY path is a leak.
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_workspace_single_approve_forbidden(
+    store, mongo_db, journal, graph, monkeypatch
+):
+    """PATH 1/4 — single approve: a caller in w1 cannot approve a w-OTHER
+    Pocket-create Action."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+    # Nothing created in either workspace.
+    assert await _count_pockets("w-OTHER") == 0
+    assert await _count_pockets("w1") == 0
+
+
+async def test_cross_workspace_single_reject_forbidden(
+    store, mongo_db, journal, graph, monkeypatch
+):
+    """PATH 2/4 — single reject: a caller in w1 cannot reject a w-OTHER
+    Pocket-create Action (asymmetric tenant scope is no tenant scope)."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+
+
+async def test_cross_workspace_bulk_approve_forbidden(store, mongo_db, journal, graph, monkeypatch):
+    """PATH 3/4 — bulk approve: a single cross-workspace item 403s the whole batch
+    before any mutation."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+    assert await _count_pockets("w-OTHER") == 0
+
+
+async def test_cross_workspace_bulk_reject_forbidden(store, mongo_db, journal, graph, monkeypatch):
+    """PATH 4/4 — bulk reject: a single cross-workspace item 403s the whole batch
+    before any mutation."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post("/instinct/actions/bulk-reject", json={"ids": [action_id], "reason": "no"})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING


### PR DESCRIPTION
SZD-5b, stacked on #1511. The second discovery gate type: propose a starter Pocket for review; approve creates it. Mirrors `_fabric_objects` (#1511) and `_external_action` exactly.

## What changed
- New `ee/pocketpaw_ee/cloud/pocket_proposals/` — `propose_pocket` (schema-1 `_pocket_create` blob: `pocket_spec={name, rippleSpec, templateSlug?}` with `workspace_id` + `user_id` as SEPARATE top-level fields so the correction flow can't move tenancy/owner — tenancy keys inside `pocket_spec` are stripped defensively; anchors `pocket_id=workspace_id`; opens the `agent.proposed` chain) + `execute_approved_pocket_create` (schema + workspace/owner + idempotency guards → `CreatePocketRequest.model_validate` → `pockets.service.create`; owns `decision.completed` via a single `_fail` chokepoint).
- `router.py` — `_assert_pocket_create_workspace` called in all four paths alongside the fabric guard; approve→executor, reject→router-owned close.

## Verified
- New `tests/cloud/test_pocket_create_gate.py` (18 tests): approve creates a Pocket owned correctly; 4-path cross-workspace gate (all 403, PENDING, nothing created); `model_validate` resolves camelCase `rippleSpec` + fails invalid specs cleanly; schema mismatch refused; idempotent; chain `[agent.proposed, human.corrected, decision.completed]`, one terminal per path; tenancy never in the editable spec.
- Regression: fabric_objects_gate + external_action_gate + bulk_actions + approval_security = 60 pass. Independently re-ran the 18 tests + confirmed the guard fires in all four router functions.

## Notes
- The empty-`workspace_id` guard short-circuit mirrors `_fabric_objects` (inherited from `_external_action`) — not exploitable (propose requires non-empty; executor fails-closed), but worth folding into any future fail-closed guard hardening.

Stacks on #1511. Completes the two-gate-type pair. Part of sovereign zero-setup discovery.