### PR TITLE
Dynamic svelte sites — write-side contract + create-svelte authoring brain (DSV-5)

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,19 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated: 2026-06-21 (DSV-5 — dynamic svelte sites write-side) — create_svelte_site
+# now accepts a DYNAMIC svelte site. The ``source`` envelope may carry live-data
+# bindings (``objects``/``sources``/``actions``/``auth``) as SIBLING keys on the
+# {path: contents} file map: the per-value string check now EXEMPTS those binding
+# keys (their values are lists/bools), the JSON schema's ``source`` is loosened to
+# ``additionalProperties: true``, and the handler stamps ``pattern="dynamic"`` when
+# any binding is present (else ``pattern="landing"`` for a static marketing site —
+# unchanged). The generator (generator_client._split_svelte_source) peels the
+# bindings out of ``source`` at publish and passes them as flat siblings on the
+# DSV-1 GenerateInput. Required-file validation is untouched — binding keys never
+# satisfy a §4.3 required FILE key, so they are simply ignored by the missing-keys
+# check.
+#
 # Updated: 2026-06-17 (fix/sites-plan-gate-asymmetry) — both create handlers now
 # call _require_sites_plan_or_error(workspace_id) right after input validation,
 # delegating to the shared sites.service.require_sites_plan gate. Sites is the
@@ -163,14 +176,36 @@ SVELTE_REQUIRED_PREFIXES = (
     "src/lib/components/",  # at least one section component (Hero, ...)
 )
 
+# DSV-5: a DYNAMIC svelte site carries its live-data bindings as SIBLING keys on
+# the same ``source`` envelope that holds the {path: contents} SvelteKit files —
+# ``objects`` (the D1 table defs) / ``sources`` (reads) / ``actions`` (writes) —
+# lists — and ``auth`` — a bool. These are NOT file entries: their values are
+# lists/bools, not content strings, and they are NOT validated against the §4.3
+# required-file set. The generator (generator_client._split_svelte_source) peels
+# them out of ``source`` at publish and passes them as flat siblings on the DSV-1
+# GenerateInput. Their presence is what makes a svelte site dynamic.
+SVELTE_BINDING_KEYS = ("objects", "sources", "actions", "auth")
 
-def _missing_source_keys(source: dict[str, str]) -> list[str]:
+
+def _has_svelte_bindings(source: dict[str, Any]) -> bool:
+    """True when the ``source`` envelope carries any NON-EMPTY live-data binding
+    (DSV-5) — i.e. the svelte site is DYNAMIC.
+
+    A binding key present but empty (``objects: []`` / ``auth: false``) does NOT
+    make the site dynamic — the same emptiness the generator's ``isDynamic``
+    classifier uses (sources/actions non-empty OR auth true). Used to decide the
+    create ``pattern`` (``"dynamic"`` vs ``"landing"``)."""
+    return any(bool(source.get(k)) for k in SVELTE_BINDING_KEYS)
+
+
+def _missing_source_keys(source: dict[str, Any]) -> list[str]:
     """Return the §4.3 required keys absent from ``source`` (empty list = valid).
 
     Checks the exact composition/resting-frame keys plus that at least one
     ``src/lib/components/*.svelte`` section exists. Used to fail the create
     closed with an actionable message rather than persisting a half-authored
-    map the generator can't build into a page."""
+    map the generator can't build into a page. Binding sibling keys (DSV-5)
+    never satisfy a required FILE key, so they are simply ignored here."""
     missing = [k for k in SVELTE_REQUIRED_EXACT_KEYS if k not in source]
     for prefix in SVELTE_REQUIRED_PREFIXES:
         if not any(k.startswith(prefix) for k in source):
@@ -415,11 +450,19 @@ async def _create_svelte_site_handler(args: dict) -> dict:
     """MCP handler for ``sites_manager__create_svelte_site`` (the Svelte track).
 
     Reads workspace/user identity from the per-stream ContextVars, validates the
-    ``source`` map against the §4.3 required keys, and persists it DIRECTLY via
-    ``agent_create`` (engine="svelte", source=<map>, type="site",
-    pattern="landing", ripple_spec=None, trusted=True). Returns
-    ``{ok, pocket_id, pocket}`` on success; sets ``is_error`` when identity is
-    missing, ``source`` is absent/malformed/incomplete, or the persist fails.
+    ``source`` envelope against the §4.3 required keys, and persists it DIRECTLY
+    via ``agent_create`` (engine="svelte", source=<envelope>, type="site",
+    ripple_spec=None, trusted=True). Returns ``{ok, pocket_id, pocket}`` on
+    success; sets ``is_error`` when identity is missing, ``source`` is
+    absent/malformed/incomplete, or the persist fails.
+
+    DSV-5: the ``source`` envelope may carry live-data bindings
+    (``objects``/``sources``/``actions``/``auth``) as SIBLING keys on the file map
+    (their values are lists/bools, exempt from the file-string check). When any is
+    present the pocket is stamped ``pattern="dynamic"`` (a per-tenant D1 site);
+    otherwise ``pattern="landing"`` (a static marketing page, unchanged). The
+    generator peels the bindings out of ``source`` at publish and passes them as
+    flat siblings on the DSV-1 GenerateInput.
 
     Unlike ``create_landing_site`` there is no ``assemble_*`` step — the agent
     authored the SvelteKit components (via the design skills), so the map is
@@ -441,12 +484,19 @@ async def _create_svelte_site_handler(args: dict) -> dict:
             "src/lib/components/*.svelte sections). You write the components; this "
             "tool persists them."
         )
-    # Every value must be a string (file contents) — the map is {path: contents}.
-    bad = [k for k, v in source.items() if not isinstance(v, str)]
+    # Every FILE value must be a string (file contents) — the map is
+    # {path: contents}. DSV-5: the live-data binding siblings
+    # (objects/sources/actions/auth) are NOT files — their values are lists/bools
+    # — so they are excluded from the string check (the generator peels them out of
+    # ``source`` at publish via _split_svelte_source and passes them as flat
+    # GenerateInput siblings).
+    bad = [k for k, v in source.items() if k not in SVELTE_BINDING_KEYS and not isinstance(v, str)]
     if bad:
         return _error_response(
-            "create_svelte_site `source` values must be file-content strings; "
-            f"these keys are not strings: {', '.join(sorted(bad)[:8])}."
+            "create_svelte_site `source` file values must be content strings; "
+            f"these keys are not strings: {', '.join(sorted(bad)[:8])}. (The "
+            "live-data binding keys objects/sources/actions/auth are the only "
+            "non-string siblings allowed on `source`.)"
         )
     missing = _missing_source_keys(source)
     if missing:
@@ -472,11 +522,19 @@ async def _create_svelte_site_handler(args: dict) -> dict:
     color_raw = args.get("color")
     color = color_raw if isinstance(color_raw, str) else ""
 
+    # DSV-5: stamp ``pattern="dynamic"`` when the source envelope carries live-data
+    # bindings (objects/sources/actions/auth), else ``"landing"`` for a static
+    # marketing svelte site. ``pattern="dynamic"`` is what the sites pipeline keys
+    # on to provision the per-tenant D1 + bind it on deploy (it is authoritative in
+    # ``_is_dynamic``), and what the /sites listing + Data tab surface. A static
+    # svelte site keeps ``pattern="landing"`` exactly as before.
+    pattern = "dynamic" if _has_svelte_bindings(source) else "landing"
+
     # Persist DIRECTLY through the pockets service — NO pocket_specialist, NO
     # rippleSpec, NO catalog gate (there is no spec to gate). ``engine="svelte"``
     # + ``source`` stamp the svelte track so the generator materializes the map;
