### PR TITLE
refactor(surface): derive profiles from the registry + completeness assertion

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/service.py
+++ b/ee/pocketpaw_ee/cloud/surface/service.py
@@ -87,191 +87,89 @@ logger = logging.getLogger(__name__)
 # Surface profile resolution (the "ripple-default bias" policy table)
 #
 # A SurfaceProfile is the per-surface behavioral policy the chat agent
-# applies. ``resolve_profile`` resolves it from the surface kind (+ meta) via
-# a static table, special-casing /sites. Keep this a PURE function (no I/O):
-# it runs once per request on the hot chat path and must not block on Mongo or
-# a handler.
+# applies. ``resolve_profile`` resolves it from the surface kind (+ meta) by
+# reading the ``SurfaceSpec`` for that kind off the declarative ``SURFACES``
+# registry (SR-2): ``spec.profile_resolver(meta)`` if the row carries one (the
+# meta-aware /sites row and the rows that need the lazily-loaded per-mode MCP
+# tool ids), else the static ``spec.profile``, else ``_DEFAULT_PROFILE``. Keep
+# this a PURE function (no I/O): it runs once per request on the hot chat path
+# and must not block on Mongo or a handler.
 #
-# Non-sites surfaces use the static table below; only ones whose policy DIFFERS
-# from the default appear there. /sites is META-AWARE (three modes — see
-# ``resolve_profile``). Everything else — and any unmapped/future kind — gets
+# Only rows whose policy DIFFERS from the default carry a ``profile`` /
+# ``profile_resolver``; everything else — and any unmapped/future kind — gets
 # ``_DEFAULT_PROFILE`` (ripple on, no denies, no skills), which is exactly
-# today's behavior. That is the zero-regression guarantee.
+# today's behavior. That is the zero-regression guarantee. The lazy + memoized
+# MCP-tool-id load and the per-row profile builders live in
+# ``surface_registry`` now (the single source of truth for surfaces).
 # ---------------------------------------------------------------------------
 
 # Ripple on, no surface-specific policy. The behavior every surface had
 # before this primitive existed. Also the profile for the /sites ripple-create
 # and refine modes (both author/edit a ripple landing spec, so they KEEP ripple
-# and deny nothing).
-_DEFAULT_PROFILE = SurfaceProfile(ripple_mode="on")
-
-# The two ripple-authoring MCP tool ids the /sites SVELTE-CREATE mode forbids.
-# Spelled out here (the EE layer is the source of truth); they cross to the OSS
-# backend as a plain ``frozenset[str]`` via ``deny_mcp_tool_ids`` — never as an
-# imported ``pocketpaw_ee`` symbol (import-linter forbids EE→OSS imports).
-_SITES_SVELTE_CREATE_DENY: frozenset[str] = frozenset(
-    {
-        "mcp__pocketpaw_sites_manager__create_landing_site",
-        "mcp__pocketpaw_pocket_specialist__create",
-    }
-)
-
-# The Instinct gate tool the /belt develop station proposes its diff through.
-# Spelled as a LITERAL because its canonical constant
-# (``BELT_PROPOSE_CHANGE_TOOL_ID`` / ``BELT_TOOL_IDS``) lives in a SIBLING
-# branch's ``ee/pocketpaw_ee/agent/mcp_servers/belt.py`` — not importable on this
-# base. When both PRs land, swap this literal for the imported constant (same
-# None-degrade path as the loom/media imports below). Do NOT drift the id.
-_BELT_GATE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_belt__belt_propose_change"})
-
-# Per-mode MCP-tool allow-lists keep a mode's agent context lean: only the
-# mode's SPECIALIZED tools are named here. The "general everywhere" set — ripple
-# widgets, the pocket lifecycle (read/create/edit/plan), and connectors
-# (composio) — is kept by the OSS backend itself, so a scoped mode still renders
-# UI, makes pockets, and uses connectors. Chat (and any unmapped kind) stays
-# unrestricted (``allow_mcp_tool_ids=None``).
-#
-# Built lazily + memoized: pulling the EE mcp-server tool-id constants at module
-# import could cycle with the agent layer, and ``resolve_profile`` is on the hot
-# path. A failed import degrades to no MCP restriction so tool-scoping can never
-# break chat.
+# and deny nothing) — those are built by the registry's ``_sites_profile``.
 # Changes: 2026-06-22 (feat/surface-registry-backend, SR-1) — ``_load_handlers``
 # now builds its ``SurfaceKind -> build_preamble`` dispatch table by LOOPING over
 # the declarative ``SURFACES`` registry (``surface.surface_registry``) instead of a
