### PR TITLE
Close two discovery follow-ups: run_id correlation + edit-test coverage

### DIFF
--- a/ee/pocketpaw_ee/cloud/discovery/service.py
+++ b/ee/pocketpaw_ee/cloud/discovery/service.py
@@ -1,4 +1,10 @@
 # Discovery — service (cloud 4-file rule §5).
+# Updated: 2026-06-22 (feat/szd-finish-followups) — the trigger now mints the
+#   ``run_id`` ONCE and threads it BOTH into the 202 response AND into
+#   ``run_discovery_and_propose(run_id=...)``, so the staged proposals' discovery
+#   markers carry the SAME id the 202 handed the client. The previously-distinct
+#   "optimistic dispatch token vs. internal proposal run_id" split is gone — the
+#   client can now correlate its 202 ``run_id`` to the proposals it produced.
 # Created: 2026-06-21 (SZD finish slice F1 / feat/szd-finish-core) — the
 #   workspace-discovery TRIGGER. ``run(workspace_id, user_id, body)`` is the
 #   front door that today only a script could reach: it enumerates the
@@ -8,9 +14,9 @@
 #   (``asyncio.create_task``, mirroring chat/router's fire-and-forget) so the
 #   HTTP request returns 202 immediately instead of blocking on connector
 #   sampling + digest. The orchestrator stages its proposals durably as pending
-#   Instinct Actions, so the trigger's response only needs the optimistic
+#   Instinct Actions, so the trigger's response only needs the
 #   ``run_id`` — the action ids surface separately in the pending-actions list
-#   the ApprovalsPanel already polls.
+#   the ApprovalsPanel already polls, and the marker on each carries this run_id.
 #
 #   Sovereignty / tenancy: validate the body at entry (rule §6); pass the
 #   resolved ``workspace_id`` / ``user_id`` straight into the orchestrator,
