### PR TITLE
feat(deep_work): stamp an outcome verdict on completed tasks behind a flag (SVL-1)

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,13 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-23: Added the deep_work Self-Verifying Loop flags (SVL-1) —
+    ``deep_work_verify_loop_enabled`` (default False; kill-switch — when
+    False deep_work tasks complete exactly as before) and
+    ``deep_work_verify_max_requeues`` (default 2; the requeue bound read by
+    SVL-2, landed here so later slices don't touch config). SVL-1 only reads
+    the enable flag to stamp an observe-only OutcomeVerdict on a completing
+    task. Env: POCKETPAW_DEEP_WORK_VERIFY_* .
   - 2026-06-18: Added the four layered/learning Instinct gate defaults —
     ``instinct_approval_level`` (default "ASK", dormant),
     ``instinct_auto_approve_threshold`` (0.9), ``instinct_dry_run_mode``
@@ -428,6 +435,30 @@ class Settings(BaseSettings):
             "whenever its confidence in the cheap tier falls below this "
             "threshold. High by default — a wrong skip produces a broken "
             "pocket, so the router is deliberately conservative."
+        ),
+    )
+    deep_work_verify_loop_enabled: bool = Field(
+        default=False,
+        description=(
+            "Kill-switch for the deep_work Self-Verifying Loop. When False "
+            "(default) deep_work tasks complete exactly as before — no outcome "
+            "verification, byte-for-byte today's behaviour. When True, every "
+            "task that completes successfully has its result checked against "
+            "the success_criteria captured at intake and the resulting "
+            "OutcomeVerdict is stamped on the task's metadata "
+            "(``verify_verdict``) and logged. The verdict is observe-only in "
+            "this slice (SVL-1): the task's status is NOT changed by the "
+            "verification — that is the requeue slice (SVL-2)."
+        ),
+    )
+    deep_work_verify_max_requeues: int = Field(
+        default=2,
+        description=(
+            "Max verify-driven requeues a single deep_work task may take "
+            "before the loop stops requeuing and escalates instead. Used by "
+            "the requeue slice (SVL-2); landed here so later slices don't have "
+            "to touch config. SVL-1 only READS deep_work_verify_loop_enabled "
+            "and ignores this bound."
         ),
     )
     auto_install_bundled_skills: bool = Field(

--- a/src/pocketpaw/instinct/__init__.py
+++ b/src/pocketpaw/instinct/__init__.py
@@ -1,5 +1,9 @@
 # Instinct — decision pipeline for Paw OS.
 # Created: 2026-03-28 — Actions, approvals, audit log.
+# Updated: 2026-06-23 (feat/svl-1-verify-stamp) — SVL-1: exported the
+#   VerdictProvider seam — the VerdictProvider protocol and the shipped
+#   DeterministicVerdictProvider — so the deep_work executor can stamp an
+#   outcome verdict behind a flag without hard-wiring a concrete verifier.
 # Updated: 2026-05-21 (feat/instinct-outcome-verification) — issue #1162:
 #   exported the outcome-verification primitives — OutcomeStatus,
 #   CriterionResult, OutcomeVerdict, and the deterministic verify_outcome /
@@ -32,6 +36,10 @@ from pocketpaw.instinct.models import (
 from pocketpaw.instinct.store import InstinctStore
 from pocketpaw.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
 from pocketpaw.instinct.trace_collector import TraceCollector
+from pocketpaw.instinct.verdict_provider import (
+    DeterministicVerdictProvider,
+    VerdictProvider,
+)
 from pocketpaw.instinct.verification import check_criterion, verify_outcome
 
 __all__ = [
@@ -46,6 +54,7 @@ __all__ = [
     "Correction",
     "CorrectionPatch",
     "CriterionResult",
+    "DeterministicVerdictProvider",
     "FabricObjectSnapshot",
     "InstinctStore",
     "OutcomeStatus",
@@ -53,6 +62,7 @@ __all__ = [
     "ReasoningTrace",
     "ToolCallRef",
     "TraceCollector",
+    "VerdictProvider",
     "check_criterion",
     "compute_patches",
     "summarize_correction",

--- a/src/pocketpaw/instinct/verdict_provider.py
+++ b/src/pocketpaw/instinct/verdict_provider.py
@@ -1,0 +1,65 @@
+# Instinct VerdictProvider seam — the verifier injection point for the
+# Self-Verifying Loop (SVL-1).
+# Created: 2026-06-23 (feat/svl-1-verify-stamp)
+#
+# The Self-Verifying Loop needs a place to *swap in* how an outcome is judged
+# without the producing agent (or the deep_work executor) hard-wiring a
+# concrete verifier. This module is that seam:
+#
+#   - VerdictProvider — the protocol. Any verifier that can turn an action
+#     result + its captured success_criteria into a structured
+#     OutcomeVerdict satisfies it.
+#   - DeterministicVerdictProvider — the shipped default. It delegates to the
+#     deterministic, no-LLM verify_outcome() from
+#     pocketpaw.instinct.verification, so SVL-1 stamps a repeatable verdict
+#     with zero model calls. Later slices can introduce an LLM-as-judge
+#     provider behind the same protocol without touching the executor hook.
+#
+# OSS-core constraint: this file MUST NOT import pocketpaw_ee — an
+# import-linter contract enforces it. The verifier is external to the agent
+# that produced the result (verify_outcome is a pure deterministic check), so
+# the loop's "verify is independent of the producer" invariant holds.
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from pocketpaw.instinct.models import OutcomeVerdict
+from pocketpaw.instinct.verification import verify_outcome
+
+
+@runtime_checkable
+class VerdictProvider(Protocol):
+    """Turns an action result + its success criteria into an OutcomeVerdict.
+
+    The injection seam for the Self-Verifying Loop. Implementations decide
+    *how* to judge an outcome (deterministic token match, LLM-as-judge, a
+    hybrid); callers depend only on this shape, so the verifier can be
+    swapped without the deep_work executor knowing which one is wired in.
+    """
+
+    def verify(self, result: Any, success_criteria: list[str]) -> OutcomeVerdict:
+        """Verify a result against its captured success criteria.
+
+        Args:
+            result: The action result — string, dict, or list.
+            success_criteria: The verifiable end-state checks captured at
+                task intake. May be empty (yields an ``UNKNOWN`` verdict).
+
+        Returns:
+            A structured :class:`OutcomeVerdict`.
+        """
+        ...
+
+
+class DeterministicVerdictProvider:
+    """The shipped default VerdictProvider — no LLM, fully repeatable.
+
+    Delegates to :func:`pocketpaw.instinct.verification.verify_outcome`, the
+    deterministic foundation verifier (issue #1162). Same input always yields
+    the same verdict; no model call. This is the provider SVL-1 stamps with.
+    """
+
+    def verify(self, result: Any, success_criteria: list[str]) -> OutcomeVerdict:
+        """Delegate to the deterministic ``verify_outcome`` check."""
+        return verify_outcome(result, success_criteria)

--- a/src/pocketpaw/mission_control/executor.py
+++ b/src/pocketpaw/mission_control/executor.py
@@ -1,6 +1,13 @@
 """Mission Control Task Executor.
 
 Created: 2026-02-05
+Updated: 2026-06-23 — Self-Verifying Loop (SVL-1): when
+  ``deep_work_verify_loop_enabled`` is set, a successfully-completing task has
+  its output checked against the ``success_criteria`` in its metadata via a
+  DeterministicVerdictProvider, and the resulting OutcomeVerdict is stamped on
+  ``task.metadata["verify_verdict"]`` and logged. Observe-only — the task's
+  status is unchanged (no requeue here; that is SVL-2). Flag off ⇒ behaviour
+  is byte-for-byte unchanged.
 Updated: 2026-02-26 — Deep Work v2: Added task retry, timeout, output storage,
   and project-wide stop. Tasks now store output on task.output field. Failed tasks
   auto-retry up to max_retries. Tasks with timeout_minutes get asyncio.wait_for.
@@ -54,6 +61,7 @@ from pocketpaw.agents.router import AgentRouter  # noqa: E402
 from pocketpaw.bus.events import SystemEvent  # noqa: E402
 from pocketpaw.bus.queue import get_message_bus  # noqa: E402
 from pocketpaw.config import get_settings  # noqa: E402
+from pocketpaw.instinct.verdict_provider import DeterministicVerdictProvider  # noqa: E402
 from pocketpaw.mission_control.manager import get_mission_control_manager  # noqa: E402
 from pocketpaw.mission_control.models import (  # noqa: E402
     Activity,
@@ -262,6 +270,26 @@ class MCTaskExecutor:
             should_retry = False
             if final_status == "completed":
                 new_task_status = TaskStatus.DONE
+
+                # Self-Verifying Loop (SVL-1): when the loop is enabled, check
+                # the completed task's result against the success_criteria
+                # captured at intake and STAMP the verdict on the task — the
+                # "verify" half. This is observe-only: the verdict is recorded
+                # and logged, but the status stays DONE (no requeue in this
+                # slice — that lands in SVL-2). When the flag is off this whole
+                # block is skipped and behaviour is byte-for-byte unchanged.
+                if get_settings().deep_work_verify_loop_enabled and task_fresh:
+                    success_criteria = task_fresh.metadata.get("success_criteria", [])
+                    verdict = DeterministicVerdictProvider().verify(
+                        task_fresh.output, success_criteria
+                    )
+                    task_fresh.metadata["verify_verdict"] = verdict.model_dump()
+                    logger.info(
+                        "Task %s verify verdict: %s (%s)",
+                        task_id,
+                        verdict.status,
+                        verdict.summary,
+                    )
             elif final_status in ("error", "timeout") and task_fresh:
                 # Check if we should retry
                 if task_fresh.retry_count < task_fresh.max_retries:

--- a/tests/test_deep_work_e2e.py
+++ b/tests/test_deep_work_e2e.py
@@ -1,5 +1,11 @@
 # End-to-end tests for the Deep Work interactive intake mode (issue #1161).
 # Created: 2026-05-21 (feat/deep-work-intake)
+# Updated: 2026-06-23 (feat/svl-1-verify-stamp) — added
+#   TestVerifyOnCompletion: drives the MC executor to completion with the
+#   Self-Verifying-Loop flag on and asserts the OutcomeVerdict stamped on
+#   ``task.metadata["verify_verdict"]`` matches a direct ``verify_outcome``
+#   call, plus a flag-off case proving the verdict is absent and behaviour is
+#   unchanged.
 #
 # These exercise the full intake → planning path against a real
 # DeepWorkSession + real GoalParser + real PlannerAgent + real
@@ -13,6 +19,8 @@
 #   - The collected answers are folded into the goal that planning sees.
 #   - Planning runs to completion and produces a project + MC tasks.
 #   - The resulting MC tasks carry the intake-captured ``success_criteria``.
+#   - With the verify loop ON, a completing task is stamped with its verdict;
+#     with it OFF, the verdict is absent (SVL-1).
 
 import json
 import tempfile
@@ -353,3 +361,152 @@ class TestIntakeOneShotPath:
 
         tasks = await manager.get_project_tasks(project.id)
         assert len(tasks) == 2
+
+
+# ---------------------------------------------------------------------------
+# Self-Verifying Loop — verify-on-completion stamp (SVL-1)
+# ---------------------------------------------------------------------------
+
+import asyncio  # noqa: E402
+
+import pocketpaw.mission_control.store as store_module  # noqa: E402
+from pocketpaw.agents.protocol import AgentEvent  # noqa: E402
+from pocketpaw.config import get_settings  # noqa: E402
+from pocketpaw.instinct.verification import verify_outcome  # noqa: E402
+from pocketpaw.mission_control import TaskPriority, TaskStatus  # noqa: E402
+from pocketpaw.mission_control.executor import (  # noqa: E402
+    get_mc_task_executor,
+    reset_mc_task_executor,
+)
+
+# Output the mock agent "produces" — text that satisfies the criteria below.
+# The deterministic verifier passes a criterion when every content word of it
+# appears in the result, so this output is crafted to MEET both criteria.
+_SUCCESS_OUTPUT = (
+    "Produced a list of overdue invoices, each 30+ days past due. "
+    "Every row carries an amount and a customer email address."
+)
+_SUCCESS_CRITERIA = [
+    "A list of invoices each 30+ days past due is produced",
+    "Every row has an amount and a customer email",
+]
+
+
+@pytest.fixture
+def svl_singletons(temp_store_path):
+    """Reset MC singletons and wire them all to a shared temp store.
+
+    The executor reaches the store via the module singletons (not the
+    intake ``manager`` fixture), so the verify-on-completion tests inject the
+    store the same way ``test_mission_control_executor.py`` does.
+    """
+    reset_mission_control_store()
+    reset_mission_control_manager()
+    reset_mc_task_executor()
+
+    test_store = FileMissionControlStore(temp_store_path)
+    store_module._store_instance = test_store
+
+    yield test_store
+
+    reset_mission_control_store()
+    reset_mission_control_manager()
+    reset_mc_task_executor()
+
+
+def _svl_mock_router():
+    """A mock AgentRouter that yields the success output then 'done'."""
+
+    async def mock_run(prompt):  # noqa: ARG001
+        yield AgentEvent(type="message", content=_SUCCESS_OUTPUT)
+        yield AgentEvent(type="done", content="")
+        await asyncio.sleep(0)
+
+    router = MagicMock()
+    router.run = mock_run
+    router.stop = AsyncMock()
+    return router
+
+
+def _settings_with_verify(enabled: bool):
+    """A Settings copy with the verify-loop flag forced to ``enabled``."""
+    return get_settings().model_copy(update={"deep_work_verify_loop_enabled": enabled})
+
+
+class TestVerifyOnCompletion:
+    """SVL-1: a completing task is stamped with its outcome verdict when the
+    Self-Verifying-Loop flag is on, and left untouched when it is off."""
+
+    async def _run_one_task(self, svl_singletons, *, verify_enabled: bool):
+        """Create an agent + a task with success_criteria, run it to
+        completion through the executor with the flag set, and return the
+        reloaded task."""
+        from pocketpaw.mission_control import get_mission_control_manager
+
+        manager = get_mission_control_manager()
+        executor = get_mc_task_executor()
+
+        agent = await manager.create_agent(
+            name="FinanceBot",
+            role="Finance Assistant",
+            description="Chases overdue invoices",
+            backend="claude_agent_sdk",
+        )
+        task = await manager.create_task(
+            title="Pull the list of overdue invoices",
+            description="Query accounting for invoices 30+ days overdue",
+            priority=TaskPriority.HIGH,
+        )
+        # Stamp the intake success_criteria the planner would have captured.
+        task.metadata["success_criteria"] = list(_SUCCESS_CRITERIA)
+        await manager.save_task(task)
+        await manager.assign_task(task.id, [agent.id])
+
+        mock_router = _svl_mock_router()
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=mock_router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=_settings_with_verify(verify_enabled),
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            result = await executor.execute_task(task.id, agent.id)
+
+        assert result["status"] == "completed"
+        reloaded = await manager.get_task(task.id)
+        assert reloaded is not None
+        return reloaded
+
+    @pytest.mark.asyncio
+    async def test_flag_on_stamps_verdict_matching_direct_verify(self, svl_singletons):
+        """With the flag enabled, a successfully-completing task whose criteria
+        are met carries a ``verify_verdict`` whose status matches a direct
+        ``verify_outcome`` call on the same output + criteria."""
+        task = await self._run_one_task(svl_singletons, verify_enabled=True)
+
+        # Task still completed normally — status is DONE, not changed by verify.
+        assert task.status == TaskStatus.DONE
+
+        verdict = task.metadata.get("verify_verdict")
+        assert verdict is not None, "verify_verdict was not stamped with the flag on"
+
+        # The stamped verdict matches an independent verify_outcome call.
+        expected = verify_outcome(task.output, _SUCCESS_CRITERIA)
+        assert verdict["status"] == expected.status.value
+        # Criteria met → SOLVED.
+        assert verdict["status"] == "solved"
+
+    @pytest.mark.asyncio
+    async def test_flag_off_leaves_no_verdict_and_unchanged_behaviour(self, svl_singletons):
+        """With the flag off (default), no verdict is stamped and the task
+        completes exactly as before — status DONE, output intact."""
+        task = await self._run_one_task(svl_singletons, verify_enabled=False)
+
+        assert task.status == TaskStatus.DONE
+        assert task.output and "overdue invoices" in task.output
+        assert "verify_verdict" not in task.metadata

--- a/tests/test_deep_work_scheduler.py
+++ b/tests/test_deep_work_scheduler.py
@@ -1,5 +1,9 @@
 # Tests for Deep Work Dependency Scheduler
 # Created: 2026-02-12
+# Updated: 2026-06-23 (feat/svl-1-verify-stamp) — _make_task now accepts
+#   ``output`` and ``success_criteria`` kwargs so Self-Verifying-Loop tests
+#   (SVL-1 and later slices) can construct completed tasks carrying a result
+#   and their intake criteria.
 #
 # Covers:
 # - get_ready_tasks: blockers satisfied, excludes running tasks
@@ -64,8 +68,19 @@ def _make_task(
     task_type: str = "agent",
     assignee_ids: list[str] | None = None,
     title: str = "",
+    output: str | None = None,
+    success_criteria: list[str] | None = None,
 ) -> Task:
-    """Helper to create a Task with specific fields."""
+    """Helper to create a Task with specific fields.
+
+    ``output`` and ``success_criteria`` let Self-Verifying-Loop tests build a
+    completed task with a result and its intake criteria. ``success_criteria``
+    rides on ``metadata`` (the same key the planner stamps at intake), so the
+    verifier can be exercised against a constructed task.
+    """
+    metadata: dict = {}
+    if success_criteria is not None:
+        metadata["success_criteria"] = success_criteria
     return Task(
         id=task_id,
         title=title or f"Task {task_id}",
@@ -74,6 +89,8 @@ def _make_task(
         blocked_by=blocked_by or [],
         task_type=task_type,
         assignee_ids=assignee_ids or [],
+        output=output,
+        metadata=metadata,
     )
 
 


### PR DESCRIPTION
## What this does

When `deep_work_verify_loop_enabled` is on, a deep_work task that finishes successfully now has its result checked against the `success_criteria` captured at intake, and the verdict is recorded on the task's metadata and logged. The task still completes the same way it does today. This slice only observes and records the verdict; it does not change task status or requeue anything.

The flag defaults to off, so nothing changes for existing deployments.

## Why

The deep_work scheduler marks a task done the moment the agent stops, without checking whether the result actually met its criteria. The verifier for that check (`verify_outcome`, #1162) shipped and has sat idle with no caller. This wires it in as an observe-only first step, so we can see which "done" tasks would have failed their criteria before the loop acts on it.

First slice of the Self-Verifying Loop. Acting on a failing verdict (requeue) lands in SVL-2.

## Scope

- `instinct/verdict_provider.py` (new): `VerdictProvider` protocol + `DeterministicVerdictProvider` wrapping `verify_outcome`. The seam that lets an LLM-judge provider slot in later without touching the executor.
- `config.py`: `deep_work_verify_loop_enabled` (default False) and `deep_work_verify_max_requeues` (default 2, read by SVL-2).
- `mission_control/executor.py`: in the completion branch, when the flag is on, compute the verdict and stamp `metadata["verify_verdict"]`. Guarded so the flag-off path is unchanged. No status mutation.
- Tests: `test_deep_work_e2e.py` (flag-on stamps a matching verdict; flag-off leaves metadata untouched); `test_deep_work_scheduler.py::_make_task` gains `output`/`success_criteria` kwargs.

## Verification

`uv run pytest tests/test_deep_work_e2e.py tests/test_deep_work_scheduler.py tests/cloud/test_instinct_verification.py` -> 52 passed. Ruff clean. Import-linter OSS-core contract holds (no ee import).

## Out of scope

Requeue on failure (SVL-2), the no-progress detector (SVL-3), LLM-judge and source-trace verifiers, and any change to intake or success_criteria authoring.