### PR TITLE
Read a dynamic svelte site's D1 tables from the engine-appropriate content (DSV-2b)

### DIFF
--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -60,6 +60,18 @@
 # (or unset-tier) site resolves to an empty set and stays on the basic create
 # path, unchanged. ``site_plans`` is imported lazily inside ``add_domain``,
 # mirroring ``publish_pocket``.
+# Updated 2026-06-21 (DSV-2b — engine-appropriate objects read for svelte dynamic
+# sites): the data-read resolver ``_dynamic_pocket_objects`` now selects the
+# pocket's CONTENT ENVELOPE by engine before classifying / extracting ``objects``
+# — for ``engine == "svelte"`` it reads the dynamic bindings
+# (``objects``/``sources``/``actions``/``auth``) from the svelte ``source``
+# envelope, for ripple (the default) from ``rippleSpec``, mirroring the
+# ``version_content = (source if engine == "svelte" else ripple_spec)`` switch the
+# publish/promote path already uses. Without this a dynamic SVELTE pocket (whose
+# bindings live on ``source``, not ``rippleSpec``) showed NO tables in the Data
+# tab. ``_is_dynamic`` / ``_dynamic_objects`` are unchanged — they already operate
+# on "a content dict", so passing the engine-selected envelope is all that's
+# needed; ripple dynamic sites keep reading from ``rippleSpec`` (no regress).
 #
 # Updated 2026-06-20 (DS-3 — control-plane read of a dynamic site's D1 data):
 # added the operator data-view reads ``list_site_data_tables`` and
