### PR TITLE
Read a dynamic site's D1 data from the control plane

### DIFF
--- a/ee/pocketpaw_ee/sites/cloudflare_client.py
+++ b/ee/pocketpaw_ee/sites/cloudflare_client.py
@@ -1,9 +1,11 @@
 # ee/pocketpaw_ee/sites/cloudflare_client.py — async Cloudflare API client for
-# the Sites control plane. Two surfaces:
+# the Sites control plane. Three surfaces:
 #   * Workers for Platforms — PUT a user Worker into our dispatch namespace
 #     (one synchronous call per site; live on 200; no per-account script cap).
 #   * Cloudflare for SaaS — create a custom hostname, return the single CNAME
 #     the client pastes, poll validation + TLS status.
+#   * D1 (DS-3) — query a dynamic site's per-tenant D1 over the HTTP API so the
+#     control plane can READ its data (the operator data-view); see query_d1.
 # httpx-based; account id + token come from settings (env), not per-tenant rows
 # in v1. Non-2xx raises a CloudError so the standard envelope applies.
 #
@@ -11,6 +13,18 @@
 # header — never logged, never written to disk. All errors fail closed (raise
 # ValidationError), so a failed CF call never silently reports success.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.2).
+#
+# Updated 2026-06-20 (DS-3 — control-plane read of a dynamic site's D1): added
+# query_d1(). It POSTs to the Cloudflare D1 query endpoint
+# (POST /accounts/{acct}/d1/database/{db_id}/query) with a PARAMETERIZED
+# {sql, params} body and returns the rows from the FIRST statement's
+# ``result[0].results``. It mirrors the existing client style exactly: injectable
+# transport, the CF token in the in-memory Authorization header only, and
+# fail-closed via the shared ``_unwrap`` (a non-2xx or success:false raises
+# ValidationError). It NEVER interpolates SQL — the table identifier is validated
+# against the site's known objects by the service BEFORE it reaches here, and all
+# values bind through ``params``. The service layer (DS-3) owns that validation;
+# this method is a thin, SQL-agnostic transport.
 
 from __future__ import annotations
 
@@ -99,3 +113,44 @@ class CloudflareClient:
             resp = await client.get(url)
         result = self._unwrap(resp)
         return _map_status(result.get("status", ""), (result.get("ssl") or {}).get("status", ""))
+
+    async def query_d1(
+        self, *, database_id: str, sql: str, params: list | None = None
+    ) -> list[dict]:
+        """Run ONE parameterized SQL statement against a D1 database and return its
+        rows (DS-3 — the control-plane read of a dynamic site's data).
+
+        POSTs to the Cloudflare D1 query endpoint with a ``{sql, params}`` body.
+        The D1 query response wraps each statement's output in a ``result`` ARRAY
+        (one element per statement; a single ``sql`` returns one element), each
+        carrying its own ``results`` rows + ``meta``. This sends a single
+        statement and returns the FIRST element's ``results`` (the rows) as a list
+        of dicts — empty when the table has no rows.
+
+        SQL safety: this method NEVER builds SQL itself. The caller (the service)
+        passes a fully-formed statement whose table identifier it has already
+        validated against the site's declared ``objects`` (an unknown table is
+        rejected BEFORE this is reached); every value rides ``params`` as a bound
+        placeholder, never string-interpolated. ``params`` defaults to an empty
+        list so a value-less listing query is sent cleanly.
+
+        Fail-closed: a non-2xx, a ``success: false`` envelope, or a D1
+        statement-level failure raises ValidationError via ``_unwrap`` /
+        the per-statement ``success`` check, so a failed read never silently
+        reports empty rows."""
+        url = f"{_CF_API}/accounts/{self._account_id}/d1/database/{database_id}/query"
+        async with self._client() as client:
+            resp = await client.post(url, json={"sql": sql, "params": params or []})
+        # ``_unwrap`` checks the outer envelope (HTTP status + top-level success);
+        # for a query the ``result`` is an ARRAY of per-statement outcomes.
+        result = self._unwrap(resp)
+        statements = result if isinstance(result, list) else []
+        if not statements:
+            return []
+        first = statements[0] if isinstance(statements[0], dict) else {}
+        # A per-statement failure (e.g. malformed SQL) sets success=false on the
+        # element even when the HTTP envelope is 200 — fail closed on it too.
+        if first.get("success") is False:
+            raise ValidationError("sites.cloudflare_error", "D1 query statement failed")
+        rows = first.get("results")
+        return [r for r in rows if isinstance(r, dict)] if isinstance(rows, list) else []

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -50,6 +50,23 @@
 # recent successful live deploy (the Site doc's ``deployed_at``), or None before the
 # first deploy. The builder/gallery surface a "Last deployed <time>" label without a
 # second fetch. Optional (default None) so the field is backward-compatible.
+# Updated 2026-06-20 (DS-3 — read a dynamic site's D1 data): added the read-only
+# DTOs the operator data-view (DS-4 FE) consumes:
+#   * SiteDataTableInfo — one declared table {name, fields, primary_key} from the
+#     dynamic pocket's spec ``objects``. Always available (it comes from the spec),
+#     even when the live D1 data is not reachable.
+#   * SiteDataTablesResponse — the response of
+#     GET /sites/by-pocket/{pocket_id}/data: {pocket_id, available, reason, tables}.
+#     ``available`` is False with ``reason="live_on_cloudflare_only"`` in local/dev
+#     mode (no live D1 to read), but ``tables`` is still listed from the spec so the
+#     UI degrades cleanly instead of erroring.
+#   * SiteDataRowsResponse — the response of
+#     GET /sites/by-pocket/{pocket_id}/data/{table}: {pocket_id, table, available,
+#     reason, columns, rows}. ``rows`` is the D1 rows (capped); ``columns`` is the
+#     table's declared field names. In local mode ``available`` is False and ``rows``
+#     is empty, but ``columns`` is still listed from the spec.
+# These are READ-ONLY views (no request DTO — the inputs are path params); the
+# data view never writes through this surface.
 
 from __future__ import annotations
 
