### PR TITLE
fix(jobs): worker owns the status key, and score_applications reads live data

### DIFF
--- a/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
@@ -139,9 +139,7 @@ def _heuristic_score(row: dict[str, Any]) -> int:
         score += 15  # referral / social signal
 
     # Sparsity penalty — a record with almost nothing in it is low-signal.
-    populated = sum(
-        1 for v in row.values() if v is not None and str(v).strip() != ""
-    )
+    populated = sum(1 for v in row.values() if v is not None and str(v).strip() != "")
     if populated <= 1:
         score -= 20
     elif populated == 2:

--- a/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
@@ -1,27 +1,70 @@
 # ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
 # Created: 2026-06-20 (feat/workspace-jobs, pp#1459) — the first built-in
-# workspace job. V1 is deliberately a thin, side-effect-free reference: it
-# scores a batch of applications and projects each row through a PII allowlist
-# before the result becomes broadcast `state`. The allowlist is the security
-# point of the built-in — because a job result is merged into the pocket spec
-# and fanned out over the realtime bus to every open canvas, a job MUST strip
-# email / phone (and any non-allowlisted field) so PII never lands in the
-# broadcast/audit path. Enforced by the built-in's unit test.
+# workspace job. V1 was a thin, side-effect-free reference: a toy `len(name)`
+# score over `params["rows"]`, projected through a PII allowlist before the
+# result became broadcast `state`. The allowlist is the security point of the
+# built-in — a job result is merged into the pocket spec and fanned out over the
+# realtime bus to every open canvas, so a job MUST strip email / phone (and any
+# non-allowlisted field) so PII never lands in the broadcast/audit path.
 #
-# A real connector-backed implementation (reading the batch from the
-# workspace's stored creds via the source-read path, never params tokens) is a
-# follow-up; the contract + the PII transform are what V1 pins.
+# Updated: 2026-06-22 (fix/jobs-real-builtin-and-status) — turned the toy job
+# into a REAL data-backed job so the primitive can demo on live records, not
+# fixture rows hardcoded in a pocket spec:
+#   - SOURCE READ: when `params["source_collection"]` is set, the job reads
+#     records from that Mongo collection in the cloud DB through
+#     `jobs.service.read_source_records` (the jobs entity owns DB access — no
+#     second MongoClient, no direct Beanie-doc import). Bounded by `batch_size`.
+#   - IDEMPOTENT BATCH ADVANCEMENT: the job fetches the pocket's CURRENT
+#     `scored_rows` (via `pockets.service.get_pocket_ripple_spec`), SKIPS source
+#     records whose id is already scored, scores only the NEW ones, and returns
+#     the ACCUMULATED rows (existing + new) so the canvas grows by a batch per
+#     run — re-running pulls the next batch.
+#   - REAL HEURISTIC: a deterministic 0-100 field-based score (completeness +
+#     referral/social signal − disposable-email − sparsity), a `band`
+#     (Strong/Moderate/Weak), and `stage:"scored"`. Replaces `len(name)`.
+#   - PII ALLOWLIST still applies and is extended with `band`; email/phone/raw
+#     fields are stripped before a row reaches `state`.
+#   - FALLBACK: with no `source_collection`, the job keeps the existing
+#     `params["rows"]` behavior so current tests/specs still work.
+# The WORKER now owns the `<action>_status` flag (Bug B fix), so this built-in
+# no longer returns any status key — only `scored_rows` + the scored count.
 
-"""Built-in `score_applications` job + its PII allowlist transform."""
+"""Built-in `score_applications` job: real data-backed scoring + PII allowlist."""
 
 from __future__ import annotations
 
+import re
 from typing import Any
+
+from pocketpaw_ee.cloud.jobs import service as jobs_service
+from pocketpaw_ee.cloud.pockets import service as pockets_service
 
 # The ONLY fields a scored row may broadcast. Everything else — notably any
 # email / phone / free-text contact field — is dropped before the row reaches
 # `state`. Allowlist (not denylist) so a new raw field is dropped by default.
