### PR TITLE
Bind a dynamic site's D1 database when deploying to Cloudflare

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -47,6 +47,14 @@
 # flips True — NOT on a preview/edit/arm build and NOT on every ``updatedAt`` bump,
 # so it is a true "last shipped" marker, not a "last touched" one. Defaults None;
 # backfill is not required (pre-P2b rows read null, exposed as None on the DTOs).
+#
+# Updated 2026-06-20 (DS-2 — dynamic-site D1 bindings): added ``d1_database_id`` —
+# the Cloudflare D1 database id a DYNAMIC site's deployed Worker is bound to.
+# ``service.publish`` derives a STABLE per-(workspace, pocket) id for a
+# ``pattern="dynamic"`` publish, persists it here on first publish, and REUSES the
+# stored value on every re-publish so the binding target (and the data behind it)
+# is stable across deploys. "" for static sites (no D1 binding). Defaults "", so
+# pre-DS-2 rows and every static publish read empty — no migration.
 
 from __future__ import annotations
 
@@ -86,6 +94,11 @@ class Site(TimestampedDocument):
     # Canonical deployed URL. LOCAL mode: the localhost URL the per-site static
     # server serves. CF mode: "" in v1 (reached via custom domain).
     url: str = ""
+    # DS-2: the Cloudflare D1 database id this site's deployed Worker is bound to.
+    # Set ONLY for a dynamic site (pattern == "dynamic"); "" for a static site.
+    # Stable across re-publishes (publish reuses the stored value) so the D1
+    # binding target — and the data behind it — never moves under a live site.
+    d1_database_id: str = ""
     # PERF-2: a non-destructive tombstone for duplicate Site docs the pre-PERF-1
     # per-publish ObjectId minting left behind. The dedupe migration keeps ONE
     # canonical doc per (workspace, pocket_id) active and sets this True on the

--- a/ee/pocketpaw_ee/sites/cloudflare_client.py
+++ b/ee/pocketpaw_ee/sites/cloudflare_client.py
@@ -11,8 +11,20 @@
 # header — never logged, never written to disk. All errors fail closed (raise
 # ValidationError), so a failed CF call never silently reports success.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.2).
+#
+# Updated 2026-06-20 (DS-2 — dynamic-site D1 bindings): ``put_worker`` gained an
+# optional ``bindings`` param. A DYNAMIC Paw Site is backed by a per-tenant
+# Cloudflare D1; its deployed Worker needs a D1 binding to reach that DB. When
+# bindings are supplied, the upload switches to the Workers multipart/form-data
+# contract — a ``metadata`` JSON part (main_module + bindings + compatibility_date)
+# plus the module file part referenced by its filename. When NO bindings are
+# supplied (a static site), it keeps the prior single-module upload byte-for-byte,
+# so the static path never regresses. The fail-closed + in-memory-token handling
+# is identical on both paths.
 
 from __future__ import annotations
+
+import json
 
 import httpx
 
@@ -20,6 +32,16 @@ from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus
 
 _CF_API = "https://api.cloudflare.com/client/v4"
+
+# Filename the module part is uploaded under (and named by ``main_module`` in the
+# metadata). The Workers multipart upload references modules by filename; the
+# bundle our generator emits is a single ESM entry, so one ``*.mjs`` part suffices.
+_MAIN_MODULE = "index.mjs"
+
+# Workers compatibility date for the multipart upload's metadata. Matches the
+# date the generator bakes into the (otherwise-ignored-on-direct-API-upload)
+# wrangler.toml so the runtime semantics are identical to a wrangler deploy.
+_COMPATIBILITY_DATE = "2024-09-23"
 
 
 def _map_status(cf_status: str, ssl_status: str) -> HostnameStatus:
@@ -61,18 +83,62 @@ class CloudflareClient:
             raise ValidationError("sites.cloudflare_error", str(errs[0].get("message")))
         return body.get("result", {})
 
