### PR TITLE
Sites: DiscoveryRun orchestrator — sample connectors (local path) -> ontology draft

### DIFF
--- a/ee/pocketpaw_ee/discovery/__init__.py
+++ b/ee/pocketpaw_ee/discovery/__init__.py
@@ -6,8 +6,11 @@
 # turns into FabricMapping objects (for fabric_ingest.ingest_records) and a
 # fabric-objects proposal (object_types + objects + links).
 #
-# Pure logic: no DB, no network, no async. The first impl is
-# ``StructuredShapeDigester`` (structured ``{type: [records]}`` input).
+# The digester is pure logic (no DB, no network, no async); the first impl is
+# ``StructuredShapeDigester`` (structured ``{type: [records]}`` input). The
+# ``DiscoveryRun`` orchestrator (SZD-4) ties sampling → digest together: it reads
+# a workspace's bound connectors via the pocket-less ``ensure_connected(name,
+# "ws:<workspace_id>")`` path and feeds the sampled records to the digester.
 
 from __future__ import annotations
 
@@ -18,6 +21,12 @@ from pocketpaw_ee.discovery.models import (
     DraftObjectType,
     OntologyDraft,
 )
+from pocketpaw_ee.discovery.run import (
+    DEFAULT_SAMPLE_CAP,
+    DiscoveryRun,
+    DiscoveryRunOptions,
+    ReadAction,
+)
 
 __all__ = [
     "Digester",
@@ -26,4 +35,8 @@ __all__ = [
     "DraftObjectType",
     "DraftObject",
     "DraftLink",
+    "DiscoveryRun",
+    "DiscoveryRunOptions",
+    "ReadAction",
+    "DEFAULT_SAMPLE_CAP",
 ]

--- a/ee/pocketpaw_ee/discovery/run.py
+++ b/ee/pocketpaw_ee/discovery/run.py
@@ -1,0 +1,391 @@
+# pocketpaw_ee/discovery/run.py — the DiscoveryRun orchestrator.
+#
+# Created: 2026-06-19 (SZD-4 / feat/szd-4-discovery-run) — ties SZD-2 sampling
+# and the SZD-3 digester together. ``DiscoveryRun.run(workspace_id,
+# connector_ids, opts)`` enumerates a workspace's bound connectors, SAMPLES a
+# bounded N records per connector, groups records by type, and runs the
+# ``StructuredShapeDigester`` to produce an ``OntologyDraft``.
+#
+# CRITICAL read-path contract (a design review caught this):
+#   * Discovery runs BEFORE any pocket exists, so we do NOT call
+#     ``connector.sync(pocket_id)`` — sync requires a pocket AND returns COUNTS,
+#     not records.
+#   * Records are read through the workspace-scoped, pocket-less path:
+#     ``registry.ensure_connected(name, "ws:<workspace_id>")`` resolves the
+#     workspace adapter (the #1445 path; ``pocket_id=None`` semantically — we
+#     never pass a ``pocket:<id>`` scope key), then ``adapter.execute(action,
+#     params)`` returns an ``ActionResult`` whose ``.data`` carries the records.
+#   * This runs on the TENANT'S LOCAL RUNTIME. The cloud LOCAL-exec seam returns
+#     HTTP 503 ``connector.local_agent_unavailable`` for local-mode actions, so
+#     the orchestrator drives the local ``ConnectorRegistry`` directly.
+#
+# Slice 1 is a DETERMINISTIC digest (no LLM refine). The optional draft-refine
+# pass (cleaning the ontology with an agent) is gated behind ``opts.refine`` and,
+# when enabled, MUST use the on-box / tenant model — never route tenant raw data
+# to a cloud model. It is not wired in slice 1 (the deterministic digest is
+# accepted); ``opts.refine=True`` raises so a caller can't silently get an
+# unrefined draft while believing it was refined.
+#
+# Async orchestration; depends on the OSS connector registry/adapter surface
+# (duck-typed for testability) + the SZD-3 digester. No DB writes — the draft is
+# returned for a downstream gate to review.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from pocketpaw_ee.discovery.digester import Digester, StructuredShapeDigester
+from pocketpaw_ee.discovery.models import OntologyDraft
+
+logger = logging.getLogger(__name__)
+
+# Default per-connector sampling cap. A discovery run only needs enough records
+# to infer shapes/keys/links — not the whole dataset. Bounded so a large
+# connector can't blow up memory or wall-clock on the tenant box.
+DEFAULT_SAMPLE_CAP = 200
+
+# Trust levels whose actions are safe to invoke unattended during discovery.
+# "auto" actions are reads the agent may run without asking; anything that
+# mutates is "confirm" and must never fire on a sampling pass.
+_READ_TRUST_LEVELS = frozenset({"auto"})
+
+# HTTP methods that read rather than mutate. Discovery only ever reads.
+_READ_METHODS = frozenset({"GET", "HEAD"})
+
+
+@dataclass(frozen=True)
+class ReadAction:
+    """A single connector read to sample during discovery.
+
+    ``type_name`` labels the records this action returns so the digester can
+    group by type (one action → one logical type). When ``None``, the connector
+    name is used as the type label.
+    """
+
+    action: str
+    params: dict[str, Any] = field(default_factory=dict)
+    type_name: str | None = None
+
+
+@dataclass(frozen=True)
+class DiscoveryRunOptions:
+    """Knobs for a discovery run.
+
+    * ``sample_cap`` — max records kept per connector (the "N" in "N of M").
+    * ``read_actions`` — explicit ``{connector_id: [ReadAction, ...]}`` override.
+      When a connector is absent here, the orchestrator auto-selects its
+      read-shaped actions (GET/HEAD + ``auto`` trust level) from the adapter's
+      ``actions()`` schema. Supplying this is the precise path; auto-select is
+      the convenience default.
+    * ``allowed_connector_ids`` — permission filter. When set, only these
+      connector ids are sampled (the rest are skipped + noted). When ``None``,
+      all requested connectors are sampled — connector-level permission
+      enforcement isn't merged yet, so we degrade gracefully to allow-all and
+      record that in the draft meta.
+    * ``refine`` — request the optional on-box LLM refine pass. Not wired in
+      slice 1; setting it ``True`` raises rather than silently returning an
+      unrefined draft.
+    """
+
+    sample_cap: int = DEFAULT_SAMPLE_CAP
+    read_actions: dict[str, list[ReadAction]] = field(default_factory=dict)
+    allowed_connector_ids: frozenset[str] | None = None
+    refine: bool = False
+
+
+@runtime_checkable
+class _Adapter(Protocol):
+    """The slice of a connector adapter the orchestrator touches.
+
+    Deliberately narrow + duck-typed so a test can supply a mock without the
+    full ``ConnectorProtocol`` surface. ``actions()`` returns ``ActionSchema``
+    objects; ``execute()`` returns an ``ActionResult`` whose ``.data`` holds
+    records.
+    """
+
+    async def actions(self) -> Sequence[Any]: ...
+
+    async def execute(self, action: str, params: dict[str, Any]) -> Any: ...
+
+
+@runtime_checkable
+class _Registry(Protocol):
+    """The slice of the connector registry the orchestrator touches.
+
+    Only ``ensure_connected`` — the workspace-scoped resolve path. Duck-typed so
+    tests inject a mock and assert the scope key is ``ws:<workspace_id>`` (never
+    a ``pocket:<id>`` key, never ``sync``).
+    """
+
+    async def ensure_connected(self, connector_name: str, scope_key: str) -> Any | None: ...
+
+
+def _default_registry() -> _Registry:
+    """Lazily build the local-runtime ConnectorRegistry.
+
+    Mirrors ``src/pocketpaw/api/v1/connectors.py:_get_registry`` — the same
+    static registry rooted at ``connectors/``. Imported lazily so importing this
+    module never drags the registry in (and so tests can inject a mock instead).
+    """
+    from pathlib import Path
+
+    from pocketpaw.connectors.registry import ConnectorRegistry
+
+    return ConnectorRegistry(Path("connectors"))
+
+
+def _records_from_data(data: Any) -> list[Any]:
+    """Normalize an ActionResult ``.data`` payload into a list of records.
+
+    Adapters return reads in a few shapes: a bare ``list[dict]`` (most reads), a
+    single ``dict`` (a one-record read), or a wrapped envelope like
+    ``{"items": [...]}`` / ``{"results": [...]}`` / ``{"data": [...]}``. We
+    unwrap the common envelopes and otherwise treat a dict as one record. Empty
+    / ``None`` → no records (so an empty connector yields no rows, not a crash).
+    """
+    if data is None:
+        return []
+    if isinstance(data, Mapping):
+        for key in ("items", "results", "records", "rows", "data"):
+            inner = data.get(key)
+            if isinstance(inner, Sequence) and not isinstance(inner, (str, bytes)):
+                return list(inner)
+        # A lone dict is a single record.
+        return [data]
+    if isinstance(data, Sequence) and not isinstance(data, (str, bytes)):
+        return list(data)
+    # Scalar / unknown — no usable records.
+    return []
+
+
+def _is_read_action(schema: Any) -> bool:
+    """True when an ``ActionSchema`` looks like a safe read.
+
+    Read = GET/HEAD method AND ``auto`` trust level. Anything else (POST,
+    ``confirm``) can mutate and must never fire on a discovery pass. Tolerant of
+    enum-or-string fields so a mock can use plain strings.
+    """
+    method = str(getattr(schema, "method", "GET")).upper()
+    trust = str(getattr(schema, "trust_level", "confirm")).lower()
+    # StrEnum stringifies as "TrustLevel.auto" in some reprs; normalize to value.
+    trust = trust.rsplit(".", 1)[-1]
+    return method in _READ_METHODS and trust in _READ_TRUST_LEVELS
+
+
+class DiscoveryRun:
+    """Orchestrates one sovereign zero-setup discovery run.
+
+    ``run(workspace_id, connector_ids, opts)`` →
+      1. resolve each connector via the workspace-scoped path
+         (``ensure_connected(name, "ws:<workspace_id>")`` — pocket-less);
+      2. sample up to ``opts.sample_cap`` records/connector via
+         ``adapter.execute()`` over its read-shaped actions;
+      3. group records by type and run the ``StructuredShapeDigester``;
+      4. return an ``OntologyDraft`` labelled "based on N of M".
+
+    Degrades gracefully: an unresolvable / empty connector contributes no rows;
+    an all-empty run returns an empty draft (no crash). No DB writes — a
+    downstream gate reviews the draft.
+    """
+
+    def __init__(
+        self,
+        registry: _Registry | None = None,
+        digester: Digester | None = None,
+    ) -> None:
+        # Injected for tests; defaults to the local-runtime registry + the SZD-3
+        # structured digester. The registry is built lazily so a mock-injected
+        # run never touches the filesystem.
+        self._registry = registry
+        self._digester: Digester = digester or StructuredShapeDigester()
+
+    @property
+    def registry(self) -> _Registry:
+        if self._registry is None:
+            self._registry = _default_registry()
+        return self._registry
+
+    async def run(
+        self,
+        workspace_id: str,
+        connector_ids: Iterable[str],
+        opts: DiscoveryRunOptions | None = None,
+    ) -> OntologyDraft:
+        opts = opts or DiscoveryRunOptions()
+        if opts.refine:
+            # The on-box refine pass is not wired in slice 1. Fail loud rather
+            # than hand back a deterministic draft while a caller believes it
+            # was LLM-refined. When it lands it MUST use the tenant/on-box model.
+            raise NotImplementedError(
+                "DiscoveryRun refine pass is not implemented in slice 1; the "
+                "deterministic digest is the slice-1 contract. When wired, the "
+                "refine pass must run on the on-box / tenant model — never a "
+                "cloud model on tenant raw data."
+            )
+
+        requested = [c for c in connector_ids]
+        total_connectors = len(requested)
+
+        # Permission gate. No connector-level enforcement is merged yet, so when
+        # the caller doesn't pass an allow-list we sample all requested
+        # connectors and record the degraded posture in the draft meta.
+        permission_enforced = opts.allowed_connector_ids is not None
+        if permission_enforced:
+            allowed = opts.allowed_connector_ids or frozenset()
+            permitted = [c for c in requested if c in allowed]
+            skipped = [c for c in requested if c not in allowed]
+        else:
+            permitted = list(requested)
+            skipped = []
+
+        scope_key = f"ws:{workspace_id}"
+        grouped: dict[str, list[Any]] = {}
+        per_connector: dict[str, dict[str, Any]] = {}
+        sampled_connectors = 0
+
+        for connector_id in permitted:
+            # WORKSPACE-SCOPED, POCKET-LESS resolve — the #1445 path. NEVER
+            # ensure_connected(name, "pocket:<id>") and NEVER adapter.sync().
+            adapter = await self.registry.ensure_connected(connector_id, scope_key)
+            if adapter is None:
+                per_connector[connector_id] = {"status": "unresolved", "records": 0}
+                logger.info(
+                    "discovery: connector %s unresolved for %s — skipping",
+                    connector_id,
+                    scope_key,
+                )
+                continue
+
+            read_actions = await self._read_actions_for(connector_id, adapter, opts)
+            if not read_actions:
+                per_connector[connector_id] = {"status": "no_read_action", "records": 0}
+                logger.info(
+                    "discovery: connector %s exposes no read-shaped action — skipping",
+                    connector_id,
+                )
+                continue
+
+            connector_records = await self._sample_connector(
+                connector_id, adapter, read_actions, opts.sample_cap, grouped
+            )
+            sampled_connectors += 1
+            per_connector[connector_id] = {
+                "status": "sampled" if connector_records else "empty",
+                "records": connector_records,
+            }
+
+        draft = self._digester.digest(
+            grouped,
+            connector_meta={
+                "workspace_id": workspace_id,
+                "source": "discovery_run",
+            },
+        )
+
+        # Provenance — the "based on N of M" label + the per-connector roll-up.
+        draft.meta["discovery"] = {
+            "workspace_id": workspace_id,
+            "sampled_connectors": sampled_connectors,
+            "total_connectors": total_connectors,
+            "label": f"based on {sampled_connectors} of {total_connectors}",
+            "sample_cap": opts.sample_cap,
+            "permission_enforced": permission_enforced,
+            "skipped_by_permission": skipped,
+            "connectors": per_connector,
+        }
+        return draft
+
+    async def _read_actions_for(
+        self,
+        connector_id: str,
+        adapter: _Adapter,
+        opts: DiscoveryRunOptions,
+    ) -> list[ReadAction]:
+        """Resolve the read actions to sample for one connector.
+
+        Explicit ``opts.read_actions`` wins (the precise path). Otherwise
+        auto-select the adapter's read-shaped actions (GET/HEAD + ``auto`` trust)
+        from its ``actions()`` schema — the safe-reads-only convenience default.
+        """
+        explicit = opts.read_actions.get(connector_id)
+        if explicit:
+            return list(explicit)
+
+        try:
+            schemas = await adapter.actions()
+        except Exception as exc:  # noqa: BLE001 — a broken adapter can't block the run
+            logger.warning("discovery: actions() failed for %s: %s", connector_id, exc)
+            return []
+
+        out: list[ReadAction] = []
+        for schema in schemas or []:
+            if not _is_read_action(schema):
+                continue
+            name = getattr(schema, "name", None)
+            if not name:
+                continue
+            out.append(ReadAction(action=str(name), type_name=str(name)))
+        return out
+
+    async def _sample_connector(
+        self,
+        connector_id: str,
+        adapter: _Adapter,
+        read_actions: Sequence[ReadAction],
+        sample_cap: int,
+        grouped: dict[str, list[Any]],
+    ) -> int:
+        """Sample up to ``sample_cap`` records across a connector's read actions.
+
+        Records land in ``grouped[type_label]`` so the digester can infer one
+        type per action. The cap is enforced across ALL of the connector's
+        actions combined (the "N per connector" budget). Returns the count
+        sampled from this connector.
+        """
+        budget = max(0, sample_cap)
+        taken = 0
+        for read in read_actions:
+            if taken >= budget:
+                break
+            try:
+                result = await adapter.execute(read.action, dict(read.params))
+            except Exception as exc:  # noqa: BLE001 — one bad action can't kill the run
+                logger.warning(
+                    "discovery: execute(%s) failed on %s: %s",
+                    read.action,
+                    connector_id,
+                    exc,
+                )
+                continue
+
+            if not getattr(result, "success", False):
+                logger.info(
+                    "discovery: execute(%s) on %s returned failure: %s",
+                    read.action,
+                    connector_id,
+                    getattr(result, "error", None),
+                )
+                continue
+
+            records = _records_from_data(getattr(result, "data", None))
+            if not records:
+                continue
+
+            remaining = budget - taken
+            chunk = records[:remaining]
+            type_label = read.type_name or connector_id
+            grouped.setdefault(type_label, []).extend(chunk)
+            taken += len(chunk)
+
+        return taken
+
+
+__all__ = [
+    "DEFAULT_SAMPLE_CAP",
+    "DiscoveryRun",
+    "DiscoveryRunOptions",
+    "ReadAction",
+]

--- a/tests/ee/test_discovery_run.py
+++ b/tests/ee/test_discovery_run.py
@@ -1,0 +1,290 @@
+# tests/ee/test_discovery_run.py — unit tests for SZD-4 (DiscoveryRun).
+#
+# Created: 2026-06-19 (SZD-4 / feat/szd-4-discovery-run) — covers the
+# DiscoveryRun orchestrator with the connector read MOCKED (no live network):
+#   * a run against a mock connector yields an OntologyDraft (types inferred);
+#   * the read goes through the workspace-scoped path
+#     ``ensure_connected(name, "ws:<workspace_id>")`` (pocket-less) and NEVER
+#     ``adapter.sync()`` — both asserted via the mock's recorded calls;
+#   * sampling is capped per connector (the "N of M" budget);
+#   * an empty connector yields an empty draft with no crash;
+#   * explicit read-action overrides + a multi-connector run roll up provenance.
+#
+# Fully mocked — no DB / network. Run with:
+#   uv run --group ee pytest tests/ee/test_discovery_run.py -q
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from pocketpaw_ee.discovery import (
+    DiscoveryRun,
+    DiscoveryRunOptions,
+    OntologyDraft,
+    ReadAction,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Mock connector surface (stands in for the real adapter + registry).
+# --------------------------------------------------------------------------- #
+@dataclass
+class _MockActionResult:
+    """Mirror of pocketpaw.connectors.protocol.ActionResult (duck-typed)."""
+
+    success: bool
+    data: Any = None
+    error: str | None = None
+    records_affected: int = 0
+
+
+@dataclass
+class _MockActionSchema:
+    """Mirror of pocketpaw.connectors.protocol.ActionSchema (the read-shape bits)."""
+
+    name: str
+    method: str = "GET"
+    trust_level: str = "auto"
+
+
+class _MockAdapter:
+    """A connector adapter the orchestrator can read through.
+
+    Records every ``execute`` call so the test can assert the read path. It has
+    a ``sync`` method that BLOWS UP if called — discovery must never touch it.
+    """
+
+    def __init__(self, schemas: list[_MockActionSchema], data_by_action: dict[str, Any]) -> None:
+        self._schemas = schemas
+        self._data_by_action = data_by_action
+        self.execute_calls: list[tuple[str, dict[str, Any]]] = []
+        self.sync_called = False
+
+    async def actions(self) -> list[_MockActionSchema]:
+        return list(self._schemas)
+
+    async def execute(self, action: str, params: dict[str, Any]) -> _MockActionResult:
+        self.execute_calls.append((action, dict(params)))
+        if action not in self._data_by_action:
+            return _MockActionResult(success=False, error=f"unknown action {action}")
+        return _MockActionResult(success=True, data=self._data_by_action[action])
+
+    async def sync(self, pocket_id: str) -> Any:  # pragma: no cover - must never run
+        self.sync_called = True
+        raise AssertionError(
+            "DiscoveryRun must NOT call adapter.sync() — sync requires a pocket "
+            "and returns counts, not records."
+        )
+
+
+class _MockRegistry:
+    """A connector registry the orchestrator resolves adapters through.
+
+    Records every ``ensure_connected(name, scope_key)`` so the test can assert
+    the scope key is ``ws:<workspace_id>`` (the pocket-less #1445 path).
+    """
+
+    def __init__(self, adapters: dict[str, _MockAdapter | None]) -> None:
+        self._adapters = adapters
+        self.ensure_calls: list[tuple[str, str]] = []
+
+    async def ensure_connected(self, connector_name: str, scope_key: str) -> _MockAdapter | None:
+        self.ensure_calls.append((connector_name, scope_key))
+        return self._adapters.get(connector_name)
+
+
+def _records(n: int, prefix: str = "r") -> list[dict[str, Any]]:
+    """N uniform records with a clean ``id`` key (so a primary key is inferred)."""
+    return [{"id": f"{prefix}{i}", "name": f"name-{i}", "amount": i * 10} for i in range(n)]
+
+
+# --------------------------------------------------------------------------- #
+# A run yields an OntologyDraft via the workspace execute path.
+# --------------------------------------------------------------------------- #
+async def test_run_yields_draft_via_workspace_execute_path() -> None:
+    adapter = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_invoices", method="GET", trust_level="auto")],
+        data_by_action={"list_invoices": _records(3)},
+    )
+    registry = _MockRegistry({"billing": adapter})
+    run = DiscoveryRun(registry=registry)
+
+    draft = await run.run("ws-123", ["billing"])
+
+    # 1. It produced a real OntologyDraft with an inferred type.
+    assert isinstance(draft, OntologyDraft)
+    assert not draft.is_empty
+    assert len(draft.objects) == 3
+    assert draft.object_types, "expected at least one inferred object type"
+
+    # 2. The read went through ensure_connected with the WORKSPACE-scoped,
+    #    pocket-less key — NOT a pocket:<id> key, NOT sync().
+    assert registry.ensure_calls == [("billing", "ws:ws-123")]
+    for _name, scope_key in registry.ensure_calls:
+        assert scope_key.startswith("ws:"), f"expected ws-scoped key, got {scope_key!r}"
+        assert not scope_key.startswith("pocket:"), "discovery must be pocket-less"
+    assert adapter.sync_called is False, "discovery must never call adapter.sync()"
+    assert adapter.execute_calls == [("list_invoices", {})]
+
+    # 3. Provenance label is present ("based on N of M").
+    discovery = draft.meta["discovery"]
+    assert discovery["label"] == "based on 1 of 1"
+    assert discovery["sampled_connectors"] == 1
+    assert discovery["total_connectors"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Sampling is capped per connector.
+# --------------------------------------------------------------------------- #
+async def test_sampling_is_capped_per_connector() -> None:
+    adapter = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_rows", method="GET", trust_level="auto")],
+        data_by_action={"list_rows": _records(500)},
+    )
+    registry = _MockRegistry({"big": adapter})
+    run = DiscoveryRun(registry=registry)
+
+    draft = await run.run("ws-1", ["big"], DiscoveryRunOptions(sample_cap=50))
+
+    # Only the capped number of records are sampled.
+    assert len(draft.objects) == 50
+    assert draft.meta["discovery"]["connectors"]["big"]["records"] == 50
+    assert draft.meta["discovery"]["sample_cap"] == 50
+
+
+# --------------------------------------------------------------------------- #
+# Empty connector → empty draft, no crash.
+# --------------------------------------------------------------------------- #
+async def test_empty_connector_yields_empty_draft() -> None:
+    adapter = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_rows", method="GET", trust_level="auto")],
+        data_by_action={"list_rows": []},  # connector has no records
+    )
+    registry = _MockRegistry({"empty": adapter})
+    run = DiscoveryRun(registry=registry)
+
+    draft = await run.run("ws-1", ["empty"])
+
+    assert isinstance(draft, OntologyDraft)
+    assert draft.is_empty
+    assert draft.meta["discovery"]["connectors"]["empty"]["status"] == "empty"
+    assert draft.meta["discovery"]["label"] == "based on 1 of 1"
+    # The read was still attempted through the ws path.
+    assert registry.ensure_calls == [("empty", "ws:ws-1")]
+    assert adapter.sync_called is False
+
+
+# --------------------------------------------------------------------------- #
+# Unresolvable connector is skipped gracefully.
+# --------------------------------------------------------------------------- #
+async def test_unresolved_connector_is_skipped() -> None:
+    registry = _MockRegistry({"gone": None})  # ensure_connected returns None
+    run = DiscoveryRun(registry=registry)
+
+    draft = await run.run("ws-1", ["gone"])
+
+    assert draft.is_empty
+    assert draft.meta["discovery"]["connectors"]["gone"]["status"] == "unresolved"
+    assert registry.ensure_calls == [("gone", "ws:ws-1")]
+
+
+# --------------------------------------------------------------------------- #
+# Mutating actions (POST / confirm) are never sampled on auto-select.
+# --------------------------------------------------------------------------- #
+async def test_auto_select_skips_mutating_actions() -> None:
+    adapter = _MockAdapter(
+        schemas=[
+            _MockActionSchema(name="create_row", method="POST", trust_level="confirm"),
+            _MockActionSchema(name="delete_row", method="POST", trust_level="auto"),
+            _MockActionSchema(name="list_rows", method="GET", trust_level="auto"),
+        ],
+        data_by_action={"list_rows": _records(2), "create_row": _records(2)},
+    )
+    registry = _MockRegistry({"c": adapter})
+    run = DiscoveryRun(registry=registry)
+
+    await run.run("ws-1", ["c"])
+
+    # Only the GET + auto action fired; the POST actions never ran.
+    called = {a for a, _ in adapter.execute_calls}
+    assert called == {"list_rows"}
+
+
+# --------------------------------------------------------------------------- #
+# Explicit read-action override + multi-connector "N of M" roll-up.
+# --------------------------------------------------------------------------- #
+async def test_explicit_read_actions_and_multi_connector_rollup() -> None:
+    crm = _MockAdapter(
+        schemas=[],  # no auto-discoverable schema — forces the explicit path
+        data_by_action={"q_customers": _records(2, "cust"), "q_deals": _records(2, "deal")},
+    )
+    support = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_tickets", method="GET", trust_level="auto")],
+        data_by_action={"list_tickets": _records(4, "tkt")},
+    )
+    registry = _MockRegistry({"crm": crm, "support": support, "broken": None})
+    run = DiscoveryRun(registry=registry)
+
+    opts = DiscoveryRunOptions(
+        read_actions={
+            "crm": [
+                ReadAction(action="q_customers", type_name="Customer"),
+                ReadAction(action="q_deals", type_name="Deal"),
+            ],
+        },
+    )
+    draft = await run.run("ws-9", ["crm", "support", "broken"], opts)
+
+    # Three logical types: Customer + Deal (explicit) + list_tickets (auto).
+    type_names = {ot.name for ot in draft.object_types}
+    assert {"Customer", "Deal", "list_tickets"} <= type_names
+
+    # 2 of 3 connectors actually sampled (broken was unresolved).
+    discovery = draft.meta["discovery"]
+    assert discovery["sampled_connectors"] == 2
+    assert discovery["total_connectors"] == 3
+    assert discovery["label"] == "based on 2 of 3"
+
+    # Every read went through a ws:-scoped resolve; none used sync().
+    assert all(scope == "ws:ws-9" for _n, scope in registry.ensure_calls)
+    assert crm.sync_called is False
+    assert support.sync_called is False
+
+
+# --------------------------------------------------------------------------- #
+# Permission filter degrades gracefully (allow-all when no list given).
+# --------------------------------------------------------------------------- #
+async def test_permission_filter_skips_disallowed_connectors() -> None:
+    a = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_rows", trust_level="auto")],
+        data_by_action={"list_rows": _records(2)},
+    )
+    b = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_rows", trust_level="auto")],
+        data_by_action={"list_rows": _records(2)},
+    )
+    registry = _MockRegistry({"allowed": a, "denied": b})
+    run = DiscoveryRun(registry=registry)
+
+    opts = DiscoveryRunOptions(allowed_connector_ids=frozenset({"allowed"}))
+    draft = await run.run("ws-1", ["allowed", "denied"], opts)
+
+    discovery = draft.meta["discovery"]
+    assert discovery["permission_enforced"] is True
+    assert discovery["skipped_by_permission"] == ["denied"]
+    # The denied connector was never resolved or read.
+    assert registry.ensure_calls == [("allowed", "ws:ws-1")]
+    assert b.execute_calls == []
+
+
+# --------------------------------------------------------------------------- #
+# The on-box refine pass is not wired in slice 1 — fail loud, don't lie.
+# --------------------------------------------------------------------------- #
+async def test_refine_pass_not_implemented_in_slice_1() -> None:
+    registry = _MockRegistry({})
+    run = DiscoveryRun(registry=registry)
+
+    with pytest.raises(NotImplementedError, match="on-box / tenant model"):
+        await run.run("ws-1", [], DiscoveryRunOptions(refine=True))