-    # ``type_="site"`` + ``pattern="landing"`` keep the site identity the rest of
-    # the pipeline (publish, refine, /sites listing) keys on. ``trusted=True``
+    # ``type_="site"`` + ``pattern`` keep the site identity the rest of the
+    # pipeline (publish, refine, /sites listing) keys on. ``trusted=True``
     # short-circuits the strict catalog gate, which only runs on a non-null
     # rippleSpec anyway — the svelte path passes ``ripple_spec=None``.
     from pocketpaw_ee.cloud.pockets.service import agent_create
@@ -488,7 +546,7 @@ async def _create_svelte_site_handler(args: dict) -> dict:
             name=name,
             description=description,
             type_="site",
-            pattern="landing",
+            pattern=pattern,
             icon=icon,
             color=color,
             ripple_spec=None,
@@ -534,9 +592,15 @@ def make_create_svelte_site_tool(tool: Any) -> Any:
             "Create a Paw Site landing page on the SVELTE TRACK. You AUTHOR the "
             "SvelteKit components yourself (premium hand-written Svelte via the "
             "design skills — the quality bar is the proven spike) and pass them as "
-            "a `source` MAP { relative_path: file_contents }; the tool persists "
-            "the map and stamps the pocket type='site', pattern='landing', "
-            "engine='svelte'. You do NOT compose a rippleSpec, do NOT call "
+            "a `source` ENVELOPE { relative_path: file_contents }; the tool "
+            "persists the map and stamps the pocket type='site', engine='svelte'. "
+            "A site can be STATIC (marketing → pattern='landing') or DYNAMIC "
+            "(backed by the customer's live data → pattern='dynamic'): for a "
+            "dynamic site, declare the live-data bindings as SIBLING keys on the "
+            "same `source` object — `objects` (D1 tables), `sources` (reads), "
+            "`actions` (writes), `auth` (bool) — and author components that consume "
+            "the generated $lib/paw/ helpers; the tool stamps pattern='dynamic' "
+            "when any binding is present. You do NOT compose a rippleSpec, do NOT call "
             "get_widget_spec, do NOT call pocket_specialist. Required `source` "
             "keys (design spec §4.3): 'src/routes/+page.svelte' (imports + "
             "composes the section components), 'src/routes/+layout.svelte' "
@@ -558,12 +622,24 @@ def make_create_svelte_site_tool(tool: Any) -> Any:
                 "source": {
                     "type": "object",
                     "description": (
-                        "The SvelteKit source map { relative_path: file_contents } "
-                        "you authored — paths relative to the project root, values "
-                        "are the file contents as strings. Must include the §4.3 "
-                        "required files (see the tool description)."
+                        "The SvelteKit source ENVELOPE you authored. Mostly a "
+                        "{ relative_path: file_contents } map — paths relative to "
+                        "the project root, file values are content STRINGS, must "
+                        "include the §4.3 required files (see the tool description). "
+                        "For a DYNAMIC site it ALSO carries the live-data bindings "
+                        "as SIBLING keys on the same object: `objects` (array of D1 "
+                        "table defs {name, fields, primaryKey}), `sources` (array of "
+                        "read bindings {name, kind:'data', object}), `actions` (array "
+                        "of write bindings {name, object, op}), and `auth` (bool). "
+                        "Present bindings → the tool stamps pattern='dynamic' and the "
+                        "published site gets a per-tenant D1; absent → a static "
+                        "pattern='landing' page (unchanged)."
                     ),
-                    "additionalProperties": {"type": "string"},
+                    # File values are strings; the binding siblings
+                    # (objects/sources/actions/auth) are arrays/bools — so the
+                    # envelope allows any value type (DSV-5). The handler enforces
+                    # that every NON-binding key's value is a string.
+                    "additionalProperties": True,
                 },
                 "name": {
                     "type": "string",

--- a/ee/pocketpaw_ee/cloud/models/pocket.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket.py
@@ -47,6 +47,17 @@ leaf domain module) and is imported here. This lets ``pockets.dto`` import the
 same class from ``surface.domain`` instead of from ``models.pocket``, which
 the OSS-EE boundary contract forbids. No schema change — the embedded BSON
 shape is identical, so no Mongo migration.
+Updated: 2026-06-21 (DSV-5 — dynamic svelte sites write-side) — loosened
+``Pocket.source`` from ``dict[str, str] | None`` to ``dict[str, Any] | None``
+so a DYNAMIC svelte site's ``source`` envelope can carry its live-data bindings
+(``objects`` = a list of D1 table defs, ``sources`` / ``actions`` = lists,
+``auth`` = a bool) as SIBLING keys alongside the ``{relative_path:
+file_contents}`` SvelteKit file entries on the SAME dict. Keeping the bindings
+inside ``source`` means they ride the versioned content (``version_content =
+source`` for svelte → draft/publish/revert capture the full dynamic spec), and
+the DSV-2b read resolves ``objects`` off this same envelope. A STATIC svelte
+pocket's ``source`` stays a ``str -> str`` file map — the looser ``Any`` is a
+superset, so no behaviour change and no Mongo migration.
 """
 
 from __future__ import annotations
@@ -141,11 +152,18 @@ class Pocket(TimestampedDocument):
     # the pocket so the generator + any later refine pick the same track.
     # Legacy pockets default to ``"ripple"`` — additive, no migration.
     engine: str = "ripple"
-    # The svelte-track source map: ``{relative_path: file_contents}`` for a
-    # SvelteKit project (e.g. ``"src/routes/+page.svelte"`` → contents). The
-    # svelte analog of ``rippleSpec`` — the generator writes these files onto
-    # the paw-sites skeleton and prerenders. ``None`` for ripple pockets.
-    source: dict[str, str] | None = None
+    # The svelte-track source CONTENT ENVELOPE. Carries the
+    # ``{relative_path: file_contents}`` SvelteKit files (e.g.
+    # ``"src/routes/+page.svelte"`` → contents) the generator writes onto the
+    # paw-sites skeleton and prerenders — the svelte analog of ``rippleSpec``.
+    # For a DYNAMIC svelte site it ALSO carries the live-data bindings as
+    # SIBLING keys on the same dict: ``objects`` (a list of D1 table defs),
+    # ``sources`` / ``actions`` (lists), and ``auth`` (a bool). Hence
+    # ``dict[str, Any]`` (DSV-5): the values are file-content strings for the
+    # path entries and lists/bools for the binding entries. ``None`` for ripple
+    # pockets; a STATIC svelte pocket carries only the str->str file map (a
+    # subset of the looser type — no behaviour change).
+    source: dict[str, Any] | None = None
     # Default "workspace": new pockets are visible to every workspace member.
     # Owner can tighten to "private" (owner-only + explicit shared_with) via
     # the visibility toggle in the pocket UI.

--- a/ee/pocketpaw_ee/cloud/pockets/domain.py
+++ b/ee/pocketpaw_ee/cloud/pockets/domain.py
@@ -30,6 +30,12 @@ typed-rippleSpec transition. ``service._pocket_to_domain`` promotes the stored
 flat dict to a typed ``RippleSpec`` on read (promote-on-read; the Beanie field
 stays ``dict``, no document migration), falling back to the raw value on a
 corrupt/unpromotable spec. Every reader downstream is dual-path.
+Updated: 2026-06-21 (DSV-5 — dynamic svelte sites write-side) — loosened the
+domain ``Pocket.source`` value type from ``dict[str, str]`` to
+``dict[str, Any]`` so a dynamic svelte site's ``source`` envelope can carry its
+live-data bindings (``objects``/``sources``/``actions``/``auth``) as sibling
+keys alongside the str->str SvelteKit file entries, matching the loosened Beanie
+``Pocket.source``. Static svelte pockets keep a str->str map (a subset).
 """
 
 from __future__ import annotations