@@ -199,6 +216,50 @@ class AuditResponse(BaseModel):
     pocket_id: str
     engine: str
     findings: list[AuditFinding] = []
+
+
+class SiteDataTableInfo(BaseModel):
+    """One declared table of a dynamic site, read from the pocket spec's
+    ``objects`` (DS-3). ``name`` is the table/object name; ``fields`` is the
+    column→type map (the spec's field types); ``primary_key`` is the PRIMARY KEY
+    column (empty when the spec did not declare one). This is spec-derived, so it
+    is available even when the live D1 data is not reachable (local/dev mode)."""
+
+    name: str
+    fields: dict[str, str] = {}
+    primary_key: str = ""
+
+
+class SiteDataTablesResponse(BaseModel):
+    """The tables of a dynamic site's data store, for the operator data-view
+    (DS-3; backs GET /sites/by-pocket/{pocket_id}/data). The table LIST always
+    comes from the pocket spec's ``objects``, so it is populated even when the
+    live D1 is not reachable. ``available`` is True only when the rows behind
+    those tables can actually be read (a live Cloudflare deploy); it is False in
+    local/dev mode with ``reason="live_on_cloudflare_only"`` so the UI degrades
+    cleanly — it can show the schema but explain why no rows load."""
+
+    pocket_id: str
+    available: bool
+    reason: str = ""
+    tables: list[SiteDataTableInfo] = []
+
+
+class SiteDataRowsResponse(BaseModel):
+    """The rows of ONE table of a dynamic site's data store (DS-3; backs
+    GET /sites/by-pocket/{pocket_id}/data/{table}). ``columns`` is the table's
+    declared field names (spec-derived, always present); ``rows`` is the live D1
+    rows, CAPPED (the service applies a LIMIT). ``available`` is False in local/dev
+    mode (``reason="live_on_cloudflare_only"``) and ``rows`` is then empty, but
+    ``columns`` is still listed so the UI can render the table header + an
+    explanatory empty state instead of erroring."""
+
+    pocket_id: str
+    table: str
+    available: bool
+    reason: str = ""
+    columns: list[str] = []
+    rows: list[dict[str, Any]] = []
 
 
 class DomainRequest(BaseModel):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -82,6 +82,18 @@
 # the new draft as a SiteVersionResponse (the same row shape the versions timeline
 # uses). fabric.write (it creates a draft); an unknown version_no is a 404 (the
 # service raises ValueError).
+# Updated 2026-06-20 (DS-3 — read a dynamic site's D1 data): added two fabric.read
+# operator data-view endpoints over a DYNAMIC site's per-tenant Cloudflare D1.
+#   * GET /sites/by-pocket/{pocket_id}/data — list the site's tables (from the
+#     pocket spec's ``objects``). Always lists the schema; ``available`` is False
+#     with reason="live_on_cloudflare_only" in local/dev mode (no live D1).
+#   * GET /sites/by-pocket/{pocket_id}/data/{table} — read one table's rows
+#     (bounded LIMIT). ``table`` is validated against the spec's declared objects
+#     (unknown → 404, never interpolated); values bind through query params. Local
+#     mode degrades cleanly (available=False, columns still listed, no rows).
+#   Both delegate to sites_service; a NON-dynamic pocket → 422 (not_dynamic), a
+#   missing / access-denied pocket → 404 / 403 (the pockets service raises it).
+#   Tenant-scoped on ctx — the data view is read-only (no request body).
 
 from __future__ import annotations
 
