### PR TITLE
feat(jobs): workspace-custom jobs via entry-point registration

### DIFF
--- a/docs/wiki/jobs.md
+++ b/docs/wiki/jobs.md
@@ -3,8 +3,8 @@
 > The workspace jobs primitive runs named, parameterized, server-side async work for a pocket — durably, in the ARQ worker, under a synthetic workspace identity rather than the triggering user's session. A job is dispatched by a `kind:"job"` action on a pocket, runs to completion even after the user's socket closes, and writes its result back into the pocket's rippleSpec `state` so any open canvas updates live. It exists to give pockets a "do this in the background and tell me when it's done" capability without granting an unbounded agent loop.
 
 **Categories:** background work, async execution, ARQ, multi-tenancy, realtime
-**Concepts:** pocket job, job registry, JobCallable, WorkspaceJobDoc, kind="job" action, writeback, system:workspace_job identity, xproc bridge, state-only result, PII allowlist
-**Version:** 1
+**Concepts:** pocket job, job registry, JobCallable, WorkspaceJobDoc, kind="job" action, writeback, system:workspace_job identity, xproc bridge, state-only result, PII allowlist, custom jobs, entry-point registration
+**Version:** 2
 
 ---
 
@@ -33,7 +33,7 @@ Durability comes from **ARQ**: a job runs in the same worker process as resumabl
 
 ### Registry (`jobs/registry.py`)
 
-A module-level dict of `name → JobCallable`, following the `OptimisticCompensationRegistry` shape. `JobCallable` is a Protocol with a `name` attribute and `async __call__(*, workspace_id, pocket_id, job_id, params) -> dict`. Built-ins register at mount time via `register_builtins()`, after `init_realtime()`.
+A module-level dict of `name → JobCallable`, following the `OptimisticCompensationRegistry` shape. `JobCallable` is a Protocol with a `name` attribute and `async __call__(*, workspace_id, pocket_id, job_id, params) -> dict`. Built-ins register at mount time via `register_builtins()`, after `init_realtime()`; workspace-custom jobs register right after that via `load_entrypoint_jobs()` (`jobs/plugins.py`) — see **Custom jobs (entry-point registration)** below.
 
 ### Status doc (`models/workspace_job.py`)
 
