### PR TITLE
chore: ruff format two files drifted by #1515 (unblocks Lint on open PRs)

### DIFF
--- a/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/fabric_proposals/executor.py
@@ -321,8 +321,7 @@ async def _create_links_deduped(
         )
         if from_obj is None or to_obj is None:
             logger.info(
-                "fabric_objects: skipping link %s — endpoint not resolvable in "
-                "workspace %s",
+                "fabric_objects: skipping link %s — endpoint not resolvable in workspace %s",
                 link_type,
                 workspace_id,
             )
@@ -530,8 +529,7 @@ async def execute_approved_fabric_objects(
         user_id=approver,
         causation_id=causation,
         summary=(
-            f"{total_created} created, {total_updated} updated, "
-            f"{links_created} link(s) created"
+            f"{total_created} created, {total_updated} updated, {links_created} link(s) created"
         ),
     )
     logger.info(

--- a/ee/pocketpaw_ee/cloud/ripple_sources.py
+++ b/ee/pocketpaw_ee/cloud/ripple_sources.py
@@ -181,8 +181,7 @@ async def _resolve_fabric_objects(
     type_name = args.get("type_name")
     if not type_id and not type_name:
         logger.warning(
-            "ripple_resolver: fabric source needs a type_id or type_name "
-            "(workspace=%s pocket=%s)",
+            "ripple_resolver: fabric source needs a type_id or type_name (workspace=%s pocket=%s)",
             ctx.workspace_id,
             ctx.pocket_id,
         )


### PR DESCRIPTION
## What

`ee/pocketpaw_ee/cloud/fabric_proposals/executor.py` and `ee/pocketpaw_ee/cloud/ripple_sources.py` landed via #1515 without ruff formatting. CI Lint runs `ruff format --check .` over the whole tree, so these two files turn Lint red on every open PR, not only the one that introduced them.

## Fix

Ran `ruff format` on the two files. Whitespace and line-wrapping only, no logic change. The other 1979 files were already clean.

Merging this turns Lint green again across the open-PR queue (including #1516).