### PR TITLE
feat(jobs): server-side workspace jobs with gated trigger and live writeback

### DIFF
--- a/docs/wiki/jobs.md
+++ b/docs/wiki/jobs.md
@@ -1,0 +1,72 @@
+# jobs — Workspace jobs primitive: named, durable, server-side pocket work
+
+> The workspace jobs primitive runs named, parameterized, server-side async work for a pocket — durably, in the ARQ worker, under a synthetic workspace identity rather than the triggering user's session. A job is dispatched by a `kind:"job"` action on a pocket, runs to completion even after the user's socket closes, and writes its result back into the pocket's rippleSpec `state` so any open canvas updates live. It exists to give pockets a "do this in the background and tell me when it's done" capability without granting an unbounded agent loop.
+
+**Categories:** background work, async execution, ARQ, multi-tenancy, realtime
+**Concepts:** pocket job, job registry, JobCallable, WorkspaceJobDoc, kind="job" action, writeback, system:workspace_job identity, xproc bridge, state-only result, PII allowlist
+**Version:** 1
+
+---
+
+## What a pocket job is (and is not)
+
+A **pocket job** is a named, server-side async callable registered in an in-process registry, parameterized by a JSON `params` dict. It is:
+
+- **NOT an HTTP call** — that is a write *action* (`action_executor.run_action`).
+- **NOT a belt station run** — that is a separate develop-station surface.
+- run under the **workspace service identity** (`system:workspace_job`), never the user's session.
+- allowed to call `merge_spec` / connectors / Fabric / bus / audit; **not** allowed to touch another workspace, write code, or run unbounded.
+
+Durability comes from **ARQ**: a job runs in the same worker process as resumable chat runs, so a final `emit(PocketUpdated(...))` reaches the bus even after the user's 30-minute session expires. The worker pins `xproc.set_role("worker")` at boot, so worker-side emits route over the cross-process bridge to the web bus, where the live listeners are wired.
+
+## The contracts
+
+### Trigger action (`rippleSpec.actions`)
+
+```json
+{"actions": {"score_applications": {"kind": "job", "job": "score_applications",
+  "params": {"batch_size": 20, "connector": "snctm-api"}, "label": "Score Next Batch",
+  "requires_instinct": false}}}
+```
+
+`POST /pockets/{id}/actions/run` branches on `kind == "job"` **before** the HTTP-write path: registry lookup (`job.unknown` 400 on miss), merge the action's declared params, create a `queued` `WorkspaceJobDoc`, enqueue `execute_workspace_job(job_id)` on the `paw:jobs` queue, emit `WorkspaceJobQueued`, and return `{ok: true, code: "job_enqueued", job_id}`. A missing `kind` falls through unchanged (back-compat). `requires_instinct: true` is rejected with `job.instinct_not_yet_supported` (deferred to v1.1).
+
+### Registry (`jobs/registry.py`)
+
+A module-level dict of `name → JobCallable`, following the `OptimisticCompensationRegistry` shape. `JobCallable` is a Protocol with a `name` attribute and `async __call__(*, workspace_id, pocket_id, job_id, params) -> dict`. Built-ins register at mount time via `register_builtins()`, after `init_realtime()`.
+
+### Status doc (`models/workspace_job.py`)
+
+A Beanie document recording `workspace`, `pocket_id`, `action`, `job_name`, `params`, `triggered_by` (the viewer id, audit only), `status` (`queued`/`running`/`done`/`failed`), `arq_job_id`, `result`, `error`, and timestamps. Indexed by `(workspace, createdAt)` and `(workspace, pocket_id, createdAt)`.
+
+### Writeback
+
+On success the worker calls `merge_spec(workspace_id, user_id="system:workspace_job", pocket_id, {"merge": result})`, which fires `PocketUpdated`. The `result` is a **partial spec that may write ONLY `state`** — `ui` / `actions` / `sources` / `shape` are template-owned and rejected by `validate_job_result`, which marks the job `failed` (never a silent drop). On any failure (exception, validation reject, or timeout) the worker writes `{state: {"<action>_status": "failed", "<action>_error": "<msg>"}}` so the triggering button never hangs.
+
+### Status poll
+
+`GET /api/v1/workspaces/{ws}/jobs/{job_id}` returns `{job_id, status, timestamps, error}` (the result is already in `state`). Any workspace member may read; the service re-fetches by id and re-checks `workspace_id`, returning 404 on a cross-tenant mismatch.
+
+## Security properties
+
+- **Identity** is hardcoded `system:workspace_job`, audited, and not user-assignable. Connector calls use the workspace's stored creds, never params-supplied tokens.
+- `validate_job_params` rejects any param key matching `token` / `api_key` / `credential` / `secret` / `password` (case-insensitive) with a 400 — no credential exfil through params.
+- `validate_job_result` rejects template-owned writes (`ui`/`actions`/`sources`/`shape`).
+- **Tenancy** is enforced on both the worker re-fetch and the status poll.
+- **Timeout** is the ARQ per-function `job_timeout` = `POCKETPAW_JOB_TIMEOUT_SECONDS` (default 900s); a timed-out job is treated as a failure with a failed-state writeback.
+- **PII**: because the result becomes broadcast `state`, built-in jobs project each row through an allowlist (e.g. `score_applications` drops everything but `id`/`name`/`score`/`stage`, so `email`/`phone` never broadcast).
+- Enqueue emits an INFO `AuditEvent`; failure emits a WARNING.
+
+## Module map
+
+| Module | Role |
+|--------|------|
+| `jobs/domain.py` | Pure constants/value types (identity, queue, timeout, failed-state writeback). |
+| `jobs/registry.py` | The named registry + `validate_job_params` / `validate_job_result`. |
+| `jobs/service.py` | The only writer of `WorkspaceJobDoc`: dispatch + lifecycle + audit. |
+| `jobs/worker.py` | The ARQ `execute_workspace_job` entrypoint (run → validate → writeback). |
+| `jobs/router.py` | The status-poll route. |
+| `jobs/dto.py` | The `JobStatusResponse` wire model. |
+| `jobs/builtin/` | Built-in jobs (`score_applications`) + `register_builtins()`. |
+
+The worker entrypoint is registered into the shared `chat/runs/worker.py` `WorkerSettings.functions` with its own per-function timeout, so it runs in the same worker process as chat runs without sharing their timeout.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,11 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-06-20 (feat/workspace-jobs, pp#1459) — Mounts the workspace-jobs
+    status router (``GET /workspaces/{ws}/jobs/{job_id}``) and registers the
+    built-in jobs into the process-wide registry via ``register_builtins()``
+    AFTER ``init_realtime()`` (so a job's writeback emit has a bus to publish
+    onto). Jobs are TRIGGERED through the existing
+    ``POST /pockets/{id}/actions/run`` kind=="job" branch.
 Modified: 2026-06-13 (feat/patrol-engine) — Registers the mandate cadence
     SCHEDULER lifespan pair next to the autopilot pair, under the same
     POCKETPAW_CLOUD_SCHEDULER_ENABLED gate: ``reconcile_scheduler`` at startup
@@ -193,6 +199,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.connectors.router import router as connectors_router
     from pocketpaw_ee.cloud.cycles.router import router as cycles_router
     from pocketpaw_ee.cloud.foresight.router import router as foresight_router
+    from pocketpaw_ee.cloud.jobs.router import router as jobs_router
     from pocketpaw_ee.cloud.license import get_license_info
     from pocketpaw_ee.cloud.meetings.providers.recall.webhooks import (
         router as meetings_webhooks_router,
@@ -229,6 +236,12 @@ def mount_cloud(app: FastAPI) -> None:
     # same surface as live cycles. Persistence lands in the
     # ``foresight_runs`` Mongo collection via ``ee.cloud.foresight.service``.
     app.include_router(foresight_router, prefix="/api/v1")
+    # Workspace jobs — pp#1459. The status-poll surface
+    # (GET /workspaces/{ws}/jobs/{job_id}); jobs are TRIGGERED through the
+    # existing POST /pockets/{id}/actions/run kind=="job" branch, so there is
+    # no dispatch route here. Built-in jobs are registered after init_realtime
+    # below.
+    app.include_router(jobs_router, prefix="/api/v1")
     # Skills — per-backend API-skill install (POST /skills/api-doc).
     app.include_router(skills_router, prefix="/api/v1")
     app.include_router(meetings_router, prefix="/api/v1")
@@ -585,6 +598,13 @@ def mount_cloud(app: FastAPI) -> None:
     # first service that calls ``emit(...)`` fails with "EventBus not
     # initialized".
     init_realtime()
+
+    # Register built-in workspace jobs (pp#1459) into the process-wide job
+    # registry. Must run AFTER ``init_realtime`` so a job's writeback emit has
+    # a bus to publish onto — same lifecycle ordering as the listeners below.
+    from pocketpaw_ee.cloud.jobs.builtin import register_builtins
+
+    register_builtins()
 
     # Bridge ``AuditLogger`` (JSONL) writes into ``AuditStore`` (SQLite).
     # Cloud writers across the EE codebase (pockets/action_executor,

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -31,6 +31,12 @@
 #   (edges_fired / blocked / escalated / errors / sweep_duration_ms) so
 #   audit + dashboards listen to one event per dispatch rather than N
 #   per-row events, the same shape ``BulkActionDispatched`` uses.
+# Updated: 2026-06-20 (feat/workspace-jobs, pp#1459) — added
+#   ``WorkspaceJobQueued`` (type="workspace_job.queued") and
+#   ``WorkspaceJobUpdated`` (type="workspace_job.updated") for the workspace
+#   jobs primitive. Queued is emitted at dispatch; Updated on a terminal
+#   transition by the ARQ worker. Worker-side emits route over the xproc
+#   bridge to the web bus, the same path ``PocketUpdated`` uses.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -422,6 +428,27 @@ class PocketDeleted(Event):
 @dataclass
 class PocketOutcomeEvent(Event):
     EVENT_TYPE: ClassVar[str] = "pocket.outcome"
+
+
+# Workspace jobs — pp#1459 (feat/workspace-jobs). A pocket job is a named,
+# server-side async callable run in the ARQ worker under the synthetic
+# `system:workspace_job` identity. `WorkspaceJobQueued` is emitted at dispatch
+# (the action route's kind=="job" branch); `WorkspaceJobUpdated` is emitted on
+# a terminal transition (done / failed) by the worker. Both ride the same
+# xproc bridge as `PocketUpdated` — worker-side emits route through
+# `publish_bus_envelope` to the web bus.
+#
+# Payload (`data`) for both:
+#   job_id, workspace_id, pocket_id, action, job_name
+#   status — present on WorkspaceJobUpdated only (done | failed)
+@dataclass
+class WorkspaceJobQueued(Event):
+    EVENT_TYPE: ClassVar[str] = "workspace_job.queued"
+
+
+@dataclass
+class WorkspaceJobUpdated(Event):
+    EVENT_TYPE: ClassVar[str] = "workspace_job.updated"
 
 
 # Tasks (Mission Control work-item primitive)

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -1,5 +1,12 @@
 """arq worker entry point for Tier 2 run execution.
 
+Updated: 2026-06-20 (feat/workspace-jobs, pp#1459) — registered the workspace
+jobs entrypoint ``execute_workspace_job`` into ``WorkerSettings.functions``
+(default #1: SAME worker process, no new deploy artifact). It is wrapped with
+``arq.worker.func(timeout=...)`` so workspace jobs get their OWN per-function
+timeout (``POCKETPAW_JOB_TIMEOUT_SECONDS``, default 900s) without changing the
+chat-run timeout. The jobs share this worker's Redis pool + realtime bootstrap.
+
 Deploy as a separate process alongside the web service::
 
     arq pocketpaw_ee.cloud.chat.runs.worker.WorkerSettings
@@ -21,6 +28,7 @@ import os
 from typing import Any
 
 from arq.connections import RedisSettings
+from arq.worker import func
 
 # Imported at module scope so tests can ``monkeypatch.setattr(worker, …)``.
 from pocketpaw_ee.cloud import init_realtime
@@ -28,6 +36,8 @@ from pocketpaw_ee.cloud._core.realtime import xproc
 from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
 from pocketpaw_ee.cloud.chat.runs.run_core import execute_run
 from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
+from pocketpaw_ee.cloud.jobs.domain import job_timeout_seconds
+from pocketpaw_ee.cloud.jobs.worker import execute_workspace_job
 from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
 
 logger = logging.getLogger(__name__)
@@ -101,10 +111,23 @@ def _redis_settings() -> RedisSettings:
     return RedisSettings.from_dsn(url)
 
 
+# Workspace jobs (pp#1459) run on this same worker but get their OWN
+# per-function timeout via ``arq.worker.func`` so a long-running job can't be
+# clipped by the chat-run timeout and vice-versa. The dotted name the web
+# process enqueues (``"execute_workspace_job"``) is the function's __qualname__
+# by default; pin it explicitly so the enqueue/registration names can't drift.
+_workspace_job_fn = func(
+    execute_workspace_job,
+    name="execute_workspace_job",
+    timeout=job_timeout_seconds(),
+    max_tries=1,
+)
+
+
 class WorkerSettings:
     """arq worker configuration. Loaded by ``arq <dotted-path>``."""
 
-    functions = [execute_run_job]
+    functions = [execute_run_job, _workspace_job_fn]
     on_startup = _startup
     on_shutdown = _shutdown
     # Crash policy: no auto-retry. A failed run is left as ``failed``/``interrupted``

--- a/ee/pocketpaw_ee/cloud/jobs/__init__.py
+++ b/ee/pocketpaw_ee/cloud/jobs/__init__.py
@@ -1,0 +1,11 @@
+# ee/pocketpaw_ee/cloud/jobs/__init__.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — package marker for the
+# workspace jobs primitive. The 4-file entity shape (domain / dto / service /
+# router) plus the registry, the ARQ worker entrypoint, and the built-in jobs
+# package live here. The package __init__ stays import-light: the router and
+# built-ins are imported explicitly by `mount_cloud`, not eagerly here, so
+# importing `pocketpaw_ee.cloud.jobs` never pulls FastAPI / Beanie.
+
+"""Workspace jobs — named, server-side async callables run in the ARQ worker."""
+
+from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/jobs/builtin/__init__.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/__init__.py
@@ -1,0 +1,31 @@
+# ee/pocketpaw_ee/cloud/jobs/builtin/__init__.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — the built-in jobs
+# package + the `register_builtins()` entry point `mount_cloud` calls AFTER
+# `init_realtime()`. Built-ins are registered into the process-wide registry
+# at mount time (the same lifecycle the outcomes-ledger / upload listeners
+# use). Adding a new built-in = add it to the list here.
+
+"""Built-in workspace jobs + their mount-time registration."""
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+from pocketpaw_ee.cloud.jobs.registry import register_job
+
+# The built-ins to register at mount time. Instantiated once; jobs are
+# stateless callables so a single instance is reused for every run.
+_BUILTINS = (ScoreApplicationsJob(),)
+
+
+def register_builtins() -> None:
+    """Register every built-in job into the process-wide registry.
+
+    Called once from ``mount_cloud`` after ``init_realtime``. Idempotent —
+    re-registering a name overwrites with the same callable, so a test re-mount
+    is harmless.
+    """
+    for job in _BUILTINS:
+        register_job(job)
+
+
+__all__ = ["register_builtins"]

--- a/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
@@ -1,0 +1,72 @@
+# ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — the first built-in
+# workspace job. V1 is deliberately a thin, side-effect-free reference: it
+# scores a batch of applications and projects each row through a PII allowlist
+# before the result becomes broadcast `state`. The allowlist is the security
+# point of the built-in — because a job result is merged into the pocket spec
+# and fanned out over the realtime bus to every open canvas, a job MUST strip
+# email / phone (and any non-allowlisted field) so PII never lands in the
+# broadcast/audit path. Enforced by the built-in's unit test.
+#
+# A real connector-backed implementation (reading the batch from the
+# workspace's stored creds via the source-read path, never params tokens) is a
+# follow-up; the contract + the PII transform are what V1 pins.
+
+"""Built-in `score_applications` job + its PII allowlist transform."""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The ONLY fields a scored row may broadcast. Everything else — notably any
+# email / phone / free-text contact field — is dropped before the row reaches
+# `state`. Allowlist (not denylist) so a new raw field is dropped by default.
+_ALLOWED_ROW_FIELDS = ("id", "name", "score", "stage")
+
+
+def project_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Project one scored row to the broadcast-safe allowlist.
+
+    Drops every field not in :data:`_ALLOWED_ROW_FIELDS`, so PII like
+    ``email`` / ``phone`` can never reach the broadcast `state`.
+    """
+    return {k: row[k] for k in _ALLOWED_ROW_FIELDS if k in row}
+
+
+def _score_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Assign a toy score. Real scoring is a connector-backed follow-up; V1
+    pins the contract + the PII allowlist, not a scoring model."""
+    name = str(row.get("name", ""))
+    scored = {**row, "score": len(name), "stage": "scored"}
+    return project_row(scored)
+
+
+class ScoreApplicationsJob:
+    """Score a batch of applications and write the scored rows to `state`.
+
+    Runs under the workspace service identity. Returns a STATE-ONLY partial
+    spec — `scored_rows` (PII-stripped) and a status flag the triggering
+    button reads to stop spinning.
+    """
+
+    name = "score_applications"
+
+    async def __call__(
+        self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
+    ) -> dict:
+        # V1: score the rows passed in `params["rows"]` (a real impl reads the
+        # batch from the workspace's stored connector creds). Bounded by
+        # `batch_size` so a job can't run unbounded.
+        batch_size = int(params.get("batch_size", 20))
+        rows = list(params.get("rows", []))[: max(0, batch_size)]
+        scored = [_score_row(r) for r in rows if isinstance(r, dict)]
+        return {
+            "state": {
+                "scored_rows": scored,
+                "score_applications_status": "done",
+                "score_applications_scored_count": len(scored),
+            }
+        }
+
+
+__all__ = ["ScoreApplicationsJob", "project_row"]

--- a/ee/pocketpaw_ee/cloud/jobs/domain.py
+++ b/ee/pocketpaw_ee/cloud/jobs/domain.py
@@ -1,0 +1,75 @@
+# ee/pocketpaw_ee/cloud/jobs/domain.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — pure domain constants
+# and value types for the workspace jobs primitive. A "pocket job" is a named,
+# server-side async callable run under the WORKSPACE service identity (not the
+# triggering user's session) inside the ARQ worker, so a final
+# `emit(PocketUpdated(...))` reaches the bus even after the user's socket is
+# gone. This module holds NO Beanie / FastAPI / I/O imports so every other
+# module in the package (and the import-linter contract) can depend on it
+# freely.
+
+"""Pure domain types + constants for the workspace jobs primitive."""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Identity — every job runs under this synthetic, hardcoded actor. It is NOT
+# user-assignable and never derived from a session: a job's blast radius must
+# be auditable to "the workspace ran this", never "user X ran this as the
+# workspace". Connector calls inside a job use the workspace's STORED creds
+# (the source-read path), never tokens supplied through `params`.
+# ---------------------------------------------------------------------------
+WORKSPACE_JOB_IDENTITY = "system:workspace_job"
+
+# ARQ queue the jobs run on — distinct from the resumable-chat-run queue so a
+# burst of jobs can't starve interactive runs (they share the same worker
+# PROCESS, just different logical queues).
+JOBS_QUEUE = "paw:jobs"
+
+# Job lifecycle. `queued` on enqueue, `running` once the worker picks it up,
+# terminal as `done` / `failed`.
+JobStatus = Literal["queued", "running", "done", "failed"]
+
+# ARQ per-job timeout (DEFAULT #4 = 900s). Read from the environment so the
+# knob stays EE-side (no `src/pocketpaw/config.py` edit). A timed-out job is
+# treated exactly like a raised exception: marked `failed` + a failed-state
+# writeback so the triggering button never hangs.
+_DEFAULT_JOB_TIMEOUT_SECONDS = 900
+
+
+def job_timeout_seconds() -> int:
+    """Resolve the ARQ ``job_timeout`` for workspace jobs.
+
+    ``POCKETPAW_JOB_TIMEOUT_SECONDS`` overrides the 900s default. A malformed
+    value falls back to the default rather than crashing worker boot.
+    """
+    raw = os.environ.get("POCKETPAW_JOB_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return _DEFAULT_JOB_TIMEOUT_SECONDS
+    try:
+        val = int(raw)
+    except ValueError:
+        return _DEFAULT_JOB_TIMEOUT_SECONDS
+    return val if val > 0 else _DEFAULT_JOB_TIMEOUT_SECONDS
+
+
+def failed_state_writeback(action: str, message: str) -> dict:
+    """Build the partial-spec writeback for a failed job.
+
+    A failed job MUST still write back so the triggering button stops
+    spinning. The shape mirrors the success writeback (state-only) and is
+    keyed by the action name: ``<action>_status`` / ``<action>_error``.
+    """
+    return {"state": {f"{action}_status": "failed", f"{action}_error": message}}
+
+
+__all__ = [
+    "JOBS_QUEUE",
+    "JobStatus",
+    "WORKSPACE_JOB_IDENTITY",
+    "failed_state_writeback",
+    "job_timeout_seconds",
+]

--- a/ee/pocketpaw_ee/cloud/jobs/dto.py
+++ b/ee/pocketpaw_ee/cloud/jobs/dto.py
@@ -1,0 +1,34 @@
+# ee/pocketpaw_ee/cloud/jobs/dto.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — wire model for the job
+# status-poll endpoint. The job RESULT is not returned here — it already
+# landed in the pocket's rippleSpec `state` via the writeback, so the poll
+# only reports lifecycle (status + timestamps + error). Pure Pydantic — no
+# Beanie import (import-linter "Jobs" contract).
+
+"""Wire models for the workspace-jobs status surface."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class JobStatusResponse(BaseModel):
+    """Body for ``GET /workspaces/{ws}/jobs/{job_id}``.
+
+    Reports the job's lifecycle only. The result already merged into the
+    pocket's `state`, so a client polls this purely to know when to stop
+    showing a spinner (``done`` / ``failed``) and to surface ``error`` on a
+    failure.
+    """
+
+    job_id: str
+    status: str
+    created_at: datetime
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+    error: str | None = None
+
+
+__all__ = ["JobStatusResponse"]

--- a/ee/pocketpaw_ee/cloud/jobs/registry.py
+++ b/ee/pocketpaw_ee/cloud/jobs/registry.py
@@ -1,0 +1,170 @@
+# ee/pocketpaw_ee/cloud/jobs/registry.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — the in-process named
+# job registry + the two security validators (`validate_job_params`,
+# `validate_job_result`) that gate the dispatch and writeback boundaries.
+# Follows the module-level-dict pattern of
+# `pockets.instinct_compensation_registry.OptimisticCompensationRegistry`:
+# one process-wide dict, registered into at mount time by the built-ins
+# package. Pure module — no Beanie / FastAPI imports — so it sits on the
+# import-linter "Jobs" allowlist (only `service.py` writes Beanie).
+
+"""Named job registry + param/result validators for workspace jobs."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Errors — carry an HTTP-friendly `status` + a stable machine `code` so the
+# dispatch router can surface them as the contracted 400s without importing
+# the cloud error envelope into this pure module.
+# ---------------------------------------------------------------------------
+
+
+class JobError(Exception):
+    """Base class for registry / validation rejections."""
+
+    status: int = 400
+    code: str = "job.error"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class UnknownJobError(JobError):
+    """Raised when a job name has no registered callable → 400 `job.unknown`."""
+
+    code = "job.unknown"
+
+
+class JobParamsError(JobError):
+    """Raised when params carry a credential-shaped key → 400."""
+
+    code = "job.params_forbidden"
+
+
+class JobResultError(JobError):
+    """Raised when a job result writes a template-owned region → rejected."""
+
+    code = "job.result_forbidden"
+
+
+# ---------------------------------------------------------------------------
+# JobCallable Protocol — the shape every registered job implements.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class JobCallable(Protocol):
+    """A named, server-side async job.
+
+    ``name`` is the stable registry key used by ``rippleSpec.actions[...].job``.
+    ``__call__`` runs the job under the workspace service identity and returns
+    a PARTIAL rippleSpec the worker writes back via ``merge_spec``. The result
+    may write ONLY ``state`` — ui / actions / sources / shape are template-
+    owned and rejected by :func:`validate_job_result`.
+    """
+
+    name: str
+
+    async def __call__(
+        self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
+    ) -> dict: ...
+
+
+# ---------------------------------------------------------------------------
+# The registry — a single process-wide dict.
+# ---------------------------------------------------------------------------
+
+_JOB_REGISTRY: dict[str, JobCallable] = {}
+
+
+def get_job_registry() -> dict[str, JobCallable]:
+    """Return the process-wide name → JobCallable map (the live dict)."""
+    return _JOB_REGISTRY
+
+
+def register_job(job: JobCallable) -> None:
+    """Register a job under its ``name``.
+
+    Re-registering the same name overwrites — built-ins register at mount time
+    and tests swap doubles; last-writer-wins keeps both paths simple.
+    """
+    name = getattr(job, "name", "")
+    if not name or not isinstance(name, str):
+        raise ValueError("a registered job must expose a non-empty string `name`")
+    _JOB_REGISTRY[name] = job
+
+
+def resolve_job(job_name: str) -> JobCallable:
+    """Look a job up by name; raise :class:`UnknownJobError` on a miss."""
+    job = _JOB_REGISTRY.get(job_name)
+    if job is None:
+        raise UnknownJobError(f"no registered job named '{job_name}'")
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Security validators.
+# ---------------------------------------------------------------------------
+
+# Substrings (case-insensitive) that mark a params key as credential-bearing.
+# A job NEVER receives credentials through `params` — connector calls use the
+# workspace's stored creds. Rejecting these at dispatch closes a cred-exfil
+# vector where an action author smuggles a token into the broadcast/audit path.
+_CRED_KEY_SUBSTRINGS = ("token", "api_key", "apikey", "credential", "secret", "password")
+
+# Result keys a job is NOT allowed to write. The template owns the structure
+# (ui / actions / sources) and the shape; a job only contributes `state`.
+_FORBIDDEN_RESULT_KEYS = frozenset({"ui", "actions", "sources", "shape"})
+
+
+def validate_job_params(params: dict) -> dict:
+    """Reject credential-shaped param keys; return the params unchanged.
+
+    Case-insensitive substring match on the top-level keys. Raises
+    :class:`JobParamsError` (400) on the first offending key so no
+    credential-bearing value ever reaches a job or the audit log.
+    """
+    for key in params:
+        lowered = str(key).lower()
+        if any(sub in lowered for sub in _CRED_KEY_SUBSTRINGS):
+            raise JobParamsError(
+                f"param key '{key}' looks credential-bearing — jobs read workspace "
+                "creds server-side and never accept tokens through params"
+            )
+    return params
+
+
+def validate_job_result(result: dict) -> dict:
+    """Reject a result that writes any template-owned region.
+
+    A legal job result is a partial spec that touches ONLY ``state``. Any
+    ``ui`` / ``actions`` / ``sources`` / ``shape`` key raises
+    :class:`JobResultError`; the worker turns that into a `failed` job + a
+    failed-state writeback (never a silent drop).
+    """
+    if not isinstance(result, dict):
+        raise JobResultError(f"job result must be a dict, got {type(result).__name__}")
+    offending = _FORBIDDEN_RESULT_KEYS.intersection(result.keys())
+    if offending:
+        raise JobResultError(
+            "job result may write only `state` — these template-owned keys are "
+            f"forbidden: {', '.join(sorted(offending))}"
+        )
+    return result
+
+
+__all__ = [
+    "JobCallable",
+    "JobError",
+    "JobParamsError",
+    "JobResultError",
+    "UnknownJobError",
+    "get_job_registry",
+    "register_job",
+    "resolve_job",
+    "validate_job_params",
+    "validate_job_result",
+]

--- a/ee/pocketpaw_ee/cloud/jobs/registry.py
+++ b/ee/pocketpaw_ee/cloud/jobs/registry.py
@@ -7,6 +7,11 @@
 # one process-wide dict, registered into at mount time by the built-ins
 # package. Pure module — no Beanie / FastAPI imports — so it sits on the
 # import-linter "Jobs" allowlist (only `service.py` writes Beanie).
+# Updated: 2026-06-20 (review fix MINOR B) — `validate_job_params` now
+# RECURSES into nested dicts and lists, so a credential hidden under
+# `{"config": {"api_key": "..."}}` can no longer slip past the top-level
+# scan. The validator's contract ("a job NEVER receives credentials through
+# params") now matches its implementation at every depth.
 
 """Named job registry + param/result validators for workspace jobs."""
 
@@ -120,20 +125,38 @@ _CRED_KEY_SUBSTRINGS = ("token", "api_key", "apikey", "credential", "secret", "p
 _FORBIDDEN_RESULT_KEYS = frozenset({"ui", "actions", "sources", "shape"})
 
 
+def _scan_for_cred_keys(value: object) -> None:
+    """Walk a params value depth-first; raise on the first credential key.
+
+    Recurses into nested dicts and lists so a credential buried under
+    ``{"config": {"api_key": "..."}}`` (or inside a list of dicts) is caught
+    just like a top-level key. Scalars are inert — only dict KEYS are matched
+    against the credential substrings.
+    """
+    if isinstance(value, dict):
+        for key, child in value.items():
+            lowered = str(key).lower()
+            if any(sub in lowered for sub in _CRED_KEY_SUBSTRINGS):
+                raise JobParamsError(
+                    f"param key '{key}' looks credential-bearing — jobs read workspace "
+                    "creds server-side and never accept tokens through params"
+                )
+            _scan_for_cred_keys(child)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            _scan_for_cred_keys(child)
+
+
 def validate_job_params(params: dict) -> dict:
     """Reject credential-shaped param keys; return the params unchanged.
 
-    Case-insensitive substring match on the top-level keys. Raises
-    :class:`JobParamsError` (400) on the first offending key so no
-    credential-bearing value ever reaches a job or the audit log.
+    Case-insensitive substring match on EVERY key, at every depth — the scan
+    recurses into nested dicts and lists (see :func:`_scan_for_cred_keys`).
+    Raises :class:`JobParamsError` (400) on the first offending key so no
+    credential-bearing value ever reaches a job or the audit log, even when
+    nested under a benign-looking parent key.
     """
-    for key in params:
-        lowered = str(key).lower()
-        if any(sub in lowered for sub in _CRED_KEY_SUBSTRINGS):
-            raise JobParamsError(
-                f"param key '{key}' looks credential-bearing — jobs read workspace "
-                "creds server-side and never accept tokens through params"
-            )
+    _scan_for_cred_keys(params)
     return params
 
 

--- a/ee/pocketpaw_ee/cloud/jobs/router.py
+++ b/ee/pocketpaw_ee/cloud/jobs/router.py
@@ -1,0 +1,50 @@
+# ee/pocketpaw_ee/cloud/jobs/router.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — FastAPI router for the
+# workspace-jobs status surface. Thin adapter: it resolves identity + tenancy
+# and delegates the read to `jobs.service.get_job`, which re-checks the
+# workspace and returns None on a cross-tenant id. Any-member read (no role
+# check) via `require_membership`, which reads `workspace_id` from the path.
+# There is NO dispatch route here — jobs are triggered through the existing
+# `POST /pockets/{id}/actions/run` (kind=="job") branch.
+
+"""Workspace-jobs status-poll router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.jobs import service as jobs_service
+from pocketpaw_ee.cloud.jobs.dto import JobStatusResponse
+from pocketpaw_ee.cloud.shared.deps import require_membership
+
+router = APIRouter(prefix="/workspaces", tags=["Workspace Jobs"])
+
+
+@router.get(
+    "/{workspace_id}/jobs/{job_id}",
+    dependencies=[Depends(require_membership)],
+)
+async def get_job_status(workspace_id: str, job_id: str) -> JobStatusResponse:
+    """Return one job's lifecycle status.
+
+    Tenancy: the service re-fetches by id AND re-checks ``workspace_id`` — a
+    job belonging to another workspace reads as ``None`` here and 404s, so a
+    member of workspace A can never poll workspace B's job by id. The job
+    RESULT is not returned (it already merged into the pocket's `state`); the
+    client polls only to learn when to stop the spinner.
+    """
+    doc = await jobs_service.get_job(workspace_id, job_id)
+    if doc is None:
+        raise NotFound("workspace_job", job_id)
+    return JobStatusResponse(
+        job_id=str(doc.id),
+        status=doc.status,
+        created_at=doc.createdAt,
+        started_at=doc.started_at,
+        ended_at=doc.ended_at,
+        error=doc.error,
+    )
+
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/jobs/service.py
+++ b/ee/pocketpaw_ee/cloud/jobs/service.py
@@ -243,7 +243,20 @@ async def _emit_updated(doc: WorkspaceJobDoc) -> None:
 
 def _audit(*, severity: AuditSeverity, status: str, **context: Any) -> None:
     """Emit an AuditEvent for a job lifecycle step. Best-effort — a failing
-    audit logger must never break a job's status transition."""
+    audit logger must never break a job's status transition.
+
+    Callers carry the job's own ``action`` name in ``context``, but
+    ``AuditEvent.create`` already has an explicit ``action`` param (the audit
+    event-type). Passing both collided — ``create()`` raised
+    ``TypeError: got multiple values for keyword argument 'action'`` inside the
+    ``try`` and every job audit record was silently dropped (pp#1459 review).
+    Move the job action to ``pocket_action`` (and defensively strip any other
+    reserved key) so the splat can never shadow an explicit ``create`` param.
+    """
+    if "action" in context:
+        context["pocket_action"] = context.pop("action")
+    for reserved in ("severity", "actor", "target", "status"):
+        context.pop(reserved, None)
     try:
         get_audit_logger().log(
             AuditEvent.create(

--- a/ee/pocketpaw_ee/cloud/jobs/service.py
+++ b/ee/pocketpaw_ee/cloud/jobs/service.py
@@ -1,0 +1,269 @@
+# ee/pocketpaw_ee/cloud/jobs/service.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — the jobs entity service:
+# the ONLY module in the package that reads/writes the `WorkspaceJobDoc` Beanie
+# document (import-linter "Jobs" contract). Owns dispatch (registry lookup →
+# param validation → queued doc → ARQ enqueue → `WorkspaceJobQueued` emit +
+# INFO audit), the tenancy-checked status read, and the lifecycle transitions
+# (`mark_running` / `mark_done` / `mark_failed`) the worker drives. `mark_failed`
+# emits a WARNING `WorkspaceJobUpdated` + audit; success emits INFO.
+
+"""Workspace-jobs service — Beanie writes + dispatch + lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+from arq import create_pool
+from arq.connections import ArqRedis, RedisSettings
+
+from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import (
+    WorkspaceJobQueued,
+    WorkspaceJobUpdated,
+)
+from pocketpaw_ee.cloud.jobs.domain import JOBS_QUEUE, WORKSPACE_JOB_IDENTITY
+from pocketpaw_ee.cloud.jobs.registry import resolve_job, validate_job_params
+from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
+
+logger = logging.getLogger(__name__)
+
+# Reuse the same lazy-pool pattern as the chat-runs ArqExecutor — one pool per
+# process, double-checked lock so concurrent first-dispatches don't leak pools.
+_pool: ArqRedis | None = None
+_pool_lock = asyncio.Lock()
+
+
+async def _get_pool() -> ArqRedis:
+    global _pool
+    if _pool is None:
+        async with _pool_lock:
+            if _pool is None:
+                url = os.environ.get("POCKETPAW_REDIS_URL", "").strip()
+                if not url:
+                    raise RuntimeError(
+                        "POCKETPAW_REDIS_URL is not set — workspace jobs need Redis."
+                    )
+                _pool = await create_pool(RedisSettings.from_dsn(url))
+    return _pool
+
+
+def _reset_for_tests() -> None:
+    global _pool
+    _pool = None
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_job(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    action: str,
+    job_name: str,
+    params: dict[str, Any],
+    triggered_by: str,
+) -> dict:
+    """Resolve, persist, and enqueue a workspace job.
+
+    Order matters for the security contract:
+      1. registry lookup — unknown name raises ``UnknownJobError`` (400)
+         BEFORE any doc is written or the pool touched.
+      2. param validation — a credential-shaped key raises ``JobParamsError``
+         (400), again before any persistence.
+      3. create the ``queued`` status doc.
+      4. enqueue ``execute_workspace_job(job_id)`` on the jobs queue.
+      5. emit ``WorkspaceJobQueued`` + an INFO audit event.
+
+    Returns ``{ok: True, code: "job_enqueued", job_id}`` for the action route.
+    """
+    # (1) + (2) — gate before any write.
+    resolve_job(job_name)
+    validate_job_params(params)
+
+    # (3) — persist queued.
+    doc = WorkspaceJobDoc(
+        workspace=workspace_id,
+        pocket_id=pocket_id,
+        action=action,
+        job_name=job_name,
+        params=dict(params),
+        triggered_by=triggered_by,
+        status="queued",
+    )
+    await doc.insert()
+    job_id = str(doc.id)
+
+    # (4) — enqueue. A pool/enqueue failure must surface (the caller turns it
+    # into a 5xx); the queued doc stays so an operator can see the orphan.
+    try:
+        pool = await _get_pool()
+        arq_job = await pool.enqueue_job("execute_workspace_job", job_id, queue=JOBS_QUEUE)
+        if arq_job is not None:
+            doc.arq_job_id = getattr(arq_job, "job_id", None)
+            await doc.save()
+    except Exception:
+        logger.exception("jobs: enqueue failed for job %s (%s)", job_id, job_name)
+        raise
+
+    # (5) — emit + audit (best-effort; emit never raises, audit is wrapped).
+    await emit(
+        WorkspaceJobQueued(
+            data={
+                "job_id": job_id,
+                "workspace_id": workspace_id,
+                "pocket_id": pocket_id,
+                "action": action,
+                "job_name": job_name,
+            }
+        )
+    )
+    _audit(
+        severity=AuditSeverity.INFO,
+        status="success",
+        job_id=job_id,
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        action=action,
+        job_name=job_name,
+    )
+    return {"ok": True, "code": "job_enqueued", "job_id": job_id}
+
+
+# ---------------------------------------------------------------------------
+# Reads (tenancy-enforced)
+# ---------------------------------------------------------------------------
+
+
+async def get_job(workspace_id: str, job_id: str) -> WorkspaceJobDoc | None:
+    """Re-fetch a job by id AND re-check its workspace.
+
+    Returns ``None`` when the id is unknown OR belongs to another workspace —
+    the status route maps ``None`` to a 404 so a cross-tenant id leak is
+    impossible (criterion #8: the poll enforces tenancy).
+    """
+    doc = await get_job_by_id(job_id)
+    if doc is None or doc.workspace != workspace_id:
+        return None
+    return doc
+
+
+async def get_job_by_id(job_id: str) -> WorkspaceJobDoc | None:
+    """Fetch a job by id with no workspace filter.
+
+    Used by the WORKER, which is handed only the id at enqueue time and trusts
+    the doc's own ``workspace`` (written at dispatch by the authenticated
+    route) as the tenancy authority. A bogus / non-ObjectId id returns ``None``
+    so the worker no-ops instead of raising.
+    """
+    try:
+        return await WorkspaceJobDoc.get(job_id)
+    except Exception:
+        # An id that isn't a valid ObjectId raises; treat as not-found.
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle transitions (worker-driven)
+# ---------------------------------------------------------------------------
+
+
+async def mark_running(doc: WorkspaceJobDoc) -> None:
+    doc.status = "running"
+    doc.started_at = datetime.now(UTC)
+    await doc.save()
+
+
+async def mark_done(doc: WorkspaceJobDoc, *, result: dict[str, Any]) -> None:
+    """Mark a job done + emit an INFO ``WorkspaceJobUpdated`` and audit."""
+    doc.status = "done"
+    doc.result = result
+    doc.error = None
+    doc.ended_at = datetime.now(UTC)
+    await doc.save()
+    await _emit_updated(doc)
+    _audit(
+        severity=AuditSeverity.INFO,
+        status="success",
+        job_id=str(doc.id),
+        workspace_id=doc.workspace,
+        pocket_id=doc.pocket_id,
+        action=doc.action,
+        job_name=doc.job_name,
+        outcome="done",
+    )
+
+
+async def mark_failed(doc: WorkspaceJobDoc, *, error: str) -> None:
+    """Mark a job failed + emit a WARNING ``WorkspaceJobUpdated`` and audit."""
+    doc.status = "failed"
+    doc.error = error
+    doc.ended_at = datetime.now(UTC)
+    await doc.save()
+    await _emit_updated(doc)
+    _audit(
+        severity=AuditSeverity.WARNING,
+        status="error",
+        job_id=str(doc.id),
+        workspace_id=doc.workspace,
+        pocket_id=doc.pocket_id,
+        action=doc.action,
+        job_name=doc.job_name,
+        outcome="failed",
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+async def _emit_updated(doc: WorkspaceJobDoc) -> None:
+    await emit(
+        WorkspaceJobUpdated(
+            data={
+                "job_id": str(doc.id),
+                "workspace_id": doc.workspace,
+                "pocket_id": doc.pocket_id,
+                "action": doc.action,
+                "job_name": doc.job_name,
+                "status": doc.status,
+            }
+        )
+    )
+
+
+def _audit(*, severity: AuditSeverity, status: str, **context: Any) -> None:
+    """Emit an AuditEvent for a job lifecycle step. Best-effort — a failing
+    audit logger must never break a job's status transition."""
+    try:
+        get_audit_logger().log(
+            AuditEvent.create(
+                severity=severity,
+                actor=WORKSPACE_JOB_IDENTITY,
+                action="workspace_job",
+                target=f"job:{context.get('job_id', '')}",
+                status=status,
+                **context,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 — audit must never block the write
+        logger.warning("jobs: audit emit failed (%s)", exc)
+
+
+__all__ = [
+    "dispatch_job",
+    "get_job",
+    "get_job_by_id",
+    "mark_done",
+    "mark_failed",
+    "mark_running",
+]

--- a/ee/pocketpaw_ee/cloud/jobs/worker.py
+++ b/ee/pocketpaw_ee/cloud/jobs/worker.py
@@ -12,6 +12,15 @@
 # (state-only) before writeback; any rejection / exception / timeout marks the
 # job failed AND writes a failed-state partial so the button never hangs.
 # `merge_spec` is imported at module scope so tests can monkeypatch it.
+#
+# Updated: 2026-06-20 (review fix IMPORTANT 3) — fail-closed TENANCY RE-CHECK.
+# Before any execution or writeback, the worker fetches the pocket the doc
+# names and asserts its workspace equals the doc's workspace. `merge_spec`
+# fetches by pocket id only and trusts the passed workspace, so without this
+# the writeback would write wherever the doc points. On a mismatch the job is
+# marked failed with NO writeback (we cannot safely write to a pocket outside
+# the doc's workspace). The check sits ONCE near the top so it can't perturb
+# the failure path's "un-hang the button" guarantee.
 
 """ARQ entrypoint: execute one workspace job + write the result back."""
 
@@ -27,7 +36,7 @@ from pocketpaw_ee.cloud.jobs.domain import (
     failed_state_writeback,
 )
 from pocketpaw_ee.cloud.jobs.registry import resolve_job, validate_job_result
-from pocketpaw_ee.cloud.pockets.service import merge_spec
+from pocketpaw_ee.cloud.pockets.service import get_pocket_workspace, merge_spec
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +68,30 @@ async def execute_workspace_job(ctx: dict[str, Any], job_id: str) -> None:
     pocket_id = doc.pocket_id
     action = doc.action
 
+    # Fail-closed tenancy re-check (review fix IMPORTANT 3). `merge_spec`
+    # fetches the pocket by id only and trusts the workspace we hand it, so the
+    # writeback layer has no tenancy assertion of its own. Re-fetch the pocket
+    # and confirm it lives in the doc's workspace BEFORE we run or write. On a
+    # mismatch we can NOT safely write a failed-state partial either — that
+    # would be the same cross-workspace write we're refusing — so we mark the
+    # job failed with NO writeback and return. Done ONCE here (not in
+    # `_writeback`, which both success and failure paths call) so the failure
+    # path's "un-hang the button" guarantee stays clean.
+    pocket_workspace = await get_pocket_workspace(pocket_id)
+    if pocket_workspace != workspace_id:
+        logger.error(
+            "jobs: TENANCY MISMATCH — job %s names pocket %s in workspace %r but the "
+            "pocket lives in workspace %r; refusing writeback and marking failed",
+            job_id,
+            pocket_id,
+            workspace_id,
+            pocket_workspace,
+        )
+        await jobs_service.mark_failed(
+            doc, error="tenancy mismatch: pocket is not in the job's workspace"
+        )
+        return
+
     await jobs_service.mark_running(doc)
 
     try:
@@ -73,6 +106,12 @@ async def execute_workspace_job(ctx: dict[str, Any], job_id: str) -> None:
         result = validate_job_result(raw)
     except Exception as exc:  # noqa: BLE001 — every failure path converges here
         logger.exception("jobs: job %s (%s) failed", job_id, doc.job_name)
+        # NOTE for connector-job authors: ``str(exc)`` lands in broadcast state
+        # via ``failed_state_writeback`` and is visible to every viewer of the
+        # pocket. Do NOT let raw exception text carry PII or secrets — map your
+        # job's failure modes to FIXED, safe strings (e.g. "upstream timeout")
+        # rather than surfacing the raw message. (Tracked as a follow-up; the
+        # default below is intentionally left as-is for the built-in jobs.)
         message = str(exc) or exc.__class__.__name__
         # Writeback FIRST so the button un-hangs even if the status save races.
         await _writeback(

--- a/ee/pocketpaw_ee/cloud/jobs/worker.py
+++ b/ee/pocketpaw_ee/cloud/jobs/worker.py
@@ -1,0 +1,106 @@
+# ee/pocketpaw_ee/cloud/jobs/worker.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — the ARQ entrypoint that
+# executes one workspace job. Registered into the SHARED chat-runs
+# `WorkerSettings.functions` (default #1: same worker process, not a new
+# deploy artifact). Runs in the worker, where `xproc.set_role("worker")` is
+# already pinned, so the `merge_spec` writeback's `emit(PocketUpdated(...))`
+# routes over the cross-process bridge to the web's bus and open canvases
+# update live — the same infra resumable chat runs use.
+#
+# Identity is HARDCODED to `system:workspace_job`; the merge_spec writeback
+# always runs under it, never the triggering user. The job result is validated
+# (state-only) before writeback; any rejection / exception / timeout marks the
+# job failed AND writes a failed-state partial so the button never hangs.
+# `merge_spec` is imported at module scope so tests can monkeypatch it.
+
+"""ARQ entrypoint: execute one workspace job + write the result back."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+# Module-scope import so tests can ``monkeypatch.setattr(worker, "merge_spec", …)``.
+from pocketpaw_ee.cloud.jobs import service as jobs_service
+from pocketpaw_ee.cloud.jobs.domain import (
+    WORKSPACE_JOB_IDENTITY,
+    failed_state_writeback,
+)
+from pocketpaw_ee.cloud.jobs.registry import resolve_job, validate_job_result
+from pocketpaw_ee.cloud.pockets.service import merge_spec
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_workspace_job(ctx: dict[str, Any], job_id: str) -> None:
+    """ARQ job: run the registered callable and write its result back.
+
+    ``ctx`` is the ARQ worker context (unused — the doc carries everything).
+    The job_id is the ``WorkspaceJobDoc`` id. The worker:
+      1. re-fetches the doc — a missing doc is a no-op (it was deleted, or the
+         id is bogus); we do NOT write anything.
+      2. marks it running.
+      3. resolves + runs the registered job under the synthetic identity.
+      4. validates the result (state-only) and writes it back via merge_spec.
+      5. on ANY failure (unknown job / raise / validation reject / timeout)
+         marks the job failed AND writes a failed-state partial so the
+         triggering button stops spinning.
+
+    The worker does not know the caller's workspace independently, so it trusts
+    the doc's ``workspace`` (written at dispatch by the authenticated route) and
+    re-fetches under it — the tenancy invariant is "the doc owns its workspace".
+    """
+    doc = await jobs_service.get_job_by_id(job_id)
+    if doc is None:
+        logger.warning("jobs: execute_workspace_job got unknown job id %s — no-op", job_id)
+        return
+
+    workspace_id = doc.workspace
+    pocket_id = doc.pocket_id
+    action = doc.action
+
+    await jobs_service.mark_running(doc)
+
+    try:
+        job = resolve_job(doc.job_name)
+        raw = await job(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            job_id=job_id,
+            params=dict(doc.params),
+        )
+        # State-only contract — raises JobResultError on a template-owned write.
+        result = validate_job_result(raw)
+    except Exception as exc:  # noqa: BLE001 — every failure path converges here
+        logger.exception("jobs: job %s (%s) failed", job_id, doc.job_name)
+        message = str(exc) or exc.__class__.__name__
+        # Writeback FIRST so the button un-hangs even if the status save races.
+        await _writeback(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            partial=failed_state_writeback(action, message),
+        )
+        await jobs_service.mark_failed(doc, error=message)
+        return
+
+    # Success — write the validated state-only partial back.
+    await _writeback(workspace_id=workspace_id, pocket_id=pocket_id, partial=result)
+    await jobs_service.mark_done(doc, result=result)
+
+
+async def _writeback(*, workspace_id: str, pocket_id: str, partial: dict) -> None:
+    """Merge a partial spec into the pocket under the synthetic job identity.
+
+    Always ``user_id=system:workspace_job`` — never the triggering user. The
+    merge fires ``PocketUpdated``; from the worker that routes over xproc to
+    the web bus, so open canvases update live.
+    """
+    await merge_spec(
+        workspace_id,
+        WORKSPACE_JOB_IDENTITY,
+        pocket_id,
+        {"merge": partial},
+    )
+
+
+__all__ = ["execute_workspace_job"]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -36,6 +36,11 @@ Updated: 2026-06-11 (feat/firestore-fabric-ingest) — added
 imports, ``__all__``, and ``get_all_documents()`` so the ingestion worker's
 collections are wired into ``init_beanie``. Only
 ``ee.cloud.fabric_ingest.service`` imports the doc classes directly.
+Updated: 2026-06-20 (feat/workspace-jobs, pp#1459) — added ``WorkspaceJobDoc``
+(the durable status record for ARQ-backed pocket jobs) to the imports,
+``__all__``, and ``get_all_documents()`` so the ``workspace_jobs`` collection is
+wired into ``init_beanie``. Only ``ee.cloud.jobs.service`` writes the doc
+directly (import-linter "Jobs" contract).
 Updated: 2026-06-18 (feat/branch-primitive-versions, BP-1) — registered the
 ``ArtifactVersion`` doc (the universal Branch-primitive version log) in
 ``get_all_documents()`` via the lazy ``_ensure_version_docs()`` helper. The doc
@@ -105,6 +110,7 @@ from pocketpaw_ee.cloud.models.task_event import TaskEvent
 from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc
 from pocketpaw_ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
+from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
 
 # Lazy import to avoid circular imports
 FileUpload: type = None  # type: ignore[assignment]
@@ -243,6 +249,7 @@ __all__ = [
     "WidgetPosition",
     "Workspace",
     "WorkspaceConnector",
+    "WorkspaceJobDoc",
     "WorkspaceMembership",
     "WorkspaceSettings",
 ]
@@ -306,6 +313,9 @@ def get_all_documents():
         APIKey,
         BeltWorkspaceConfig,
         TaskEvent,
+        # Workspace jobs — durable status record for ARQ-backed pocket jobs
+        # (pp#1459). Only ``ee.cloud.jobs.service`` writes it.
+        WorkspaceJobDoc,
         cal_doc,
         evt_doc,
         mandate_doc,

--- a/ee/pocketpaw_ee/cloud/models/workspace_job.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace_job.py
@@ -1,0 +1,87 @@
+# ee/pocketpaw_ee/cloud/models/workspace_job.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — Beanie document backing
+# one workspace-job run. A job is dispatched from `POST /pockets/{id}/actions/run`
+# when the action's `kind == "job"`, runs in the ARQ worker under the synthetic
+# `system:workspace_job` identity, and writes its result back to the pocket's
+# rippleSpec `state`. This doc is the durable status record the status-poll
+# endpoint reads and the worker re-fetches (with a tenancy re-check) before it
+# touches anything.
+#
+# Tenancy: `workspace` is required + indexed. Every read filters by it; the
+# worker re-fetches by id AND re-checks `workspace` before writeback, and the
+# poll route re-checks the path workspace against the doc → 404 on mismatch.
+# Sibling shape: mirrors `ChatRunDoc` (status enum + arq_job_id + error +
+# timestamps) since both are ARQ-backed run records.
+
+"""Beanie document for one workspace-job run."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from beanie import Document, Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.jobs.domain import JobStatus
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class WorkspaceJobDoc(Document):
+    """One dispatched workspace job and its lifecycle status.
+
+    Fields:
+        workspace: tenant id. Indexed; every read filters by it.
+        pocket_id: the pocket the triggering action ran on (writeback target).
+        action: the `rippleSpec.actions` key that triggered the job — used to
+            key the failed-state writeback (``<action>_status`` / ``_error``).
+        job_name: the registered job name (registry lookup key).
+        params: the merged params dict the job ran with (credential-shaped keys
+            already rejected at dispatch).
+        triggered_by: the VIEWER who clicked the action. Audit only — the job
+            itself runs under the synthetic ``system:workspace_job`` identity,
+            never this user's session.
+        status: queued → running → done | failed.
+        arq_job_id: the ARQ job id the enqueue returned (None until enqueued /
+            on enqueue failure). Forensic — lets an operator correlate with the
+            worker log.
+        result: the validated state-only partial spec the job produced on
+            success (``{}`` otherwise).
+        error: the failure message on a failed job (None on success).
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    pocket_id: str
+    action: str
+    job_name: str
+    params: dict[str, Any] = Field(default_factory=dict)
+    triggered_by: str
+    status: JobStatus = "queued"
+    arq_job_id: str | None = None
+    result: dict[str, Any] = Field(default_factory=dict)
+    error: str | None = None
+    createdAt: datetime = Field(default_factory=_utcnow)
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+
+    class Settings:
+        name = "workspace_jobs"
+        indexes = [
+            # Point lookup by id is Mongo's `_id`; the status poll + worker
+            # re-fetch ALSO filter by workspace for tenancy, so index the pair
+            # the way the sibling run/sweep docs index their tenancy reads.
+            IndexModel([("workspace", 1), ("createdAt", -1)], name="ws_created"),
+            # Per-pocket history scan (operator debugging / future per-pocket
+            # job feed).
+            IndexModel(
+                [("workspace", 1), ("pocket_id", 1), ("createdAt", -1)],
+                name="ws_pocket_created",
+            ),
+        ]
+
+
+__all__ = ["WorkspaceJobDoc"]

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -1,5 +1,10 @@
 """Pockets domain — request/response schemas.
 
+Updated: 2026-06-20 (feat/workspace-jobs, pp#1459) — ``RunActionResponse``
+gained ``job_id``, set ONLY on a ``kind:"job"`` action dispatch
+(``code:"job_enqueued"``). It carries the WorkspaceJobDoc id the client polls
+via ``GET /workspaces/{ws}/jobs/{job_id}``; None on every other action path.
+
 Changes: Added agents, rippleSpec (aliased), and widgets fields to CreatePocketRequest
 so the frontend can pass the full pocket spec on creation instead of requiring
 separate follow-up calls.
@@ -565,6 +570,10 @@ class RunActionResponse(BaseModel):
     # executor returns it as ``_optimistic_compensation_id`` (internal key);
     # the router maps it onto this public field.
     optimistic_compensation_id: str | None = None
+    # Workspace jobs (pp#1459) — set ONLY on a ``kind:"job"`` action dispatch
+    # (``code:"job_enqueued"``). Carries the WorkspaceJobDoc id the client polls
+    # via ``GET /workspaces/{ws}/jobs/{job_id}``. None on every other path.
+    job_id: str | None = None
     on_success: list[dict] = Field(default_factory=list)
     on_error: list[dict] = Field(default_factory=list)
 

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -8,6 +8,12 @@ the ARQ worker under the synthetic ``system:workspace_job`` identity, and
 returns ``{ok:true, code:"job_enqueued", job_id}``. A missing ``kind`` falls
 through unchanged (back-compat); ``requires_instinct:true`` on a job is rejected
 with ``job.instinct_not_yet_supported`` (deferred to v1.1).
+Updated: 2026-06-20 (review fix MINOR A) — ``_dispatch_job`` now REJECTS any
+non-empty client ``params`` on a ``kind:"job"`` run with
+``job.params_not_accepted`` (400). A job is parameterized only by its declared
+author-time params, so accepting per-click input would let a clicker widen the
+job's scope — the rejection makes that guarantee explicit instead of a silent
+drop.
 
 Updated: 2026-06-15 (feat/invoke-tool-v1) — UNLOCKED ``POST /{id}/tools/run``.
 Added the owner-only ``PUT /{id}/backend/tool-policy`` route (the tool-allowlist
@@ -1039,6 +1045,13 @@ async def _dispatch_job(
     ``requires_instinct:true`` is rejected with ``job.instinct_not_yet_supported``
     (DEFAULT #2 — the Instinct path is untested for jobs, deferred to v1.1; do
     NOT silently fire an ungated job that declared it wanted a gate).
+
+    Client-supplied ``params`` are REJECTED with ``job.params_not_accepted``
+    (400) — a job is parameterized only by its DECLARED (author-time) params,
+    so accepting per-click input would let a clicker widen the job's scope.
+    Enforcing the rejection makes the scope guarantee explicit rather than a
+    silent drop. The normal (non-job) action path is unaffected: it never
+    reaches this function — the ``kind:"job"`` branch returns first.
     """
     from pocketpaw_ee.cloud.jobs import service as jobs_service
     from pocketpaw_ee.cloud.jobs.registry import JobError
@@ -1048,6 +1061,16 @@ async def _dispatch_job(
             400,
             "job.instinct_not_yet_supported",
             "requires_instinct is not yet supported for jobs (deferred to v1.1)",
+        )
+
+    # A clicker cannot widen a job's scope: a job's params come from the
+    # binding (declared, author-time), never from per-click input. Reject any
+    # non-empty client params rather than silently dropping them.
+    if request_params:
+        raise CloudError(
+            400,
+            "job.params_not_accepted",
+            "a job action does not accept client params — its params are fixed by the binding",
         )
 
     job_name = raw_action.get("job")

--- a/ee/pocketpaw_ee/cloud/pockets/router.py
+++ b/ee/pocketpaw_ee/cloud/pockets/router.py
@@ -1,5 +1,14 @@
 """Pockets domain — FastAPI router.
 
+Updated: 2026-06-20 (feat/workspace-jobs, pp#1459) — ``run_pocket_action`` now
+branches on ``raw_action["kind"] == "job"`` BEFORE the path-resolution +
+``action_executor.run_action`` HTTP-write path. A job action enqueues a named
+server-side job (``_dispatch_job`` → ``jobs.service.dispatch_job``) that runs in
+the ARQ worker under the synthetic ``system:workspace_job`` identity, and
+returns ``{ok:true, code:"job_enqueued", job_id}``. A missing ``kind`` falls
+through unchanged (back-compat); ``requires_instinct:true`` on a job is rejected
+with ``job.instinct_not_yet_supported`` (deferred to v1.1).
+
 Updated: 2026-06-15 (feat/invoke-tool-v1) — UNLOCKED ``POST /{id}/tools/run``.
 Added the owner-only ``PUT /{id}/backend/tool-policy`` route (the tool-allowlist
 analog of write-policy) and rewired ``run_pocket_tool`` to read the per-pocket
@@ -1010,6 +1019,72 @@ async def set_pocket_approval_route(
     return PocketBackendConfigResponse(**result)
 
 
+async def _dispatch_job(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    action: str,
+    raw_action: dict,
+    request_params: dict,
+) -> RunActionResponse:
+    """Enqueue a ``kind:"job"`` action as a workspace job (pp#1459).
+
+    Merges the action's DECLARED params (the trusted, author-time spec data)
+    with no client params — a job's params come from the binding, not the
+    click — looks the job up in the registry, persists a queued status doc,
+    enqueues the ARQ job, and returns ``{ok:true, code:"job_enqueued",
+    job_id}``. The client polls ``GET /workspaces/{ws}/jobs/{job_id}``.
+
+    ``requires_instinct:true`` is rejected with ``job.instinct_not_yet_supported``
+    (DEFAULT #2 — the Instinct path is untested for jobs, deferred to v1.1; do
+    NOT silently fire an ungated job that declared it wanted a gate).
+    """
+    from pocketpaw_ee.cloud.jobs import service as jobs_service
+    from pocketpaw_ee.cloud.jobs.registry import JobError
+
+    if raw_action.get("requires_instinct"):
+        raise CloudError(
+            400,
+            "job.instinct_not_yet_supported",
+            "requires_instinct is not yet supported for jobs (deferred to v1.1)",
+        )
+
+    job_name = raw_action.get("job")
+    if not isinstance(job_name, str) or not job_name:
+        raise CloudError(
+            400,
+            "job.unknown",
+            f"action '{action}' is kind=job but declares no job name",
+        )
+
+    # The job's params are the action's DECLARED params (author-time, trusted).
+    # Client-sent params are ignored for jobs — a job is parameterized by the
+    # binding, not by per-click input, so a client cannot widen a job's scope.
+    declared_params = raw_action.get("params")
+    params = declared_params if isinstance(declared_params, dict) else {}
+
+    try:
+        result = await jobs_service.dispatch_job(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            action=action,
+            job_name=job_name,
+            params=params,
+            triggered_by=user_id,
+        )
+    except JobError as exc:
+        # Registry miss / credential-bearing param → the contracted 400s.
+        raise CloudError(exc.status, exc.code, exc.message) from exc
+
+    return RunActionResponse(
+        ok=True,
+        action=action,
+        code=result["code"],
+        job_id=result["job_id"],
+    )
+
+
 @router.post(
     "/{pocket_id}/actions/run",
     dependencies=[Depends(require_pocket_action_run)],
@@ -1061,6 +1136,22 @@ async def run_pocket_action(
             action=body.action,
             error=f"action '{body.action}' is malformed",
             code="bad_binding",
+        )
+
+    # Workspace jobs (pp#1459) — a ``kind:"job"`` action does NOT fire an HTTP
+    # write. It enqueues a named server-side job that runs in the ARQ worker
+    # under the synthetic workspace identity. Branch BEFORE the path resolution
+    # + ``action_executor.run_action`` path below: a job action carries no
+    # ``path`` (it's not an HTTP call), so it would otherwise be rejected by
+    # the path check. A missing ``kind`` falls through unchanged (back-compat).
+    if raw_action.get("kind") == "job":
+        return await _dispatch_job(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            user_id=user_id,
+            action=body.action,
+            raw_action=raw_action,
+            request_params=body.params,
         )
 
     # Resolve the request path. The read-time normalizer rewrites an inline

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -4,6 +4,13 @@ Sole owner of writes to the ``Pocket`` Beanie document. Module-level
 ``async def`` API. The doc → domain mapping helpers (formerly in
 ``repositories.py``) live alongside the public API as private helpers.
 
+Updated: 2026-06-20 (feat/workspace-jobs, pp#1459) — ``_check_domain_edit_access``
+now allows the synthetic ``system:workspace_job`` identity so a workspace job
+can merge its result back even on a private (non-workspace-visible) pocket.
+The authorization already happened at dispatch (the triggering user passed
+``require_pocket_action_run``); the writeback is the downstream system effect of
+that authorized dispatch, and the identity is not user-assignable.
+
 Public API (returns wire dicts for legacy router compatibility):
 - ``create``, ``list_pockets``, ``get``, ``update``, ``delete``
 - ``ensure_home_pocket`` — resolve-or-provision the user's home pocket
@@ -513,6 +520,19 @@ def _check_domain_owner(domain_pocket: Pocket, user_id: str) -> None:
 
 
 def _check_domain_edit_access(domain_pocket: Pocket, user_id: str) -> None:
+    # Workspace jobs (pp#1459) — the trusted, hardcoded ``system:workspace_job``
+    # writer is allowed to merge its result back regardless of the pocket's
+    # owner / shared_with / visibility. The authorization decision already
+    # happened at DISPATCH time (the triggering user passed
+    # ``require_pocket_action_run``, owner/shared_with-only); the worker
+    # writeback is a downstream system effect of that authorized dispatch.
+    # The identity is synthetic and not user-assignable, so this cannot be
+    # forged from a request. Without this, a job on a private (non-workspace-
+    # visible) pocket would 403 at writeback and the button would hang.
+    from pocketpaw_ee.cloud.jobs.domain import WORKSPACE_JOB_IDENTITY
+
+    if user_id == WORKSPACE_JOB_IDENTITY:
+        return
     if domain_pocket.owner == user_id:
         return
     if user_id in domain_pocket.team:

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -10,6 +10,9 @@ can merge its result back even on a private (non-workspace-visible) pocket.
 The authorization already happened at dispatch (the triggering user passed
 ``require_pocket_action_run``); the writeback is the downstream system effect of
 that authorized dispatch, and the identity is not user-assignable.
+Also adds ``get_pocket_workspace`` (review fix IMPORTANT 3) — a session-free
+tenancy read the jobs worker uses to fail closed before a cross-workspace
+writeback.
 
 Public API (returns wire dicts for legacy router compatibility):
 - ``create``, ``list_pockets``, ``get``, ``update``, ``delete``
@@ -2543,6 +2546,26 @@ async def has_action_run_access(pocket_id: str, user_id: str) -> bool:
     if doc.owner == user_id:
         return True
     return user_id in (doc.shared_with or [])
+
+
+async def get_pocket_workspace(pocket_id: str) -> str | None:
+    """Return the workspace a pocket belongs to, or ``None`` if it doesn't exist.
+
+    A workspace-free tenancy read for callers that hold a pocket id but no
+    user session — notably the workspace-jobs worker, which re-asserts that
+    the pocket the job's doc names actually lives in the doc's workspace
+    BEFORE writing anything back (defense-in-depth: ``merge_spec`` fetches by
+    id only and trusts the passed workspace). A malformed / unknown id returns
+    ``None`` so the caller fails closed rather than raising. Keeps the Beanie
+    ``WorkspaceJobDoc``-adjacent ``_PocketDoc`` load inside this service module.
+    """
+    try:
+        doc = await _PocketDoc.get(PydanticObjectId(pocket_id))
+    except Exception:  # noqa: BLE001 — malformed id surfaces as "not found"
+        return None
+    if doc is None:
+        return None
+    return doc.workspace
 
 
 async def is_member(pocket_id: str, user_id: str) -> bool:

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -380,6 +380,23 @@ source_modules = [
 forbidden_modules = ["pocketpaw_ee.cloud.models.fabric_ingest_state"]
 
 [[tool.importlinter.contracts]]
+name = "Jobs — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    # Only ``jobs.service`` owns the WorkspaceJobDoc Beanie write. The router,
+    # dto, domain, registry, the ARQ worker entrypoint, and the built-in jobs
+    # all go through the service — none may import the Beanie doc directly.
+    "pocketpaw_ee.cloud.jobs.router",
+    "pocketpaw_ee.cloud.jobs.dto",
+    "pocketpaw_ee.cloud.jobs.domain",
+    "pocketpaw_ee.cloud.jobs.registry",
+    "pocketpaw_ee.cloud.jobs.worker",
+    "pocketpaw_ee.cloud.jobs.builtin.score_applications",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.workspace_job"]
+
+[[tool.importlinter.contracts]]
 name = "Sessions — Beanie writes only from service.py"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/tests/cloud/jobs/test_jobs.py
+++ b/tests/cloud/jobs/test_jobs.py
@@ -31,6 +31,12 @@
 #   - MINOR B: a credential NESTED under a benign key → 400.
 # A new ``seed_pocket`` fixture inserts a real Pocket doc so the worker's
 # tenancy re-check has something to fetch.
+#
+# Updated: 2026-06-20 (audit-collision fix) — adds the C12 regression test
+# ``test_lifecycle_audit_emit_succeeds`` that asserts the lifecycle audit emit
+# actually reaches the logger. The earlier tests passed while the audit was
+# silently broken (the `action` kwarg collided in AuditEvent.create and the
+# best-effort except swallowed it); this test fails if that collision returns.
 
 from __future__ import annotations
 
@@ -295,6 +301,70 @@ async def test_get_job_enforces_tenancy(mongo_db: Any, fake_pool: _FakePool) -> 
     assert await jobs_service.get_job(WS, job_id) is not None
     # Wrong workspace → None even though the id is real (router maps to 404).
     assert await jobs_service.get_job(OTHER_WS, job_id) is None
+
+
+# ---------------------------------------------------------------------------
+# C12 (audit) — the lifecycle audit emit must actually SUCCEED, not be eaten
+# by the best-effort except. Regression guard for the pp#1459 review: _audit
+# passed `action` BOTH as AuditEvent.create's explicit param AND inside
+# **context, so create() raised TypeError and every job audit record was
+# silently dropped. The earlier tests passed *because* the failure was
+# swallowed — this one asserts the success path so the collision can't return.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAuditLogger:
+    """Captures the AuditEvents that reach the logger's ``.log``."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def log(self, event: Any) -> None:
+        self.events.append(event)
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_audit_emit_succeeds(
+    mongo_db: Any,  # noqa: ARG001 — forces Beanie init
+    fake_pool: _FakePool,
+    seed_pocket,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    recorder = _RecordingAuditLogger()
+    monkeypatch.setattr(jobs_service, "get_audit_logger", lambda: recorder)
+
+    async def _fake_merge_spec(workspace_id, user_id, pocket_id, body):  # type: ignore[no-untyped-def]
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
+
+    pocket_id = await seed_pocket(workspace=WS)
+    with caplog.at_level("WARNING"):
+        result = await jobs_service.dispatch_job(
+            workspace_id=WS,
+            pocket_id=pocket_id,
+            action="run_echo",
+            job_name="echo_job",
+            params={"value": "hi"},
+            triggered_by=VIEWER,
+        )
+        await jobs_worker.execute_workspace_job({}, result["job_id"])
+
+    # The best-effort except NEVER fired — i.e. AuditEvent.create did not raise.
+    assert "jobs: audit emit failed" not in caplog.text
+    # Both lifecycle steps audited: enqueue (success) + done.
+    assert len(recorder.events) >= 2
+    enqueue_event = recorder.events[0]
+    # The audit event-type stays the stable string; the job's own action name
+    # rides in context under `pocket_action` (renamed to dodge the create()
+    # kwarg collision), so both survive into the record.
+    assert enqueue_event.action == "workspace_job"
+    assert enqueue_event.actor == WORKSPACE_JOB_IDENTITY
+    assert enqueue_event.context.get("pocket_action") == "run_echo"
+    # The literal `action` key must be gone from context (renamed), so it can
+    # never shadow create()'s explicit param again.
+    assert "action" not in enqueue_event.context
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/jobs/test_jobs.py
+++ b/tests/cloud/jobs/test_jobs.py
@@ -16,6 +16,21 @@
 #
 # These mirror the repo's pytest-asyncio + mongo_db fixture conventions
 # (see tests/cloud/pockets/test_merge_spec_endpoint.py and conftest.py).
+#
+# Updated: 2026-06-20 (review fix pass) — adds coverage for the review
+# findings:
+#   - IMPORTANT 1: router HTTP-handler tests for the ``kind:"job"`` dispatch
+#     (job_enqueued + job_id, requires_instinct → 400, no-kind back-compat).
+#   - IMPORTANT 2: drives the REAL ARQ entrypoint with ``xproc.is_worker()``
+#     True and asserts the worker→merge_spec→emit chain produces a
+#     ``PocketUpdated`` through ``publish_bus_envelope`` (not just emit in
+#     isolation).
+#   - IMPORTANT 3: a job whose doc names a pocket in a DIFFERENT workspace →
+#     job failed, NO merge_spec call (fail-closed tenancy re-check).
+#   - MINOR A: non-empty client params on a job action → 400.
+#   - MINOR B: a credential NESTED under a benign key → 400.
+# A new ``seed_pocket`` fixture inserts a real Pocket doc so the worker's
+# tenancy re-check has something to fetch.
 
 from __future__ import annotations
 
@@ -123,6 +138,31 @@ def test_clean_params_pass_validation() -> None:
     jobs_registry.validate_job_params({"batch_size": 20, "connector": "snctm-api"})
 
 
+@pytest.mark.parametrize(
+    "nested_params",
+    [
+        {"config": {"api_key": "leak-me"}},
+        {"outer": {"inner": {"token": "leak-me"}}},
+        {"items": [{"name": "ok"}, {"secret": "leak-me"}]},
+        {"a": [{"b": {"password": "leak-me"}}]},
+    ],
+)
+def test_nested_cred_bearing_param_rejected(nested_params: dict) -> None:
+    # MINOR B — the scrub recurses, so a credential buried under a benign key
+    # (or inside a list of dicts) is rejected just like a top-level one.
+    with pytest.raises(JobParamsError) as exc:
+        jobs_registry.validate_job_params(nested_params)
+    assert exc.value.code == "job.params_forbidden"
+    assert exc.value.status == 400
+
+
+def test_nested_clean_params_pass_validation() -> None:
+    # Deeply nested but credential-free → accepted untouched.
+    jobs_registry.validate_job_params(
+        {"config": {"batch_size": 10, "rows": [{"id": "a1"}, {"id": "a2"}]}}
+    )
+
+
 # ---------------------------------------------------------------------------
 # 6. _validate_job_result rejects ui/actions/sources/shape writes.
 # ---------------------------------------------------------------------------
@@ -163,6 +203,27 @@ async def fake_pool(monkeypatch: pytest.MonkeyPatch) -> _FakePool:
 
     monkeypatch.setattr(jobs_service, "_get_pool", _get_pool)
     return pool
+
+
+@pytest_asyncio.fixture
+async def seed_pocket(mongo_db: Any):  # noqa: ARG001 — mongo_db forces Beanie init
+    """Insert a real Pocket doc and return its ObjectId string.
+
+    The worker's fail-closed tenancy re-check (IMPORTANT 3) fetches the pocket
+    the job names and asserts it lives in the job's workspace, so the worker
+    tests need a persisted pocket whose id is a valid ObjectId and whose
+    ``workspace`` matches the dispatch. Returns a factory so a test can seed a
+    pocket in a chosen workspace (the tenancy-mismatch test seeds one in a
+    DIFFERENT workspace than the job doc).
+    """
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    async def _seed(*, workspace: str = WS, owner: str = "owner-1") -> str:
+        doc = _PocketDoc(workspace=workspace, name="jobs-test-pocket", owner=owner)
+        await doc.insert()
+        return str(doc.id)
+
+    return _seed
 
 
 @pytest.mark.asyncio
@@ -243,7 +304,7 @@ async def test_get_job_enforces_tenancy(mongo_db: Any, fake_pool: _FakePool) -> 
 
 @pytest.mark.asyncio
 async def test_worker_writeback_uses_system_identity(
-    mongo_db: Any, fake_pool: _FakePool, monkeypatch: pytest.MonkeyPatch
+    mongo_db: Any, fake_pool: _FakePool, seed_pocket, monkeypatch: pytest.MonkeyPatch
 ) -> None:  # noqa: ARG001
     captured: dict[str, Any] = {}
 
@@ -256,9 +317,11 @@ async def test_worker_writeback_uses_system_identity(
 
     monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
 
+    # Seed a real pocket in WS so the worker's tenancy re-check passes.
+    pocket_id = await seed_pocket(workspace=WS)
     result = await jobs_service.dispatch_job(
         workspace_id=WS,
-        pocket_id=POCKET,
+        pocket_id=pocket_id,
         action="run_echo",
         job_name="echo_job",
         params={"value": "hello"},
@@ -271,7 +334,7 @@ async def test_worker_writeback_uses_system_identity(
     assert captured["user_id"] == WORKSPACE_JOB_IDENTITY
     assert captured["user_id"] == "system:workspace_job"
     assert captured["workspace_id"] == WS
-    assert captured["pocket_id"] == POCKET
+    assert captured["pocket_id"] == pocket_id
     # Writeback is a partial-spec merge carrying only state.
     assert captured["body"]["merge"]["state"]["echo_value"] == "hello"
 
@@ -287,7 +350,7 @@ async def test_worker_writeback_uses_system_identity(
 
 @pytest.mark.asyncio
 async def test_worker_failure_writes_failed_state(
-    mongo_db: Any, fake_pool: _FakePool, monkeypatch: pytest.MonkeyPatch
+    mongo_db: Any, fake_pool: _FakePool, seed_pocket, monkeypatch: pytest.MonkeyPatch
 ) -> None:  # noqa: ARG001
     captured: dict[str, Any] = {}
 
@@ -297,9 +360,10 @@ async def test_worker_failure_writes_failed_state(
 
     monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
 
+    pocket_id = await seed_pocket(workspace=WS)
     result = await jobs_service.dispatch_job(
         workspace_id=WS,
-        pocket_id=POCKET,
+        pocket_id=pocket_id,
         action="run_boom",
         job_name="boom_job",
         params={},
@@ -322,7 +386,7 @@ async def test_worker_failure_writes_failed_state(
 
 @pytest.mark.asyncio
 async def test_worker_rejects_template_owned_result(
-    mongo_db: Any, fake_pool: _FakePool, monkeypatch: pytest.MonkeyPatch
+    mongo_db: Any, fake_pool: _FakePool, seed_pocket, monkeypatch: pytest.MonkeyPatch
 ) -> None:  # noqa: ARG001
     captured: dict[str, Any] = {}
 
@@ -332,9 +396,10 @@ async def test_worker_rejects_template_owned_result(
 
     monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
 
+    pocket_id = await seed_pocket(workspace=WS)
     result = await jobs_service.dispatch_job(
         workspace_id=WS,
-        pocket_id=POCKET,
+        pocket_id=pocket_id,
         action="run_bad",
         job_name="bad_result_job",  # returns a `ui` write → must be rejected
         params={},
@@ -371,6 +436,44 @@ async def test_worker_tenancy_recheck_missing_doc_noop(
     assert called["merge"] is False
 
 
+@pytest.mark.asyncio
+async def test_worker_tenancy_mismatch_fails_without_writeback(
+    mongo_db: Any, fake_pool: _FakePool, seed_pocket, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    """IMPORTANT 3 — a job whose doc.pocket lives in a DIFFERENT workspace than
+    doc.workspace is marked failed with NO merge_spec call (fail-closed)."""
+    called = {"merge": False}
+
+    async def _fake_merge_spec(*a, **k):  # type: ignore[no-untyped-def]
+        called["merge"] = True
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
+
+    # The pocket really lives in OTHER_WS, but we dispatch the job under WS —
+    # simulating a doc whose workspace no longer matches the pocket's tenancy.
+    pocket_id = await seed_pocket(workspace=OTHER_WS)
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        action="run_echo",
+        job_name="echo_job",
+        params={"value": "hi"},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    await jobs_worker.execute_workspace_job({}, job_id)
+
+    # No cross-workspace write fired.
+    assert called["merge"] is False
+    # The job is marked failed so the caller / poll sees the rejection.
+    doc = await jobs_service.get_job(WS, job_id)
+    assert doc is not None
+    assert doc.status == "failed"
+    assert doc.error
+
+
 # ---------------------------------------------------------------------------
 # 9. xproc bridge — when the worker role is set, emit routes a PocketUpdated
 #    through publish_bus_envelope (not the local bus).
@@ -399,6 +502,79 @@ async def test_emit_routes_through_xproc_when_worker(
     assert len(published) == 1
     assert published[0].type == "pocket.updated"
     assert published[0].data["id"] == POCKET
+
+
+@pytest.mark.asyncio
+async def test_worker_writeback_emits_pocket_updated_in_worker_context(
+    mongo_db: Any, fake_pool: _FakePool, seed_pocket, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    """IMPORTANT 2 — drive the REAL ARQ entrypoint with ``is_worker()`` True and
+    a real ``merge_spec`` writeback, and assert the worker→merge_spec→emit chain
+    publishes a ``PocketUpdated`` through ``publish_bus_envelope`` for the right
+    pocket. Unlike ``test_emit_routes_through_xproc_when_worker`` (which hand-
+    builds the event and calls ``emit`` in isolation), this exercises the
+    writeback that PRODUCES the emit in worker context.
+    """
+    from pocketpaw_ee.cloud._core.realtime import emit as emit_mod
+    from pocketpaw_ee.cloud._core.realtime import xproc
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    published: list[Any] = []
+
+    async def _fake_publish(event):  # type: ignore[no-untyped-def]
+        published.append(event)
+
+    # Catalog validation is orthogonal to the emit chain under test — no-op it
+    # so a minimal seeded spec doesn't trip the strict gate. Everything else on
+    # the merge_spec path (merge, normalize, save, _pocket_event_payload, emit)
+    # runs for real, so the PocketUpdated is the one merge_spec actually fires.
+    async def _noop_gate_catalog(*a, **k):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(pockets_service, "_gate_catalog", _noop_gate_catalog)
+
+    # Seed a real pocket in WS with a minimal valid rippleSpec so the state-only
+    # job result merges cleanly.
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    pdoc = _PocketDoc(
+        workspace=WS,
+        name="jobs-emit-pocket",
+        owner="owner-1",
+        rippleSpec={"version": "1.0", "state": {}, "ui": {"id": "n_root0001", "type": "card"}},
+    )
+    await pdoc.insert()
+    pocket_id = str(pdoc.id)
+
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        action="run_echo",
+        job_name="echo_job",
+        params={"value": "emitted"},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    # Flip to worker context ONLY for the worker run — dispatch above already
+    # emitted (WorkspaceJobQueued) against the recording bus in web context.
+    monkeypatch.setattr(xproc, "is_worker", lambda: True)
+    monkeypatch.setattr(emit_mod.xproc, "publish_bus_envelope", _fake_publish)
+
+    await jobs_worker.execute_workspace_job({}, job_id)
+
+    # The writeback's merge_spec fired a PocketUpdated for THIS pocket, and it
+    # routed over the xproc bridge (not the local bus) because is_worker()=True.
+    pocket_updates = [e for e in published if e.type == "pocket.updated"]
+    assert pocket_updates, f"expected a pocket.updated emit, saw: {[e.type for e in published]}"
+    # merge_spec's PocketUpdated carries the id under ``pocket_id`` (see
+    # _pocket_event_payload). Assert it names the pocket the job wrote to.
+    assert any(e.data.get("pocket_id") == pocket_id for e in pocket_updates)
+
+    # And the merge actually persisted the job's state-only result.
+    refreshed = await _PocketDoc.get(pdoc.id)
+    assert refreshed is not None
+    assert refreshed.rippleSpec["state"]["echo_value"] == "emitted"
 
 
 # ---------------------------------------------------------------------------
@@ -471,3 +647,146 @@ def test_system_identity_bypasses_edit_check_on_private_pocket() -> None:
     # An arbitrary user is still rejected.
     with pytest.raises(Forbidden):
         _check_domain_edit_access(pocket, "random-user")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# IMPORTANT 1 + MINOR A — router HTTP-handler coverage for the ``kind:"job"``
+# dispatch in ``POST /pockets/{id}/actions/run``. Mirrors the app/auth-override
+# pattern of tests/cloud/pockets/test_tools_run.py, but runs over an async
+# httpx client so the real ``dispatch_job`` (which writes a Beanie doc) works
+# against the ``mongo_db`` fixture. The ARQ pool is faked (``fake_pool``) so
+# nothing is really enqueued. ``pockets_service.get`` is stubbed to return a
+# pocket whose ``rippleSpec.actions`` carries the action under test, so the
+# route reads the binding without a real Mongo pocket.
+# ---------------------------------------------------------------------------
+
+ROUTER_WS = "ws-jobs-1"
+ROUTER_USER = "user-jobs-1"
+
+
+def _job_action_spec(action: dict) -> dict:
+    """A minimal pocket wire-dict whose rippleSpec.actions has one action."""
+    return {"_id": "pkt-router-1", "rippleSpec": {"actions": {"act1": action}}}
+
+
+@pytest_asyncio.fixture
+async def jobs_router_client(monkeypatch: pytest.MonkeyPatch):
+    """Mount the pockets router with auth/license overridden; yield an async
+    client + a place to pin the pocket the route loads."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.cloud.pockets.router import router as pockets_router
+    from pocketpaw_ee.cloud.shared.deps import (
+        current_user_id,
+        current_workspace_id,
+        require_pocket_action_run,
+    )
+
+    state: dict[str, Any] = {"pocket": None}
+
+    async def _get(pocket_id, user_id):  # type: ignore[no-untyped-def]
+        return state["pocket"]
+
+    monkeypatch.setattr(pockets_service, "get", _get)
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(pockets_router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[require_pocket_action_run] = lambda: None
+    app.dependency_overrides[current_user_id] = lambda: ROUTER_USER
+    app.dependency_overrides[current_workspace_id] = lambda: ROUTER_WS
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client, state
+
+
+@pytest.mark.asyncio
+async def test_route_kind_job_enqueues_and_returns_job_id(
+    mongo_db: Any, fake_pool: _FakePool, jobs_router_client
+) -> None:  # noqa: ARG001
+    """(a) a kind:"job" action → code:"job_enqueued" + a job_id; the ARQ pool
+    was asked to enqueue (faked, nothing real queued)."""
+    client, state = jobs_router_client
+    state["pocket"] = _job_action_spec({"kind": "job", "job": "echo_job"})
+
+    res = await client.post("/pockets/pkt-router-1/actions/run", json={"action": "act1"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ok"] is True
+    assert body["code"] == "job_enqueued"
+    assert body["job_id"]
+    # The faked pool received exactly one enqueue — nothing hit real Redis.
+    assert len(fake_pool.calls) == 1
+    assert fake_pool.calls[0][0][0] == "execute_workspace_job"
+
+
+@pytest.mark.asyncio
+async def test_route_kind_job_requires_instinct_rejected(
+    mongo_db: Any, fake_pool: _FakePool, jobs_router_client
+) -> None:  # noqa: ARG001
+    """(b) a kind:"job" action with requires_instinct:true → HTTP 400 with
+    code job.instinct_not_yet_supported; nothing enqueued."""
+    client, state = jobs_router_client
+    state["pocket"] = _job_action_spec(
+        {"kind": "job", "job": "echo_job", "requires_instinct": True}
+    )
+
+    res = await client.post("/pockets/pkt-router-1/actions/run", json={"action": "act1"})
+    assert res.status_code == 400, res.text
+    assert res.json()["error"]["code"] == "job.instinct_not_yet_supported"
+    assert fake_pool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_route_kind_job_rejects_client_params(
+    mongo_db: Any, fake_pool: _FakePool, jobs_router_client
+) -> None:  # noqa: ARG001
+    """MINOR A — non-empty client params on a kind:"job" run → HTTP 400 with
+    code job.params_not_accepted; nothing enqueued (a clicker can't widen the
+    job's scope)."""
+    client, state = jobs_router_client
+    state["pocket"] = _job_action_spec({"kind": "job", "job": "echo_job"})
+
+    res = await client.post(
+        "/pockets/pkt-router-1/actions/run",
+        json={"action": "act1", "params": {"value": "smuggled"}},
+    )
+    assert res.status_code == 400, res.text
+    assert res.json()["error"]["code"] == "job.params_not_accepted"
+    assert fake_pool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_route_no_kind_does_not_enqueue_job(
+    mongo_db: Any, fake_pool: _FakePool, jobs_router_client, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    """(c) an action with NO kind still hits the existing (non-job) action path
+    (back-compat) — it does NOT enqueue a job nor return job_enqueued.
+
+    We stub the credential reader to return None so the legacy path short-
+    circuits at the "no backend configured" gate — that's enough to prove the
+    request fell through to the HTTP-write branch rather than the job branch.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    async def _no_creds(workspace_id, pocket_id):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(pockets_service, "get_pocket_backend_for_executor", _no_creds)
+
+    client, state = jobs_router_client
+    # A classic HTTP-write action: no `kind`, carries a path.
+    state["pocket"] = _job_action_spec({"path": "/things", "method": "POST"})
+
+    res = await client.post("/pockets/pkt-router-1/actions/run", json={"action": "act1"})
+    # The legacy path was taken: it reached the backend-config gate (400
+    # pocket_backend.not_configured), NOT the job branch.
+    assert res.status_code == 400, res.text
+    assert res.json()["error"]["code"] == "pocket_backend.not_configured"
+    # Crucially — no job was enqueued and no job_enqueued response was produced.
+    assert fake_pool.calls == []

--- a/tests/cloud/jobs/test_jobs.py
+++ b/tests/cloud/jobs/test_jobs.py
@@ -1,0 +1,473 @@
+# tests/cloud/jobs/test_jobs.py
+# Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — TDD coverage for the
+# workspace jobs primitive. Pins the nine acceptance criteria from the design:
+#   1. registry lookup on an unknown job name → `job.unknown` (400)
+#   2. dispatch creates a queued status doc + returns its job_id (ARQ pool mocked)
+#   3. status poll returns the doc; wrong-workspace re-fetch → 404
+#   4. on done the worker writes back via merge_spec under
+#      user_id="system:workspace_job"
+#   5. failure path writes {state: {<action>_status: "failed", ...}} so the
+#      button never hangs
+#   6. _validate_job_result rejects a result writing ui/actions/sources → failed
+#   7. a cred-bearing param (api_key/token/secret) → 400 at dispatch
+#   8. tenancy: poll with a mismatched workspace → 404
+#   9. the xproc bridge: when the worker role is set, emit() routes a
+#      PocketUpdated through publish_bus_envelope rather than the local bus
+#
+# These mirror the repo's pytest-asyncio + mongo_db fixture conventions
+# (see tests/cloud/pockets/test_merge_spec_endpoint.py and conftest.py).
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud.jobs import registry as jobs_registry
+from pocketpaw_ee.cloud.jobs import service as jobs_service
+from pocketpaw_ee.cloud.jobs import worker as jobs_worker
+from pocketpaw_ee.cloud.jobs.domain import WORKSPACE_JOB_IDENTITY
+from pocketpaw_ee.cloud.jobs.registry import (
+    JobParamsError,
+    JobResultError,
+    UnknownJobError,
+)
+
+WS = "ws-jobs-1"
+OTHER_WS = "ws-jobs-2"
+POCKET = "pkt-jobs-1"
+VIEWER = "viewer-1"
+
+
+# ---------------------------------------------------------------------------
+# Registry test-doubles — registered/cleared per test so the module-level
+# registry never leaks state between tests.
+# ---------------------------------------------------------------------------
+
+
+class _EchoJob:
+    """A registered job that echoes its params into a single state key."""
+
+    name = "echo_job"
+
+    async def __call__(
+        self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
+    ) -> dict:
+        return {"state": {"echo_value": params.get("value", "")}}
+
+
+class _BadResultJob:
+    """A registered job that (incorrectly) tries to write a ui node."""
+
+    name = "bad_result_job"
+
+    async def __call__(
+        self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
+    ) -> dict:
+        return {"ui": {"id": "x", "type": "text"}}
+
+
+class _BoomJob:
+    """A registered job that raises."""
+
+    name = "boom_job"
+
+    async def __call__(
+        self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
+    ) -> dict:
+        raise RuntimeError("boom")
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Register the test doubles and restore the registry afterwards."""
+    saved = dict(jobs_registry.get_job_registry())
+    jobs_registry.get_job_registry().clear()
+    jobs_registry.register_job(_EchoJob())
+    jobs_registry.register_job(_BadResultJob())
+    jobs_registry.register_job(_BoomJob())
+    yield
+    reg = jobs_registry.get_job_registry()
+    reg.clear()
+    reg.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# 1. Registry lookup on an unknown job → UnknownJobError (400).
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_job_raises_job_unknown() -> None:
+    with pytest.raises(UnknownJobError) as exc:
+        jobs_registry.resolve_job("does_not_exist")
+    assert exc.value.code == "job.unknown"
+    assert exc.value.status == 400
+
+
+# ---------------------------------------------------------------------------
+# 7. A cred-bearing param → JobParamsError (400). (Listed before #2 because
+#    dispatch validates params, so this guards the dispatch path too.)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_key", ["api_key", "API_KEY", "token", "secret", "my_credential"])
+def test_cred_bearing_param_rejected(bad_key: str) -> None:
+    with pytest.raises(JobParamsError) as exc:
+        jobs_registry.validate_job_params({bad_key: "leak-me", "batch_size": 10})
+    assert exc.value.code == "job.params_forbidden"
+    assert exc.value.status == 400
+
+
+def test_clean_params_pass_validation() -> None:
+    # No raise — a benign params dict is accepted untouched.
+    jobs_registry.validate_job_params({"batch_size": 20, "connector": "snctm-api"})
+
+
+# ---------------------------------------------------------------------------
+# 6. _validate_job_result rejects ui/actions/sources/shape writes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("forbidden_key", ["ui", "actions", "sources", "shape"])
+def test_validate_job_result_rejects_template_owned_keys(forbidden_key: str) -> None:
+    with pytest.raises(JobResultError) as exc:
+        jobs_registry.validate_job_result({forbidden_key: {"anything": 1}})
+    assert exc.value.code == "job.result_forbidden"
+
+
+def test_validate_job_result_accepts_state_only() -> None:
+    # State-only is the only legal shape — returns the result unchanged.
+    out = jobs_registry.validate_job_result({"state": {"k": "v"}})
+    assert out == {"state": {"k": "v"}}
+
+
+# ---------------------------------------------------------------------------
+# 2. Dispatch creates a queued doc + returns job_id (ARQ pool mocked).
+# ---------------------------------------------------------------------------
+
+
+class _FakePool:
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+
+    async def enqueue_job(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((args, kwargs))
+
+
+@pytest_asyncio.fixture
+async def fake_pool(monkeypatch: pytest.MonkeyPatch) -> _FakePool:
+    pool = _FakePool()
+
+    async def _get_pool() -> _FakePool:
+        return pool
+
+    monkeypatch.setattr(jobs_service, "_get_pool", _get_pool)
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_dispatch_creates_doc_and_returns_job_id(mongo_db: Any, fake_pool: _FakePool) -> None:  # noqa: ARG001 — mongo_db forces Beanie init
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=POCKET,
+        action="run_echo",
+        job_name="echo_job",
+        params={"value": "hi"},
+        triggered_by=VIEWER,
+    )
+    assert result["ok"] is True
+    assert result["code"] == "job_enqueued"
+    job_id = result["job_id"]
+    assert job_id
+
+    # The status doc was persisted as `queued`.
+    doc = await jobs_service.get_job(WS, job_id)
+    assert doc is not None
+    assert doc.status == "queued"
+    assert doc.workspace == WS
+    assert doc.job_name == "echo_job"
+    assert doc.triggered_by == VIEWER
+
+    # The ARQ pool was asked to enqueue exactly one job, on the jobs queue.
+    assert len(fake_pool.calls) == 1
+    (args, kwargs) = fake_pool.calls[0]
+    assert args[0] == "execute_workspace_job"
+    assert job_id in args
+    assert kwargs.get("queue") == "paw:jobs"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_job_raises_before_enqueue(
+    mongo_db: Any, fake_pool: _FakePool
+) -> None:  # noqa: ARG001
+    with pytest.raises(UnknownJobError):
+        await jobs_service.dispatch_job(
+            workspace_id=WS,
+            pocket_id=POCKET,
+            action="run_x",
+            job_name="not_a_real_job",
+            params={},
+            triggered_by=VIEWER,
+        )
+    # Nothing enqueued — the lookup gates before the pool is touched.
+    assert fake_pool.calls == []
+
+
+# ---------------------------------------------------------------------------
+# 3 + 8. Status poll returns the doc; wrong workspace → None (router 404s).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_job_enforces_tenancy(mongo_db: Any, fake_pool: _FakePool) -> None:  # noqa: ARG001
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=POCKET,
+        action="run_echo",
+        job_name="echo_job",
+        params={"value": "hi"},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    # Right workspace → found.
+    assert await jobs_service.get_job(WS, job_id) is not None
+    # Wrong workspace → None even though the id is real (router maps to 404).
+    assert await jobs_service.get_job(OTHER_WS, job_id) is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Worker writeback calls merge_spec with the synthetic identity.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_writeback_uses_system_identity(
+    mongo_db: Any, fake_pool: _FakePool, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    captured: dict[str, Any] = {}
+
+    async def _fake_merge_spec(workspace_id, user_id, pocket_id, body):  # type: ignore[no-untyped-def]
+        captured["workspace_id"] = workspace_id
+        captured["user_id"] = user_id
+        captured["pocket_id"] = pocket_id
+        captured["body"] = body
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
+
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=POCKET,
+        action="run_echo",
+        job_name="echo_job",
+        params={"value": "hello"},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    await jobs_worker.execute_workspace_job({}, job_id)
+
+    assert captured["user_id"] == WORKSPACE_JOB_IDENTITY
+    assert captured["user_id"] == "system:workspace_job"
+    assert captured["workspace_id"] == WS
+    assert captured["pocket_id"] == POCKET
+    # Writeback is a partial-spec merge carrying only state.
+    assert captured["body"]["merge"]["state"]["echo_value"] == "hello"
+
+    doc = await jobs_service.get_job(WS, job_id)
+    assert doc is not None
+    assert doc.status == "done"
+
+
+# ---------------------------------------------------------------------------
+# 5. Failure path writes {state: {<action>_status: "failed", ...}}.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_failure_writes_failed_state(
+    mongo_db: Any, fake_pool: _FakePool, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    captured: dict[str, Any] = {}
+
+    async def _fake_merge_spec(workspace_id, user_id, pocket_id, body):  # type: ignore[no-untyped-def]
+        captured["body"] = body
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
+
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=POCKET,
+        action="run_boom",
+        job_name="boom_job",
+        params={},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    await jobs_worker.execute_workspace_job({}, job_id)
+
+    # The button never hangs: a failed-state writeback fires under the action.
+    state = captured["body"]["merge"]["state"]
+    assert state["run_boom_status"] == "failed"
+    assert "run_boom_error" in state
+
+    doc = await jobs_service.get_job(WS, job_id)
+    assert doc is not None
+    assert doc.status == "failed"
+    assert doc.error
+
+
+@pytest.mark.asyncio
+async def test_worker_rejects_template_owned_result(
+    mongo_db: Any, fake_pool: _FakePool, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    captured: dict[str, Any] = {}
+
+    async def _fake_merge_spec(workspace_id, user_id, pocket_id, body):  # type: ignore[no-untyped-def]
+        captured["body"] = body
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
+
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=POCKET,
+        action="run_bad",
+        job_name="bad_result_job",  # returns a `ui` write → must be rejected
+        params={},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    await jobs_worker.execute_workspace_job({}, job_id)
+
+    # The forbidden result was NOT written; a failed-state writeback fired.
+    assert "ui" not in captured["body"]["merge"]
+    state = captured["body"]["merge"]["state"]
+    assert state["run_bad_status"] == "failed"
+
+    doc = await jobs_service.get_job(WS, job_id)
+    assert doc is not None
+    assert doc.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_worker_tenancy_recheck_missing_doc_noop(
+    mongo_db: Any, fake_pool: _FakePool, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    """A worker handed an id with no matching doc must not call merge_spec."""
+    called = {"merge": False}
+
+    async def _fake_merge_spec(*a, **k):  # type: ignore[no-untyped-def]
+        called["merge"] = True
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _fake_merge_spec)
+    # No doc was created for this id.
+    await jobs_worker.execute_workspace_job({}, "no-such-job-id")
+    assert called["merge"] is False
+
+
+# ---------------------------------------------------------------------------
+# 9. xproc bridge — when the worker role is set, emit routes a PocketUpdated
+#    through publish_bus_envelope (not the local bus).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_routes_through_xproc_when_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pocketpaw_ee.cloud._core.realtime import emit as emit_mod
+    from pocketpaw_ee.cloud._core.realtime import xproc
+    from pocketpaw_ee.cloud._core.realtime.events import PocketUpdated
+
+    published: list[Any] = []
+
+    async def _fake_publish(event):  # type: ignore[no-untyped-def]
+        published.append(event)
+
+    monkeypatch.setattr(xproc, "is_worker", lambda: True)
+    monkeypatch.setattr(emit_mod.xproc, "publish_bus_envelope", _fake_publish)
+
+    evt = PocketUpdated(data={"id": POCKET, "workspace": WS})
+    await emit_mod.emit(evt)
+
+    assert len(published) == 1
+    assert published[0].type == "pocket.updated"
+    assert published[0].data["id"] == POCKET
+
+
+# ---------------------------------------------------------------------------
+# Built-in PII allowlist — score_applications strips email/phone before the
+# scored rows become broadcast state.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_score_applications_strips_pii() -> None:
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import (
+        ScoreApplicationsJob,
+        project_row,
+    )
+
+    # The pure projection drops any non-allowlisted field — notably PII.
+    projected = project_row(
+        {
+            "id": "a1",
+            "name": "Jordan",
+            "score": 6,
+            "stage": "scored",
+            "email": "jordan@example.com",
+            "phone": "+1-555-0100",
+            "ssn": "000-00-0000",
+        }
+    )
+    assert "email" not in projected
+    assert "phone" not in projected
+    assert "ssn" not in projected
+    assert projected == {"id": "a1", "name": "Jordan", "score": 6, "stage": "scored"}
+
+    # End-to-end through the job: a row carrying PII never reaches the result.
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=POCKET,
+        job_id="j1",
+        params={"rows": [{"id": "a1", "name": "Jordan", "email": "jordan@example.com"}]},
+    )
+    rows = result["state"]["scored_rows"]
+    assert rows and all("email" not in r and "phone" not in r for r in rows)
+    assert result["state"]["score_applications_status"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# Writeback access — merge_spec's edit-access check ALLOWS the synthetic job
+# identity on a private pocket (so the writeback never 403s + hangs), but
+# still rejects an arbitrary user.
+# ---------------------------------------------------------------------------
+
+
+class _PrivatePocket:
+    """Minimal stand-in carrying only the fields the access check reads."""
+
+    id = "pkt-private"
+    owner = "owner-1"
+    team: tuple[str, ...] = ()
+    shared_with: tuple[str, ...] = ()
+    visibility = "private"
+
+
+def test_system_identity_bypasses_edit_check_on_private_pocket() -> None:
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+    from pocketpaw_ee.cloud.pockets.service import _check_domain_edit_access
+
+    pocket = _PrivatePocket()
+    # The synthetic job identity is allowed (no raise) even on a private pocket.
+    _check_domain_edit_access(pocket, WORKSPACE_JOB_IDENTITY)  # type: ignore[arg-type]
+    # An arbitrary user is still rejected.
+    with pytest.raises(Forbidden):
+        _check_domain_edit_access(pocket, "random-user")  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #1459.

## What this adds

A pocket can already trigger an HTTP read (a source) or a gated HTTP write (an action). Neither covers a server-side computation that runs for minutes, produces results progressively, and has to survive the user closing their browser. This adds that third kind: a workspace job.

A job is a named async callable in a per-workspace registry. A pocket action with `kind: "job"` enqueues it onto the ARQ worker, which runs it under a synthetic service identity and merges the result back into the pocket's `rippleSpec.state`. Because the worker emits `PocketUpdated` over the existing cross-process bridge, an open canvas updates live even after the triggering session is gone.

The concrete driver is the SNCTM `score_next_batch.py` sidecar: a button that scores a batch (minutes of work) and writes the scores into pocket state. That sidecar calls `merge_spec` from a process with no realtime context, so its `PocketUpdated` emit silently fails. A job runs where the emit actually reaches the bus.

## How it works

- Trigger: `run_pocket_action` branches on `kind == "job"` before the existing action path and enqueues `execute_workspace_job` on the `paw:jobs` queue. Actions without `kind` take the existing path unchanged, so nothing else moves.
- Registry: a module-level dict of named `JobCallable`s, plus validators for params and results.
- Status doc: a Beanie `WorkspaceJobDoc` (queued/running/done/failed) with a `GET /workspaces/{ws}/jobs/{job_id}` poll.
- Writeback: on success the worker merges a state-only partial under `system:workspace_job`; on any failure (a raise, a validation reject, or a timeout) it writes a failed-state partial so the button stops spinning.

## Decisions

- ARQ, not `asyncio.Task`. The 30-minute session expiry is the deciding factor: a job started at minute 0 must still emit at minute 8 after the socket is gone. ARQ is already an EE dependency with a running pool and the cross-process emit bridge.
- Same worker process. `execute_workspace_job` joins the existing `WorkerSettings.functions` rather than adding a deploy artifact. Split it out later if load grows.
- `requires_instinct: true` is rejected with 400 `job.instinct_not_yet_supported` for now. The Instinct bridge exists but is untested for jobs, so v1.1 owns it rather than shipping a gated path that runs ungated.
- Job timeout defaults to 900s (`POCKETPAW_JOB_TIMEOUT_SECONDS`), above the 5 to 8 minute SNCTM batch.

## Security

- The execution identity is the hardcoded constant `system:workspace_job`. Nothing in a request can influence it.
- Params are scrubbed for credential-shaped keys (token, api_key, secret, and the like), now recursively, so a credential nested under a benign key is still rejected. Jobs read workspace creds server-side and never take tokens through params.
- A job result may write only `state`. Any attempt to write `ui`, `actions`, `sources`, or `shape` is rejected and the job is marked failed.
- Tenancy is enforced on the poll (a mismatched workspace returns 404) and re-asserted fail-closed in the worker before writeback, so a job can only write the pocket its doc names within its own workspace.
- The built-in `score_applications` job projects rows through a field allowlist, dropping email and phone before anything reaches broadcast state.

## Review and tests

Built and reviewed in three stages: spec compliance, code quality, and a security audit. Spec and quality both passed; the security audit found no critical issues. The review pass added router-level tests for the dispatch branch, a worker-context test for the live emit chain, and the fail-closed tenancy re-check, then tightened the credential scrub to recurse and made the dispatch reject client-supplied params instead of silently dropping them.

Running the tests also surfaced a bug the reads had missed: the job audit emit passed `action` both as `AuditEvent.create`'s explicit argument and inside its keyword splat, so every audit write raised a `TypeError` that the best-effort `except` swallowed. The audit trail was writing nothing. Fixed by renaming the job's action into the audit context, with a test that now asserts the emit succeeds.

- `tests/cloud/jobs/`: 34 passing
- `tests/cloud/pockets/` (the direct consumers of the router and `merge_spec` edits): 128 passing, no back-compat change
- ruff clean, import-linter boundary kept

## Docs

`docs/wiki/jobs.md` describes the primitive, the action shape, and the writeback contract.

## Follow-ups (not in this PR)

- Retire the SNCTM `score_next_batch.py` sidecar by registering `score_applications` and switching the Score button to `kind: "job"`. That lives in nerve-snctm, not here.
- A `job_enqueued` spinner in paw-enterprise so the click shows progress.
- For future connector-backed jobs, map exceptions to fixed strings before they reach broadcast state and audit, since a raw exception message could carry a row value. Today's only job raises nothing data-bearing.
- `requires_instinct` support in v1.1.
