### PR TITLE
Sovereign zero-setup discovery slice 2: unstructured exhaust + governed rules

### DIFF
--- a/docs/design/szd-slice2-build-plan.md
+++ b/docs/design/szd-slice2-build-plan.md
@@ -1,0 +1,64 @@
+<!-- Slice-2 build plan + S2-R0 design decision. Created 2026-06-20 by crew (captain-in-charge,
+     captain out). Source: understand-workflow wf_a3f8a304 (6 agents, 5 ground-truth maps of the
+     slice-1 code + gate discipline + kb-go integration + rules-design). This doc is the artifact
+     the captain reviews at the PR gate. Status: BUILD-IN-PROGRESS. -->
+
+# Sovereign Zero-Setup Discovery — Slice 2 Build Plan
+
+**Date:** 2026-06-20 · **Branch:** `feat/szd-slice2-discovery` (worktree `.claude/worktrees/szd2-int`, off `origin/dev`)
+**Scope:** slice 2 = **(K)** `KbCompileDigester` — unstructured exhaust → ontology, on-box; **(R)** rules-discovery — reverse-engineer draft governed Instinct rules from exhaust, surfaced through the gate.
+
+## Ground-truth facts (from the code map — do not re-litigate)
+
+- **No digester registry.** Wiring is constructor injection at `run.py:203` (`self._digester = digester or StructuredShapeDigester()`).
+- **No Instinct rule store/model exists.** `instinct/store.py:252-335` has 4 tables, none for rules. The only `InstinctRule` is template CEL config (`bundled_templates/schema.py:397-412`); the only "learned rule" is a soul procedural string (`correction_soul_bridge.py:99-142`). **Rules-discovery is build-from-zero.**
+- **Gate dispatch is a per-path `if blob is not None` chain in FOUR router functions** (approve / bulk_approve / reject / bulk_reject) — no central registry. Missing one tenancy guard = cross-tenant approval escalation (the PR #1183 class bug).
+- **kb-go on-box keyless ONLY via `convo ingest` or `prepare`+`accept`.** `kb ingest` / `kb build` POST to Anthropic (`kb.go:1349`) and must NEVER touch tenant exhaust. **This is the #1 sovereignty constraint — encoded as a test, not trusted to the code path.**
+- **pocketpaw implementers run SEQUENTIALLY in one worktree** (nested-repo rule — `isolation:"worktree"` does not isolate the nested pocketPaw checkout).
+
+## S2-R0 — Design decision (made by crew, captain out; documented for review)
+
+The interactive `/paw-brainstorm` gate the plan recommends needs the captain present; with the captain out, the crew adopts the plan's well-reasoned default and documents it here for PR-gate review.
+
+- **P2 — `Rule` data model.** `when: CelExpression` (reuse `bundled_templates/expressions`), `action: InstinctRuleActionT` = `Literal["require_approval","notify","block"]` (reuse `schema.py:121`), `scope` = `workspace_id` + optional `pocket_id`/`object_type`, `confidence: float [0,1]` (`_clamp`), `provenance` = the audit-row / correction / record ids it was inferred from. A `RuleDraft` mirrors `DraftObjectType`'s draft/confidence split for the digest output. **No new primitives** — reuses CEL + the action literal.
+- **P2-home — persistence.** EE Beanie `RuleDoc`, alongside the gate types (parallels the slice-1 "Digester home → EE" open question). Registered in `ALL_DOCUMENTS` so the `beanie_test_db` fixture picks it up. Tenancy/owner are top-level fields, NEVER nested in the editable `rule_spec`.
+- **P3 — enforcement BOUNDARY (the scoping call).** Slice 2 = the full **discovery pipeline**: exhaust → digest → propose → review/edit → approve → **persist as an active, workspace-scoped, human-OWNED, EDITABLE `RuleDoc`** + a `get_active_rules(workspace_id)` read API. This delivers the Edra-parity core — *white-box, human-editable, owned executable rules; raw data never left the box.* The rule shape is enforcement-ready (CEL `when` + action literal, `InstinctRule`-compatible).
+  **Out of scope for slice 2 (explicit slice-3 follow-up): wiring approved workspace rules into the LIVE gate dispatch** (`instinct_composer.py:248` / `instinct_dispatch`). Rewiring live, security-critical gate evaluation for every action is high-stakes and deserves the captain's review of the approach before it ships. Slice 2 makes rules discoverable, governed, and owned; slice 3 makes them enforced-at-dispatch. The `get_active_rules` API is the seam.
+
+## Slices (dependency-ordered; each independently mergeable, each ships unit + smoke tests)
+
+### Track K — KbCompileDigester (M; reuses 100% of the slice-1 gated flow)
+
+- **S2-K1 — `KbCompileDigester`.** New `ee/pocketpaw_ee/discovery/kb_compile.py` (digester + module-local `_kb` subprocess seam cloned from `cloud/agents/knowledge.py:71-97`). Add to `discovery/__init__.py` import + `__all__`. Contract: `digest(records, connector_meta=None) -> OntologyDraft` matching the `Digester` Protocol (`digester.py:57-71`); `records` = text blobs; never raises on empty/degenerate; stamps `meta["digester"]="kb-compile"`; populates types/properties/links so `to_fabric_mapping_kwargs()` yields a valid `FabricMapping` (article `id` = `source_id_field`; concept co-occurrence → `DraftLink`). On-box pipeline: `kb convo ingest <tmp> --scope workspace:{wid}:discovery` → `kb list/show/graph --format json` → infer ontology. **Sovereignty tripwire test (mandatory):** `fake_kb` asserts `args[0] not in ("ingest","build")`. Tests: unit (clone `test_structured_shape_digester.py`, mock `_kb`) + smoke (real `kb` binary, `convo ingest`→`list`, skip if binary absent). **Deps:** none.
+- **S2-K2 — DiscoveryRun digester selection (OPTIONAL/flagged).** `digester_kind: Literal["structured","unstructured"]="structured"` on `DiscoveryRunOptions`; `_select_digester(opts)`; injected `digester` overrides the flag. Deferrable — a caller can already inject `DiscoveryRun(digester=KbCompileDigester())` with zero new code. Build only if the choice should live inside the run. **Deps:** S2-K1.
+
+### Track R — Rules-discovery (L; build-from-zero, after S2-R0)
+
+- **S2-R1 — `Rule` model + persistence.** `ee/pocketpaw_ee/discovery/rule_models.py` (`Rule` + `RuleDraft`) + a `RuleDoc` Beanie doc + accessors (incl. `get_active_rules(workspace_id)`), registered in `ALL_DOCUMENTS`. `Rule.model_validate(blob['rule_spec'])` round-trips at the executor chokepoint; confidence clamps; tenancy/owner separate from `rule_spec`. Tests: unit (validate accept/reject, CEL validates, action literal, clamp) + smoke (`beanie_test_db` round-trip). **Deps:** S2-R0.
+- **S2-R2 — `RuleDigester` inference engine.** `ee/pocketpaw_ee/discovery/rule_digester.py`: read `instinct_audit` (`query_audit`) + `instinct_corrections` (`get_corrections_for_pocket`) + optional `KbCompileDigester` output → emit `RuleDraft`s with confidence. **Generalize the existing 3×-correction promotion** (`correction_soul_bridge.py:99-142`) from soul-string to structured `RuleDraft`. Deterministic (no LLM on the hot path — sovereignty/on-box). Own confidence floor (NOT `KEY_CONFIDENCE_FLOOR`). Tests: unit (N corrections→1 draft; <threshold→none; weak→low-confidence-skipped; empty→empty) + smoke. **Deps:** S2-R1.
+- **S2-R3 — `_instinct_rule` gate type.** New `ee/pocketpaw_ee/cloud/instinct_rule_proposals/{propose,executor,__init__}.py`, cloning `_pocket_create` (SZD-5b) EXACTLY. Blob: `kind, schema=1, workspace_id, rule_spec, summary, correlation_id, proposed_event_id`. Mint `correlation_id` before the blob; `store.propose(pocket_id=workspace_id, …)`; back-write `proposed_event_id`. Executor: schema-guard → tenancy → idempotency → `Rule.model_validate(rule_spec)` in try/`_fail` → write via R1 service (never raw) → `mark_executed` + chain-close (executor owns `decision.completed` on approve). Tests: unit (blob shape, schema-mismatch terminal, idempotent re-approve, malformed→`_fail`) + smoke (propose→approve→EXECUTED→rule landed). **Deps:** S2-R0, S2-R1.
+- **S2-R4 — Router four-path dispatch + tenancy (SECURITY-CRITICAL).** `instinct/router.py`: `_instinct_rule_blob` accessor; `_assert_instinct_rule_workspace` guard called in **ALL FOUR** paths (approve, bulk_approve, reject, bulk_reject); dispatch branch in approve + bulk_approve (read blob, `_emit_human_corrected`, `execute_approved_instinct_rule`, non-fatal try/except); close branch in reject + bulk_reject (`_emit_human_corrected(rejected)` + `_emit_decision_completed_rejected`, no executor, bulk ends with `continue`). Tests (clone `test_instinct_approval_security.py`): **cross-workspace 403 on all FOUR paths** + exactly-one chain-close per path. **Deps:** S2-R3.
+- **S2-R5 — Orchestrate third proposal path.** `discovery/orchestrate.py`: `_draft_to_instinct_rules(draft, …)` builder (own confidence threshold); lazy-import + `propose_instinct_rule`; third file+stamp block (`_stamp_discovery_marker(blob_key="_instinct_rule", role="instinct_rules")`); add `"_instinct_rule"` to the supersede marker tuple (`:337` — one-line, else stale rule proposals never supersede); `instinct_action_id: str|None` on `DiscoveryProposalResult`. Tests: unit (files PENDING `_instinct_rule`; 2nd run supersedes; low-confidence skip+flag; empty→none) + smoke (approve→EXECUTED). **Deps:** S2-R2, S2-R3, S2-R4.
+- **S2-R6 — `human.corrected` on edited rule proposals (learning loop; lowest priority / follow-up OK).** Wire the review edit→approve so editing a rule draft emits `human.corrected` + feeds rule-inference confidence (generalize `Correction` beyond Action scalars to `rule_spec` keys). Tests: unit + smoke. **Deps:** S2-R5.
+
+### Integration + UI
+
+- **S2-E1 — Backend E2E.** `tests/ee/test_szd2_e2e.py`: `DiscoveryRun(digester=KbCompileDigester())` over unstructured text records → files THREE proposals (`_fabric_objects`, `_pocket_create`, `_instinct_rule`, shared `run_id`) → approve all → real executors → assert EXECUTED + materialization via `FabricStore.query` + rule landed via `get_active_rules`. **Sovereignty assertion:** mocked `_kb` proves `ingest`/`build` never called. **Deps:** S2-K1, S2-R5.
+- **S2-UI — paw-enterprise rule review card + preview e2e** (separate repo / worktree, `VITE_CLOUD_URL`). Extend the slice-1 discovery-review surface with a rule card (`when`/`action`/scope/confidence/provenance + accept/edit/reject). Tests: vitest unit + **preview-panel e2e via the proven `/sidepanel` bypass recipe** (worktree + absolute-ripple-path + free port). **Deps:** S2-R3 (blob shape).
+
+## Build order (supervised, sequential in `szd2-int`; STOP at captain gate, never merge)
+
+```
+K1 → (K2 deferred) → R1 → R2 → R3 → R4 → R5 → (R6 opt) → E1   [pocketPaw, sequential]
+                                                            S2-UI [paw-enterprise, own worktree]
+```
+
+## Risks (slice-2-specific)
+
+- **RK-1 sovereignty (#1):** KbCompileDigester must use ONLY `convo ingest`/`prepare`+`accept`; the `fake_kb` tripwire test is non-negotiable.
+- **RK-2 on-box model:** keep R2 inference deterministic; no cloud-LLM refine pass in slice 2.
+- **RK-3 subprocess reaping:** `_kb` via `asyncio.to_thread`, honour `timeout`.
+- **RK-5 four-path trap:** R4 must assert cross-workspace 403 on all four paths.
+- **RK-6 double chain-close:** approve→executor owns, reject→router owns; exactly one.
+- **RK-7 rule confidence floor:** R5 uses its own threshold, not `KEY_CONFIDENCE_FLOOR`.
+- **RK-10 git collision:** sequential in one worktree.

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -37,6 +37,11 @@
 #   jobs primitive. Queued is emitted at dispatch; Updated on a terminal
 #   transition by the ARQ worker. Worker-side emits route over the xproc
 #   bridge to the web bus, the same path ``PocketUpdated`` uses.
+# Updated: 2026-06-20 (feat/szd-slice2-discovery, S2-R1) — added
+#   ``RuleCreated`` (type="instinct.rule.created") and ``RuleArchived``
+#   (type="instinct.rule.archived") for the discovered-rules entity. Emitted by
+#   ``rules.service`` on every state-mutating call per cloud rule 9 (emit on
+#   every write).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -856,6 +861,21 @@ class InstinctApprovalAutoApproved(Event):
 @dataclass
 class BulkActionDispatched(Event):
     EVENT_TYPE: ClassVar[str] = "pocket.bulk_action.dispatched"
+
+
+# Discovered governed rules (SZD slice-2 / S2-R1). Emitted by
+# ``rules.service`` on every state-mutating call — ``created`` when an approved
+# rule lands, ``archived`` when one is retired/superseded. ``data`` carries the
+# rule id + workspace + owner so a downstream WS fan-out can refresh the
+# workspace's rule list without re-reading the doc.
+@dataclass
+class RuleCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "instinct.rule.created"
+
+
+@dataclass
+class RuleArchived(Event):
+    EVENT_TYPE: ClassVar[str] = "instinct.rule.archived"
 
 
 # Outcome event emission (RFC 03 v2 / Wave 3c). Fires AFTER a write

--- a/ee/pocketpaw_ee/cloud/instinct_rule_proposals/__init__.py
+++ b/ee/pocketpaw_ee/cloud/instinct_rule_proposals/__init__.py
@@ -1,0 +1,33 @@
+# ee/cloud/instinct_rule_proposals/__init__.py — the gated governed-rule-create
+# Instinct proposal type (a peer of ``_pocket_create`` / ``_fabric_objects`` /
+# ``_pocket_write`` / ``_code_change`` / ``_external_action`` / ``_belt_plan`` /
+# ``_artifact_change``).
+# Created: 2026-06-20 (S2-R3 — _instinct_rule proposal type) — a proposed governed
+#   rule (a CEL ``when`` + a gate ``action``, scoped to a tenant, with confidence +
+#   provenance) staged for human review through the Instinct gate. "Sovereign
+#   zero-setup discovery" reverse-engineers a rule from a tenant's exhaust and
+#   proposes "create this rule"; a human approves / edits / rejects in The Tray; on
+#   approve the executor persists the rule via the canonical, workspace-scoped
+#   ``rules.service.create_rule`` write path. Fully generic — no domain-specific logic.
+#
+# Re-exports the propose helper + the apply-on-approve executor + the three blob
+# constants so callers (the discovery surface, the instinct router) import from the
+# package root, mirroring how the Pocket-create gate is imported.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.instinct_rule_proposals.executor import execute_approved_instinct_rule
+from pocketpaw_ee.cloud.instinct_rule_proposals.propose import (
+    INSTINCT_RULE_KIND,
+    INSTINCT_RULE_PARAM_KEY,
+    INSTINCT_RULE_SCHEMA,
+    propose_instinct_rule,
+)
+
+__all__ = [
+    "INSTINCT_RULE_KIND",
+    "INSTINCT_RULE_PARAM_KEY",
+    "INSTINCT_RULE_SCHEMA",
+    "execute_approved_instinct_rule",
+    "propose_instinct_rule",
+]

--- a/ee/pocketpaw_ee/cloud/instinct_rule_proposals/executor.py
+++ b/ee/pocketpaw_ee/cloud/instinct_rule_proposals/executor.py
@@ -1,0 +1,403 @@
+# ee/cloud/instinct_rule_proposals/executor.py — apply an approved governed-rule create.
+# Created: 2026-06-20 (S2-R3 — _instinct_rule Instinct proposal type).
+#
+# What this module does (the apply-on-approve half of the governed-rule gate): the
+# propose helper (``instinct_rule_proposals.propose.propose_instinct_rule``) files an
+# Instinct Action carrying an ``_instinct_rule`` blob THROUGH Instinct (the human
+# approve/reject layer). After a human approves the Action, the ee instinct router's
+# ``approve_action`` (wired in S2-R4) fires ``execute_approved_instinct_rule`` here —
+# exactly mirroring how ``pocket_proposals.executor.execute_approved_pocket_create``
+# is fired for a gated Pocket create. This function:
+#
+#   1. Reads the ``_instinct_rule`` blob from ``action.parameters``. A missing blob →
+#      return (no chain was opened, nothing to close). A schema-mismatched blob →
+#      mark_failed + close the chain, return.
+#   2. Workspace + owner guard — an empty ``workspace_id`` / ``user_id`` on the blob →
+#      mark_failed + close (a rule with no tenant to scope it / no owner to own it is
+#      a tenancy hole).
+#   3. Idempotency guard — if the Action is already terminal (executed / failed) or
+#      the blob already carries an ``outcome``, the create is NOT re-run. Re-approve /
+#      retry never double-creates.
+#   4. Validates the staged spec at the entry to the create path:
+#      ``draft = RuleDraft.model_validate(blob["rule_spec"])`` — a structurally
+#      invalid spec (bad action literal, invalid CEL) fails CLEANLY (mark_failed +
+#      close), not silently. Then ``await rules.service.create_rule(workspace_id,
+#      owner_user_id, body)``, scoped by the blob's top-level ``workspace_id`` / owned
+#      by its top-level ``user_id`` (NOT anything inside ``rule_spec`` — tenancy/owner
+#      are un-editable).
+#   5. Back-writes the outcome ``{status, rule_id, name, executed_at}`` onto the
+#      persisted blob via the direct-SQL pattern.
+#   6. Records the result on the Action (``mark_executed`` / ``mark_failed``) and
+#      CLOSES the Decision-Graph chain exactly once.
+#
+# EXACTLY-ONE-TERMINAL discipline (critical): on APPROVE the EXECUTOR owns the
+# ``decision.completed`` chain close — the router does NOT emit it (mirrors the
+# Pocket-create executor). On REJECT the ROUTER owns the close and the executor never
+# runs. Every terminal path here goes through the single ``_fail`` chokepoint
+# (failure) or the one success emit at the end — never both.
+#
+# Never raises — a failure here must not break the approve response. The router wraps
+# the call too; this is belt-and-braces. A create error is captured as
+# ``status=failed`` with a ``failed`` terminal, NOT re-raised.
+#
+# Security (this code creates a rule in a tenant's workspace on approval):
+#   * tenancy + owner are read off the blob's SEPARATE top-level ``workspace_id`` /
+#     ``user_id`` fields — NEVER off ``rule_spec`` (which the correction flow can
+#     edit). An empty workspace_id / user_id is refused. The router's (S2-R4)
+#     ``_assert_instinct_rule_workspace`` is the primary gate; this is belt-and-braces.
+#   * the write primitive is the SHIPPED ``rules.service.create_rule`` — this module
+#     does NOT touch the Beanie document directly, so it inherits the proven
+#     workspace-scoped, validate-at-entry create path (which itself re-asserts the
+#     draft's scope.workspace_id matches the caller's workspace).
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from pocketpaw_ee.cloud.instinct_rule_proposals.propose import (
+    INSTINCT_RULE_PARAM_KEY,
+    INSTINCT_RULE_SCHEMA,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_uuid(raw: Any) -> UUID | None:
+    """Coerce a value to a ``UUID``, or ``None`` if it can't be."""
+    if isinstance(raw, UUID):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return UUID(raw)
+        except ValueError:
+            return None
+    return None
+
+
+async def _persist_outcome(
+    *,
+    store: Any,
+    action_id: str,
+    status: str,
+    summary: dict[str, Any],
+    executed_at: str,
+) -> None:
+    """Back-write the create outcome onto the persisted ``_instinct_rule`` blob.
+
+    Direct SQL update — the same pattern the Pocket-create executor's
+    ``_persist_outcome`` uses. The blob's ``outcome`` carries the created rule id +
+    name + timestamp so a reader (audit, a re-invocation idempotency check) sees the
+    result structurally. Best-effort: a write failure leaves the blob without the
+    structured outcome but the free-text ``mark_executed`` / ``mark_failed`` outcome
+    still records it.
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(INSTINCT_RULE_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["outcome"] = {"status": status, "executed_at": executed_at, **summary}
+        params[INSTINCT_RULE_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — back-write is best-effort
+        logger.warning(
+            "instinct_rule: failed to persist outcome onto action %s — the "
+            "structured outcome is unavailable (free-text outcome still recorded)",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _emit_chain_close(
+    *,
+    passed: bool,
+    action_outcome: str,
+    error_class: str | None,
+    reason: str | None,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    user_id: str,
+    causation_id: UUID | None,
+    summary: str | None = None,
+) -> None:
+    """Emit the ``decision.completed`` chain-close for a governed-rule create.
+
+    Mirrors ``pocket_proposals.executor._emit_chain_close`` — the executor owns the
+    chain close on the approve path. ``correlation_id`` is read off the blob;
+    ``causation_id`` is the ``human.corrected`` event the router emitted just before
+    approval so the terminal chains back to the human approval.
+
+    Returns early when ``correlation_id`` is None (a blob with a malformed / missing
+    id): there is no chain to close. Best-effort: a Decision-Graph wiring failure must
+    never break the approve response — the journal write is the source of truth; the
+    Slice 4 reconciler is the safety net.
+    """
+    if correlation_id is None:
+        return
+
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_decision_completed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    payload: dict[str, Any] = {
+        "passed": passed,
+        "action_outcome": action_outcome,
+    }
+    if error_class:
+        payload["error_class"] = error_class
+    if reason:
+        payload["reason"] = reason
+    if summary:
+        payload["summary"] = summary
+
+    try:
+        record_decision_completed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+            causation_id=causation_id,
+        )
+    except Exception:  # noqa: BLE001 — chain close is best-effort
+        logger.warning(
+            "instinct_rule decision.completed emit failed for correlation_id=%s "
+            "(action_outcome=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_outcome,
+            exc_info=True,
+        )
+
+
+def _already_executed(action: Any, blob: dict[str, Any]) -> bool:
+    """Idempotency guard — True when this rule create already ran.
+
+    Two signals, either is sufficient:
+      * the blob already carries an ``outcome`` (a prior run back-wrote it), or
+      * the Action is already in a terminal state (executed / failed).
+
+    Re-invocation (bulk re-approve, retry) must never re-run the create — a rule
+    create has no natural idempotency key (each call mints a fresh rule id), so the
+    Action's terminal ``status`` + the back-written outcome are the ONLY guard against
+    a double-create. The Action's ``status`` is the authoritative gate, and the
+    back-written outcome is the belt-and-braces signal in case status reads are stale.
+    """
+    if isinstance(blob.get("outcome"), dict):
+        return True
+    status = getattr(action, "status", None)
+    status_value = getattr(status, "value", status)
+    return str(status_value) in ("executed", "failed")
+
+
+async def execute_approved_instinct_rule(
+    action: Any,
+    *,
+    human_event_id: Any | None = None,
+) -> None:
+    """Persist the governed rule carried by a freshly-approved Action.
+
+    Called best-effort from the instinct router's ``approve_action`` /
+    ``bulk_approve_actions`` (wired in S2-R4) after ``store.approve()`` succeeds — the
+    same hook shape the Pocket-create executor uses. ``action`` is the approved Action.
+
+    ``human_event_id`` is the id of the ``human.corrected`` event the router emitted
+    just before calling this — threaded through so the terminal ``decision.completed``
+    event can chain its ``causation_id`` back to the approval, completing the causal
+    walk ``agent.proposed → human.corrected → decision.completed``. ``None`` is
+    tolerated (the chain still folds via the shared ``correlation_id``).
+
+    Never raises — a failure here must not break the approve response. The router
+    wraps the call too; this is belt-and-braces. The Action is marked executed on a
+    successful create or failed with a clear outcome on any error, and the
+    Decision-Graph chain is closed exactly once (success → landed, failure → failed).
+    """
+    from pocketpaw.stores import get_instinct_store
+
+    store = get_instinct_store()
+    params = getattr(action, "parameters", None) or {}
+    blob = params.get(INSTINCT_RULE_PARAM_KEY)
+    if not isinstance(blob, dict):
+        # Not an instinct-rule Action at all — no chain was opened for it, so there
+        # is nothing to close. Return without a terminal emit.
+        logger.warning("approved action %s carries no _instinct_rule blob", action.id)
+        return
+
+    # Read the chain ids + tenancy/owner off the blob up front so EVERY terminal path
+    # can close the chain it opened. Tenancy/owner come from the SEPARATE top-level
+    # fields — NEVER from ``rule_spec`` (which the correction flow can edit). A
+    # malformed / missing correlation id → None and the close no-ops (the Slice 4
+    # abandon-sweeper closes any chain left open).
+    correlation_id = _coerce_uuid(blob.get("correlation_id"))
+    workspace_id = str(blob.get("workspace_id") or "")
+    owner_user_id = str(blob.get("user_id") or "")
+    approver = str(getattr(action, "approved_by", "") or "") or owner_user_id or "system"
+    causation = _coerce_uuid(human_event_id)
+
+    async def _fail(reason: str, *, error_class: str) -> None:
+        """Mark the Action failed AND close the chain with one terminal — the single
+        failure-path chokepoint so a path can never both fail and double-fire the
+        terminal."""
+        await store.mark_failed(action.id, reason)
+        await _persist_outcome(
+            store=store,
+            action_id=str(action.id),
+            status="failed",
+            summary={"reason": reason},
+            executed_at=datetime.now(UTC).isoformat(),
+        )
+        _emit_chain_close(
+            passed=False,
+            action_outcome="failed",
+            error_class=error_class,
+            reason=reason,
+            correlation_id=correlation_id,
+            workspace_id=workspace_id,
+            user_id=approver,
+            causation_id=causation,
+            summary=reason,
+        )
+
+    # Schema guard — a stale blob from an incompatible build fails loud rather than
+    # persisting a misinterpreted rule.
+    if blob.get("schema") != INSTINCT_RULE_SCHEMA:
+        await _fail(
+            "instinct-rule schema mismatch — the blob is from an incompatible "
+            "build and cannot be executed",
+            error_class="SchemaMismatch",
+        )
+        return
+
+    # Tenancy — a rule create with no workspace is a tenancy hole. The rule is created
+    # scoped by workspace_id; fail loud so a malformed blob is recorded, not silently
+    # created unscoped.
+    if not workspace_id:
+        await _fail(
+            "instinct-rule blob carries no workspace_id — cannot scope the rule",
+            error_class="MissingWorkspace",
+        )
+        return
+    if not owner_user_id:
+        await _fail(
+            "instinct-rule blob carries no user_id — cannot assign an owner",
+            error_class="MissingOwner",
+        )
+        return
+
+    # Idempotency — never re-run the create on a re-invocation.
+    if _already_executed(action, blob):
+        logger.info(
+            "instinct_rule: action %s already executed (idempotency guard) — "
+            "skipping the rule create",
+            action.id,
+        )
+        return
+
+    rule_spec = blob.get("rule_spec")
+    if not isinstance(rule_spec, dict):
+        await _fail(
+            "instinct-rule blob carries no rule_spec to create",
+            error_class="MalformedBlob",
+        )
+        return
+
+    # Validate the staged spec at the entry to the create path — a structurally
+    # invalid draft (bad action literal, invalid CEL, missing required field) fails
+    # CLEANLY here rather than blowing up inside the service. ``RuleDraft`` is the
+    # editable rule_spec shape; ``CreateRuleRequest`` wraps it with the (un-editable)
+    # owner for the service.
+    try:
+        from pocketpaw_ee.cloud.rules.dto import CreateRuleRequest
+        from pocketpaw_ee.discovery.rule_models import RuleDraft
+
+        draft = RuleDraft.model_validate(rule_spec)
+        body = CreateRuleRequest(draft=draft, owner_user_id=owner_user_id)
+    except Exception as exc:  # noqa: BLE001 — a bad spec is a failed outcome, not a crash
+        await _fail(
+            f"instinct-rule spec is invalid: {exc}",
+            error_class=type(exc).__name__,
+        )
+        return
+
+    # Persist the rule through the SHIPPED service, scoped by the blob's top-level
+    # workspace_id / owned by its top-level user_id. Any failure (the service's own
+    # tenancy assertion, a store error) is captured as a failed outcome — NEVER
+    # re-raised into the router.
+    try:
+        from pocketpaw_ee.cloud.rules import service as rules_service
+
+        created = await rules_service.create_rule(workspace_id, owner_user_id, body)
+    except Exception as exc:  # noqa: BLE001 — never let a create break approve
+        logger.warning(
+            "instinct_rule: create crashed for action %s (workspace=%s)",
+            action.id,
+            workspace_id,
+            exc_info=True,
+        )
+        await _fail(
+            f"rule create failed: {exc}",
+            error_class=type(exc).__name__,
+        )
+        return
+
+    created_dict = created or {}
+    rule_id = str(created_dict.get("id") or "")
+    rule_name = str(created_dict.get("name") or body.draft.name)
+    summary = {"rule_id": rule_id, "name": rule_name}
+
+    # Success — mark executed, back-write the structured outcome, close the chain.
+    await store.mark_executed(
+        action.id,
+        f"governed rule created: {rule_name!r} (id={rule_id})",
+    )
+    await _persist_outcome(
+        store=store,
+        action_id=str(action.id),
+        status="executed",
+        summary=summary,
+        executed_at=datetime.now(UTC).isoformat(),
+    )
+    # Close the chain on the SUCCESS path. This is the ONLY terminal on the happy path
+    # (every failure path above closed via ``_fail`` and returned), so exactly one
+    # ``decision.completed`` lands per create.
+    _emit_chain_close(
+        passed=True,
+        action_outcome="landed",
+        error_class=None,
+        reason=None,
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        user_id=approver,
+        causation_id=causation,
+        summary=f"created governed rule {rule_name!r} (id={rule_id})",
+    )
+    logger.info(
+        "instinct_rule: executed action %s → created rule %s (%r) (ok)",
+        action.id,
+        rule_id,
+        rule_name,
+    )
+
+
+__all__ = ["execute_approved_instinct_rule"]

--- a/ee/pocketpaw_ee/cloud/instinct_rule_proposals/propose.py
+++ b/ee/pocketpaw_ee/cloud/instinct_rule_proposals/propose.py
@@ -1,0 +1,335 @@
+# ee/cloud/instinct_rule_proposals/propose.py — propose a gated governed-rule create.
+# Created: 2026-06-20 (S2-R3 — _instinct_rule Instinct proposal type).
+#
+# What this module does (the propose half of the governed-rule gate): "sovereign
+# zero-setup discovery" reverse-engineers a candidate governed rule (a CEL ``when``
+# + a gate ``action``, scoped to a tenant) from a workspace's exhaust — audit rows,
+# corrections, the on-box ontology — and stages it as a PROPOSED rule for a human to
+# approve / edit / reject through the Instinct gate before any rule becomes active.
+# This files an Instinct ``Action`` carrying an ``_instinct_rule`` blob (schema 1)
+# under ``Action.parameters``. A human approves it in The Tray; the apply-on-approve
+# executor (``instinct_rule_proposals.executor.execute_approved_instinct_rule``) then
+# persists the rule via the canonical ``rules.service.create_rule`` write path. This
+# module does NOT create a rule — it only gates.
+#
+# The blob is the gated governed-rule kind, sitting alongside the Pocket-create
+# gate's ``_pocket_create`` (SZD-5b), the Fabric-objects gate's ``_fabric_objects``
+# (SZD-5a), the pocket-write bridge's ``_pocket_write``, the Belt develop-station's
+# ``_code_change``, the external-action gate's ``_external_action``, the mandate
+# foreman's ``_belt_plan``, and the Branch-primitive merge gate's ``_artifact_change``.
+# The router + executor dispatch on the presence of the ``_instinct_rule`` parameters
+# key (the Action model has no literal ``kind`` column; the blob also carries
+# ``kind="instinct_rule"`` for readers that introspect it).
+#
+# Schema 1 (first version — the schema-version pattern is replicated from
+# ``pocket_proposals.propose.POCKET_CREATE_SCHEMA``). The blob carries:
+#   * ``schema`` / ``kind`` — version + discriminator;
+#   * ``workspace_id`` — the originating tenant. The executor's tenancy gate reads it
+#     HERE; a proposed rule isn't bound to an EXISTING pocket, so tenancy lives on the
+#     blob — and the rule is created scoped to this workspace. SECURITY: this is a
+#     SEPARATE top-level blob field, NOT nested inside ``rule_spec`` — the
+#     correction/edit flow diffs the proposal's editable shape, so keeping tenancy out
+#     of the editable spec means a tenant editing the proposal cannot move it to
+#     another workspace.
+#   * ``user_id`` — the approver/owner the rule is owned by. Also a SEPARATE top-level
+#     blob field for the same reason: the owner cannot be edited via the correction
+#     flow (a tenant can't reassign ownership of the staged rule).
+#   * ``rule_spec`` — the editable ``RuleDraft``-shaped sub-dict the executor
+#     model_validates: ``{name, description?, when (CEL), action, scope, confidence,
+#     provenance}``. This is the ONLY part of the blob a correction edit may touch.
+#   * ``summary`` — a human-readable one-liner for the gate UI (The Tray);
+#   * ``correlation_id`` / ``proposed_event_id`` — the Decision-Graph chain ids,
+#     minted here at propose time (``agent.proposed`` opens the chain). The router's
+#     approve / reject paths and the executor close the SAME chain.
+#
+# Security:
+#   * NO rule is created here — the spec is staged as DATA on the blob and only
+#     persisted after a human approves.
+#   * Tenancy + owner are bound on SEPARATE top-level blob fields (NOT in the editable
+#     ``rule_spec``) so the correction flow cannot move ownership / workspace. The
+#     router's (S2-R4) ``_assert_instinct_rule_workspace`` is the primary tenancy
+#     gate on the FOUR approve/reject paths; the executor re-validates here. A
+#     cross-workspace approve OR reject is refused — asymmetric tenant scope is no
+#     tenant scope (pocketpaw#1183 / #1250). The R3 blob keeps ``workspace_id`` as the
+#     tenancy anchor so R4 can assert on it.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+logger = logging.getLogger(__name__)
+
+# The Instinct Action kind discriminator for a governed-rule proposal. The router
+# + executor dispatch on the presence of the parameters key below; the blob also
+# carries ``kind="instinct_rule"`` for readers that introspect it.
+INSTINCT_RULE_KIND = "instinct_rule"
+
+# The parameters key under which the governed-rule blob rides — peer of the
+# Pocket-create gate's ``_pocket_create``, the Fabric-objects gate's
+# ``_fabric_objects``, belt's ``_code_change``, and the external-action gate's
+# ``_external_action``. The router + executor dispatch on this key being present.
+INSTINCT_RULE_PARAM_KEY = "_instinct_rule"
+
+# Schema version stamped on the ``_instinct_rule`` blob. Bump when the blob shape
+# changes so a stale pending Action approved after a deploy fails loud instead of
+# persisting a misinterpreted rule (same discipline as the Pocket-create gate's
+# ``POCKET_CREATE_SCHEMA``). Starts at 1 — first version.
+INSTINCT_RULE_SCHEMA = 1
+
+
+def _emit_agent_proposed(
+    *,
+    correlation_id: UUID,
+    action_id: str,
+    workspace_id: str,
+    user_id: str,
+    name: str,
+) -> UUID | None:
+    """Emit the chain-opening ``agent.proposed`` event for a governed-rule create.
+
+    Mirrors ``pocket_proposals.propose._emit_agent_proposed``: the proposing caller
+    is the actor (``kind="agent"`` with the requesting user on its id, the workspace
+    on its scope_context). A proposed rule isn't bound to an EXISTING pocket — its
+    tenancy is the workspace — so ``pocket_id`` on the chain carries the workspace id
+    (matching how the Action's ``pocket_id`` field carries the workspace).
+
+    Returns the emitted event id so the caller can persist it on the blob's
+    ``proposed_event_id`` field for the ``human.corrected`` causation chain, or
+    ``None`` when the emit raised — best-effort per RFC 09; the Slice 4 reconciler
+    picks up any orphans.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import record_agent_proposed
+
+    actor = Actor(
+        kind="agent",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}"],
+    )
+    intent = f"create the governed rule {name!r}"
+    payload: dict[str, Any] = {
+        # Fields the projection's ``_fold_proposed`` consumes.
+        "intent": intent,
+        "action": "instinct_rule",
+        "pocket_id": workspace_id,
+        "inputs": [],
+        # Richer fields for the explain narrator.
+        "proposal_kind": "instinct_rule",
+        "proposal": {"name": name},
+        "action_id": action_id,
+    }
+    try:
+        entry = record_agent_proposed(
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=[f"workspace:{workspace_id}"],
+            payload=payload,
+        )
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort
+        logger.warning(
+            "instinct_rule agent.proposed emit failed for correlation_id=%s "
+            "(action_id=%s) — Slice 4 reconciler will catch up",
+            correlation_id,
+            action_id,
+            exc_info=True,
+        )
+        return None
+
+
+async def _persist_chain_ids(
+    *,
+    store: Any,
+    action_id: str,
+    correlation_id: str,
+    proposed_event_id: str | None,
+) -> None:
+    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted Action's
+    ``parameters._instinct_rule`` blob after ``agent.proposed`` fired.
+
+    The blob is built with ``correlation_id`` already set (minted before build);
+    ``proposed_event_id`` is the field this back-write fills in. Direct SQL update —
+    the same pattern the Pocket-create gate's ``_persist_chain_ids`` uses.
+    Best-effort: a write failure leaves ``proposed_event_id`` None and the eventual
+    ``human.corrected`` emits without a causation_id (the chain still folds;
+    causation_id is optional on EventEntry).
+    """
+    import json as _json
+
+    import aiosqlite
+
+    try:
+        action = await store.get_action(action_id)
+        if action is None:
+            return
+        params = dict(getattr(action, "parameters", None) or {})
+        blob = params.get(INSTINCT_RULE_PARAM_KEY)
+        if not isinstance(blob, dict):
+            return
+        blob = dict(blob)
+        blob["correlation_id"] = correlation_id
+        blob["proposed_event_id"] = proposed_event_id
+        params[INSTINCT_RULE_PARAM_KEY] = blob
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE instinct_actions SET parameters = ?,"
+                " updated_at = datetime('now') WHERE id = ?",
+                (_json.dumps(params), action_id),
+            )
+            await db.commit()
+    except Exception:  # noqa: BLE001 — write-back is best-effort
+        logger.warning(
+            "instinct_rule: failed to persist chain ids onto action %s — the "
+            "chain's human.corrected will emit without causation_id",
+            action_id,
+            exc_info=True,
+        )
+
+
+def _rule_name(rule_spec: dict[str, Any]) -> str:
+    """Read a human-readable name off the rule_spec for titles / summaries."""
+    name = str(rule_spec.get("name") or "").strip()
+    return name or "governed rule"
+
+
+async def propose_instinct_rule(
+    *,
+    workspace_id: str,
+    user_id: str,
+    rule_spec: dict[str, Any],
+    summary: str | None = None,
+    correlation_id: str | None = None,
+    assignee: str | None = None,
+) -> str:
+    """Build + store an Instinct ``Action`` for a gated governed-rule create.
+
+    Files an Action carrying the ``_instinct_rule`` blob (schema 1) and opens the
+    Decision-Graph chain (``agent.proposed``). Returns the proposed Action id. NO
+    rule is created here — the ``rule_spec`` is staged as DATA and only persisted
+    after a human approves.
+
+    Args:
+        workspace_id: the originating tenant. Bound on the router's approve / reject
+            paths (S2-R4) and re-validated at execution; the rule is created scoped
+            to it. Required — a rule create with no tenant is a tenancy hole. Rides
+            as a SEPARATE top-level blob field (NOT in ``rule_spec``) so the
+            correction flow can't move it.
+        user_id: the approver/owner the rule is owned by. Required. Also a SEPARATE
+            top-level blob field — the owner can't be edited via the correction flow.
+        rule_spec: the editable ``RuleDraft``-shaped sub-dict (``{name, description?,
+            when, action, scope, confidence, provenance}``). Staged verbatim; the
+            executor ``RuleDraft.model_validate``s it at the gate chokepoint. The ONLY
+            tenant-editable part of the blob.
+        summary: a human-readable one-liner for the gate UI. Defaults to a sensible
+            one built from the rule name.
+        correlation_id: an optional pre-minted chain id. When omitted a fresh one is
+            minted here (the common case).
+        assignee: the workspace member who should approve. Defaults to ``user_id`` so
+            the proposer's queue carries it.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
+    from pocketpaw.stores import get_instinct_store
+
+    workspace_id = str(workspace_id or "")
+    if not workspace_id:
+        raise ValueError("propose_instinct_rule requires a non-empty workspace_id")
+    user_id = str(user_id or "")
+    if not user_id:
+        raise ValueError("propose_instinct_rule requires a non-empty user_id (the owner)")
+    if not isinstance(rule_spec, dict) or not rule_spec:
+        raise ValueError("propose_instinct_rule requires a non-empty rule_spec")
+
+    name = _rule_name(rule_spec)
+
+    # Mint the chain correlation_id BEFORE building the blob so the stored Action
+    # carries it from the first write. The same id threads through approve / reject
+    # (router) and execute (executor) so the whole create folds into ONE Decision
+    # chain.
+    corr = correlation_id or str(uuid4())
+
+    human_summary = summary or f"Create the governed rule {name!r}."
+
+    blob: dict[str, Any] = {
+        "kind": INSTINCT_RULE_KIND,
+        "schema": INSTINCT_RULE_SCHEMA,
+        # Tenancy + owner are SEPARATE top-level fields (NOT in rule_spec) so the
+        # correction/edit flow can never change them.
+        "workspace_id": workspace_id,
+        "user_id": user_id,
+        # The editable staged RuleDraft body.
+        "rule_spec": rule_spec,
+        "summary": human_summary,
+        # RFC 09 chain-correlation fields (schema 1 carries them from the start).
+        "correlation_id": corr,
+        "proposed_event_id": None,
+    }
+
+    title = f"Governed rule — {name}"
+    recommendation = f"Approve to create the proposed governed rule. {human_summary}"
+    trigger = ActionTrigger(
+        type="agent",
+        source=user_id or "instinct_rule",
+        reason="proposed governed rule requires approval",
+    )
+
+    store = get_instinct_store()
+    action_obj = await store.propose(
+        # ``pocket_id`` carries the workspace for rule-create proposals — they aren't
+        # bound to an EXISTING pocket the way Mission Control items are (mirrors the
+        # Pocket-create gate). The workspace also rides on the blob (the executor's
+        # tenancy gate reads it there); pocket_id mirrors it so the existing
+        # per-pocket queries still surface the row.
+        pocket_id=workspace_id,
+        title=title,
+        description=recommendation,
+        recommendation=recommendation,
+        trigger=trigger,
+        category=ActionCategory.WORKFLOW,
+        priority=ActionPriority.MEDIUM,
+        parameters={INSTINCT_RULE_PARAM_KEY: blob},
+        assignee=assignee or user_id or None,
+        workspace_id=workspace_id,
+    )
+
+    logger.info(
+        "instinct_rule: proposed governed rule %r → Instinct action %s "
+        "(workspace=%s, owner=%s, correlation_id=%s)",
+        name,
+        action_obj.id,
+        workspace_id,
+        user_id,
+        corr,
+    )
+
+    # Open the Decision-Graph chain now that the Action is stored. ``agent.proposed``
+    # is the chain origin; its event id is back-written onto the blob so the router's
+    # ``human.corrected`` can cite it as causation. Best-effort: a Decision-Graph
+    # wiring failure must NOT fail the propose response.
+    proposed_event_id = _emit_agent_proposed(
+        correlation_id=UUID(corr),
+        action_id=action_obj.id,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=name,
+    )
+    if proposed_event_id is not None:
+        await _persist_chain_ids(
+            store=store,
+            action_id=action_obj.id,
+            correlation_id=corr,
+            proposed_event_id=str(proposed_event_id),
+        )
+
+    return action_obj.id
+
+
+__all__ = [
+    "INSTINCT_RULE_KIND",
+    "INSTINCT_RULE_PARAM_KEY",
+    "INSTINCT_RULE_SCHEMA",
+    "propose_instinct_rule",
+]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -48,6 +48,11 @@ lives in the ``pocketpaw_ee.versions`` package (its own entity), so it is
 imported lazily here — the same out-of-models discipline the belt/mandates docs
 use — to keep ``cloud.models`` from hard-importing the versions package. Only
 ``pocketpaw_ee.versions.service`` imports the doc class directly.
+Updated: 2026-06-20 (feat/szd-slice2-discovery, S2-R1) — added ``InstinctRuleDoc``
+(the persisted, approved, workspace-scoped, owned rule discovered from exhaust) to
+the imports, ``__all__``, and ``get_all_documents()`` so the ``instinct_rules``
+collection is wired into ``init_beanie`` and the ``beanie_test_db`` fixture. Only
+``ee.cloud.rules.service`` imports the doc class directly (import-linter "Rules").
 """
 
 from __future__ import annotations
@@ -84,6 +89,7 @@ from pocketpaw_ee.cloud.models.foresight_workspace_scenario import (
 )
 from pocketpaw_ee.cloud.models.group import Group, GroupAgent
 from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval
+from pocketpaw_ee.cloud.models.instinct_rule import InstinctRuleDoc
 from pocketpaw_ee.cloud.models.invite import Invite
 from pocketpaw_ee.cloud.models.lead import Lead, LeadSource
 from pocketpaw_ee.cloud.models.meeting import (
@@ -214,6 +220,7 @@ __all__ = [
     "Group",
     "GroupAgent",
     "InstinctApproval",
+    "InstinctRuleDoc",
     "Invite",
     "Lead",
     "LeadSource",
@@ -278,6 +285,9 @@ def get_all_documents():
         Invite,
         Group,
         InstinctApproval,
+        # Discovered governed rules (SZD slice-2). Only ``ee.cloud.rules.service``
+        # writes it.
+        InstinctRuleDoc,
         Message,
         ReadState,
         Task,

--- a/ee/pocketpaw_ee/cloud/models/instinct_rule.py
+++ b/ee/pocketpaw_ee/cloud/models/instinct_rule.py
@@ -1,0 +1,53 @@
+# InstinctRuleDoc Beanie document — a persisted, approved, workspace-scoped, OWNED rule.
+# Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery) — the persistence home for
+# a rule discovered from workspace exhaust and approved through the Instinct gate.
+#
+# It carries the editable ``RuleDraft`` fields (name / description / when / action /
+# scope / confidence / provenance) PLUS the non-editable governance fields kept
+# SEPARATE from the draft: ``workspace`` (indexed tenancy), ``owner_user_id`` (who
+# approved it), and ``status`` (active | archived). Tenancy/owner live here as
+# top-level columns — NOT nested in any editable ``rule_spec`` — so a tenant editing
+# the rule can never move it to another workspace.
+#
+# Only ``ee.cloud.rules.service`` imports this doc (import-linter "Rules" contract).
+# The ``scope`` is stored as a plain JSON sub-dict; the service re-validates it into
+# a ``RuleScope`` on the way in and projects it back out on read.
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from beanie import Indexed
+from pydantic import Field
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class InstinctRuleDoc(TimestampedDocument):
+    """One approved, workspace-scoped governed rule.
+
+    Tenancy: ``workspace`` is required and indexed; every read in
+    ``rules/service.py`` filters on it. ``status`` is ``"active"`` on create
+    and flips to ``"archived"`` when superseded or retired — the active read
+    excludes archived rows. The CEL ``when`` + ``action`` literal make the
+    persisted rule ``InstinctRule``-compatible for the (slice-3) enforcement
+    seam; this slice only makes it discoverable, governed, and readable via
+    ``get_active_rules``.
+    """
+
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    owner_user_id: str
+    status: Literal["active", "archived"] = "active"
+
+    # --- editable RuleDraft fields (the rule_spec content) ---
+    name: str
+    description: str | None = None
+    when: str  # CEL expression text (validated on the draft before persist)
+    action: str  # "require_approval" | "notify" | "block"
+    # Stored flat as JSON; the service maps it to/from a RuleScope value object.
+    scope: dict[str, Any] = Field(default_factory=dict)
+    confidence: float = 0.0
+    provenance: list[str] = Field(default_factory=list)
+
+    class Settings(TimestampedDocument.Settings):
+        name = "instinct_rules"

--- a/ee/pocketpaw_ee/cloud/rules/__init__.py
+++ b/ee/pocketpaw_ee/cloud/rules/__init__.py
@@ -1,0 +1,22 @@
+# Cloud rules entity — re-exports for the gate executor + read seam.
+# Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery). The discovered-rules
+# entity: the persistence + read API for governed Instinct rules mined from
+# workspace exhaust and approved through the gate. No HTTP router this slice
+# (rules are born only via the S2-R3 ``_instinct_rule`` executor; see the
+# ``no-router`` note in service.py). Re-exports the service entry points so the
+# executor + the slice-3 dispatcher import from the package root.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.rules.domain import Rule
+from pocketpaw_ee.cloud.rules.dto import CreateRuleRequest, RuleResponse
+from pocketpaw_ee.cloud.rules.service import archive_rule, create_rule, get_active_rules
+
+__all__ = [
+    "CreateRuleRequest",
+    "Rule",
+    "RuleResponse",
+    "archive_rule",
+    "create_rule",
+    "get_active_rules",
+]

--- a/ee/pocketpaw_ee/cloud/rules/domain.py
+++ b/ee/pocketpaw_ee/cloud/rules/domain.py
@@ -1,0 +1,43 @@
+# Rules — domain value objects.
+# Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery). Frozen value objects
+# constructed in service.py from an InstinctRuleDoc (read path) or a validated
+# RuleDraft (create path). Per the ee/cloud rule §3, tenancy (``workspace_id``)
+# is required at construction — there is no default, so a Rule can never be built
+# without a workspace. Consumers outside the service only ever see ``Rule``.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One approved, workspace-scoped governed rule.
+
+    Required tenancy first (``workspace_id`` has no default). The ``when`` /
+    ``action`` pair is enforcement-ready (CEL + the template action literal).
+    ``scope_*`` flatten the rule's RuleScope; ``scope_workspace_id`` always
+    equals ``workspace_id`` (the create path asserts the match before
+    construction). Built from a validated ``RuleDraft`` plus the governance
+    fields (owner / status) that live OUTSIDE the editable draft.
+    """
+
+    workspace_id: str
+    id: str
+    owner_user_id: str
+    name: str
+    when: str
+    action: str
+    status: str  # "active" | "archived"
+    scope_workspace_id: str
+    scope_pocket_id: str | None
+    scope_object_type: str | None
+    confidence: float
+    provenance: tuple[str, ...] = field(default_factory=tuple)
+    description: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+__all__ = ["Rule"]

--- a/ee/pocketpaw_ee/cloud/rules/dto.py
+++ b/ee/pocketpaw_ee/cloud/rules/dto.py
@@ -1,0 +1,74 @@
+# Rules — request / response schemas.
+# Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery). Per cloud rule §4 the
+# request schema (``CreateRuleRequest``) is distinct from the response schema
+# (``RuleResponse``) — never one model for both, so fields can't leak silently.
+#
+# ``CreateRuleRequest`` is what the R3 ``_instinct_rule`` executor hands to
+# ``rules.service.create_rule``: the editable ``RuleDraft`` plus ``owner_user_id``
+# (the approver). Tenancy is NOT in this DTO — it arrives as the service's explicit
+# ``workspace_id`` parameter, and the service asserts it matches ``draft.scope``.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from pocketpaw_ee.discovery.rule_models import RuleDraft
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class CreateRuleRequest(BaseModel):
+    """Body for ``rules.service.create_rule``.
+
+    Carries the editable ``RuleDraft`` (the ``rule_spec`` content) plus the
+    ``owner_user_id`` of the approver. Tenancy is the service's ``workspace_id``
+    parameter, not a field here — keeping it out of the request means an edited
+    draft can never move the rule to another workspace.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    draft: RuleDraft
+    owner_user_id: str
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class RuleScopeResponse(BaseModel):
+    workspace_id: str
+    pocket_id: str | None = None
+    object_type: str | None = None
+
+
+class RuleResponse(BaseModel):
+    """Wire shape for one governed rule.
+
+    Flattens the persisted doc into the JSON the review surface + the
+    ``get_active_rules`` consumers read. ``scope`` nests the rule's RuleScope.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    workspace_id: str
+    owner_user_id: str
+    name: str
+    description: str | None = None
+    when: str
+    action: str
+    status: str
+    scope: RuleScopeResponse
+    confidence: float
+    provenance: list[str]
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+__all__ = ["CreateRuleRequest", "RuleResponse", "RuleScopeResponse"]

--- a/ee/pocketpaw_ee/cloud/rules/service.py
+++ b/ee/pocketpaw_ee/cloud/rules/service.py
@@ -1,0 +1,167 @@
+# Rules — service (the sole owner of InstinctRuleDoc writes).
+# Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery). The R3 ``_instinct_rule``
+# gate executor calls ``create_rule`` at approve time; ``get_active_rules`` is the
+# slice-2 read seam (slice-3 wires it into live gate dispatch). Follows the ee/cloud
+# 4-file rules: module-level ``async def``, validate-at-entry, tenant filter on every
+# read, emit on every write, errors via CloudError.
+#
+# no-router: rules have NO direct HTTP surface this slice. A rule is born ONLY by
+#   approving an ``_instinct_rule`` gate proposal (S2-R3 executor → this service);
+#   it is never POSTed by a client. The read seam ``get_active_rules`` is consumed
+#   in-process by the (slice-3) gate dispatcher, not over HTTP. A read router can be
+#   added later if a workspace rule-list endpoint is needed; omitted by design now.
+
+from __future__ import annotations
+
+from typing import Any
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import RuleArchived, RuleCreated
+from pocketpaw_ee.cloud.models.instinct_rule import InstinctRuleDoc
+from pocketpaw_ee.cloud.rules.domain import Rule
+from pocketpaw_ee.cloud.rules.dto import CreateRuleRequest, RuleResponse, RuleScopeResponse
+
+# ---------------------------------------------------------------------------
+# Private mapping helpers — Beanie doc ↔ domain ↔ wire dict
+# ---------------------------------------------------------------------------
+
+
+def _doc_to_domain(doc: InstinctRuleDoc) -> Rule:
+    scope = doc.scope or {}
+    return Rule(
+        workspace_id=doc.workspace,
+        id=str(doc.id),
+        owner_user_id=doc.owner_user_id,
+        name=doc.name,
+        when=doc.when,
+        action=doc.action,
+        status=doc.status,
+        scope_workspace_id=str(scope.get("workspace_id") or doc.workspace),
+        scope_pocket_id=scope.get("pocket_id"),
+        scope_object_type=scope.get("object_type"),
+        confidence=doc.confidence,
+        provenance=tuple(doc.provenance),
+        description=doc.description,
+        created_at=getattr(doc, "createdAt", None),
+        updated_at=getattr(doc, "updatedAt", None),
+    )
+
+
+def _domain_to_response(rule: Rule) -> RuleResponse:
+    return RuleResponse(
+        id=rule.id,
+        workspace_id=rule.workspace_id,
+        owner_user_id=rule.owner_user_id,
+        name=rule.name,
+        description=rule.description,
+        when=rule.when,
+        action=rule.action,
+        status=rule.status,
+        scope=RuleScopeResponse(
+            workspace_id=rule.scope_workspace_id,
+            pocket_id=rule.scope_pocket_id,
+            object_type=rule.scope_object_type,
+        ),
+        confidence=rule.confidence,
+        provenance=list(rule.provenance),
+        created_at=rule.created_at,
+        updated_at=rule.updated_at,
+    )
+
+
+def _wire_dict(doc: InstinctRuleDoc) -> dict:
+    return _domain_to_response(_doc_to_domain(doc)).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def create_rule(workspace_id: str, user_id: str, body: CreateRuleRequest | dict) -> dict:
+    """Persist an approved governed rule, returning its wire dict.
+
+    Validates at entry (re-parses for internal callers), asserts the draft's
+    ``scope.workspace_id`` matches the caller's ``workspace_id`` (tenancy can't
+    be moved by an edited draft), writes the ``InstinctRuleDoc``, and emits
+    ``RuleCreated``. Raises ``ValidationError`` (a CloudError) on a tenancy
+    mismatch — never a silent cross-tenant write.
+    """
+    body = CreateRuleRequest.model_validate(body)
+    draft = body.draft
+
+    if draft.scope.workspace_id != workspace_id:
+        raise ValidationError(
+            "rule.workspace_mismatch",
+            "rule scope workspace does not match the caller's workspace — "
+            "a discovered rule cannot be persisted into another tenant",
+        )
+
+    doc = InstinctRuleDoc(
+        workspace=workspace_id,
+        owner_user_id=body.owner_user_id,
+        status="active",
+        name=draft.name,
+        description=draft.description,
+        when=draft.when,
+        action=draft.action,
+        scope=draft.scope.model_dump(),
+        confidence=draft.confidence,
+        provenance=list(draft.provenance),
+    )
+    await doc.insert()
+    wire = _wire_dict(doc)
+    await emit(RuleCreated(data=wire))
+    return wire
+
+
+async def get_active_rules(workspace_id: str) -> list[dict]:
+    """Return the active governed rules for one workspace, as wire dicts.
+
+    Tenant-filtered (``workspace == workspace_id``) and ``status == "active"``
+    — archived rows are excluded. This is the seam the slice-3 gate dispatcher
+    consults; slice-2 only exposes the read.
+    """
+    cursor = InstinctRuleDoc.find(
+        InstinctRuleDoc.workspace == workspace_id,
+        InstinctRuleDoc.status == "active",
+    )
+    return [_wire_dict(doc) async for doc in cursor]
+
+
+async def archive_rule(workspace_id: str, user_id: str, rule_id: str) -> dict:
+    """Flip a rule to ``archived`` (retire / supersede), returning its wire dict.
+
+    Tenant-scoped lookup (``workspace == workspace_id``) so a caller can never
+    archive another tenant's rule. Raises ``ValidationError`` if the id is not
+    found in this workspace. Emits ``RuleArchived``.
+    """
+    doc = await InstinctRuleDoc.find_one(
+        InstinctRuleDoc.id == _as_object_id(rule_id),
+        InstinctRuleDoc.workspace == workspace_id,
+    )
+    if doc is None:
+        raise ValidationError(
+            "rule.not_found",
+            f"rule {rule_id} not found in workspace {workspace_id}",
+        )
+    doc.status = "archived"
+    await doc.save()
+    wire = _wire_dict(doc)
+    await emit(RuleArchived(data=wire))
+    return wire
+
+
+def _as_object_id(rule_id: str) -> Any:
+    """Coerce a string id to a Beanie PydanticObjectId, surfacing a malformed
+    id as a handled ValidationError rather than an unguarded ObjectId error."""
+    from beanie import PydanticObjectId
+
+    try:
+        return PydanticObjectId(rule_id)
+    except Exception as exc:  # noqa: BLE001 — a bad id is a validation failure
+        raise ValidationError("rule.invalid_id", f"invalid rule id: {rule_id}") from exc
+
+
+__all__ = ["archive_rule", "create_rule", "get_active_rules"]

--- a/ee/pocketpaw_ee/discovery/__init__.py
+++ b/ee/pocketpaw_ee/discovery/__init__.py
@@ -29,6 +29,11 @@
 # the editable ``rule_spec`` blob). ``when`` (CEL) + ``action`` (the template
 # literal) make an approved draft enforcement-ready; the cloud ``rules`` entity
 # persists it.
+#
+# Updated 2026-06-20 (S2-R2 / feat/szd-slice2-discovery): added ``RuleDigester``
+# — the deterministic (no-LLM, on-box) engine that reverse-engineers ``RuleDraft``s
+# from Instinct exhaust (correction history + audit), generalizing the existing
+# 3x-correction → soul-procedural promotion into structured, gate-ready drafts.
 
 from __future__ import annotations
 
@@ -47,6 +52,7 @@ from pocketpaw_ee.discovery.orchestrate import (
     assemble_discovery_pocket,
     run_discovery_and_propose,
 )
+from pocketpaw_ee.discovery.rule_digester import RuleDigester
 from pocketpaw_ee.discovery.rule_models import RuleDraft, RuleScope
 from pocketpaw_ee.discovery.run import (
     DEFAULT_SAMPLE_CAP,
@@ -59,6 +65,7 @@ __all__ = [
     "Digester",
     "StructuredShapeDigester",
     "KbCompileDigester",
+    "RuleDigester",
     "RuleDraft",
     "RuleScope",
     "OntologyDraft",

--- a/ee/pocketpaw_ee/discovery/__init__.py
+++ b/ee/pocketpaw_ee/discovery/__init__.py
@@ -23,6 +23,12 @@
 # email / chat text). It compiles the text into a kb-go wiki ON-BOX via the
 # keyless ``kb convo ingest`` path (never ``kb ingest`` / ``kb build``, which
 # POST to Anthropic) and infers the OntologyDraft from the compiled articles.
+#
+# Updated 2026-06-20 (S2-R1 / feat/szd-slice2-discovery): added ``RuleDraft`` +
+# ``RuleScope`` — the pure-data shape for RULES discovery (the digester output AND
+# the editable ``rule_spec`` blob). ``when`` (CEL) + ``action`` (the template
+# literal) make an approved draft enforcement-ready; the cloud ``rules`` entity
+# persists it.
 
 from __future__ import annotations
 
@@ -41,6 +47,7 @@ from pocketpaw_ee.discovery.orchestrate import (
     assemble_discovery_pocket,
     run_discovery_and_propose,
 )
+from pocketpaw_ee.discovery.rule_models import RuleDraft, RuleScope
 from pocketpaw_ee.discovery.run import (
     DEFAULT_SAMPLE_CAP,
     DiscoveryRun,
@@ -52,6 +59,8 @@ __all__ = [
     "Digester",
     "StructuredShapeDigester",
     "KbCompileDigester",
+    "RuleDraft",
+    "RuleScope",
     "OntologyDraft",
     "DraftObjectType",
     "DraftObject",

--- a/ee/pocketpaw_ee/discovery/__init__.py
+++ b/ee/pocketpaw_ee/discovery/__init__.py
@@ -17,10 +17,17 @@
 # a DiscoveryRun's OntologyDraft into the two gated Instinct proposals (Fabric
 # objects + a starter Pocket) a human reviews, with key-confidence gating and
 # supersede-on-rerun.
+#
+# Updated 2026-06-20 (S2-K1 / feat/szd-slice2-discovery): added
+# ``KbCompileDigester`` — a second Digester for UNSTRUCTURED exhaust (ticket /
+# email / chat text). It compiles the text into a kb-go wiki ON-BOX via the
+# keyless ``kb convo ingest`` path (never ``kb ingest`` / ``kb build``, which
+# POST to Anthropic) and infers the OntologyDraft from the compiled articles.
 
 from __future__ import annotations
 
 from pocketpaw_ee.discovery.digester import Digester, StructuredShapeDigester
+from pocketpaw_ee.discovery.kb_compile import KbCompileDigester
 from pocketpaw_ee.discovery.models import (
     DraftLink,
     DraftObject,
@@ -44,6 +51,7 @@ from pocketpaw_ee.discovery.run import (
 __all__ = [
     "Digester",
     "StructuredShapeDigester",
+    "KbCompileDigester",
     "OntologyDraft",
     "DraftObjectType",
     "DraftObject",

--- a/ee/pocketpaw_ee/discovery/kb_compile.py
+++ b/ee/pocketpaw_ee/discovery/kb_compile.py
@@ -1,0 +1,497 @@
+# pocketpaw_ee/discovery/kb_compile.py — the KbCompileDigester (S2-K1).
+#
+# Created: 2026-06-20 (S2-K1 / feat/szd-slice2-discovery) — the second Digester
+# implementation for sovereign zero-setup discovery. Where StructuredShapeDigester
+# reverse-engineers an ontology from typed record dicts, KbCompileDigester handles
+# UNSTRUCTURED exhaust (ticket bodies, email/chat text) that has no record shape:
+# it compiles the text into a kb-go wiki ON-BOX, reads the compiled articles back,
+# and infers the OntologyDraft from them.
+#
+# Contract: ``digest(records, connector_meta=None) -> OntologyDraft`` — the same
+# sync Digester Protocol StructuredShapeDigester satisfies. Here ``records`` are
+# TEXT blobs grouped by type label (``{type_label: [text, ...]}`` — the shape the
+# DiscoveryRun sampler lands in ``grouped`` for an unstructured connector), or a
+# flat ``list[text]``. Never raises on empty/degenerate input (degrades via
+# ``draft.meta``). Stamps ``meta["digester"] = "kb-compile"``.
+#
+# Inference: article ``categories`` → object types; article ``id`` →
+# ``source_id_field``; properties over ``{title, summary, concepts, categories}``;
+# concept co-occurrence (two articles of different types sharing a concept) →
+# a ``DraftLink`` with ``via_field`` = the shared concept. Every confidence is
+# ``_clamp``-bounded into [0, 1]. ``to_fabric_mapping_kwargs()`` yields a valid
+# ``FabricMapping`` for each keyed type.
+#
+# SOVEREIGNTY (load-bearing, encoded as a test): compilation uses ONLY the
+# keyless on-box path (``kb convo ingest`` — deterministic, no LLM). It must
+# NEVER call ``kb ingest`` / ``kb build``, which POST raw tenant text to the
+# Anthropic API (kb.go:1349). The ``_kb`` seam below clones
+# ``cloud/agents/knowledge.py`` (binary resolution + subprocess + timeout) and is
+# the seam the unit tests mock; the digest path simply never asks it for ingest.
+#
+# Pure orchestration over a subprocess: no DB, no async, honours the subprocess
+# timeout. Depends on stdlib + the OSS PropertyDef + the discovery models.
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from pocketpaw.fabric.models import PropertyDef
+from pocketpaw_ee.discovery.models import (
+    DraftLink,
+    DraftObject,
+    DraftObjectType,
+    OntologyDraft,
+    _clamp,
+)
+
+logger = logging.getLogger(__name__)
+
+# The four article fields the digester projects as properties.
+_ARTICLE_PROPERTY_FIELDS: tuple[tuple[str, str], ...] = (
+    ("title", "string"),
+    ("summary", "string"),
+    ("concepts", "string"),
+    ("categories", "string"),
+)
+
+# Confidence when the article id cleanly keys a categorized type (the article id
+# is the natural, always-unique idempotency key for a compiled article).
+_KEYED_CONFIDENCE = 0.85
+# Confidence floor for an uncategorized / keyless degraded type.
+_KEYLESS_CONFIDENCE = 0.1
+
+
+# --------------------------------------------------------------------------- #
+# kb-go subprocess seam — cloned from cloud/agents/knowledge.py:36-97.
+# This is the seam the unit tests MOCK. The digest path only ever asks it for
+# the keyless on-box commands (convo ingest / list / show / graph), NEVER for
+# `ingest` / `build` (those POST to Anthropic — a sovereignty violation).
+# --------------------------------------------------------------------------- #
+def _resolve_kb_bin() -> str:
+    """Find the kb binary, in order of preference (mirrors knowledge.py).
+
+    1. ``POCKETPAW_KB_BIN`` env var (explicit override).
+    2. ``kb-go`` on PATH, then ``kb`` on PATH.
+    3. Workspace-local checkout at ``<paw-workspace>/kb-go/kb``.
+
+    Returns the literal ``"kb-go"`` when nothing resolves so the error message
+    stays informative. Resolved at import time.
+    """
+    explicit = os.environ.get("POCKETPAW_KB_BIN")
+    if explicit:
+        return explicit
+    for name in ("kb-go", "kb"):
+        path = shutil.which(name)
+        if path:
+            return path
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "kb-go" / "kb"
+        if candidate.exists():
+            return str(candidate)
+    return "kb-go"
+
+
+KB_BIN = _resolve_kb_bin()
+
+
+def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict | list | str:
+    """Call the kb binary, return parsed JSON or raw text.
+
+    Cloned from ``cloud/agents/knowledge.py:_kb`` — a blocking ``subprocess.run``
+    with a timeout. Callers keep it synchronous (the Digester Protocol is sync);
+    the orchestrator already drives the whole digest under ``asyncio.to_thread``.
+    """
+    cmd = [KB_BIN, *args, "--json"]
+    try:
+        result = subprocess.run(
+            cmd,
+            input=input_text,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"kb binary not found at {KB_BIN!r}. "
+            "Install: go install github.com/qbtrix/kb-go@latest, "
+            "or set POCKETPAW_KB_BIN to the binary path (e.g. /path/to/kb-go/kb), "
+            "or place the workspace-local checkout at <paw-workspace>/kb-go/kb."
+        ) from exc
+    if result.returncode != 0:
+        logger.warning("kb failed (exit %d): %s", result.returncode, result.stderr[:200])
+        raise RuntimeError(f"kb failed: {result.stderr[:200]}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return result.stdout.strip()
+
+
+class KbCompileDigester:
+    """Infers an OntologyDraft from unstructured text exhaust, compiled on-box.
+
+    Input shape: ``{type_label: [text, ...]}`` (text blobs grouped the way the
+    DiscoveryRun sampler lands them in ``grouped``) or a flat ``list[text]``.
+    Each label's blobs are compiled into a discovery-private kb-go scope via the
+    KEYLESS ``kb convo ingest`` path; the compiled articles are read back
+    (``list`` → ``show``) and their concept graph queried (``graph``); the draft
+    is inferred from the articles.
+
+    Conforms to the ``Digester`` Protocol structurally (single sync ``digest``).
+    """
+
+    def __init__(self, scope_prefix: str = "workspace", scope_suffix: str = "discovery") -> None:
+        # Scope shape: ``{scope_prefix}:{workspace_id}:{scope_suffix}`` — a
+        # discovery-private kb-go scope so compiled exhaust never collides with
+        # an agent/workspace KB.
+        self._scope_prefix = scope_prefix
+        self._scope_suffix = scope_suffix
+
+    # ------------------------------------------------------------------ public
+    def digest(
+        self,
+        records: Any,
+        connector_meta: Mapping[str, Any] | None = None,
+    ) -> OntologyDraft:
+        meta = dict(connector_meta or {})
+        grouped = self._normalize_input(records)
+
+        draft = OntologyDraft(meta={"digester": "kb-compile", **meta})
+        if not grouped:
+            draft.meta["degraded"] = "empty"
+            return draft
+
+        scope = self._compile_scope(meta)
+
+        # 1) Compile every text blob into the discovery scope, keyless + on-box.
+        for label, blobs in grouped.items():
+            self._compile_blobs(scope, label, blobs)
+
+        # 2) Read the compiled articles back (list → show for full bodies).
+        articles = self._read_articles(scope)
+        if not articles:
+            # The compile produced nothing readable — degrade cleanly to empty.
+            draft.meta["degraded"] = "empty"
+            return draft
+
+        # 3) Query the concept co-occurrence graph (on-box, no LLM). Best-effort:
+        #    link inference falls back to the article concepts if graph is empty.
+        self._read_concept_graph(scope)
+
+        # 4) Group articles into object types by category.
+        typed, uncategorized = self._partition_by_category(articles)
+
+        if typed:
+            for type_name, type_articles in typed.items():
+                draft.object_types.append(self._build_typed_object_type(type_name, type_articles))
+                for art in type_articles:
+                    draft.objects.append(
+                        DraftObject(
+                            type_name=type_name,
+                            source_id=str(art.get("id")) if art.get("id") else None,
+                            properties=self._project_article(art),
+                        )
+                    )
+
+        if uncategorized:
+            # Articles with no category degrade to a single objects-only type
+            # named from the connector — no usable key, low confidence, no links.
+            objects_type = self._objects_only_type_name(meta)
+            draft.object_types.append(self._build_keyless_object_type(objects_type, uncategorized))
+            for art in uncategorized:
+                draft.objects.append(
+                    DraftObject(
+                        type_name=objects_type,
+                        source_id=None,
+                        properties=self._project_article(art),
+                    )
+                )
+
+        # 5) Links from concept co-occurrence across DIFFERENT typed articles.
+        draft.links = self._infer_concept_links(typed)
+
+        if uncategorized and not typed:
+            draft.meta.setdefault("degraded", "objects-only")
+        elif not draft.links and len(draft.object_types) <= 1 and not typed:
+            draft.meta.setdefault("degraded", "objects-only")
+
+        return draft
+
+    # -------------------------------------------------------------- normalize
+    def _normalize_input(self, records: Any) -> dict[str, list[str]]:
+        """Coerce the input into ``{type_label: [text, ...]}`` of non-empty strings.
+
+        Accepts a mapping of label→text-blobs, or a flat sequence of text blobs
+        (single anonymous label). Empty / None inputs → ``{}``. Non-string blobs
+        are coerced via ``str``; empty/whitespace-only blobs are dropped. Labels
+        whose blob list empties out are dropped so an all-empty input degrades.
+        """
+        if not records:
+            return {}
+
+        def _clean(blobs: Any) -> list[str]:
+            if isinstance(blobs, (str, bytes)):
+                items: Sequence[Any] = [blobs]
+            elif isinstance(blobs, Sequence):
+                items = blobs
+            else:
+                return []
+            out: list[str] = []
+            for b in items:
+                text = b.decode("utf-8", "replace") if isinstance(b, bytes) else str(b)
+                text = text.strip()
+                if text:
+                    out.append(text)
+            return out
+
+        if isinstance(records, Mapping):
+            out: dict[str, list[str]] = {}
+            for label, blobs in records.items():
+                cleaned = _clean(blobs)
+                if cleaned:
+                    out[str(label)] = cleaned
+            return out
+
+        if isinstance(records, Sequence) and not isinstance(records, (str, bytes)):
+            cleaned = _clean(records)
+            return {"Record": cleaned} if cleaned else {}
+
+        return {}
+
+    # ------------------------------------------------------------------- scope
+    def _compile_scope(self, meta: Mapping[str, Any]) -> str:
+        wid = str(meta.get("workspace_id") or "default")
+        return f"{self._scope_prefix}:{wid}:{self._scope_suffix}"
+
+    @staticmethod
+    def _objects_only_type_name(meta: Mapping[str, Any]) -> str:
+        raw = str(meta.get("connector") or meta.get("default_type") or "Document")
+        # Title-case a connector-ish label into a type name (zendesk → Zendesk).
+        cleaned = "".join(ch for ch in raw if ch.isalnum()) or "Document"
+        return cleaned[:1].upper() + cleaned[1:]
+
+    # ---------------------------------------------------------------- compile
+    def _compile_blobs(self, scope: str, label: str, blobs: Sequence[str]) -> None:
+        """Compile a label's text blobs into ``scope`` via the keyless path.
+
+        Writes the blobs to a temp transcript file and runs ``kb convo ingest``
+        — fully deterministic, no LLM, no API key (kb-go convo.go). NEVER
+        ``kb ingest`` / ``kb build``. Subprocess failures are non-fatal: one
+        bad label can't kill the digest (it just contributes no articles).
+        """
+        if not blobs:
+            return
+        # A simple transcript: one labelled turn per blob. ``convo ingest``
+        # parses turns heuristically; the exact format is forgiving.
+        transcript = "\n\n".join(f"{label}: {blob}" for blob in blobs)
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".txt", encoding="utf-8", delete=False
+            ) as fh:
+                fh.write(transcript)
+                tmp_path = fh.name
+            _kb("convo", "ingest", tmp_path, "--scope", scope)
+        except Exception as exc:  # noqa: BLE001 — one bad label can't kill the run
+            logger.warning("kb-compile: convo ingest failed for label %s: %s", label, exc)
+        finally:
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+    # ------------------------------------------------------------------- read
+    def _read_articles(self, scope: str) -> list[dict[str, Any]]:
+        """Read compiled articles back: ``list`` for ids, ``show`` for bodies.
+
+        ``kb list --json`` omits ``concepts`` / ``categories`` (kb.go:cmdList),
+        so each article is enriched via ``kb show <id>`` which returns the full
+        WikiArticle (id, title, summary, content, concepts, categories).
+        """
+        try:
+            listed = _kb("list", "--scope", scope)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("kb-compile: list failed for scope %s: %s", scope, exc)
+            return []
+        if not isinstance(listed, list):
+            return []
+
+        articles: list[dict[str, Any]] = []
+        for entry in listed:
+            if not isinstance(entry, Mapping):
+                continue
+            art_id = entry.get("id")
+            if not art_id:
+                continue
+            full = self._show_article(scope, str(art_id))
+            if full is None:
+                # Fall back to the lean list entry (no concepts/categories).
+                full = dict(entry)
+            articles.append(full)
+        return articles
+
+    def _show_article(self, scope: str, article_id: str) -> dict[str, Any] | None:
+        try:
+            shown = _kb("show", article_id, "--scope", scope)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("kb-compile: show failed for %s: %s", article_id, exc)
+            return None
+        if isinstance(shown, Mapping) and shown.get("id"):
+            return dict(shown)
+        return None
+
+    def _read_concept_graph(self, scope: str) -> dict[str, Any]:
+        """Query the concept co-occurrence graph (on-box, no LLM). Best-effort."""
+        try:
+            graph = _kb("graph", "--scope", scope, "--format", "json")
+        except Exception as exc:  # noqa: BLE001 — graph is advisory; never fatal
+            logger.info("kb-compile: graph failed for scope %s: %s", scope, exc)
+            return {}
+        return dict(graph) if isinstance(graph, Mapping) else {}
+
+    # -------------------------------------------------------------- inference
+    @staticmethod
+    def _partition_by_category(
+        articles: Sequence[Mapping[str, Any]],
+    ) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
+        """Split articles into ``{category: [article, ...]}`` + uncategorized.
+
+        An article's first category names its object type. Articles with no
+        category are uncategorized (they degrade to objects-only).
+        """
+        typed: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        uncategorized: list[dict[str, Any]] = []
+        for art in articles:
+            cats = art.get("categories") or []
+            cat = None
+            if isinstance(cats, Sequence) and not isinstance(cats, (str, bytes)):
+                for c in cats:
+                    if isinstance(c, str) and c.strip():
+                        cat = c.strip()
+                        break
+            elif isinstance(cats, str) and cats.strip():
+                cat = cats.strip()
+            if cat:
+                typed[cat].append(dict(art))
+            else:
+                uncategorized.append(dict(art))
+        return dict(typed), uncategorized
+
+    @staticmethod
+    def _project_article(art: Mapping[str, Any]) -> dict[str, Any]:
+        """Project an article onto the four ontology property fields."""
+        return {
+            "id": art.get("id"),
+            "title": art.get("title", ""),
+            "summary": art.get("summary", ""),
+            "concepts": list(art.get("concepts") or []),
+            "categories": list(art.get("categories") or []),
+        }
+
+    def _build_typed_object_type(
+        self, type_name: str, articles: Sequence[Mapping[str, Any]]
+    ) -> DraftObjectType:
+        """Build a keyed object type — article ``id`` is the source_id_field.
+
+        The article id is always unique and fully populated for a compiled
+        article, so the key confidence is high. Type confidence scales with the
+        sample size (how many articles landed in this category).
+        """
+        properties = [PropertyDef(name="id", type="string", required=True)]
+        field_map: dict[str, str] = {"id": "id"}
+        for field, ptype in _ARTICLE_PROPERTY_FIELDS:
+            properties.append(PropertyDef(name=field, type=ptype, required=False))
+            field_map[field] = field
+
+        size_signal = _clamp(len(articles) / 3.0)  # 3+ articles → full size signal
+        type_conf = _clamp(0.5 + 0.5 * size_signal)
+
+        return DraftObjectType(
+            name=type_name,
+            properties=properties,
+            source_id_field="id",
+            field_map=field_map,
+            confidence=round(type_conf, 3),
+            key_confidence=round(_KEYED_CONFIDENCE, 3),
+            record_count=len(articles),
+        )
+
+    def _build_keyless_object_type(
+        self, type_name: str, articles: Sequence[Mapping[str, Any]]
+    ) -> DraftObjectType:
+        """Build an objects-only type — no usable key, low confidence."""
+        properties: list[PropertyDef] = []
+        field_map: dict[str, str] = {}
+        for field, ptype in _ARTICLE_PROPERTY_FIELDS:
+            properties.append(PropertyDef(name=field, type=ptype, required=False))
+            field_map[field] = field
+        return DraftObjectType(
+            name=type_name,
+            properties=properties,
+            source_id_field=None,
+            field_map=field_map,
+            confidence=round(_clamp(0.3), 3),
+            key_confidence=round(_KEYLESS_CONFIDENCE, 3),
+            record_count=len(articles),
+        )
+
+    def _infer_concept_links(self, typed: Mapping[str, list[dict[str, Any]]]) -> list[DraftLink]:
+        """Link articles of different types that share a concept.
+
+        Concept co-occurrence is the unstructured analogue of a foreign key: two
+        articles of different object types tagged with the same concept signal a
+        relationship. ``via_field`` is the shared concept; ``link_type`` records
+        the concept; confidence scales with how rare (and thus how specific) the
+        concept is across the corpus.
+        """
+        if len(typed) < 2:
+            return []
+
+        # concept -> [(type_name, source_id), ...]
+        concept_index: dict[str, list[tuple[str, str]]] = defaultdict(list)
+        for type_name, articles in typed.items():
+            for art in articles:
+                sid = art.get("id")
+                if not sid:
+                    continue
+                for concept in art.get("concepts") or []:
+                    if isinstance(concept, str) and concept.strip():
+                        concept_index[concept.strip()].append((type_name, str(sid)))
+
+        links: list[DraftLink] = []
+        for concept, endpoints in concept_index.items():
+            if len(endpoints) < 2:
+                continue
+            # Rarer concepts are more specific signals → higher confidence.
+            specificity = _clamp(2.0 / len(endpoints))
+            confidence = _clamp(0.4 + 0.4 * specificity)
+            # Emit a link for each cross-type pair sharing the concept.
+            for i in range(len(endpoints)):
+                from_type, from_sid = endpoints[i]
+                for j in range(i + 1, len(endpoints)):
+                    to_type, to_sid = endpoints[j]
+                    if from_type == to_type:
+                        continue  # same-type co-occurrence isn't a cross-type link
+                    links.append(
+                        DraftLink(
+                            from_type=from_type,
+                            from_source_id=from_sid,
+                            to_type=to_type,
+                            to_source_id=to_sid,
+                            link_type=f"shares_concept_{concept.lower()}",
+                            via_field=concept,
+                            confidence=round(confidence, 3),
+                        )
+                    )
+        return links

--- a/ee/pocketpaw_ee/discovery/orchestrate.py
+++ b/ee/pocketpaw_ee/discovery/orchestrate.py
@@ -1,9 +1,9 @@
-# pocketpaw_ee/discovery/orchestrate.py — wire DiscoveryRun → the two gated proposals.
+# pocketpaw_ee/discovery/orchestrate.py — wire DiscoveryRun → the gated proposals.
 #
 # Created: 2026-06-19 (SZD-6 / feat/szd-6-integration) — the integration slice
 # that connects the pieces the earlier SZD slices built in isolation. A discovery
 # run yields an ``OntologyDraft`` (SZD-3/4); this module turns that draft into the
-# two STAGED Instinct proposals a human reviews through the gate:
+# STAGED Instinct proposals a human reviews through the gate:
 #
 #   1. a ``_fabric_objects`` proposal (SZD-5a) — the discovered ontology
 #      (object_types + objects + links) staged for materialisation into Fabric;
@@ -12,9 +12,24 @@
 #      ``fabric.objects`` ripple source (SZD-1), so when both proposals are
 #      approved the Pocket renders the freshly-materialised Fabric data.
 #
-# Nothing here writes Fabric or creates a Pocket — both halves are GATED. This
-# module only builds the two proposals and returns their Action ids; a human
-# approves them in The Tray and the apply-on-approve executors do the writes.
+# Updated 2026-06-20 (S2-R5 / feat/szd-slice2-discovery): a discovery run now ALSO
+# proposes a THIRD kind — governed Instinct RULES:
+#
+#   3. zero or more ``_instinct_rule`` proposals (S2-R3) — candidate governed rules
+#      the ``RuleDigester`` (S2-R2) reverse-engineers from the workspace's Instinct
+#      CORRECTION exhaust (``store.get_corrections_for_pocket(workspace_id)`` +
+#      ``store.query_audit(...)`` — corrections anchor on ``pocket_id ==
+#      workspace_id``, the non-pocket convention). Each qualifying RuleDraft is
+#      filed as its OWN ``_instinct_rule`` proposal (one rule = one gate blob, NOT
+#      batched like fabric objects), gated on the digester's OWN confidence floor
+#      (``RULE_CONFIDENCE_FLOOR``, NOT ``KEY_CONFIDENCE_FLOOR``). The rules block is
+#      ADDITIVE: if there is no correction exhaust (or every draft is sub-floor) it
+#      proposes nothing and the run still produces the fabric + pocket pair exactly
+#      as before.
+#
+# Nothing here writes Fabric, creates a Pocket, or persists a rule — every half is
+# GATED. This module only builds the proposals and returns their Action ids; a
+# human approves them in The Tray and the apply-on-approve executors do the writes.
 #
 # KEY-CONFIDENCE GATE (a design-review must): the digester emits a per-type
 # ``key_confidence`` and a ``source_id_field`` that is empty when no stable key
@@ -28,13 +43,13 @@
 # see what was held back (rather than silently dropping records).
 #
 # SUPERSEDE-ON-RERUN: a discovery run is re-runnable. A second run for the same
-# workspace SUPERSEDES the prior STILL-OPEN (PENDING) discovery proposal pair
-# rather than stacking a duplicate. Both proposals are tagged with a
-# ``discovery_run`` marker (a shared ``run_id`` + the proposal ``role``) on their
-# blob so the supersede sweep can find the prior open pair for this workspace and
-# reject it (status REJECTED, reason "superseded by discovery run <id>") before
-# filing the new pair. Approved / rejected / executed proposals are left alone —
-# only the still-open pair is collapsed.
+# workspace SUPERSEDES the prior STILL-OPEN (PENDING) discovery proposals (the
+# fabric + pocket pair AND any ``_instinct_rule`` proposals) rather than stacking
+# duplicates. Every proposal is tagged with a ``discovery_run`` marker (a shared
+# ``run_id`` + the proposal ``role``) on its blob so the supersede sweep can find
+# the prior open proposals for this workspace and reject each (status REJECTED,
+# reason "superseded by discovery run <id>") before filing the new set. Approved /
+# rejected / executed proposals are left alone — only the still-open ones collapse.
 #
 # Async orchestration; depends on the SZD-4 DiscoveryRun + the SZD-5a/5b propose
 # helpers + the OSS InstinctStore (for the supersede sweep). No direct Fabric /
@@ -43,11 +58,19 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 from uuid import uuid4
 
 from pocketpaw_ee.discovery.models import DraftObjectType, OntologyDraft
+from pocketpaw_ee.discovery.rule_digester import (
+    RULE_CONFIDENCE_FLOOR as _RULE_CONFIDENCE_FLOOR,
+)
+from pocketpaw_ee.discovery.rule_digester import (
+    RuleDigester,
+)
+from pocketpaw_ee.discovery.rule_models import RuleDraft
 from pocketpaw_ee.discovery.run import DiscoveryRun, DiscoveryRunOptions
 
 logger = logging.getLogger(__name__)
@@ -58,11 +81,19 @@ logger = logging.getLogger(__name__)
 # blank source_id at ingest time. Such types are skipped + flagged, never staged.
 KEY_CONFIDENCE_FLOOR = 0.5
 
-# The blob key (set on BOTH proposals' parameters blob) tagging a proposal as part
-# of a discovery run, so the supersede sweep can find a workspace's prior open
-# pair. Carries ``{run_id, role, workspace_id}``. ``role`` is "fabric_objects" or
-# "pocket_create".
+# The blob key (set on EVERY discovery proposal's parameters blob) tagging it as
+# part of a discovery run, so the supersede sweep can find a workspace's prior open
+# proposals. Carries ``{run_id, role, workspace_id}``. ``role`` is "fabric_objects",
+# "pocket_create", or "instinct_rules".
 DISCOVERY_MARKER_KEY = "discovery_run"
+
+# The minimum per-rule confidence for a reverse-engineered governed rule to be
+# PROPOSED through the gate — the rule digester's OWN floor (RK-7), deliberately
+# NOT ``KEY_CONFIDENCE_FLOOR`` (that gates Fabric idempotency keys, a different
+# concern). A weakly-inferred governed rule that silently gates a tenant's actions
+# is worse than no rule, so sub-floor drafts are dropped, never proposed. Sourced
+# from the rule digester so the gate and the digester share one threshold.
+RULE_CONFIDENCE_FLOOR = _RULE_CONFIDENCE_FLOOR
 
 # The synthetic ``source_connector`` namespace stamped on every staged object so
 # the Fabric ingest dedup key ``(source_connector, source_id)`` is stable across
@@ -84,13 +115,17 @@ class DiscoveryProposalResult:
     * ``fabric_objects_action_id`` / ``pocket_action_id`` — the two gated Action
       ids a human reviews. ``None`` for either when there was nothing to stage
       (an empty draft → no fabric proposal → no pocket proposal).
-    * ``run_id`` — the discovery-run marker shared by both proposals (used to
-      supersede this pair on the next run).
+    * ``instinct_action_ids`` — the governed-rule (``_instinct_rule``) proposal
+      Action ids, ONE per qualifying reverse-engineered RuleDraft (S2-R5). Empty
+      when there is no correction exhaust or every draft is sub-floor — the rules
+      block is ADDITIVE and never blocks the fabric + pocket pair.
+    * ``run_id`` — the discovery-run marker shared by ALL proposals (used to
+      supersede this run's set on the next run).
     * ``materialised_types`` — the high-confidence type names that were staged.
     * ``skipped_types`` — ``{type_name: reason}`` for types held back (keyless /
       low-confidence) so a human can see what was NOT staged.
-    * ``superseded_action_ids`` — the prior open pair this run collapsed (empty on
-      a first run).
+    * ``superseded_action_ids`` — the prior open proposals this run collapsed
+      (empty on a first run).
     """
 
     run_id: str
@@ -99,6 +134,7 @@ class DiscoveryProposalResult:
     materialised_types: list[str]
     skipped_types: dict[str, str]
     superseded_action_ids: list[str]
+    instinct_action_ids: list[str]
 
 
 def _is_materialisable(ot: DraftObjectType) -> tuple[bool, str]:
@@ -258,6 +294,41 @@ def assemble_discovery_pocket(
     }
 
 
+def _draft_to_instinct_rules(
+    *,
+    draft: OntologyDraft,
+    corrections: Sequence[Any],
+    audit: Sequence[Any] | None,
+    workspace_id: str,
+) -> list[dict[str, Any]]:
+    """Reverse-engineer governed-rule ``rule_spec`` dicts from the workspace exhaust.
+
+    Sibling to :func:`_draft_to_fabric_proposal_kwargs` / :func:`assemble_discovery_pocket`:
+    pure, no I/O. Runs the :class:`RuleDigester` (S2-R2) over the workspace's Instinct
+    correction exhaust (the primary signal) plus its audit trail (corroboration) and
+    the discovered ``OntologyDraft`` (scope hint — when it names exactly one type the
+    rule is scoped to that ``object_type``), then serialises each emitted ``RuleDraft``
+    into the editable ``rule_spec`` sub-dict :func:`propose_instinct_rule` stages.
+
+    The digester applies its OWN confidence floor (:data:`RULE_CONFIDENCE_FLOOR`, NOT
+    :data:`KEY_CONFIDENCE_FLOOR`) and the recurrence threshold internally, dropping
+    sub-floor / under-recurring drafts — so this returns ONLY the rule_specs that
+    clear the gate. Empty / thin exhaust → ``[]`` (the digester never raises), which
+    keeps the rules block ADDITIVE: no exhaust → no rule proposals → the fabric +
+    pocket pair is filed exactly as before.
+
+    Each returned dict is a ``RuleDraft.model_dump(mode="json")`` — the verbatim
+    shape the executor ``RuleDraft.model_validate``s at the gate chokepoint.
+    """
+    drafts: list[RuleDraft] = RuleDigester().infer(
+        corrections=corrections,
+        audit=audit,
+        ontology=draft,
+        workspace_id=workspace_id,
+    )
+    return [d.model_dump(mode="json") for d in drafts]
+
+
 async def _supersede_prior_open_pair(
     *,
     store: Any,
@@ -330,11 +401,14 @@ async def _supersede_prior_open_pair(
 def _find_discovery_marker(params: dict[str, Any]) -> dict[str, Any] | None:
     """Pull the ``discovery_run`` marker off either proposal's blob, or None.
 
-    The marker rides on the per-proposal blob (``_fabric_objects`` or
-    ``_pocket_create``) under :data:`DISCOVERY_MARKER_KEY`, so a single read of
-    the Action's parameters surfaces it regardless of which proposal kind this is.
+    The marker rides on the per-proposal blob (``_fabric_objects``,
+    ``_pocket_create``, or ``_instinct_rule``) under :data:`DISCOVERY_MARKER_KEY`,
+    so a single read of the Action's parameters surfaces it regardless of which
+    proposal kind this is. ``_instinct_rule`` MUST be in this tuple — without it a
+    stale open rule proposal would never be found by the supersede sweep and would
+    stack on every re-run.
     """
-    for blob_key in ("_fabric_objects", "_pocket_create"):
+    for blob_key in ("_fabric_objects", "_pocket_create", "_instinct_rule"):
         blob = params.get(blob_key)
         if isinstance(blob, dict):
             marker = blob.get(DISCOVERY_MARKER_KEY)
@@ -412,13 +486,25 @@ async def run_discovery_and_propose(
 
     if not objects:
         # Nothing high-confidence to materialise — no fabric proposal, so no
-        # starter pocket either (a dashboard with no live source is noise). The
-        # prior pair is still superseded; the run is a clean no-op otherwise.
+        # starter pocket either (a dashboard with no live source is noise). Rules
+        # are reverse-engineered from CORRECTION exhaust (independent of object
+        # materialisation), so the rules block still runs: a workspace with a
+        # correction history but no keyable types can still surface governed-rule
+        # proposals. The prior set is still superseded.
+        instinct_action_ids = await _propose_instinct_rules(
+            store=store,
+            draft=draft,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            run_id=run_id,
+        )
         logger.info(
             "discovery: no high-confidence objects to stage for workspace %s "
-            "(skipped types: %s) — no proposals filed",
+            "(skipped types: %s) — no fabric/pocket proposals filed (%d rule "
+            "proposal(s))",
             workspace_id,
             ", ".join(skipped) or "none",
+            len(instinct_action_ids),
         )
         return DiscoveryProposalResult(
             run_id=run_id,
@@ -427,6 +513,7 @@ async def run_discovery_and_propose(
             materialised_types=materialised_types,
             skipped_types=skipped,
             superseded_action_ids=superseded,
+            instinct_action_ids=instinct_action_ids,
         )
 
     skipped_note = f" {len(skipped)} low-confidence type(s) held back." if skipped else ""
@@ -481,12 +568,25 @@ async def run_discovery_and_propose(
         },
     )
 
+    # 3) The THIRD proposal path (S2-R5) — governed RULES reverse-engineered from
+    #    the workspace's Instinct correction exhaust. ADDITIVE: zero exhaust (or
+    #    only sub-floor drafts) → no rule proposals, and the fabric + pocket pair
+    #    above is filed exactly as before.
+    instinct_action_ids = await _propose_instinct_rules(
+        store=store,
+        draft=draft,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        run_id=run_id,
+    )
+
     logger.info(
-        "discovery: filed proposal pair for workspace %s (fabric=%s pocket=%s, "
-        "run=%s, %d materialised / %d skipped, %d superseded)",
+        "discovery: filed proposals for workspace %s (fabric=%s pocket=%s, "
+        "%d rule(s), run=%s, %d materialised / %d skipped, %d superseded)",
         workspace_id,
         fabric_action_id,
         pocket_action_id,
+        len(instinct_action_ids),
         run_id,
         len(materialised_types),
         len(skipped),
@@ -500,6 +600,7 @@ async def run_discovery_and_propose(
         materialised_types=materialised_types,
         skipped_types=skipped,
         superseded_action_ids=superseded,
+        instinct_action_ids=instinct_action_ids,
     )
 
 
@@ -550,8 +651,108 @@ async def _stamp_discovery_marker(
         )
 
 
+async def _propose_instinct_rules(
+    *,
+    store: Any,
+    draft: OntologyDraft,
+    workspace_id: str,
+    user_id: str,
+    run_id: str,
+) -> list[str]:
+    """Read the workspace's Instinct exhaust → file zero or more ``_instinct_rule``
+    proposals, ONE per qualifying reverse-engineered rule (S2-R5).
+
+    The THIRD discovery proposal path. Reads the correction exhaust (the primary
+    inference signal) + the audit trail (corroboration) off the SAME InstinctStore
+    handle the fabric / pocket proposals use — corrections anchor on ``pocket_id ==
+    workspace_id`` (the discovery non-pocket convention), so a single
+    ``get_corrections_for_pocket(workspace_id)`` surfaces them. Runs the pure
+    :func:`_draft_to_instinct_rules` builder (which gates on the digester's OWN
+    confidence floor, not ``KEY_CONFIDENCE_FLOOR``), then files each qualifying
+    ``rule_spec`` as its OWN gated proposal via the lazily-imported
+    ``propose_instinct_rule`` (one rule = one gate blob — NOT batched the way fabric
+    objects are) and stamps the shared discovery marker on each so the next run can
+    supersede it.
+
+    ADDITIVE + best-effort: no exhaust (or every draft sub-floor) → ``[]`` and the
+    run still files the fabric + pocket pair exactly as before. Reading the exhaust
+    or filing a rule must NOT break the fabric / pocket proposals that already
+    landed — any failure here logs and returns whatever was filed so far.
+    """
+    from pocketpaw_ee.cloud.instinct_rule_proposals.propose import propose_instinct_rule
+
+    # Read the exhaust off the shared store handle. Corrections are the primary
+    # signal; audit corroborates. Both are best-effort — a read failure degrades to
+    # "no rules proposed", never blocks the fabric/pocket pair.
+    try:
+        corrections = await store.get_corrections_for_pocket(workspace_id, limit=1000)
+    except Exception:  # noqa: BLE001 — exhaust read is best-effort
+        logger.warning(
+            "discovery: failed to read correction exhaust for workspace %s — "
+            "filing no rule proposals this run",
+            workspace_id,
+            exc_info=True,
+        )
+        return []
+    try:
+        audit = await store.query_audit(
+            pocket_id=workspace_id, workspace_id=workspace_id, limit=1000
+        )
+    except Exception:  # noqa: BLE001 — audit is corroboration only
+        audit = None
+
+    rule_specs = _draft_to_instinct_rules(
+        draft=draft,
+        corrections=corrections,
+        audit=audit,
+        workspace_id=workspace_id,
+    )
+    if not rule_specs:
+        return []
+
+    instinct_action_ids: list[str] = []
+    for rule_spec in rule_specs:
+        try:
+            action_id = await propose_instinct_rule(
+                workspace_id=workspace_id,
+                user_id=user_id,
+                rule_spec=rule_spec,
+                summary=str(rule_spec.get("description") or "")
+                or f"Create the discovered governed rule {rule_spec.get('name')!r}.",
+            )
+        except Exception:  # noqa: BLE001 — one bad propose can't block the rest
+            logger.warning(
+                "discovery: failed to file a governed-rule proposal for workspace %s "
+                "— continuing with the remaining drafts",
+                workspace_id,
+                exc_info=True,
+            )
+            continue
+        await _stamp_discovery_marker(
+            store=store,
+            action_id=action_id,
+            blob_key="_instinct_rule",
+            marker={
+                "run_id": run_id,
+                "role": "instinct_rules",
+                "workspace_id": workspace_id,
+            },
+        )
+        instinct_action_ids.append(action_id)
+
+    if instinct_action_ids:
+        logger.info(
+            "discovery: filed %d governed-rule proposal(s) for workspace %s (run %s)",
+            len(instinct_action_ids),
+            workspace_id,
+            run_id,
+        )
+    return instinct_action_ids
+
+
 __all__ = [
     "KEY_CONFIDENCE_FLOOR",
+    "RULE_CONFIDENCE_FLOOR",
     "DISCOVERY_MARKER_KEY",
     "DiscoveryProposalResult",
     "assemble_discovery_pocket",

--- a/ee/pocketpaw_ee/discovery/rule_digester.py
+++ b/ee/pocketpaw_ee/discovery/rule_digester.py
@@ -1,0 +1,297 @@
+# pocketpaw_ee/discovery/rule_digester.py — RuleDigester (SZD slice-2 S2-R2).
+#
+# Created: 2026-06-20 (S2-R2 / feat/szd-slice2-discovery) — the deterministic
+# inference engine that reverse-engineers candidate GOVERNED rules from a
+# tenant's Instinct exhaust (correction history + audit trail). It generalizes
+# the existing 3x-correction → soul-procedural promotion
+# (``instinct/correction_soul_bridge.py``: ``_PROMOTION_THRESHOLD = 3`` +
+# ``_synthesize_rule``) from a natural-language soul STRING into a structured,
+# gate-ready ``RuleDraft`` (CEL ``when`` + action literal + scope + provenance +
+# confidence).
+#
+# SOVEREIGNTY (RK-2): pure / deterministic — NO LLM, NO network. Rule inference
+# runs on-box. An LLM refine pass is explicitly out of scope this slice. The only
+# inputs are exhaust the box already holds.
+#
+# Heuristic (per qualifying correction PATH):
+#   1. Group corrections by ``patch.path`` (the same axis the seed counts).
+#   2. A path qualifies when it recurs >= RULE_RECUR_THRESHOLD (mirrors the
+#      seed's promotion threshold of 3).
+#   3. ``when`` — a CEL equality on the corrected field's most-common ``after``
+#      value (``action.<field> == "<value>"``); when no constant target exists
+#      (humans set a different value each time) the signal is weak and the draft
+#      is dropped below the confidence floor (see step 5).
+#   4. ``action`` — inferred from the corrected field's nature:
+#        * escalation fields (category / priority) consistently raised
+#          → ``require_approval``;
+#        * suppression shapes (recommendation blanked, or a suppress/mute/notify
+#          parameter key) → ``notify``;
+#        * everything else defaults to ``require_approval`` (the safe gate).
+#   5. ``confidence`` — scales with recurrence count AND value consistency:
+#        floor-anchored, + slope per extra recurrence, + a consistency bonus.
+#      Clamped to [0, 1] by the RuleDraft model. Drafts BELOW
+#      RULE_CONFIDENCE_FLOOR are SKIPPED (a weakly-inferred governed rule is
+#      worse than a skipped one — never emit noise into the gate).
+#   6. ``provenance`` — the contributing correction ids (traceable to source).
+#   7. ``scope`` — workspace_id (required tenancy; falls back to the corrections'
+#      pocket_id when not passed), and object_type from a single-type OntologyDraft
+#      hint when one is supplied.
+#
+# Degrades cleanly: empty / insufficient / patch-less exhaust → [] (never raises).
+# Pure data + logic — depends only on the OSS Correction model, the RuleDraft /
+# RuleScope contract (S2-R1), and the optional OntologyDraft hint.
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+
+from pocketpaw.instinct.correction import Correction
+from pocketpaw_ee.discovery.models import OntologyDraft
+from pocketpaw_ee.discovery.rule_models import RuleDraft, RuleScope
+
+# Same axis as the seed promotion (correction_soul_bridge._PROMOTION_THRESHOLD):
+# a path must be corrected at least this many times before it can become a rule.
+RULE_RECUR_THRESHOLD = 3
+
+# The rule digester's OWN confidence floor (RK-7) — deliberately NOT the
+# ontology digester's KEY_CONFIDENCE_FLOOR (that is idempotency-key specific).
+# A governed rule below this floor is dropped rather than proposed: a weak rule
+# that silently gates a tenant's actions is worse than no rule at all.
+RULE_CONFIDENCE_FLOOR = 0.45
+
+# Confidence shaping constants (deterministic, no tuning model).
+_BASE_CONFIDENCE = 0.5  # a clean threshold-count consistent signal starts here
+_RECUR_SLOPE = 0.05  # added per recurrence beyond the threshold
+_CONSISTENCY_WEIGHT = 0.25  # bonus for a single dominant ``after`` value
+
+# Correction paths whose nature implies a particular gate disposition.
+_ESCALATION_FIELDS = ("category", "priority")
+_SUPPRESSION_FIELDS = ("recommendation",)
+_SUPPRESSION_PARAM_HINTS = ("suppress", "mute", "notify", "silence")
+
+
+def _normalize(value: object) -> str:
+    """Stable string form of a corrected value, for grouping + CEL emission."""
+    if value is None:
+        return ""
+    if hasattr(value, "value"):  # enum → its string value (matches store shape)
+        return str(value.value)
+    return str(value)
+
+
+def _cel_field(path: str) -> str:
+    """Map a correction ``path`` to its CEL accessor under ``action``.
+
+    ``category`` → ``action.category``; ``parameters.foo`` → ``action.parameters.foo``.
+    Only dotted identifier segments are produced, so the result always parses as
+    a CEL field selector.
+    """
+    return "action." + path
+
+
+def _cel_literal(value: str) -> str:
+    """A CEL double-quoted string literal with the inner quotes escaped."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+class RuleDigester:
+    """Reverse-engineer candidate governed rules from Instinct exhaust.
+
+    Deterministic and side-effect-free. ``infer`` consumes the correction
+    history (the primary signal) plus an optional audit trail and an optional
+    discovered ontology, and returns a list of ``RuleDraft`` — one per
+    correction path that recurs often and consistently enough to clear the
+    confidence floor. It never raises on thin or malformed input.
+    """
+
+    def infer(
+        self,
+        *,
+        corrections: Sequence[Correction] | None,
+        audit: Sequence[object] | None = None,
+        ontology: OntologyDraft | None = None,
+        workspace_id: str | None = None,
+    ) -> list[RuleDraft]:
+        """Emit ``RuleDraft``s reverse-engineered from the exhaust.
+
+        ``corrections`` is the exhaust shape returned by
+        ``InstinctStore.get_corrections_for_pocket`` (``list[Correction]``).
+        ``audit`` (``list[AuditEntry]`` from ``query_audit``) is accepted for
+        corroboration / future weighting but is not required to produce a draft.
+        ``ontology`` is the optional ``KbCompileDigester`` / structured digester
+        output used to scope a rule to a discovered ``object_type``.
+        ``workspace_id`` sets the rule's tenancy; when omitted it falls back to
+        the corrections' ``pocket_id`` (discovery anchors non-pocket blobs with
+        ``pocket_id == workspace_id``).
+        """
+        if not corrections:
+            return []
+
+        # Group every single-path patch by its path. Each entry collects the
+        # contributing correction ids and the corrected ``after`` values.
+        by_path: dict[str, _PathSignal] = {}
+        for correction in corrections:
+            for patch in correction.patches:
+                signal = by_path.setdefault(patch.path, _PathSignal(path=patch.path))
+                signal.add(correction_id=correction.id, after=_normalize(patch.after))
+
+        resolved_ws = workspace_id or self._infer_workspace(corrections)
+        object_type = self._infer_object_type(ontology)
+
+        drafts: list[RuleDraft] = []
+        for path in sorted(by_path):  # deterministic ordering
+            signal = by_path[path]
+            if signal.count < RULE_RECUR_THRESHOLD:
+                continue
+            draft = self._build_draft(
+                signal=signal,
+                workspace_id=resolved_ws,
+                object_type=object_type,
+            )
+            if draft is None:
+                continue
+            # The own confidence floor (RK-7): drop weak rules rather than
+            # propose noise into the gate.
+            if draft.confidence < RULE_CONFIDENCE_FLOOR:
+                continue
+            drafts.append(draft)
+        return drafts
+
+    # ------------------------------------------------------------------ #
+    # Draft construction
+    # ------------------------------------------------------------------ #
+    def _build_draft(
+        self,
+        *,
+        signal: _PathSignal,
+        workspace_id: str,
+        object_type: str | None,
+    ) -> RuleDraft | None:
+        """Synthesize a single RuleDraft from one path's signal, or None."""
+        dominant, dominance, dominant_count = signal.dominant_after()
+        field = _cel_field(signal.path)
+        is_suppression = self._is_suppression(signal.path, dominant)
+
+        # A value is a real "constant target" only when the SAME value was
+        # chosen more than once. A path where every ``after`` differs (humans
+        # rewrite freely) has dominant_count == 1 — no consensus, no target —
+        # and degrades to the weak presence branch below the floor.
+        has_target = bool(dominant) and dominant_count >= 2
+
+        if has_target:
+            when = f"{field} == {_cel_literal(dominant)}"
+        elif is_suppression:
+            # consistently cleared → match the cleared state
+            when = f'{field} == ""'
+        else:
+            # No constant target and not a suppression — a presence rule only.
+            # This is the weak branch; confidence will fall below the floor.
+            when = f"has({field})"
+
+        confidence = self._score(signal=signal, dominance=dominance, has_target=has_target)
+        action = "notify" if is_suppression else self._infer_action(signal.path)
+
+        return RuleDraft(
+            name=f"corrected:{signal.path}",
+            description=(
+                f"Inferred from {signal.count} repeated correction(s) on "
+                f"'{signal.path}' in this workspace."
+            ),
+            when=when,
+            action=action,
+            scope=RuleScope(
+                workspace_id=workspace_id,
+                object_type=object_type,
+            ),
+            confidence=confidence,
+            provenance=list(signal.correction_ids),
+        )
+
+    def _score(self, *, signal: _PathSignal, dominance: float, has_target: bool) -> float:
+        """Deterministic confidence in [0, 1] (clamped by RuleDraft).
+
+        Anchored at a base for a clean threshold-count signal, raised per extra
+        recurrence and by how dominant the most-common corrected value is.
+        Inconsistent signals (no single dominant value, no constant target)
+        score below the floor and get dropped upstream.
+        """
+        recur_bonus = _RECUR_SLOPE * max(0, signal.count - RULE_RECUR_THRESHOLD)
+        consistency_bonus = _CONSISTENCY_WEIGHT * dominance
+        score = _BASE_CONFIDENCE + recur_bonus + consistency_bonus
+        if not has_target:
+            # A presence-only rule (no constant value) is inherently weak — pull
+            # it below the base so only a suppression-with-target survives.
+            score -= 0.30
+        return score
+
+    @staticmethod
+    def _infer_action(path: str) -> str:
+        """Map a corrected path to a gate disposition (default require_approval)."""
+        field = path.split(".", 1)[0]
+        if field in _ESCALATION_FIELDS:
+            return "require_approval"
+        # Default to the safe gate: ask a human before acting.
+        return "require_approval"
+
+    @staticmethod
+    def _is_suppression(path: str, dominant: str) -> bool:
+        """True when the correction shape reads as suppressing the auto-output."""
+        if path in _SUPPRESSION_FIELDS and dominant == "":
+            return True
+        if path.startswith("parameters."):
+            key = path.split(".", 1)[1].lower()
+            return any(hint in key for hint in _SUPPRESSION_PARAM_HINTS)
+        return False
+
+    @staticmethod
+    def _infer_workspace(corrections: Sequence[Correction]) -> str:
+        """Fallback tenancy: the (single) pocket_id the corrections share."""
+        for correction in corrections:
+            if correction.pocket_id:
+                return correction.pocket_id
+        return ""
+
+    @staticmethod
+    def _infer_object_type(ontology: OntologyDraft | None) -> str | None:
+        """Scope to a discovered object_type when the ontology names exactly one."""
+        if ontology is None:
+            return None
+        if len(ontology.object_types) == 1:
+            return ontology.object_types[0].name
+        return None
+
+
+class _PathSignal:
+    """Mutable accumulator for one correction path's recurrence + value spread."""
+
+    __slots__ = ("path", "correction_ids", "_afters")
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.correction_ids: list[str] = []
+        self._afters: Counter[str] = Counter()
+
+    def add(self, *, correction_id: str, after: str) -> None:
+        self.correction_ids.append(correction_id)
+        self._afters[after] += 1
+
+    @property
+    def count(self) -> int:
+        return len(self.correction_ids)
+
+    def dominant_after(self) -> tuple[str, float, int]:
+        """Most-common corrected value, its share in [0, 1], and its raw count.
+
+        Returns ``("", 0.0, 0)`` when there were no values. When the most common
+        value is the empty string (the field was consistently blanked), the
+        returned value is ``""`` but the dominance share is still meaningful.
+        """
+        if not self._afters:
+            return "", 0.0, 0
+        value, freq = self._afters.most_common(1)[0]
+        return value, freq / self.count, freq
+
+
+__all__ = ["RuleDigester", "RULE_CONFIDENCE_FLOOR", "RULE_RECUR_THRESHOLD"]

--- a/ee/pocketpaw_ee/discovery/rule_models.py
+++ b/ee/pocketpaw_ee/discovery/rule_models.py
@@ -1,0 +1,81 @@
+# pocketpaw_ee/discovery/rule_models.py — the RuleDraft shape produced by rules-discovery.
+#
+# Created: 2026-06-20 (S2-R1 / feat/szd-slice2-discovery) — the pure-data contract
+# for sovereign zero-setup RULES discovery. A ``RuleDraft`` is the digester output
+# AND the editable ``rule_spec`` blob carried through the Instinct gate:
+#
+#   - ``when``    — a CEL expression (reuses ``bundled_templates.CelExpression``;
+#                   parses at validation, never evaluates here).
+#   - ``action``  — the gate disposition, reusing the template literal
+#                   ``InstinctRuleActionT`` = require_approval | notify | block.
+#   - ``scope``   — workspace_id (required tenancy) + optional pocket_id / object_type.
+#   - ``confidence`` — clamped into [0, 1] via the shared ``discovery.models._clamp``
+#                   (silent clamp — a noisy inference score never fails validation).
+#   - ``provenance`` — the audit-row / correction / record ids the rule was inferred
+#                   from, so a reviewer can trace WHY the rule was proposed.
+#
+# ``RuleDraft.model_validate(blob)`` round-trips from a plain dict (the stored
+# ``rule_spec``) so the R3 executor can re-validate at the gate chokepoint. The
+# draft is deliberately FREE of approver identity / top-level tenancy: the R3 blob
+# carries workspace_id / owner as SEPARATE top-level fields so a tenant editing the
+# draft cannot move the rule to another workspace. Pure data, no I/O — depends only
+# on pydantic + the OSS CEL field + the discovery clamp helper.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from pocketpaw.bundled_templates.expressions import CelExpression
+from pocketpaw.bundled_templates.schema import InstinctRuleActionT
+from pocketpaw_ee.discovery.models import _clamp
+
+
+class RuleScope(BaseModel):
+    """Where a discovered rule applies.
+
+    ``workspace_id`` is required tenancy (no default) — it is the only
+    mandatory field. ``pocket_id`` narrows the rule to a single pocket and
+    ``object_type`` to a single Fabric object type; both ``None`` means the
+    rule is workspace-wide.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: str
+    pocket_id: str | None = None
+    object_type: str | None = None
+
+
+class RuleDraft(BaseModel):
+    """A candidate governed rule reverse-engineered from workspace exhaust.
+
+    The digester emits these; the review surface edits them; the gate
+    persists an approved one as an ``InstinctRuleDoc``. The shape is
+    enforcement-ready: ``when`` (CEL) + ``action`` map straight onto the
+    template ``InstinctRule`` the runtime composer already evaluates.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str | None = None
+    # CEL trigger — parses at validation (malformed → ValidationError), never
+    # evaluated here; the runtime binds a real row/event context later.
+    when: CelExpression
+    # Gate disposition, reusing the template literal so an approved draft is
+    # ``InstinctRule``-compatible.
+    action: InstinctRuleActionT
+    scope: RuleScope
+    # Inference confidence in [0, 1]; clamped (never raised) so a noisy score
+    # from the rule digester degrades gracefully.
+    confidence: float = 0.0
+    # Ids of the audit rows / corrections / records the rule was inferred from.
+    provenance: list[str] = Field(default_factory=list)
+
+    @field_validator("confidence")
+    @classmethod
+    def _clamp_confidence(cls, value: float) -> float:
+        return _clamp(value)
+
+
+__all__ = ["RuleDraft", "RuleScope"]

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,22 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-20 (S2-R4 — _instinct_rule proposal type) — wired the
+#   governed-rule-create gate kind into the FOUR-path dispatch. ``_instinct_rule_blob``
+#   + ``_assert_instinct_rule_workspace`` are the peers of the existing blob accessors
+#   + tenancy guards. The blob (``Action.parameters._instinct_rule``) carries the
+#   editable ``rule_spec`` plus, as SEPARATE top-level fields, the originating
+#   ``workspace_id`` and the owner ``user_id`` (kept OUT of the editable spec so the
+#   correction flow can't move tenancy/owner). On APPROVE the router emits
+#   ``human.corrected`` then fires
+#   ``instinct_rule_proposals.executor.execute_approved_instinct_rule`` (which persists
+#   the rule via the workspace-scoped ``rules.service.create_rule`` after a
+#   ``RuleDraft.model_validate`` at entry, and OWNS the chain close). On REJECT the
+#   router emits ``human.corrected`` + ``decision.completed(rejected)`` itself (the
+#   executor never runs on reject — no rule is created). The
+#   ``_assert_instinct_rule_workspace`` 403 runs in ALL FOUR locations (approve /
+#   bulk-approve / reject / bulk-reject) BEFORE any mutation — asymmetric tenant scope
+#   is no tenant scope (pocketpaw#1183 / #1250). Same exactly-one-terminal discipline
+#   as the Pocket-create gate.
 # Updated: 2026-06-19 (SZD-5b — _pocket_create proposal type) — added a gated
 #   starter-Pocket-create proposal kind (TENANCY GATE). ``_pocket_create_blob`` +
 #   ``_assert_pocket_create_workspace`` are the peers of the existing blob
@@ -615,6 +632,49 @@ def _assert_pocket_create_workspace(action: Any, current_workspace: str) -> None
         )
 
 
+def _instinct_rule_blob(action: Any) -> dict[str, Any] | None:
+    """Return the ``_instinct_rule`` blob on an Action, or ``None``.
+
+    The blob is the gated governed-rule-create payload
+    ``ee.cloud.instinct_rule_proposals.propose`` stores under
+    ``Action.parameters._instinct_rule`` (the editable ``rule_spec`` +, as SEPARATE
+    top-level fields, the originating ``workspace_id`` and the owner ``user_id``).
+    This is a peer gated proposal kind — the approve path dispatches the
+    apply-on-approve executor on its presence, exactly as it dispatches the
+    Pocket-create executor on ``_pocket_create``. Anything that is not a dict is
+    treated as "no instinct rule".
+    """
+    params = getattr(action, "parameters", None)
+    if not isinstance(params, dict):
+        return None
+    blob = params.get("_instinct_rule")
+    return blob if isinstance(blob, dict) else None
+
+
+def _assert_instinct_rule_workspace(action: Any, current_workspace: str) -> None:
+    """Reject approving / rejecting a governed-rule create from another workspace.
+
+    Mirror of ``_assert_pocket_create_workspace`` for the ``_instinct_rule`` blob.
+    ``require_action_any_workspace("instinct.approve")`` only proves the caller
+    holds the role SOMEWHERE; this binds the rule-create Action to the caller's
+    active workspace. A proposed rule carries no EXISTING pocket the way a parked
+    write does, so its tenancy lives entirely on the blob's top-level
+    ``workspace_id`` (NEVER inside the editable ``rule_spec``). A blob whose
+    ``workspace_id`` differs from the caller's active workspace → 403, on BOTH the
+    approve and reject side (asymmetric tenant scope is no tenant scope —
+    pocketpaw#1183 / #1250). A non-instinct-rule Action (no blob) is unaffected.
+    """
+    blob = _instinct_rule_blob(action)
+    if blob is None:
+        return
+    blob_workspace = str(blob.get("workspace_id") or "")
+    if blob_workspace and blob_workspace != current_workspace:
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This instinct rule belongs to a different workspace",
+        )
+
+
 def _assert_pocket_write_workspace(action: Any, current_workspace: str) -> None:
     """Reject approving a parked pocket write from another workspace.
 
@@ -937,6 +997,7 @@ async def bulk_approve_actions(
             _assert_external_action_workspace(action, workspace_id)
             _assert_fabric_objects_workspace(action, workspace_id)
             _assert_pocket_create_workspace(action, workspace_id)
+            _assert_instinct_rule_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -1092,6 +1153,38 @@ async def bulk_approve_actions(
                 )
             continue
 
+        # A bulk-approved gated ``_instinct_rule`` Action persists its proposed
+        # governed rule. Mirrors the Pocket-create branch above: per-item
+        # ``human.corrected(accepted)`` (bulk-approve has no edit surface), the
+        # ``agent.proposed`` event id (off the blob's ``proposed_event_id``) as
+        # causation, then the executor (which owns the chain close). Matched BEFORE
+        # the pocket-write fallthrough and ``continue``d so the kinds never cross.
+        instinct_rule_blob = _instinct_rule_blob(action)
+        if instinct_rule_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=instinct_rule_blob,
+                action=action,
+                user_id=approver_id,
+                workspace_id=workspace_id,
+                disposition="accepted",
+                note=req.note,
+                causation_override=_code_change_proposed_event_id(instinct_rule_blob),
+            )
+            try:
+                from pocketpaw_ee.cloud.instinct_rule_proposals import (
+                    executor as instinct_rule_executor,
+                )
+
+                await instinct_rule_executor.execute_approved_instinct_rule(
+                    action, human_event_id=human_event_id
+                )
+            except Exception:
+                logger.exception(
+                    "bulk-approve instinct-rule execution failed for %s (non-fatal)",
+                    action.id,
+                )
+            continue
+
         # MANDATES — a bulk-approved ``_belt_plan`` Action fires the plan
         # executor, exactly like the single-approve hook (disposition is always
         # ``accepted`` — bulk-approve has no edit surface). The executor owns
@@ -1225,6 +1318,7 @@ async def bulk_reject_actions(
             _assert_external_action_workspace(action, workspace_id)
             _assert_fabric_objects_workspace(action, workspace_id)
             _assert_pocket_create_workspace(action, workspace_id)
+            _assert_instinct_rule_workspace(action, workspace_id)
             _assert_belt_plan_workspace(action, workspace_id)
             _assert_artifact_change_workspace(action, workspace_id)
 
@@ -1364,6 +1458,32 @@ async def bulk_reject_actions(
             )
             continue
 
+        # A bulk-rejected gated ``_instinct_rule`` Action closes its chain HERE
+        # (the executor never runs on reject — the router owns the close). NO
+        # governed rule is created. Mirrors the Pocket-create reject branch.
+        # Matched AFTER pocket-write + code-change + external-action +
+        # fabric-objects + pocket-create and ``continue``d so the kinds never cross.
+        instinct_rule_blob = _instinct_rule_blob(action)
+        if instinct_rule_blob is not None:
+            human_event_id = _emit_human_corrected(
+                blob=instinct_rule_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                disposition="rejected",
+                note=req.reason or None,
+                causation_override=_code_change_proposed_event_id(instinct_rule_blob),
+            )
+            _emit_decision_completed_rejected(
+                blob=instinct_rule_blob,
+                action=action,
+                user_id=rejector_id,
+                workspace_id=workspace_id,
+                reason=req.reason,
+                causation_override=human_event_id,
+            )
+            continue
+
         # MANDATES — a bulk-rejected ``_belt_plan`` Action closes its chain
         # here (the plan executor never runs on reject), mirroring the
         # code-change branch above.
@@ -1474,6 +1594,11 @@ async def approve_action(
     # pocket. Approving it creates a Pocket in the tenant's workspace, so the
     # cross-workspace gate is mandatory here.
     _assert_pocket_create_workspace(before, workspace_id)
+    # Same tenancy gate for a gated governed-rule-create Action — its
+    # ``_instinct_rule`` blob carries the workspace (and owner) on SEPARATE
+    # top-level fields, not a pocket. Approving it creates an active governed rule
+    # in the tenant's workspace, so the cross-workspace gate is mandatory here.
+    _assert_instinct_rule_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -1719,6 +1844,48 @@ async def approve_action(
         except Exception:
             logger.exception("pocket-create execution after approval failed (non-fatal)")
 
+    # When the approved Action carries a gated ``_instinct_rule`` blob, persist the
+    # proposed governed rule via ``rules.service.create_rule`` (workspace-scoped,
+    # owned by the blob's top-level ``user_id``). Same best-effort, lazy-import,
+    # never-break-the-approve-response shape as the Pocket-create hook above; the
+    # executor records success / failure on the Action itself. A non-instinct-rule
+    # Action skips this.
+    #
+    # The rule create is part of its own Decision-Graph chain (the propose helper
+    # minted the ``correlation_id`` + emitted ``agent.proposed``). Emit the
+    # ``human.corrected`` event for the approval HERE (the router owns the
+    # human-action emit on every approve path), citing the ``agent.proposed`` event
+    # id (stored on the blob as ``proposed_event_id`` — the same field the
+    # Pocket-create path reads, so ``_code_change_proposed_event_id`` resolves it)
+    # as causation, then thread its event id into the executor so the terminal
+    # ``decision.completed`` chains back to the approval. The executor owns the
+    # chain CLOSE (success or failure) — the router does NOT emit
+    # ``decision.completed`` here, mirroring the Pocket-create executor. No double
+    # terminal.
+    instinct_rule_blob = _instinct_rule_blob(approved)
+    if instinct_rule_blob is not None:
+        disposition = "edited" if edited_fields else "accepted"
+        note = correction.context_summary if correction is not None else None
+        human_event_id = _emit_human_corrected(
+            blob=instinct_rule_blob,
+            action=approved,
+            user_id=approver_id,
+            workspace_id=workspace_id,
+            disposition=disposition,
+            note=note,
+            causation_override=_code_change_proposed_event_id(instinct_rule_blob),
+        )
+        try:
+            from pocketpaw_ee.cloud.instinct_rule_proposals import (
+                executor as instinct_rule_executor,
+            )
+
+            await instinct_rule_executor.execute_approved_instinct_rule(
+                approved, human_event_id=human_event_id
+            )
+        except Exception:
+            logger.exception("instinct-rule execution after approval failed (non-fatal)")
+
     # MANDATES — when the approved Action carries a ``_belt_plan`` blob (the
     # mandate foreman's shift plan), dispatch the plan executor. Same shape as
     # the code-change hook: the router owns the ``human.corrected`` emit, the
@@ -1859,6 +2026,10 @@ async def reject_action(
     # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
     # 403 before any mutation, exactly like the approve side.
     _assert_pocket_create_workspace(before, workspace_id)
+    # Same tenancy gate for a gated governed-rule-create Action on the REJECT side —
+    # asymmetric tenant scope is no tenant scope: a cross-workspace reject must
+    # 403 before any mutation, exactly like the approve side.
+    _assert_instinct_rule_workspace(before, workspace_id)
     # Same tenancy gate for a mandate shift-plan Action (belt_plan) — its
     # ``_belt_plan`` blob carries the workspace.
     _assert_belt_plan_workspace(before, workspace_id)
@@ -2002,6 +2173,33 @@ async def reject_action(
         )
         _emit_decision_completed_rejected(
             blob=pocket_create_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            reason=reason,
+            causation_override=human_event_id,
+        )
+
+    # A rejected gated ``_instinct_rule`` Action closes its chain HERE (the
+    # executor never runs on reject — the router owns the close, mirroring the
+    # Pocket-create reject path). NO governed rule is created.
+    # ``human.corrected(rejected)`` cites the ``agent.proposed`` event (off the
+    # blob's ``proposed_event_id``); ``decision.completed(rejected)`` cites the
+    # human event so the chain reads ``agent.proposed → human.corrected →
+    # decision.completed``.
+    instinct_rule_blob = _instinct_rule_blob(action)
+    if instinct_rule_blob is not None:
+        human_event_id = _emit_human_corrected(
+            blob=instinct_rule_blob,
+            action=action,
+            user_id=rejector_id,
+            workspace_id=workspace_id,
+            disposition="rejected",
+            note=reason or None,
+            causation_override=_code_change_proposed_event_id(instinct_rule_blob),
+        )
+        _emit_decision_completed_rejected(
+            blob=instinct_rule_blob,
             action=action,
             user_id=rejector_id,
             workspace_id=workspace_id,

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -358,6 +358,19 @@ source_modules = [
 forbidden_modules = ["pocketpaw_ee.cloud.models.instinct_approval"]
 
 [[tool.importlinter.contracts]]
+name = "Rules — Beanie writes only from service.py"
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    # Discovered governed rules (SZD slice-2). Only ``rules.service`` owns the
+    # InstinctRuleDoc Beanie write; dto/domain go through it. No router this slice
+    # (rules are born via the _instinct_rule gate executor, not over HTTP).
+    "pocketpaw_ee.cloud.rules.dto",
+    "pocketpaw_ee.cloud.rules.domain",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.instinct_rule"]
+
+[[tool.importlinter.contracts]]
 name = "Notifications — Beanie writes only from service.py"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/tests/ee/test_discovery_rules_propose.py
+++ b/tests/ee/test_discovery_rules_propose.py
@@ -1,0 +1,413 @@
+# tests/ee/test_discovery_rules_propose.py — S2-R5: orchestrate the THIRD
+# (governed-rule) discovery proposal path alongside the fabric + pocket pair.
+#
+# Created: 2026-06-20 (S2-R5 / feat/szd-slice2-discovery). Covers the wiring that
+# makes ``run_discovery_and_propose`` ALSO file ``_instinct_rule`` proposals — one
+# per qualifying ``RuleDraft`` the ``RuleDigester`` (S2-R2) reverse-engineers from
+# the workspace's Instinct correction exhaust — and supersede prior open rule
+# proposals on a re-run. Clones the run→propose→supersede→approve structure of
+# ``test_discovery_propose.py`` (connector read MOCKED; isolated InstinctStore via
+# the lazy ``get_instinct_store`` seam; mongomock Beanie via ``beanie_test_db``; an
+# inert recording bus so service ``emit()`` is quiet). Asserts:
+#
+#   * a run WITH qualifying correction exhaust files a PENDING ``_instinct_rule``
+#     proposal carrying the shared ``run_id`` + ``role:"instinct_rules"`` — ALONGSIDE
+#     the fabric + pocket pair (additive, not instead of);
+#   * a SECOND run SUPERSEDES the prior open rule proposal (flips it to REJECTED /
+#     superseded, does not stack a second);
+#   * a low-confidence / sub-floor rule draft is SKIPPED (no proposal filed) with no
+#     crash;
+#   * a run with NO correction exhaust files the fabric + pocket pair but ZERO rule
+#     proposals (additive, non-breaking);
+#   * tenancy: a workspace mismatch raises at entry like the existing path;
+#   * (smoke) approving the filed rule proposal via the executor → EXECUTED, and the
+#     rule LANDS via ``rules.service.get_active_rules``.
+#
+# Run with:
+#   uv run --group ee pytest tests/ee/test_discovery_rules_propose.py -q
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.discovery import (  # noqa: E402
+    DiscoveryRun,
+    DiscoveryRunOptions,
+    ReadAction,
+    run_discovery_and_propose,
+)
+from pocketpaw_ee.discovery.orchestrate import (  # noqa: E402
+    _find_discovery_marker,
+)
+
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+from pocketpaw.instinct.correction import Correction, CorrectionPatch  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Mock connector surface (same shape as tests/ee/test_discovery_propose.py).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MockActionResult:
+    success: bool
+    data: Any = None
+    error: str | None = None
+    records_affected: int = 0
+
+
+@dataclass
+class _MockActionSchema:
+    name: str
+    method: str = "GET"
+    trust_level: str = "auto"
+
+
+class _MockAdapter:
+    def __init__(self, schemas: list[_MockActionSchema], data_by_action: dict[str, Any]) -> None:
+        self._schemas = schemas
+        self._data_by_action = data_by_action
+
+    async def actions(self) -> list[_MockActionSchema]:
+        return list(self._schemas)
+
+    async def execute(self, action: str, params: dict[str, Any]) -> _MockActionResult:
+        if action not in self._data_by_action:
+            return _MockActionResult(success=False, error=f"unknown action {action}")
+        return _MockActionResult(success=True, data=self._data_by_action[action])
+
+
+class _MockRegistry:
+    def __init__(self, adapters: dict[str, _MockAdapter | None]) -> None:
+        self._adapters = adapters
+
+    async def ensure_connected(self, connector_name: str, scope_key: str) -> _MockAdapter | None:
+        return self._adapters.get(connector_name)
+
+
+# Clean, id-keyed records → a HIGH key_confidence type the gate materialises.
+def _customers(n: int) -> list[dict[str, Any]]:
+    return [{"id": f"cust-{i}", "name": f"Customer {i}", "tier": "gold"} for i in range(n)]
+
+
+def _mock_run(adapters: dict[str, _MockAdapter | None]) -> DiscoveryRun:
+    return DiscoveryRun(registry=_MockRegistry(adapters))
+
+
+def _opts_for(read_actions: dict[str, list[ReadAction]]) -> DiscoveryRunOptions:
+    return DiscoveryRunOptions(read_actions=read_actions)
+
+
+# ---------------------------------------------------------------------------
+# Correction exhaust helpers — corrections anchor on pocket_id == workspace_id
+# (the discovery non-pocket convention). ``RuleDigester`` qualifies a path that
+# recurs >= RULE_RECUR_THRESHOLD (3) times with a single dominant ``after`` value.
+# ---------------------------------------------------------------------------
+
+
+def _strong_correction(workspace_id: str, idx: int) -> Correction:
+    """A correction that consistently raises ``category`` to ``escalated`` — three
+    of these on the same path clear the recurrence threshold AND carry a single
+    dominant target value, so the RuleDigester emits a high-confidence draft."""
+    return Correction(
+        action_id=f"act-{idx}",
+        pocket_id=workspace_id,
+        actor="u1",
+        patches=[CorrectionPatch(path="category", before="normal", after="escalated")],
+        context_summary=f"raised category #{idx}",
+        action_title=f"Ticket #{idx}",
+    )
+
+
+def _weak_correction(workspace_id: str, idx: int) -> Correction:
+    """A correction whose ``after`` differs every time — no constant target. Three
+    of these clear the recurrence count but produce a presence-only rule scored
+    BELOW the rule confidence floor, so the digester drops it (no draft)."""
+    return Correction(
+        action_id=f"wact-{idx}",
+        pocket_id=workspace_id,
+        actor="u1",
+        patches=[CorrectionPatch(path="description", before="x", after=f"unique-{idx}")],
+        context_summary=f"rewrote description #{idx}",
+        action_title=f"Ticket #{idx}",
+    )
+
+
+async def _seed_corrections(store: InstinctStore, corrections: list[Correction]) -> None:
+    for correction in corrections:
+        await store.record_correction(correction)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — isolated stores wired into the lazy get_*_store seams (cloned from
+# test_discovery_propose.py).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    monkeypatch.setenv("AUTH_SECRET", "discovery-rules-propose-test-secret")
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Inert recording EventBus so service ``emit()`` calls don't raise."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        async def publish(self, event: Any) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler: Any) -> None:  # noqa: ARG002
+            return
+
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = _RecordingBus()  # type: ignore[attr-defined]
+    yield bus_mod._bus
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    st = InstinctStore(tmp_path / "instinct_discovery_rules_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+@pytest.fixture
+def fabric(tmp_path: Path, monkeypatch) -> FabricStore:
+    fs = FabricStore(tmp_path / "fabric_discovery_rules_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda: fs)
+    return fs
+
+
+def _rule_proposals(actions: list[Any]) -> list[Any]:
+    """Pending actions carrying an ``_instinct_rule`` blob (the rule proposals)."""
+    from pocketpaw_ee.cloud.instinct_rule_proposals import INSTINCT_RULE_PARAM_KEY
+
+    return [a for a in actions if INSTINCT_RULE_PARAM_KEY in (a.parameters or {})]
+
+
+# ---------------------------------------------------------------------------
+# A run WITH qualifying correction exhaust files a PENDING _instinct_rule
+# proposal — alongside the fabric + pocket pair, sharing the run_id.
+# ---------------------------------------------------------------------------
+
+
+async def test_run_with_corrections_files_tagged_rule_proposal(store, fabric):
+    # Seed the qualifying correction exhaust (3x same path, same target value).
+    await _seed_corrections(store, [_strong_correction("w1", i) for i in range(3)])
+
+    adapters = {"crm": _MockAdapter(schemas=[], data_by_action={"list_customers": _customers(3)})}
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+
+    # The fabric + pocket pair is filed EXACTLY as before (additive).
+    assert result.fabric_objects_action_id is not None
+    assert result.pocket_action_id is not None
+
+    # At least one rule proposal was filed, carrying the SHARED run_id + role.
+    assert result.instinct_action_ids, "expected a governed-rule proposal to be filed"
+    rule_action_id = result.instinct_action_ids[0]
+    rule_action = await store.get_action(rule_action_id)
+    assert rule_action.status == ActionStatus.PENDING
+
+    marker = _find_discovery_marker(rule_action.parameters)
+    assert marker is not None
+    assert marker["run_id"] == result.run_id
+    assert marker["role"] == "instinct_rules"
+    assert marker["workspace_id"] == "w1"
+
+    # The fabric marker shares the same run_id (one run → three roles).
+    fabric_marker = _find_discovery_marker(
+        (await store.get_action(result.fabric_objects_action_id)).parameters
+    )
+    assert fabric_marker["run_id"] == result.run_id
+
+    # The staged rule_spec was reverse-engineered from the corrected ``category`` path.
+    from pocketpaw_ee.cloud.instinct_rule_proposals import INSTINCT_RULE_PARAM_KEY
+
+    blob = rule_action.parameters[INSTINCT_RULE_PARAM_KEY]
+    assert blob["workspace_id"] == "w1"
+    assert blob["user_id"] == "u1"
+    assert blob["rule_spec"]["scope"]["workspace_id"] == "w1"
+    assert "category" in blob["rule_spec"]["when"]
+
+
+# ---------------------------------------------------------------------------
+# A SECOND run supersedes the prior open rule proposal (no duplicate stack).
+# ---------------------------------------------------------------------------
+
+
+async def test_second_run_supersedes_prior_open_rule_proposal(store, fabric):
+    await _seed_corrections(store, [_strong_correction("w1", i) for i in range(3)])
+
+    adapters = {"crm": _MockAdapter(schemas=[], data_by_action={"list_customers": _customers(2)})}
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    first = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+    assert first.instinct_action_ids, "first run should file a rule proposal"
+    first_rule_id = first.instinct_action_ids[0]
+    assert (await store.get_action(first_rule_id)).status == ActionStatus.PENDING
+
+    second = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+
+    # The first run's rule proposal was superseded (REJECTED), not left stacked.
+    assert first_rule_id in second.superseded_action_ids
+    first_rule = await store.get_action(first_rule_id)
+    assert first_rule.status == ActionStatus.REJECTED
+    assert "superseded" in (first_rule.rejected_reason or "").lower()
+
+    # The SECOND run's rule proposal is the only open rule proposal now.
+    pending = await store.list_actions(
+        pocket_id="w1", status=ActionStatus.PENDING, workspace_id="w1"
+    )
+    pending_rule_ids = {a.id for a in _rule_proposals(pending)}
+    assert pending_rule_ids == set(second.instinct_action_ids)
+
+
+# ---------------------------------------------------------------------------
+# A low-confidence / sub-floor rule draft is skipped (no proposal filed), no crash.
+# ---------------------------------------------------------------------------
+
+
+async def test_low_confidence_rule_draft_skipped(store, fabric):
+    # Weak corrections recur enough but carry NO constant target → the digester
+    # scores them below RULE_CONFIDENCE_FLOOR and drops them (no draft).
+    await _seed_corrections(store, [_weak_correction("w1", i) for i in range(3)])
+
+    adapters = {"crm": _MockAdapter(schemas=[], data_by_action={"list_customers": _customers(2)})}
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+
+    # Fabric + pocket still filed; ZERO rule proposals (the weak draft was skipped).
+    assert result.fabric_objects_action_id is not None
+    assert result.pocket_action_id is not None
+    assert result.instinct_action_ids == []
+
+    pending = await store.list_actions(
+        pocket_id="w1", status=ActionStatus.PENDING, workspace_id="w1"
+    )
+    assert _rule_proposals(pending) == []
+
+
+# ---------------------------------------------------------------------------
+# A run with NO correction exhaust files the fabric+pocket pair but ZERO rule
+# proposals (additive, non-breaking — the existing path is untouched).
+# ---------------------------------------------------------------------------
+
+
+async def test_no_corrections_files_no_rule_proposal(store, fabric):
+    adapters = {"crm": _MockAdapter(schemas=[], data_by_action={"list_customers": _customers(2)})}
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+
+    # The fabric + pocket pair is filed exactly as before.
+    assert result.fabric_objects_action_id is not None
+    assert result.pocket_action_id is not None
+    # No correction exhaust → no rule proposals.
+    assert result.instinct_action_ids == []
+
+    pending = await store.list_actions(
+        pocket_id="w1", status=ActionStatus.PENDING, workspace_id="w1"
+    )
+    assert _rule_proposals(pending) == []
+
+
+# ---------------------------------------------------------------------------
+# Tenancy validation at entry (mismatch raises like the existing path).
+# ---------------------------------------------------------------------------
+
+
+async def test_requires_workspace_and_user(store, fabric):
+    with pytest.raises(ValueError, match="workspace_id"):
+        await run_discovery_and_propose(
+            workspace_id="", user_id="u1", connector_ids=[], discovery_run=_mock_run({})
+        )
+    with pytest.raises(ValueError, match="user_id"):
+        await run_discovery_and_propose(
+            workspace_id="w1", user_id="", connector_ids=[], discovery_run=_mock_run({})
+        )
+
+
+# ---------------------------------------------------------------------------
+# (Smoke) approving the filed rule proposal → EXECUTED, rule LANDS.
+# ---------------------------------------------------------------------------
+
+
+async def test_approving_rule_proposal_lands_the_rule(store, fabric, beanie_test_db):
+    from pocketpaw_ee.cloud.instinct_rule_proposals import execute_approved_instinct_rule
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    await _seed_corrections(store, [_strong_correction("w1", i) for i in range(3)])
+
+    adapters = {"crm": _MockAdapter(schemas=[], data_by_action={"list_customers": _customers(2)})}
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+    assert result.instinct_action_ids, "expected a rule proposal to approve"
+    rule_action_id = result.instinct_action_ids[0]
+
+    approved = await store.approve(rule_action_id, approver="u1")
+    await execute_approved_instinct_rule(approved)
+
+    final = await store.get_action(rule_action_id)
+    assert final.status == ActionStatus.EXECUTED, final.error
+
+    # The rule LANDED — visible via the slice-2 read seam.
+    active = await rules_service.get_active_rules("w1")
+    assert len(active) == 1
+    landed = active[0]
+    assert landed["workspace_id"] == "w1"
+    assert landed["owner_user_id"] == "u1"
+    assert landed["scope"]["workspace_id"] == "w1"

--- a/tests/ee/test_instinct_rule_propose.py
+++ b/tests/ee/test_instinct_rule_propose.py
@@ -1,0 +1,335 @@
+# tests/ee/test_instinct_rule_propose.py — S2-R3 (_instinct_rule gate type).
+#
+# Created: 2026-06-20 (S2-R3 / feat/szd-slice2-discovery). Covers the propose +
+# apply-on-approve executor for the ``_instinct_rule`` Instinct proposal type —
+# the gate that stages a discovered governed rule for a human to approve / edit /
+# reject before it becomes an active ``InstinctRuleDoc``. Clones the discipline of
+# ``test_discovery_propose.py`` (isolated InstinctStore via the lazy
+# ``get_instinct_store`` seam + mongomock Beanie via ``beanie_test_db`` + an inert
+# recording bus so service ``emit()`` is quiet). Asserts:
+#
+#   * propose builds the EXACT blob shape (kind / schema=1 / workspace_id /
+#     rule_spec editable sub-dict / summary / correlation_id minted /
+#     proposed_event_id back-written), with tenancy + owner as SEPARATE top-level
+#     fields (NOT inside the editable rule_spec);
+#   * approve → executor → EXECUTED, and the rule LANDS (visible via
+#     ``rules.service.get_active_rules``);
+#   * a schema-version mismatch (blob schema=2) → terminal FAILED, NO rule written;
+#   * idempotent re-approve → no double-write (active-rule count stable);
+#   * a malformed rule_spec (bad action / invalid CEL) → executor ``_fail`` (not a
+#     crash), no rule written;
+#   * the executor emits exactly ONE ``decision.completed`` chain-close on approve.
+#
+# Run with:
+#   uv run --group ee pytest tests/ee/test_instinct_rule_propose.py -q
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.instinct_rule_proposals import (  # noqa: E402
+    INSTINCT_RULE_KIND,
+    INSTINCT_RULE_PARAM_KEY,
+    INSTINCT_RULE_SCHEMA,
+    execute_approved_instinct_rule,
+    propose_instinct_rule,
+)
+
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# A valid editable rule_spec (RuleDraft-shaped). Tenancy lives in scope here, but
+# the propose helper carries workspace_id / owner as SEPARATE top-level blob fields.
+# ---------------------------------------------------------------------------
+
+
+def _rule_spec(workspace_id: str = "w1") -> dict[str, Any]:
+    return {
+        "name": "Require approval on high-value invoices",
+        "description": "Flag invoices over 10k for human review.",
+        "when": "object.amount > 10000",
+        "action": "require_approval",
+        "scope": {"workspace_id": workspace_id, "object_type": "Invoice"},
+        "confidence": 0.82,
+        "provenance": ["audit:row-1", "correction:c-9"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — isolated InstinctStore + inert bus, cloned from test_discovery_propose.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    monkeypatch.setenv("AUTH_SECRET", "instinct-rule-propose-test-secret")
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Inert recording EventBus so ``rules.service.create_rule``'s ``emit()`` is quiet."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        async def publish(self, event: Any) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler: Any) -> None:  # noqa: ARG002
+            return
+
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = _RecordingBus()  # type: ignore[attr-defined]
+    yield bus_mod._bus
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    st = InstinctStore(tmp_path / "instinct_rule_test.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+# ---------------------------------------------------------------------------
+# propose: EXACT blob shape, chain ids, tenancy/owner separation.
+# ---------------------------------------------------------------------------
+
+
+async def test_propose_builds_exact_blob_shape(store):
+    action_id = await propose_instinct_rule(
+        workspace_id="w1",
+        user_id="u1",
+        rule_spec=_rule_spec("w1"),
+        summary="Stage the high-value-invoice rule for review.",
+    )
+
+    action = await store.get_action(action_id)
+    assert action.status == ActionStatus.PENDING
+
+    blob = action.parameters[INSTINCT_RULE_PARAM_KEY]
+
+    # EXACT key set — kind, schema, workspace_id, rule_spec, summary, correlation_id,
+    # proposed_event_id (+ no stray keys).
+    assert set(blob.keys()) == {
+        "kind",
+        "schema",
+        "workspace_id",
+        "user_id",
+        "rule_spec",
+        "summary",
+        "correlation_id",
+        "proposed_event_id",
+    }
+    assert blob["kind"] == INSTINCT_RULE_KIND == "instinct_rule"
+    assert blob["schema"] == INSTINCT_RULE_SCHEMA == 1
+
+    # Tenancy + owner ride as SEPARATE top-level fields — NOT inside the editable
+    # rule_spec (so a tenant editing the proposal can't move workspace/owner).
+    assert blob["workspace_id"] == "w1"
+    assert blob["user_id"] == "u1"
+    # Tenancy/owner are NOT smuggled into the editable rule_spec.
+    assert "workspace_id" not in blob["rule_spec"]
+    assert "owner" not in blob["rule_spec"]
+    assert "user_id" not in blob["rule_spec"]
+
+    # rule_spec is the editable RuleDraft sub-dict, verbatim.
+    assert blob["rule_spec"]["name"] == "Require approval on high-value invoices"
+    assert blob["rule_spec"]["action"] == "require_approval"
+    assert blob["rule_spec"]["when"] == "object.amount > 10000"
+    assert blob["rule_spec"]["scope"]["workspace_id"] == "w1"
+
+    assert blob["summary"] == "Stage the high-value-invoice rule for review."
+
+    # correlation_id minted; proposed_event_id back-written (a real id, not None).
+    assert blob["correlation_id"]
+    assert blob["proposed_event_id"]
+
+    # pocket_id == workspace_id anchoring (the Action surfaces in per-workspace queries).
+    assert str(action.pocket_id) == "w1"
+
+
+async def test_propose_requires_workspace_and_user(store):
+    with pytest.raises(ValueError, match="workspace_id"):
+        await propose_instinct_rule(workspace_id="", user_id="u1", rule_spec=_rule_spec())
+    with pytest.raises(ValueError, match="user_id"):
+        await propose_instinct_rule(workspace_id="w1", user_id="", rule_spec=_rule_spec())
+
+
+# ---------------------------------------------------------------------------
+# approve → executor → EXECUTED, rule LANDS.
+# ---------------------------------------------------------------------------
+
+
+async def test_approve_executes_and_rule_lands(store, beanie_test_db):
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    action_id = await propose_instinct_rule(
+        workspace_id="w1",
+        user_id="u1",
+        rule_spec=_rule_spec("w1"),
+    )
+
+    approved = await store.approve(action_id, approver="u1")
+    await execute_approved_instinct_rule(approved)
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED, final.error
+
+    # The rule LANDED — visible via the slice-2 read seam.
+    active = await rules_service.get_active_rules("w1")
+    assert len(active) == 1
+    landed = active[0]
+    assert landed["name"] == "Require approval on high-value invoices"
+    assert landed["action"] == "require_approval"
+    assert landed["workspace_id"] == "w1"
+    assert landed["owner_user_id"] == "u1"
+    assert landed["scope"]["workspace_id"] == "w1"
+    assert landed["scope"]["object_type"] == "Invoice"
+
+    # The structured outcome was back-written onto the blob.
+    outcome = final.parameters[INSTINCT_RULE_PARAM_KEY]["outcome"]
+    assert outcome["status"] == "executed"
+    assert outcome["rule_id"]
+
+
+# ---------------------------------------------------------------------------
+# Schema-version mismatch → terminal FAILED, NO rule written.
+# ---------------------------------------------------------------------------
+
+
+async def test_schema_mismatch_fails_terminal_no_write(store, beanie_test_db):
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    action_id = await propose_instinct_rule(
+        workspace_id="w1",
+        user_id="u1",
+        rule_spec=_rule_spec("w1"),
+    )
+
+    approved = await store.approve(action_id, approver="u1")
+    # Corrupt the in-memory blob to an incompatible build schema (the executor
+    # reads action.parameters directly — same mutation pattern as the pocket-create
+    # gate test).
+    approved.parameters[INSTINCT_RULE_PARAM_KEY]["schema"] = 2
+    await execute_approved_instinct_rule(approved)
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.FAILED, final.error
+    assert "schema mismatch" in (final.error or "").lower()
+
+    # NO rule written.
+    assert await rules_service.get_active_rules("w1") == []
+
+
+# ---------------------------------------------------------------------------
+# Idempotent re-approve → no double-write.
+# ---------------------------------------------------------------------------
+
+
+async def test_idempotent_reapprove_no_double_write(store, beanie_test_db):
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    action_id = await propose_instinct_rule(
+        workspace_id="w1",
+        user_id="u1",
+        rule_spec=_rule_spec("w1"),
+    )
+
+    approved = await store.approve(action_id, approver="u1")
+    await execute_approved_instinct_rule(approved)
+    assert len(await rules_service.get_active_rules("w1")) == 1
+
+    # Re-invoke the executor on the now-terminal Action — must NOT create a 2nd rule.
+    again = await store.get_action(action_id)
+    await execute_approved_instinct_rule(again)
+    assert len(await rules_service.get_active_rules("w1")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Malformed rule_spec → executor _fail (not a crash), no rule written.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_spec",
+    [
+        # invalid action literal
+        {
+            "name": "bad",
+            "when": "object.amount > 1",
+            "action": "nuke",
+            "scope": {"workspace_id": "w1"},
+        },
+        # invalid CEL trigger
+        {
+            "name": "bad",
+            "when": "this is (not valid CEL",
+            "action": "notify",
+            "scope": {"workspace_id": "w1"},
+        },
+    ],
+)
+async def test_malformed_rule_spec_fails_not_crash(store, beanie_test_db, bad_spec):
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    action_id = await propose_instinct_rule(
+        workspace_id="w1",
+        user_id="u1",
+        rule_spec=_rule_spec("w1"),
+    )
+
+    approved = await store.approve(action_id, approver="u1")
+    # Swap in a structurally-invalid rule_spec on the in-memory blob.
+    approved.parameters[INSTINCT_RULE_PARAM_KEY]["rule_spec"] = bad_spec
+    # Must NOT raise — a bad spec is a failed outcome, not a crash.
+    await execute_approved_instinct_rule(approved)
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.FAILED, final.error
+    assert await rules_service.get_active_rules("w1") == []
+
+
+# ---------------------------------------------------------------------------
+# The executor emits EXACTLY ONE decision.completed chain-close on approve.
+# ---------------------------------------------------------------------------
+
+
+async def test_executor_emits_exactly_one_chain_close_on_approve(
+    store, beanie_test_db, monkeypatch
+):
+    calls: list[dict[str, Any]] = []
+
+    from pocketpaw_ee.cloud.instinct_rule_proposals import executor as rule_executor
+
+    real_close = rule_executor._emit_chain_close
+
+    def _spy(**kwargs: Any) -> None:
+        calls.append(kwargs)
+        return real_close(**kwargs)
+
+    monkeypatch.setattr(rule_executor, "_emit_chain_close", _spy)
+
+    action_id = await propose_instinct_rule(
+        workspace_id="w1",
+        user_id="u1",
+        rule_spec=_rule_spec("w1"),
+    )
+    approved = await store.approve(action_id, approver="u1")
+    await execute_approved_instinct_rule(approved)
+
+    final = await store.get_action(action_id)
+    assert final.status == ActionStatus.EXECUTED, final.error
+
+    # Exactly one terminal close, and it is the success terminal.
+    assert len(calls) == 1
+    assert calls[0]["passed"] is True
+    assert calls[0]["action_outcome"] == "landed"

--- a/tests/ee/test_instinct_rule_router.py
+++ b/tests/ee/test_instinct_rule_router.py
@@ -1,0 +1,506 @@
+# tests/ee/test_instinct_rule_router.py — S2-R4 (router four-path dispatch + tenancy).
+#
+# Created: 2026-06-20 (S2-R4 / feat/szd-slice2-discovery). The security gate on the
+# ``_instinct_rule`` Instinct proposal type. Clones the cross-workspace-403 discipline
+# of ``tests/cloud/test_instinct_approval_security.py`` (the ``_pocket_write`` /
+# ``_code_change`` peers) for the governed-rule-create gate, and adds the router-driven
+# round-trip the security clone does not need.
+#
+# THE LOAD-BEARING ASSERTION (RK-5 — the four-path trap): a foreign-workspace
+# ``_instinct_rule`` Action is refused with 403 + ``instinct.cross_workspace_approval``
+# on ALL FOUR router entry points — ``approve_action``, ``bulk_approve_actions``,
+# ``reject_action``, ``bulk_reject_actions``. Missing the guard on even ONE path is a
+# cross-tenant approval escalation (the pocketpaw#1183 bug class). Each path gets its
+# own explicit test below; do not delete any.
+#
+# Plus (RK-6 — exactly-one chain-close):
+#   * a SAME-workspace approve VIA THE ROUTER lands the rule (asserted through
+#     ``rules.service.get_active_rules``) and emits exactly ONE ``decision.completed``
+#     (the executor owns the close on approve);
+#   * a SAME-workspace reject VIA THE ROUTER closes the chain (the router owns it) with
+#     exactly ONE ``decision.completed`` and writes NO rule;
+#   * a mixed bulk approve / bulk reject does not cross-fire kinds (an ``_instinct_rule``
+#     item routes to the rule executor / rule close; a sibling ``_pocket_write`` item in
+#     the same batch routes to its own path).
+#
+# The 403 tests are sync and drive the router over HTTP via ``TestClient`` (the
+# TestClient owns the only event loop, matching the security clone) — they 403 BEFORE
+# any executor/DB touch, so no Beanie is needed. The round-trip tests that actually land
+# a rule are async (``AsyncClient`` + ``ASGITransport`` + the ``beanie_test_db``
+# mongomock fixture) so the router's in-request executor and the post-hoc
+# ``get_active_rules`` read share one event loop and one in-memory database.
+#
+# Run with:
+#   uv run --group ee pytest tests/ee/test_instinct_rule_router.py -q
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.instinct_rule_proposals import (  # noqa: E402
+    INSTINCT_RULE_PARAM_KEY,
+    propose_instinct_rule,
+)
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+TRIGGER = {"type": "agent", "source": "claude", "reason": "rule router test"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — auth doubles + a CloudError-aware app (cloned from the security test)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "user-A", workspace_id: str = "ws-A") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Inert recording EventBus so ``rules.service.create_rule``'s ``emit()`` is quiet.
+
+    ``tests/ee`` has no autouse RecordingBus; mint a minimal one (per
+    test_instinct_rule_propose / test_rules_service)."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        async def publish(self, event: Any) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler: Any) -> None:  # noqa: ARG002
+            return
+
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = _RecordingBus()  # type: ignore[attr-defined]
+    yield bus_mod._bus
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+def _rule_spec(workspace_id: str, name: str = "Require approval on high-value invoices") -> dict:
+    """A valid editable RuleDraft-shaped rule_spec. Tenancy lives in ``scope`` here, but
+    the propose helper carries ``workspace_id`` / owner as SEPARATE top-level blob
+    fields (so the cross-workspace gate reads the blob's top-level workspace_id)."""
+    return {
+        "name": name,
+        "description": "Flag invoices over 10k for human review.",
+        "when": "object.amount > 10000",
+        "action": "require_approval",
+        "scope": {"workspace_id": workspace_id, "object_type": "Invoice"},
+        "confidence": 0.82,
+        "provenance": ["audit:row-1", "correction:c-9"],
+    }
+
+
+def _pocket_write_params(workspace_id: str) -> dict:
+    """A sibling ``_pocket_write`` blob — the shape the pocket-write bridge stores. Used
+    in the mixed-batch tests to prove kinds don't cross-fire."""
+    return {
+        "_pocket_write": {
+            "schema": 2,
+            "action": "mark_renewed",
+            "method": "POST",
+            "path": "/leases/42/renew",
+            "params": {"rent": 2000},
+            "idempotency_key": "idem-xyz",
+            "outcome": "renewal_completed",
+            "workspace_id": workspace_id,
+            "requested_by": "requester-9",
+            "correlation_id": None,
+            "parked_policy_event_id": None,
+        }
+    }
+
+
+@pytest.fixture
+def router_store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "instinct_rule_router.db")
+
+
+def _make_app(user: _FakeUser, monkeypatch) -> FastAPI:
+    """Build a FastAPI app over the instinct router with a CloudError handler so a
+    ``Forbidden`` maps to a 403 (not a 500), and the license / plan deps stubbed."""
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return app
+
+
+def _make_client(router_store: InstinctStore, user: _FakeUser, monkeypatch) -> TestClient:
+    return TestClient(_make_app(user, monkeypatch))
+
+
+def _propose_rule_action(client: TestClient, *, workspace_id: str, name: str = "rule") -> str:
+    """Seed a pending Action carrying an ``_instinct_rule`` blob over HTTP and return
+    its id. The blob's top-level ``workspace_id`` is what the cross-workspace gate
+    reads."""
+    resp = client.post(
+        "/instinct/actions",
+        json={
+            "pocket_id": workspace_id,
+            "title": f"governed rule {name}",
+            "trigger": TRIGGER,
+            "parameters": {
+                INSTINCT_RULE_PARAM_KEY: {
+                    "kind": "instinct_rule",
+                    "schema": 1,
+                    "workspace_id": workspace_id,
+                    "user_id": "user-A",
+                    "rule_spec": _rule_spec(workspace_id, name=name),
+                    "summary": f"Create the governed rule {name!r}.",
+                    "correlation_id": None,
+                    "proposed_event_id": None,
+                }
+            },
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _propose_pocket_write_action(client: TestClient, *, workspace_id: str) -> str:
+    resp = client.post(
+        "/instinct/actions",
+        json={
+            "pocket_id": "pocket-A",
+            "title": "ws write",
+            "trigger": TRIGGER,
+            "parameters": _pocket_write_params(workspace_id),
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _status_of(client: TestClient, action_id: str) -> str:
+    resp = client.get("/instinct/actions", params={"limit": 500})
+    assert resp.status_code == 200, resp.text
+    for action in resp.json()["actions"]:
+        if action["id"] == action_id:
+            return action["status"]
+    raise AssertionError(f"action {action_id} not found")
+
+
+# ===========================================================================
+# THE FOUR-PATH SECURITY GATE — cross-workspace 403 on every entry point.
+# Each path is a separate test: missing the guard on ONE = the escalation bug.
+# ===========================================================================
+
+
+class TestInstinctRuleCrossWorkspace403:
+    """``_assert_instinct_rule_workspace`` must refuse a foreign-workspace
+    ``_instinct_rule`` Action with 403 + ``instinct.cross_workspace_approval`` on the
+    approve, bulk-approve, reject, AND bulk-reject paths. A rule create carries no
+    pocket, so without this gate a ws-A admin could approve (and APPLY) a ws-B rule
+    into ws-B."""
+
+    def test_single_approve_of_foreign_workspace_rule_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose_rule_action(client, workspace_id="ws-B")
+            resp = client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_bulk_approve_of_foreign_workspace_rule_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose_rule_action(client, workspace_id="ws-A", name="own")
+            foreign = _propose_rule_action(client, workspace_id="ws-B", name="foreign")
+            resp = client.post("/instinct/actions/bulk-approve", json={"ids": [own, foreign]})
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            # The whole batch is rejected — nothing flipped.
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+    def test_single_reject_of_foreign_workspace_rule_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            action_id = _propose_rule_action(client, workspace_id="ws-B")
+            resp = client.post(f"/instinct/actions/{action_id}/reject", json={"reason": "nope"})
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, action_id) == "pending"
+
+    def test_bulk_reject_of_foreign_workspace_rule_is_403(
+        self, router_store: InstinctStore, monkeypatch
+    ) -> None:
+        client = _make_client(router_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+        with patch("pocketpaw_ee.instinct.router._store", return_value=router_store):
+            own = _propose_rule_action(client, workspace_id="ws-A", name="own")
+            foreign = _propose_rule_action(client, workspace_id="ws-B", name="foreign")
+            resp = client.post(
+                "/instinct/actions/bulk-reject",
+                json={"ids": [own, foreign], "reason": "batch nope"},
+            )
+            assert resp.status_code == 403, resp.text
+            assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+            assert _status_of(client, own) == "pending"
+            assert _status_of(client, foreign) == "pending"
+
+
+# ===========================================================================
+# SAME-WORKSPACE round-trip VIA THE ROUTER — the rule lands / no rule on reject,
+# with exactly ONE decision.completed per path (RK-6: approve→executor owns,
+# reject→router owns, never both).
+# ===========================================================================
+
+
+async def _async_router_client(
+    router_store: InstinctStore, user: _FakeUser, monkeypatch
+) -> AsyncClient:
+    """Async client over the instinct router app, sharing the test event loop with the
+    ``beanie_test_db`` mongomock DB so the in-request executor's write is visible to a
+    post-hoc ``get_active_rules`` read."""
+    app = _make_app(user, monkeypatch)
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver")
+
+
+async def _seed_rule_action(workspace_id: str, *, name: str = "rule") -> str:
+    """Seed a pending ``_instinct_rule`` Action through the real propose helper (it mints
+    the correlation_id + opens the chain), returning the action id. Caller must have
+    pointed ``pocketpaw.stores.get_instinct_store`` at the shared store."""
+    return await propose_instinct_rule(
+        workspace_id=workspace_id,
+        user_id="user-A",
+        rule_spec=_rule_spec(workspace_id, name=name),
+        summary=f"Stage {name!r}.",
+    )
+
+
+@pytest.fixture
+def shared_store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """An InstinctStore wired to BOTH store seams — the router's
+    ``pocketpaw_ee.instinct.router._store`` (patched per-test) and the propose/executor's
+    ``pocketpaw.stores.get_instinct_store`` (patched here) — so propose + router-approve
+    + executor all share one store."""
+    st = InstinctStore(tmp_path / "instinct_rule_roundtrip.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+async def test_same_workspace_approve_via_router_lands_rule_one_close(
+    shared_store: InstinctStore, beanie_test_db, monkeypatch
+) -> None:
+    """A ws-A approver approving a ws-A ``_instinct_rule`` Action THROUGH THE ROUTER
+    lands the governed rule (visible via ``rules.service.get_active_rules``) and emits
+    exactly ONE ``decision.completed`` (the executor owns the close on approve)."""
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    closes: list[dict[str, Any]] = []
+    import pocketpaw_ee.cloud.decisions.journal_writer as jw
+
+    real_close = jw.record_decision_completed
+
+    def _spy_close(**kwargs: Any) -> Any:
+        closes.append(kwargs)
+        return real_close(**kwargs)
+
+    monkeypatch.setattr(jw, "record_decision_completed", _spy_close)
+
+    action_id = await _seed_rule_action("ws-A")
+
+    user = _FakeUser("user-A", "ws-A")
+    with patch("pocketpaw_ee.instinct.router._store", return_value=shared_store):
+        async with await _async_router_client(shared_store, user, monkeypatch) as client:
+            resp = await client.post(f"/instinct/actions/{action_id}/approve")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["action"]["status"] == "approved"
+
+    # The rule LANDED in ws-A via the router-driven approve.
+    active = await rules_service.get_active_rules("ws-A")
+    assert len(active) == 1
+    assert active[0]["name"] == "rule"
+    assert active[0]["action"] == "require_approval"
+    assert active[0]["workspace_id"] == "ws-A"
+
+    # The action reached EXECUTED (the executor's mark_executed).
+    final = await shared_store.get_action(action_id)
+    status_value = getattr(final.status, "value", final.status)
+    assert str(status_value) == "executed", final.error
+
+    # Exactly ONE decision.completed — the executor's success close, no router double.
+    assert len(closes) == 1
+    assert closes[0]["payload"]["passed"] is True
+    assert closes[0]["payload"]["action_outcome"] == "landed"
+
+
+async def test_same_workspace_reject_via_router_closes_chain_no_rule(
+    shared_store: InstinctStore, beanie_test_db, monkeypatch
+) -> None:
+    """A ws-A approver rejecting a ws-A ``_instinct_rule`` Action THROUGH THE ROUTER
+    closes the chain (the ROUTER owns the close on reject) with exactly ONE
+    ``decision.completed`` and writes NO rule (the executor never runs on reject)."""
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    closes: list[dict[str, Any]] = []
+    import pocketpaw_ee.cloud.decisions.journal_writer as jw
+
+    real_close = jw.record_decision_completed
+
+    def _spy_close(**kwargs: Any) -> Any:
+        closes.append(kwargs)
+        return real_close(**kwargs)
+
+    monkeypatch.setattr(jw, "record_decision_completed", _spy_close)
+
+    action_id = await _seed_rule_action("ws-A")
+
+    user = _FakeUser("user-A", "ws-A")
+    with patch("pocketpaw_ee.instinct.router._store", return_value=shared_store):
+        async with await _async_router_client(shared_store, user, monkeypatch) as client:
+            resp = await client.post(
+                f"/instinct/actions/{action_id}/reject", json={"reason": "not now"}
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] == "rejected"
+
+    # NO rule was written — reject never runs the executor.
+    assert await rules_service.get_active_rules("ws-A") == []
+
+    # Exactly ONE decision.completed — the router's rejected close.
+    assert len(closes) == 1
+    assert closes[0]["payload"]["passed"] is False
+    assert closes[0]["payload"]["action_outcome"] == "rejected"
+
+
+# ===========================================================================
+# MIXED BATCH — kinds never cross-fire. An _instinct_rule item routes to the rule
+# executor / rule close; a sibling _pocket_write item routes to its own path.
+# ===========================================================================
+
+
+async def test_bulk_approve_mixed_batch_routes_each_kind(
+    shared_store: InstinctStore, beanie_test_db, monkeypatch
+) -> None:
+    """A bulk-approve of a batch mixing an ``_instinct_rule`` and a ``_pocket_write``
+    lands the rule (rule executor fired) and does NOT mis-route the pocket-write through
+    the rule path. The pocket-write executor is patched off (its real apply needs pocket
+    creds); we assert it was invoked with the right action and the rule landed once."""
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    pocket_write_calls: list[Any] = []
+
+    async def _fake_execute_write(action: Any) -> None:
+        pocket_write_calls.append(action)
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.instinct_bridge.execute_approved_write",
+        _fake_execute_write,
+    )
+
+    rule_action = await _seed_rule_action("ws-A", name="mixed-rule")
+
+    user = _FakeUser("user-A", "ws-A")
+    with patch("pocketpaw_ee.instinct.router._store", return_value=shared_store):
+        async with await _async_router_client(shared_store, user, monkeypatch) as client:
+            # Seed the sibling pocket-write over the same async client.
+            pw_resp = await client.post(
+                "/instinct/actions",
+                json={
+                    "pocket_id": "pocket-A",
+                    "title": "ws-A write",
+                    "trigger": TRIGGER,
+                    "parameters": _pocket_write_params("ws-A"),
+                },
+            )
+            assert pw_resp.status_code == 201, pw_resp.text
+            pw_action = pw_resp.json()["id"]
+
+            resp = await client.post(
+                "/instinct/actions/bulk-approve", json={"ids": [rule_action, pw_action]}
+            )
+            assert resp.status_code == 200, resp.text
+            assert len(resp.json()["affected"]) == 2
+
+    # The rule landed exactly once (the rule executor fired on the rule item only).
+    active = await rules_service.get_active_rules("ws-A")
+    assert len(active) == 1
+    assert active[0]["name"] == "mixed-rule"
+
+    # The pocket-write item routed to ITS OWN executor — not the rule path.
+    assert len(pocket_write_calls) == 1
+
+
+async def test_bulk_reject_mixed_batch_routes_each_kind(
+    shared_store: InstinctStore, beanie_test_db, monkeypatch
+) -> None:
+    """A bulk-reject of a mixed batch closes each kind on its own reject branch: the
+    ``_instinct_rule`` item writes NO rule and the batch flips both items to rejected.
+    Each kind's reject branch ``continue``s, so neither leaks into the other."""
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    rule_action = await _seed_rule_action("ws-A", name="reject-rule")
+
+    user = _FakeUser("user-A", "ws-A")
+    with patch("pocketpaw_ee.instinct.router._store", return_value=shared_store):
+        async with await _async_router_client(shared_store, user, monkeypatch) as client:
+            pw_resp = await client.post(
+                "/instinct/actions",
+                json={
+                    "pocket_id": "pocket-A",
+                    "title": "ws-A write",
+                    "trigger": TRIGGER,
+                    "parameters": _pocket_write_params("ws-A"),
+                },
+            )
+            assert pw_resp.status_code == 201, pw_resp.text
+            pw_action = pw_resp.json()["id"]
+
+            resp = await client.post(
+                "/instinct/actions/bulk-reject",
+                json={"ids": [rule_action, pw_action], "reason": "batch reject"},
+            )
+            assert resp.status_code == 200, resp.text
+            affected = {a["id"] for a in resp.json()["affected"]}
+            assert affected == {rule_action, pw_action}
+
+            # Both flipped to rejected.
+            listing = await client.get("/instinct/actions", params={"limit": 500})
+            by_id = {a["id"]: a["status"] for a in listing.json()["actions"]}
+    assert by_id[rule_action] == "rejected"
+    assert by_id[pw_action] == "rejected"
+
+    # No rule was written on the reject path.
+    assert await rules_service.get_active_rules("ws-A") == []

--- a/tests/ee/test_kb_compile_digester.py
+++ b/tests/ee/test_kb_compile_digester.py
@@ -1,0 +1,346 @@
+# tests/ee/test_kb_compile_digester.py — unit + smoke tests for the KbCompileDigester (S2-K1).
+#
+# Created: 2026-06-20 (S2-K1 / feat/szd-slice2-discovery) — covers the on-box
+# unstructured-exhaust → OntologyDraft digester. Mirrors the pure-logic style of
+# test_structured_shape_digester.py: one `digester` fixture, a `fake_kb` fixture
+# that REPLACES the `_kb` subprocess seam with an in-memory fake (no binary, no
+# network, no Anthropic call). The fake records every call's argv so the
+# SOVEREIGNTY tripwire can assert `kb ingest` / `kb build` are NEVER invoked
+# across a digest() run (the keyless compile constraint encoded as a test, same
+# spirit as the adapter.sync() tripwire in test_discovery_run.py).
+#
+# Covers:
+#   * unstructured text → categorized articles → object types + properties;
+#   * article `id` is the source_id_field with key_confidence >= 0.8;
+#   * concept co-occurrence (kb graph) → a DraftLink with via_field=shared concept;
+#   * FabricMapping(**ot.to_fabric_mapping_kwargs()) round-trips per inferred type;
+#   * empty input → is_empty / degraded == "empty";
+#   * uncategorized articles → degraded == "objects-only", source_id_field is None;
+#   * isinstance(draft, OntologyDraft);
+#   * SOVEREIGNTY TRIPWIRE: args[0] not in ("ingest", "build") across the run;
+#   * smoke: real kb binary convo ingest → list round-trip in a tmp scope
+#     (skipped cleanly when no binary is resolvable).
+#
+# Pure-logic + mocked subprocess. Run with:
+#   uv run --group ee pytest tests/ee/test_kb_compile_digester.py -q
+
+from __future__ import annotations
+
+import shutil
+import uuid
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.discovery import OntologyDraft  # noqa: E402
+from pocketpaw_ee.discovery.kb_compile import KbCompileDigester  # noqa: E402
+
+from pocketpaw.connectors.fabric_ingest import FabricMapping  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fakes — the kb-go subprocess seam, in memory
+# --------------------------------------------------------------------------- #
+def _make_fake_kb(
+    monkeypatch,
+    *,
+    articles: list[dict],
+    edges: list[dict] | None = None,
+    nodes: list[dict] | None = None,
+):
+    """Patch the `_kb` seam the digester calls with an in-memory fake.
+
+    ``articles`` is the canned list of WikiArticle-shaped dicts the fake's
+    `list`/`show` serve back (keyed by the compile scope). ``nodes``/``edges``
+    feed the `graph --format json` response (kb-go concept graph shape:
+    nodes=[{id,label,kind,size}], edges=[{source,target,weight}]).
+
+    Returns the ``calls`` list (every call's argv tuple) so a test can assert
+    the keyless path and the sovereignty tripwire.
+    """
+    calls: list[tuple[str, ...]] = []
+    store: dict[str, list[dict]] = {}
+
+    def _scope_of(args: tuple[str, ...]) -> str:
+        if "--scope" in args:
+            return args[args.index("--scope") + 1]
+        return "default"
+
+    def _fake_kb(*args, input_text=None, timeout=120):
+        calls.append(args)
+        # SOVEREIGNTY: the keyed/off-box compile paths must NEVER be reached.
+        assert args[0] != "ingest", (
+            "sovereignty: KbCompileDigester must not call `kb ingest` (off-box LLM)"
+        )
+        assert args[0] != "build", (
+            "sovereignty: KbCompileDigester must not call `kb build` (off-box LLM)"
+        )
+
+        scope = _scope_of(args)
+        # Keyless compile: convo ingest <file> --scope <s> | accept --scope <s>.
+        if args[0] in ("convo", "accept"):
+            store.setdefault(scope, [])
+            for a in articles:
+                if a not in store[scope]:
+                    store[scope].append(a)
+            return {"articles": len(articles), "accepted": len(articles)}
+        if args[0] == "list":
+            # kb list omits concepts/categories — return the lean shape.
+            return [
+                {
+                    "id": a["id"],
+                    "title": a.get("title", ""),
+                    "summary": a.get("summary", ""),
+                }
+                for a in store.get(scope, [])
+            ]
+        if args[0] == "show":
+            article_id = args[1]
+            for a in store.get(scope, []):
+                if a["id"] == article_id:
+                    return dict(a)
+            return {}
+        if args[0] == "graph":
+            return {
+                "scope": scope,
+                "nodes": nodes or [],
+                "edges": edges or [],
+            }
+        return {}
+
+    monkeypatch.setattr("pocketpaw_ee.discovery.kb_compile._kb", _fake_kb)
+    return calls
+
+
+# Two well-categorized articles sharing the "billing" concept — the canonical
+# happy-path fixture used by most tests.
+_TWO_TYPED_ARTICLES = [
+    {
+        "id": "a1",
+        "title": "Login lockout after billing failure",
+        "summary": "Customer cannot log in; billing lock triggered.",
+        "concepts": ["billing", "login"],
+        "categories": ["SupportTicket"],
+    },
+    {
+        "id": "a2",
+        "title": "Refund requested on invoice 12",
+        "summary": "Refund request tied to a billing dispute.",
+        "concepts": ["billing", "refund"],
+        "categories": ["RefundRequest"],
+    },
+]
+
+# graph nodes (concept kind) + an edge sharing the "billing" concept across the
+# two articles → drives a cross-type DraftLink via the shared concept.
+_BILLING_GRAPH_NODES = [
+    {"id": "c0", "label": "billing", "kind": "concept", "size": 2},
+    {"id": "c1", "label": "login", "kind": "concept", "size": 1},
+    {"id": "c2", "label": "refund", "kind": "concept", "size": 1},
+]
+_BILLING_GRAPH_EDGES = [
+    {"source": "c0", "target": "c1", "weight": 1},
+    {"source": "c0", "target": "c2", "weight": 1},
+]
+
+
+@pytest.fixture
+def digester() -> KbCompileDigester:
+    return KbCompileDigester()
+
+
+# --------------------------------------------------------------------------- #
+# Type + property inference
+# --------------------------------------------------------------------------- #
+def test_unstructured_text_compiles_to_typed_articles(digester, monkeypatch) -> None:
+    calls = _make_fake_kb(monkeypatch, articles=_TWO_TYPED_ARTICLES)
+    exhaust = {
+        "zendesk": [
+            "Customer can't log in, billing locked.",
+            "Refund requested on invoice 12.",
+        ]
+    }
+    draft = digester.digest(exhaust, {"connector": "zendesk", "workspace_id": "w1"})
+
+    assert isinstance(draft, OntologyDraft)
+    # categories → object types
+    assert sorted(ot.name for ot in draft.object_types) == ["RefundRequest", "SupportTicket"]
+    # the compile went through a KEYLESS path, never `kb ingest` / `kb build`
+    assert any(c[0] in ("convo", "accept") for c in calls)
+    assert all(c[0] not in ("ingest", "build") for c in calls)
+    # provenance stamped
+    assert draft.meta["digester"] == "kb-compile"
+    assert draft.meta["connector"] == "zendesk"
+
+
+def test_properties_inferred_over_article_fields(digester, monkeypatch) -> None:
+    _make_fake_kb(monkeypatch, articles=_TWO_TYPED_ARTICLES)
+    draft = digester.digest({"zendesk": ["body one", "body two"]})
+    ot = draft.type_by_name("SupportTicket")
+    assert ot is not None
+    prop_names = {p.name for p in ot.properties}
+    # properties span {title, summary, concepts, categories}
+    assert {"title", "summary", "concepts", "categories"} <= prop_names
+
+
+# --------------------------------------------------------------------------- #
+# Primary key — the article id
+# --------------------------------------------------------------------------- #
+def test_article_id_is_the_source_id_field(digester, monkeypatch) -> None:
+    _make_fake_kb(monkeypatch, articles=_TWO_TYPED_ARTICLES)
+    draft = digester.digest({"zendesk": ["one ticket body"]})
+    ot = draft.type_by_name("SupportTicket")
+    assert ot is not None
+    assert ot.source_id_field == "id"
+    assert ot.key_confidence >= 0.8
+
+
+def test_source_id_extracted_onto_objects(digester, monkeypatch) -> None:
+    _make_fake_kb(monkeypatch, articles=_TWO_TYPED_ARTICLES)
+    draft = digester.digest({"zendesk": ["one", "two"]})
+    sids = sorted(o.source_id for o in draft.objects if o.source_id is not None)
+    assert sids == ["a1", "a2"]
+
+
+# --------------------------------------------------------------------------- #
+# Concept co-occurrence → links
+# --------------------------------------------------------------------------- #
+def test_concept_cooccurrence_yields_links(digester, monkeypatch) -> None:
+    _make_fake_kb(
+        monkeypatch,
+        articles=_TWO_TYPED_ARTICLES,
+        nodes=_BILLING_GRAPH_NODES,
+        edges=_BILLING_GRAPH_EDGES,
+    )
+    draft = digester.digest({"zendesk": ["a", "b"]})
+    # the two articles share the "billing" concept → at least one cross-type link
+    assert draft.links, "expected a concept-cooccurrence link"
+    shared = [lk for lk in draft.links if lk.via_field == "billing"]
+    assert shared, "expected a DraftLink whose via_field is the shared concept"
+    lk = shared[0]
+    assert lk.from_type != lk.to_type
+    assert {lk.from_source_id, lk.to_source_id} <= {"a1", "a2"}
+    assert 0.0 < lk.confidence <= 1.0
+
+
+# --------------------------------------------------------------------------- #
+# FabricMapping round-trip — the draft must be directly usable by ingest
+# --------------------------------------------------------------------------- #
+def test_draft_types_build_fabric_mapping(digester, monkeypatch) -> None:
+    _make_fake_kb(monkeypatch, articles=_TWO_TYPED_ARTICLES)
+    draft = digester.digest({"zendesk": ["x", "y"]})
+    assert draft.object_types
+    for ot in draft.object_types:
+        mapping = FabricMapping(**ot.to_fabric_mapping_kwargs())
+        assert mapping.type_name == ot.name
+        assert mapping.source_id_field == "id"
+
+
+# --------------------------------------------------------------------------- #
+# Degradation
+# --------------------------------------------------------------------------- #
+def test_empty_exhaust_yields_empty_draft(digester, monkeypatch) -> None:
+    _make_fake_kb(monkeypatch, articles=[])
+    assert digester.digest({}).is_empty
+    assert digester.digest(None).is_empty
+    draft = digester.digest({})
+    assert draft.meta.get("degraded") == "empty"
+    assert draft.meta["digester"] == "kb-compile"
+
+
+def test_compile_yielding_no_articles_degrades_empty(digester, monkeypatch) -> None:
+    # input present, but the compile produced nothing readable back.
+    _make_fake_kb(monkeypatch, articles=[])
+    draft = digester.digest({"zendesk": ["some text"]})
+    assert draft.is_empty
+    assert draft.meta.get("degraded") == "empty"
+
+
+def test_uncategorized_articles_degrade_to_objects_only(digester, monkeypatch) -> None:
+    uncategorized = [
+        {
+            "id": "u1",
+            "title": "Misc note",
+            "summary": "no category",
+            "concepts": [],
+            "categories": [],
+        },
+        {
+            "id": "u2",
+            "title": "Another note",
+            "summary": "also no category",
+            "concepts": [],
+            "categories": [],
+        },
+    ]
+    _make_fake_kb(monkeypatch, articles=uncategorized)
+    draft = digester.digest({"zendesk": ["a", "b"]})
+    assert draft.meta.get("degraded") == "objects-only"
+    assert draft.object_types
+    for ot in draft.object_types:
+        assert ot.source_id_field is None
+        assert ot.key_confidence < 0.3
+    # objects still produced, with no source_id
+    assert draft.objects
+    assert all(o.source_id is None for o in draft.objects)
+    assert draft.links == []
+
+
+# --------------------------------------------------------------------------- #
+# Sovereignty tripwire — non-negotiable
+# --------------------------------------------------------------------------- #
+def test_sovereignty_never_calls_ingest_or_build(digester, monkeypatch) -> None:
+    calls = _make_fake_kb(
+        monkeypatch,
+        articles=_TWO_TYPED_ARTICLES,
+        nodes=_BILLING_GRAPH_NODES,
+        edges=_BILLING_GRAPH_EDGES,
+    )
+    digester.digest(
+        {"zendesk": ["t1", "t2"], "intercom": ["t3"]},
+        {"workspace_id": "w1", "connector": "zendesk"},
+    )
+    assert calls, "expected the digester to drive the kb seam at least once"
+    # the load-bearing assertion: across the WHOLE digest run, the off-box
+    # LLM-compile commands are never invoked.
+    assert all(c[0] not in ("ingest", "build") for c in calls)
+    # and at least one keyless compile actually ran.
+    assert any(c[0] in ("convo", "accept") for c in calls)
+
+
+def test_returns_ontology_draft_type(digester, monkeypatch) -> None:
+    _make_fake_kb(monkeypatch, articles=_TWO_TYPED_ARTICLES)
+    assert isinstance(digester.digest({"zendesk": ["t"]}), OntologyDraft)
+
+
+# --------------------------------------------------------------------------- #
+# Smoke — real kb binary, convo ingest → list round-trip (skip if absent)
+# --------------------------------------------------------------------------- #
+def _kb_binary_present() -> bool:
+    from pocketpaw_ee.discovery import kb_compile
+
+    bin_path = kb_compile.KB_BIN
+    if shutil.which(bin_path):
+        return True
+    from pathlib import Path
+
+    return Path(bin_path).exists()
+
+
+@pytest.mark.skipif(not _kb_binary_present(), reason="kb binary not resolvable on this runner")
+def test_smoke_real_kb_convo_ingest_roundtrip(digester) -> None:
+    # A real, isolated scope so we never touch a shared KB. The digest drives
+    # the keyless on-box compile end-to-end against the real binary.
+    scope_tag = f"szd2smoke-{uuid.uuid4().hex[:8]}"
+    exhaust = {
+        scope_tag: [
+            "Customer reports a billing lockout after a failed payment. "
+            "The refund was requested and the account was unlocked.",
+        ]
+    }
+    draft = digester.digest(exhaust, {"workspace_id": scope_tag, "connector": "smoke"})
+    # The real binary must not have crashed; we get an OntologyDraft back either
+    # way (empty if convo extraction produced nothing, populated otherwise).
+    assert isinstance(draft, OntologyDraft)
+    assert draft.meta["digester"] == "kb-compile"

--- a/tests/ee/test_rule_digester.py
+++ b/tests/ee/test_rule_digester.py
@@ -1,0 +1,273 @@
+# tests/ee/test_rule_digester.py — unit tests for SZD slice-2 S2-R2.
+#
+# Created: 2026-06-20 (S2-R2 / feat/szd-slice2-discovery) — covers RuleDigester,
+# the deterministic engine that reverse-engineers governed RuleDrafts from a
+# tenant's Instinct exhaust (corrections + audit). It generalizes the existing
+# 3x-correction → soul-procedural promotion (correction_soul_bridge.py) into a
+# structured, gate-ready RuleDraft. Tests assert:
+#   * N identical corrections on one path → exactly one draft, provenance = those
+#     correction ids, confidence rising with N;
+#   * below-threshold corrections → no draft;
+#   * a weak / inconsistent signal → confidence below the floor → skipped;
+#   * empty / insufficient exhaust → [] (never raises);
+#   * every emitted draft's ``when`` is valid CEL (round-trips through RuleDraft
+#     with no ValidationError);
+#   * mixed correction paths → one draft per qualifying path, none for the rest;
+#   * an ontology hint scopes the draft to a discovered object_type.
+#
+# Pure-logic tests — no DB / network / async. Hand-rolled Correction / AuditEntry
+# fixtures mirror the store's return shape (store.get_corrections_for_pocket →
+# list[Correction]; store.query_audit → list[AuditEntry]). Run with:
+#   uv run --group ee pytest tests/ee/test_rule_digester.py -q
+
+from __future__ import annotations
+
+from pocketpaw_ee.discovery import (
+    DraftObjectType,
+    OntologyDraft,
+    RuleDigester,
+    RuleDraft,
+)
+from pocketpaw_ee.discovery.rule_digester import (
+    RULE_CONFIDENCE_FLOOR,
+    RULE_RECUR_THRESHOLD,
+)
+
+from pocketpaw.instinct.correction import Correction, CorrectionPatch
+
+WS = "ws-acme"
+
+
+# --------------------------------------------------------------------------- #
+# Fixture helpers — mirror store.get_corrections_for_pocket → list[Correction]
+# --------------------------------------------------------------------------- #
+def _correction(
+    *,
+    cid: str,
+    path: str,
+    before: object,
+    after: object,
+    pocket_id: str = WS,
+    actor: str = "user:alice",
+) -> Correction:
+    """One Correction carrying a single field-level patch (the store shape)."""
+    return Correction(
+        id=cid,
+        action_id=f"act-{cid}",
+        pocket_id=pocket_id,
+        actor=actor,
+        patches=[CorrectionPatch(path=path, before=before, after=after)],
+        context_summary=f"edited {path}",
+        action_title="Some action",
+    )
+
+
+def _digester() -> RuleDigester:
+    return RuleDigester()
+
+
+# --------------------------------------------------------------------------- #
+# N identical corrections on one path → exactly one draft
+# --------------------------------------------------------------------------- #
+def test_recurring_identical_correction_yields_one_draft() -> None:
+    corrections = [
+        _correction(cid=f"c{i}", path="category", before="normal", after="urgent")
+        for i in range(RULE_RECUR_THRESHOLD)
+    ]
+    drafts = _digester().infer(corrections=corrections, workspace_id=WS)
+
+    assert len(drafts) == 1
+    draft = drafts[0]
+    assert isinstance(draft, RuleDraft)
+    # provenance carries exactly the contributing correction ids
+    assert set(draft.provenance) == {c.id for c in corrections}
+    # workspace tenancy is set
+    assert draft.scope.workspace_id == WS
+    # a consistent category escalation → require_approval
+    assert draft.action == "require_approval"
+
+
+def test_confidence_rises_with_recurrence_count() -> None:
+    base = [
+        _correction(cid=f"c{i}", path="priority", before="low", after="high")
+        for i in range(RULE_RECUR_THRESHOLD)
+    ]
+    more = base + [
+        _correction(cid=f"c{i}", path="priority", before="low", after="high")
+        for i in range(RULE_RECUR_THRESHOLD, RULE_RECUR_THRESHOLD + 4)
+    ]
+    low = _digester().infer(corrections=base, workspace_id=WS)
+    high = _digester().infer(corrections=more, workspace_id=WS)
+
+    assert len(low) == 1 and len(high) == 1
+    assert high[0].confidence > low[0].confidence
+    assert high[0].confidence <= 1.0  # clamped
+
+
+# --------------------------------------------------------------------------- #
+# Below threshold → no draft
+# --------------------------------------------------------------------------- #
+def test_below_threshold_yields_no_draft() -> None:
+    corrections = [
+        _correction(cid=f"c{i}", path="category", before="normal", after="urgent")
+        for i in range(RULE_RECUR_THRESHOLD - 1)
+    ]
+    drafts = _digester().infer(corrections=corrections, workspace_id=WS)
+    assert drafts == []
+
+
+# --------------------------------------------------------------------------- #
+# Weak / inconsistent signal → confidence below floor → skipped
+# --------------------------------------------------------------------------- #
+def test_weak_inconsistent_signal_skipped_below_floor() -> None:
+    # The same path recurs at threshold, but every corrected value differs —
+    # no constant target. The inferred rule is weak; confidence < floor → skip.
+    corrections = [
+        _correction(cid=f"c{i}", path="title", before="x", after=f"rewrite-{i}")
+        for i in range(RULE_RECUR_THRESHOLD)
+    ]
+    drafts = _digester().infer(corrections=corrections, workspace_id=WS)
+    assert drafts == []  # below RULE_CONFIDENCE_FLOOR → skipped, not emitted
+
+
+def test_floor_is_distinct_from_key_confidence_floor() -> None:
+    # Guard the RK-7 risk: the rule floor is its own constant, not the
+    # idempotency-key floor borrowed from the ontology digester.
+    from pocketpaw_ee.discovery.orchestrate import KEY_CONFIDENCE_FLOOR
+
+    assert RULE_CONFIDENCE_FLOOR is not KEY_CONFIDENCE_FLOOR
+    assert 0.0 < RULE_CONFIDENCE_FLOOR < 1.0
+
+
+# --------------------------------------------------------------------------- #
+# Empty / insufficient exhaust → [] (never raises)
+# --------------------------------------------------------------------------- #
+def test_empty_exhaust_returns_empty() -> None:
+    assert _digester().infer(corrections=[], workspace_id=WS) == []
+    assert _digester().infer(corrections=None, workspace_id=WS) == []  # type: ignore[arg-type]
+
+
+def test_corrections_with_no_patches_do_not_crash() -> None:
+    empty = Correction(
+        id="c-empty",
+        action_id="a1",
+        pocket_id=WS,
+        actor="user:alice",
+        patches=[],
+        context_summary="no edits",
+        action_title="t",
+    )
+    assert _digester().infer(corrections=[empty], workspace_id=WS) == []
+
+
+# --------------------------------------------------------------------------- #
+# Emitted draft's ``when`` validates as CEL
+# --------------------------------------------------------------------------- #
+def test_emitted_when_is_valid_cel() -> None:
+    for path in ("category", "priority", "parameters.assignee"):
+        corrections = [
+            _correction(cid=f"{path}-{i}", path=path, before="a", after="b")
+            for i in range(RULE_RECUR_THRESHOLD + 1)
+        ]
+        drafts = _digester().infer(corrections=corrections, workspace_id=WS)
+        assert len(drafts) == 1
+        # Re-validate the emitted spec through a fresh RuleDraft — a malformed
+        # CEL ``when`` would raise ValidationError here.
+        round_tripped = RuleDraft.model_validate(drafts[0].model_dump())
+        assert round_tripped.when == drafts[0].when
+        assert round_tripped.when  # non-empty CEL text
+
+
+# --------------------------------------------------------------------------- #
+# Mixed paths → one draft per qualifying path, none for the rest
+# --------------------------------------------------------------------------- #
+def test_mixed_paths_one_draft_per_qualifying_path() -> None:
+    corrections: list[Correction] = []
+    # "category" qualifies (>= threshold, consistent)
+    corrections += [
+        _correction(cid=f"cat-{i}", path="category", before="n", after="urgent")
+        for i in range(RULE_RECUR_THRESHOLD + 1)
+    ]
+    # "priority" qualifies (>= threshold, consistent)
+    corrections += [
+        _correction(cid=f"pri-{i}", path="priority", before="low", after="high")
+        for i in range(RULE_RECUR_THRESHOLD)
+    ]
+    # "description" does NOT qualify (below threshold)
+    corrections += [
+        _correction(cid=f"desc-{i}", path="description", before="x", after="y")
+        for i in range(RULE_RECUR_THRESHOLD - 1)
+    ]
+    drafts = _digester().infer(corrections=corrections, workspace_id=WS)
+
+    paths_covered = {d.name for d in drafts}
+    # exactly two drafts, one each for the two qualifying paths
+    assert len(drafts) == 2
+    # provenance never bleeds across paths
+    for d in drafts:
+        prov_paths = {pid.split("-")[0] for pid in d.provenance}
+        assert len(prov_paths) == 1
+    assert "description" not in " ".join(paths_covered).lower() or len(drafts) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Suppression-shaped correction → notify action
+# --------------------------------------------------------------------------- #
+def test_repeated_recommendation_suppression_infers_notify() -> None:
+    # Humans repeatedly blank the recommendation (suppress the auto-suggestion).
+    corrections = [
+        _correction(cid=f"sup-{i}", path="recommendation", before="auto-suggest", after="")
+        for i in range(RULE_RECUR_THRESHOLD + 1)
+    ]
+    drafts = _digester().infer(corrections=corrections, workspace_id=WS)
+    assert len(drafts) == 1
+    assert drafts[0].action == "notify"
+
+
+# --------------------------------------------------------------------------- #
+# Ontology hint → scope the draft to a discovered object_type
+# --------------------------------------------------------------------------- #
+def test_ontology_hint_scopes_to_object_type() -> None:
+    corrections = [
+        _correction(cid=f"c-{i}", path="parameters.ticket_type", before="bug", after="incident")
+        for i in range(RULE_RECUR_THRESHOLD + 1)
+    ]
+    ontology = OntologyDraft(
+        object_types=[DraftObjectType(name="Ticket", confidence=0.9)],
+    )
+    drafts = _digester().infer(corrections=corrections, workspace_id=WS, ontology=ontology)
+    assert len(drafts) == 1
+    # the single discovered type is attached as scope when it is the only type
+    assert drafts[0].scope.object_type == "Ticket"
+
+
+def test_ontology_absent_leaves_object_type_none() -> None:
+    corrections = [
+        _correction(cid=f"c-{i}", path="category", before="n", after="urgent")
+        for i in range(RULE_RECUR_THRESHOLD + 1)
+    ]
+    drafts = _digester().infer(corrections=corrections, workspace_id=WS)
+    assert len(drafts) == 1
+    assert drafts[0].scope.object_type is None
+
+
+# --------------------------------------------------------------------------- #
+# Workspace fallback — derive from correction.pocket_id when not passed
+# --------------------------------------------------------------------------- #
+def test_workspace_id_falls_back_to_correction_pocket() -> None:
+    corrections = [
+        _correction(cid=f"c-{i}", path="category", before="n", after="urgent", pocket_id="ws-x")
+        for i in range(RULE_RECUR_THRESHOLD + 1)
+    ]
+    drafts = _digester().infer(corrections=corrections)  # no workspace_id arg
+    assert len(drafts) == 1
+    assert drafts[0].scope.workspace_id == "ws-x"
+
+
+def test_returns_rule_draft_instances() -> None:
+    corrections = [
+        _correction(cid=f"c-{i}", path="category", before="n", after="urgent")
+        for i in range(RULE_RECUR_THRESHOLD + 1)
+    ]
+    drafts = _digester().infer(corrections=corrections, workspace_id=WS)
+    assert all(isinstance(d, RuleDraft) for d in drafts)

--- a/tests/ee/test_rule_models.py
+++ b/tests/ee/test_rule_models.py
@@ -1,0 +1,144 @@
+# tests/ee/test_rule_models.py — unit tests for the discovery RuleDraft model (S2-R1).
+#
+# Pure-logic coverage of ``pocketpaw_ee.discovery.rule_models.RuleDraft`` — the
+# digester output AND the editable ``rule_spec`` blob shape. No DB, no bus.
+# Asserts: model_validate accepts a well-formed plain dict and round-trips,
+# rejects a bad action (not in InstinctRuleActionT), clamps an out-of-range
+# confidence into [0, 1] (silent clamp, mirroring discovery.models._clamp —
+# does NOT raise), validates the ``when`` CEL (malformed CEL → ValidationError),
+# round-trips scope, and preserves provenance.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.discovery.rule_models import RuleDraft, RuleScope
+from pydantic import ValidationError
+
+
+def _well_formed_blob() -> dict:
+    return {
+        "name": "Escalate large refunds",
+        "description": "Refunds over $1000 need a human.",
+        "when": "amount > 1000",
+        "action": "require_approval",
+        "scope": {
+            "workspace_id": "ws_alpha",
+            "pocket_id": "pk_refunds",
+            "object_type": "refund",
+        },
+        "confidence": 0.82,
+        "provenance": ["audit:row1", "correction:c2", "audit:row3"],
+    }
+
+
+def test_model_validate_accepts_well_formed_dict() -> None:
+    draft = RuleDraft.model_validate(_well_formed_blob())
+    assert draft.name == "Escalate large refunds"
+    assert draft.when == "amount > 1000"
+    assert draft.action == "require_approval"
+    assert draft.scope.workspace_id == "ws_alpha"
+    assert draft.confidence == pytest.approx(0.82)
+
+
+def test_round_trips_from_plain_dict() -> None:
+    """The blob → RuleDraft → blob round-trip is lossless (the R3 executor
+    re-validates the stored ``rule_spec`` dict at the chokepoint)."""
+    blob = _well_formed_blob()
+    draft = RuleDraft.model_validate(blob)
+    dumped = draft.model_dump()
+    reloaded = RuleDraft.model_validate(dumped)
+    assert reloaded == draft
+    # Scope survives the round-trip intact.
+    assert reloaded.scope.pocket_id == "pk_refunds"
+    assert reloaded.scope.object_type == "refund"
+
+
+def test_rejects_bad_action() -> None:
+    blob = _well_formed_blob()
+    blob["action"] = "delete_everything"  # not in InstinctRuleActionT
+    with pytest.raises(ValidationError):
+        RuleDraft.model_validate(blob)
+
+
+@pytest.mark.parametrize("action", ["require_approval", "notify", "block"])
+def test_accepts_each_valid_action(action: str) -> None:
+    blob = _well_formed_blob()
+    blob["action"] = action
+    draft = RuleDraft.model_validate(blob)
+    assert draft.action == action
+
+
+def test_confidence_out_of_range_clamps_not_raises() -> None:
+    """Out-of-range confidence is CLAMPED into [0, 1], not rejected — mirrors
+    discovery.models._clamp so a noisy inference score never fails validation."""
+    high = RuleDraft.model_validate({**_well_formed_blob(), "confidence": 1.7})
+    assert high.confidence == 1.0
+
+    low = RuleDraft.model_validate({**_well_formed_blob(), "confidence": -0.4})
+    assert low.confidence == 0.0
+
+    exact = RuleDraft.model_validate({**_well_formed_blob(), "confidence": 0.5})
+    assert exact.confidence == pytest.approx(0.5)
+
+
+def test_when_validates_cel() -> None:
+    """A malformed CEL ``when`` raises (CelExpression parses at validation)."""
+    blob = _well_formed_blob()
+    blob["when"] = "amount >>> "  # not valid CEL
+    with pytest.raises(ValidationError):
+        RuleDraft.model_validate(blob)
+
+
+def test_when_rejects_empty_string() -> None:
+    blob = _well_formed_blob()
+    blob["when"] = ""
+    with pytest.raises(ValidationError):
+        RuleDraft.model_validate(blob)
+
+
+def test_scope_round_trips() -> None:
+    scope = RuleScope(workspace_id="ws_x", pocket_id=None, object_type=None)
+    assert scope.workspace_id == "ws_x"
+    assert scope.pocket_id is None
+    assert scope.object_type is None
+    # Nested round-trip through the draft.
+    draft = RuleDraft.model_validate(
+        {
+            "name": "n",
+            "when": "true",
+            "action": "notify",
+            "scope": {"workspace_id": "ws_x"},
+            "confidence": 0.1,
+        }
+    )
+    assert draft.scope.workspace_id == "ws_x"
+    assert draft.scope.pocket_id is None
+
+
+def test_scope_requires_workspace_id() -> None:
+    """Tenancy lives in scope.workspace_id — a draft without it is invalid."""
+    blob = _well_formed_blob()
+    blob["scope"] = {"pocket_id": "pk_x"}  # missing workspace_id
+    with pytest.raises(ValidationError):
+        RuleDraft.model_validate(blob)
+
+
+def test_provenance_preserved() -> None:
+    blob = _well_formed_blob()
+    blob["provenance"] = ["audit:a", "audit:b", "correction:c"]
+    draft = RuleDraft.model_validate(blob)
+    assert draft.provenance == ["audit:a", "audit:b", "correction:c"]
+
+
+def test_provenance_defaults_empty() -> None:
+    blob = _well_formed_blob()
+    del blob["provenance"]
+    draft = RuleDraft.model_validate(blob)
+    assert draft.provenance == []
+
+
+def test_description_optional() -> None:
+    blob = _well_formed_blob()
+    del blob["description"]
+    draft = RuleDraft.model_validate(blob)
+    assert draft.description is None

--- a/tests/ee/test_rules_service.py
+++ b/tests/ee/test_rules_service.py
@@ -1,0 +1,137 @@
+# tests/ee/test_rules_service.py — EE persistence tests for the rules entity (S2-R1).
+#
+# Exercises ``pocketpaw_ee.cloud.rules.service`` against the in-memory
+# ``beanie_test_db`` fixture (mongomock-motor). Covers:
+#   - create_rule persists an InstinctRuleDoc and returns a wire dict
+#   - get_active_rules(workspace_id) returns the created rule
+#   - a SECOND workspace's get_active_rules returns NONE (tenancy isolation)
+#   - archived rules are excluded from get_active_rules
+# ``tests/ee`` has no autouse RecordingBus, so a local inert bus fixture keeps
+# the service's ``emit`` call from raising (mirrors test_discovery_propose.py).
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.rules import service as rules_service
+from pocketpaw_ee.cloud.rules.dto import CreateRuleRequest
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Inert recording EventBus so service ``emit()`` calls don't raise.
+
+    The cloud create path emits via ``_core.realtime.emit.emit`` which asserts
+    a bus is set; ``tests/cloud`` has an autouse fixture for this but
+    ``tests/ee`` does not, so we mint a minimal one (per test_discovery_propose).
+    """
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        async def publish(self, event: Any) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler: Any) -> None:  # noqa: ARG002
+            return
+
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = _RecordingBus()  # type: ignore[attr-defined]
+    yield bus_mod._bus
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+def _draft_blob(workspace_id: str = "ws_alpha", name: str = "Escalate refunds") -> dict:
+    return {
+        "name": name,
+        "description": "Refunds over $1000 need a human.",
+        "when": "amount > 1000",
+        "action": "require_approval",
+        "scope": {"workspace_id": workspace_id, "pocket_id": "pk_refunds"},
+        "confidence": 0.82,
+        "provenance": ["audit:row1", "correction:c2"],
+    }
+
+
+def _create_body(workspace_id: str = "ws_alpha", name: str = "Escalate refunds") -> dict:
+    return {
+        "draft": _draft_blob(workspace_id=workspace_id, name=name),
+        "owner_user_id": "user_1",
+    }
+
+
+async def test_create_rule_persists_and_returns_wire_dict(beanie_test_db) -> None:
+    wire = await rules_service.create_rule(
+        workspace_id="ws_alpha",
+        user_id="user_1",
+        body=_create_body(),
+    )
+    assert isinstance(wire, dict)
+    assert wire["id"]
+    assert wire["workspace_id"] == "ws_alpha"
+    assert wire["owner_user_id"] == "user_1"
+    assert wire["status"] == "active"
+    assert wire["name"] == "Escalate refunds"
+    assert wire["when"] == "amount > 1000"
+    assert wire["action"] == "require_approval"
+    assert wire["scope"]["workspace_id"] == "ws_alpha"
+    assert wire["confidence"] == pytest.approx(0.82)
+    assert wire["provenance"] == ["audit:row1", "correction:c2"]
+
+
+async def test_create_rule_accepts_typed_request(beanie_test_db) -> None:
+    """create_rule re-validates at entry, so a typed CreateRuleRequest works
+    identically to a plain dict (internal callers pass the typed form)."""
+    body = CreateRuleRequest.model_validate(_create_body())
+    wire = await rules_service.create_rule(workspace_id="ws_alpha", user_id="user_1", body=body)
+    assert wire["name"] == "Escalate refunds"
+
+
+async def test_get_active_rules_returns_created(beanie_test_db) -> None:
+    await rules_service.create_rule(workspace_id="ws_alpha", user_id="user_1", body=_create_body())
+    rows = await rules_service.get_active_rules("ws_alpha")
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Escalate refunds"
+    assert rows[0]["workspace_id"] == "ws_alpha"
+    assert rows[0]["status"] == "active"
+
+
+async def test_get_active_rules_tenant_isolated(beanie_test_db) -> None:
+    """A second workspace sees NONE of the first workspace's rules."""
+    await rules_service.create_rule(
+        workspace_id="ws_alpha", user_id="user_1", body=_create_body("ws_alpha")
+    )
+    rows_other = await rules_service.get_active_rules("ws_beta")
+    assert rows_other == []
+
+
+async def test_get_active_rules_excludes_archived(beanie_test_db) -> None:
+    """Archived rules are filtered out of the active read."""
+    wire = await rules_service.create_rule(
+        workspace_id="ws_alpha", user_id="user_1", body=_create_body()
+    )
+    # Directly archive via the service-owned archive helper.
+    archived = await rules_service.archive_rule(
+        workspace_id="ws_alpha", user_id="user_1", rule_id=wire["id"]
+    )
+    assert archived["status"] == "archived"
+
+    rows = await rules_service.get_active_rules("ws_alpha")
+    assert rows == []
+
+
+async def test_create_rule_rejects_workspace_mismatch(beanie_test_db) -> None:
+    """The draft scope workspace must match the caller's workspace — a
+    mismatch is a ValidationError (CloudError), not a silent cross-tenant write."""
+    from pocketpaw_ee.cloud._core.errors import CloudError
+
+    body = _create_body(workspace_id="ws_other")  # scope says ws_other
+    with pytest.raises(CloudError):
+        await rules_service.create_rule(
+            workspace_id="ws_alpha",  # caller is ws_alpha
+            user_id="user_1",
+            body=body,
+        )

--- a/tests/ee/test_szd2_e2e.py
+++ b/tests/ee/test_szd2_e2e.py
@@ -1,0 +1,463 @@
+# tests/ee/test_szd2_e2e.py — S2-E1: the slice-2 backend end-to-end test.
+#
+# Created: 2026-06-20 (S2-E1 / feat/szd-slice2-discovery). This is the headline
+# proof of slice 2: a SINGLE discovery run over UNSTRUCTURED tenant exhaust
+# (ticket / email / chat bodies) produces THREE governed Instinct proposals —
+#
+#   1. ``_fabric_objects`` — the ontology the KbCompileDigester compiled on-box
+#      (>=2 typed object types + >=1 concept-cooccurrence link) staged for Fabric;
+#   2. ``_pocket_create`` — a starter dashboard bound to the ``fabric.objects``
+#      source for each discovered type;
+#   3. ``_instinct_rule`` — a governed rule the RuleDigester reverse-engineered
+#      from the workspace's Instinct correction exhaust;
+#
+# all carrying the SAME ``run_id`` with distinct roles. The test then APPROVES all
+# three through their real executors, asserts each reaches ``EXECUTED``, and proves
+# materialisation: the Fabric objects exist (``FabricStore.query``, workspace
+# scoped), the starter Pocket's ``fabric.objects`` ``$source`` RESOLVES to the
+# discovered rows on read, and the governed rule LANDED via
+# ``rules.service.get_active_rules``.
+#
+# SOVEREIGNTY (mandatory, the slice's headline guarantee): the ``_kb`` subprocess
+# seam is mocked with an in-memory fake that RECORDS every argv. After the whole
+# run the test asserts ``kb ingest`` and ``kb build`` were NEVER invoked — the two
+# commands that POST raw tenant text to Anthropic (kb.go:1349). No tenant exhaust
+# left the box; the entire ontology was compiled keyless + on-box.
+#
+# Backed by ``beanie_test_db`` (mongomock) + isolated InstinctStore / FabricStore
+# via the lazy ``get_*_store`` seams + an inert recording bus (cloned from
+# test_discovery_propose.py). The connector read is mocked (no live network); the
+# kb-go binary is mocked (no subprocess, deterministic, sovereignty-checkable).
+#
+# Run with:
+#   uv run --group ee pytest tests/ee/test_szd2_e2e.py -q
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.discovery import (  # noqa: E402
+    DiscoveryRun,
+    DiscoveryRunOptions,
+    ReadAction,
+    run_discovery_and_propose,
+)
+from pocketpaw_ee.discovery.kb_compile import KbCompileDigester  # noqa: E402
+from pocketpaw_ee.discovery.orchestrate import _find_discovery_marker  # noqa: E402
+
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+from pocketpaw.instinct.correction import Correction, CorrectionPatch  # noqa: E402
+from pocketpaw.instinct.models import ActionStatus  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Mock connector surface (same shape as tests/ee/test_discovery_propose.py).
+# For UNSTRUCTURED discovery each read action returns a list of TEXT bodies (the
+# exhaust) rather than typed record dicts — the KbCompileDigester compiles them.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MockActionResult:
+    success: bool
+    data: Any = None
+    error: str | None = None
+    records_affected: int = 0
+
+
+@dataclass
+class _MockActionSchema:
+    name: str
+    method: str = "GET"
+    trust_level: str = "auto"
+
+
+class _MockAdapter:
+    def __init__(self, schemas: list[_MockActionSchema], data_by_action: dict[str, Any]) -> None:
+        self._schemas = schemas
+        self._data_by_action = data_by_action
+
+    async def actions(self) -> list[_MockActionSchema]:
+        return list(self._schemas)
+
+    async def execute(self, action: str, params: dict[str, Any]) -> _MockActionResult:
+        if action not in self._data_by_action:
+            return _MockActionResult(success=False, error=f"unknown action {action}")
+        return _MockActionResult(success=True, data=self._data_by_action[action])
+
+
+class _MockRegistry:
+    def __init__(self, adapters: dict[str, _MockAdapter | None]) -> None:
+        self._adapters = adapters
+
+    async def ensure_connected(self, connector_name: str, scope_key: str) -> _MockAdapter | None:
+        return self._adapters.get(connector_name)
+
+
+# ---------------------------------------------------------------------------
+# The UNSTRUCTURED exhaust — raw ticket / email / chat bodies, no record shape.
+# These are the text blobs the KbCompileDigester compiles on-box into articles.
+# ---------------------------------------------------------------------------
+
+_TICKET_BODIES = [
+    "Customer cannot log in after a failed payment — billing lock triggered.",
+    "Account locked following a declined card; the user is stuck at the login screen.",
+    "Login lockout reported again after a billing failure on renewal.",
+]
+
+_REFUND_BODIES = [
+    "Refund requested on invoice 12 — billing dispute, customer wants money back.",
+    "The customer is asking for a refund tied to a duplicate billing charge.",
+]
+
+
+# ---------------------------------------------------------------------------
+# The CANNED kb-go output. The mock `_kb` serves these CATEGORIZED articles back
+# (the shape `kb show --json` returns): two object types (SupportTicket,
+# RefundRequest) sharing the "billing" concept → a cross-type DraftLink. The
+# article `id` is the natural primary key (key_confidence >= 0.8), so both types
+# are MATERIALISABLE (pass the KEY_CONFIDENCE_FLOOR gate in orchestrate).
+# ---------------------------------------------------------------------------
+
+_COMPILED_ARTICLES = [
+    {
+        "id": "tkt-1",
+        "title": "Login lockout after billing failure",
+        "summary": "Customer cannot log in; billing lock triggered by a failed payment.",
+        "concepts": ["billing", "login"],
+        "categories": ["SupportTicket"],
+    },
+    {
+        "id": "tkt-2",
+        "title": "Account locked after declined card",
+        "summary": "Declined card left the account locked at the login screen.",
+        "concepts": ["billing", "login"],
+        "categories": ["SupportTicket"],
+    },
+    {
+        "id": "ref-1",
+        "title": "Refund requested on invoice 12",
+        "summary": "Refund request tied to a billing dispute on a duplicate charge.",
+        "concepts": ["billing", "refund"],
+        "categories": ["RefundRequest"],
+    },
+]
+
+# kb graph: concept nodes + edges so concept co-occurrence yields a cross-type
+# link. "billing" is shared across SupportTicket + RefundRequest articles.
+_GRAPH_NODES = [
+    {"id": "c0", "label": "billing", "kind": "concept", "size": 3},
+    {"id": "c1", "label": "login", "kind": "concept", "size": 2},
+    {"id": "c2", "label": "refund", "kind": "concept", "size": 1},
+]
+_GRAPH_EDGES = [
+    {"source": "c0", "target": "c1", "weight": 2},
+    {"source": "c0", "target": "c2", "weight": 1},
+]
+
+
+def _install_fake_kb(
+    monkeypatch,
+    *,
+    articles: list[dict],
+    nodes: list[dict],
+    edges: list[dict],
+) -> list[tuple[str, ...]]:
+    """Replace the `_kb` subprocess seam with an in-memory, sovereignty-checkable
+    fake that RECORDS every call's argv.
+
+    Mirrors the fake in test_kb_compile_digester.py: the keyless on-box commands
+    (``convo`` / ``accept`` / ``list`` / ``show`` / ``graph``) are served from an
+    in-memory store keyed by ``--scope``; ``ingest`` / ``build`` (the off-box
+    Anthropic-POSTing commands) are NEVER expected — the returned ``calls`` list
+    is the evidence the sovereignty assertion checks at the end of the run.
+    """
+    calls: list[tuple[str, ...]] = []
+    store: dict[str, list[dict]] = {}
+
+    def _scope_of(args: tuple[str, ...]) -> str:
+        if "--scope" in args:
+            return args[args.index("--scope") + 1]
+        return "default"
+
+    def _fake_kb(*args, input_text=None, timeout=120):  # noqa: ARG001
+        calls.append(args)
+        scope = _scope_of(args)
+        if args[0] in ("convo", "accept"):
+            store.setdefault(scope, [])
+            for a in articles:
+                if a not in store[scope]:
+                    store[scope].append(a)
+            return {"articles": len(articles), "accepted": len(articles)}
+        if args[0] == "list":
+            return [
+                {"id": a["id"], "title": a.get("title", ""), "summary": a.get("summary", "")}
+                for a in store.get(scope, [])
+            ]
+        if args[0] == "show":
+            article_id = args[1]
+            for a in store.get(scope, []):
+                if a["id"] == article_id:
+                    return dict(a)
+            return {}
+        if args[0] == "graph":
+            return {"scope": scope, "nodes": nodes, "edges": edges}
+        return {}
+
+    monkeypatch.setattr("pocketpaw_ee.discovery.kb_compile._kb", _fake_kb)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Correction exhaust — the rules-discovery signal. Three corrections on the SAME
+# path with a single dominant ``after`` value clear the recurrence threshold AND
+# carry a constant target, so the RuleDigester emits one high-confidence draft.
+# Corrections anchor on ``pocket_id == workspace_id`` (the discovery non-pocket
+# convention). Mirrors test_discovery_rules_propose.py.
+# ---------------------------------------------------------------------------
+
+
+def _strong_correction(workspace_id: str, idx: int) -> Correction:
+    return Correction(
+        action_id=f"act-{idx}",
+        pocket_id=workspace_id,
+        actor="u1",
+        patches=[CorrectionPatch(path="category", before="normal", after="escalated")],
+        context_summary=f"raised category #{idx}",
+        action_title=f"Ticket #{idx}",
+    )
+
+
+async def _seed_corrections(store: InstinctStore, corrections: list[Correction]) -> None:
+    for correction in corrections:
+        await store.record_correction(correction)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — isolated stores + inert bus (cloned from test_discovery_propose.py).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def auth_secret(monkeypatch):
+    monkeypatch.setenv("AUTH_SECRET", "szd2-e2e-test-secret")
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Inert recording EventBus so service ``emit()`` calls don't raise."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        async def publish(self, event: Any) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler: Any) -> None:  # noqa: ARG002
+            return
+
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = _RecordingBus()  # type: ignore[attr-defined]
+    yield bus_mod._bus
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    st = InstinctStore(tmp_path / "instinct_szd2_e2e.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda: st)
+    return st
+
+
+@pytest.fixture
+def fabric(tmp_path: Path, monkeypatch) -> FabricStore:
+    fs = FabricStore(tmp_path / "fabric_szd2_e2e.db")
+    monkeypatch.setattr("pocketpaw.stores.get_fabric_store", lambda: fs)
+    return fs
+
+
+# ---------------------------------------------------------------------------
+# The slice-2 end-to-end test.
+# ---------------------------------------------------------------------------
+
+
+async def test_szd2_unstructured_exhaust_to_three_governed_proposals(
+    store, fabric, beanie_test_db, monkeypatch
+):
+    """UNSTRUCTURED exhaust → THREE proposals (ontology + starter pocket + governed
+    rule) → approve all → discovered data + rule materialise — with a sovereignty
+    assertion that no tenant exhaust ever left the box.
+
+    This single test is the S2-E1 backend gate: it exercises the whole slice-2
+    pipeline through the real ``run_discovery_and_propose`` orchestrator and the
+    real apply-on-approve executors, with ONLY the two external seams faked (the
+    connector read and the kb-go subprocess).
+    """
+    from pocketpaw_ee.cloud.fabric_proposals import executor as fo_executor
+    from pocketpaw_ee.cloud.instinct_rule_proposals import (
+        INSTINCT_RULE_PARAM_KEY,
+        execute_approved_instinct_rule,
+    )
+    from pocketpaw_ee.cloud.pocket_proposals import executor as pc_executor
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.cloud.rules import service as rules_service
+
+    from pocketpaw.fabric.models import FabricQuery
+
+    workspace_id = "w1"
+    user_id = "u1"
+
+    # ── BUILD ITEM 1: mock the `_kb` seam → unstructured text compiles on-box into
+    #    CATEGORIZED articles → a rich OntologyDraft (2 typed types + a link). The
+    #    fake records every argv for the sovereignty assertion.
+    kb_calls = _install_fake_kb(
+        monkeypatch,
+        articles=_COMPILED_ARTICLES,
+        nodes=_GRAPH_NODES,
+        edges=_GRAPH_EDGES,
+    )
+
+    # ── BUILD ITEM 2: seed correction exhaust so rules-discovery has a signal to
+    #    mine (3x the same path with a constant target → one high-confidence rule).
+    await _seed_corrections(store, [_strong_correction(workspace_id, i) for i in range(3)])
+
+    # ── BUILD ITEM 3: run discovery with the KbCompileDigester over a mock adapter
+    #    that returns the UNSTRUCTURED text bodies (grouped by read type label).
+    adapters = {
+        "support": _MockAdapter(
+            schemas=[],
+            data_by_action={
+                "list_tickets": _TICKET_BODIES,
+                "list_refunds": _REFUND_BODIES,
+            },
+        ),
+    }
+    opts = DiscoveryRunOptions(
+        read_actions={
+            "support": [
+                ReadAction(action="list_tickets", type_name="tickets"),
+                ReadAction(action="list_refunds", type_name="refunds"),
+            ]
+        }
+    )
+    discovery_run = DiscoveryRun(
+        registry=_MockRegistry(adapters),
+        digester=KbCompileDigester(),
+    )
+
+    result = await run_discovery_and_propose(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        connector_ids=["support"],
+        opts=opts,
+        discovery_run=discovery_run,
+    )
+
+    # ── BUILD ITEM 4: THREE PENDING proposals, each carrying the shared run_id with
+    #    its distinct role.
+    assert result.fabric_objects_action_id is not None, "expected a _fabric_objects proposal"
+    assert result.pocket_action_id is not None, "expected a _pocket_create proposal"
+    assert result.instinct_action_ids, "expected at least one _instinct_rule proposal"
+    rule_action_id = result.instinct_action_ids[0]
+
+    fabric_action = await store.get_action(result.fabric_objects_action_id)
+    pocket_action = await store.get_action(result.pocket_action_id)
+    rule_action = await store.get_action(rule_action_id)
+    assert fabric_action.status == ActionStatus.PENDING
+    assert pocket_action.status == ActionStatus.PENDING
+    assert rule_action.status == ActionStatus.PENDING
+
+    # The three proposal kinds are present, distinct, and share ONE run_id.
+    assert "_fabric_objects" in fabric_action.parameters
+    assert "_pocket_create" in pocket_action.parameters
+    assert INSTINCT_RULE_PARAM_KEY in rule_action.parameters
+
+    fo_marker = _find_discovery_marker(fabric_action.parameters)
+    pc_marker = _find_discovery_marker(pocket_action.parameters)
+    ir_marker = _find_discovery_marker(rule_action.parameters)
+    assert fo_marker is not None and pc_marker is not None and ir_marker is not None
+    assert fo_marker["run_id"] == pc_marker["run_id"] == ir_marker["run_id"] == result.run_id
+    assert fo_marker["role"] == "fabric_objects"
+    assert pc_marker["role"] == "pocket_create"
+    assert ir_marker["role"] == "instinct_rules"
+
+    # The compiled ontology carried >=2 typed object types + >=1 link into the
+    # fabric proposal (the KbCompileDigester output materialised through the gate).
+    fo_blob = fabric_action.parameters["_fabric_objects"]
+    staged_types = {ot["type_name"] for ot in fo_blob["object_types"]}
+    assert {"SupportTicket", "RefundRequest"} <= staged_types
+    assert fo_blob.get("links"), "expected a concept-cooccurrence link in the ontology"
+
+    # ── BUILD ITEM 5: APPROVE all three → real executors → each reaches EXECUTED.
+    approved_fo = await store.approve(result.fabric_objects_action_id, approver=user_id)
+    await fo_executor.execute_approved_fabric_objects(approved_fo)
+    final_fo = await store.get_action(result.fabric_objects_action_id)
+    assert final_fo.status == ActionStatus.EXECUTED, final_fo.error
+
+    approved_pc = await store.approve(result.pocket_action_id, approver=user_id)
+    await pc_executor.execute_approved_pocket_create(approved_pc)
+    final_pc = await store.get_action(result.pocket_action_id)
+    assert final_pc.status == ActionStatus.EXECUTED, final_pc.error
+
+    approved_ir = await store.approve(rule_action_id, approver=user_id)
+    await execute_approved_instinct_rule(approved_ir)
+    final_ir = await store.get_action(rule_action_id)
+    assert final_ir.status == ActionStatus.EXECUTED, final_ir.error
+
+    # ── BUILD ITEM 6a: the discovered Fabric objects EXIST (workspace-scoped query).
+    tickets = await fabric.query(FabricQuery(type_name="SupportTicket"), workspace_id=workspace_id)
+    refunds = await fabric.query(FabricQuery(type_name="RefundRequest"), workspace_id=workspace_id)
+    assert {o.source_id for o in tickets.objects} == {"tkt-1", "tkt-2"}
+    assert {o.source_id for o in refunds.objects} == {"ref-1"}
+    assert all(o.type_name == "SupportTicket" for o in tickets.objects)
+
+    # ── BUILD ITEM 6b: the starter Pocket's fabric.objects $source RESOLVES to the
+    #    discovered rows on read (pockets.service.get replaces the marker live).
+    pocket_id = final_pc.parameters["_pocket_create"]["outcome"]["pocket_id"]
+    wire = await pockets_service.get(pocket_id, user_id)
+    assert wire["workspace"] == workspace_id
+    spec = wire.get("rippleSpec") or wire.get("ripple_spec") or {}
+    resolved_tickets = spec.get("state", {}).get("rows_SupportTicket")
+    assert isinstance(resolved_tickets, list), f"expected resolved rows, got {resolved_tickets!r}"
+    assert {r["source_id"] for r in resolved_tickets} == {"tkt-1", "tkt-2"}
+    assert all(r["type_name"] == "SupportTicket" for r in resolved_tickets)
+    # The raw stored spec still carries the verbatim $source marker (resolution is
+    # on read, not at persistence) — the binding is durable across reloads.
+    raw_spec = final_pc.parameters["_pocket_create"]["pocket_spec"]["rippleSpec"]
+    assert raw_spec["state"]["rows_SupportTicket"] == {
+        "$source": "fabric.objects",
+        "type_name": "SupportTicket",
+    }
+
+    # ── BUILD ITEM 6c: the governed rule LANDED via the slice-2 read seam, scoped
+    #    to the workspace, with the reverse-engineered when/action.
+    active = await rules_service.get_active_rules(workspace_id)
+    assert len(active) == 1, active
+    landed = active[0]
+    assert landed["workspace_id"] == workspace_id
+    assert landed["owner_user_id"] == user_id
+    assert landed["scope"]["workspace_id"] == workspace_id
+    assert landed["status"] == "active"
+    # The rule's CEL trigger was reverse-engineered from the corrected ``category``
+    # path, and its action is a valid gate disposition.
+    assert "category" in landed["when"]
+    assert landed["action"] in ("require_approval", "notify", "block")
+
+    # ── BUILD ITEM 7: SOVEREIGNTY ASSERTION (mandatory) — across the WHOLE run the
+    #    off-box, Anthropic-POSTing kb commands were NEVER invoked. No tenant
+    #    exhaust left the box; the entire ontology was compiled keyless + on-box.
+    assert kb_calls, "expected the digester to drive the kb seam at least once"
+    assert all(c[0] not in ("ingest", "build") for c in kb_calls), (
+        "sovereignty violation: KbCompileDigester invoked an off-box kb command "
+        f"(ingest/build) — argv seen: {[c[0] for c in kb_calls]}"
+    )
+    # and at least one KEYLESS on-box compile actually ran.
+    assert any(c[0] in ("convo", "accept") for c in kb_calls)


### PR DESCRIPTION
## What this is

Slice 2 of sovereign zero-setup discovery. Slice 1 (merged in #1515) discovers a Fabric ontology and a starter Pocket from a tenant's **structured** connectors. Slice 2 adds the two pieces that were deferred:

- **KbCompileDigester** discovers from **unstructured** exhaust (ticket bodies, email and chat text). It compiles the text into a kb-go wiki on the tenant's own box, reads the compiled articles back, and infers an ontology from them. It plugs into the existing `Digester` interface, so slice-1's run/propose/approve flow needed no rework.
- **Rules-discovery** reverse-engineers draft governed rules (the Edra-grade layer) from a tenant's Instinct exhaust, specifically its correction history, and stages them as `_instinct_rule` proposals through the gate. A human reviews, edits, and approves; the approved rule is persisted as a workspace-scoped, owned, editable record. This generalizes the existing "same field corrected 3 times" soul-memory promotion into a structured, gate-governed rule.

The whole thing runs on the tenant's box. Raw exhaust never leaves it.

## The sovereignty guarantee

kb-go has two ingest paths: a keyless on-box one (`convo ingest`) and a cloud one (`kb ingest` / `kb build`) that POSTs text to Anthropic. KbCompileDigester only ever calls the keyless path. That constraint is enforced as a test, not left to code review. A tripwire asserts `kb ingest` and `kb build` are never invoked across a digest, and the E2E re-asserts it across the full run.

## Design decision made without the captain (flagged for review)

Rules-discovery had no prior data model. No rule store, no enforcement path. With the captain out, rather than stall I made the call and wrote it up in `docs/design/szd-slice2-build-plan.md` (S2-R0):

- The **rule model** reuses `CelExpression` for the `when` and the existing `require_approval` / `notify` / `block` action literal. No new primitives.
- **Persistence** is an EE Beanie `RuleDoc`, alongside the gate types.
- **Scope boundary:** slice 2 takes a discovered rule all the way to persisted, owned, and editable (the Edra parity, white-box owned rules that never left the box), plus a `get_active_rules(workspace_id)` read API. Wiring those rules into the **live gate dispatch** is left for slice 3. Changing how the gate evaluates every action is high-stakes and deserves a look before it ships. The read API is the seam.

If you'd have modeled the rule differently, this is the place to push back.

## What's in it

| Slice | What |
|-------|------|
| S2-K1 | KbCompileDigester plus the sovereignty tripwire |
| S2-R1 | Rule / RuleDraft model, RuleDoc persistence, `get_active_rules` |
| S2-R2 | RuleDigester, infers rule drafts from correction exhaust |
| S2-R3 | `_instinct_rule` gate type (propose + executor), cloning `_pocket_create` |
| S2-R4 | Router four-path wiring plus the cross-tenant guard |
| S2-R5 | Orchestrator files the third proposal plus supersede-on-rerun |
| S2-E1 | End-to-end: unstructured exhaust to three proposals to approve to everything lands |

## Testing

133 tests pass across the discovery, rule, and instinct suites. The ones that matter most:

- The **E2E** drives the whole pipeline: mocked unstructured exhaust produces `_fabric_objects` + `_pocket_create` + `_instinct_rule` proposals, all three approve, the Fabric objects become queryable, the starter Pocket renders the discovered rows, the rule lands via `get_active_rules`, and the sovereignty assertion confirms no off-box call happened.
- The **four-path security test** asserts a cross-workspace `_instinct_rule` approval is rejected on all four router paths (approve, bulk-approve, reject, bulk-reject). Missing the guard on any one path is the #1183 escalation bug, so this one isn't optional.
- ruff is clean; mypy introduces no new real errors (only the pre-existing, tolerated `import-untyped` noise on OSS imports).

## Scope boundary and follow-ups

- **Live rule enforcement at the gate** goes to slice 3 (the `get_active_rules` seam is ready for it).
- **The learning loop** (editing a rule draft before approval feeds inference confidence) is a follow-up; the gate already emits `human.corrected` on approve and reject.
- **The digester-selection flag** on `DiscoveryRunOptions` is deferred. A caller selects the digester by injecting it, which the E2E does.
- **The rule review UI plus preview** is a separate paw-enterprise PR (mirrors slice-1's #457).
- One honest caveat: kb-go's keyless `convo ingest` tags every article `conversation` rather than a domain category, so against the live binary the unstructured ontology degrades toward objects-only until a categorizing pass lands. The inference logic is fully covered against a mock; the richness of the live output is bounded by what the compiler emits.

This does not merge on green. Captain reviews.