-# hand-written literal dict. Behavior is unchanged: same kinds, same handlers, same
-# lazy-import-on-first-call + memoization, same GENERIC fall-back. Profiles are NOT
-# touched here — ``_build_profiles`` / ``resolve_profile`` / ``compose_entity_profile``
-# remain the profile source of truth until SR-2 migrates them onto the registry rows.
-_PROFILE_CACHE: dict[str, Any] | None = None
+# hand-written literal dict.
+# Changes: 2026-06-22 (feat/surface-registry-backend-profiles, SR-2) —
+# ``resolve_profile`` now SOURCES profiles from the same ``SURFACES`` registry
+# instead of a local ``_build_profiles`` table: it indexes the row for the kind
+# and applies ``profile_resolver(meta)`` / ``profile`` / ``_DEFAULT_PROFILE`` in
+# that order. Behavior is byte-identical for every ``(kind, meta)`` (the /sites
+# meta-fork and the lazy + memoized MCP-tool-id load moved verbatim into
+# ``surface_registry``). ``compose_entity_profile`` is unchanged.
+_DEFAULT_PROFILE = SurfaceProfile(ripple_mode="on")
+
+# Cached ``SurfaceKind -> SurfaceSpec`` index, built once on first
+# ``resolve_profile`` from the lazily-imported registry (the same deferral
+# ``_load_handlers`` uses so a broken handler import can't break import time).
+_SPEC_BY_KIND: dict[SurfaceKind, Any] | None = None
 
 
-def _build_profiles() -> dict[str, Any]:
-    loaded = True
-    foresight_allow: frozenset[str] | None
-    sites_allow: frozenset[str] | None
-    studio_allow: frozenset[str] | None
-    belt_allow: frozenset[str] | None
-    try:
-        from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
-        from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
-        from pocketpaw_ee.agent.mcp_servers.media import MEDIA_TOOL_IDS
-        from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS
+def _spec_by_kind() -> dict[SurfaceKind, Any]:
+    global _SPEC_BY_KIND
+    if _SPEC_BY_KIND is None:
+        from pocketpaw_ee.cloud.surface.surface_registry import SURFACES
 
-        foresight_allow = frozenset(FORESIGHT_TOOL_IDS)
-        sites_allow = frozenset(SITES_TOOL_IDS)
-        # /studio scopes to the media-generation tools (image + video). Crossed
-        # over from the EE mcp-server module as a plain frozenset[str] — never an
-        # imported pocketpaw_ee symbol leaks into the OSS surface service.
-        studio_allow = frozenset(MEDIA_TOOL_IDS)
-        # /belt (the develop station) scopes to the loom orientation tools (so
-        # the agent grounds itself before coding) UNION the Instinct gate tool
-        # (so it proposes the diff through the gate). LOOM_TOOL_IDS is importable
-        # on this base; the gate tool id is the literal _BELT_GATE_TOOL_IDS until
-        # its sibling-branch constant lands.
-        belt_allow = frozenset(LOOM_TOOL_IDS) | _BELT_GATE_TOOL_IDS
-    except Exception:  # noqa: BLE001 — degrade to no restriction, never break chat
-        logger.warning(
-            "surface: could not load mcp tool ids; per-mode MCP scoping disabled",
-            exc_info=True,
-        )
-        loaded = False
-        foresight_allow = None
-        sites_allow = None
-        studio_allow = None
-        belt_allow = None
-
-    return {
-        "by_kind": {
-            # Foresight: its scenario tools + the general-everywhere set.
-            SurfaceKind.FORESIGHT: SurfaceProfile(
-                ripple_mode="on", allow_mcp_tool_ids=foresight_allow
-            ),
-            # Files names no specialized MCP tools — document scaffolding rides
-            # the built-in Read/Write/Edit tools (never filtered). Empty allow =
-            # general-everywhere only; None when the import degraded.
-            SurfaceKind.FILES: SurfaceProfile(
-                ripple_mode="on",
-                allow_mcp_tool_ids=frozenset() if loaded else None,
-            ),
-            # Studio: media generation (image + video). Ripple OFF so the agent
-            # generates media instead of defaulting to a ripple ui-spec dashboard;
-            # scoped to the media MCP tools (+ general-everywhere); the `studio`
-            # skill carries the generate→gallery flow.
-            SurfaceKind.STUDIO: SurfaceProfile(
-                ripple_mode="off",
-                allow_mcp_tool_ids=studio_allow,
-                skill_names=frozenset({"studio"}),
-            ),
-            # Code: edit + run code. Ripple OFF so the agent edits code instead of
-            # building a dashboard; the SDK-tool allowlist scopes it to the coding
-            # built-ins; the `code` skill carries the edit→run→verify loop.
-            SurfaceKind.CODE: SurfaceProfile(
-                ripple_mode="off",
-                skill_names=frozenset({"code"}),
-                allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
-            ),
-            # Belt: the develop station (orient→develop→propose via gate). Ripple
-            # OFF so the agent runs the station loop instead of building a
-            # dashboard. SDK-tool allowlist scopes it to the coding built-ins; the
-            # `belt` skill carries the station playbook; the MCP allow-list is the
-            # loom orientation tools (ground first) UNION the Instinct gate tool
-            # (propose the diff). belt_allow is None when the import degraded.
-            SurfaceKind.BELT: SurfaceProfile(
-                ripple_mode="off",
-                skill_names=frozenset({"belt"}),
-                allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
-                allow_mcp_tool_ids=belt_allow,
-            ),
-        },
-        # /sites is meta-aware (below). Both modes scope to the sites authoring
-        # tools + general. svelte-create additionally denies the two ripple-create
-        # tools (deny runs AFTER allow) and drops ripple + surfaces the svelte skill.
-        "sites_default": SurfaceProfile(ripple_mode="on", allow_mcp_tool_ids=sites_allow),
-        "sites_svelte_create": SurfaceProfile(
-            ripple_mode="off",
-            deny_mcp_tool_ids=_SITES_SVELTE_CREATE_DENY,
-            allow_mcp_tool_ids=sites_allow,
-            skill_names=frozenset({"create-svelte-site"}),
-        ),
-    }
-
-
-def _profiles() -> dict[str, Any]:
-    global _PROFILE_CACHE
-    if _PROFILE_CACHE is None:
-        _PROFILE_CACHE = _build_profiles()
-    return _PROFILE_CACHE
+        _SPEC_BY_KIND = {spec.kind: spec for spec in SURFACES}
+    return _SPEC_BY_KIND
 
 
 def resolve_profile(surface_kind: SurfaceKind, meta: SurfaceMeta) -> SurfaceProfile:
     """Resolve a ``SurfaceKind`` (+ ``meta``) to its behavioral ``SurfaceProfile``.
 
     Pure lookup — no I/O, safe to call once per request on the hot chat path.
+    Sourced from the declarative ``SURFACES`` registry (SR-2): the row for the
+    kind supplies the profile via ``profile_resolver(meta)`` (meta-aware rows
+    and rows that need the lazily-loaded per-mode MCP tool ids), else its static
+    ``profile``, else ``_DEFAULT_PROFILE``.
 
-    /sites is META-AWARE — it carries three modes, and only the svelte-CREATE
-    one loses ripple:
+    /sites is META-AWARE — its row carries a ``profile_resolver`` that branches
+    on ``meta`` across three modes, and only the svelte-CREATE one loses ripple:
 
       * refine (``meta.pocket_id`` set, ANY engine) edits the existing ripple
-        landing spec → KEEP ripple (``_DEFAULT_PROFILE``). Refine WINS over
-        engine: a ``pocket_id`` present means refine even if ``engine="svelte"``.
+        landing spec → KEEP ripple. Refine WINS over engine: a ``pocket_id``
+        present means refine even if ``engine="svelte"``.
       * create + svelte (``meta.engine == "svelte"``, no ``pocket_id``)
         hand-authors SvelteKit → DROP ripple, deny the two ripple-create tools,
-        surface the create-svelte-site skill (``_SITES_SVELTE_CREATE_PROFILE``).
+        surface the create-svelte-site skill.
       * create + ripple (``engine`` None/"ripple", no ``pocket_id``) authors a
-        ripple landing page → KEEP ripple (``_DEFAULT_PROFILE``).
+        ripple landing page → KEEP ripple.
 
-    Every other kind (and any unmapped/future kind, and every kind whose policy
-    matches the default) returns ``_DEFAULT_PROFILE`` (``ripple_mode="on"``), so
-    the only surface that deviates from today's behavior is /sites svelte-create.
+    Every other kind (and any unmapped/future kind, and every kind whose row
+    carries no profile) returns ``_DEFAULT_PROFILE`` (``ripple_mode="on"``), so
+    the only surface that deviates from a plain ripple-on default is /sites
+    svelte-create plus the explicitly-scoped FORESIGHT / FILES / STUDIO / CODE /
+    BELT rows — exactly today's behavior.
     """