@@ -98,6 +110,8 @@ from pocketpaw_ee.sites.dto import (
     MakeEditableRequest,
     PublishRequest,
     RequestPublishResponse,
+    SiteDataRowsResponse,
+    SiteDataTablesResponse,
     SitePreviewResponse,
     SiteResponse,
     SiteStatusResponse,
@@ -231,6 +245,52 @@ async def status_by_pocket(
     status, is_live}. Derived from the tenant-scoped Site deployment doc — an
     unpublished pocket (no Site) reads draft / not live (NOT a 404)."""
     return await sites_service.pocket_status(workspace_id=ctx.workspace_id, pocket_id=pocket_id)
+
+
+@router.get("/sites/by-pocket/{pocket_id}/data", response_model=SiteDataTablesResponse)
+async def site_data_tables_by_pocket(
+    pocket_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> SiteDataTablesResponse:
+    """List a DYNAMIC site's data tables for the operator data-view (DS-3):
+    {pocket_id, available, reason, tables}. The table list comes from the pocket
+    spec's ``objects`` (the declared D1 tables), so it is populated even when the
+    live D1 is not reachable. ``available`` is False with
+    ``reason="live_on_cloudflare_only"`` in local/dev mode (no live D1) so the UI
+    degrades cleanly — it can show the schema but explain why no rows load.
+
+    A NON-dynamic pocket (a static landing / brochure) has no data store, so the
+    service raises ValidationError("sites.not_dynamic") → 422. A missing /
+    access-denied pocket surfaces as 404 / 403 (the pockets service raises it).
+    Tenant-scoped on ctx."""
+    return await sites_service.list_site_data_tables(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, pocket_id=pocket_id
+    )
+
+
+@router.get("/sites/by-pocket/{pocket_id}/data/{table}", response_model=SiteDataRowsResponse)
+async def site_data_rows_by_pocket(
+    pocket_id: str,
+    table: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> SiteDataRowsResponse:
+    """Read the rows of ONE table of a DYNAMIC site's D1 (DS-3): {pocket_id,
+    table, available, reason, columns, rows}. ``rows`` is the live D1 rows (capped
+    by a LIMIT); ``columns`` is the table's declared field names.
+
+    SQL safety: ``table`` is validated against the pocket spec's declared
+    ``objects`` — an unknown table is a 404 (NotFound("site_table")), never
+    interpolated into SQL; every value binds through query params. In local/dev
+    mode (no live D1) ``available`` is False with
+    ``reason="live_on_cloudflare_only"`` and ``rows`` empty, but ``columns`` is
+    still listed from the spec. A NON-dynamic pocket → 422
+    ("sites.not_dynamic"); a missing / access-denied pocket → 404 / 403.
+    Tenant-scoped on ctx."""
+    return await sites_service.read_site_data_table(
+        workspace_id=ctx.workspace_id, user_id=ctx.user_id, pocket_id=pocket_id, table=table
+    )
 
 
 @router.post("/sites/by-pocket/{pocket_id}/audit", response_model=AuditResponse)

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,24 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-20 (DS-3 — control-plane read of a dynamic site's D1 data):
+# added the operator data-view reads ``list_site_data_tables`` and
+# ``read_site_data_table`` (backing GET /sites/by-pocket/{pocket_id}/data and
+# .../data/{table}). The table LIST comes from the dynamic pocket spec's
+# top-level ``objects`` (always available, even with no live D1); the per-table
+# read runs a bounded, PARAMETERIZED ``SELECT * FROM <table> LIMIT ?`` over the
+# per-tenant Cloudflare D1 via cloudflare_client.query_d1. SQL safety: the table
+# identifier is validated against the spec's declared object names (an unknown
+# table → 404, never interpolated), and every value binds through ``params``. A
+# NON-dynamic pocket → 400 ("sites.not_dynamic"). Local/dev mode
+# (``_local_mode()``) has no live D1, so the read DEGRADES cleanly — it returns
+# ``available=False`` / ``reason="live_on_cloudflare_only"`` with the schema still
+# listed from the spec (no error). Self-contained ``_is_dynamic`` /
+# ``_derive_d1_database_id`` helpers mirror the sibling DS-2 (feat/sites-d1-
+# bindings) branch so the READ targets the SAME D1 a deploy binds, but this branch
+# does NOT depend on DS-2's code (it reads Site.d1_database_id via getattr with an
+# empty default, else derives the id) so it builds green on its own.
+#
 # Updated 2026-06-19 (P2b-backend — "Last Deployed" + revert endpoint): publish()
 # now stamps the Site doc's ``deployed_at`` (UTC) ONLY when a non-preview deploy
 # succeeds (when ``deployed`` flips True) — the true "last shipped" marker, not a
@@ -281,6 +299,9 @@ from pocketpaw_ee.sites.dto import (
     AuditResponse,
     DevPreviewResponse,
     DomainStatusResponse,
+    SiteDataRowsResponse,
+    SiteDataTableInfo,
+    SiteDataTablesResponse,
     SitePreviewResponse,
     SiteResponse,
     SiteStatusResponse,
@@ -352,6 +373,86 @@ def _live_object_id(workspace_id: str, pocket_id: str) -> ObjectId:
 
     digest = hashlib.sha1(f"{workspace_id}:{pocket_id}".encode()).digest()
     return ObjectId(digest[:12])
+
+
+# DS-3: the row cap for a table read. The data-view lists recent records, not a
+# full export — a bounded read keeps the control-plane call cheap and the UI
+# responsive. Overridable via PAW_SITES_DATA_ROW_LIMIT.
+_DATA_ROW_LIMIT_DEFAULT = 200
+
+
+def _data_row_limit() -> int:
+    """The max rows a single table read returns (DS-3). Bounded so the operator
+    data-view stays a recent-records list, not an unbounded export. Reads
+    PAW_SITES_DATA_ROW_LIMIT (a positive int) and falls back to the default for an
+    unset / malformed value."""
+    import os
+
+    raw = os.environ.get("PAW_SITES_DATA_ROW_LIMIT")
+    try:
+        n = int(raw) if raw else _DATA_ROW_LIMIT_DEFAULT
+    except (TypeError, ValueError):
+        return _DATA_ROW_LIMIT_DEFAULT
+    return n if n > 0 else _DATA_ROW_LIMIT_DEFAULT
+
+
+def _is_dynamic(pattern: str | None, ripple_spec: dict[str, Any] | None) -> bool:
+    """Classify a pocket as a DYNAMIC site (DS-3, self-contained — does NOT depend
+    on DS-2's copy of this helper).
+
+    ``pattern == "dynamic"`` is authoritative (the create-dynamic-site tool stamps
+    it). As a safety net — for a pocket that carries dynamic bindings but was not
+    stamped — a spec declaring any top-level ``sources`` / ``actions`` (or
+    ``auth``) is also dynamic, mirroring the generator's own classifier. Anything
+    else (a static landing / brochure pocket) is NOT dynamic and has no D1 to
+    read."""
+    if pattern == "dynamic":
+        return True
+    if not isinstance(ripple_spec, dict):
+        return False
+    return bool(ripple_spec.get("sources") or ripple_spec.get("actions") or ripple_spec.get("auth"))
+
+
+def _dynamic_objects(ripple_spec: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """The declared tables (the spec's top-level ``objects``) of a dynamic site.
+
+    ``objects`` is an ARRAY of ``{name, fields, primaryKey}`` table definitions
+    (the dynamic-site authoring shape — see the create-dynamic-site skill). The D1
+    migration is derived from these, so they are the AUTHORITATIVE set of tables a
+    control-plane read may touch. Returns only well-formed entries (a dict with a
+    non-empty string ``name``); a spec with no ``objects`` returns an empty list."""
+    if not isinstance(ripple_spec, dict):
+        return []
+    raw = ripple_spec.get("objects")
+    if not isinstance(raw, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for obj in raw:
+        if isinstance(obj, dict) and isinstance(obj.get("name"), str) and obj.get("name"):
+            out.append(obj)
+    return out
+
+
+def _derive_d1_database_id(workspace_id: str, pocket_id: str) -> str:
+    """A STABLE D1 database id for a dynamic site, derived from
+    ``(workspace_id, pocket_id)`` (DS-3, self-contained).
+
+    DS-2 (feat/sites-d1-bindings) introduces ``Site.d1_database_id`` and an
+    identically-shaped derive helper for the DEPLOY (bind) path. This branch is
+    off dev and does NOT have DS-2 yet, so to build green on its own it resolves
+    the D1 id the SAME way: read the Site doc's ``d1_database_id`` when present
+    (via getattr with an empty default), else derive it deterministically from the
+    pair. The derivation must match DS-2's exactly so the READ targets the SAME
+    database the DEPLOY bound; both hash ``"d1:{workspace}:{pocket}"`` into a UUID.
+
+    Shaped like a Cloudflare D1 id (a UUID) so it slots into the query path
+    unchanged once a real provisioner persists Cloudflare's returned id on the
+    Site doc (the getattr read picks that up automatically)."""
+    import hashlib
+    import uuid
+
+    digest = hashlib.sha1(f"d1:{workspace_id}:{pocket_id}".encode()).digest()
+    return str(uuid.UUID(bytes=digest[:16]))
 
 
 def _capture_base() -> str:
@@ -1461,6 +1562,172 @@ async def audit_pocket(
     )
 
 
+# DS-3 — the reason string the local/dev-mode degradation surfaces. The data
+# behind a dynamic site lives in a per-tenant Cloudflare D1 reachable only on a
+# live CF deploy; local mode has no D1, so the read returns this instead of an
+# error (the schema is still listed from the spec).
+_DATA_UNAVAILABLE_LOCAL = "live_on_cloudflare_only"
+
+
+async def _dynamic_pocket_objects(
+    *, workspace_id: str, user_id: str, pocket_id: str
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Read a pocket and return ``(ripple_spec, objects)`` for a DYNAMIC site, or
+    raise (DS-3 shared resolver).
+
+    Loads the pocket via the pockets service's PUBLIC ``get`` (wire dict — entity
+    isolation; it raises NotFound / Forbidden itself for a missing / access-denied
+    pocket, mapped to 404 / 403). A NON-dynamic pocket (a static landing /
+    brochure, or a custom pocket with no data bindings) raises
+    ValidationError("sites.not_dynamic") → the router maps it to 400: there is no
+    data store to read. The returned ``objects`` are the spec's declared tables
+    (the authoritative table set a read may touch). ``workspace_id`` keeps the
+    surface tenant-uniform with the other by-pocket reads (the pockets read scopes
+    on ``user_id``; the D1 id derivation is workspace-scoped)."""
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    pocket = await pockets_service.get(pocket_id, user_id)
+    pattern = pocket.get("pattern")
+    ripple_spec = pocket.get("rippleSpec") if isinstance(pocket.get("rippleSpec"), dict) else {}
+    if not _is_dynamic(pattern, ripple_spec):
+        raise ValidationError(
+            "sites.not_dynamic",
+            "This site is not a dynamic site — it has no live data store to read.",
+        )
+    return ripple_spec or {}, _dynamic_objects(ripple_spec)
+
+
+def _table_columns(obj: dict[str, Any]) -> list[str]:
+    """The declared column names of a spec ``objects`` table (DS-3). ``fields`` is
+    a {column: type} map; an absent / malformed ``fields`` yields no columns."""
+    fields = obj.get("fields")
+    return list(fields.keys()) if isinstance(fields, dict) else []
+
+
+async def list_site_data_tables(
+    *, workspace_id: str, user_id: str, pocket_id: str
+) -> SiteDataTablesResponse:
+    """List a dynamic site's tables for the operator data-view (DS-3).
+
+    Backs ``GET /sites/by-pocket/{pocket_id}/data``. The table LIST is always read
+    from the pocket spec's ``objects`` (the declared D1 tables), so it is populated
+    even when the live D1 data is not reachable. ``available`` reflects whether the
+    ROWS behind those tables can actually be read:
+      * in local/dev mode (``_local_mode()`` — PAW_SITES_LOCAL=1 or no
+        PAW_CF_ACCOUNT_ID) there is no live D1, so ``available`` is False with
+        ``reason="live_on_cloudflare_only"``; the UI still shows the schema and an
+        explanatory empty state instead of erroring;
+      * with a live Cloudflare deploy, ``available`` is True (the per-table read
+        then returns rows).
+
+    A NON-dynamic pocket raises ValidationError("sites.not_dynamic") → 400 (no data
+    store). A missing / access-denied pocket surfaces as 404 / 403 via the pockets
+    service. Tenant-scoped: the pockets read scopes on ``user_id``; the D1 id (when
+    a live read happens) is derived per (workspace, pocket)."""
+    _spec, objects = await _dynamic_pocket_objects(
+        workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+    )
+    tables = [
+        SiteDataTableInfo(
+            name=obj["name"],
+            fields=obj.get("fields") if isinstance(obj.get("fields"), dict) else {},
+            primary_key=obj.get("primaryKey") if isinstance(obj.get("primaryKey"), str) else "",
+        )
+        for obj in objects
+    ]
+    available = not _local_mode()
+    return SiteDataTablesResponse(
+        pocket_id=pocket_id,
+        available=available,
+        reason="" if available else _DATA_UNAVAILABLE_LOCAL,
+        tables=tables,
+    )
+
+
+async def read_site_data_table(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    table: str,
+    _cloudflare: Any | None = None,
+) -> SiteDataRowsResponse:
+    """Read the rows of ONE table of a dynamic site's D1 (DS-3).
+
+    Backs ``GET /sites/by-pocket/{pocket_id}/data/{table}``. The flow:
+      1. resolve the pocket's declared ``objects`` (a non-dynamic pocket → 400);
+      2. VALIDATE ``table`` against those declared names — an unknown table raises
+         NotFound("site_table") → 404. This is the SQL-safety gate: the table
+         identifier reaching the query is ALWAYS one of the spec's known object
+         names, never attacker-supplied free text, so it is safe to embed as the
+         FROM identifier (D1 / SQLite cannot bind an identifier as a placeholder).
+         Every VALUE still binds through ``params``; the only interpolated token is
+         this whitelisted identifier;
+      3. in local/dev mode (``_local_mode()``) there is NO live D1 — return a clean
+         ``available=False`` / ``reason="live_on_cloudflare_only"`` shape with the
+         table's declared ``columns`` and empty ``rows`` (the UI degrades cleanly);
+      4. otherwise derive the D1 database id (the Site doc's ``d1_database_id`` if
+         present — DS-2 forward-compat — else the deterministic
+         ``_derive_d1_database_id``) and run a bounded ``SELECT * FROM <table>
+         LIMIT ?`` via the Cloudflare D1 query API, returning the rows.
+
+    The row count is capped (``_data_row_limit()``) so the data-view stays a
+    recent-records list, not an unbounded export. Tenant-scoped: the pockets read
+    scopes on ``user_id``; the D1 id is per (workspace, pocket), and the Site doc
+    read filters on ``workspace`` — a foreign workspace cannot read another
+    tenant's data. ``_cloudflare`` is injectable so the path is unit-testable
+    without a live D1."""
+    _spec, objects = await _dynamic_pocket_objects(
+        workspace_id=workspace_id, user_id=user_id, pocket_id=pocket_id
+    )
+
+    # SQL-safety gate: the requested table MUST be one of the spec's declared
+    # object names. An unknown table is a 404 — never reaches a query, never
+    # interpolated. ``next`` finds the matching object (for its declared columns).
+    target = next((obj for obj in objects if obj.get("name") == table), None)
+    if target is None:
+        raise NotFound("site_table", table)
+    columns = _table_columns(target)
+
+    # Local/dev mode: no live D1 to read. Degrade cleanly — list the declared
+    # columns from the spec, return no rows, and say why.
+    if _local_mode() and _cloudflare is None:
+        return SiteDataRowsResponse(
+            pocket_id=pocket_id,
+            table=table,
+            available=False,
+            reason=_DATA_UNAVAILABLE_LOCAL,
+            columns=columns,
+            rows=[],
+        )
+
+    # Resolve the D1 database id: prefer a stored id (DS-2's Site.d1_database_id,
+    # via getattr so this branch builds without DS-2), else derive it
+    # deterministically so the READ targets the SAME db a deploy bound.
+    doc = await _canonical_site_doc(workspace_id, pocket_id)
+    stored_db_id = getattr(doc, "d1_database_id", "") if doc is not None else ""
+    db_id = stored_db_id or _derive_d1_database_id(workspace_id, pocket_id)
+
+    cf = _cloudflare or _cf_client()
+    # ``table`` is whitelisted above (it equals a declared object name), so it is
+    # safe to embed as the FROM identifier — SQLite/D1 cannot bind an identifier as
+    # a placeholder. The LIMIT VALUE binds through ``params``.
+    limit = _data_row_limit()
+    rows = await cf.query_d1(
+        database_id=db_id,
+        sql=f"SELECT * FROM {table} LIMIT ?",  # noqa: S608 — table is whitelisted, value is bound
+        params=[limit],
+    )
+    return SiteDataRowsResponse(
+        pocket_id=pocket_id,
+        table=table,
+        available=True,
+        reason="",
+        columns=columns,
+        rows=rows,
+    )
+
+
 async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusResponse:
     """Derive a pocket's draft/published + is_live state from the BRANCH version
     pointers AND the real Site deploy state — NOT from "a Site doc exists".
@@ -1852,6 +2119,8 @@ __all__ = [
     "publish_pocket",
     "preview_pocket",
     "pocket_status",
+    "list_site_data_tables",
+    "read_site_data_table",
     "request_publish_pocket",
     "version_history",
     "revert_pocket_version",

--- a/tests/ee/sites/test_data_read.py
+++ b/tests/ee/sites/test_data_read.py
@@ -1,0 +1,309 @@
+# tests/ee/sites/test_data_read.py — DS-3: control-plane read of a dynamic site's
+# Cloudflare D1 data. Created 2026-06-20 (feat/sites-d1-read).
+#
+# Covers the two operator data-view reads (service + the cloudflare_client D1
+# query method) with fakes so no live D1 / network is touched:
+#   * list_site_data_tables — lists a dynamic site's tables from the pocket spec's
+#     ``objects``; in LOCAL mode it returns available=False /
+#     reason="live_on_cloudflare_only" but STILL lists the schema (degrades
+#     cleanly, no error).
+#   * read_site_data_table — with an injected D1 CF client, returns the table's
+#     rows from a mocked D1 response; an UNKNOWN table is rejected (404) before any
+#     query (the SQL-safety gate); a NON-dynamic pocket raises not_dynamic;
+#     tenant-scoping holds (the foreign-workspace D1 id differs); LOCAL mode (no
+#     injected CF) returns the unavailable_local shape with columns still listed.
+#   * cloudflare_client.query_d1 — parses rows out of the D1 query envelope
+#     (result[0].results), sends a parameterized {sql, params} body, and fails
+#     closed on a non-2xx.
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError  # noqa: E402
+from pocketpaw_ee.sites import service as sites_service  # noqa: E402
+from pocketpaw_ee.sites.cloudflare_client import CloudflareClient  # noqa: E402
+
+_PATCH_GET = "pocketpaw_ee.cloud.pockets.service.get"
+
+# A dynamic-site pocket wire dict: pattern="dynamic" + a spec carrying top-level
+# ``objects`` (the declared D1 tables) the data-view reads.
+_DYNAMIC_WIRE = {
+    "name": "Guestbook",
+    "pattern": "dynamic",
+    "rippleSpec": {
+        "type": "container",
+        "objects": [
+            {
+                "name": "entry",
+                "fields": {"id": "text", "name": "text", "message": "text"},
+                "primaryKey": "id",
+            },
+            {
+                "name": "rsvp",
+                "fields": {"id": "text", "guests": "integer"},
+                "primaryKey": "id",
+            },
+        ],
+        "sources": [{"name": "entries", "kind": "data", "object": "entry"}],
+    },
+}
+
+
+class _FakeD1CF:
+    """A Cloudflare client double that records the D1 query it was asked to run and
+    returns canned rows — so the service path is exercised without a live D1."""
+
+    def __init__(self, rows: list[dict] | None = None) -> None:
+        self.rows = rows if rows is not None else [{"id": "1", "name": "Ada", "message": "hi"}]
+        self.calls: list[dict] = []
+
+    async def query_d1(self, *, database_id: str, sql: str, params=None) -> list[dict]:
+        self.calls.append({"database_id": database_id, "sql": sql, "params": params})
+        return self.rows
+
+
+# --------------------------------------------------------------------------- #
+# list_site_data_tables
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_list_tables_lists_objects_from_spec(monkeypatch):
+    """A dynamic site lists its tables (name, fields, primary key) from the spec's
+    ``objects`` — schema is always available even with no live D1."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_DYNAMIC_WIRE)) as mock_get:
+        res = await sites_service.list_site_data_tables(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+    mock_get.assert_awaited_once_with("pk1", "u1")
+    assert res.pocket_id == "pk1"
+    names = [t.name for t in res.tables]
+    assert names == ["entry", "rsvp"]
+    entry = next(t for t in res.tables if t.name == "entry")
+    assert entry.fields == {"id": "text", "name": "text", "message": "text"}
+    assert entry.primary_key == "id"
+
+
+@pytest.mark.asyncio
+async def test_list_tables_local_mode_unavailable_but_schema_listed(monkeypatch):
+    """In LOCAL mode (no CF creds) the data is not reachable, but the read DEGRADES
+    cleanly — available=False, reason='live_on_cloudflare_only', and the tables are
+    STILL listed from the spec (no error)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_DYNAMIC_WIRE)):
+        res = await sites_service.list_site_data_tables(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+    assert res.available is False
+    assert res.reason == "live_on_cloudflare_only"
+    assert [t.name for t in res.tables] == ["entry", "rsvp"]
+
+
+@pytest.mark.asyncio
+async def test_list_tables_non_dynamic_pocket_rejected(monkeypatch):
+    """A NON-dynamic pocket (a static landing) has no data store → not_dynamic."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    landing = {"name": "Brochure", "pattern": "landing", "rippleSpec": {"type": "container"}}
+    with patch(_PATCH_GET, new=AsyncMock(return_value=landing)):
+        with pytest.raises(ValidationError) as exc:
+            await sites_service.list_site_data_tables(
+                workspace_id="ws1", user_id="u1", pocket_id="pk1"
+            )
+    assert exc.value.code == "sites.not_dynamic"
+
+
+@pytest.mark.asyncio
+async def test_list_tables_available_when_cf_configured(monkeypatch):
+    """With CF creds configured (not local mode) the table list reports
+    available=True (the rows behind the tables can be read)."""
+    monkeypatch.setenv("PAW_CF_ACCOUNT_ID", "acct_1")
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_DYNAMIC_WIRE)):
+        res = await sites_service.list_site_data_tables(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+    assert res.available is True
+    assert res.reason == ""
+
+
+# --------------------------------------------------------------------------- #
+# read_site_data_table
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_read_table_returns_rows_for_dynamic_site(beanie_test_db, monkeypatch):
+    """A dynamic site's table read returns the D1 rows (via the injected CF
+    client), with the declared columns and a bounded, PARAMETERIZED query."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    cf = _FakeD1CF(rows=[{"id": "1", "name": "Ada"}, {"id": "2", "name": "Grace"}])
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_DYNAMIC_WIRE)):
+        res = await sites_service.read_site_data_table(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1", table="entry", _cloudflare=cf
+        )
+    assert res.available is True
+    assert res.table == "entry"
+    assert res.columns == ["id", "name", "message"]
+    assert res.rows == [{"id": "1", "name": "Ada"}, {"id": "2", "name": "Grace"}]
+    # The query was bounded + parameterized (the LIMIT value rides params, the
+    # table is the whitelisted identifier — never a free-text interpolation).
+    assert len(cf.calls) == 1
+    call = cf.calls[0]
+    assert "FROM entry" in call["sql"]
+    assert "LIMIT ?" in call["sql"]
+    assert isinstance(call["params"], list) and len(call["params"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_read_table_unknown_table_rejected_before_query(beanie_test_db, monkeypatch):
+    """An UNKNOWN table is rejected (404) BEFORE any D1 query runs — the SQL-safety
+    gate: the identifier must be one of the spec's declared objects."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    cf = _FakeD1CF()
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_DYNAMIC_WIRE)):
+        with pytest.raises(NotFound) as exc:
+            await sites_service.read_site_data_table(
+                workspace_id="ws1",
+                user_id="u1",
+                pocket_id="pk1",
+                table="users; DROP TABLE entry",
+                _cloudflare=cf,
+            )
+    assert exc.value.status_code == 404
+    # No query was ever sent for the unknown / injection-shaped table.
+    assert cf.calls == []
+
+
+@pytest.mark.asyncio
+async def test_read_table_non_dynamic_pocket_rejected(monkeypatch):
+    """A NON-dynamic pocket → not_dynamic (no data store to read)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    landing = {"name": "Brochure", "pattern": "landing", "rippleSpec": {"type": "container"}}
+    with patch(_PATCH_GET, new=AsyncMock(return_value=landing)):
+        with pytest.raises(ValidationError) as exc:
+            await sites_service.read_site_data_table(
+                workspace_id="ws1", user_id="u1", pocket_id="pk1", table="entry"
+            )
+    assert exc.value.code == "sites.not_dynamic"
+
+
+@pytest.mark.asyncio
+async def test_read_table_local_mode_unavailable_shape(monkeypatch):
+    """LOCAL mode (no injected CF, no creds) returns the clean unavailable shape —
+    available=False, reason='live_on_cloudflare_only', no rows — but the table's
+    declared columns are STILL listed from the spec (no error)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_DYNAMIC_WIRE)):
+        res = await sites_service.read_site_data_table(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1", table="entry"
+        )
+    assert res.available is False
+    assert res.reason == "live_on_cloudflare_only"
+    assert res.rows == []
+    assert res.columns == ["id", "name", "message"]
+
+
+@pytest.mark.asyncio
+async def test_read_table_tenant_scoped_d1_id(beanie_test_db, monkeypatch):
+    """Tenant-scoping: the derived D1 database id is a function of (workspace,
+    pocket), so two workspaces reading the SAME pocket id target DIFFERENT
+    databases — a foreign workspace cannot read another tenant's data."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    cf_a, cf_b = _FakeD1CF(), _FakeD1CF()
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_DYNAMIC_WIRE)):
+        await sites_service.read_site_data_table(
+            workspace_id="ws_A", user_id="u1", pocket_id="pk1", table="entry", _cloudflare=cf_a
+        )
+        await sites_service.read_site_data_table(
+            workspace_id="ws_B", user_id="u1", pocket_id="pk1", table="entry", _cloudflare=cf_b
+        )
+    assert cf_a.calls[0]["database_id"] != cf_b.calls[0]["database_id"]
+
+
+# --------------------------------------------------------------------------- #
+# cloudflare_client.query_d1
+# --------------------------------------------------------------------------- #
+
+
+def _d1_client(handler) -> CloudflareClient:
+    transport = httpx.MockTransport(handler)
+    return CloudflareClient(
+        account_id="acct_1",
+        api_token="tok_1",
+        zone_id="zone_1",
+        dispatch_namespace="paw-sites",
+        _transport=transport,
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_d1_parses_rows_and_sends_parameterized_body():
+    """query_d1 POSTs a {sql, params} body to the D1 query endpoint and returns the
+    rows out of the D1 envelope's result[0].results."""
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json
+
+        seen["url"] = str(request.url)
+        seen["method"] = request.method
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "success": True,
+                "result": [
+                    {
+                        "success": True,
+                        "meta": {"rows_read": 2},
+                        "results": [{"id": "1", "name": "Ada"}, {"id": "2", "name": "Grace"}],
+                    }
+                ],
+            },
+        )
+
+    client = _d1_client(handler)
+    rows = await client.query_d1(
+        database_id="db_1", sql="SELECT * FROM entry LIMIT ?", params=[200]
+    )
+    assert rows == [{"id": "1", "name": "Ada"}, {"id": "2", "name": "Grace"}]
+    assert "d1/database/db_1/query" in seen["url"]
+    assert seen["method"] == "POST"
+    assert seen["body"] == {"sql": "SELECT * FROM entry LIMIT ?", "params": [200]}
+
+
+@pytest.mark.asyncio
+async def test_query_d1_empty_results_returns_empty_list():
+    """A table with no rows returns an empty list (not an error)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"success": True, "result": [{"success": True, "results": []}]}
+        )
+
+    client = _d1_client(handler)
+    rows = await client.query_d1(
+        database_id="db_1", sql="SELECT * FROM entry LIMIT ?", params=[200]
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_query_d1_non_2xx_fails_closed():
+    """A non-2xx D1 response fails closed (raises) — never a silent empty read."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"success": False, "errors": [{"message": "denied"}]})
+
+    client = _d1_client(handler)
+    with pytest.raises(ValidationError):
+        await client.query_d1(database_id="db_1", sql="SELECT 1", params=[])

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -695,3 +695,104 @@ async def test_revert_by_pocket_cross_tenant_is_404(beanie_test_db, monkeypatch)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         resp = await c.post(f"/api/v1/sites/by-pocket/pk_rev3/versions/{foreign.version_no}/revert")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# data view (DS-3): GET /sites/by-pocket/{pocket_id}/data lists a dynamic site's
+# tables (from the spec's objects), and GET .../data/{table} reads one table's
+# rows. fabric.read; tenant-scoped; a non-dynamic pocket is a 422; an unknown
+# table is a 404; local mode degrades cleanly (available=False).
+# ---------------------------------------------------------------------------
+
+_DATA_DYNAMIC_WIRE = {
+    "name": "Guestbook",
+    "pattern": "dynamic",
+    "rippleSpec": {
+        "type": "container",
+        "objects": [
+            {
+                "name": "entry",
+                "fields": {"id": "text", "name": "text", "message": "text"},
+                "primaryKey": "id",
+            }
+        ],
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_data_tables_by_pocket_lists_schema(beanie_test_db, monkeypatch):
+    """GET .../data lists the dynamic site's tables from the spec's objects; in
+    local mode (no CF creds) available=False but the schema is still listed."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(return_value=_DATA_DYNAMIC_WIRE),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_dyn/data")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["pocket_id"] == "pk_dyn"
+    assert body["available"] is False
+    assert body["reason"] == "live_on_cloudflare_only"
+    assert [t["name"] for t in body["tables"]] == ["entry"]
+
+
+@pytest.mark.asyncio
+async def test_data_tables_by_pocket_non_dynamic_is_422(beanie_test_db, monkeypatch):
+    """A NON-dynamic pocket has no data store → 422 (not_dynamic)."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(return_value={"name": "x", "pattern": "landing", "rippleSpec": {"type": "c"}}),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_landing/data")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_data_rows_by_pocket_local_mode_degrades(beanie_test_db, monkeypatch):
+    """GET .../data/{table} in local mode returns the clean unavailable shape with
+    the table's declared columns listed and no rows."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(return_value=_DATA_DYNAMIC_WIRE),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_dyn/data/entry")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["table"] == "entry"
+    assert body["available"] is False
+    assert body["columns"] == ["id", "name", "message"]
+    assert body["rows"] == []
+
+
+@pytest.mark.asyncio
+async def test_data_rows_by_pocket_unknown_table_is_404(beanie_test_db, monkeypatch):
+    """An unknown table is rejected with a 404 (the SQL-safety gate)."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        AsyncMock(return_value=_DATA_DYNAMIC_WIRE),
+    )
+    app = _build_app("ws_owner", monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.get("/api/v1/sites/by-pocket/pk_dyn/data/unknown_table")
+    assert resp.status_code == 404


### PR DESCRIPTION
A dynamic Paw Site stores its data in a Cloudflare D1, but the control plane had no way to read it — the data was only reachable through the deployed site's own remote functions, so an operator couldn't see records or form submissions. This adds a read path.

## What changed
- New `query_d1` on the Cloudflare client (the D1 HTTP query API), same style as the rest of the client: injectable transport, parameterized, fail-closed, token in-memory only.
- Two tenant-scoped endpoints:
  - `GET /sites/by-pocket/{id}/data` — lists the dynamic site's tables (from the spec's `objects`).
  - `GET /sites/by-pocket/{id}/data/{table}` — returns rows for one table (capped at 200).
