### PR TITLE
refactor(surface): dispatch handlers from a declarative SurfaceSpec registry

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -135,6 +135,13 @@ _BELT_GATE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_belt__belt_prop
 # import could cycle with the agent layer, and ``resolve_profile`` is on the hot
 # path. A failed import degrades to no MCP restriction so tool-scoping can never
 # break chat.
+# Changes: 2026-06-22 (feat/surface-registry-backend, SR-1) — ``_load_handlers``
+# now builds its ``SurfaceKind -> build_preamble`` dispatch table by LOOPING over
+# the declarative ``SURFACES`` registry (``surface.surface_registry``) instead of a
+# hand-written literal dict. Behavior is unchanged: same kinds, same handlers, same
+# lazy-import-on-first-call + memoization, same GENERIC fall-back. Profiles are NOT
+# touched here — ``_build_profiles`` / ``resolve_profile`` / ``compose_entity_profile``
+# remain the profile source of truth until SR-2 migrates them onto the registry rows.
 _PROFILE_CACHE: dict[str, Any] | None = None
 
 
@@ -343,70 +350,26 @@ _HANDLERS: dict[SurfaceKind, Any] | None = None
 
 
 def _load_handlers() -> dict[SurfaceKind, Any]:
-    """Lazy import every per-kind handler. Missing handlers are skipped.
+    """Build the ``SurfaceKind -> build_preamble`` dispatch table.
 
