### PR TITLE
Sites: sovereign zero-setup discovery — slice-1 backend (convergence)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/fabric.py
@@ -34,8 +34,9 @@
 #     workspace (fix/fabric-stats-workspace-scope: the original instance-wide
 #     stats leaked another tenant's experimental type names into chat on a
 #     shared box). Counts mirror fabric_query's visibility exactly; the type
-#     list holds only types with object rows visible to the workspace (type
-#     DEFINITIONS are global in the schema — see FabricStore.list_types).
+#     list holds only the caller workspace's own types (SZD-2: the
+#     fabric_object_types table now carries a workspace_id; a NULL workspace_id
+#     is a legacy/global type visible to all — see FabricStore.list_types).
 #
 # Read-only: neither tool writes anything. FabricCreateTool is deliberately
 # NOT wrapped — ontology writes from the SDK backend should arrive as gated

--- a/ee/pocketpaw_ee/cloud/fabric_proposals/__init__.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/__init__.py
@@ -1,0 +1,33 @@
+# ee/cloud/fabric_proposals/__init__.py — the gated Fabric-ontology Instinct
+# proposal type (a peer of ``_pocket_write`` / ``_code_change`` /
+# ``_external_action`` / ``_belt_plan`` / ``_artifact_change``).
+# Created: 2026-06-19 (SZD-5a — _fabric_objects proposal type) — a proposed
+#   Fabric ontology (object types + objects + links) staged for human review
+#   through the Instinct gate. "Sovereign zero-setup discovery" infers a tenant's
+#   ontology from connector data and proposes "create these Fabric objects"; a
+#   human approves or rejects in The Tray; on approve the executor materialises
+#   the ontology in Fabric via the canonical, workspace-scoped, idempotent
+#   ``connectors.fabric_ingest.ingest_records`` upsert loop. Fully generic — no
+#   domain-specific logic.
+#
+# Re-exports the propose helper + the apply-on-approve executor so callers (the
+# discovery surface, the instinct router) import from the package root, mirroring
+# how the external-action gate is imported.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.fabric_proposals.executor import execute_approved_fabric_objects
+from pocketpaw_ee.cloud.fabric_proposals.propose import (
+    FABRIC_OBJECTS_KIND,
+    FABRIC_OBJECTS_PARAM_KEY,
+    FABRIC_OBJECTS_SCHEMA,
+    propose_fabric_objects,
+)
+
+__all__ = [
+    "FABRIC_OBJECTS_KIND",
+    "FABRIC_OBJECTS_PARAM_KEY",
+    "FABRIC_OBJECTS_SCHEMA",
+    "execute_approved_fabric_objects",
+    "propose_fabric_objects",
+]

