### PR TITLE
fix(jobs): correct the arq enqueue contract so workspace jobs actually run

### DIFF
--- a/ee/pocketpaw_ee/cloud/jobs/domain.py
+++ b/ee/pocketpaw_ee/cloud/jobs/domain.py
@@ -7,6 +7,14 @@
 # gone. This module holds NO Beanie / FastAPI / I/O imports so every other
 # module in the package (and the import-linter contract) can depend on it
 # freely.
+#
+# Updated: 2026-06-20 (fix/jobs-arq-enqueue-contract) — removed the aspirational
+# ``JOBS_QUEUE = "paw:jobs"`` constant. It was wired into the enqueue as
+# ``queue=JOBS_QUEUE``, but arq's selector is ``_queue_name``, so the kwarg was
+# forwarded to the job function and crashed every job. The shared worker listens
+# only on arq's default queue anyway; jobs now ride that queue with no selector
+# (single-process design). True queue isolation is deferred to a dedicated
+# worker. See the queue note below.
 
 """Pure domain types + constants for the workspace jobs primitive."""
 
@@ -24,10 +32,16 @@ from typing import Literal
 # ---------------------------------------------------------------------------
 WORKSPACE_JOB_IDENTITY = "system:workspace_job"
 
-# ARQ queue the jobs run on — distinct from the resumable-chat-run queue so a
-# burst of jobs can't starve interactive runs (they share the same worker
-# PROCESS, just different logical queues).
-JOBS_QUEUE = "paw:jobs"
+# Queue: workspace jobs ride arq's DEFAULT queue, the SAME one the resumable
+# chat runs use, on the single shared worker process (default #1: same worker,
+# no new deploy artifact — see ``chat/runs/worker.py`` ``WorkerSettings``, which
+# sets no ``queue_name`` and registers both ``execute_run_job`` and
+# ``execute_workspace_job`` there). There is intentionally no jobs-specific
+# queue constant: arq's queue selector is ``_queue_name``, and the enqueue in
+# ``service.py`` deliberately omits it so the job rides the default queue. True
+# queue isolation (so a burst of jobs can't starve interactive runs) needs a
+# second worker PROCESS bound to a dedicated queue — deferred to a future
+# dedicated-worker enhancement, not wired here.
 
 # Job lifecycle. `queued` on enqueue, `running` once the worker picks it up,
 # terminal as `done` / `failed`.