@@ -46,6 +46,36 @@ On success the worker calls `merge_spec(workspace_id, user_id="system:workspace_
 ### Status poll
 
 `GET /api/v1/workspaces/{ws}/jobs/{job_id}` returns `{job_id, status, timestamps, error}` (the result is already in `state`). Any workspace member may read; the service re-fetches by id and re-checks `workspace_id`, returning 404 on a cross-tenant mismatch.
+
+## Custom jobs (entry-point registration)
+
+Built-in jobs ship inside `pocketpaw_ee`. A **workspace/deploy** ships its own jobs without editing this repo by publishing a small Python package that declares an entry-point in the `pocketpaw.jobs` group — the same SAFE discovery mechanism the OSS core uses for its optional providers (`pocketpaw._registry`). There is **no runtime import of user-supplied code**: discovery reads installed-package metadata only, and `load_entrypoint_jobs()` runs once at process startup right after `register_builtins()` in BOTH the web app (`mount_cloud`) and the ARQ worker (`_startup`), so a custom job resolves identically on either side of the dispatch boundary.
+
+This repo ships **no** `pocketpaw.jobs` entry-point of its own (like the OSS core, it owns the group but registers nothing into it).
+
+### The contract
+
+A `pocketpaw.jobs` entry-point must resolve to a **zero-arg factory** that returns either a single `JobCallable` or an iterable of them. Each resolved object must satisfy the `JobCallable` protocol — a `name: str` attribute plus an `async def __call__(self, *, workspace_id, pocket_id, job_id, params) -> dict`. A provider that fails to load, whose factory raises, or that resolves to a non-`JobCallable` is **skipped with a logged warning** and never blocks startup or other valid providers.
+
+A custom-job package author writes:
+
+```toml
+# pyproject.toml of the custom-job package
+[project.entry-points."pocketpaw.jobs"]
+my_jobs = "my_pkg:make_jobs"
+```
+
+```python
+# my_pkg/__init__.py
+def make_jobs():
+    return [MyDailyDigestJob()]   # one JobCallable, or a list of them
+```
+
+Once that package is installed in the web + worker environments, the job's `name` is registered on boot and can be dispatched via a `kind:"job"` action (`{"kind":"job","job":"my_daily_digest", ...}`).
+
+### Same security contract applies
+
+A custom job runs under the same boundary as a built-in: writeback is **state-only** (`validate_job_result` rejects `ui`/`actions`/`sources`/`shape`), params are **credential-scrubbed** before the job sees them (`validate_job_params`), it runs under the `system:workspace_job` identity, and connector calls use the workspace's stored creds — never params-supplied tokens. **PII projection is the job author's responsibility**: because a result becomes broadcast `state`, a custom job must project rows through its own allowlist exactly as `score_applications` does (drop `email`/`phone` etc. before returning).
 
 ## Security properties
 
@@ -63,6 +93,7 @@ On success the worker calls `merge_spec(workspace_id, user_id="system:workspace_
 |--------|------|
 | `jobs/domain.py` | Pure constants/value types (identity, queue, timeout, failed-state writeback). |
 | `jobs/registry.py` | The named registry + `validate_job_params` / `validate_job_result`. |
+| `jobs/plugins.py` | Discovers + registers workspace-custom jobs from `pocketpaw.jobs` entry-points (`load_entrypoint_jobs`). |
 | `jobs/service.py` | The only writer of `WorkspaceJobDoc`: dispatch + lifecycle + audit. |
 | `jobs/worker.py` | The ARQ `execute_workspace_job` entrypoint (run → validate → writeback). |
 | `jobs/router.py` | The status-poll route. |

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-06-22 (feat/jobs-custom-job-entrypoints) — After
+    ``register_builtins()`` the mount now calls ``load_entrypoint_jobs()`` to
+    discover + register WORKSPACE-CUSTOM jobs declared by installed packages
+    under the ``pocketpaw.jobs`` entry-point group (SAFE plugin path; no runtime
+    import of user code). No-op when no custom-job package is installed.
 Modified: 2026-06-20 (feat/workspace-jobs, pp#1459) — Mounts the workspace-jobs
     status router (``GET /workspaces/{ws}/jobs/{job_id}``) and registers the
     built-in jobs into the process-wide registry via ``register_builtins()``
@@ -605,6 +610,16 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.jobs.builtin import register_builtins
 
     register_builtins()
+
+    # Discover + register WORKSPACE-CUSTOM jobs declared by installed packages
+    # under the ``pocketpaw.jobs`` entry-point group (the SAFE plugin path — no
+    # runtime import of user-supplied code, just installed-package metadata).
+    # Runs AFTER ``register_builtins()`` so a custom job may overwrite a built-in
+    # of the same name (last-writer-wins). Degrades to a no-op when no custom job
+    # package is installed — same as the OSS core's optional-provider discovery.
+    from pocketpaw_ee.cloud.jobs.plugins import load_entrypoint_jobs
+
+    load_entrypoint_jobs()
 
     # Bridge ``AuditLogger`` (JSONL) writes into ``AuditStore`` (SQLite).
     # Cloud writers across the EE codebase (pockets/action_executor,

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -1,5 +1,12 @@
 """arq worker entry point for Tier 2 run execution.
 
+Updated: 2026-06-22 (feat/jobs-custom-job-entrypoints) — ``_startup`` now also
+calls ``load_entrypoint_jobs()`` right after ``register_builtins()`` so the
+worker registers WORKSPACE-CUSTOM jobs (declared under the ``pocketpaw.jobs``
+entry-point group) in its own process. Without this a custom job would resolve
+in the web process but raise ``UnknownJobError`` in the worker that runs it.
+No-op when no custom-job package is installed.
+
 Updated: 2026-06-22 (feat/jobs-worker-register-and-connector-read) — PRODUCTION
 FIX: ``_startup`` now calls ``register_builtins()`` AFTER ``init_realtime()`` so
 the worker process populates the process-wide job registry on boot. The registry
@@ -93,6 +100,16 @@ async def _startup(ctx: dict[str, Any]) -> None:
     from pocketpaw_ee.cloud.jobs.builtin import register_builtins
 
     register_builtins()
+    # Discover + register WORKSPACE-CUSTOM jobs from installed packages' entry
+    # points (group ``pocketpaw.jobs``). The worker runs in its OWN process, so
+    # like the built-ins these must be registered here too — otherwise a custom
+    # job dispatched by the web app would ``resolve_job`` fine there but raise
+    # ``UnknownJobError`` in the worker that actually runs it. Called AFTER
+    # ``register_builtins()`` (same ordering as ``mount_cloud``). No-op when no
+    # custom-job package is installed.
+    from pocketpaw_ee.cloud.jobs.plugins import load_entrypoint_jobs
+
+    load_entrypoint_jobs()
     if not _boot_sweep_enabled():
         logger.info("worker boot: stale-run sweep disabled (%s)", _BOOT_SWEEP_ENV)
         return

--- a/ee/pocketpaw_ee/cloud/jobs/plugins.py
+++ b/ee/pocketpaw_ee/cloud/jobs/plugins.py
@@ -1,0 +1,125 @@
+# ee/pocketpaw_ee/cloud/jobs/plugins.py
+# Created: 2026-06-22 (feat/jobs-custom-job-entrypoints) — the SAFE
+# entry-point discovery path for WORKSPACE-CUSTOM jobs. A deploy/workspace
+# ships a custom job by declaring an entry-point in the new
+# ``pocketpaw.jobs`` group; ``load_entrypoint_jobs()`` discovers those
+# entry-points at process startup, loads each one, and registers the
+# resolved ``JobCallable``(s) into the same process-wide registry the
+# built-ins use. No runtime ``import`` of user-supplied code paths —
+# discovery is via installed-package metadata only, mirroring how the OSS
+# core (``pocketpaw._registry``) finds its optional providers and degrades
+# gracefully when none are installed. This module owns the discovery logic
+# so ``registry.py`` can stay a pure, dependency-free registry contract.
+
+"""Entry-point discovery + registration for workspace-custom jobs.
+
+A custom job package declares::
+
+    [project.entry-points."pocketpaw.jobs"]
+    my_jobs = "my_pkg:make_jobs"
+
+where ``make_jobs`` is a zero-arg factory returning a single
+:class:`~pocketpaw_ee.cloud.jobs.registry.JobCallable` or an iterable of
+them. :func:`load_entrypoint_jobs` is called once per process at startup
+(right after ``register_builtins()``) by BOTH the web app (``mount_cloud``)
+and the ARQ worker (``_startup``), so a custom job resolves the same way on
+either side of the dispatch boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from importlib.metadata import entry_points
+
+from pocketpaw_ee.cloud.jobs.registry import JobCallable, register_job
+
+logger = logging.getLogger(__name__)
+
+# The entry-point group a workspace/deploy declares a custom job under. The
+# OSS core ships no entry-points of its own; this repo doesn't either — the
+# group exists purely for downstream packages to extend (see docs/wiki/jobs.md).
+JOBS_ENTRYPOINT_GROUP = "pocketpaw.jobs"
+
+
+def _coerce_to_jobs(resolved: object) -> list[JobCallable]:
+    """Normalise a factory's return value into a list of candidate jobs.
+
+    The contract is "a zero-arg factory returning a ``JobCallable`` OR an
+    iterable of them". A bare callable (which a single ``JobCallable``
+    instance is) must NOT be iterated, so we special-case it before the
+    generic iterable branch. Strings/bytes are never valid job containers.
+    """
+    if isinstance(resolved, (str, bytes)):
+        return []
+    if isinstance(resolved, Iterable):
+        return list(resolved)
+    return [resolved]
+
+
+def load_entrypoint_jobs() -> int:
+    """Discover + register workspace-custom jobs from installed entry-points.
+
+    Discovers every entry-point in the ``pocketpaw.jobs`` group, calls each
+    (the entry-point resolves to a zero-arg factory), and registers each
+    resolved :class:`JobCallable` into the process-wide registry via
+    :func:`register_job`.
+
+    Safety + resilience properties:
+
+    - **No-op when none are installed.** An OSS / no-plugin install finds no
+      entry-points and returns ``0`` with no error — same graceful degradation
+      as ``pocketpaw._registry``.
+    - **A bad provider never crashes startup.** If an entry-point fails to load,
+      its factory raises, or a resolved object doesn't satisfy the
+      :class:`JobCallable` protocol (missing ``name`` / async ``__call__``), it
+      is skipped with a logged warning and the next provider still loads.
+    - **Idempotent.** Safe to call once per process; re-registering an existing
+      name just overwrites (last-writer-wins, same as the built-ins).
+
+    Returns the number of jobs successfully registered (handy for logging /
+    tests).
+    """
+    registered = 0
+    for ep in entry_points(group=JOBS_ENTRYPOINT_GROUP):
+        try:
+            factory = ep.load()
+        except Exception as exc:  # noqa: BLE001 — isolate one bad plugin
+            logger.warning("workspace-custom job entry-point %r failed to load: %s", ep.name, exc)
+            continue
+
+        try:
+            resolved = factory()
+        except Exception as exc:  # noqa: BLE001 — isolate a bad factory
+            logger.warning("workspace-custom job factory %r raised on call: %s", ep.name, exc)
+            continue
+
+        for job in _coerce_to_jobs(resolved):
+            if not isinstance(job, JobCallable):
+                logger.warning(
+                    "workspace-custom job from entry-point %r is not a JobCallable "
+                    "(needs a `name` attribute and an async `__call__`) — skipping: %r",
+                    ep.name,
+                    job,
+                )
+                continue
+            try:
+                register_job(job)
+            except Exception as exc:  # noqa: BLE001 — a nameless/invalid job
+                logger.warning(
+                    "workspace-custom job from entry-point %r failed to register: %s",
+                    ep.name,
+                    exc,
+                )
+                continue
+            registered += 1
+            logger.info(
+                "registered workspace-custom job %r from entry-point %r",
+                getattr(job, "name", "?"),
+                ep.name,
+            )
+
+    return registered
+
+
+__all__ = ["JOBS_ENTRYPOINT_GROUP", "load_entrypoint_jobs"]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -385,12 +385,14 @@ type = "forbidden"
 allow_indirect_imports = "true"
 source_modules = [
     # Only ``jobs.service`` owns the WorkspaceJobDoc Beanie write. The router,
-    # dto, domain, registry, the ARQ worker entrypoint, and the built-in jobs
-    # all go through the service — none may import the Beanie doc directly.
+    # dto, domain, registry, the entry-point plugin loader, the ARQ worker
+    # entrypoint, and the built-in jobs all go through the service — none may
+    # import the Beanie doc directly.
     "pocketpaw_ee.cloud.jobs.router",
     "pocketpaw_ee.cloud.jobs.dto",
     "pocketpaw_ee.cloud.jobs.domain",
     "pocketpaw_ee.cloud.jobs.registry",
+    "pocketpaw_ee.cloud.jobs.plugins",
     "pocketpaw_ee.cloud.jobs.worker",
     "pocketpaw_ee.cloud.jobs.builtin.score_applications",
 ]

--- a/tests/cloud/jobs/test_plugins.py
+++ b/tests/cloud/jobs/test_plugins.py
@@ -1,0 +1,231 @@
+# tests/cloud/jobs/test_plugins.py
+# Created: 2026-06-22 (feat/jobs-custom-job-entrypoints) — TDD coverage for the
+# SAFE entry-point discovery path that registers WORKSPACE-CUSTOM jobs. These
+# tests never install a real package: they monkeypatch the
+# ``entry_points`` symbol the loader calls and feed it fake entry-points whose
+# ``.load()`` returns a factory. They pin:
+#   - a single-JobCallable factory registers and resolves by name;
+#   - a factory returning a LIST registers every job;
+#   - no entry-points → graceful no-op (returns 0, no raise);
+#   - a provider that fails to ``.load()`` is skipped with a warning, doesn't
+#     crash, and doesn't block a sibling valid provider;
+#   - a factory that raises on call is skipped, sibling still loads;
+#   - a resolved object that is NOT a JobCallable is skipped with a warning,
+#     sibling still loads;
+#   - re-running is idempotent (re-registering the same name just overwrites).
+# Mirrors the registry-isolation convention in test_jobs.py (save/clear/restore
+# the module-level registry per test).
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pocketpaw_ee.cloud.jobs import plugins as jobs_plugins
+from pocketpaw_ee.cloud.jobs import registry as jobs_registry
+from pocketpaw_ee.cloud.jobs.registry import UnknownJobError
+
+# ---------------------------------------------------------------------------
+# Test doubles — JobCallables, factories, and a fake entry-point.
+# ---------------------------------------------------------------------------
+
+
+class _StubJob:
+    """A minimal valid JobCallable a custom-job package would ship."""
+
+    def __init__(self, name: str = "stub_custom_job") -> None:
+        self.name = name
+
+    async def __call__(
+        self, *, workspace_id: str, pocket_id: str, job_id: str, params: dict
+    ) -> dict:
+        return {"state": {"ran": self.name}}
+
+
+class _NotAJob:
+    """Resolves from a factory but has no `name` / `__call__` — not a JobCallable."""
+
+
+class _FakeEntryPoint:
+    """Mimics ``importlib.metadata.EntryPoint`` for the loader's needs.
+
+    The loader only touches ``.name`` and ``.load()``; ``load`` here returns
+    the supplied factory (or raises ``load_exc`` to simulate an import failure).
+    """
+
+    def __init__(self, name: str, factory=None, *, load_exc: Exception | None = None) -> None:
+        self.name = name
+        self._factory = factory
+        self._load_exc = load_exc
+
+    def load(self):
+        if self._load_exc is not None:
+            raise self._load_exc
+        return self._factory
+
+
+def _patch_entry_points(monkeypatch, eps: list[_FakeEntryPoint]) -> None:
+    """Patch the ``entry_points`` symbol the loader imported into its module.
+
+    The loader calls ``entry_points(group=...)`` and iterates the result, so the
+    fake must accept the ``group`` kwarg and return our list.
+    """
+
+    def _fake_entry_points(*, group: str):
+        assert group == jobs_plugins.JOBS_ENTRYPOINT_GROUP
+        return eps
+
+    monkeypatch.setattr(jobs_plugins, "entry_points", _fake_entry_points)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isolate the module-level registry per test (save / clear / restore)."""
+    saved = dict(jobs_registry.get_job_registry())
+    jobs_registry.get_job_registry().clear()
+    yield
+    reg = jobs_registry.get_job_registry()
+    reg.clear()
+    reg.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — a factory returning a single JobCallable.
+# ---------------------------------------------------------------------------
+
+
+def test_loads_single_job_from_factory(monkeypatch) -> None:
+    def make_jobs():
+        return _StubJob("the_stub_name")
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("my_jobs", make_jobs)])
+
+    count = jobs_plugins.load_entrypoint_jobs()
+
+    assert count == 1
+    # The contract: the resolved job is now in the process registry by name.
+    resolved = jobs_registry.resolve_job("the_stub_name")
+    assert resolved.name == "the_stub_name"
+
+
+def test_loads_list_of_jobs_from_factory(monkeypatch) -> None:
+    def make_jobs():
+        return [_StubJob("job_a"), _StubJob("job_b")]
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("my_jobs", make_jobs)])
+
+    count = jobs_plugins.load_entrypoint_jobs()
+
+    assert count == 2
+    assert jobs_registry.resolve_job("job_a").name == "job_a"
+    assert jobs_registry.resolve_job("job_b").name == "job_b"
+
+
+# ---------------------------------------------------------------------------
+# Graceful no-op when there are no entry-points.
+# ---------------------------------------------------------------------------
+
+
+def test_no_entry_points_is_a_noop(monkeypatch) -> None:
+    _patch_entry_points(monkeypatch, [])
+
+    count = jobs_plugins.load_entrypoint_jobs()
+
+    assert count == 0
+    assert jobs_registry.get_job_registry() == {}
+
+
+# ---------------------------------------------------------------------------
+# A bad provider is skipped with a warning and doesn't block a valid sibling.
+# ---------------------------------------------------------------------------
+
+
+def test_load_failure_is_skipped_and_does_not_block_siblings(monkeypatch, caplog) -> None:
+    def good_factory():
+        return _StubJob("good_one")
+
+    bad = _FakeEntryPoint("broken", load_exc=ImportError("no module named whatever"))
+    good = _FakeEntryPoint("good", good_factory)
+    _patch_entry_points(monkeypatch, [bad, good])
+
+    with caplog.at_level(logging.WARNING, logger=jobs_plugins.__name__):
+        count = jobs_plugins.load_entrypoint_jobs()
+
+    # The good sibling still registered despite the broken one.
+    assert count == 1
+    assert jobs_registry.resolve_job("good_one").name == "good_one"
+    assert any("failed to load" in rec.message for rec in caplog.records)
+
+
+def test_factory_that_raises_is_skipped_and_does_not_block_siblings(monkeypatch, caplog) -> None:
+    def boom_factory():
+        raise RuntimeError("factory blew up")
+
+    def good_factory():
+        return _StubJob("survivor")
+
+    boom = _FakeEntryPoint("boomer", boom_factory)
+    good = _FakeEntryPoint("good", good_factory)
+    _patch_entry_points(monkeypatch, [boom, good])
+
+    with caplog.at_level(logging.WARNING, logger=jobs_plugins.__name__):
+        count = jobs_plugins.load_entrypoint_jobs()
+
+    assert count == 1
+    assert jobs_registry.resolve_job("survivor").name == "survivor"
+    assert any("raised on call" in rec.message for rec in caplog.records)
+
+
+def test_non_jobcallable_is_skipped_and_does_not_block_siblings(monkeypatch, caplog) -> None:
+    def bad_factory():
+        return _NotAJob()  # no name / no __call__ → not a JobCallable
+
+    def good_factory():
+        return _StubJob("also_survives")
+
+    bad = _FakeEntryPoint("bad_shape", bad_factory)
+    good = _FakeEntryPoint("good", good_factory)
+    _patch_entry_points(monkeypatch, [bad, good])
+
+    with caplog.at_level(logging.WARNING, logger=jobs_plugins.__name__):
+        count = jobs_plugins.load_entrypoint_jobs()
+
+    assert count == 1
+    assert jobs_registry.resolve_job("also_survives").name == "also_survives"
+    with pytest.raises(UnknownJobError):
+        jobs_registry.resolve_job("_NotAJob")
+    assert any("not a JobCallable" in rec.message for rec in caplog.records)
+
+
+def test_mixed_list_skips_only_the_bad_member(monkeypatch) -> None:
+    """A factory returning [good, bad] registers the good one, skips the bad."""
+
+    def make_jobs():
+        return [_StubJob("kept"), _NotAJob()]
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("mixed", make_jobs)])
+
+    count = jobs_plugins.load_entrypoint_jobs()
+
+    assert count == 1
+    assert jobs_registry.resolve_job("kept").name == "kept"
+
+
+# ---------------------------------------------------------------------------
+# Idempotent — calling twice re-registers the same name (last-writer-wins).
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_reload_overwrites_same_name(monkeypatch) -> None:
+    def make_jobs():
+        return _StubJob("dupe")
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("my_jobs", make_jobs)])
+
+    first = jobs_plugins.load_entrypoint_jobs()
+    second = jobs_plugins.load_entrypoint_jobs()
+
+    assert first == 1
+    assert second == 1  # re-registers, no error, no duplicate growth
+    assert len(jobs_registry.get_job_registry()) == 1
+    assert jobs_registry.resolve_job("dupe").name == "dupe"

--- a/tests/cloud/runs/test_worker.py
+++ b/tests/cloud/runs/test_worker.py
@@ -186,3 +186,60 @@ async def test_startup_registers_builtin_jobs(mongo_db, monkeypatch):  # noqa: A
     finally:
         registry.clear()
         registry.update(saved)
+
+
+async def test_startup_registers_entrypoint_custom_jobs(mongo_db, monkeypatch):  # noqa: ARG001
+    """``_startup`` must also call ``load_entrypoint_jobs()`` so the worker
+    process (separate from the web ``mount_cloud``) registers WORKSPACE-CUSTOM
+    jobs declared under the ``pocketpaw.jobs`` entry-point group. Without it a
+    custom job dispatched by the web app resolves there but raises
+    ``UnknownJobError`` in the worker that actually runs it. We don't install a
+    real package — we monkeypatch the ``entry_points`` symbol the loader calls.
+    """
+    from pocketpaw_ee.cloud.jobs import plugins as jobs_plugins
+    from pocketpaw_ee.cloud.jobs.registry import (
+        UnknownJobError,
+        get_job_registry,
+        resolve_job,
+    )
+
+    async def _noop_db(_uri):
+        return None
+
+    def _noop_realtime():
+        return None
+
+    monkeypatch.setattr(worker, "init_cloud_db", _noop_db)
+    monkeypatch.setattr(worker, "init_realtime", _noop_realtime)
+    monkeypatch.delenv(worker._BOOT_SWEEP_ENV, raising=False)
+
+    class _StubCustomJob:
+        name = "custom_from_entrypoint"
+
+        async def __call__(self, *, workspace_id, pocket_id, job_id, params):
+            return {"state": {"ran": self.name}}
+
+    class _FakeEP:
+        name = "tenant_jobs"
+
+        def load(self):
+            return lambda: _StubCustomJob()
+
+    def _fake_entry_points(*, group):
+        return [_FakeEP()] if group == jobs_plugins.JOBS_ENTRYPOINT_GROUP else []
+
+    monkeypatch.setattr(jobs_plugins, "entry_points", _fake_entry_points)
+
+    registry = get_job_registry()
+    saved = dict(registry)
+    registry.clear()
+    try:
+        with pytest.raises(UnknownJobError):
+            resolve_job("custom_from_entrypoint")
+
+        await worker._startup({})
+
+        assert resolve_job("custom_from_entrypoint").name == "custom_from_entrypoint"
+    finally:
+        registry.clear()
+        registry.update(saved)


### PR DESCRIPTION
Stacked on #1535. Adds a safe path for a workspace or deploy to ship a CUSTOM job (e.g. a client-specific scorer), without the runtime arbitrary-import risk: a custom job is a Python callable discovered from an installed package's entry-points and registered at process startup.

## How it works

`load_entrypoint_jobs()` (new `jobs/plugins.py`) discovers entry-points in the group `pocketpaw.jobs` via importlib, treats each as a zero-arg factory returning a `JobCallable` (or a list), validates each against the protocol, and registers the valid ones. Bad providers (import error, factory raises, or a non-JobCallable) are skipped with a logged warning, so one bad plugin never crashes boot or blocks the others. No-op when there are no entry-points. This mirrors the OSS core's existing optional-provider discovery pattern.

It runs in BOTH processes right after `register_builtins()`: `mount_cloud()` (web, for dispatch validation) and the ARQ worker `_startup()` (for execution). No runtime import of user-supplied paths — jobs come only from packages installed in the image.

## Shipping a custom job

```toml
[project.entry-points."pocketpaw.jobs"]
my_jobs = "my_pkg:make_jobs"   # make_jobs() returns a JobCallable or a list
```

The same security contract as built-ins applies: state-only writeback, params are credential-scrubbed, the job runs under `system:workspace_job`, and the PII allowlist on broadcast rows is the job author's responsibility (documented in docs/wiki/jobs.md).

## Tests

61 jobs + worker tests pass, including 8 loader tests (single + list factory, no-op when none, bad-provider skip without blocking siblings, non-JobCallable rejected, idempotent reload) and a worker-startup test that boots the ARQ startup path and asserts an entry-point job registers. ruff clean, import-linter kept (the new `jobs.plugins` is in the Jobs allowlist).