### PR TITLE
fix(soul): include PROCEDURAL memories in bootstrap auto-recall (SVL-4)

### DIFF
--- a/src/pocketpaw/soul/_bridge.py
+++ b/src/pocketpaw/soul/_bridge.py
@@ -2,6 +2,14 @@
 # Created: 2026-03-02
 # SoulBootstrapProvider implements BootstrapProviderProtocol.
 # SoulBridge provides high-level observe/recall for the agent loop.
+#
+# Changelog:
+# 2026-06-24 (SVL-4): get_context auto-recall now includes PROCEDURAL memories
+#   alongside SEMANTIC. Minted correction-rules (CorrectionSoulBridge stores
+#   them as PROCEDURAL) and session-learned procedural how-tos were previously
+#   structurally excluded from the bootstrap system-prompt injection — they
+#   only surfaced when the agent voluntarily called a recall tool. They now
+#   auto-recall into the bootstrap knowledge context.
 
 from __future__ import annotations
 
@@ -80,21 +88,24 @@ class SoulBootstrapProvider:
             except Exception:
                 pass
 
-        # Cross-session soul memory — inject general semantic facts the soul has
-        # learned so the agent carries persistent context across chat sessions.
+        # Cross-session soul memory — inject general semantic facts AND
+        # procedural rules the soul has learned so the agent carries persistent
+        # context across chat sessions. PROCEDURAL covers minted
+        # correction-rules (CorrectionSoulBridge) and session-learned how-tos,
+        # which were previously excluded from bootstrap injection.
         try:
             from soul_protocol import MemoryType
 