-_ALLOWED_ROW_FIELDS = ("id", "name", "score", "stage")
+_ALLOWED_ROW_FIELDS = ("id", "name", "score", "band", "stage")
+
+# Generic field fallbacks — kept deliberately broad so the job works on any
+# application/lead/submission shape, not just one customer's schema.
+_ID_FIELDS = ("id", "_id", "application_id", "submission_id")
+_NAME_FIELDS = ("name", "fullName", "full_name", "firstName", "first_name")
+_EMAIL_FIELDS = ("email", "emailAddress", "email_address")
+_MESSAGE_FIELDS = ("message", "what_brings_you", "bio", "answers", "notes", "about")
+_REFERRAL_FIELDS = ("referral", "referred_by", "referrer", "linkedin", "twitter", "social")
+
+# Disposable / throwaway email domains — a negative signal. Substring match so
+# subdomains (e.g. `foo.mailinator.com`) are caught too.
+_DISPOSABLE_PATTERNS = (
+    "mailinator",
+    "tempmail",
+    "temp-mail",
+    "throwaway",
+    "guerrillamail",
+    "10minutemail",
+    "trashmail",
+)
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 
 def project_row(row: dict[str, Any]) -> dict[str, Any]:
@@ -33,20 +76,117 @@ def project_row(row: dict[str, Any]) -> dict[str, Any]:
     return {k: row[k] for k in _ALLOWED_ROW_FIELDS if k in row}
 
 
+def _first_present(row: dict[str, Any], fields: tuple[str, ...]) -> Any:
+    """Return the first non-empty value among ``fields``, else ``None``."""
+    for f in fields:
+        val = row.get(f)
+        if val is not None and str(val).strip() != "":
+            return val
+    return None
+
+
+def _record_id(row: dict[str, Any]) -> str | None:
+    """Resolve a stable id for dedup. ``None`` when the record has none."""
+    val = _first_present(row, _ID_FIELDS)
+    return str(val) if val is not None else None
+
+
+def _band_for(score: int) -> str:
+    """Map a 0-100 score to a coarse band."""
+    if score >= 70:
+        return "Strong"
+    if score >= 40:
+        return "Moderate"
+    return "Weak"
+
+
+def _heuristic_score(row: dict[str, Any]) -> int:
+    """Deterministic field-based score, clamped to 0-100.
+
+    Rewards completeness (name + a valid-looking email + a non-trivial
+    message/answers/bio field) and a referral/social signal; penalizes a
+    disposable-email pattern and very sparse records. Pure + deterministic so
+    re-running on the same record yields the same score.
+    """
+    score = 0
+
+    name = _first_present(row, _NAME_FIELDS)
+    if name is not None:
+        score += 20
+
+    email = _first_present(row, _EMAIL_FIELDS)
+    email_str = str(email).strip().lower() if email is not None else ""
+    if email_str:
+        if _EMAIL_RE.match(email_str):
+            score += 20
+        else:
+            score += 5  # present but malformed — minor credit
+        if any(p in email_str for p in _DISPOSABLE_PATTERNS):
+            score -= 30  # disposable address — strong negative
+
+    message = _first_present(row, _MESSAGE_FIELDS)
+    if message is not None:
+        text = message if isinstance(message, str) else str(message)
+        length = len(text.strip())
+        if length >= 120:
+            score += 30
+        elif length >= 40:
+            score += 20
+        elif length > 0:
+            score += 8
+
+    if _first_present(row, _REFERRAL_FIELDS) is not None:
+        score += 15  # referral / social signal
+
+    # Sparsity penalty — a record with almost nothing in it is low-signal.
+    populated = sum(
+        1 for v in row.values() if v is not None and str(v).strip() != ""
+    )
+    if populated <= 1:
+        score -= 20
+    elif populated == 2:
+        score -= 8
+
+    return max(0, min(100, score))
+
+
 def _score_row(row: dict[str, Any]) -> dict[str, Any]:
-    """Assign a toy score. Real scoring is a connector-backed follow-up; V1
-    pins the contract + the PII allowlist, not a scoring model."""
-    name = str(row.get("name", ""))
-    scored = {**row, "score": len(name), "stage": "scored"}
+    """Score one source record and project it to the broadcast-safe allowlist.
+
+    Carries the resolved id + name through so the projected row stays useful
+    even when the source used a fallback field name (``_id`` / ``fullName``).
+    """
+    rid = _record_id(row)
+    name = _first_present(row, _NAME_FIELDS)
+    score = _heuristic_score(row)
+    scored = {
+        **row,
+        "id": rid,
+        "name": name if name is not None else "",
+        "score": score,
+        "band": _band_for(score),
+        "stage": "scored",
+    }
     return project_row(scored)
