### PR TITLE
Finish discovery: trigger + on-box categorization + refine + edit-in-review (F1-F4)

### DIFF
--- a/docs/design/szd-finish-build-plan.md
+++ b/docs/design/szd-finish-build-plan.md
@@ -1,0 +1,227 @@
+All anchors confirmed across all four maps (the kb-go category hardcode is at `convo.go:625` exactly as Map C states, with the `"conversation"` filter also at `:766`/`:820`). I have everything I need to write the plan.
+
+---
+
+# Sovereign Zero-Setup Discovery — Finish-Build Plan (FULL polish)
+
+**Worktrees:** pocketpaw integration = `…/pocketPaw/.claude/worktrees/szd2-int` (branch `feat/szd-slice2-discovery`); paw-enterprise UI = `…/paw-enterprise/.claude/worktrees/szd2-ui`. kb-go lives at `…/paw-workspace/kb-go` (separate repo).
+
+**Six gaps → six slices:** F1 trigger (#1), F2 categorization (#3), F3 refine (#5), F4 edit-in-review (#4), F5 real-connector E2E (#6), **F6 live rule enforcement (#2 — captain-review gate)**.
+
+---
+
+## 1 · VERTICAL SLICES (dependency-ordered)
+
+### F1 — Discovery TRIGGER endpoint + UI button (gap #1)
+**Repo:** pocketpaw (backend) + paw-enterprise (frontend). **Worktree:** `szd2-int` + `szd2-ui`.
+**Depends on:** nothing — orchestrator (`run_discovery_and_propose`) and proposal staging already ship. Build first; everything else is testable through it.
+
+**Backend — create 4-file entity** `ee/pocketpaw_ee/cloud/discovery/{router.py, service.py, dto.py, domain.py}` (cloud 4-file rule):
+- `router.py` — `POST /cloud/discovery/run`, prefix `/cloud/discovery`, `dependencies=[Depends(require_license)]`, route-gated `Depends(require_action_any_workspace("connector.execute"))`. Resolve workspace from `current_workspace_id` (`_core/deps.py:50`, re-exported `shared.deps`), user from `current_user_id` — **no `{workspace_id}` path param** (the UI auto-threads `X-Workspace-Id`, `api.ts:141`). Mirror `connectors/router.py:87-108`.
+- `service.py` — `run(workspace_id, user_id, body)`: `connectors_service.list_connectors(workspace_id, user_id=user_id)` → `connector_ids = [r.name for r in rows if r.enabled]`; build `DiscoveryRunOptions(sample_cap=body.sample_cap or DEFAULT_SAMPLE_CAP)`; fire `run_discovery_and_propose(workspace_id, user_id, connector_ids, opts)` (signature `orchestrate.py:420`) via **`asyncio.create_task`** (mirror `chat/router.py:762`); return `202` with `run_id` immediately. **Do not** thread `digester_kind` — `DiscoveryRunOptions` (`run.py:74-93`) has no such field; structured-vs-unstructured is chosen inside `DiscoveryRun`. v1 lets the run default.
+- `dto.py` — `DiscoveryRunRequest{sample_cap: int|None, connector_ids: list[str]|None}` + `DiscoveryRunResponse{run_id, fabric_objects_action_id, pocket_action_id, instinct_action_ids, materialised_types, skipped_types}` (mirrors `DiscoveryProposalResult`, `orchestrate.py:112-137`).
+- **Mount:** `ee/pocketpaw_ee/cloud/__init__.py` — `app.include_router(discovery_router, prefix="/api/v1")` alongside the connectors/jobs includes (`__init__.py:225,244`).
+
+**Frontend** — `paw-enterprise/src/lib/core/workspaces/connectors-api.ts` (or new `core/discovery/api.ts`): add `runWorkspaceDiscovery(body)` → `api.post<DiscoveryRunResult>('/cloud/discovery/run', body)` (chokepoint `api.ts:345`; never `runtime/api.ts`, that proxies OSS `instinct/actions`). In `ApprovalsPanel.svelte`: add `runDiscovery()` handler + `discovering = $state(false)`; place a Compass button in the list header (`:660-677`) and the empty-state CTA (`:692`, "No pending actions"). On success, reload via `listPendingActions()` (the onMount call, `:79-81`); proposals flow into the existing `discoveryActions` `$derived` (`:131`) → existing run group → `DiscoveryReviewCard` (zero new rendering).
+
+**Contract:** `POST /api/v1/cloud/discovery/run {sample_cap?} → 202 {run_id, …action_ids}`. Proposals surface as pending Instinct Actions the ApprovalsPanel already reads — no extra surfacing.
+**Tests:** (be) `test_run_enumerates_enabled_connectors_only` (disabled connectors excluded); `test_run_returns_202_with_run_id`; `test_run_requires_connector_execute_action` (403 without perm); `test_run_resolves_workspace_from_active_not_path`. (fe) smoke: button disabled while `discovering`; success path calls `listPendingActions`. Preview e2e: click "Discover my workspace" on empty state → spinner → list reload.
+
+---
+
+### F2 — Unstructured CATEGORIZATION via on-box model (gap #3)
+**Repo:** kb-go (optional, see below) + pocketpaw (digester). **Worktree:** `szd2-int`. **Depends on:** F3's `_refine.py` client helper for the model call (build F3's helper first, or co-build — see Order). Mergeable independently of F1.
+
+**Root cause (confirmed):** `kb convo ingest` hardcodes `Categories: []string{"conversation"}` (`kb-go/convo.go:625`), so `_partition_by_category` (`kb_compile.py:192`) sees one bucket → objects-only draft. The deterministic path *cannot* infer `SupportTicket` vs `RefundRequest` — that's a semantic judgment.
+
+**Fix — route unstructured exhaust through kb agent-mode `prepare → on-box-model → accept`** in `KbCompileDigester._compile_blobs` (`kb_compile.py:284`), keeping `kb convo ingest` as the **no-model fallback** (graceful degrade to today's behavior):
+1. Write blobs to `<tmp>/<label>.txt` (already done).
+2. `kb prepare <tmpdir> --pattern "*.txt" --scope "workspace:<wid>:discovery" --json` → `{items:[{source,hash,raw_id,prompt}]}`. Keyless, no network (`kb.go:1956`).
+3. For each `item.prompt`: send to the **on-box model** (F3's `resolve_llm_client(settings, force_provider="ollama")` → `create_openai_client()` → `chat.completions.create(response_format={"type":"json_object"})`). Parse → article JSON carrying `"categories":["broad","topics"]` (the prepare prompt asks for this, `kb.go:1342`).
+4. `echo '<json>' | kb accept --scope … --json` → writes `WikiArticle` with model-supplied `Categories` (`kb.go:2178`). Keyless.
+5. Unchanged read-back: `kb list/show --scope … --json` (`kb_compile.py:315-352`) — now yields real categories → `_partition_by_category` produces keyed/typed object types.
+
+**Sovereignty tripwire (extend existing):** the digester already forbids `kb ingest`/`kb build` (`kb_compile.py:25-26,76-77` — those POST raw text to Anthropic, `kb.go:1348`). The new model call **must** resolve through `force_provider="ollama"` only. kb-go itself needs **no change** for this slice (prepare/accept already exist); the `convo.go:625` hardcode stays as the fallback path's behavior.
+
+**Contract:** when an on-box model is configured, unstructured exhaust yields domain-categorized object types; when not, falls back to today's `conversation`-bucket behavior with no error.
+**Tests:** `test_compile_uses_prepare_accept_when_model_configured` (stub Ollama client returns 2 categories → assert 2 typed buckets from `_partition_by_category`); `test_compile_falls_back_to_convo_ingest_without_model`; `test_compile_never_calls_kb_ingest_or_build` (the tripwire — assert subprocess never invoked with `ingest`/`build`); `test_prepare_accept_use_discovery_scope`. Run kb commands against a real `~/.knowledge-base` in CI temp HOME.
+
+---
+
+### F3 — On-box REFINE pass (gap #5, un-stub `opts.refine`)
+**Repo:** pocketpaw. **Worktree:** `szd2-int`. **Depends on:** nothing structural; **co-requisite with F2** (both need the `_refine.py` Ollama client helper — build the helper here, F2 imports it).
+
+`run.py:218-227` currently raises `NotImplementedError` on `opts.refine`. Wire it:
+1. **New `ee/pocketpaw_ee/discovery/_refine.py`** — `resolve_llm_client(settings, force_provider="ollama")` (`client.py:152`) + `create_openai_client(timeout=120.0)` (`client.py:98`). **Hard-pin local** — never read `settings.llm_provider` directly (an `auto` resolve with a cloud key would pick Anthropic and leak raw tenant text). `force_provider="ollama"` is the sovereignty enforcement point.
+2. **Refine the deterministic draft, not raw text.** Run `digest()` first; send the model the *draft* (type names, property names, sample summaries from already-compiled articles) and ask it to clean/merge/rename types + drop spurious links. Minimizes raw-text exposure; deterministic draft is the floor.
+3. **Fail closed on sovereignty, soft on availability.** If Ollama can't connect (`ollama serve` down, formatted at `providers/ollama.py:91`), **return the deterministic draft** with `draft.meta["refine"]="unavailable"` — never raise, never fall back to cloud. Mirror the templated-fallback shape of `decisions/explain/extractor.py:193-213`, but the fallback is "the deterministic draft."
+4. Replace the `NotImplementedError` block (`run.py:218-222`) with a call into `_refine.refine_draft(draft, settings)`.
+
+**Contract:** `opts.refine=True` returns a cleaned draft when Ollama is up; returns the un-refined deterministic draft (never an error, never a cloud call) when down.
+**Tests (sovereignty as mechanical assertion):** `test_refine_resolves_ollama_only` (assert `llm.api_key is None`, `llm.is_ollama is True`); `test_refine_with_cloud_key_set_still_routes_ollama` (set a fake cloud key → assert `force_provider="ollama"` still used, no Anthropic client built); `test_refine_unavailable_returns_deterministic_draft` (Ollama down → draft returned, `meta["refine"]=="unavailable"`, no raise); `test_refine_never_posts_raw_text_to_cloud`.
+
+---
+
+### F4 — EDIT-in-review (blob-mutate, gap #4)
+**Repo:** pocketpaw (backend) + paw-enterprise (frontend). **Worktree:** `szd2-int` + `szd2-ui`. **Depends on:** F1 (need proposals on screen to edit). Independent of F2/F3/F6.
+
+**Backend — new `PATCH /instinct/actions/{action_id}/proposal`** in `ee/pocketpaw_ee/instinct/router.py` (mutate editable blob sub-fields of a **PENDING** action; does **not** flip status — Approve stays a separate click). Handler:
+1. **Load + status guard.** `before = await store.get_action(action_id)` (`store.py:724`); 404 if missing; **409** if `before.status != PENDING`.
+2. **Tenancy gate first (security chokepoint).** Run the same three asserts approve uses, against the *current* blob, before any mutation: `_assert_fabric_objects_workspace` / `_assert_pocket_create_workspace` / `_assert_instinct_rule_workspace` (`router.py:568,611,654`).
+3. **Resolve the one editable sub-field** via `_*_blob(before)` (`router.py:550,592,635`); 422 if payload kind ≠ blob kind.
+4. **Immutability pin (core new logic).** Copy `before`'s blob, overwrite **only** the editable sub-key, force immutable fields back from `before`:
+   - `_instinct_rule`: pin top-level `workspace_id`/`user_id`/`schema`/`kind`/`correlation_id`/`proposed_event_id`/`summary`. **Also pin `rule_spec.scope.workspace_id`** — the *second* tenancy copy the executor scopes by (`instinct_rule_proposals/executor.py`). Mismatch → 403.
+   - `_pocket_create`: pin top-level `workspace_id`/`user_id`/`schema`; run incoming `pocket_spec` through `_normalize_pocket_spec` (`pocket_proposals/propose.py:197`) to strip sneaked `workspace`/`owner`.
+   - `_fabric_objects`: pin top-level `workspace_id`/`schema`; replace only `object_types`/`objects`/`links`.
+5. **Re-validate per blob (422, never persist broken):** `_instinct_rule` → `RuleDraft.model_validate(rule_spec)` (`rule_models.py:49` — parses CEL `when`); `_pocket_create` → `CreatePocketRequest.model_validate(pocket_spec)`; `_fabric_objects` → shape-check each item (`fabric_proposals/propose.py:32-39`).
+6. **Persist** via thin `store.update_parameters(action_id, params)` (or reuse `_persist_edits` with `edited={"parameters"}`).
+7. **Learning loop:** `compute_patches(before, after)` (`correction.py:52`) → build `Correction` → `await store.record_correction(...)` (`store.py:1189`) → `_emit_human_corrected(blob=new_blob, action=after, disposition="edited", …)` (`chain_emitters.py:141`). Lands `agent.proposed → human.corrected(edited)` *without* `decision.completed` (chain stays open for the eventual approve). Return `{action, correction}`.
+
+**Frontend** — `runtime/api.ts`: add `editProposal(actionId, edits)` → `runtime<ApproveResponse>('instinct/actions/${id}/proposal', {method:'PATCH', …})` (reuse `ApproveResponse`, `api.ts:194`). `DiscoveryReviewCard.svelte`: add `onEdit?` prop + `editing = $state(false)`; make highest-value fields inline-editable behind a pencil — rule `when` (`:220`, `<code>`→`<input>`), rule `name` (`:209`), `action` (badge→`<select>` over require_approval/notify/block), fabric type-name chips (`:146`), drop-link `X` on `.drc-link-row` (`:178`), pocket name (`:196`). Keep a11y intact (real `<input>`/`<select>` + labels, no `svelte-ignore`). On Save, assemble only the touched sub-shape, call `onEdit`, replace the action with the server-returned fresh one (re-renders via `$derived` props). 422 → inline field error; 403 → non-recoverable toast. **Save does not approve.**
+
+**Contract:** edit mutates blob, re-validates, captures `edited` correction, never flips status, never lets a client overwrite either tenancy copy.
+**Tests:** `test_patch_pins_workspace_id_top_level` (client sends foreign `workspace_id` → pinned back, 403/ignored); `test_patch_pins_rule_scope_workspace_id` (the **second** tenancy copy — the security crux); `test_patch_rejects_non_pending_409`; `test_patch_bad_cel_returns_422_not_persisted`; `test_patch_emits_human_corrected_edited_without_completed`; `test_patch_kind_mismatch_422`. (fe) preview e2e: edit a rule `when`, Save, card re-renders with validated value, Approve still required.
+
+---
+
+### F5 — Real-connector live E2E (gap #6) — see §5 for the full spec.
+**Repo:** pocketpaw. **Worktree:** `szd2-int`. **Depends on:** F1+F2+F3 merged (it drives the trigger end-to-end). Build last.
+
+---
+
+## 2 · F6 ENFORCEMENT DESIGN (for captain review)
+
+> **This is the high-stakes slice. Read before it ships.** It wires *approved workspace-discovered* Instinct rules into the **live action gate**. Default OFF, fully backward-compatible, fail-safe on every CEL error. Repo: **pocketpaw**, worktree `szd2-int`. Depends on F1 (needs discovered rules to exist), but the enforcement code itself is independent — it can be the **last** thing merged so the captain reviews it in isolation.
+
+### Core principle — merge discovered rules as extra `InstinctRule`s *inside* the composer call, flag-gated, fail-open per rule
+The discovered `Rule.action` and template `InstinctRule.action` share the **identical** `Literal["require_approval","notify","block"]` vocabulary, and both `when` are CEL strings. `RuleResponse.when/action` (`rules/dto.py:64-65`) is byte-compatible with `InstinctRule`. So the safest merge converts each active discovered rule into an `InstinctRule` and rides the **exact same** 5-step evaluation, precedence, audit, and triage machinery that already ships. **No new verdict path, no new outcome mapping, no triage change.**
+
+### WHERE — `gate_action` in `instinct_dispatch.py`, before `resolve_instinct` (`:342`)
+This is the single impure entry point for *every* dispatch flow (executor gate 1.5, temporal dispatcher, bulk fan-out), it already has `workspace_id` in scope, and it's the designated impure layer. The composer (`instinct_composer.py`) is import-linter-pure (`:58`) and **must stay that way** — `get_active_rules` is a Beanie read, so the fetch cannot live there. **Do not** wire this in `action_executor`.
+
+```python
+# instinct_dispatch.py, inside gate_action, just before resolve_instinct (~:341)
+effective_template = template
+if get_settings().instinct_enforce_discovered_rules:        # NEW flag, default False
+    discovered = await _load_discovered_instinct_rules(
+        workspace_id, pocket_id, action_name, row_context, workspace_context,
+    )
+    if discovered:
+        effective_template = _merge_discovered_rules(template, discovered)
+decision = resolve_instinct(effective_template, action_name, row_context, ...)   # unchanged call
+```
+
+`_merge_discovered_rules` returns `template.model_copy(deep=False)` with a **copied** `InstinctRulesDef` whose `rules = list(discovered) + list(template.instinct_rules.rules)`. Discovered rules go **first** so a discovered `block` wins step-1's first-match short-circuit; for `require_approval`/`notify` order is immaterial. **The template object is never mutated** — 100% backward-compat for any other reader.
+
+### HOW the vocabulary maps to gate outcomes (for free — identical literals)
+| discovered `action` | composer step | verdict | live gate outcome |
+|---|---|---|---|
+| `block` | step 1 (`:256`) | `BLOCK` | `instinct_blocked` — action aborted (`action_executor.py:904`) |
+| `require_approval` | step 2 (`:274`) | `ESCALATE_APPROVAL` | routes to `_route_escalation` → 4-lane triage → human-pending (or AUTO/OPTIMISTIC/DRY_RUN if workspace opted into TRIAGE) |
+| `notify` | step 5 (`:287`) | unchanged + `notify_rules` | rides existing notify side-effect path |
+
+A discovered `require_approval` produces the same `ESCALATE_APPROVAL` an operator-overlay rule does → flows through the unchanged 4-lane triage. A discovered `block` produces `BLOCK`, which triage rule 1 (`instinct_triage.py:151`) already treats as a non-overridable floor. **Zero new outcome wiring.**
+
+### Scoping — bound the rule set to this action
+`get_active_rules(workspace_id)` (`rules/service.py:119`) returns all active workspace rules. In `_load_discovered_instinct_rules`, **filter before conversion**: keep a rule only if `scope.pocket_id` is null (workspace-wide) **or** matches the current `pocket_id`. Keeps another pocket's rule from firing here. (`object_type` scoping is a later refinement.)
+
+### THE FEATURE FLAG (off by default — backward-compat proof)
+Add to `Settings` (`config.py`, alongside the instinct block at `:1343-1377`):
+```python
+instinct_enforce_discovered_rules: bool = Field(
+    default=False,
+    description="When true, approved workspace-discovered Instinct rules "
+        "(rules.service.get_active_rules) are merged with template rules at the "
+        "live gate. Off by default — template-rule path unchanged. "
+        "Env: POCKETPAW_INSTINCT_ENFORCE_DISCOVERED_RULES.",
+)
+```
+**Proof:** when `False`, `gate_action` never calls `get_active_rules`, `effective_template is template`, and `resolve_instinct` gets byte-identical args — the entire discovered branch is dead code on the default path. This is a **separate, narrower** flag than `instinct_approval_level`: enforcing *which CEL conditions fire* and activating *whether escalations can auto-resolve* are independent risk axes and must toggle independently. A workspace can enforce discovered rules while the triager stays dormant (every discovered `require_approval` still goes to a human).
+
+### FAIL-SAFE — never block silently (the security-critical part)
+Two failure points, two safe behaviors:
+
+1. **`get_active_rules` read fails** (DB hiccup, bad workspace id): wrap in `try/except`, log WARNING, treat as **empty set** → fall through to the pure template path. Fail-**open** on the discovered layer — a store outage can never block/escalate an action the template alone would allow. Mirrors `resolve_workspace_approval_level`'s read-failure stance (`service.py:1296`).
+
+2. **A discovered rule's CEL errors** — the dangerous one. Today `_eval_rule` (`instinct_composer.py:387`) re-raises eval failure as `InstinctResolutionError`, which `gate_action` maps to `NotFound` → the action **404s** (`:350-357`). For *template* rules that loud-fail is intentional (author bug). For *discovered* rules it's a silent denial-of-service — exactly the "must fail-safe, never block silently" hazard.
+   **Fix — guarded probe in `_load_discovered_instinct_rules`, no composer change:**
+   - **Parse failure** at `InstinctRule.model_validate({"when":…, "action":…})`: drop that one rule, log WARNING, keep the rest.
+   - **Eval failure:** before merging, run each converted rule through a guarded `evaluate_cel(rule.when, merged_context, resolver, now)` probe; on `CelEvaluationError`, **drop that rule only** (log WARNING with workspace/rule id), merge only the clean ones. The composer's own eval is then a safe re-run.
+   - Net: the discovered layer is **fail-open per rule** — a broken discovered rule is inert, never a block, never a 404. Asymmetry with template rules (which keep loud-fail) is correct: template rules are authored/version-controlled; discovered rules are inferred, lower-trust. A discovered rule can only ever *add* a block/escalate, never relax the template floor.
+
+### One edge flagged for the captain
+The guarded probe evaluates each surviving discovered rule **twice** (probe + composer). Negligible for a handful of pure-CEL rules (no I/O). If counts grow, the fast-follow is a `strict: bool` param on `resolve_instinct`/`_eval_rule` that swallows `CelEvaluationError → False` for the discovered subset — but that touches the import-pure composer signature and needs its own test pass. **Recommendation: ship the guarded-probe first (composer untouched = stronger backward-compat); `strict` is a profiling-gated fast-follow.**
+
+### Files (all in `szd2-int`)
+`ee/pocketpaw_ee/cloud/pockets/instinct_dispatch.py` (inject in `gate_action:282`, before `resolve_instinct:342`; verdict branch `:359-389`; `NotFound` map `:350-357`); `src/pocketpaw/bundled_templates/instinct_composer.py` (`resolve_instinct:181`, `_eval_rule:367`, `evaluate_cel:387`, purity `:58`); `src/pocketpaw/bundled_templates/schema.py` (`InstinctRule`/`InstinctRulesDef`); `ee/pocketpaw_ee/cloud/rules/service.py` (`get_active_rules:119`); `ee/pocketpaw_ee/cloud/rules/dto.py` (`RuleResponse.when/action:64-65`, `scope:67`); `ee/pocketpaw_ee/cloud/pockets/instinct_triage.py` (BLOCK floor `:151` — read-only); `src/pocketpaw/config.py` (new flag near `:1350`).
+
+### Test plan (proves change-for-matching, inertness, fail-safe)
+All in `tests/cloud/` (`uv sync --dev --group ee`), targeting `gate_action` with stubbed `get_active_rules` + real `resolve_instinct`:
+- **Backward-compat (iron law):** `test_flag_off_does_not_call_get_active_rules` (patch it to raise; default flag → never called, byte-identical verdict).
+- **Behavior change:** `test_discovered_block_rule_blocks_matching_action`; `test_discovered_require_approval_escalates`; `test_discovered_notify_rule_rides_proceed`.
+- **Inertness:** `test_discovered_rule_inert_when_when_false`; `test_discovered_rule_scoped_to_other_pocket_is_inert`.
+- **Precedence:** `test_discovered_block_beats_template_execute`.
+- **Fail-safe (security-critical):** `test_get_active_rules_read_failure_falls_through_to_template` (raise → proceed, WARNING, no 404); `test_discovered_rule_cel_eval_error_is_dropped_not_blocking` (missing identifier → dropped, NOT blocked, NOT 404 — the "never block silently" proof); `test_discovered_rule_parse_failure_dropped_others_survive`.
+- **Triage compose:** `test_discovered_escalate_flows_through_triage_lanes` (under `approval_level=TRIAGE` + trusted pocket+compensate → reaches AUTO/OPTIMISTIC exactly like a template escalation).
+
+---
+
+## 3 · BUILD ORDER (supervised sequential dispatch)
+
+**pocketpaw implementers run sequentially in ONE worktree** (`isolation:"worktree"` on the main checkout does *not* isolate nested-repo cwd — concurrent pocketpaw committers collide on branch state). **Frontend runs in its own worktree** (`szd2-ui`), can parallel the backend.
+
+```
+ORDER  SLICE                 REPO          WORKTREE        BRANCH (stack on prior)
+─────  ────────────────────  ────────────  ──────────────  ───────────────────────────────
+  1    F1-be trigger         pocketpaw     szd2-int        feat/szd-f1-discovery-trigger
+  2    F3 refine helper      pocketpaw     szd2-int        feat/szd-f3-refine  ← off F1 tip
+  3    F2 categorization     pocketpaw     szd2-int        feat/szd-f2-categorize ← off F3 tip
+  4    F4-be edit-PATCH      pocketpaw     szd2-int        feat/szd-f4-edit ← off F2 tip
+  5    F6 enforcement        pocketpaw     szd2-int        feat/szd-f6-enforce ← off F4 tip ★captain-review
+  6    F5 real-conn E2E      pocketpaw     szd2-int        feat/szd-f5-e2e ← off F6 tip
+─────  ────────────────────  ────────────  ──────────────  ───────────────────────────────
+  ‖    F1-fe button          paw-enterprise szd2-ui        feat/szd-f1-discovery-button   (parallel)
+  ‖    F4-fe edit card       paw-enterprise szd2-ui        feat/szd-f4-edit-card ← off F1-fe tip
+```
+
+**Stacking rationale:** F2 and F3 both touch the discovery package (`_refine.py` ↔ `kb_compile.py`) and F4/F6 touch `instinct/` and `pockets/` — stack each on the prior tip so additive EOF insertions don't cosmetically conflict. Build F3's `_refine.py` helper **before** F2 (F2 imports it). **F6 is its own commit/PR on top of F4** so the captain reviews enforcement in isolation. **F5 last** (it exercises the full merged stack).
+
+**Worktrees:** reuse the existing `szd2-int` (pocketpaw) and `szd2-ui` (paw-enterprise) — both already on the slice-2 discovery branches with the discovery plumbing in place. **No fresh worktrees needed.** Each PR targets `dev`. **Stop at the captain-review gate — never merge.** Stacked-PR base merges use `--rebase`, not `--squash`.
+
+---
+
+## 4 · RISKS (specific to this finish)
+
+| # | Risk | Mitigation |
+|---|---|---|
+| R1 | **F6 enforcement breaks the live gate** — a discovered rule blocks/404s a legit action for *all* workspaces. | Default-OFF flag (dead code on default path); per-rule guarded-CEL probe drops broken rules (fail-open); store-read failure falls through to template; `test_flag_off_does_not_call_get_active_rules` proves byte-identical default behavior. **Captain reviews F6 in isolation before merge.** |
+| R2 | **Sovereignty leak on the on-box model** (F2/F3) — an `auto` LLM resolve with a tenant cloud key POSTs raw tenant text to Anthropic. | Hard-pin `force_provider="ollama"` everywhere (never read `settings.llm_provider`); extend the `kb_compile` tripwire to forbid `kb ingest`/`kb build`; mechanical tests assert `llm.api_key is None`, `is_ollama`, and that a cloud key still routes to Ollama. Refine fails *closed* on sovereignty (returns deterministic draft, never cloud). |
+| R3 | **F4 edit re-validation bypasses tenancy** — client overwrites `_instinct_rule.workspace_id` *or* the second copy `rule_spec.scope.workspace_id` (executor scopes by the latter). | Pin **both** tenancy copies from `before` (mismatch → 403); run tenancy asserts *before* merge; `_normalize_pocket_spec` strips sneaked keys; dedicated tests for each copy. |
+| R4 | **Categorization quality** — the on-box model emits junk/over-broad categories → noisy object types. | Deterministic `convo ingest` stays the floor/fallback (no-model degrades to today's behavior, never worse); refine operates on the *draft* not raw text; edit-in-review (F4) lets a human rename/merge bad types before approve. Real-connector E2E (F5) asserts category sanity on a known fixture. |
+| R5 | **Async trigger (F1) loses the run** — `asyncio.create_task` is fire-and-forget; a crash mid-digest yields no proposals and no error surfaced. | v1 returns `run_id` for optimistic confirm + the orchestrator stages proposals durably as Instinct Actions; log task exceptions. Documented upgrade path to ARQ enqueue (`jobs/service.py:106-114`) if digest latency/durability becomes an issue. |
+| R6 | **kb-go `convo.go:625` fallback still tags `conversation`** — if model path silently disabled, drafts regress to objects-only without a signal. | Log which path was taken (`prepare/accept` vs `convo ingest`) in `_compile_blobs`; F5 asserts the model path produced ≥2 domain categories on the fixture, catching a silent fallback. |
+
+---
+
+## 5 · F5 — Real-connector live E2E: what it MUST exercise and assert (gap #6)
+
+**Repo:** pocketpaw, worktree `szd2-int`, branch stacked on F6. Drive a **real** connector (not a stub) end-to-end through the finished stack.
+
+**Must exercise (full path):**
+1. Bind a real connector to a workspace (e.g. a fixture Gmail/GitHub/CSV connector with seeded, non-sensitive sample data) → enable it.
+2. `POST /cloud/discovery/run` (F1) → `202 {run_id}`. Assert only enabled connectors enumerated.
+3. Discovery samples the connector, runs the **unstructured** digest through `kb prepare → on-box model → kb accept` (F2) and the **refine** pass (F3) on a live Ollama. Assert ≥2 **domain** categories materialize (not just `conversation`) and typed object types appear — proving F2's model path fired, not the fallback.
+4. Proposals stage as pending Instinct Actions; assert `fabric_objects_action_id`/`pocket_action_id`/`instinct_action_ids` populated and visible in `listPendingActions`.
+5. **Edit** one proposal via `PATCH …/proposal` (F4) — tighten a rule `when` or rename a type; assert re-validation passes, an `edited` correction is recorded, status stays PENDING.
+6. **Approve** the edited proposal → executor materializes it (rule active / pocket created / fabric ingested).
+7. With `instinct_enforce_discovered_rules=true` (F6), run a governed action that the approved discovered rule targets → assert the verdict (`block`/`require_approval`) fires through the live gate and outcome (`instinct_blocked`/`instinct_pending`) is correct; flip the flag off → assert the same action proceeds (proves the flag gates real behavior).
+
+**Must assert — sovereignty + no-PII-leak (non-negotiable):**
+- **No-PII-leak / sovereignty:** capture all outbound HTTP during the run; assert **zero** requests to `api.anthropic.com` or any cloud LLM host — every model call hit the local Ollama endpoint only. Assert `kb ingest`/`kb build` subprocesses were **never** invoked (the tripwire). Assert no tenant raw text appears in any cloud-bound payload (there should be none). Assert the on-box client resolved with `api_key is None`.
+- **Tenancy:** the F4 edit cannot cross workspaces — a PATCH with a foreign workspace id is pinned/403'd; the approved rule scopes to the correct workspace only.
+- **Graceful degrade:** repeat the run with Ollama stopped → assert discovery still produces the deterministic draft (objects-only), refine returns `meta["refine"]=="unavailable"`, and **no** cloud fallback occurred — the sovereign floor holds even with the model down.
+- **Idempotence/supersede:** a second `run` supersedes the prior proposals (assert `superseded_action_ids`).
+
+---
+
+**Plan files for implementers (verbatim handoff):** all backend paths under `…/pocketPaw/.claude/worktrees/szd2-int/`; all frontend paths under `…/paw-enterprise/.claude/worktrees/szd2-ui/`. F6 (§2) is the captain-review artifact — ship it as its own PR on top of F4. Never merge; stop at the captain-review gate.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -198,6 +198,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.chat.runs.router import router as runs_router
     from pocketpaw_ee.cloud.connectors.router import router as connectors_router
     from pocketpaw_ee.cloud.cycles.router import router as cycles_router
+    from pocketpaw_ee.cloud.discovery.router import router as discovery_router
     from pocketpaw_ee.cloud.foresight.router import router as foresight_router
     from pocketpaw_ee.cloud.jobs.router import router as jobs_router
     from pocketpaw_ee.cloud.license import get_license_info
@@ -223,6 +224,11 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(chat_router, prefix="/api/v1")
     app.include_router(runs_router, prefix="/api/v1")
     app.include_router(connectors_router, prefix="/api/v1")
+    # Discovery — zero-setup workspace-discovery TRIGGER
+    # (POST /cloud/discovery/run). Workspace-scoped (no path param); fires the
+    # orchestrator in the background and stages proposals as pending Instinct
+    # Actions. Mounted next to connectors since discovery samples them.
+    app.include_router(discovery_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")
     # Pocket chat — agent-driven pocket creation SSE stream (POST /pockets/chat).
     app.include_router(pocket_chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/discovery/__init__.py
+++ b/ee/pocketpaw_ee/cloud/discovery/__init__.py
@@ -1,0 +1,6 @@
+# Discovery — cloud entity package (workspace-discovery TRIGGER).
+# Created: 2026-06-21 (SZD finish slice F1 / feat/szd-finish-core) — the
+#   4-file entity (domain/dto/service/router) that exposes the
+#   workspace-discovery run over HTTP (``POST /cloud/discovery/run``). Before
+#   this slice a discovery run could only be started from a script; the router
+#   makes it reachable so the UI can fire it.

--- a/ee/pocketpaw_ee/cloud/discovery/domain.py
+++ b/ee/pocketpaw_ee/cloud/discovery/domain.py
@@ -1,0 +1,27 @@
+# Discovery — domain value objects (cloud 4-file rule §3).
+# Created: 2026-06-21 (SZD finish slice F1 / feat/szd-finish-core) — a frozen
+#   value object carrying the tenancy + knobs for one workspace-discovery run.
+#   Tenancy (``workspace_id`` / ``user_id``) is required at construction with no
+#   defaults, per the ee/cloud rule §3, so a run request can never be built
+#   without the originating tenant. The service builds this from the validated
+#   request body before handing the run to the orchestrator.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DiscoveryRunCommand:
+    """One workspace-discovery run, fully scoped.
+
+    Constructed in ``service.py`` from the validated ``DiscoveryRunRequest``
+    plus the caller's resolved tenancy. ``connector_ids`` is the FINAL list to
+    sample (already resolved from the request override or the workspace's
+    enabled connectors), and ``sample_cap`` the resolved per-connector cap.
+    """
+
+    workspace_id: str
+    user_id: str
+    connector_ids: tuple[str, ...]
+    sample_cap: int

--- a/ee/pocketpaw_ee/cloud/discovery/dto.py
+++ b/ee/pocketpaw_ee/cloud/discovery/dto.py
@@ -1,0 +1,49 @@
+# Discovery — request/response DTOs (cloud 4-file rule §4).
+# Created: 2026-06-21 (SZD finish slice F1 / feat/szd-finish-core) — the wire
+#   contract for the workspace-discovery TRIGGER endpoint
+#   ``POST /cloud/discovery/run``. ``DiscoveryRunRequest`` is the (optional)
+#   body; ``DiscoveryRunResponse`` mirrors ``DiscoveryProposalResult``
+#   (orchestrate.py) so the same proposal-id shape the orchestrator returns is
+#   surfaced on the wire. Request and response are distinct models per the
+#   ee/cloud rule §4 (never reuse one model for both directions).
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class DiscoveryRunRequest(BaseModel):
+    """Body for ``POST /cloud/discovery/run`` — every field optional.
+
+    * ``sample_cap`` — max records sampled per connector (the "N" in "N of M").
+      ``None`` lets the run default (``DEFAULT_SAMPLE_CAP``).
+    * ``connector_ids`` — explicit override of which bound connectors to sample.
+      ``None`` (the common case) lets the service enumerate the workspace's
+      ENABLED connectors server-side, so the UI never has to gather ids.
+    """
+
+    sample_cap: int | None = None
+    connector_ids: list[str] | None = None
+
+
+class DiscoveryRunResponse(BaseModel):
+    """The trigger's response — the staged-proposal ids for optimistic confirm.
+
+    Mirrors :class:`pocketpaw_ee.discovery.orchestrate.DiscoveryProposalResult`.
+
+    NOTE ON THE ASYNC SHAPE: the orchestrate call is fire-and-forget
+    (``asyncio.create_task``), so when the run is dispatched in the background
+    the action-id fields below are NOT yet known at response time — they are
+    returned EMPTY (``None`` / ``[]``) and the proposals surface separately as
+    pending Instinct Actions that the ApprovalsPanel already polls. ``run_id``
+    is always populated immediately for the optimistic confirmation. The
+    full-id shape is still modelled so a synchronous/awaited caller (tests, a
+    future awaited mode) gets the complete result.
+    """
+
+    run_id: str
+    fabric_objects_action_id: str | None = None
+    pocket_action_id: str | None = None
+    instinct_action_ids: list[str] = Field(default_factory=list)
+    materialised_types: list[str] = Field(default_factory=list)
+    skipped_types: dict[str, str] = Field(default_factory=dict)

--- a/ee/pocketpaw_ee/cloud/discovery/router.py
+++ b/ee/pocketpaw_ee/cloud/discovery/router.py
@@ -1,0 +1,58 @@
+# Discovery — FastAPI router (cloud 4-file rule).
+# Created: 2026-06-21 (SZD finish slice F1 / feat/szd-finish-core) — the
+#   workspace-discovery TRIGGER endpoint ``POST /cloud/discovery/run`` (mounted
+#   at /api/v1/cloud/discovery via mount_cloud()). Mirrors connectors/router's
+#   active-workspace dep chain: NO ``{workspace_id}`` path param — the workspace
+#   resolves from ``current_workspace_id`` (the UI auto-threads X-Workspace-Id),
+#   the user from ``current_user_id``. License-gated at the router level and
+#   route-gated on ``connector.execute`` (the same action the connectors execute
+#   route requires — discovery samples connectors, so it needs the same right).
+#   Returns 202 Accepted: the run is fired in the background and the proposals
+#   surface as pending Instinct Actions; the body carries the optimistic run_id.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, status
+
+from pocketpaw_ee.cloud.discovery import service as discovery_service
+from pocketpaw_ee.cloud.discovery.dto import DiscoveryRunRequest, DiscoveryRunResponse
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import (
+    current_user_id,
+    current_workspace_id,
+    require_action_any_workspace,
+)
+
+router = APIRouter(
+    prefix="/cloud/discovery",
+    tags=["Discovery"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.post(
+    "/run",
+    response_model=DiscoveryRunResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(require_action_any_workspace("connector.execute"))],
+)
+async def run_discovery(
+    body: DiscoveryRunRequest | None = None,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> DiscoveryRunResponse:
+    """Trigger a zero-setup discovery run for the active workspace.
+
+    Enumerates the workspace's ENABLED connectors server-side (or honours an
+    explicit ``connector_ids`` override), samples them, digests the exhaust into
+    an ontology draft, and stages the gated proposals (fabric objects + starter
+    pocket + any inferred governed rules) as pending Instinct Actions a human
+    reviews in The Tray. Fires in the background and returns 202 immediately —
+    the proposals appear in the pending-actions list the ApprovalsPanel polls.
+
+    Gated by ``connector.execute`` (MEMBER+) in addition to the license check:
+    discovery reads the workspace's connectors, so it requires the same right as
+    executing a connector action.
+    """
+    result = await discovery_service.run(workspace_id, user_id, body or DiscoveryRunRequest())
+    return DiscoveryRunResponse.model_validate(result)

--- a/ee/pocketpaw_ee/cloud/discovery/service.py
+++ b/ee/pocketpaw_ee/cloud/discovery/service.py
@@ -1,0 +1,115 @@
+# Discovery — service (cloud 4-file rule §5).
+# Created: 2026-06-21 (SZD finish slice F1 / feat/szd-finish-core) — the
+#   workspace-discovery TRIGGER. ``run(workspace_id, user_id, body)`` is the
+#   front door that today only a script could reach: it enumerates the
+#   workspace's ENABLED connectors (``connectors.service.list_connectors``),
+#   builds ``DiscoveryRunOptions``, and FIRES
+#   ``orchestrate.run_discovery_and_propose`` as a background task
+#   (``asyncio.create_task``, mirroring chat/router's fire-and-forget) so the
+#   HTTP request returns 202 immediately instead of blocking on connector
+#   sampling + digest. The orchestrator stages its proposals durably as pending
+#   Instinct Actions, so the trigger's response only needs the optimistic
+#   ``run_id`` — the action ids surface separately in the pending-actions list
+#   the ApprovalsPanel already polls.
+#
+#   Sovereignty / tenancy: validate the body at entry (rule §6); pass the
+#   resolved ``workspace_id`` / ``user_id`` straight into the orchestrator,
+#   which re-asserts tenancy at its own entry. No Beanie writes happen here
+#   (the orchestrator + proposal services own all persistence), so this entity
+#   needs no import-linter ``models.*`` contract.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from uuid import uuid4
+
+from pocketpaw_ee.cloud.discovery.dto import DiscoveryRunRequest, DiscoveryRunResponse
+from pocketpaw_ee.discovery.orchestrate import (
+    DiscoveryProposalResult,
+    run_discovery_and_propose,
+)
+from pocketpaw_ee.discovery.run import DiscoveryRunOptions
+
+logger = logging.getLogger(__name__)
+
+
+def _log_task_result(task: asyncio.Task[DiscoveryProposalResult]) -> None:
+    """Done-callback for the fire-and-forget discovery task.
+
+    ``asyncio.create_task`` swallows exceptions unless the task is awaited or
+    its result is inspected. Without this, a crash mid-digest would yield no
+    proposals AND no log line (risk R5 in the build plan). Here we surface the
+    failure (or the staged-proposal summary) without ever re-raising into the
+    event loop.
+    """
+    try:
+        result = task.result()
+    except asyncio.CancelledError:  # pragma: no cover - shutdown path
+        logger.warning("discovery.run task cancelled")
+    except Exception:  # noqa: BLE001 - background task must not crash the loop
+        logger.exception("discovery.run task failed")
+    else:
+        logger.info(
+            "discovery.run staged proposals run_id=%s materialised=%d skipped=%d rules=%d",
+            result.run_id,
+            len(result.materialised_types),
+            len(result.skipped_types),
+            len(result.instinct_action_ids),
+        )
+
+
+async def run(
+    workspace_id: str,
+    user_id: str,
+    body: DiscoveryRunRequest,
+) -> dict:
+    """Trigger a workspace-discovery run and return immediately (202-shaped).
+
+    Steps:
+      1. Validate the body at entry (rule §6 — internal callers re-parse).
+      2. Enumerate the workspace's ENABLED connectors (the request may override
+         with an explicit ``connector_ids`` list; the common UI path leaves it
+         ``None`` and lets the service resolve it server-side). Disabled
+         connectors are excluded.
+      3. Build ``DiscoveryRunOptions`` (only ``sample_cap`` is exposed in v1 —
+         ``DiscoveryRunOptions`` has no ``digester_kind``; structured-vs-
+         unstructured is chosen inside ``DiscoveryRun``).
+      4. FIRE the orchestrator as a background task and return the optimistic
+         ``run_id`` now. The proposals land as pending Instinct Actions.
+
+    Returns a wire dict (rule §5) shaped like ``DiscoveryRunResponse``. Because
+    the run is fire-and-forget, the action-id fields are EMPTY in the response;
+    ``run_id`` is a dispatch token for optimistic UI confirmation (distinct from
+    the orchestrator's internal proposal run_id, which tags the staged Actions).
+    """
+    # Lazy import to avoid a router→service→connectors import cycle at module load.
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    body = DiscoveryRunRequest.model_validate(body)
+
+    if body.connector_ids is not None:
+        connector_ids = list(body.connector_ids)
+    else:
+        rows = await connectors_service.list_connectors(workspace_id, user_id=user_id)
+        connector_ids = [r.name for r in rows if r.enabled]
+
+    opts = DiscoveryRunOptions(sample_cap=body.sample_cap or DiscoveryRunOptions().sample_cap)
+
+    run_id = uuid4().hex
+
+    task = asyncio.create_task(
+        run_discovery_and_propose(workspace_id, user_id, connector_ids, opts)
+    )
+    task.add_done_callback(_log_task_result)
+
+    logger.info(
+        "discovery.run dispatched run_id=%s workspace=%s connectors=%d",
+        run_id,
+        workspace_id,
+        len(connector_ids),
+    )
+
+    # no-event: the orchestrator stages durable Instinct Actions (each emits its
+    # own proposal event); a duplicate trigger-level event would desync nothing.
+    return DiscoveryRunResponse(run_id=run_id).model_dump()

--- a/ee/pocketpaw_ee/discovery/_refine.py
+++ b/ee/pocketpaw_ee/discovery/_refine.py
@@ -1,0 +1,294 @@
+# pocketpaw_ee/discovery/_refine.py — the on-box REFINE pass for discovery (F3).
+#
+# Created: 2026-06-21 (F3 / feat/szd-finish-core) — un-stubs ``opts.refine`` on
+# ``DiscoveryRun``. After the DETERMINISTIC digest produces an ``OntologyDraft``,
+# this pass asks the tenant's ON-BOX model (Ollama) to clean it up: merge
+# near-duplicate types, rename to canonical names, and drop spurious links. It
+# sends the model the DRAFT shape (type names, property names, sample
+# summaries already in the draft) — NOT raw tenant exhaust.
+#
+# SOVEREIGNTY (the whole point of this slice, encoded as mechanical tests):
+# refining touches tenant data, so the model MUST be the tenant's on-box model
+# and NEVER a cloud model. The enforcement point is the hard pin
+# ``resolve_llm_client(settings, force_provider="ollama")`` — we never read
+# ``settings.llm_provider`` (an ``auto`` resolve with a cloud key set would pick
+# Anthropic and leak raw tenant text). ``force_provider="ollama"`` guarantees
+# ``api_key is None`` / ``is_ollama is True``; ``create_openai_client`` then
+# talks to the local Ollama ``/v1`` endpoint with the literal ``"ollama"``
+# sentinel key — no cloud key is ever in the request path.
+#
+# FAIL CLOSED ON SOVEREIGNTY, SOFT ON AVAILABILITY: if Ollama can't connect
+# (``ollama serve`` down) or returns garbage, we RETURN the original
+# deterministic draft with ``draft.meta["refine"] = "unavailable"`` — we never
+# raise and never fall back to a cloud model. Refine is an enhancement; the
+# deterministic digest is the contract floor. On success we stamp
+# ``draft.meta["refine"] = "applied"``. Mirrors the templated-fallback shape of
+# ``cloud/decisions/explain/extractor.py`` (but the fallback is the draft).
+#
+# ``resolve_on_box_descriptor`` / ``resolve_on_box_client`` are the shared
+# helpers slice F2 (unstructured categorization) also imports for its on-box
+# model call — both lanes resolve the same way so the sovereignty pin lives in
+# one place.
+#
+# Pure orchestration over the OSS ``pocketpaw.llm`` client seam + the discovery
+# models. No DB, honours a request timeout. Async (one model round-trip).
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from pocketpaw.config import Settings
+from pocketpaw.llm.client import LLMClient, resolve_llm_client
+from pocketpaw_ee.discovery.models import (
+    DraftObjectType,
+    OntologyDraft,
+)
+
+logger = logging.getLogger(__name__)
+
+# The on-box model gets a generous timeout — a local model on a tenant box is
+# slower than a cloud API, and refine is not latency-sensitive (it runs once,
+# behind a human-reviewed gate).
+_REFINE_TIMEOUT_S = 120.0
+
+# Cap how many types/links we describe to the model so the prompt stays bounded
+# on a large draft (the deterministic draft is the floor either way).
+_MAX_TYPES_IN_PROMPT = 60
+
+_REFINE_SYSTEM = (
+    "You are an ontology editor. You are given a DRAFT ontology that was "
+    "reverse-engineered deterministically from a tenant's data. Your job is to "
+    "CLEAN it: merge near-duplicate object types (e.g. 'Ticket' and 'Tickets'), "
+    "rename types to a single canonical, human-readable name, and drop links "
+    "that look spurious. Do NOT invent new types or properties that are not in "
+    "the draft. Reply with a single JSON object of the form "
+    '{"object_types": [{"name": str, "source_id_field": str|null, '
+    '"field_map": {..}, "confidence": float, "key_confidence": float}], '
+    '"links": []}. Keep field_map keys/values exactly as given for types you '
+    "keep. Return ONLY the JSON object."
+)
+
+
+def resolve_on_box_descriptor(settings: Settings) -> LLMClient:
+    """Resolve the on-box (Ollama) ``LLMClient`` descriptor — hard-pinned local.
+
+    SOVEREIGNTY ENFORCEMENT POINT. ``force_provider="ollama"`` is passed
+    unconditionally so this never reads ``settings.llm_provider``: an ``auto``
+    resolve on a tenant with a cloud key configured would otherwise pick
+    Anthropic and leak raw tenant text. The returned descriptor always has
+    ``provider == "ollama"``, ``api_key is None``, ``is_ollama is True``.
+
+    Shared with slice F2 (unstructured categorization) so both on-box model
+    lanes resolve identically.
+    """
+    return resolve_llm_client(settings, force_provider="ollama")
+
+
+def resolve_on_box_client(settings: Settings) -> Any:
+    """Build the on-box ``AsyncOpenAI`` client bound to the local Ollama endpoint.
+
+    Wraps ``resolve_on_box_descriptor`` + ``create_openai_client`` so callers get
+    a ready-to-use client with one call. The client talks to
+    ``{ollama_host}/v1`` with the literal ``"ollama"`` sentinel key — never a
+    cloud key. ``timeout`` is generous because a local model is slower than a
+    cloud API.
+    """
+    descriptor = resolve_on_box_descriptor(settings)
+    return descriptor.create_openai_client(timeout=_REFINE_TIMEOUT_S)
+
+
+def _draft_payload(draft: OntologyDraft) -> dict[str, Any]:
+    """Build the bounded DRAFT-shape payload sent to the model.
+
+    Sends only the inferred SHAPE — type names, property names, sample
+    summaries already in the draft — never raw tenant exhaust. The
+    deterministic draft is the floor, so an over-large draft is simply
+    truncated for the prompt.
+    """
+    types: list[dict[str, Any]] = []
+    for ot in draft.object_types[:_MAX_TYPES_IN_PROMPT]:
+        types.append(
+            {
+                "name": ot.name,
+                "source_id_field": ot.source_id_field,
+                "field_map": dict(ot.field_map),
+                "property_names": [p.name for p in ot.properties],
+                "confidence": ot.confidence,
+                "key_confidence": ot.key_confidence,
+                "record_count": ot.record_count,
+            }
+        )
+    links: list[dict[str, Any]] = []
+    for link in draft.links:
+        links.append(
+            {
+                "from_type": link.from_type,
+                "to_type": link.to_type,
+                "link_type": link.link_type,
+                "via_field": link.via_field,
+                "confidence": link.confidence,
+            }
+        )
+    return {"object_types": types, "links": links}
+
+
+def _extract_content(resp: Any) -> str | None:
+    """Pull the text content out of a chat-completion response, or None."""
+    try:
+        return resp.choices[0].message.content
+    except (AttributeError, IndexError, TypeError):
+        return None
+
+
+def _apply_cleaned(draft: OntologyDraft, cleaned: dict[str, Any]) -> OntologyDraft:
+    """Apply a cleaned ontology onto a COPY of the deterministic draft.
+
+    The model returns the canonical ``object_types`` (merged/renamed) and the
+    surviving ``links``. We rebuild the draft's types from the cleaned list and
+    keep only the links the model kept, re-pointing any object whose type was
+    renamed/merged onto a surviving type. Objects whose type vanished entirely
+    are dropped (the model merged them away). Never raises on a partial/odd
+    payload — a malformed shape is caught by the caller and degrades to the
+    deterministic draft.
+    """
+    out = draft.model_copy(deep=True)
+
+    cleaned_types = cleaned.get("object_types")
+    if isinstance(cleaned_types, list) and cleaned_types:
+        # Index the original types so we can carry forward fields the model
+        # omitted (properties, record_count) by name match.
+        by_name = {ot.name: ot for ot in draft.object_types}
+        rebuilt: list[DraftObjectType] = []
+        for raw in cleaned_types:
+            if not isinstance(raw, Mapping):
+                continue
+            name = raw.get("name")
+            if not name or not isinstance(name, str):
+                continue
+            base = by_name.get(name)
+            rebuilt.append(
+                DraftObjectType(
+                    name=name,
+                    properties=list(base.properties) if base else [],
+                    source_id_field=raw.get("source_id_field")
+                    if "source_id_field" in raw
+                    else (base.source_id_field if base else None),
+                    field_map=dict(raw.get("field_map") or (base.field_map if base else {})),
+                    confidence=_as_float(raw.get("confidence"), base.confidence if base else 0.0),
+                    key_confidence=_as_float(
+                        raw.get("key_confidence"), base.key_confidence if base else 0.0
+                    ),
+                    record_count=base.record_count if base else 0,
+                )
+            )
+        if rebuilt:
+            out.object_types = rebuilt
+            surviving = {ot.name for ot in rebuilt}
+            # Keep only objects whose type survived the merge/rename.
+            out.objects = [o for o in out.objects if o.type_name in surviving]
+
+    # Links: the model returns the links it kept. Drop everything else. A
+    # missing/empty "links" key means "drop all links" (the model deemed them
+    # spurious) only when the key is explicitly present; otherwise leave intact.
+    if "links" in cleaned:
+        cleaned_links = cleaned.get("links")
+        if not cleaned_links:
+            out.links = []
+        elif isinstance(cleaned_links, list):
+            keep = {
+                (str(item.get("from_type")), str(item.get("to_type")), str(item.get("via_field")))
+                for item in cleaned_links
+                if isinstance(item, Mapping)
+            }
+            out.links = [
+                link for link in out.links if (link.from_type, link.to_type, link.via_field) in keep
+            ]
+
+    return out
+
+
+def _as_float(value: Any, default: float) -> float:
+    """Coerce a model-supplied confidence into a float, falling back on default."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+async def refine_draft(draft: OntologyDraft, settings: Settings) -> OntologyDraft:
+    """Refine a deterministic ``OntologyDraft`` with the tenant's ON-BOX model.
+
+    Sends the model the DRAFT shape (type/property names, sample summaries in
+    the draft — never raw exhaust) and asks it to merge/rename types and drop
+    spurious links, then applies the cleaned result onto a copy of the draft.
+
+    Sovereignty: the client is hard-pinned to Ollama via ``resolve_on_box_client``
+    (``force_provider="ollama"``). No cloud model is ever reached.
+
+    Fail closed on sovereignty, soft on availability: on ANY failure (Ollama
+    down, malformed response, parse error) return the ORIGINAL deterministic
+    draft with ``meta["refine"] = "unavailable"`` — never raise, never fall back
+    to a cloud model. On success stamp ``meta["refine"] = "applied"``.
+    """
+    client = resolve_on_box_client(settings)
+    payload = _draft_payload(draft)
+    user_content = (
+        "Clean this draft ontology. Merge near-duplicate types, rename to "
+        "canonical names, and drop spurious links. Draft:\n"
+        + json.dumps(payload, ensure_ascii=False)
+    )
+
+    try:
+        resp = await client.chat.completions.create(
+            model=settings.ollama_model,
+            messages=[
+                {"role": "system", "content": _REFINE_SYSTEM},
+                {"role": "user", "content": user_content},
+            ],
+            response_format={"type": "json_object"},
+        )
+    except Exception:  # noqa: BLE001 — availability failure must degrade, not raise
+        logger.warning(
+            "discovery refine: on-box model unavailable; returning deterministic draft",
+            exc_info=True,
+        )
+        return _unavailable(draft)
+
+    content = _extract_content(resp)
+    if not content:
+        logger.info("discovery refine: empty model response; returning deterministic draft")
+        return _unavailable(draft)
+
+    try:
+        cleaned = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        logger.info("discovery refine: non-JSON model response; returning deterministic draft")
+        return _unavailable(draft)
+
+    if not isinstance(cleaned, Mapping):
+        return _unavailable(draft)
+
+    try:
+        refined = _apply_cleaned(draft, dict(cleaned))
+    except Exception:  # noqa: BLE001 — a broken payload degrades to the floor
+        logger.warning("discovery refine: failed to apply cleaned draft", exc_info=True)
+        return _unavailable(draft)
+
+    refined.meta["refine"] = "applied"
+    return refined
+
+
+def _unavailable(draft: OntologyDraft) -> OntologyDraft:
+    """Return the deterministic draft, flagged refine-unavailable (no mutation)."""
+    draft.meta["refine"] = "unavailable"
+    return draft
+
+
+__all__ = [
+    "resolve_on_box_descriptor",
+    "resolve_on_box_client",
+    "refine_draft",
+]

--- a/ee/pocketpaw_ee/discovery/kb_compile.py
+++ b/ee/pocketpaw_ee/discovery/kb_compile.py
@@ -1,4 +1,4 @@
-# pocketpaw_ee/discovery/kb_compile.py — the KbCompileDigester (S2-K1).
+# pocketpaw_ee/discovery/kb_compile.py — the KbCompileDigester (S2-K1, F2).
 #
 # Created: 2026-06-20 (S2-K1 / feat/szd-slice2-discovery) — the second Digester
 # implementation for sovereign zero-setup discovery. Where StructuredShapeDigester
@@ -6,6 +6,20 @@
 # UNSTRUCTURED exhaust (ticket bodies, email/chat text) that has no record shape:
 # it compiles the text into a kb-go wiki ON-BOX, reads the compiled articles back,
 # and infers the OntologyDraft from them.
+#
+# F2 (2026-06-21 / feat/szd-finish-core) — ON-BOX CATEGORIZATION. ``kb convo
+# ingest`` hardcodes every article's category to "conversation" (kb-go
+# convo.go:625), so on real text the ontology collapses to a single
+# objects-only type. F2 routes unstructured exhaust through kb's AGENT MODE
+# (``kb prepare`` → on-box Ollama model → ``kb accept``) WHEN an on-box model is
+# configured, so real text gets DOMAIN categories (SupportTicket, RefundRequest,
+# ...). ``kb prepare`` / ``kb accept`` are keyless (no network); the only model
+# call is the per-prompt compile, hard-pinned to the tenant's local Ollama via
+# F3's ``_refine.resolve_on_box_client`` (``force_provider="ollama"``). When no
+# model is configured (or resolution fails), ``_compile_blobs`` falls back to the
+# original ``kb convo ingest`` path — graceful degrade to today's behavior, never
+# an error. The chosen path is logged ("prepare/accept" vs "convo ingest") so a
+# silent regression to the conversation-only bucket is visible.
 #
 # Contract: ``digest(records, connector_meta=None) -> OntologyDraft`` — the same
 # sync Digester Protocol StructuredShapeDigester satisfies. Here ``records`` are
@@ -21,18 +35,28 @@
 # ``_clamp``-bounded into [0, 1]. ``to_fabric_mapping_kwargs()`` yields a valid
 # ``FabricMapping`` for each keyed type.
 #
-# SOVEREIGNTY (load-bearing, encoded as a test): compilation uses ONLY the
-# keyless on-box path (``kb convo ingest`` — deterministic, no LLM). It must
-# NEVER call ``kb ingest`` / ``kb build``, which POST raw tenant text to the
-# Anthropic API (kb.go:1349). The ``_kb`` seam below clones
-# ``cloud/agents/knowledge.py`` (binary resolution + subprocess + timeout) and is
-# the seam the unit tests mock; the digest path simply never asks it for ingest.
+# SOVEREIGNTY (load-bearing, encoded as tests): every kb command is keyless and
+# on-box (``prepare`` / ``accept`` / ``convo ingest`` / ``list`` / ``show`` /
+# ``graph``), and the F2 categorization model call resolves through
+# ``resolve_on_box_client`` (Ollama only — ``api_key is None``). The digester
+# must NEVER call ``kb ingest`` / ``kb build``, which POST raw tenant text to the
+# Anthropic API (kb.go:1349) — the ``_kb`` seam asserts this on every call. The
+# seam clones ``cloud/agents/knowledge.py`` (binary resolution + subprocess +
+# timeout) and is the seam the unit tests mock.
 #
-# Pure orchestration over a subprocess: no DB, no async, honours the subprocess
-# timeout. Depends on stdlib + the OSS PropertyDef + the discovery models.
+# Sync → async bridge: ``digest()`` is sync (Digester Protocol) but the on-box
+# model call is async. ``_run_coro`` runs the coroutine via ``asyncio.run`` when
+# no loop is running (unit tests) and on a worker thread when one IS (the
+# orchestrator calls ``digest()`` directly inside its async ``run()``), the
+# same pattern as ``pocketpaw.__main__._run_async``.
+#
+# Pure orchestration over a subprocess + the on-box LLM client seam: no DB,
+# honours the subprocess timeout. Depends on stdlib + the OSS PropertyDef + the
+# discovery models + F3's ``_refine`` on-box client helper.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -40,11 +64,13 @@ import shutil
 import subprocess
 import tempfile
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Coroutine, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
 from pocketpaw.fabric.models import PropertyDef
+from pocketpaw_ee.discovery._refine import resolve_on_box_client
 from pocketpaw_ee.discovery.models import (
     DraftLink,
     DraftObject,
@@ -73,8 +99,11 @@ _KEYLESS_CONFIDENCE = 0.1
 # --------------------------------------------------------------------------- #
 # kb-go subprocess seam — cloned from cloud/agents/knowledge.py:36-97.
 # This is the seam the unit tests MOCK. The digest path only ever asks it for
-# the keyless on-box commands (convo ingest / list / show / graph), NEVER for
-# `ingest` / `build` (those POST to Anthropic — a sovereignty violation).
+# the keyless on-box commands (prepare / accept / convo ingest / list / show /
+# graph), NEVER for `ingest` / `build` (those POST raw tenant text to Anthropic
+# — a sovereignty violation). The F2 categorization model call does NOT go
+# through this seam at all: it resolves through ``resolve_on_box_client`` (Ollama
+# only) so no cloud key is ever in any request path.
 # --------------------------------------------------------------------------- #
 def _resolve_kb_bin() -> str:
     """Find the kb binary, in order of preference (mirrors knowledge.py).
@@ -103,13 +132,29 @@ def _resolve_kb_bin() -> str:
 KB_BIN = _resolve_kb_bin()
 
 
+# The off-box LLM-compile commands the digester must NEVER invoke — they POST
+# raw tenant text to the Anthropic API (kb.go:1349). The sovereignty tripwire.
+_FORBIDDEN_KB_COMMANDS = frozenset({"ingest", "build"})
+
+
 def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict | list | str:
     """Call the kb binary, return parsed JSON or raw text.
 
     Cloned from ``cloud/agents/knowledge.py:_kb`` — a blocking ``subprocess.run``
     with a timeout. Callers keep it synchronous (the Digester Protocol is sync);
     the orchestrator already drives the whole digest under ``asyncio.to_thread``.
+
+    SOVEREIGNTY TRIPWIRE (mechanical, not just a comment): refuses ``kb ingest``
+    / ``kb build`` before the subprocess ever runs. Those POST raw tenant text to
+    Anthropic (kb.go:1349); the digest path is keyless on-box only. A bug that
+    routes a compile through them raises here instead of leaking.
     """
+    if args and args[0] in _FORBIDDEN_KB_COMMANDS:
+        raise RuntimeError(
+            f"sovereignty: kb {args[0]!r} POSTs raw tenant text to Anthropic and "
+            "must never run in discovery — use the keyless on-box path "
+            "(prepare/accept or convo ingest)."
+        )
     cmd = [KB_BIN, *args, "--json"]
     try:
         result = subprocess.run(
@@ -137,25 +182,59 @@ def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict |
         return result.stdout.strip()
 
 
+# --------------------------------------------------------------------------- #
+# Sync → async bridge — mirrors pocketpaw.__main__._run_async.
+# The Digester Protocol is sync, but the F2 on-box model call is async. When no
+# event loop is running (unit tests, a CLI) ``asyncio.run`` is used directly;
+# when one IS (the orchestrator calls ``digest()`` inside its async ``run()``)
+# the coroutine is driven on a dedicated worker thread so we never raise
+# "asyncio.run() cannot be called from a running event loop".
+# --------------------------------------------------------------------------- #
+def _run_coro(coro: Coroutine[Any, Any, Any]) -> Any:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with ThreadPoolExecutor(max_workers=1) as ex:
+        return ex.submit(asyncio.run, coro).result()
+
+
 class KbCompileDigester:
     """Infers an OntologyDraft from unstructured text exhaust, compiled on-box.
 
     Input shape: ``{type_label: [text, ...]}`` (text blobs grouped the way the
     DiscoveryRun sampler lands them in ``grouped``) or a flat ``list[text]``.
-    Each label's blobs are compiled into a discovery-private kb-go scope via the
-    KEYLESS ``kb convo ingest`` path; the compiled articles are read back
-    (``list`` → ``show``) and their concept graph queried (``graph``); the draft
-    is inferred from the articles.
+    Each label's blobs are compiled into a discovery-private kb-go scope; the
+    compiled articles are read back (``list`` → ``show``) and their concept graph
+    queried (``graph``); the draft is inferred from the articles.
+
+    F2 categorization: when ``settings`` is supplied AND an on-box model
+    resolves, each label is compiled via kb AGENT MODE (``kb prepare`` → on-box
+    Ollama model → ``kb accept``) so real text gets DOMAIN categories. When no
+    model is configured (``settings is None``) or resolution fails, the digester
+    falls back to the KEYLESS ``kb convo ingest`` path — graceful degrade to
+    today's "conversation"-bucket behavior, never an error.
 
     Conforms to the ``Digester`` Protocol structurally (single sync ``digest``).
     """
 
-    def __init__(self, scope_prefix: str = "workspace", scope_suffix: str = "discovery") -> None:
+    def __init__(
+        self,
+        scope_prefix: str = "workspace",
+        scope_suffix: str = "discovery",
+        *,
+        settings: Any | None = None,
+    ) -> None:
         # Scope shape: ``{scope_prefix}:{workspace_id}:{scope_suffix}`` — a
         # discovery-private kb-go scope so compiled exhaust never collides with
         # an agent/workspace KB.
         self._scope_prefix = scope_prefix
         self._scope_suffix = scope_suffix
+        # When set, F2 routes compilation through the on-box-model prepare/accept
+        # path. ``None`` (the default) keeps the deterministic convo-ingest path,
+        # so existing callers/tests that construct ``KbCompileDigester()`` with no
+        # args are unaffected.
+        self._settings = settings
 
     # ------------------------------------------------------------------ public
     def digest(
@@ -282,15 +361,165 @@ class KbCompileDigester:
 
     # ---------------------------------------------------------------- compile
     def _compile_blobs(self, scope: str, label: str, blobs: Sequence[str]) -> None:
-        """Compile a label's text blobs into ``scope`` via the keyless path.
+        """Compile a label's text blobs into ``scope``, keyless + on-box.
 
-        Writes the blobs to a temp transcript file and runs ``kb convo ingest``
-        — fully deterministic, no LLM, no API key (kb-go convo.go). NEVER
-        ``kb ingest`` / ``kb build``. Subprocess failures are non-fatal: one
-        bad label can't kill the digest (it just contributes no articles).
+        Two paths, both keyless and on-box (NEVER ``kb ingest`` / ``kb build``):
+
+        * **F2 agent mode** (``kb prepare`` → on-box Ollama model → ``kb accept``)
+          when an on-box model resolves — real text gets DOMAIN categories.
+        * **Fallback** (``kb convo ingest``) when no model is configured or the
+          resolve fails — the deterministic "conversation"-bucket path.
+
+        Subprocess / model failures are non-fatal: one bad label can't kill the
+        digest (it just contributes no articles). The chosen path is logged so a
+        silent regression to the conversation-only bucket is visible.
         """
         if not blobs:
             return
+
+        client = self._resolve_model_client()
+        if client is not None:
+            if self._compile_via_agent_mode(scope, label, blobs, client):
+                logger.info(
+                    "kb-compile: label %s compiled via prepare/accept (on-box categorization)",
+                    label,
+                )
+                return
+            # Agent mode resolved a client but produced nothing usable — fall
+            # through to the deterministic floor rather than dropping the label.
+            logger.warning(
+                "kb-compile: prepare/accept yielded no articles for label %s; "
+                "falling back to convo ingest",
+                label,
+            )
+
+        self._compile_via_convo_ingest(scope, label, blobs)
+        logger.info(
+            "kb-compile: label %s compiled via convo ingest (deterministic fallback)", label
+        )
+
+    def _resolve_model_client(self) -> Any | None:
+        """Resolve the on-box model client, or ``None`` if not available.
+
+        ``None`` when no ``settings`` was supplied (no model configured) OR when
+        the on-box resolve fails (Ollama not set up). Either way the caller
+        degrades to the deterministic ``convo ingest`` path — never an error.
+        """
+        if self._settings is None:
+            return None
+        try:
+            return resolve_on_box_client(self._settings)
+        except Exception as exc:  # noqa: BLE001 — unavailable model ⇒ graceful degrade
+            logger.warning(
+                "kb-compile: on-box model unavailable (%s); falling back to convo ingest", exc
+            )
+            return None
+
+    def _compile_via_agent_mode(
+        self, scope: str, label: str, blobs: Sequence[str], client: Any
+    ) -> bool:
+        """F2 path: prepare → on-box model → accept. Returns True iff it persisted.
+
+        ``kb prepare`` and ``kb accept`` are keyless (no network, kb.go:1959);
+        the only model call is the per-prompt compile, hard-pinned to the
+        tenant's local Ollama (``client`` from ``resolve_on_box_client``). The
+        model returns the article JSON carrying ``"categories": ["DomainType"]``
+        which ``accept`` writes as the WikiArticle's categories.
+        """
+        tmpdir = tempfile.mkdtemp(prefix="szd-kbcompile-")
+        try:
+            # One transcript file per blob so prepare emits one prompt per blob.
+            for i, blob in enumerate(blobs):
+                fpath = Path(tmpdir) / f"{i:04d}.txt"
+                fpath.write_text(f"{label}: {blob}", encoding="utf-8")
+
+            prepared = _kb("prepare", tmpdir, "--pattern", "*.txt", "--scope", scope)
+            items = prepared.get("items") if isinstance(prepared, Mapping) else None
+            if not items:
+                return False
+
+            articles: list[dict[str, Any]] = []
+            for item in items:
+                if not isinstance(item, Mapping):
+                    continue
+                prompt = item.get("prompt")
+                if not isinstance(prompt, str) or not prompt.strip():
+                    continue
+                article = self._categorize_one(client, prompt, item)
+                if article is not None:
+                    articles.append(article)
+
+            if not articles:
+                return False
+
+            payload = json.dumps({"scope": scope, "articles": articles}, ensure_ascii=False)
+            _kb("accept", "--scope", scope, input_text=payload)
+            return True
+        except Exception as exc:  # noqa: BLE001 — one bad label can't kill the run
+            logger.warning("kb-compile: agent-mode compile failed for label %s: %s", label, exc)
+            return False
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def _categorize_one(
+        self, client: Any, prompt: str, item: Mapping[str, Any]
+    ) -> dict[str, Any] | None:
+        """Send one prepare prompt to the on-box model → a categorized article.
+
+        The model resolves through ``resolve_on_box_client`` (Ollama only — no
+        cloud key), so this is sovereign. Parses the JSON-object response into an
+        article and carries ``source``/``hash``/``raw_id`` forward from the
+        prepare item so ``accept`` round-trips the raw-doc linkage. Returns
+        ``None`` (skip this article) on any model/parse failure — never raises.
+        """
+        try:
+            article = _run_coro(self._call_model(client, prompt))
+        except Exception as exc:  # noqa: BLE001 — model failure ⇒ skip this article
+            logger.warning("kb-compile: on-box model call failed: %s", exc)
+            return None
+        if not isinstance(article, Mapping):
+            return None
+
+        out = dict(article)
+        # Carry the prepare item's provenance forward (the model may omit them).
+        for key in ("source", "hash", "raw_id"):
+            out.setdefault(key, item.get(key))
+        # ``accept`` skips articles without a title or content.
+        if not out.get("title") or not out.get("content"):
+            return None
+        return out
+
+    async def _call_model(self, client: Any, prompt: str) -> Any:
+        """One on-box chat completion → parsed article JSON (or ``None``).
+
+        SOVEREIGNTY: ``client`` is bound to the local Ollama endpoint
+        (``resolve_on_box_client`` hard-pins ``force_provider="ollama"`` —
+        ``api_key is None``). ``response_format={"type":"json_object"}`` makes the
+        model return a single JSON object — the compiled article.
+        """
+        resp = await client.chat.completions.create(
+            model=self._settings.ollama_model,
+            messages=[{"role": "user", "content": prompt}],
+            response_format={"type": "json_object"},
+        )
+        try:
+            content = resp.choices[0].message.content
+        except (AttributeError, IndexError, TypeError):
+            return None
+        if not content:
+            return None
+        try:
+            return json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    def _compile_via_convo_ingest(self, scope: str, label: str, blobs: Sequence[str]) -> None:
+        """Fallback path: deterministic ``kb convo ingest`` (keyless, no LLM).
+
+        Writes the blobs to a temp transcript file and runs ``kb convo ingest``
+        — fully deterministic, no LLM, no API key (kb-go convo.go). NEVER
+        ``kb ingest`` / ``kb build``. Subprocess failures are non-fatal.
+        """
         # A simple transcript: one labelled turn per blob. ``convo ingest``
         # parses turns heuristically; the exact format is forgiving.
         transcript = "\n\n".join(f"{label}: {blob}" for blob in blobs)

--- a/ee/pocketpaw_ee/discovery/run.py
+++ b/ee/pocketpaw_ee/discovery/run.py
@@ -19,16 +19,23 @@
 #     HTTP 503 ``connector.local_agent_unavailable`` for local-mode actions, so
 #     the orchestrator drives the local ``ConnectorRegistry`` directly.
 #
-# Slice 1 is a DETERMINISTIC digest (no LLM refine). The optional draft-refine
-# pass (cleaning the ontology with an agent) is gated behind ``opts.refine`` and,
-# when enabled, MUST use the on-box / tenant model — never route tenant raw data
-# to a cloud model. It is not wired in slice 1 (the deterministic digest is
-# accepted); ``opts.refine=True`` raises so a caller can't silently get an
-# unrefined draft while believing it was refined.
+# The default path is a DETERMINISTIC digest (no LLM). The optional draft-refine
+# pass (cleaning the inferred ontology with the tenant's model) is gated behind
+# ``opts.refine``.
+#
+# WIRED IN F3 (feat/szd-finish-core): when ``opts.refine`` is True, after the
+# deterministic ``digest()`` produces the draft we run it through
+# ``_refine.refine_draft(draft, settings)`` — which is HARD-PINNED to the
+# tenant's ON-BOX model (Ollama) via ``resolve_llm_client(force_provider=
+# "ollama")`` and NEVER routes tenant data to a cloud model. Refine fails closed
+# on sovereignty, soft on availability: if Ollama is down it returns the
+# deterministic draft with ``meta["refine"]="unavailable"`` rather than raising
+# or falling back to a cloud call. ``opts.refine=False`` (the default) is the
+# unchanged deterministic path.
 #
 # Async orchestration; depends on the OSS connector registry/adapter surface
-# (duck-typed for testability) + the SZD-3 digester. No DB writes — the draft is
-# returned for a downstream gate to review.
+# (duck-typed for testability) + the SZD-3 digester + the F3 ``_refine`` helper.
+# No DB writes — the draft is returned for a downstream gate to review.
 
 from __future__ import annotations
 
@@ -85,9 +92,12 @@ class DiscoveryRunOptions:
       all requested connectors are sampled — connector-level permission
       enforcement isn't merged yet, so we degrade gracefully to allow-all and
       record that in the draft meta.
-    * ``refine`` — request the optional on-box LLM refine pass. Not wired in
-      slice 1; setting it ``True`` raises rather than silently returning an
-      unrefined draft.
+    * ``refine`` — request the optional on-box LLM refine pass (F3). When
+      ``True``, the deterministic draft is cleaned by the tenant's ON-BOX model
+      (Ollama, hard-pinned — never a cloud model). Fails soft on availability:
+      if Ollama is down the deterministic draft is returned with
+      ``meta["refine"]="unavailable"``. Default ``False`` is the deterministic
+      path.
     """
 
     sample_cap: int = DEFAULT_SAMPLE_CAP
@@ -215,16 +225,6 @@ class DiscoveryRun:
         opts: DiscoveryRunOptions | None = None,
     ) -> OntologyDraft:
         opts = opts or DiscoveryRunOptions()
-        if opts.refine:
-            # The on-box refine pass is not wired in slice 1. Fail loud rather
-            # than hand back a deterministic draft while a caller believes it
-            # was LLM-refined. When it lands it MUST use the tenant/on-box model.
-            raise NotImplementedError(
-                "DiscoveryRun refine pass is not implemented in slice 1; the "
-                "deterministic digest is the slice-1 contract. When wired, the "
-                "refine pass must run on the on-box / tenant model — never a "
-                "cloud model on tenant raw data."
-            )
 
         requested = [c for c in connector_ids]
         total_connectors = len(requested)
@@ -296,6 +296,19 @@ class DiscoveryRun:
             "skipped_by_permission": skipped,
             "connectors": per_connector,
         }
+
+        # Optional ON-BOX refine pass (F3). Runs ONLY when the caller opts in.
+        # Hard-pinned to the tenant's Ollama model inside ``refine_draft`` —
+        # never a cloud model on tenant data. Fails soft: if Ollama is down the
+        # deterministic draft comes back stamped ``meta["refine"]="unavailable"``
+        # rather than raising. The default path (``opts.refine=False``) skips
+        # this entirely and stays purely deterministic.
+        if opts.refine:
+            from pocketpaw.config import get_settings
+            from pocketpaw_ee.discovery import _refine
+
+            draft = await _refine.refine_draft(draft, get_settings())
+
         return draft
 
     async def _read_actions_for(

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,23 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-06-21 (F4 — edit-in-review PATCH proposal endpoint) — added
+#   ``PATCH /instinct/actions/{action_id}/proposal`` (``edit_proposal``). It lets a
+#   reviewer MUTATE the editable sub-fields of a PENDING discovery proposal (rename an
+#   inferred type, drop a spurious link, fix an inferred key, tighten a discovered rule's
+#   CEL) BEFORE approving — turning the gate from approve/reject-only into review-EDIT-
+#   approve. The edit NEVER flips status (Approve stays a separate click), so the chain
+#   lands ``agent.proposed → human.corrected(edited)`` with NO ``decision.completed`` (it
+#   stays OPEN for the eventual approve). Handler order: load + 404; 409 if not PENDING;
+#   tenancy gate FIRST (``_assert_*_workspace`` on the CURRENT blob); resolve the editable
+#   sub-field by blob kind (422 on kind mismatch); IMMUTABILITY PIN — copy the stored blob,
+#   overwrite ONLY the editable sub-key, force every immutable field back from the stored
+#   blob. The SECURITY CRUX: tenancy is DUPLICATED on an ``_instinct_rule`` blob — the
+#   top-level ``workspace_id`` AND the SECOND copy at ``rule_spec.scope.workspace_id``
+#   (the executor scopes the rule by the second one) — so BOTH are pinned and a client
+#   mismatch on EITHER is a 403. Re-validate per kind (``RuleDraft`` /
+#   ``CreatePocketRequest`` / fabric shape — 422, never persist broken), persist via the
+#   new status-preserving ``store.update_parameters``, then ``record_correction`` +
+#   ``_emit_human_corrected(disposition="edited")``. Returns ``{action, correction}``.
 # Updated: 2026-06-20 (S2-R4 — _instinct_rule proposal type) — wired the
 #   governed-rule-create gate kind into the FOUR-path dispatch. ``_instinct_rule_blob``
 #   + ``_assert_instinct_rule_workspace`` are the peers of the existing blob accessors
@@ -300,7 +318,7 @@ from pocketpaw_ee.cloud._core.deps import (
     current_workspace_id,
     require_plan_feature,
 )
-from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud._core.errors import ConflictError, Forbidden, ValidationError
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import require_action_any_workspace
 
@@ -771,6 +789,30 @@ class ApproveRequest(BaseModel):
     category: ActionCategory | None = None
     priority: ActionPriority | None = None
     parameters: dict[str, Any] | None = None
+
+
+class EditProposalRequest(BaseModel):
+    """Body for ``PATCH /instinct/actions/{action_id}/proposal`` (F4 — edit-in-review).
+
+    Each field is the editable sub-shape for ONE discovery proposal kind; the handler
+    edits ONLY the sub-field matching the action's blob kind and pins every immutable
+    field (tenancy, owner, schema, chain ids) back from the stored blob. Exactly one
+    of the three editable fields should be set; a payload kind that doesn't match the
+    action's blob kind is a 422.
+
+    SECURITY: ``workspace_id`` here is NOT an editable tenancy field — it exists only so
+    a client that smuggles a foreign top-level ``workspace_id`` is caught and refused
+    with 403 (mismatch). The handler always pins tenancy from the stored blob; it never
+    moves a proposal to another workspace. For ``_instinct_rule`` the SECOND tenancy copy
+    (``rule_spec.scope.workspace_id``) is pinned the same way — a mismatch there is also a
+    403 (the executor scopes the persisted rule by that copy).
+    """
+
+    rule_spec: dict[str, Any] | None = None  # _instinct_rule editable sub-shape
+    pocket_spec: dict[str, Any] | None = None  # _pocket_create editable sub-shape
+    fabric: dict[str, Any] | None = None  # _fabric_objects: {object_types?, objects?, links?}
+    # NOT editable — present only to catch a smuggled foreign tenancy (→ 403).
+    workspace_id: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -2281,6 +2323,299 @@ async def reject_action(
         logger.exception("customer-decision delivery after rejection failed (non-fatal)")
 
     return action
+
+
+# ---------------------------------------------------------------------------
+# F4 — edit-in-review PATCH endpoint
+# ---------------------------------------------------------------------------
+#
+# A reviewer mutates the editable sub-fields of a PENDING discovery proposal (rename an
+# inferred type, drop a spurious link, fix an inferred key, tighten a discovered rule's
+# CEL) BEFORE approving. The edit NEVER flips status — Approve stays a separate click,
+# so the Decision-Graph chain stays OPEN (``agent.proposed → human.corrected(edited)``
+# with NO ``decision.completed``).
+#
+# The security crux: tenancy is DUPLICATED on a discovery blob — the top-level
+# ``workspace_id`` (the gate reads this) AND, for ``_instinct_rule``, the SECOND copy at
+# ``rule_spec.scope.workspace_id`` (the executor scopes the persisted rule by this one).
+# The edit endpoint pins BOTH from the stored blob and refuses any client attempt to
+# change either (mismatch → 403). Miss the second copy and a tenant edits a proposal into
+# another workspace.
+
+
+def _pin_immutable(before_value: Any, request_value: Any) -> None:
+    """Raise 403 if a client tried to change an immutable (tenancy) field.
+
+    ``request_value`` is what the client sent for the field; ``before_value`` is the
+    stored value. A truthy ``request_value`` that differs from ``before_value`` is a
+    cross-workspace edit attempt — the same 403 + code the approve/reject gate raises.
+    A ``None`` / absent request value is fine: the caller pins ``before_value`` back.
+    """
+    if request_value is not None and str(request_value) != str(before_value):
+        raise Forbidden(
+            "instinct.cross_workspace_approval",
+            "This proposal belongs to a different workspace",
+        )
+
+
+@router.patch(
+    "/instinct/actions/{action_id}/proposal",
+    response_model=ApproveResponse,
+    dependencies=[Depends(require_action_any_workspace("instinct.approve"))],
+)
+async def edit_proposal(
+    action_id: str,
+    req: EditProposalRequest,
+    user: Any = Depends(current_user),
+    workspace_id: str = Depends(current_workspace_id),
+):
+    """Edit the editable sub-fields of a PENDING discovery proposal before approving.
+
+    Mutates ONLY the editable blob sub-field matching the action's kind; does NOT flip
+    status. Steps:
+
+    1. Load + guard — 404 if missing, 409 if not PENDING (its chain is closed).
+    2. Tenancy gate FIRST — the matching ``_assert_*_workspace`` against the CURRENT
+       blob, before any mutation (the same chokepoint approve/reject use).
+    3. Resolve the editable sub-field by which blob key is present; 422 if the payload's
+       kind doesn't match the action's blob kind.
+    4. Immutability pin (the core security logic) — copy the stored blob, overwrite ONLY
+       the editable sub-key, force every immutable field back from the stored blob. For
+       ``_instinct_rule`` pin BOTH ``workspace_id`` AND ``rule_spec.scope.workspace_id``;
+       a client mismatch on either → 403.
+    5. Re-validate per blob type (422, never persist broken) — ``RuleDraft`` /
+       ``CreatePocketRequest`` model_validate; fabric shape-check.
+    6. Persist the mutated parameters via ``store.update_parameters`` (status-preserving).
+    7. Learning loop — ``compute_patches`` → ``Correction`` → ``record_correction`` →
+       ``_emit_human_corrected(disposition="edited")`` (NO ``decision.completed``).
+
+    Returns ``{action, correction}`` (the same shape as approve).
+    """
+    store = _store()
+    before = await store.get_action(action_id)
+    if not before:
+        raise HTTPException(404, "Action not found")
+
+    # 1 — only a PENDING proposal can be edited. An approved / rejected / executed
+    # action's chain is closed; an edit-in-review is meaningless after the gate flipped.
+    if before.status != ActionStatus.PENDING:
+        raise ConflictError(
+            "instinct.not_pending",
+            "Only a pending proposal can be edited",
+        )
+
+    # 2 — TENANCY GATE FIRST (before any mutation), against the CURRENT blob. The same
+    # cross-workspace chokepoint the approve / reject paths run. ``require_action_any_*``
+    # only proved the caller holds ``instinct.approve`` somewhere; this binds the Action
+    # to the caller's active workspace. Non-discovery blobs are unaffected (no-op).
+    _assert_fabric_objects_workspace(before, workspace_id)
+    _assert_pocket_create_workspace(before, workspace_id)
+    _assert_instinct_rule_workspace(before, workspace_id)
+
+    # 3 — resolve the ONE editable sub-field by which discovery blob the action carries.
+    params = dict(before.parameters or {})
+    blob_key, before_blob, editable, new_blob = _resolve_editable_blob(before, req)
+
+    # 5 — re-validate the proposed sub-shape (422; runs BEFORE persist so a broken blob
+    # never lands). The pin in _resolve already forced tenancy back / 403'd a mismatch.
+    _revalidate_blob(blob_key, new_blob)
+
+    # 6 — persist the mutated parameters bag (status-preserving).
+    params[blob_key] = new_blob
+    after = await store.update_parameters(action_id, params)
+    if after is None:
+        raise HTTPException(404, "Action not found")
+
+    # 7 — learning loop. compute_patches diffs the top-level parameters.<key>; a rule_spec
+    # edit yields a patch at parameters._instinct_rule. Record the Correction, then emit
+    # human.corrected(edited) — the SAME helper approve uses — citing the agent.proposed
+    # event as causation. We do NOT emit decision.completed: the chain stays OPEN for the
+    # eventual approve click.
+    actor_id = str(user.id)
+    correction: Correction | None = None
+    patches = compute_patches(before, after)
+    if patches:
+        correction = Correction(
+            action_id=before.id,
+            pocket_id=before.pocket_id,
+            actor=actor_id,
+            patches=patches,
+            context_summary=summarize_correction(before, patches),
+            action_title=before.title,
+        )
+        await store.record_correction(correction)
+        await _forward_to_soul(correction, after)
+
+    note = correction.context_summary if correction is not None else None
+    _emit_human_corrected(
+        blob=new_blob,
+        action=after,
+        user_id=actor_id,
+        workspace_id=workspace_id,
+        disposition="edited",
+        note=note,
+        causation_override=_code_change_proposed_event_id(new_blob),
+    )
+
+    return ApproveResponse(action=after, correction=correction)
+
+
+def _resolve_editable_blob(
+    before: Action, req: EditProposalRequest
+) -> tuple[str, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Resolve which discovery blob the action carries, validate the payload kind matches,
+    and return ``(blob_key, before_blob, editable_subfield, new_blob)`` with EVERY
+    immutable field already pinned from ``before_blob`` (a client mismatch → 403).
+
+    422 if the action carries no editable discovery blob, or the payload's kind does not
+    match the action's blob kind.
+    """
+    fabric_before = _fabric_objects_blob(before)
+    pocket_before = _pocket_create_blob(before)
+    rule_before = _instinct_rule_blob(before)
+
+    # --- _instinct_rule -----------------------------------------------------
+    if rule_before is not None:
+        if req.rule_spec is None:
+            raise ValidationError(
+                "instinct.edit_kind_mismatch",
+                "This proposal is an instinct rule; send rule_spec",
+            )
+        # The SECOND tenancy copy lives at rule_spec.scope.workspace_id — pin it. A
+        # foreign value here would re-scope the persisted rule into another workspace.
+        before_scope_ws = (rule_before.get("rule_spec") or {}).get("scope", {}).get("workspace_id")
+        incoming_spec = dict(req.rule_spec)
+        incoming_scope = dict(incoming_spec.get("scope") or {})
+        _pin_immutable(before_scope_ws, incoming_scope.get("workspace_id"))
+        incoming_scope["workspace_id"] = before_scope_ws
+        incoming_spec["scope"] = incoming_scope
+
+        # The top-level tenancy copy — pin it (and 403 a smuggled foreign value).
+        _pin_immutable(rule_before.get("workspace_id"), req.workspace_id)
+
+        new_blob = dict(rule_before)
+        new_blob["rule_spec"] = incoming_spec
+        # Force EVERY immutable top-level field back from the stored blob.
+        for key in (
+            "workspace_id",
+            "user_id",
+            "schema",
+            "kind",
+            "correlation_id",
+            "proposed_event_id",
+            "summary",
+        ):
+            if key in rule_before:
+                new_blob[key] = rule_before[key]
+        return ("_instinct_rule", rule_before, incoming_spec, new_blob)
+
+    # --- _pocket_create -----------------------------------------------------
+    if pocket_before is not None:
+        if req.pocket_spec is None:
+            raise ValidationError(
+                "instinct.edit_kind_mismatch",
+                "This proposal creates a pocket; send pocket_spec",
+            )
+        _pin_immutable(pocket_before.get("workspace_id"), req.workspace_id)
+        # Strip any sneaked workspace / owner keys out of the editable spec at the same
+        # chokepoint the propose path uses, then force the name back if the client dropped
+        # it (CreatePocketRequest requires it; the original carried it).
+        from pocketpaw_ee.cloud.pocket_proposals.propose import _normalize_pocket_spec
+
+        before_name = (pocket_before.get("pocket_spec") or {}).get("name", "")
+        normalized = _normalize_pocket_spec(
+            ripple_spec=req.pocket_spec.get("rippleSpec") or req.pocket_spec.get("ripple_spec"),
+            name=str(req.pocket_spec.get("name") or before_name),
+            template_slug=req.pocket_spec.get("templateSlug")
+            or req.pocket_spec.get("template_slug"),
+            extra={
+                k: v
+                for k, v in req.pocket_spec.items()
+                if k not in {"rippleSpec", "ripple_spec", "name", "templateSlug", "template_slug"}
+            },
+        )
+        new_blob = dict(pocket_before)
+        new_blob["pocket_spec"] = normalized
+        for key in (
+            "workspace_id",
+            "user_id",
+            "schema",
+            "kind",
+            "correlation_id",
+            "proposed_event_id",
+            "summary",
+        ):
+            if key in pocket_before:
+                new_blob[key] = pocket_before[key]
+        return ("_pocket_create", pocket_before, normalized, new_blob)
+
+    # --- _fabric_objects ----------------------------------------------------
+    if fabric_before is not None:
+        if req.fabric is None:
+            raise ValidationError(
+                "instinct.edit_kind_mismatch",
+                "This proposal writes fabric objects; send fabric",
+            )
+        _pin_immutable(fabric_before.get("workspace_id"), req.workspace_id)
+        new_blob = dict(fabric_before)
+        # Replace ONLY the three editable lists; everything else (workspace_id, schema,
+        # kind, chain ids, summary) is left exactly as stored.
+        for sub in ("object_types", "objects", "links"):
+            if sub in req.fabric:
+                new_blob[sub] = req.fabric[sub]
+        for key in (
+            "workspace_id",
+            "schema",
+            "kind",
+            "correlation_id",
+            "proposed_event_id",
+            "summary",
+        ):
+            if key in fabric_before:
+                new_blob[key] = fabric_before[key]
+        return ("_fabric_objects", fabric_before, new_blob, new_blob)
+
+    raise ValidationError(
+        "instinct.not_editable",
+        "This action carries no editable discovery proposal",
+    )
+
+
+def _revalidate_blob(blob_key: str, new_blob: dict[str, Any]) -> None:
+    """Re-validate the mutated sub-shape per blob kind (422 on failure, never persist).
+
+    ``_instinct_rule`` parses the CEL ``when`` (a tightened-but-malformed ``when`` fails
+    HERE, exactly as the executor would); ``_pocket_create`` re-parses the
+    ``CreatePocketRequest`` body; ``_fabric_objects`` shape-checks the editable lists.
+    """
+    if blob_key == "_instinct_rule":
+        from pocketpaw_ee.discovery.rule_models import RuleDraft
+
+        try:
+            RuleDraft.model_validate(new_blob.get("rule_spec") or {})
+        except Exception as exc:  # noqa: BLE001 — surface as a clean 422
+            raise ValidationError(
+                "instinct.invalid_rule_spec", f"Edited rule is invalid: {exc}"
+            ) from exc
+    elif blob_key == "_pocket_create":
+        from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+        try:
+            CreatePocketRequest.model_validate(new_blob.get("pocket_spec") or {})
+        except Exception as exc:  # noqa: BLE001
+            raise ValidationError(
+                "instinct.invalid_pocket_spec", f"Edited pocket spec is invalid: {exc}"
+            ) from exc
+    elif blob_key == "_fabric_objects":
+        for sub in ("object_types", "objects", "links"):
+            items = new_blob.get(sub)
+            if items is None:
+                continue
+            if not isinstance(items, list) or any(not isinstance(it, dict) for it in items):
+                raise ValidationError(
+                    "instinct.invalid_fabric_objects",
+                    f"Edited fabric '{sub}' must be a list of objects",
+                )
 
 
 def _apply_edits(before: Action, req: ApproveRequest) -> tuple[Action, set[str]]:

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,9 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-06-21 (F4 — edit-in-review) — added ``update_parameters(action_id,
+#   params)``: a thin, status-preserving write of the JSON ``parameters`` bag (does NOT
+#   touch ``status``/``approved_*``), used by the router's PATCH proposal-edit endpoint
+#   to persist a re-validated, tenancy-pinned blob on a PENDING action before approval.
 # Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — ADDITIVE
 #   generic scope on the actions table. ``instinct_actions`` now carries a
 #   nullable ``scope_type`` column (additive ALTER, mirrors the assignee /
@@ -730,6 +734,28 @@ class InstinctStore:
             ) as cur:
                 row = await cur.fetchone()
                 return self._row_to_action(row) if row else None
+
+    async def update_parameters(self, action_id: str, parameters: dict[str, Any]) -> Action | None:
+        """Persist a new ``parameters`` JSON bag on an Action, status-preserving.
+
+        F4 (edit-in-review) — the PATCH proposal-edit endpoint mutates only the editable
+        sub-fields of a PENDING discovery proposal's blob and writes the re-validated,
+        tenancy-pinned ``parameters`` back here. This is a CONTENT write only: it touches
+        ``parameters`` + ``updated_at`` and NEVER ``status`` / ``approved_*`` / chain
+        terminals (the approve click stays a separate, deliberate step). Returns the
+        reloaded Action, or ``None`` if the id doesn't resolve.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            cur = await db.execute(
+                "UPDATE instinct_actions SET parameters = ?, "
+                "updated_at = datetime('now') WHERE id = ?",
+                (json.dumps(parameters or {}), action_id),
+            )
+            await db.commit()
+            if cur.rowcount == 0:
+                return None
+        return await self.get_action(action_id)
 
     async def pending(
         self,

--- a/tests/cloud/test_discovery_router.py
+++ b/tests/cloud/test_discovery_router.py
@@ -1,0 +1,208 @@
+# test_discovery_router.py — contract tests for the workspace-discovery TRIGGER.
+# Created: 2026-06-21 (SZD finish slice F1 / feat/szd-finish-core) — pins the
+#   POST /cloud/discovery/run front door: (1) only ENABLED connectors reach the
+#   orchestrator, (2) 202 + run_id on success, (3) the connector.execute action
+#   gate denies with 403, (4) the workspace resolves from the active workspace
+#   (current_workspace_id) — there is NO {workspace_id} path param.
+#
+# Pattern mirrors test_knowledge_router.py: override current_active_user with a
+# fake User that owns the active workspace, patch the RBAC check the gate
+# consumes (pocketpaw_ee.cloud._core.deps.check_workspace_action — imported
+# by-name there, so the consumer is the patch target), and patch
+# run_discovery_and_propose so the test never samples real connectors.
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud.discovery.router import router as discovery_router
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.discovery.orchestrate import DiscoveryProposalResult
+
+_WS = "ws-a"
+_USER = "u-a"
+
+
+def _fake_result(run_id: str = "orch-run-1") -> DiscoveryProposalResult:
+    return DiscoveryProposalResult(
+        run_id=run_id,
+        fabric_objects_action_id="fa-1",
+        pocket_action_id="pa-1",
+        materialised_types=["Invoice"],
+        skipped_types={},
+        superseded_action_ids=[],
+        instinct_action_ids=["ir-1"],
+    )
+
+
+def _build_app(monkeypatch, *, allow: bool = True) -> FastAPI:
+    """Mount the discovery router with auth + license overridden.
+
+    ``allow`` toggles the RBAC gate: when False the connector.execute check
+    raises GuardForbidden, exercising the 403 deny path.
+    """
+    from pocketpaw_ee.cloud._core import deps as core_deps
+    from pocketpaw_ee.guards.rbac import Forbidden as GuardForbidden
+
+    if allow:
+        monkeypatch.setattr(core_deps, "check_workspace_action", lambda *a, **k: None)
+    else:
+
+        def _deny(*_a, **_k):
+            raise GuardForbidden("connector.execute_denied", "Access denied")
+
+        monkeypatch.setattr(core_deps, "check_workspace_action", _deny)
+
+    fake_user = SimpleNamespace(
+        id=_USER,
+        active_workspace=_WS,
+        workspaces=[SimpleNamespace(workspace=_WS, role="owner")],
+    )
+
+    async def _fake_current_active_user():
+        return fake_user
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = _fake_current_active_user
+    app.include_router(discovery_router, prefix="/api/v1")
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch, mongo_db):  # noqa: ARG001 — mongo_db wires Beanie
+    app = _build_app(monkeypatch, allow=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# 202 + run_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_returns_202_with_run_id(client: AsyncClient, monkeypatch):
+    """A permitted caller gets 202 Accepted and an opaque run_id."""
+    from pocketpaw_ee.cloud.discovery import service as discovery_service
+
+    fake_orch = AsyncMock(return_value=_fake_result())
+    monkeypatch.setattr(discovery_service, "run_discovery_and_propose", fake_orch)
+
+    resp = await client.post("/api/v1/cloud/discovery/run", json={})
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert isinstance(body["run_id"], str) and body["run_id"]
+    # Fire-and-forget: action ids are NOT ready synchronously, returned empty.
+    assert body["fabric_objects_action_id"] is None
+    assert body["instinct_action_ids"] == []
+    # Let the background task drain so the orchestrator was actually invoked.
+    await asyncio.sleep(0)
+    assert fake_orch.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Only ENABLED connectors reach the orchestrator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_enumerates_enabled_connectors_only(client: AsyncClient, monkeypatch):
+    """Disabled connectors are excluded from the connector_ids passed to the
+    orchestrator; enabled ones are included."""
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.discovery import service as discovery_service
+
+    fake_orch = AsyncMock(return_value=_fake_result())
+    monkeypatch.setattr(discovery_service, "run_discovery_and_propose", fake_orch)
+
+    # Enable exactly one real connector from the catalog in this workspace.
+    catalog = await connectors_service.list_connectors(_WS, user_id=_USER)
+    assert catalog, "registry catalog should be non-empty"
+    enabled_name = catalog[0].name
+    from pocketpaw_ee.cloud.connectors.dto import EnableConnectorRequest
+
+    await connectors_service.enable_connector(
+        _WS, enabled_name, EnableConnectorRequest(scope="workspace")
+    )
+
+    resp = await client.post("/api/v1/cloud/discovery/run", json={})
+    assert resp.status_code == 202, resp.text
+    await asyncio.sleep(0)  # drain the fire-and-forget task
+
+    assert fake_orch.await_count == 1
+    # signature: run_discovery_and_propose(workspace_id, user_id, connector_ids, opts)
+    call = fake_orch.await_args
+    passed_workspace, passed_user, passed_connector_ids = call.args[0], call.args[1], call.args[2]
+    assert passed_workspace == _WS
+    assert passed_user == _USER
+    assert enabled_name in passed_connector_ids
+    # Every passed id corresponds to an enabled connector — nothing disabled leaks.
+    all_rows = await connectors_service.list_connectors(_WS, user_id=_USER)
+    enabled_set = {r.name for r in all_rows if r.enabled}
+    disabled_names = {r.name for r in all_rows if not r.enabled}
+    assert set(passed_connector_ids) <= enabled_set
+    assert not (set(passed_connector_ids) & disabled_names)
+
+
+# ---------------------------------------------------------------------------
+# Action gate — 403 without connector.execute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_requires_connector_execute_action(monkeypatch, mongo_db):  # noqa: ARG001
+    """A caller without connector.execute is denied 403 before any run fires."""
+    from pocketpaw_ee.cloud.discovery import service as discovery_service
+
+    fake_orch = AsyncMock(return_value=_fake_result())
+    monkeypatch.setattr(discovery_service, "run_discovery_and_propose", fake_orch)
+
+    app = _build_app(monkeypatch, allow=False)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        resp = await c.post("/api/v1/cloud/discovery/run", json={})
+
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["error"]["code"] == "connector.execute_denied"
+    # The denial happens at the gate — the orchestrator must never have run.
+    await asyncio.sleep(0)
+    assert fake_orch.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Workspace resolves from the active workspace, not a path param
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_resolves_workspace_from_active_not_path(client: AsyncClient, monkeypatch):
+    """The route has NO {workspace_id} path param — the workspace the
+    orchestrator runs against comes from current_workspace_id (the fake user's
+    active workspace), not from the URL."""
+    from pocketpaw_ee.cloud.discovery import service as discovery_service
+
+    fake_orch = AsyncMock(return_value=_fake_result())
+    monkeypatch.setattr(discovery_service, "run_discovery_and_propose", fake_orch)
+
+    # A bare /run path (no workspace segment) is the only valid shape.
+    resp = await client.post("/api/v1/cloud/discovery/run", json={})
+    assert resp.status_code == 202, resp.text
+    await asyncio.sleep(0)
+
+    assert fake_orch.await_count == 1
+    assert fake_orch.await_args.args[0] == _WS
+
+    # A would-be path-param variant does not exist — 404/405, never 202.
+    bad = await client.post(f"/api/v1/cloud/discovery/{_WS}/run", json={})
+    assert bad.status_code in (404, 405)

--- a/tests/ee/test_discovery_refine.py
+++ b/tests/ee/test_discovery_refine.py
@@ -1,0 +1,356 @@
+# tests/ee/test_discovery_refine.py — unit tests for SZD finish-slice F3
+# (the on-box REFINE pass).
+#
+# Created: 2026-06-21 (F3 / feat/szd-finish-core) — covers
+# ``pocketpaw_ee.discovery._refine`` and the un-stubbed ``opts.refine`` path on
+# ``DiscoveryRun.run``. The Ollama client is STUBBED (no running Ollama, no
+# network); these tests are the MECHANICAL enforcement of the sovereignty rule:
+# refine MUST resolve through ``resolve_llm_client(settings, force_provider=
+# "ollama")`` so tenant data never reaches a cloud model — even when a cloud
+# (Anthropic) key is configured.
+#
+# Sovereignty / availability matrix asserted here:
+#   * resolve_on_box_client → api_key is None, is_ollama is True;
+#   * a fake cloud key set in settings → STILL forces ollama (no Anthropic);
+#   * Ollama down (connection error) → return the deterministic draft with
+#     meta["refine"]=="unavailable", NEVER raise, NEVER fall back to cloud;
+#   * a stubbed cleaned-ontology JSON → draft reflects it + meta["refine"]==
+#     "applied";
+#   * run(opts.refine=True) invokes refine_draft; run(opts.refine=False) is the
+#     unchanged deterministic path and never calls refine_draft.
+#
+# Fully mocked — no DB / network / Ollama. Run with:
+#   uv run --group ee pytest tests/ee/test_discovery_refine.py -q
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from pocketpaw_ee.discovery import _refine
+from pocketpaw_ee.discovery.models import (
+    DraftLink,
+    DraftObject,
+    DraftObjectType,
+    OntologyDraft,
+)
+
+from pocketpaw.config import Settings
+
+
+# --------------------------------------------------------------------------- #
+# Stub Ollama client (stands in for the AsyncOpenAI client create_openai_client
+# returns). It records the model used and either returns a canned completion or
+# raises a connection error.
+# --------------------------------------------------------------------------- #
+class _StubMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _StubChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _StubMessage(content)
+
+
+class _StubCompletion:
+    def __init__(self, content: str) -> None:
+        self.choices = [_StubChoice(content)]
+
+
+class _StubCompletions:
+    def __init__(self, content: str | None, raise_exc: Exception | None) -> None:
+        self._content = content
+        self._raise = raise_exc
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> _StubCompletion:
+        self.calls.append(kwargs)
+        if self._raise is not None:
+            raise self._raise
+        return _StubCompletion(self._content or "")
+
+
+class _StubChat:
+    def __init__(self, completions: _StubCompletions) -> None:
+        self.completions = completions
+
+
+class _StubOpenAIClient:
+    """Mirror of the AsyncOpenAI surface refine_draft touches: chat.completions."""
+
+    def __init__(self, *, content: str | None = None, raise_exc: Exception | None = None) -> None:
+        self.completions = _StubCompletions(content, raise_exc)
+        self.chat = _StubChat(self.completions)
+        self.closed = False
+
+    async def close(self) -> None:  # tolerated-if-called cleanup hook
+        self.closed = True
+
+
+def _sample_draft() -> OntologyDraft:
+    """A small deterministic draft for refine to clean.
+
+    Two near-duplicate types (``Ticket`` / ``Tickets``) the model is asked to
+    merge, and one spurious link the model is asked to drop.
+    """
+    return OntologyDraft(
+        object_types=[
+            DraftObjectType(
+                name="Ticket",
+                source_id_field="id",
+                field_map={"subject": "subject"},
+                confidence=0.6,
+                key_confidence=0.8,
+                record_count=3,
+            ),
+            DraftObjectType(
+                name="Tickets",
+                source_id_field="id",
+                field_map={"subject": "subject"},
+                confidence=0.4,
+                key_confidence=0.5,
+                record_count=2,
+            ),
+        ],
+        objects=[
+            DraftObject(type_name="Ticket", source_id="t1", properties={"subject": "hi"}),
+        ],
+        links=[
+            DraftLink(
+                from_type="Ticket",
+                from_source_id="t1",
+                to_type="Tickets",
+                to_source_id="t9",
+                link_type="related",
+                via_field="ref",
+                confidence=0.2,
+            ),
+        ],
+        meta={"digester": "structured-shape"},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# resolve_on_box_client is hard-pinned to Ollama (the sovereignty enforcement
+# point): api_key is None, is_ollama is True.
+# --------------------------------------------------------------------------- #
+def test_refine_resolves_ollama_only() -> None:
+    settings = Settings()
+    llm = _refine.resolve_on_box_descriptor(settings)
+
+    assert llm.is_ollama is True
+    assert llm.api_key is None
+    assert llm.provider == "ollama"
+
+
+# --------------------------------------------------------------------------- #
+# Even with a cloud (Anthropic) key configured, refine STILL routes ollama —
+# never an Anthropic client. This is the leak the slice exists to prevent.
+# --------------------------------------------------------------------------- #
+def test_refine_with_cloud_key_set_still_routes_ollama() -> None:
+    # A tenant with a cloud key set AND llm_provider="auto" would, without the
+    # hard pin, resolve to anthropic and leak raw tenant text.
+    settings = Settings(anthropic_api_key="sk-ant-fake-cloud-key", llm_provider="auto")
+
+    llm = _refine.resolve_on_box_descriptor(settings)
+
+    assert llm.is_ollama is True, "force_provider='ollama' must override the cloud key"
+    assert llm.is_anthropic is False
+    assert llm.api_key is None, "no cloud key may ride into the on-box client"
+
+
+# --------------------------------------------------------------------------- #
+# Ollama down → deterministic draft returned, meta['refine']=='unavailable',
+# NEVER raise, NEVER a cloud call.
+# --------------------------------------------------------------------------- #
+async def test_refine_unavailable_returns_deterministic_draft(monkeypatch) -> None:
+    draft = _sample_draft()
+    settings = Settings()
+
+    stub = _StubOpenAIClient(raise_exc=ConnectionError("Cannot connect to Ollama"))
+    monkeypatch.setattr(_refine, "resolve_on_box_client", lambda s: stub)
+
+    out = await _refine.refine_draft(draft, settings)
+
+    # The deterministic draft survives, untouched in shape, flagged unavailable.
+    assert out.meta["refine"] == "unavailable"
+    assert {ot.name for ot in out.object_types} == {"Ticket", "Tickets"}
+    assert len(out.links) == 1  # nothing dropped — refine never ran
+
+
+# --------------------------------------------------------------------------- #
+# A model that returns a cleaned ontology JSON → draft reflects it, flagged
+# 'applied'.
+# --------------------------------------------------------------------------- #
+async def test_refine_applied_cleans_draft(monkeypatch) -> None:
+    draft = _sample_draft()
+    settings = Settings()
+
+    cleaned = {
+        # The two near-duplicate types merged into one canonical type.
+        "object_types": [
+            {
+                "name": "SupportTicket",
+                "source_id_field": "id",
+                "field_map": {"subject": "subject"},
+                "confidence": 0.9,
+                "key_confidence": 0.9,
+            }
+        ],
+        # The spurious link dropped (empty list).
+        "links": [],
+    }
+    stub = _StubOpenAIClient(content=json.dumps(cleaned))
+    monkeypatch.setattr(_refine, "resolve_on_box_client", lambda s: stub)
+
+    out = await _refine.refine_draft(draft, settings)
+
+    assert out.meta["refine"] == "applied"
+    type_names = {ot.name for ot in out.object_types}
+    assert "SupportTicket" in type_names
+    assert "Tickets" not in type_names, "near-duplicate type should be merged away"
+    assert out.links == [], "spurious link should be dropped"
+
+    # The model was asked for a JSON object response (sovereign one-shot shape).
+    call = stub.completions.calls[0]
+    assert call["response_format"] == {"type": "json_object"}
+    assert call["model"] == settings.ollama_model
+
+
+# --------------------------------------------------------------------------- #
+# A malformed model response degrades to the deterministic draft (never raises,
+# never a cloud retry).
+# --------------------------------------------------------------------------- #
+async def test_refine_malformed_response_returns_deterministic_draft(monkeypatch) -> None:
+    draft = _sample_draft()
+    settings = Settings()
+
+    stub = _StubOpenAIClient(content="not json at all {")
+    monkeypatch.setattr(_refine, "resolve_on_box_client", lambda s: stub)
+
+    out = await _refine.refine_draft(draft, settings)
+
+    assert out.meta["refine"] == "unavailable"
+    assert {ot.name for ot in out.object_types} == {"Ticket", "Tickets"}
+
+
+# --------------------------------------------------------------------------- #
+# run(opts.refine=True) invokes refine_draft on the deterministic draft.
+# --------------------------------------------------------------------------- #
+async def test_run_refine_true_calls_refine(monkeypatch) -> None:
+    from dataclasses import dataclass
+
+    from pocketpaw_ee.discovery import DiscoveryRun, DiscoveryRunOptions
+
+    @dataclass
+    class _Result:
+        success: bool
+        data: Any = None
+        error: str | None = None
+
+    @dataclass
+    class _Schema:
+        name: str
+        method: str = "GET"
+        trust_level: str = "auto"
+
+    class _Adapter:
+        async def actions(self) -> list[_Schema]:
+            return [_Schema(name="list_rows")]
+
+        async def execute(self, action: str, params: dict[str, Any]) -> _Result:
+            return _Result(success=True, data=[{"id": "r1", "name": "a"}])
+
+    class _Registry:
+        async def ensure_connected(self, name: str, scope_key: str) -> _Adapter:
+            return _Adapter()
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_refine(draft: OntologyDraft, settings: Any) -> OntologyDraft:
+        captured["called"] = True
+        draft.meta["refine"] = "applied"
+        return draft
+
+    monkeypatch.setattr(_refine, "refine_draft", _fake_refine)
+
+    run = DiscoveryRun(registry=_Registry())
+    draft = await run.run("ws-1", ["c"], DiscoveryRunOptions(refine=True))
+
+    assert captured.get("called") is True
+    assert draft.meta["refine"] == "applied"
+
+
+# --------------------------------------------------------------------------- #
+# run(opts.refine=False) is the unchanged deterministic path — refine_draft is
+# never called and the draft carries no refine marker.
+# --------------------------------------------------------------------------- #
+async def test_run_refine_false_is_deterministic(monkeypatch) -> None:
+    from dataclasses import dataclass
+
+    from pocketpaw_ee.discovery import DiscoveryRun, DiscoveryRunOptions
+
+    @dataclass
+    class _Result:
+        success: bool
+        data: Any = None
+        error: str | None = None
+
+    @dataclass
+    class _Schema:
+        name: str
+        method: str = "GET"
+        trust_level: str = "auto"
+
+    class _Adapter:
+        async def actions(self) -> list[_Schema]:
+            return [_Schema(name="list_rows")]
+
+        async def execute(self, action: str, params: dict[str, Any]) -> _Result:
+            return _Result(success=True, data=[{"id": "r1", "name": "a"}])
+
+    class _Registry:
+        async def ensure_connected(self, name: str, scope_key: str) -> _Adapter:
+            return _Adapter()
+
+    called = {"refine": False}
+
+    async def _fake_refine(draft: OntologyDraft, settings: Any) -> OntologyDraft:
+        called["refine"] = True
+        return draft
+
+    monkeypatch.setattr(_refine, "refine_draft", _fake_refine)
+
+    run = DiscoveryRun(registry=_Registry())
+    draft = await run.run("ws-1", ["c"], DiscoveryRunOptions(refine=False))
+
+    assert called["refine"] is False, "deterministic path must not call refine_draft"
+    assert "refine" not in draft.meta
+    assert not draft.is_empty
+
+
+# --------------------------------------------------------------------------- #
+# Sanity: refine never builds an Anthropic client even when one is available —
+# the only client factory it may reach for is create_openai_client (ollama).
+# --------------------------------------------------------------------------- #
+def test_refine_client_factory_is_openai_compatible_only() -> None:
+    settings = Settings(anthropic_api_key="sk-ant-fake-cloud-key")
+    client = _refine.resolve_on_box_client(settings)
+
+    # The real path returns an AsyncOpenAI bound to the ollama /v1 endpoint with
+    # the literal "ollama" sentinel key — never a real cloud key.
+    base_url = str(getattr(client, "base_url", ""))
+    assert "/v1" in base_url
+    assert "11434" in base_url or "ollama" in base_url.lower()
+    api_key = getattr(client, "api_key", None)
+    assert api_key == "ollama", "the on-box client must use the ollama sentinel key"
+
+
+@pytest.mark.parametrize("refine_flag", [True, False])
+def test_options_refine_flag_roundtrips(refine_flag: bool) -> None:
+    from pocketpaw_ee.discovery import DiscoveryRunOptions
+
+    opts = DiscoveryRunOptions(refine=refine_flag)
+    assert opts.refine is refine_flag

--- a/tests/ee/test_discovery_run.py
+++ b/tests/ee/test_discovery_run.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-import pytest
 from pocketpaw_ee.discovery import (
     DiscoveryRun,
     DiscoveryRunOptions,
@@ -280,11 +279,33 @@ async def test_permission_filter_skips_disallowed_connectors() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# The on-box refine pass is not wired in slice 1 — fail loud, don't lie.
+# The on-box refine pass is WIRED in F3 — opts.refine=True runs the deterministic
+# digest, then routes it through the on-box refine helper (no longer raises).
+# The deep sovereignty/availability assertions live in test_discovery_refine.py;
+# here we just prove run() delegates to _refine.refine_draft and never raises.
 # --------------------------------------------------------------------------- #
-async def test_refine_pass_not_implemented_in_slice_1() -> None:
-    registry = _MockRegistry({})
+async def test_refine_pass_delegates_to_on_box_refine(monkeypatch) -> None:
+    from pocketpaw_ee.discovery import _refine
+
+    adapter = _MockAdapter(
+        schemas=[_MockActionSchema(name="list_rows", trust_level="auto")],
+        data_by_action={"list_rows": _records(2)},
+    )
+    registry = _MockRegistry({"c": adapter})
     run = DiscoveryRun(registry=registry)
 
-    with pytest.raises(NotImplementedError, match="on-box / tenant model"):
-        await run.run("ws-1", [], DiscoveryRunOptions(refine=True))
+    seen: dict[str, Any] = {}
+
+    async def _fake_refine(draft: OntologyDraft, settings: Any) -> OntologyDraft:
+        seen["called"] = True
+        draft.meta["refine"] = "applied"
+        return draft
+
+    monkeypatch.setattr(_refine, "refine_draft", _fake_refine)
+
+    draft = await run.run("ws-1", ["c"], DiscoveryRunOptions(refine=True))
+
+    assert seen.get("called") is True, "refine=True must delegate to _refine.refine_draft"
+    assert draft.meta["refine"] == "applied"
+    # The deterministic provenance is still stamped underneath the refine pass.
+    assert draft.meta["discovery"]["label"] == "based on 1 of 1"

--- a/tests/ee/test_instinct_proposal_edit.py
+++ b/tests/ee/test_instinct_proposal_edit.py
@@ -1,0 +1,372 @@
+# tests/ee/test_instinct_proposal_edit.py — F4 (edit-in-review PATCH endpoint).
+#
+# Created: 2026-06-21 (F4 / feat/szd-finish-core). Covers the
+# ``PATCH /instinct/actions/{action_id}/proposal`` endpoint that lets a reviewer
+# MUTATE a staged discovery proposal (rename an inferred type, drop a spurious link,
+# fix an inferred key, tighten a discovered rule's CEL) BEFORE approving — turning the
+# Instinct gate from approve/reject-only into review-EDIT-approve. The edit NEVER flips
+# status (Approve stays a separate, deliberate second click).
+#
+# THE LOAD-BEARING ASSERTIONS (the security crux): a discovery proposal blob carries the
+# tenant id in TWO places — the top-level ``workspace_id`` AND (for ``_instinct_rule``)
+# ``rule_spec.scope.workspace_id`` — and the executor scopes the persisted rule by the
+# SECOND one. The edit endpoint must pin BOTH from the original blob and reject any
+# client attempt to change either (mismatch → 403). Miss the second copy and a tenant
+# edits a proposal into another workspace.
+#   * ``test_patch_pins_workspace_id_top_level`` — a foreign top-level ``workspace_id``
+#     is pinned back / 403, never persisted.
+#   * ``test_patch_pins_rule_scope_workspace_id`` — THE crux — a foreign
+#     ``rule_spec.scope.workspace_id`` → 403, not persisted.
+#
+# Plus the gate invariants:
+#   * ``test_patch_rejects_non_pending_409`` — editing an approved/rejected action → 409.
+#   * ``test_patch_bad_cel_returns_422_not_persisted`` — a malformed CEL ``when`` → 422,
+#     blob unchanged (re-validation happens BEFORE persist).
+#   * ``test_patch_emits_human_corrected_edited_without_completed`` — a valid edit emits
+#     ``human.corrected(disposition="edited")`` and NO ``decision.completed`` (the chain
+#     stays open for the eventual approve).
+#   * ``test_patch_kind_mismatch_422`` — payload kind ≠ blob kind → 422.
+#   * ``test_patch_edits_rule_when_then_still_pending`` — a valid edit to the rule
+#     ``when`` persists and status stays PENDING.
+#
+# The 403/409/422 tests are sync and drive the router over HTTP via ``TestClient`` (the
+# guard fires BEFORE any executor/DB touch, mirroring test_instinct_rule_router). The
+# tests that assert chain emits / persistence are async (``AsyncClient`` +
+# ``ASGITransport``) and patch the journal writer so no Beanie is needed.
+#
+# Run with:
+#   uv run --group ee pytest tests/ee/test_instinct_proposal_edit.py -q
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.instinct_rule_proposals import INSTINCT_RULE_PARAM_KEY  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+TRIGGER = {"type": "agent", "source": "claude", "reason": "proposal edit test"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — auth doubles + a CloudError-aware app (cloned from the rule router test)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = "user-A", workspace_id: str = "ws-A") -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+        self.workspaces = [_FakeMembership(workspace=workspace_id, role="admin")]
+
+
+def _rule_spec(workspace_id: str, name: str = "Require approval on high-value invoices") -> dict:
+    """A valid editable RuleDraft-shaped rule_spec. Tenancy is duplicated here in
+    ``scope.workspace_id`` AND on the blob's top-level ``workspace_id`` — the edit
+    endpoint must pin BOTH."""
+    return {
+        "name": name,
+        "description": "Flag invoices over 10k for human review.",
+        "when": "object.amount > 10000",
+        "action": "require_approval",
+        "scope": {"workspace_id": workspace_id, "object_type": "Invoice"},
+        "confidence": 0.82,
+        "provenance": ["audit:row-1", "correction:c-9"],
+    }
+
+
+def _rule_blob(workspace_id: str, *, name: str = "rule") -> dict:
+    """The ``_instinct_rule`` blob the propose helper stores. Tenancy / owner are SEPARATE
+    top-level fields; ``rule_spec.scope.workspace_id`` is the SECOND tenancy copy."""
+    return {
+        "kind": "instinct_rule",
+        "schema": 1,
+        "workspace_id": workspace_id,
+        "user_id": "user-A",
+        "rule_spec": _rule_spec(workspace_id, name=name),
+        "summary": f"Create the governed rule {name!r}.",
+        "correlation_id": None,
+        "proposed_event_id": None,
+    }
+
+
+@pytest.fixture
+def edit_store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "instinct_proposal_edit.db")
+
+
+def _make_app(user: _FakeUser, monkeypatch) -> FastAPI:
+    """Build a FastAPI app over the instinct router with a CloudError handler so a
+    ``Forbidden`` / ``Conflict`` map to 403 / 409 (not 500), license / plan deps stubbed."""
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: user.active_workspace
+    return app
+
+
+def _make_client(edit_store: InstinctStore, user: _FakeUser, monkeypatch) -> TestClient:
+    return TestClient(_make_app(user, monkeypatch))
+
+
+def _propose_rule_action(client: TestClient, *, workspace_id: str, name: str = "rule") -> str:
+    """Seed a PENDING Action carrying an ``_instinct_rule`` blob over HTTP, return its id."""
+    resp = client.post(
+        "/instinct/actions",
+        json={
+            "pocket_id": workspace_id,
+            "title": f"governed rule {name}",
+            "trigger": TRIGGER,
+            "parameters": {INSTINCT_RULE_PARAM_KEY: _rule_blob(workspace_id, name=name)},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _action_by_id(client: TestClient, action_id: str) -> dict[str, Any]:
+    resp = client.get("/instinct/actions", params={"limit": 500})
+    assert resp.status_code == 200, resp.text
+    for action in resp.json()["actions"]:
+        if action["id"] == action_id:
+            return action
+    raise AssertionError(f"action {action_id} not found")
+
+
+def _stored_rule_blob(client: TestClient, action_id: str) -> dict[str, Any]:
+    return _action_by_id(client, action_id)["parameters"][INSTINCT_RULE_PARAM_KEY]
+
+
+# ===========================================================================
+# THE SECURITY CRUX — BOTH tenancy copies are pinned. A foreign top-level
+# ``workspace_id`` OR a foreign ``rule_spec.scope.workspace_id`` → 403, never persisted.
+# ===========================================================================
+
+
+def test_patch_pins_workspace_id_top_level(edit_store: InstinctStore, monkeypatch) -> None:
+    """A client sending a foreign TOP-LEVEL ``workspace_id`` in the edit is refused with
+    403 and the blob is never persisted with the foreign workspace."""
+    client = _make_client(edit_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=edit_store):
+        action_id = _propose_rule_action(client, workspace_id="ws-A")
+        # The editable sub-field is fine, but the client also smuggles a foreign
+        # top-level workspace_id alongside it.
+        edited_spec = _rule_spec("ws-A")
+        edited_spec["when"] = "object.amount > 5000"
+        resp = client.patch(
+            f"/instinct/actions/{action_id}/proposal",
+            json={"workspace_id": "ws-EVIL", "rule_spec": edited_spec},
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+
+        # The blob's top-level workspace_id is STILL ws-A — the foreign value never landed.
+        blob = _stored_rule_blob(client, action_id)
+        assert blob["workspace_id"] == "ws-A"
+        # And the editable when was NOT persisted (the whole edit was refused).
+        assert blob["rule_spec"]["when"] == "object.amount > 10000"
+        assert _action_by_id(client, action_id)["status"] == "pending"
+
+
+def test_patch_pins_rule_scope_workspace_id(edit_store: InstinctStore, monkeypatch) -> None:
+    """THE security crux — a client sending a foreign ``rule_spec.scope.workspace_id``
+    (the SECOND tenancy copy, which the executor scopes the rule by) → 403, not persisted.
+    Miss this copy and a tenant edits the rule into another workspace."""
+    client = _make_client(edit_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=edit_store):
+        action_id = _propose_rule_action(client, workspace_id="ws-A")
+        # Foreign workspace smuggled INSIDE the editable rule_spec's scope.
+        edited_spec = _rule_spec("ws-A")
+        edited_spec["scope"]["workspace_id"] = "ws-EVIL"
+        resp = client.patch(
+            f"/instinct/actions/{action_id}/proposal",
+            json={"rule_spec": edited_spec},
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "instinct.cross_workspace_approval"
+
+        # The SECOND tenancy copy is STILL ws-A — the foreign scope never landed.
+        blob = _stored_rule_blob(client, action_id)
+        assert blob["rule_spec"]["scope"]["workspace_id"] == "ws-A"
+        assert _action_by_id(client, action_id)["status"] == "pending"
+
+
+# ===========================================================================
+# GATE INVARIANTS — status / kind / re-validation.
+# ===========================================================================
+
+
+def test_patch_rejects_non_pending_409(edit_store: InstinctStore, monkeypatch) -> None:
+    """Editing an already-approved (non-PENDING) action → 409. Its chain is closed; an
+    edit-in-review only makes sense before the approve click."""
+    client = _make_client(edit_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=edit_store):
+        action_id = _propose_rule_action(client, workspace_id="ws-A")
+        # Flip the action out of PENDING directly via the store (no executor side-effects).
+        import asyncio
+
+        asyncio.run(edit_store.approve(action_id, approver="user-A"))
+
+        edited_spec = _rule_spec("ws-A")
+        edited_spec["when"] = "object.amount > 1"
+        resp = client.patch(
+            f"/instinct/actions/{action_id}/proposal",
+            json={"rule_spec": edited_spec},
+        )
+        assert resp.status_code == 409, resp.text
+
+
+def test_patch_bad_cel_returns_422_not_persisted(edit_store: InstinctStore, monkeypatch) -> None:
+    """A malformed CEL ``when`` fails re-validation with 422 and the blob is unchanged —
+    re-validation runs BEFORE persist, so a broken rule never lands."""
+    client = _make_client(edit_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=edit_store):
+        action_id = _propose_rule_action(client, workspace_id="ws-A")
+        edited_spec = _rule_spec("ws-A")
+        edited_spec["when"] = "object.amount >>> (((bad cel"
+        resp = client.patch(
+            f"/instinct/actions/{action_id}/proposal",
+            json={"rule_spec": edited_spec},
+        )
+        assert resp.status_code == 422, resp.text
+
+        # The stored when is unchanged — the broken edit never persisted.
+        blob = _stored_rule_blob(client, action_id)
+        assert blob["rule_spec"]["when"] == "object.amount > 10000"
+        assert _action_by_id(client, action_id)["status"] == "pending"
+
+
+def test_patch_kind_mismatch_422(edit_store: InstinctStore, monkeypatch) -> None:
+    """A payload whose kind (``pocket_spec``) does not match the action's blob kind
+    (``_instinct_rule``) → 422. The endpoint edits ONLY the matching sub-field."""
+    client = _make_client(edit_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=edit_store):
+        action_id = _propose_rule_action(client, workspace_id="ws-A")
+        resp = client.patch(
+            f"/instinct/actions/{action_id}/proposal",
+            json={"pocket_spec": {"name": "wrong kind"}},
+        )
+        assert resp.status_code == 422, resp.text
+
+        # The rule blob is untouched.
+        blob = _stored_rule_blob(client, action_id)
+        assert blob["rule_spec"]["when"] == "object.amount > 10000"
+
+
+def test_patch_edits_rule_when_then_still_pending(edit_store: InstinctStore, monkeypatch) -> None:
+    """A valid edit to the rule ``when`` persists the tightened CEL AND keeps the action
+    PENDING — the edit does NOT approve; Approve stays a separate click."""
+    client = _make_client(edit_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=edit_store):
+        action_id = _propose_rule_action(client, workspace_id="ws-A")
+        edited_spec = _rule_spec("ws-A")
+        edited_spec["when"] = "object.amount > 25000"
+        resp = client.patch(
+            f"/instinct/actions/{action_id}/proposal",
+            json={"rule_spec": edited_spec},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["action"]["status"] == "pending"
+        assert resp.json()["correction"] is not None
+
+        # The tightened when PERSISTED; tenancy copies are intact; status still PENDING.
+        blob = _stored_rule_blob(client, action_id)
+        assert blob["rule_spec"]["when"] == "object.amount > 25000"
+        assert blob["workspace_id"] == "ws-A"
+        assert blob["rule_spec"]["scope"]["workspace_id"] == "ws-A"
+        assert _action_by_id(client, action_id)["status"] == "pending"
+
+
+# ===========================================================================
+# CHAIN — a valid edit emits human.corrected(edited) and NO decision.completed
+# (the chain stays OPEN for the eventual approve).
+# ===========================================================================
+
+
+async def _async_client(user: _FakeUser, monkeypatch) -> AsyncClient:
+    app = _make_app(user, monkeypatch)
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver")
+
+
+async def test_patch_emits_human_corrected_edited_without_completed(
+    edit_store: InstinctStore, monkeypatch
+) -> None:
+    """A valid edit lands ``agent.proposed → human.corrected(edited)`` WITHOUT a
+    ``decision.completed`` — the chain stays open for the eventual approve click."""
+    import pocketpaw_ee.cloud.decisions.journal_writer as jw
+
+    corrected: list[dict[str, Any]] = []
+    completed: list[dict[str, Any]] = []
+
+    def _spy_corrected(**kwargs: Any) -> Any:
+        corrected.append(kwargs)
+
+        class _E:
+            id = "evt-corrected"
+
+        return _E()
+
+    def _spy_completed(**kwargs: Any) -> Any:
+        completed.append(kwargs)
+        return None
+
+    monkeypatch.setattr(jw, "record_human_corrected", _spy_corrected)
+    monkeypatch.setattr(jw, "record_decision_completed", _spy_completed)
+
+    user = _FakeUser("user-A", "ws-A")
+    with patch("pocketpaw_ee.instinct.router._store", return_value=edit_store):
+        async with await _async_client(user, monkeypatch) as client:
+            # Seed a rule action carrying a non-null correlation_id so the emit fires.
+            blob = _rule_blob("ws-A")
+            blob["correlation_id"] = "11111111-1111-1111-1111-111111111111"
+            seed = await client.post(
+                "/instinct/actions",
+                json={
+                    "pocket_id": "ws-A",
+                    "title": "governed rule emit",
+                    "trigger": TRIGGER,
+                    "parameters": {INSTINCT_RULE_PARAM_KEY: blob},
+                },
+            )
+            assert seed.status_code == 201, seed.text
+            action_id = seed.json()["id"]
+
+            edited_spec = _rule_spec("ws-A")
+            edited_spec["when"] = "object.amount > 50000"
+            resp = await client.patch(
+                f"/instinct/actions/{action_id}/proposal",
+                json={"rule_spec": edited_spec},
+            )
+            assert resp.status_code == 200, resp.text
+
+    # human.corrected fired exactly once with disposition="edited".
+    assert len(corrected) == 1
+    assert corrected[0]["payload"]["disposition"] == "edited"
+    # NO decision.completed — the chain stays open for the eventual approve.
+    assert completed == []

--- a/tests/ee/test_kb_compile_categorize.py
+++ b/tests/ee/test_kb_compile_categorize.py
@@ -1,0 +1,369 @@
+# tests/ee/test_kb_compile_categorize.py — F2 on-box CATEGORIZATION tests.
+#
+# Created: 2026-06-21 (F2 / feat/szd-finish-core) — covers the prepare/accept
+# agent-mode categorization path added to KbCompileDigester._compile_blobs.
+#
+# The slice: route unstructured exhaust through kb's agent-mode
+# (`kb prepare` → on-box Ollama model → `kb accept`) WHEN a model is configured,
+# so real text gets DOMAIN categories (SupportTicket, RefundRequest, ...) instead
+# of the single hardcoded "conversation" category `kb convo ingest` always tags.
+# When no on-box model is configured, the digester falls back to today's
+# `kb convo ingest` path (graceful degrade, no error).
+#
+# Covers:
+#   * prepare/accept path runs when a model is configured → 2 typed buckets;
+#   * fallback to `convo ingest` when no model is configured (no error);
+#   * the sovereignty tripwire holds across the WHOLE compile (never ingest/build);
+#   * prepare/accept use the discovery scope `workspace:<wid>:discovery`.
+#
+# Both seams are stubbed: the `_kb` subprocess seam (canned prepare/accept/list/
+# show output, in memory) AND the on-box Ollama client (canned categorized
+# article JSON). No running Ollama, no real kb binary required.
+#
+# Run with:
+#   uv run --group ee pytest tests/ee/test_kb_compile_categorize.py -q
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.discovery import OntologyDraft  # noqa: E402
+from pocketpaw_ee.discovery.kb_compile import KbCompileDigester  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fakes — the kb-go subprocess seam, agent-mode aware (prepare/accept)
+# --------------------------------------------------------------------------- #
+def _make_fake_kb(monkeypatch) -> list[tuple[str, ...]]:
+    """Patch the `_kb` seam with an agent-mode-aware in-memory fake.
+
+    Models the real prepare → accept → list → show round-trip:
+
+      * ``prepare <dir> --pattern ... --scope <s>`` → one ``item`` per blob file
+        with a ``prompt`` (we don't parse the prompt; the model stub ignores it);
+      * ``accept --scope <s>`` (article JSON on stdin) → stores the supplied
+        articles under ``<s>`` with the MODEL's categories;
+      * ``list --scope <s>`` → lean entries; ``show <id> --scope <s>`` → full body;
+      * ``convo ingest`` (the FALLBACK) → stores a single "conversation"-tagged
+        article so a fallback run still yields a (degraded) draft.
+
+    Returns the ``calls`` list so a test can assert which path ran and that the
+    sovereignty tripwire (never ``ingest`` / ``build``) holds.
+    """
+    calls: list[tuple[str, ...]] = []
+    store: dict[str, list[dict]] = {}
+    # A monotonic id so multiple accepted articles in one scope stay distinct.
+    counter = {"n": 0}
+
+    def _scope_of(args: tuple[str, ...]) -> str:
+        if "--scope" in args:
+            return args[args.index("--scope") + 1]
+        return "default"
+
+    def _fake_kb(*args: str, input_text: str | None = None, timeout: int = 120) -> Any:
+        calls.append(args)
+        # SOVEREIGNTY: the off-box LLM-compile paths must NEVER be reached.
+        assert args[0] != "ingest", (
+            "sovereignty: KbCompileDigester must not call `kb ingest` (off-box LLM)"
+        )
+        assert args[0] != "build", (
+            "sovereignty: KbCompileDigester must not call `kb build` (off-box LLM)"
+        )
+
+        scope = _scope_of(args)
+
+        if args[0] == "prepare":
+            # Emit one prepare item per "file" — the digester writes ONE temp
+            # file per label, so a single item per prepare call is realistic.
+            return {
+                "scope": scope,
+                "items": [
+                    {
+                        "source": "blob.txt",
+                        "hash": "deadbeef",
+                        "raw_id": "deadbeef00000000",
+                        "prompt": "Compile this text into a wiki article with categories.",
+                    }
+                ],
+                "pending": 1,
+                "cached": 0,
+                "total": 1,
+            }
+
+        if args[0] == "accept":
+            # The article JSON the digester compiled (from the model) is on stdin.
+            store.setdefault(scope, [])
+            try:
+                payload = json.loads(input_text) if input_text else {}
+            except json.JSONDecodeError:
+                payload = {}
+            arts = payload.get("articles", []) if isinstance(payload, dict) else []
+            for a in arts:
+                counter["n"] += 1
+                art = dict(a)
+                # `accept` slugifies the title into the id; emulate a stable id.
+                art.setdefault("id", f"art-{counter['n']}")
+                store[scope].append(art)
+            return {"accepted": len(arts), "articles": len(arts), "concepts": 0}
+
+        if args[0] == "convo":
+            # FALLBACK: `convo ingest` hardcodes a single "conversation" article.
+            store.setdefault(scope, [])
+            counter["n"] += 1
+            store[scope].append(
+                {
+                    "id": f"convo-{counter['n']}",
+                    "title": "Conversation",
+                    "summary": "deterministic convo ingest",
+                    "content": "body",
+                    "concepts": [],
+                    "categories": ["conversation"],
+                }
+            )
+            return {"articles": 1}
+
+        if args[0] == "list":
+            return [
+                {"id": a["id"], "title": a.get("title", ""), "summary": a.get("summary", "")}
+                for a in store.get(scope, [])
+            ]
+
+        if args[0] == "show":
+            article_id = args[1]
+            for a in store.get(scope, []):
+                if a["id"] == article_id:
+                    return dict(a)
+            return {}
+
+        if args[0] == "graph":
+            return {"scope": scope, "nodes": [], "edges": []}
+
+        return {}
+
+    monkeypatch.setattr("pocketpaw_ee.discovery.kb_compile._kb", _fake_kb)
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# Fake on-box model — returns a categorized article per prompt
+# --------------------------------------------------------------------------- #
+class _FakeChatCompletions:
+    def __init__(self, articles: list[dict]) -> None:
+        # One canned article per model call, cycled in order.
+        self._articles = list(articles)
+        self._i = 0
+
+    async def create(self, **kwargs: Any) -> Any:
+        # Assert the call is shaped the way the slice requires.
+        assert kwargs.get("response_format") == {"type": "json_object"}, (
+            "categorization must request a JSON object response"
+        )
+        art = self._articles[self._i % len(self._articles)]
+        self._i += 1
+        content = json.dumps(art)
+
+        class _Msg:
+            def __init__(self, c: str) -> None:
+                self.content = c
+
+        class _Choice:
+            def __init__(self, c: str) -> None:
+                self.message = _Msg(c)
+
+        class _Resp:
+            def __init__(self, c: str) -> None:
+                self.choices = [_Choice(c)]
+
+        return _Resp(content)
+
+
+class _FakeChat:
+    def __init__(self, articles: list[dict]) -> None:
+        self.completions = _FakeChatCompletions(articles)
+
+
+class _FakeOllamaClient:
+    """Stand-in for the AsyncOpenAI client resolve_on_box_client returns."""
+
+    def __init__(self, articles: list[dict]) -> None:
+        self.chat = _FakeChat(articles)
+
+
+# Two DOMAIN-categorized articles the model "compiles" — proves the model path
+# escapes the single "conversation" bucket the deterministic path is stuck on.
+_MODEL_ARTICLES = [
+    {
+        "source": "blob.txt",
+        "hash": "deadbeef",
+        "raw_id": "deadbeef00000000",
+        "title": "Login lockout after billing failure",
+        "summary": "Customer cannot log in; billing lock triggered.",
+        "content": "Full ticket body about a billing lockout.",
+        "concepts": ["billing", "login"],
+        "categories": ["SupportTicket"],
+    },
+    {
+        "source": "blob.txt",
+        "hash": "cafef00d",
+        "raw_id": "cafef00d00000000",
+        "title": "Refund requested on invoice 12",
+        "summary": "Refund request tied to a billing dispute.",
+        "content": "Full refund-request body referencing invoice 12.",
+        "concepts": ["billing", "refund"],
+        "categories": ["RefundRequest"],
+    },
+]
+
+
+def _stub_on_box_client(monkeypatch, articles: list[dict]) -> _FakeOllamaClient:
+    """Make resolve_on_box_client return ONE shared fake categorizing client.
+
+    The digester resolves a client once per label (per ``_compile_blobs``); a
+    single shared client makes its completion stub cycle through ``articles``
+    across labels, so two labels get two distinct categories.
+    """
+    client = _FakeOllamaClient(articles)
+    monkeypatch.setattr(
+        "pocketpaw_ee.discovery.kb_compile.resolve_on_box_client",
+        lambda settings: client,
+    )
+    return client
+
+
+class _FakeSettings:
+    """Minimal settings stub — only the fields the categorize path reads."""
+
+    ollama_model = "llama3.2"
+
+
+# --------------------------------------------------------------------------- #
+# 1) prepare/accept path runs when a model is configured
+# --------------------------------------------------------------------------- #
+def test_compile_uses_prepare_accept_when_model_configured(monkeypatch) -> None:
+    calls = _make_fake_kb(monkeypatch)
+    _stub_on_box_client(monkeypatch, _MODEL_ARTICLES)
+
+    digester = KbCompileDigester(settings=_FakeSettings())
+    exhaust = {
+        "support": ["Customer can't log in, billing locked."],
+        "refunds": ["Refund requested on invoice 12."],
+    }
+    draft = digester.digest(exhaust, {"connector": "zendesk", "workspace_id": "w1"})
+
+    assert isinstance(draft, OntologyDraft)
+    # The model supplied DOMAIN categories → TWO typed buckets, not objects-only.
+    names = sorted(ot.name for ot in draft.object_types)
+    assert names == ["RefundRequest", "SupportTicket"], names
+    # Each typed bucket keys on the article id (high key confidence).
+    for ot in draft.object_types:
+        assert ot.source_id_field == "id"
+        assert ot.key_confidence >= 0.8
+    # The subprocess calls were prepare + accept, NOT convo ingest.
+    cmds = [c[0] for c in calls]
+    assert "prepare" in cmds
+    assert "accept" in cmds
+    assert "convo" not in cmds, "model path must not fall back to convo ingest"
+
+
+# --------------------------------------------------------------------------- #
+# 2) fallback to convo ingest when no model configured
+# --------------------------------------------------------------------------- #
+def test_compile_falls_back_to_convo_ingest_without_model(monkeypatch) -> None:
+    calls = _make_fake_kb(monkeypatch)
+    # No on-box client stub — but guard against any accidental resolution by
+    # making resolve raise (simulating "no ollama configured / unavailable").
+    monkeypatch.setattr(
+        "pocketpaw_ee.discovery.kb_compile.resolve_on_box_client",
+        lambda settings: (_ for _ in ()).throw(RuntimeError("no ollama")),
+    )
+
+    # settings=None → no model configured → the digester takes the convo path.
+    digester = KbCompileDigester(settings=None)
+    draft = digester.digest({"zendesk": ["some ticket text"]}, {"workspace_id": "w1"})
+
+    assert isinstance(draft, OntologyDraft)
+    cmds = [c[0] for c in calls]
+    # Fell back to the deterministic keyless path — no error raised.
+    assert "convo" in cmds
+    assert "prepare" not in cmds
+    assert "accept" not in cmds
+
+
+def test_compile_falls_back_when_model_resolution_fails(monkeypatch) -> None:
+    """A configured-but-unavailable model degrades to convo ingest, no error."""
+    calls = _make_fake_kb(monkeypatch)
+    monkeypatch.setattr(
+        "pocketpaw_ee.discovery.kb_compile.resolve_on_box_client",
+        lambda settings: (_ for _ in ()).throw(RuntimeError("ollama serve is down")),
+    )
+
+    digester = KbCompileDigester(settings=_FakeSettings())
+    draft = digester.digest({"zendesk": ["ticket text"]}, {"workspace_id": "w1"})
+
+    assert isinstance(draft, OntologyDraft)
+    cmds = [c[0] for c in calls]
+    # Model configured but resolve failed → graceful degrade to convo ingest.
+    assert "convo" in cmds
+    assert "accept" not in cmds
+
+
+# --------------------------------------------------------------------------- #
+# 3) sovereignty tripwire across the whole compile (model path)
+# --------------------------------------------------------------------------- #
+def test_compile_never_calls_kb_ingest_or_build(monkeypatch) -> None:
+    calls = _make_fake_kb(monkeypatch)
+    _stub_on_box_client(monkeypatch, _MODEL_ARTICLES)
+
+    digester = KbCompileDigester(settings=_FakeSettings())
+    digester.digest(
+        {"support": ["t1"], "refunds": ["t2"]},
+        {"workspace_id": "w1", "connector": "zendesk"},
+    )
+
+    assert calls, "expected the digester to drive the kb seam at least once"
+    # The load-bearing assertion: across the WHOLE compile (prepare/accept model
+    # path included), the off-box LLM-compile commands are NEVER invoked.
+    assert all(c[0] not in ("ingest", "build") for c in calls)
+    # And the on-box agent-mode pair actually ran.
+    assert any(c[0] == "prepare" for c in calls)
+    assert any(c[0] == "accept" for c in calls)
+
+
+def test_compile_never_calls_ingest_or_build_on_fallback(monkeypatch) -> None:
+    """The tripwire also holds on the fallback (no-model) path."""
+    calls = _make_fake_kb(monkeypatch)
+    digester = KbCompileDigester(settings=None)
+    digester.digest({"zendesk": ["t1", "t2"]}, {"workspace_id": "w1"})
+    assert all(c[0] not in ("ingest", "build") for c in calls)
+
+
+# --------------------------------------------------------------------------- #
+# 4) prepare/accept use the discovery scope
+# --------------------------------------------------------------------------- #
+def test_prepare_accept_use_discovery_scope(monkeypatch) -> None:
+    calls = _make_fake_kb(monkeypatch)
+    _stub_on_box_client(monkeypatch, _MODEL_ARTICLES)
+
+    digester = KbCompileDigester(settings=_FakeSettings())
+    digester.digest({"support": ["t"]}, {"workspace_id": "w7"})
+
+    expected_scope = "workspace:w7:discovery"
+
+    def _scope_of(args: tuple[str, ...]) -> str | None:
+        if "--scope" in args:
+            return args[args.index("--scope") + 1]
+        return None
+
+    prepare_calls = [c for c in calls if c[0] == "prepare"]
+    accept_calls = [c for c in calls if c[0] == "accept"]
+    assert prepare_calls, "expected a prepare call"
+    assert accept_calls, "expected an accept call"
+    assert all(_scope_of(c) == expected_scope for c in prepare_calls)
+    assert all(_scope_of(c) == expected_scope for c in accept_calls)
+    # prepare also passes the txt pattern so it scans the transcript files.
+    assert all("--pattern" in c for c in prepare_calls)


### PR DESCRIPTION
## What this is

The first half of finishing sovereign zero-setup discovery end to end. Slices 1 and 2 (in #1515 and #1521) built the discovery engine, but a customer couldn't actually reach it, it degraded on real messy text, and review was all-or-nothing. This PR closes those gaps.

**Stacked on #1521** (slice 2). Review and merge that first; this targets the slice-2 branch so the diff shows only the finish work.

## What's in it

- **F1 — the front door.** A new `POST /api/v1/cloud/discovery/run` endpoint enumerates the workspace's enabled connectors and fires a discovery run, returning 202 with a run id. The proposals surface as pending Instinct actions the review panel already polls. Until now discovery could only be started from a script.
- **F2 — works on real messy text.** `kb convo ingest` tags every article "conversation", so unstructured discovery used to collapse to one objects-only type. This routes exhaust through kb's `prepare → on-box model → accept` so real tickets and emails get domain categories (SupportTicket, RefundRequest). When no on-box model is configured it falls back to the old deterministic path, and it logs which path ran so a silent regression is visible.
- **F3 — the on-box refine pass.** `opts.refine` used to raise. It now cleans the inferred ontology (merge, rename, drop spurious links) using the tenant's own Ollama model. It fails closed on sovereignty (never a cloud call) and soft on availability (Ollama down returns the deterministic draft, stamped `refine=unavailable`, never an error).
- **F4 — edit before you approve.** A new `PATCH /instinct/actions/{id}/proposal` lets a reviewer tighten a rule's CEL, rename a type, drop a link, or fix a key on a pending proposal, then approve the edited version. It re-validates per blob type, records the change as a correction (feeding the learning loop), and never flips status.

## Sovereignty

F2 and F3 both call a model, and both hard-pin `force_provider="ollama"` so a tenant cloud key can never route raw text to Anthropic. That pin is asserted by mechanical tests (the resolved client has `api_key is None`). The existing `kb ingest`/`kb build` tripwire is extended and now also lives as a runtime assertion inside the `_kb` seam, not just in tests.

## Security (F4)

A discovery proposal carries the tenant id in two places: the top-level `workspace_id` and `rule_spec.scope.workspace_id` (the executor scopes the saved rule by the second one). The edit endpoint pins both from the original blob and 403s any client attempt to change either. Both pins have dedicated tests.

## Testing

All slices ship unit + integration tests; the discovery suite stays green. ruff clean, import-linter green, mypy introduces no new real errors.

Does not merge on green. Captain reviews.