@@ -67,7 +81,6 @@ def failed_state_writeback(action: str, message: str) -> dict:
 
 
 __all__ = [
-    "JOBS_QUEUE",
     "JobStatus",
     "WORKSPACE_JOB_IDENTITY",
     "failed_state_writeback",

--- a/ee/pocketpaw_ee/cloud/jobs/service.py
+++ b/ee/pocketpaw_ee/cloud/jobs/service.py
@@ -6,6 +6,13 @@
 # INFO audit), the tenancy-checked status read, and the lifecycle transitions
 # (`mark_running` / `mark_done` / `mark_failed`) the worker drives. `mark_failed`
 # emits a WARNING `WorkspaceJobUpdated` + audit; success emits INFO.
+#
+# Updated: 2026-06-20 (fix/jobs-arq-enqueue-contract) — fixed the showstopper
+# enqueue: dropped the bogus ``queue=JOBS_QUEUE`` kwarg (arq's selector is
+# ``_queue_name``; the stray ``queue=`` was forwarded to the job function and
+# raised ``TypeError`` on every dispatch). Jobs now ride arq's default queue on
+# the shared worker, matching ``chat/runs/arq_executor.py``. Removed the now-
+# unused ``JOBS_QUEUE`` import.
 
 """Workspace-jobs service — Beanie writes + dispatch + lifecycle."""
 
@@ -26,7 +33,7 @@ from pocketpaw_ee.cloud._core.realtime.events import (
     WorkspaceJobQueued,
     WorkspaceJobUpdated,
 )
-from pocketpaw_ee.cloud.jobs.domain import JOBS_QUEUE, WORKSPACE_JOB_IDENTITY
+from pocketpaw_ee.cloud.jobs.domain import WORKSPACE_JOB_IDENTITY
 from pocketpaw_ee.cloud.jobs.registry import resolve_job, validate_job_params
 from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
 
@@ -79,7 +86,7 @@ async def dispatch_job(
       2. param validation — a credential-shaped key raises ``JobParamsError``
          (400), again before any persistence.
       3. create the ``queued`` status doc.
-      4. enqueue ``execute_workspace_job(job_id)`` on the jobs queue.
+      4. enqueue ``execute_workspace_job(job_id)`` on the shared default queue.
       5. emit ``WorkspaceJobQueued`` + an INFO audit event.
 
     Returns ``{ok: True, code: "job_enqueued", job_id}`` for the action route.
@@ -105,7 +112,16 @@ async def dispatch_job(
     # into a 5xx); the queued doc stays so an operator can see the orphan.
     try:
         pool = await _get_pool()
-        arq_job = await pool.enqueue_job("execute_workspace_job", job_id, queue=JOBS_QUEUE)
+        # arq 0.28's queue selector is ``_queue_name`` (underscore-prefixed),
+        # NOT ``queue``. Any non-control kwarg is forwarded to the job FUNCTION
+        # as a call arg, so ``queue=`` would land on
+        # ``execute_workspace_job(ctx, job_id)`` and crash every job with a
+        # ``TypeError``. Jobs ride the same default queue as chat runs on the
+        # one shared worker process (single-process design — see
+        # ``chat/runs/worker.py`` ``WorkerSettings``), so we enqueue with the
+        # job id positional and no queue kwarg, exactly like
+        # ``chat/runs/arq_executor.py``.
+        arq_job = await pool.enqueue_job("execute_workspace_job", job_id)
         if arq_job is not None:
             doc.arq_job_id = getattr(arq_job, "job_id", None)
             await doc.save()

--- a/ee/pocketpaw_ee/cloud/jobs/worker.py
+++ b/ee/pocketpaw_ee/cloud/jobs/worker.py
@@ -21,6 +21,17 @@
 # marked failed with NO writeback (we cannot safely write to a pocket outside
 # the doc's workspace). The check sits ONCE near the top so it can't perturb
 # the failure path's "un-hang the button" guarantee.
+#
+# Updated: 2026-06-20 (fix/jobs-arq-enqueue-contract, BUG 2) — the SUCCESS-path
+# writeback now HONORS ``merge_spec``'s rejection. ``merge_spec`` returns
+# ``{ok: False, warnings: [...]}`` when the catalog / action-wiring gate blocks
+# the merge — it persists NOTHING in that case. The worker previously discarded
+# that return and marked the job ``done`` regardless, so a rejected writeback
+# looked successful (button done, canvas unchanged). Now ``_writeback`` returns
+# the result dict and the success path escalates ``ok: False`` into the shared
+# failure handling (mark ``failed`` + failed-state writeback). The escalation is
+# success-path-only; the failure path's writeback stays best-effort and is never
+# re-escalated, so it can't loop.
 
 """ARQ entrypoint: execute one workspace job + write the result back."""
 
@@ -122,19 +133,56 @@ async def execute_workspace_job(ctx: dict[str, Any], job_id: str) -> None:
         await jobs_service.mark_failed(doc, error=message)
         return
 
-    # Success — write the validated state-only partial back.
-    await _writeback(workspace_id=workspace_id, pocket_id=pocket_id, partial=result)
+    # Success — write the validated state-only partial back. ``merge_spec``
+    # can still REJECT the merge (``ok: False``) when the catalog / action-
+    # wiring gate blocks it: in that case it persists NOTHING. Marking the job
+    # ``done`` on a write that never landed is a silent partial (the button
+    # shows done, the canvas never changed), so escalate a rejected writeback
+    # into the SAME failure handling — mark the job failed + write the failed-
+    # state marker so the button un-hangs. (The ok-check is success-path-only;
+    # the failure path's ``_writeback`` below stays best-effort and is NOT
+    # escalated, so it can't loop.)
+    try:
+        wb = await _writeback(workspace_id=workspace_id, pocket_id=pocket_id, partial=result)
+        if wb is not None and wb.get("ok") is False:
+            warnings = wb.get("warnings") or []
+            raise _WritebackRejectedError(
+                "writeback rejected by merge_spec: " + "; ".join(str(w) for w in warnings)
+            )
+    except Exception as exc:  # noqa: BLE001 — converge on the same failure path
+        logger.exception("jobs: job %s (%s) writeback failed/rejected", job_id, doc.job_name)
+        message = str(exc) or exc.__class__.__name__
+        # Best-effort failed-state writeback so the button stops spinning. This
+        # call is NOT ok-checked — a doubly-rejected merge must not loop.
+        await _writeback(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            partial=failed_state_writeback(action, message),
+        )
+        await jobs_service.mark_failed(doc, error=message)
+        return
+
     await jobs_service.mark_done(doc, result=result)
 
 
-async def _writeback(*, workspace_id: str, pocket_id: str, partial: dict) -> None:
+class _WritebackRejectedError(RuntimeError):
+    """Raised when ``merge_spec`` returns ``ok: False`` on the success-path
+    writeback (catalog / action-wiring gate blocked the merge), so the success
+    path converges on the shared failure handling."""
+
+
+async def _writeback(*, workspace_id: str, pocket_id: str, partial: dict) -> dict | None:
     """Merge a partial spec into the pocket under the synthetic job identity.
 
     Always ``user_id=system:workspace_job`` — never the triggering user. The
     merge fires ``PocketUpdated``; from the worker that routes over xproc to
     the web bus, so open canvases update live.
+
+    Returns ``merge_spec``'s result dict (carrying ``ok`` + ``warnings``) so the
+    SUCCESS path can detect a gate rejection (``ok: False``) and escalate to the
+    failure handling. The failure path ignores the return (best-effort).
     """
-    await merge_spec(
+    return await merge_spec(
         workspace_id,
         WORKSPACE_JOB_IDENTITY,
         pocket_id,

--- a/tests/cloud/jobs/test_jobs.py
+++ b/tests/cloud/jobs/test_jobs.py
@@ -37,6 +37,22 @@
 # actually reaches the logger. The earlier tests passed while the audit was
 # silently broken (the `action` kwarg collided in AuditEvent.create and the
 # best-effort except swallowed it); this test fails if that collision returns.
+#
+# Updated: 2026-06-20 (fix/jobs-arq-enqueue-contract — live-smoke showstopper):
+#   - BUG 1 (arq enqueue contract): rewrote the enqueue assertion in
+#     ``test_dispatch_creates_doc_and_returns_job_id`` to pin the CORRECT
+#     contract (job id positional, NO ``queue``/``_queue_name`` kwarg — jobs
+#     ride the shared chat-runs default queue) instead of codifying the
+#     ``queue="paw:jobs"`` bug. Added
+#     ``test_dispatch_enqueue_does_not_forward_stray_kwarg_to_job_fn`` — a pool
+#     that mimics arq's real ``*args/**kwargs`` forwarding to the job function,
+#     so a stray kwarg raises TypeError (the regression guard the mocked-pool
+#     tests were missing).
+#   - BUG 2 (writeback honors rejection): added
+#     ``test_worker_success_writeback_rejection_marks_failed`` (merge_spec
+#     ok:False on the success path → job ``failed`` + failed-state writeback)
+#     and ``test_worker_success_writeback_ok_still_done`` (ok:True → still
+#     ``done``, no regression).
 
 from __future__ import annotations
 
@@ -255,12 +271,19 @@ async def test_dispatch_creates_doc_and_returns_job_id(mongo_db: Any, fake_pool:
     assert doc.job_name == "echo_job"
     assert doc.triggered_by == VIEWER
 
-    # The ARQ pool was asked to enqueue exactly one job, on the jobs queue.
+    # The ARQ pool was asked to enqueue exactly one job. arq 0.28's
+    # ``enqueue_job(function, *args, _job_id=None, _queue_name=None, **kwargs)``
+    # forwards ``**kwargs`` to the job FUNCTION as call args, so the enqueue
+    # must pass the job id positionally and carry NO stray kwarg. Jobs ride the
+    # shared chat-runs default queue on the one worker (single-process design),
+    # so there is no queue selector here (``_queue_name`` would be the real one,
+    # never ``queue``).
     assert len(fake_pool.calls) == 1
     (args, kwargs) = fake_pool.calls[0]
     assert args[0] == "execute_workspace_job"
     assert job_id in args
-    assert kwargs.get("queue") == "paw:jobs"
+    assert "queue" not in kwargs
+    assert "_queue_name" not in kwargs
 
 
 @pytest.mark.asyncio
@@ -278,6 +301,74 @@ async def test_dispatch_unknown_job_raises_before_enqueue(
         )
     # Nothing enqueued — the lookup gates before the pool is touched.
     assert fake_pool.calls == []
+
+
+# ---------------------------------------------------------------------------
+# BUG 1 regression guard — the arq enqueue contract. ``_FakePool`` records
+# kwargs but never FORWARDS them, so it can't catch the real failure: arq's
+# ``enqueue_job(function, *args, **kwargs)`` passes ``**kwargs`` straight to the
+# job FUNCTION. A stray ``queue=`` kwarg therefore reaches
+# ``execute_workspace_job(ctx, job_id, queue=...)`` → TypeError, crashing the
+# worker on EVERY job. This pool mimics that forwarding so the dispatch can be
+# proven against the real arq call shape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_enqueue_does_not_forward_stray_kwarg_to_job_fn(
+    mongo_db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001 — mongo_db forces Beanie init
+    """Reproduce the showstopper: any kwarg the dispatch passes to
+    ``enqueue_job`` (other than arq's underscore-prefixed control kwargs) is
+    forwarded to the job function and explodes it with a TypeError.
+
+    FAILS on the unfixed code (``queue=JOBS_QUEUE`` is forwarded →
+    ``TypeError: got an unexpected keyword argument 'queue'``); PASSES once the
+    dispatch drops the ``queue=`` kwarg and matches the chat-runs contract.
+    """
+    forwarded: dict[str, Any] = {}
+
+    # A stub job function with the SAME signature the real worker registers:
+    # ``execute_workspace_job(ctx, job_id)`` — no ``queue`` parameter.
+    async def _stub_execute_workspace_job(ctx: dict, job_id: str) -> None:
+        forwarded["job_id"] = job_id
+
+    class _ForwardingPool:
+        """Mimics arq.ArqRedis.enqueue_job: strips the underscore control
+        kwargs and forwards everything else to the registered job function."""
+
+        async def enqueue_job(
+            self,
+            function: str,
+            *args: Any,
+            _job_id: Any = None,
+            _queue_name: Any = None,
+            _defer_until: Any = None,
+            _defer_by: Any = None,
+            _expires: Any = None,
+            **kwargs: Any,
+        ) -> None:
+            # arq forwards (*args, **kwargs) to the job coroutine, prepending
+            # the worker ctx. A stray ``queue=`` lands in **kwargs and detonates.
+            await _stub_execute_workspace_job({}, *args, **kwargs)
+
+    async def _get_pool() -> _ForwardingPool:
+        return _ForwardingPool()
+
+    monkeypatch.setattr(jobs_service, "_get_pool", _get_pool)
+
+    # No TypeError → the dispatch passes only what the job function accepts.
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=POCKET,
+        action="run_echo",
+        job_name="echo_job",
+        params={"value": "hi"},
+        triggered_by=VIEWER,
+    )
+    assert result["ok"] is True
+    # The forwarding pool actually reached the stub job with the job id.
+    assert forwarded["job_id"] == result["job_id"]
 
 
 # ---------------------------------------------------------------------------
@@ -408,6 +499,97 @@ async def test_worker_writeback_uses_system_identity(
     # Writeback is a partial-spec merge carrying only state.
     assert captured["body"]["merge"]["state"]["echo_value"] == "hello"
 
+    doc = await jobs_service.get_job(WS, job_id)
+    assert doc is not None
+    assert doc.status == "done"
+
+
+# ---------------------------------------------------------------------------
+# BUG 2 — the success-path writeback must HONOR merge_spec's rejection. When
+# the catalog / action-wiring gate rejects the merge, merge_spec persists
+# NOTHING and returns {ok: False, warnings: [...]}. The worker must NOT then
+# mark the job ``done`` (the button would show done while the canvas never
+# changed) — it must treat the rejected writeback as a failure: mark the job
+# ``failed`` AND write the failed-state marker so the button stops spinning.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_success_writeback_rejection_marks_failed(
+    mongo_db: Any, fake_pool: _FakePool, seed_pocket, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    """A job whose success writeback is REJECTED by merge_spec (ok:False) ends
+    ``failed`` (not ``done``), and a failed-state writeback is attempted so the
+    button un-hangs. FAILS on the unfixed worker, which discards merge_spec's
+    return and marks the job ``done`` on a write that never persisted."""
+    calls: list[dict] = []
+
+    async def _rejecting_merge_spec(workspace_id, user_id, pocket_id, body):  # type: ignore[no-untyped-def]
+        calls.append(dict(body))
+        # First call is the success-path writeback — gate REJECTS it.
+        # The failure-path writeback (the second call) must still succeed so
+        # the button un-hangs; mimic merge_spec persisting the failed marker.
+        if len(calls) == 1:
+            return {"ok": False, "warnings": ["catalog: widget not allowed"]}
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _rejecting_merge_spec)
+
+    pocket_id = await seed_pocket(workspace=WS)
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        action="run_echo",
+        job_name="echo_job",
+        params={"value": "hi"},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    await jobs_worker.execute_workspace_job({}, job_id)
+
+    # Two merge_spec calls: the rejected success writeback, then the
+    # best-effort failed-state writeback.
+    assert len(calls) == 2
+    failed_state = calls[1]["merge"]["state"]
+    assert failed_state["run_echo_status"] == "failed"
+    assert "run_echo_error" in failed_state
+
+    doc = await jobs_service.get_job(WS, job_id)
+    assert doc is not None
+    assert doc.status == "failed"
+    assert doc.error
+
+
+@pytest.mark.asyncio
+async def test_worker_success_writeback_ok_still_done(
+    mongo_db: Any, fake_pool: _FakePool, seed_pocket, monkeypatch: pytest.MonkeyPatch
+) -> None:  # noqa: ARG001
+    """Regression guard for BUG 2's fix: a writeback that merge_spec ACCEPTS
+    (ok:True) still ends the job ``done`` — the ok-check escalation fires only
+    on rejection, so the happy path is unchanged."""
+    captured: dict[str, Any] = {}
+
+    async def _accepting_merge_spec(workspace_id, user_id, pocket_id, body):  # type: ignore[no-untyped-def]
+        captured["body"] = body
+        return {"ok": True}
+
+    monkeypatch.setattr(jobs_worker, "merge_spec", _accepting_merge_spec)
+
+    pocket_id = await seed_pocket(workspace=WS)
+    result = await jobs_service.dispatch_job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        action="run_echo",
+        job_name="echo_job",
+        params={"value": "hi"},
+        triggered_by=VIEWER,
+    )
+    job_id = result["job_id"]
+
+    await jobs_worker.execute_workspace_job({}, job_id)
+
+    assert captured["body"]["merge"]["state"]["echo_value"] == "hi"
     doc = await jobs_service.get_job(WS, job_id)
     assert doc is not None
     assert doc.status == "done"


### PR DESCRIPTION
A live smoke of the workspace jobs primitive (merged in #1516) found that every job crashes the moment it is dispatched. The unit tests passed because they mock the arq pool, so the bug only shows against real arq. This fixes that, plus a silent-partial the smoke surfaced alongside it.

## Bug 1 (showstopper): wrong enqueue kwarg

`dispatch_job` called `pool.enqueue_job("execute_workspace_job", job_id, queue=JOBS_QUEUE)`. In arq 0.28 the queue selector is `_queue_name`, not `queue`. Any other keyword is forwarded to the job function, so `queue=` reached `execute_workspace_job(ctx, job_id)` and raised `TypeError: got an unexpected keyword argument 'queue'`. The worker crashed on every job and the writeback never happened.

Fix: drop the kwarg. Jobs ride arq's default queue on the shared worker, the same way the sibling chat-run executor (`arq_executor.py`) does, which matches the single-worker design. The `JOBS_QUEUE` constant was aspirational and wired wrong; real queue isolation needs a second worker process and is deferred.

## Bug 2: writeback ignored merge_spec's rejection

The worker's success-path writeback discarded `merge_spec`'s return. When the catalog / action-wiring gate rejects a merge (`ok: false`), nothing persists, yet the job was still marked `done`. The result was a silent partial: the button reads done while the canvas never changed. The success path now escalates `ok: false` into the existing failure handling (mark `failed` plus the failed-state marker so the button un-hangs). The failure-path writeback stays best-effort and never re-escalates.

## Tests

Both fixes are test-first. The new tests fail on the unfixed code (the forwarding-pool repro raises the real `TypeError`; the rejection test marks `done` instead of `failed`) and pass after.

- `tests/cloud/jobs/`: 37 passing (was 34)
- `tests/cloud/pockets/`: 124 passing. The 4 failures in `test_gallery_site_exclusion.py` are pre-existing on dev (a missing `ws_gallery` seed from #1507), unrelated to this change and tracked separately.
- ruff and import-linter clean

The mocked-pool tests asserted `queue == "paw:jobs"`, which codified the wrong contract. The new tests pin the real arq contract so this cannot regress.