### PR TITLE
Make the discovery model lane configurable

### DIFF
--- a/ee/pocketpaw_ee/discovery/_refine.py
+++ b/ee/pocketpaw_ee/discovery/_refine.py
@@ -1,33 +1,58 @@
-# pocketpaw_ee/discovery/_refine.py — the on-box REFINE pass for discovery (F3).
+# pocketpaw_ee/discovery/_refine.py — the discovery model-lane resolver + REFINE
+# pass (F3).
 #
 # Created: 2026-06-21 (F3 / feat/szd-finish-core) — un-stubs ``opts.refine`` on
 # ``DiscoveryRun``. After the DETERMINISTIC digest produces an ``OntologyDraft``,
-# this pass asks the tenant's ON-BOX model (Ollama) to clean it up: merge
-# near-duplicate types, rename to canonical names, and drop spurious links. It
-# sends the model the DRAFT shape (type names, property names, sample
-# summaries already in the draft) — NOT raw tenant exhaust.
+# this pass asks the discovery model to clean it up: merge near-duplicate types,
+# rename to canonical names, and drop spurious links. It sends the model the
+# DRAFT shape (type names, property names, sample summaries already in the
+# draft) — NOT raw tenant exhaust.
 #
-# SOVEREIGNTY (the whole point of this slice, encoded as mechanical tests):
-# refining touches tenant data, so the model MUST be the tenant's on-box model
-# and NEVER a cloud model. The enforcement point is the hard pin
-# ``resolve_llm_client(settings, force_provider="ollama")`` — we never read
-# ``settings.llm_provider`` (an ``auto`` resolve with a cloud key set would pick
-# Anthropic and leak raw tenant text). ``force_provider="ollama"`` guarantees
-# ``api_key is None`` / ``is_ollama is True``; ``create_openai_client`` then
-# talks to the local Ollama ``/v1`` endpoint with the literal ``"ollama"``
-# sentinel key — no cloud key is ever in the request path.
+# 2026-06-22 — CONFIGURABLE SOVEREIGNTY POSTURE. WHICH model the categorize (F2)
+# and refine (F3) lanes call is governed by ``settings.discovery_sovereign_model``
+# (default True), NOT a code constant:
+#   * sovereign-local (True, the default — unchanged behavior): the model is
+#     hard-pinned to the tenant's on-box Ollama via
+#     ``resolve_llm_client(settings, force_provider="ollama")``. We never read
+#     ``settings.llm_provider`` (an ``auto`` resolve with a cloud key set would
+#     pick Anthropic and leak the inferred shape). The pin guarantees
+#     ``api_key is None`` / ``is_ollama is True``; ``create_openai_client`` then
+#     talks to the local Ollama ``/v1`` endpoint with the literal ``"ollama"``
+#     sentinel key — no cloud key is ever in the request path. Nothing leaves
+#     the box. The safe default for regulated / sovereign tenants.
+#   * configured-provider (False): the model is the workspace's CONFIGURED
+#     provider via ``resolve_llm_client(settings)`` with NO force — anthropic /
+#     openai / openai_compatible / gemini / litellm honored, a CLOUD model
+#     allowed. This is the tenant's EXPLICIT opt-in to send discovery's inferred
+#     data shape to their configured model. Most businesses are fine here
+#     (faster, richer categories); the regulated few keep the default.
 #
-# FAIL CLOSED ON SOVEREIGNTY, SOFT ON AVAILABILITY: if Ollama can't connect
-# (``ollama serve`` down) or returns garbage, we RETURN the original
-# deterministic draft with ``draft.meta["refine"] = "unavailable"`` — we never
-# raise and never fall back to a cloud model. Refine is an enhancement; the
-# deterministic digest is the contract floor. On success we stamp
-# ``draft.meta["refine"] = "applied"``. Mirrors the templated-fallback shape of
-# ``cloud/decisions/explain/extractor.py`` (but the fallback is the draft).
+# FAIL CLOSED ON SOVEREIGNTY, SOFT ON AVAILABILITY: under EITHER posture, if the
+# model can't connect or returns garbage, we RETURN the original deterministic
+# draft with ``draft.meta["refine"] = "unavailable"`` — we never raise. Under the
+# default (sovereign) posture we never fall back to a cloud model; under the
+# opt-in posture the configured (possibly cloud) provider is already the chosen
+# lane, so there is nothing to "fall back" to — an unreachable provider still
+# degrades to the deterministic floor, never a silent re-route. Refine is an
+# enhancement; the deterministic digest is the contract floor. On success we
+# stamp ``draft.meta["refine"] = "applied"``. Mirrors the templated-fallback
+# shape of ``cloud/decisions/explain/extractor.py`` (but the fallback is the
+# draft).
+#
+# The kb ingest/build tripwire (``kb_compile._kb`` refusing ``ingest`` /
+# ``build``) is INDEPENDENT of this posture and stays UNCONDITIONAL — that path
+# POSTs raw tenant text to Anthropic's KB API and is never correct, sovereign or
+# not.
+#
+# FOLLOW-UP: this slice resolves only the ``resolve_llm_client`` providers
+# (ollama / openai / anthropic-api / openai_compatible / gemini / litellm). Using
+# the workspace's configured AGENT BACKEND (e.g. the Claude Code / claude_agent_sdk
+# loop) as the discovery one-shot is a SEPARATE, larger integration — the agent
+# loop is not a chat-completions endpoint — and is left as a future option.
 #
 # ``resolve_on_box_descriptor`` / ``resolve_on_box_client`` are the shared