+
+
+def _already_scored_ids(existing_rows: list[Any]) -> set[str]:
+    """Collect the ids already present in the pocket's ``scored_rows``."""
+    ids: set[str] = set()
+    for r in existing_rows:
+        if isinstance(r, dict):
+            rid = r.get("id")
+            if rid is not None:
+                ids.add(str(rid))
+    return ids
 
 
 class ScoreApplicationsJob:
     """Score a batch of applications and write the scored rows to `state`.
 
     Runs under the workspace service identity. Returns a STATE-ONLY partial
-    spec — `scored_rows` (PII-stripped) and a status flag the triggering
-    button reads to stop spinning.
+    spec — `scored_rows` (PII-stripped) and the scored count. The WORKER owns
+    the `<action>_status` flag, so this built-in returns no status key.
     """
 
     name = "score_applications"
@@ -54,19 +194,73 @@ class ScoreApplicationsJob:
     async def __call__(
         self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
     ) -> dict:
-        # V1: score the rows passed in `params["rows"]` (a real impl reads the
-        # batch from the workspace's stored connector creds). Bounded by
-        # `batch_size` so a job can't run unbounded.
-        batch_size = int(params.get("batch_size", 20))
-        rows = list(params.get("rows", []))[: max(0, batch_size)]
-        scored = [_score_row(r) for r in rows if isinstance(r, dict)]
+        batch_size = max(0, int(params.get("batch_size", 20)))
+        source_collection = params.get("source_collection")
+
+        if isinstance(source_collection, str) and source_collection.strip():
+            scored_rows = await self._run_source_backed(
+                workspace_id=workspace_id,
+                pocket_id=pocket_id,
+                source_collection=source_collection,
+                batch_size=batch_size,
+            )
+        else:
+            # Fallback — score the rows passed in `params["rows"]` directly.
+            rows = list(params.get("rows", []))[:batch_size]
+            scored_rows = [_score_row(r) for r in rows if isinstance(r, dict)]
+
         return {
             "state": {
-                "scored_rows": scored,
-                "score_applications_status": "done",
-                "score_applications_scored_count": len(scored),
+                "scored_rows": scored_rows,
+                "score_applications_scored_count": len(scored_rows),
             }
         }
+
+    async def _run_source_backed(
+        self,
+        *,
+        workspace_id: str,
+        pocket_id: str,
+        source_collection: str,
+        batch_size: int,
+    ) -> list[dict[str, Any]]:
+        """Read a page of live source records, score the next NEW batch, and
+        return the ACCUMULATED rows (existing scored + newly scored).
+
+        Idempotent: records whose id is already in the pocket's current
+        ``scored_rows`` are skipped, so re-running advances to the next batch
+        instead of re-scoring the same records.
+        """
+        # Current scored rows on the pocket — the dedup + accumulation base.
+        spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
+        state = spec.get("state") if isinstance(spec, dict) else None
+        existing_rows = state.get("scored_rows") if isinstance(state, dict) else None
+        existing_rows = list(existing_rows) if isinstance(existing_rows, list) else []
+        seen_ids = _already_scored_ids(existing_rows)
+
+        if batch_size == 0:
+            return existing_rows
+
+        # Read a bounded page from the source. Pull a few-hundred window so the
+        # next unscored batch is in reach without an unbounded scan; the page is
+        # then filtered to NEW records and capped at `batch_size`.
+        page = await jobs_service.read_source_records(source_collection, limit=300)
+
+        new_scored: list[dict[str, Any]] = []
+        for record in page:
+            if not isinstance(record, dict):
+                continue
+            rid = _record_id(record)
+            # Skip records with no resolvable id (can't dedup) and ones already
+            # scored.
+            if rid is None or rid in seen_ids:
+                continue
+            new_scored.append(_score_row(record))
+            seen_ids.add(rid)
+            if len(new_scored) >= batch_size:
+                break
+
+        return existing_rows + new_scored
 
 
 __all__ = ["ScoreApplicationsJob", "project_row"]

--- a/ee/pocketpaw_ee/cloud/jobs/service.py
+++ b/ee/pocketpaw_ee/cloud/jobs/service.py
@@ -13,6 +13,16 @@
 # raised ``TypeError`` on every dispatch). Jobs now ride arq's default queue on
 # the shared worker, matching ``chat/runs/arq_executor.py``. Removed the now-
 # unused ``JOBS_QUEUE`` import.