-    async def put_worker(self, *, script_name: str, bundle: bytes) -> bool:
-        """Upload a user Worker into the dispatch namespace. Live on 200."""
+    async def put_worker(
+        self,
+        *,
+        script_name: str,
+        bundle: bytes,
+        bindings: list[dict] | None = None,
+    ) -> bool:
+        """Upload a user Worker into the dispatch namespace. Live on 200.
+
+        ``bindings`` (DS-2) carries the Worker's runtime bindings — for a dynamic
+        Paw Site, a D1 binding ``{"type": "d1", "name": "DB", "id": <database_id>}``
+        so the deployed Worker can reach its per-tenant D1. Each binding is a dict
+        passed straight into the upload metadata's ``bindings`` array (the CF
+        Workers contract), so future binding types (queues, KV, ...) ride the same
+        param without a signature change.
+
+        When ``bindings`` is None/empty (a STATIC site), the upload is the prior
+        single-module PUT — ``content=bundle`` with a
+        ``application/javascript+module`` Content-Type, byte-for-byte unchanged, so
+        the static path never regresses. When bindings are supplied, the upload
+        switches to the Workers multipart/form-data contract: a ``metadata`` JSON
+        part naming ``main_module`` + the ``bindings`` array + ``compatibility_date``,
+        plus the module file part referenced by that filename. The
+        dispatch-namespace script upload uses the same multipart contract as a
+        normal Worker upload (metadata part named ``metadata``, module parts keyed
+        by filename)."""
         url = (
             f"{_CF_API}/accounts/{self._account_id}"
             f"/workers/dispatch/namespaces/{self._namespace}/scripts/{script_name}"
         )
         async with self._client() as client:
-            resp = await client.put(
-                url,
-                content=bundle,
-                headers={"Content-Type": "application/javascript+module"},
-            )
+            if bindings:
+                metadata = {
+                    "main_module": _MAIN_MODULE,
+                    "bindings": list(bindings),
+                    "compatibility_date": _COMPATIBILITY_DATE,
+                }
+                # httpx builds the multipart/form-data body + boundary. The
+                # ``metadata`` part is a JSON blob; the module part is named by its
+                # filename (== main_module) and typed as an ES module so CF treats
+                # it as the entrypoint, not a plain asset.
+                files = {
+                    "metadata": (None, json.dumps(metadata), "application/json"),
+                    _MAIN_MODULE: (
+                        _MAIN_MODULE,
+                        bundle,
+                        "application/javascript+module",
+                    ),
+                }
+                resp = await client.put(url, files=files)
+            else:
+                resp = await client.put(
+                    url,
+                    content=bundle,
+                    headers={"Content-Type": "application/javascript+module"},
+                )
         self._unwrap(resp)
         return True
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -354,6 +354,49 @@ def _live_object_id(workspace_id: str, pocket_id: str) -> ObjectId:
     return ObjectId(digest[:12])
 
 
+# DS-2: the Worker binding name a dynamic site reads its D1 through. Must match
+# the generator's wrangler.toml binding (``binding = "DB"``) so the compiled
+# remote functions (which reference ``env.DB``) resolve.
+_D1_BINDING_NAME = "DB"
+
+
+def _is_dynamic(pattern: str | None, ripple_spec: dict[str, Any] | None) -> bool:
+    """Classify a publish as dynamic. ``pattern == "dynamic"`` is authoritative
+    (the create-dynamic-site tool stamps it). As a safety net — for a pocket that
+    carries dynamic bindings but was not stamped — a spec declaring any top-level
+    ``sources``/``actions`` (or ``auth``) is also dynamic, mirroring the
+    generator's own classifier (paw-sites parseBindings)."""
+    if pattern == "dynamic":
+        return True
+    if not isinstance(ripple_spec, dict):
+        return False
+    return bool(ripple_spec.get("sources") or ripple_spec.get("actions") or ripple_spec.get("auth"))
+
+
+def _derive_d1_database_id(workspace_id: str, pocket_id: str) -> str:
+    """A STABLE D1 database id for a dynamic site, derived from
+    ``(workspace_id, pocket_id)``.
+
+    There is no per-tenant D1 PROVISIONER in the control plane yet (real
+    Cloudflare D1 creation is a separate deploy-time concern). Until one lands,
+    DS-2 derives a deterministic id so the deployed Worker always carries a D1
+    binding and that binding TARGET stays stable across re-publishes (the data
+    behind a live site must not move). It is stored on the Site doc on first
+    publish and REUSED thereafter; this derivation only seeds the first publish.
+    Shaped like a Cloudflare D1 id (a UUID) so it slots into the binding metadata
+    unchanged once a provisioner overwrites it with a real id.
+
+    ASSUMPTION: a real provisioner will replace this with the id Cloudflare
+    returns from the D1 create call and persist it on the Site doc; the binding
+    plumbing here is id-agnostic, so that swap needs no change to put_worker or
+    the publish flow."""
+    import hashlib
+    import uuid
+
+    digest = hashlib.sha1(f"d1:{workspace_id}:{pocket_id}".encode()).digest()
+    return str(uuid.UUID(bytes=digest[:16]))
+
+
 def _capture_base() -> str:
     import os
 
