### PR TITLE
fix(jobs): register builtins in the worker + let a job read from a bound connector

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -1,5 +1,15 @@
 """arq worker entry point for Tier 2 run execution.
 
+Updated: 2026-06-22 (feat/jobs-worker-register-and-connector-read) — PRODUCTION
+FIX: ``_startup`` now calls ``register_builtins()`` AFTER ``init_realtime()`` so
+the worker process populates the process-wide job registry on boot. The registry
+is a module-level dict; the worker runs in a SEPARATE process from the web
+``mount_cloud`` that registered the built-ins there, so without this the
+worker's registry was EMPTY and ``execute_workspace_job`` → ``resolve_job(name)``
+raised ``UnknownJobError`` for EVERY job in a real deploy. Mirrors the ordering
+in ``ee/pocketpaw_ee/cloud/__init__.py:mount_cloud`` (register after
+init_realtime so a job's writeback emit has a bus to publish onto).
+
 Updated: 2026-06-20 (feat/workspace-jobs, pp#1459) — registered the workspace
 jobs entrypoint ``execute_workspace_job`` into ``WorkerSettings.functions``
 (default #1: SAME worker process, no new deploy artifact). It is wrapped with
@@ -73,6 +83,16 @@ async def _startup(ctx: dict[str, Any]) -> None:
     mongo_uri = os.environ.get("CLOUD_MONGODB_URI", "mongodb://localhost:27017/paw-enterprise")
     await init_cloud_db(mongo_uri)
     init_realtime()
+    # Register the built-in workspace jobs into the process-wide registry. The
+    # registry is a module-level dict and the worker runs in its OWN process, so
+    # the registration ``mount_cloud`` does for the web process does NOT carry
+    # over here. Without this the worker's registry is empty and
+    # ``execute_workspace_job`` → ``resolve_job(name)`` raises ``UnknownJobError``
+    # for every job. Called AFTER ``init_realtime()`` (same ordering as
+    # ``mount_cloud``) so a job's writeback emit has a bus to publish onto.
+    from pocketpaw_ee.cloud.jobs.builtin import register_builtins
+
+    register_builtins()
     if not _boot_sweep_enabled():
         logger.info("worker boot: stale-run sweep disabled (%s)", _BOOT_SWEEP_ENV)
         return

--- a/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
+++ b/ee/pocketpaw_ee/cloud/jobs/builtin/score_applications.py
@@ -28,6 +28,17 @@
 #     `params["rows"]` behavior so current tests/specs still work.
 # The WORKER now owns the `<action>_status` flag (Bug B fix), so this built-in
 # no longer returns any status key — only `scored_rows` + the scored count.
+#
+# Updated: 2026-06-22 (feat/jobs-worker-register-and-connector-read) — added a
+# CONNECTOR source mode: when `params` carries `connector` (and `action`), the
+# job reads its batch from the workspace's BOUND connector via
+# `jobs.service.execute_connector_action` (the jobs entity owns the connectors
+# call — the built-in never imports the connectors service directly) and scores
+# those records. Source PRECEDENCE is connector > source_collection > rows; the
+# Mongo `source_collection` and inline `rows` fallbacks are PRESERVED. The same
+# idempotent dedup (skip ids already in the pocket's `scored_rows`), the same
+# real heuristic + band, and the same PII allowlist (id/name/score/band/stage)
+# apply to all three source modes — only WHERE the batch comes from differs.
 
 """Built-in `score_applications` job: real data-backed scoring + PII allowlist."""
 
@@ -193,9 +204,30 @@ class ScoreApplicationsJob:
         self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
     ) -> dict:
         batch_size = max(0, int(params.get("batch_size", 20)))
+        connector = params.get("connector")
+        connector_action = params.get("action")
         source_collection = params.get("source_collection")
 
-        if isinstance(source_collection, str) and source_collection.strip():
+        # Source PRECEDENCE: connector > source_collection > inline rows. A
+        # `connector` (with its `action`) reads the batch from the workspace's
+        # bound connector; otherwise a `source_collection` reads from Mongo;
+        # otherwise the inline `params["rows"]` fallback keeps current
+        # specs/tests working.
+        if (
+            isinstance(connector, str)
+            and connector.strip()
+            and isinstance(connector_action, str)
+            and connector_action.strip()
+        ):
+            scored_rows = await self._run_connector_backed(
+                workspace_id=workspace_id,
+                pocket_id=pocket_id,
+                connector=connector,
+                connector_action=connector_action,
+                connector_params=params.get("connector_params"),
+                batch_size=batch_size,
+            )
+        elif isinstance(source_collection, str) and source_collection.strip():
             scored_rows = await self._run_source_backed(
                 workspace_id=workspace_id,
                 pocket_id=pocket_id,
@@ -214,6 +246,96 @@ class ScoreApplicationsJob:
             }
         }
 
+    async def _existing_scored_rows(
+        self, *, workspace_id: str, pocket_id: str
+    ) -> list[dict[str, Any]]:
+        """The pocket's CURRENT ``scored_rows`` — the dedup + accumulation base.
+
+        Shared by every data-backed source mode (connector + collection) so the
+        idempotent batch advancement is identical regardless of where the batch
+        comes from.
+        """
+        spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
+        state = spec.get("state") if isinstance(spec, dict) else None
+        existing_rows = state.get("scored_rows") if isinstance(state, dict) else None
+        return list(existing_rows) if isinstance(existing_rows, list) else []
+
+    def _score_next_batch(
+        self,
+        *,
+        existing_rows: list[dict[str, Any]],
+        page: list[Any],
+        batch_size: int,
+    ) -> list[dict[str, Any]]:
+        """Score the next NEW batch from ``page`` and return the ACCUMULATED rows.
+
+        Idempotent: records whose id is already in ``existing_rows`` are skipped,
+        so re-running advances to the next batch instead of re-scoring the same
+        records. Records with no resolvable id are skipped (can't dedup). The new
+        batch is capped at ``batch_size``; the result is ``existing_rows`` plus
+        the newly-scored ones (PII-projected by :func:`_score_row`).
+        """
+        seen_ids = _already_scored_ids(existing_rows)
+        if batch_size == 0:
+            return existing_rows
+
+        new_scored: list[dict[str, Any]] = []
+        for record in page:
+            if not isinstance(record, dict):
+                continue
+            rid = _record_id(record)
+            if rid is None or rid in seen_ids:
+                continue
+            new_scored.append(_score_row(record))
+            seen_ids.add(rid)
+            if len(new_scored) >= batch_size:
+                break
+
+        return existing_rows + new_scored
+
+    async def _run_connector_backed(
+        self,
+        *,
+        workspace_id: str,
+        pocket_id: str,
+        connector: str,
+        connector_action: str,
+        connector_params: Any,
+        batch_size: int,
+    ) -> list[dict[str, Any]]:
+        """Read a batch from a BOUND connector, score the next NEW records, and
+        return the ACCUMULATED rows (existing scored + newly scored).
+
+        The connector read goes through ``jobs.service.execute_connector_action``
+        (the jobs entity owns the connectors call); on a connector failure that
+        helper raises ``CloudError`` which propagates to the worker's failure
+        path. Same idempotent dedup as the Mongo path: records already scored on
+        the pocket are skipped. The connector's data payload may be a list of
+        records (the common shape) or a single record dict (normalized to a
+        one-element list).
+        """
+        existing_rows = await self._existing_scored_rows(
+            workspace_id=workspace_id, pocket_id=pocket_id
+        )
+        if batch_size == 0:
+            return existing_rows
+
+        params = connector_params if isinstance(connector_params, dict) else {}
+        data = await jobs_service.execute_connector_action(
+            workspace_id, connector, connector_action, params
+        )
+        # Normalize the connector data payload to a list of records: a
+        # list-shaped action returns the records directly; a scalar one returns a
+        # single dict we wrap. Anything else reads as "no records".
+        if isinstance(data, list):
+            page: list[Any] = data
+        elif isinstance(data, dict):
+            page = [data]
+        else:
+            page = []
+
+        return self._score_next_batch(existing_rows=existing_rows, page=page, batch_size=batch_size)
+
     async def _run_source_backed(
         self,
         *,
@@ -229,13 +351,9 @@ class ScoreApplicationsJob:
         ``scored_rows`` are skipped, so re-running advances to the next batch
         instead of re-scoring the same records.
         """
-        # Current scored rows on the pocket — the dedup + accumulation base.
-        spec = await pockets_service.get_pocket_ripple_spec(workspace_id, pocket_id)
-        state = spec.get("state") if isinstance(spec, dict) else None
-        existing_rows = state.get("scored_rows") if isinstance(state, dict) else None
-        existing_rows = list(existing_rows) if isinstance(existing_rows, list) else []
-        seen_ids = _already_scored_ids(existing_rows)
-
+        existing_rows = await self._existing_scored_rows(
+            workspace_id=workspace_id, pocket_id=pocket_id
+        )
         if batch_size == 0:
             return existing_rows
 
@@ -244,21 +362,7 @@ class ScoreApplicationsJob:
         # then filtered to NEW records and capped at `batch_size`.
         page = await jobs_service.read_source_records(source_collection, limit=300)
 
-        new_scored: list[dict[str, Any]] = []
-        for record in page:
-            if not isinstance(record, dict):
-                continue
-            rid = _record_id(record)
-            # Skip records with no resolvable id (can't dedup) and ones already
-            # scored.
-            if rid is None or rid in seen_ids:
-                continue
-            new_scored.append(_score_row(record))
-            seen_ids.add(rid)
-            if len(new_scored) >= batch_size:
-                break
-
-        return existing_rows + new_scored
+        return self._score_next_batch(existing_rows=existing_rows, page=page, batch_size=batch_size)
 
 
 __all__ = ["ScoreApplicationsJob", "project_row"]

--- a/ee/pocketpaw_ee/cloud/jobs/service.py
+++ b/ee/pocketpaw_ee/cloud/jobs/service.py
@@ -23,6 +23,17 @@
 # is the SHARED one Beanie was initialized against — pulled off
 # ``WorkspaceJobDoc.get_pymongo_collection().database`` — so tests (mongomock)
 # and production resolve the same database with no extra connection.
+#
+# Updated: 2026-06-22 (feat/jobs-worker-register-and-connector-read) — added
+# ``execute_connector_action``, the jobs entity's ONLY door to the connectors
+# entity. A data-backed built-in (e.g. ``score_applications`` connector source
+# mode) reads its batch from a workspace's BOUND connector through THIS service
+# so the import-linter "Jobs reaches connectors via service" contract stays
+# clean (the built-in never imports the connectors service directly). The call
+# runs under ``WORKSPACE_JOB_IDENTITY`` with ``pocket_id=None`` (workspace-scope
+# credentials, never tokens through params) and unwraps the connector's data
+# payload; a non-success response raises ``CloudError(code="job.connector_error")``
+# so the worker's failure path marks the job failed + un-hangs the button.
 
 """Workspace-jobs service — Beanie writes + dispatch + lifecycle."""
 
@@ -38,6 +49,7 @@ from arq import create_pool
 from arq.connections import ArqRedis, RedisSettings
 
 from pocketpaw.security.audit import AuditEvent, AuditSeverity, get_audit_logger
+from pocketpaw_ee.cloud._core.errors import CloudError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     WorkspaceJobQueued,
@@ -225,6 +237,61 @@ async def read_source_records(collection: str, *, limit: int) -> list[dict[str, 
         return []
 
 
+async def execute_connector_action(
+    workspace_id: str,
+    connector_name: str,
+    action: str,
+    params: dict | None = None,
+) -> list[dict] | dict:
+    """Run one read action on a workspace's BOUND connector and return its data.
+
+    The jobs entity's ONLY door to the connectors entity: a data-backed built-in
+    (e.g. ``score_applications`` connector source mode) reads its batch from a
+    bound connector through HERE so the import-linter "Jobs reaches connectors
+    via service" contract stays clean — the built-in never imports the
+    connectors service directly.
+
+    The call runs under :data:`WORKSPACE_JOB_IDENTITY` with workspace-scope
+    credentials (``pocket_id=None``): a job NEVER receives tokens through
+    ``params`` — connector calls use the workspace's stored creds. On a
+    non-success response (or any raised connectors error) this raises
+    :class:`CloudError` (code ``job.connector_error``), which the worker's
+    failure path turns into a ``failed`` job + a failed-state writeback so the
+    triggering button never hangs.
+
+    Returns the connector's ``data`` payload (the records) — a ``list[dict]``
+    for a list-shaped action, or a single ``dict`` for a scalar one.
+    """
+    # Lazy import — keeps the jobs service free of a connectors dependency at
+    # module load (and the import graph acyclic).
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
+
+    try:
+        response = await connectors_service.execute(
+            workspace_id,
+            connector_name,
+            ExecuteActionRequest(action=action, params=params or {}, pocket_id=None),
+            user_id=WORKSPACE_JOB_IDENTITY,
+        )
+    except CloudError:
+        # A connectors-side CloudError (NotFound, Forbidden, local-agent 503, …)
+        # already carries a precise code; re-raise as the jobs-contract error so
+        # the worker's failure path handles it uniformly and the button un-hangs.
+        raise CloudError(
+            502,
+            "job.connector_error",
+            f"connector '{connector_name}' action '{action}' failed",
+        ) from None
+    if not response.success:
+        raise CloudError(
+            502,
+            "job.connector_error",
+            f"connector '{connector_name}' action '{action}' returned an error",
+        )
+    return response.data
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle transitions (worker-driven)
 # ---------------------------------------------------------------------------
@@ -329,6 +396,7 @@ def _audit(*, severity: AuditSeverity, status: str, **context: Any) -> None:
 
 __all__ = [
     "dispatch_job",
+    "execute_connector_action",
     "get_job",
     "get_job_by_id",
     "mark_done",

--- a/tests/cloud/jobs/test_jobs.py
+++ b/tests/cloud/jobs/test_jobs.py
@@ -1266,3 +1266,247 @@ async def test_score_applications_missing_source_collection_returns_empty(
     rows = result["state"]["scored_rows"]
     # Existing batch preserved; nothing new added.
     assert [r["id"] for r in rows] == ["app-1"]
+
+
+# ---------------------------------------------------------------------------
+# CHANGE 2 (this PR) — score_applications CONNECTOR source mode. When `params`
+# carries `connector` + `action`, the job reads its batch from the workspace's
+# BOUND connector via `jobs.service.execute_connector_action` (which calls
+# `connectors_service.execute`) and scores those records — same idempotent
+# dedup, same heuristic + band, same PII allowlist as the Mongo path. Source
+# precedence is connector > source_collection > rows. The connector call is
+# mocked by monkeypatching `connectors_service.execute` to return sample
+# records, so nothing real is dispatched.
+# ---------------------------------------------------------------------------
+
+
+def _connector_response(records: Any) -> Any:
+    """Build a real ``ExecuteActionResponse`` (success) carrying ``records`` as
+    the data payload — the shape ``execute_connector_action`` unwraps."""
+    from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse
+
+    return ExecuteActionResponse(success=True, data=records, execution_mode="cloud")
+
+
+def _patch_connector_execute(monkeypatch: pytest.MonkeyPatch, records: Any):
+    """Monkeypatch ``connectors_service.execute`` to return ``records`` and
+    capture the call args. ``execute_connector_action`` lazy-imports the
+    connectors service inside the function, so patching the real module object
+    is what the lazy import resolves to.
+
+    Returns the ``captured`` dict so a test can assert the call ran under the
+    workspace job identity with ``pocket_id=None``.
+    """
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_execute(workspace_id, name, body, *, user_id=None):  # type: ignore[no-untyped-def]
+        captured["workspace_id"] = workspace_id
+        captured["name"] = name
+        captured["body"] = body
+        captured["user_id"] = user_id
+        return _connector_response(records)
+
+    monkeypatch.setattr(connectors_service, "execute", _fake_execute)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_score_applications_connector_backed_scores_records(
+    mongo_db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A connector-backed run scores the records the mocked
+    ``connectors_service.execute`` returns, and the connector call runs under
+    the workspace job identity with workspace-scope credentials
+    (``pocket_id=None``)."""
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    captured = _patch_connector_execute(
+        monkeypatch,
+        [
+            {
+                "id": "lead-1",
+                "name": "Jordan Strong",
+                "email": "jordan@acme.com",
+                "message": "x" * 150,
+                "referral": "linkedin.com/in/jordan",
+            },
+            {"id": "lead-2", "name": "Sam Sparse"},
+            {"id": "lead-3", "name": "Casey Throwaway", "email": "casey@mailinator.com"},
+        ],
+    )
+    pocket_id = await _seed_pocket_with_scored_rows(workspace=WS, scored_rows=[])
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-conn-1",
+        params={"connector": "snctm-api", "action": "list_leads", "batch_size": 20},
+    )
+
+    rows = result["state"]["scored_rows"]
+    assert {r["id"] for r in rows} == {"lead-1", "lead-2", "lead-3"}
+    assert result["state"]["score_applications_scored_count"] == 3
+    by_id = {r["id"]: r for r in rows}
+    assert by_id["lead-1"]["band"] == "Strong"
+    assert by_id["lead-3"]["score"] < by_id["lead-1"]["score"]
+    assert all(r["stage"] == "scored" for r in rows)
+    # No status key from the built-in (the worker owns it).
+    assert "score_applications_status" not in result["state"]
+
+    # The connector call ran under the synthetic job identity with
+    # workspace-scope creds (no pocket binding, no params-borne tokens).
+    assert captured["name"] == "snctm-api"
+    assert captured["user_id"] == WORKSPACE_JOB_IDENTITY
+    assert captured["body"].action == "list_leads"
+    assert captured["body"].pocket_id is None
+
+
+@pytest.mark.asyncio
+async def test_score_applications_connector_backed_is_idempotent(
+    mongo_db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-running a connector-backed job SKIPS records already in the pocket's
+    ``scored_rows`` and pulls the next ``batch_size``, accumulating onto the
+    existing rows (idempotent batch advancement)."""
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    _patch_connector_execute(
+        monkeypatch,
+        [
+            {"id": "lead-1", "name": "One", "email": "one@acme.com"},
+            {"id": "lead-2", "name": "Two", "email": "two@acme.com"},
+            {"id": "lead-3", "name": "Three", "email": "three@acme.com"},
+        ],
+    )
+    # lead-1 is already scored on the pocket.
+    pocket_id = await _seed_pocket_with_scored_rows(
+        workspace=WS,
+        scored_rows=[
+            {"id": "lead-1", "name": "One", "score": 40, "band": "Moderate", "stage": "scored"}
+        ],
+    )
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-conn-2",
+        params={"connector": "snctm-api", "action": "list_leads", "batch_size": 1},
+    )
+
+    rows = result["state"]["scored_rows"]
+    ids = [r["id"] for r in rows]
+    assert ids[0] == "lead-1"
+    assert len(rows) == 2  # one already-scored + exactly one NEW (batch_size=1)
+    new_id = ids[1]
+    assert new_id in ("lead-2", "lead-3")
+    assert new_id != "lead-1"
+    # The preserved row keeps its original score (not re-scored).
+    assert rows[0]["score"] == 40
+    assert result["state"]["score_applications_scored_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_score_applications_connector_backed_strips_pii(
+    mongo_db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The broadcast rows from a connector-backed run carry ONLY the allowlist —
+    no email / phone / raw connector field reaches ``state``."""
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    _patch_connector_execute(
+        monkeypatch,
+        [
+            {
+                "id": "lead-1",
+                "name": "Jordan",
+                "email": "jordan@acme.com",
+                "phone": "+1-555-0100",
+                "ssn": "000-00-0000",
+                "message": "Hello there, here is my note.",
+            }
+        ],
+    )
+    pocket_id = await _seed_pocket_with_scored_rows(workspace=WS, scored_rows=[])
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-conn-3",
+        params={"connector": "snctm-api", "action": "list_leads", "batch_size": 20},
+    )
+
+    rows = result["state"]["scored_rows"]
+    assert rows
+    row = rows[0]
+    assert "email" not in row
+    assert "phone" not in row
+    assert "ssn" not in row
+    assert "message" not in row
+    assert set(row.keys()) <= {"id", "name", "score", "band", "stage"}
+
+
+@pytest.mark.asyncio
+async def test_score_applications_connector_precedence_over_collection(
+    mongo_db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Source precedence: when BOTH `connector` and `source_collection` are set,
+    the connector wins — the Mongo collection is never read."""
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    _patch_connector_execute(monkeypatch, [{"id": "from-connector", "name": "Via Connector"}])
+    # Seed a Mongo collection with a DIFFERENT id; if precedence were wrong the
+    # collection's record would show up in the scored rows.
+    await _seed_source(mongo_db, "applications", [{"id": "from-collection", "name": "Via Mongo"}])
+    pocket_id = await _seed_pocket_with_scored_rows(workspace=WS, scored_rows=[])
+
+    job = ScoreApplicationsJob()
+    result = await job(
+        workspace_id=WS,
+        pocket_id=pocket_id,
+        job_id="j-conn-4",
+        params={
+            "connector": "snctm-api",
+            "action": "list_leads",
+            "source_collection": "applications",
+            "batch_size": 20,
+        },
+    )
+
+    ids = {r["id"] for r in result["state"]["scored_rows"]}
+    assert ids == {"from-connector"}
+    assert "from-collection" not in ids
+
+
+@pytest.mark.asyncio
+async def test_score_applications_connector_error_propagates(
+    mongo_db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-success connector response raises ``CloudError(job.connector_error)``
+    out of the job, so the worker's failure path marks the job failed + un-hangs
+    the button. (The built-in does not swallow connector failures the way the
+    best-effort Mongo read degrades to 'no records'.)"""
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.cloud.connectors import service as connectors_service
+    from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse
+    from pocketpaw_ee.cloud.jobs.builtin.score_applications import ScoreApplicationsJob
+
+    async def _failing_execute(workspace_id, name, body, *, user_id=None):  # type: ignore[no-untyped-def]
+        return ExecuteActionResponse(success=False, data=None, error="upstream 500")
+
+    monkeypatch.setattr(connectors_service, "execute", _failing_execute)
+    pocket_id = await _seed_pocket_with_scored_rows(workspace=WS, scored_rows=[])
+
+    job = ScoreApplicationsJob()
+    with pytest.raises(CloudError) as exc:
+        await job(
+            workspace_id=WS,
+            pocket_id=pocket_id,
+            job_id="j-conn-5",
+            params={"connector": "snctm-api", "action": "list_leads", "batch_size": 20},
+        )
+    assert exc.value.code == "job.connector_error"

--- a/tests/cloud/runs/test_worker.py
+++ b/tests/cloud/runs/test_worker.py
@@ -138,3 +138,51 @@ async def test_worker_settings_exposes_execute_run_job():
     assert worker.WorkerSettings.max_tries == 1
     assert worker.WorkerSettings.on_startup is worker._startup
     assert worker.WorkerSettings.on_shutdown is worker._shutdown
+
+
+async def test_startup_registers_builtin_jobs(mongo_db, monkeypatch):  # noqa: ARG001
+    """PRODUCTION FIX — the worker boots in its OWN process, so the registry
+    ``mount_cloud`` populates for the web process is empty here. ``_startup``
+    must call ``register_builtins()`` or ``execute_workspace_job`` →
+    ``resolve_job(name)`` raises ``UnknownJobError`` for EVERY job in a real
+    deploy. Clear the registry, run ``_startup``, and assert the built-ins are
+    registered.
+    """
+    from pocketpaw_ee.cloud.jobs.registry import (
+        UnknownJobError,
+        get_job_registry,
+        resolve_job,
+    )
+
+    async def _noop_db(_uri):
+        return None
+
+    def _noop_realtime():
+        return None
+
+    monkeypatch.setattr(worker, "init_cloud_db", _noop_db)
+    monkeypatch.setattr(worker, "init_realtime", _noop_realtime)
+    # Sweep off — we are only exercising the registration step on boot.
+    monkeypatch.delenv(worker._BOOT_SWEEP_ENV, raising=False)
+
+    # Start from an empty registry so the assertion can ONLY pass if `_startup`
+    # registered the built-ins itself (not because the web mount happened to run
+    # earlier in the test session). Restore afterwards so the module-level dict
+    # doesn't leak state to sibling tests.
+    registry = get_job_registry()
+    saved = dict(registry)
+    registry.clear()
+    try:
+        # Pre-condition: with an empty registry the resolve raises.
+        with pytest.raises(UnknownJobError):
+            resolve_job("score_applications")
+
+        await worker._startup({})
+
+        # Post-condition: the built-in is now resolvable.
+        assert "score_applications" in registry
+        job = resolve_job("score_applications")
+        assert job.name == "score_applications"
+    finally:
+        registry.clear()
+        registry.update(saved)


### PR DESCRIPTION
Two changes to the workspace jobs primitive, both needed for jobs to do real work in a real deploy.

## Production bug: the ARQ worker never registered jobs

The job registry is a process-wide module dict. The web app populates it in `mount_cloud()` via `register_builtins()`, but the ARQ worker's `_startup` only called `init_cloud_db` + `init_realtime()` and never `register_builtins()`. So in a real deploy the worker's registry is empty and `execute_workspace_job` to `resolve_job(name)` raises `UnknownJobError` for every job. It only worked in local testing because a test wrapper added the registration.

Fix: `_startup` now calls `register_builtins()` after `init_realtime()`, mirroring `mount_cloud()`. A new test boots the worker startup path against an empty registry and asserts the built-ins resolve.

## A job can read its batch from a bound connector

Adds `jobs.service.execute_connector_action(workspace_id, connector_name, action, params)` — the jobs entity's single door to connectors. It calls `connectors_service.execute(...)` under the synthetic `system:workspace_job` identity (credentials are resolved server-side from the workspace's stored connector config, never passed through params), and raises `job.connector_error` on a non-success response so a connector failure surfaces as a failed job rather than a silent empty read.

`score_applications` gains a `connector` source mode: when `params` carries `connector` + `action`, it reads the batch through that bound connector and scores those records. Source precedence is connector, then source_collection, then inline rows; the idempotent batch advancement, the real heuristic + band, and the PII allowlist apply across all three modes.

## Tests

52 jobs + worker tests pass (added worker-startup registration, connector-backed scoring, idempotency, PII, precedence, and error-propagation tests). ruff check + format clean, import-linter contracts kept. The 4 pre-existing `test_gallery_site_exclusion` failures are unrelated (a missing seed on dev, confirmed by stashing this branch).