+#
+# Updated: 2026-06-22 (fix/jobs-real-builtin-and-status) — added
+# ``read_source_records``, a bounded, session-free read of an arbitrary Mongo
+# collection in the cloud DB. The data-backed ``score_applications`` built-in
+# reads its records through THIS service (the jobs entity owns DB access for
+# jobs), so the built-in never opens a second MongoClient and never imports a
+# Beanie document class directly (import-linter "Jobs" contract). The DB handle
+# is the SHARED one Beanie was initialized against — pulled off
+# ``WorkspaceJobDoc.get_pymongo_collection().database`` — so tests (mongomock)
+# and production resolve the same database with no extra connection.
 
 """Workspace-jobs service — Beanie writes + dispatch + lifecycle."""
 
@@ -186,6 +196,35 @@ async def get_job_by_id(job_id: str) -> WorkspaceJobDoc | None:
         return None
 
 
+async def read_source_records(collection: str, *, limit: int) -> list[dict[str, Any]]:
+    """Read up to ``limit`` records from a Mongo ``collection`` in the cloud DB.
+
+    The data-backed built-ins (e.g. ``score_applications``) read their input
+    batch through here so they never open a second MongoClient and never touch
+    a Beanie document class directly (the import-linter "Jobs" contract keeps
+    Beanie/DB access inside the jobs service). The DB handle is the SHARED one
+    Beanie was initialized against — taken off
+    ``WorkspaceJobDoc.get_pymongo_collection().database`` — so a job reads the
+    same database the rest of the cloud writes, with no extra connection.
+
+    Bounded by ``limit`` (the caller pages from this slice) so a job can never
+    pull an unbounded result set. ``limit <= 0`` reads nothing. A blank
+    collection name reads nothing. Best-effort: a read error returns ``[]`` so
+    the built-in degrades to "no new records" rather than crashing the job.
+    """
+    name = (collection or "").strip()
+    capped = max(0, int(limit))
+    if not name or capped == 0:
+        return []
+    try:
+        db = WorkspaceJobDoc.get_pymongo_collection().database
+        cursor = db[name].find({}).limit(capped)
+        return [doc async for doc in cursor]
+    except Exception:  # noqa: BLE001 — a missing/unreadable source is "no records"
+        logger.warning("jobs: read_source_records failed for collection %r", name, exc_info=True)
+        return []
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle transitions (worker-driven)
 # ---------------------------------------------------------------------------
@@ -295,4 +334,5 @@ __all__ = [
     "mark_done",
     "mark_failed",
     "mark_running",
+    "read_source_records",
 ]

--- a/ee/pocketpaw_ee/cloud/jobs/worker.py
+++ b/ee/pocketpaw_ee/cloud/jobs/worker.py
@@ -32,6 +32,19 @@
 # failure handling (mark ``failed`` + failed-state writeback). The escalation is
 # success-path-only; the failure path's writeback stays best-effort and is never
 # re-escalated, so it can't loop.
+#
+# Updated: 2026-06-22 (fix/jobs-real-builtin-and-status, BUG B) — the WORKER now
+# owns the generic ``<action>_status`` flag on BOTH the success and failure
+# paths. Previously the success status came from the built-in, which HARDCODED
+# ``score_applications_status``, so a status-bound widget + the frontend's
+# optimistic ``<action>_status:"running"`` only lined up when the action
+# happened to be named ``score_applications``. The failure path already stamped
+# ``<action>_status`` (via ``failed_state_writeback(action, ...)``); the success
+# path now stamps ``result["state"]["<action>_status"] = "done"`` from
+# ``doc.action`` BEFORE the writeback. Built-ins no longer return any status
+# key. The stamp happens before the ok:false → failed escalation, so a rejected
+# writeback still escalates correctly (the failed-state marker overwrites the
+# optimistic "done" the same way the rejection path always has).
 
 """ARQ entrypoint: execute one workspace job + write the result back."""
 
@@ -132,6 +145,18 @@ async def execute_workspace_job(ctx: dict[str, Any], job_id: str) -> None:
         )
         await jobs_service.mark_failed(doc, error=message)
         return
