### PR TITLE
feat(deep_work): escalate stuck verify loops early via a no-progress detector (SVL-3)

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,13 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-23: Added the deep_work Self-Verifying Loop flags (SVL-1) —
+    ``deep_work_verify_loop_enabled`` (default False; kill-switch — when
+    False deep_work tasks complete exactly as before) and
+    ``deep_work_verify_max_requeues`` (default 2; the requeue bound read by
+    SVL-2, landed here so later slices don't touch config). SVL-1 only reads
+    the enable flag to stamp an observe-only OutcomeVerdict on a completing
+    task. Env: POCKETPAW_DEEP_WORK_VERIFY_* .
   - 2026-06-18: Added the four layered/learning Instinct gate defaults —
     ``instinct_approval_level`` (default "ASK", dormant),
     ``instinct_auto_approve_threshold`` (0.9), ``instinct_dry_run_mode``
@@ -428,6 +435,30 @@ class Settings(BaseSettings):
             "whenever its confidence in the cheap tier falls below this "
             "threshold. High by default — a wrong skip produces a broken "
             "pocket, so the router is deliberately conservative."
+        ),
+    )
+    deep_work_verify_loop_enabled: bool = Field(
+        default=False,
+        description=(
+            "Kill-switch for the deep_work Self-Verifying Loop. When False "
+            "(default) deep_work tasks complete exactly as before — no outcome "
+            "verification, byte-for-byte today's behaviour. When True, every "
+            "task that completes successfully has its result checked against "
+            "the success_criteria captured at intake and the resulting "
+            "OutcomeVerdict is stamped on the task's metadata "
+            "(``verify_verdict``) and logged. The verdict is observe-only in "
+            "this slice (SVL-1): the task's status is NOT changed by the "
+            "verification — that is the requeue slice (SVL-2)."
+        ),
+    )
+    deep_work_verify_max_requeues: int = Field(
+        default=2,
+        description=(
+            "Max verify-driven requeues a single deep_work task may take "
+            "before the loop stops requeuing and escalates instead. Used by "
+            "the requeue slice (SVL-2); landed here so later slices don't have "
+            "to touch config. SVL-1 only READS deep_work_verify_loop_enabled "
+            "and ignores this bound."
         ),
     )
     auto_install_bundled_skills: bool = Field(

--- a/src/pocketpaw/instinct/__init__.py
+++ b/src/pocketpaw/instinct/__init__.py
@@ -1,5 +1,9 @@
 # Instinct — decision pipeline for Paw OS.
 # Created: 2026-03-28 — Actions, approvals, audit log.
+# Updated: 2026-06-23 (feat/svl-1-verify-stamp) — SVL-1: exported the
+#   VerdictProvider seam — the VerdictProvider protocol and the shipped
+#   DeterministicVerdictProvider — so the deep_work executor can stamp an
+#   outcome verdict behind a flag without hard-wiring a concrete verifier.
 # Updated: 2026-05-21 (feat/instinct-outcome-verification) — issue #1162:
 #   exported the outcome-verification primitives — OutcomeStatus,
 #   CriterionResult, OutcomeVerdict, and the deterministic verify_outcome /
@@ -32,6 +36,10 @@ from pocketpaw.instinct.models import (
 from pocketpaw.instinct.store import InstinctStore
 from pocketpaw.instinct.trace import FabricObjectSnapshot, ReasoningTrace, ToolCallRef
 from pocketpaw.instinct.trace_collector import TraceCollector
+from pocketpaw.instinct.verdict_provider import (
+    DeterministicVerdictProvider,
+    VerdictProvider,
+)
 from pocketpaw.instinct.verification import check_criterion, verify_outcome
 
 __all__ = [
@@ -46,6 +54,7 @@ __all__ = [
     "Correction",
     "CorrectionPatch",
     "CriterionResult",
+    "DeterministicVerdictProvider",
     "FabricObjectSnapshot",
     "InstinctStore",
     "OutcomeStatus",
@@ -53,6 +62,7 @@ __all__ = [
     "ReasoningTrace",
     "ToolCallRef",
     "TraceCollector",
+    "VerdictProvider",
     "check_criterion",
     "compute_patches",
     "summarize_correction",

--- a/src/pocketpaw/instinct/verdict_provider.py
+++ b/src/pocketpaw/instinct/verdict_provider.py
@@ -1,0 +1,65 @@
+# Instinct VerdictProvider seam — the verifier injection point for the
+# Self-Verifying Loop (SVL-1).
+# Created: 2026-06-23 (feat/svl-1-verify-stamp)
+#
+# The Self-Verifying Loop needs a place to *swap in* how an outcome is judged
+# without the producing agent (or the deep_work executor) hard-wiring a
+# concrete verifier. This module is that seam:
+#
+#   - VerdictProvider — the protocol. Any verifier that can turn an action
+#     result + its captured success_criteria into a structured
+#     OutcomeVerdict satisfies it.
+#   - DeterministicVerdictProvider — the shipped default. It delegates to the
+#     deterministic, no-LLM verify_outcome() from
+#     pocketpaw.instinct.verification, so SVL-1 stamps a repeatable verdict
+#     with zero model calls. Later slices can introduce an LLM-as-judge
+#     provider behind the same protocol without touching the executor hook.
+#
+# OSS-core constraint: this file MUST NOT import pocketpaw_ee — an
+# import-linter contract enforces it. The verifier is external to the agent
+# that produced the result (verify_outcome is a pure deterministic check), so
+# the loop's "verify is independent of the producer" invariant holds.
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from pocketpaw.instinct.models import OutcomeVerdict
+from pocketpaw.instinct.verification import verify_outcome
+
+
+@runtime_checkable
+class VerdictProvider(Protocol):
+    """Turns an action result + its success criteria into an OutcomeVerdict.
+
+    The injection seam for the Self-Verifying Loop. Implementations decide
+    *how* to judge an outcome (deterministic token match, LLM-as-judge, a
+    hybrid); callers depend only on this shape, so the verifier can be
+    swapped without the deep_work executor knowing which one is wired in.
+    """
+
+    def verify(self, result: Any, success_criteria: list[str]) -> OutcomeVerdict:
+        """Verify a result against its captured success criteria.
+
+        Args:
+            result: The action result — string, dict, or list.
+            success_criteria: The verifiable end-state checks captured at
+                task intake. May be empty (yields an ``UNKNOWN`` verdict).
+
+        Returns:
+            A structured :class:`OutcomeVerdict`.
+        """
+        ...
+
+
+class DeterministicVerdictProvider:
+    """The shipped default VerdictProvider — no LLM, fully repeatable.
+
+    Delegates to :func:`pocketpaw.instinct.verification.verify_outcome`, the
+    deterministic foundation verifier (issue #1162). Same input always yields
+    the same verdict; no model call. This is the provider SVL-1 stamps with.
+    """
+
+    def verify(self, result: Any, success_criteria: list[str]) -> OutcomeVerdict:
+        """Delegate to the deterministic ``verify_outcome`` check."""
+        return verify_outcome(result, success_criteria)

--- a/src/pocketpaw/mission_control/executor.py
+++ b/src/pocketpaw/mission_control/executor.py
@@ -1,6 +1,23 @@
 """Mission Control Task Executor.
 
 Created: 2026-02-05
+Updated: 2026-06-23 — Self-Verifying Loop (SVL-3): a no-progress / oscillation
+  guard now runs INSIDE the PARTIAL / NOT_SOLVED branch, BEFORE the SVL-2
+  budget-bounded requeue decision. When there is a prior attempt to compare
+  against, it builds the current unmet-criteria fingerprint
+  (``frozenset(cr.criterion for cr in unmet)``) and the previous attempt's
+  fingerprint from the last ``verify_feedback`` record. If the task is making
+  no progress — the SAME criteria still failing (``current == prev``,
+  oscillation/stuck) OR the unmet count not shrinking (``len(current) >=
+  len(prev)``, divergence) — it escalates to BLOCKED EARLY with
+  ``verify_escalation_reason="no_progress"`` instead of burning the whole
+  requeue budget circling a dead end (``should_retry`` stays False so the
+  existing escalation cascade handles it). A task that IS progressing (strictly
+  shrinking, different unmet set) falls through to the unchanged SVL-2 requeue
+  path. The escalation cascade branch now reads ``verify_escalation_reason`` off
+  the task and tailors the operator-facing activity/broadcast to the actual
+  cause (budget_exhausted vs no_progress) rather than assuming budget burn. Flag
+  off ⇒ behaviour is byte-for-byte unchanged.
 Updated: 2026-06-23 — Self-Verifying Loop (SVL-2): the completion hook now
   ACTS on the SVL-1 verdict. A SOLVED / UNKNOWN result still passes through as
   DONE (a passing or uncheckable result is never requeued or mutated). A
@@ -328,7 +345,42 @@ class MCTaskExecutor:
                         # share a budget.
                         n = task_fresh.metadata.get("verify_requeue_count", 0)
                         max_requeues = get_settings().deep_work_verify_max_requeues
-                        if n < max_requeues:
+
+                        # SVL-3 no-progress / oscillation guard: a task can fail
+                        # the SAME criteria attempt after attempt and burn the
+                        # whole requeue budget circling a dead end. Before the
+                        # budget-bounded requeue decision, compare THIS attempt's
+                        # unmet set against the PREVIOUS attempt's. If it is
+                        # making no progress — the exact same criteria still
+                        # failing (oscillation/stuck), OR the unmet count not
+                        # shrinking (divergence) — escalate to BLOCKED EARLY
+                        # rather than wait for the budget. A task that is making
+                        # progress (strictly shrinking, different set) falls
+                        # through to the existing SVL-2 requeue logic unchanged.
+                        prior_feedback = task_fresh.metadata.get("verify_feedback")
+                        no_progress = False
+                        if prior_feedback:
+                            current = frozenset(cr.criterion for cr in unmet)
+                            prev = frozenset(
+                                item["criterion"]
+                                for item in prior_feedback[-1].get("unmet_criteria", [])
+                            )
+                            no_progress = current == prev or len(current) >= len(prev)
+
+                        if no_progress:
+                            # Same/non-shrinking unmet set: stuck. Escalate to
+                            # the SAME BLOCKED status + cascade branch as a
+                            # budget exhaustion, distinguished only by the
+                            # reason. should_retry stays False so the escalation
+                            # cascade — not the requeue path — handles it.
+                            new_task_status = TaskStatus.BLOCKED
+                            task_fresh.metadata["verify_escalation_reason"] = "no_progress"
+                            logger.info(
+                                "Task %s made no progress across requeues (unmet set "
+                                "unchanged/not shrinking); escalating to BLOCKED",
+                                task_id,
+                            )
+                        elif n < max_requeues:
                             # Append this attempt's unmet criteria to the
                             # CUMULATIVE feedback log so attempt N sees the
                             # rejections from attempts 1..N-1.
@@ -442,20 +494,26 @@ class MCTaskExecutor:
                     )
 
             elif final_status == "completed" and new_task_status == TaskStatus.BLOCKED:
-                # SVL-2 verify-escalation: the result never met its criteria and
-                # the requeue budget is spent. Surface it as a needs-review
-                # escalation in the activity feed — NOT a completion — and
-                # broadcast so an operator sees it.
+                # Verify-escalation: the result never met its criteria. Surface
+                # it as a needs-review escalation in the activity feed — NOT a
+                # completion — and broadcast so an operator sees it. The
+                # escalation has two causes (SVL-2 budget exhaustion, SVL-3
+                # no-progress); read the actual reason off the task so the
+                # operator sees WHY it stuck rather than assuming budget burn.
                 verify_n = task_fresh.metadata.get("verify_requeue_count", 0) if task_fresh else 0
                 verify_max = get_settings().deep_work_verify_max_requeues
+                escalation_reason = (
+                    task_fresh.metadata.get("verify_escalation_reason") if task_fresh else None
+                )
+                if escalation_reason == "no_progress":
+                    cause = "output kept failing the same success criteria with no progress"
+                else:
+                    cause = f"output failed its success criteria after {verify_max} requeue(s)"
                 await self._log_activity(
                     ActivityType.TASK_UPDATED,
                     agent_id=agent_id,
                     task_id=task_id,
-                    message=(
-                        f"{agent.name} escalated '{task.title}' — output failed its "
-                        f"success criteria after {verify_max} requeue(s); needs review"
-                    ),
+                    message=(f"{agent.name} escalated '{task.title}' — {cause}; needs review"),
                 )
                 await self._broadcast_event(
                     "mc_task_blocked",
@@ -463,6 +521,7 @@ class MCTaskExecutor:
                         "task_id": task_id,
                         "agent_id": agent_id,
                         "reason": "verify_escalation",
+                        "escalation_reason": escalation_reason,
                         "verify_requeue_count": verify_n,
                         "verify_max_requeues": verify_max,
                         "timestamp": now_iso(),

--- a/src/pocketpaw/mission_control/executor.py
+++ b/src/pocketpaw/mission_control/executor.py
@@ -1,6 +1,13 @@
 """Mission Control Task Executor.
 
 Created: 2026-02-05
+Updated: 2026-06-23 — Self-Verifying Loop (SVL-1): when
+  ``deep_work_verify_loop_enabled`` is set, a successfully-completing task has
+  its output checked against the ``success_criteria`` in its metadata via a
+  DeterministicVerdictProvider, and the resulting OutcomeVerdict is stamped on
+  ``task.metadata["verify_verdict"]`` and logged. Observe-only — the task's
+  status is unchanged (no requeue here; that is SVL-2). Flag off ⇒ behaviour
+  is byte-for-byte unchanged.
 Updated: 2026-02-26 — Deep Work v2: Added task retry, timeout, output storage,
   and project-wide stop. Tasks now store output on task.output field. Failed tasks
   auto-retry up to max_retries. Tasks with timeout_minutes get asyncio.wait_for.
@@ -54,6 +61,7 @@ from pocketpaw.agents.router import AgentRouter  # noqa: E402
 from pocketpaw.bus.events import SystemEvent  # noqa: E402
 from pocketpaw.bus.queue import get_message_bus  # noqa: E402
 from pocketpaw.config import get_settings  # noqa: E402
+from pocketpaw.instinct.verdict_provider import DeterministicVerdictProvider  # noqa: E402
 from pocketpaw.mission_control.manager import get_mission_control_manager  # noqa: E402
 from pocketpaw.mission_control.models import (  # noqa: E402
     Activity,
@@ -262,6 +270,26 @@ class MCTaskExecutor:
             should_retry = False
             if final_status == "completed":
                 new_task_status = TaskStatus.DONE
+
+                # Self-Verifying Loop (SVL-1): when the loop is enabled, check
+                # the completed task's result against the success_criteria
+                # captured at intake and STAMP the verdict on the task — the
+                # "verify" half. This is observe-only: the verdict is recorded
+                # and logged, but the status stays DONE (no requeue in this
+                # slice — that lands in SVL-2). When the flag is off this whole
+                # block is skipped and behaviour is byte-for-byte unchanged.
+                if get_settings().deep_work_verify_loop_enabled and task_fresh:
+                    success_criteria = task_fresh.metadata.get("success_criteria", [])
+                    verdict = DeterministicVerdictProvider().verify(
+                        task_fresh.output, success_criteria
+                    )
+                    task_fresh.metadata["verify_verdict"] = verdict.model_dump()
+                    logger.info(
+                        "Task %s verify verdict: %s (%s)",
+                        task_id,
+                        verdict.status,
+                        verdict.summary,
+                    )
             elif final_status in ("error", "timeout") and task_fresh:
                 # Check if we should retry
                 if task_fresh.retry_count < task_fresh.max_retries:

--- a/src/pocketpaw/mission_control/executor.py
+++ b/src/pocketpaw/mission_control/executor.py
@@ -1,6 +1,25 @@
 """Mission Control Task Executor.
 
 Created: 2026-02-05
+Updated: 2026-06-23 — Self-Verifying Loop (SVL-2): the completion hook now
+  ACTS on the SVL-1 verdict. A SOLVED / UNKNOWN result still passes through as
+  DONE (a passing or uncheckable result is never requeued or mutated). A
+  PARTIAL / NOT_SOLVED result is requeued: the SPECIFIC unmet criteria (+ their
+  details) are appended to a cumulative ``verify_feedback`` log, the task is set
+  back to ASSIGNED and re-dispatched via the EXISTING error-retry mechanism
+  (``should_retry`` lever + ``execute_task_background``), bounded by
+  ``deep_work_verify_max_requeues`` via a SEPARATE ``verify_requeue_count``
+  counter (independent of the error ``retry_count``). When the budget is
+  exhausted the task escalates to BLOCKED with
+  ``verify_escalation_reason="budget_exhausted"``. ``_build_task_prompt`` now
+  renders a "## Why the last attempt was rejected" section from
+  ``verify_feedback`` so the re-dispatched agent sees exactly what to fix. The
+  DONE side-effects (TASK_COMPLETED activity + deliverable save) are gated on
+  the RESOLVED ``new_task_status == DONE``, so neither a verify-requeue
+  (ASSIGNED) nor a verify-escalation (BLOCKED) marks failing work as completed
+  or saves its rejected output; an escalation logs a needs-review activity and
+  broadcasts ``mc_task_blocked`` instead. Flag off ⇒ behaviour is byte-for-byte
+  unchanged.
 Updated: 2026-06-23 — Self-Verifying Loop (SVL-1): when
   ``deep_work_verify_loop_enabled`` is set, a successfully-completing task has
   its output checked against the ``success_criteria`` in its metadata via a
@@ -61,6 +80,7 @@ from pocketpaw.agents.router import AgentRouter  # noqa: E402
 from pocketpaw.bus.events import SystemEvent  # noqa: E402
 from pocketpaw.bus.queue import get_message_bus  # noqa: E402
 from pocketpaw.config import get_settings  # noqa: E402
+from pocketpaw.instinct.models import OutcomeStatus  # noqa: E402
 from pocketpaw.instinct.verdict_provider import DeterministicVerdictProvider  # noqa: E402
 from pocketpaw.mission_control.manager import get_mission_control_manager  # noqa: E402
 from pocketpaw.mission_control.models import (  # noqa: E402
@@ -271,13 +291,14 @@ class MCTaskExecutor:
             if final_status == "completed":
                 new_task_status = TaskStatus.DONE
 
-                # Self-Verifying Loop (SVL-1): when the loop is enabled, check
-                # the completed task's result against the success_criteria
-                # captured at intake and STAMP the verdict on the task — the
-                # "verify" half. This is observe-only: the verdict is recorded
-                # and logged, but the status stays DONE (no requeue in this
-                # slice — that lands in SVL-2). When the flag is off this whole
-                # block is skipped and behaviour is byte-for-byte unchanged.
+                # Self-Verifying Loop: when the loop is enabled, check the
+                # completed task's result against the success_criteria captured
+                # at intake and STAMP the verdict on the task — the "verify"
+                # half (SVL-1). SVL-2 then ACTS on the verdict: a result that
+                # does NOT meet its criteria is requeued with the specific unmet
+                # criteria fed back, up to a budget, then escalated to BLOCKED.
+                # When the flag is off this whole block is skipped and behaviour
+                # is byte-for-byte unchanged.
                 if get_settings().deep_work_verify_loop_enabled and task_fresh:
                     success_criteria = task_fresh.metadata.get("success_criteria", [])
                     verdict = DeterministicVerdictProvider().verify(
@@ -290,6 +311,69 @@ class MCTaskExecutor:
                         verdict.status,
                         verdict.summary,
                     )
+
+                    # SVL-2: act on the verdict. SOLVED / UNKNOWN pass through
+                    # as DONE — a passing (or uncheckable) result is NEVER
+                    # requeued or mutated. PARTIAL / NOT_SOLVED means the output
+                    # missed at least one captured criterion: requeue the task
+                    # with the unmet criteria fed back, bounded by
+                    # deep_work_verify_max_requeues, then escalate to BLOCKED.
+                    if verdict.status in (
+                        OutcomeStatus.PARTIAL,
+                        OutcomeStatus.NOT_SOLVED,
+                    ):
+                        unmet = [cr for cr in verdict.criteria_results if not cr.met]
+                        # Verify-specific counter, SEPARATE from the error
+                        # retry_count so verify requeues and error retries never
+                        # share a budget.
+                        n = task_fresh.metadata.get("verify_requeue_count", 0)
+                        max_requeues = get_settings().deep_work_verify_max_requeues
+                        if n < max_requeues:
+                            # Append this attempt's unmet criteria to the
+                            # CUMULATIVE feedback log so attempt N sees the
+                            # rejections from attempts 1..N-1.
+                            task_fresh.metadata.setdefault("verify_feedback", []).append(
+                                {
+                                    "attempt": n + 1,
+                                    "status": verdict.status.value,
+                                    "summary": verdict.summary,
+                                    "unmet_criteria": [
+                                        {
+                                            "criterion": cr.criterion,
+                                            "detail": cr.detail,
+                                        }
+                                        for cr in unmet
+                                    ],
+                                }
+                            )
+                            task_fresh.metadata["verify_requeue_count"] = n + 1
+                            # Mirror the error-retry branch: ASSIGNED + the
+                            # should_retry lever drive the re-dispatch and the
+                            # callback-skip; no new dispatch machinery.
+                            new_task_status = TaskStatus.ASSIGNED
+                            should_retry = True
+                            logger.info(
+                                "Task %s failed verify (%s); requeue %d/%d with "
+                                "%d unmet criterion(s)",
+                                task_id,
+                                verdict.status,
+                                n + 1,
+                                max_requeues,
+                                len(unmet),
+                            )
+                        else:
+                            # Budget exhausted — escalate to BLOCKED (the status
+                            # the manual-retry endpoint already admits) and stamp
+                            # the reason so the operator sees why it stuck.
+                            new_task_status = TaskStatus.BLOCKED
+                            task_fresh.metadata["verify_escalation_reason"] = "budget_exhausted"
+                            logger.info(
+                                "Task %s failed verify (%s) after %d requeue(s); "
+                                "escalating to BLOCKED (budget exhausted)",
+                                task_id,
+                                verdict.status,
+                                n,
+                            )
             elif final_status in ("error", "timeout") and task_fresh:
                 # Check if we should retry
                 if task_fresh.retry_count < task_fresh.max_retries:
@@ -331,8 +415,16 @@ class MCTaskExecutor:
                 },
             )
 
-            # Log completion activity
-            if final_status == "completed":
+            # Log completion activity. The DONE side-effects (completion log +
+            # deliverable save) must run ONLY when the task actually landed
+            # DONE. SVL-2 keeps final_status == "completed" while diverting a
+            # failing result to either ASSIGNED (verify-requeue) or BLOCKED
+            # (verify-escalation), so this branch is gated on the resolved
+            # ``new_task_status`` — not on ``final_status`` alone. SOLVED /
+            # UNKNOWN / flag-off all resolve to DONE and enter here unchanged; a
+            # requeued or escalated failing result never logs "completed" or
+            # saves its rejected output as a deliverable.
+            if final_status == "completed" and new_task_status == TaskStatus.DONE:
                 await self._log_activity(
                     ActivityType.TASK_COMPLETED,
                     agent_id=agent_id,
@@ -349,30 +441,91 @@ class MCTaskExecutor:
                         task_title=task.title,
                     )
 
-            elif should_retry:
+            elif final_status == "completed" and new_task_status == TaskStatus.BLOCKED:
+                # SVL-2 verify-escalation: the result never met its criteria and
+                # the requeue budget is spent. Surface it as a needs-review
+                # escalation in the activity feed — NOT a completion — and
+                # broadcast so an operator sees it.
+                verify_n = task_fresh.metadata.get("verify_requeue_count", 0) if task_fresh else 0
+                verify_max = get_settings().deep_work_verify_max_requeues
                 await self._log_activity(
                     ActivityType.TASK_UPDATED,
                     agent_id=agent_id,
                     task_id=task_id,
                     message=(
-                        f"{agent.name} retrying '{task.title}' "
-                        f"(attempt {task_fresh.retry_count}/{task_fresh.max_retries}): "
-                        f"{error_message}"
+                        f"{agent.name} escalated '{task.title}' — output failed its "
+                        f"success criteria after {verify_max} requeue(s); needs review"
                     ),
                 )
-                # Broadcast retry event for frontend
                 await self._broadcast_event(
-                    "mc_task_retry",
+                    "mc_task_blocked",
                     {
                         "task_id": task_id,
                         "agent_id": agent_id,
-                        "retry_count": task_fresh.retry_count if task_fresh else 0,
-                        "max_retries": task_fresh.max_retries if task_fresh else 0,
-                        "error": error_message,
+                        "reason": "verify_escalation",
+                        "verify_requeue_count": verify_n,
+                        "verify_max_requeues": verify_max,
                         "timestamp": now_iso(),
                     },
                 )
-                # Re-dispatch for retry
+
+            elif should_retry:
+                # should_retry is set by two paths: the error/timeout auto-retry
+                # branch (carries error_message + the error retry_count) and the
+                # SVL-2 verify requeue (no error_message; tracked by the separate
+                # verify_requeue_count). Pick the message + counters per path so
+                # an operator sees the right story.
+                is_verify_requeue = final_status == "completed"
+                if is_verify_requeue:
+                    verify_n = (
+                        task_fresh.metadata.get("verify_requeue_count", 0) if task_fresh else 0
+                    )
+                    verify_max = get_settings().deep_work_verify_max_requeues
+                    await self._log_activity(
+                        ActivityType.TASK_UPDATED,
+                        agent_id=agent_id,
+                        task_id=task_id,
+                        message=(
+                            f"{agent.name} requeuing '{task.title}' — result did not "
+                            f"meet its success criteria "
+                            f"(verify requeue {verify_n}/{verify_max})"
+                        ),
+                    )
+                    await self._broadcast_event(
+                        "mc_task_retry",
+                        {
+                            "task_id": task_id,
+                            "agent_id": agent_id,
+                            "reason": "verify_requeue",
+                            "verify_requeue_count": verify_n,
+                            "verify_max_requeues": verify_max,
+                            "timestamp": now_iso(),
+                        },
+                    )
+                else:
+                    await self._log_activity(
+                        ActivityType.TASK_UPDATED,
+                        agent_id=agent_id,
+                        task_id=task_id,
+                        message=(
+                            f"{agent.name} retrying '{task.title}' "
+                            f"(attempt {task_fresh.retry_count}/{task_fresh.max_retries}): "
+                            f"{error_message}"
+                        ),
+                    )
+                    # Broadcast retry event for frontend
+                    await self._broadcast_event(
+                        "mc_task_retry",
+                        {
+                            "task_id": task_id,
+                            "agent_id": agent_id,
+                            "retry_count": task_fresh.retry_count if task_fresh else 0,
+                            "max_retries": task_fresh.max_retries if task_fresh else 0,
+                            "error": error_message,
+                            "timestamp": now_iso(),
+                        },
+                    )
+                # Re-dispatch for retry / requeue — same mechanism for both.
                 asyncio.create_task(self.execute_task_background(task_id, agent_id))
 
             elif final_status in ("error", "timeout"):
@@ -739,6 +892,35 @@ class MCTaskExecutor:
         sim_tick = task.metadata.get("simulation_tick")
         if sim_tick is not None:
             prompt_parts.append(f"**Simulation Tick:** {sim_tick}")
+
+        # Self-Verifying Loop (SVL-2): if a prior attempt was rejected because
+        # its output missed one or more success criteria, surface the SPECIFIC
+        # unmet criteria so the re-dispatched agent sees exactly what to fix
+        # rather than a bare "try again". The feedback log is cumulative across
+        # attempts (attempt N carries 1..N-1), so render every prior attempt's
+        # rejections — most recent first.
+        verify_feedback = task.metadata.get("verify_feedback")
+        if verify_feedback:
+            prompt_parts.extend(
+                [
+                    "",
+                    "## Why the last attempt was rejected",
+                    "A previous attempt did NOT meet the success criteria below. "
+                    "Address each unmet criterion in your work this time:",
+                ]
+            )
+            for record in reversed(verify_feedback):
+                attempt = record.get("attempt")
+                summary = record.get("summary", "")
+                header = f"**Attempt {attempt}** ({summary}):" if attempt else f"**{summary}**:"
+                prompt_parts.append(header)
+                for item in record.get("unmet_criteria", []):
+                    criterion = item.get("criterion", "")
+                    detail = item.get("detail", "")
+                    line = f"- {criterion}"
+                    if detail:
+                        line += f" — {detail}"
+                    prompt_parts.append(line)
 
         prompt_parts.extend(
             [

--- a/tests/test_deep_work_e2e.py
+++ b/tests/test_deep_work_e2e.py
@@ -1,5 +1,13 @@
 # End-to-end tests for the Deep Work interactive intake mode (issue #1161).
 # Created: 2026-05-21 (feat/deep-work-intake)
+# Updated: 2026-06-23 (feat/svl-3-no-progress) — added TestVerifyNoProgress:
+#   drives the MC executor's verify loop with a budget > 1 and proves the SVL-3
+#   no-progress / oscillation guard. A task that returns the SAME failing output
+#   (same unmet criteria) on consecutive attempts escalates to BLOCKED with
+#   ``verify_escalation_reason == "no_progress"`` BEFORE the requeue budget is
+#   spent, and the escalation activity/broadcast reflects the no_progress cause.
+#   A task whose unmet set strictly shrinks (2 → 1 → solved) keeps requeuing and
+#   is NOT escalated early — it converges to DONE.
 # Updated: 2026-06-23 (feat/svl-1-verify-stamp) — added
 #   TestVerifyOnCompletion: drives the MC executor to completion with the
 #   Self-Verifying-Loop flag on and asserts the OutcomeVerdict stamped on
@@ -536,6 +544,51 @@ def _svl_failing_router():
     return router
 
 
+# --- Budget-exhaustion scenario (three criteria, shrinking-but-never-solved) --
+#
+# SVL-3 escalates EARLY when an attempt makes no progress (same or non-shrinking
+# unmet set). So to exercise SVL-2's BUDGET-exhaustion path we need a task that
+# keeps making genuine progress every requeue yet never fully solves before the
+# budget runs out. With three criteria the unmet set can shrink 3 → 2 → 1 across
+# a budget of 2 and still be failing at the escalation point — progress on every
+# pass (no-progress guard never fires), budget exhausted at the end.
+_BUDGET_CRITERIA = [
+    "A list of invoices each 30+ days past due is produced",
+    "Every row has an amount and a customer email",
+    "A summary total of the outstanding balance is included",
+]
+# outputs[i] meets i criteria: 0 → 1 → 2 (never all 3). Each leaves a strictly
+# smaller unmet set than the last: 3 unmet → 2 unmet → 1 unmet.
+_BUDGET_OUTPUTS = [
+    "I could not retrieve the requested information at all.",
+    "A summary total of the outstanding balance is included in my notes, nothing else done.",
+    (
+        "Each row has an amount and a customer email. "
+        "A summary total of the outstanding balance is included."
+    ),
+]
+
+
+def _svl_shrinking_failing_router():
+    """A mock AgentRouter that meets one MORE criterion each call but never all
+    of them — the unmet set strictly shrinks every requeue yet the result keeps
+    failing. Drives SVL-2's budget-exhaustion path WITHOUT tripping the SVL-3
+    no-progress guard (which would escalate a stuck/non-shrinking task early)."""
+    state = {"calls": 0}
+
+    async def mock_run(prompt):  # noqa: ARG001
+        idx = min(state["calls"], len(_BUDGET_OUTPUTS) - 1)
+        state["calls"] += 1
+        yield AgentEvent(type="message", content=_BUDGET_OUTPUTS[idx])
+        yield AgentEvent(type="done", content="")
+        await asyncio.sleep(0)
+
+    router = MagicMock()
+    router.run = mock_run
+    router.stop = AsyncMock()
+    return router
+
+
 def _svl_converging_router(fail_times: int, *, captured_prompts: list[str] | None = None):
     """A mock AgentRouter that FAILS its criteria ``fail_times`` times, then
     succeeds — to prove the loop converges once the agent finally satisfies the
@@ -593,6 +646,30 @@ class TestVerifyRequeueLoop:
         await manager.assign_task(task.id, [agent.id])
         return manager, agent, task
 
+    async def _make_budget_agent_and_task(self):
+        """Same as ``_make_agent_and_task`` but with the THREE-criterion
+        budget-exhaustion criteria — paired with ``_svl_shrinking_failing_router``
+        so the unmet set shrinks every requeue (no SVL-3 early escalation) and
+        the BUDGET is what finally trips the escalation."""
+        from pocketpaw.mission_control import get_mission_control_manager
+
+        manager = get_mission_control_manager()
+        agent = await manager.create_agent(
+            name="FinanceBot",
+            role="Finance Assistant",
+            description="Chases overdue invoices",
+            backend="claude_agent_sdk",
+        )
+        task = await manager.create_task(
+            title="Pull the list of overdue invoices",
+            description="Query accounting for invoices 30+ days overdue",
+            priority=TaskPriority.HIGH,
+        )
+        task.metadata["success_criteria"] = list(_BUDGET_CRITERIA)
+        await manager.save_task(task)
+        await manager.assign_task(task.id, [agent.id])
+        return manager, agent, task
+
     async def _run_once(self, executor, task_id, agent_id, mock_router, settings):
         """Run a single execute_task pass with the verify settings patched.
 
@@ -620,11 +697,13 @@ class TestVerifyRequeueLoop:
         then lands BLOCKED with the escalation reason stamped. The verify
         counter is separate from the error retry_count."""
 
-        manager, agent, task = await self._make_agent_and_task()
+        manager, agent, task = await self._make_budget_agent_and_task()
         executor = get_mc_task_executor()
         max_requeues = 2
         settings = _settings_with_verify_budget(True, max_requeues)
-        router = _svl_failing_router()
+        # Shrinking-but-never-solved output so the budget (not the SVL-3
+        # no-progress guard) is what finally escalates the task.
+        router = _svl_shrinking_failing_router()
 
         # First two passes requeue (status back to ASSIGNED), counter climbs.
         for expected_n in (1, 2):
@@ -659,11 +738,12 @@ class TestVerifyRequeueLoop:
         a needs-review escalation activity."""
         from pocketpaw.mission_control import ActivityType
 
-        manager, agent, task = await self._make_agent_and_task()
+        manager, agent, task = await self._make_budget_agent_and_task()
         executor = get_mc_task_executor()
         max_requeues = 1  # exhaust quickly: one requeue, then escalate
         settings = _settings_with_verify_budget(True, max_requeues)
-        router = _svl_failing_router()
+        # Shrinking-but-never-solved so it escalates on BUDGET, not no-progress.
+        router = _svl_shrinking_failing_router()
 
         # Spy on the deliverable save across every pass — it must never fire for
         # this task, since the output never passes its criteria.
@@ -792,11 +872,13 @@ class TestVerifyRequeueLoop:
         ``asyncio.create_task`` chain run. The loop must auto-requeue itself and
         settle on BLOCKED without the test driving each pass."""
 
-        manager, agent, task = await self._make_agent_and_task()
+        manager, agent, task = await self._make_budget_agent_and_task()
         executor = get_mc_task_executor()
         max_requeues = 2
         settings = _settings_with_verify_budget(True, max_requeues)
-        router = _svl_failing_router()
+        # Shrinking-but-never-solved so the chain settles on BUDGET exhaustion
+        # rather than the SVL-3 no-progress early escalation.
+        router = _svl_shrinking_failing_router()
 
         with (
             patch(
@@ -832,3 +914,193 @@ class TestVerifyRequeueLoop:
         assert settled.status == TaskStatus.BLOCKED
         assert settled.metadata["verify_escalation_reason"] == "budget_exhausted"
         assert settled.metadata["verify_requeue_count"] == max_requeues
+
+
+# ---------------------------------------------------------------------------
+# SVL-3: no-progress / oscillation guard
+# ---------------------------------------------------------------------------
+
+# An output that satisfies EXACTLY ONE of the two _SUCCESS_CRITERIA — it names
+# the row/amount/customer/email criterion in full but never produces the
+# overdue-invoice list. So the unmet set shrinks from {both} to {criterion-1}.
+_PARTIAL_OUTPUT = (
+    "Each row carries an amount and a customer email address, "
+    "but I could not produce the overdue list."
+)
+
+
+def _svl_scripted_router(outputs: list[str], *, captured_prompts: list[str] | None = None):
+    """A mock AgentRouter that yields ``outputs[i]`` on the i-th call, clamping
+    to the last entry once the list is exhausted. Lets a test script the exact
+    unmet-criteria trajectory across requeues (same set vs. shrinking set)."""
+    state = {"calls": 0}
+
+    async def mock_run(prompt):
+        if captured_prompts is not None:
+            captured_prompts.append(prompt)
+        idx = min(state["calls"], len(outputs) - 1)
+        state["calls"] += 1
+        yield AgentEvent(type="message", content=outputs[idx])
+        yield AgentEvent(type="done", content="")
+        await asyncio.sleep(0)
+
+    router = MagicMock()
+    router.run = mock_run
+    router.stop = AsyncMock()
+    return router
+
+
+class TestVerifyNoProgress:
+    """SVL-3: a task that keeps failing the SAME criteria (or whose unmet set is
+    not shrinking) is escalated to BLOCKED EARLY — before the requeue budget is
+    spent. A task making progress (strictly shrinking unmet set) keeps requeuing
+    normally and is never escalated for no-progress."""
+
+    async def _make_agent_and_task(self):
+        from pocketpaw.mission_control import get_mission_control_manager
+
+        manager = get_mission_control_manager()
+        agent = await manager.create_agent(
+            name="FinanceBot",
+            role="Finance Assistant",
+            description="Chases overdue invoices",
+            backend="claude_agent_sdk",
+        )
+        task = await manager.create_task(
+            title="Pull the list of overdue invoices",
+            description="Query accounting for invoices 30+ days overdue",
+            priority=TaskPriority.HIGH,
+        )
+        task.metadata["success_criteria"] = list(_SUCCESS_CRITERIA)
+        await manager.save_task(task)
+        await manager.assign_task(task.id, [agent.id])
+        return manager, agent, task
+
+    async def _run_once(self, executor, task_id, agent_id, mock_router, settings):
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=mock_router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=settings,
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            return await executor.execute_task(task_id, agent_id)
+
+    @pytest.mark.asyncio
+    async def test_same_failure_escalates_before_budget(self, svl_singletons):
+        """Two consecutive attempts that fail the SAME criteria escalate to
+        BLOCKED with ``verify_escalation_reason == "no_progress"`` BEFORE the
+        (generous) requeue budget is reached — proving it escalated on stuck,
+        not on budget."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        # Generous budget so a budget-exhaustion escalation is impossible this
+        # early; any BLOCKED here MUST be the no-progress guard.
+        max_requeues = 5
+        settings = _settings_with_verify_budget(True, max_requeues)
+        # Always the same failing output → identical unmet set every attempt.
+        router = _svl_failing_router()
+
+        # Pass 1: first failure, no prior attempt to compare → normal requeue.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        after_first = await manager.get_task(task.id)
+        assert after_first.status == TaskStatus.ASSIGNED
+        assert after_first.metadata["verify_requeue_count"] == 1
+        assert "verify_escalation_reason" not in after_first.metadata
+
+        # Pass 2: same unmet set as pass 1 → no progress → escalate EARLY.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        blocked = await manager.get_task(task.id)
+        assert blocked.status == TaskStatus.BLOCKED
+        assert blocked.metadata["verify_escalation_reason"] == "no_progress"
+        # Escalated EARLY: the counter is still 1, far below the budget of 5.
+        assert blocked.metadata["verify_requeue_count"] == 1
+        assert blocked.metadata["verify_requeue_count"] < max_requeues
+
+    @pytest.mark.asyncio
+    async def test_no_progress_escalation_reports_its_reason(self, svl_singletons):
+        """The escalation activity + broadcast reflect the no_progress cause,
+        not the budget-exhaustion wording."""
+        from pocketpaw.mission_control import ActivityType
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(True, 5)
+        router = _svl_failing_router()
+
+        # Capture the broadcast events on the escalating (second) pass.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+
+        captured_events: list[tuple[str, dict]] = []
+
+        async def _capture(event_type, data):
+            captured_events.append((event_type, data))
+
+        with patch.object(executor, "_broadcast_event", new=_capture):
+            await self._run_once(executor, task.id, agent.id, router, settings)
+
+        blocked = await manager.get_task(task.id)
+        assert blocked.status == TaskStatus.BLOCKED
+        assert blocked.metadata["verify_escalation_reason"] == "no_progress"
+
+        # The escalation activity names the no-progress cause and asks for review.
+        feed = await manager.get_activity_feed(limit=100)
+        escalations = [
+            a
+            for a in feed
+            if a.task_id == task.id
+            and a.type == ActivityType.TASK_UPDATED
+            and "escalated" in a.message
+        ]
+        assert escalations, "expected a needs-review escalation activity"
+        msg = escalations[0].message
+        assert "needs review" in msg
+        assert "no progress" in msg
+        # And it does NOT claim the budget was exhausted.
+        assert "requeue(s)" not in msg
+
+        # The mc_task_blocked broadcast carries the no_progress reason.
+        blocked_events = [d for (t, d) in captured_events if t == "mc_task_blocked"]
+        assert blocked_events, "expected an mc_task_blocked broadcast"
+        assert blocked_events[0]["escalation_reason"] == "no_progress"
+
+    @pytest.mark.asyncio
+    async def test_progressing_task_is_not_escalated_early(self, svl_singletons):
+        """A task whose unmet set strictly shrinks (2 unmet → 1 unmet → solved)
+        keeps requeuing and converges to DONE — the no-progress guard must NOT
+        fire while real progress is being made."""
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(True, 5)
+        # Attempt 1: both criteria unmet. Attempt 2: one criterion now met (set
+        # shrank). Attempt 3: passing output → solved.
+        router = _svl_scripted_router([_FAILING_OUTPUT, _PARTIAL_OUTPUT, _SUCCESS_OUTPUT])
+
+        # Pass 1: 2 unmet, first failure → requeue.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        after_1 = await manager.get_task(task.id)
+        assert after_1.status == TaskStatus.ASSIGNED
+        assert after_1.metadata["verify_requeue_count"] == 1
+        assert "verify_escalation_reason" not in after_1.metadata
+
+        # Pass 2: 1 unmet — strictly fewer than the prior 2 → progress →
+        # requeue again, NOT escalated.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        after_2 = await manager.get_task(task.id)
+        assert after_2.status == TaskStatus.ASSIGNED, (
+            "a shrinking unmet set must keep requeuing, not escalate"
+        )
+        assert after_2.metadata["verify_requeue_count"] == 2
+        assert "verify_escalation_reason" not in after_2.metadata
+
+        # Pass 3: all criteria met → DONE, no escalation ever stamped.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert done.metadata["verify_verdict"]["status"] == "solved"
+        assert "verify_escalation_reason" not in done.metadata

--- a/tests/test_deep_work_e2e.py
+++ b/tests/test_deep_work_e2e.py
@@ -1,5 +1,11 @@
 # End-to-end tests for the Deep Work interactive intake mode (issue #1161).
 # Created: 2026-05-21 (feat/deep-work-intake)
+# Updated: 2026-06-23 (feat/svl-1-verify-stamp) — added
+#   TestVerifyOnCompletion: drives the MC executor to completion with the
+#   Self-Verifying-Loop flag on and asserts the OutcomeVerdict stamped on
+#   ``task.metadata["verify_verdict"]`` matches a direct ``verify_outcome``
+#   call, plus a flag-off case proving the verdict is absent and behaviour is
+#   unchanged.
 #
 # These exercise the full intake → planning path against a real
 # DeepWorkSession + real GoalParser + real PlannerAgent + real
@@ -13,6 +19,8 @@
 #   - The collected answers are folded into the goal that planning sees.
 #   - Planning runs to completion and produces a project + MC tasks.
 #   - The resulting MC tasks carry the intake-captured ``success_criteria``.
+#   - With the verify loop ON, a completing task is stamped with its verdict;
+#     with it OFF, the verdict is absent (SVL-1).
 
 import json
 import tempfile
@@ -353,3 +361,152 @@ class TestIntakeOneShotPath:
 
         tasks = await manager.get_project_tasks(project.id)
         assert len(tasks) == 2
+
+
+# ---------------------------------------------------------------------------
+# Self-Verifying Loop — verify-on-completion stamp (SVL-1)
+# ---------------------------------------------------------------------------
+
+import asyncio  # noqa: E402
+
+import pocketpaw.mission_control.store as store_module  # noqa: E402
+from pocketpaw.agents.protocol import AgentEvent  # noqa: E402
+from pocketpaw.config import get_settings  # noqa: E402
+from pocketpaw.instinct.verification import verify_outcome  # noqa: E402
+from pocketpaw.mission_control import TaskPriority, TaskStatus  # noqa: E402
+from pocketpaw.mission_control.executor import (  # noqa: E402
+    get_mc_task_executor,
+    reset_mc_task_executor,
+)
+
+# Output the mock agent "produces" — text that satisfies the criteria below.
+# The deterministic verifier passes a criterion when every content word of it
+# appears in the result, so this output is crafted to MEET both criteria.
+_SUCCESS_OUTPUT = (
+    "Produced a list of overdue invoices, each 30+ days past due. "
+    "Every row carries an amount and a customer email address."
+)
+_SUCCESS_CRITERIA = [
+    "A list of invoices each 30+ days past due is produced",
+    "Every row has an amount and a customer email",
+]
+
+
+@pytest.fixture
+def svl_singletons(temp_store_path):
+    """Reset MC singletons and wire them all to a shared temp store.
+
+    The executor reaches the store via the module singletons (not the
+    intake ``manager`` fixture), so the verify-on-completion tests inject the
+    store the same way ``test_mission_control_executor.py`` does.
+    """
+    reset_mission_control_store()
+    reset_mission_control_manager()
+    reset_mc_task_executor()
+
+    test_store = FileMissionControlStore(temp_store_path)
+    store_module._store_instance = test_store
+
+    yield test_store
+
+    reset_mission_control_store()
+    reset_mission_control_manager()
+    reset_mc_task_executor()
+
+
+def _svl_mock_router():
+    """A mock AgentRouter that yields the success output then 'done'."""
+
+    async def mock_run(prompt):  # noqa: ARG001
+        yield AgentEvent(type="message", content=_SUCCESS_OUTPUT)
+        yield AgentEvent(type="done", content="")
+        await asyncio.sleep(0)
+
+    router = MagicMock()
+    router.run = mock_run
+    router.stop = AsyncMock()
+    return router
+
+
+def _settings_with_verify(enabled: bool):
+    """A Settings copy with the verify-loop flag forced to ``enabled``."""
+    return get_settings().model_copy(update={"deep_work_verify_loop_enabled": enabled})
+
+
+class TestVerifyOnCompletion:
+    """SVL-1: a completing task is stamped with its outcome verdict when the
+    Self-Verifying-Loop flag is on, and left untouched when it is off."""
+
+    async def _run_one_task(self, svl_singletons, *, verify_enabled: bool):
+        """Create an agent + a task with success_criteria, run it to
+        completion through the executor with the flag set, and return the
+        reloaded task."""
+        from pocketpaw.mission_control import get_mission_control_manager
+
+        manager = get_mission_control_manager()
+        executor = get_mc_task_executor()
+
+        agent = await manager.create_agent(
+            name="FinanceBot",
+            role="Finance Assistant",
+            description="Chases overdue invoices",
+            backend="claude_agent_sdk",
+        )
+        task = await manager.create_task(
+            title="Pull the list of overdue invoices",
+            description="Query accounting for invoices 30+ days overdue",
+            priority=TaskPriority.HIGH,
+        )
+        # Stamp the intake success_criteria the planner would have captured.
+        task.metadata["success_criteria"] = list(_SUCCESS_CRITERIA)
+        await manager.save_task(task)
+        await manager.assign_task(task.id, [agent.id])
+
+        mock_router = _svl_mock_router()
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=mock_router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=_settings_with_verify(verify_enabled),
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            result = await executor.execute_task(task.id, agent.id)
+
+        assert result["status"] == "completed"
+        reloaded = await manager.get_task(task.id)
+        assert reloaded is not None
+        return reloaded
+
+    @pytest.mark.asyncio
+    async def test_flag_on_stamps_verdict_matching_direct_verify(self, svl_singletons):
+        """With the flag enabled, a successfully-completing task whose criteria
+        are met carries a ``verify_verdict`` whose status matches a direct
+        ``verify_outcome`` call on the same output + criteria."""
+        task = await self._run_one_task(svl_singletons, verify_enabled=True)
+
+        # Task still completed normally — status is DONE, not changed by verify.
+        assert task.status == TaskStatus.DONE
+
+        verdict = task.metadata.get("verify_verdict")
+        assert verdict is not None, "verify_verdict was not stamped with the flag on"
+
+        # The stamped verdict matches an independent verify_outcome call.
+        expected = verify_outcome(task.output, _SUCCESS_CRITERIA)
+        assert verdict["status"] == expected.status.value
+        # Criteria met → SOLVED.
+        assert verdict["status"] == "solved"
+
+    @pytest.mark.asyncio
+    async def test_flag_off_leaves_no_verdict_and_unchanged_behaviour(self, svl_singletons):
+        """With the flag off (default), no verdict is stamped and the task
+        completes exactly as before — status DONE, output intact."""
+        task = await self._run_one_task(svl_singletons, verify_enabled=False)
+
+        assert task.status == TaskStatus.DONE
+        assert task.output and "overdue invoices" in task.output
+        assert "verify_verdict" not in task.metadata

--- a/tests/test_deep_work_e2e.py
+++ b/tests/test_deep_work_e2e.py
@@ -510,3 +510,325 @@ class TestVerifyOnCompletion:
         assert task.status == TaskStatus.DONE
         assert task.output and "overdue invoices" in task.output
         assert "verify_verdict" not in task.metadata
+
+
+# ---------------------------------------------------------------------------
+# SVL-2: requeue loop with diagnostic feedback + budget
+# ---------------------------------------------------------------------------
+
+# Output that DOES NOT satisfy either criterion in _SUCCESS_CRITERIA — the
+# deterministic verifier needs every content token of a criterion to appear in
+# the result, so a result about something unrelated yields NOT_SOLVED.
+_FAILING_OUTPUT = "I looked into the request but could not find the data needed."
+
+
+def _svl_failing_router():
+    """A mock AgentRouter whose output FAILS the success criteria every time."""
+
+    async def mock_run(prompt):  # noqa: ARG001
+        yield AgentEvent(type="message", content=_FAILING_OUTPUT)
+        yield AgentEvent(type="done", content="")
+        await asyncio.sleep(0)
+
+    router = MagicMock()
+    router.run = mock_run
+    router.stop = AsyncMock()
+    return router
+
+
+def _svl_converging_router(fail_times: int, *, captured_prompts: list[str] | None = None):
+    """A mock AgentRouter that FAILS its criteria ``fail_times`` times, then
+    succeeds — to prove the loop converges once the agent finally satisfies the
+    criteria. Optionally records each prompt it was handed so a test can assert
+    the rejection feedback was injected on the requeue."""
+    state = {"calls": 0}
+
+    async def mock_run(prompt):
+        if captured_prompts is not None:
+            captured_prompts.append(prompt)
+        state["calls"] += 1
+        content = _FAILING_OUTPUT if state["calls"] <= fail_times else _SUCCESS_OUTPUT
+        yield AgentEvent(type="message", content=content)
+        yield AgentEvent(type="done", content="")
+        await asyncio.sleep(0)
+
+    router = MagicMock()
+    router.run = mock_run
+    router.stop = AsyncMock()
+    return router
+
+
+def _settings_with_verify_budget(enabled: bool, max_requeues: int):
+    """A Settings copy with the verify-loop flag and requeue budget forced."""
+    return get_settings().model_copy(
+        update={
+            "deep_work_verify_loop_enabled": enabled,
+            "deep_work_verify_max_requeues": max_requeues,
+        }
+    )
+
+
+class TestVerifyRequeueLoop:
+    """SVL-2: a completed task whose result does NOT meet its success_criteria
+    is requeued with the specific unmet criteria fed back, bounded by
+    ``deep_work_verify_max_requeues``, then escalated to BLOCKED."""
+
+    async def _make_agent_and_task(self):
+        from pocketpaw.mission_control import get_mission_control_manager
+
+        manager = get_mission_control_manager()
+        agent = await manager.create_agent(
+            name="FinanceBot",
+            role="Finance Assistant",
+            description="Chases overdue invoices",
+            backend="claude_agent_sdk",
+        )
+        task = await manager.create_task(
+            title="Pull the list of overdue invoices",
+            description="Query accounting for invoices 30+ days overdue",
+            priority=TaskPriority.HIGH,
+        )
+        task.metadata["success_criteria"] = list(_SUCCESS_CRITERIA)
+        await manager.save_task(task)
+        await manager.assign_task(task.id, [agent.id])
+        return manager, agent, task
+
+    async def _run_once(self, executor, task_id, agent_id, mock_router, settings):
+        """Run a single execute_task pass with the verify settings patched.
+
+        Mirrors exactly what the production re-dispatch
+        (``execute_task_background`` → ``execute_task``) invokes, but driven
+        synchronously so transitions can be asserted step by step."""
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=mock_router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=settings,
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            return await executor.execute_task(task_id, agent_id)
+
+    @pytest.mark.asyncio
+    async def test_failing_task_requeues_then_escalates_to_blocked(self, svl_singletons):
+        """A task whose output never meets its criteria is requeued at most
+        ``deep_work_verify_max_requeues`` times (each requeue back to ASSIGNED),
+        then lands BLOCKED with the escalation reason stamped. The verify
+        counter is separate from the error retry_count."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        max_requeues = 2
+        settings = _settings_with_verify_budget(True, max_requeues)
+        router = _svl_failing_router()
+
+        # First two passes requeue (status back to ASSIGNED), counter climbs.
+        for expected_n in (1, 2):
+            await self._run_once(executor, task.id, agent.id, router, settings)
+            reloaded = await manager.get_task(task.id)
+            assert reloaded.status == TaskStatus.ASSIGNED, (
+                f"pass {expected_n} should requeue to ASSIGNED, got {reloaded.status}"
+            )
+            assert reloaded.metadata["verify_requeue_count"] == expected_n
+            # Verify counter must NOT bleed into the error retry_count.
+            assert reloaded.retry_count == 0
+            assert "verify_escalation_reason" not in reloaded.metadata
+
+        # Third pass: budget exhausted → BLOCKED + reason stamped.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        blocked = await manager.get_task(task.id)
+        assert blocked.status == TaskStatus.BLOCKED
+        assert blocked.metadata["verify_escalation_reason"] == "budget_exhausted"
+        # Bounded: never exceeded the budget.
+        assert blocked.metadata["verify_requeue_count"] == max_requeues
+        # Cumulative feedback records every rejected attempt.
+        feedback = blocked.metadata["verify_feedback"]
+        assert len(feedback) == max_requeues
+        # The error retry path was never touched.
+        assert blocked.retry_count == 0
+
+    @pytest.mark.asyncio
+    async def test_escalation_does_not_mark_done_or_save_deliverable(self, svl_singletons):
+        """The whole point of the loop is "don't mark failing work as done". A
+        budget-exhausted escalation must NOT log a TASK_COMPLETED activity and
+        must NOT save the rejected output as a deliverable — it must instead log
+        a needs-review escalation activity."""
+        from pocketpaw.mission_control import ActivityType
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        max_requeues = 1  # exhaust quickly: one requeue, then escalate
+        settings = _settings_with_verify_budget(True, max_requeues)
+        router = _svl_failing_router()
+
+        # Spy on the deliverable save across every pass — it must never fire for
+        # this task, since the output never passes its criteria.
+        with patch.object(executor, "_save_task_deliverable", new=AsyncMock()) as deliverable_spy:
+            # Pass 1: requeue. Pass 2: budget (1) exhausted → escalate to BLOCKED.
+            await self._run_once(executor, task.id, agent.id, router, settings)
+            await self._run_once(executor, task.id, agent.id, router, settings)
+
+        blocked = await manager.get_task(task.id)
+        assert blocked.status == TaskStatus.BLOCKED
+        assert blocked.metadata["verify_escalation_reason"] == "budget_exhausted"
+
+        # The failing output was NEVER saved as a deliverable.
+        deliverable_spy.assert_not_called()
+        # And no DELIVERABLE document exists for the task.
+        docs = await manager.get_task_documents(task.id)
+        assert docs == [] or all(d.type.value != "deliverable" for d in docs)
+
+        # No TASK_COMPLETED activity was logged for this task; an escalation
+        # (TASK_UPDATED, "escalated ... needs review") was.
+        feed = await manager.get_activity_feed(limit=100)
+        task_activities = [a for a in feed if a.task_id == task.id]
+        assert all(a.type != ActivityType.TASK_COMPLETED for a in task_activities), (
+            "an escalated task must not log a TASK_COMPLETED activity"
+        )
+        escalations = [
+            a
+            for a in task_activities
+            if a.type == ActivityType.TASK_UPDATED and "escalated" in a.message
+        ]
+        assert escalations, "expected a needs-review escalation activity"
+        assert "needs review" in escalations[0].message
+
+    @pytest.mark.asyncio
+    async def test_requeue_prompt_carries_the_unmet_criteria(self, svl_singletons):
+        """The rebuilt prompt for a requeued attempt names the SPECIFIC unmet
+        criteria so the re-dispatched agent sees exactly what to fix."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(True, 2)
+
+        captured: list[str] = []
+        router = _svl_converging_router(fail_times=99, captured_prompts=captured)
+
+        # First pass fails → requeue. Second pass rebuilds the prompt.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        await self._run_once(executor, task.id, agent.id, router, settings)
+
+        # The first prompt had no rejection section; the second one does.
+        assert "Why the last attempt was rejected" not in captured[0]
+        second = captured[1]
+        assert "Why the last attempt was rejected" in second
+        # The specific unmet criteria text appears in the feedback section.
+        for criterion in _SUCCESS_CRITERIA:
+            assert criterion in second
+
+    @pytest.mark.asyncio
+    async def test_loop_converges_when_agent_finally_succeeds(self, svl_singletons):
+        """If the agent fails once then produces a passing result on the
+        requeue, the task converges to DONE within budget — no escalation."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(True, 2)
+        router = _svl_converging_router(fail_times=1)
+
+        # Pass 1: fails → requeue to ASSIGNED.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        mid = await manager.get_task(task.id)
+        assert mid.status == TaskStatus.ASSIGNED
+        assert mid.metadata["verify_requeue_count"] == 1
+
+        # Pass 2: now passes → DONE, no escalation, counter unchanged.
+        await self._run_once(executor, task.id, agent.id, router, settings)
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert done.metadata["verify_verdict"]["status"] == "solved"
+        assert "verify_escalation_reason" not in done.metadata
+        assert done.metadata["verify_requeue_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_solved_task_goes_straight_to_done_no_requeue(self, svl_singletons):
+        """A passing (SOLVED) result is NEVER requeued or mutated: status DONE,
+        no requeue counter, no feedback, no escalation."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(True, 2)
+        router = _svl_mock_router()  # always emits the passing output
+
+        result = await self._run_once(executor, task.id, agent.id, router, settings)
+        assert result["status"] == "completed"
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert done.metadata["verify_verdict"]["status"] == "solved"
+        assert done.metadata.get("verify_requeue_count", 0) == 0
+        assert "verify_feedback" not in done.metadata
+        assert "verify_escalation_reason" not in done.metadata
+
+    @pytest.mark.asyncio
+    async def test_flag_off_never_requeues_a_failing_task(self, svl_singletons):
+        """With the flag OFF a failing result completes DONE exactly as before —
+        no verdict, no requeue, no escalation. SVL-2 is fully inert."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        settings = _settings_with_verify_budget(False, 2)
+        router = _svl_failing_router()
+
+        result = await self._run_once(executor, task.id, agent.id, router, settings)
+        assert result["status"] == "completed"
+
+        done = await manager.get_task(task.id)
+        assert done.status == TaskStatus.DONE
+        assert "verify_verdict" not in done.metadata
+        assert "verify_requeue_count" not in done.metadata
+        assert "verify_feedback" not in done.metadata
+        assert "verify_escalation_reason" not in done.metadata
+
+    @pytest.mark.asyncio
+    async def test_real_redispatch_chain_auto_requeues_to_blocked(self, svl_singletons):
+        """End-to-end through the REAL re-dispatch path: launch via
+        ``execute_task_background`` and let the production
+        ``asyncio.create_task`` chain run. The loop must auto-requeue itself and
+        settle on BLOCKED without the test driving each pass."""
+
+        manager, agent, task = await self._make_agent_and_task()
+        executor = get_mc_task_executor()
+        max_requeues = 2
+        settings = _settings_with_verify_budget(True, max_requeues)
+        router = _svl_failing_router()
+
+        with (
+            patch(
+                "pocketpaw.mission_control.executor.AgentRouter",
+                return_value=router,
+            ),
+            patch(
+                "pocketpaw.mission_control.executor.get_settings",
+                return_value=settings,
+            ),
+            patch("pocketpaw.mission_control.executor.get_message_bus") as mock_bus,
+        ):
+            mock_bus.return_value.publish_system = AsyncMock()
+            launched = await executor.execute_task_background(task.id, agent.id)
+            assert launched is True
+
+            # Poll until the self-requeuing chain settles on a terminal state.
+            for _ in range(200):
+                await asyncio.sleep(0.02)
+                current = await manager.get_task(task.id)
+                if (
+                    current.status == TaskStatus.BLOCKED
+                    and current.id not in executor._running_tasks
+                ):
+                    break
+            else:  # pragma: no cover - only hit if the loop never settles
+                pytest.fail(
+                    f"requeue chain did not settle; last status={current.status}, "
+                    f"requeues={current.metadata.get('verify_requeue_count')}"
+                )
+
+        settled = await manager.get_task(task.id)
+        assert settled.status == TaskStatus.BLOCKED
+        assert settled.metadata["verify_escalation_reason"] == "budget_exhausted"
+        assert settled.metadata["verify_requeue_count"] == max_requeues

--- a/tests/test_deep_work_scheduler.py
+++ b/tests/test_deep_work_scheduler.py
@@ -1,5 +1,9 @@
 # Tests for Deep Work Dependency Scheduler
 # Created: 2026-02-12
+# Updated: 2026-06-23 (feat/svl-1-verify-stamp) — _make_task now accepts
+#   ``output`` and ``success_criteria`` kwargs so Self-Verifying-Loop tests
+#   (SVL-1 and later slices) can construct completed tasks carrying a result
+#   and their intake criteria.
 #
 # Covers:
 # - get_ready_tasks: blockers satisfied, excludes running tasks
@@ -64,8 +68,19 @@ def _make_task(
     task_type: str = "agent",
     assignee_ids: list[str] | None = None,
     title: str = "",
+    output: str | None = None,
+    success_criteria: list[str] | None = None,
 ) -> Task:
-    """Helper to create a Task with specific fields."""
+    """Helper to create a Task with specific fields.
+
+    ``output`` and ``success_criteria`` let Self-Verifying-Loop tests build a
+    completed task with a result and its intake criteria. ``success_criteria``
+    rides on ``metadata`` (the same key the planner stamps at intake), so the
+    verifier can be exercised against a constructed task.
+    """
+    metadata: dict = {}
+    if success_criteria is not None:
+        metadata["success_criteria"] = success_criteria
     return Task(
         id=task_id,
         title=title or f"Task {task_id}",
@@ -74,6 +89,8 @@ def _make_task(
         blocked_by=blocked_by or [],
         task_type=task_type,
         assignee_ids=assignee_ids or [],
+        output=output,
+        metadata=metadata,
     )
 
 


### PR DESCRIPTION
## What this does

Builds on #1539. Adds a no-progress / oscillation guard to the verify loop. When a task keeps failing the same success criteria, or its unmet set stops shrinking, it is escalated to BLOCKED early instead of burning the whole requeue budget circling a dead end. A task that is making progress (strictly shrinking unmet set) keeps requeuing normally.

Stacked on #1539. The flag defaults to off.

## Why

A fixed retry budget alone is not enough. The literature on self-correcting loops shows naive "feed the error back and retry" often converges to the same wrong fix or oscillates between two failure modes, spending the whole budget on a loop that will not converge. Detecting non-progress and escalating early is the field-recommended guard.

## How it works

- Before the budget-bounded requeue decision, the current attempt's unmet-criteria set is compared to the previous attempt's.
- No progress means the same criteria still failing, or the unmet count not shrinking. That escalates to BLOCKED with `verify_escalation_reason="no_progress"` (the same BLOCKED status and escalation path as budget exhaustion, distinguished only by the reason).
- A strictly shrinking unmet set falls through to the unchanged requeue logic.
- The escalation activity and `mc_task_blocked` broadcast now report the actual cause (no_progress vs budget_exhausted).

## Scope

- `mission_control/executor.py`: the no-progress comparison plus reason-aware escalation.
- Tests: same-failure escalates before budget; escalation reports its reason; a progressing task (2 unmet -> 1 -> solved) is not escalated early. The SVL-2 budget tests were updated to use a genuinely-progressing-but-never-solving scenario, since identical output now correctly trips the no-progress guard first.

## Verification

`uv run pytest tests/test_deep_work_e2e.py tests/test_mission_control_executor.py tests/test_deep_work_v2.py tests/test_deep_work_scheduler.py` -> 137 passed. Ruff clean.

## Out of scope

LLM-judge and source-trace verifiers, criticality tags, and per-project budget.