@@ -80,8 +86,10 @@ async def run(
 
     Returns a wire dict (rule §5) shaped like ``DiscoveryRunResponse``. Because
     the run is fire-and-forget, the action-id fields are EMPTY in the response;
-    ``run_id`` is a dispatch token for optimistic UI confirmation (distinct from
-    the orchestrator's internal proposal run_id, which tags the staged Actions).
+    ``run_id`` is the dispatch token for optimistic UI confirmation AND the same
+    id the orchestrator tags onto the staged proposals' discovery markers (it is
+    passed in via ``run_discovery_and_propose(run_id=...)``), so a client can
+    correlate the 202 response to the proposals it produced.
     """
     # Lazy import to avoid a router→service→connectors import cycle at module load.
     from pocketpaw_ee.cloud.connectors import service as connectors_service
@@ -96,10 +104,14 @@ async def run(
 
     opts = DiscoveryRunOptions(sample_cap=body.sample_cap or DiscoveryRunOptions().sample_cap)
 
+    # Mint the run_id ONCE here and thread it BOTH into the 202 response AND into
+    # the orchestrator, so the client's dispatch token tags the staged proposals'
+    # discovery markers. A client can then correlate the 202 ``run_id`` to the
+    # proposals it produced when they surface in the pending-actions list.
     run_id = uuid4().hex
 
     task = asyncio.create_task(
-        run_discovery_and_propose(workspace_id, user_id, connector_ids, opts)
+        run_discovery_and_propose(workspace_id, user_id, connector_ids, opts, run_id=run_id)
     )
     task.add_done_callback(_log_task_result)
 

--- a/ee/pocketpaw_ee/discovery/orchestrate.py
+++ b/ee/pocketpaw_ee/discovery/orchestrate.py
@@ -51,6 +51,13 @@
 # reason "superseded by discovery run <id>") before filing the new set. Approved /
 # rejected / executed proposals are left alone — only the still-open ones collapse.
 #
+# Updated 2026-06-22 (feat/szd-finish-followups): ``run_discovery_and_propose`` now
+# takes an OPTIONAL keyword ``run_id``. When provided it tags this run's proposal
+# markers instead of minting a fresh one, so the F1 trigger can hand the SAME id
+# back in its 202 response AND pass it here — letting a client CORRELATE the 202
+# dispatch token to the proposals it produced. Default ``None`` mints as before
+# (backward-compatible).
+#
 # Async orchestration; depends on the SZD-4 DiscoveryRun + the SZD-5a/5b propose
 # helpers + the OSS InstinctStore (for the supersede sweep). No direct Fabric /
 # Pocket writes.
@@ -424,6 +431,7 @@ async def run_discovery_and_propose(
     opts: DiscoveryRunOptions | None = None,
     *,
     discovery_run: DiscoveryRun | None = None,
+    run_id: str | None = None,
 ) -> DiscoveryProposalResult:
     """Run discovery for a workspace and stage the two gated proposals.
 
@@ -449,6 +457,11 @@ async def run_discovery_and_propose(
         opts: discovery-run knobs (sampling cap, explicit read actions, ...).
         discovery_run: an injected ``DiscoveryRun`` (tests pass a mock-registry
             run); defaults to a fresh one driving the local-runtime registry.
+        run_id: an OPTIONAL pre-minted discovery-run id. When provided it tags this
+            run's proposal markers (so a caller that already handed a client a
+            dispatch token — the F1 trigger's 202 ``run_id`` — can CORRELATE that
+            token to the staged proposals). When ``None`` (the default) a fresh
+            ``uuid4().hex`` is minted as before — backward-compatible.
     """
     from pocketpaw_ee.cloud.fabric_proposals.propose import propose_fabric_objects
     from pocketpaw_ee.cloud.pocket_proposals.propose import propose_pocket
@@ -468,8 +481,11 @@ async def run_discovery_and_propose(
     )
 
     # The shared discovery-run marker — both proposals carry it so the NEXT run can
-    # find + supersede this still-open pair.
-    run_id = uuid4().hex
+    # find + supersede this still-open pair. When the caller pre-minted a run_id
+    # (the F1 trigger hands the same id back to the client in its 202), reuse it so
+    # the 202 dispatch token CORRELATES to these staged proposals; otherwise mint a
+    # fresh one (backward-compatible default).
+    run_id = run_id or uuid4().hex
 
     from pocketpaw.stores import get_instinct_store
 

--- a/tests/ee/test_discovery_propose.py
+++ b/tests/ee/test_discovery_propose.py
@@ -1,6 +1,13 @@
 # tests/ee/test_discovery_propose.py — SZD-6 integration: wire DiscoveryRun → the
 # two gated proposals + the starter-Pocket assembler + supersede-on-rerun.
 #
+# Updated: 2026-06-22 (feat/szd-finish-followups) — added two tests for the new
+# OPTIONAL ``run_id`` parameter on ``run_discovery_and_propose``:
+#   * ``test_passed_run_id_tags_proposal_markers`` — a caller-provided run_id tags
+#     the proposals' discovery markers (the F1 trigger's 202 token correlates);
+#   * ``test_omitted_run_id_mints_fresh_marker`` — the default path still mints a
+#     fresh uuid4 (backward-compatible).
+#
 # Created: 2026-06-19 (SZD-6 / feat/szd-6-integration). Covers the integration
 # entry point ``run_discovery_and_propose`` end to end, with the connector read
 # MOCKED (no live network) and real-but-isolated InstinctStore + FabricStore +
@@ -268,6 +275,64 @@ async def test_run_files_two_tagged_pending_proposals(store, fabric):
         "$source": "fabric.objects",
         "type_name": "Customer",
     }
+
+
+# ---------------------------------------------------------------------------
+# A caller-provided run_id tags the proposals' markers (followup-1: lets the F1
+# trigger correlate its 202 dispatch token to the proposals it produced).
+# ---------------------------------------------------------------------------
+
+
+async def test_passed_run_id_tags_proposal_markers(store, fabric):
+    """When ``run_discovery_and_propose`` is called with an explicit ``run_id``, the
+    staged proposals carry THAT exact id in their discovery markers (not a freshly
+    minted one) — so the F1 trigger's 202 ``run_id`` correlates to its proposals."""
+    adapters = {
+        "crm": _MockAdapter(schemas=[], data_by_action={"list_customers": _customers(2)}),
+    }
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    pinned_run_id = "deadbeefcafebabe0123456789abcdef"
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+        run_id=pinned_run_id,
+    )
+
+    # The result carries the caller's id (not a fresh uuid4).
+    assert result.run_id == pinned_run_id
+
+    # And BOTH proposals' markers carry that exact id.
+    fabric_action = await store.get_action(result.fabric_objects_action_id)
+    pocket_action = await store.get_action(result.pocket_action_id)
+    fo_marker = _find_discovery_marker(fabric_action.parameters)
+    pc_marker = _find_discovery_marker(pocket_action.parameters)
+    assert fo_marker is not None and pc_marker is not None
+    assert fo_marker["run_id"] == pc_marker["run_id"] == pinned_run_id
+
+
+async def test_omitted_run_id_mints_fresh_marker(store, fabric):
+    """The default path (no ``run_id``) still mints a fresh uuid4 — backward-compatible."""
+    adapters = {
+        "crm": _MockAdapter(schemas=[], data_by_action={"list_customers": _customers(2)}),
+    }
+    opts = _opts_for({"crm": [ReadAction(action="list_customers", type_name="Customer")]})
+
+    result = await run_discovery_and_propose(
+        workspace_id="w1",
+        user_id="u1",
+        connector_ids=["crm"],
+        opts=opts,
+        discovery_run=_mock_run(adapters),
+    )
+    # A minted run_id is a non-empty uuid4 hex (32 chars), and the markers carry it.
+    assert result.run_id and len(result.run_id) == 32
+    fabric_action = await store.get_action(result.fabric_objects_action_id)
+    fo_marker = _find_discovery_marker(fabric_action.parameters)
+    assert fo_marker is not None and fo_marker["run_id"] == result.run_id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ee/test_instinct_proposal_edit.py
+++ b/tests/ee/test_instinct_proposal_edit.py
@@ -29,6 +29,15 @@
 #   * ``test_patch_edits_rule_when_then_still_pending`` — a valid edit to the rule
 #     ``when`` persists and status stays PENDING.
 #