+
+    # Stamp the generic status flag the triggering button reads. The WORKER
+    # owns ``<action>_status`` on BOTH paths (the failure path already stamps it
+    # via ``failed_state_writeback(action, ...)``): the built-in returns only its
+    # domain state (``scored_rows`` etc.), never a status key, so a status-bound
+    # widget + the frontend's optimistic ``<action>_status:"running"`` line up
+    # for ANY action name — not just one that happens to match the built-in.
+    # Done here, before the writeback + the ok:false escalation, so a rejected
+    # writeback still overwrites this "done" with the failed-state marker.
+    result.setdefault("state", {})
+    if isinstance(result["state"], dict):
+        result["state"][f"{action}_status"] = "done"
 
     # Success — write the validated state-only partial back. ``merge_spec``
     # can still REJECT the merge (``ok: False``) when the catalog / action-

--- a/tests/cloud/jobs/test_jobs.py
+++ b/tests/cloud/jobs/test_jobs.py
@@ -498,6 +498,11 @@ async def test_worker_writeback_uses_system_identity(
     assert captured["pocket_id"] == pocket_id
     # Writeback is a partial-spec merge carrying only state.
     assert captured["body"]["merge"]["state"]["echo_value"] == "hello"
+    # Bug B — the WORKER (not the built-in) owns the success status flag, keyed
+    # by the job's ACTION name. `echo_job` returns no status key; the worker
+    # stamps `run_echo_status: "done"` so a status-bound widget lines up for any
+    # action name.
+    assert captured["body"]["merge"]["state"]["run_echo_status"] == "done"
 
     doc = await jobs_service.get_job(WS, job_id)
     assert doc is not None
@@ -842,12 +847,15 @@ async def test_score_applications_strips_pii() -> None:
         project_row,
     )
 