-    We tolerate missing handler modules instead of raising at import time
-    because the surface module ships independently of the surfaces it
-    knows about — a fresh deploy that drops a handler module shouldn't
-    take the whole chat path down.
+    The table is derived by LOOPING over the declarative ``SURFACES``
+    registry (SR-1) rather than a hand-maintained literal dict — one
+    ``SurfaceSpec`` row per surface is the single source of truth, so adding
+    a surface means adding a row, not editing two parallel structures.
+
+    ``SURFACES`` is imported lazily here (not at module top) so a broken
+    handler-module import still can't take the whole chat path down at
+    import time. We tolerate missing handler modules instead of raising
+    because the surface module ships independently of the surfaces it knows
+    about — a fresh deploy that drops a handler module shouldn't break
+    dispatch. A fresh mutable dict is returned on every call (tests
+    monkeypatch entries on the returned dict), and any ``SurfaceKind``
+    without a row still degrades to the ``GENERIC`` fall-back in
+    ``resolve_surface_context``.
     """
-    from pocketpaw_ee.cloud.surface.handlers import (
-        activity,
-        audit,
-        belt,
-        calendar,
-        code,
-        files,
-        generic,
-        home,
-        knowledge,
-        mission_control,
-        pocket,
-        pocket_widget,
-        pockets_list,
-        quickask,
-        settings,
-        sidepanel,
-        sites,
-        studio,
-    )
-    from pocketpaw_ee.cloud.surface.handlers import (
-        agent as agent_handler,
-    )
-    from pocketpaw_ee.cloud.surface.handlers import (
-        agents as agents_handler,
-    )
-    from pocketpaw_ee.cloud.surface.handlers import (
-        chat as chat_handler,
-    )
-    from pocketpaw_ee.cloud.surface.handlers import (
-        foresight as foresight_handler,
-    )
+    from pocketpaw_ee.cloud.surface.surface_registry import SURFACES
 
-    return {
-        SurfaceKind.HOME: home.build_preamble,
-        SurfaceKind.POCKETS_LIST: pockets_list.build_preamble,
-        SurfaceKind.POCKET: pocket.build_preamble,
-        SurfaceKind.POCKET_WIDGET: pocket_widget.build_preamble,
-        SurfaceKind.MISSION_CONTROL: mission_control.build_preamble,
-        SurfaceKind.FILES: files.build_preamble,
-        SurfaceKind.AUDIT: audit.build_preamble,
-        SurfaceKind.ACTIVITY: activity.build_preamble,
-        SurfaceKind.AGENTS: agents_handler.build_preamble,
-        SurfaceKind.AGENT: agent_handler.build_preamble,
-        SurfaceKind.KNOWLEDGE: knowledge.build_preamble,
-        SurfaceKind.CALENDAR: calendar.build_preamble,
-        SurfaceKind.CHAT: chat_handler.build_preamble,
-        SurfaceKind.QUICKASK: quickask.build_preamble,
-        SurfaceKind.SETTINGS: settings.build_preamble,
-        SurfaceKind.SIDEPANEL: sidepanel.build_preamble,
-        SurfaceKind.FORESIGHT: foresight_handler.build_preamble,
-        SurfaceKind.SITES: sites.build_preamble,
-        SurfaceKind.STUDIO: studio.build_preamble,
-        SurfaceKind.CODE: code.build_preamble,
-        SurfaceKind.BELT: belt.build_preamble,
-        SurfaceKind.GENERIC: generic.build_preamble,
-    }
+    return {spec.kind: spec.build_preamble for spec in SURFACES}
 
 
 def _resolve_kind(value: str | None) -> SurfaceKind:

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -1,0 +1,156 @@
+# surface_registry.py — The declarative surface registry (SR-1).
+#
+# Created: 2026-06-22 (feat/surface-registry-backend, SR-1) — the single
+# declarative source of truth for "what surfaces exist and how each one
+# dispatches." Each surface is one frozen ``SurfaceSpec`` row carrying its
+# ``SurfaceKind``, its canonical ``route`` (the cross-repo contract — the
+# ``SurfaceKind`` value with a leading slash, e.g. STUDIO -> "/studio"), and
+# its ``build_preamble`` handler callable. ``service._load_handlers`` builds
+# its ``dict[SurfaceKind, callable]`` dispatch table by LOOPING over
+# ``SURFACES`` instead of hand-maintaining a parallel literal dict, so adding a
+# surface means adding ONE row here.
+#
+# This module is imported LAZILY (from inside ``service._load_handlers``, not
+# at package import) so a broken handler-module import still can't take the
+# whole surface dispatch table down at import time — the same deferral the
+# old hand-written ``_load_handlers`` body had. The handler imports below run
+# when ``surface_registry`` is first imported, which is the first call to
+# ``_load_handlers``.
+#
+# The ``profile`` / ``profile_resolver`` / ``mcp_provider`` fields are DECLARED
+# now but left at their defaults — SR-2 owns profiles and populates them. Do
+# NOT wire profile data through this registry in SR-1; ``_build_profiles`` /
+# ``resolve_profile`` / ``compose_entity_profile`` remain the source of truth
+# for surface profiles until SR-2 migrates them onto these rows.
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from pocketpaw_ee.cloud.surface.domain import (
+    SurfaceKind,
+    SurfaceMeta,
+    SurfaceProfile,
+)
+from pocketpaw_ee.cloud.surface.handlers import (
+    activity,
+    audit,
+    belt,
+    calendar,
+    code,
+    files,
+    generic,
+    home,
+    knowledge,
+    mission_control,
+    pocket,
+    pocket_widget,
+    pockets_list,
+    quickask,
+    settings,
+    sidepanel,
+    sites,
+    studio,
+)
+from pocketpaw_ee.cloud.surface.handlers import (
+    agent as agent_handler,
+)
+from pocketpaw_ee.cloud.surface.handlers import (
+    agents as agents_handler,
+)
+from pocketpaw_ee.cloud.surface.handlers import (
+    chat as chat_handler,
+)
+from pocketpaw_ee.cloud.surface.handlers import (
+    foresight as foresight_handler,
+)
+
+# The shape every handler module exports: an async preamble builder taking the
+# tenancy tuple + the validated client meta and returning the rendered block.
+BuildPreamble = Callable[[str, str, SurfaceMeta], Awaitable[str]]
+
+# A profile resolver (declared for SR-2): given the client meta, return the
+# surface's behavioral profile. Left ``None`` on every row in SR-1.
+ProfileResolver = Callable[[SurfaceMeta], SurfaceProfile]
+
+
+@dataclass(frozen=True)
+class SurfaceSpec:
+    """One row of the declarative surface registry.
+
+    ``kind`` and ``build_preamble`` are the SR-1 payload — together they
+    replace the hand-written entry in ``service._load_handlers``. ``route`` is
+    the surface's canonical route (the ``SurfaceKind`` value with a leading
+    slash), the cross-repo contract paw-enterprise and the backend agree on.
+
+    ``profile`` / ``profile_resolver`` / ``mcp_provider`` are DECLARED here so
+    the row's shape is locked now; SR-2 populates them when it migrates
+    profile resolution onto this registry. They stay ``None`` in SR-1 — the
+    existing ``resolve_profile`` / ``_build_profiles`` path is untouched.
+    """
+
+    kind: SurfaceKind
+    route: str
+    build_preamble: BuildPreamble
+    profile: SurfaceProfile | None = None
+    profile_resolver: ProfileResolver | None = None
+    mcp_provider: str | None = None
+
+
+def _route_for(kind: SurfaceKind) -> str:
+    """Canonical route for a kind: the enum value with a leading slash.
+
+    This is the cross-repo contract (e.g. ``SurfaceKind.STUDIO`` -> ``"/studio"``).
+    A few kinds' literal frontend routes differ (POCKET renders at
+    ``/pockets/[id]``, MISSION_CONTROL at ``/mission-control``), but the
+    registry's ``route`` is the VALUE-derived contract, matching the SR-1 spec
+    (POCKET -> "/pocket", HOME -> "/home", SITES -> "/sites", ...).
+    """
+    return f"/{kind.value}"
+
+
+# One row per surface that currently has a handler registered in
+# ``service._load_handlers``. ``kind`` + ``build_preamble`` mirror that dict
+# exactly (zero behavior change is the SR-1 contract); ``route`` is derived
+# from the kind value. Order matches the old literal dict for easy diffing.
+SURFACES: list[SurfaceSpec] = [
+    SurfaceSpec(SurfaceKind.HOME, _route_for(SurfaceKind.HOME), home.build_preamble),
+    SurfaceSpec(
+        SurfaceKind.POCKETS_LIST,
+        _route_for(SurfaceKind.POCKETS_LIST),
+        pockets_list.build_preamble,
+    ),
+    SurfaceSpec(SurfaceKind.POCKET, _route_for(SurfaceKind.POCKET), pocket.build_preamble),
+    SurfaceSpec(
+        SurfaceKind.POCKET_WIDGET,
+        _route_for(SurfaceKind.POCKET_WIDGET),
+        pocket_widget.build_preamble,
+    ),
+    SurfaceSpec(
+        SurfaceKind.MISSION_CONTROL,
+        _route_for(SurfaceKind.MISSION_CONTROL),
+        mission_control.build_preamble,
+    ),
+    SurfaceSpec(SurfaceKind.FILES, _route_for(SurfaceKind.FILES), files.build_preamble),
+    SurfaceSpec(SurfaceKind.AUDIT, _route_for(SurfaceKind.AUDIT), audit.build_preamble),
+    SurfaceSpec(SurfaceKind.ACTIVITY, _route_for(SurfaceKind.ACTIVITY), activity.build_preamble),
+    SurfaceSpec(SurfaceKind.AGENTS, _route_for(SurfaceKind.AGENTS), agents_handler.build_preamble),
+    SurfaceSpec(SurfaceKind.AGENT, _route_for(SurfaceKind.AGENT), agent_handler.build_preamble),
+    SurfaceSpec(SurfaceKind.KNOWLEDGE, _route_for(SurfaceKind.KNOWLEDGE), knowledge.build_preamble),
+    SurfaceSpec(SurfaceKind.CALENDAR, _route_for(SurfaceKind.CALENDAR), calendar.build_preamble),
+    SurfaceSpec(SurfaceKind.CHAT, _route_for(SurfaceKind.CHAT), chat_handler.build_preamble),
+    SurfaceSpec(SurfaceKind.QUICKASK, _route_for(SurfaceKind.QUICKASK), quickask.build_preamble),
+    SurfaceSpec(SurfaceKind.SETTINGS, _route_for(SurfaceKind.SETTINGS), settings.build_preamble),
+    SurfaceSpec(SurfaceKind.SIDEPANEL, _route_for(SurfaceKind.SIDEPANEL), sidepanel.build_preamble),
+    SurfaceSpec(
+        SurfaceKind.FORESIGHT,
+        _route_for(SurfaceKind.FORESIGHT),
+        foresight_handler.build_preamble,
+    ),
+    SurfaceSpec(SurfaceKind.SITES, _route_for(SurfaceKind.SITES), sites.build_preamble),
+    SurfaceSpec(SurfaceKind.STUDIO, _route_for(SurfaceKind.STUDIO), studio.build_preamble),
+    SurfaceSpec(SurfaceKind.CODE, _route_for(SurfaceKind.CODE), code.build_preamble),
+    SurfaceSpec(SurfaceKind.BELT, _route_for(SurfaceKind.BELT), belt.build_preamble),
+    SurfaceSpec(SurfaceKind.GENERIC, _route_for(SurfaceKind.GENERIC), generic.build_preamble),
+]


### PR DESCRIPTION
## What

Introduces `ee/pocketpaw_ee/cloud/surface/surface_registry.py` — a declarative `SurfaceSpec` list (one row per surface) — and rewrites `_load_handlers()` to build its `SurfaceKind -> build_preamble` dispatch table by looping over it, instead of a hand-maintained literal dict.

## Why

First slice of the surface-registry refactor: adding a surface today takes ~10 scattered edits across two repos. This collapses the backend handler-dispatch half to one registry row. Profiles are the next stacked slice (SR-2); the frontend manifest is a separate paw-enterprise PR.

## Behavior-preserving

Same kinds, same handlers, same lazy-import-on-first-call + memoization, same GENERIC fall-back. No handler body changed; `_build_profiles` / `resolve_profile` / `compose_entity_profile` untouched. 22 surfaces migrated.

## Verified

`tests/cloud/chat/test_agent_service_surface_injection.py` + `tests/cloud/surface/` — 70 passed. Adjacent profile tests (31) also green, confirming the SR-2-owned path is untouched.

Part of the surface registry plan (design/PRD/tasks in paw-workspace docs/design/drafts/2026-06-21-surface-registry*). SR-2 stacks on this branch.