+# Updated: 2026-06-22 (feat/szd-finish-followups) — happy-path edit coverage for the
+# OTHER two blob kinds the PATCH endpoint handles (the rule kind already had it):
+#   * ``test_patch_pocket_create_renames_pocket`` — rename a pending ``_pocket_create``
+#     proposal → re-validates (CreatePocketRequest), persists, status stays PENDING,
+#     top-level tenancy/owner pinned.
+#   * ``test_patch_fabric_objects_drops_a_link`` — drop a spurious link on a pending
+#     ``_fabric_objects`` proposal → re-validates the lists, persists, status stays
+#     PENDING, ``workspace_id`` pinned.
+#
 # The 403/409/422 tests are sync and drive the router over HTTP via ``TestClient`` (the
 # guard fires BEFORE any executor/DB touch, mirroring test_instinct_rule_router). The
 # tests that assert chain emits / persistence are async (``AsyncClient`` +
@@ -53,8 +62,10 @@ from httpx import ASGITransport, AsyncClient  # noqa: E402
 from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
 from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
 from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.fabric_proposals import FABRIC_OBJECTS_PARAM_KEY  # noqa: E402
 from pocketpaw_ee.cloud.instinct_rule_proposals import INSTINCT_RULE_PARAM_KEY  # noqa: E402
 from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.pocket_proposals import POCKET_CREATE_PARAM_KEY  # noqa: E402
 from pocketpaw_ee.instinct.router import router  # noqa: E402
 
 from pocketpaw.instinct.store import InstinctStore  # noqa: E402
@@ -110,6 +121,74 @@ def _rule_blob(workspace_id: str, *, name: str = "rule") -> dict:
     }
 
 