-    # The pure projection drops any non-allowlisted field — notably PII.
+    # The pure projection drops any non-allowlisted field — notably PII. `band`
+    # is now part of the allowlist (the heuristic emits a Strong/Moderate/Weak
+    # band alongside the score).
     projected = project_row(
         {
             "id": "a1",
             "name": "Jordan",
-            "score": 6,
+            "score": 60,
+            "band": "Moderate",
             "stage": "scored",
             "email": "jordan@example.com",
             "phone": "+1-555-0100",
@@ -857,9 +865,18 @@ async def test_score_applications_strips_pii() -> None:
     assert "email" not in projected
     assert "phone" not in projected
     assert "ssn" not in projected
-    assert projected == {"id": "a1", "name": "Jordan", "score": 6, "stage": "scored"}
+    assert projected == {
+        "id": "a1",
+        "name": "Jordan",
+        "score": 60,
+        "band": "Moderate",
+        "stage": "scored",
+    }
 
-    # End-to-end through the job: a row carrying PII never reaches the result.
+    # End-to-end through the job (params.rows fallback): a row carrying PII
+    # never reaches the result. The built-in NO LONGER returns a status key —
+    # Bug B moved `<action>_status` ownership to the worker — so the result is
+    # exactly `scored_rows` + the scored count.
     job = ScoreApplicationsJob()
     result = await job(
         workspace_id=WS,
@@ -869,7 +886,15 @@ async def test_score_applications_strips_pii() -> None:
     )
     rows = result["state"]["scored_rows"]
     assert rows and all("email" not in r and "phone" not in r for r in rows)
-    assert result["state"]["score_applications_status"] == "done"
+    # The built-in itself stamps NO status key (the worker owns it now).
+    assert "score_applications_status" not in result["state"]
+    assert result["state"]["score_applications_scored_count"] == 1
+    # The scored row carries the heuristic's score + band + stage.
+    scored = rows[0]
+    assert scored["id"] == "a1"
+    assert isinstance(scored["score"], int) and 0 <= scored["score"] <= 100
+    assert scored["band"] in ("Strong", "Moderate", "Weak")
+    assert scored["stage"] == "scored"
 
 
 # ---------------------------------------------------------------------------
@@ -1042,3 +1067,202 @@ async def test_route_no_kind_does_not_enqueue_job(
     assert res.json()["error"]["code"] == "pocket_backend.not_configured"
     # Crucially — no job was enqueued and no job_enqueued response was produced.
     assert fake_pool.calls == []
+
+
+# ---------------------------------------------------------------------------
+# CHANGE 2 — score_applications is a REAL data-backed job. With a
+# `source_collection` it reads LIVE records from that Mongo collection in the
+# cloud DB, scores the NEW ones with the real heuristic, SKIPS records already
+# in the pocket's `scored_rows` (idempotent batch advancement), accumulates the
+# rows so the canvas grows by a batch per run, and strips PII before broadcast.
+# Seeds the source via the `mongo_db` fixture handle (Beanie is initialized
+# against it, so the built-in's shared DB handle resolves to the same database).
+# ---------------------------------------------------------------------------
+
+
+async def _seed_source(mongo_db: Any, collection: str, records: list[dict]) -> None:
+    """Insert raw source records into a Mongo collection in the test DB."""
+    for rec in records:
+        await mongo_db[collection].insert_one(dict(rec))
+
+
+async def _seed_pocket_with_scored_rows(*, workspace: str, scored_rows: list[dict]) -> str:
+    """Insert a pocket whose rippleSpec.state.scored_rows is pre-populated, so
+    the built-in's idempotent dedup has an existing batch to skip against."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace,
+        name="score-apps-pocket",
+        owner="owner-1",
+        rippleSpec={"version": "1.0", "state": {"scored_rows": list(scored_rows)}},
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+@pytest.mark.asyncio
+async def test_score_applications_source_backed_scores_new_records(
+    mongo_db: Any,
+) -> None:
+    """A `source_collection`-backed run reads live records and scores the next
+    `batch_size`, emitting a real heuristic score + band + stage per row."""
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    await _seed_source(
+        mongo_db,
+        "applications",
+        [
+            {
+                "id": "app-1",
+                "name": "Jordan Strong",
+                "email": "jordan@acme.com",
+                "message": "x" * 150,
+                "referral": "linkedin.com/in/jordan",
+            },
+            {"id": "app-2", "name": "Sam Sparse"},
+            {
+                "id": "app-3",
+                "name": "Casey Throwaway",
+                "email": "casey@mailinator.com",
+            },
+        ],
+    )
+    pocket_id = await _seed_pocket_with_scored_rows(workspace=WS, scored_rows=[])
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-src-1",
+        params={"source_collection": "applications", "batch_size": 20},
+    )
+
+    rows = result["state"]["scored_rows"]
+    assert {r["id"] for r in rows} == {"app-1", "app-2", "app-3"}
+    assert result["state"]["score_applications_scored_count"] == 3
+    by_id = {r["id"]: r for r in rows}
+    # The complete, referral-bearing record outscores the disposable-email one.
+    assert by_id["app-1"]["band"] == "Strong"
+    assert by_id["app-3"]["score"] < by_id["app-1"]["score"]
+    assert all(r["stage"] == "scored" for r in rows)
+    # No status key from the built-in (the worker owns it).
+    assert "score_applications_status" not in result["state"]
+
+
+@pytest.mark.asyncio
+async def test_score_applications_source_backed_is_idempotent(
+    mongo_db: Any,
+) -> None:
+    """Re-running SKIPS records already in the pocket's `scored_rows` and pulls
+    the NEXT batch, accumulating onto the existing rows (the canvas grows by a
+    batch per run rather than re-scoring the same records)."""
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    await _seed_source(
+        mongo_db,
+        "applications",
+        [
+            {"id": "app-1", "name": "One", "email": "one@acme.com"},
+            {"id": "app-2", "name": "Two", "email": "two@acme.com"},
+            {"id": "app-3", "name": "Three", "email": "three@acme.com"},
+        ],
+    )
+    # app-1 is already scored on the pocket.
+    pocket_id = await _seed_pocket_with_scored_rows(
+        workspace=WS,
+        scored_rows=[
+            {"id": "app-1", "name": "One", "score": 40, "band": "Moderate", "stage": "scored"}
+        ],
+    )
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-src-2",
+        params={"source_collection": "applications", "batch_size": 1},
+    )
+
+    rows = result["state"]["scored_rows"]
+    ids = [r["id"] for r in rows]
+    # app-1 (already scored) is preserved untouched; exactly ONE new record was
+    # added (batch_size=1) — and it is NOT app-1.
+    assert ids[0] == "app-1"
+    assert len(rows) == 2
+    new_id = ids[1]
+    assert new_id in ("app-2", "app-3")
+    assert new_id != "app-1"
+    # The preserved row keeps its original score (not re-scored).
+    assert rows[0]["score"] == 40
+    assert result["state"]["score_applications_scored_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_score_applications_source_backed_strips_pii(
+    mongo_db: Any,
+) -> None:
+    """The broadcast rows from a source-backed run carry ONLY the allowlist —
+    no email / phone / raw source field reaches `state`."""
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    await _seed_source(
+        mongo_db,
+        "applications",
+        [
+            {
+                "id": "app-1",
+                "name": "Jordan",
+                "email": "jordan@acme.com",
+                "phone": "+1-555-0100",
+                "ssn": "000-00-0000",
+                "message": "Hello there, here is my note.",
+            }
+        ],
+    )
+    pocket_id = await _seed_pocket_with_scored_rows(workspace=WS, scored_rows=[])
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-src-3",
+        params={"source_collection": "applications", "batch_size": 20},
+    )
+
+    rows = result["state"]["scored_rows"]
+    assert rows
+    row = rows[0]
+    assert "email" not in row
+    assert "phone" not in row
+    assert "ssn" not in row
+    assert "message" not in row
+    assert set(row.keys()) <= {"id", "name", "score", "band", "stage"}
+
+
+@pytest.mark.asyncio
+async def test_score_applications_missing_source_collection_returns_empty(
+    mongo_db: Any,
+) -> None:
+    """A source collection that doesn't exist reads as 'no records' (the read
+    is best-effort) — the job returns the existing rows unchanged, not a crash."""
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    pocket_id = await _seed_pocket_with_scored_rows(
+        workspace=WS,
+        scored_rows=[
+            {"id": "app-1", "name": "One", "score": 40, "band": "Moderate", "stage": "scored"}
+        ],
+    )
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-src-4",
+        params={"source_collection": "does_not_exist", "batch_size": 20},
+    )
+
+    rows = result["state"]["scored_rows"]
+    # Existing batch preserved; nothing new added.
+    assert [r["id"] for r in rows] == ["app-1"]


### PR DESCRIPTION
Two changes to the workspace jobs primitive (follow-up to #1516 / #1519), both validated by running a real job in the live client.

## Bug B: the worker owns the job status flag

Before, on failure the worker wrote `<action>_status` but on success the status came from the builtin, which hardcoded `score_applications_status`. So a status-bound widget (and the frontend's optimistic `<action>_status:"running"` flag) only lined up when the action happened to be named score_applications. Now the worker stamps `<action>_status: "done"` on success too (from `doc.action`), mirroring the failure path, so any job action's status tracks running to done/failed generically. The builtin no longer returns a status key.

## score_applications now reads live data

The builtin scored hardcoded `params["rows"]` with a placeholder `len(name)`. It now does real work, which is the connector-backed follow-up the original PR deferred:

- Reads its batch from a live source: when `params.source_collection` is set, it reads records from that collection in the cloud DB, through a new `read_source_records` in the jobs service so the Beanie-writes-only-from-service contract holds.
- Idempotent batch advancement: it reads the pocket's current `scored_rows`, skips ids already scored, scores only the new ones, and returns the accumulated set. Re-running pulls the next batch, the same behavior as the `score_next_batch.py` operator script it replaces.
- A real field-based heuristic (completeness plus referral/social signal, minus disposable-email and sparsity) producing a 0-100 score, a band (Strong/Moderate/Weak), and stage.
- The PII allowlist still applies: broadcast rows carry only id/name/score/band/stage; email/phone/raw fields are stripped.
- `params.rows` still works when no source_collection is given.

## Validation

Verified live, not just in tests: ran this against a local backend plus the ARQ worker with a seeded applicants collection. Triggering the pocket's job action read the next batch from the live collection, scored each with the heuristic, and the canvas updated from idle to done with the scored rows over the WebSocket path. A second run advanced to the next batch (10 rows, no re-scoring), with scores tracking quality (complete + referral 70, no referral 60, disposable-email 18, near-empty 20) and emails stripped. This is the same read then score then write-back the `score_next_batch.py` sidecar did, now native in the primitive: the worker emits PocketUpdated from a connected process, so the sidecar's HTTP-merge workaround is gone.

Tests: 41 jobs tests pass (added source-backed scoring, idempotency, and PII tests; updated the status assertions for Bug B). import-linter contracts kept. The 4 pre-existing `test_gallery_site_exclusion` failures are unrelated (a missing seed on dev, confirmed by stashing this branch).