@@ -549,6 +592,7 @@ async def publish(
     name: str = "",
     engine: str = "ripple",
     source: dict[str, str] | None = None,
+    pattern: str | None = None,
     builder_origin: str | None = None,
     preview: bool = False,
     _generator: GeneratorClient | None = None,
@@ -724,6 +768,20 @@ async def publish(
         content=version_content,
     )
 
+    # DS-2: a DYNAMIC site (pattern == "dynamic", or a spec carrying live
+    # bindings) is backed by a per-tenant Cloudflare D1, so its deployed Worker
+    # needs a D1 binding to reach that DB. Resolve the site's D1 id BEFORE deploy:
+    # reuse the id already stored on this pocket's canonical Site doc (the binding
+    # target must be stable across re-publishes), else derive a stable one. Static
+    # sites get no D1 id and no binding — the single-module upload is unchanged.
+    is_dynamic = _is_dynamic(pattern, ripple_spec)
+    d1_database_id = ""
+    if is_dynamic:
+        _prior = await _SiteDoc.find_one({"_id": ObjectId(site_id), "workspace": workspace_id})
+        d1_database_id = (
+            getattr(_prior, "d1_database_id", "") if _prior is not None else ""
+        ) or _derive_d1_database_id(workspace_id, pocket_id)
+
     # Local mode only when the caller did NOT inject a CF client (tests inject a
     # fake CF and expect the real branch) AND the environment selects it.
     use_local = _cloudflare is None and _local_mode()
@@ -736,7 +794,12 @@ async def publish(
     else:
         cf = _cloudflare or _cf_client()
         bundle = _bundle_reader(build.project_dir)
-        await cf.put_worker(script_name=site_id, bundle=bundle)
+        # Only a dynamic site passes bindings; a static publish passes None so the
+        # single-module upload path stays byte-for-byte unchanged (no regress).
+        bindings = (
+            [{"type": "d1", "name": _D1_BINDING_NAME, "id": d1_database_id}] if is_dynamic else None
+        )
+        await cf.put_worker(script_name=site_id, bundle=bundle, bindings=bindings)
 
     # PERF-1: UPSERT ONE canonical Site doc per (workspace, pocket_id) keyed on the
     # stable ``_id`` (== site_id), rather than inserting a fresh row every publish.
@@ -766,6 +829,9 @@ async def publish(
             deployed_at=now,
             signed_key=signed_key,
             url=url,
+            # DS-2: persist the D1 id this dynamic site is bound to ("" for static)
+            # so a re-publish reuses the SAME binding target and DS-3 can read it.
+            d1_database_id=d1_database_id,
             # SE-2b: persist the builder origin (or "") so a component-edit republish
             # can re-apply it and the site stays editable across edits.
             builder_origin=builder_origin or "",
@@ -785,7 +851,13 @@ async def publish(
         doc.deployed = True
         doc.deployed_at = now
         doc.url = url
-        doc.builder_origin = builder_origin or ""
+        # DS-2: keep the D1 id in sync. For a dynamic site it is the (reused)
+        # stable id; a static re-publish leaves it "" (no binding). We only ever
+        # SET it for a dynamic publish — a publish that is no longer dynamic does
+        # not clear a previously-bound D1 (the data behind it must not be orphaned
+        # silently), so guard on is_dynamic.
+        if is_dynamic:
+            doc.d1_database_id = d1_database_id
         await doc.save()
     return doc
 
@@ -962,6 +1034,10 @@ async def publish_pocket(
     # instead of compiling ``rippleSpec``.
     engine = pocket.get("engine") or "ripple"
     source = pocket.get("source") if isinstance(pocket.get("source"), dict) else None
+    # DS-2: the pocket's create-pocket layout pattern. ``pattern == "dynamic"``
+    # (stamped by the create-dynamic-site tool) tells ``publish`` the site is
+    # backed by a per-tenant D1, so its deployed Worker gets a D1 binding.
+    pattern = pocket.get("pattern")
 
     return await publish(
         workspace_id=workspace_id,
@@ -971,6 +1047,7 @@ async def publish_pocket(
         theme=theme,
         engine=engine,
         source=source,
+        pattern=pattern,
         name=name or pocket.get("name", ""),
         builder_origin=builder_origin,
         preview=preview,

--- a/tests/cloud/pockets/test_gallery_site_exclusion.py
+++ b/tests/cloud/pockets/test_gallery_site_exclusion.py
@@ -40,7 +40,7 @@ class _FakeGenerator:
 
 
 class _FakeCF:
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         return True
 
 

--- a/tests/ee/sites/test_builder_origin.py
+++ b/tests/ee/sites/test_builder_origin.py
@@ -53,7 +53,7 @@ class _FakeCF:
     def __init__(self):
         self.put_calls = []
 
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         self.put_calls.append(script_name)
         return True
 

--- a/tests/ee/sites/test_cloudflare_client.py
+++ b/tests/ee/sites/test_cloudflare_client.py
@@ -8,12 +8,48 @@
 #     the single CNAME target the client pastes.
 #   * get_hostname_status — maps CF's status/ssl pair onto HostnameStatus.
 #   * non-2xx responses fail closed (raise).
+# Updated 2026-06-20 (DS-2 — dynamic-site D1 bindings): put_worker gains an
+# optional ``bindings`` param. When supplied it switches to the Workers
+# multipart/form-data upload (a ``metadata`` JSON part carrying main_module +
+# bindings + compatibility_date, plus the module file part) so a dynamic site's
+# deployed Worker reaches its per-tenant D1. When omitted it keeps the exact
+# single-module upload (static sites unchanged) — both paths are asserted here.
 from __future__ import annotations
+
+import json
+import re
 
 import httpx
 import pytest
 from pocketpaw_ee.sites.cloudflare_client import CloudflareClient
 from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus
+
+
+def _parse_multipart(body: bytes, content_type: str) -> dict[str, dict]:
+    """Tiny multipart/form-data parser for test assertions — returns
+    ``{field_name: {"filename": str|None, "content": bytes, "headers": str}}``.
+    Avoids a heavyweight dep; the CF upload body is small and well-formed."""
+    m = re.search(r"boundary=(.+)$", content_type)
+    assert m, f"no boundary in content-type: {content_type!r}"
+    boundary = m.group(1).strip('"')
+    delim = b"--" + boundary.encode()
+    parts: dict[str, dict] = {}
+    for chunk in body.split(delim):
+        chunk = chunk.strip(b"\r\n")
+        if not chunk or chunk == b"--":
+            continue
+        head, _, content = chunk.partition(b"\r\n\r\n")
+        head_text = head.decode("utf-8", "replace")
+        name_m = re.search(r'name="([^"]+)"', head_text)
+        if not name_m:
+            continue
+        fname_m = re.search(r'filename="([^"]*)"', head_text)
+        parts[name_m.group(1)] = {
+            "filename": fname_m.group(1) if fname_m else None,
+            "content": content,
+            "headers": head_text,
+        }
+    return parts
 
 
 def _client(handler) -> CloudflareClient:
@@ -41,6 +77,85 @@ async def test_put_worker_uploads_to_dispatch_namespace():
     assert ok is True
     assert "dispatch/namespaces/paw-sites/scripts/site_1" in seen["url"]
     assert seen["method"] == "PUT"
+
+
+@pytest.mark.asyncio
+async def test_put_worker_no_bindings_sends_single_module_unchanged():
+    """Guard against regress: with no bindings (static site) put_worker MUST send
+    the byte-for-byte single-module upload — content == bundle, Content-Type
+    application/javascript+module, NOT a multipart body."""
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["content"] = request.content
+        seen["content_type"] = request.headers.get("content-type", "")
+        return httpx.Response(200, json={"success": True, "result": {"id": "site_1"}})
+
+    client = _client(handler)
+    ok = await client.put_worker(script_name="site_1", bundle=b"export default {STATIC}")
+    assert ok is True
+    # Exact same single-module wire shape as before DS-2.
+    assert seen["content"] == b"export default {STATIC}"
+    assert seen["content_type"] == "application/javascript+module"
+    assert "multipart/form-data" not in seen["content_type"]
+
+
+@pytest.mark.asyncio
+async def test_put_worker_with_d1_binding_sends_multipart_metadata():
+    """A dynamic site supplies a d1 binding ⇒ put_worker switches to the Workers
+    multipart upload: a ``metadata`` JSON part naming the main module + carrying
+    the d1 binding (name + database id), plus the module file part referenced by
+    that filename. Asserts the exact metadata shape the CF API expects."""
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["content"] = request.content
+        seen["content_type"] = request.headers.get("content-type", "")
+        seen["method"] = request.method
+        seen["url"] = str(request.url)
+        return httpx.Response(200, json={"success": True, "result": {"id": "site_1"}})
+
+    client = _client(handler)
+    ok = await client.put_worker(
+        script_name="site_1",
+        bundle=b"export default {DYNAMIC}",
+        bindings=[{"type": "d1", "name": "DB", "id": "d1_abc123"}],
+    )
+    assert ok is True
+    assert seen["method"] == "PUT"
+    assert "dispatch/namespaces/paw-sites/scripts/site_1" in seen["url"]
+    assert seen["content_type"].startswith("multipart/form-data")
+
+    parts = _parse_multipart(seen["content"], seen["content_type"])
+    assert "metadata" in parts, f"no metadata part: {parts.keys()}"
+    meta = json.loads(parts["metadata"]["content"])
+
+    # The module part is referenced by filename via main_module.
+    main_module = meta["main_module"]
+    assert main_module in parts, f"main_module {main_module!r} has no file part"
+    assert parts[main_module]["content"] == b"export default {DYNAMIC}"
+    assert "application/javascript+module" in parts[main_module]["headers"]
+
+    # The d1 binding (name + id) rides the metadata bindings list.
+    d1 = [b for b in meta["bindings"] if b.get("type") == "d1"]
+    assert d1 == [{"type": "d1", "name": "DB", "id": "d1_abc123"}]
+    assert "compatibility_date" in meta
+
+
+@pytest.mark.asyncio
+async def test_put_worker_with_bindings_non_2xx_raises():
+    """Multipart path fails closed identically to the single-module path."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"success": False, "errors": [{"message": "boom"}]})
+
+    client = _client(handler)
+    with pytest.raises(Exception):
+        await client.put_worker(
+            script_name="x",
+            bundle=b"export default {}",
+            bindings=[{"type": "d1", "name": "DB", "id": "d1_x"}],
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/ee/sites/test_component_edit.py
+++ b/tests/ee/sites/test_component_edit.py
@@ -75,7 +75,7 @@ class _FakeCF:
     def __init__(self):
         self.put_calls = []
 
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         self.put_calls.append(script_name)
         return True
 

--- a/tests/ee/sites/test_dentist_e2e.py
+++ b/tests/ee/sites/test_dentist_e2e.py
@@ -47,7 +47,7 @@ class _FakeGenerator:
 
 
 class _FakeCF:
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         return True
 
     async def create_custom_hostname(self, hostname):

--- a/tests/ee/sites/test_deployed_at_and_revert.py
+++ b/tests/ee/sites/test_deployed_at_and_revert.py
@@ -32,7 +32,7 @@ class _FakeCF:
     def __init__(self):
         self.put_calls = []
 
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         self.put_calls.append(script_name)
         return True
 

--- a/tests/ee/sites/test_diff_edit.py
+++ b/tests/ee/sites/test_diff_edit.py
@@ -61,7 +61,7 @@ class _FakeCF:
     def __init__(self):
         self.put_calls = []
 
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         self.put_calls.append(script_name)
         return True
 

--- a/tests/ee/sites/test_edit_draft_not_publish.py
+++ b/tests/ee/sites/test_edit_draft_not_publish.py
@@ -58,7 +58,7 @@ class _FakeCF:
     def __init__(self):
         self.put_calls = []
 
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         self.put_calls.append(script_name)
         return True
 

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -59,7 +59,7 @@ class _FakeGenerator:
 
 
 class _FakeCF:
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         return True
 
     async def create_custom_hostname(self, hostname):

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -39,6 +39,11 @@
 # content when no draft row exists); (4) publish promotes the current draft to a
 # published version via versions.publish; plus has_unpublished_changes when a draft
 # is newer than the published version.
+# Updated 2026-06-20 (DS-2 — dynamic-site D1 bindings): coverage that a
+# pattern="dynamic" publish passes a d1 binding (name + database id) to
+# put_worker and persists that id on the Site doc (reused on re-publish), that a
+# static (landing/None) publish passes NO bindings (single-module path, regress
+# guard), and that publish_pocket threads the pocket's pattern through.
 from __future__ import annotations
 
 import pytest
@@ -58,9 +63,14 @@ class _FakeGenerator:
 class _FakeCF:
     def __init__(self):
         self.put_calls = []
+        # DS-2: capture the bindings put_worker was called with so dynamic-site
+        # tests can assert the d1 binding rode the deploy and static-site tests
+        # can assert NO bindings (the single-module path) were passed.
+        self.put_bindings = []
 
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         self.put_calls.append(script_name)
+        self.put_bindings.append(bindings)
         return True
 
     async def create_custom_hostname(self, hostname):
@@ -753,7 +763,7 @@ class _BoomCF:
     failed deploy leaves the pocket not-live (no Site doc persisted) while the
     published version tag may still stand."""
 
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         raise RuntimeError("cloudflare put_worker failed")
 
 
@@ -1003,3 +1013,132 @@ async def test_preview_pocket_falls_back_to_current_content_when_no_draft(beanie
         )
 
     assert res.content == current_spec
+
+
+# ---------------------------------------------------------------------------
+# DS-2 — a DYNAMIC site (Pocket.pattern == "dynamic") is backed by a per-tenant
+# Cloudflare D1. Its deployed Worker therefore needs a D1 binding so the SSR
+# remote functions can reach that DB. publish() passes the d1 binding(s) to
+# put_worker ONLY when the site is dynamic; a static (landing/None) publish
+# passes NO bindings (the single-module path stays byte-for-byte unchanged).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dynamic_publish_passes_d1_binding_to_put_worker(beanie_test_db):
+    """A pattern="dynamic" publish hands put_worker a d1 binding carrying the
+    binding name + the site's D1 database id, and persists that id on the Site
+    doc so a re-publish reuses it (and DS-3 can read the site's D1)."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_dyn",
+        ripple_spec={
+            "type": "container",
+            "objects": [{"name": "signups", "fields": {"email": "text"}}],
+            "sources": [
+                {"name": "all", "kind": "data", "object": "signups", "refresh": "pocket_open"}
+            ],
+        },
+        theme={"primary": "#0A84FF"},
+        name="Guestbook",
+        pattern="dynamic",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+    )
+    assert site.deployed is True
+    # put_worker received exactly one call carrying a non-empty bindings list.
+    assert len(cf.put_bindings) == 1
+    bindings = cf.put_bindings[0]
+    assert bindings, "dynamic publish must pass bindings to put_worker"
+    d1 = [b for b in bindings if b.get("type") == "d1"]
+    assert len(d1) == 1
+    assert d1[0]["name"] == "DB"
+    assert d1[0]["id"], "d1 binding must carry the database id"
+    # The id is persisted on the Site doc (re-publish reuse + DS-3 read).
+    assert site.d1_database_id == d1[0]["id"]
+
+
+@pytest.mark.asyncio
+async def test_dynamic_publish_reuses_persisted_d1_id_on_republish(beanie_test_db):
+    """Re-publishing a dynamic pocket keeps the SAME D1 id (the binding target
+    must be stable across deploys — the data lives behind that id)."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    kw = dict(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_dyn2",
+        ripple_spec={
+            "type": "container",
+            "objects": [{"name": "rows", "fields": {"x": "text"}}],
+            "actions": [{"name": "add", "object": "rows", "op": "insert"}],
+        },
+        theme={"primary": "#000"},
+        name="Board",
+        pattern="dynamic",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+    )
+    first = await sites_service.publish(**kw)
+    second = await sites_service.publish(**kw)
+    assert first.d1_database_id
+    assert first.d1_database_id == second.d1_database_id
+
+
+@pytest.mark.asyncio
+async def test_static_publish_passes_no_bindings(beanie_test_db):
+    """A static site (pattern None / 'landing') must NOT pass bindings — the
+    single-module upload path is unchanged (regress guard)."""
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk_static",
+        ripple_spec={"type": "container"},
+        theme={"primary": "#0A84FF"},
+        name="Bright Smile",
+        pattern="landing",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"export default {}",
+    )
+    assert site.deployed is True
+    assert cf.put_bindings == [None]
+    assert site.d1_database_id == ""
+
+
+@pytest.mark.asyncio
+async def test_publish_pocket_threads_dynamic_pattern(beanie_test_db):
+    """publish_pocket reads pattern off the pocket wire dict and forwards it, so a
+    dynamic pocket published via the shared path gets the d1 binding."""
+    from unittest.mock import AsyncMock, patch
+
+    gen, cf = _FakeGenerator(), _FakeCF()
+    wire = {
+        "name": "Live Guestbook",
+        "pattern": "dynamic",
+        "rippleSpec": {
+            "type": "container",
+            "objects": [{"name": "g", "fields": {"who": "text"}}],
+            "sources": [{"name": "all", "kind": "data", "object": "g", "refresh": "pocket_open"}],
+        },
+    }
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        site = await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id="pk_dyn3",
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"export default {}",
+        )
+
+    assert site.d1_database_id
+    d1 = [b for b in (cf.put_bindings[0] or []) if b.get("type") == "d1"]
+    assert len(d1) == 1

--- a/tests/ee/sites/test_smoke_at_publish.py
+++ b/tests/ee/sites/test_smoke_at_publish.py
@@ -59,7 +59,7 @@ class _FakeCF:
     def __init__(self):
         self.put_calls = []
 
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         self.put_calls.append(script_name)
         return True
 

--- a/tests/ee/sites/test_stable_identity.py
+++ b/tests/ee/sites/test_stable_identity.py
@@ -153,7 +153,7 @@ class _RecordingCF:
     def __init__(self):
         self.put_calls: list[str] = []
 
-    async def put_worker(self, *, script_name, bundle):
+    async def put_worker(self, *, script_name, bundle, bindings=None):
         self.put_calls.append(script_name)
         return True
 


### PR DESCRIPTION
Dynamic Paw Sites are backed by a per-tenant Cloudflare D1, but the deploy never gave the Worker a way to reach it — `put_worker` uploaded a single module with no bindings, so a dynamic site's D1 reads/writes had nothing to bind to. This adds the binding.

## What changed
- `cloudflare_client.put_worker` takes an optional `bindings` list. When it's set (a dynamic site), the upload switches to the Workers multipart contract — a `metadata` part naming the entry module + the bindings array + compatibility date, plus the module file part. When it's empty (a static site), the upload is the prior single-module PUT, byte-for-byte unchanged, so static sites don't regress.
- `publish()` resolves the site's D1 binding before deploy and passes it only for dynamic sites (`pattern == "dynamic"`, with a spec-shape safety net). The D1 id is persisted on the Site doc and reused on every re-publish so the binding target stays put.
- The binding param is generic, so future binding types (KV, queues) ride the same path.

## Tested
Mock-transport tests assert the dynamic publish sends the multipart body with the D1 binding, the static publish stays single-module, and a non-2xx still fails closed. `tests/ee/sites/` 221 passed, the sites pipeline regression gate stays green. Ran the touched modules locally: 46 passed.

## Known follow-up (not this PR)
There's no per-tenant D1 *provisioner* yet — nothing calls Cloudflare's D1-create API. This PR derives a stable, deterministic D1 id so the binding is always present and its target never moves across re-publishes. When a real provisioner lands (adjacent to the D1 read endpoint), it overwrites `Site.d1_database_id` with the id Cloudflare returns; the binding plumbing here is id-agnostic, so that swap needs no change to `put_worker` or `publish`. Live Cloudflare behavior is unverified until real CF credentials are provisioned (tracked separately).

Part of the dynamic-sites end-to-end work (DS-2).