-    profiles = _profiles()
-    if surface_kind == SurfaceKind.SITES:
-        # refine (pocket_id) edits the existing ripple landing spec → keep ripple.
-        # It wins over engine, so check it FIRST.
-        if meta.pocket_id is None and meta.engine == "svelte":
-            return profiles["sites_svelte_create"]
-        return profiles["sites_default"]
-    return profiles["by_kind"].get(surface_kind, _DEFAULT_PROFILE)
+    spec = _spec_by_kind().get(surface_kind)
+    if spec is None:
+        return _DEFAULT_PROFILE
+    if spec.profile_resolver is not None:
+        return spec.profile_resolver(meta)
+    if spec.profile is not None:
+        return spec.profile
+    return _DEFAULT_PROFILE
 
 
 def compose_entity_profile(base: SurfaceProfile, override: dict[str, Any] | None) -> SurfaceProfile:

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -1,4 +1,4 @@
-# surface_registry.py — The declarative surface registry (SR-1).
+# surface_registry.py — The declarative surface registry (SR-1 + SR-2).
 #
 # Created: 2026-06-22 (feat/surface-registry-backend, SR-1) — the single
 # declarative source of truth for "what surfaces exist and how each one
@@ -10,23 +10,34 @@
 # ``SURFACES`` instead of hand-maintaining a parallel literal dict, so adding a
 # surface means adding ONE row here.
 #
-# This module is imported LAZILY (from inside ``service._load_handlers``, not
-# at package import) so a broken handler-module import still can't take the
-# whole surface dispatch table down at import time — the same deferral the
-# old hand-written ``_load_handlers`` body had. The handler imports below run
-# when ``surface_registry`` is first imported, which is the first call to
-# ``_load_handlers``.
+# This module is imported LAZILY (from inside ``service._load_handlers`` and
+# ``service._registry``, not at package import) so a broken handler-module
+# import still can't take the whole surface dispatch table down at import time
+# — the same deferral the old hand-written ``_load_handlers`` body had. The
+# handler imports below run when ``surface_registry`` is first imported, which
+# is the first call to ``_load_handlers`` / ``resolve_profile``.
 #