@@ -133,10 +139,13 @@ class Pocket:
     # Paw Sites generation track: ``"ripple"`` (default) compiles
     # ``ripple_spec``; ``"svelte"`` materializes ``source`` instead.
     engine: str = "ripple"
-    # The svelte-track source map ``{relative_path: file_contents}`` — the
-    # SvelteKit files the generator writes onto the skeleton. ``None`` for
-    # ripple pockets.
-    source: dict[str, str] | None = None
+    # The svelte-track source content envelope. Carries the
+    # ``{relative_path: file_contents}`` SvelteKit files the generator writes
+    # onto the skeleton AND, for a DYNAMIC svelte site, the live-data bindings
+    # (``objects``/``sources``/``actions``/``auth``) as sibling keys on the same
+    # dict — hence ``dict[str, Any]`` (DSV-5). ``None`` for ripple pockets; a
+    # static svelte pocket carries only the str->str file map (a subset).
+    source: dict[str, Any] | None = None
     # Optional per-entity surface-profile override (the JSON-shaped dict that
     # mirrors the surface-domain ``SurfaceProfile``). Consumed by the
     # entity-aware resolve_profile (entity-rooms chunk ①). ``None`` = use the

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -136,6 +136,13 @@ by default a partial ``ripple_spec`` body that omits instance-owned regions
 merge), so a frontend canvas-only PATCH no longer wipes instance data. A caller
 that genuinely wants to clear instance state sends ``reset_state: true`` to
 restore the old wholesale write. Wire-level ``ripple_spec`` stays ``dict | None``.
+Updated: 2026-06-21 (DSV-5 — dynamic svelte sites write-side) — loosened the
+``source`` value type from ``dict[str, str]`` to ``dict[str, Any]`` on
+``CreatePocketRequest`` and ``PocketResponse`` so a dynamic svelte site's
+``source`` envelope can carry its live-data bindings
+(``objects``/``sources``/``actions``/``auth``) as sibling keys alongside the
+str->str SvelteKit file entries. Static svelte pockets keep a str->str map (a
+subset); ripple pockets keep ``source=None``.
 """
 
 from __future__ import annotations
@@ -171,11 +178,13 @@ class CreatePocketRequest(BaseModel):
     # Optional; omitting it persists ``None`` (legacy behaviour).
     pattern: str | None = None
     # Paw Sites generation track (``"ripple"`` default | ``"svelte"``) and,
-    # for svelte sites, the hand-written SvelteKit source map
-    # ``{relative_path: file_contents}``. Omitting them persists the ripple
-    # defaults (``engine="ripple"``, ``source=None``).
+    # for svelte sites, the hand-written SvelteKit source ENVELOPE
+    # ``{relative_path: file_contents}``, which for a DYNAMIC svelte site also
+    # carries the live-data bindings (``objects``/``sources``/``actions``/
+    # ``auth``) as sibling keys — hence ``dict[str, Any]`` (DSV-5). Omitting them
+    # persists the ripple defaults (``engine="ripple"``, ``source=None``).
     engine: str = "ripple"
-    source: dict[str, str] | None = None
+    source: dict[str, Any] | None = None
     # Optional per-entity surface-profile override. Consumed by the
     # entity-aware resolve_profile (entity-rooms chunk ①); None = use the
     # surface-kind default. Reuses the persisted ``PocketSurfaceProfile``
@@ -334,10 +343,13 @@ class PocketResponse(BaseModel):
     # The create-pocket layout pattern (``"landing"`` for marketing
     # sites), or ``None`` for legacy pockets.
     pattern: str | None = None
-    # Paw Sites generation track (``"ripple"`` | ``"svelte"``) and the
-    # svelte source map (or ``None`` for ripple pockets).
+    # Paw Sites generation track (``"ripple"`` | ``"svelte"``) and the svelte
+    # source envelope (or ``None`` for ripple pockets). For a dynamic svelte
+    # site the envelope carries the live-data bindings (``objects``/``sources``/
+    # ``actions``/``auth``) as siblings on the file map — hence
+    # ``dict[str, Any]`` (DSV-5).
     engine: str = "ripple"
-    source: dict[str, str] | None = None
+    source: dict[str, Any] | None = None
     # Optional per-entity surface-profile override. Consumed by the
     # entity-aware resolve_profile (entity-rooms chunk ①); None = use the
     # surface-kind default. Wire alias ``surfaceProfile``.

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -3977,7 +3977,7 @@ async def agent_create(
     color: str = "",
     ripple_spec: dict | None = None,
     engine: str = "ripple",
-    source: dict[str, str] | None = None,
+    source: dict[str, Any] | None = None,
     trusted: bool = False,
 ) -> tuple[dict | None, str | None, str | None]:
     """Insert a brand-new pocket owned by ``owner_id`` in ``workspace_id``.