### PR DESCRIPTION
SZD-4, stacked on #1513. Ties sampling→digest: a `DiscoveryRun` samples a workspace's bound connectors and runs the SZD-3 digester to produce an `OntologyDraft`.

## What changed
- New `ee/pocketpaw_ee/discovery/run.py` — `DiscoveryRun.run(workspace_id, connector_ids, opts)`. Reads via the workspace-scoped, pocket-less path: `registry.ensure_connected(name, "ws:<workspace_id>")` then `adapter.execute(read_action, params)`, reading records from `ActionResult.data`. **Never calls `sync()`** (which needs a pocket and returns only counts). Drives the tenant's LOCAL registry directly (the cloud LOCAL-exec seam 503s).
- Read actions: explicit `opts.read_actions` map, or auto-select of GET/HEAD + auto-trust (safe-reads-only) actions — never mutating ones.
- Deterministic digest for slice 1 (no LLM); `opts.refine=True` raises `NotImplementedError` with a note that a refine pass must use the on-box/tenant model, never a cloud model on tenant raw data.
- Sampling capped (200/connector); draft carries a "based on N of M" meta + per-connector rollup. Permission degrades to allow-all with `permission_enforced: false` until #1498 lands.

## Verified
- New `tests/ee/test_discovery_run.py` (8 tests): the read goes through `ensure_connected("ws:...")` + `execute`, and asserts `sync()` is NEVER called; sampling cap; empty connector → empty draft; unresolved connector skipped; mutating actions excluded from auto-select; permission filter; refine NotImplemented. Re-ran with the digester suite: 22 pass.

## Notes
- No single canonical "list_records" action across connectors → auto-select is a heuristic (GET/HEAD + auto-trust); a connector whose only read is confirm-trust must be supplied via `opts.read_actions`. The discovery surface (SZD-6) configures this.

Stacks on #1513. Feeds SZD-6 (wires the draft into the gate proposals). Part of sovereign zero-setup discovery.