+def _pocket_blob(workspace_id: str, *, name: str = "Discovered data") -> dict:
+    """The ``_pocket_create`` blob the propose helper stores. Tenancy / owner are SEPARATE
+    top-level fields; the editable ``pocket_spec`` is a CreatePocketRequest body (the
+    rippleSpec rides under the ``rippleSpec`` camelCase alias)."""
+    return {
+        "kind": "pocket_create",
+        "schema": 1,
+        "workspace_id": workspace_id,
+        "user_id": "user-A",
+        "pocket_spec": {
+            "name": name,
+            "rippleSpec": {
+                "version": "1.0",
+                "root": {"id": "root", "type": "container", "props": {}, "children": []},
+                "state": {},
+            },
+        },
+        "summary": f"Create the starter Pocket {name!r}.",
+        "correlation_id": None,
+        "proposed_event_id": None,
+    }
+
+
+def _fabric_blob(workspace_id: str) -> dict:
+    """The ``_fabric_objects`` blob the propose helper stores. Tenancy is a SEPARATE
+    top-level field; the editable shape is the three lists object_types / objects / links.
+    Seeded with TWO links so a happy-path edit can drop the spurious one."""
+    return {
+        "kind": "fabric_objects",
+        "schema": 1,
+        "workspace_id": workspace_id,
+        "object_types": [
+            {"type_name": "Customer", "description": "", "properties": []},
+            {"type_name": "Order", "description": "", "properties": []},
+        ],
+        "objects": [
+            {
+                "type_name": "Customer",
+                "properties": {"name": "Ada"},
+                "source_connector": "discovery:Customer",
+                "source_id": "cust-1",
+            },
+            {
+                "type_name": "Order",
+                "properties": {"total": 42},
+                "source_connector": "discovery:Order",
+                "source_id": "ord-1",
+            },
+        ],
+        "links": [
+            {
+                "from": {"source_connector": "discovery:Customer", "source_id": "cust-1"},
+                "to": {"source_connector": "discovery:Order", "source_id": "ord-1"},
+                "link_type": "placed",
+            },
+            {
+                # A SPURIOUS link the reviewer drops in the happy-path edit.
+                "from": {"source_connector": "discovery:Customer", "source_id": "cust-1"},
+                "to": {"source_connector": "discovery:Order", "source_id": "ord-1"},
+                "link_type": "bogus",
+            },
+        ],
+        "summary": "Create 2 Fabric object(s) across 2 type(s) and 2 link(s).",
+        "correlation_id": None,
+        "proposed_event_id": None,
+    }
+
+
 @pytest.fixture
 def edit_store(tmp_path: Path) -> InstinctStore:
     return InstinctStore(tmp_path / "instinct_proposal_edit.db")