- Non-dynamic pockets are rejected (422 `sites.not_dynamic`); an unknown table is a 404 before any query runs.
- **Local/dev (no live D1):** returns `available: false, reason: "live_on_cloudflare_only"` with the table schema still listed from the spec — the UI shows the schema + an empty state instead of an error.

## SQL safety
The table name is validated against the spec's declared `objects` before anything runs (an injection-shaped table is a 404 with zero CF calls); only that whitelisted identifier is used as the `FROM` token (D1/SQLite can't bind an identifier), and every value binds through params.

## Tested
`tests/ee/sites/test_data_read.py` (12) + 4 router tests: rows returned for a dynamic site (mock D1), unknown-table rejected pre-query, non-dynamic rejected, tenant-scoped, local-mode shape, fail-closed on non-2xx. `tests/ee/sites/` 230 passed. Ran the new file locally: 12 passed. Live D1 unverified until real CF creds (tracked separately).

## Merge sequencing (with #1520)
This and #1520 (DS-2) both add the same byte-identical helpers `_derive_d1_database_id` + `_is_dynamic` and rely on `Site.d1_database_id`. Whichever merges second will have a trivial duplicate-definition conflict on those two helpers — keep one copy on rebase (identical bodies, no behavioral divergence). Recommend merging #1520 first, then rebasing this.

Part of the dynamic-sites end-to-end work (DS-3); backs the data view (DS-4).