-# helpers slice F2 (unstructured categorization) also imports for its on-box
-# model call — both lanes resolve the same way so the sovereignty pin lives in
+# helpers slice F2 (unstructured categorization) also imports for its discovery
+# model call — both lanes resolve the same way so the posture decision lives in
 # one place.
 #
 # Pure orchestration over the OSS ``pocketpaw.llm`` client seam + the discovery
@@ -73,31 +98,62 @@ _REFINE_SYSTEM = (
 
 
 def resolve_on_box_descriptor(settings: Settings) -> LLMClient:
-    """Resolve the on-box (Ollama) ``LLMClient`` descriptor — hard-pinned local.
+    """Resolve the discovery-model ``LLMClient`` descriptor — posture-governed.
 
-    SOVEREIGNTY ENFORCEMENT POINT. ``force_provider="ollama"`` is passed
-    unconditionally so this never reads ``settings.llm_provider``: an ``auto``
-    resolve on a tenant with a cloud key configured would otherwise pick
-    Anthropic and leak raw tenant text. The returned descriptor always has
-    ``provider == "ollama"``, ``api_key is None``, ``is_ollama is True``.
+    The provider is chosen by ``settings.discovery_sovereign_model``:
 
-    Shared with slice F2 (unstructured categorization) so both on-box model
-    lanes resolve identically.
+    * **sovereign-local (True, the default)** → ``resolve_llm_client(settings,
+      force_provider="ollama")``. The pin is the enforcement point: this never
+      reads ``settings.llm_provider`` (an ``auto`` resolve on a tenant with a
+      cloud key configured would otherwise pick Anthropic and leak the inferred
+      shape). The descriptor always has ``provider == "ollama"``,
+      ``api_key is None``, ``is_ollama is True`` — nothing leaves the box.
+    * **configured-provider (False)** → ``resolve_llm_client(settings)`` with NO
+      force. The workspace's configured provider is honored (anthropic / openai /
+      openai_compatible / gemini / litellm — a CLOUD model is allowed). This is
+      the tenant's explicit opt-in to send discovery's inferred data shape to
+      their configured model.
+
+    Despite the name (kept stable because slice F2 imports it), this is the
+    single discovery-model resolution point for BOTH the categorize and refine
+    lanes — the posture decision lives here, once.
     """
-    return resolve_llm_client(settings, force_provider="ollama")
+    if settings.discovery_sovereign_model:
+        return resolve_llm_client(settings, force_provider="ollama")
+    return resolve_llm_client(settings)
 
 
 def resolve_on_box_client(settings: Settings) -> Any:
-    """Build the on-box ``AsyncOpenAI`` client bound to the local Ollama endpoint.
+    """Build the ``AsyncOpenAI`` client for the discovery model — posture-governed.
 
     Wraps ``resolve_on_box_descriptor`` + ``create_openai_client`` so callers get
-    a ready-to-use client with one call. The client talks to
-    ``{ollama_host}/v1`` with the literal ``"ollama"`` sentinel key — never a
-    cloud key. ``timeout`` is generous because a local model is slower than a
-    cloud API.
+    a ready-to-use client with one call. Under the default sovereign posture the
+    client talks to ``{ollama_host}/v1`` with the literal ``"ollama"`` sentinel
+    key — never a cloud key. Under the opt-in posture
+    (``discovery_sovereign_model=False``) the client targets the workspace's
+    configured provider (which may be a cloud endpoint with the tenant's
+    configured key). ``timeout`` is generous because a local model is slower than
+    a cloud API.
     """
     descriptor = resolve_on_box_descriptor(settings)
     return descriptor.create_openai_client(timeout=_REFINE_TIMEOUT_S)
+
+
+def resolve_discovery_model_name(settings: Settings) -> str:
+    """Resolve the model NAME the discovery one-shot should request — posture-aware.
+
+    Under the default sovereign posture the model is the on-box
+    ``settings.ollama_model``. Under the opt-in posture the model name comes from
+    the configured provider's resolved descriptor (e.g. ``settings.openai_model``
+    for ``openai``), so the chat-completion request targets the right model for
+    whichever provider the tenant configured. Falls back to ``ollama_model`` if
+    the descriptor carries no usable model name. Shared by F2 (categorize) and F3
+    (refine) so both lanes pick the model the same way.
+    """
+    if settings.discovery_sovereign_model:
+        return settings.ollama_model
+    descriptor = resolve_on_box_descriptor(settings)
+    return descriptor.model or settings.ollama_model
 
 
 def _draft_payload(draft: OntologyDraft) -> dict[str, Any]:
