### PR TITLE
Surface a site's pattern on the sites API so the gallery can mark dynamic sites

### DIFF
--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -14,8 +14,13 @@ Also adds ``get_pocket_workspace`` (review fix IMPORTANT 3) — a session-free
 tenancy read the jobs worker uses to fail closed before a cross-workspace
 writeback.
 
+Updated: 2026-06-20 (DS-1a) — added ``patterns_for_pockets`` (sites surfaces a
+published site's source-pocket ``pattern`` without importing the Pocket model;
+the Pocket read stays here, the sole owner of Pocket reads — entity isolation).
+
 Public API (returns wire dicts for legacy router compatibility):
 - ``create``, ``list_pockets``, ``get``, ``update``, ``delete``
+- ``patterns_for_pockets`` — batch {pocket_id: Pocket.pattern} for a workspace
 - ``ensure_home_pocket`` — resolve-or-provision the user's home pocket
 - ``create_from_ripple_spec`` — agent-generated pockets
 - ``add_widget``, ``update_widget``, ``remove_widget``, ``reorder_widgets``
@@ -1560,6 +1565,48 @@ async def list_pockets(
             query["_id"] = {"$nin": oids}
     docs = await _PocketDoc.find(query).to_list()
     return [await _resolved_wire_dict(d, user_id) for d in docs]
+
+
+async def patterns_for_pockets(workspace_id: str, pocket_ids: list[str]) -> dict[str, str | None]:
+    """Map each given ``pocket_id`` to its ``Pocket.pattern`` in ONE query.
+
+    The sites service surfaces a published site's authoring ``pattern``
+    ("dynamic" | "landing" | ...) on its list/status responses (DS-1a), but the
+    pattern lives on the source Pocket, not the Site. This is the cross-entity
+    read sites uses WITHOUT importing the Pocket Beanie model — the Pocket read
+    stays here (the sole owner of Pocket reads, entity isolation), the same way
+    ``sites.service.site_pocket_ids`` keeps the Site read on the sites side.
+
+    ONE ``$in`` query (no N+1) projected to ``_id`` + ``pattern`` only, so a
+    long gallery resolves all its patterns in a single round-trip. Tenant-scoped
+    on ``workspace``: a pocket in another workspace is not returned even if its
+    id is passed. The result is keyed by the wire-string ``pocket_id``; a pocket
+    whose ``pattern`` is unset reads ``None`` (the caller defaults it to ""),
+    and an id with no matching pocket (deleted / cross-tenant / malformed) is
+    simply absent from the map (the caller treats absent as "" too).
+
+    Malformed ids that cannot cast to an ObjectId are skipped — they can't match
+    a stored ``_id`` anyway. An empty list is a no-op (empty map)."""
+    if not pocket_ids:
+        return {}
+    oids: list[PydanticObjectId] = []
+    for pid in pocket_ids:
+        try:
+            oids.append(PydanticObjectId(pid))
+        except (InvalidId, TypeError, ValueError):
+            continue
+    if not oids:
+        return {}
+    # Project to only the two fields we need — a pattern lookup must not pull each
+    # full (potentially large rippleSpec-carrying) doc into memory. Raw pymongo
+    # projection avoids constructing a full Beanie model per pocket; ``find`` over
+    # ``get_pymongo_collection`` is the same accessor the other reads here use.
+    collection = _PocketDoc.get_pymongo_collection()
+    rows = await collection.find(
+        {"workspace": workspace_id, "_id": {"$in": oids}},
+        {"_id": 1, "pattern": 1},
+    ).to_list(length=None)
+    return {str(row["_id"]): row.get("pattern") for row in rows}
 
 
 async def get(pocket_id: str, user_id: str) -> dict:

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -50,6 +50,14 @@
 # recent successful live deploy (the Site doc's ``deployed_at``), or None before the
 # first deploy. The builder/gallery surface a "Last deployed <time>" label without a
 # second fetch. Optional (default None) so the field is backward-compatible.
+# Updated 2026-06-20 (DS-1a — surface dynamic-site pattern): SiteResponse and
+# SiteStatusResponse gain ``pattern`` — the SOURCE pocket's authoring pattern
+# ("dynamic" for a live-data site, "landing" for a marketing page, "" / other for
+# the rest). It lives on ``Pocket.pattern``, not the Site, so the service resolves
+# it from the source pocket (sites/service.py: patterns_for_pockets) per list +
+# status response. The frontend uses it to badge dynamic sites in the gallery.
+# Default "" so the field is backward-compatible and empty-safe (a pocket with no
+# pattern, or a missing/cross-tenant pocket, reads "").
 
 from __future__ import annotations
 
@@ -85,6 +93,11 @@ class SiteResponse(BaseModel):
     # P2b: ISO-8601 timestamp of the most recent successful live deploy, or None
     # before the first deploy (a preview-only / never-deployed pocket reads None).
     deployed_at: str | None = None
+    # DS-1a: the source pocket's authoring pattern ("dynamic" | "landing" | ...),
+    # resolved from Pocket.pattern (it lives on the pocket, not the Site). "" when
+    # the pocket has no pattern or could not be resolved. Lets the frontend badge
+    # dynamic sites in the gallery without a second fetch.
+    pattern: str = ""
 
 
 class SitePreviewResponse(BaseModel):
@@ -133,6 +146,11 @@ class SiteStatusResponse(BaseModel):
     # read from the canonical Site doc's ``deployed_at``. None when the pocket has
     # never been deployed (no Site doc, or a pre-P2b row that predates the field).
     deployed_at: str | None = None
+    # DS-1a: the source pocket's authoring pattern ("dynamic" | "landing" | ...),
+    # resolved from Pocket.pattern. "" when the pocket has no pattern. Same field
+    # the list response carries, so a by-pocket status read can badge a dynamic
+    # site too.
+    pattern: str = ""
 
 
 class SiteVersionResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,16 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-20 (DS-1a — surface dynamic-site pattern): list_for_workspace()
+# and pocket_status() now carry the SOURCE pocket's authoring ``pattern``
+# ("dynamic" | "landing" | ...) on their responses so the frontend can badge
+# dynamic sites. The pattern lives on Pocket.pattern, not the Site, so it is
+# resolved via pockets_service.patterns_for_pockets — ONE batch read for the list
+# (no N+1), a single-id read for status — keeping the Pocket read on the pockets
+# side (entity isolation; this service never imports the Pocket model). _to_response
+# gained an optional ``pattern`` arg; both DTOs default it to "" (empty-safe for a
+# pocket with no pattern or a missing/cross-tenant pocket).
+#
 # Updated 2026-06-19 (P2b-backend — "Last Deployed" + revert endpoint): publish()
 # now stamps the Site doc's ``deployed_at`` (UTC) ONLY when a non-preview deploy
 # succeeds (when ``deployed`` flips True) — the true "last shipped" marker, not a
@@ -484,7 +494,7 @@ async def _promote_pocket_draft_to_published(
         )
 
 
-def _to_response(doc: _SiteDoc) -> SiteResponse:
+def _to_response(doc: _SiteDoc, pattern: str = "") -> SiteResponse:
     deployed_at = getattr(doc, "deployed_at", None)
     return SiteResponse(
         id=str(doc.id),
@@ -500,6 +510,10 @@ def _to_response(doc: _SiteDoc) -> SiteResponse:
         # P2b: ISO string of the last successful live deploy, or None before the
         # first deploy (pre-P2b rows read null via the getattr default).
         deployed_at=deployed_at.isoformat() if deployed_at is not None else None,
+        # DS-1a: the source pocket's authoring pattern ("dynamic" | "landing" |
+        # ...), resolved by the caller from Pocket.pattern (it lives on the pocket,
+        # not the Site). "" when unset / unresolved so the gallery is empty-safe.
+        pattern=pattern,
     )
 
 
@@ -1550,6 +1564,14 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
     # no deployed site or the doc predates the field (a pre-P2b row).
     deployed_at = getattr(doc, "deployed_at", None) if doc is not None else None
 
+    # DS-1a: resolve the source pocket's authoring pattern so a by-pocket status
+    # read can badge a dynamic site too. ONE read, tenant-scoped; "" when the
+    # pocket has no pattern or could not be resolved (empty-safe).
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    patterns = await pockets_service.patterns_for_pockets(workspace_id, [pocket_id])
+    pattern = patterns.get(pocket_id) or ""
+
     return SiteStatusResponse(
         pocket_id=pocket_id,
         status=status,
@@ -1561,6 +1583,7 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
         # dupe. None when the pocket has no deployed site.
         url=(doc.url or None) if doc is not None else None,
         deployed_at=deployed_at.isoformat() if deployed_at is not None else None,
+        pattern=pattern,
     )
 
 
@@ -1698,11 +1721,27 @@ async def list_for_workspace(workspace_id: str) -> list[SiteResponse]:
     gallery to one card per pocket. ``archived: {"$ne": True}`` (not ``False``)
     so docs predating the field — which have no ``archived`` key in Mongo — still
     count as active.
+
+    DS-1a: each card also carries its source pocket's authoring ``pattern``
+    ("dynamic" | "landing" | ...) so the frontend can badge dynamic sites. The
+    pattern lives on the source Pocket, not the Site, so it is resolved in ONE
+    batch read (``pockets_service.patterns_for_pockets`` — no N+1) keyed on the
+    listed pockets, then attached per card. A pocket with no pattern (or one that
+    could not be resolved) reads "" so the gallery is empty-safe.
     """
     cursor = _SiteDoc.find({"workspace": workspace_id, "archived": {"$ne": True}}).sort(
         -_SiteDoc.createdAt
     )  # type: ignore[operator]
-    return [_to_response(doc) async for doc in cursor]
+    docs = [doc async for doc in cursor]
+    # ONE cross-entity read for every card's pattern (no per-site fetch). The
+    # Pocket read stays in the pockets service (entity isolation) — this service
+    # never imports the Pocket model.
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    patterns = await pockets_service.patterns_for_pockets(
+        workspace_id, [doc.pocket_id for doc in docs]
+    )
+    return [_to_response(doc, patterns.get(doc.pocket_id) or "") for doc in docs]
 
 
 async def site_pocket_ids(workspace_id: str) -> set[str]:

--- a/tests/ee/sites/test_pattern_field.py
+++ b/tests/ee/sites/test_pattern_field.py
@@ -1,0 +1,176 @@
+# tests/ee/sites/test_pattern_field.py — DS-1a: a published site surfaces its
+# SOURCE pocket's authoring ``pattern`` ("dynamic" | "landing" | ...) on the
+# sites-list (list_for_workspace) and the by-pocket status (pocket_status)
+# responses, so the frontend can badge dynamic sites.
+#
+# The pattern lives on Pocket.pattern, not the Site, so the service resolves it via
+# pockets_service.patterns_for_pockets. These tests seed a REAL Pocket doc (so its
+# ObjectId can be matched), publish a Site whose pocket_id == that doc's id, and
+# assert the response carries the pocket's pattern. Empty-safe cases (no pattern,
+# missing pocket) read "".
+#
+# Created: 2026-06-20 (feat/sites-pattern-field, DS-1a).
+from __future__ import annotations
+
+import pytest
+from bson import ObjectId
+from pocketpaw_ee.sites import service as sites_service
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakeCF:
+    def __init__(self):
+        self.put_calls = []
+
+    async def put_worker(self, *, script_name, bundle):
+        self.put_calls.append(script_name)
+        return True
+
+
+async def _seed_pocket(*, workspace_id: str, owner: str, name: str, pattern: str | None) -> str:
+    """Insert a real Pocket doc and return its id (the wire-string ObjectId).
+
+    Returns the id so the published Site's ``pocket_id`` can point at it — the
+    pattern resolution matches on the Pocket's ``_id``."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace_id,
+        name=name,
+        owner=owner,
+        type="site",
+        pattern=pattern,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _publish_for_pocket(*, workspace_id: str, pocket_id: str) -> None:
+    """Publish a site for an existing pocket. ``name`` is passed explicitly so
+    publish does not try to read the pocket through the full access path."""
+    await sites_service.publish(
+        workspace_id=workspace_id,
+        user_id="u1",
+        pocket_id=pocket_id,
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_for_workspace_surfaces_dynamic_pattern(beanie_test_db):
+    """A site published from a pocket with pattern="dynamic" lists with
+    pattern == "dynamic"."""
+    pocket_id = await _seed_pocket(
+        workspace_id="ws1", owner="u1", name="Guestbook", pattern="dynamic"
+    )
+    await _publish_for_pocket(workspace_id="ws1", pocket_id=pocket_id)
+
+    sites = await sites_service.list_for_workspace("ws1")
+
+    assert len(sites) == 1
+    assert sites[0].pocket_id == pocket_id
+    assert sites[0].pattern == "dynamic"
+
+
+@pytest.mark.asyncio
+async def test_list_for_workspace_distinguishes_patterns(beanie_test_db):
+    """A dynamic and a landing site in the same workspace each surface their own
+    source pocket's pattern — the field is per-card, resolved from the pocket."""
+    dyn = await _seed_pocket(workspace_id="ws1", owner="u1", name="Bookings", pattern="dynamic")
+    landing = await _seed_pocket(workspace_id="ws1", owner="u1", name="Dental", pattern="landing")
+    await _publish_for_pocket(workspace_id="ws1", pocket_id=dyn)
+    await _publish_for_pocket(workspace_id="ws1", pocket_id=landing)
+
+    by_pocket = {s.pocket_id: s.pattern for s in await sites_service.list_for_workspace("ws1")}
+
+    assert by_pocket[dyn] == "dynamic"
+    assert by_pocket[landing] == "landing"
+
+
+@pytest.mark.asyncio
+async def test_list_for_workspace_empty_safe_when_pocket_has_no_pattern(beanie_test_db):
+    """A site whose source pocket has no pattern (None) reads "" — no crash, the
+    gallery stays empty-safe."""
+    pocket_id = await _seed_pocket(workspace_id="ws1", owner="u1", name="Legacy", pattern=None)
+    await _publish_for_pocket(workspace_id="ws1", pocket_id=pocket_id)
+
+    sites = await sites_service.list_for_workspace("ws1")
+
+    assert len(sites) == 1
+    assert sites[0].pattern == ""
+
+
+@pytest.mark.asyncio
+async def test_list_for_workspace_empty_safe_when_pocket_missing(beanie_test_db):
+    """A site whose source pocket no longer exists (deleted, or a non-ObjectId
+    pocket_id) reads "" rather than crashing the list."""
+    await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="not-an-objectid",  # cannot resolve to a Pocket doc
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+
+    sites = await sites_service.list_for_workspace("ws1")
+
+    assert len(sites) == 1
+    assert sites[0].pattern == ""
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_surfaces_dynamic_pattern(beanie_test_db):
+    """The by-pocket status read carries the source pocket's pattern too, so a
+    builder/gallery status fetch can badge a dynamic site."""
+    pocket_id = await _seed_pocket(workspace_id="ws1", owner="u1", name="Orders", pattern="dynamic")
+    await _publish_for_pocket(workspace_id="ws1", pocket_id=pocket_id)
+
+    res = await sites_service.pocket_status(workspace_id="ws1", pocket_id=pocket_id)
+
+    assert res.pattern == "dynamic"
+
+
+@pytest.mark.asyncio
+async def test_pocket_status_pattern_is_tenant_scoped(beanie_test_db):
+    """A pocket's pattern does not leak across workspaces: a foreign workspace's
+    status read for the same pocket id reads "" (the batch read is workspace-
+    scoped)."""
+    pocket_id = await _seed_pocket(
+        workspace_id="ws_owner", owner="u1", name="Private", pattern="dynamic"
+    )
+    await _publish_for_pocket(workspace_id="ws_owner", pocket_id=pocket_id)
+
+    res = await sites_service.pocket_status(workspace_id="ws_intruder", pocket_id=pocket_id)
+
+    assert res.pattern == ""
+
+
+@pytest.mark.asyncio
+async def test_patterns_for_pockets_batch_read(beanie_test_db):
+    """The pockets-service helper returns a {pocket_id: pattern} map in one read,
+    tenant-scoped, with missing/cross-tenant ids simply absent."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    a = await _seed_pocket(workspace_id="ws1", owner="u1", name="A", pattern="dynamic")
+    b = await _seed_pocket(workspace_id="ws1", owner="u1", name="B", pattern="landing")
+    other = await _seed_pocket(workspace_id="ws2", owner="u1", name="C", pattern="dynamic")
+    missing = str(ObjectId())
+
+    out = await pockets_service.patterns_for_pockets("ws1", [a, b, other, missing, "garbage"])
+
+    assert out == {a: "dynamic", b: "landing"}


### PR DESCRIPTION
The sites gallery can't tell a dynamic (live-data) site from a static marketing page — a site's `pattern` lives on the source Pocket, not the Site doc, and the sites API never surfaced it. This adds it.

## What changed
- `pattern` field added to the sites list response (`SiteResponse`) and the by-pocket status response (`SiteStatusResponse`).
- The sites service resolves each site's pattern from its source pocket via a new `patterns_for_pockets` helper on the pockets service — one batched `$in` query for the whole list (no N+1), tenant-scoped. The Pocket read stays inside the pockets service, so the sites service never imports the Pocket model (entity isolation, mirroring the existing `site_pocket_ids` pattern).
- Empty-safe: a pocket with no pattern, or one that can't be resolved (deleted / cross-tenant / non-ObjectId id), reads `""`.

## Tested
New `tests/ee/sites/test_pattern_field.py` (7 tests): dynamic pattern on the list, multiple patterns distinguished, empty-safe paths, pattern on status, status tenant-scoping, and the batch helper. `tests/ee/sites/` 221 passed. Ran the new file locally: 7 passed.

First slice of the dynamic-sites work (DS-1a) — unblocks the gallery badge (DS-1b).