--- a/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
@@ -1,0 +1,544 @@
+# ee/cloud/fabric_proposals/executor.py — apply an approved Fabric-ontology write.
+# Created: 2026-06-19 (SZD-5a — _fabric_objects Instinct proposal type).
+#
+# What this module does (the apply-on-approve half of the Fabric-objects gate):
+# the propose helper (``fabric_proposals.propose.propose_fabric_objects``) files
+# an Instinct Action carrying a ``_fabric_objects`` blob THROUGH Instinct (the
+# human approve/reject layer). After a human approves the Action, the ee instinct
+# router's ``approve_action`` fires ``execute_approved_fabric_objects`` here —
+# exactly mirroring how ``external_actions.executor.
+# execute_approved_external_action`` is fired for a gated connector call. This
+# function:
+#
+#   1. Reads the ``_fabric_objects`` blob from ``action.parameters``. A missing
+#      blob → return (no chain was opened, nothing to close). A schema-mismatched
+#      blob → mark_failed + close the chain, return.
+#   2. Idempotency guard — if the Action is already terminal (executed / failed)
+#      or the blob already carries an ``outcome``, the write is NOT re-run.
+#      Re-approve / retry never double-applies. The ingest loop itself is ALSO
+#      idempotent (dedup by ``(source_connector, source_id)``), so even a
+#      double-fire that slips past this guard creates N stable objects, not N*records.
+#   3. Materialises the ontology via the canonical
+#      ``connectors.fabric_ingest.ingest_records`` upsert loop, WORKSPACE-SCOPED
+#      by the blob's ``workspace_id`` (SZD-2 per-tenant types). Objects are grouped
+#      by type so each group rides one FabricMapping. Links are created with
+#      ``(from, to, link_type)`` dedup against the existing links.
+#   4. Back-writes the outcome ``{status, created, updated, links_created, executed_at}``
+#      onto the persisted blob via the direct-SQL pattern.
+#   5. Records the result on the Action (``mark_executed`` / ``mark_failed``) and
+#      CLOSES the Decision-Graph chain exactly once.
+#
+# EXACTLY-ONE-TERMINAL discipline (critical): on APPROVE the EXECUTOR owns the
+# ``decision.completed`` chain close — the router does NOT emit it (mirrors the
+# external-action executor). On REJECT the ROUTER owns the close and the executor
+# never runs. Every terminal path here goes through the single ``_fail``
+# chokepoint (failure) or the one success emit at the end — never both.
+#
+# Never raises — a failure here must not break the approve response. The router
+# wraps the call too; this is belt-and-braces. A Fabric write error is captured
+# as ``status=failed`` with a ``failed`` terminal, NOT re-raised.
+#
+# Security (this code writes typed objects into a tenant's Fabric on approval):
+#   * tenancy: every Fabric write is scoped by the blob's ``workspace_id``; an
+#     empty workspace_id is refused (a tenancy hole). The router's
+#     ``_assert_fabric_objects_workspace`` is the primary gate; this is
+#     belt-and-braces.
+#   * the write primitive is the SHIPPED ``ingest_records`` — this module does
+#     NOT call raw ``define_type`` / ``create_object`` / ``link``, so it inherits
+#     the proven workspace-scoped, provenance-stamped, idempotent upsert.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.fabric_proposals.propose import (
+    FABRIC_OBJECTS_PARAM_KEY,
+    FABRIC_OBJECTS_SCHEMA,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    summary: dict[str, Any],
+    executed_at: str,
+) -> None:
+    """Back-write the write outcome onto the persisted ``_fabric_objects`` blob.
+
+    Direct SQL update — the same pattern the external-action executor's
+    ``_persist_outcome`` uses. The blob's ``outcome`` carries the counts +
+    timestamp so a reader (audit, a re-invocation idempotency check) sees the
+    result structurally. Best-effort: a write failure leaves the blob without the
+    structured outcome but the free-text ``mark_executed`` / ``mark_failed``
+    outcome still records it.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(FABRIC_OBJECTS_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {"status": status, "executed_at": executed_at, **summary}
+        params[FABRIC_OBJECTS_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "fabric_objects: failed to persist outcome onto action %s — the "
+            "structured outcome is unavailable (free-text outcome still recorded)",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a Fabric-objects write.
+
+    Mirrors ``external_actions.executor._emit_chain_close`` — the executor owns
+    the chain close on the approve path. ``correlation_id`` is read off the blob;
+    ``causation_id`` is the ``human.corrected`` event the router emitted just
+    before approval so the terminal chains back to the human approval.
+
+    Returns early when ``correlation_id`` is None (a blob with a malformed /
+    missing id): there is no chain to close. Best-effort: a Decision-Graph wiring
+    failure must never break the approve response — the journal write is the
+    source of truth; the Slice 4 reconciler is the safety net.
+    """
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if summary:
+        payload["summary"] = summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "fabric_objects decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this Fabric write already ran.
+
+    Two signals, either is sufficient:
+      * the blob already carries an ``outcome`` (a prior run back-wrote it), or
+      * the Action is already in a terminal state (executed / failed).
+
+    Re-invocation (bulk re-approve, retry) must never re-run the write. The
+    Action's ``status`` is the authoritative gate, and the back-written outcome
+    is the belt-and-braces signal in case status reads are stale. (The ingest
+    loop is itself idempotent, so even a slip is harmless — this guard avoids the
+    redundant work + the duplicate terminal.)
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+# The reserved record key carrying the object's source id. It is prefixed +
+# suffixed so it can't collide with a real property name, and it is excluded from
+# the projected field_map so it never lands in the object's properties.
+_SOURCE_ID_KEY = "__fabric_proposal_source_id__"
+
+
+def _build_ingest_batches(
+    object_types: list[dict[str, Any]],
+    objects: list[dict[str, Any]],
+) -> list[tuple[Any, str, list[dict[str, Any]]]]:
+    """Group objects by (type_name, source_connector) into ingest batches.
+
+    Returns a list of ``(FabricMapping, source_connector, [records])`` — one
+    batch per (type, connector) so each ``ingest_records`` call stamps the right
+    ``source_connector`` provenance. Each record is a FLAT dict: the object's
+    properties at the top level, plus the object's ``source_id`` under the
+    reserved key. The mapping's ``field_map`` is an IDENTITY projection over the
+    union of property keys in the batch (so ``ingest_records`` stores each
+    property verbatim), and ``source_id_field`` reads the reserved key. The type's
+    declared properties (from ``object_types``) ride on the mapping so
+    ``ensure_type`` defines the type with the proposed schema; a type referenced
+    by an object but absent from ``object_types`` is ensured with empty
+    properties (the upsert still stamps provenance).
+    """
+    from pocketpaw.connectors.fabric_ingest import FabricMapping
+    from pocketpaw.fabric.models import PropertyDef
+
+    # Index the declared type schemas by name (case-insensitive) for lookup.
+    type_schemas: dict[str, dict[str, Any]] = {}
+    for t in object_types:
+        name = str(t.get("type_name") or "").strip()
+        if name:
+            type_schemas[name.lower()] = t
+
+    # Group objects by (type_name, source_connector), preserving insertion order.
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for obj in objects:
+        type_name = str(obj.get("type_name") or "").strip()
+        connector = str(obj.get("source_connector") or "").strip()
+        if not type_name or not connector:
+            continue
+        grouped.setdefault((type_name, connector), []).append(obj)
+
+    batches: list[tuple[Any, str, list[dict[str, Any]]]] = []
+    for (type_name, connector), objs in grouped.items():
+        decl = type_schemas.get(type_name.lower(), {})
+        prop_defs = [
+            PropertyDef(**p)
+            for p in (decl.get("properties") or [])
+            if isinstance(p, dict) and p.get("name")
+        ]
+        records: list[dict[str, Any]] = []
+        prop_keys: set[str] = set()
+        for obj in objs:
+            props = dict(obj.get("properties") or {})
+            prop_keys.update(props.keys())
+            record = dict(props)
+            record[_SOURCE_ID_KEY] = obj["source_id"]
+            records.append(record)
+        field_map: dict[str, Any] = {k: k for k in prop_keys}
+        mapping = FabricMapping(
+            type_name=type_name,
+            source_id_field=_SOURCE_ID_KEY,
+            field_map=field_map,
+            properties=prop_defs,
+            type_description=str(decl.get("description") or ""),
+            type_icon=str(decl.get("icon") or "box"),
+            type_color=str(decl.get("color") or "#0A84FF"),
+        )
+        batches.append((mapping, connector, records))
+    return batches
+
+
+async def _create_links_deduped(
+    *,
+    store: Any,
+    links: list[dict[str, Any]],
+    workspace_id: str,
+) -> int:
+    """Create the proposed links, WORKSPACE-SCOPED, deduped by (from, to, link_type).
+
+    Each link references its endpoints by ``(source_connector, source_id)`` — the
+    natural key the objects were upserted under — so we resolve them to the
+    materialised object ids via ``get_object_by_source`` (the same workspace-scoped
+    read the ingest loop uses). A link whose endpoint can't be resolved (the object
+    wasn't in this proposal and doesn't already exist) is skipped. An EXISTING link
+    with the same ``(from_id, to_id, link_type)`` is NOT recreated — re-approve (or
+    two proposals asserting the same link) does not duplicate. Returns the count of
+    NEW links created.
+
+    ``store.link`` is not idempotent on its own, so the dedup lives here: we check
+    ``list_links(from_id, to_id, link_type, workspace_id)`` before each create.
+    """
+    created = 0
+    for link in links:
+        from_ref = link.get("from") or {}
+        to_ref = link.get("to") or {}
+        link_type = str(link.get("link_type") or "").strip()
+        if not link_type:
+            continue
+
+        from_obj = await store.get_object_by_source(
+            source_connector=str(from_ref.get("source_connector") or ""),
+            source_id=str(from_ref.get("source_id") or ""),
+            workspace_id=workspace_id,
+        )
+        to_obj = await store.get_object_by_source(
+            source_connector=str(to_ref.get("source_connector") or ""),
+            source_id=str(to_ref.get("source_id") or ""),
+            workspace_id=workspace_id,
+        )
+        if from_obj is None or to_obj is None:
+            logger.info(
+                "fabric_objects: skipping link %s — endpoint not resolvable in "
+                "workspace %s",
+                link_type,
+                workspace_id,
+            )
+            continue
+
+        # Dedup by (from, to, link_type) within the tenant — skip if it exists.
+        existing, total = await store.list_links(
+            from_id=from_obj.id,
+            to_id=to_obj.id,
+            link_type=link_type,
+            workspace_id=workspace_id,
+        )
+        if total > 0:
+            continue
+
+        await store.link(
+            from_id=from_obj.id,
+            to_id=to_obj.id,
+            link_type=link_type,
+            workspace_id=workspace_id,
+        )
+        created += 1
+    return created
+
+
+async def execute_approved_fabric_objects(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """Materialise the Fabric ontology carried by a freshly-approved Action.
+
+    Called best-effort from the instinct router's ``approve_action`` /
+    ``bulk_approve_actions`` after ``store.approve()`` succeeds — the same hook
+    shape the external-action executor uses. ``action`` is the approved Action.
+
+    ``human_event_id`` is the id of the ``human.corrected`` event the router
+    emitted just before calling this — threaded through so the terminal
+    ``decision.completed`` event can chain its ``causation_id`` back to the
+    approval, completing the causal walk ``agent.proposed → human.corrected →
+    decision.completed``. ``None`` is tolerated (the chain still folds via the
+    shared ``correlation_id``).
+
+    Never raises — a failure here must not break the approve response. The router
+    wraps the call too; this is belt-and-braces. The Action is marked executed on
+    a successful write or failed with a clear outcome on any error, and the
+    Decision-Graph chain is closed exactly once (success → landed, failure →
+    failed).
+    """
+    from pocketpaw.stores import get_fabric_store, get_instinct_store
+
+    store = get_instinct_store()
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(FABRIC_OBJECTS_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not a fabric-objects Action at all — no chain was opened for it, so
+        # there is nothing to close. Return without a terminal emit.
+        logger.warning("approved action %s carries no _fabric_objects blob", action.id)
+        return
+
+    # Read the chain ids off the blob up front so EVERY terminal path can close
+    # the chain it opened. A malformed / missing id → None and the close no-ops
+    # (the Slice 4 abandon-sweeper closes any chain left open).
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    requested_by = str(blob.get("requested_by") or "")
+    approver = str(getattr(action, "approved_by", "") or "") or requested_by or "system"
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Mark the Action failed AND close the chain with one terminal — the
+        single failure-path chokepoint so a path can never both fail and
+        double-fire the terminal."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            summary={"reason": reason},
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=approver,
+            causation_id=causation,
+            summary=reason,
+        )
+
+    # Schema guard — a stale blob from an incompatible build fails loud rather
+    # than writing a misinterpreted ontology.
+    if blob.get("schema") != FABRIC_OBJECTS_SCHEMA:
+        await _fail(
+            "fabric-objects schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    # Tenancy — a Fabric write with no workspace is a tenancy hole. The Fabric
+    # writes are scoped by workspace_id; fail loud so a malformed blob is
+    # recorded, not silently written unscoped.
+    if not workspace_id:
+        await _fail(
+            "fabric-objects blob carries no workspace_id — cannot scope the write",
+            error_class="MissingWorkspace",
+        )
+        return
+
+    # Idempotency — never re-run the write on a re-invocation.
+    if _already_executed(action, blob):
+        logger.info(
+            "fabric_objects: action %s already executed (idempotency guard) — "
+            "skipping the Fabric write",
+            action.id,
+        )
+        return
+
+    objects = blob.get("objects")
+    if not isinstance(objects, list) or not objects:
+        await _fail(
+            "fabric-objects blob carries no objects to materialise",
+            error_class="MalformedBlob",
+        )
+        return
+    object_types = blob.get("object_types") if isinstance(blob.get("object_types"), list) else []
+    links = blob.get("links") if isinstance(blob.get("links"), list) else []
+
+    # Materialise the ontology. Any failure (bad property, store error) is
+    # captured as a failed outcome — NEVER re-raised into the router.
+    try:
+        from pocketpaw.connectors.fabric_ingest import ingest_records
+
+        fabric = get_fabric_store()
+        batches = _build_ingest_batches(object_types, objects)
+
+        total_created = 0
+        total_updated = 0
+        for mapping, connector, records in batches:
+            # REUSE the shipped, workspace-scoped, idempotent upsert loop — one
+            # call per (type, connector) batch so the right provenance is stamped.
+            ingest_result = await ingest_records(
+                fabric,
+                connector,
+                records,
+                mapping,
+                workspace_id=workspace_id,
+            )
+            total_created += ingest_result.created
+            total_updated += ingest_result.updated
+
+        links_created = await _create_links_deduped(
+            store=fabric,
+            links=links,
+            workspace_id=workspace_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — never let a Fabric write break approve
+        logger.warning(
+            "fabric_objects: write crashed for action %s (workspace=%s)",
+            action.id,
+            workspace_id,
+            exc_info=True,
+        )
+        await _fail(
+            f"fabric write failed: {exc}",
+            error_class=type(exc).__name__,
+        )
+        return
+
+    summary = {
+        "created": total_created,
+        "updated": total_updated,
+        "links_created": links_created,
+    }
+
+    # Success — mark executed, back-write the structured outcome, close the chain.
+    await store.mark_executed(
+        action.id,
+        f"fabric ontology materialised: {total_created} created, "
+        f"{total_updated} updated, {links_created} link(s) created",
+    )
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        summary=summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    # Close the chain on the SUCCESS path. This is the ONLY terminal on the happy
+    # path (every failure path above closed via ``_fail`` and returned), so
+    # exactly one ``decision.completed`` lands per write.
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=approver,
+        causation_id=causation,
+        summary=(
+            f"{total_created} created, {total_updated} updated, "
+            f"{links_created} link(s) created"
+        ),
+    )
+    logger.info(
+        "fabric_objects: executed action %s → %d created / %d updated / %d links (ok)",
+        action.id,
+        total_created,
+        total_updated,
+        links_created,
+    )
+
+
+__all__ = ["execute_approved_fabric_objects"]

--- a/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
@@ -452,8 +452,10 @@ async def execute_approved_fabric_objects(
             error_class="MalformedBlob",
         )
         return
-    object_types = blob.get("object_types") if isinstance(blob.get("object_types"), list) else []
-    links = blob.get("links") if isinstance(blob.get("links"), list) else []
+    _ot = blob.get("object_types")
+    object_types: list[dict[str, Any]] = _ot if isinstance(_ot, list) else []
+    _lk = blob.get("links")
+    links: list[dict[str, Any]] = _lk if isinstance(_lk, list) else []
 
     # Materialise the ontology. Any failure (bad property, store error) is
     # captured as a failed outcome — NEVER re-raised into the router.

--- a/ee/pocketpaw_ee/cloud/fabric_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/propose.py
@@ -1,0 +1,445 @@
+# ee/cloud/fabric_proposals/propose.py — propose a gated Fabric-ontology write.
+# Created: 2026-06-19 (SZD-5a — _fabric_objects Instinct proposal type).
+#
+# What this module does (the propose half of the Fabric-objects gate): "sovereign
+# zero-setup discovery" stages a PROPOSED Fabric ontology — a set of object types,
+# objects, and links it inferred from a tenant's connector data — for a human to
+# review through the Instinct gate before any of it is written to Fabric. This
+# files an Instinct ``Action`` carrying a ``_fabric_objects`` blob (schema 1)
+# under ``Action.parameters``. A human approves it in The Tray; the
+# apply-on-approve executor (``fabric_proposals.executor.
+# execute_approved_fabric_objects``) then materialises the ontology in Fabric via
+# the canonical ``connectors.fabric_ingest.ingest_records`` upsert loop. This
+# module does NOT write Fabric — it only gates.
+#
+# The blob is the gated Fabric-ontology kind, sitting alongside the pocket-write
+# bridge's ``_pocket_write``, the Belt develop-station's ``_code_change``, the
+# external-action gate's ``_external_action``, the mandate foreman's
+# ``_belt_plan``, and the Branch-primitive merge gate's ``_artifact_change``. The
+# router + executor dispatch on the presence of the ``_fabric_objects``
+# parameters key (the Action model has no literal ``kind`` column; the blob also
+# carries ``kind="fabric_objects"`` for readers that introspect it).
+#
+# Schema 1 (this is the first version — the schema-version pattern is replicated
+# from ``external_actions.propose.EXTERNAL_ACTION_SCHEMA`` /
+# ``instinct_bridge._POCKET_WRITE_SCHEMA`` / belt's ``CODE_CHANGE_SCHEMA``,
+# starting at 1). The blob carries:
+#   * ``schema`` / ``kind`` — version + discriminator;
+#   * ``workspace_id`` — the originating tenant (the executor's tenancy gate
+#     reads it HERE; a Fabric ontology isn't bound to a pocket the way a parked
+#     write is, so tenancy lives entirely on the blob — and the Fabric writes are
+#     workspace-scoped via this id, building on SZD-2's per-tenant type catalog);
+#   * ``object_types`` — the ObjectTypes to ensure-exist: each
+#     ``{type_name, description?, icon?, color?, properties[]}``;
+#   * ``objects`` — the objects to upsert: each
+#     ``{type_name, properties, source_connector, source_id}``. ``source_id`` is
+#     the idempotency key — re-approving (or two proposals asserting the same
+#     ``(source_connector, source_id)``) updates rather than duplicates;
+#   * ``links`` — the links to create: each ``{from, to, link_type}``, deduped by
+#     ``(from, to, link_type)`` at execution;
+#   * ``summary`` — a human-readable one-liner for the gate UI (The Tray);
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids,
+#     minted here at propose time (``agent.proposed`` opens the chain). The
+#     router's approve / reject paths and the executor close the SAME chain.
+#
+# Security:
+#   * NO Fabric mutation happens here — the ontology is staged as DATA on the
+#     blob and only materialised after a human approves.
+#   * Tenancy is bound on the router's approve / reject paths via
+#     ``_assert_fabric_objects_workspace`` and re-validated at execution (the
+#     Fabric writes are scoped by the blob's ``workspace_id``). A
+#     cross-workspace approve OR reject is refused — asymmetric tenant scope is
+#     no tenant scope (pocketpaw#1183 / #1250).
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator for a Fabric-objects proposal. The
+# router + executor dispatch on the presence of the parameters key below; the
+# blob also carries ``kind="fabric_objects"`` for readers that introspect it.
+FABRIC_OBJECTS_KIND = "fabric_objects"
+
+# The parameters key under which the Fabric-objects blob rides — peer of the
+# pocket-write bridge's ``_pocket_write``, belt's ``_code_change``, and the
+# external-action gate's ``_external_action``. The router + executor dispatch on
+# this key being present.
+FABRIC_OBJECTS_PARAM_KEY = "_fabric_objects"
+
+# Schema version stamped on the ``_fabric_objects`` blob. Bump when the blob
+# shape changes so a stale pending Action approved after a deploy fails loud
+# instead of writing a misinterpreted ontology (same discipline as the
+# external-action gate's ``EXTERNAL_ACTION_SCHEMA``). Starts at 1 — first version.
+FABRIC_OBJECTS_SCHEMA = 1
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    workspace_id: str,
+    user_id: str,
+    type_count: int,
+    object_count: int,
+    link_count: int,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a Fabric-objects write.
+
+    Mirrors ``external_actions.propose._emit_agent_proposed``: the proposing
+    caller is the actor (``kind="agent"`` with the requesting user on its id, the
+    workspace on its scope_context). A Fabric ontology isn't bound to a pocket —
+    its tenancy is the workspace — so ``pocket_id`` on the chain carries the
+    workspace id (matching how the Action's ``pocket_id`` field carries the
+    workspace).
+
+    Returns the emitted event id so the caller can persist it on the blob's
+    ``proposed_event_id`` field for the ``human.corrected`` causation chain, or
+    ``None`` when the emit raised — best-effort per RFC 09; the Slice 4
+    reconciler picks up any orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = (
+        f"create {object_count} Fabric object(s) across {type_count} type(s) "
+        f"and {link_count} link(s)"
+    )
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "fabric_objects",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator.
+        "proposal_kind": "fabric_objects",
+        "proposal": {
+            "type_count": type_count,
+            "object_count": object_count,
+            "link_count": link_count,
+        },
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "fabric_objects agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._fabric_objects`` blob after ``agent.proposed`` fired.
+
+    The blob is built with ``correlation_id`` already set (minted before build);
+    ``proposed_event_id`` is the field this back-write fills in. Direct SQL
+    update — the same pattern the external-action gate's ``_persist_chain_ids``
+    uses. Best-effort: a write failure leaves ``proposed_event_id`` None and the
+    eventual ``human.corrected`` emits without a causation_id (the chain still
+    folds; causation_id is optional on EventEntry).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(FABRIC_OBJECTS_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[FABRIC_OBJECTS_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "fabric_objects: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _normalize_object_types(object_types: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Coerce the proposed object types into a stable, JSON-safe blob shape.
+
+    Each entry keeps ``type_name`` + the optional presentation/properties fields
+    the executor's FabricMapping consumes. ``properties`` is a list of
+    PropertyDef-shaped dicts (``{name, type, required, description, ...}``);
+    anything not a dict is dropped (a malformed property can't be materialised).
+    """
+    out: list[dict[str, Any]] = []
+    for entry in object_types or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("type_name") or "").strip()
+        if not name:
+            continue
+        props = [p for p in (entry.get("properties") or []) if isinstance(p, dict)]
+        out.append(
+            {
+                "type_name": name,
+                "description": str(entry.get("description") or ""),
+                "icon": str(entry.get("icon") or "box"),
+                "color": str(entry.get("color") or "#0A84FF"),
+                "properties": props,
+            }
+        )
+    return out
+
+
+def _normalize_objects(objects: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Coerce the proposed objects into a stable, JSON-safe blob shape.
+
+    Each entry MUST carry ``type_name`` + ``source_connector`` + ``source_id``
+    (the idempotency key) and a ``properties`` dict. Entries missing any of those
+    are dropped — without a stable ``(source_connector, source_id)`` an object
+    cannot be deduplicated and would silently duplicate on re-approve.
+    """
+    out: list[dict[str, Any]] = []
+    for entry in objects or []:
+        if not isinstance(entry, dict):
+            continue
+        type_name = str(entry.get("type_name") or "").strip()
+        source_connector = str(entry.get("source_connector") or "").strip()
+        source_id = str(entry.get("source_id") or "").strip()
+        props = entry.get("properties")
+        if not type_name or not source_connector or not source_id or not isinstance(props, dict):
+            continue
+        out.append(
+            {
+                "type_name": type_name,
+                "properties": dict(props),
+                "source_connector": source_connector,
+                "source_id": source_id,
+            }
+        )
+    return out
+
+
+def _normalize_links(links: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Coerce the proposed links into a stable, JSON-safe blob shape.
+
+    Each entry MUST carry ``from`` + ``to`` + ``link_type``. ``from`` / ``to``
+    reference an object by its ``(source_connector, source_id)`` natural key so
+    the executor can resolve them to the materialised object ids AFTER the
+    upsert (the Fabric object ids don't exist yet at propose time). Entries
+    missing any field are dropped.
+    """
+    out: list[dict[str, Any]] = []
+    for entry in links or []:
+        if not isinstance(entry, dict):
+            continue
+        from_ref = entry.get("from")
+        to_ref = entry.get("to")
+        link_type = str(entry.get("link_type") or "").strip()
+        if not isinstance(from_ref, dict) or not isinstance(to_ref, dict) or not link_type:
+            continue
+        out.append(
+            {
+                "from": {
+                    "source_connector": str(from_ref.get("source_connector") or "").strip(),
+                    "source_id": str(from_ref.get("source_id") or "").strip(),
+                },
+                "to": {
+                    "source_connector": str(to_ref.get("source_connector") or "").strip(),
+                    "source_id": str(to_ref.get("source_id") or "").strip(),
+                },
+                "link_type": link_type,
+            }
+        )
+    return out
+
+
+async def propose_fabric_objects(
+    *,
+    workspace_id: str,
+    objects: list[dict[str, Any]],
+    object_types: list[dict[str, Any]] | None = None,
+    links: list[dict[str, Any]] | None = None,
+    requested_by: str,
+    summary: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+) -> str:
+    """Build + store an Instinct ``Action`` for a gated Fabric-ontology write.
+
+    Files an Action carrying the ``_fabric_objects`` blob (schema 1) and opens
+    the Decision-Graph chain (``agent.proposed``). Returns the proposed Action
+    id. NO Fabric mutation happens here — the ontology is staged as DATA and only
+    materialised after a human approves.
+
+    Args:
+        workspace_id: the originating tenant. Bound on the router's approve /
+            reject paths and re-validated at execution; the Fabric writes are
+            scoped by it. Required — a Fabric write with no tenant to scope it to
+            is a tenancy hole.
+        objects: the objects to upsert. Each carries
+            ``{type_name, properties, source_connector, source_id}``. ``source_id``
+            is the idempotency key. Required + non-empty — a proposal with no
+            objects has nothing to materialise.
+        object_types: the ObjectTypes to ensure-exist. Each carries
+            ``{type_name, description?, icon?, color?, properties[]}``. Optional —
+            when omitted, the executor ensures each object's type by name with
+            empty properties.
+        links: the links to create. Each carries ``{from, to, link_type}`` where
+            ``from`` / ``to`` reference objects by ``(source_connector,
+            source_id)``. Deduped by ``(from, to, link_type)`` at execution.
+        requested_by: the user id that proposed the write (chain actor + audit).
+        summary: a human-readable one-liner for the gate UI. A sensible default
+            is built from the counts when omitted.
+        correlation_id: an optional pre-minted chain id. When omitted a fresh one
+            is minted here (the common case).
+        assignee: the workspace member who should approve. Defaults to
+            ``requested_by`` so the proposer's queue carries it.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_fabric_objects requires a non-empty workspace_id")
+
+    norm_types = _normalize_object_types(object_types)
+    norm_objects = _normalize_objects(objects)
+    norm_links = _normalize_links(links)
+    if not norm_objects:
+        raise ValueError(
+            "propose_fabric_objects requires at least one object with a "
+            "type_name, source_connector, source_id, and properties"
+        )
+
+    # Mint the chain correlation_id BEFORE building the blob so the stored Action
+    # carries it from the first write. The same id threads through approve /
+    # reject (router) and execute (executor) so the whole write folds into ONE
+    # Decision chain.
+    corr = correlation_id or str(uuid4())
+
+    human_summary = summary or (
+        f"Create {len(norm_objects)} Fabric object(s) across "
+        f"{len(norm_types)} type(s) and {len(norm_links)} link(s)."
+    )
+
+    blob: dict[str, Any] = {
+        "kind": FABRIC_OBJECTS_KIND,
+        "schema": FABRIC_OBJECTS_SCHEMA,
+        "workspace_id": workspace_id,
+        "object_types": norm_types,
+        "objects": norm_objects,
+        "links": norm_links,
+        "requested_by": requested_by,
+        "summary": human_summary,
+        # RFC 09 chain-correlation fields (schema 1 carries them from the start).
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    title = (
+        f"Fabric ontology — {len(norm_objects)} object(s), "
+        f"{len(norm_types)} type(s), {len(norm_links)} link(s)"
+    )
+    recommendation = f"Approve to create the proposed Fabric ontology. {human_summary}"
+    trigger = ActionTrigger(
+        type="agent",
+        source=requested_by or "fabric_objects",
+        reason="proposed Fabric ontology requires approval",
+    )
+
+    store = get_instinct_store()
+    action_obj = await store.propose(
+        # ``pocket_id`` carries the workspace for Fabric-objects writes — they
+        # aren't bound to a pocket the way Mission Control items are (mirrors the
+        # external-action gate). The workspace also rides on the blob (the
+        # executor's tenancy gate reads it there); pocket_id mirrors it so the
+        # existing per-pocket queries still surface the row.
+        pocket_id=workspace_id,
+        title=title,
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.WORKFLOW,
+        priority=ActionPriority.MEDIUM,
+        parameters={FABRIC_OBJECTS_PARAM_KEY: blob},
+        assignee=assignee or requested_by or None,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "fabric_objects: proposed %d object(s) / %d type(s) / %d link(s) → "
+        "Instinct action %s (workspace=%s, correlation_id=%s)",
+        len(norm_objects),
+        len(norm_types),
+        len(norm_links),
+        action_obj.id,
+        workspace_id,
+        corr,
+    )
+
+    # Open the Decision-Graph chain now that the Action is stored. ``agent.
+    # proposed`` is the chain origin; its event id is back-written onto the blob
+    # so the router's ``human.corrected`` can cite it as causation. Best-effort:
+    # a Decision-Graph wiring failure must NOT fail the propose response.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        workspace_id=workspace_id,
+        user_id=requested_by,
+        type_count=len(norm_types),
+        object_count=len(norm_objects),
+        link_count=len(norm_links),
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+__all__ = [
+    "FABRIC_OBJECTS_KIND",
+    "FABRIC_OBJECTS_PARAM_KEY",
+    "FABRIC_OBJECTS_SCHEMA",
+    "propose_fabric_objects",
+]

--- a/ee/pocketpaw_ee/cloud/pocket_proposals/__init__.py
+++ b/ee/pocketpaw_ee/cloud/pocket_proposals/__init__.py
@@ -1,0 +1,32 @@
+# ee/cloud/pocket_proposals/__init__.py — the gated starter-Pocket-create Instinct
+# proposal type (a peer of ``_fabric_objects`` / ``_pocket_write`` /
+# ``_code_change`` / ``_external_action`` / ``_belt_plan`` / ``_artifact_change``).
+# Created: 2026-06-19 (SZD-5b — _pocket_create proposal type) — a proposed starter
+#   Pocket (a rippleSpec + name, optional template slug) staged for human review
+#   through the Instinct gate. "Sovereign zero-setup discovery" infers a starter
+#   Pocket for a tenant and proposes "create this Pocket"; a human approves or
+#   rejects in The Tray; on approve the executor creates the Pocket via the
+#   canonical, workspace-scoped ``pockets.service.create`` write path. Fully
+#   generic — no domain-specific logic.
+#
+# Re-exports the propose helper + the apply-on-approve executor so callers (the
+# discovery surface, the instinct router) import from the package root, mirroring
+# how the Fabric-objects gate is imported.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.pocket_proposals.executor import execute_approved_pocket_create
+from pocketpaw_ee.cloud.pocket_proposals.propose import (
+    POCKET_CREATE_KIND,
+    POCKET_CREATE_PARAM_KEY,
+    POCKET_CREATE_SCHEMA,
+    propose_pocket,
+)
+
+__all__ = [
+    "POCKET_CREATE_KIND",
+    "POCKET_CREATE_PARAM_KEY",
+    "POCKET_CREATE_SCHEMA",
+    "execute_approved_pocket_create",
+    "propose_pocket",
+]

--- a/ee/pocketpaw_ee/cloud/pocket_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/pocket_proposals/executor.py
@@ -1,0 +1,406 @@
+# ee/cloud/pocket_proposals/executor.py — apply an approved starter-Pocket create.
+# Created: 2026-06-19 (SZD-5b — _pocket_create Instinct proposal type).
+#
+# What this module does (the apply-on-approve half of the Pocket-create gate): the
+# propose helper (``pocket_proposals.propose.propose_pocket``) files an Instinct
+# Action carrying a ``_pocket_create`` blob THROUGH Instinct (the human
+# approve/reject layer). After a human approves the Action, the ee instinct
+# router's ``approve_action`` fires ``execute_approved_pocket_create`` here —
+# exactly mirroring how ``fabric_proposals.executor.execute_approved_fabric_objects``
+# is fired for a gated Fabric write. This function:
+#
+#   1. Reads the ``_pocket_create`` blob from ``action.parameters``. A missing blob
+#      → return (no chain was opened, nothing to close). A schema-mismatched blob →
+#      mark_failed + close the chain, return.
+#   2. Workspace guard — an empty ``workspace_id`` on the blob → mark_failed +
+#      close (a Pocket create with no tenant to scope it to is a tenancy hole).
+#   3. Idempotency guard — if the Action is already terminal (executed / failed) or
+#      the blob already carries an ``outcome``, the create is NOT re-run.
+#      Re-approve / retry never double-creates.
+#   4. Validates the staged spec at the entry to the create path:
+#      ``body = CreatePocketRequest.model_validate(blob["pocket_spec"])`` — a
+#      structurally invalid spec fails CLEANLY (mark_failed + close), not silently.
+#      Then ``await pockets.service.create(workspace_id, user_id, body)``, scoped
+#      by the blob's top-level ``workspace_id`` / owned by its top-level
+#      ``user_id`` (NOT anything inside ``pocket_spec`` — tenancy/owner are
+#      un-editable).
+#   5. Back-writes the outcome ``{status, pocket_id, name, executed_at}`` onto the
+#      persisted blob via the direct-SQL pattern.
+#   6. Records the result on the Action (``mark_executed`` / ``mark_failed``) and
+#      CLOSES the Decision-Graph chain exactly once.
+#
+# EXACTLY-ONE-TERMINAL discipline (critical): on APPROVE the EXECUTOR owns the
+# ``decision.completed`` chain close — the router does NOT emit it (mirrors the
+# Fabric-objects executor). On REJECT the ROUTER owns the close and the executor
+# never runs. Every terminal path here goes through the single ``_fail`` chokepoint
+# (failure) or the one success emit at the end — never both.
+#
+# Never raises — a failure here must not break the approve response. The router
+# wraps the call too; this is belt-and-braces. A create error is captured as
+# ``status=failed`` with a ``failed`` terminal, NOT re-raised.
+#
+# Security (this code creates a Pocket in a tenant's workspace on approval):
+#   * tenancy + owner are read off the blob's SEPARATE top-level ``workspace_id`` /
+#     ``user_id`` fields — NEVER off ``pocket_spec`` (which the correction flow can
+#     edit). An empty workspace_id is refused (a tenancy hole). The router's
+#     ``_assert_pocket_create_workspace`` is the primary gate; this is
+#     belt-and-braces.
+#   * the write primitive is the SHIPPED ``pockets.service.create`` — this module
+#     does NOT touch the Beanie document directly, so it inherits the proven
+#     workspace-scoped, validate-at-entry create path.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.pocket_proposals.propose import (
+    POCKET_CREATE_PARAM_KEY,
+    POCKET_CREATE_SCHEMA,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    summary: dict[str, Any],
+    executed_at: str,
+) -> None:
+    """Back-write the create outcome onto the persisted ``_pocket_create`` blob.
+
+    Direct SQL update — the same pattern the Fabric-objects executor's
+    ``_persist_outcome`` uses. The blob's ``outcome`` carries the created pocket id
+    + name + timestamp so a reader (audit, a re-invocation idempotency check) sees
+    the result structurally. Best-effort: a write failure leaves the blob without
+    the structured outcome but the free-text ``mark_executed`` / ``mark_failed``
+    outcome still records it.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(POCKET_CREATE_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {"status": status, "executed_at": executed_at, **summary}
+        params[POCKET_CREATE_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "pocket_create: failed to persist outcome onto action %s — the "
+            "structured outcome is unavailable (free-text outcome still recorded)",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a Pocket create.
+
+    Mirrors ``fabric_proposals.executor._emit_chain_close`` — the executor owns the
+    chain close on the approve path. ``correlation_id`` is read off the blob;
+    ``causation_id`` is the ``human.corrected`` event the router emitted just
+    before approval so the terminal chains back to the human approval.
+
+    Returns early when ``correlation_id`` is None (a blob with a malformed /
+    missing id): there is no chain to close. Best-effort: a Decision-Graph wiring
+    failure must never break the approve response — the journal write is the source
+    of truth; the Slice 4 reconciler is the safety net.
+    """
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if summary:
+        payload["summary"] = summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "pocket_create decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this Pocket create already ran.
+
+    Two signals, either is sufficient:
+      * the blob already carries an ``outcome`` (a prior run back-wrote it), or
+      * the Action is already in a terminal state (executed / failed).
+
+    Re-invocation (bulk re-approve, retry) must never re-run the create — a Pocket
+    create has no natural idempotency key (each call mints a fresh pocket id), so
+    the Action's terminal ``status`` + the back-written outcome are the ONLY guard
+    against a double-create. The Action's ``status`` is the authoritative gate, and
+    the back-written outcome is the belt-and-braces signal in case status reads are
+    stale.
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+async def execute_approved_pocket_create(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """Create the starter Pocket carried by a freshly-approved Action.
+
+    Called best-effort from the instinct router's ``approve_action`` /
+    ``bulk_approve_actions`` after ``store.approve()`` succeeds — the same hook
+    shape the Fabric-objects executor uses. ``action`` is the approved Action.
+
+    ``human_event_id`` is the id of the ``human.corrected`` event the router
+    emitted just before calling this — threaded through so the terminal
+    ``decision.completed`` event can chain its ``causation_id`` back to the
+    approval, completing the causal walk ``agent.proposed → human.corrected →
+    decision.completed``. ``None`` is tolerated (the chain still folds via the
+    shared ``correlation_id``).
+
+    Never raises — a failure here must not break the approve response. The router
+    wraps the call too; this is belt-and-braces. The Action is marked executed on a
+    successful create or failed with a clear outcome on any error, and the
+    Decision-Graph chain is closed exactly once (success → landed, failure →
+    failed).
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(POCKET_CREATE_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not a pocket-create Action at all — no chain was opened for it, so there
+        # is nothing to close. Return without a terminal emit.
+        logger.warning("approved action %s carries no _pocket_create blob", action.id)
+        return
+
+    # Read the chain ids + tenancy/owner off the blob up front so EVERY terminal
+    # path can close the chain it opened. Tenancy/owner come from the SEPARATE
+    # top-level fields — NEVER from ``pocket_spec`` (which the correction flow can
+    # edit). A malformed / missing correlation id → None and the close no-ops (the
+    # Slice 4 abandon-sweeper closes any chain left open).
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    owner_user_id = str(blob.get("user_id") or "")
+    approver = str(getattr(action, "approved_by", "") or "") or owner_user_id or "system"
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Mark the Action failed AND close the chain with one terminal — the
+        single failure-path chokepoint so a path can never both fail and
+        double-fire the terminal."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            summary={"reason": reason},
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=approver,
+            causation_id=causation,
+            summary=reason,
+        )
+
+    # Schema guard — a stale blob from an incompatible build fails loud rather than
+    # creating a misinterpreted Pocket.
+    if blob.get("schema") != POCKET_CREATE_SCHEMA:
+        await _fail(
+            "pocket-create schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    # Tenancy — a Pocket create with no workspace is a tenancy hole. The Pocket is
+    # created scoped by workspace_id; fail loud so a malformed blob is recorded, not
+    # silently created unscoped.
+    if not workspace_id:
+        await _fail(
+            "pocket-create blob carries no workspace_id — cannot scope the create",
+            error_class="MissingWorkspace",
+        )
+        return
+    if not owner_user_id:
+        await _fail(
+            "pocket-create blob carries no user_id — cannot assign an owner",
+            error_class="MissingOwner",
+        )
+        return
+
+    # Idempotency — never re-run the create on a re-invocation.
+    if _already_executed(action, blob):
+        logger.info(
+            "pocket_create: action %s already executed (idempotency guard) — "
+            "skipping the Pocket create",
+            action.id,
+        )
+        return
+
+    pocket_spec = blob.get("pocket_spec")
+    if not isinstance(pocket_spec, dict):
+        await _fail(
+            "pocket-create blob carries no pocket_spec to create",
+            error_class="MalformedBlob",
+        )
+        return
+
+    # Validate the staged spec at the entry to the create path — a structurally
+    # invalid spec (e.g. a missing/blank name) fails CLEANLY here rather than
+    # blowing up inside the service. ``CreatePocketRequest`` carries the camelCase
+    # aliases (``rippleSpec`` / ``templateSlug``) with populate_by_name=True, so a
+    # spec authored with either spelling resolves.
+    try:
+        from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+        body = CreatePocketRequest.model_validate(pocket_spec)
+    except Exception as exc:  # noqa: BLE001 — a bad spec is a failed outcome, not a crash
+        await _fail(
+            f"pocket-create spec is invalid: {exc}",
+            error_class=type(exc).__name__,
+        )
+        return
+
+    # Create the Pocket through the SHIPPED service, scoped by the blob's top-level
+    # workspace_id / owned by its top-level user_id. Any failure (validation inside
+    # the service, store error) is captured as a failed outcome — NEVER re-raised
+    # into the router.
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        created = await pockets_service.create(workspace_id, owner_user_id, body)
+    except Exception as exc:  # noqa: BLE001 — never let a create break approve
+        logger.warning(
+            "pocket_create: create crashed for action %s (workspace=%s)",
+            action.id,
+            workspace_id,
+            exc_info=True,
+        )
+        await _fail(
+            f"pocket create failed: {exc}",
+            error_class=type(exc).__name__,
+        )
+        return
+
+    # The pockets wire dict carries the id under the legacy ``_id`` key (with
+    # ``id`` accepted as a fallback for any future wire-shape change) and the
+    # tenant under ``workspace``.
+    created_dict = created or {}
+    pocket_id = str(created_dict.get("_id") or created_dict.get("id") or "")
+    pocket_name = str(created_dict.get("name") or body.name)
+    summary = {"pocket_id": pocket_id, "name": pocket_name}
+
+    # Success — mark executed, back-write the structured outcome, close the chain.
+    await store.mark_executed(
+        action.id,
+        f"starter Pocket created: {pocket_name!r} (id={pocket_id})",
+    )
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        summary=summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    # Close the chain on the SUCCESS path. This is the ONLY terminal on the happy
+    # path (every failure path above closed via ``_fail`` and returned), so exactly
+    # one ``decision.completed`` lands per create.
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=approver,
+        causation_id=causation,
+        summary=f"created Pocket {pocket_name!r} (id={pocket_id})",
+    )
+    logger.info(
+        "pocket_create: executed action %s → created Pocket %s (%r) (ok)",
+        action.id,
+        pocket_id,
+        pocket_name,
+    )
+
+
+__all__ = ["execute_approved_pocket_create"]

--- a/ee/pocketpaw_ee/cloud/pocket_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/pocket_proposals/propose.py
@@ -1,0 +1,386 @@
+# ee/cloud/pocket_proposals/propose.py — propose a gated starter-Pocket create.
+# Created: 2026-06-19 (SZD-5b — _pocket_create Instinct proposal type).
+#
+# What this module does (the propose half of the Pocket-create gate): "sovereign
+# zero-setup discovery" stages a PROPOSED starter Pocket — a rippleSpec + name (an
+# optional template slug) it inferred for a tenant — for a human to review through
+# the Instinct gate before any Pocket is created. This files an Instinct ``Action``
+# carrying a ``_pocket_create`` blob (schema 1) under ``Action.parameters``. A
+# human approves it in The Tray; the apply-on-approve executor
+# (``pocket_proposals.executor.execute_approved_pocket_create``) then creates the
+# Pocket via the canonical ``pockets.service.create`` write path. This module does
+# NOT create a Pocket — it only gates.
+#
+# The blob is the gated Pocket-create kind, sitting alongside the Fabric-objects
+# gate's ``_fabric_objects`` (SZD-5a), the pocket-write bridge's ``_pocket_write``,
+# the Belt develop-station's ``_code_change``, the external-action gate's
+# ``_external_action``, the mandate foreman's ``_belt_plan``, and the
+# Branch-primitive merge gate's ``_artifact_change``. The router + executor
+# dispatch on the presence of the ``_pocket_create`` parameters key (the Action
+# model has no literal ``kind`` column; the blob also carries
+# ``kind="pocket_create"`` for readers that introspect it).
+#
+# Schema 1 (this is the first version — the schema-version pattern is replicated
+# from ``fabric_proposals.propose.FABRIC_OBJECTS_SCHEMA`` /
+# ``external_actions.propose.EXTERNAL_ACTION_SCHEMA``, starting at 1). The blob
+# carries:
+#   * ``schema`` / ``kind`` — version + discriminator;
+#   * ``workspace_id`` — the originating tenant. The executor's tenancy gate reads
+#     it HERE; a proposed Pocket isn't bound to an EXISTING pocket the way a parked
+#     write is, so tenancy lives entirely on the blob — and the new Pocket is
+#     created scoped to this workspace. SECURITY: this is a SEPARATE top-level
+#     blob field, NOT nested inside ``pocket_spec`` — the correction/edit flow
+#     diffs the proposal's editable shape, so keeping tenancy out of the editable
+#     spec means a tenant editing the proposal cannot move it to another
+#     workspace.
+#   * ``user_id`` — the approver/owner the Pocket is created under. Also a SEPARATE
+#     top-level blob field for the same reason: the owner cannot be edited via the
+#     correction flow (a tenant can't reassign ownership of the staged Pocket).
+#   * ``pocket_spec`` — the staged ``CreatePocketRequest`` body the executor
+#     model_validates: ``{ripple_spec, name, template_slug?}`` plus any other
+#     CreatePocketRequest-shaped fields (description, type, icon, color, ...). This
+#     is the ONLY part of the blob that a correction edit may legitimately touch.
+#   * ``summary`` — a human-readable one-liner for the gate UI (The Tray);
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids,
+#     minted here at propose time (``agent.proposed`` opens the chain). The
+#     router's approve / reject paths and the executor close the SAME chain.
+#
+# Security:
+#   * NO Pocket is created here — the spec is staged as DATA on the blob and only
+#     materialised after a human approves.
+#   * Tenancy + owner are bound on SEPARATE top-level blob fields (NOT in the
+#     editable ``pocket_spec``) so the correction flow cannot move ownership /
+#     workspace. They are bound on the router's approve / reject paths via
+#     ``_assert_pocket_create_workspace`` and re-validated at execution (the Pocket
+#     is created scoped by the blob's ``workspace_id`` / owned by ``user_id``). A
+#     cross-workspace approve OR reject is refused — asymmetric tenant scope is no
+#     tenant scope (pocketpaw#1183 / #1250).
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator for a Pocket-create proposal. The router
+# + executor dispatch on the presence of the parameters key below; the blob also
+# carries ``kind="pocket_create"`` for readers that introspect it.
+POCKET_CREATE_KIND = "pocket_create"
+
+# The parameters key under which the Pocket-create blob rides — peer of the
+# Fabric-objects gate's ``_fabric_objects``, the pocket-write bridge's
+# ``_pocket_write``, belt's ``_code_change``, and the external-action gate's
+# ``_external_action``. The router + executor dispatch on this key being present.
+POCKET_CREATE_PARAM_KEY = "_pocket_create"
+
+# Schema version stamped on the ``_pocket_create`` blob. Bump when the blob shape
+# changes so a stale pending Action approved after a deploy fails loud instead of
+# creating a misinterpreted Pocket (same discipline as the Fabric-objects gate's
+# ``FABRIC_OBJECTS_SCHEMA``). Starts at 1 — first version.
+POCKET_CREATE_SCHEMA = 1
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    workspace_id: str,
+    user_id: str,
+    name: str,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a Pocket create.
+
+    Mirrors ``fabric_proposals.propose._emit_agent_proposed``: the proposing
+    caller is the actor (``kind="agent"`` with the requesting user on its id, the
+    workspace on its scope_context). A proposed Pocket isn't bound to an EXISTING
+    pocket — its tenancy is the workspace — so ``pocket_id`` on the chain carries
+    the workspace id (matching how the Action's ``pocket_id`` field carries the
+    workspace).
+
+    Returns the emitted event id so the caller can persist it on the blob's
+    ``proposed_event_id`` field for the ``human.corrected`` causation chain, or
+    ``None`` when the emit raised — best-effort per RFC 09; the Slice 4 reconciler
+    picks up any orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"create the starter Pocket {name!r}"
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "pocket_create",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator.
+        "proposal_kind": "pocket_create",
+        "proposal": {"name": name},
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "pocket_create agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
+    Action's ``parameters._pocket_create`` blob after ``agent.proposed`` fired.
+
+    The blob is built with ``correlation_id`` already set (minted before build);
+    ``proposed_event_id`` is the field this back-write fills in. Direct SQL update
+    — the same pattern the Fabric-objects gate's ``_persist_chain_ids`` uses.
+    Best-effort: a write failure leaves ``proposed_event_id`` None and the eventual
+    ``human.corrected`` emits without a causation_id (the chain still folds;
+    causation_id is optional on EventEntry).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(POCKET_CREATE_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[POCKET_CREATE_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "pocket_create: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _normalize_pocket_spec(
+    *,
+    ripple_spec: dict[str, Any] | None,
+    name: str,
+    template_slug: str | None,
+    extra: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the staged ``pocket_spec`` — the editable ``CreatePocketRequest``
+    body the executor model_validates.
+
+    Carries ``name`` (required), ``rippleSpec`` (camelCase alias — kept as-is so
+    ``CreatePocketRequest.model_validate`` resolves it via the alias), and the
+    optional ``templateSlug``. Any ``extra`` keys (description, type, icon, color,
+    visibility, ...) are merged in so a richer starter Pocket can be staged — but
+    ``workspace_id`` / ``user_id`` are NEVER placed here (they ride as separate
+    top-level blob fields so the correction flow can't edit tenancy/owner).
+
+    SECURITY: tenancy keys are stripped from ``extra`` defensively — even if a
+    caller passes ``workspace``/``workspace_id``/``owner``/``user_id`` in extra,
+    they never reach the editable spec.
+    """
+    spec: dict[str, Any] = {}
+    for k, v in (extra or {}).items():
+        # Never let a tenancy/owner key sneak into the editable spec.
+        if k in {"workspace", "workspace_id", "owner", "user_id"}:
+            continue
+        spec[k] = v
+    spec["name"] = name
+    if ripple_spec is not None:
+        # Use the camelCase alias so model_validate resolves it; the DTO sets
+        # populate_by_name=True so either spelling works, but the alias is the
+        # canonical wire shape.
+        spec["rippleSpec"] = ripple_spec
+    if template_slug:
+        spec["templateSlug"] = template_slug
+    return spec
+
+
+async def propose_pocket(
+    *,
+    workspace_id: str,
+    user_id: str,
+    ripple_spec: dict[str, Any] | None = None,
+    name: str,
+    template_slug: str | None = None,
+    extra: dict[str, Any] | None = None,
+    summary: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+) -> str:
+    """Build + store an Instinct ``Action`` for a gated starter-Pocket create.
+
+    Files an Action carrying the ``_pocket_create`` blob (schema 1) and opens the
+    Decision-Graph chain (``agent.proposed``). Returns the proposed Action id. NO
+    Pocket is created here — the spec is staged as DATA and only materialised after
+    a human approves.
+
+    Args:
+        workspace_id: the originating tenant. Bound on the router's approve /
+            reject paths and re-validated at execution; the Pocket is created
+            scoped to it. Required — a Pocket create with no tenant is a tenancy
+            hole. Rides as a SEPARATE top-level blob field (NOT in ``pocket_spec``)
+            so the correction flow can't move it.
+        user_id: the approver/owner the Pocket is created under. Required. Also a
+            SEPARATE top-level blob field — the owner can't be edited via the
+            correction flow.
+        ripple_spec: the staged rippleSpec for the new Pocket. Optional — a
+            template-only proposal can omit it (the template compiles into the spec
+            at create time). Stored under the ``rippleSpec`` camelCase alias inside
+            ``pocket_spec``.
+        name: the new Pocket's name. Required + non-empty.
+        template_slug: an optional bundled-template slug to compile-on-install.
+        extra: optional additional ``CreatePocketRequest`` fields (description,
+            type, icon, color, visibility, ...) merged into the staged spec.
+            Tenancy/owner keys are stripped defensively.
+        summary: a human-readable one-liner for the gate UI. Defaults to a sensible
+            one built from the name.
+        correlation_id: an optional pre-minted chain id. When omitted a fresh one
+            is minted here (the common case).
+        assignee: the workspace member who should approve. Defaults to ``user_id``
+            so the proposer's queue carries it.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_pocket requires a non-empty workspace_id")
+    user_id = str(user_id or "")
+    if not user_id:
+        raise ValueError("propose_pocket requires a non-empty user_id (the owner)")
+    name = str(name or "").strip()
+    if not name:
+        raise ValueError("propose_pocket requires a non-empty name")
+
+    pocket_spec = _normalize_pocket_spec(
+        ripple_spec=ripple_spec,
+        name=name,
+        template_slug=template_slug,
+        extra=extra,
+    )
+
+    # Mint the chain correlation_id BEFORE building the blob so the stored Action
+    # carries it from the first write. The same id threads through approve / reject
+    # (router) and execute (executor) so the whole create folds into ONE Decision
+    # chain.
+    corr = correlation_id or str(uuid4())
+
+    human_summary = summary or f"Create the starter Pocket {name!r}."
+
+    blob: dict[str, Any] = {
+        "kind": POCKET_CREATE_KIND,
+        "schema": POCKET_CREATE_SCHEMA,
+        # Tenancy + owner are SEPARATE top-level fields (NOT in pocket_spec) so the
+        # correction/edit flow can never change them.
+        "workspace_id": workspace_id,
+        "user_id": user_id,
+        # The editable staged CreatePocketRequest body.
+        "pocket_spec": pocket_spec,
+        "summary": human_summary,
+        # RFC 09 chain-correlation fields (schema 1 carries them from the start).
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    title = f"Starter Pocket — {name}"
+    recommendation = f"Approve to create the proposed starter Pocket. {human_summary}"
+    trigger = ActionTrigger(
+        type="agent",
+        source=user_id or "pocket_create",
+        reason="proposed starter Pocket requires approval",
+    )
+
+    store = get_instinct_store()
+    action_obj = await store.propose(
+        # ``pocket_id`` carries the workspace for Pocket-create proposals — they
+        # aren't bound to an EXISTING pocket the way Mission Control items are
+        # (mirrors the Fabric-objects gate). The workspace also rides on the blob
+        # (the executor's tenancy gate reads it there); pocket_id mirrors it so the
+        # existing per-pocket queries still surface the row.
+        pocket_id=workspace_id,
+        title=title,
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.WORKFLOW,
+        priority=ActionPriority.MEDIUM,
+        parameters={POCKET_CREATE_PARAM_KEY: blob},
+        assignee=assignee or user_id or None,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "pocket_create: proposed starter Pocket %r → Instinct action %s "
+        "(workspace=%s, owner=%s, correlation_id=%s)",
+        name,
+        action_obj.id,
+        workspace_id,
+        user_id,
+        corr,
+    )
+
+    # Open the Decision-Graph chain now that the Action is stored. ``agent.
+    # proposed`` is the chain origin; its event id is back-written onto the blob so
+    # the router's ``human.corrected`` can cite it as causation. Best-effort: a
+    # Decision-Graph wiring failure must NOT fail the propose response.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=name,
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+__all__ = [
+    "POCKET_CREATE_KIND",
+    "POCKET_CREATE_PARAM_KEY",
+    "POCKET_CREATE_SCHEMA",
+    "propose_pocket",
+]

--- a/ee/pocketpaw_ee/cloud/ripple_sources.py
+++ b/ee/pocketpaw_ee/cloud/ripple_sources.py
@@ -6,6 +6,18 @@ live here, next to the entities they read.
 
 Tenancy rule (from CLAUDE.md ee/cloud rule 7): every Mongo read MUST
 scope by ctx.workspace_id.
+
+Updated 2026-06-19 (SZD-1 — fabric.objects ripple source): added two
+Fabric-backed sources so a rippleSpec can render discovered Fabric data, not
+just pockets/members. ``fabric.objects`` resolves an ``ObjectType`` (by
+``type_id`` and/or ``type_name``) into widget rows; ``fabric.query`` is the
+filtered variant (same args plus a ``filters`` bag). Both are workspace-scoped
+by handing ``ctx.workspace_id`` to ``FabricStore.query`` — the store applies
+its own ``workspace_id = ? OR workspace_id IS NULL`` tenant guard (W4a), so a
+spec in workspace A can never surface workspace B's objects. The store is the
+local SQLite Fabric DB (``~/.pocketpaw/fabric.db`` via ``get_fabric_store``),
+NOT Mongo, so the "every Mongo read scopes by workspace" rule is satisfied here
+by the SQLite tenant scope instead — same invariant, different store.
 """
 
 from __future__ import annotations
@@ -113,3 +125,129 @@ async def _workspace_members(ctx: ResolveCtx, args: dict[str, Any]) -> list[dict
         logger.warning("ripple_resolver: workspace.members called with empty workspace_id")
         return []
     return await _list_workspace_members(ctx.workspace_id)
+
+
+# Hard cap on rows a single Fabric source resolution returns into a spec — a
+# ripple widget renders client-side, so an unbounded type with thousands of
+# objects would bloat the resolved spec and the wire payload. The caller can
+# request fewer via ``limit``; this is the ceiling, mirroring the fabric MCP
+# tool's MAX_QUERY_LIMIT spirit.
+_FABRIC_SOURCE_MAX_ROWS = 500
+
+
+def _fabric_object_to_row(obj: Any) -> dict[str, Any]:
+    """Project a FabricObject into a flat widget row.
+
+    The object's JSON ``properties`` bag is spread to the top level so a
+    column-oriented widget (table, kanban, list) can bind directly to property
+    names, with ``id`` / ``type_id`` / ``type_name`` and provenance kept on
+    reserved keys. A property literally named one of the reserved keys would be
+    shadowed; that's an acceptable, documented edge — reserved keys win so the
+    row always carries a stable id.
+    """
+    row: dict[str, Any] = dict(obj.properties or {})
+    row.update(
+        {
+            "id": obj.id,
+            "type_id": obj.type_id,
+            "type_name": obj.type_name,
+            "source_connector": obj.source_connector,
+            "source_id": obj.source_id,
+        }
+    )
+    return row
+
+
+async def _resolve_fabric_objects(
+    ctx: ResolveCtx, args: dict[str, Any], *, allow_filters: bool
+) -> list[dict[str, Any]]:
+    """Shared resolver for the ``fabric.objects`` / ``fabric.query`` sources.
+
+    Builds a :class:`FabricQuery` from ``args`` and runs it scoped to
+    ``ctx.workspace_id``. Workspace scoping is NOT optional here: a missing
+    workspace returns ``[]`` rather than an unscoped (cross-tenant) read, so a
+    spec resolved without workspace context can never leak the whole instance's
+    objects. ``allow_filters`` gates the property-filter bag — ``fabric.objects``
+    is the simple "all rows of a type" source, ``fabric.query`` adds filters.
+    """
+    if not ctx.workspace_id:
+        logger.warning(
+            "ripple_resolver: fabric source called with empty workspace_id (pocket=%s)",
+            ctx.pocket_id,
+        )
+        return []
+
+    type_id = args.get("type_id")
+    type_name = args.get("type_name")
+    if not type_id and not type_name:
+        logger.warning(
+            "ripple_resolver: fabric source needs a type_id or type_name "
+            "(workspace=%s pocket=%s)",
+            ctx.workspace_id,
+            ctx.pocket_id,
+        )
+        return []
+    # Reject non-string identifiers up front — FabricQuery would coerce/raise,
+    # but a clean empty result keeps a malformed spec from bricking the canvas.
+    if type_id is not None and not isinstance(type_id, str):
+        logger.warning("ripple_resolver: fabric source type_id must be a string")
+        return []
+    if type_name is not None and not isinstance(type_name, str):
+        logger.warning("ripple_resolver: fabric source type_name must be a string")
+        return []
+
+    raw_limit = args.get("limit", _FABRIC_SOURCE_MAX_ROWS)
+    limit = raw_limit if isinstance(raw_limit, int) and raw_limit > 0 else _FABRIC_SOURCE_MAX_ROWS
+    limit = min(limit, _FABRIC_SOURCE_MAX_ROWS)
+    raw_offset = args.get("offset", 0)
+    offset = raw_offset if isinstance(raw_offset, int) and raw_offset >= 0 else 0
+
+    filters = args.get("filters") if allow_filters else None
+    if filters is not None and not isinstance(filters, dict):
+        logger.warning("ripple_resolver: fabric.query filters must be a JSON object")
+        return []
+
+    # Lazy imports keep the resolver free of a hard Fabric dependency at module
+    # import time and mirror the fabric MCP tool's availability guard.
+    from pocketpaw.fabric.models import FabricQuery
+    from pocketpaw.stores import get_fabric_store
+
+    store = get_fabric_store()
+    q = FabricQuery(
+        type_id=type_id,
+        type_name=type_name,
+        filters=filters or {},
+        limit=limit,
+        offset=offset,
+    )
+    # workspace_id is threaded as a PLAIN str from the server-built ctx (never
+    # from the spec), so the store applies its W4a tenant scope: only this
+    # workspace's rows (plus legacy NULL-workspace rows) come back.
+    result = await store.query(q, workspace_id=ctx.workspace_id)
+    return [_fabric_object_to_row(obj) for obj in result.objects]
+
+
+@register("fabric.objects")
+async def _fabric_objects(ctx: ResolveCtx, args: dict[str, Any]) -> list[dict[str, Any]]:
+    """Resolve an ObjectType into widget rows, workspace-scoped (SZD-1).
+
+    Args: ``type_id`` and/or ``type_name`` (at least one required), optional
+    ``limit`` / ``offset``. Returns one row per object of that type in the
+    caller's workspace, the JSON properties spread to the top level (see
+    :func:`_fabric_object_to_row`). This is the source the "sovereign zero-setup
+    discovery" starter-Pocket binds to so it renders discovered Fabric data.
+    """
+    return await _resolve_fabric_objects(ctx, args, allow_filters=False)
+
+
+@register("fabric.query")
+async def _fabric_query(ctx: ResolveCtx, args: dict[str, Any]) -> list[dict[str, Any]]:
+    """Filtered variant of ``fabric.objects`` (SZD-1).
+
+    Same args as ``fabric.objects`` plus a ``filters`` bag (the exact
+    ``FabricQuery.filters`` shape: ``{"status": "active"}`` for equality,
+    ``{"rent": {">": 1000}}`` for comparison). Still workspace-scoped — the
+    store binds every filter value as a parameter, so there is no injection
+    surface from a spec-supplied filter.
+    """
+    return await _resolve_fabric_objects(ctx, args, allow_filters=True)

--- a/ee/pocketpaw_ee/discovery/__init__.py
+++ b/ee/pocketpaw_ee/discovery/__init__.py
@@ -6,8 +6,11 @@
 # turns into FabricMapping objects (for fabric_ingest.ingest_records) and a
 # fabric-objects proposal (object_types + objects + links).
 #
-# Pure logic: no DB, no network, no async. The first impl is
-# ``StructuredShapeDigester`` (structured ``{type: [records]}`` input).
+# The digester is pure logic (no DB, no network, no async); the first impl is
+# ``StructuredShapeDigester`` (structured ``{type: [records]}`` input). The
+# ``DiscoveryRun`` orchestrator (SZD-4) ties sampling → digest together: it reads
+# a workspace's bound connectors via the pocket-less ``ensure_connected(name,
+# "ws:<workspace_id>")`` path and feeds the sampled records to the digester.
 
 from __future__ import annotations
 
@@ -18,6 +21,12 @@ from pocketpaw_ee.discovery.models import (
     DraftObjectType,
     OntologyDraft,
 )
+from pocketpaw_ee.discovery.run import (
+    DEFAULT_SAMPLE_CAP,
+    DiscoveryRun,
+    DiscoveryRunOptions,
+    ReadAction,
+)
 
 __all__ = [
     "Digester",
@@ -26,4 +35,8 @@ __all__ = [
     "DraftObjectType",
     "DraftObject",
     "DraftLink",
+    "DiscoveryRun",
+    "DiscoveryRunOptions",
+    "ReadAction",
+    "DEFAULT_SAMPLE_CAP",
 ]

--- a/ee/pocketpaw_ee/discovery/__init__.py
+++ b/ee/pocketpaw_ee/discovery/__init__.py
@@ -1,0 +1,29 @@
+# pocketpaw_ee/discovery/ — sovereign zero-setup ontology discovery (digesters).
+#
+# Created: 2026-06-19 (SZD-3 / feat/szd-3-digester) — the digester layer for
+# sovereign zero-setup discovery. A Digester samples a connector's records and
+# reverse-engineers a candidate ontology (an OntologyDraft) that downstream code
+# turns into FabricMapping objects (for fabric_ingest.ingest_records) and a
+# fabric-objects proposal (object_types + objects + links).
+#
+# Pure logic: no DB, no network, no async. The first impl is
+# ``StructuredShapeDigester`` (structured ``{type: [records]}`` input).
+
+from __future__ import annotations
+
+from pocketpaw_ee.discovery.digester import Digester, StructuredShapeDigester
+from pocketpaw_ee.discovery.models import (
+    DraftLink,
+    DraftObject,
+    DraftObjectType,
+    OntologyDraft,
+)
+
+__all__ = [
+    "Digester",
+    "StructuredShapeDigester",
+    "OntologyDraft",
+    "DraftObjectType",
+    "DraftObject",
+    "DraftLink",
+]

--- a/ee/pocketpaw_ee/discovery/__init__.py
+++ b/ee/pocketpaw_ee/discovery/__init__.py
@@ -11,6 +11,12 @@
 # ``DiscoveryRun`` orchestrator (SZD-4) ties sampling → digest together: it reads
 # a workspace's bound connectors via the pocket-less ``ensure_connected(name,
 # "ws:<workspace_id>")`` path and feeds the sampled records to the digester.
+#
+# Updated 2026-06-19 (SZD-6 / feat/szd-6-integration): added the orchestrate
+# layer (``run_discovery_and_propose`` + ``assemble_discovery_pocket``) that wires
+# a DiscoveryRun's OntologyDraft into the two gated Instinct proposals (Fabric
+# objects + a starter Pocket) a human reviews, with key-confidence gating and
+# supersede-on-rerun.
 
 from __future__ import annotations
 
@@ -20,6 +26,13 @@ from pocketpaw_ee.discovery.models import (
     DraftObject,
     DraftObjectType,
     OntologyDraft,
+)
+from pocketpaw_ee.discovery.orchestrate import (
+    DISCOVERY_MARKER_KEY,
+    KEY_CONFIDENCE_FLOOR,
+    DiscoveryProposalResult,
+    assemble_discovery_pocket,
+    run_discovery_and_propose,
 )
 from pocketpaw_ee.discovery.run import (
     DEFAULT_SAMPLE_CAP,
@@ -39,4 +52,9 @@ __all__ = [
     "DiscoveryRunOptions",
     "ReadAction",
     "DEFAULT_SAMPLE_CAP",
+    "run_discovery_and_propose",
+    "assemble_discovery_pocket",
+    "DiscoveryProposalResult",
+    "KEY_CONFIDENCE_FLOOR",
+    "DISCOVERY_MARKER_KEY",
 ]

--- a/ee/pocketpaw_ee/discovery/digester.py
+++ b/ee/pocketpaw_ee/discovery/digester.py
@@ -1,0 +1,486 @@
+# pocketpaw_ee/discovery/digester.py — the Digester interface + StructuredShapeDigester.
+#
+# Created: 2026-06-19 (SZD-3 / feat/szd-3-digester) — sovereign zero-setup
+# discovery reverse-engineers a candidate ontology from sampled connector
+# records. This module is the digester: structured records → an OntologyDraft.
+#
+# ``Digester`` is a Protocol: ``digest(records, connector_meta) -> OntologyDraft``.
+# ``StructuredShapeDigester`` is the structured-record implementation:
+#
+#   * records arrive as ``{type_name: [record_dict, ...]}`` (one list per
+#     source/type), the natural shape a connector sampler produces;
+#   * object types come from the field shapes; property types from value types
+#     (str / int / float / bool / datetime-ish), aggregated across the sample;
+#   * the primary key is inferred per type — prefer a field named
+#     ``id`` / ``_id`` / ``<type>_id`` / ``<type>id``, else the highest-cardinality
+#     unique field — with confidence reflecting the signal strength;
+#   * links are inferred from fields whose values match another type's keys
+#     (a foreign-key shape).
+#
+# Pure logic: no DB, no network, no async. Depends only on stdlib + pydantic +
+# the OSS PropertyDef / discovery models. Unit-testable in isolation.
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime
+from typing import Any, Protocol, runtime_checkable
+
+from pocketpaw.fabric.models import PropertyDef
+from pocketpaw_ee.discovery.models import (
+    DraftLink,
+    DraftObject,
+    DraftObjectType,
+    OntologyDraft,
+    _clamp,
+)
+
+# Field names that strongly signal a primary key, in priority order. ``{type}``
+# is substituted with the (lowercased) type name at inference time so that, e.g.
+# ``customer_id`` on the ``Customer`` type beats a generic high-cardinality field.
+_KEY_NAME_PRIORITY = ("id", "_id", "{type}_id", "{type}id", "uid", "uuid", "key", "pk")
+
+# ISO-8601-ish date / datetime detection (cheap, no parsing libs). Matches
+# "2026-06-19", "2026-06-19T22:00:00", "2026-06-19 22:00:00Z", etc.
+_DATETIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}"  # date
+    r"([T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$"  # optional time
+)
+
+# Common foreign-key suffixes used when matching a field on type A to the key of
+# type B (e.g. ``customer_id`` -> ``Customer``).
+_FK_SUFFIXES = ("_id", "id", "_ref", "_key", "_uid")
+
+
+@runtime_checkable
+class Digester(Protocol):
+    """Reverse-engineers a candidate ontology from sampled connector records.
+
+    Implementations take a record sample (shape is implementation-defined; the
+    structured digester expects ``{type_name: [record, ...]}``) plus connector
+    metadata, and return an :class:`OntologyDraft` that downstream code can turn
+    into ``FabricMapping`` objects and a fabric-objects proposal.
+    """
+
+    def digest(
+        self,
+        records: Any,
+        connector_meta: Mapping[str, Any] | None = None,
+    ) -> OntologyDraft: ...
+
+
+def _is_datetimeish(value: Any) -> bool:
+    """True if a value looks like a date/datetime (native or ISO-ish string)."""
+    if isinstance(value, (datetime, date)):
+        return True
+    if isinstance(value, str):
+        return bool(_DATETIME_RE.match(value.strip()))
+    return False
+
+
+def _scalar_type(value: Any) -> str | None:
+    """Map a single value to a PropertyDef type, or None if not a clean scalar.
+
+    Returns one of: ``"date"``, ``"boolean"``, ``"number"``, ``"string"``.
+    ``None`` for nulls (carry no type signal) and for nested/polymorphic shapes
+    (dict / list) — those are recorded as ``"string"`` at the type level but do
+    not vote on a clean scalar type.
+    """
+    if value is None:
+        return None
+    # bool is a subclass of int — check it first.
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, (datetime, date)):
+        return "date"
+    if isinstance(value, str):
+        return "date" if _is_datetimeish(value) else "string"
+    # dict / list / other — nested or polymorphic; no clean scalar vote.
+    return None
+
+
+def _hashable(value: Any) -> Any:
+    """Return a hashable surrogate for a value (for cardinality counting).
+
+    Nested / unhashable values (dict, list) collapse to their repr so they can
+    still be counted without crashing — they just won't be good key candidates.
+    """
+    try:
+        hash(value)
+        return value
+    except TypeError:
+        return repr(value)
+
+
+class _FieldStats:
+    """Accumulates per-field signal across a type's record sample."""
+
+    __slots__ = ("type_votes", "present", "non_null", "values", "distinct")
+
+    def __init__(self) -> None:
+        self.type_votes: Counter[str] = Counter()
+        self.present = 0  # records where the key is present (even if null)
+        self.non_null = 0  # records with a non-null value
+        # distinct non-null hashable values (capped implicitly by sample size)
+        self.distinct: set[Any] = set()
+        # the raw non-null values seen, for FK matching (capped surrogate)
+        self.values: list[Any] = []
+
+    def observe(self, value: Any) -> None:
+        self.present += 1
+        if value is None:
+            return
+        self.non_null += 1
+        vt = _scalar_type(value)
+        if vt is not None:
+            self.type_votes[vt] += 1
+        else:
+            # nested / polymorphic — record as string so the property still types.
+            self.type_votes["string"] += 1
+        h = _hashable(value)
+        self.distinct.add(h)
+        self.values.append(h)
+
+    @property
+    def cardinality_ratio(self) -> float:
+        """distinct / non_null — 1.0 means every value is unique."""
+        if self.non_null == 0:
+            return 0.0
+        return len(self.distinct) / self.non_null
+
+    def dominant_type(self) -> str:
+        """The most-voted PropertyDef type; ``string`` when no votes."""
+        if not self.type_votes:
+            return "string"
+        return self.type_votes.most_common(1)[0][0]
+
+    @property
+    def type_purity(self) -> float:
+        """Fraction of non-null values agreeing with the dominant type."""
+        total = sum(self.type_votes.values())
+        if total == 0:
+            return 0.0
+        return self.type_votes.most_common(1)[0][1] / total
+
+
+class StructuredShapeDigester:
+    """Infers an OntologyDraft from structured records grouped by type.
+
+    Input shape: ``{type_name: [record_dict, ...]}``. A flat ``list[dict]`` is
+    also accepted and treated as a single anonymous type (named from
+    ``connector_meta["default_type"]`` or ``"Record"``).
+    """
+
+    def __init__(self, default_type_name: str = "Record") -> None:
+        self._default_type_name = default_type_name
+
+    # ------------------------------------------------------------------ public
+    def digest(
+        self,
+        records: Any,
+        connector_meta: Mapping[str, Any] | None = None,
+    ) -> OntologyDraft:
+        meta = dict(connector_meta or {})
+        grouped = self._normalize_input(records, meta)
+
+        draft = OntologyDraft(meta={"digester": "structured_shape", **meta})
+        if not grouped:
+            draft.meta["degraded"] = "empty"
+            return draft
+
+        # Pass 1 — per-type field stats + property defs + key inference.
+        type_stats: dict[str, dict[str, _FieldStats]] = {}
+        for type_name, rows in grouped.items():
+            clean_rows = [r for r in rows if isinstance(r, Mapping)]
+            stats = self._collect_field_stats(clean_rows)
+            type_stats[type_name] = stats
+            draft_type = self._build_object_type(type_name, clean_rows, stats)
+            draft.object_types.append(draft_type)
+
+        # Pass 2 — objects (rows projected, with the inferred source_id).
+        key_by_type = {ot.name: ot.source_id_field for ot in draft.object_types}
+        for type_name, rows in grouped.items():
+            key_field = key_by_type.get(type_name)
+            for row in rows:
+                if not isinstance(row, Mapping):
+                    continue
+                source_id = self._extract_source_id(row, key_field)
+                draft.objects.append(
+                    DraftObject(
+                        type_name=type_name,
+                        source_id=source_id,
+                        properties=dict(row),
+                    )
+                )
+
+        # Pass 3 — links from foreign-key shapes (field values matching another
+        # type's keys). Skipped entirely when fewer than two types have keys.
+        draft.links = self._infer_links(grouped, draft, type_stats, key_by_type)
+
+        if not draft.links and len(draft.object_types) <= 1:
+            draft.meta.setdefault("degraded", "objects-only")
+        return draft
+
+    # -------------------------------------------------------------- normalize
+    def _normalize_input(self, records: Any, meta: Mapping[str, Any]) -> dict[str, list[Any]]:
+        """Coerce the input into ``{type_name: [record, ...]}``.
+
+        Accepts: a mapping of type->rows, or a flat sequence of records (single
+        anonymous type). Empty / None inputs return ``{}``. Empty per-type lists
+        are dropped so an all-empty mapping degrades to an empty draft.
+        """
+        if not records:
+            return {}
+        if isinstance(records, Mapping):
+            out: dict[str, list[Any]] = {}
+            for type_name, rows in records.items():
+                if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes)):
+                    row_list = list(rows)
+                else:
+                    row_list = []
+                if row_list:
+                    out[str(type_name)] = row_list
+            return out
+        if isinstance(records, Sequence) and not isinstance(records, (str, bytes)):
+            row_list = list(records)
+            if not row_list:
+                return {}
+            name = str(meta.get("default_type") or self._default_type_name)
+            return {name: row_list}
+        return {}
+
+    # --------------------------------------------------------------- pass one
+    def _collect_field_stats(self, rows: list[Mapping[str, Any]]) -> dict[str, _FieldStats]:
+        stats: dict[str, _FieldStats] = defaultdict(_FieldStats)
+        for row in rows:
+            for field, value in row.items():
+                stats[str(field)].observe(value)
+        return dict(stats)
+
+    def _build_object_type(
+        self,
+        type_name: str,
+        rows: list[Mapping[str, Any]],
+        stats: dict[str, _FieldStats],
+    ) -> DraftObjectType:
+        record_count = len(rows)
+        properties: list[PropertyDef] = []
+        field_map: dict[str, str] = {}
+        for field, fstat in stats.items():
+            prop_type = fstat.dominant_type()
+            # required if present (and non-null) in every sampled record.
+            required = record_count > 0 and fstat.non_null == record_count
+            properties.append(PropertyDef(name=field, type=prop_type, required=required))
+            field_map[field] = field
+
+        key_field, key_conf = self._infer_primary_key(type_name, rows, stats)
+
+        # Type confidence: blend sample size signal with average property-type
+        # purity (how consistent the field shapes are across records).
+        size_signal = _clamp(record_count / 5.0)  # 5+ records → full size signal
+        purities = [s.type_purity for s in stats.values() if s.non_null]
+        avg_purity = sum(purities) / len(purities) if purities else 0.0
+        type_conf = _clamp(0.4 * size_signal + 0.6 * avg_purity) if stats else 0.0
+
+        return DraftObjectType(
+            name=type_name,
+            properties=properties,
+            source_id_field=key_field,
+            field_map=field_map,
+            confidence=round(type_conf, 3),
+            key_confidence=round(key_conf, 3),
+            record_count=record_count,
+        )
+
+    def _infer_primary_key(
+        self,
+        type_name: str,
+        rows: list[Mapping[str, Any]],
+        stats: dict[str, _FieldStats],
+    ) -> tuple[str | None, float]:
+        """Infer the primary-key field + confidence.
+
+        Strategy:
+          1. A named-key candidate (``id``, ``<type>_id``, …) that is unique +
+             fully-populated wins with high confidence; merely present but not
+             perfectly unique still wins by name but with reduced confidence.
+          2. Else the highest-cardinality field that is fully-unique and fully
+             populated, with confidence scaled by how distinctive it is and how
+             much the name resembles a key.
+          3. Else no key — ``(None, low)``.
+        """
+        if not rows or not stats:
+            return None, 0.0
+
+        n = len(rows)
+        type_lc = re.sub(r"[^a-z0-9]", "", type_name.lower())
+        # Resolve the priority name list against this type.
+        name_priority = [p.replace("{type}", type_lc) for p in _KEY_NAME_PRIORITY]
+
+        # 1) named candidates, in priority order.
+        lower_to_field = {f.lower(): f for f in stats}
+        for rank, wanted in enumerate(name_priority):
+            field = lower_to_field.get(wanted)
+            if field is None:
+                continue
+            fstat = stats[field]
+            unique = fstat.non_null > 0 and len(fstat.distinct) == fstat.non_null
+            populated = fstat.non_null == n
+            # base confidence high for a named key, boosted by uniqueness +
+            # population, gently decayed by priority rank.
+            base = 0.95 - 0.05 * rank
+            conf = base
+            if not unique:
+                conf -= 0.25
+            if not populated:
+                conf -= 0.15
+            return field, _clamp(conf)
+
+        # 2) high-cardinality unique fallback.
+        best_field: str | None = None
+        best_card = 0.0
+        for field, fstat in stats.items():
+            unique = fstat.non_null > 0 and len(fstat.distinct) == fstat.non_null
+            populated = fstat.non_null == n
+            if unique and populated and fstat.cardinality_ratio >= best_card:
+                # prefer string/number keys; skip boolean/date as keys.
+                if fstat.dominant_type() in ("boolean", "date"):
+                    continue
+                best_card = fstat.cardinality_ratio
+                best_field = field
+        if best_field is not None:
+            # name resemblance bonus (ends with id/key/etc.)
+            name_bonus = 0.1 if any(best_field.lower().endswith(s) for s in _FK_SUFFIXES) else 0.0
+            # a single-record sample can't prove uniqueness — temper it.
+            sample_signal = _clamp((n - 1) / 4.0)  # need a few rows to trust it
+            conf = _clamp(0.45 + 0.25 * sample_signal + name_bonus)
+            return best_field, conf
+
+        # 3) no usable key.
+        return None, 0.1
+
+    @staticmethod
+    def _extract_source_id(row: Mapping[str, Any], key_field: str | None) -> str | None:
+        if key_field is None:
+            return None
+        raw = row.get(key_field)
+        if raw is None:
+            return None
+        sid = str(raw).strip()
+        return sid or None
+
+    # --------------------------------------------------------------- pass three
+    def _infer_links(
+        self,
+        grouped: dict[str, list[Any]],
+        draft: OntologyDraft,
+        type_stats: dict[str, dict[str, _FieldStats]],
+        key_by_type: dict[str, str | None],
+    ) -> list[DraftLink]:
+        """Infer FK links: a field on type A whose values match type B's keys.
+
+        For every (typeA, field) and every other typeB with a key, we test how
+        many of typeA's field values land in typeB's key value set. A high
+        overlap signals a foreign key. The field is skipped if it IS typeA's own
+        key (self-reference noise) unless it clearly targets another type.
+        """
+        # Build per-type key value sets (as hashable surrogates).
+        key_values: dict[str, set[Any]] = {}
+        for type_name, key_field in key_by_type.items():
+            if not key_field:
+                continue
+            stats = type_stats.get(type_name, {})
+            fstat = stats.get(key_field)
+            if fstat is not None:
+                key_values[type_name] = set(fstat.distinct)
+
+        if len(key_values) < 1:
+            return []
+
+        # Map a type's key surrogate -> source_id (string) for endpoint lookup.
+        # Reuse the already-projected DraftObjects.
+        sid_by_type_value: dict[str, dict[Any, str]] = defaultdict(dict)
+        for obj in draft.objects:
+            key_field = key_by_type.get(obj.type_name)
+            if not key_field or obj.source_id is None:
+                continue
+            raw = obj.properties.get(key_field)
+            sid_by_type_value[obj.type_name][_hashable(raw)] = obj.source_id
+
+        links: list[DraftLink] = []
+        for from_type, rows in grouped.items():
+            stats = type_stats.get(from_type, {})
+            own_key = key_by_type.get(from_type)
+            for field, fstat in stats.items():
+                if fstat.non_null == 0:
+                    continue
+                field_vals = set(fstat.distinct)
+                for to_type, kvals in key_values.items():
+                    if to_type == from_type and field == own_key:
+                        continue  # self-key, not a link
+                    if not kvals:
+                        continue
+                    overlap = field_vals & kvals
+                    if not overlap:
+                        continue
+                    coverage = len(overlap) / len(field_vals)
+                    # Require a meaningful overlap to call it an FK. A lone
+                    # accidental match on a low-cardinality field is noise.
+                    if coverage < 0.5 and len(overlap) < 2:
+                        continue
+                    # Name resemblance: ``customer_id`` -> ``Customer`` boosts.
+                    name_match = self._name_targets_type(field, to_type)
+                    confidence = _clamp(0.4 + 0.4 * coverage + (0.2 if name_match else 0.0))
+                    link_type = self._link_type_name(field, to_type)
+                    # Emit one link per matching row.
+                    for row in rows:
+                        if not isinstance(row, Mapping):
+                            continue
+                        val = row.get(field)
+                        if val is None:
+                            continue
+                        h = _hashable(val)
+                        if h not in kvals:
+                            continue
+                        to_sid = sid_by_type_value.get(to_type, {}).get(h)
+                        from_sid = self._extract_source_id(row, own_key)
+                        if to_sid is None or from_sid is None:
+                            continue
+                        links.append(
+                            DraftLink(
+                                from_type=from_type,
+                                from_source_id=from_sid,
+                                to_type=to_type,
+                                to_source_id=to_sid,
+                                link_type=link_type,
+                                via_field=field,
+                                confidence=round(confidence, 3),
+                            )
+                        )
+        return links
+
+    @staticmethod
+    def _name_targets_type(field: str, type_name: str) -> bool:
+        """True if a field name resembles a FK to ``type_name`` (customer_id→Customer)."""
+        f = field.lower()
+        t = re.sub(r"[^a-z0-9]", "", type_name.lower())
+        stem = f
+        for suf in _FK_SUFFIXES:
+            if f.endswith(suf):
+                stem = f[: -len(suf)]
+                break
+        stem = re.sub(r"[^a-z0-9]", "", stem)
+        return stem == t or stem == t.rstrip("s") or f"{stem}s" == t
+
+    @staticmethod
+    def _link_type_name(field: str, to_type: str) -> str:
+        """Derive a readable link_type from the FK field / target type."""
+        f = field.lower()
+        for suf in _FK_SUFFIXES:
+            if f.endswith(suf) and len(f) > len(suf):
+                return f"belongs_to_{f[: -len(suf)]}"
+        return f"references_{to_type.lower()}"

--- a/ee/pocketpaw_ee/discovery/models.py
+++ b/ee/pocketpaw_ee/discovery/models.py
@@ -1,0 +1,135 @@
+# pocketpaw_ee/discovery/models.py — the OntologyDraft shape produced by a Digester.
+#
+# Created: 2026-06-19 (SZD-3 / feat/szd-3-digester) — the data contract for
+# sovereign zero-setup discovery. A Digester samples a connector's records and
+# reverse-engineers a candidate ontology into an ``OntologyDraft``. The draft is
+# designed to be DIRECTLY usable two ways:
+#
+#   1. Build a ``pocketpaw.connectors.fabric_ingest.FabricMapping`` per type —
+#      each ``DraftObjectType`` carries the inferred ``source_id_field`` and a
+#      ``field_map`` projection (the two things ``ingest_records`` requires
+#      beyond ``type_name``), plus the ``PropertyDef`` list for the ObjectType.
+#   2. Feed a fabric-objects proposal — ``object_types`` + ``objects`` +
+#      ``links`` map onto ObjectType / FabricObject / FabricLink.
+#
+# Every inference (type, property type, primary key, link) carries a
+# ``confidence`` in [0, 1] so a downstream gate can sort strong signals from
+# weak ones. Pure data, no I/O — depends only on pydantic and the OSS
+# ``PropertyDef`` model.
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from pocketpaw.fabric.models import PropertyDef
+
+
+def _clamp(value: float) -> float:
+    """Clamp a confidence score into [0.0, 1.0]."""
+    return max(0.0, min(1.0, value))
+
+
+class DraftObjectType(BaseModel):
+    """An inferred object type plus everything needed to build its FabricMapping.
+
+    The ``source_id_field`` / ``field_map`` pair is exactly what
+    ``fabric_ingest.FabricMapping`` needs beyond ``type_name`` (the projection
+    + the idempotency key). ``properties`` is the ObjectType's PropertyDef list.
+    ``key_confidence`` reflects how strong the primary-key signal was; when no
+    usable key was found, ``source_id_field`` is ``None`` and confidence is low
+    (objects-only — not safe to dedup or link on).
+    """
+
+    name: str
+    properties: list[PropertyDef] = Field(default_factory=list)
+    # The inferred primary-key / idempotency field. ``None`` when no stable key
+    # could be inferred — the type then degrades to objects-only.
+    source_id_field: str | None = None
+    # {fabric_property: record_key} projection — feeds FabricMapping.field_map.
+    field_map: dict[str, str] = Field(default_factory=dict)
+    # Confidence in the type itself (shape consistency across records).
+    confidence: float = 0.0
+    # Confidence in the inferred primary key specifically.
+    key_confidence: float = 0.0
+    record_count: int = 0
+
+    def to_fabric_mapping_kwargs(self) -> dict[str, Any]:
+        """Return kwargs ready to construct a ``FabricMapping``.
+
+        Usage::
+
+            from pocketpaw.connectors.fabric_ingest import FabricMapping
+            mapping = FabricMapping(**draft_type.to_fabric_mapping_kwargs())
+
+        Only valid when ``source_id_field`` is set; callers should check
+        ``key_confidence`` / ``source_id_field`` first for low-confidence types.
+        """
+        return {
+            "type_name": self.name,
+            "source_id_field": self.source_id_field or "",
+            "field_map": dict(self.field_map),
+            "properties": list(self.properties),
+        }
+
+
+class DraftObject(BaseModel):
+    """A single inferred object row, ready to become a FabricObject.
+
+    ``source_id`` is the value extracted from the type's inferred
+    ``source_id_field`` (``None`` when the type has no key). ``properties`` is
+    the raw projected record.
+    """
+
+    type_name: str
+    source_id: str | None = None
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class DraftLink(BaseModel):
+    """An inferred relationship between two objects (by source_id).
+
+    A link is inferred when a field on one type holds values that match the
+    primary keys of another type (a foreign-key shape). The endpoints are
+    referenced by ``(type_name, source_id)`` rather than Fabric object ids,
+    since the draft pre-dates persistence — the proposal step resolves these to
+    real ``FabricObject`` ids.
+    """
+
+    from_type: str
+    from_source_id: str
+    to_type: str
+    to_source_id: str
+    link_type: str
+    # The field on ``from_type`` that carried the foreign key.
+    via_field: str
+    confidence: float = 0.0
+
+
+class OntologyDraft(BaseModel):
+    """A candidate ontology reverse-engineered from sampled connector records.
+
+    Directly consumable to (a) build per-type ``FabricMapping`` objects for
+    ``ingest_records`` and (b) feed a fabric-objects proposal (object_types +
+    objects + links). Degrades cleanly: empty records → empty draft; no clear
+    key → objects-only with low confidence and no links.
+    """
+
+    object_types: list[DraftObjectType] = Field(default_factory=list)
+    objects: list[DraftObject] = Field(default_factory=list)
+    links: list[DraftLink] = Field(default_factory=list)
+    # Free-form provenance / notes from the digester (connector name, sample
+    # size, degradation flags) — never load-bearing for ingest.
+    meta: dict[str, Any] = Field(default_factory=dict)
+
+    def type_by_name(self, name: str) -> DraftObjectType | None:
+        """Look up an inferred type by name (case-sensitive), or None."""
+        for ot in self.object_types:
+            if ot.name == name:
+                return ot
+        return None
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.object_types and not self.objects

--- a/ee/pocketpaw_ee/discovery/orchestrate.py
+++ b/ee/pocketpaw_ee/discovery/orchestrate.py
@@ -1,0 +1,559 @@
+# pocketpaw_ee/discovery/orchestrate.py — wire DiscoveryRun → the two gated proposals.
+#
+# Created: 2026-06-19 (SZD-6 / feat/szd-6-integration) — the integration slice
+# that connects the pieces the earlier SZD slices built in isolation. A discovery
+# run yields an ``OntologyDraft`` (SZD-3/4); this module turns that draft into the
+# two STAGED Instinct proposals a human reviews through the gate:
+#
+#   1. a ``_fabric_objects`` proposal (SZD-5a) — the discovered ontology
+#      (object_types + objects + links) staged for materialisation into Fabric;
+#   2. a ``_pocket_create`` proposal (SZD-5b) — a starter dashboard Pocket whose
+#      rippleSpec binds one widget per HIGH-CONFIDENCE discovered type to the
+#      ``fabric.objects`` ripple source (SZD-1), so when both proposals are
+#      approved the Pocket renders the freshly-materialised Fabric data.
+#
+# Nothing here writes Fabric or creates a Pocket — both halves are GATED. This
+# module only builds the two proposals and returns their Action ids; a human
+# approves them in The Tray and the apply-on-approve executors do the writes.
+#
+# KEY-CONFIDENCE GATE (a design-review must): the digester emits a per-type
+# ``key_confidence`` and a ``source_id_field`` that is empty when no stable key
+# was inferred. The Fabric ingest path DEDUPES on ``(source_connector,
+# source_id)`` — so staging objects of a keyless / low-confidence type would make
+# every record collapse onto a single blank ``source_id`` (ingest drops all but
+# one). We therefore GATE: only types whose ``key_confidence >=
+# KEY_CONFIDENCE_FLOOR`` AND that carry a non-empty ``source_id_field`` contribute
+# objects + links + a starter-Pocket widget. Low-confidence keyless types are
+# SKIPPED from materialisation and FLAGGED in the returned summary so a human can
+# see what was held back (rather than silently dropping records).
+#
+# SUPERSEDE-ON-RERUN: a discovery run is re-runnable. A second run for the same
+# workspace SUPERSEDES the prior STILL-OPEN (PENDING) discovery proposal pair
+# rather than stacking a duplicate. Both proposals are tagged with a
+# ``discovery_run`` marker (a shared ``run_id`` + the proposal ``role``) on their
+# blob so the supersede sweep can find the prior open pair for this workspace and
+# reject it (status REJECTED, reason "superseded by discovery run <id>") before
+# filing the new pair. Approved / rejected / executed proposals are left alone —
+# only the still-open pair is collapsed.
+#
+# Async orchestration; depends on the SZD-4 DiscoveryRun + the SZD-5a/5b propose
+# helpers + the OSS InstinctStore (for the supersede sweep). No direct Fabric /
+# Pocket writes.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from pocketpaw_ee.discovery.models import DraftObjectType, OntologyDraft
+from pocketpaw_ee.discovery.run import DiscoveryRun, DiscoveryRunOptions
+
+logger = logging.getLogger(__name__)
+
+# Minimum per-type ``key_confidence`` for a discovered type to be MATERIALISED.
+# Below this floor (or with no inferred ``source_id_field``) a type has no stable
+# idempotency key, so staging its objects would collapse every record onto one
+# blank source_id at ingest time. Such types are skipped + flagged, never staged.
+KEY_CONFIDENCE_FLOOR = 0.5
+
+# The blob key (set on BOTH proposals' parameters blob) tagging a proposal as part
+# of a discovery run, so the supersede sweep can find a workspace's prior open
+# pair. Carries ``{run_id, role, workspace_id}``. ``role`` is "fabric_objects" or
+# "pocket_create".
+DISCOVERY_MARKER_KEY = "discovery_run"
+
+# The synthetic ``source_connector`` namespace stamped on every staged object so
+# the Fabric ingest dedup key ``(source_connector, source_id)`` is stable across
+# re-runs. Namespaced per type so two types can reuse the same source_id without
+# colliding, and so a discovered object never collides with a real connector's
+# ingested object.
+_DISCOVERY_CONNECTOR_PREFIX = "discovery"
+
+
+def _discovery_connector(type_name: str) -> str:
+    """The synthetic source_connector for a discovered type's objects."""
+    return f"{_DISCOVERY_CONNECTOR_PREFIX}:{type_name}"
+
+
+@dataclass(frozen=True)
+class DiscoveryProposalResult:
+    """The outcome of :func:`run_discovery_and_propose`.
+
+    * ``fabric_objects_action_id`` / ``pocket_action_id`` — the two gated Action
+      ids a human reviews. ``None`` for either when there was nothing to stage
+      (an empty draft → no fabric proposal → no pocket proposal).
+    * ``run_id`` — the discovery-run marker shared by both proposals (used to
+      supersede this pair on the next run).
+    * ``materialised_types`` — the high-confidence type names that were staged.
+    * ``skipped_types`` — ``{type_name: reason}`` for types held back (keyless /
+      low-confidence) so a human can see what was NOT staged.
+    * ``superseded_action_ids`` — the prior open pair this run collapsed (empty on
+      a first run).
+    """
+
+    run_id: str
+    fabric_objects_action_id: str | None
+    pocket_action_id: str | None
+    materialised_types: list[str]
+    skipped_types: dict[str, str]
+    superseded_action_ids: list[str]
+
+
+def _is_materialisable(ot: DraftObjectType) -> tuple[bool, str]:
+    """Decide whether a draft type is safe to materialise.
+
+    Returns ``(ok, reason)``. A type is materialisable only when it carries a
+    non-empty ``source_id_field`` AND ``key_confidence >= KEY_CONFIDENCE_FLOOR``.
+    ``reason`` explains a skip (for the flagged summary) and is empty when ok.
+    """
+    if not ot.source_id_field:
+        return False, "no inferred primary key (keyless)"
+    if ot.key_confidence < KEY_CONFIDENCE_FLOOR:
+        return (
+            False,
+            f"key confidence {ot.key_confidence:.2f} below floor {KEY_CONFIDENCE_FLOOR:.2f}",
+        )
+    return True, ""
+
+
+def _draft_to_fabric_proposal_kwargs(
+    draft: OntologyDraft,
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[str],
+    dict[str, str],
+]:
+    """Map an ``OntologyDraft`` → ``propose_fabric_objects`` kwargs, GATED on key
+    confidence.
+
+    Returns ``(object_types, objects, links, materialised_type_names,
+    skipped)``:
+      * only HIGH-CONFIDENCE keyed types contribute object_types + objects;
+      * each object carries a synthetic ``(source_connector, source_id)`` so the
+        ingest dedup key is stable (``source_connector =
+        "discovery:<type>"``, ``source_id`` = the digester's inferred source_id);
+      * links are kept only when BOTH endpoints are materialisable types AND both
+        endpoints have a source_id (the link's natural-key endpoints reference the
+        SAME synthetic connector namespace the objects use);
+      * ``skipped`` maps each held-back type name → a human reason.
+    """
+    materialisable: dict[str, DraftObjectType] = {}
+    skipped: dict[str, str] = {}
+    for ot in draft.object_types:
+        ok, reason = _is_materialisable(ot)
+        if ok:
+            materialisable[ot.name] = ot
+        else:
+            skipped[ot.name] = reason
+
+    # object_types — PropertyDef list serialised to the proposal's dict shape.
+    object_types: list[dict[str, Any]] = []
+    for name, ot in materialisable.items():
+        object_types.append(
+            {
+                "type_name": name,
+                "description": f"Discovered from connector data ({ot.record_count} sampled).",
+                "properties": [p.model_dump(mode="json") for p in ot.properties],
+            }
+        )
+
+    # objects — only for materialisable types, only rows that carry a source_id.
+    objects: list[dict[str, Any]] = []
+    for obj in draft.objects:
+        if obj.type_name not in materialisable:
+            continue
+        if not obj.source_id:
+            # A materialisable type whose individual row lacks the key value —
+            # skip the row (can't dedup it) rather than collapse it onto blank.
+            continue
+        objects.append(
+            {
+                "type_name": obj.type_name,
+                "properties": dict(obj.properties),
+                "source_connector": _discovery_connector(obj.type_name),
+                "source_id": obj.source_id,
+            }
+        )
+
+    # links — both endpoints must be materialisable + carry a source_id.
+    links: list[dict[str, Any]] = []
+    for link in draft.links:
+        if link.from_type not in materialisable or link.to_type not in materialisable:
+            continue
+        if not link.from_source_id or not link.to_source_id:
+            continue
+        links.append(
+            {
+                "from": {
+                    "source_connector": _discovery_connector(link.from_type),
+                    "source_id": link.from_source_id,
+                },
+                "to": {
+                    "source_connector": _discovery_connector(link.to_type),
+                    "source_id": link.to_source_id,
+                },
+                "link_type": link.link_type,
+            }
+        )
+
+    return object_types, objects, links, list(materialisable.keys()), skipped
+
+
+def assemble_discovery_pocket(
+    draft: OntologyDraft,
+    materialised_types: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a starter-dashboard rippleSpec from a discovery draft.
+
+    A simple dashboard: one widget (a table) per HIGH-CONFIDENCE discovered type,
+    each bound to the ``fabric.objects`` ripple source for that type via a
+    ``{"$source": "fabric.objects", "type_name": <name>}`` marker placed under the
+    spec's ``state`` (the binding the SZD-1 resolver replaces with live rows on
+    read). Each table widget reads its rows from the matching state key.
+
+    ``materialised_types`` lets the caller pass the gated high-confidence type
+    list directly (the common path — keeps the assembler's gate identical to the
+    fabric-proposal gate). When omitted, the assembler applies the same
+    :func:`_is_materialisable` gate to the draft so a stand-alone call still skips
+    keyless / low-confidence types.
+
+    Pure: no I/O. Returns a rippleSpec dict (``{version, root, state}``) — the
+    same shape the pocket-create proposal stages under its ``rippleSpec`` alias.
+    """
+    if materialised_types is None:
+        materialised_types = [ot.name for ot in draft.object_types if _is_materialisable(ot)[0]]
+
+    state: dict[str, Any] = {}
+    children: list[dict[str, Any]] = []
+    for type_name in materialised_types:
+        # State key per type — the resolver replaces the $source marker with the
+        # workspace-scoped rows of that Fabric type on read.
+        state_key = f"rows_{type_name}"
+        state[state_key] = {"$source": "fabric.objects", "type_name": type_name}
+        children.append(
+            {
+                "id": f"table_{type_name}",
+                "type": "table",
+                "props": {
+                    "title": type_name,
+                    # The widget binds its rows to the state key the source feeds.
+                    "rows": f"$state.{state_key}",
+                },
+            }
+        )
+
+    return {
+        "version": "1.0",
+        "root": {
+            "id": "root",
+            "type": "container",
+            "props": {"title": "Discovered data"},
+            "children": children,
+        },
+        "state": state,
+    }
+
+
+async def _supersede_prior_open_pair(
+    *,
+    store: Any,
+    workspace_id: str,
+    rejector: str,
+    new_run_id: str,
+) -> list[str]:
+    """Reject the workspace's prior STILL-OPEN discovery proposal pair.
+
+    Lists the workspace's PENDING actions, keeps the ones tagged with a
+    ``discovery_run`` marker (either proposal kind), and rejects each so the new
+    run's pair doesn't stack on top of a stale one. Returns the superseded action
+    ids. Approved / rejected / executed proposals are NOT touched (only PENDING).
+
+    Best-effort: a supersede failure logs but does NOT block filing the new pair
+    (a duplicate open pair is recoverable; a failed discovery run is worse).
+    """
+    superseded: list[str] = []
+    try:
+        from pocketpaw.instinct.models import ActionStatus
+
+        pending = await store.list_actions(
+            pocket_id=workspace_id,
+            status=ActionStatus.PENDING,
+            workspace_id=workspace_id,
+            limit=500,
+        )
+    except Exception:  # noqa: BLE001 — the sweep is best-effort
+        logger.warning(
+            "discovery: failed to list prior open proposals for workspace %s — "
+            "filing the new pair without superseding",
+            workspace_id,
+            exc_info=True,
+        )
+        return superseded
+
+    for action in pending:
+        params = getattr(action, "parameters", None) or {}
+        marker = _find_discovery_marker(params)
+        if marker is None:
+            continue
+        # Never supersede the pair we're about to file (defensive — they don't
+        # exist yet at sweep time, but guard against a re-entrant call).
+        if marker.get("run_id") == new_run_id:
+            continue
+        try:
+            await store.reject(
+                action.id,
+                reason=f"superseded by discovery run {new_run_id}",
+                rejector=rejector or "discovery",
+            )
+            superseded.append(action.id)
+        except Exception:  # noqa: BLE001 — one bad reject can't block the rest
+            logger.warning(
+                "discovery: failed to supersede prior open proposal %s — continuing",
+                action.id,
+                exc_info=True,
+            )
+
+    if superseded:
+        logger.info(
+            "discovery: superseded %d prior open proposal(s) for workspace %s (new run %s)",
+            len(superseded),
+            workspace_id,
+            new_run_id,
+        )
+    return superseded
+
+
+def _find_discovery_marker(params: dict[str, Any]) -> dict[str, Any] | None:
+    """Pull the ``discovery_run`` marker off either proposal's blob, or None.
+
+    The marker rides on the per-proposal blob (``_fabric_objects`` or
+    ``_pocket_create``) under :data:`DISCOVERY_MARKER_KEY`, so a single read of
+    the Action's parameters surfaces it regardless of which proposal kind this is.
+    """
+    for blob_key in ("_fabric_objects", "_pocket_create"):
+        blob = params.get(blob_key)
+        if isinstance(blob, dict):
+            marker = blob.get(DISCOVERY_MARKER_KEY)
+            if isinstance(marker, dict):
+                return marker
+    return None
+
+
+async def run_discovery_and_propose(
+    workspace_id: str,
+    user_id: str,
+    connector_ids: list[str],
+    opts: DiscoveryRunOptions | None = None,
+    *,
+    discovery_run: DiscoveryRun | None = None,
+) -> DiscoveryProposalResult:
+    """Run discovery for a workspace and stage the two gated proposals.
+
+    The integration entry point (SZD-6). Validates tenancy at entry, runs a
+    discovery pass to an ``OntologyDraft``, GATES the draft on per-type key
+    confidence, then:
+      1. supersedes the workspace's prior STILL-OPEN discovery proposal pair;
+      2. files a ``_fabric_objects`` proposal for the high-confidence ontology;
+      3. files a ``_pocket_create`` proposal for a starter dashboard bound to the
+         ``fabric.objects`` source for each materialised type.
+
+    Both proposals are GATED — nothing is written to Fabric and no Pocket is
+    created here; a human approves them in The Tray and the apply-on-approve
+    executors do the writes. Returns a :class:`DiscoveryProposalResult` carrying
+    the two Action ids (either ``None`` when there was nothing to stage).
+
+    Args:
+        workspace_id: the originating tenant. Required — discovery, the proposals,
+            and the supersede sweep are all workspace-scoped by it.
+        user_id: the approver/owner. Required — the Pocket is created under it and
+            the proposals are assigned to it.
+        connector_ids: the workspace's bound connectors to sample.
+        opts: discovery-run knobs (sampling cap, explicit read actions, ...).
+        discovery_run: an injected ``DiscoveryRun`` (tests pass a mock-registry
+            run); defaults to a fresh one driving the local-runtime registry.
+    """
+    from pocketpaw_ee.cloud.fabric_proposals.propose import propose_fabric_objects
+    from pocketpaw_ee.cloud.pocket_proposals.propose import propose_pocket
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("run_discovery_and_propose requires a non-empty workspace_id")
+    user_id = str(user_id or "")
+    if not user_id:
+        raise ValueError("run_discovery_and_propose requires a non-empty user_id")
+
+    run = discovery_run or DiscoveryRun()
+    draft = await run.run(workspace_id, connector_ids, opts)
+
+    object_types, objects, links, materialised_types, skipped = _draft_to_fabric_proposal_kwargs(
+        draft
+    )
+
+    # The shared discovery-run marker — both proposals carry it so the NEXT run can
+    # find + supersede this still-open pair.
+    run_id = uuid4().hex
+
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+
+    # 1) Supersede the prior open pair BEFORE filing the new one (so the new pair
+    #    is never itself collapsed and the queue never shows two open pairs).
+    superseded = await _supersede_prior_open_pair(
+        store=store,
+        workspace_id=workspace_id,
+        rejector=user_id,
+        new_run_id=run_id,
+    )
+
+    if not objects:
+        # Nothing high-confidence to materialise — no fabric proposal, so no
+        # starter pocket either (a dashboard with no live source is noise). The
+        # prior pair is still superseded; the run is a clean no-op otherwise.
+        logger.info(
+            "discovery: no high-confidence objects to stage for workspace %s "
+            "(skipped types: %s) — no proposals filed",
+            workspace_id,
+            ", ".join(skipped) or "none",
+        )
+        return DiscoveryProposalResult(
+            run_id=run_id,
+            fabric_objects_action_id=None,
+            pocket_action_id=None,
+            materialised_types=materialised_types,
+            skipped_types=skipped,
+            superseded_action_ids=superseded,
+        )
+
+    skipped_note = f" {len(skipped)} low-confidence type(s) held back." if skipped else ""
+    fabric_summary = (
+        f"Discovered {len(objects)} object(s) across {len(materialised_types)} "
+        f"type(s) and {len(links)} link(s) from connector data.{skipped_note}"
+    )
+    fabric_action_id = await propose_fabric_objects(
+        workspace_id=workspace_id,
+        objects=objects,
+        object_types=object_types,
+        links=links,
+        requested_by=user_id,
+        summary=fabric_summary,
+    )
+    # The marker rides on the blob, not the per-object dicts — stamp it via a
+    # direct blob back-write (the propose helper normalises objects and would drop
+    # an unknown per-object key). Done after propose so the Action exists.
+    await _stamp_discovery_marker(
+        store=store,
+        action_id=fabric_action_id,
+        blob_key="_fabric_objects",
+        marker={
+            "run_id": run_id,
+            "role": "fabric_objects",
+            "workspace_id": workspace_id,
+        },
+    )
+
+    # 2) The starter Pocket — one widget per materialised type, bound to
+    #    fabric.objects so it renders the (to-be-)materialised rows.
+    ripple_spec = assemble_discovery_pocket(draft, materialised_types)
+    pocket_summary = (
+        f"Starter dashboard for {len(materialised_types)} discovered type(s): "
+        f"{', '.join(materialised_types)}."
+    )
+    pocket_action_id = await propose_pocket(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        ripple_spec=ripple_spec,
+        name="Discovered data",
+        summary=pocket_summary,
+    )
+    await _stamp_discovery_marker(
+        store=store,
+        action_id=pocket_action_id,
+        blob_key="_pocket_create",
+        marker={
+            "run_id": run_id,
+            "role": "pocket_create",
+            "workspace_id": workspace_id,
+        },
+    )
+
+    logger.info(
+        "discovery: filed proposal pair for workspace %s (fabric=%s pocket=%s, "
+        "run=%s, %d materialised / %d skipped, %d superseded)",
+        workspace_id,
+        fabric_action_id,
+        pocket_action_id,
+        run_id,
+        len(materialised_types),
+        len(skipped),
+        len(superseded),
+    )
+
+    return DiscoveryProposalResult(
+        run_id=run_id,
+        fabric_objects_action_id=fabric_action_id,
+        pocket_action_id=pocket_action_id,
+        materialised_types=materialised_types,
+        skipped_types=skipped,
+        superseded_action_ids=superseded,
+    )
+
+
+async def _stamp_discovery_marker(
+    *,
+    store: Any,
+    action_id: str,
+    blob_key: str,
+    marker: dict[str, Any],
+) -> None:
+    """Write the ``discovery_run`` marker onto a filed proposal's blob.
+
+    Direct-SQL blob back-write — the same pattern the propose helpers use for
+    ``_persist_chain_ids``. Best-effort: a stamp failure leaves the proposal
+    un-marked (it just won't be auto-superseded by the next run; a human can still
+    reject it). A failed stamp must NOT fail the proposal that was already filed.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(blob_key)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob[DISCOVERY_MARKER_KEY] = dict(marker)
+        params[blob_key] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — marker stamp is best-effort
+        logger.warning(
+            "discovery: failed to stamp discovery_run marker onto action %s "
+            "(blob=%s) — it won't be auto-superseded by the next run",
+            action_id,
+            blob_key,
+            exc_info=True,
+        )
+
+
+__all__ = [
+    "KEY_CONFIDENCE_FLOOR",
+    "DISCOVERY_MARKER_KEY",
+    "DiscoveryProposalResult",
+    "assemble_discovery_pocket",
+    "run_discovery_and_propose",
+]

--- a/ee/pocketpaw_ee/discovery/run.py
+++ b/ee/pocketpaw_ee/discovery/run.py
@@ -1,0 +1,391 @@
+# pocketpaw_ee/discovery/run.py — the DiscoveryRun orchestrator.
+#
+# Created: 2026-06-19 (SZD-4 / feat/szd-4-discovery-run) — ties SZD-2 sampling
+# and the SZD-3 digester together. ``DiscoveryRun.run(workspace_id,
+# connector_ids, opts)`` enumerates a workspace's bound connectors, SAMPLES a
+# bounded N records per connector, groups records by type, and runs the
+# ``StructuredShapeDigester`` to produce an ``OntologyDraft``.
+#
+# CRITICAL read-path contract (a design review caught this):
+#   * Discovery runs BEFORE any pocket exists, so we do NOT call
+#     ``connector.sync(pocket_id)`` — sync requires a pocket AND returns COUNTS,
+#     not records.
+#   * Records are read through the workspace-scoped, pocket-less path:
+#     ``registry.ensure_connected(name, "ws:<workspace_id>")`` resolves the
+#     workspace adapter (the #1445 path; ``pocket_id=None`` semantically — we
+#     never pass a ``pocket:<id>`` scope key), then ``adapter.execute(action,
+#     params)`` returns an ``ActionResult`` whose ``.data`` carries the records.
+#   * This runs on the TENANT'S LOCAL RUNTIME. The cloud LOCAL-exec seam returns
+#     HTTP 503 ``connector.local_agent_unavailable`` for local-mode actions, so
+#     the orchestrator drives the local ``ConnectorRegistry`` directly.
+#
+# Slice 1 is a DETERMINISTIC digest (no LLM refine). The optional draft-refine
+# pass (cleaning the ontology with an agent) is gated behind ``opts.refine`` and,
+# when enabled, MUST use the on-box / tenant model — never route tenant raw data
+# to a cloud model. It is not wired in slice 1 (the deterministic digest is
+# accepted); ``opts.refine=True`` raises so a caller can't silently get an
+# unrefined draft while believing it was refined.
+#
+# Async orchestration; depends on the OSS connector registry/adapter surface
+# (duck-typed for testability) + the SZD-3 digester. No DB writes — the draft is
+# returned for a downstream gate to review.
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from pocketpaw_ee.discovery.digester import Digester, StructuredShapeDigester
+from pocketpaw_ee.discovery.models import OntologyDraft
+
+logger = logging.getLogger(__name__)
+
+# Default per-connector sampling cap. A discovery run only needs enough records
+# to infer shapes/keys/links — not the whole dataset. Bounded so a large
+# connector can't blow up memory or wall-clock on the tenant box.
+DEFAULT_SAMPLE_CAP = 200
+
+# Trust levels whose actions are safe to invoke unattended during discovery.
+# "auto" actions are reads the agent may run without asking; anything that
+# mutates is "confirm" and must never fire on a sampling pass.
+_READ_TRUST_LEVELS = frozenset({"auto"})
+
+# HTTP methods that read rather than mutate. Discovery only ever reads.
+_READ_METHODS = frozenset({"GET", "HEAD"})
+
+
+@dataclass(frozen=True)
+class ReadAction:
+    """A single connector read to sample during discovery.
+
+    ``type_name`` labels the records this action returns so the digester can
+    group by type (one action → one logical type). When ``None``, the connector
+    name is used as the type label.
+    """
+
+    action: str
+    params: dict[str, Any] = field(default_factory=dict)
+    type_name: str | None = None
+
+
+@dataclass(frozen=True)
+class DiscoveryRunOptions:
+    """Knobs for a discovery run.
+
+    * ``sample_cap`` — max records kept per connector (the "N" in "N of M").
+    * ``read_actions`` — explicit ``{connector_id: [ReadAction, ...]}`` override.
+      When a connector is absent here, the orchestrator auto-selects its
+      read-shaped actions (GET/HEAD + ``auto`` trust level) from the adapter's
+      ``actions()`` schema. Supplying this is the precise path; auto-select is
+      the convenience default.
+    * ``allowed_connector_ids`` — permission filter. When set, only these
+      connector ids are sampled (the rest are skipped + noted). When ``None``,
+      all requested connectors are sampled — connector-level permission
+      enforcement isn't merged yet, so we degrade gracefully to allow-all and
+      record that in the draft meta.
+    * ``refine`` — request the optional on-box LLM refine pass. Not wired in
+      slice 1; setting it ``True`` raises rather than silently returning an
+      unrefined draft.
+    """
+
+    sample_cap: int = DEFAULT_SAMPLE_CAP
+    read_actions: dict[str, list[ReadAction]] = field(default_factory=dict)
+    allowed_connector_ids: frozenset[str] | None = None
+    refine: bool = False
+
+
+@runtime_checkable
+class _Adapter(Protocol):
+    """The slice of a connector adapter the orchestrator touches.
+
+    Deliberately narrow + duck-typed so a test can supply a mock without the
+    full ``ConnectorProtocol`` surface. ``actions()`` returns ``ActionSchema``
+    objects; ``execute()`` returns an ``ActionResult`` whose ``.data`` holds
+    records.
+    """
+
+    async def actions(self) -> Sequence[Any]: ...
+
+    async def execute(self, action: str, params: dict[str, Any]) -> Any: ...
+
+
+@runtime_checkable
+class _Registry(Protocol):
+    """The slice of the connector registry the orchestrator touches.
+
+    Only ``ensure_connected`` — the workspace-scoped resolve path. Duck-typed so
+    tests inject a mock and assert the scope key is ``ws:<workspace_id>`` (never
+    a ``pocket:<id>`` key, never ``sync``).
+    """
+
+    async def ensure_connected(self, connector_name: str, scope_key: str) -> Any | None: ...
+
+
+def _default_registry() -> _Registry:
+    """Lazily build the local-runtime ConnectorRegistry.
+
+    Mirrors ``src/pocketpaw/api/v1/connectors.py:_get_registry`` — the same
+    static registry rooted at ``connectors/``. Imported lazily so importing this
+    module never drags the registry in (and so tests can inject a mock instead).
+    """
+    from pathlib import Path
+
+    from pocketpaw.connectors.registry import ConnectorRegistry
+
+    return ConnectorRegistry(Path("connectors"))
+
+
+def _records_from_data(data: Any) -> list[Any]:
+    """Normalize an ActionResult ``.data`` payload into a list of records.
+
+    Adapters return reads in a few shapes: a bare ``list[dict]`` (most reads), a
+    single ``dict`` (a one-record read), or a wrapped envelope like
+    ``{"items": [...]}`` / ``{"results": [...]}`` / ``{"data": [...]}``. We
+    unwrap the common envelopes and otherwise treat a dict as one record. Empty
+    / ``None`` → no records (so an empty connector yields no rows, not a crash).
+    """
+    if data is None:
+        return []
+    if isinstance(data, Mapping):
+        for key in ("items", "results", "records", "rows", "data"):
+            inner = data.get(key)
+            if isinstance(inner, Sequence) and not isinstance(inner, (str, bytes)):
+                return list(inner)
+        # A lone dict is a single record.
+        return [data]
+    if isinstance(data, Sequence) and not isinstance(data, (str, bytes)):
+        return list(data)
+    # Scalar / unknown — no usable records.
+    return []
+
+
+def _is_read_action(schema: Any) -> bool:
+    """True when an ``ActionSchema`` looks like a safe read.
+
+    Read = GET/HEAD method AND ``auto`` trust level. Anything else (POST,
+    ``confirm``) can mutate and must never fire on a discovery pass. Tolerant of
+    enum-or-string fields so a mock can use plain strings.
+    """
+    method = str(getattr(schema, "method", "GET")).upper()
+    trust = str(getattr(schema, "trust_level", "confirm")).lower()
+    # StrEnum stringifies as "TrustLevel.auto" in some reprs; normalize to value.
+    trust = trust.rsplit(".", 1)[-1]
+    return method in _READ_METHODS and trust in _READ_TRUST_LEVELS
+
+
+class DiscoveryRun:
+    """Orchestrates one sovereign zero-setup discovery run.
+
+    ``run(workspace_id, connector_ids, opts)`` →
+      1. resolve each connector via the workspace-scoped path
+         (``ensure_connected(name, "ws:<workspace_id>")`` — pocket-less);
+      2. sample up to ``opts.sample_cap`` records/connector via
+         ``adapter.execute()`` over its read-shaped actions;
+      3. group records by type and run the ``StructuredShapeDigester``;
+      4. return an ``OntologyDraft`` labelled "based on N of M".
+
+    Degrades gracefully: an unresolvable / empty connector contributes no rows;
+    an all-empty run returns an empty draft (no crash). No DB writes — a
+    downstream gate reviews the draft.
+    """
+
+    def __init__(
+        self,
+        registry: _Registry | None = None,
+        digester: Digester | None = None,
+    ) -> None:
+        # Injected for tests; defaults to the local-runtime registry + the SZD-3
+        # structured digester. The registry is built lazily so a mock-injected
+        # run never touches the filesystem.
+        self._registry = registry
+        self._digester: Digester = digester or StructuredShapeDigester()
+
+    @property
+    def registry(self) -> _Registry:
+        if self._registry is None:
+            self._registry = _default_registry()
+        return self._registry
+
+    async def run(
+        self,
+        workspace_id: str,
+        connector_ids: Iterable[str],
+        opts: DiscoveryRunOptions | None = None,
+    ) -> OntologyDraft:
+        opts = opts or DiscoveryRunOptions()
+        if opts.refine:
+            # The on-box refine pass is not wired in slice 1. Fail loud rather
+            # than hand back a deterministic draft while a caller believes it
+            # was LLM-refined. When it lands it MUST use the tenant/on-box model.
+            raise NotImplementedError(
+                "DiscoveryRun refine pass is not implemented in slice 1; the "
+                "deterministic digest is the slice-1 contract. When wired, the "
+                "refine pass must run on the on-box / tenant model — never a "
+                "cloud model on tenant raw data."
+            )
+
+        requested = [c for c in connector_ids]
+        total_connectors = len(requested)
+
+        # Permission gate. No connector-level enforcement is merged yet, so when
+        # the caller doesn't pass an allow-list we sample all requested
+        # connectors and record the degraded posture in the draft meta.
+        permission_enforced = opts.allowed_connector_ids is not None
+        if permission_enforced:
+            allowed = opts.allowed_connector_ids or frozenset()
+            permitted = [c for c in requested if c in allowed]
+            skipped = [c for c in requested if c not in allowed]
+        else:
+            permitted = list(requested)
+            skipped = []
+
+        scope_key = f"ws:{workspace_id}"
+        grouped: dict[str, list[Any]] = {}
+        per_connector: dict[str, dict[str, Any]] = {}
+        sampled_connectors = 0
+
+        for connector_id in permitted:
+            # WORKSPACE-SCOPED, POCKET-LESS resolve — the #1445 path. NEVER
+            # ensure_connected(name, "pocket:<id>") and NEVER adapter.sync().
+            adapter = await self.registry.ensure_connected(connector_id, scope_key)
+            if adapter is None:
+                per_connector[connector_id] = {"status": "unresolved", "records": 0}
+                logger.info(
+                    "discovery: connector %s unresolved for %s — skipping",
+                    connector_id,
+                    scope_key,
+                )
+                continue
+
+            read_actions = await self._read_actions_for(connector_id, adapter, opts)
+            if not read_actions:
+                per_connector[connector_id] = {"status": "no_read_action", "records": 0}
+                logger.info(
+                    "discovery: connector %s exposes no read-shaped action — skipping",
+                    connector_id,
+                )
+                continue
+
+            connector_records = await self._sample_connector(
+                connector_id, adapter, read_actions, opts.sample_cap, grouped
+            )
+            sampled_connectors += 1
+            per_connector[connector_id] = {
+                "status": "sampled" if connector_records else "empty",
+                "records": connector_records,
+            }
+
+        draft = self._digester.digest(
+            grouped,
+            connector_meta={
+                "workspace_id": workspace_id,
+                "source": "discovery_run",
+            },
+        )
+
+        # Provenance — the "based on N of M" label + the per-connector roll-up.
+        draft.meta["discovery"] = {
+            "workspace_id": workspace_id,
+            "sampled_connectors": sampled_connectors,
+            "total_connectors": total_connectors,
+            "label": f"based on {sampled_connectors} of {total_connectors}",
+            "sample_cap": opts.sample_cap,
+            "permission_enforced": permission_enforced,
+            "skipped_by_permission": skipped,
+            "connectors": per_connector,
+        }
+        return draft
+
+    async def _read_actions_for(
+        self,
+        connector_id: str,
+        adapter: _Adapter,
+        opts: DiscoveryRunOptions,
+    ) -> list[ReadAction]:
+        """Resolve the read actions to sample for one connector.
+
+        Explicit ``opts.read_actions`` wins (the precise path). Otherwise
+        auto-select the adapter's read-shaped actions (GET/HEAD + ``auto`` trust)
+        from its ``actions()`` schema — the safe-reads-only convenience default.
+        """
+        explicit = opts.read_actions.get(connector_id)
+        if explicit:
+            return list(explicit)
+
+        try:
+            schemas = await adapter.actions()
+        except Exception as exc:  # noqa: BLE001 — a broken adapter can't block the run
+            logger.warning("discovery: actions() failed for %s: %s", connector_id, exc)
+            return []
+
+        out: list[ReadAction] = []
+        for schema in schemas or []:
+            if not _is_read_action(schema):
+                continue
+            name = getattr(schema, "name", None)
+            if not name:
+                continue
+            out.append(ReadAction(action=str(name), type_name=str(name)))
+        return out
+
+    async def _sample_connector(
+        self,
+        connector_id: str,
+        adapter: _Adapter,
+        read_actions: Sequence[ReadAction],
+        sample_cap: int,
+        grouped: dict[str, list[Any]],
+    ) -> int:
+        """Sample up to ``sample_cap`` records across a connector's read actions.
+
+        Records land in ``grouped[type_label]`` so the digester can infer one
+        type per action. The cap is enforced across ALL of the connector's
+        actions combined (the "N per connector" budget). Returns the count
+        sampled from this connector.
+        """
+        budget = max(0, sample_cap)
+        taken = 0
+        for read in read_actions:
+            if taken >= budget:
+                break
+            try:
+                result = await adapter.execute(read.action, dict(read.params))
+            except Exception as exc:  # noqa: BLE001 — one bad action can't kill the run
+                logger.warning(
+                    "discovery: execute(%s) failed on %s: %s",
+                    read.action,
+                    connector_id,
+                    exc,
+                )
+                continue
+
+            if not getattr(result, "success", False):
+                logger.info(
+                    "discovery: execute(%s) on %s returned failure: %s",
+                    read.action,
+                    connector_id,
+                    getattr(result, "error", None),
+                )
+                continue
+
+            records = _records_from_data(getattr(result, "data", None))
+            if not records:
+                continue
+
+            remaining = budget - taken
+            chunk = records[:remaining]
+            type_label = read.type_name or connector_id
+            grouped.setdefault(type_label, []).extend(chunk)
+            taken += len(chunk)
+
+        return taken
+
+
+__all__ = [
+    "DEFAULT_SAMPLE_CAP",
+    "DiscoveryRun",
+    "DiscoveryRunOptions",
+    "ReadAction",
+]

--- a/ee/pocketpaw_ee/fabric/router.py
+++ b/ee/pocketpaw_ee/fabric/router.py
@@ -35,6 +35,14 @@
 #   the store's scoped ``list_types()`` / ``stats()`` (own rows + legacy NULL
 #   rows, matching every other scoped read; type list = defined types with at
 #   least one visible object row — definitions stay global in the schema).
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — the
+#   ``POST /fabric/types`` (define_type) endpoint now stamps the caller's
+#   ``current_workspace_id`` onto the new type, so the discovered-type catalog
+#   is private per tenant: a type defined by workspace A is invisible/unusable
+#   from workspace B (``get_type_by_name`` / ``list_types`` / ``stats`` are
+#   scoped on the type's own ``workspace_id`` now). This supersedes the W4a /
+#   fix/fabric-stats note above that called definitions "global in the schema"
+#   — they carry their own workspace column as of SZD-2.
 
 from __future__ import annotations
 
@@ -125,13 +133,18 @@ async def list_types(workspace_id: str = Depends(current_workspace_id)):
     status_code=201,
     dependencies=[Depends(require_action_any_workspace("fabric.write"))],
 )
-async def define_type(req: DefineTypeRequest):
+async def define_type(
+    req: DefineTypeRequest,
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Define an object type stamped with the caller's active workspace (SZD-2)."""
     return await _store().define_type(
         name=req.name,
         properties=req.properties,
         description=req.description,
         icon=req.icon,
         color=req.color,
+        workspace_id=workspace_id,
     )
 
 

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,20 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-19 (SZD-5a — _fabric_objects proposal type) — added a gated
+#   Fabric-ontology proposal kind. ``_fabric_objects_blob`` +
+#   ``_assert_fabric_objects_workspace`` are the peers of the existing blob
+#   accessors + tenancy guards. The blob (``Action.parameters._fabric_objects``)
+#   carries {object_types[], objects[], links[], workspace_id}. On APPROVE the
+#   router emits ``human.corrected`` then fires
+#   ``fabric_proposals.executor.execute_approved_fabric_objects`` (which
+#   materialises the ontology via the workspace-scoped, idempotent
+#   ``connectors.fabric_ingest.ingest_records`` upsert loop and OWNS the chain
+#   close). On REJECT the router emits ``human.corrected`` +
+#   ``decision.completed(rejected)`` itself (the executor never runs on reject —
+#   no Fabric write happens). The ``_assert_fabric_objects_workspace`` 403 runs
+#   in ALL FOUR locations (approve / bulk-approve / reject / bulk-reject) BEFORE
+#   any mutation — asymmetric tenant scope is no tenant scope (pocketpaw#1183 /
+#   #1250). Same exactly-one-terminal discipline as the external-action gate.
 # Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — added the
 #   FIFTH gated proposal kind: the Branch-primitive artifact-change MERGE GATE.
 #   ``_artifact_change_blob`` + ``_assert_artifact_change_workspace`` are the
@@ -498,6 +513,48 @@ def _assert_external_action_workspace(action: Any, current_workspace: str) -> No
         )
 
 
+def _fabric_objects_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_fabric_objects`` blob on an Action, or ``None``.
+
+    The blob is the gated Fabric-ontology payload
+    ``ee.cloud.fabric_proposals.propose`` stores under
+    ``Action.parameters._fabric_objects`` (object_types / objects / links + the
+    originating ``workspace_id``). This is a peer gated proposal kind — the
+    approve path dispatches the apply-on-approve executor on its presence,
+    exactly as it dispatches the external-action executor on ``_external_action``.
+    Anything that is not a dict is treated as "no fabric objects".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_fabric_objects")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_fabric_objects_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting a Fabric-ontology write from another workspace.
+
+    Mirror of ``_assert_external_action_workspace`` for the ``_fabric_objects``
+    blob. ``require_action_any_workspace("instinct.approve")`` only proves the
+    caller holds the role SOMEWHERE; this binds the Fabric-objects Action to the
+    caller's active workspace. A Fabric write carries no pocket the way a parked
+    write does, so its tenancy lives entirely on the blob's ``workspace_id``. A
+    blob whose ``workspace_id`` differs from the caller's active workspace → 403,
+    on BOTH the approve and reject side (asymmetric tenant scope is no tenant
+    scope — pocketpaw#1183 / #1250). A non-fabric-objects Action (no blob) is
+    unaffected.
+    """
+    blob = _fabric_objects_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This fabric-objects write belongs to a different workspace",
+        )
+
+
 def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
     """Reject approving a parked pocket write from another workspace.
 
@@ -818,6 +875,7 @@ async def bulk_approve_actions(
             _assert_pocket_write_workspace(action, workspace_id)
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
+            _assert_fabric_objects_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -904,6 +962,39 @@ async def bulk_approve_actions(
             except Exception:
                 logger.exception(
                     "bulk-approve external-action execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
+        # A bulk-approved gated ``_fabric_objects`` Action materialises its
+        # proposed ontology in Fabric. Mirrors the external-action branch above:
+        # per-item ``human.corrected(accepted)`` (bulk-approve has no edit
+        # surface), the ``agent.proposed`` event id (off the blob's
+        # ``proposed_event_id``) as causation, then the executor (which owns the
+        # chain close). Matched BEFORE the pocket-write fallthrough and
+        # ``continue``d so the kinds never cross.
+        fabric_objects_blob = _fabric_objects_blob(action)
+        if fabric_objects_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=fabric_objects_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(fabric_objects_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.fabric_proposals import (
+                    executor as fabric_objects_executor,
+                )
+
+                await fabric_objects_executor.execute_approved_fabric_objects(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve fabric-objects execution failed for %s (non-fatal)",
                     action.id,
                 )
             continue
@@ -1039,6 +1130,7 @@ async def bulk_reject_actions(
             _assert_pocket_write_workspace(action, workspace_id)
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
+            _assert_fabric_objects_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -1118,6 +1210,32 @@ async def bulk_reject_actions(
             )
             _emit_decision_completed_rejected(
                 blob=external_action_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            continue
+
+        # A bulk-rejected gated ``_fabric_objects`` Action closes its chain HERE
+        # (the executor never runs on reject — the router owns the close). NO
+        # Fabric write happens. Mirrors the external-action reject branch.
+        # Matched AFTER pocket-write + code-change + external-action and
+        # ``continue``d so the kinds never cross.
+        fabric_objects_blob = _fabric_objects_blob(action)
+        if fabric_objects_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=fabric_objects_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(fabric_objects_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=fabric_objects_blob,
                 action=action,
                 user_id=rejector_id,
                 workspace_id=workspace_id,
@@ -1226,6 +1344,11 @@ async def approve_action(
     # Same tenancy gate for a gated external-action Action — its
     # ``_external_action`` blob carries the workspace, not a pocket.
     _assert_external_action_workspace(before, workspace_id)
+    # Same tenancy gate for a gated Fabric-objects Action — its
+    # ``_fabric_objects`` blob carries the workspace, not a pocket. Approving it
+    # writes typed objects into the tenant's Fabric, so the cross-workspace gate
+    # is mandatory here.
+    _assert_fabric_objects_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -1392,6 +1515,45 @@ async def approve_action(
         except Exception:
             logger.exception("external-action execution after approval failed (non-fatal)")
 
+    # When the approved Action carries a gated ``_fabric_objects`` blob,
+    # materialise the proposed ontology in Fabric (workspace-scoped, idempotent
+    # ingest). Same best-effort, lazy-import, never-break-the-approve-response
+    # shape as the external-action hook above; the executor records success /
+    # failure on the Action itself. A non-fabric-objects Action skips this.
+    #
+    # The Fabric-objects write is part of its own Decision-Graph chain (the
+    # propose helper minted the ``correlation_id`` + emitted ``agent.proposed``).
+    # Emit the ``human.corrected`` event for the approval HERE (the router owns
+    # the human-action emit on every approve path), citing the ``agent.proposed``
+    # event id (stored on the blob as ``proposed_event_id`` — the same field the
+    # external-action path reads, so ``_code_change_proposed_event_id`` resolves
+    # it) as causation, then thread its event id into the executor so the terminal
+    # ``decision.completed`` chains back to the approval. The executor owns the
+    # chain CLOSE (success or failure) — the router does NOT emit
+    # ``decision.completed`` here, mirroring the external-action executor. No
+    # double terminal.
+    fabric_objects_blob = _fabric_objects_blob(approved)
+    if fabric_objects_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=fabric_objects_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(fabric_objects_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.fabric_proposals import executor as fabric_objects_executor
+
+            await fabric_objects_executor.execute_approved_fabric_objects(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("fabric-objects execution after approval failed (non-fatal)")
+
     # MANDATES — when the approved Action carries a ``_belt_plan`` blob (the
     # mandate foreman's shift plan), dispatch the plan executor. Same shape as
     # the code-change hook: the router owns the ``human.corrected`` emit, the
@@ -1524,6 +1686,10 @@ async def reject_action(
     _assert_pocket_write_workspace(before, workspace_id)
     _assert_code_change_workspace(before, workspace_id)
     _assert_external_action_workspace(before, workspace_id)
+    # Same tenancy gate for a gated Fabric-objects Action on the REJECT side —
+    # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
+    # 403 before any mutation, exactly like the approve side.
+    _assert_fabric_objects_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -1613,6 +1779,33 @@ async def reject_action(
         )
         _emit_decision_completed_rejected(
             blob=external_action_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
+
+    # A rejected gated ``_fabric_objects`` Action closes its chain HERE (the
+    # executor never runs on reject — the router owns the close, mirroring the
+    # external-action reject path). NO Fabric write happens.
+    # ``human.corrected(rejected)`` cites the ``agent.proposed`` event (off the
+    # blob's ``proposed_event_id``); ``decision.completed(rejected)`` cites the
+    # human event so the chain reads ``agent.proposed → human.corrected →
+    # decision.completed``.
+    fabric_objects_blob = _fabric_objects_blob(action)
+    if fabric_objects_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=fabric_objects_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(fabric_objects_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=fabric_objects_blob,
             action=action,
             user_id=rejector_id,
             workspace_id=workspace_id,

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,22 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-19 (SZD-5b — _pocket_create proposal type) — added a gated
+#   starter-Pocket-create proposal kind (TENANCY GATE). ``_pocket_create_blob`` +
+#   ``_assert_pocket_create_workspace`` are the peers of the existing blob
+#   accessors + tenancy guards. The blob (``Action.parameters._pocket_create``)
+#   carries the staged ``pocket_spec`` plus, as SEPARATE top-level fields, the
+#   originating ``workspace_id`` and the owner ``user_id`` (kept OUT of the
+#   editable spec so the correction flow can't move tenancy/owner). On APPROVE the
+#   router emits ``human.corrected`` then fires
+#   ``pocket_proposals.executor.execute_approved_pocket_create`` (which creates the
+#   Pocket via the workspace-scoped ``pockets.service.create`` after a
+#   ``CreatePocketRequest.model_validate`` at entry, and OWNS the chain close). On
+#   REJECT the router emits ``human.corrected`` + ``decision.completed(rejected)``
+#   itself (the executor never runs on reject — no Pocket is created). The
+#   ``_assert_pocket_create_workspace`` 403 runs in ALL FOUR locations (approve /
+#   bulk-approve / reject / bulk-reject) BEFORE any mutation — asymmetric tenant
+#   scope is no tenant scope (pocketpaw#1183 / #1250). Same exactly-one-terminal
+#   discipline as the Fabric-objects gate.
 # Updated: 2026-06-19 (SZD-5a — _fabric_objects proposal type) — added a gated
 #   Fabric-ontology proposal kind. ``_fabric_objects_blob`` +
 #   ``_assert_fabric_objects_workspace`` are the peers of the existing blob
@@ -555,6 +572,49 @@ def _assert_fabric_objects_workspace(action: Any, current_workspace: str) -> Non
         )
 
 
+def _pocket_create_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_pocket_create`` blob on an Action, or ``None``.
+
+    The blob is the gated starter-Pocket-create payload
+    ``ee.cloud.pocket_proposals.propose`` stores under
+    ``Action.parameters._pocket_create`` (the staged ``pocket_spec`` +, as SEPARATE
+    top-level fields, the originating ``workspace_id`` and the owner ``user_id``).
+    This is a peer gated proposal kind — the approve path dispatches the
+    apply-on-approve executor on its presence, exactly as it dispatches the
+    Fabric-objects executor on ``_fabric_objects``. Anything that is not a dict is
+    treated as "no pocket create".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_pocket_create")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_pocket_create_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting a starter-Pocket create from another workspace.
+
+    Mirror of ``_assert_fabric_objects_workspace`` for the ``_pocket_create`` blob.
+    ``require_action_any_workspace("instinct.approve")`` only proves the caller
+    holds the role SOMEWHERE; this binds the Pocket-create Action to the caller's
+    active workspace. A proposed Pocket carries no EXISTING pocket the way a parked
+    write does, so its tenancy lives entirely on the blob's top-level
+    ``workspace_id`` (NEVER inside the editable ``pocket_spec``). A blob whose
+    ``workspace_id`` differs from the caller's active workspace → 403, on BOTH the
+    approve and reject side (asymmetric tenant scope is no tenant scope —
+    pocketpaw#1183 / #1250). A non-pocket-create Action (no blob) is unaffected.
+    """
+    blob = _pocket_create_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This pocket create belongs to a different workspace",
+        )
+
+
 def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
     """Reject approving a parked pocket write from another workspace.
 
@@ -876,6 +936,7 @@ async def bulk_approve_actions(
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
             _assert_fabric_objects_workspace(action, workspace_id)
+            _assert_pocket_create_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -995,6 +1056,38 @@ async def bulk_approve_actions(
             except Exception:
                 logger.exception(
                     "bulk-approve fabric-objects execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
+        # A bulk-approved gated ``_pocket_create`` Action creates its proposed
+        # starter Pocket. Mirrors the Fabric-objects branch above: per-item
+        # ``human.corrected(accepted)`` (bulk-approve has no edit surface), the
+        # ``agent.proposed`` event id (off the blob's ``proposed_event_id``) as
+        # causation, then the executor (which owns the chain close). Matched BEFORE
+        # the pocket-write fallthrough and ``continue``d so the kinds never cross.
+        pocket_create_blob = _pocket_create_blob(action)
+        if pocket_create_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=pocket_create_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(pocket_create_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.pocket_proposals import (
+                    executor as pocket_create_executor,
+                )
+
+                await pocket_create_executor.execute_approved_pocket_create(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve pocket-create execution failed for %s (non-fatal)",
                     action.id,
                 )
             continue
@@ -1131,6 +1224,7 @@ async def bulk_reject_actions(
             _assert_code_change_workspace(action, workspace_id)
             _assert_external_action_workspace(action, workspace_id)
             _assert_fabric_objects_workspace(action, workspace_id)
+            _assert_pocket_create_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -1244,6 +1338,32 @@ async def bulk_reject_actions(
             )
             continue
 
+        # A bulk-rejected gated ``_pocket_create`` Action closes its chain HERE
+        # (the executor never runs on reject — the router owns the close). NO
+        # Pocket is created. Mirrors the Fabric-objects reject branch. Matched
+        # AFTER pocket-write + code-change + external-action + fabric-objects and
+        # ``continue``d so the kinds never cross.
+        pocket_create_blob = _pocket_create_blob(action)
+        if pocket_create_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=pocket_create_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(pocket_create_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=pocket_create_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            continue
+
         # MANDATES — a bulk-rejected ``_belt_plan`` Action closes its chain
         # here (the plan executor never runs on reject), mirroring the
         # code-change branch above.
@@ -1349,6 +1469,11 @@ async def approve_action(
     # writes typed objects into the tenant's Fabric, so the cross-workspace gate
     # is mandatory here.
     _assert_fabric_objects_workspace(before, workspace_id)
+    # Same tenancy gate for a gated Pocket-create Action — its ``_pocket_create``
+    # blob carries the workspace (and owner) on SEPARATE top-level fields, not a
+    # pocket. Approving it creates a Pocket in the tenant's workspace, so the
+    # cross-workspace gate is mandatory here.
+    _assert_pocket_create_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -1554,6 +1679,46 @@ async def approve_action(
         except Exception:
             logger.exception("fabric-objects execution after approval failed (non-fatal)")
 
+    # When the approved Action carries a gated ``_pocket_create`` blob, create the
+    # proposed starter Pocket via ``pockets.service.create`` (workspace-scoped,
+    # owned by the blob's top-level ``user_id``). Same best-effort, lazy-import,
+    # never-break-the-approve-response shape as the Fabric-objects hook above; the
+    # executor records success / failure on the Action itself. A non-pocket-create
+    # Action skips this.
+    #
+    # The Pocket create is part of its own Decision-Graph chain (the propose helper
+    # minted the ``correlation_id`` + emitted ``agent.proposed``). Emit the
+    # ``human.corrected`` event for the approval HERE (the router owns the
+    # human-action emit on every approve path), citing the ``agent.proposed`` event
+    # id (stored on the blob as ``proposed_event_id`` — the same field the
+    # Fabric-objects path reads, so ``_code_change_proposed_event_id`` resolves it)
+    # as causation, then thread its event id into the executor so the terminal
+    # ``decision.completed`` chains back to the approval. The executor owns the
+    # chain CLOSE (success or failure) — the router does NOT emit
+    # ``decision.completed`` here, mirroring the Fabric-objects executor. No double
+    # terminal.
+    pocket_create_blob = _pocket_create_blob(approved)
+    if pocket_create_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=pocket_create_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(pocket_create_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.pocket_proposals import executor as pocket_create_executor
+
+            await pocket_create_executor.execute_approved_pocket_create(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("pocket-create execution after approval failed (non-fatal)")
+
     # MANDATES — when the approved Action carries a ``_belt_plan`` blob (the
     # mandate foreman's shift plan), dispatch the plan executor. Same shape as
     # the code-change hook: the router owns the ``human.corrected`` emit, the
@@ -1690,6 +1855,10 @@ async def reject_action(
     # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
     # 403 before any mutation, exactly like the approve side.
     _assert_fabric_objects_workspace(before, workspace_id)
+    # Same tenancy gate for a gated Pocket-create Action on the REJECT side —
+    # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
+    # 403 before any mutation, exactly like the approve side.
+    _assert_pocket_create_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -1806,6 +1975,33 @@ async def reject_action(
         )
         _emit_decision_completed_rejected(
             blob=fabric_objects_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
+
+    # A rejected gated ``_pocket_create`` Action closes its chain HERE (the
+    # executor never runs on reject — the router owns the close, mirroring the
+    # Fabric-objects reject path). NO Pocket is created.
+    # ``human.corrected(rejected)`` cites the ``agent.proposed`` event (off the
+    # blob's ``proposed_event_id``); ``decision.completed(rejected)`` cites the
+    # human event so the chain reads ``agent.proposed → human.corrected →
+    # decision.completed``.
+    pocket_create_blob = _pocket_create_blob(action)
+    if pocket_create_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=pocket_create_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(pocket_create_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=pocket_create_blob,
             action=action,
             user_id=rejector_id,
             workspace_id=workspace_id,

--- a/src/pocketpaw/connectors/fabric_ingest.py
+++ b/src/pocketpaw/connectors/fabric_ingest.py
@@ -12,6 +12,15 @@
 #   existing ObjectType by id (the EE Firestore→Fabric worker's per-workspace
 #   mapping) ride this same canonical upsert loop instead of hand-rolling a
 #   parallel one. Additive; name-based callers are unchanged.
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ensure_type() now
+#   threads ``workspace_id`` into both the get_type_by_name() resolve and the
+#   define_type() create, so the type catalog stays per-tenant: a connector
+#   ingesting into workspace A resolves/defines its ObjectType inside A, and the
+#   same logical type name in workspace B resolves to B's own type (or is
+#   defined fresh for B) rather than silently reusing A's. ``ingest_records``
+#   already carried ``workspace_id`` for the object writes; it now forwards it to
+#   ensure_type so the TYPE mint is scoped too. ``None`` (OSS / single-tenant
+#   callers) keeps the prior unscoped behavior.
 #
 # WHY THIS EXISTS
 # ---------------
@@ -117,22 +126,30 @@ class IngestResult:
         return self.created + self.updated
 
 
-async def ensure_type(store: FabricStore, mapping: FabricMapping) -> str:
+async def ensure_type(
+    store: FabricStore, mapping: FabricMapping, workspace_id: str | None = None
+) -> str:
     """Ensure the mapping's ObjectType exists; return its ``type_id``.
 
     When the mapping carries an explicit ``type_id`` (the caller's config
     references an existing type by id), return it directly — no name lookup,
     no implicit define.
 
-    Otherwise, define-once-by-name: if a type with this name already exists (a
-    prior sync, a manually-defined ontology type, the EE fabric registry),
-    reuse it rather than creating a second type that would split the same
-    logical objects across two ``type_id``s. Name match is case-insensitive
-    (see get_type_by_name).
+    Otherwise, define-once-by-name: if a type with this name already exists in
+    the caller's workspace (a prior sync, a manually-defined ontology type, the
+    EE fabric registry), reuse it rather than creating a second type that would
+    split the same logical objects across two ``type_id``s. Name match is
+    case-insensitive (see get_type_by_name).
+
+    SZD-2: ``workspace_id`` scopes both the resolve and the define so the type
+    catalog is per-tenant — workspace A's "CalendarEvent" type is neither found
+    nor reused when ingesting into workspace B, and a fresh define for B is
+    stamped with B's workspace. ``None`` keeps the unscoped behavior for OSS /
+    single-tenant callers.
     """
     if mapping.type_id:
         return mapping.type_id
-    existing = await store.get_type_by_name(mapping.type_name)
+    existing = await store.get_type_by_name(mapping.type_name, workspace_id=workspace_id)
     if existing is not None:
         return existing.id
     created = await store.define_type(
@@ -141,6 +158,7 @@ async def ensure_type(store: FabricStore, mapping: FabricMapping) -> str:
         description=mapping.type_description,
         icon=mapping.type_icon,
         color=mapping.type_color,
+        workspace_id=workspace_id,
     )
     return created.id
 
@@ -172,7 +190,7 @@ async def ingest_records(
     lacking a usable source_id are skipped (counted) — without a stable key they
     cannot be deduplicated and would silently duplicate on every sync.
     """
-    type_id = await ensure_type(store, mapping)
+    type_id = await ensure_type(store, mapping, workspace_id=workspace_id)
     result = IngestResult(type_name=mapping.type_name)
 
     for record in records:

--- a/src/pocketpaw/fabric/models.py
+++ b/src/pocketpaw/fabric/models.py
@@ -19,6 +19,15 @@
 #   latency / infinite-loop risk); PathHop.link_type carries Field(max_length=200)
 #   as a sanity bound on an LLM-facing string (values are already bound params,
 #   so this is hygiene, not injection defense).
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — ObjectType gains an
+#   optional ``workspace_id`` so the discovered-type catalog is per-tenant. This
+#   reverses the earlier W4a choice (object_types deliberately had NO workspace
+#   column then); the "sovereign zero-setup discovery" feature requires each
+#   tenant's discovered object TYPES to stay private, so a type defined in
+#   workspace A must be invisible/unusable from workspace B. ``None`` = a
+#   legacy/global type predating tenancy (or an OSS / single-tenant caller),
+#   which a scoped read still sees — exactly the NULL-as-legacy boundary the
+#   W4a object/link scoping already uses.
 
 from __future__ import annotations
 
@@ -66,6 +75,10 @@ class ObjectType(BaseModel):
     icon: str = "box"
     color: str = "#0A84FF"
     properties: list[PropertyDef] = Field(default_factory=list)
+    # Tenancy (SZD-2): the owning workspace of this object TYPE. ``None`` =
+    # legacy/global type written before per-type tenancy or by an OSS /
+    # single-tenant caller; a scoped read still sees it (own rows + NULL).
+    workspace_id: str | None = None
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
 

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -99,6 +99,42 @@
 #   tenant-scoped per hop, so this changes no result, it just makes the last read
 #   self-guarding. Walk is iterative, fixed-depth, no cross-hop cycle re-visit
 #   (see the note in _query_path).
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — closes the LAST
+#   cross-tenant leak in the Fabric store: the object-TYPE catalog was GLOBAL.
+#   W4a deliberately left ``fabric_object_types`` without a ``workspace_id``
+#   column ("definitions are not per-tenant data"), and ``list_types`` / ``stats``
+#   only hid type NAMES indirectly by joining to a visible object row. But the
+#   "sovereign zero-setup discovery" feature requires the DISCOVERED type catalog
+#   to be private per workspace, and ``define_type`` / ``get_type_by_name`` took
+#   no workspace — so a type defined in workspace A was directly visible and
+#   reusable from workspace B (``get_type_by_name`` returned it, ``ensure_type``
+#   reused its id). This change:
+#     1. Adds a ``workspace_id TEXT`` column to ``fabric_object_types`` via the
+#        same additive ALTER migration the W4a object/link columns use (idempotent
+#        — the duplicate-column OperationalError is swallowed on every boot). A
+#        pre-existing row keeps NULL ``workspace_id`` = legacy/global; the backfill
+#        below attributes a row to a workspace ONLY when every object of that type
+#        unambiguously shares one workspace (otherwise it stays NULL = global, the
+#        documented sentinel — a type cannot be safely attributed after the fact
+#        when its objects span tenants or predate tenancy).
+#     2. ``define_type`` stamps the caller's ``workspace_id``; ``get_type_by_name``
+#        and ``get_type`` take an optional ``workspace_id`` and apply the same
+#        ``(workspace_id = ? OR workspace_id IS NULL)`` scope as every other W4a
+#        read. A scoped read for workspace B can therefore neither see nor reuse
+#        workspace A's type. ``workspace_id=None`` = unscoped (OSS / agent-tool /
+#        single-tenant callers), full backward compatibility.
+#     3. ``list_types`` / ``stats`` now scope on the TYPE's OWN ``workspace_id``
+#        (own rows + legacy NULL) instead of joining through a visible object row,
+#        so a tenant's empty (object-less) type is visible to its owner and an
+#        owned-but-empty type no longer disappears — the type catalog is now first
+#        -class tenant data, not metadata inferred from object rows.
+#     4. The unique-name index becomes UNIQUE on ``(workspace_id, LOWER(name))``
+#        (was a global UNIQUE on ``LOWER(name)``) so two workspaces may each define
+#        their own "Customer" type; the concurrent-``ensure_type`` race guard now
+#        holds PER workspace. The de-dup pass keys on ``(workspace_id, name)`` to
+#        match. ``ensure_type`` / ``ingest_records`` (connectors/fabric_ingest.py)
+#        thread ``workspace_id`` so existing ingestion keeps working and minted
+#        types land in the caller's tenant.
 
 
 from __future__ import annotations
@@ -141,6 +177,11 @@ CREATE TABLE IF NOT EXISTS fabric_object_types (
     icon TEXT DEFAULT 'box',
     color TEXT DEFAULT '#0A84FF',
     properties_schema TEXT DEFAULT '[]',
+    -- Tenancy (SZD-2): the owning workspace of this object TYPE. NULL =
+    -- legacy/global type written before per-type tenancy or by an OSS caller;
+    -- a scoped read still sees it (own rows + NULL). On a pre-SZD-2 DB this
+    -- column is added by the ALTER migration in _ensure_schema, NOT here.
+    workspace_id TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -187,19 +228,34 @@ CREATE INDEX IF NOT EXISTS idx_links_type ON fabric_links(link_type);
 _WORKSPACE_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_objects_workspace ON fabric_objects(workspace_id)",
     "CREATE INDEX IF NOT EXISTS idx_links_workspace ON fabric_links(workspace_id)",
+    # SZD-2: a plain (non-unique) index on the type's workspace for scoped
+    # list_types / stats reads. The UNIQUE (workspace_id, LOWER(name)) index is
+    # created separately (_TYPE_NAME_UNIQUE_INDEX_SQL) after the de-dup pass.
+    "CREATE INDEX IF NOT EXISTS idx_object_types_workspace ON fabric_object_types(workspace_id)",
 )
 
-# A UNIQUE index on the (case-folded) type name closes a concurrent
+# A UNIQUE index on (workspace_id, case-folded type name) closes a concurrent
 # ``ensure_type`` race: two callers both miss ``get_type_by_name`` and both run
 # ``define_type``, leaving two type rows with the SAME name but different ids —
 # objects of "the same logical type" then split across two ``type_id``s. Created
 # AFTER SCHEMA_SQL (same reason as _WORKSPACE_INDEX_SQL): a pre-existing DB may
 # already hold duplicate-name rows, so _ensure_schema de-dups defensively before
 # creating the index. ``get_type_by_name`` matches case-insensitively, so the
-# uniqueness key is LOWER(name) to match.
+# name key is LOWER(name).
+#
+# SZD-2: the uniqueness key now includes ``workspace_id`` so two DIFFERENT
+# workspaces may each define their own "Customer" type — the race guard is
+# per-workspace. SQLite treats NULLs as DISTINCT in a UNIQUE index, so legacy
+# NULL-workspace rows are NOT collapsed by this index (multiple NULL-workspace
+# "Customer" rows can coexist); the de-dup pass that runs first keys on
+# (workspace_id, name) and still collapses true within-workspace duplicates
+# (including NULL/NULL pairs) up front. The old global index on LOWER(name)
+# (``idx_object_types_name_unique``) is DROPPED in the migration first, because
+# it would otherwise reject a second workspace defining a name the first used.
+_OLD_GLOBAL_TYPE_NAME_INDEX = "idx_object_types_name_unique"
 _TYPE_NAME_UNIQUE_INDEX_SQL = (
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_object_types_name_unique"
-    " ON fabric_object_types(LOWER(name))"
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_object_types_ws_name_unique"
+    " ON fabric_object_types(workspace_id, LOWER(name))"
 )
 
 # Whitelist of filter operators -> SQL operator. User input never reaches the
@@ -318,28 +374,45 @@ class FabricStore:
             return
         async with aiosqlite.connect(self._db_path) as db:
             await db.executescript(SCHEMA_SQL)
-            # Additive migration (W4a): tenancy columns on a pre-existing DB.
-            # CREATE TABLE IF NOT EXISTS won't add a column to a table that
+            # Additive migration (W4a + SZD-2): tenancy columns on a pre-existing
+            # DB. CREATE TABLE IF NOT EXISTS won't add a column to a table that
             # already exists, so ALTER and swallow the duplicate-column error
             # that fires on every subsequent boot — same pattern as the W2b
             # instinct hash-chain / assignee migrations. Pre-existing rows keep
-            # NULL workspace_id (legacy/global; see the module header).
-            for _tbl in ("fabric_objects", "fabric_links"):
+            # NULL workspace_id (legacy/global; see the module header). SZD-2
+            # extends the same ALTER to fabric_object_types so the type catalog
+            # is per-tenant too.
+            for _tbl in ("fabric_objects", "fabric_links", "fabric_object_types"):
                 try:
                     await db.execute(f"ALTER TABLE {_tbl} ADD COLUMN workspace_id TEXT")
                 except aiosqlite.OperationalError:
                     pass
+            # SZD-2: drop the pre-SZD-2 GLOBAL unique index on LOWER(name) if it
+            # exists. It enforced one type name per WHOLE DB; under per-workspace
+            # tenancy two tenants must be able to use the same name, so it would
+            # otherwise reject the second tenant's define_type. The replacement
+            # (workspace_id, LOWER(name)) index is created below. DROP IF EXISTS
+            # is a no-op on a fresh / already-migrated DB.
+            await db.execute(f"DROP INDEX IF EXISTS {_OLD_GLOBAL_TYPE_NAME_INDEX}")
             # Create the tenancy indexes only after the column is guaranteed to
             # exist (fresh DB via CREATE TABLE, or pre-existing DB via the ALTER
             # above). Doing this inside SCHEMA_SQL would fail on a pre-W4a DB.
             for _idx in _WORKSPACE_INDEX_SQL:
                 await db.execute(_idx)
-            # Unique-name index on fabric_object_types. A pre-existing DB may
-            # already hold duplicate-name rows (the ensure_type race this index
-            # prevents could have fired before this code shipped), so de-dup
-            # FIRST, then create the index. Both steps are wrapped so a residual
-            # duplicate can never crash _ensure_schema — a metering/ontology
-            # nicety must not take the store down on boot.
+            # SZD-2 backfill: attribute a NULL-workspace type to a tenant ONLY
+            # when every object of that type unambiguously shares one workspace.
+            # A type whose objects span tenants (or that has no objects, or whose
+            # objects are themselves legacy NULL) stays NULL = global, the
+            # documented sentinel — it cannot be safely attributed after the
+            # fact. Idempotent: a second run finds nothing left to attribute.
+            await self._backfill_object_type_workspaces(db)
+            # Unique (workspace_id, name) index on fabric_object_types. A
+            # pre-existing DB may already hold duplicate (workspace, name) rows
+            # (the ensure_type race this index prevents could have fired before
+            # this code shipped), so de-dup FIRST, then create the index. Both
+            # steps are wrapped so a residual duplicate can never crash
+            # _ensure_schema — a metering/ontology nicety must not take the store
+            # down on boot.
             await self._dedup_object_types(db)
             try:
                 await db.execute(_TYPE_NAME_UNIQUE_INDEX_SQL)
@@ -350,37 +423,88 @@ class FabricStore:
                 # is a race guard, not a correctness invariant the store needs
                 # to function.
                 logger.warning(
-                    "could not create unique index on fabric_object_types(name) — "
-                    "duplicate type names may remain; ensure_type race guard is off",
+                    "could not create unique index on "
+                    "fabric_object_types(workspace_id, name) — duplicate type "
+                    "names may remain; ensure_type race guard is off",
                     exc_info=True,
                 )
             await db.commit()
         self._initialized = True
 
     @staticmethod
-    async def _dedup_object_types(db: aiosqlite.Connection) -> None:
-        """Collapse duplicate-name object types before the UNIQUE index is built.
+    async def _backfill_object_type_workspaces(db: aiosqlite.Connection) -> None:
+        """Attribute NULL-workspace object types to a tenant where unambiguous (SZD-2).
 
-        Two type rows can share a name (case-insensitively) only on a DB that
-        predates the unique index — the concurrent ``ensure_type`` race. Keep the
-        LOWEST rowid per case-folded name (the first-defined survivor), re-point
-        any objects bound to a losing type id at the survivor's id so no object is
-        orphaned, then delete the loser type rows. Best-effort: a failure here is
-        swallowed (logged) so it can never crash ``_ensure_schema``; the index
-        creation that follows is itself try/except-guarded as the final backstop.
+        A pre-SZD-2 row has NULL ``workspace_id``. We can sometimes recover the
+        owning tenant from its objects: if EVERY non-NULL object of the type
+        carries the SAME ``workspace_id`` and there is exactly one such workspace,
+        the type clearly belongs to that tenant and we stamp it. Otherwise — the
+        type has no objects, or its objects span multiple workspaces, or its
+        objects are themselves all legacy NULL — the row stays NULL = global (the
+        documented sentinel), because it cannot be safely attributed after the
+        fact. Only NULL-workspace type rows are touched, so this never re-homes a
+        type a caller already stamped. Idempotent: a second run re-derives the
+        same single-workspace attributions and finds nothing new to change.
+        Best-effort: any failure is swallowed (logged) so it can never crash
+        ``_ensure_schema``.
+        """
+        try:
+            db.row_factory = aiosqlite.Row
+            # For each NULL-workspace type, the DISTINCT non-NULL workspaces of
+            # its objects. A HAVING COUNT(DISTINCT ...) = 1 keeps only the
+            # types whose objects unambiguously live in a single tenant.
+            async with db.execute(
+                "SELECT o.type_id AS type_id, MIN(o.workspace_id) AS ws "
+                "FROM fabric_objects o "
+                "JOIN fabric_object_types t ON t.id = o.type_id "
+                "WHERE t.workspace_id IS NULL AND o.workspace_id IS NOT NULL "
+                "GROUP BY o.type_id "
+                "HAVING COUNT(DISTINCT o.workspace_id) = 1"
+            ) as cur:
+                rows = await cur.fetchall()
+            for row in rows:
+                await db.execute(
+                    "UPDATE fabric_object_types SET workspace_id = ? "
+                    "WHERE id = ? AND workspace_id IS NULL",
+                    (row["ws"], row["type_id"]),
+                )
+        except aiosqlite.Error:
+            logger.warning(
+                "fabric_object_types workspace backfill failed — leaving rows NULL",
+                exc_info=True,
+            )
+        finally:
+            db.row_factory = None
+
+    @staticmethod
+    async def _dedup_object_types(db: aiosqlite.Connection) -> None:
+        """Collapse duplicate (workspace, name) object types before the UNIQUE index.
+
+        Two type rows can share a (workspace_id, case-folded name) only on a DB
+        that predates the unique index — the concurrent ``ensure_type`` race.
+        Keep the LOWEST rowid per (workspace, case-folded name) (the
+        first-defined survivor), re-point any objects bound to a losing type id
+        at the survivor's id so no object is orphaned, then delete the loser type
+        rows. SZD-2: the de-dup key now includes ``workspace_id`` so two tenants'
+        same-named types are NOT collapsed into one — only true within-workspace
+        duplicates are (legacy NULL/NULL pairs included, so the survivor of a pair
+        of global "Customer" rows is kept and the index can be created). Best
+        -effort: a failure here is swallowed (logged) so it can never crash
+        ``_ensure_schema``; the index creation that follows is itself try/except
+        -guarded as the final backstop.
         """
         try:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT rowid, id, name FROM fabric_object_types ORDER BY rowid ASC"
+                "SELECT rowid, id, name, workspace_id FROM fabric_object_types ORDER BY rowid ASC"
             ) as cur:
                 rows = await cur.fetchall()
-            survivor_by_name: dict[str, str] = {}
+            survivor_by_key: dict[tuple[str | None, str], str] = {}
             for row in rows:
-                key = (row["name"] or "").strip().lower()
-                survivor_id = survivor_by_name.get(key)
+                key = (row["workspace_id"], (row["name"] or "").strip().lower())
+                survivor_id = survivor_by_key.get(key)
                 if survivor_id is None:
-                    survivor_by_name[key] = row["id"]
+                    survivor_by_key[key] = row["id"]
                     continue
                 loser_id = row["id"]
                 if loser_id == survivor_id:
@@ -416,20 +540,30 @@ class FabricStore:
         description: str = "",
         icon: str = "box",
         color: str = "#0A84FF",
+        workspace_id: str | None = None,
     ) -> ObjectType:
+        """Define a new object type, optionally scoped to a tenant (SZD-2).
+
+        ``workspace_id`` stamps the owning workspace on the type row so the
+        discovered-type catalog stays private per tenant: a type defined here
+        for workspace A is invisible/unusable from workspace B (see
+        :meth:`get_type_by_name`). ``None`` writes a legacy/global type (OSS /
+        agent-tool / single-tenant callers), visible to every scoped read.
+        """
         obj_type = ObjectType(
             name=name,
             description=description,
             icon=icon,
             color=color,
             properties=properties,
+            workspace_id=workspace_id,
         )
         await self._ensure_schema()
         async with self._conn() as db:
             await db.execute(
                 "INSERT INTO fabric_object_types"
-                " (id, name, description, icon, color, properties_schema)"
-                " VALUES (?, ?, ?, ?, ?, ?)",
+                " (id, name, description, icon, color, properties_schema, workspace_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     obj_type.id,
                     obj_type.name,
@@ -437,64 +571,91 @@ class FabricStore:
                     obj_type.icon,
                     obj_type.color,
                     json.dumps([p.model_dump() for p in properties]),
+                    workspace_id,
                 ),
             )
             await db.commit()
         return obj_type
 
-    async def get_type(self, type_id: str) -> ObjectType | None:
+    async def get_type(self, type_id: str, workspace_id: str | None = None) -> ObjectType | None:
+        """Fetch one object type by id, optionally scoped to ``workspace_id`` (SZD-2).
+
+        When ``workspace_id`` is supplied, a type owned by another tenant returns
+        ``None`` (legacy NULL-workspace types stay visible). ``None`` leaves the
+        read unscoped (OSS / agent-tool / single-tenant callers). Note that
+        :meth:`create_object` calls this UNSCOPED on purpose — it only needs the
+        type's name to denormalize onto the object row, and the object write
+        itself carries the tenancy guard.
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_object_types WHERE id = ?"
+        params: list[Any] = [type_id]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM fabric_object_types WHERE id = ?", (type_id,)
-            ) as cur:
+            async with db.execute(sql, params) as cur:
                 row = await cur.fetchone()
                 if not row:
                     return None
                 return self._row_to_type(row)
 
-    async def get_type_by_name(self, name: str) -> ObjectType | None:
+    async def get_type_by_name(
+        self, name: str, workspace_id: str | None = None
+    ) -> ObjectType | None:
+        """Resolve an object type by (case-insensitive) name, scoped to a tenant (SZD-2).
+
+        This is the read ``ensure_type`` uses to decide "reuse the existing type
+        or define a new one". Scoping it is the core of SZD-2: a type defined in
+        workspace A must be invisible AND non-reusable from workspace B, so a
+        scoped lookup returns only the caller's own type (or a legacy NULL-
+        workspace type). With ``workspace_id`` set, two tenants that both have a
+        "Customer" type each resolve to THEIR OWN id; ``None`` is unscoped and
+        returns the first match by rowid (OSS / single-tenant callers).
+        """
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        sql = "SELECT * FROM fabric_object_types WHERE LOWER(name) = LOWER(?)"
+        params: list[Any] = [name]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        # When scoped, the caller's OWN type wins over a legacy NULL-workspace
+        # type of the same name: order own-rows-first (workspace_id NOT NULL),
+        # then by rowid for a stable pick.
+        sql += " ORDER BY (workspace_id IS NULL), rowid LIMIT 1"
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM fabric_object_types WHERE LOWER(name) = LOWER(?)", (name,)
-            ) as cur:
+            async with db.execute(sql, params) as cur:
                 row = await cur.fetchone()
                 if not row:
                     return None
                 return self._row_to_type(row)
 
     async def list_types(self, workspace_id: str | None = None) -> list[ObjectType]:
-        """List object types, optionally scoped to a tenant (W4a follow-up).
+        """List object types, optionally scoped to a tenant (SZD-2).
 
-        Type DEFINITIONS are global — ``fabric_object_types`` has no
-        ``workspace_id`` column (a deliberate W4a choice: the shared schema is
-        not per-tenant data). But the type NAMES a tenant can see are tenant
-        metadata: on a shared deployment, listing every defined type leaks what
-        other tenants are modeling. So a scoped call returns only the types
-        with at least one object row VISIBLE to that workspace — the same
-        visibility ``query()`` applies (own rows plus legacy NULL-workspace
-        rows, via ``_workspace_scope``). A defined type with no visible rows
-        (including the caller's own empty types) is omitted; it reappears the
-        moment a visible object exists. ``workspace_id=None`` keeps the
-        original unscoped behavior (all defined types) for OSS / single-tenant
-        callers.
+        SZD-2: type definitions are now first-class TENANT data —
+        ``fabric_object_types`` carries its own ``workspace_id``. A scoped call
+        returns the caller's OWN types plus legacy NULL-workspace types (the
+        same ``_workspace_scope`` visibility every other W4a read uses), scoped
+        on the TYPE's column directly. This supersedes the earlier
+        join-through-a-visible-object-row approach (fix/fabric-stats-workspace-
+        scope): a tenant's empty (object-less) type is now correctly listed for
+        its owner and is invisible to other tenants. ``workspace_id=None`` keeps
+        the original unscoped behavior (all defined types) for OSS / single-
+        tenant callers.
         """
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            if workspace_id is None:
+            ws_cond, params = _workspace_scope(workspace_id)
+            if ws_cond is None:
                 sql = "SELECT * FROM fabric_object_types ORDER BY name"
-                params: list[Any] = []
             else:
-                ws_cond, params = _workspace_scope(workspace_id, column="o.workspace_id")
-                sql = (
-                    "SELECT DISTINCT t.* FROM fabric_object_types t"
-                    " JOIN fabric_objects o ON o.type_id = t.id"
-                    f" WHERE {ws_cond} ORDER BY t.name"
-                )
+                sql = f"SELECT * FROM fabric_object_types WHERE {ws_cond} ORDER BY name"
             async with db.execute(sql, params) as cur:
                 return [self._row_to_type(row) async for row in cur]
 
@@ -1083,12 +1244,11 @@ class FabricStore:
         legacy NULL-workspace rows, via ``_workspace_scope``) so stats and
         query always agree: ``stats(workspace_id=w)["objects"]`` equals the
         ``total`` of an unfiltered scoped query. ``links`` applies the same
-        scope to ``fabric_links``. ``types`` counts the DEFINED types with at
-        least one visible object row — matching ``list_types(workspace_id=w)``
-        — because type definitions are global but which types a tenant sees is
-        tenant metadata (the cross-tenant type-name leak this closes).
-        ``workspace_id=None`` keeps the original unscoped, instance-wide
-        behavior for OSS / single-tenant callers.
+        scope to ``fabric_links``. SZD-2: ``types`` now counts types scoped on
+        the TYPE's OWN ``workspace_id`` (own rows + legacy NULL) so it matches
+        ``list_types(workspace_id=w)`` exactly — including the caller's empty,
+        object-less types. ``workspace_id=None`` keeps the original unscoped,
+        instance-wide behavior for OSS / single-tenant callers.
         """
         await self._ensure_schema()
         async with self._conn() as db:
@@ -1103,11 +1263,9 @@ class FabricStore:
                 }
             obj_cond, obj_params = _workspace_scope(workspace_id)
             link_cond, link_params = _workspace_scope(workspace_id)
-            type_cond, type_params = _workspace_scope(workspace_id, column="o.workspace_id")
+            type_cond, type_params = _workspace_scope(workspace_id)
             types = await db.execute_fetchall(
-                "SELECT COUNT(DISTINCT t.id) FROM fabric_object_types t"
-                " JOIN fabric_objects o ON o.type_id = t.id"
-                f" WHERE {type_cond}",
+                f"SELECT COUNT(*) FROM fabric_object_types WHERE {type_cond}",
                 type_params,
             )
             objects = await db.execute_fetchall(
@@ -1126,6 +1284,11 @@ class FabricStore:
 
     def _row_to_type(self, row: Any) -> ObjectType:
         props_raw = json.loads(row["properties_schema"]) if row["properties_schema"] else []
+        # SZD-2: surface the type's owning workspace. ``keys()`` guard keeps the
+        # helper resilient to any legacy SELECT projection that omitted the
+        # column (defensive — current callers all SELECT *).
+        keys = row.keys() if hasattr(row, "keys") else ()
+        workspace_id = row["workspace_id"] if "workspace_id" in keys else None
         return ObjectType(
             id=row["id"],
             name=row["name"],
@@ -1133,6 +1296,7 @@ class FabricStore:
             icon=row["icon"] or "box",
             color=row["color"] or "#0A84FF",
             properties=[PropertyDef(**p) for p in props_raw],
+            workspace_id=workspace_id,
         )
 
     def _row_to_object(self, row: Any) -> FabricObject:

--- a/tests/cloud/test_ee_fabric.py
+++ b/tests/cloud/test_ee_fabric.py
@@ -43,6 +43,17 @@
 #   result, NOT an error), a single-hop fan-out exceeding MAX_FRONTIER (clean
 #   ValueError, never a SQLite bound-variable crash), and a path deeper than
 #   MAX_HOPS rejected at FabricQuery construction.
+# Updated: 2026-06-19 (SZD-2 — workspace-scope object TYPES) — reworked
+#   TestStatsWorkspaceScoping and TestTypeNameUniqueIndex for the new per-type
+#   tenancy. fabric_object_types now carries its OWN workspace_id, so scoped
+#   list_types / stats filter on the type's column (own rows + legacy NULL)
+#   instead of inferring visibility from object rows. Concretely: define_type
+#   takes a workspace_id and a type stamped for ws-b is invisible to ws-a;
+#   an owner's EMPTY (object-less) type IS now visible to its owner (the old
+#   "omit empty types" rule was an artifact of the join-through-objects
+#   approach and is inverted here); the unique index is now
+#   (workspace_id, LOWER(name)) named idx_object_types_ws_name_unique, and the
+#   race guard is exercised within a single workspace.
 
 from __future__ import annotations
 
@@ -416,19 +427,20 @@ class TestWorkspaceScoping:
 
 
 class TestStatsWorkspaceScoping:
-    """fix/fabric-stats-workspace-scope — scoped stats() and list_types().
+    """Scoped stats() and list_types() (fix/fabric-stats-workspace-scope, SZD-2).
 
-    The last two W4a reads were left instance-wide. On a shared ``fabric.db``
-    that leaked: a tenant's chat called fabric_stats and got back another
-    context's experimental type names (``Lease`` / ``Lease2``), and the global
-    object count (13) disagreed with what the workspace-scoped query actually
-    saw (11). These tests pin both: scoped counts mirror ``query()`` exactly,
-    and a scoped type list never names a type only another tenant has rows for.
+    On a shared ``fabric.db`` an unscoped read leaked across tenants: a tenant's
+    chat called fabric_stats and got back another context's experimental type
+    names (``Lease`` / ``Lease2``), and the global object count disagreed with
+    what the workspace-scoped query actually saw. These tests pin both: scoped
+    counts mirror ``query()`` exactly, and a scoped type list never names
+    another tenant's type.
 
-    Subtlety being guarded: ``fabric_object_types`` has NO workspace column —
-    type DEFINITIONS are global. So a scoped type list cannot come from the
-    type table; it must be derived from types with at least one object row
-    VISIBLE to the workspace.
+    SZD-2 changed the mechanism: ``fabric_object_types`` now carries its OWN
+    ``workspace_id``, so a scoped type list filters on the type table directly
+    (own rows + legacy NULL), not by inferring visibility from object rows. A
+    type is therefore isolated by who DEFINED it, not by who has rows of it —
+    and an owner's empty type is visible to its owner.
     """
 
     @pytest.mark.asyncio
@@ -460,15 +472,13 @@ class TestStatsWorkspaceScoping:
     async def test_scoped_type_list_excludes_other_tenant_type_names(
         self, store: FabricStore
     ) -> None:
-        # The exact live leak: ws-b defines "Lease" / "Lease2" and only B has
-        # rows of them. ws-a, which only models "Customer", must NOT see those
-        # type names — even though the type DEFINITIONS are global.
-        customer = await store.define_type(name="Customer", properties=[])
-        lease = await store.define_type(name="Lease", properties=[])
-        lease2 = await store.define_type(name="Lease2", properties=[])
-        await store.create_object(customer.id, {"name": "A1"}, workspace_id="ws-a")
-        await store.create_object(lease.id, {"tenant": "B-co"}, workspace_id="ws-b")
-        await store.create_object(lease2.id, {"tenant": "B-co"}, workspace_id="ws-b")
+        # The exact live leak: ws-b defines "Lease" / "Lease2". ws-a, which only
+        # models "Customer", must NOT see those type names. SZD-2 — isolation is
+        # by who DEFINED the type (its own workspace_id), so types are stamped on
+        # define_type.
+        await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+        await store.define_type(name="Lease", properties=[], workspace_id="ws-b")
+        await store.define_type(name="Lease2", properties=[], workspace_id="ws-b")
 
         a_types = {t.name for t in await store.list_types(workspace_id="ws-a")}
         assert a_types == {"Customer"}
@@ -482,10 +492,8 @@ class TestStatsWorkspaceScoping:
     async def test_stats_types_count_matches_scoped_type_list(self, store: FabricStore) -> None:
         # stats["types"] is the count of types VISIBLE to the workspace — it
         # must equal len(list_types(workspace_id)), not the global type count.
-        customer = await store.define_type(name="Customer", properties=[])
-        lease = await store.define_type(name="Lease", properties=[])
-        await store.create_object(customer.id, {"name": "A1"}, workspace_id="ws-a")
-        await store.create_object(lease.id, {"tenant": "B-co"}, workspace_id="ws-b")
+        await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+        await store.define_type(name="Lease", properties=[], workspace_id="ws-b")
 
         a_stats = await store.stats(workspace_id="ws-a")
         a_types = await store.list_types(workspace_id="ws-a")
@@ -533,35 +541,48 @@ class TestStatsWorkspaceScoping:
         assert names == {"Customer", "Lease"}
 
     @pytest.mark.asyncio
-    async def test_scoped_type_with_no_visible_rows_is_omitted(self, store: FabricStore) -> None:
-        # A defined type with zero visible rows (even the caller's own empty
-        # type) is omitted, and reappears the moment a visible object exists.
-        empty = await store.define_type(name="Empty", properties=[])
-        assert {t.name for t in await store.list_types(workspace_id="ws-a")} == set()
-
-        await store.create_object(empty.id, {"k": "v"}, workspace_id="ws-a")
+    async def test_owner_sees_own_empty_type(self, store: FabricStore) -> None:
+        # SZD-2: an owner's EMPTY (object-less) type IS visible to its owner —
+        # type definitions are first-class tenant data now, not inferred from
+        # object rows (this inverts the pre-SZD-2 "omit empty types" rule). A
+        # type owned by ws-a remains invisible to ws-b regardless of objects.
+        await store.define_type(name="Empty", properties=[], workspace_id="ws-a")
         assert {t.name for t in await store.list_types(workspace_id="ws-a")} == {"Empty"}
+        assert (await store.stats(workspace_id="ws-a"))["types"] == 1
+        # ws-b never defined it -> does not see it.
+        assert {t.name for t in await store.list_types(workspace_id="ws-b")} == set()
+        assert (await store.stats(workspace_id="ws-b"))["types"] == 0
 
 
 class TestTypeNameUniqueIndex:
-    """A UNIQUE index on fabric_object_types(name) closes the ensure_type race."""
+    """A UNIQUE index on fabric_object_types(workspace_id, name) closes the
+    ensure_type race PER workspace (SZD-2 — was a global LOWER(name) index)."""
 
     @pytest.mark.asyncio
     async def test_concurrent_same_name_defines_one_type(self, store: FabricStore) -> None:
-        # Two concurrent define_type calls for the same name must not leave two
-        # type rows. The UNIQUE index makes the second INSERT fail rather than
-        # silently splitting the same logical type across two ids.
+        # Two concurrent define_type calls for the same name WITHIN one workspace
+        # must not leave two type rows. The UNIQUE (workspace_id, name) index
+        # makes the second INSERT fail rather than silently splitting the same
+        # logical type across two ids.
         results = await asyncio.gather(
-            store.define_type(name="Customer", properties=[]),
-            store.define_type(name="Customer", properties=[]),
+            store.define_type(name="Customer", properties=[], workspace_id="ws-a"),
+            store.define_type(name="Customer", properties=[], workspace_id="ws-a"),
             return_exceptions=True,
         )
         # At least one succeeded; any second one either errored or was rejected.
         ok = [r for r in results if not isinstance(r, Exception)]
         assert ok, "at least one define_type must succeed"
 
-        types = [t for t in await store.list_types() if t.name == "Customer"]
+        types = [t for t in await store.list_types(workspace_id="ws-a") if t.name == "Customer"]
         assert len(types) == 1, "the unique index must prevent a duplicate type row"
+
+    @pytest.mark.asyncio
+    async def test_two_workspaces_may_define_same_name(self, store: FabricStore) -> None:
+        # SZD-2: the uniqueness key includes workspace_id, so the SAME name in
+        # two different workspaces is allowed — each tenant gets its own type.
+        a = await store.define_type(name="Customer", properties=[], workspace_id="ws-a")
+        b = await store.define_type(name="Customer", properties=[], workspace_id="ws-b")
+        assert a.id != b.id
 
     @pytest.mark.asyncio
     async def test_unique_index_exists(self, store: FabricStore) -> None:
@@ -573,7 +594,9 @@ class TestTypeNameUniqueIndex:
                 " AND tbl_name='fabric_object_types'"
             ) as cur:
                 names = {row["name"] async for row in cur}
-        assert "idx_object_types_name_unique" in names
+        assert "idx_object_types_ws_name_unique" in names
+        # The old global index must NOT exist (it was dropped in the migration).
+        assert "idx_object_types_name_unique" not in names
 
     @pytest.mark.asyncio
     async def test_preexisting_duplicate_names_are_deduped(self, tmp_path: Path) -> None:

--- a/tests/cloud/test_fabric_mcp.py
+++ b/tests/cloud/test_fabric_mcp.py
@@ -226,12 +226,13 @@ async def test_stats_does_not_leak_other_tenant_type_names(store):
     """The live leak, pinned at the MCP boundary.
 
     w2 alone models "Lease" / "Lease2"; w1 models "Customer". A w1-scoped
-    fabric_stats must NOT name w2's experimental types — even though the type
-    DEFINITIONS are global in the schema.
+    fabric_stats must NOT name w2's experimental types. SZD-2 — type isolation
+    is by who DEFINED the type (its own workspace_id), so w2's experimental
+    types are stamped with workspace="w2".
     """
     await _seed_customers(store)  # Customer rows in w1 (+ one in w2)
-    lease = await store.define_type(name="Lease", properties=[])
-    lease2 = await store.define_type(name="Lease2", properties=[])
+    lease = await store.define_type(name="Lease", properties=[], workspace_id="w2")
+    lease2 = await store.define_type(name="Lease2", properties=[], workspace_id="w2")
     await store.create_object(lease.id, {"tenant": "X"}, workspace_id="w2")
     await store.create_object(lease2.id, {"tenant": "Y"}, workspace_id="w2")
 

--- a/tests/cloud/test_fabric_objects_gate.py
+++ b/tests/cloud/test_fabric_objects_gate.py
@@ -1,0 +1,533 @@
+# tests/cloud/test_fabric_objects_gate.py — the gated _fabric_objects proposal
+# type (SZD-5a), a tenancy gate over a proposed Fabric ontology.
+#
+# Created: 2026-06-19 (SZD-5a — _fabric_objects Instinct proposal type).
+#
+# What this pins:
+#   * propose_fabric_objects — blob shape (schema 1, object_types, objects,
+#     links, workspace_id, correlation_id, summary), tenancy (workspace
+#     required), object-count requirement.
+#   * execute_approved_fabric_objects against a REAL tmp FabricStore:
+#       - happy path: objects materialised via ingest_records, types defined,
+#         links created, action EXECUTED, structured outcome back-written.
+#       - dedup: re-approve (or two proposals asserting the same
+#         (source_connector, source_id)) does NOT duplicate objects OR links.
+#       - schema mismatch: a stale schema blob → FAILED, no Fabric write.
+#   * the 4-PATH cross-workspace tenancy gate through the REAL router:
+#       - approve / reject (single) AND bulk-approve / bulk-reject all 403 a
+#         cross-workspace caller — a missing guard on ANY of the four is a leak.
+#   * the MANDATORY production-path chain test: propose → approve via the REAL
+#     router → executor materialises objects → walk the decision chain and assert
+#     EXACTLY agent.proposed → human.corrected → decision.completed (one
+#     terminal), and the reject path's router-owned close (executor never runs).
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The instinct store is
+# patched to a tmp-file InstinctStore; the FABRIC store is patched to a tmp-file
+# FabricStore so the writes are real but isolated. The integration tests wire a
+# fresh on-disk journal + DecisionGraph (same fixture shape as
+# tests/cloud/test_external_action_gate.py) and drive the router over a
+# TestClient with stubbed auth deps.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.fabric_proposals import executor as fo_executor  # noqa: E402
+from pocketpaw_ee.cloud.fabric_proposals import propose as fo_propose  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired everywhere the gate reads it
+    (the propose helper + the executor both lazy-import
+    ``pocketpaw.stores.get_instinct_store``)."""
+    st = InstinctStore(tmp_path / "instinct_fabric_objects_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+@pytest.fixture
+def fabric(tmp_path: Path, monkeypatch) -> FabricStore:
+    """Isolated FabricStore on a tmp file, wired into ``get_fabric_store`` so the
+    executor writes real (but isolated) typed objects + links."""
+    fs = FabricStore(tmp_path / "fabric_objects_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda: fs)
+    return fs
+
+
+# A canonical proposal payload reused across tests.
+_OBJECT_TYPES = [
+    {
+        "type_name": "Customer",
+        "description": "A discovered customer",
+        "properties": [
+            {"name": "name", "type": "string"},
+            {"name": "email", "type": "string"},
+        ],
+    },
+    {
+        "type_name": "Order",
+        "properties": [{"name": "total", "type": "number"}],
+    },
+]
+_OBJECTS = [
+    {
+        "type_name": "Customer",
+        "properties": {"name": "Acme Inc", "email": "ops@acme.test"},
+        "source_connector": "crm",
+        "source_id": "cust-1",
+    },
+    {
+        "type_name": "Order",
+        "properties": {"total": 42},
+        "source_connector": "billing",
+        "source_id": "ord-9",
+    },
+]
+_LINKS = [
+    {
+        "from": {"source_connector": "billing", "source_id": "ord-9"},
+        "to": {"source_connector": "crm", "source_id": "cust-1"},
+        "link_type": "placed_by",
+    }
+]
+
+
+async def _propose(store, **overrides) -> str:
+    kwargs: dict[str, Any] = dict(
+        workspace_id="w1",
+        objects=_OBJECTS,
+        object_types=_OBJECT_TYPES,
+        links=_LINKS,
+        requested_by="u1",
+    )
+    kwargs.update(overrides)
+    return await fo_propose.propose_fabric_objects(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# propose — blob shape + tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_builds_fabric_objects_blob(store):
+    """propose_fabric_objects files an Action carrying a well-formed schema-1
+    ``_fabric_objects`` blob — object_types, objects, links, workspace_id,
+    correlation_id, summary."""
+    action_id = await _propose(store)
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+
+    blob = action.parameters["_fabric_objects"]
+    assert blob["kind"] == "fabric_objects"
+    assert blob["schema"] == 1
+    assert blob["workspace_id"] == "w1"
+    assert len(blob["object_types"]) == 2
+    assert len(blob["objects"]) == 2
+    assert len(blob["links"]) == 1
+    assert blob["objects"][0]["source_connector"] == "crm"
+    assert blob["objects"][0]["source_id"] == "cust-1"
+    assert blob["requested_by"] == "u1"
+    assert blob["correlation_id"]
+    assert blob["summary"]
+
+
+async def test_propose_requires_workspace(store):
+    """A propose with no workspace_id is rejected — a Fabric write with no tenant
+    to scope it to is a tenancy hole."""
+    with pytest.raises(ValueError, match="workspace_id"):
+        await fo_propose.propose_fabric_objects(
+            workspace_id="",
+            objects=_OBJECTS,
+            requested_by="u1",
+        )
+
+
+async def test_propose_requires_objects(store):
+    """A propose with no usable objects is rejected — nothing to materialise."""
+    with pytest.raises(ValueError, match="object"):
+        await fo_propose.propose_fabric_objects(
+            workspace_id="w1",
+            objects=[],
+            requested_by="u1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# executor — happy path, dedup, schema
+# ---------------------------------------------------------------------------
+
+
+async def _propose_and_approve(store, **overrides) -> Any:
+    action_id = await _propose(store, **overrides)
+    return await store.approve(action_id, approver="u1")
+
+
+async def test_executor_happy_path_materialises_objects(store, fabric):
+    """On approve the executor materialises the proposed objects via
+    ingest_records (workspace-scoped), defines the types, creates the link, marks
+    EXECUTED, and back-writes the structured outcome."""
+    approved = await _propose_and_approve(store)
+    await fo_executor.execute_approved_fabric_objects(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED
+    outcome = final.parameters["_fabric_objects"]["outcome"]
+    assert outcome["status"] == "executed"
+    assert outcome["created"] == 2
+    assert outcome["updated"] == 0
+    assert outcome["links_created"] == 1
+    assert "executed_at" in outcome
+
+    # The objects exist in Fabric, workspace-scoped, with provenance.
+    cust = await fabric.get_object_by_source(
+        source_connector="crm", source_id="cust-1", workspace_id="w1"
+    )
+    assert cust is not None
+    assert cust.properties["name"] == "Acme Inc"
+    assert cust.properties["email"] == "ops@acme.test"
+    ord_obj = await fabric.get_object_by_source(
+        source_connector="billing", source_id="ord-9", workspace_id="w1"
+    )
+    assert ord_obj is not None
+    assert ord_obj.properties["total"] == 42
+
+    # The types were defined in w1.
+    types = await fabric.list_types(workspace_id="w1")
+    type_names = {t.name for t in types}
+    assert {"Customer", "Order"} <= type_names
+
+    # The link exists, workspace-scoped.
+    links, total = await fabric.list_links(
+        from_id=ord_obj.id, to_id=cust.id, link_type="placed_by", workspace_id="w1"
+    )
+    assert total == 1
+
+
+async def test_executor_reapprove_does_not_duplicate(store, fabric):
+    """Re-running the executor (idempotency-guard bypassed by re-proposing the
+    SAME objects in a SECOND action) does NOT duplicate objects OR links — the
+    ingest dedup keys on (source_connector, source_id) and the link dedup on
+    (from, to, link_type)."""
+    # First proposal — materialise.
+    approved1 = await _propose_and_approve(store)
+    await fo_executor.execute_approved_fabric_objects(approved1)
+
+    # Second proposal asserting the SAME objects + link.
+    approved2 = await _propose_and_approve(store)
+    await fo_executor.execute_approved_fabric_objects(approved2)
+
+    final2 = await store.get_action(approved2.id)
+    out2 = final2.parameters["_fabric_objects"]["outcome"]
+    # Second run UPDATES the existing objects (no new create) and creates NO new
+    # link (the (from,to,link_type) already exists).
+    assert out2["created"] == 0
+    assert out2["updated"] == 2
+    assert out2["links_created"] == 0
+
+    # Exactly ONE object per type — no duplicates split across two type_ids or
+    # two rows.
+    from pocketpaw.fabric.models import FabricQuery
+
+    cust_result = await fabric.query(FabricQuery(type_name="Customer"), workspace_id="w1")
+    ord_result = await fabric.query(FabricQuery(type_name="Order"), workspace_id="w1")
+    assert len(cust_result.objects) == 1
+    assert len(ord_result.objects) == 1
+
+    ord_obj = await fabric.get_object_by_source(
+        source_connector="billing", source_id="ord-9", workspace_id="w1"
+    )
+    cust = await fabric.get_object_by_source(
+        source_connector="crm", source_id="cust-1", workspace_id="w1"
+    )
+    _links, total = await fabric.list_links(
+        from_id=ord_obj.id, to_id=cust.id, link_type="placed_by", workspace_id="w1"
+    )
+    assert total == 1  # still ONE link
+
+
+async def test_executor_idempotent_never_reruns(store, fabric):
+    """Re-invoking the executor on an already-EXECUTED Action short-circuits
+    before any Fabric write (the idempotency guard)."""
+    approved = await _propose_and_approve(store)
+    await fo_executor.execute_approved_fabric_objects(approved)
+    types_after_first = await fabric.list_types(workspace_id="w1")
+
+    reloaded = await store.get_action(approved.id)
+    await fo_executor.execute_approved_fabric_objects(reloaded)
+    types_after_second = await fabric.list_types(workspace_id="w1")
+    # No additional type rows — the guard skipped the re-run.
+    assert len(types_after_second) == len(types_after_first)
+
+
+async def test_executor_schema_mismatch_refuses(store, fabric):
+    """A stale blob with an incompatible schema version → FAILED, no Fabric
+    write."""
+    approved = await _propose_and_approve(store)
+    approved.parameters["_fabric_objects"]["schema"] = 999  # incompatible
+
+    await fo_executor.execute_approved_fabric_objects(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "schema" in str(final.error).lower()
+    # Nothing was written.
+    types = await fabric.list_types(workspace_id="w1")
+    assert types == []
+
+
+async def test_executor_no_blob_is_noop(store, fabric):
+    """An Action with no ``_fabric_objects`` blob is a clean no-op."""
+    from pocketpaw.instinct.models import ActionTrigger
+
+    action = await store.propose(
+        pocket_id="w1",
+        title="not fabric",
+        description="",
+        recommendation="",
+        trigger=ActionTrigger(type="agent", source="x", reason="y"),
+    )
+    approved = await store.approve(action.id, approver="u1")
+    await fo_executor.execute_approved_fabric_objects(approved)
+    types = await fabric.list_types(workspace_id="w1")
+    assert types == []
+
+
+# ---------------------------------------------------------------------------
+# Integration fixtures — journal + decision graph + router client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "u1", workspace_id: str = "w1") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _make_client(user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _events_by_correlation(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+# ---------------------------------------------------------------------------
+# MANDATORY production-path chain tests
+# ---------------------------------------------------------------------------
+
+
+async def test_production_path_approve_runs_executor_one_terminal(
+    store, fabric, journal, graph, monkeypatch
+):
+    """propose → approve through the REAL router → the executor materialises the
+    objects → walk the decision chain and assert EXACTLY agent.proposed →
+    human.corrected → decision.completed (ONE terminal, executor owns the close)."""
+    action_id = await _propose(store)
+    blob = (await store.get_action(action_id)).parameters["_fabric_objects"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED
+    # The objects landed in Fabric.
+    assert (
+        await fabric.get_object_by_source(
+            source_connector="crm", source_id="cust-1", workspace_id="w1"
+        )
+    ) is not None
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is True
+    assert (terminal.payload or {})["action_outcome"] == "landed"
+    hc = chain[1]
+    assert terminal.causation_id == hc.id
+
+
+async def test_production_path_reject_router_closes_executor_never_runs(
+    store, fabric, journal, graph, monkeypatch
+):
+    """Reject path: the ROUTER emits human.corrected + decision.completed
+    (rejected); the executor NEVER runs (no Fabric write)."""
+    action_id = await _propose(store)
+    blob = (await store.get_action(action_id)).parameters["_fabric_objects"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED
+    # NO Fabric write happened on reject.
+    assert (
+        await fabric.get_object_by_source(
+            source_connector="crm", source_id="cust-1", workspace_id="w1"
+        )
+    ) is None
+    types = await fabric.list_types(workspace_id="w1")
+    assert types == []
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is False
+    assert (terminal.payload or {})["action_outcome"] == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# 4-PATH cross-workspace tenancy gate — a missing guard on ANY path is a leak.
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_workspace_single_approve_forbidden(store, fabric, journal, graph, monkeypatch):
+    """PATH 1/4 — single approve: a caller in w1 cannot approve a w-OTHER
+    Fabric-objects Action."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+    # Nothing written.
+    assert await fabric.list_types(workspace_id="w-OTHER") == []
+
+
+async def test_cross_workspace_single_reject_forbidden(store, fabric, journal, graph, monkeypatch):
+    """PATH 2/4 — single reject: a caller in w1 cannot reject a w-OTHER
+    Fabric-objects Action (asymmetric tenant scope is no tenant scope)."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+
+
+async def test_cross_workspace_bulk_approve_forbidden(store, fabric, journal, graph, monkeypatch):
+    """PATH 3/4 — bulk approve: a single cross-workspace item 403s the whole
+    batch before any mutation."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+    assert await fabric.list_types(workspace_id="w-OTHER") == []
+
+
+async def test_cross_workspace_bulk_reject_forbidden(store, fabric, journal, graph, monkeypatch):
+    """PATH 4/4 — bulk reject: a single cross-workspace item 403s the whole
+    batch before any mutation."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post("/instinct/actions/bulk-reject", json={"ids": [action_id], "reason": "no"})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING

--- a/tests/cloud/test_fabric_objects_source.py
+++ b/tests/cloud/test_fabric_objects_source.py
@@ -1,0 +1,132 @@
+# tests/cloud/test_fabric_objects_source.py
+# Created: 2026-06-19 (SZD-1 — fabric.objects ripple source).
+#
+# Smoke-proves the SZD-1 invariant for the "sovereign zero-setup discovery"
+# feature: the `fabric.objects` / `fabric.query` ripple sources resolve an
+# ObjectType into widget rows, and they are WORKSPACE-SCOPED — a spec resolved
+# in workspace A sees only workspace A's objects, never workspace B's. The
+# sources are backed by a real (temp) FabricStore so the store's own
+# `workspace_id = ? OR workspace_id IS NULL` tenant guard is exercised end to
+# end, not mocked away.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+# Importing ripple_sources triggers the @register side-effects that put
+# fabric.objects / fabric.query into the resolver registry (the cloud app does
+# this eagerly at startup; tests must import it explicitly).
+import pocketpaw_ee.cloud.ripple_sources  # noqa: F401
+import pytest
+from pocketpaw_ee.cloud.ripple_resolver import ResolveCtx, resolve_ripple_spec
+
+from pocketpaw.fabric.store import FabricStore
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+async def _seed_store(db_path: Path) -> FabricStore:
+    """A FabricStore with a 'Lead' type and objects in two workspaces."""
+    store = FabricStore(db_path)
+    lead_a = await store.define_type(name="Lead", properties=[], workspace_id=WS_A)
+    lead_b = await store.define_type(name="Lead", properties=[], workspace_id=WS_B)
+    await store.create_object(
+        type_id=lead_a.id, properties={"name": "Acme", "status": "hot"}, workspace_id=WS_A
+    )
+    await store.create_object(
+        type_id=lead_a.id, properties={"name": "Globex", "status": "cold"}, workspace_id=WS_A
+    )
+    # Workspace B owns a separate object of its own same-named type — this is
+    # the row that must NOT leak into a workspace-A resolution.
+    await store.create_object(
+        type_id=lead_b.id, properties={"name": "Initech", "status": "hot"}, workspace_id=WS_B
+    )
+    return store
+
+
+@pytest.mark.asyncio
+async def test_fabric_objects_source_resolves_workspace_rows(tmp_path: Path) -> None:
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx = ResolveCtx(workspace_id=WS_A, user_id="u1", pocket_id="p1")
+    spec = {"state": {"leads": {"$source": "fabric.objects", "type_name": "Lead"}}}
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx)
+
+    rows = out["state"]["leads"]
+    names = {r["name"] for r in rows}
+    # Exactly workspace A's two Leads — Globex + Acme — and NOT workspace B's
+    # Initech (the cross-tenant leak this proves is closed).
+    assert names == {"Acme", "Globex"}, f"unexpected rows: {rows!r}"
+    assert "Initech" not in names
+    # Properties are spread to the top level alongside reserved keys.
+    assert all("id" in r and "type_name" in r and "status" in r for r in rows)
+    assert all(r["type_name"] == "Lead" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_fabric_objects_source_other_workspace_sees_only_its_own(tmp_path: Path) -> None:
+    """Cross-workspace proof — the SAME spec resolved as workspace B returns
+    only B's object, demonstrating the scope tracks ctx, not the spec."""
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx_b = ResolveCtx(workspace_id=WS_B, user_id="u2", pocket_id="p2")
+    spec = {"state": {"leads": {"$source": "fabric.objects", "type_name": "Lead"}}}
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx_b)
+
+    names = {r["name"] for r in out["state"]["leads"]}
+    assert names == {"Initech"}, f"workspace B leaked rows: {names!r}"
+    assert "Acme" not in names and "Globex" not in names
+
+
+@pytest.mark.asyncio
+async def test_fabric_query_source_applies_filter_within_workspace(tmp_path: Path) -> None:
+    """fabric.query adds a property filter and stays workspace-scoped."""
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx = ResolveCtx(workspace_id=WS_A, user_id="u1", pocket_id="p1")
+    spec = {
+        "state": {
+            "hot": {
+                "$source": "fabric.query",
+                "type_name": "Lead",
+                "filters": {"status": "hot"},
+            }
+        }
+    }
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx)
+
+    names = {r["name"] for r in out["state"]["hot"]}
+    # Only workspace A's hot lead (Acme). Globex is cold; Initech is workspace B.
+    assert names == {"Acme"}, f"filter/scope mismatch: {names!r}"
+
+
+@pytest.mark.asyncio
+async def test_fabric_objects_source_no_type_returns_empty(tmp_path: Path) -> None:
+    """A spec marker with neither type_id nor type_name resolves to [] (never
+    raises, never returns the whole workspace)."""
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx = ResolveCtx(workspace_id=WS_A, user_id="u1", pocket_id="p1")
+    spec = {"state": {"leads": {"$source": "fabric.objects"}}}
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx)
+
+    assert out["state"]["leads"] == []
+
+
+@pytest.mark.asyncio
+async def test_fabric_objects_source_no_workspace_returns_empty(tmp_path: Path) -> None:
+    """Empty workspace context resolves to [] rather than an unscoped read."""
+    store = await _seed_store(tmp_path / "fabric.db")
+    ctx = ResolveCtx(workspace_id="", user_id="u1", pocket_id="p1")
+    spec = {"state": {"leads": {"$source": "fabric.objects", "type_name": "Lead"}}}
+
+    with patch("pocketpaw.stores.get_fabric_store", return_value=store):
+        out = await resolve_ripple_spec(spec, ctx)
+
+    assert out["state"]["leads"] == []

--- a/tests/cloud/test_pocket_create_gate.py
+++ b/tests/cloud/test_pocket_create_gate.py
@@ -1,0 +1,520 @@
+# tests/cloud/test_pocket_create_gate.py — the gated _pocket_create proposal type
+# (SZD-5b), a tenancy gate over a proposed starter Pocket.
+#
+# Created: 2026-06-19 (SZD-5b — _pocket_create Instinct proposal type).
+#
+# What this pins:
+#   * propose_pocket — blob shape (schema 1, pocket_spec, SEPARATE top-level
+#     workspace_id + user_id, correlation_id, summary), tenancy (workspace + owner
+#     required), name requirement, AND the security invariant: tenancy/owner are
+#     NOT inside the editable pocket_spec.
+#   * execute_approved_pocket_create against the REAL pockets.service.create
+#     (mongomock Beanie):
+#       - happy path: a Pocket is created in the workspace, owned correctly, action
+#         EXECUTED, structured outcome (pocket_id/name) back-written.
+#       - model_validate is enforced: a rippleSpec camelCase-alias spec resolves; a
+#         structurally invalid spec (blank name) FAILS cleanly (no Pocket created),
+#         not silently.
+#       - schema mismatch: a stale schema blob → FAILED, no Pocket created.
+#       - idempotency: re-approve / re-invoke does NOT double-create.
+#   * the 4-PATH cross-workspace tenancy gate through the REAL router:
+#       - approve / reject (single) AND bulk-approve / bulk-reject all 403 a
+#         cross-workspace caller — a missing guard on ANY of the four is a leak.
+#   * the MANDATORY production-path chain test: propose → approve via the REAL
+#     router → executor creates the Pocket → walk the decision chain and assert
+#     EXACTLY agent.proposed → human.corrected → decision.completed (one terminal),
+#     and the reject path's router-owned close (executor never runs).
+#
+# `pocketpaw_ee` is import-skipped on an OSS-only install. The instinct store is
+# patched to a tmp-file InstinctStore; the Pocket create runs against the shared
+# mongomock Beanie ``mongo_db`` fixture so the create is real but isolated. The
+# integration tests wire a fresh on-disk journal + DecisionGraph (same fixture
+# shape as tests/cloud/test_fabric_objects_gate.py) and drive the router over a
+# TestClient with stubbed auth deps.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.decisions.service import (  # noqa: E402
+    DecisionGraph,
+    get_decision_graph,
+    reset_projection_for_tests,
+)
+from pocketpaw_ee.cloud.decisions.store import set_db_path  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.pocket_proposals import executor as pc_executor  # noqa: E402
+from pocketpaw_ee.cloud.pocket_proposals import propose as pc_propose  # noqa: E402
+from pocketpaw_ee.cloud.pockets import service as pockets_service  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+from soul_protocol.engine.journal import open_journal  # noqa: E402
+
+import pocketpaw.journal_dep as journal_dep  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    """Stable AUTH_SECRET so the pockets create path's token machinery is quiet."""
+    monkeypatch.setenv("AUTH_SECRET", "pocket-create-gate-test-secret")
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore on a tmp file, wired everywhere the gate reads it
+    (the propose helper + the executor both lazy-import
+    ``pocketpaw.stores.get_instinct_store``)."""
+    st = InstinctStore(tmp_path / "instinct_pocket_create_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+# A canonical rippleSpec staged on the proposal. The camelCase alias ``rippleSpec``
+# is exercised by the model_validate test.
+_RIPPLE_SPEC = {
+    "version": "1.0",
+    "root": {"id": "root", "type": "container", "children": []},
+}
+
+
+async def _propose(store, **overrides) -> str:
+    kwargs: dict[str, Any] = dict(
+        workspace_id="w1",
+        user_id="u1",
+        ripple_spec=_RIPPLE_SPEC,
+        name="Starter dashboard",
+    )
+    kwargs.update(overrides)
+    return await pc_propose.propose_pocket(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# propose — blob shape + tenancy + the un-editable-tenancy security invariant
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_builds_pocket_create_blob(store):
+    """propose_pocket files an Action carrying a well-formed schema-1
+    ``_pocket_create`` blob — pocket_spec, SEPARATE top-level workspace_id +
+    user_id, correlation_id, summary."""
+    action_id = await _propose(store)
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.status == ActionStatus.PENDING
+
+    blob = action.parameters["_pocket_create"]
+    assert blob["kind"] == "pocket_create"
+    assert blob["schema"] == 1
+    # Tenancy + owner are SEPARATE top-level blob fields.
+    assert blob["workspace_id"] == "w1"
+    assert blob["user_id"] == "u1"
+    # The staged spec carries name + the camelCase rippleSpec alias.
+    spec = blob["pocket_spec"]
+    assert spec["name"] == "Starter dashboard"
+    assert spec["rippleSpec"] == _RIPPLE_SPEC
+    assert blob["correlation_id"]
+    assert blob["summary"]
+
+
+async def test_propose_tenancy_not_in_editable_spec(store):
+    """SECURITY — workspace_id / user_id are NEVER inside the editable pocket_spec
+    (the correction flow can edit pocket_spec; it must not be able to move tenancy
+    or owner). Even a caller passing them via ``extra`` cannot smuggle them in."""
+    action_id = await _propose(
+        store,
+        extra={"workspace_id": "w-EVIL", "user_id": "u-EVIL", "description": "ok"},
+    )
+    blob = (await store.get_action(action_id)).parameters["_pocket_create"]
+    spec = blob["pocket_spec"]
+    assert "workspace_id" not in spec
+    assert "user_id" not in spec
+    assert "workspace" not in spec
+    assert "owner" not in spec
+    # The legitimate extra field rode through.
+    assert spec["description"] == "ok"
+    # The real tenancy/owner are unchanged on the top-level fields.
+    assert blob["workspace_id"] == "w1"
+    assert blob["user_id"] == "u1"
+
+
+async def test_propose_requires_workspace(store):
+    """A propose with no workspace_id is rejected — a Pocket create with no tenant
+    to scope it to is a tenancy hole."""
+    with pytest.raises(ValueError, match="workspace_id"):
+        await pc_propose.propose_pocket(
+            workspace_id="", user_id="u1", name="x", ripple_spec=_RIPPLE_SPEC
+        )
+
+
+async def test_propose_requires_owner(store):
+    """A propose with no user_id (owner) is rejected."""
+    with pytest.raises(ValueError, match="user_id"):
+        await pc_propose.propose_pocket(
+            workspace_id="w1", user_id="", name="x", ripple_spec=_RIPPLE_SPEC
+        )
+
+
+async def test_propose_requires_name(store):
+    """A propose with a blank name is rejected — nothing to create."""
+    with pytest.raises(ValueError, match="name"):
+        await pc_propose.propose_pocket(
+            workspace_id="w1", user_id="u1", name="  ", ripple_spec=_RIPPLE_SPEC
+        )
+
+
+# ---------------------------------------------------------------------------
+# executor — happy path, model_validate, schema, idempotency (real Beanie create)
+# ---------------------------------------------------------------------------
+
+
+async def _propose_and_approve(store, **overrides) -> Any:
+    action_id = await _propose(store, **overrides)
+    return await store.approve(action_id, approver="u1")
+
+
+async def test_executor_happy_path_creates_pocket(store, mongo_db):
+    """On approve the executor creates the Pocket via pockets.service.create
+    (workspace-scoped, owned by the blob's top-level user_id), marks EXECUTED, and
+    back-writes the structured outcome carrying the created pocket id + name."""
+    approved = await _propose_and_approve(store)
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED
+    outcome = final.parameters["_pocket_create"]["outcome"]
+    assert outcome["status"] == "executed"
+    assert outcome["name"] == "Starter dashboard"
+    assert outcome["pocket_id"]
+    assert "executed_at" in outcome
+
+    # The Pocket exists in w1, owned by u1.
+    wire = await pockets_service.get(outcome["pocket_id"], "u1")
+    assert wire["name"] == "Starter dashboard"
+    assert wire["workspace"] == "w1"
+    assert wire["owner"] == "u1"
+
+
+async def test_executor_model_validate_resolves_camelcase_alias(store, mongo_db):
+    """The staged spec uses the camelCase ``rippleSpec`` alias; model_validate at
+    the entry to the create path resolves it (populate_by_name=True) so the spec
+    materialises with the rippleSpec attached."""
+    approved = await _propose_and_approve(store)
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.EXECUTED
+    pocket_id = final.parameters["_pocket_create"]["outcome"]["pocket_id"]
+    wire = await pockets_service.get(pocket_id, "u1")
+    # The rippleSpec round-tripped onto the created pocket (normalized).
+    assert wire.get("rippleSpec") is not None
+
+
+async def test_executor_invalid_spec_fails_cleanly(store, mongo_db, monkeypatch):
+    """A structurally invalid staged spec (blank name violates the DTO's
+    min_length=1) FAILS the action cleanly at model_validate — NOT a silent
+    skip, NOT a crash — and no Pocket is created."""
+    approved = await _propose_and_approve(store)
+    # Corrupt the staged spec to an invalid CreatePocketRequest (name too short).
+    # The propose helper rejects a blank name, so we tamper the persisted blob
+    # directly to simulate a malformed/edited spec reaching the executor.
+    approved.parameters["_pocket_create"]["pocket_spec"]["name"] = ""
+
+    before_count = await _count_pockets("w1")
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "invalid" in str(final.error).lower()
+    # Nothing was created.
+    assert await _count_pockets("w1") == before_count
+
+
+async def test_executor_schema_mismatch_refuses(store, mongo_db):
+    """A stale blob with an incompatible schema version → FAILED, no Pocket
+    created."""
+    approved = await _propose_and_approve(store)
+    approved.parameters["_pocket_create"]["schema"] = 999  # incompatible
+
+    before_count = await _count_pockets("w1")
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "schema" in str(final.error).lower()
+    assert await _count_pockets("w1") == before_count
+
+
+async def test_executor_missing_workspace_refuses(store, mongo_db):
+    """A blob whose top-level workspace_id is empty → FAILED, no Pocket created
+    (belt-and-braces behind the router gate)."""
+    approved = await _propose_and_approve(store)
+    approved.parameters["_pocket_create"]["workspace_id"] = ""
+
+    before_count = await _count_pockets("w1")
+    await pc_executor.execute_approved_pocket_create(approved)
+
+    final = await store.get_action(approved.id)
+    assert final.status == ActionStatus.FAILED
+    assert "workspace" in str(final.error).lower()
+    assert await _count_pockets("w1") == before_count
+
+
+async def test_executor_idempotent_never_reruns(store, mongo_db):
+    """Re-invoking the executor on an already-EXECUTED Action short-circuits before
+    any create (the idempotency guard) — re-approve / retry never double-creates."""
+    approved = await _propose_and_approve(store)
+    await pc_executor.execute_approved_pocket_create(approved)
+    count_after_first = await _count_pockets("w1")
+    assert count_after_first == 1
+
+    reloaded = await store.get_action(approved.id)
+    await pc_executor.execute_approved_pocket_create(reloaded)
+    # No additional pocket — the guard skipped the re-run.
+    assert await _count_pockets("w1") == count_after_first
+
+
+async def test_executor_no_blob_is_noop(store, mongo_db):
+    """An Action with no ``_pocket_create`` blob is a clean no-op."""
+    from pocketpaw.instinct.models import ActionTrigger
+
+    action = await store.propose(
+        pocket_id="w1",
+        title="not pocket-create",
+        description="",
+        recommendation="",
+        trigger=ActionTrigger(type="agent", source="x", reason="y"),
+    )
+    approved = await store.approve(action.id, approver="u1")
+    before_count = await _count_pockets("w1")
+    await pc_executor.execute_approved_pocket_create(approved)
+    assert await _count_pockets("w1") == before_count
+
+
+async def _count_pockets(workspace_id: str) -> int:
+    """Count the pockets in a workspace via the service list path."""
+    wires = await pockets_service.list_pockets(workspace_id, "u1")
+    return len(wires)
+
+
+# ---------------------------------------------------------------------------
+# Integration fixtures — journal + decision graph + router client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path) -> DecisionGraph:
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "u1", workspace_id: str = "w1") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _make_client(user: _FakeUser, monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return TestClient(app)
+
+
+def _events_by_correlation(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+# ---------------------------------------------------------------------------
+# MANDATORY production-path chain tests
+# ---------------------------------------------------------------------------
+
+
+async def test_production_path_approve_runs_executor_one_terminal(
+    store, mongo_db, journal, graph, monkeypatch
+):
+    """propose → approve through the REAL router → the executor creates the Pocket
+    → walk the decision chain and assert EXACTLY agent.proposed → human.corrected →
+    decision.completed (ONE terminal, executor owns the close)."""
+    action_id = await _propose(store)
+    blob = (await store.get_action(action_id)).parameters["_pocket_create"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED
+    # The Pocket landed in w1, owned by u1.
+    pocket_id = final.parameters["_pocket_create"]["outcome"]["pocket_id"]
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["workspace"] == "w1"
+    assert wire["owner"] == "u1"
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is True
+    assert (terminal.payload or {})["action_outcome"] == "landed"
+    hc = chain[1]
+    assert terminal.causation_id == hc.id
+
+
+async def test_production_path_reject_router_closes_executor_never_runs(
+    store, mongo_db, journal, graph, monkeypatch
+):
+    """Reject path: the ROUTER emits human.corrected + decision.completed
+    (rejected); the executor NEVER runs (no Pocket created)."""
+    action_id = await _propose(store)
+    blob = (await store.get_action(action_id)).parameters["_pocket_create"]
+    corr = UUID(blob["correlation_id"])
+
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "not now"})
+    assert resp.status_code == 200, resp.text
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.REJECTED
+    # NO Pocket was created on reject.
+    assert await _count_pockets("w1") == 0
+
+    chain = _events_by_correlation(journal, corr)
+    actions = [e.action for e in chain]
+    assert actions == [
+        "agent.proposed",
+        "human.corrected",
+        "decision.completed",
+    ], actions
+    assert actions.count("decision.completed") == 1
+    terminal = chain[-1]
+    assert (terminal.payload or {})["passed"] is False
+    assert (terminal.payload or {})["action_outcome"] == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# 4-PATH cross-workspace tenancy gate — a missing guard on ANY path is a leak.
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_workspace_single_approve_forbidden(
+    store, mongo_db, journal, graph, monkeypatch
+):
+    """PATH 1/4 — single approve: a caller in w1 cannot approve a w-OTHER
+    Pocket-create Action."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post(f"/instinct/actions/{action_id}/approve")
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+    # Nothing created in either workspace.
+    assert await _count_pockets("w-OTHER") == 0
+    assert await _count_pockets("w1") == 0
+
+
+async def test_cross_workspace_single_reject_forbidden(
+    store, mongo_db, journal, graph, monkeypatch
+):
+    """PATH 2/4 — single reject: a caller in w1 cannot reject a w-OTHER
+    Pocket-create Action (asymmetric tenant scope is no tenant scope)."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "no"})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+
+
+async def test_cross_workspace_bulk_approve_forbidden(store, mongo_db, journal, graph, monkeypatch):
+    """PATH 3/4 — bulk approve: a single cross-workspace item 403s the whole batch
+    before any mutation."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post("/instinct/actions/bulk-approve", json={"ids": [action_id]})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING
+    assert await _count_pockets("w-OTHER") == 0
+
+
+async def test_cross_workspace_bulk_reject_forbidden(store, mongo_db, journal, graph, monkeypatch):
+    """PATH 4/4 — bulk reject: a single cross-workspace item 403s the whole batch
+    before any mutation."""
+    action_id = await _propose(store, workspace_id="w-OTHER")
+    user = _FakeUser("u1", "w1")
+    client = _make_client(user, monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda: store)
+
+    resp = client.post("/instinct/actions/bulk-reject", json={"ids": [action_id], "reason": "no"})
+    assert resp.status_code == 403, resp.text
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.PENDING

--- a/tests/ee/test_discovery_propose.py
+++ b/tests/ee/test_discovery_propose.py
@@ -1,0 +1,517 @@
+# tests/ee/test_discovery_propose.py — SZD-6 integration: wire DiscoveryRun → the
+# two gated proposals + the starter-Pocket assembler + supersede-on-rerun.
+#
+# Created: 2026-06-19 (SZD-6 / feat/szd-6-integration). Covers the integration
+# entry point ``run_discovery_and_propose`` end to end, with the connector read
+# MOCKED (no live network) and real-but-isolated InstinctStore + FabricStore +
+# mongomock Beanie:
+#
+#   * a run against a mock connector files TWO proposals (a _fabric_objects pair +
+#     a _pocket_create pair) — both PENDING, both tagged with a shared discovery
+#     run marker;
+#   * approving BOTH (fabric via the executor, pocket via the executor) creates
+#     the Fabric objects AND a Pocket whose spec references the fabric.objects
+#     source for each discovered type;
+#   * a SECOND run supersedes the first run's still-open pair (the first two
+#     actions go REJECTED — superseded, not duplicated — and a fresh pair opens);
+#   * a low-confidence keyless type is SKIPPED from materialisation and FLAGGED in
+#     the result (no crash, not staged);
+#   * the assembler binds one fabric.objects widget per high-confidence type.
+#
+# Run with:
+#   uv run --group ee pytest tests/ee/test_discovery_propose.py -q
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.discovery import (  # noqa: E402
+    DiscoveryRun,
+    DiscoveryRunOptions,
+    OntologyDraft,
+    ReadAction,
+    assemble_discovery_pocket,
+    run_discovery_and_propose,
+)
+from pocketpaw_ee.discovery.orchestrate import (  # noqa: E402
+    _draft_to_fabric_proposal_kwargs,
+    _find_discovery_marker,
+)
+
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Mock connector surface (same shape as tests/ee/test_discovery_run.py).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MockActionResult:
+    success: bool
+    data: Any = None
+    error: str | None = None
+    records_affected: int = 0
+
+
+@dataclass
+class _MockActionSchema:
+    name: str
+    method: str = "GET"
+    trust_level: str = "auto"
+
+
+class _MockAdapter:
+    def __init__(self, schemas: list[_MockActionSchema], data_by_action: dict[str, Any]) -> None:
+        self._schemas = schemas
+        self._data_by_action = data_by_action
+
+    async def actions(self) -> list[_MockActionSchema]:
+        return list(self._schemas)
+
+    async def execute(self, action: str, params: dict[str, Any]) -> _MockActionResult:
+        if action not in self._data_by_action:
+            return _MockActionResult(success=False, error=f"unknown action {action}")
+        return _MockActionResult(success=True, data=self._data_by_action[action])
+
+
+class _MockRegistry:
+    def __init__(self, adapters: dict[str, _MockAdapter | None]) -> None:
+        self._adapters = adapters
+
+    async def ensure_connected(self, connector_name: str, scope_key: str) -> _MockAdapter | None:
+        return self._adapters.get(connector_name)
+
+
+# Clean, id-keyed records → a HIGH key_confidence type the gate materialises.
+def _customers(n: int) -> list[dict[str, Any]]:
+    return [{"id": f"cust-{i}", "name": f"Customer {i}", "tier": "gold"} for i in range(n)]
+
+
+# Records with only repeated, non-unique fields → a KEYLESS low-confidence type
+# the gate skips + flags.
+def _events(n: int) -> list[dict[str, Any]]:
+    return [{"category": "click", "page": "home"} for _ in range(n)]
+
+
+def _mock_run(adapters: dict[str, _MockAdapter | None]) -> DiscoveryRun:
+    return DiscoveryRun(registry=_MockRegistry(adapters))
+
+
+def _opts_for(read_actions: dict[str, list[ReadAction]]) -> DiscoveryRunOptions:
+    return DiscoveryRunOptions(read_actions=read_actions)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — isolated stores wired into the lazy get_*_store seams.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    """Stable AUTH_SECRET so the pockets create path's token machinery is quiet."""
+    monkeypatch.setenv("AUTH_SECRET", "discovery-propose-test-secret")
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Install an inert recording EventBus so service ``emit()`` calls don't raise.
+
+    The pockets create path (exercised by the approve test) emits ``PocketCreated``
+    via ``_core.realtime.emit.emit`` which asserts a bus is set. ``tests/cloud``
+    has an autouse RecordingBus fixture for this; ``tests/ee`` doesn't, so we mint
+    a minimal one here. Inert by design — tests assert on store state, not events.
+    """
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        async def publish(self, event: Any) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler: Any) -> None:  # noqa: ARG002
+            return
+
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = _RecordingBus()  # type: ignore[attr-defined]
+    yield bus_mod._bus
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    st = InstinctStore(tmp_path / "instinct_discovery_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+@pytest.fixture
+def fabric(tmp_path: Path, monkeypatch) -> FabricStore:
+    fs = FabricStore(tmp_path / "fabric_discovery_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda: fs)
+    return fs
+
+
+# ---------------------------------------------------------------------------
+# The assembler binds one fabric.objects widget per high-confidence type.
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_discovery_pocket_binds_fabric_objects_source() -> None:
+    """The starter-Pocket spec binds one fabric.objects state source per
+    materialised type, and the widget reads its rows from that state key."""
+    draft = OntologyDraft.model_validate(
+        {
+            "object_types": [
+                {"name": "Customer", "source_id_field": "id", "key_confidence": 0.95},
+                {"name": "Order", "source_id_field": "id", "key_confidence": 0.9},
+            ],
+            "objects": [],
+            "links": [],
+        }
+    )
+    spec = assemble_discovery_pocket(draft, ["Customer", "Order"])
+
+    assert spec["version"] == "1.0"
+    # One fabric.objects state source per type, bound to that type by name.
+    assert spec["state"]["rows_Customer"] == {
+        "$source": "fabric.objects",
+        "type_name": "Customer",
+    }
+    assert spec["state"]["rows_Order"] == {
+        "$source": "fabric.objects",
+        "type_name": "Order",
+    }
+    # One widget per type, each reading the matching state key.
+    widget_ids = {c["id"] for c in spec["root"]["children"]}
+    assert widget_ids == {"table_Customer", "table_Order"}
+    rows_bindings = {c["props"]["rows"] for c in spec["root"]["children"]}
+    assert rows_bindings == {"$state.rows_Customer", "$state.rows_Order"}
+
+
+def test_assemble_discovery_pocket_skips_keyless_types() -> None:
+    """A stand-alone assemble call applies the key-confidence gate itself —
+    keyless / low-confidence types get no widget."""
+    draft = OntologyDraft.model_validate(
+        {
+            "object_types": [
+                {"name": "Customer", "source_id_field": "id", "key_confidence": 0.95},
+                {"name": "Event", "source_id_field": "", "key_confidence": 0.1},
+            ],
+        }
+    )
+    spec = assemble_discovery_pocket(draft)  # no explicit materialised list
+    state_keys = set(spec["state"].keys())
+    assert state_keys == {"rows_Customer"}, state_keys
+
+
+# ---------------------------------------------------------------------------
+# A run files TWO proposals, both PENDING, both discovery-tagged.
+# ---------------------------------------------------------------------------
+
+
+async def test_run_files_two_tagged_pending_proposals(store, fabric):
+    adapters = {
+        "crm": _MockAdapter(
+            schemas=[],
+            data_by_action={"list_customers": _customers(3)},
+        ),
+    }
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+
+    # TWO proposals filed.
+    assert result.fabric_objects_action_id is not None
+    assert result.pocket_action_id is not None
+    assert result.materialised_types == ["Customer"]
+    assert result.skipped_types == {}
+    assert result.superseded_action_ids == []  # first run supersedes nothing
+
+    fabric_action = await store.get_action(result.fabric_objects_action_id)
+    pocket_action = await store.get_action(result.pocket_action_id)
+    assert fabric_action.status == ActionStatus.PENDING
+    assert pocket_action.status == ActionStatus.PENDING
+
+    # Both blobs carry the SHARED discovery-run marker (same run_id, distinct roles).
+    fo_marker = _find_discovery_marker(fabric_action.parameters)
+    pc_marker = _find_discovery_marker(pocket_action.parameters)
+    assert fo_marker is not None and pc_marker is not None
+    assert fo_marker["run_id"] == pc_marker["run_id"] == result.run_id
+    assert fo_marker["role"] == "fabric_objects"
+    assert pc_marker["role"] == "pocket_create"
+
+    # The fabric proposal staged the 3 customers with a stable synthetic dedup key.
+    fo_blob = fabric_action.parameters["_fabric_objects"]
+    assert len(fo_blob["objects"]) == 3
+    assert all(o["source_connector"] == "discovery:Customer" for o in fo_blob["objects"])
+    assert {o["source_id"] for o in fo_blob["objects"]} == {"cust-0", "cust-1", "cust-2"}
+
+    # The pocket proposal staged a spec binding the fabric.objects source.
+    spec = pocket_action.parameters["_pocket_create"]["pocket_spec"]["rippleSpec"]
+    assert spec["state"]["rows_Customer"] == {
+        "$source": "fabric.objects",
+        "type_name": "Customer",
+    }
+
+
+# ---------------------------------------------------------------------------
+# A low-confidence keyless type is skipped + flagged (no crash).
+# ---------------------------------------------------------------------------
+
+
+async def test_low_confidence_keyless_type_skipped_and_flagged(store, fabric):
+    adapters = {
+        "mixed": _MockAdapter(
+            schemas=[],
+            data_by_action={
+                "list_customers": _customers(3),  # keyed → materialised
+                "list_events": _events(4),  # keyless → skipped + flagged
+            },
+        ),
+    }
+    opts = _opts_for(
+        {
+            "mixed": [
+                ReadAction(action="list_customers", type_name="Customer"),
+                ReadAction(action="list_events", type_name="Event"),
+            ]
+        }
+    )
+
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["mixed"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+
+    # Customer materialised; Event skipped + flagged with a human reason.
+    assert result.materialised_types == ["Customer"]
+    assert "Event" in result.skipped_types
+    assert "key" in result.skipped_types["Event"].lower()
+
+    # The fabric proposal carries ONLY the Customer objects (no keyless Event row).
+    fo_blob = (await store.get_action(result.fabric_objects_action_id)).parameters[
+        "_fabric_objects"
+    ]
+    staged_types = {o["type_name"] for o in fo_blob["objects"]}
+    assert staged_types == {"Customer"}
+
+    # The starter pocket binds ONLY the Customer source.
+    spec = (await store.get_action(result.pocket_action_id)).parameters["_pocket_create"][
+        "pocket_spec"
+    ]["rippleSpec"]
+    assert set(spec["state"].keys()) == {"rows_Customer"}
+
+
+# ---------------------------------------------------------------------------
+# Approving BOTH proposals materialises the objects + creates the bound pocket.
+# ---------------------------------------------------------------------------
+
+
+async def test_approving_both_creates_objects_and_bound_pocket(store, fabric, beanie_test_db):
+    from pocketpaw_ee.cloud.fabric_proposals import executor as fo_executor
+    from pocketpaw_ee.cloud.pocket_proposals import executor as pc_executor
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    adapters = {
+        "crm": _MockAdapter(
+            schemas=[],
+            data_by_action={"list_customers": _customers(2)},
+        ),
+    }
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+
+    # Approve + execute the FABRIC proposal → objects land in Fabric.
+    approved_fo = await store.approve(result.fabric_objects_action_id, approver="u1")
+    await fo_executor.execute_approved_fabric_objects(approved_fo)
+    final_fo = await store.get_action(result.fabric_objects_action_id)
+    assert final_fo.status == ActionStatus.EXECUTED
+
+    from pocketpaw.fabric.models import FabricQuery
+
+    cust_rows = await fabric.query(FabricQuery(type_name="Customer"), workspace_id="w1")
+    assert len(cust_rows.objects) == 2
+    assert {o.source_id for o in cust_rows.objects} == {"cust-0", "cust-1"}
+
+    # Approve + execute the POCKET proposal → a Pocket whose spec references the
+    # fabric.objects source for the discovered type is created.
+    approved_pc = await store.approve(result.pocket_action_id, approver="u1")
+    await pc_executor.execute_approved_pocket_create(approved_pc)
+    final_pc = await store.get_action(result.pocket_action_id)
+    assert final_pc.status == ActionStatus.EXECUTED, final_pc.error
+
+    pocket_id = final_pc.parameters["_pocket_create"]["outcome"]["pocket_id"]
+    wire = await pockets_service.get(pocket_id, "u1")
+    assert wire["workspace"] == "w1"
+    # pockets.service.get RESOLVES the $source marker into live Fabric rows on
+    # read — so the created pocket's Customer state binding now carries the two
+    # discovered objects we just materialised. This is the end-to-end proof: the
+    # starter pocket's fabric.objects source surfaces the discovered Fabric data.
+    spec = wire.get("rippleSpec") or wire.get("ripple_spec") or {}
+    resolved_rows = spec.get("state", {}).get("rows_Customer")
+    assert isinstance(resolved_rows, list), f"expected resolved rows, got {resolved_rows!r}"
+    assert {r["source_id"] for r in resolved_rows} == {"cust-0", "cust-1"}
+    assert all(r["type_name"] == "Customer" for r in resolved_rows)
+    # The raw spec stored on the doc still carries the verbatim marker (resolution
+    # happens on read, not at persistence) — confirm the binding is durable.
+    raw_pocket_blob = final_pc.parameters["_pocket_create"]["pocket_spec"]["rippleSpec"]
+    assert raw_pocket_blob["state"]["rows_Customer"] == {
+        "$source": "fabric.objects",
+        "type_name": "Customer",
+    }
+
+
+# ---------------------------------------------------------------------------
+# A second run SUPERSEDES the first run's still-open pair (no duplicate stack).
+# ---------------------------------------------------------------------------
+
+
+async def test_second_run_supersedes_prior_open_pair(store, fabric):
+    adapters = {
+        "crm": _MockAdapter(schemas=[], data_by_action={"list_customers": _customers(2)}),
+    }
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    first = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+    # Both first-run proposals are PENDING.
+    assert (await store.get_action(first.fabric_objects_action_id)).status == ActionStatus.PENDING
+    assert (await store.get_action(first.pocket_action_id)).status == ActionStatus.PENDING
+
+    second = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+
+    # The first run's pair was superseded (REJECTED), not left stacked.
+    assert set(second.superseded_action_ids) == {
+        first.fabric_objects_action_id,
+        first.pocket_action_id,
+    }
+    first_fo = await store.get_action(first.fabric_objects_action_id)
+    first_pc = await store.get_action(first.pocket_action_id)
+    assert first_fo.status == ActionStatus.REJECTED
+    assert first_pc.status == ActionStatus.REJECTED
+    assert "superseded" in (first_fo.rejected_reason or "").lower()
+
+    # The SECOND run's pair is the only open pair now.
+    second_fo = await store.get_action(second.fabric_objects_action_id)
+    second_pc = await store.get_action(second.pocket_action_id)
+    assert second_fo.status == ActionStatus.PENDING
+    assert second_pc.status == ActionStatus.PENDING
+
+    pending = await store.list_actions(
+        pocket_id="w1", status=ActionStatus.PENDING, workspace_id="w1"
+    )
+    pending_ids = {a.id for a in pending}
+    assert pending_ids == {
+        second.fabric_objects_action_id,
+        second.pocket_action_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tenancy validation at entry.
+# ---------------------------------------------------------------------------
+
+
+async def test_requires_workspace_and_user(store, fabric):
+    with pytest.raises(ValueError, match="workspace_id"):
+        await run_discovery_and_propose(
+            workspace_id="", user_id="u1", connector_ids=[], discovery_run=_mock_run({})
+        )
+    with pytest.raises(ValueError, match="user_id"):
+        await run_discovery_and_propose(
+            workspace_id="w1", user_id="", connector_ids=[], discovery_run=_mock_run({})
+        )
+
+
+# ---------------------------------------------------------------------------
+# An empty draft (no high-confidence objects) files NO proposals but still
+# supersedes the prior open pair.
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_draft_files_no_proposals(store, fabric):
+    adapters = {"empty": _MockAdapter(schemas=[], data_by_action={"list_rows": []})}
+    opts = _opts_for({"empty": [ReadAction(action="list_rows", type_name="Thing")]})
+
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["empty"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+
+    assert result.fabric_objects_action_id is None
+    assert result.pocket_action_id is None
+    assert result.materialised_types == []
+    # No PENDING discovery proposals were filed.
+    pending = await store.list_actions(
+        pocket_id="w1", status=ActionStatus.PENDING, workspace_id="w1"
+    )
+    assert pending == []
+
+
+# ---------------------------------------------------------------------------
+# The draft → fabric-proposal mapping carries links between materialised types.
+# ---------------------------------------------------------------------------
+
+
+def test_draft_to_fabric_mapping_keeps_links_between_materialised_types() -> None:
+    """Links between two high-confidence types survive the mapping, with both
+    endpoints rewritten to the synthetic discovery connector namespace."""
+    from pocketpaw_ee.discovery.digester import StructuredShapeDigester
+
+    grouped = {
+        "Invoice": [
+            {"id": f"inv-{i}", "amount": i * 10, "customer_id": f"cust-{i % 2}"} for i in range(4)
+        ],
+        "Customer": [{"id": f"cust-{i}", "name": f"C{i}"} for i in range(2)],
+    }
+    draft = StructuredShapeDigester().digest(grouped, {})
+    object_types, objects, links, materialised, skipped = _draft_to_fabric_proposal_kwargs(draft)
+
+    assert set(materialised) == {"Invoice", "Customer"}
+    assert skipped == {}
+    assert links, "expected an inferred Invoice→Customer link to survive mapping"
+    for link in links:
+        assert link["from"]["source_connector"] == "discovery:Invoice"
+        assert link["to"]["source_connector"] == "discovery:Customer"
+        assert link["from"]["source_id"] and link["to"]["source_id"]
+        assert link["link_type"]

--- a/tests/ee/test_discovery_run.py
+++ b/tests/ee/test_discovery_run.py
@@ -1,0 +1,290 @@
+# tests/ee/test_discovery_run.py — unit tests for SZD-4 (DiscoveryRun).
+#
+# Created: 2026-06-19 (SZD-4 / feat/szd-4-discovery-run) — covers the
+# DiscoveryRun orchestrator with the connector read MOCKED (no live network):
+#   * a run against a mock connector yields an OntologyDraft (types inferred);
+#   * the read goes through the workspace-scoped path
+#     ``ensure_connected(name, "ws:<workspace_id>")`` (pocket-less) and NEVER
+#     ``adapter.sync()`` — both asserted via the mock's recorded calls;
+#   * sampling is capped per connector (the "N of M" budget);
+#   * an empty connector yields an empty draft with no crash;
+#   * explicit read-action overrides + a multi-connector run roll up provenance.
+#
+# Fully mocked — no DB / network. Run with:
+#   uv run --group ee pytest tests/ee/test_discovery_run.py -q
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from pocketpaw_ee.discovery import (
+    DiscoveryRun,
+    DiscoveryRunOptions,
+    OntologyDraft,
+    ReadAction,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Mock connector surface (stands in for the real adapter + registry).
+# --------------------------------------------------------------------------- #
+@dataclass
+class _MockActionResult:
+    """Mirror of pocketpaw.connectors.protocol.ActionResult (duck-typed)."""
+
+    success: bool
+    data: Any = None
+    error: str | None = None
+    records_affected: int = 0
+
+
+@dataclass
+class _MockActionSchema:
+    """Mirror of pocketpaw.connectors.protocol.ActionSchema (the read-shape bits)."""
+
+    name: str
+    method: str = "GET"
+    trust_level: str = "auto"
+
+
+class _MockAdapter:
+    """A connector adapter the orchestrator can read through.
+
+    Records every ``execute`` call so the test can assert the read path. It has
+    a ``sync`` method that BLOWS UP if called — discovery must never touch it.
+    """
+
+    def __init__(self, schemas: list[_MockActionSchema], data_by_action: dict[str, Any]) -> None:
+        self._schemas = schemas
+        self._data_by_action = data_by_action
+        self.execute_calls: list[tuple[str, dict[str, Any]]] = []
+        self.sync_called = False
+
+    async def actions(self) -> list[_MockActionSchema]:
+        return list(self._schemas)
+
+    async def execute(self, action: str, params: dict[str, Any]) -> _MockActionResult:
+        self.execute_calls.append((action, dict(params)))
+        if action not in self._data_by_action:
+            return _MockActionResult(success=False, error=f"unknown action {action}")
+        return _MockActionResult(success=True, data=self._data_by_action[action])
+
+    async def sync(self, pocket_id: str) -> Any:  # pragma: no cover - must never run
+        self.sync_called = True
+        raise AssertionError(
+            "DiscoveryRun must NOT call adapter.sync() — sync requires a pocket "
+            "and returns counts, not records."
+        )
+
+
+class _MockRegistry:
+    """A connector registry the orchestrator resolves adapters through.
+
+    Records every ``ensure_connected(name, scope_key)`` so the test can assert
+    the scope key is ``ws:<workspace_id>`` (the pocket-less #1445 path).
+    """
+
+    def __init__(self, adapters: dict[str, _MockAdapter | None]) -> None:
+        self._adapters = adapters
+        self.ensure_calls: list[tuple[str, str]] = []
+
+    async def ensure_connected(self, connector_name: str, scope_key: str) -> _MockAdapter | None:
+        self.ensure_calls.append((connector_name, scope_key))
+        return self._adapters.get(connector_name)
+
+
+def _records(n: int, prefix: str = "r") -> list[dict[str, Any]]:
+    """N uniform records with a clean ``id`` key (so a primary key is inferred)."""
+    return [{"id": f"{prefix}{i}", "name": f"name-{i}", "amount": i * 10} for i in range(n)]
+
+
+# --------------------------------------------------------------------------- #
+# A run yields an OntologyDraft via the workspace execute path.
+# --------------------------------------------------------------------------- #
+async def test_run_yields_draft_via_workspace_execute_path() -> None:
+    adapter = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_invoices", method="GET", trust_level="auto")],
+        data_by_action={"list_invoices": _records(3)},
+    )
+    registry = _MockRegistry({"billing": adapter})
+    run = DiscoveryRun(registry=registry)
+
+    draft = await run.run("ws-123", ["billing"])
+
+    # 1. It produced a real OntologyDraft with an inferred type.
+    assert isinstance(draft, OntologyDraft)
+    assert not draft.is_empty
+    assert len(draft.objects) == 3
+    assert draft.object_types, "expected at least one inferred object type"
+
+    # 2. The read went through ensure_connected with the WORKSPACE-scoped,
+    #    pocket-less key — NOT a pocket:<id> key, NOT sync().
+    assert registry.ensure_calls == [("billing", "ws:ws-123")]
+    for _name, scope_key in registry.ensure_calls:
+        assert scope_key.startswith("ws:"), f"expected ws-scoped key, got {scope_key!r}"
+        assert not scope_key.startswith("pocket:"), "discovery must be pocket-less"
+    assert adapter.sync_called is False, "discovery must never call adapter.sync()"
+    assert adapter.execute_calls == [("list_invoices", {})]
+
+    # 3. Provenance label is present ("based on N of M").
+    discovery = draft.meta["discovery"]
+    assert discovery["label"] == "based on 1 of 1"
+    assert discovery["sampled_connectors"] == 1
+    assert discovery["total_connectors"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Sampling is capped per connector.
+# --------------------------------------------------------------------------- #
+async def test_sampling_is_capped_per_connector() -> None:
+    adapter = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_rows", method="GET", trust_level="auto")],
+        data_by_action={"list_rows": _records(500)},
+    )
+    registry = _MockRegistry({"big": adapter})
+    run = DiscoveryRun(registry=registry)
+
+    draft = await run.run("ws-1", ["big"], DiscoveryRunOptions(sample_cap=50))
+
+    # Only the capped number of records are sampled.
+    assert len(draft.objects) == 50
+    assert draft.meta["discovery"]["connectors"]["big"]["records"] == 50
+    assert draft.meta["discovery"]["sample_cap"] == 50
+
+
+# --------------------------------------------------------------------------- #
+# Empty connector → empty draft, no crash.
+# --------------------------------------------------------------------------- #
+async def test_empty_connector_yields_empty_draft() -> None:
+    adapter = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_rows", method="GET", trust_level="auto")],
+        data_by_action={"list_rows": []},  # connector has no records
+    )
+    registry = _MockRegistry({"empty": adapter})
+    run = DiscoveryRun(registry=registry)
+
+    draft = await run.run("ws-1", ["empty"])
+
+    assert isinstance(draft, OntologyDraft)
+    assert draft.is_empty
+    assert draft.meta["discovery"]["connectors"]["empty"]["status"] == "empty"
+    assert draft.meta["discovery"]["label"] == "based on 1 of 1"
+    # The read was still attempted through the ws path.
+    assert registry.ensure_calls == [("empty", "ws:ws-1")]
+    assert adapter.sync_called is False
+
+
+# --------------------------------------------------------------------------- #
+# Unresolvable connector is skipped gracefully.
+# --------------------------------------------------------------------------- #
+async def test_unresolved_connector_is_skipped() -> None:
+    registry = _MockRegistry({"gone": None})  # ensure_connected returns None
+    run = DiscoveryRun(registry=registry)
+
+    draft = await run.run("ws-1", ["gone"])
+
+    assert draft.is_empty
+    assert draft.meta["discovery"]["connectors"]["gone"]["status"] == "unresolved"
+    assert registry.ensure_calls == [("gone", "ws:ws-1")]
+
+
+# --------------------------------------------------------------------------- #
+# Mutating actions (POST / confirm) are never sampled on auto-select.
+# --------------------------------------------------------------------------- #
+async def test_auto_select_skips_mutating_actions() -> None:
+    adapter = _MockAdapter(
+        schemas=[
+            _MockActionSchema(name="create_row", method="POST", trust_level="confirm"),
+            _MockActionSchema(name="delete_row", method="POST", trust_level="auto"),
+            _MockActionSchema(name="list_rows", method="GET", trust_level="auto"),
+        ],
+        data_by_action={"list_rows": _records(2), "create_row": _records(2)},
+    )
+    registry = _MockRegistry({"c": adapter})
+    run = DiscoveryRun(registry=registry)
+
+    await run.run("ws-1", ["c"])
+
+    # Only the GET + auto action fired; the POST actions never ran.
+    called = {a for a, _ in adapter.execute_calls}
+    assert called == {"list_rows"}
+
+
+# --------------------------------------------------------------------------- #
+# Explicit read-action override + multi-connector "N of M" roll-up.
+# --------------------------------------------------------------------------- #
+async def test_explicit_read_actions_and_multi_connector_rollup() -> None:
+    crm = _MockAdapter(
+        schemas=[],  # no auto-discoverable schema — forces the explicit path
+        data_by_action={"q_customers": _records(2, "cust"), "q_deals": _records(2, "deal")},
+    )
+    support = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_tickets", method="GET", trust_level="auto")],
+        data_by_action={"list_tickets": _records(4, "tkt")},
+    )
+    registry = _MockRegistry({"crm": crm, "support": support, "broken": None})
+    run = DiscoveryRun(registry=registry)
+
+    opts = DiscoveryRunOptions(
+        read_actions={
+            "crm": [
+                ReadAction(action="q_customers", type_name="Customer"),
+                ReadAction(action="q_deals", type_name="Deal"),
+            ],
+        },
+    )
+    draft = await run.run("ws-9", ["crm", "support", "broken"], opts)
+
+    # Three logical types: Customer + Deal (explicit) + list_tickets (auto).
+    type_names = {ot.name for ot in draft.object_types}
+    assert {"Customer", "Deal", "list_tickets"} <= type_names
+
+    # 2 of 3 connectors actually sampled (broken was unresolved).
+    discovery = draft.meta["discovery"]
+    assert discovery["sampled_connectors"] == 2
+    assert discovery["total_connectors"] == 3
+    assert discovery["label"] == "based on 2 of 3"
+
+    # Every read went through a ws:-scoped resolve; none used sync().
+    assert all(scope == "ws:ws-9" for _n, scope in registry.ensure_calls)
+    assert crm.sync_called is False
+    assert support.sync_called is False
+
+
+# --------------------------------------------------------------------------- #
+# Permission filter degrades gracefully (allow-all when no list given).
+# --------------------------------------------------------------------------- #
+async def test_permission_filter_skips_disallowed_connectors() -> None:
+    a = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_rows", trust_level="auto")],
+        data_by_action={"list_rows": _records(2)},
+    )
+    b = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_rows", trust_level="auto")],
+        data_by_action={"list_rows": _records(2)},
+    )
+    registry = _MockRegistry({"allowed": a, "denied": b})
+    run = DiscoveryRun(registry=registry)
+
+    opts = DiscoveryRunOptions(allowed_connector_ids=frozenset({"allowed"}))
+    draft = await run.run("ws-1", ["allowed", "denied"], opts)
+
+    discovery = draft.meta["discovery"]
+    assert discovery["permission_enforced"] is True
+    assert discovery["skipped_by_permission"] == ["denied"]
+    # The denied connector was never resolved or read.
+    assert registry.ensure_calls == [("allowed", "ws:ws-1")]
+    assert b.execute_calls == []
+
+
+# --------------------------------------------------------------------------- #
+# The on-box refine pass is not wired in slice 1 — fail loud, don't lie.
+# --------------------------------------------------------------------------- #
+async def test_refine_pass_not_implemented_in_slice_1() -> None:
+    registry = _MockRegistry({})
+    run = DiscoveryRun(registry=registry)
+
+    with pytest.raises(NotImplementedError, match="on-box / tenant model"):
+        await run.run("ws-1", [], DiscoveryRunOptions(refine=True))

--- a/tests/ee/test_structured_shape_digester.py
+++ b/tests/ee/test_structured_shape_digester.py
@@ -1,0 +1,261 @@
+# tests/ee/test_structured_shape_digester.py — unit tests for SZD-3.
+#
+# Created: 2026-06-19 (SZD-3 / feat/szd-3-digester) — covers StructuredShapeDigester:
+#   * object types + property types inferred from sample records;
+#   * a stable, named primary key with high confidence;
+#   * links inferred from foreign-key shapes between two types;
+#   * the OntologyDraft round-trips into a fabric_ingest.FabricMapping;
+#   * clean degradation: empty records, nested/polymorphic records, no clear key.
+#
+# Pure-logic tests — no DB / network / async. Run with:
+#   uv run --group ee pytest tests/ee/test_structured_shape_digester.py -q
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from pocketpaw_ee.discovery import OntologyDraft, StructuredShapeDigester
+
+from pocketpaw.connectors.fabric_ingest import FabricMapping
+
+
+@pytest.fixture
+def digester() -> StructuredShapeDigester:
+    return StructuredShapeDigester()
+
+
+# --------------------------------------------------------------------------- #
+# Object types + property types
+# --------------------------------------------------------------------------- #
+def test_infers_types_and_property_types(digester: StructuredShapeDigester) -> None:
+    records = {
+        "Customer": [
+            {"id": "c1", "name": "Acme", "revenue": 1000, "active": True, "signed": "2026-01-02"},
+            {
+                "id": "c2",
+                "name": "Globex",
+                "revenue": 2500.5,
+                "active": False,
+                "signed": "2026-02-15",
+            },
+        ]
+    }
+    draft = digester.digest(records, {"connector": "demo"})
+
+    assert [ot.name for ot in draft.object_types] == ["Customer"]
+    ot = draft.type_by_name("Customer")
+    assert ot is not None
+    props = {p.name: p.type for p in ot.properties}
+    assert props["id"] == "string"
+    assert props["name"] == "string"
+    assert props["revenue"] == "number"  # int + float both vote number
+    assert props["active"] == "boolean"
+    assert props["signed"] == "date"  # ISO-ish string detected as date
+
+    # required = present non-null in every record
+    required = {p.name: p.required for p in ot.properties}
+    assert required["id"] is True
+    assert required["name"] is True
+
+
+def test_native_datetime_typed_as_date(digester: StructuredShapeDigester) -> None:
+    records = {"Event": [{"id": "e1", "at": datetime(2026, 6, 19, 22, 0, 0)}]}
+    draft = digester.digest(records)
+    ot = draft.type_by_name("Event")
+    assert ot is not None
+    assert {p.name: p.type for p in ot.properties}["at"] == "date"
+
+
+# --------------------------------------------------------------------------- #
+# Primary key inference
+# --------------------------------------------------------------------------- #
+def test_named_id_field_is_primary_key_high_confidence(
+    digester: StructuredShapeDigester,
+) -> None:
+    records = {
+        "Order": [
+            {"id": "o1", "total": 10},
+            {"id": "o2", "total": 20},
+            {"id": "o3", "total": 30},
+        ]
+    }
+    draft = digester.digest(records)
+    ot = draft.type_by_name("Order")
+    assert ot is not None
+    assert ot.source_id_field == "id"
+    assert ot.key_confidence >= 0.9  # named, unique, fully populated
+
+
+def test_type_prefixed_id_field_preferred(digester: StructuredShapeDigester) -> None:
+    # No plain "id" — the <type>_id field should win.
+    records = {
+        "Customer": [
+            {"customer_id": "c1", "name": "A"},
+            {"customer_id": "c2", "name": "B"},
+        ]
+    }
+    draft = digester.digest(records)
+    ot = draft.type_by_name("Customer")
+    assert ot is not None
+    assert ot.source_id_field == "customer_id"
+    assert ot.key_confidence >= 0.8
+
+
+def test_high_cardinality_unique_field_fallback_key(
+    digester: StructuredShapeDigester,
+) -> None:
+    # No id-named field; "email" is unique + fully populated → fallback key.
+    records = {
+        "Person": [
+            {"email": "a@x.com", "city": "NY"},
+            {"email": "b@x.com", "city": "NY"},
+            {"email": "c@x.com", "city": "LA"},
+        ]
+    }
+    draft = digester.digest(records)
+    ot = draft.type_by_name("Person")
+    assert ot is not None
+    assert ot.source_id_field == "email"
+    # fallback key is less certain than a named id
+    assert 0.0 < ot.key_confidence < 0.9
+
+
+def test_source_id_extracted_onto_objects(digester: StructuredShapeDigester) -> None:
+    records = {"Order": [{"id": "o1", "x": 1}, {"id": "o2", "x": 2}]}
+    draft = digester.digest(records)
+    sids = sorted(o.source_id for o in draft.objects)
+    assert sids == ["o1", "o2"]
+
+
+# --------------------------------------------------------------------------- #
+# Link inference
+# --------------------------------------------------------------------------- #
+def test_links_inferred_from_foreign_keys(digester: StructuredShapeDigester) -> None:
+    records = {
+        "Customer": [
+            {"id": "c1", "name": "Acme"},
+            {"id": "c2", "name": "Globex"},
+        ],
+        "Order": [
+            {"id": "o1", "customer_id": "c1", "total": 10},
+            {"id": "o2", "customer_id": "c1", "total": 20},
+            {"id": "o3", "customer_id": "c2", "total": 30},
+        ],
+    }
+    draft = digester.digest(records)
+
+    # Three orders, each linking to its customer.
+    cust_links = [lk for lk in draft.links if lk.from_type == "Order" and lk.to_type == "Customer"]
+    assert len(cust_links) == 3
+    pairs = {(lk.from_source_id, lk.to_source_id) for lk in cust_links}
+    assert pairs == {("o1", "c1"), ("o2", "c1"), ("o3", "c2")}
+    # FK field name → link_type + via_field captured
+    assert all(lk.via_field == "customer_id" for lk in cust_links)
+    assert all(lk.link_type == "belongs_to_customer" for lk in cust_links)
+    # name + coverage signal → reasonably high confidence
+    assert all(lk.confidence >= 0.6 for lk in cust_links)
+
+
+def test_no_links_when_no_foreign_keys(digester: StructuredShapeDigester) -> None:
+    records = {
+        "Customer": [{"id": "c1"}, {"id": "c2"}],
+        "Product": [{"id": "p1"}, {"id": "p2"}],
+    }
+    draft = digester.digest(records)
+    assert draft.links == []
+
+
+# --------------------------------------------------------------------------- #
+# FabricMapping round-trip — the draft must be directly usable by ingest
+# --------------------------------------------------------------------------- #
+def test_draft_type_builds_fabric_mapping(digester: StructuredShapeDigester) -> None:
+    records = {
+        "Invoice": [
+            {"invoice_id": "i1", "amount": 100, "paid": True},
+            {"invoice_id": "i2", "amount": 200, "paid": False},
+        ]
+    }
+    draft = digester.digest(records)
+    ot = draft.type_by_name("Invoice")
+    assert ot is not None
+
+    mapping = FabricMapping(**ot.to_fabric_mapping_kwargs())
+    assert mapping.type_name == "Invoice"
+    assert mapping.source_id_field == "invoice_id"
+
+    # the mapping's own extract/project must work on the raw records
+    rec = records["Invoice"][0]
+    assert mapping.extract_source_id(rec) == "i1"
+    projected = mapping.project(rec)
+    assert projected["amount"] == 100
+    assert projected["paid"] is True
+    assert projected["invoice_id"] == "i1"
+
+
+# --------------------------------------------------------------------------- #
+# Degradation
+# --------------------------------------------------------------------------- #
+def test_empty_records_yield_empty_draft(digester: StructuredShapeDigester) -> None:
+    assert digester.digest({}).is_empty
+    assert digester.digest([]).is_empty
+    assert digester.digest(None).is_empty
+    # mapping of empty lists also degrades to empty
+    draft = digester.digest({"Customer": []})
+    assert draft.is_empty
+    assert draft.meta.get("degraded") == "empty"
+
+
+def test_nested_polymorphic_records_no_crash(digester: StructuredShapeDigester) -> None:
+    records = {
+        "Thing": [
+            {"id": "t1", "blob": {"nested": [1, 2, 3]}, "tags": ["a", "b"]},
+            {"id": "t2", "blob": "now a string", "tags": None},
+            {"id": "t3", "blob": 42},
+        ]
+    }
+    draft = digester.digest(records)  # must not raise
+    ot = draft.type_by_name("Thing")
+    assert ot is not None
+    assert ot.source_id_field == "id"
+    # nested/polymorphic field still gets a type (string) and is projectable
+    props = {p.name: p.type for p in ot.properties}
+    assert "blob" in props
+    assert len(draft.objects) == 3
+
+
+def test_no_clear_key_objects_only_low_confidence(
+    digester: StructuredShapeDigester,
+) -> None:
+    # No id-named field, no unique field — every value repeats.
+    records = {
+        "Log": [
+            {"level": "info", "scope": "auth"},
+            {"level": "info", "scope": "auth"},
+            {"level": "warn", "scope": "auth"},
+        ]
+    }
+    draft = digester.digest(records)
+    ot = draft.type_by_name("Log")
+    assert ot is not None
+    assert ot.source_id_field is None  # no usable key
+    assert ot.key_confidence < 0.3  # low confidence
+    # objects still produced (objects-only), but with no source_id and no links
+    assert len(draft.objects) == 3
+    assert all(o.source_id is None for o in draft.objects)
+    assert draft.links == []
+    assert draft.meta.get("degraded") == "objects-only"
+
+
+def test_flat_list_input_single_anonymous_type(
+    digester: StructuredShapeDigester,
+) -> None:
+    records = [{"id": "r1", "v": 1}, {"id": "r2", "v": 2}]
+    draft = digester.digest(records, {"default_type": "Widget"})
+    assert [ot.name for ot in draft.object_types] == ["Widget"]
+    assert draft.type_by_name("Widget").source_id_field == "id"
+
+
+def test_returns_ontology_draft_type(digester: StructuredShapeDigester) -> None:
+    draft = digester.digest({"X": [{"id": "1"}]})
+    assert isinstance(draft, OntologyDraft)

--- a/tests/test_fabric_type_scoping.py
+++ b/tests/test_fabric_type_scoping.py
@@ -1,0 +1,314 @@
+# tests/test_fabric_type_scoping.py
+# Created: 2026-06-19 (SZD-2 — workspace-scope object TYPES).
+#
+# Proves the SZD-2 invariant for the "sovereign zero-setup discovery" feature:
+# the Fabric object-TYPE catalog is private per workspace. A type defined in
+# workspace A must be invisible AND non-reusable from workspace B —
+# get_type_by_name / get_type / list_types / stats all scope on the type's own
+# workspace_id (own rows + legacy NULL), and ensure_type / ingest_records thread
+# the workspace through so connector ingestion stays inside its tenant.
+#
+# Also covers:
+#   * legacy NULL-workspace types stay globally visible (back-compat),
+#   * two workspaces may each define a same-named type (the unique index is now
+#     (workspace_id, LOWER(name)), not a global LOWER(name)),
+#   * the additive migration runs idempotently on a pre-SZD-2 DB (twice, no
+#     error), including dropping the old global unique index, and
+#   * the SZD-2 backfill attributes a NULL-workspace type to a tenant only when
+#     its objects unambiguously share one workspace.
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.connectors.fabric_ingest import FabricMapping, ingest_records
+from pocketpaw.fabric.models import PropertyDef
+from pocketpaw.fabric.store import SCHEMA_SQL, FabricStore
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+# ---------------------------------------------------------------------------
+# Core SZD-2 invariant: A cannot read/reuse B's types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_type_defined_in_a_is_invisible_to_b(tmp_path: Path) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type(name="Customer", properties=[], workspace_id=WS_A)
+
+    # B asks for the same name by its own scope -> not found (cannot read A's).
+    assert await store.get_type_by_name("Customer", workspace_id=WS_B) is None
+    # A sees its own type.
+    a_type = await store.get_type_by_name("Customer", workspace_id=WS_A)
+    assert a_type is not None
+    assert a_type.workspace_id == WS_A
+
+    # list_types is scoped: A sees Customer, B sees nothing.
+    a_names = {t.name for t in await store.list_types(workspace_id=WS_A)}
+    b_names = {t.name for t in await store.list_types(workspace_id=WS_B)}
+    assert a_names == {"Customer"}
+    assert b_names == set()
+
+    # get_type by id is scoped too: B cannot fetch A's type by id.
+    assert await store.get_type(a_type.id, workspace_id=WS_B) is None
+    assert (await store.get_type(a_type.id, workspace_id=WS_A)).id == a_type.id
+
+
+@pytest.mark.asyncio
+async def test_ensure_type_does_not_reuse_other_workspaces_type(tmp_path: Path) -> None:
+    """ensure_type for B must NOT return A's type id — it mints B's own."""
+    store = FabricStore(tmp_path / "fabric.db")
+    mapping = FabricMapping(
+        type_name="CalendarEvent",
+        source_id_field="id",
+        field_map={"summary": "summary"},
+        properties=[PropertyDef(name="summary", type="string")],
+    )
+
+    # A ingests one record -> defines A's CalendarEvent type.
+    await ingest_records(
+        store,
+        connector="gcal",
+        records=[{"id": "a1", "summary": "A standup"}],
+        mapping=mapping,
+        workspace_id=WS_A,
+    )
+    # B ingests -> must define B's OWN CalendarEvent, distinct id.
+    await ingest_records(
+        store,
+        connector="gcal",
+        records=[{"id": "b1", "summary": "B standup"}],
+        mapping=mapping,
+        workspace_id=WS_B,
+    )
+
+    a_type = await store.get_type_by_name("CalendarEvent", workspace_id=WS_A)
+    b_type = await store.get_type_by_name("CalendarEvent", workspace_id=WS_B)
+    assert a_type is not None and b_type is not None
+    # The whole point: two distinct, workspace-owned types with the same name.
+    assert a_type.id != b_type.id
+    assert a_type.workspace_id == WS_A
+    assert b_type.workspace_id == WS_B
+
+    # Each workspace lists only its own type.
+    assert [t.workspace_id for t in await store.list_types(workspace_id=WS_A)] == [WS_A]
+    assert [t.workspace_id for t in await store.list_types(workspace_id=WS_B)] == [WS_B]
+
+    # stats counts only the tenant's own type.
+    assert (await store.stats(workspace_id=WS_A))["types"] == 1
+    assert (await store.stats(workspace_id=WS_B))["types"] == 1
+
+
+@pytest.mark.asyncio
+async def test_reingest_same_workspace_reuses_type(tmp_path: Path) -> None:
+    """Within ONE workspace, ensure_type still reuses (define-once-by-name)."""
+    store = FabricStore(tmp_path / "fabric.db")
+    mapping = FabricMapping(type_name="Ticket", source_id_field="tid", field_map={"title": "title"})
+    r1 = await ingest_records(
+        store,
+        connector="hd",
+        records=[{"tid": "t1", "title": "x"}],
+        mapping=mapping,
+        workspace_id=WS_A,
+    )
+    r2 = await ingest_records(
+        store,
+        connector="hd",
+        records=[{"tid": "t2", "title": "y"}],
+        mapping=mapping,
+        workspace_id=WS_A,
+    )
+    assert r1.created == 1 and r2.created == 1
+    a_types = [t for t in await store.list_types(workspace_id=WS_A) if t.name == "Ticket"]
+    assert len(a_types) == 1  # one type, reused — not duplicated
+
+
+# ---------------------------------------------------------------------------
+# Legacy NULL-workspace types stay globally visible (back-compat)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legacy_null_workspace_type_visible_to_all(tmp_path: Path) -> None:
+    store = FabricStore(tmp_path / "fabric.db")
+    # No workspace_id -> legacy/global type.
+    await store.define_type(name="GlobalThing", properties=[])
+
+    # Both tenants see it; the unscoped read sees it; B can reuse it via name.
+    assert (await store.get_type_by_name("GlobalThing", workspace_id=WS_A)) is not None
+    assert (await store.get_type_by_name("GlobalThing", workspace_id=WS_B)) is not None
+    assert (await store.get_type_by_name("GlobalThing")) is not None
+    assert {t.name for t in await store.list_types(workspace_id=WS_A)} == {"GlobalThing"}
+    assert {t.name for t in await store.list_types()} == {"GlobalThing"}
+
+
+@pytest.mark.asyncio
+async def test_own_type_wins_over_legacy_same_name(tmp_path: Path) -> None:
+    """When both a legacy NULL type and the caller's own type share a name, the
+    scoped lookup resolves to the caller's OWN type (own-rows-first ordering)."""
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type(name="Customer", properties=[])  # legacy/global
+    own = await store.define_type(name="Customer", properties=[], workspace_id=WS_A)
+
+    resolved = await store.get_type_by_name("Customer", workspace_id=WS_A)
+    assert resolved is not None
+    assert resolved.id == own.id
+    assert resolved.workspace_id == WS_A
+
+
+@pytest.mark.asyncio
+async def test_unscoped_callers_see_everything(tmp_path: Path) -> None:
+    """workspace_id=None is fully backward-compatible: sees all defined types."""
+    store = FabricStore(tmp_path / "fabric.db")
+    await store.define_type(name="A", properties=[], workspace_id=WS_A)
+    await store.define_type(name="B", properties=[], workspace_id=WS_B)
+    await store.define_type(name="G", properties=[])
+    names = {t.name for t in await store.list_types()}
+    assert names == {"A", "B", "G"}
+    assert (await store.stats())["types"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Migration idempotency on a pre-SZD-2 DB
+# ---------------------------------------------------------------------------
+
+
+# The faithful pre-SZD-2 schema: fabric_object_types had NO workspace_id column,
+# fabric_objects / fabric_links already had one (from W4a), and the type-name
+# unique index was GLOBAL on LOWER(name). Written out literally rather than
+# regex-stripping the live SCHEMA_SQL so the test pins the exact historic shape
+# the migration must upgrade from.
+_PRE_SZD2_SCHEMA = """
+CREATE TABLE fabric_object_types (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    icon TEXT DEFAULT 'box',
+    color TEXT DEFAULT '#0A84FF',
+    properties_schema TEXT DEFAULT '[]',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE fabric_objects (
+    id TEXT PRIMARY KEY,
+    type_id TEXT NOT NULL REFERENCES fabric_object_types(id),
+    type_name TEXT DEFAULT '',
+    properties TEXT NOT NULL DEFAULT '{}',
+    source_connector TEXT,
+    source_id TEXT,
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE fabric_links (
+    id TEXT PRIMARY KEY,
+    from_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    to_object_id TEXT NOT NULL REFERENCES fabric_objects(id),
+    link_type TEXT NOT NULL,
+    properties TEXT DEFAULT '{}',
+    workspace_id TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX idx_object_types_name_unique ON fabric_object_types(LOWER(name));
+"""
+
+
+def _make_pre_szd2_db(path: Path) -> None:
+    """Materialize a DB whose fabric_object_types has NO workspace_id column and
+    carries the OLD global unique index on LOWER(name) — the faithful pre-SZD-2
+    state a deployment would be upgrading from."""
+    # Sanity: confirm SCHEMA_SQL (the current schema) does carry the column we
+    # are deliberately omitting here, so this stays a true "before" snapshot.
+    types_block = SCHEMA_SQL.split("CREATE TABLE IF NOT EXISTS fabric_objects")[0]
+    assert "workspace_id" in types_block, "current object_types should have workspace_id"
+    conn = sqlite3.connect(path)
+    conn.executescript(_PRE_SZD2_SCHEMA)
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent_on_pre_szd2_db(tmp_path: Path) -> None:
+    db = tmp_path / "fabric.db"
+    _make_pre_szd2_db(db)
+
+    # First open: runs the migration (ALTER + drop old index + new index).
+    store1 = FabricStore(db)
+    assert await store1.list_types() == []  # opens cleanly, no OperationalError
+    # After migration two workspaces can define the same name (old global
+    # unique index would have rejected the second).
+    await store1.define_type(name="Customer", properties=[], workspace_id=WS_A)
+    await store1.define_type(name="Customer", properties=[], workspace_id=WS_B)
+
+    # Second open on the SAME file re-runs _ensure_schema end to end. The ALTER's
+    # duplicate-column error and the DROP/CREATE INDEX must all be no-ops.
+    store2 = FabricStore(db)
+    a = await store2.get_type_by_name("Customer", workspace_id=WS_A)
+    b = await store2.get_type_by_name("Customer", workspace_id=WS_B)
+    assert a is not None and b is not None and a.id != b.id
+
+
+@pytest.mark.asyncio
+async def test_backfill_attributes_unambiguous_type(tmp_path: Path) -> None:
+    """A pre-SZD-2 NULL-workspace type whose objects all live in one workspace is
+    attributed to that workspace on migration; an ambiguous one stays NULL."""
+    db = tmp_path / "fabric.db"
+    _make_pre_szd2_db(db)
+
+    # Seed pre-SZD-2 state directly: types have no workspace_id column yet, but
+    # objects (which predate SZD-2 and DO have workspace_id from W4a) carry one.
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO fabric_object_types (id, name, properties_schema) VALUES (?, ?, '[]')",
+        ("ot-solo", "Solo"),
+    )
+    conn.execute(
+        "INSERT INTO fabric_object_types (id, name, properties_schema) VALUES (?, ?, '[]')",
+        ("ot-mixed", "Mixed"),
+    )
+    # Solo: all objects in WS_A -> backfill attributes Solo to WS_A.
+    conn.execute(
+        "INSERT INTO fabric_objects (id, type_id, properties, workspace_id)"
+        " VALUES ('o1', 'ot-solo', '{}', ?)",
+        (WS_A,),
+    )
+    conn.execute(
+        "INSERT INTO fabric_objects (id, type_id, properties, workspace_id)"
+        " VALUES ('o2', 'ot-solo', '{}', ?)",
+        (WS_A,),
+    )
+    # Mixed: objects span WS_A and WS_B -> cannot attribute, stays NULL/global.
+    conn.execute(
+        "INSERT INTO fabric_objects (id, type_id, properties, workspace_id)"
+        " VALUES ('o3', 'ot-mixed', '{}', ?)",
+        (WS_A,),
+    )
+    conn.execute(
+        "INSERT INTO fabric_objects (id, type_id, properties, workspace_id)"
+        " VALUES ('o4', 'ot-mixed', '{}', ?)",
+        (WS_B,),
+    )
+    conn.commit()
+    conn.close()
+
+    store = FabricStore(db)
+    await store.list_types()  # triggers migration + backfill
+
+    solo = await store.get_type("ot-solo")
+    mixed = await store.get_type("ot-mixed")
+    assert solo is not None and mixed is not None
+    assert solo.workspace_id == WS_A  # unambiguous -> attributed
+    assert mixed.workspace_id is None  # ambiguous -> stays global
+
+    # Consequence: WS_A sees Solo (attributed) + Mixed (global); WS_B sees only
+    # Mixed (global), NOT Solo.
+    a_names = {t.name for t in await store.list_types(workspace_id=WS_A)}
+    b_names = {t.name for t in await store.list_types(workspace_id=WS_B)}
+    assert a_names == {"Solo", "Mixed"}
+    assert b_names == {"Mixed"}


### PR DESCRIPTION
Convergence PR for sovereign zero-setup discovery, slice 1 (backend). Wires the six reviewed component slices into the end-to-end pipeline: sample a workspace's bound connectors → reverse-engineer an ontology → stage it as two governed Instinct proposals → on approve, materialize the Fabric objects + a starter Pocket that renders the discovered data.

## Component slices (each individually reviewed; this branch is their clean merge + the wiring)
- #1509 workspace-scope Fabric types
- #1510 fabric.objects / fabric.query ripple sources
- #1511 `_fabric_objects` gate type (4-path tenancy guards)
- #1512 `_pocket_create` gate type (4-path tenancy guards)
- #1513 StructuredShapeDigester
- #1514 DiscoveryRun orchestrator (local read path)

## The wiring (this PR's own change — `ee/pocketpaw_ee/discovery/orchestrate.py`)
- `run_discovery_and_propose(...)`: DiscoveryRun → OntologyDraft → `propose_fabric_objects` + `propose_pocket`; returns the two Action ids; both tagged with a shared `discovery_run` marker.
- `assemble_discovery_pocket(draft)`: a starter dashboard — one widget per high-confidence type, bound to the `fabric.objects` source.
- Per-type key-confidence gate: keyless / low-confidence types are skipped (surfaced in `skipped_types` with a reason), with a synthetic stable dedup key so ingest never collapses records onto a blank id.
- Supersede-on-rerun: a 2nd run rejects the workspace's prior still-open discovery pair before filing the new one (no stacking).

## Verified (the backend e2e)
- New `tests/ee/test_discovery_propose.py` (9 tests): a mock-connector run files BOTH proposals (PENDING, shared marker); approving + executing both materializes the discovered objects AND creates a Pocket whose `{"$source": fabric.objects}` binding resolves to the discovered rows — proof the starter Pocket renders the data; supersede confirmed (first pair REJECTED, only the second PENDING); low-confidence keyless types skipped, no crash.
- Full slice-1 backend suite (the six component test files + this): 76 pass. Ruff clean.

## Notes
- Supersede directly rejects the prior open pair (never human-seen). Folding the superseded proposals' Decision-Graph chain to a terminal is a small follow-up.
- The `discovery_run` marker is a post-propose SQL back-write (propose helpers drop unknown keys); best-effort.

Remaining for the full slice: the in-app review UX (SZD-7) + the live e2e on the snctm-admin connector (SZD-8). Part of sovereign zero-setup discovery — design/PRD/tasks in `docs/design/drafts/2026-06-19-sovereign-zero-setup-discovery*`.