@@ -219,19 +275,25 @@ def _as_float(value: Any, default: float) -> float:
 
 
 async def refine_draft(draft: OntologyDraft, settings: Settings) -> OntologyDraft:
-    """Refine a deterministic ``OntologyDraft`` with the tenant's ON-BOX model.
+    """Refine a deterministic ``OntologyDraft`` with the discovery model.
 
     Sends the model the DRAFT shape (type/property names, sample summaries in
     the draft — never raw exhaust) and asks it to merge/rename types and drop
     spurious links, then applies the cleaned result onto a copy of the draft.
 
-    Sovereignty: the client is hard-pinned to Ollama via ``resolve_on_box_client``
-    (``force_provider="ollama"``). No cloud model is ever reached.
+    Sovereignty posture: the client comes from ``resolve_on_box_client``, which
+    pins Ollama when ``settings.discovery_sovereign_model`` is True (the default —
+    no cloud model is ever reached) and honors the workspace's configured
+    provider (cloud allowed) when it is False. The posture decision lives in the
+    resolver, not here.
 
-    Fail closed on sovereignty, soft on availability: on ANY failure (Ollama
-    down, malformed response, parse error) return the ORIGINAL deterministic
-    draft with ``meta["refine"] = "unavailable"`` — never raise, never fall back
-    to a cloud model. On success stamp ``meta["refine"] = "applied"``.
+    Fail closed on sovereignty, soft on availability: on ANY failure (model
+    unreachable, malformed response, parse error) return the ORIGINAL
+    deterministic draft with ``meta["refine"] = "unavailable"`` — never raise.
+    Under the default posture this also means never reaching a cloud model;
+    under the opt-in posture the configured provider is already the chosen lane,
+    so an unreachable provider degrades to the floor rather than re-routing. On
+    success stamp ``meta["refine"] = "applied"``.
     """
     client = resolve_on_box_client(settings)
     payload = _draft_payload(draft)
@@ -243,7 +305,7 @@ async def refine_draft(draft: OntologyDraft, settings: Settings) -> OntologyDraf
 
     try:
         resp = await client.chat.completions.create(
-            model=settings.ollama_model,
+            model=resolve_discovery_model_name(settings),
             messages=[
                 {"role": "system", "content": _REFINE_SYSTEM},
                 {"role": "user", "content": user_content},
@@ -290,5 +352,6 @@ def _unavailable(draft: OntologyDraft) -> OntologyDraft:
 __all__ = [
     "resolve_on_box_descriptor",
     "resolve_on_box_client",
+    "resolve_discovery_model_name",
     "refine_draft",
 ]

--- a/ee/pocketpaw_ee/discovery/kb_compile.py
+++ b/ee/pocketpaw_ee/discovery/kb_compile.py
@@ -7,19 +7,27 @@
 # it compiles the text into a kb-go wiki ON-BOX, reads the compiled articles back,
 # and infers the OntologyDraft from them.
 #
-# F2 (2026-06-21 / feat/szd-finish-core) — ON-BOX CATEGORIZATION. ``kb convo
-# ingest`` hardcodes every article's category to "conversation" (kb-go
+# F2 (2026-06-21 / feat/szd-finish-core) — DISCOVERY-MODEL CATEGORIZATION.
+# ``kb convo ingest`` hardcodes every article's category to "conversation" (kb-go
 # convo.go:625), so on real text the ontology collapses to a single
 # objects-only type. F2 routes unstructured exhaust through kb's AGENT MODE
-# (``kb prepare`` → on-box Ollama model → ``kb accept``) WHEN an on-box model is
-# configured, so real text gets DOMAIN categories (SupportTicket, RefundRequest,
-# ...). ``kb prepare`` / ``kb accept`` are keyless (no network); the only model
-# call is the per-prompt compile, hard-pinned to the tenant's local Ollama via
-# F3's ``_refine.resolve_on_box_client`` (``force_provider="ollama"``). When no
+# (``kb prepare`` → discovery model → ``kb accept``) WHEN a model is configured,
+# so real text gets DOMAIN categories (SupportTicket, RefundRequest, ...).
+# ``kb prepare`` / ``kb accept`` are keyless (no network); the only model call is
+# the per-prompt compile, whose client + model NAME come from F3's
+# ``_refine.resolve_on_box_client`` / ``resolve_discovery_model_name``. When no
 # model is configured (or resolution fails), ``_compile_blobs`` falls back to the
 # original ``kb convo ingest`` path — graceful degrade to today's behavior, never
 # an error. The chosen path is logged ("prepare/accept" vs "convo ingest") so a
 # silent regression to the conversation-only bucket is visible.
+#
+# MODEL-LANE SOVEREIGNTY POSTURE (2026-06-22, shared with F3): WHICH model the
+# per-prompt compile reaches is governed by ``settings.discovery_sovereign_model``
+# (default True → on-box Ollama only, ``api_key is None``; False → the
+# workspace's configured provider, a cloud model allowed — the tenant's explicit
+# opt-in). The resolution lives once in ``_refine``; this digester just consumes
+# it. The kb ingest/build TRIPWIRE below is INDEPENDENT of that posture and stays
+# UNCONDITIONAL.
 #
 # Contract: ``digest(records, connector_meta=None) -> OntologyDraft`` — the same
 # sync Digester Protocol StructuredShapeDigester satisfies. Here ``records`` are
@@ -38,10 +46,12 @@
 # SOVEREIGNTY (load-bearing, encoded as tests): every kb command is keyless and
 # on-box (``prepare`` / ``accept`` / ``convo ingest`` / ``list`` / ``show`` /
 # ``graph``), and the F2 categorization model call resolves through
-# ``resolve_on_box_client`` (Ollama only — ``api_key is None``). The digester
-# must NEVER call ``kb ingest`` / ``kb build``, which POST raw tenant text to the
-# Anthropic API (kb.go:1349) — the ``_kb`` seam asserts this on every call. The
-# seam clones ``cloud/agents/knowledge.py`` (binary resolution + subprocess +
+# ``resolve_on_box_client`` — Ollama-only by default, or the configured provider
+# under the explicit opt-in posture. INDEPENDENT of that posture, the digester
+# must NEVER call ``kb ingest`` / ``kb build`` (which POST raw tenant text to the
+# Anthropic KB API, kb.go:1349) — the ``_kb`` seam asserts this on EVERY call,
+# unconditionally; sovereign or opt-in, that path is never correct. The seam
+# clones ``cloud/agents/knowledge.py`` (binary resolution + subprocess +
 # timeout) and is the seam the unit tests mock.
 #
 # Sync → async bridge: ``digest()`` is sync (Digester Protocol) but the on-box
@@ -70,7 +80,10 @@ from pathlib import Path
 from typing import Any
 
 from pocketpaw.fabric.models import PropertyDef
-from pocketpaw_ee.discovery._refine import resolve_on_box_client
+from pocketpaw_ee.discovery._refine import (
+    resolve_discovery_model_name,
+    resolve_on_box_client,
+)
 from pocketpaw_ee.discovery.models import (
     DraftLink,
     DraftObject,
@@ -399,11 +412,14 @@ class KbCompileDigester:
         )
 
     def _resolve_model_client(self) -> Any | None:
-        """Resolve the on-box model client, or ``None`` if not available.
+        """Resolve the discovery-model client, or ``None`` if not available.
 
         ``None`` when no ``settings`` was supplied (no model configured) OR when
-        the on-box resolve fails (Ollama not set up). Either way the caller
-        degrades to the deterministic ``convo ingest`` path — never an error.
+        the resolve fails (the chosen provider isn't set up). Either way the
+        caller degrades to the deterministic ``convo ingest`` path — never an
+        error. WHICH provider this resolves (on-box Ollama vs. the configured
+        provider) is governed by ``settings.discovery_sovereign_model``; see
+        ``_refine.resolve_on_box_client``.
         """
         if self._settings is None:
             return None