@@ -150,6 +229,38 @@ def _propose_rule_action(client: TestClient, *, workspace_id: str, name: str = "
     return resp.json()["id"]
 
 
+def _propose_pocket_action(
+    client: TestClient, *, workspace_id: str, name: str = "Discovered data"
+) -> str:
+    """Seed a PENDING Action carrying a ``_pocket_create`` blob over HTTP, return its id."""
+    resp = client.post(
+        "/instinct/actions",
+        json={
+            "pocket_id": workspace_id,
+            "title": f"starter pocket {name}",
+            "trigger": TRIGGER,
+            "parameters": {POCKET_CREATE_PARAM_KEY: _pocket_blob(workspace_id, name=name)},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _propose_fabric_action(client: TestClient, *, workspace_id: str) -> str:
+    """Seed a PENDING Action carrying a ``_fabric_objects`` blob over HTTP, return its id."""
+    resp = client.post(
+        "/instinct/actions",
+        json={
+            "pocket_id": workspace_id,
+            "title": "fabric ontology",
+            "trigger": TRIGGER,
+            "parameters": {FABRIC_OBJECTS_PARAM_KEY: _fabric_blob(workspace_id)},
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
 def _action_by_id(client: TestClient, action_id: str) -> dict[str, Any]:
     resp = client.get("/instinct/actions", params={"limit": 500})
     assert resp.status_code == 200, resp.text
@@ -161,6 +272,14 @@ def _action_by_id(client: TestClient, action_id: str) -> dict[str, Any]:
 
 def _stored_rule_blob(client: TestClient, action_id: str) -> dict[str, Any]:
     return _action_by_id(client, action_id)["parameters"][INSTINCT_RULE_PARAM_KEY]
+
+
+def _stored_pocket_blob(client: TestClient, action_id: str) -> dict[str, Any]:
+    return _action_by_id(client, action_id)["parameters"][POCKET_CREATE_PARAM_KEY]
+
+
+def _stored_fabric_blob(client: TestClient, action_id: str) -> dict[str, Any]:
+    return _action_by_id(client, action_id)["parameters"][FABRIC_OBJECTS_PARAM_KEY]
 
 
 # ===========================================================================
@@ -300,6 +419,68 @@ def test_patch_edits_rule_when_then_still_pending(edit_store: InstinctStore, mon
         assert blob["rule_spec"]["when"] == "object.amount > 25000"
         assert blob["workspace_id"] == "ws-A"
         assert blob["rule_spec"]["scope"]["workspace_id"] == "ws-A"
+        assert _action_by_id(client, action_id)["status"] == "pending"
+
+
+def test_patch_pocket_create_renames_pocket(edit_store: InstinctStore, monkeypatch) -> None:
+    """A valid edit to a ``_pocket_create`` proposal renames the staged Pocket: it
+    re-validates (CreatePocketRequest), persists, status stays PENDING, and the top-level
+    tenancy / owner stay pinned (they live OUTSIDE the editable pocket_spec)."""
+    client = _make_client(edit_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=edit_store):
+        action_id = _propose_pocket_action(client, workspace_id="ws-A", name="Discovered data")
+        # Rename the pocket; carry the rippleSpec along so CreatePocketRequest re-validates.
+        edited_spec = {
+            "name": "Renamed dashboard",
+            "rippleSpec": {
+                "version": "1.0",
+                "root": {"id": "root", "type": "container", "props": {}, "children": []},
+                "state": {},
+            },
+        }
+        resp = client.patch(
+            f"/instinct/actions/{action_id}/proposal",
+            json={"pocket_spec": edited_spec},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["action"]["status"] == "pending"
+        assert resp.json()["correction"] is not None
+
+        # The new name PERSISTED; tenancy/owner pinned; status still PENDING.
+        blob = _stored_pocket_blob(client, action_id)
+        assert blob["pocket_spec"]["name"] == "Renamed dashboard"
+        assert blob["workspace_id"] == "ws-A"
+        assert blob["user_id"] == "user-A"
+        assert _action_by_id(client, action_id)["status"] == "pending"
+
+
+def test_patch_fabric_objects_drops_a_link(edit_store: InstinctStore, monkeypatch) -> None:
+    """A valid edit to a ``_fabric_objects`` proposal drops a spurious link: it re-validates
+    the editable lists, persists, status stays PENDING, and the top-level ``workspace_id``
+    stays pinned (it lives OUTSIDE the editable lists)."""
+    client = _make_client(edit_store, _FakeUser("user-A", "ws-A"), monkeypatch)
+    with patch("pocketpaw_ee.instinct.router._store", return_value=edit_store):
+        action_id = _propose_fabric_action(client, workspace_id="ws-A")
+        before = _stored_fabric_blob(client, action_id)
+        assert len(before["links"]) == 2  # seeded with the real link + the spurious one
+
+        # Keep ONLY the legitimate link (drop the "bogus" one).
+        kept_links = [link for link in before["links"] if link["link_type"] == "placed"]
+        resp = client.patch(
+            f"/instinct/actions/{action_id}/proposal",
+            json={"fabric": {"links": kept_links}},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["action"]["status"] == "pending"
+        assert resp.json()["correction"] is not None
+
+        # The spurious link is GONE; objects/types untouched; tenancy pinned; still PENDING.
+        blob = _stored_fabric_blob(client, action_id)
+        assert len(blob["links"]) == 1
+        assert blob["links"][0]["link_type"] == "placed"
+        assert {ot["type_name"] for ot in blob["object_types"]} == {"Customer", "Order"}
+        assert len(blob["objects"]) == 2
+        assert blob["workspace_id"] == "ws-A"
         assert _action_by_id(client, action_id)["status"] == "pending"
 
 

--- a/tests/ee/test_szd2_finish_e2e.py
+++ b/tests/ee/test_szd2_finish_e2e.py
@@ -1,5 +1,11 @@
 # tests/ee/test_szd2_finish_e2e.py — F5: the FINISH end-to-end test.
 #
+# Updated: 2026-06-22 (feat/szd-finish-followups) — the F1 trigger now mints the
+# run_id once and threads it into ``run_discovery_and_propose(run_id=...)``. The
+# delegating-orchestrator stub accepts + forwards the new keyword, and STEP 3 now
+# also asserts the 202 ``trigger_resp["run_id"]`` equals the proposals' marker
+# run_id (the correlation followup-1 adds).
+#
 # Created: 2026-06-21 (F5 / feat/szd-finish-enforce). This is the headline proof
 # that the WHOLE finished Sovereign Zero-Setup Discovery feature works as ONE
 # coherent flow — every stage F1→F6 wired together and driven through the REAL
@@ -559,13 +565,16 @@ async def test_szd_finish_trigger_to_edit_to_approve_to_enforce_sovereign(
 
     captured: dict[str, Any] = {}
 
-    async def _delegating_orchestrator(ws_id, u_id, connector_ids, run_opts=None):  # noqa: ARG001
+    async def _delegating_orchestrator(ws_id, u_id, connector_ids, run_opts=None, *, run_id=None):  # noqa: ARG001
         # (a) record what the F1 trigger resolved — the enabled-only enumeration.
         captured["connector_ids"] = list(connector_ids)
         captured["workspace_id"] = ws_id
         captured["user_id"] = u_id
+        captured["run_id"] = run_id
         # (b) drive the REAL finished orchestrator with our injected run + opts so
-        #     the deterministic flow exercises F2 (categorize) + F3 (refine).
+        #     the deterministic flow exercises F2 (categorize) + F3 (refine). Thread
+        #     the trigger's run_id through so the proposals' markers correlate to the
+        #     202 dispatch token.
         try:
             result = await orchestrate.run_discovery_and_propose(
                 ws_id,
@@ -573,6 +582,7 @@ async def test_szd_finish_trigger_to_edit_to_approve_to_enforce_sovereign(
                 connector_ids,
                 opts,
                 discovery_run=_make_discovery_run(registry, settings),
+                run_id=run_id,
             )
         except BaseException as exc:  # noqa: BLE001 — surface the swallowed task error
             captured["error"] = exc
@@ -644,6 +654,9 @@ async def test_szd_finish_trigger_to_edit_to_approve_to_enforce_sovereign(
     ir_marker = _find_discovery_marker(rule_action.parameters)
     assert fo_marker and pc_marker and ir_marker
     assert fo_marker["run_id"] == pc_marker["run_id"] == ir_marker["run_id"] == result.run_id
+    # CORRELATION (followup-1) — the 202 trigger run_id is the SAME id tagging the
+    # proposals' markers, so a client can match its 202 to the proposals it made.
+    assert trigger_resp["run_id"] == result.run_id == captured["run_id"]
 
     # ── STEP 4 — EDIT (F4). PATCH the rule proposal to TIGHTEN its CEL `when`. The
     #    edit re-validates, records an `edited` correction, and keeps PENDING. We


### PR DESCRIPTION
Two small follow-ups left over from the Sovereign Zero-Setup Discovery finish. Stacked on #1528 (targets feat/szd-finish-enforce).

## 1. Correlate the trigger run_id with the proposals

The F1 trigger minted a run_id for its 202 response, but the orchestrator minted its own separate id to tag the staged proposals. So a client got back a run_id that matched nothing it could find later.

`run_discovery_and_propose` now takes an optional `run_id`. When passed, it tags the proposal markers with that id instead of minting a fresh one. The F1 service mints the id once and hands it both to the 202 response and to the orchestrator, so the dispatch token a client holds actually points at the proposals it produced. Leaving the arg off mints as before, so nothing that called the orchestrator directly changes.

## 2. Happy-path edit tests for the other two blob kinds

The PATCH edit endpoint handles three discovery blob kinds, but only the rule kind had a happy-path edit test (that's where the dual-tenancy risk lives). Added the missing two:

- rename a pending `_pocket_create` proposal (re-validates CreatePocketRequest, stays pending, tenancy/owner pinned)
- drop a spurious link on a pending `_fabric_objects` proposal (re-validates the lists, stays pending, workspace_id pinned)

## Checks

- `tests/ee/test_instinct_proposal_edit.py test_discovery_propose.py test_discovery_rules_propose.py test_szd2_finish_e2e.py` — 28 passed
- adjacent guard run (`test_szd2_e2e.py`, `test_discovery_run.py`) — 9 passed
- ruff check + format clean, import-linter 25/0

The finish E2E now also asserts the 202 run_id equals the proposals' marker run_id, so the correlation is covered end to end.