@@ -2276,18 +2288,49 @@ async def audit_pocket(
 _DATA_UNAVAILABLE_LOCAL = "live_on_cloudflare_only"
 
 
+def _dynamic_content_envelope(pocket: dict[str, Any]) -> dict[str, Any]:
+    """The ENGINE-APPROPRIATE content envelope a dynamic site's bindings live on
+    (DSV-2b).
+
+    A dynamic pocket carries its live-data bindings — ``objects`` (the D1 tables),
+    ``sources`` (reads), ``actions`` (writes), optional ``auth`` — as SIBLING KEYS
+    on its content. WHICH content holds them depends on the generation engine, and
+    must match the publish/promote switch (``version_content = source if engine ==
+    "svelte" else ripple_spec``):
+
+      * ``engine == "svelte"`` → the bindings are siblings on the svelte ``source``
+        envelope (the same dict that also carries the ``{path: contents}``
+        hand-written SvelteKit files). This is the CONTRACT the create-svelte brain
+        + the generator must store to: ``objects``/``sources``/``actions``/``auth``
+        sit alongside the file entries on ``source``.
+      * any other engine (``"ripple"``, the default) → the bindings are siblings on
+        ``rippleSpec`` (the ripple-track precedent the create-dynamic-site tool
+        already stamps).
+
+    Returns the selected dict (``{}`` when absent / malformed), so the
+    engine-agnostic ``_is_dynamic`` / ``_dynamic_objects`` helpers can read the
+    bindings off it without caring which engine produced it."""
+    engine = pocket.get("engine") or "ripple"
+    key = "source" if engine == "svelte" else "rippleSpec"
+    content = pocket.get(key)
+    return content if isinstance(content, dict) else {}
+
+
 async def _dynamic_pocket_objects(
     *, workspace_id: str, user_id: str, pocket_id: str
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
-    """Read a pocket and return ``(ripple_spec, objects)`` for a DYNAMIC site, or
-    raise (DS-3 shared resolver).
+    """Read a pocket and return ``(content_envelope, objects)`` for a DYNAMIC site,
+    or raise (DS-3 shared resolver; DSV-2b made it engine-aware).
 
     Loads the pocket via the pockets service's PUBLIC ``get`` (wire dict — entity
     isolation; it raises NotFound / Forbidden itself for a missing / access-denied
-    pocket, mapped to 404 / 403). A NON-dynamic pocket (a static landing /
+    pocket, mapped to 404 / 403). The dynamic bindings (``objects`` and friends)
+    are read off the ENGINE-APPROPRIATE content envelope (DSV-2b): a svelte site's
+    bindings live on its ``source`` map, a ripple site's on its ``rippleSpec`` —
+    see ``_dynamic_content_envelope``. A NON-dynamic pocket (a static landing /
     brochure, or a custom pocket with no data bindings) raises
     ValidationError("sites.not_dynamic") → the router maps it to 400: there is no
-    data store to read. The returned ``objects`` are the spec's declared tables
+    data store to read. The returned ``objects`` are the envelope's declared tables
     (the authoritative table set a read may touch). ``workspace_id`` keeps the
     surface tenant-uniform with the other by-pocket reads (the pockets read scopes
     on ``user_id``; the D1 id derivation is workspace-scoped)."""
@@ -2295,13 +2338,13 @@ async def _dynamic_pocket_objects(
 
     pocket = await pockets_service.get(pocket_id, user_id)
     pattern = pocket.get("pattern")
-    ripple_spec = pocket.get("rippleSpec") if isinstance(pocket.get("rippleSpec"), dict) else {}
-    if not _is_dynamic(pattern, ripple_spec):
+    content = _dynamic_content_envelope(pocket)
+    if not _is_dynamic(pattern, content):
         raise ValidationError(
             "sites.not_dynamic",
             "This site is not a dynamic site — it has no live data store to read.",
         )
-    return ripple_spec or {}, _dynamic_objects(ripple_spec)
+    return content, _dynamic_objects(content)
 
 
 def _table_columns(obj: dict[str, Any]) -> list[str]:

--- a/tests/ee/sites/test_data_read_svelte.py
+++ b/tests/ee/sites/test_data_read_svelte.py
@@ -1,0 +1,252 @@
+# tests/ee/sites/test_data_read_svelte.py — DSV-2b: engine-appropriate objects
+# read for a DYNAMIC SVELTE site. Created 2026-06-21 (feat/dsv-2b-objects-read).
+#
+# DS-3 reads a dynamic site's tables from the pocket's ``rippleSpec.objects`` — the
+# RIPPLE-track storage shape. A dynamic SVELTE pocket stores its bindings
+# (``objects``/``sources``/``actions``/``auth``) as sibling keys on its ``source``
+# content envelope instead (mirroring the publish switch ``version_content =
+# (source if engine == "svelte" else ripple_spec)``). These tests prove the
+# data-read path now selects the engine-appropriate envelope:
+#   * a dynamic SVELTE pocket (engine="svelte", objects on ``source``) →
+#     list_site_data_tables returns its tables; _is_dynamic true.
+#   * a dynamic SVELTE pocket → read_site_data_table reads a table's rows + columns.
+#   * a RIPPLE dynamic pocket is UNCHANGED — still reads from ``rippleSpec`` (no
+#     regress), even if its ``source`` is empty/absent.
+#   * a STATIC svelte pocket (engine="svelte", no bindings on ``source``) → NOT
+#     dynamic (not_dynamic), so no tables.
+#   * the ``rippleSpec`` of a svelte pocket is IGNORED — bindings there do NOT make
+#     a svelte pocket dynamic (the engine selects the envelope, not a union).
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.errors import ValidationError  # noqa: E402
+from pocketpaw_ee.sites import service as sites_service  # noqa: E402
+
+_PATCH_GET = "pocketpaw_ee.cloud.pockets.service.get"
+
+
+# A dynamic SVELTE pocket wire dict: engine="svelte" + the dynamic bindings
+# (``objects`` = the D1 tables, plus ``sources``) carried as SIBLING KEYS on the
+# ``source`` content envelope, ALONGSIDE the hand-written SvelteKit files. This is
+# the contract the create-svelte brain + generator must store to.
+_SVELTE_DYNAMIC_WIRE = {
+    "name": "Svelte Guestbook",
+    "pattern": "dynamic",
+    "engine": "svelte",
+    "source": {
+        # The {path: contents} SvelteKit files.
+        "src/routes/+page.svelte": "<h1>Guestbook</h1>",
+        # The dynamic bindings, as siblings on the same envelope.
+        "objects": [
+            {
+                "name": "entry",
+                "fields": {"id": "text", "name": "text", "message": "text"},
+                "primaryKey": "id",
+            },
+            {
+                "name": "rsvp",
+                "fields": {"id": "text", "guests": "integer"},
+                "primaryKey": "id",
+            },
+        ],
+        "sources": [{"name": "entries", "kind": "data", "object": "entry"}],
+    },
+}
+
+
+class _FakeD1CF:
+    """A Cloudflare client double recording the D1 query and returning canned rows
+    so the read path is exercised without a live D1 (mirror of DS-3's fake)."""
+
+    def __init__(self, rows: list[dict] | None = None) -> None:
+        self.rows = rows if rows is not None else [{"id": "1", "name": "Ada", "message": "hi"}]
+        self.calls: list[dict] = []
+
+    async def query_d1(self, *, database_id: str, sql: str, params=None) -> list[dict]:
+        self.calls.append({"database_id": database_id, "sql": sql, "params": params})
+        return self.rows
+
+
+# --------------------------------------------------------------------------- #
+# dynamic SVELTE site — objects read from the ``source`` envelope
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_svelte_dynamic_lists_tables_from_source_envelope(monkeypatch):
+    """A dynamic SVELTE pocket lists its tables from ``source.objects`` (the
+    engine-appropriate envelope), not ``rippleSpec`` — so the Data tab is populated
+    for a svelte dynamic site."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_SVELTE_DYNAMIC_WIRE)) as mock_get:
+        res = await sites_service.list_site_data_tables(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+    mock_get.assert_awaited_once_with("pk1", "u1")
+    names = [t.name for t in res.tables]
+    assert names == ["entry", "rsvp"]
+    entry = next(t for t in res.tables if t.name == "entry")
+    assert entry.fields == {"id": "text", "name": "text", "message": "text"}
+    assert entry.primary_key == "id"
+
+
+@pytest.mark.asyncio
+async def test_svelte_dynamic_is_classified_dynamic(monkeypatch):
+    """A dynamic SVELTE pocket classifies as dynamic via the engine-appropriate
+    envelope — it does NOT raise not_dynamic."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_SVELTE_DYNAMIC_WIRE)):
+        # No raise → dynamic. The call returns a populated table list.
+        res = await sites_service.list_site_data_tables(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+    assert [t.name for t in res.tables] == ["entry", "rsvp"]
+
+
+@pytest.mark.asyncio
+async def test_svelte_dynamic_reads_table_rows(beanie_test_db, monkeypatch):
+    """A dynamic SVELTE pocket's table read returns the D1 rows + declared columns,
+    proving the per-table read also resolves objects off the ``source`` envelope."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    cf = _FakeD1CF(rows=[{"id": "1", "name": "Ada"}, {"id": "2", "name": "Grace"}])
+    with patch(_PATCH_GET, new=AsyncMock(return_value=_SVELTE_DYNAMIC_WIRE)):
+        res = await sites_service.read_site_data_table(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1", table="entry", _cloudflare=cf
+        )
+    assert res.available is True
+    assert res.table == "entry"
+    assert res.columns == ["id", "name", "message"]
+    assert res.rows == [{"id": "1", "name": "Ada"}, {"id": "2", "name": "Grace"}]
+    assert len(cf.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_svelte_dynamic_via_bindings_safety_net(monkeypatch):
+    """A svelte pocket NOT stamped pattern="dynamic" but carrying ``sources`` on its
+    ``source`` envelope is still dynamic (the _is_dynamic bindings safety-net works
+    on the engine-appropriate envelope)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    wire = {
+        "name": "Unstamped svelte",
+        "engine": "svelte",
+        # pattern absent → relies on the bindings safety-net.
+        "source": {
+            "src/routes/+page.svelte": "<h1>Hi</h1>",
+            "objects": [{"name": "lead", "fields": {"id": "text"}, "primaryKey": "id"}],
+            "sources": [{"name": "leads", "kind": "data", "object": "lead"}],
+        },
+    }
+    with patch(_PATCH_GET, new=AsyncMock(return_value=wire)):
+        res = await sites_service.list_site_data_tables(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+    assert [t.name for t in res.tables] == ["lead"]
+
+
+# --------------------------------------------------------------------------- #
+# no regress — ripple dynamic still reads from rippleSpec
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_ripple_dynamic_still_reads_ripplespec(monkeypatch):
+    """A RIPPLE dynamic pocket (the DS-3 shape) is UNCHANGED — its tables still come
+    from ``rippleSpec.objects``, even though ``source`` is absent. No regress."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    ripple_wire = {
+        "name": "Ripple Guestbook",
+        "pattern": "dynamic",
+        # engine absent → defaults to "ripple"; bindings live on rippleSpec.
+        "rippleSpec": {
+            "type": "container",
+            "objects": [
+                {"name": "entry", "fields": {"id": "text", "name": "text"}, "primaryKey": "id"},
+            ],
+            "sources": [{"name": "entries", "kind": "data", "object": "entry"}],
+        },
+    }
+    with patch(_PATCH_GET, new=AsyncMock(return_value=ripple_wire)):
+        res = await sites_service.list_site_data_tables(
+            workspace_id="ws1", user_id="u1", pocket_id="pk1"
+        )
+    assert [t.name for t in res.tables] == ["entry"]
+
+
+@pytest.mark.asyncio
+async def test_ripple_engine_ignores_source_envelope(monkeypatch):
+    """A pocket on the RIPPLE engine reads ONLY ``rippleSpec`` — bindings sitting on
+    its ``source`` map are NOT read (the engine selects the envelope, never a
+    union)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    wire = {
+        "name": "Ripple w/ stray source",
+        "engine": "ripple",
+        "rippleSpec": {"type": "container"},  # no bindings here → not dynamic
+        "source": {
+            "objects": [{"name": "ghost", "fields": {"id": "text"}, "primaryKey": "id"}],
+            "sources": [{"name": "x", "kind": "data", "object": "ghost"}],
+        },
+    }
+    with patch(_PATCH_GET, new=AsyncMock(return_value=wire)):
+        with pytest.raises(ValidationError) as exc:
+            await sites_service.list_site_data_tables(
+                workspace_id="ws1", user_id="u1", pocket_id="pk1"
+            )
+    assert exc.value.code == "sites.not_dynamic"
+
+
+# --------------------------------------------------------------------------- #
+# static svelte site — no bindings → not dynamic
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_static_svelte_not_dynamic(monkeypatch):
+    """A STATIC svelte pocket (engine="svelte", only files on ``source``, no
+    bindings, pattern="landing") has no data store → not_dynamic / no tables."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    wire = {
+        "name": "Bakery landing",
+        "pattern": "landing",
+        "engine": "svelte",
+        "source": {
+            "src/routes/+page.svelte": "<h1>Fresh bread</h1>",
+            "src/routes/+layout.svelte": "<slot />",
+        },
+    }
+    with patch(_PATCH_GET, new=AsyncMock(return_value=wire)):
+        with pytest.raises(ValidationError) as exc:
+            await sites_service.list_site_data_tables(
+                workspace_id="ws1", user_id="u1", pocket_id="pk1"
+            )
+    assert exc.value.code == "sites.not_dynamic"
+
+
+@pytest.mark.asyncio
+async def test_svelte_rippleSpec_bindings_do_not_make_dynamic(monkeypatch):
+    """A svelte pocket whose bindings were (wrongly) put on ``rippleSpec`` instead
+    of ``source`` is NOT dynamic for the svelte engine — the engine reads ONLY the
+    ``source`` envelope, so stale rippleSpec bindings are ignored (not_dynamic)."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    wire = {
+        "name": "Svelte w/ rippleSpec bindings",
+        "engine": "svelte",
+        # bindings on the WRONG envelope for svelte → ignored
+        "rippleSpec": {
+            "objects": [{"name": "stray", "fields": {"id": "text"}, "primaryKey": "id"}],
+            "sources": [{"name": "x", "kind": "data", "object": "stray"}],
+        },
+        "source": {"src/routes/+page.svelte": "<h1>Hi</h1>"},  # no bindings here
+    }
+    with patch(_PATCH_GET, new=AsyncMock(return_value=wire)):
+        with pytest.raises(ValidationError) as exc:
+            await sites_service.list_site_data_tables(
+                workspace_id="ws1", user_id="u1", pocket_id="pk1"
+            )
+    assert exc.value.code == "sites.not_dynamic"


### PR DESCRIPTION
Makes the control-plane D1 read (DS-3) work for dynamic SVELTE sites. DS-3 read `objects` from the rippleSpec; a dynamic svelte pocket carries its bindings as sibling keys on its `source` content envelope (so they ride the versioned content — version_content = source for svelte). One resolver (`_dynamic_pocket_objects`, used by both data-read endpoints) now picks the envelope by engine (`source` for svelte, `rippleSpec` for ripple), mirroring the existing publish/promote switch. Ripple is the default branch — byte-unchanged.

## Tested
`tests/ee/sites/test_data_read_svelte.py` (8): svelte dynamic lists tables from source envelope + classified dynamic + reads rows; ripple unchanged; engine ignores the other envelope; static not dynamic. tests/ee/sites/ 252 passed; ruff clean.

## Prerequisite for the write side (flagged, not in this PR)
`Pocket.source` is typed `dict[str, str]`; persisting `objects` (a list) as a sibling needs it loosened to `dict[str, Any]` — that lands with DSV-5 (the create-svelte dynamic brain). This is read-side groundwork; dormant + harmless until a svelte pocket carries bindings. Standalone (not stacked).