@@ -411,9 +427,23 @@ class KbCompileDigester:
             return resolve_on_box_client(self._settings)
         except Exception as exc:  # noqa: BLE001 — unavailable model ⇒ graceful degrade
             logger.warning(
-                "kb-compile: on-box model unavailable (%s); falling back to convo ingest", exc
+                "kb-compile: discovery model unavailable (%s); falling back to convo ingest",
+                exc,
             )
             return None
+
+    def _discovery_model_name(self) -> str:
+        """Resolve the model name for the categorize one-shot — posture-aware.
+
+        Delegates to ``_refine.resolve_discovery_model_name`` when ``settings``
+        carries the posture flag; falls back to ``settings.ollama_model`` for the
+        minimal settings stubs that only expose ``ollama_model``. Backward
+        compatible: a stub without ``discovery_sovereign_model`` keeps the
+        original on-box model name.
+        """
+        if getattr(self._settings, "discovery_sovereign_model", True):
+            return self._settings.ollama_model
+        return resolve_discovery_model_name(self._settings)
 
     def _compile_via_agent_mode(
         self, scope: str, label: str, blobs: Sequence[str], client: Any
@@ -490,15 +520,19 @@ class KbCompileDigester:
         return out
 
     async def _call_model(self, client: Any, prompt: str) -> Any:
-        """One on-box chat completion → parsed article JSON (or ``None``).
+        """One discovery-model chat completion → parsed article JSON (or ``None``).
 
-        SOVEREIGNTY: ``client`` is bound to the local Ollama endpoint
-        (``resolve_on_box_client`` hard-pins ``force_provider="ollama"`` —
-        ``api_key is None``). ``response_format={"type":"json_object"}`` makes the
-        model return a single JSON object — the compiled article.
+        SOVEREIGNTY POSTURE: ``client`` comes from ``resolve_on_box_client``,
+        which pins the local Ollama endpoint (``force_provider="ollama"`` —
+        ``api_key is None``) when ``settings.discovery_sovereign_model`` is True
+        (the default) and honors the workspace's configured provider (cloud
+        allowed) when the tenant has explicitly opted out. The model NAME is
+        resolved the same posture-aware way via ``resolve_discovery_model_name``.
+        ``response_format={"type":"json_object"}`` makes the model return a single
+        JSON object — the compiled article.
         """
         resp = await client.chat.completions.create(
-            model=self._settings.ollama_model,
+            model=self._discovery_model_name(),
             messages=[{"role": "user", "content": prompt}],
             response_format={"type": "json_object"},
         )

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,13 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-22: Added ``discovery_sovereign_model`` (default True) — the model-lane
+    sovereignty posture for discovery's categorize (F2) / refine (F3) passes.
+    True (default, unchanged behavior): hard-pin the model to the on-box Ollama
+    so tenant data never leaves the box. False: use the workspace's configured
+    provider via ``resolve_llm_client`` — a CLOUD model is allowed (explicit
+    tenant opt-in). The kb ingest/build tripwire holds regardless. Env:
+    POCKETPAW_DISCOVERY_SOVEREIGN_MODEL.
   - 2026-06-21: Added ``instinct_enforce_discovered_rules`` (default False, F6) —
     when true, approved workspace-discovered Instinct rules are merged with
     template rules at the live gate and govern actions. Off by default; the
@@ -1407,6 +1414,39 @@ class Settings(BaseSettings):
             "the live gate. Off by default — the template-rule path is unchanged "
             "and the whole discovered branch is dead code on the default path. "
             "Set via POCKETPAW_INSTINCT_ENFORCE_DISCOVERED_RULES."
+        ),
+    )
+
+    # Sovereign Zero-Setup Discovery — model-lane sovereignty posture (2026-06-22).
+    # Discovery's categorize (F2) and refine (F3) passes send the tenant's data
+    # SHAPE (type/property names, article summaries — never raw exhaust) to a
+    # model. WHICH model is a sovereignty choice, not a code constant:
+    #   * sovereign-local (default, True): the model is hard-pinned to the
+    #     tenant's on-box Ollama. ``api_key is None``; no cloud key ever rides
+    #     into the request path. Nothing leaves the box. This is the safe
+    #     default and matches the original shipped behavior.
+    #   * configured-provider (False): discovery uses the workspace's CONFIGURED
+    #     provider via ``resolve_llm_client(settings)`` — anthropic / openai /
+    #     openai_compatible / gemini / litellm, a CLOUD model is allowed. This is
+    #     the tenant's EXPLICIT opt-in to send discovery exhaust to their own
+    #     configured model. Most businesses are fine here (faster, better
+    #     categories); regulated / sovereign tenants keep the default.
+    # Independent of the kb-ingest tripwire: ``kb ingest`` / ``kb build`` (which
+    # POST raw tenant text to Anthropic's KB API) are NEVER called regardless of
+    # this setting — that path is never correct and stays hard-blocked.
+    discovery_sovereign_model: bool = Field(
+        default=True,
+        description=(
+            "Sovereignty posture for discovery's categorize/refine model call. "
+            "True (default): hard-pin the model to the tenant's on-box Ollama — "
+            "data never leaves the box, no cloud key in the request path "
+            "(sovereign-local, the safe default for regulated tenants). False: "
+            "use the workspace's configured provider via resolve_llm_client — a "
+            "CLOUD model is allowed; this is the tenant's explicit opt-in to send "
+            "discovery's inferred data shape to their configured model (faster, "
+            "richer categories — fine for most businesses). The kb ingest/build "
+            "tripwire holds regardless of this setting. Set via "
+            "POCKETPAW_DISCOVERY_SOVEREIGN_MODEL."
         ),
     )
 

--- a/tests/ee/test_discovery_model_lane.py
+++ b/tests/ee/test_discovery_model_lane.py
@@ -1,0 +1,336 @@
+# tests/ee/test_discovery_model_lane.py — model-lane sovereignty posture tests.
+#
+# Created: 2026-06-22 (feat/szd-model-lane-configurable) — covers
+# ``settings.discovery_sovereign_model``, the configurable posture for discovery's
+# categorize (F2) / refine (F3) model call. The provider lane is no longer a code
+# constant; it is chosen by the setting:
+#
+#   * True (DEFAULT, unchanged sovereign behavior): the resolver hard-pins the
+#     on-box Ollama (``force_provider="ollama"``) — ``api_key is None``, nothing
+#     leaves the box. The pre-existing sovereignty guarantee holds by default.
+#   * False (explicit opt-in): the resolver uses the workspace's CONFIGURED
+#     provider via ``resolve_llm_client(settings)`` (no force) — a cloud model is
+#     allowed.
+#
+# Asserted here:
+#   * default True → resolved client is ollama, api_key is None;
+#   * False + a configured provider (openai) → that provider resolves, NOT ollama;
+#   * False + no resolvable provider/key → graceful degrade (refine returns the
+#     deterministic draft flagged "unavailable"; the categorize digester falls
+#     back to convo ingest) — never raises, never a silent cloud leak;
+#   * the kb ingest/build TRIPWIRE holds under BOTH postures (never reached).
+#
+# Fully mocked — no DB / network / Ollama / kb binary. Run with:
+#   uv run --group ee pytest tests/ee/test_discovery_model_lane.py -q
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.discovery import _refine  # noqa: E402
+from pocketpaw_ee.discovery.kb_compile import KbCompileDigester  # noqa: E402
+from pocketpaw_ee.discovery.models import (  # noqa: E402
+    DraftLink,
+    DraftObject,
+    DraftObjectType,
+    OntologyDraft,
+)
+
+from pocketpaw.config import Settings  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _no_provider_settings(*, sovereign: bool) -> Settings:
+    """A Settings with NO resolvable cloud provider.
+
+    The local dev config file can leak real-looking keys into a bare
+    ``Settings()`` (deepseek / litellm), so we explicitly null every provider
+    key/url and pin ``llm_provider="auto"``. With nothing resolvable, ``auto``
+    falls through to ollama — proving the opt-in posture never silently picks a
+    cloud lane just because a stray key was on disk.
+    """
+    return Settings(
+        llm_provider="auto",
+        discovery_sovereign_model=sovereign,
+        anthropic_api_key=None,
+        openai_api_key=None,
+        openai_compatible_base_url="",
+        openai_compatible_api_key=None,
+        google_api_key=None,
+        openrouter_api_key=None,
+        litellm_api_key=None,
+    )
+
+
+def _sample_draft() -> OntologyDraft:
+    """A small deterministic draft (two near-duplicate types, one spurious link)."""
+    return OntologyDraft(
+        object_types=[
+            DraftObjectType(
+                name="Ticket",
+                source_id_field="id",
+                field_map={"subject": "subject"},
+                confidence=0.6,
+                key_confidence=0.8,
+                record_count=3,
+            ),
+            DraftObjectType(
+                name="Tickets",
+                source_id_field="id",
+                field_map={"subject": "subject"},
+                confidence=0.4,
+                key_confidence=0.5,
+                record_count=2,
+            ),
+        ],
+        objects=[
+            DraftObject(type_name="Ticket", source_id="t1", properties={"subject": "hi"}),
+        ],
+        links=[
+            DraftLink(
+                from_type="Ticket",
+                from_source_id="t1",
+                to_type="Tickets",
+                to_source_id="t9",
+                link_type="related",
+                via_field="ref",
+                confidence=0.2,
+            ),
+        ],
+        meta={"digester": "structured-shape"},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 1) DEFAULT posture (sovereign True) — forces ollama, api_key is None.
+#    The existing sovereignty guarantee holds by default.
+# --------------------------------------------------------------------------- #
+def test_sovereign_true_forces_ollama() -> None:
+    settings = Settings()  # discovery_sovereign_model defaults to True
+    assert settings.discovery_sovereign_model is True
+
+    llm = _refine.resolve_on_box_descriptor(settings)
+
+    assert llm.is_ollama is True
+    assert llm.api_key is None
+    assert llm.provider == "ollama"
+    # The model name is the on-box model under the default posture.
+    assert _refine.resolve_discovery_model_name(settings) == settings.ollama_model
+
+
+def test_sovereign_true_forces_ollama_even_with_cloud_key() -> None:
+    # A tenant with a cloud key set AND llm_provider="auto" would, without the
+    # pin, resolve to anthropic. The default sovereign posture must still force
+    # ollama — the leak the original slice exists to prevent.
+    settings = Settings(anthropic_api_key="sk-ant-fake-cloud-key", llm_provider="auto")
+    assert settings.discovery_sovereign_model is True
+
+    llm = _refine.resolve_on_box_descriptor(settings)
+
+    assert llm.is_ollama is True, "default posture must override the cloud key"
+    assert llm.is_anthropic is False
+    assert llm.api_key is None
+
+
+# --------------------------------------------------------------------------- #
+# 2) OPT-IN posture (sovereign False) + a configured provider — uses
+#    resolve_llm_client(settings) with NO force, resolves to that provider
+#    (NOT forced ollama).
+# --------------------------------------------------------------------------- #
+def test_sovereign_false_uses_configured_provider() -> None:
+    settings = Settings(
+        discovery_sovereign_model=False,
+        llm_provider="openai",
+        openai_api_key="sk-fake-openai-key",
+    )
+
+    llm = _refine.resolve_on_box_descriptor(settings)
+
+    # The configured provider is honored — NOT forced back to ollama.
+    assert llm.provider == "openai"
+    assert llm.is_ollama is False
+    assert llm.api_key == "sk-fake-openai-key"
+    # The model name follows the configured provider, not the ollama model.
+    assert _refine.resolve_discovery_model_name(settings) == settings.openai_model
+
+
+def test_sovereign_false_resolves_via_no_force_resolve(monkeypatch) -> None:
+    # Prove the opt-in posture calls resolve_llm_client WITHOUT force_provider.
+    settings = Settings(
+        discovery_sovereign_model=False,
+        llm_provider="openai",
+        openai_api_key="sk-fake-openai-key",
+    )
+
+    captured: dict[str, Any] = {}
+    real_resolve = _refine.resolve_llm_client
+
+    def _spy(s: Settings, *, force_provider: str | None = None):
+        captured["force_provider"] = force_provider
+        return real_resolve(s, force_provider=force_provider)
+
+    monkeypatch.setattr(_refine, "resolve_llm_client", _spy)
+
+    _refine.resolve_on_box_descriptor(settings)
+
+    assert captured["force_provider"] is None, "opt-in posture must not force a provider"
+
+
+# --------------------------------------------------------------------------- #
+# 3) OPT-IN posture but NO resolvable provider/key — graceful degrade.
+#    refine returns the deterministic draft flagged "unavailable"; the digester
+#    falls back to convo ingest. Never raises, never a silent cloud leak.
+# --------------------------------------------------------------------------- #
+async def test_sovereign_false_with_no_provider_degrades_refine(monkeypatch) -> None:
+    draft = _sample_draft()
+    settings = _no_provider_settings(sovereign=False)
+
+    # With nothing configured, auto falls through to ollama (no key) — no leak.
+    descriptor = _refine.resolve_on_box_descriptor(settings)
+    assert descriptor.is_ollama is True
+    assert descriptor.api_key is None, "no resolvable provider must not pick up a stray cloud key"
+
+    # The (unreachable) provider raises on connect → refine degrades to the floor.
+    class _DownCompletions:
+        async def create(self, **kwargs: Any) -> Any:
+            raise ConnectionError("no provider reachable")
+
+    class _DownChat:
+        completions = _DownCompletions()
+
+    class _DownClient:
+        chat = _DownChat()
+
+    monkeypatch.setattr(_refine, "resolve_on_box_client", lambda s: _DownClient())
+
+    out = await _refine.refine_draft(draft, settings)
+
+    assert out.meta["refine"] == "unavailable", "must degrade, never raise"
+    assert {ot.name for ot in out.object_types} == {"Ticket", "Tickets"}
+    assert len(out.links) == 1  # nothing dropped — refine never applied
+
+
+def test_sovereign_false_with_no_provider_degrades_categorize(monkeypatch) -> None:
+    # The digester resolves no usable client → falls back to the deterministic
+    # convo-ingest path. Never raises.
+    settings = _no_provider_settings(sovereign=False)
+
+    def _down_resolve(s: Settings) -> Any:
+        raise RuntimeError("no provider reachable")
+
+    calls = _install_fake_kb(monkeypatch)
+    monkeypatch.setattr("pocketpaw_ee.discovery.kb_compile.resolve_on_box_client", _down_resolve)
+
+    digester = KbCompileDigester(settings=settings)
+    draft = digester.digest(
+        {"support": ["Customer can't log in."]},
+        {"connector": "zendesk", "workspace_id": "w1"},
+    )
+
+    assert isinstance(draft, OntologyDraft)
+    # Fell back to convo ingest (the deterministic floor), never raised.
+    cmds = [c[0] for c in calls]
+    assert "convo" in cmds, "no-provider opt-in must fall back to convo ingest"
+    assert "prepare" not in cmds, "no model client → agent mode must not run"
+
+
+# --------------------------------------------------------------------------- #
+# 4) The kb ingest/build TRIPWIRE is UNCONDITIONAL — never reached under either
+#    posture, model client present or not.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("sovereign", [True, False])
+def test_tripwire_holds_regardless_of_setting(monkeypatch, sovereign: bool) -> None:
+    settings = _no_provider_settings(sovereign=sovereign)
+
+    calls = _install_fake_kb(monkeypatch)
+    # No model client either way — exercises the full compile + read path.
+    monkeypatch.setattr(
+        "pocketpaw_ee.discovery.kb_compile.resolve_on_box_client",
+        lambda s: (_ for _ in ()).throw(RuntimeError("no model")),
+    )
+
+    digester = KbCompileDigester(settings=settings)
+    digester.digest(
+        {"support": ["text one"], "refunds": ["text two"]},
+        {"connector": "zendesk", "workspace_id": "w1"},
+    )
+
+    cmds = [c[0] for c in calls]
+    assert "ingest" not in cmds, "sovereignty tripwire: kb ingest must never run"
+    assert "build" not in cmds, "sovereignty tripwire: kb build must never run"
+
+
+def test_tripwire_seam_refuses_ingest_and_build() -> None:
+    # The mechanical assertion in the real _kb seam — independent of any setting.
+    from pocketpaw_ee.discovery import kb_compile
+
+    with pytest.raises(RuntimeError, match="sovereignty"):
+        kb_compile._kb("ingest", "some/path")
+    with pytest.raises(RuntimeError, match="sovereignty"):
+        kb_compile._kb("build", "some/path")
+
+
+# --------------------------------------------------------------------------- #
+# Shared fake kb seam — records calls, refuses ingest/build, models the
+# convo-ingest + list/show round-trip the digester reads back.
+# --------------------------------------------------------------------------- #
+def _install_fake_kb(monkeypatch) -> list[tuple[str, ...]]:
+    calls: list[tuple[str, ...]] = []
+    store: dict[str, list[dict]] = {}
+    counter = {"n": 0}
+
+    def _scope_of(args: tuple[str, ...]) -> str:
+        if "--scope" in args:
+            return args[args.index("--scope") + 1]
+        return "default"
+
+    def _fake_kb(*args: str, input_text: str | None = None, timeout: int = 120) -> Any:
+        calls.append(args)
+        # The real seam refuses these BEFORE the subprocess; mirror it so a test
+        # that somehow routed here would also fail loud.
+        assert args[0] not in ("ingest", "build"), (
+            "sovereignty: KbCompileDigester must never call kb ingest/build"
+        )
+        scope = _scope_of(args)
+
+        if args[0] == "convo":
+            store.setdefault(scope, [])
+            counter["n"] += 1
+            store[scope].append(
+                {
+                    "id": f"convo-{counter['n']}",
+                    "title": "Conversation",
+                    "summary": "deterministic convo ingest",
+                    "content": "body",
+                    "concepts": [],
+                    "categories": ["conversation"],
+                }
+            )
+            return {"articles": 1}
+
+        if args[0] == "list":
+            return [
+                {"id": a["id"], "title": a.get("title", ""), "summary": a.get("summary", "")}
+                for a in store.get(scope, [])
+            ]
+
+        if args[0] == "show":
+            article_id = args[1]
+            for a in store.get(scope, []):
+                if a["id"] == article_id:
+                    return dict(a)
+            return {}
+
+        if args[0] == "graph":
+            return {"scope": scope, "nodes": [], "edges": []}
+
+        return {}
+
+    monkeypatch.setattr("pocketpaw_ee.discovery.kb_compile._kb", _fake_kb)
+    return calls


### PR DESCRIPTION
Discovery's categorize and refine passes used to hard-pin the model to a local Ollama, with no way to change it. That is the right default for tenants who can't let anything leave the box, but most businesses are fine running discovery on a cloud model, and forcing local on everyone just makes it slower and the categories weaker for no reason.

This adds a setting so the posture is a choice instead of a constant.

## What changed

New setting `discovery_sovereign_model` (env `POCKETPAW_DISCOVERY_SOVEREIGN_MODEL`), default `True`:

- `True` (default): the model is pinned to the on-box Ollama, exactly as before. `api_key is None`, nothing leaves the box. Regulated and sovereign tenants get the safe default with no action.
- `False`: discovery resolves the workspace's configured provider through `resolve_llm_client(settings)` with no force, so anthropic / openai / openai_compatible / gemini / litellm are honored and a cloud model is allowed. This is the tenant opting in to send discovery's inferred data shape to their own configured model.

The provider decision now lives in one place (`_refine.resolve_on_box_descriptor`), and both the categorize (F2) and refine (F3) lanes go through it.

## What did not change

- Default behavior is identical to before: sovereign-local. The existing F2/F3 tests that assert the default still pass untouched.
- The kb ingest/build tripwire stays unconditional. That path POSTs raw tenant text to the Anthropic KB API and is never correct, sovereign or not, so it stays hard-blocked regardless of this setting.
- Wiring the configured agent backend (e.g. the Claude Code SDK loop) as the discovery one-shot is out of scope here. The agent loop isn't a chat-completions endpoint, so that's a separate, larger piece of work. Left a follow-up note in `_refine.py`.

## Tests

New `tests/ee/test_discovery_model_lane.py`:

- default True forces ollama, `api_key is None`
- False with a configured provider resolves that provider, not forced ollama
- False with nothing resolvable degrades gracefully (refine returns the deterministic draft flagged unavailable, categorize falls back to convo ingest) and never raises or silently leaks to cloud
- the tripwire holds under both postures

All green:

```
37 passed   # model-lane + refine + kb_compile categorize/digester
```

ruff check + format clean, import-linter contracts all kept.