### PR TITLE
feat(deep_work): requeue tasks that fail their success criteria (SVL-2)

### DIFF
--- a/src/pocketpaw/mission_control/executor.py
+++ b/src/pocketpaw/mission_control/executor.py
@@ -1,6 +1,25 @@
 """Mission Control Task Executor.
 
 Created: 2026-02-05
+Updated: 2026-06-23 — Self-Verifying Loop (SVL-2): the completion hook now
+  ACTS on the SVL-1 verdict. A SOLVED / UNKNOWN result still passes through as
+  DONE (a passing or uncheckable result is never requeued or mutated). A
+  PARTIAL / NOT_SOLVED result is requeued: the SPECIFIC unmet criteria (+ their
+  details) are appended to a cumulative ``verify_feedback`` log, the task is set
+  back to ASSIGNED and re-dispatched via the EXISTING error-retry mechanism
+  (``should_retry`` lever + ``execute_task_background``), bounded by
+  ``deep_work_verify_max_requeues`` via a SEPARATE ``verify_requeue_count``
+  counter (independent of the error ``retry_count``). When the budget is
+  exhausted the task escalates to BLOCKED with
+  ``verify_escalation_reason="budget_exhausted"``. ``_build_task_prompt`` now
+  renders a "## Why the last attempt was rejected" section from
+  ``verify_feedback`` so the re-dispatched agent sees exactly what to fix. The
+  DONE side-effects (TASK_COMPLETED activity + deliverable save) are gated on
+  the RESOLVED ``new_task_status == DONE``, so neither a verify-requeue
+  (ASSIGNED) nor a verify-escalation (BLOCKED) marks failing work as completed
+  or saves its rejected output; an escalation logs a needs-review activity and
+  broadcasts ``mc_task_blocked`` instead. Flag off ⇒ behaviour is byte-for-byte
+  unchanged.
 Updated: 2026-06-23 — Self-Verifying Loop (SVL-1): when
   ``deep_work_verify_loop_enabled`` is set, a successfully-completing task has
   its output checked against the ``success_criteria`` in its metadata via a
@@ -61,6 +80,7 @@ from pocketpaw.agents.router import AgentRouter  # noqa: E402
 from pocketpaw.bus.events import SystemEvent  # noqa: E402
 from pocketpaw.bus.queue import get_message_bus  # noqa: E402
 from pocketpaw.config import get_settings  # noqa: E402
+from pocketpaw.instinct.models import OutcomeStatus  # noqa: E402
 from pocketpaw.instinct.verdict_provider import DeterministicVerdictProvider  # noqa: E402
 from pocketpaw.mission_control.manager import get_mission_control_manager  # noqa: E402
 from pocketpaw.mission_control.models import (  # noqa: E402
@@ -271,13 +291,14 @@ class MCTaskExecutor:
             if final_status == "completed":
                 new_task_status = TaskStatus.DONE
 
-                # Self-Verifying Loop (SVL-1): when the loop is enabled, check
-                # the completed task's result against the success_criteria
-                # captured at intake and STAMP the verdict on the task — the
-                # "verify" half. This is observe-only: the verdict is recorded
-                # and logged, but the status stays DONE (no requeue in this
-                # slice — that lands in SVL-2). When the flag is off this whole
-                # block is skipped and behaviour is byte-for-byte unchanged.
+                # Self-Verifying Loop: when the loop is enabled, check the
+                # completed task's result against the success_criteria captured
+                # at intake and STAMP the verdict on the task — the "verify"
+                # half (SVL-1). SVL-2 then ACTS on the verdict: a result that
+                # does NOT meet its criteria is requeued with the specific unmet
+                # criteria fed back, up to a budget, then escalated to BLOCKED.
+                # When the flag is off this whole block is skipped and behaviour
+                # is byte-for-byte unchanged.
                 if get_settings().deep_work_verify_loop_enabled and task_fresh:
                     success_criteria = task_fresh.metadata.get("success_criteria", [])
                     verdict = DeterministicVerdictProvider().verify(
@@ -290,6 +311,69 @@ class MCTaskExecutor:
                         verdict.status,
                         verdict.summary,
                     )
+
+                    # SVL-2: act on the verdict. SOLVED / UNKNOWN pass through
+                    # as DONE — a passing (or uncheckable) result is NEVER
+                    # requeued or mutated. PARTIAL / NOT_SOLVED means the output
+                    # missed at least one captured criterion: requeue the task
+                    # with the unmet criteria fed back, bounded by
+                    # deep_work_verify_max_requeues, then escalate to BLOCKED.
+                    if verdict.status in (
+                        OutcomeStatus.PARTIAL,
+                        OutcomeStatus.NOT_SOLVED,
+                    ):
+                        unmet = [cr for cr in verdict.criteria_results if not cr.met]
+                        # Verify-specific counter, SEPARATE from the error
+                        # retry_count so verify requeues and error retries never
+                        # share a budget.
+                        n = task_fresh.metadata.get("verify_requeue_count", 0)
+                        max_requeues = get_settings().deep_work_verify_max_requeues
+                        if n < max_requeues:
+                            # Append this attempt's unmet criteria to the
+                            # CUMULATIVE feedback log so attempt N sees the
+                            # rejections from attempts 1..N-1.
+                            task_fresh.metadata.setdefault("verify_feedback", []).append(
+                                {
+                                    "attempt": n + 1,
+                                    "status": verdict.status.value,
+                                    "summary": verdict.summary,
+                                    "unmet_criteria": [
+                                        {
+                                            "criterion": cr.criterion,
+                                            "detail": cr.detail,
+                                        }
+                                        for cr in unmet
+                                    ],
+                                }
+                            )
+                            task_fresh.metadata["verify_requeue_count"] = n + 1
+                            # Mirror the error-retry branch: ASSIGNED + the
+                            # should_retry lever drive the re-dispatch and the
+                            # callback-skip; no new dispatch machinery.
+                            new_task_status = TaskStatus.ASSIGNED
+                            should_retry = True
+                            logger.info(
+                                "Task %s failed verify (%s); requeue %d/%d with "
+                                "%d unmet criterion(s)",
+                                task_id,
+                                verdict.status,
+                                n + 1,
+                                max_requeues,
+                                len(unmet),
+                            )
+                        else:
+                            # Budget exhausted — escalate to BLOCKED (the status
+                            # the manual-retry endpoint already admits) and stamp
+                            # the reason so the operator sees why it stuck.
+                            new_task_status = TaskStatus.BLOCKED
+                            task_fresh.metadata["verify_escalation_reason"] = "budget_exhausted"
+                            logger.info(
+                                "Task %s failed verify (%s) after %d requeue(s); "
+                                "escalating to BLOCKED (budget exhausted)",
+                                task_id,
+                                verdict.status,
+                                n,
+                            )
             elif final_status in ("error", "timeout") and task_fresh:
                 # Check if we should retry
                 if task_fresh.retry_count < task_fresh.max_retries:
@@ -331,8 +415,16 @@ class MCTaskExecutor:
                 },
             )
 
-            # Log completion activity
-            if final_status == "completed":
+            # Log completion activity. The DONE side-effects (completion log +
+            # deliverable save) must run ONLY when the task actually landed
+            # DONE. SVL-2 keeps final_status == "completed" while diverting a
+            # failing result to either ASSIGNED (verify-requeue) or BLOCKED
+            # (verify-escalation), so this branch is gated on the resolved
+            # ``new_task_status`` — not on ``final_status`` alone. SOLVED /
+            # UNKNOWN / flag-off all resolve to DONE and enter here unchanged; a
+            # requeued or escalated failing result never logs "completed" or
+            # saves its rejected output as a deliverable.
+            if final_status == "completed" and new_task_status == TaskStatus.DONE:
                 await self._log_activity(
                     ActivityType.TASK_COMPLETED,
                     agent_id=agent_id,
@@ -349,30 +441,91 @@ class MCTaskExecutor:
                         task_title=task.title,
                     )
 
-            elif should_retry:
+            elif final_status == "completed" and new_task_status == TaskStatus.BLOCKED:
+                # SVL-2 verify-escalation: the result never met its criteria and
+                # the requeue budget is spent. Surface it as a needs-review
+                # escalation in the activity feed — NOT a completion — and
+                # broadcast so an operator sees it.
+                verify_n = task_fresh.metadata.get("verify_requeue_count", 0) if task_fresh else 0
+                verify_max = get_settings().deep_work_verify_max_requeues
                 await self._log_activity(
                     ActivityType.TASK_UPDATED,
                     agent_id=agent_id,
                     task_id=task_id,
                     message=(
-                        f"{agent.name} retrying '{task.title}' "
-                        f"(attempt {task_fresh.retry_count}/{task_fresh.max_retries}): "
-                        f"{error_message}"
+                        f"{agent.name} escalated '{task.title}' — output failed its "
+                        f"success criteria after {verify_max} requeue(s); needs review"
                     ),
                 )
-                # Broadcast retry event for frontend
                 await self._broadcast_event(
-                    "mc_task_retry",
+                    "mc_task_blocked",
                     {
                         "task_id": task_id,
                         "agent_id": agent_id,
-                        "retry_count": task_fresh.retry_count if task_fresh else 0,
-                        "max_retries": task_fresh.max_retries if task_fresh else 0,
-                        "error": error_message,
+                        "reason": "verify_escalation",
+                        "verify_requeue_count": verify_n,
+                        "verify_max_requeues": verify_max,
                         "timestamp": now_iso(),
                     },
                 )
-                # Re-dispatch for retry
+
+            elif should_retry:
+                # should_retry is set by two paths: the error/timeout auto-retry
+                # branch (carries error_message + the error retry_count) and the
+                # SVL-2 verify requeue (no error_message; tracked by the separate
+                # verify_requeue_count). Pick the message + counters per path so
+                # an operator sees the right story.
+                is_verify_requeue = final_status == "completed"
+                if is_verify_requeue:
+                    verify_n = (
+                        task_fresh.metadata.get("verify_requeue_count", 0) if task_fresh else 0
+                    )
+                    verify_max = get_settings().deep_work_verify_max_requeues
+                    await self._log_activity(
+                        ActivityType.TASK_UPDATED,
+                        agent_id=agent_id,
+                        task_id=task_id,
+                        message=(
+                            f"{agent.name} requeuing '{task.title}' — result did not "
+                            f"meet its success criteria "
+                            f"(verify requeue {verify_n}/{verify_max})"
+                        ),
+                    )
+                    await self._broadcast_event(
+                        "mc_task_retry",
+                        {
+                            "task_id": task_id,
+                            "agent_id": agent_id,
+                            "reason": "verify_requeue",
+                            "verify_requeue_count": verify_n,
+                            "verify_max_requeues": verify_max,
+                            "timestamp": now_iso(),
+                        },
+                    )
+                else:
+                    await self._log_activity(
+                        ActivityType.TASK_UPDATED,
+                        agent_id=agent_id,
+                        task_id=task_id,
+                        message=(
+                            f"{agent.name} retrying '{task.title}' "
+                            f"(attempt {task_fresh.retry_count}/{task_fresh.max_retries}): "
+                            f"{error_message}"
+                        ),
+                    )
+                    # Broadcast retry event for frontend
+                    await self._broadcast_event(
+                        "mc_task_retry",
+                        {
+                            "task_id": task_id,
+                            "agent_id": agent_id,
+                            "retry_count": task_fresh.retry_count if task_fresh else 0,
+                            "max_retries": task_fresh.max_retries if task_fresh else 0,
+                            "error": error_message,
+                            "timestamp": now_iso(),
+                        },
+                    )
+                # Re-dispatch for retry / requeue — same mechanism for both.
                 asyncio.create_task(self.execute_task_background(task_id, agent_id))
 
             elif final_status in ("error", "timeout"):
@@ -739,6 +892,35 @@ class MCTaskExecutor:
         sim_tick = task.metadata.get("simulation_tick")
         if sim_tick is not None:
             prompt_parts.append(f"**Simulation Tick:** {sim_tick}")
+
+        # Self-Verifying Loop (SVL-2): if a prior attempt was rejected because
+        # its output missed one or more success criteria, surface the SPECIFIC
+        # unmet criteria so the re-dispatched agent sees exactly what to fix
+        # rather than a bare "try again". The feedback log is cumulative across
+        # attempts (attempt N carries 1..N-1), so render every prior attempt's
+        # rejections — most recent first.
+        verify_feedback = task.metadata.get("verify_feedback")
+        if verify_feedback:
+            prompt_parts.extend(
+                [
+                    "",
+                    "## Why the last attempt was rejected",
+                    "A previous attempt did NOT meet the success criteria below. "
+                    "Address each unmet criterion in your work this time:",
+                ]
+            )
+            for record in reversed(verify_feedback):
+                attempt = record.get("attempt")
+                summary = record.get("summary", "")
+                header = f"**Attempt {attempt}** ({summary}):" if attempt else f"**{summary}**:"
+                prompt_parts.append(header)
+                for item in record.get("unmet_criteria", []):
+                    criterion = item.get("criterion", "")
+                    detail = item.get("detail", "")
+                    line = f"- {criterion}"
+                    if detail:
+                        line += f" — {detail}"
+                    prompt_parts.append(line)
 
         prompt_parts.extend(
             [

--- a/tests/test_deep_work_e2e.py
+++ b/tests/test_deep_work_e2e.py
@@ -510,3 +510,325 @@ class TestVerifyOnCompletion:
         assert task.status == TaskStatus.DONE
         assert task.output and "overdue invoices" in task.output
         assert "verify_verdict" not in task.metadata
+
+
+# ---------------------------------------------------------------------------
+# SVL-2: requeue loop with diagnostic feedback + budget
+# ---------------------------------------------------------------------------
+
+# Output that DOES NOT satisfy either criterion in _SUCCESS_CRITERIA — the
+# deterministic verifier needs every content token of a criterion to appear in
+# the result, so a result about something unrelated yields NOT_SOLVED.
+_FAILING_OUTPUT = "I looked into the request but could not find the data needed."
+
+
+def _svl_failing_router():
+    """A mock AgentRouter whose output FAILS the success criteria every time."""
+
+    async def mock_run(prompt):  # noqa: ARG001
+        yield AgentEvent(type="message", content=_FAILING_OUTPUT)
+        yield AgentEvent(type="done", content="")
+        await asyncio.sleep(0)
+
+    router = MagicMock()
+    router.run = mock_run
+    router.stop = AsyncMock()
+    return router
+
+
+def _svl_converging_router(fail_times: int, *, captured_prompts: list[str] | None = None):
+    """A mock AgentRouter that FAILS its criteria ``fail_times`` times, then
+    succeeds — to prove the loop converges once the agent finally satisfies the
+    criteria. Optionally records each prompt it was handed so a test can assert
+    the rejection feedback was injected on the requeue."""
+    state = {"calls": 0}
+
+    async def mock_run(prompt):
+        if captured_prompts is not None:
+            captured_prompts.append(prompt)
+        state["calls"] += 1
+        content = _FAILING_OUTPUT if state["calls"] <= fail_times else _SUCCESS_OUTPUT
+        yield AgentEvent(type="message", content=content)
+        yield AgentEvent(type="done", content="")
+        await asyncio.sleep(0)
+
+    router = MagicMock()
+    router.run = mock_run
+    router.stop = AsyncMock()
+    return router
+
+
+def _settings_with_verify_budget(enabled: bool, max_requeues: int):
+    """A Settings copy with the verify-loop flag and requeue budget forced."""
+    return get_settings().model_copy(
+        update={
+            "deep_work_verify_loop_enabled": enabled,
+            "deep_work_verify_max_requeues": max_requeues,
+        }
+    )
+
+
+class TestVerifyRequeueLoop:
+    """SVL-2: a completed task whose result does NOT meet its success_criteria
+    is requeued with the specific unmet criteria fed back, bounded by
+    ``deep_work_verify_max_requeues``, then escalated to BLOCKED."""
+
+    async def _make_agent_and_task(self):
+        from pocketpaw.mission_control import get_mission_control_manager
+
+        manager = get_mission_control_manager()
+        agent = await manager.create_agent(
+            name="FinanceBot",
+            role="Finance Assistant",
+            description="Chases overdue invoices",
+            backend="claude_agent_sdk",
+        )
+        task = await manager.create_task(
+            title="Pull the list of overdue invoices",
+            description="Query accounting for invoices 30+ days overdue",
+            priority=TaskPriority.HIGH,
+        )
+        task.metadata["success_criteria"] = list(_SUCCESS_CRITERIA)
+        await manager.save_task(task)
+        await manager.assign_task(task.id, [agent.id])
+        return manager, agent, task
+
+    async def _run_once(self, executor, task_id, agent_id, mock_router, settings):
+        """Run a single execute_task pass with the verify settings patched.
+
+        Mirrors exactly what the production re-dispatch
+        (``execute_task_background`` → ``execute_task``) invokes, but driven
+        synchronously so transitions can be asserted step by step."""
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=mock_router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=settings,
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            return await executor.execute_task(task_id, agent_id)
+
+    @pytest.mark.asyncio
+    async def test_failing_task_requeues_then_escalates_to_blocked(self, svl_singletons):
+        """A task whose output never meets its criteria is requeued at most
+        ``deep_work_verify_max_requeues`` times (each requeue back to ASSIGNED),
+        then lands BLOCKED with the escalation reason stamped. The verify
+        counter is separate from the error retry_count."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        max_requeues = 2
+        settings = _settings_with_verify_budget(True, max_requeues)
+        router = _svl_failing_router()
+
+        # First two passes requeue (status back to ASSIGNED), counter climbs.
+        for expected_n in (1, 2):
+            await self._run_once(executor, task.id, agent.id, router, settings)
+            reloaded = await manager.get_task(task.id)
+            assert reloaded.status == TaskStatus.ASSIGNED, (
+                f"pass {expected_n} should requeue to ASSIGNED, got {reloaded.status}"
+            )
+            assert reloaded.metadata["verify_requeue_count"] == expected_n
+            # Verify counter must NOT bleed into the error retry_count.
+            assert reloaded.retry_count == 0
+            assert "verify_escalation_reason" not in reloaded.metadata
+
+        # Third pass: budget exhausted → BLOCKED + reason stamped.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        blocked = await manager.get_task(task.id)
+        assert blocked.status == TaskStatus.BLOCKED
+        assert blocked.metadata["verify_escalation_reason"] == "budget_exhausted"
+        # Bounded: never exceeded the budget.
+        assert blocked.metadata["verify_requeue_count"] == max_requeues
+        # Cumulative feedback records every rejected attempt.
+        feedback = blocked.metadata["verify_feedback"]
+        assert len(feedback) == max_requeues
+        # The error retry path was never touched.
+        assert blocked.retry_count == 0
+
+    @pytest.mark.asyncio
+    async def test_escalation_does_not_mark_done_or_save_deliverable(self, svl_singletons):
+        """The whole point of the loop is "don't mark failing work as done". A
+        budget-exhausted escalation must NOT log a TASK_COMPLETED activity and
+        must NOT save the rejected output as a deliverable — it must instead log
+        a needs-review escalation activity."""
+        from pocketpaw.mission_control import ActivityType
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        max_requeues = 1  # exhaust quickly: one requeue, then escalate
+        settings = _settings_with_verify_budget(True, max_requeues)
+        router = _svl_failing_router()
+
+        # Spy on the deliverable save across every pass — it must never fire for
+        # this task, since the output never passes its criteria.
+        with patch.object(executor, "_save_task_deliverable", new=AsyncMock()) as deliverable_spy:
+            # Pass 1: requeue. Pass 2: budget (1) exhausted → escalate to BLOCKED.
+            await self._run_once(executor, task.id, agent.id, router, settings)
+            await self._run_once(executor, task.id, agent.id, router, settings)
+
+        blocked = await manager.get_task(task.id)
+        assert blocked.status == TaskStatus.BLOCKED
+        assert blocked.metadata["verify_escalation_reason"] == "budget_exhausted"
+
+        # The failing output was NEVER saved as a deliverable.
+        deliverable_spy.assert_not_called()
+        # And no DELIVERABLE document exists for the task.
+        docs = await manager.get_task_documents(task.id)
+        assert docs == [] or all(d.type.value != "deliverable" for d in docs)
+
+        # No TASK_COMPLETED activity was logged for this task; an escalation
+        # (TASK_UPDATED, "escalated ... needs review") was.
+        feed = await manager.get_activity_feed(limit=100)
+        task_activities = [a for a in feed if a.task_id == task.id]
+        assert all(a.type != ActivityType.TASK_COMPLETED for a in task_activities), (
+            "an escalated task must not log a TASK_COMPLETED activity"
+        )
+        escalations = [
+            a
+            for a in task_activities
+            if a.type == ActivityType.TASK_UPDATED and "escalated" in a.message
+        ]
+        assert escalations, "expected a needs-review escalation activity"
+        assert "needs review" in escalations[0].message
+
+    @pytest.mark.asyncio
+    async def test_requeue_prompt_carries_the_unmet_criteria(self, svl_singletons):
+        """The rebuilt prompt for a requeued attempt names the SPECIFIC unmet
+        criteria so the re-dispatched agent sees exactly what to fix."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(True, 2)
+
+        captured: list[str] = []
+        router = _svl_converging_router(fail_times=99, captured_prompts=captured)
+
+        # First pass fails → requeue. Second pass rebuilds the prompt.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        await self._run_once(executor, task.id, agent.id, router, settings)
+
+        # The first prompt had no rejection section; the second one does.
+        assert "Why the last attempt was rejected" not in captured[0]
+        second = captured[1]
+        assert "Why the last attempt was rejected" in second
+        # The specific unmet criteria text appears in the feedback section.
+        for criterion in _SUCCESS_CRITERIA:
+            assert criterion in second
+
+    @pytest.mark.asyncio
+    async def test_loop_converges_when_agent_finally_succeeds(self, svl_singletons):
+        """If the agent fails once then produces a passing result on the
+        requeue, the task converges to DONE within budget — no escalation."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(True, 2)
+        router = _svl_converging_router(fail_times=1)
+
+        # Pass 1: fails → requeue to ASSIGNED.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        mid = await manager.get_task(task.id)
+        assert mid.status == TaskStatus.ASSIGNED
+        assert mid.metadata["verify_requeue_count"] == 1
+
+        # Pass 2: now passes → DONE, no escalation, counter unchanged.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert done.metadata["verify_verdict"]["status"] == "solved"
+        assert "verify_escalation_reason" not in done.metadata
+        assert done.metadata["verify_requeue_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_solved_task_goes_straight_to_done_no_requeue(self, svl_singletons):
+        """A passing (SOLVED) result is NEVER requeued or mutated: status DONE,
+        no requeue counter, no feedback, no escalation."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(True, 2)
+        router = _svl_mock_router()  # always emits the passing output
+
+        result = await self._run_once(executor, task.id, agent.id, router, settings)
+        assert result["status"] == "completed"
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert done.metadata["verify_verdict"]["status"] == "solved"
+        assert done.metadata.get("verify_requeue_count", 0) == 0
+        assert "verify_feedback" not in done.metadata
+        assert "verify_escalation_reason" not in done.metadata
+
+    @pytest.mark.asyncio
+    async def test_flag_off_never_requeues_a_failing_task(self, svl_singletons):
+        """With the flag OFF a failing result completes DONE exactly as before —
+        no verdict, no requeue, no escalation. SVL-2 is fully inert."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(False, 2)
+        router = _svl_failing_router()
+
+        result = await self._run_once(executor, task.id, agent.id, router, settings)
+        assert result["status"] == "completed"
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert "verify_verdict" not in done.metadata
+        assert "verify_requeue_count" not in done.metadata
+        assert "verify_feedback" not in done.metadata
+        assert "verify_escalation_reason" not in done.metadata
+
+    @pytest.mark.asyncio
+    async def test_real_redispatch_chain_auto_requeues_to_blocked(self, svl_singletons):
+        """End-to-end through the REAL re-dispatch path: launch via
+        ``execute_task_background`` and let the production
+        ``asyncio.create_task`` chain run. The loop must auto-requeue itself and
+        settle on BLOCKED without the test driving each pass."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        max_requeues = 2
+        settings = _settings_with_verify_budget(True, max_requeues)
+        router = _svl_failing_router()
+
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=settings,
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            launched = await executor.execute_task_background(task.id, agent.id)
+            assert launched is True
+
+            # Poll until the self-requeuing chain settles on a terminal state.
+            for _ in range(200):
+                await asyncio.sleep(0.02)
+                current = await manager.get_task(task.id)
+                if (
+                    current.status == TaskStatus.BLOCKED
+                    and current.id not in executor._running_tasks
+                ):
+                    break
+            else:  # pragma: no cover - only hit if the loop never settles
+                pytest.fail(
+                    f"requeue chain did not settle; last status={current.status}, "
+                    f"requeues={current.metadata.get('verify_requeue_count')}"
+                )
+
+        settled = await manager.get_task(task.id)
+        assert settled.status == TaskStatus.BLOCKED
+        assert settled.metadata["verify_escalation_reason"] == "budget_exhausted"
+        assert settled.metadata["verify_requeue_count"] == max_requeues


### PR DESCRIPTION
## What this does

Builds on #1538. When the verify loop is enabled and a deep_work task finishes but its result does not meet its `success_criteria`, the task is requeued instead of being marked done. The specific unmet criteria are fed back to the next attempt, the requeue is bounded by `deep_work_verify_max_requeues` (default 2), and a task that still fails after the budget is escalated to BLOCKED for human review (the status the manual-retry endpoint already accepts).

Stacked on #1538 (SVL-1). The flag defaults to off, so nothing changes for existing deployments.

## How it works

- The verdict computed in SVL-1 now drives the outcome. SOLVED or UNKNOWN (no criteria) pass through as DONE and are never mutated; PARTIAL or NOT_SOLVED trigger a requeue.
- Requeue reuses the executor's existing auto-retry mechanism (the same `should_retry` + `execute_task_background` path the error/timeout retry uses), bounded by a separate `verify_requeue_count` so verify requeues and error retries never share a budget.
- The unmet criteria are appended to a cumulative `metadata["verify_feedback"]` log and rendered in the next attempt's prompt under "## Why the last attempt was rejected", so the agent sees exactly what to fix.
- On budget exhaustion the task escalates to BLOCKED with a needs-review activity and an `mc_task_blocked` broadcast. The DONE side-effects (completion log + deliverable save) are gated on the resolved status, so an escalated task does not log completion or save its rejected output as a deliverable.

## Scope

- `mission_control/executor.py`: act on the verdict (requeue / escalate), reuse the existing re-dispatch, gate the DONE side-effects on the resolved status, render feedback in `_build_task_prompt`.
- Tests: `test_deep_work_e2e.py` covers bounded requeue then BLOCKED, convergence to DONE once the agent passes, SOLVED straight to DONE, flag-off unchanged, and that an escalated task does not mark completed or save a deliverable.

## Verification

`uv run pytest tests/test_deep_work_e2e.py tests/test_mission_control_executor.py tests/test_deep_work_v2.py tests/test_deep_work_scheduler.py` -> 134 passed. Ruff clean.

## Out of scope

The no-progress / oscillation detector (SVL-3), LLM-judge and source-trace verifiers, criticality tags, and per-project budget.