-# The ``profile`` / ``profile_resolver`` / ``mcp_provider`` fields are DECLARED
-# now but left at their defaults — SR-2 owns profiles and populates them. Do
-# NOT wire profile data through this registry in SR-1; ``_build_profiles`` /
-# ``resolve_profile`` / ``compose_entity_profile`` remain the source of truth
-# for surface profiles until SR-2 migrates them onto these rows.
+# Changes: 2026-06-22 (feat/surface-registry-backend-profiles, SR-2) — PROFILES
+# now DERIVE from these rows too, with ZERO behavior change. Every surface whose
+# policy differs from the ripple-on default carries either a static ``profile``
+# (CODE — needs no lazily-loaded MCP tool ids and is not meta-aware) or a
+# ``profile_resolver`` (FORESIGHT / FILES / STUDIO / BELT / SITES — they need the
+# lazily-imported per-mode MCP tool-id sets, and SITES additionally forks on
+# ``meta``). ``service.resolve_profile`` reads ``spec.profile_resolver(meta)`` if
+# present, else ``spec.profile`` if set, else the shared ripple-on default —
+# producing IDENTICAL results to the pre-SR-2 ``_build_profiles`` table for every
+# ``(kind, meta)``. The lazy + memoized MCP-tool-id load lives here now
+# (``_mcp_tool_ids`` / ``_MCP_TOOL_IDS_CACHE``); a failed import degrades to no
+# MCP restriction exactly as before, so tool-scoping can never break chat. A
+# startup assertion (``_assert_registry_complete``, run at module import)
+# guarantees every ``SurfaceKind`` has exactly one row and no row names a bogus
+# kind — resolving the design's open question (keep the enum + assert).
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import NamedTuple
 
 from pocketpaw_ee.cloud.surface.domain import (
     SurfaceKind,
@@ -70,8 +81,9 @@ from pocketpaw_ee.cloud.surface.handlers import (
 # tenancy tuple + the validated client meta and returning the rendered block.
 BuildPreamble = Callable[[str, str, SurfaceMeta], Awaitable[str]]
 
-# A profile resolver (declared for SR-2): given the client meta, return the
-# surface's behavioral profile. Left ``None`` on every row in SR-1.
+# A profile resolver: given the client meta, return the surface's behavioral
+# profile. Set on the rows whose profile depends on the lazily-loaded per-mode
+# MCP tool-id sets (FORESIGHT / FILES / STUDIO / BELT) or on ``meta`` (SITES).
 ProfileResolver = Callable[[SurfaceMeta], SurfaceProfile]
 
 
@@ -84,10 +96,15 @@ class SurfaceSpec:
     the surface's canonical route (the ``SurfaceKind`` value with a leading
     slash), the cross-repo contract paw-enterprise and the backend agree on.
 
-    ``profile`` / ``profile_resolver`` / ``mcp_provider`` are DECLARED here so
-    the row's shape is locked now; SR-2 populates them when it migrates
-    profile resolution onto this registry. They stay ``None`` in SR-1 — the
-    existing ``resolve_profile`` / ``_build_profiles`` path is untouched.
+    ``profile`` / ``profile_resolver`` (SR-2) carry the surface's behavioral
+    ``SurfaceProfile``. ``service.resolve_profile`` reads ``profile_resolver``
+    first (meta-aware or lazy-tool-id rows), then the static ``profile`` (rows
+    that need neither), then falls back to the shared ripple-on default for
+    rows that leave both ``None``. At most one of ``profile`` /
+    ``profile_resolver`` is set on any row.
+
+    ``mcp_provider`` is reserved for a later pass that maps a surface to its
+    owning MCP server; unused today.
     """
 
     kind: SurfaceKind
@@ -110,10 +127,199 @@ def _route_for(kind: SurfaceKind) -> str:
     return f"/{kind.value}"
 
 
+# ---------------------------------------------------------------------------
+# Profile data (SR-2 — migrated verbatim from ``service._build_profiles``).
+#
+# A SurfaceProfile is the per-surface behavioral policy the chat agent applies.
+# Only surfaces whose policy DIFFERS from the ripple-on default carry one here;
+# everything else (and any unmapped/future kind) resolves to ``_DEFAULT_PROFILE``
+# in ``service.resolve_profile`` — exactly today's behavior (the zero-regression
+# guarantee). The per-mode MCP allow-lists need EE agent-layer tool-id constants
+# that could cycle at import; they are loaded LAZILY + memoized below, and a
+# failed import degrades to no MCP restriction so tool-scoping can never break
+# chat. Resolvers (not static profiles) carry these rows so the lazy load stays
+# off the module-import path.
+# ---------------------------------------------------------------------------
+
+# The two ripple-authoring MCP tool ids the /sites SVELTE-CREATE mode forbids.
+# Spelled out here (the EE layer is the source of truth); they cross to the OSS
+# backend as a plain ``frozenset[str]`` via ``deny_mcp_tool_ids`` — never as an
+# imported ``pocketpaw_ee`` symbol (import-linter forbids EE→OSS imports).
+_SITES_SVELTE_CREATE_DENY: frozenset[str] = frozenset(
+    {
+        "mcp__pocketpaw_sites_manager__create_landing_site",
+        "mcp__pocketpaw_pocket_specialist__create",
+    }
+)
+
+# The Instinct gate tool the /belt develop station proposes its diff through.
+# Spelled as a LITERAL because its canonical constant
+# (``BELT_PROPOSE_CHANGE_TOOL_ID`` / ``BELT_TOOL_IDS``) lives in a SIBLING
+# branch's ``ee/pocketpaw_ee/agent/mcp_servers/belt.py`` — not importable on this
+# base. When both PRs land, swap this literal for the imported constant (same
+# None-degrade path as the loom/media imports below). Do NOT drift the id.
+_BELT_GATE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_belt__belt_propose_change"})
+
+
+class _McpToolIds(NamedTuple):
+    """The lazily-loaded per-mode MCP allow-lists.
+
+    ``loaded`` records whether the EE agent-layer import succeeded. When it
+    FAILED every allow-list is ``None`` (no MCP restriction) — the degrade path
+    that keeps tool-scoping from ever breaking chat. ``loaded`` distinguishes
+    the FILES "general-everywhere only" case (``frozenset()`` when loaded) from
+    the degraded ``None``.
+    """
+
+    loaded: bool
+    foresight_allow: frozenset[str] | None
+    sites_allow: frozenset[str] | None
+    studio_allow: frozenset[str] | None
+    belt_allow: frozenset[str] | None
+
+
+# Built lazily + memoized: pulling the EE mcp-server tool-id constants at module
+# import could cycle with the agent layer, and ``resolve_profile`` is on the hot
+# path. A failed import degrades to no MCP restriction so tool-scoping can never
+# break chat.
+_MCP_TOOL_IDS_CACHE: _McpToolIds | None = None
+
+
+def _load_mcp_tool_ids() -> _McpToolIds:
+    """Load (or memoize) the per-mode MCP allow-lists from the EE agent layer.
+
+    Degrades to all-``None`` (no MCP restriction, ``loaded=False``) if the
+    import fails — identical to the pre-SR-2 ``_build_profiles`` try/except.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    try:
+        from pocketpaw_ee.agent.mcp_servers.foresight import FORESIGHT_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.loom import LOOM_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.media import MEDIA_TOOL_IDS
+        from pocketpaw_ee.agent.mcp_servers.sites import SITES_TOOL_IDS
+
+        return _McpToolIds(
+            loaded=True,
+            foresight_allow=frozenset(FORESIGHT_TOOL_IDS),
+            sites_allow=frozenset(SITES_TOOL_IDS),
+            # /studio scopes to the media-generation tools (image + video).
+            # Crossed over from the EE mcp-server module as a plain
+            # frozenset[str] — never an imported pocketpaw_ee symbol leaks into
+            # the OSS surface service.
+            studio_allow=frozenset(MEDIA_TOOL_IDS),
+            # /belt (the develop station) scopes to the loom orientation tools
+            # (so the agent grounds itself before coding) UNION the Instinct
+            # gate tool (so it proposes the diff through the gate).
+            belt_allow=frozenset(LOOM_TOOL_IDS) | _BELT_GATE_TOOL_IDS,
+        )
+    except Exception:  # noqa: BLE001 — degrade to no restriction, never break chat
+        logger.warning(
+            "surface: could not load mcp tool ids; per-mode MCP scoping disabled",
+            exc_info=True,
+        )
+        return _McpToolIds(
+            loaded=False,
+            foresight_allow=None,
+            sites_allow=None,
+            studio_allow=None,
+            belt_allow=None,
+        )
+
+
+def _mcp_tool_ids() -> _McpToolIds:
+    global _MCP_TOOL_IDS_CACHE
+    if _MCP_TOOL_IDS_CACHE is None:
+        _MCP_TOOL_IDS_CACHE = _load_mcp_tool_ids()
+    return _MCP_TOOL_IDS_CACHE
+
+
+# --- Per-row profile resolvers -------------------------------------------------
+#
+# Each closes over the lazily-memoized ``_mcp_tool_ids()`` and reproduces the
+# EXACT ``SurfaceProfile`` the old ``_build_profiles().by_kind`` (or the /sites
+# special-case in ``resolve_profile``) returned for that surface.
+
+
+def _foresight_profile(_meta: SurfaceMeta) -> SurfaceProfile:
+    # Foresight: its scenario tools + the general-everywhere set.
+    return SurfaceProfile(ripple_mode="on", allow_mcp_tool_ids=_mcp_tool_ids().foresight_allow)
+
+
+def _files_profile(_meta: SurfaceMeta) -> SurfaceProfile:
+    # Files names no specialized MCP tools — document scaffolding rides the
+    # built-in Read/Write/Edit tools (never filtered). Empty allow =
+    # general-everywhere only; None when the import degraded.
+    ids = _mcp_tool_ids()
+    return SurfaceProfile(
+        ripple_mode="on",
+        allow_mcp_tool_ids=frozenset() if ids.loaded else None,
+    )
+
+
+def _studio_profile(_meta: SurfaceMeta) -> SurfaceProfile:
+    # Studio: media generation (image + video). Ripple OFF so the agent
+    # generates media instead of defaulting to a ripple ui-spec dashboard;
+    # scoped to the media MCP tools (+ general-everywhere); the `studio` skill
+    # carries the generate→gallery flow.
+    return SurfaceProfile(
+        ripple_mode="off",
+        allow_mcp_tool_ids=_mcp_tool_ids().studio_allow,
+        skill_names=frozenset({"studio"}),
+    )
+
+
+def _belt_profile(_meta: SurfaceMeta) -> SurfaceProfile:
+    # Belt: the develop station (orient→develop→propose via gate). Ripple OFF so
+    # the agent runs the station loop instead of building a dashboard. SDK-tool
+    # allowlist scopes it to the coding built-ins; the `belt` skill carries the
+    # station playbook; the MCP allow-list is the loom orientation tools (ground
+    # first) UNION the Instinct gate tool (propose the diff). belt_allow is None
+    # when the import degraded.
+    return SurfaceProfile(
+        ripple_mode="off",
+        skill_names=frozenset({"belt"}),
+        allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
+        allow_mcp_tool_ids=_mcp_tool_ids().belt_allow,
+    )
+
+
+def _sites_profile(meta: SurfaceMeta) -> SurfaceProfile:
+    """/sites is META-AWARE — three modes, only svelte-CREATE loses ripple.
+
+      * refine (``meta.pocket_id`` set, ANY engine) edits the existing ripple
+        landing spec → KEEP ripple (sites default). Refine WINS over engine: a
+        ``pocket_id`` present means refine even if ``engine="svelte"``.
+      * create + svelte (``meta.engine == "svelte"``, no ``pocket_id``)
+        hand-authors SvelteKit → DROP ripple, deny the two ripple-create tools,
+        surface the create-svelte-site skill.
+      * create + ripple (``engine`` None/"ripple", no ``pocket_id``) authors a
+        ripple landing page → KEEP ripple (sites default).
+
+    Both modes scope to the sites authoring tools + general. svelte-create
+    additionally denies the two ripple-create tools (deny runs AFTER allow).
+    """
+    sites_allow = _mcp_tool_ids().sites_allow
+    if meta.pocket_id is None and meta.engine == "svelte":
+        return SurfaceProfile(
+            ripple_mode="off",
+            deny_mcp_tool_ids=_SITES_SVELTE_CREATE_DENY,
+            allow_mcp_tool_ids=sites_allow,
+            skill_names=frozenset({"create-svelte-site"}),
+        )
+    return SurfaceProfile(ripple_mode="on", allow_mcp_tool_ids=sites_allow)
+
+
 # One row per surface that currently has a handler registered in
 # ``service._load_handlers``. ``kind`` + ``build_preamble`` mirror that dict
 # exactly (zero behavior change is the SR-1 contract); ``route`` is derived
-# from the kind value. Order matches the old literal dict for easy diffing.
+# from the kind value. ``profile`` / ``profile_resolver`` (SR-2) mirror the
+# old ``_build_profiles`` table exactly — rows that need the lazily-loaded MCP
+# tool ids or are meta-aware carry a ``profile_resolver``; CODE (no lazy data,
+# not meta-aware) carries a static ``profile``; every other row leaves both
+# ``None`` and resolves to the shared ripple-on default. Order matches the old
+# literal dict for easy diffing.
 SURFACES: list[SurfaceSpec] = [
     SurfaceSpec(SurfaceKind.HOME, _route_for(SurfaceKind.HOME), home.build_preamble),
     SurfaceSpec(
@@ -132,7 +338,12 @@ SURFACES: list[SurfaceSpec] = [
         _route_for(SurfaceKind.MISSION_CONTROL),
         mission_control.build_preamble,
     ),
-    SurfaceSpec(SurfaceKind.FILES, _route_for(SurfaceKind.FILES), files.build_preamble),
+    SurfaceSpec(
+        SurfaceKind.FILES,
+        _route_for(SurfaceKind.FILES),
+        files.build_preamble,
+        profile_resolver=_files_profile,
+    ),
     SurfaceSpec(SurfaceKind.AUDIT, _route_for(SurfaceKind.AUDIT), audit.build_preamble),
     SurfaceSpec(SurfaceKind.ACTIVITY, _route_for(SurfaceKind.ACTIVITY), activity.build_preamble),
     SurfaceSpec(SurfaceKind.AGENTS, _route_for(SurfaceKind.AGENTS), agents_handler.build_preamble),
@@ -147,10 +358,84 @@ SURFACES: list[SurfaceSpec] = [
         SurfaceKind.FORESIGHT,
         _route_for(SurfaceKind.FORESIGHT),
         foresight_handler.build_preamble,
+        profile_resolver=_foresight_profile,
     ),
-    SurfaceSpec(SurfaceKind.SITES, _route_for(SurfaceKind.SITES), sites.build_preamble),
-    SurfaceSpec(SurfaceKind.STUDIO, _route_for(SurfaceKind.STUDIO), studio.build_preamble),
-    SurfaceSpec(SurfaceKind.CODE, _route_for(SurfaceKind.CODE), code.build_preamble),
-    SurfaceSpec(SurfaceKind.BELT, _route_for(SurfaceKind.BELT), belt.build_preamble),
+    SurfaceSpec(
+        SurfaceKind.SITES,
+        _route_for(SurfaceKind.SITES),
+        sites.build_preamble,
+        profile_resolver=_sites_profile,
+    ),
+    SurfaceSpec(
+        SurfaceKind.STUDIO,
+        _route_for(SurfaceKind.STUDIO),
+        studio.build_preamble,
+        profile_resolver=_studio_profile,
+    ),
+    SurfaceSpec(
+        SurfaceKind.CODE,
+        _route_for(SurfaceKind.CODE),
+        code.build_preamble,
+        # Code: edit + run code. Ripple OFF so the agent edits code instead of
+        # building a dashboard; the SDK-tool allowlist scopes it to the coding
+        # built-ins; the `code` skill carries the edit→run→verify loop. No
+        # lazily-loaded MCP tool ids and not meta-aware, so this is a STATIC
+        # profile (no resolver needed).
+        profile=SurfaceProfile(
+            ripple_mode="off",
+            skill_names=frozenset({"code"}),
+            allowed_sdk_tools=frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"}),
+        ),
+    ),
+    SurfaceSpec(
+        SurfaceKind.BELT,
+        _route_for(SurfaceKind.BELT),
+        belt.build_preamble,
+        profile_resolver=_belt_profile,
+    ),
     SurfaceSpec(SurfaceKind.GENERIC, _route_for(SurfaceKind.GENERIC), generic.build_preamble),
 ]
+
+
+def _assert_registry_complete(surfaces: list[SurfaceSpec] | None = None) -> None:
+    """Fail fast at import if the registry isn't a clean 1:1 with ``SurfaceKind``.
+
+    Guarantees every ``SurfaceKind`` member has EXACTLY ONE ``SurfaceSpec`` and
+    every ``SurfaceSpec.kind`` is a real ``SurfaceKind`` — no orphan rows, no
+    duplicate rows, no missing kinds. Resolves the SR design's open question:
+    keep the enum as the closed set of surfaces and ASSERT the registry covers
+    it, rather than deriving the enum from the registry. Runs at module import
+    (call at the bottom of this file) so a drift between the enum and the table
+    surfaces as an ``ImportError`` on the first surface call, not as a silent
+    wrong-profile / missing-handler at request time.
+
+    ``surfaces`` defaults to the module ``SURFACES``; tests inject a mutated
+    list to prove the assertion fires.
+    """
+    rows = SURFACES if surfaces is None else surfaces
+
+    kinds = [spec.kind for spec in rows]
+
+    # Every row names a real SurfaceKind (no bogus / orphan rows).
+    orphans = [k for k in kinds if not isinstance(k, SurfaceKind)]
+    if orphans:
+        raise AssertionError(f"surface registry has rows with non-SurfaceKind kinds: {orphans!r}")
+
+    # No duplicate rows for the same kind.
+    seen: set[SurfaceKind] = set()
+    dupes: set[SurfaceKind] = set()
+    for k in kinds:
+        if k in seen:
+            dupes.add(k)
+        seen.add(k)
+    if dupes:
+        raise AssertionError(f"surface registry has duplicate rows for kinds: {sorted(dupes)!r}")
+
+    # Every SurfaceKind member is covered by exactly one row.
+    missing = [k for k in SurfaceKind if k not in seen]
+    if missing:
+        raise AssertionError(f"surface registry is missing rows for kinds: {missing!r}")
+
+
+# Run the completeness check at import so an enum/registry drift fails fast.
+_assert_registry_complete()

--- a/tests/cloud/surface/test_surface_registry.py
+++ b/tests/cloud/surface/test_surface_registry.py
@@ -1,0 +1,104 @@
+# tests/cloud/surface/test_surface_registry.py — SR-2 registry guarantees.
+#
+# Created: 2026-06-22 (feat/surface-registry-backend-profiles, SR-2) — guards the
+# two SR-2 additions to the declarative SURFACES registry:
+#   1. ``_assert_registry_complete`` — the startup consistency check that the
+#      registry is a clean 1:1 with ``SurfaceKind`` (no orphan rows, no dupes,
+#      no missing kinds). Tests inject a mutated row list and assert it RAISES.
+#   2. The SITES meta-fork now lives on the SITES row's ``profile_resolver``.
+#      We re-pin the three-mode branching through the public ``resolve_profile``
+#      to prove the registry sources the EXACT pre-SR-2 behavior: svelte-create
+#      drops ripple + denies the two ripple-create tools; ripple-create and
+#      refine keep ripple and deny nothing (refine wins over engine).
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.surface import SurfaceKind, SurfaceMeta, SurfaceProfile, resolve_profile
+from pocketpaw_ee.cloud.surface.surface_registry import (
+    SURFACES,
+    SurfaceSpec,
+    _assert_registry_complete,
+    _route_for,
+    generic,
+)
+
+_SITES_SVELTE_CREATE_DENY = frozenset(
+    {
+        "mcp__pocketpaw_sites_manager__create_landing_site",
+        "mcp__pocketpaw_pocket_specialist__create",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Completeness assertion (the SR design's "keep the enum + assert" answer).
+# ---------------------------------------------------------------------------
+
+
+def test_real_registry_passes_completeness_check():
+    """The shipped SURFACES list is a clean 1:1 with SurfaceKind — the assertion
+    that runs at import must accept it without raising."""
+    _assert_registry_complete()  # default arg = the real SURFACES
+    _assert_registry_complete(SURFACES)
+
+
+def test_completeness_check_fails_on_missing_kind():
+    """Drop a kind's row → the assertion fires (a SurfaceKind with no spec)."""
+    incomplete = [s for s in SURFACES if s.kind is not SurfaceKind.GENERIC]
+    with pytest.raises(AssertionError, match="missing rows"):
+        _assert_registry_complete(incomplete)
+
+
+def test_completeness_check_fails_on_duplicate_kind():
+    """Add a second row for an existing kind → the assertion fires (dupe)."""
+    dupe_row = SurfaceSpec(SurfaceKind.HOME, _route_for(SurfaceKind.HOME), generic.build_preamble)
+    with pytest.raises(AssertionError, match="duplicate rows"):
+        _assert_registry_complete([*SURFACES, dupe_row])
+
+
+def test_completeness_check_fails_on_orphan_kind():
+    """A row whose ``kind`` is not a real SurfaceKind → the assertion fires."""
+
+    class _Bogus:
+        value = "bogus"
+
+    orphan = SurfaceSpec(_Bogus(), "/bogus", generic.build_preamble)  # type: ignore[arg-type]
+    with pytest.raises(AssertionError, match="non-SurfaceKind"):
+        _assert_registry_complete([*SURFACES, orphan])
+
+
+# ---------------------------------------------------------------------------
+# SITES meta-fork spot-check — sourced from the SITES row's profile_resolver.
+# ---------------------------------------------------------------------------
+
+
+def test_sites_svelte_create_drops_ripple_and_denies():
+    """svelte-create (engine="svelte", no pocket_id) → ripple OFF + deny set +
+    create-svelte-site skill. The ONLY /sites mode that loses ripple."""
+    profile = resolve_profile(SurfaceKind.SITES, SurfaceMeta(engine="svelte"))
+    assert isinstance(profile, SurfaceProfile)
+    assert profile.ripple_mode == "off"
+    assert profile.deny_mcp_tool_ids == _SITES_SVELTE_CREATE_DENY
+    assert "create-svelte-site" in profile.skill_names
+
+
+def test_sites_ripple_create_keeps_ripple():
+    """ripple-create (engine None/"ripple", no pocket_id) → ripple ON, no deny."""
+    for meta in (SurfaceMeta(), SurfaceMeta(engine="ripple")):
+        profile = resolve_profile(SurfaceKind.SITES, meta)
+        assert profile.ripple_mode == "on", f"{meta!r} must keep ripple"
+        assert profile.deny_mcp_tool_ids == frozenset(), f"{meta!r} must deny nothing"
+
+
+def test_sites_refine_keeps_ripple_and_wins_over_engine():
+    """refine (pocket_id set) → ripple ON, no deny — and a pocket_id wins over
+    engine="svelte" (a published svelte site re-opened for refine still edits a
+    ripple spec)."""
+    for meta in (
+        SurfaceMeta(pocket_id="pkt_1"),
+        SurfaceMeta(pocket_id="pkt_1", engine="svelte"),
+    ):
+        profile = resolve_profile(SurfaceKind.SITES, meta)
+        assert profile.ripple_mode == "on", f"refine {meta!r} must keep ripple"
+        assert profile.deny_mcp_tool_ids == frozenset(), f"refine {meta!r} must deny nothing"


### PR DESCRIPTION
## What

Stacks on #1531. Moves each surface's `SurfaceProfile` onto its `SurfaceSpec` row and rewrites `resolve_profile` to source from the registry (`profile_resolver(meta)` → static `profile` → default). Adds a startup assertion that every `SurfaceKind` has exactly one row (no orphans/dupes/missing). The old `_build_profiles`/`_PROFILE_CACHE` literals are deleted.

## Why

Second backend slice: completes the registry so adding a surface is one row carrying both its handler and its profile, instead of edits in three places. Resolves the design's enum-source-of-truth question (keep the enum, assert completeness).

## Behavior-preserving (this drives ripple_mode + tool scoping, so verified carefully)

- SITES 3-mode meta-fork reproduced byte-for-byte (refine wins over engine; only svelte-create drops ripple).
- Meta-aware rows (FORESIGHT/FILES/STUDIO/BELT/SITES) use `profile_resolver` closures so the lazy MCP tool-id import still defers (no cycle, degrade-to-None preserved — FILES stays `frozenset()` loaded / `None` degraded).
- `compose_entity_profile`, handler bodies, `domain.py` untouched.

## Verified

185 passed across the profile/surface/entity test set + 7 new registry tests (assertion orphan/dupe/missing + SITES fork spot-check) + a degraded-import spot-check. ruff clean. (Two pre-existing `test_ui_agent_invariant` failures need a live Mongo — confirmed identical on the SR-1 base.)

Base PR #1531; merge that first (with --rebase per the stacked-PR rule), then this.