@@ -3997,14 +3997,18 @@ async def agent_create(
     ``engine`` / ``source`` select the Paw Sites generation track. The
     default ``engine="ripple"`` compiles ``ripple_spec`` into the site;
     ``engine="svelte"`` materializes ``source`` (a hand-written SvelteKit
-    source map ``{relative_path: file_contents}``) instead — the svelte
+    source envelope ``{relative_path: file_contents}``) instead — the svelte
     analog of ``ripple_spec``. The svelte-site create flow
     (``create_svelte_site`` / ``pocketpaw-create-svelte-site``) passes
     ``engine="svelte"`` + ``source=<map>`` with ``ripple_spec=None`` and
     ``trusted=True`` (the source is author-controlled component files, not
-    LLM-drafted ripple JSON, so there is no catalog gate to run). Both keep
-    today's defaults (``engine="ripple"``, ``source=None``) for ripple
-    callers — additive, no Mongo migration.
+    LLM-drafted ripple JSON, so there is no catalog gate to run). For a
+    DYNAMIC svelte site (DSV-5) the ``source`` envelope ALSO carries the
+    live-data bindings (``objects``/``sources``/``actions``/``auth``) as
+    SIBLING keys alongside the file entries — hence ``dict[str, Any]``; they
+    ride the versioned content and the generator extracts them at publish.
+    Both keep today's defaults (``engine="ripple"``, ``source=None``) for
+    ripple callers — additive, no Mongo migration.
 
     ``trusted=True`` skips the STRICT catalog gate — use it ONLY for a
     code-assembled spec the caller fully controls (the deterministic Paw Site

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,22 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-06-21 (DSV-5 — dynamic svelte sites write-side): build() now SPLITS
+# a svelte pocket's ``source`` content envelope before sending it to the generator.
+# A DYNAMIC svelte pocket stores its live-data bindings
+# (``objects``/``sources``/``actions``/``auth``) as SIBLING keys on the same
+# ``source`` dict that holds the ``{path: contents}`` SvelteKit files (the contract
+# DSV-2b's read assumes). The generator's DSV-1 ``GenerateInput`` expects the
+# bindings as FLAT siblings alongside ``source`` (``input.objects`` /
+# ``input.sources`` / ``input.actions`` / ``input.auth`` — what ``parseBindings``
+# reads), NOT nested inside ``source`` (``materializeSource`` writes every
+# ``source`` key to disk as a file, so a binding key mixed in would break the
+# build). ``_split_svelte_source`` peels the binding keys out: the file map goes on
+# ``input.source`` and the bindings spread as flat siblings. A STATIC svelte pocket
+# carries no binding keys, so the split is a no-op and the wire bytes are unchanged.
+# ``build``/``_build_one``'s ``source`` param is widened to ``dict[str, Any]`` to
+# carry the (list/bool) binding values.
+#
 # Updated 2026-06-19 (fix/sites-preview-fresh-build, P0a + P1a — the #1 Paw Sites
 # bug: the editable PREVIEW served STALE anchorless HTML so the hover edit-pill
 # never appeared). ROOT CAUSE: PERF-4 overloaded the ``smoke`` flag — it gated
@@ -152,6 +168,44 @@ _INSTALL_INPUT_FILES = ("package.json", "bun.lock", "bun.lockb", "package-lock.j
 # LIVE publish fail-gates on these; a preview build tolerates them (the live
 # publish still gates + rolls back, so a broken edit can never go live).
 _WORKERD_SSR_MARKERS = ("window is not defined", "document is not defined", "No such module")
+
+# DSV-5: a DYNAMIC svelte pocket stores its live-data bindings as SIBLING keys on
+# the same ``source`` content envelope that carries the ``{path: contents}``
+# SvelteKit files (DSV-2b reads ``objects`` off exactly this envelope, and the
+# publish/promote switch versions the whole ``source`` dict). These are the
+# binding keys the generator's DSV-1 ``GenerateInput`` expects as FLAT siblings
+# alongside ``source`` (not nested inside it): ``objects`` (the D1 table defs),
+# ``sources`` (reads), ``actions`` (writes) — lists — and ``auth`` — a bool.
+_SVELTE_BINDING_KEYS = ("objects", "sources", "actions", "auth")
+
+
+def _split_svelte_source(
+    source: dict[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split a svelte ``source`` content envelope into ``(files, bindings)``
+    (DSV-5).
+
+    A dynamic svelte pocket persists its live-data bindings
+    (``objects``/``sources``/``actions``/``auth``) as SIBLING keys on the SAME
+    dict that holds the ``{relative_path: file_contents}`` SvelteKit files. The
+    generator can't receive them mixed together: ``materializeSource`` writes
+    EVERY ``source`` key to disk as a file (``writeFile(path, contents)`` keyed on
+    the key), so a binding key like ``objects`` (a list value) would be treated as
+    a file path and break the build. DSV-1's ``parseBindings`` instead reads the
+    bindings as FLAT siblings on ``GenerateInput`` (``input.objects`` /
+    ``input.sources`` / ``input.actions`` / ``input.auth``), NOT nested under
+    ``input.source``.
+
+    So this peels the binding keys OUT of the envelope: it returns the file map
+    (everything that is NOT a recognized binding key — written to ``input.source``)
+    and the bindings dict (only the recognized keys that are present — spread as
+    flat siblings on ``GenerateInput``). A STATIC svelte pocket carries no binding
+    keys, so ``bindings`` is empty and ``files`` is the unchanged source map — the
+    pre-DSV-5 wire bytes are preserved exactly."""
+    src = source or {}
+    files = {k: v for k, v in src.items() if k not in _SVELTE_BINDING_KEYS}
+    bindings = {k: src[k] for k in _SVELTE_BINDING_KEYS if k in src}
+    return files, bindings
 
 
 def reap_build_workerd(project_dir: str) -> int:
@@ -446,7 +500,7 @@ class GeneratorClient:
         capture_api_base: str,
         capture_signed_key: str,
         engine: str = "ripple",
-        source: dict[str, str] | None = None,
+        source: dict[str, Any] | None = None,
         builder_origin: str | None = None,
         pocket_id: str | None = None,
         smoke: bool = True,
@@ -462,6 +516,18 @@ class GeneratorClient:
         carries ``rippleSpec`` and OMITS ``source`` (gaining only the
         ``engine: "ripple"`` tag). ``siteConfig`` + ``theme`` are sent on both
         tracks unchanged. Stages 1, 3-8 (install/smoke/...) are track-agnostic.
+
+        DSV-5: a DYNAMIC svelte pocket's ``source`` envelope ALSO carries its
+        live-data bindings (``objects``/``sources``/``actions``/``auth``) as
+        SIBLING keys on the same dict as the files. build() SPLITS the envelope
+        (``_split_svelte_source``) before sending: the file map goes on
+        ``input.source`` and the bindings are spread as FLAT siblings on the
+        generator input (``input.objects`` / ``input.sources`` / ``input.actions``
+        / ``input.auth``) — the exact shape DSV-1's ``parseBindings`` reads, NOT
+        nested under ``source`` (materializeSource would otherwise try to write a
+        binding key as a file and break the build). A STATIC svelte pocket carries
+        no binding keys, so the split is a no-op: ``input.source`` is the unchanged
+        file map and no binding siblings are added (pre-DSV-5 wire bytes).
 
         ``builder_origin`` (SE-2b) makes the site EDITABLE: when set, it rides
         ``siteConfig.builderOrigin`` and the paw-sites generator (SE-1) injects
@@ -536,7 +602,7 @@ class GeneratorClient:
         capture_api_base: str,
         capture_signed_key: str,
         engine: str,
-        source: dict[str, str] | None,
+        source: dict[str, Any] | None,
         builder_origin: str | None,
         pocket_id: str | None,
         smoke: bool,
@@ -569,7 +635,19 @@ class GeneratorClient:
             "siteConfig": site_config,
         }
         if engine == "svelte":
-            input_json["source"] = source or {}
+            # DSV-5: a DYNAMIC svelte pocket carries its live-data bindings
+            # (objects/sources/actions/auth) as SIBLING keys on the same ``source``
+            # envelope that holds the {path: contents} files. Peel them out: the
+            # file map goes on ``input.source`` (materializeSource writes each key
+            # as a file, so a binding key mixed in would break the build), and the
+            # bindings are spread as FLAT siblings on GenerateInput — the exact
+            # shape DSV-1's parseBindings reads (``input.objects`` / ``input.sources``
+            # / ``input.actions`` / ``input.auth``), NOT nested under ``source``. A
+            # STATIC svelte pocket has no binding keys → ``bindings`` is empty and
+            # ``input.source`` is the unchanged file map (pre-DSV-5 wire bytes).
+            files, bindings = _split_svelte_source(source)
+            input_json["source"] = files
+            input_json.update(bindings)
         else:
             input_json["rippleSpec"] = ripple_spec
         gen = await self._runner.generate(input_json, out_dir)

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
@@ -48,6 +48,21 @@ So: **do NOT call `get_widget_spec`. Do NOT draft a `rippleSpec`. Do NOT
 call `pocket_specialist__create`. Do NOT delegate to a subagent.** Author
 the components, assemble the `source` map, and call `create_svelte_site`.
 
+**Two kinds of svelte site — static and dynamic.** Most of this skill builds
+a **STATIC** marketing page (prerendered HTML, no live data). But a svelte
+site can also be **DYNAMIC** — backed by the customer's **own live data** (a
+per-tenant database), with reads AND writes: a guestbook that lists entries
+and lets visitors add one, a public booking list, a submissions board. You
+declare the data layer as bindings on the same `source` envelope and author
+components that read/write it through generated helpers. The full recipe is in
+**[Dynamic svelte sites](#dynamic-svelte-sites--live-data-on-the-svelte-track)**
+below — read it when the user wants live data, not a brochure. Everything up
+to STEP 4 (authoring, the prerender rule, the source map) applies to both;
+the dynamic section layers the data bindings on top. (The ripple track has a
+sibling brain, `pocketpaw-create-dynamic-site`, for the same live-data idea —
+this skill is the svelte-track equivalent; keep the two data-authoring models
+in step.)
+
 ## The quality bar
 
 A landing page **sells**. It reads top to bottom as a conversion funnel:
@@ -206,8 +221,11 @@ Notes that the tool enforces, so get them right:
 ## STEP 3 — Call `create_svelte_site`
 
 Hand the source map to the tool. It persists the pocket stamped
-`type="site"` + `pattern="landing"` + `engine="svelte"` with your map as
-`source` — directly, with no rippleSpec and no specialist.
+`type="site"` + `engine="svelte"` with your map as `source` — directly, with
+no rippleSpec and no specialist. It stamps `pattern="landing"` for a static
+site, or **`pattern="dynamic"` automatically when your `source` carries
+live-data bindings** (`objects`/`sources`/`actions`/`auth` — see the dynamic
+section). You don't pass `pattern`; the tool derives it from the bindings.
 
 ```
 mcp__pocketpaw_sites_manager__create_svelte_site(
@@ -237,6 +255,165 @@ claim a phantom publish. (If a component sets resting state only in
 `onMount`, the smoke build still passes but the baked HTML is wrong — which
 is exactly why the prerender rule above is non-negotiable.)
 
+## Dynamic svelte sites — live data on the svelte track
+
+Everything above builds a **static** page. A **dynamic** svelte site is backed
+by the customer's **own live database** (a per-tenant Cloudflare D1), with
+**reads and writes**. You still author premium Svelte exactly as above — the
+difference is you also **declare a data layer** and **wire components to it**.
+
+### How it works (the contract)
+
+You declare the data layer as **four sibling keys on the same `source`
+envelope** that already holds your `{path: contents}` files:
+
+| key | type | what it is |
+|---|---|---|
+| `objects` | array | the **tables** — each `{ name, fields, primaryKey }` |
+| `sources` | array | the **reads** — each `{ name, kind: "data", object, ... }` |
+| `actions` | array | the **writes** — each `{ name, object, op }` |
+| `auth` | bool | gate the site behind sign-in (omit / `false` = public) |
+
+These live **alongside** your file keys on `source` — not nested, not a
+separate argument. `create_svelte_site` peels them off, stamps the pocket
+`pattern="dynamic"`, and at publish the generator provisions the D1, runs a
+migration from `objects`, compiles read/write **remote functions**, and emits
+typed helpers into the **reserved `src/lib/paw/` namespace** (it owns that
+folder — never author files under `src/lib/paw/` yourself; it's a build error).
+
+The exact binding shapes (they're validated at generate time — a `source`/
+`action` that names an undeclared `object` fails the build):
+
+```jsonc
+// objects[] — a table
+{ "name": "entry",
+  "fields": { "id": "text", "name": "text", "message": "text", "created": "timestamp" },
+  "primaryKey": "id" }
+// field types: "text" | "integer" | "real" | "boolean" | "timestamp"
+
+// sources[] — a read binding
+{ "name": "entries", "kind": "data", "object": "entry",
+  "orderBy": "created desc", "limit": 100,
+  "refresh": "pocket_open" }   // "pocket_open" | "interval" | "manual" | "live"
+
+// actions[] — a write binding
+{ "name": "sign", "object": "entry", "op": "insert" }   // op: "insert" | "update" | "delete"
+```
+
+### Authoring components against the data layer
+
+The generator emits typed helpers your components import from `$lib/paw/`. You
+do **not** write the D1 queries, the migration, or the remote functions — you
+**consume** the generated handles:
+
+- **Read** — `import { useSource } from '$lib/paw/sources';` then
+  `const entries = useSource('entries');` gives a reactive handle with a stable
+  shape: `entries.loading`, `entries.data` (the rows), `entries.error`, and
+  `entries.refresh()`. Use `entries.data` directly in markup
+  (`{#each entries.data as e}`). `useSource` is typed to the EXACT source names
+  you declared — an unknown name is a compile error.
+- **Write** — the simplest, most robust write is a **native form**: each write
+  `action` compiles to a SvelteKit remote `form` you spread onto a `<form>` so
+  the write works progressively (even with JS off) and re-runs the affected
+  source on success. Import the action helper and spread it:
+  `import { useAction } from '$lib/paw/actions';` then
+  `const sign = useAction('sign');` and `<form {...sign}> ... </form>` with
+  plain `name=`d inputs matching the object's non-primary-key fields. (Prefer
+  the spread-onto-`<form>` shape over a detached RPC call — it's the
+  progressively-enhanced path the generator guarantees.)
+
+### The prerender rule still applies — with a twist
+
+A dynamic source's first paint is the **empty/loading** frame at prerender
+time (D1 isn't queried until the client hydrates and `useSource` runs). So:
+**render a graceful resting frame in markup** — an empty-state message, a
+skeleton, or the form on its own — never gate the section's *structure* behind
+`entries.loading`. With JS off, a dynamic section should still show its heading,
+its form, and a "no entries yet" line — the live rows fill in on hydrate.
+
+### Auth (optional)
+
+Set `"auth": true` on the `source` envelope to gate the whole site behind
+sign-in. The generator scaffolds the signup/login/logout flow + sessions and
+guards the data remote functions so reads/writes require a signed-in user. Your
+components consume the generated auth surface from `$lib/paw/` (the same
+reserved namespace). Leave `auth` off (or `false`) for a public site — the
+guestbook below is public.
+
+### Worked example — a public guestbook (1 table, 1 read, 1 write)
+
+A guestbook: visitors see past entries and add their own. One table (`entry`),
+one read source (`entries`), one write action (`sign`), public (no `auth`).
+
+**The bindings (siblings on `source`):**
+
+```jsonc
+{
+  // ... the §4.3 file keys (+page.svelte, +layout.svelte, +page.ts, app.css) ...
+  "src/lib/components/Guestbook.svelte": "<the component below>",
+
+  // ── live-data bindings, siblings on the SAME source object ──
+  "objects": [
+    { "name": "entry",
+      "fields": { "id": "text", "name": "text", "message": "text", "created": "timestamp" },
+      "primaryKey": "id" }
+  ],
+  "sources": [
+    { "name": "entries", "kind": "data", "object": "entry",
+      "orderBy": "created desc", "limit": 100, "refresh": "pocket_open" }
+  ],
+  "actions": [
+    { "name": "sign", "object": "entry", "op": "insert" }
+  ]
+}
+```
+
+**The component (`src/lib/components/Guestbook.svelte`)** — reads via
+`useSource`, writes via the action form, resting frame in markup:
+
+```svelte
+<script>
+  import { useSource } from '$lib/paw/sources';
+  import { useAction } from '$lib/paw/actions';
+
+  const entries = useSource('entries');   // { loading, data, error, refresh }
+  const sign = useAction('sign');         // spread onto <form> below
+</script>
+
+<section class="guestbook" id="guestbook">
+  <h2>Guestbook</h2>
+
+  <!-- WRITE: a native form — works with JS off, re-runs `entries` on success -->
+  <form {...sign} class="gb-form">
+    <input name="name" placeholder="Your name" required />
+    <textarea name="message" placeholder="Say hi" required></textarea>
+    <button type="submit">Sign the guestbook</button>
+  </form>
+
+  <!-- READ: resting frame is in markup; rows fill in on hydrate -->
+  {#if entries.error}
+    <p class="gb-error">Couldn't load entries. Try again.</p>
+  {:else if entries.data && entries.data.length}
+    <ul class="gb-list">
+      {#each entries.data as e}
+        <li><strong>{e.name}</strong><span>{e.message}</span></li>
+      {/each}
+    </ul>
+  {:else}
+    <p class="gb-empty">No entries yet — be the first to sign.</p>
+  {/if}
+</section>
+
+<style>
+  /* real styles via the design skills — omitted here for brevity */
+</style>
+```
+
+Then `+page.svelte` imports and renders `<Guestbook />` like any other section,
+and you call `create_svelte_site(source = <the envelope with bindings>)`. The
+tool sees the bindings, stamps `pattern="dynamic"`, and publish provisions the
+D1 + wires the read/write layer. Done.
+
 ## Quality bar — done right when
 
 1. **You authored real Svelte.** Premium hand-written components via the
@@ -256,9 +433,11 @@ is exactly why the prerender rule above is non-negotiable.)
 ## Related tools (via MCP)
 
 - `mcp__pocketpaw_sites_manager__create_svelte_site` — **the create step.**
-  Pass the `source` map you authored; the tool persists the pocket stamped
-  `type="site"` + `pattern="landing"` + `engine="svelte"`. Returns
-  `{ok, pocket_id, pocket}`.
+  Pass the `source` envelope you authored; the tool persists the pocket stamped
+  `type="site"` + `engine="svelte"`, and `pattern="landing"` (static) or
+  `pattern="dynamic"` (when `source` carries `objects`/`sources`/`actions`/
+  `auth` bindings — see [Dynamic svelte sites](#dynamic-svelte-sites--live-data-on-the-svelte-track)).
+  Returns `{ok, pocket_id, pocket}`.
 - `mcp__pocketpaw_sites_manager__publish` — publish the pocket as a live
   site; show the user the `url`.
 - `mcp__pocketpaw_pocket__list_pockets` — find an existing pocket if the

--- a/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_create_svelte_site.py
@@ -280,3 +280,157 @@ class TestCreateSvelteSiteEndToEnd:
 
         assert out.get("is_error") is True
         assert "src/routes/+page.ts" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# DSV-5 — DYNAMIC svelte site: bindings accepted on source + pattern="dynamic"
+# ---------------------------------------------------------------------------
+
+
+def _dynamic_source() -> dict:
+    """A §4.3-complete svelte source map PLUS the live-data bindings as SIBLING
+    keys on the same envelope (the DSV-5 dynamic contract)."""
+    src = _sample_source()
+    src["objects"] = [
+        {
+            "name": "entry",
+            "fields": {"id": "text", "name": "text", "message": "text"},
+            "primaryKey": "id",
+        }
+    ]
+    src["sources"] = [
+        {"name": "entries", "kind": "data", "object": "entry", "refresh": "pocket_open"}
+    ]
+    src["actions"] = [{"name": "sign", "object": "entry", "op": "insert"}]
+    return src
+
+
+class TestDynamicSvelteBindings:
+    def test_has_svelte_bindings_detects_dynamic(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _has_svelte_bindings
+
+        assert _has_svelte_bindings(_dynamic_source()) is True
+        # Static (no bindings) → not dynamic.
+        assert _has_svelte_bindings(_sample_source()) is False
+        # Present-but-empty bindings → NOT dynamic (mirrors the generator's
+        # isDynamic classifier).
+        assert _has_svelte_bindings({**_sample_source(), "objects": [], "auth": False}) is False
+        # Auth-only is dynamic.
+        assert _has_svelte_bindings({**_sample_source(), "auth": True}) is True
+
+    def test_binding_keys_pinned(self) -> None:
+        """Pin the binding sibling keys so the write contract can't silently drift
+        from the generator's parseBindings / generator_client split."""
+        from pocketpaw_ee.agent.mcp_servers.sites_create import SVELTE_BINDING_KEYS
+
+        assert set(SVELTE_BINDING_KEYS) == {"objects", "sources", "actions", "auth"}
+
+    def test_missing_keys_ignores_binding_siblings(self) -> None:
+        """The §4.3 required-file check is unaffected by binding siblings — a
+        complete file map plus bindings still validates clean."""
+        from pocketpaw_ee.agent.mcp_servers.sites_create import _missing_source_keys
+
+        assert _missing_source_keys(_dynamic_source()) == []
+
+    @pytest.mark.asyncio
+    async def test_persists_dynamic_pocket_with_bindings_and_pattern_dynamic(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """A dynamic source envelope persists with engine=="svelte",
+        pattern=="dynamic", and the FULL envelope (files + binding siblings, with
+        non-string types intact) on ``source`` — ground truth read from Mongo."""
+        from unittest.mock import patch
+
+        from bson import ObjectId
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+        source = _dynamic_source()
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=workspace_id,
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=user_id,
+            ),
+        ):
+            out = await sites_create_mcp._create_svelte_site_handler(
+                {"source": source, "name": "Svelte Guestbook"}
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        assert body["pocket"]["pattern"] == "dynamic"
+
+        doc = await _PocketDoc.get(ObjectId(body["pocket_id"]))
+        assert doc is not None
+        assert doc.engine == "svelte"
+        assert doc.pattern == "dynamic"
+        # The full envelope persisted — files + binding siblings.
+        assert doc.source == source
+        assert isinstance(doc.source["objects"], list)
+        assert doc.source["actions"][0]["op"] == "insert"
+
+    @pytest.mark.asyncio
+    async def test_static_svelte_still_stamps_pattern_landing(
+        self, beanie_test_db, recording_bus
+    ) -> None:
+        """A static svelte source (no bindings) keeps pattern=="landing" — DSV-5
+        does not regress the static path."""
+        from unittest.mock import patch
+
+        from bson import ObjectId
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value=str(ObjectId()),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value=str(ObjectId()),
+            ),
+        ):
+            out = await sites_create_mcp._create_svelte_site_handler(
+                {"source": _sample_source(), "name": "Static Svelte"}
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        doc = await _PocketDoc.get(ObjectId(body["pocket_id"]))
+        assert doc is not None
+        assert doc.pattern == "landing"
+
+    @pytest.mark.asyncio
+    async def test_non_string_file_value_still_rejected(self) -> None:
+        """A non-string value under a key that is NOT a recognized binding key is
+        still rejected (only objects/sources/actions/auth are exempt from the
+        file-string check) — a typo'd component path with a list value fails."""
+        from unittest.mock import patch
+
+        from pocketpaw_ee.agent.mcp_servers import sites_create as sites_create_mcp
+
+        bad = _sample_source()
+        bad["src/lib/components/Bad.svelte"] = ["not", "a", "string"]
+        with (
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+                return_value="ws_1",
+            ),
+            patch(
+                "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+                return_value="u_1",
+            ),
+        ):
+            out = await sites_create_mcp._create_svelte_site_handler({"source": bad})
+
+        assert out.get("is_error") is True
+        assert "src/lib/components/Bad.svelte" in out["content"][0]["text"]

--- a/tests/ee/pockets/test_svelte_source_envelope.py
+++ b/tests/ee/pockets/test_svelte_source_envelope.py
@@ -1,0 +1,139 @@
+# tests/ee/pockets/test_svelte_source_envelope.py
+# Created: 2026-06-21 (feat/dsv-5-svelte-dynamic-brain) — DSV-5 write-side: the
+# loosened ``Pocket.source`` (``dict[str, str]`` -> ``dict[str, Any]``) must
+# persist + read back a DYNAMIC svelte site's ``source`` CONTENT ENVELOPE, which
+# carries the live-data bindings (``objects``/``sources``/``actions``/``auth``) as
+# SIBLING keys alongside the ``{path: contents}`` SvelteKit files on the same dict.
+# DSV-2b's read resolves ``objects`` off exactly this envelope, so the round-trip
+# is the write-side half of that contract.
+#
+# Ground truth: insert a real (mongomock) Beanie ``Pocket`` doc and read it back —
+# proving the binding siblings survive Mongo serialization with their NON-string
+# types intact (objects/sources/actions = lists of dicts, auth = bool). A STATIC
+# svelte pocket (str->str source map) must still round-trip unchanged (the looser
+# ``Any`` is a superset).
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from bson import ObjectId  # noqa: E402
+
+# A dynamic svelte source ENVELOPE: the §4.3 SvelteKit files PLUS the live-data
+# bindings as sibling keys on the same dict (the DSV-5 contract).
+_DYNAMIC_ENVELOPE: dict = {
+    # ── the {path: contents} SvelteKit files (string values) ──
+    "src/routes/+page.svelte": (
+        "<script>import Guestbook from '$lib/components/Guestbook.svelte';</script><Guestbook />"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css';</script>",
+    "src/routes/+page.ts": "export const prerender = true;",
+    "src/app.css": ":root{}",
+    "src/lib/components/Guestbook.svelte": "<section><h2>Guestbook</h2></section>",
+    # ── the live-data bindings, siblings on the SAME envelope (NON-string) ──
+    "objects": [
+        {
+            "name": "entry",
+            "fields": {"id": "text", "name": "text", "message": "text"},
+            "primaryKey": "id",
+        }
+    ],
+    "sources": [{"name": "entries", "kind": "data", "object": "entry", "refresh": "pocket_open"}],
+    "actions": [{"name": "sign", "object": "entry", "op": "insert"}],
+    "auth": True,
+}
+
+# A static svelte source map: only the str->str file entries, no bindings.
+_STATIC_MAP: dict = {
+    "src/routes/+page.svelte": (
+        "<script>import Hero from '$lib/components/Hero.svelte';</script><Hero />"
+    ),
+    "src/routes/+layout.svelte": "<script>import '../app.css';</script>",
+    "src/routes/+page.ts": "export const prerender = true;",
+    "src/app.css": ":root{}",
+    "src/lib/components/Hero.svelte": "<section><h1>hi</h1></section>",
+}
+
+
+@pytest.mark.asyncio
+async def test_dynamic_source_envelope_round_trips(beanie_test_db) -> None:
+    """A dynamic svelte pocket persists its ``source`` envelope — files AND the
+    binding siblings — and reads back BYTE-FOR-BYTE, with the non-string binding
+    types (lists/bool) intact. This is the DSV-5 write-side half of the contract
+    DSV-2b's read assumes."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    doc = Pocket(
+        workspace=str(ObjectId()),
+        name="Svelte Guestbook",
+        owner=str(ObjectId()),
+        type="site",
+        pattern="dynamic",
+        engine="svelte",
+        source=_DYNAMIC_ENVELOPE,
+    )
+    await doc.insert()
+
+    # Ground truth: re-read straight from Mongo (not the in-memory object).
+    read = await Pocket.get(doc.id)
+    assert read is not None
+    assert read.engine == "svelte"
+    assert read.pattern == "dynamic"
+    # The whole envelope survived — files + bindings.
+    assert read.source == _DYNAMIC_ENVELOPE
+    # The binding siblings kept their NON-string types.
+    assert isinstance(read.source["objects"], list)
+    assert read.source["objects"][0]["name"] == "entry"
+    assert isinstance(read.source["sources"], list)
+    assert isinstance(read.source["actions"], list)
+    assert read.source["auth"] is True
+    # A file entry is still a content string.
+    assert isinstance(read.source["src/routes/+page.svelte"], str)
+
+
+@pytest.mark.asyncio
+async def test_static_svelte_source_map_still_round_trips(beanie_test_db) -> None:
+    """A STATIC svelte pocket (str->str source map, no bindings) round-trips
+    unchanged under the loosened ``dict[str, Any]`` type — the looser type is a
+    superset, so the pre-DSV-5 behaviour is preserved exactly."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    doc = Pocket(
+        workspace=str(ObjectId()),
+        name="Static Svelte",
+        owner=str(ObjectId()),
+        type="site",
+        pattern="landing",
+        engine="svelte",
+        source=_STATIC_MAP,
+    )
+    await doc.insert()
+
+    read = await Pocket.get(doc.id)
+    assert read is not None
+    assert read.source == _STATIC_MAP
+    # Every value is still a content string (no bindings present).
+    assert all(isinstance(v, str) for v in read.source.values())
+    assert read.pattern == "landing"
+
+
+@pytest.mark.asyncio
+async def test_model_dump_preserves_binding_envelope(beanie_test_db) -> None:
+    """A JSON model_dump (the wire path the agent view / DTO ride) preserves the
+    binding envelope intact — the loosened type does not coerce or drop the
+    non-string siblings."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket
+
+    doc = Pocket(
+        workspace=str(ObjectId()),
+        name="Svelte Guestbook",
+        owner=str(ObjectId()),
+        type="site",
+        pattern="dynamic",
+        engine="svelte",
+        source=_DYNAMIC_ENVELOPE,
+    )
+    dumped = doc.model_dump(mode="json", by_alias=True)
+    assert dumped["source"] == _DYNAMIC_ENVELOPE
+    assert dumped["source"]["auth"] is True

--- a/tests/ee/sites/test_generator_client_svelte.py
+++ b/tests/ee/sites/test_generator_client_svelte.py
@@ -26,6 +26,18 @@
 # fakes here returned a ripple-shaped result (with ``rippleVersion``) for BOTH
 # tracks, which masked it. This test pins the REAL svelte output shape so the
 # regression can't return.
+#
+# Updated 2026-06-21 (feat/dsv-5-svelte-dynamic-brain): DSV-5 — a DYNAMIC svelte
+# pocket carries its live-data bindings (objects/sources/actions/auth) as SIBLING
+# keys on the same ``source`` envelope as the files. build() must SPLIT the
+# envelope before sending: the file map goes on ``input.source`` and the bindings
+# are spread as FLAT siblings on the GenerateInput (the exact shape DSV-1's
+# parseBindings reads — ``input.objects`` / ``input.sources`` / ``input.actions`` /
+# ``input.auth``, NOT nested inside ``source``). A STATIC svelte pocket has no
+# binding keys, so the split is a no-op and ``input.source`` is the unchanged file
+# map (the existing test_svelte_build_sends_source_not_ripple_spec still asserts
+# ``sent["source"] == _SOURCE_MAP`` byte-for-byte). The added tests pin both the
+# dynamic split and the static no-op.
 
 from __future__ import annotations
 
@@ -220,3 +232,139 @@ async def test_svelte_result_shape_no_ripple_version() -> None:
     assert isinstance(result, BuildResult)
     assert result.project_dir == "/tmp/site_sv"
     assert result.ripple_version is None
+
+
+# --------------------------------------------------------------------------- #
+# DSV-5 — dynamic svelte pocket: bindings split out of source onto GenerateInput
+# --------------------------------------------------------------------------- #
+
+# A DYNAMIC svelte source envelope: the §4.3 files PLUS the live-data bindings as
+# sibling keys on the SAME dict (the DSV-5 storage contract).
+_DYNAMIC_OBJECTS = [
+    {
+        "name": "entry",
+        "fields": {"id": "text", "name": "text", "message": "text"},
+        "primaryKey": "id",
+    }
+]
+_DYNAMIC_SOURCES = [
+    {"name": "entries", "kind": "data", "object": "entry", "refresh": "pocket_open"}
+]
+_DYNAMIC_ACTIONS = [{"name": "sign", "object": "entry", "op": "insert"}]
+_DYNAMIC_ENVELOPE = {
+    **_SOURCE_MAP,
+    "objects": _DYNAMIC_OBJECTS,
+    "sources": _DYNAMIC_SOURCES,
+    "actions": _DYNAMIC_ACTIONS,
+    "auth": True,
+}
+
+
+@pytest.mark.asyncio
+async def test_dynamic_svelte_splits_bindings_onto_generate_input() -> None:
+    """DSV-5: a dynamic svelte pocket's bindings are spread as FLAT siblings on
+    the GenerateInput (the DSV-1 parseBindings shape), and ``input.source`` carries
+    ONLY the {path: contents} files — never the binding keys (materializeSource
+    would otherwise try to write a binding key as a file)."""
+    runner = _CapturingRunner()
+    client = GeneratorClient(_runner=runner)
+    await client.build(
+        engine="svelte",
+        source=_DYNAMIC_ENVELOPE,
+        ripple_spec=None,
+        theme={},
+        site_id="site_dyn",
+        title="Guestbook",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+    )
+    sent = runner.input_json
+    assert sent is not None
+    # The bindings ride as FLAT siblings on the input — exactly what parseBindings
+    # reads (input.objects / input.sources / input.actions / input.auth).
+    assert sent["objects"] == _DYNAMIC_OBJECTS
+    assert sent["sources"] == _DYNAMIC_SOURCES
+    assert sent["actions"] == _DYNAMIC_ACTIONS
+    assert sent["auth"] is True
+    # ``source`` carries ONLY the files — the binding keys are peeled OUT of it.
+    assert sent["source"] == _SOURCE_MAP
+    for k in ("objects", "sources", "actions", "auth"):
+        assert k not in sent["source"]
+    # Still the svelte fork — no rippleSpec.
+    assert sent["engine"] == "svelte"
+    assert "rippleSpec" not in sent
+
+
+@pytest.mark.asyncio
+async def test_static_svelte_passes_no_bindings() -> None:
+    """A STATIC svelte pocket (no binding keys on source) sends NO binding siblings
+    and ``input.source`` is the unchanged file map — the split is a no-op, so the
+    wire bytes match the pre-DSV-5 payload exactly."""
+    runner = _CapturingRunner()
+    client = GeneratorClient(_runner=runner)
+    await client.build(
+        engine="svelte",
+        source=_SOURCE_MAP,
+        ripple_spec=None,
+        theme={},
+        site_id="site_static",
+        title="Tally",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+    )
+    sent = runner.input_json
+    assert sent is not None
+    # No binding siblings added.
+    for k in ("objects", "sources", "actions", "auth"):
+        assert k not in sent
+    # source is the unchanged file map.
+    assert sent["source"] == _SOURCE_MAP
+
+
+@pytest.mark.asyncio
+async def test_partial_bindings_only_present_keys_are_passed() -> None:
+    """A read-only dynamic site (objects + sources, no actions, no auth) passes
+    ONLY the present binding keys — absent keys are not synthesized onto the input
+    (so the generator's parseBindings sees exactly what was authored)."""
+    runner = _CapturingRunner()
+    client = GeneratorClient(_runner=runner)
+    envelope = {**_SOURCE_MAP, "objects": _DYNAMIC_OBJECTS, "sources": _DYNAMIC_SOURCES}
+    await client.build(
+        engine="svelte",
+        source=envelope,
+        ripple_spec=None,
+        theme={},
+        site_id="site_ro",
+        title="Read only",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+    )
+    sent = runner.input_json
+    assert sent is not None
+    assert sent["objects"] == _DYNAMIC_OBJECTS
+    assert sent["sources"] == _DYNAMIC_SOURCES
+    # Not authored → not on the input.
+    assert "actions" not in sent
+    assert "auth" not in sent
+    assert sent["source"] == _SOURCE_MAP
+
+
+def test_split_svelte_source_unit() -> None:
+    """The pure splitter: files vs bindings, with an empty/None envelope handled."""
+    from pocketpaw_ee.sites.generator_client import _split_svelte_source
+
+    files, bindings = _split_svelte_source(_DYNAMIC_ENVELOPE)
+    assert files == _SOURCE_MAP
+    assert bindings == {
+        "objects": _DYNAMIC_OBJECTS,
+        "sources": _DYNAMIC_SOURCES,
+        "actions": _DYNAMIC_ACTIONS,
+        "auth": True,
+    }
+    # Static map → no bindings, files unchanged.
+    f2, b2 = _split_svelte_source(_SOURCE_MAP)
+    assert f2 == _SOURCE_MAP
+    assert b2 == {}
+    # None → empty, empty.
+    f3, b3 = _split_svelte_source(None)
+    assert f3 == {} and b3 == {}


### PR DESCRIPTION
The pocketpaw write side that makes dynamic svelte sites real: persist the bindings, wire them into the generator, teach the brain.

## What changed
- **Pocket.source loosened** `dict[str,str]` → `dict[str,Any]` (5 spots: model, domain, 2 DTOs, agent_create), so a svelte pocket's source envelope can carry `objects/sources/actions/auth` as siblings next to the file map — keeping bindings INSIDE the versioned content (version_content = source for svelte → draft/publish/revert capture the full spec). No re-narrow on the wire (verified by a real Beanie round-trip with non-string values).
- **generator_client wires the bindings**: `_split_svelte_source` peels the binding keys out of `source` and passes them as FLAT siblings on the GenerateInput — matching DSV-1's `parseBindings({objects,sources,actions,auth})` exactly (verified against the paw-sites branch). Static svelte → no binding keys → wire bytes unchanged.
- **create-svelte-site skill** teaches dynamic svelte (declare bindings, consume useSource/useAction from $lib/paw/, the auth flow, the prerender rule) with a worked guestbook example; the create_svelte_site MCP tool exempts binding keys from the file check + stamps pattern=dynamic when bindings are present.

## Tested
New test_svelte_source_envelope.py (3) + generator_client_svelte (+4) + create_svelte_site (+7). tests/ee/sites + pockets + sites_mcp 327 passed; broader -k pocket/sites/svelte 618 passed; ruff clean.

To dev (standalone; harmless until the paw-sites DSV chain lands + dist rebuilds — the generator ignores the extra fields until DSV-1).