-            semantic_memories = await soul.recall(
+            recalled_memories = await soul.recall(
                 query="",
-                types=[MemoryType.SEMANTIC],
+                types=[MemoryType.SEMANTIC, MemoryType.PROCEDURAL],
                 limit=5,
             )
-            if semantic_memories:
-                for m in semantic_memories:
+            if recalled_memories:
+                for m in recalled_memories:
                     knowledge.append(f"[{m.type.value}] {m.content}")
         except Exception:
-            logger.debug("Soul semantic recall failed for bootstrap context", exc_info=True)
+            logger.debug("Soul memory recall failed for bootstrap context", exc_info=True)
 
         return BootstrapContext(
             name=soul.name if hasattr(soul, "name") else "Paw",

--- a/tests/test_soul_integration.py
+++ b/tests/test_soul_integration.py
@@ -138,3 +138,127 @@ class TestSoulIntegration:
         assert (tmp_path / "corrupt.soul.corrupt").exists()
 
         _reset_manager()
+
+    async def test_bootstrap_recall_requests_procedural_and_semantic(self):
+        """SVL-4: the bootstrap auto-recall must request BOTH SEMANTIC and
+        PROCEDURAL memory types, and surface whatever recall returns into the
+        knowledge context.
+
+        Minted correction-rules (CorrectionSoulBridge writes them as
+        ``type="procedural"`` → ``MemoryType.PROCEDURAL``) and session-learned
+        how-tos were previously excluded by a ``types=[SEMANTIC]``-only filter,
+        so they could never reach the bootstrap system prompt.
+
+        This test drives the seam deterministically by stubbing ``soul.recall``:
+        it asserts (1) PROCEDURAL is now in the requested ``types`` set, and
+        (2) a returned PROCEDURAL entry's content surfaces in ``ctx.knowledge``
+        alongside a SEMANTIC one (no regression). It does NOT depend on the
+        underlying store's relevance scoring — see
+        ``test_bootstrap_empty_query_recall_is_inert`` for the separate,
+        pre-existing limitation that the empty query returns nothing from the
+        real BM25 store.
+        """
+        from unittest.mock import AsyncMock
+
+        from soul_protocol import MemoryEntry, MemoryType, Soul
+
+        from pocketpaw.soul import SoulBootstrapProvider
+
+        soul = await Soul.birth(
+            name="RecallFilterTest",
+            archetype="Test Agent",
+            persona="I am a test agent.",
+        )
+
+        semantic_entry = MemoryEntry(
+            type=MemoryType.SEMANTIC,
+            content="The user's company is named Acme Corp.",
+            importance=8,
+        )
+        procedural_entry = MemoryEntry(
+            type=MemoryType.PROCEDURAL,
+            content="Always greet the user by their first name.",
+            importance=7,
+        )
+
+        recall_mock = AsyncMock(return_value=[semantic_entry, procedural_entry])
+        soul.recall = recall_mock  # type: ignore[method-assign]
+
+        provider = SoulBootstrapProvider(soul)
+        ctx = await provider.get_context()
+
+        # (1) The auto-recall must request PROCEDURAL alongside SEMANTIC.
+        recall_mock.assert_awaited()
+        requested_types = recall_mock.await_args.kwargs["types"]
+        assert MemoryType.PROCEDURAL in requested_types, (
+            "bootstrap recall no longer requests PROCEDURAL memories — "
+            "minted correction-rules would be structurally excluded again"
+        )
+        assert MemoryType.SEMANTIC in requested_types, (
+            "bootstrap recall dropped SEMANTIC memories — regression"
+        )
+
+        # (2) Both surface in the knowledge context.
+        knowledge_blob = "\n".join(ctx.knowledge)
+        assert "Always greet the user by their first name." in knowledge_blob, (
+            "PROCEDURAL memory did not surface in bootstrap context"
+        )
+        assert "The user's company is named Acme Corp." in knowledge_blob, (
+            "SEMANTIC memory did not surface in bootstrap context"
+        )
+
+    async def test_bootstrap_empty_query_recall_is_inert(self):
+        """Documents a pre-existing limitation discovered in SVL-4.
+
+        ``get_context`` recalls with ``query=""``. In soul-protocol 0.4.0 the
+        memory stores are BM25/token-overlap based and only return entries
+        whose relevance score is > 0. An empty query produces zero tokens, so
+        recall returns NOTHING regardless of memory type — the SEMANTIC-only
+        filter was never actually surfacing memories either.
+
+        The SVL-4 ``types`` fix is necessary (PROCEDURAL is no longer excluded)
+        but not sufficient on its own: until the empty-query path is addressed
+        (a captain-scoped change to the query/retrieval strategy), neither
+        SEMANTIC nor PROCEDURAL memories reach the bootstrap from the real
+        store. This test locks in that observed behavior so a future fix that
+        makes the empty query return results will flip it and prompt a review.
+        """
+        from soul_protocol import MemoryType, Soul
+
+        soul = await Soul.birth(
+            name="EmptyQueryProbe",
+            archetype="Test Agent",
+            persona="I am a test agent.",
+        )
+        await soul.remember(
+            "The user's company is named Acme Corp.",
+            type=MemoryType.SEMANTIC,
+            importance=8,
+        )
+        await soul.remember(
+            "Always greet the user by their first name.",
+            type=MemoryType.PROCEDURAL,
+            importance=7,
+        )
+
+        # Empty query == the literal call get_context makes today.
+        empty = await soul.recall(
+            query="",
+            types=[MemoryType.SEMANTIC, MemoryType.PROCEDURAL],
+            limit=5,
+        )
+        assert empty == [], (
+            "empty-query recall now returns results — the SVL-4 follow-up "
+            "(non-empty bootstrap query) may have landed; revisit get_context"
+        )
+
+        # A token-bearing query DOES surface both, confirming the data is there
+        # and only the empty query is the blocker.
+        hit = await soul.recall(
+            query="company greet user",
+            types=[MemoryType.SEMANTIC, MemoryType.PROCEDURAL],
+            limit=5,
+        )
+        contents = {m.content for m in hit}
+        assert "The user's company is named Acme Corp." in contents
+        assert "Always greet the user by their first name." in contents


### PR DESCRIPTION
## What this does

The bootstrap auto-recall in `SoulBootstrapProvider.get_context` recalled only SEMANTIC memories. Minted correction-rules (`CorrectionSoulBridge` stores them as PROCEDURAL) and session-learned procedural how-tos were structurally excluded from the bootstrap system-prompt injection. This adds PROCEDURAL to the recall type filter so those memories are no longer excluded by type.

## Important: this is a prerequisite, not a complete fix

While testing, I found the same `get_context` recall calls `soul.recall(query="", ...)` — an empty query. In soul-protocol 0.4.0 the memory stores are BM25/token-overlap and only return entries with a relevance score above zero, so an empty query returns nothing regardless of type. That means:

- the original SEMANTIC-only recall was already a latent no-op against the real store, and
- this type-filter fix is necessary but inert on its own until the empty-query path is addressed.

Choosing how the bootstrap should retrieve (importance-ordered listing, a synthetic query, or a soul-protocol API change) is a design decision that overlaps with the retrieval-layer work, so it is left as a follow-up. The added test `test_bootstrap_empty_query_recall_is_inert` locks in the current behavior so a future fix flips it and prompts review.

## Scope

- `soul/_bridge.py`: add `MemoryType.PROCEDURAL` to the `get_context` recall type filter.
- Tests: a stubbed-recall test proving PROCEDURAL is now requested alongside SEMANTIC; a test documenting the empty-query inertness.

## Verification

Bridge tests: 3 passed. Full soul suite: 140 passed, 1 skipped. Ruff clean.

## Follow-up

Make the bootstrap recall actually return memories on an empty query (importance-ordered listing or a synthetic query). Overlaps the retrieval-layer candidate; tracked for a separate change.