### PR TITLE
Billing and credit subsystem: wallet, subscriptions, per-site plans

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -197,6 +197,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.chat.router import router as chat_router
     from pocketpaw_ee.cloud.chat.runs.router import router as runs_router
     from pocketpaw_ee.cloud.connectors.router import router as connectors_router
+    from pocketpaw_ee.cloud.credits.router import router as credits_router
     from pocketpaw_ee.cloud.cycles.router import router as cycles_router
     from pocketpaw_ee.cloud.foresight.router import router as foresight_router
     from pocketpaw_ee.cloud.jobs.router import router as jobs_router
@@ -223,6 +224,10 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(chat_router, prefix="/api/v1")
     app.include_router(runs_router, prefix="/api/v1")
     app.include_router(connectors_router, prefix="/api/v1")
+    # Credit ledger (BC-1) — the workspace-scoped wallet read surface
+    # (GET /credits/balance, GET /credits/history). Grant / debit are
+    # in-process only (the billing subsystem calls the service directly).
+    app.include_router(credits_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")
     # Pocket chat — agent-driven pocket creation SSE stream (POST /pockets/chat).
     app.include_router(pocket_chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-06-24 (integration/billing-credits, BC-2) — Mounts the Billing
+    Gateway primitive: the authenticated ``/billing/topup`` router (Dodo hosted
+    checkout) and, SEPARATELY with NO auth dependency, the public
+    ``/billing/webhooks/dodo`` router (Standard-Webhooks-signed; verified before
+    the payload is trusted, then grants credits exactly once via BC-1).
 Modified: 2026-06-20 (feat/workspace-jobs, pp#1459) — Mounts the workspace-jobs
     status router (``GET /workspaces/{ws}/jobs/{job_id}``) and registers the
     built-in jobs into the process-wide registry via ``register_builtins()``
@@ -194,6 +199,8 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.audit.router import router as audit_router
     from pocketpaw_ee.cloud.audit.router import workspace_router as audit_workspace_router
     from pocketpaw_ee.cloud.auth.router import router as auth_router
+    from pocketpaw_ee.cloud.billing.router import router as billing_router
+    from pocketpaw_ee.cloud.billing.webhooks import router as billing_webhooks_router
     from pocketpaw_ee.cloud.chat.router import router as chat_router
     from pocketpaw_ee.cloud.chat.runs.router import router as runs_router
     from pocketpaw_ee.cloud.connectors.router import router as connectors_router
@@ -228,6 +235,12 @@ def mount_cloud(app: FastAPI) -> None:
     # (GET /credits/balance, GET /credits/history). Grant / debit are
     # in-process only (the billing subsystem calls the service directly).
     app.include_router(credits_router, prefix="/api/v1")
+    # Billing (BC-2, the Gateway primitive) — the authenticated top-up surface
+    # (POST /billing/topup → Dodo hosted checkout). The PUBLIC inbound webhook
+    # (POST /billing/webhooks/dodo) is mounted SEPARATELY just below with NO auth
+    # dependency — Dodo is the caller; trust is the Standard-Webhooks signature.
+    app.include_router(billing_router, prefix="/api/v1")
+    app.include_router(billing_webhooks_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")
     # Pocket chat — agent-driven pocket creation SSE stream (POST /pockets/chat).
     app.include_router(pocket_chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,11 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-06-24 (integration/billing-credits, BC-6) — Mounts the
+    Entitlements resolver router (``GET /entitlements`` -> the caller workspace's
+    plan + features + monthly credit allotment). The plan CATALOG read
+    (``GET /billing/plans``) is added to the billing router; both build on the
+    declarative plan catalog (``billing.plans``) over the existing
+    ``PLAN_FEATURES`` / ``Workspace.plan`` tiers.
 Modified: 2026-06-24 (integration/billing-credits, BC-2) — Mounts the Billing
     Gateway primitive: the authenticated ``/billing/topup`` router (Dodo hosted
     checkout) and, SEPARATELY with NO auth dependency, the public
@@ -206,6 +212,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.connectors.router import router as connectors_router
     from pocketpaw_ee.cloud.credits.router import router as credits_router
     from pocketpaw_ee.cloud.cycles.router import router as cycles_router
+    from pocketpaw_ee.cloud.entitlements.router import router as entitlements_router
     from pocketpaw_ee.cloud.foresight.router import router as foresight_router
     from pocketpaw_ee.cloud.jobs.router import router as jobs_router
     from pocketpaw_ee.cloud.license import get_license_info
@@ -241,6 +248,11 @@ def mount_cloud(app: FastAPI) -> None:
     # dependency — Dodo is the caller; trust is the Standard-Webhooks signature.
     app.include_router(billing_router, prefix="/api/v1")
     app.include_router(billing_webhooks_router, prefix="/api/v1")
+    # Entitlements (BC-6, the Entitlement primitive) — the workspace-scoped
+    # resolver (GET /entitlements -> the workspace's plan + features + monthly
+    # credit allotment). The plan CATALOG read (GET /billing/plans) is on the
+    # billing router above; this router carries only the per-workspace resolve.
+    app.include_router(entitlements_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")
     # Pocket chat — agent-driven pocket creation SSE stream (POST /pockets/chat).
     app.include_router(pocket_chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -66,6 +66,17 @@ class SeatLimitError(CloudError):
         super().__init__(402, "billing.seat_limit", f"Seat limit of {seats} reached")
 
 
+class InsufficientCredits(CloudError):
+    """Credit wallet has too few credits for the requested debit (402)."""
+
+    def __init__(self, requested: int, available: int) -> None:
+        super().__init__(
+            402,
+            "credits.insufficient",
+            f"Insufficient credits: requested {requested}, available {available}",
+        )
+
+
 class RateLimited(CloudError):
     """Rate limit exceeded (429)."""
 
@@ -96,6 +107,7 @@ __all__ = [
     "CloudError",
     "ConflictError",
     "Forbidden",
+    "InsufficientCredits",
     "Internal",
     "NotFound",
     "RateLimited",

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -59,6 +59,19 @@ class ValidationError(CloudError):
         super().__init__(422, code, message)
 
 
+class BadRequest(CloudError):
+    """Malformed / untrusted request (400).
+
+    Distinct from ``ValidationError`` (422, a well-formed request that fails a
+    field-level rule): a 400 is for a request that can't be trusted at all — a
+    webhook whose signature doesn't verify, a body that isn't parseable. Used by
+    the billing webhook so an unverifiable Dodo delivery returns 400, not 422.
+    """
+
+    def __init__(self, code: str, message: str = "Bad request") -> None:
+        super().__init__(400, code, message)
+
+
 class SeatLimitError(CloudError):
     """Seat/billing limit reached (402)."""
 
@@ -104,6 +117,7 @@ def with_cause(error: CloudError, cause: BaseException) -> CloudError:
 
 
 __all__ = [
+    "BadRequest",
     "CloudError",
     "ConflictError",
     "Forbidden",

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -480,6 +480,18 @@ class BillingTopupCaptured(Event):
     EVENT_TYPE: ClassVar[str] = "billing.topup.captured"
 
 
+# Billing — subscription renewal grant (BC-7, the Subscription primitive).
+# Emitted by ``billing.service`` after a VERIFIED ``subscription.active`` /
+# ``subscription.renewed`` webhook drove a credit grant of the tier's monthly
+# allotment. The grant is ADDITIVE (unused credits roll over), keyed on the
+# per-renewal webhook event id. data: {workspace_id, gateway, event_id,
+# plan_key, subscription_id, amount_credits, balance_after}. Fires once per
+# delivery (a replayed renewal is a no-op grant, so it does NOT re-emit).
+@dataclass
+class BillingSubscriptionGranted(Event):
+    EVENT_TYPE: ClassVar[str] = "billing.subscription.granted"
+
+
 # Tasks (Mission Control work-item primitive)
 @dataclass
 class TaskProposed(Event):

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -492,6 +492,17 @@ class BillingSubscriptionGranted(Event):
     EVENT_TYPE: ClassVar[str] = "billing.subscription.granted"
 
 
+# Sites — a pocket was published as a live Paw Site on a per-site annual plan
+# (BC-9, the per-site plan layer). Emitted by ``sites.service.publish_pocket``
+# after the Site doc is inserted/upserted with its ``plan_tier`` stamped. Fires
+# once per publish. data: {workspace_id, site_id, pocket_id, owner, plan_tier}.
+# Listeners (billing dashboard, site-plan analytics, BC-10 Cloudflare
+# provisioner) key off this to react to a new published site at a tier.
+@dataclass
+class SitePublished(Event):
+    EVENT_TYPE: ClassVar[str] = "site.published"
+
+
 # Tasks (Mission Control work-item primitive)
 @dataclass
 class TaskProposed(Event):

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -451,6 +451,25 @@ class WorkspaceJobUpdated(Event):
     EVENT_TYPE: ClassVar[str] = "workspace_job.updated"
 
 
+# Credit ledger (BC-1, the Ledger primitive). Emitted by
+# ``credits.service`` after EVERY successful grant / debit on a workspace's
+# credit wallet (EE cloud rule 9 — emit on every write). A no-op idempotent
+# replay does NOT re-emit (the movement was already applied + emitted on the
+# first call). Listeners (billing dashboard, low-balance alerts, usage meter)
+# key off this single event per movement.
+#
+# Payload (carried under ``Event.data``):
+#   workspace_id      — tenancy.
+#   kind              — genesis | grant | spend | transfer.
+#   amount_delta      — signed credits this movement applied (+grant / -spend).
+#   balance_after     — the wallet balance once this movement landed.
+#   cause             — business reason (top_up | compute_spend | promo | ...).
+#   idempotency_key   — the caller's exactly-once key for this movement.
+@dataclass
+class CreditMovement(Event):
+    EVENT_TYPE: ClassVar[str] = "credits.movement"
+
+
 # Tasks (Mission Control work-item primitive)
 @dataclass
 class TaskProposed(Event):

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -470,6 +470,16 @@ class CreditMovement(Event):
     EVENT_TYPE: ClassVar[str] = "credits.movement"
 
 
+# Billing — top-up payment captured (BC-2, the Gateway primitive). Emitted by
+# ``billing.service`` after a VERIFIED ``payment.succeeded`` webhook drove a
+# credit grant. data: {workspace_id, gateway, gateway_ref, event_id,
+# amount_credits, currency}. Fires once per delivery (a replayed webhook is a
+# no-op grant, so it does NOT re-emit).
+@dataclass
+class BillingTopupCaptured(Event):
+    EVENT_TYPE: ClassVar[str] = "billing.topup.captured"
+
+
 # Tasks (Mission Control work-item primitive)
 @dataclass
 class TaskProposed(Event):

--- a/ee/pocketpaw_ee/cloud/billing/__init__.py
+++ b/ee/pocketpaw_ee/cloud/billing/__init__.py
@@ -1,0 +1,14 @@
+# ee/pocketpaw_ee/cloud/billing/__init__.py — Billing entity package marker
+# (BC-2, the Gateway primitive). Plain marker — the routers are imported
+# explicitly by ``ee.cloud.__init__:mount_cloud``, not eagerly here, so importing
+# this package never pulls FastAPI / Beanie / the dodopayments SDK.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): a user buys credits.
+# ``service.create_topup`` returns a Dodo HOSTED-CHECKOUT url; a verified
+# ``payment.succeeded`` webhook grants credits EXACTLY ONCE via BC-1's
+# idempotent ``credits.grant``. Dodo is the only gateway in v1, behind the
+# ``providers`` abstraction (Razorpay et al. land later).
+
+"""Billing — Dodo one-time top-up + verified idempotent webhook (Gateway primitive)."""
+
+from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/billing/domain.py
+++ b/ee/pocketpaw_ee/cloud/billing/domain.py
@@ -1,0 +1,53 @@
+# ee/pocketpaw_ee/cloud/billing/domain.py — frozen, framework-free value objects
+# the billing provider abstraction hands back across its boundary (BC-2, the
+# Gateway primitive).
+#
+# These are the normalized shapes EVERY payment provider (Dodo today; Razorpay
+# later) returns, so the service / webhook layer never touches a Dodo-specific
+# SDK type. A provider adapts its SDK's response into these; the rest of the
+# billing subsystem only ever sees these two dataclasses.
+#
+#   * ``OneTimeCheckout`` — what ``create_one_time`` returns: the hosted-checkout
+#     url the user is sent to, plus the gateway's own payment reference.
+#   * ``GatewayEvent``    — a VERIFIED, normalized inbound webhook event. The
+#     signature has already been checked before one of these exists.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class OneTimeCheckout:
+    """A created one-time-payment hosted checkout, normalized across gateways.
+
+    ``checkout_url`` is the hosted page the buyer is redirected to.
+    ``gateway_ref`` is the gateway's own id for the created payment (Dodo's
+    ``payment_id``), kept for reconciliation / support lookups.
+    """
+
+    checkout_url: str
+    gateway_ref: str
+
+
+@dataclass(frozen=True)
+class GatewayEvent:
+    """A VERIFIED, normalized inbound webhook event.
+
+    Only constructed AFTER the provider has verified the signature, so the
+    fields can be trusted. ``event_id`` is the gateway's unique delivery id
+    (Standard Webhooks ``webhook-id``) — it is the idempotency key the credit
+    grant keys on so a replayed delivery grants EXACTLY ONCE. ``amount_credits``
+    is integer credits (1 credit == $0.01); the provider converts the gateway's
+    money amount back to credits. ``raw`` is the parsed event body, retained for
+    audit / debugging (it carries no secret — the secret never enters the body).
+    """
+
+    event_id: str
+    type: str
+    amount_credits: int
+    workspace_id: str
+    currency: str
+    raw: dict = field(default_factory=dict)

--- a/ee/pocketpaw_ee/cloud/billing/domain.py
+++ b/ee/pocketpaw_ee/cloud/billing/domain.py
@@ -1,18 +1,26 @@
 # ee/pocketpaw_ee/cloud/billing/domain.py — frozen, framework-free value objects
 # the billing provider abstraction hands back across its boundary (BC-2, the
-# Gateway primitive).
+# Gateway primitive; BC-7, the Subscription primitive).
 #
 # These are the normalized shapes EVERY payment provider (Dodo today; Razorpay
 # later) returns, so the service / webhook layer never touches a Dodo-specific
 # SDK type. A provider adapts its SDK's response into these; the rest of the
-# billing subsystem only ever sees these two dataclasses.
+# billing subsystem only ever sees these dataclasses.
 #
-#   * ``OneTimeCheckout`` — what ``create_one_time`` returns: the hosted-checkout
-#     url the user is sent to, plus the gateway's own payment reference.
-#   * ``GatewayEvent``    — a VERIFIED, normalized inbound webhook event. The
-#     signature has already been checked before one of these exists.
+#   * ``OneTimeCheckout``      — what ``create_one_time`` returns: the hosted-
+#     checkout url the user is sent to, plus the gateway's own payment reference.
+#   * ``GatewayEvent``         — a VERIFIED, normalized inbound one-time webhook
+#     event. The signature has already been checked before one of these exists.
+#   * ``SubscriptionCheckout`` — what ``create_subscription`` returns: the hosted-
+#     checkout url for a RECURRING checkout, plus the gateway's subscription ref.
+#   * ``SubscriptionEvent``    — a VERIFIED, normalized inbound SUBSCRIPTION
+#     webhook event (active / renewed / cancelled). Carries the tier (plan_key)
+#     and the gateway subscription id so the service can grant the allotment and
+#     update the workspace plan. Like ``GatewayEvent``, only built post-verify.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
+# Updated 2026-06-24 (BC-7): added ``SubscriptionCheckout`` + ``SubscriptionEvent``
+#   for the recurring-subscription flow (subscribe + renewal credit grant).
 
 from __future__ import annotations
 
@@ -50,4 +58,44 @@ class GatewayEvent:
     amount_credits: int
     workspace_id: str
     currency: str
+    raw: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SubscriptionCheckout:
+    """A created RECURRING-subscription hosted checkout, normalized across gateways.
+
+    ``checkout_url`` is the hosted page the buyer is redirected to to confirm the
+    subscription. ``subscription_id`` is the gateway's own id for the created
+    subscription (Dodo's ``subscription_id``), kept so a later cancel / change can
+    address it and so the renewal webhook can be reconciled against it.
+    """
+
+    checkout_url: str
+    subscription_id: str
+
+
+@dataclass(frozen=True)
+class SubscriptionEvent:
+    """A VERIFIED, normalized inbound SUBSCRIPTION webhook event.
+
+    Only constructed AFTER the provider has verified the signature, so the fields
+    can be trusted. ``event_id`` is the gateway's unique delivery id (Standard
+    Webhooks ``webhook-id``) — the idempotency key the per-renewal credit grant
+    keys on, so a REPLAY of one renewal grants nothing while each NEW month's
+    renewal (a fresh delivery id) grants again. ``type`` is the normalized event
+    (``subscription.active`` | ``subscription.renewed`` | ``subscription.cancelled``).
+    ``plan_key`` is the tier pulled from the subscription metadata (the catalog
+    then yields the monthly allotment). ``product_id`` is the gateway's recurring-
+    product id (the reverse-map fallback when metadata lacks ``plan_key``).
+    ``subscription_id`` is the gateway subscription this event belongs to. ``raw``
+    is the parsed body, retained for audit (it carries no secret).
+    """
+
+    event_id: str
+    type: str
+    workspace_id: str
+    plan_key: str
+    product_id: str
+    subscription_id: str
     raw: dict = field(default_factory=dict)

--- a/ee/pocketpaw_ee/cloud/billing/domain.py
+++ b/ee/pocketpaw_ee/cloud/billing/domain.py
@@ -21,6 +21,12 @@
 # Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
 # Updated 2026-06-24 (BC-7): added ``SubscriptionCheckout`` + ``SubscriptionEvent``
 #   for the recurring-subscription flow (subscribe + renewal credit grant).
+# Updated 2026-06-24 (BC-9): added ``site_id`` to ``SubscriptionEvent`` — the
+#   discriminator that tells a PER-SITE annual sub (each published site has its own
+#   plan) from a WORKSPACE-plan sub. The provider populates it from the
+#   subscription metadata's ``site_id`` (stamped at per-site subscribe time); a
+#   workspace-plan sub carries no ``site_id`` (""), so the webhook routes it to the
+#   workspace path. Defaults "" so a BC-7 workspace-plan delivery is unchanged.
 
 from __future__ import annotations
 
@@ -90,6 +96,14 @@ class SubscriptionEvent:
     product id (the reverse-map fallback when metadata lacks ``plan_key``).
     ``subscription_id`` is the gateway subscription this event belongs to. ``raw``
     is the parsed body, retained for audit (it carries no secret).
+
+    ``site_id`` (BC-9) is the discriminator that tells a PER-SITE annual sub (each
+    published site has its OWN plan) from a WORKSPACE-plan sub: a per-site
+    subscribe stamps ``site_id`` on the metadata, a workspace-plan subscribe does
+    not. The webhook routes a delivery WITH a ``site_id`` to the SITE (update the
+    site's subscription_status / renewal date) and a delivery WITHOUT one to the
+    workspace path (grant credits / change the workspace plan). Defaults "" so a
+    BC-7 workspace-plan delivery is unchanged.
     """
 
     event_id: str
@@ -98,4 +112,5 @@ class SubscriptionEvent:
     plan_key: str
     product_id: str
     subscription_id: str
+    site_id: str = ""
     raw: dict = field(default_factory=dict)

--- a/ee/pocketpaw_ee/cloud/billing/dto.py
+++ b/ee/pocketpaw_ee/cloud/billing/dto.py
@@ -10,6 +10,10 @@
 # Updated 2026-06-24 (BC-7): added ``CreateSubscriptionRequest`` /
 #   ``CreateSubscriptionResponse`` for ``POST /billing/subscribe`` — open a
 #   recurring checkout for a plan tier. Same hosted-url-out shape as top-up.
+# Updated 2026-06-24 (S1 review fix): ``CreateTopupRequest.amount_credits`` now
+#   carries an upper bound (``le=1_000_000`` == $10,000). Without a ceiling a
+#   typo'd / hostile amount could open a checkout for an absurd sum; over-ceiling
+#   now 422s at the DTO before the service is reached.
 
 from __future__ import annotations
 
@@ -20,10 +24,16 @@ class CreateTopupRequest(BaseModel):
     """Body of ``POST /billing/topup`` — buy ``amount_credits`` of credits.
 
     ``amount_credits`` is integer credits (1 credit == $0.01); it must be a
-    positive integer. The service validates again at entry (defence in depth).
+    positive integer at or below the ceiling. The service validates again at
+    entry (defence in depth).
     """
 
-    amount_credits: int = Field(..., gt=0, description="Credits to buy (1 credit == $0.01).")
+    amount_credits: int = Field(
+        ...,
+        gt=0,
+        le=1_000_000,
+        description="Credits to buy (1 credit == $0.01). Capped at 1,000,000 credits ($10,000).",
+    )
 
 
 class CreateTopupResponse(BaseModel):

--- a/ee/pocketpaw_ee/cloud/billing/dto.py
+++ b/ee/pocketpaw_ee/cloud/billing/dto.py
@@ -7,6 +7,9 @@
 # the signature is over the exact bytes) and returns a tiny ack envelope.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
+# Updated 2026-06-24 (BC-7): added ``CreateSubscriptionRequest`` /
+#   ``CreateSubscriptionResponse`` for ``POST /billing/subscribe`` — open a
+#   recurring checkout for a plan tier. Same hosted-url-out shape as top-up.
 
 from __future__ import annotations
 
@@ -25,6 +28,23 @@ class CreateTopupRequest(BaseModel):
 
 class CreateTopupResponse(BaseModel):
     """Hosted-checkout url the caller redirects the buyer to."""
+
+    checkout_url: str
+
+
+class CreateSubscriptionRequest(BaseModel):
+    """Body of ``POST /billing/subscribe`` — subscribe to ``plan_key``.
+
+    ``plan_key`` is a plan-catalog tier key (e.g. ``team`` / ``business`` /
+    ``enterprise``). The service validates it against the catalog and resolves the
+    Dodo recurring product before opening a checkout.
+    """
+
+    plan_key: str = Field(..., min_length=1, description="Plan tier key to subscribe to.")
+
+
+class CreateSubscriptionResponse(BaseModel):
+    """Hosted recurring-checkout url the caller redirects the buyer to."""
 
     checkout_url: str
 

--- a/ee/pocketpaw_ee/cloud/billing/dto.py
+++ b/ee/pocketpaw_ee/cloud/billing/dto.py
@@ -1,0 +1,36 @@
+# ee/pocketpaw_ee/cloud/billing/dto.py — request/response schemas for the
+# billing HTTP surface (BC-2, the Gateway primitive).
+#
+# Distinct Request / Response DTOs per the EE cloud rule 4. The authenticated
+# top-up endpoint (POST /billing/topup) takes a credit amount and hands back a
+# hosted-checkout url. The public webhook endpoint reads RAW bytes (no DTO —
+# the signature is over the exact bytes) and returns a tiny ack envelope.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CreateTopupRequest(BaseModel):
+    """Body of ``POST /billing/topup`` — buy ``amount_credits`` of credits.
+
+    ``amount_credits`` is integer credits (1 credit == $0.01); it must be a
+    positive integer. The service validates again at entry (defence in depth).
+    """
+
+    amount_credits: int = Field(..., gt=0, description="Credits to buy (1 credit == $0.01).")
+
+
+class CreateTopupResponse(BaseModel):
+    """Hosted-checkout url the caller redirects the buyer to."""
+
+    checkout_url: str
+
+
+class WebhookAck(BaseModel):
+    """Tiny ack the webhook endpoint returns on a 200."""
+
+    ok: bool = True
+    granted: bool = False

--- a/ee/pocketpaw_ee/cloud/billing/plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/plans.py
@@ -1,0 +1,149 @@
+# ee/pocketpaw_ee/cloud/billing/plans.py — the PLAN CATALOG: the billing/
+# declarative view of the workspace plan tiers (BC-6, the Plan primitive).
+#
+# This is the read-only catalog the subscription (BC-7) and per-site (BC-9)
+# layers build on. For each EXISTING tier in ``guards.abac.PLAN_FEATURES`` it
+# pairs the tier's feature set with its billing facts:
+#   * ``monthly_credit_allotment`` — credits granted per renewal (integer credits,
+#     1 credit == $0.01). Config-tunable constants live below; BC-7 will grant
+#     these on a subscription renewal.
+#   * ``dodo_product_id`` — the Dodo recurring-product id for the tier, or None
+#     until BC-7 / config populates it (optionally read from the
+#     ``POCKETPAW_DODO_PLAN_PRODUCTS`` mapping setting when configured).
+#   * ``features`` — SOURCED FROM ``PLAN_FEATURES`` (referenced, never duplicated)
+#     so there is exactly one source of truth for what a tier unlocks.
+#
+# Read-only by design: no DB, no writes, no emit. ``list_plans`` / ``get_plan``
+# return frozen ``PlanTier`` value objects built fresh from the live
+# ``PLAN_FEATURES`` mapping + the allotment constants, so the catalog can never
+# drift from the policy gate.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-6): new module.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pocketpaw_ee.guards.abac import PLAN_FEATURES
+
+# ---------------------------------------------------------------------------
+# Tunable constants — the monthly credit allotment per tier.
+# ---------------------------------------------------------------------------
+#
+# Integer credits, 1 credit == $0.01 (the same denomination the ledger and Dodo
+# top-ups use). These are the per-renewal grant amounts BC-7 will apply on a
+# subscription cycle. Defaults are deliberately round and modest — a real price
+# sheet tunes them, but the SHAPE (free=0, then a growing ladder) is the
+# contract. Picked so the ladder is obvious: free grants nothing, each paid tier
+# is a clear step up.
+#
+#   free        =      0 credits  ($0)      — no recurring grant
+#   team        = 50_000 credits  ($500)
+#   business    = 200_000 credits ($2,000)
+#   enterprise  = 1_000_000 credits ($10,000)
+_MONTHLY_CREDIT_ALLOTMENT: dict[str, int] = {
+    "free": 0,
+    "team": 50_000,
+    "business": 200_000,
+    "enterprise": 1_000_000,
+}
+
+# Order the catalog is listed in — the price ladder, cheapest first. Any tier in
+# PLAN_FEATURES not named here is appended afterwards (so a new tier never
+# silently drops out of the catalog).
+_TIER_ORDER: tuple[str, ...] = ("free", "team", "business", "enterprise")
+
+
+@dataclass(frozen=True)
+class PlanTier:
+    """One row of the billing plan catalog — the declarative view of a tier.
+
+    ``key`` matches the ``Workspace.plan`` string and the ``PLAN_FEATURES`` key.
+    ``features`` is a copy of the tier's ``PLAN_FEATURES`` set (the source of
+    truth), so a caller can read it without reaching into the policy module.
+    ``monthly_credit_allotment`` is integer credits (1 credit == $0.01) granted
+    per renewal. ``dodo_product_id`` is the recurring-product id, or None until
+    BC-7 / config populates it.
+    """
+
+    key: str
+    monthly_credit_allotment: int
+    dodo_product_id: str | None
+    features: frozenset[str]
+
+
+def _dodo_product_for(key: str) -> str | None:
+    """Resolve the Dodo recurring-product id for a tier, or None.
+
+    Reads an optional ``POCKETPAW_DODO_PLAN_PRODUCTS`` mapping
+    (``{tier_key: product_id}``) off settings when present. None is the correct
+    default in v1 — BC-7 wires recurring checkout and populates this. Lazy
+    ``get_settings`` import so building the catalog never forces config load in
+    a context that doesn't have it (e.g. a unit test of ``list_plans``); any
+    config error degrades safely to None rather than breaking the read.
+    """
+    try:
+        from pocketpaw.config import get_settings
+
+        mapping = getattr(get_settings(), "dodo_plan_products", None)
+    except Exception:
+        return None
+    if not isinstance(mapping, dict):
+        return None
+    val = mapping.get(key)
+    return val if isinstance(val, str) and val else None
+
+
+def _build(key: str) -> PlanTier:
+    """Construct a ``PlanTier`` for ``key`` from the live PLAN_FEATURES + config.
+
+    ``features`` is copied from PLAN_FEATURES (referenced, not duplicated) so the
+    catalog can never drift from the policy gate. An unknown ``key`` yields an
+    empty feature set and a 0 allotment — but callers go through ``get_plan`` /
+    ``list_plans``, which only ever pass known keys.
+    """
+    return PlanTier(
+        key=key,
+        monthly_credit_allotment=_MONTHLY_CREDIT_ALLOTMENT.get(key, 0),
+        dodo_product_id=_dodo_product_for(key),
+        features=frozenset(PLAN_FEATURES.get(key, set())),
+    )
+
+
+def _catalog_keys() -> list[str]:
+    """All tier keys, in ladder order, with any unlisted tiers appended.
+
+    Driven off the LIVE ``PLAN_FEATURES`` keys so a new tier added to the policy
+    module shows up in the catalog automatically (appended after the ordered
+    ones) instead of being silently dropped.
+    """
+    known = list(PLAN_FEATURES.keys())
+    ordered = [k for k in _TIER_ORDER if k in known]
+    extra = [k for k in known if k not in _TIER_ORDER]
+    return ordered + extra
+
+
+def list_plans() -> list[PlanTier]:
+    """Return the full plan catalog, cheapest tier first.
+
+    Each ``PlanTier`` is built fresh from the live ``PLAN_FEATURES`` mapping +
+    the allotment constants, so the catalog always matches the policy gate.
+    """
+    return [_build(key) for key in _catalog_keys()]
+
+
+def get_plan(key: str | None) -> PlanTier | None:
+    """Resolve a single tier by its ``key`` (the ``Workspace.plan`` string).
+
+    Returns None for an unknown / missing key. Callers that need a guaranteed
+    floor (the entitlements resolver) map a None back to the ``free`` base tier
+    themselves — this function does NOT silently substitute, so a typo in a
+    lookup is visible rather than masked.
+    """
+    if not key or key not in PLAN_FEATURES:
+        return None
+    return _build(key)
+
+
+# The base/floor tier key — a workspace with no/unknown plan resolves here.
+BASE_PLAN_KEY = "free"

--- a/ee/pocketpaw_ee/cloud/billing/providers/__init__.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/__init__.py
@@ -1,0 +1,11 @@
+# ee/pocketpaw_ee/cloud/billing/providers/__init__.py — payment-provider
+# abstraction package marker (BC-2, the Gateway primitive).
+#
+# ``base`` defines the ``IPaymentsProvider`` ABC — the ONLY surface the billing
+# service depends on. ``dodo`` is the single v1 implementation. A later gateway
+# (Razorpay) is a new module here plus a one-line factory swap; nothing in the
+# service / webhook / router layer changes.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new package.
+
+from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/billing/providers/base.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/base.py
@@ -1,25 +1,38 @@
 # ee/pocketpaw_ee/cloud/billing/providers/base.py — the payment-provider port
-# (BC-2, the Gateway primitive).
+# (BC-2, the Gateway primitive; BC-7, the Subscription primitive).
 #
-# ``IPaymentsProvider`` is the ABC every gateway implements. It carries ONLY the
-# BC-2 surface — a one-time top-up checkout and an inbound webhook verify+parse.
-# Subscription methods are deliberately ABSENT: they land with the subscription
-# task, not as speculative stubs here. The billing service depends only on this
-# ABC, so swapping Dodo for Razorpay (or running both) never touches the service.
+# ``IPaymentsProvider`` is the ABC every gateway implements. It carries the BC-2
+# surface — a one-time top-up checkout and an inbound webhook verify+parse — plus
+# the BC-7 RECURRING-subscription surface: open a subscription checkout, cancel a
+# subscription, and parse a verified subscription webhook into a normalized event.
+# The billing service depends only on this ABC, so swapping Dodo for Razorpay (or
+# running both) never touches the service.
 #
-# Both methods speak in the framework-free ``domain`` value objects
-# (``OneTimeCheckout`` / ``GatewayEvent``), never a vendor SDK type — that is the
-# whole point of the port.
+# Every method speaks in the framework-free ``domain`` value objects
+# (``OneTimeCheckout`` / ``GatewayEvent`` / ``SubscriptionCheckout`` /
+# ``SubscriptionEvent``), never a vendor SDK type — that is the whole point of the
+# port. The single ``verify_and_parse_webhook`` handles BOTH one-time AND
+# subscription deliveries (the signature check is the same), returning whichever
+# normalized event the delivery's ``type`` indicates.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new module.
 # Updated 2026-06-24 (security): name the bad-signature exception in the port
 #   docstring — ``BadRequest`` (400), not ``ValidationError`` (422).
+# Updated 2026-06-24 (BC-7): added the subscription surface —
+#   ``create_subscription`` + ``cancel_subscription``, and documented that
+#   ``verify_and_parse_webhook`` now also returns a ``SubscriptionEvent`` for a
+#   verified subscription.* delivery.
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from pocketpaw_ee.cloud.billing.domain import GatewayEvent, OneTimeCheckout
+from pocketpaw_ee.cloud.billing.domain import (
+    GatewayEvent,
+    OneTimeCheckout,
+    SubscriptionCheckout,
+    SubscriptionEvent,
+)
 
 
 class IPaymentsProvider(ABC):
@@ -53,8 +66,8 @@ class IPaymentsProvider(ABC):
         *,
         payload: bytes,
         headers: dict[str, str],
-    ) -> GatewayEvent:
-        """VERIFY the webhook signature, then parse it into a ``GatewayEvent``.
+    ) -> GatewayEvent | SubscriptionEvent:
+        """VERIFY the webhook signature, then parse it into a normalized event.
 
         The signature is checked FIRST, against the RAW ``payload`` bytes. On a
         bad / missing signature (or malformed headers / stale timestamp) the
@@ -62,5 +75,44 @@ class IPaymentsProvider(ABC):
         ``ValidationError`` / 422) — it never returns an unverified event. Only
         after verification passes is the body parsed and normalized. ``event_id``
         is the gateway's unique delivery id (the idempotency key the grant uses).
+
+        Returns a ``GatewayEvent`` for a one-time payment delivery (``payment.*``)
+        or a ``SubscriptionEvent`` for a recurring-subscription delivery
+        (``subscription.*``). The service routes on the returned type.
+        """
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------ #
+    # Subscriptions (BC-7)
+    # ------------------------------------------------------------------ #
+
+    @abstractmethod
+    async def create_subscription(
+        self,
+        *,
+        plan_key: str,
+        product_id: str,
+        workspace_id: str,
+        customer_email: str | None,
+        metadata: dict,
+    ) -> SubscriptionCheckout:
+        """Create a RECURRING subscription and return its hosted checkout.
+
+        ``product_id`` is the gateway's recurring-product id for the tier
+        (resolved by the service from config). The provider attaches ``metadata``
+        — which MUST carry ``workspace_id`` AND ``plan_key`` so the renewal
+        webhook can route the grant back to the right wallet at the right tier —
+        and returns the hosted ``checkout_url`` plus the gateway ``subscription_id``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def cancel_subscription(self, subscription_id: str) -> None:
+        """Cancel the gateway subscription identified by ``subscription_id``.
+
+        Idempotent from the caller's view — cancelling an already-cancelled
+        subscription should not raise a hard error. The entitlement revert
+        (``Workspace.plan`` → free) is driven by the resulting cancellation
+        webhook, NOT here, so this method only tells the gateway to stop billing.
         """
         raise NotImplementedError

--- a/ee/pocketpaw_ee/cloud/billing/providers/base.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/base.py
@@ -12,6 +12,8 @@
 # whole point of the port.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new module.
+# Updated 2026-06-24 (security): name the bad-signature exception in the port
+#   docstring — ``BadRequest`` (400), not ``ValidationError`` (422).
 
 from __future__ import annotations
 
@@ -56,8 +58,9 @@ class IPaymentsProvider(ABC):
 
         The signature is checked FIRST, against the RAW ``payload`` bytes. On a
         bad / missing signature (or malformed headers / stale timestamp) the
-        implementation RAISES — it never returns an unverified event. Only after
-        verification passes is the body parsed and normalized. ``event_id`` is the
-        gateway's unique delivery id (the idempotency key the grant uses).
+        implementation RAISES ``BadRequest`` (→ 400, an untrusted request — not
+        ``ValidationError`` / 422) — it never returns an unverified event. Only
+        after verification passes is the body parsed and normalized. ``event_id``
+        is the gateway's unique delivery id (the idempotency key the grant uses).
         """
         raise NotImplementedError

--- a/ee/pocketpaw_ee/cloud/billing/providers/base.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/base.py
@@ -1,0 +1,63 @@
+# ee/pocketpaw_ee/cloud/billing/providers/base.py — the payment-provider port
+# (BC-2, the Gateway primitive).
+#
+# ``IPaymentsProvider`` is the ABC every gateway implements. It carries ONLY the
+# BC-2 surface — a one-time top-up checkout and an inbound webhook verify+parse.
+# Subscription methods are deliberately ABSENT: they land with the subscription
+# task, not as speculative stubs here. The billing service depends only on this
+# ABC, so swapping Dodo for Razorpay (or running both) never touches the service.
+#
+# Both methods speak in the framework-free ``domain`` value objects
+# (``OneTimeCheckout`` / ``GatewayEvent``), never a vendor SDK type — that is the
+# whole point of the port.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new module.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from pocketpaw_ee.cloud.billing.domain import GatewayEvent, OneTimeCheckout
+
+
+class IPaymentsProvider(ABC):
+    """Port for a one-time-payment gateway (Dodo in v1; Razorpay later).
+
+    Implementations adapt their SDK to the normalized ``domain`` shapes so the
+    rest of the billing subsystem stays gateway-agnostic.
+    """
+
+    @abstractmethod
+    async def create_one_time(
+        self,
+        *,
+        amount_credits: int,
+        workspace_id: str,
+        customer_email: str | None,
+        metadata: dict,
+    ) -> OneTimeCheckout:
+        """Create a one-time payment and return its hosted checkout.
+
+        ``amount_credits`` is integer credits (1 credit == $0.01). The provider
+        converts to the gateway's money amount, attaches ``metadata`` (which MUST
+        carry ``workspace_id`` so the webhook can route the grant), and returns
+        the hosted ``checkout_url`` plus the ``gateway_ref``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def verify_and_parse_webhook(
+        self,
+        *,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> GatewayEvent:
+        """VERIFY the webhook signature, then parse it into a ``GatewayEvent``.
+
+        The signature is checked FIRST, against the RAW ``payload`` bytes. On a
+        bad / missing signature (or malformed headers / stale timestamp) the
+        implementation RAISES — it never returns an unverified event. Only after
+        verification passes is the body parsed and normalized. ``event_id`` is the
+        gateway's unique delivery id (the idempotency key the grant uses).
+        """
+        raise NotImplementedError

--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -70,6 +70,12 @@
 #   return a ``SubscriptionEvent`` for a verified ``subscription.*`` delivery
 #   (plan_key from metadata, with a product_id reverse-map fallback off the
 #   configured plan->product mapping).
+# Updated 2026-06-24 (BC-9): ``verify_and_parse_webhook`` now also reads
+#   ``data.metadata.site_id`` onto the ``SubscriptionEvent`` — the discriminator
+#   that tells a PER-SITE annual sub (each published site has its own plan) from a
+#   WORKSPACE-plan sub. A per-site subscribe stamps ``site_id`` on the metadata;
+#   the service routes a delivery with one to the site, without one to the
+#   workspace path. No new SDK call — site subs reuse ``create_subscription``.
 
 from __future__ import annotations
 
@@ -360,6 +366,11 @@ class DodoProvider:
             product_id = str(data.get("product_id") or "")
             plan_key = str(meta.get("plan_key") or "") or self._plan_key_for_product(product_id)
             subscription_id = str(data.get("subscription_id") or "")
+            # BC-9: a per-site annual sub stamps ``site_id`` on its metadata; a
+            # workspace-plan sub does not. This is the discriminator the service
+            # routes on — a delivery WITH a site_id updates the SITE, one WITHOUT
+            # it follows the BC-7 workspace path. Pull it straight off metadata.
+            site_id = str(meta.get("site_id") or "")
             return SubscriptionEvent(
                 event_id=event_id,
                 type=event_type,
@@ -367,6 +378,7 @@ class DodoProvider:
                 plan_key=plan_key,
                 product_id=product_id,
                 subscription_id=subscription_id,
+                site_id=site_id,
                 raw=verified,
             )
 

--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -38,6 +38,9 @@
 # secret and the API key are NEVER logged.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new module.
+# Updated 2026-06-24 (security): warn (don't silently swallow) when a
+#   payment.succeeded event carries a non-int / missing ``total_amount`` — the
+#   safe-coerce-to-0 behavior is unchanged, but ops now get a log to triage.
 
 from __future__ import annotations
 
@@ -223,7 +226,20 @@ class DodoProvider:
         # ``total_amount`` is the lowest denomination (cents for USD). 1 credit ==
         # 1 cent, so cents map 1:1 back onto credits.
         raw_amount = data.get("total_amount")
-        amount_credits = int(raw_amount) if isinstance(raw_amount, int) else 0
+        if isinstance(raw_amount, int):
+            amount_credits = int(raw_amount)
+        else:
+            # Safe-coerce to 0 (the service's amount<=0 guard then no-ops the
+            # grant), but warn so ops can triage a malformed/missing amount on
+            # a success event. No money value to leak here — it isn't a number.
+            amount_credits = 0
+            if event_type == "payment.succeeded":
+                logger.warning(
+                    "billing.webhook: payment.succeeded had non-int total_amount "
+                    "(type=%s, event_id=%s) — coercing to 0, grant will no-op",
+                    type(raw_amount).__name__,
+                    event_id,
+                )
         currency = str(data.get("currency") or "")
 
         return GatewayEvent(

--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -1,0 +1,243 @@
+# ee/pocketpaw_ee/cloud/billing/providers/dodo.py — the Dodo Payments
+# implementation of ``IPaymentsProvider`` (BC-2, the Gateway primitive).
+#
+# Two responsibilities, both adapting the real SDK to the framework-free
+# ``domain`` shapes:
+#
+#   * ``create_one_time`` — builds an async ``DodoPayments`` client from settings
+#     and calls ``payments.create(...)`` with ``payment_link=True`` to get a
+#     HOSTED checkout url back, ``metadata={"workspace_id": ...}`` so the webhook
+#     can route the grant, and a pay-what-you-want cart line on the configured
+#     credit product whose ``amount`` == the purchased credits (1 credit == $0.01
+#     == 1 cent == the currency's lowest denomination, so amount_credits maps
+#     1:1 onto Dodo's cents — NO division).
+#
+#   * ``verify_and_parse_webhook`` — verifies the Standard-Webhooks signature
+#     with ``standardwebhooks.Webhook(...).verify(payload, headers)`` (raises on a
+#     bad/missing signature, malformed headers, or a stale timestamp) BEFORE the
+#     body is trusted, then normalizes the verified event into a ``GatewayEvent``.
+#     ``event_id`` is the Standard-Webhooks ``webhook-id`` header (the idempotency
+#     key); ``workspace_id`` is pulled from the payment's ``metadata``.
+#
+# SDK-API NOTES (discovered by reading the installed packages, NOT the brief):
+#   * ``standardwebhooks.Webhook`` takes ``whsecret=`` (it strips a ``whsec_``
+#     prefix and base64-decodes), NOT ``base64_secret=`` as the brief stated.
+#   * Dodo's ``payments.create`` / ``checkout_sessions.create`` do NOT accept a
+#     raw amount — they require a ``product_cart`` of pre-existing Dodo product
+#     ids plus ``billing`` (country) and ``customer`` (email). A one-time top-up
+#     for an arbitrary credit amount is therefore modeled as a pay-what-you-want
+#     line on a configured credits product (``dodo_credit_product_id``), with the
+#     amount carried on the cart item.
+#   * The hosted url comes back as ``response.payment_link`` (only populated when
+#     ``payment_link=True``); ``response.payment_id`` is the gateway ref.
+#   * The webhook body is ``{business_id, data: Payment, timestamp, type}``; the
+#     buyer's metadata lives at ``data.metadata`` and the money amount at
+#     ``data.total_amount`` (lowest denomination) with ``data.currency``.
+#
+# SECURITY: the signature is verified before the payload is parsed. The webhook
+# secret and the API key are NEVER logged.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new module.
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from pocketpaw_ee.cloud._core.errors import BadRequest, ValidationError
+from pocketpaw_ee.cloud.billing.domain import GatewayEvent, OneTimeCheckout
+
+logger = logging.getLogger(__name__)
+
+# Default billing country for the hosted checkout. Dodo requires a country on
+# the billing address; the buyer can change it on the hosted page. "US" is a
+# neutral default — the real value is confirmed by the customer at checkout.
+_DEFAULT_BILLING_COUNTRY = "US"
+# A new-customer line needs an email. Dodo collects the real one on the hosted
+# page; this placeholder only satisfies the create call when the caller has no
+# email on file. The buyer's actual email lands on the resulting Payment.
+_PLACEHOLDER_EMAIL = "billing@pocketpaw.local"
+
+
+class DodoProvider:
+    """Dodo Payments gateway adapter. Implements ``IPaymentsProvider``."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None,
+        environment: str,
+        webhook_secret: str | None,
+        credit_product_id: str | None,
+    ) -> None:
+        # Stored, not validated here — a deployment may construct the provider
+        # with billing disabled. Each call validates the inputs IT needs, so a
+        # misconfiguration fails loudly at the point of use with a clear code.
+        self._api_key = api_key
+        self._environment = environment or "test_mode"
+        self._webhook_secret = webhook_secret
+        self._credit_product_id = credit_product_id
+
+    @classmethod
+    def from_settings(cls, settings: Any) -> DodoProvider:
+        """Build a provider from a ``pocketpaw.config.Settings`` instance."""
+        return cls(
+            api_key=getattr(settings, "dodo_payments_api_key", None),
+            environment=getattr(settings, "dodo_environment", "test_mode"),
+            webhook_secret=getattr(settings, "dodo_webhook_secret", None),
+            credit_product_id=getattr(settings, "dodo_credit_product_id", None),
+        )
+
+    # ------------------------------------------------------------------ #
+    # Checkout
+    # ------------------------------------------------------------------ #
+
+    def _client(self):  # pragma: no cover - thin SDK wiring, mocked in tests
+        """Construct the async DodoPayments client from settings.
+
+        Imported lazily so importing this module (e.g. at app mount) never pulls
+        the SDK, and so tests can patch ``billing.providers.dodo.AsyncDodoPayments``.
+        """
+        if not self._api_key:
+            raise ValidationError(
+                "billing.gateway_unconfigured",
+                "Dodo Payments API key is not configured (POCKETPAW_DODO_PAYMENTS_API_KEY).",
+            )
+        return AsyncDodoPayments(bearer_token=self._api_key, environment=self._environment)
+
+    async def create_one_time(
+        self,
+        *,
+        amount_credits: int,
+        workspace_id: str,
+        customer_email: str | None,
+        metadata: dict,
+    ) -> OneTimeCheckout:
+        if (
+            not isinstance(amount_credits, int)
+            or isinstance(amount_credits, bool)
+            or amount_credits <= 0
+        ):
+            raise ValidationError(
+                "billing.invalid_amount", "amount_credits must be a positive integer"
+            )
+        if not workspace_id:
+            raise ValidationError("billing.invalid_workspace", "workspace_id is required")
+        if not self._credit_product_id:
+            raise ValidationError(
+                "billing.product_unconfigured",
+                "Dodo credit product id is not configured (POCKETPAW_DODO_CREDIT_PRODUCT_ID).",
+            )
+
+        # 1 credit == $0.01 == 1 cent == the currency's lowest denomination, so
+        # amount_credits maps 1:1 onto Dodo's amount field — no division.
+        cart_amount_cents = amount_credits
+
+        # workspace_id MUST ride on metadata so the webhook can route the grant.
+        # The provider stamps it authoritatively, overriding any caller value.
+        meta = {k: str(v) for k, v in dict(metadata or {}).items()}
+        meta["workspace_id"] = str(workspace_id)
+
+        client = self._client()
+        response = await client.payments.create(
+            billing={"country": _DEFAULT_BILLING_COUNTRY},
+            customer={"email": customer_email or _PLACEHOLDER_EMAIL},
+            product_cart=[
+                {
+                    "product_id": self._credit_product_id,
+                    "quantity": 1,
+                    "amount": cart_amount_cents,
+                }
+            ],
+            payment_link=True,
+            metadata=meta,
+        )
+
+        checkout_url = getattr(response, "payment_link", None)
+        gateway_ref = getattr(response, "payment_id", "") or ""
+        if not checkout_url:
+            # payment_link is only populated when payment_link=True succeeds.
+            raise ValidationError(
+                "billing.no_checkout_url",
+                "Dodo did not return a hosted payment link for the top-up.",
+            )
+        return OneTimeCheckout(checkout_url=str(checkout_url), gateway_ref=str(gateway_ref))
+
+    # ------------------------------------------------------------------ #
+    # Webhook
+    # ------------------------------------------------------------------ #
+
+    def verify_and_parse_webhook(
+        self,
+        *,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> GatewayEvent:
+        if not self._webhook_secret:
+            raise ValidationError(
+                "billing.webhook_unconfigured",
+                "Dodo webhook secret is not configured (POCKETPAW_DODO_WEBHOOK_SECRET).",
+            )
+
+        # SECURITY: verify the signature against the RAW bytes BEFORE the body is
+        # parsed or trusted. ``Webhook`` takes ``whsecret`` (strips a ``whsec_``
+        # prefix, base64-decodes); ``.verify`` returns the parsed JSON and RAISES
+        # ``WebhookVerificationError`` on a bad/missing signature, malformed
+        # headers, or a timestamp outside the 5-minute tolerance.
+        wh = Webhook(self._webhook_secret)
+        try:
+            verified = wh.verify(payload, headers)
+        except WebhookVerificationError as exc:
+            # Do NOT include the secret or signature in the message. A bad/missing
+            # signature is a 400 (untrusted request), not a 422 (field rule).
+            raise BadRequest(
+                "billing.webhook_invalid_signature",
+                "Dodo webhook signature did not verify.",
+            ) from exc
+
+        # The Standard-Webhooks delivery id is the idempotency key. It lives in
+        # the ``webhook-id`` header (verify already required it to be present).
+        lower = {k.lower(): v for k, v in headers.items()}
+        event_id = lower.get("webhook-id", "")
+        if not event_id:  # pragma: no cover - verify() already enforces this
+            raise BadRequest(
+                "billing.webhook_missing_id", "Dodo webhook is missing the webhook-id header."
+            )
+
+        if not isinstance(verified, dict):
+            # verify() returns json.loads(...) — normally a dict; be defensive.
+            try:
+                verified = json.loads(payload or b"{}")
+            except ValueError as exc:
+                raise BadRequest(
+                    "billing.webhook_malformed", "Dodo webhook body was not valid JSON."
+                ) from exc
+
+        event_type = str(verified.get("type") or "")
+        data = verified.get("data") if isinstance(verified.get("data"), dict) else {}
+
+        meta = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
+        workspace_id = str(meta.get("workspace_id") or "")
+
+        # ``total_amount`` is the lowest denomination (cents for USD). 1 credit ==
+        # 1 cent, so cents map 1:1 back onto credits.
+        raw_amount = data.get("total_amount")
+        amount_credits = int(raw_amount) if isinstance(raw_amount, int) else 0
+        currency = str(data.get("currency") or "")
+
+        return GatewayEvent(
+            event_id=event_id,
+            type=event_type,
+            amount_credits=amount_credits,
+            workspace_id=workspace_id,
+            currency=currency,
+            raw=verified,
+        )
+
+
+# Lazy SDK imports — pulled at module import time so they CAN be monkeypatched on
+# this module in tests, but the actual network client is only built inside
+# ``_client()``. ``standardwebhooks`` is pure-Python (no network), safe to import.
+from dodopayments import AsyncDodoPayments  # noqa: E402
+from standardwebhooks import Webhook, WebhookVerificationError  # noqa: E402

--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -34,6 +34,29 @@
 #     buyer's metadata lives at ``data.metadata`` and the money amount at
 #     ``data.total_amount`` (lowest denomination) with ``data.currency``.
 #
+# SUBSCRIPTIONS (BC-7), again adapting the real SDK:
+#
+#   * ``create_subscription`` — calls ``client.subscriptions.create(...)`` with a
+#     single ``product_id`` (NOT a product_cart — the SDK's subscription create
+#     takes one recurring product id + a ``quantity``, unlike the one-time cart),
+#     ``payment_link=True`` for a HOSTED checkout, and ``metadata={"workspace_id",
+#     "plan_key"}`` so the renewal webhook can route the grant to the right wallet
+#     at the right tier. The hosted url is ``response.payment_link``; the gateway
+#     subscription ref is ``response.subscription_id``.
+#
+#   * ``cancel_subscription`` — calls ``client.subscriptions.update(<id>,
+#     status="cancelled")`` (the SDK has no ``.cancel`` — cancellation is a status
+#     PATCH). The entitlement revert is driven by the resulting webhook, not here.
+#
+#   * ``verify_and_parse_webhook`` ALSO recognizes the subscription event family.
+#     The real Dodo event names (verified against the SDK's WebhookEventType
+#     literal in ``types/webhook_event_type.py``) are ``subscription.active``,
+#     ``subscription.renewed``, ``subscription.cancelled`` (among others). The
+#     event body is ``{business_id, data: Subscription, timestamp, type}``; the
+#     buyer's metadata lives at ``data.metadata`` (carrying ``workspace_id`` +
+#     ``plan_key``), the recurring product at ``data.product_id`` (the reverse-map
+#     fallback for the tier), and the subscription id at ``data.subscription_id``.
+#
 # SECURITY: the signature is verified before the payload is parsed. The webhook
 # secret and the API key are NEVER logged.
 #
@@ -41,6 +64,12 @@
 # Updated 2026-06-24 (security): warn (don't silently swallow) when a
 #   payment.succeeded event carries a non-int / missing ``total_amount`` — the
 #   safe-coerce-to-0 behavior is unchanged, but ops now get a log to triage.
+# Updated 2026-06-24 (BC-7): implemented the subscription surface
+#   (``create_subscription`` + ``cancel_subscription``) over
+#   ``client.subscriptions.*``, and extended ``verify_and_parse_webhook`` to
+#   return a ``SubscriptionEvent`` for a verified ``subscription.*`` delivery
+#   (plan_key from metadata, with a product_id reverse-map fallback off the
+#   configured plan->product mapping).
 
 from __future__ import annotations
 
@@ -49,9 +78,20 @@ import logging
 from typing import Any
 
 from pocketpaw_ee.cloud._core.errors import BadRequest, ValidationError
-from pocketpaw_ee.cloud.billing.domain import GatewayEvent, OneTimeCheckout
+from pocketpaw_ee.cloud.billing.domain import (
+    GatewayEvent,
+    OneTimeCheckout,
+    SubscriptionCheckout,
+    SubscriptionEvent,
+)
 
 logger = logging.getLogger(__name__)
+
+# The verified subscription event families this provider normalizes. Other
+# subscription.* deliveries (on_hold / paused / failed / expired / plan_changed /
+# updated) are still parsed into a SubscriptionEvent — the service decides which
+# ones act — but these three are the ones BC-7's grant/revert logic keys on.
+_SUBSCRIPTION_EVENT_PREFIX = "subscription."
 
 # Default billing country for the hosted checkout. Dodo requires a country on
 # the billing address; the buyer can change it on the hosted page. "US" is a
@@ -73,6 +113,7 @@ class DodoProvider:
         environment: str,
         webhook_secret: str | None,
         credit_product_id: str | None,
+        plan_products: dict[str, str] | None = None,
     ) -> None:
         # Stored, not validated here — a deployment may construct the provider
         # with billing disabled. Each call validates the inputs IT needs, so a
@@ -81,16 +122,37 @@ class DodoProvider:
         self._environment = environment or "test_mode"
         self._webhook_secret = webhook_secret
         self._credit_product_id = credit_product_id
+        # plan_key -> recurring product_id (BC-7). Used only for the REVERSE map
+        # at webhook-parse time (product_id -> plan_key) when a subscription
+        # delivery's metadata lacks plan_key; the forward direction (picking a
+        # product for a tier) is the service's job, passed in to create_subscription.
+        self._plan_products = dict(plan_products or {})
 
     @classmethod
     def from_settings(cls, settings: Any) -> DodoProvider:
         """Build a provider from a ``pocketpaw.config.Settings`` instance."""
+        plan_products = getattr(settings, "dodo_plan_products", None)
         return cls(
             api_key=getattr(settings, "dodo_payments_api_key", None),
             environment=getattr(settings, "dodo_environment", "test_mode"),
             webhook_secret=getattr(settings, "dodo_webhook_secret", None),
             credit_product_id=getattr(settings, "dodo_credit_product_id", None),
+            plan_products=plan_products if isinstance(plan_products, dict) else None,
         )
+
+    def _plan_key_for_product(self, product_id: str) -> str:
+        """Reverse-resolve a tier key from a recurring product id, or ''.
+
+        The plan->product config is the forward map; this inverts it so a
+        subscription webhook whose metadata is missing ``plan_key`` can still be
+        routed by the product id Dodo always sends on ``data.product_id``.
+        """
+        if not product_id:
+            return ""
+        for key, pid in self._plan_products.items():
+            if pid == product_id:
+                return str(key)
+        return ""
 
     # ------------------------------------------------------------------ #
     # Checkout
@@ -168,6 +230,71 @@ class DodoProvider:
         return OneTimeCheckout(checkout_url=str(checkout_url), gateway_ref=str(gateway_ref))
 
     # ------------------------------------------------------------------ #
+    # Subscriptions (BC-7)
+    # ------------------------------------------------------------------ #
+
+    async def create_subscription(
+        self,
+        *,
+        plan_key: str,
+        product_id: str,
+        workspace_id: str,
+        customer_email: str | None,
+        metadata: dict,
+    ) -> SubscriptionCheckout:
+        if not plan_key:
+            raise ValidationError("billing.invalid_plan", "plan_key is required")
+        if not workspace_id:
+            raise ValidationError("billing.invalid_workspace", "workspace_id is required")
+        if not product_id:
+            raise ValidationError(
+                "billing.plan_product_unconfigured",
+                f"No Dodo recurring product id is configured for plan '{plan_key}' "
+                "(POCKETPAW_DODO_PLAN_PRODUCTS).",
+            )
+
+        # workspace_id AND plan_key MUST ride on metadata so the renewal webhook
+        # can route the grant to the right wallet at the right tier. The provider
+        # stamps both authoritatively, overriding any caller value.
+        meta = {k: str(v) for k, v in dict(metadata or {}).items()}
+        meta["workspace_id"] = str(workspace_id)
+        meta["plan_key"] = str(plan_key)
+
+        # The SDK's subscription create takes a SINGLE recurring product_id +
+        # quantity (NOT a product_cart like the one-time path). payment_link=True
+        # returns a HOSTED checkout url on ``response.payment_link``.
+        client = self._client()
+        response = await client.subscriptions.create(
+            billing={"country": _DEFAULT_BILLING_COUNTRY},
+            customer={"email": customer_email or _PLACEHOLDER_EMAIL},
+            product_id=product_id,
+            quantity=1,
+            payment_link=True,
+            metadata=meta,
+        )
+
+        checkout_url = getattr(response, "payment_link", None)
+        subscription_id = getattr(response, "subscription_id", "") or ""
+        if not checkout_url:
+            # payment_link is only populated when payment_link=True succeeds.
+            raise ValidationError(
+                "billing.no_checkout_url",
+                "Dodo did not return a hosted payment link for the subscription.",
+            )
+        return SubscriptionCheckout(
+            checkout_url=str(checkout_url), subscription_id=str(subscription_id)
+        )
+
+    async def cancel_subscription(self, subscription_id: str) -> None:
+        if not subscription_id:
+            raise ValidationError("billing.invalid_subscription", "subscription_id is required")
+        # The SDK has no ``.cancel`` — cancellation is a status PATCH via
+        # ``subscriptions.update(<id>, status="cancelled")``. Dodo emits the
+        # ``subscription.cancelled`` webhook that drives the entitlement revert.
+        client = self._client()
+        await client.subscriptions.update(subscription_id, status="cancelled")
+
+    # ------------------------------------------------------------------ #
     # Webhook
     # ------------------------------------------------------------------ #
 
@@ -176,7 +303,7 @@ class DodoProvider:
         *,
         payload: bytes,
         headers: dict[str, str],
-    ) -> GatewayEvent:
+    ) -> GatewayEvent | SubscriptionEvent:
         if not self._webhook_secret:
             raise ValidationError(
                 "billing.webhook_unconfigured",
@@ -222,6 +349,26 @@ class DodoProvider:
 
         meta = data.get("metadata") if isinstance(data.get("metadata"), dict) else {}
         workspace_id = str(meta.get("workspace_id") or "")
+
+        # SUBSCRIPTION family (BC-7) — a ``subscription.*`` delivery normalizes to
+        # a ``SubscriptionEvent``, NOT a GatewayEvent. The tier comes from the
+        # metadata's ``plan_key`` (stamped at subscribe time); if it's missing,
+        # fall back to reverse-mapping the recurring ``data.product_id`` through
+        # the configured plan->product mapping. No money amount on the wire here —
+        # the grant uses the catalog's allotment, not an event amount.
+        if event_type.startswith(_SUBSCRIPTION_EVENT_PREFIX):
+            product_id = str(data.get("product_id") or "")
+            plan_key = str(meta.get("plan_key") or "") or self._plan_key_for_product(product_id)
+            subscription_id = str(data.get("subscription_id") or "")
+            return SubscriptionEvent(
+                event_id=event_id,
+                type=event_type,
+                workspace_id=workspace_id,
+                plan_key=plan_key,
+                product_id=product_id,
+                subscription_id=subscription_id,
+                raw=verified,
+            )
 
         # ``total_amount`` is the lowest denomination (cents for USD). 1 credit ==
         # 1 cent, so cents map 1:1 back onto credits.

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -1,27 +1,46 @@
 # ee/pocketpaw_ee/cloud/billing/router.py — the authenticated billing surface
-# (BC-2, the Gateway primitive).
+# (BC-2, the Gateway primitive; BC-6, the Plan catalog read).
 #
-# One authenticated route, scoped to the caller's CURRENT workspace (resolved via
-# the standard ``current_workspace_id`` / ``current_user_id`` deps) and gated on
-# a live license:
-#   * POST /billing/topup — buy credits; returns a Dodo HOSTED-CHECKOUT url.
+# Authenticated routes, gated on a live license:
+#   * POST /billing/topup — buy credits; returns a Dodo HOSTED-CHECKOUT url
+#     (scoped to the caller's CURRENT workspace via ``current_workspace_id`` /
+#     ``current_user_id``).
+#   * GET  /billing/plans — list the PLAN CATALOG (each tier -> monthly credit
+#     allotment + Dodo product id + features). Tenant-independent: the catalog is
+#     the same for every workspace, so no workspace scoping (BC-6).
 #
-# THIN adapter per the "primitive = service + thin adapters" shape — all logic
-# lives in ``billing.service``. The PUBLIC inbound webhook lives in
-# ``billing.webhooks`` (no auth) and is mounted SEPARATELY in mount_cloud().
+# THIN adapter per the "primitive = service + thin adapters" shape — top-up logic
+# lives in ``billing.service``; the catalog is built by ``billing.plans``. The
+# PUBLIC inbound webhook lives in ``billing.webhooks`` (no auth) and is mounted
+# SEPARATELY in mount_cloud(). The per-workspace ENTITLEMENTS resolver (GET
+# /entitlements) lives on its own ``entitlements.router`` (it IS workspace-scoped).
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
+# Updated 2026-06-24 (BC-6): added GET /billing/plans (the plan catalog read).
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
+from pocketpaw_ee.cloud.billing import plans as plan_catalog
 from pocketpaw_ee.cloud.billing import service as billing_service
 from pocketpaw_ee.cloud.billing.dto import CreateTopupRequest, CreateTopupResponse
+from pocketpaw_ee.cloud.entitlements.dto import PlanCatalogResponse, plan_tier_to_dto
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
 
 router = APIRouter(prefix="/billing", tags=["Billing"], dependencies=[Depends(require_license)])
+
+
+@router.get("/plans", response_model=PlanCatalogResponse)
+async def list_billing_plans() -> PlanCatalogResponse:
+    """List the plan catalog — every tier with its allotment + features.
+
+    Tenant-independent: the catalog is the same for every workspace (features
+    come straight from ``PLAN_FEATURES``; allotments from the billing config
+    constants). Cheapest tier first.
+    """
+    return PlanCatalogResponse(plans=[plan_tier_to_dto(t) for t in plan_catalog.list_plans()])
 
 
 @router.post("/topup", response_model=CreateTopupResponse)

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -1,0 +1,44 @@
+# ee/pocketpaw_ee/cloud/billing/router.py — the authenticated billing surface
+# (BC-2, the Gateway primitive).
+#
+# One authenticated route, scoped to the caller's CURRENT workspace (resolved via
+# the standard ``current_workspace_id`` / ``current_user_id`` deps) and gated on
+# a live license:
+#   * POST /billing/topup — buy credits; returns a Dodo HOSTED-CHECKOUT url.
+#
+# THIN adapter per the "primitive = service + thin adapters" shape — all logic
+# lives in ``billing.service``. The PUBLIC inbound webhook lives in
+# ``billing.webhooks`` (no auth) and is mounted SEPARATELY in mount_cloud().
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud.billing import service as billing_service
+from pocketpaw_ee.cloud.billing.dto import CreateTopupRequest, CreateTopupResponse
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+router = APIRouter(prefix="/billing", tags=["Billing"], dependencies=[Depends(require_license)])
+
+
+@router.post("/topup", response_model=CreateTopupResponse)
+async def create_topup(
+    body: CreateTopupRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> CreateTopupResponse:
+    """Buy ``amount_credits`` of credits for the caller's workspace.
+
+    Returns the hosted-checkout url the buyer is redirected to. Credits are NOT
+    granted here — they land when Dodo posts a verified ``payment.succeeded`` to
+    the public webhook. ``amount_credits`` is integer credits (1 credit == $0.01).
+    """
+    result = await billing_service.create_topup(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        amount_credits=body.amount_credits,
+    )
+    return CreateTopupResponse(checkout_url=result["checkout_url"])

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -20,6 +20,10 @@
 # Updated 2026-06-24 (BC-7): added POST /billing/subscribe — open a recurring
 #   checkout for a plan tier (returns a hosted url; the plan upgrade + first credit
 #   grant land on the verified subscription.active webhook, not here).
+# Updated 2026-06-24 (BC-10): added GET /billing/site-plans — the PER-SITE plan
+#   catalog (each tier -> annual price + the Cloudflare features it resells). Like
+#   /billing/plans it is tenant-independent (no workspace scoping); the frontend
+#   (BC-11) reads it to render the publish tier picker.
 
 from __future__ import annotations
 
@@ -27,13 +31,19 @@ from fastapi import APIRouter, Depends
 
 from pocketpaw_ee.cloud.billing import plans as plan_catalog
 from pocketpaw_ee.cloud.billing import service as billing_service
+from pocketpaw_ee.cloud.billing import site_plans as site_plan_catalog
 from pocketpaw_ee.cloud.billing.dto import (
     CreateSubscriptionRequest,
     CreateSubscriptionResponse,
     CreateTopupRequest,
     CreateTopupResponse,
 )
-from pocketpaw_ee.cloud.entitlements.dto import PlanCatalogResponse, plan_tier_to_dto
+from pocketpaw_ee.cloud.entitlements.dto import (
+    PlanCatalogResponse,
+    SitePlanCatalogResponse,
+    plan_tier_to_dto,
+    site_plan_tier_to_dto,
+)
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
 
@@ -49,6 +59,19 @@ async def list_billing_plans() -> PlanCatalogResponse:
     constants). Cheapest tier first.
     """
     return PlanCatalogResponse(plans=[plan_tier_to_dto(t) for t in plan_catalog.list_plans()])
+
+
+@router.get("/site-plans", response_model=SitePlanCatalogResponse)
+async def list_billing_site_plans() -> SitePlanCatalogResponse:
+    """List the PER-SITE plan catalog — every tier with its annual price + the
+    Cloudflare features it resells (BC-10 provisions those when a domain is added).
+
+    Tenant-independent: the per-site catalog is the same for every workspace, so
+    no workspace scoping (mirrors GET /billing/plans). Cheapest tier first.
+    """
+    return SitePlanCatalogResponse(
+        site_plans=[site_plan_tier_to_dto(t) for t in site_plan_catalog.list_site_plans()]
+    )
 
 
 @router.post("/topup", response_model=CreateTopupResponse)

--- a/ee/pocketpaw_ee/cloud/billing/router.py
+++ b/ee/pocketpaw_ee/cloud/billing/router.py
@@ -17,6 +17,9 @@
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
 # Updated 2026-06-24 (BC-6): added GET /billing/plans (the plan catalog read).
+# Updated 2026-06-24 (BC-7): added POST /billing/subscribe — open a recurring
+#   checkout for a plan tier (returns a hosted url; the plan upgrade + first credit
+#   grant land on the verified subscription.active webhook, not here).
 
 from __future__ import annotations
 
@@ -24,7 +27,12 @@ from fastapi import APIRouter, Depends
 
 from pocketpaw_ee.cloud.billing import plans as plan_catalog
 from pocketpaw_ee.cloud.billing import service as billing_service
-from pocketpaw_ee.cloud.billing.dto import CreateTopupRequest, CreateTopupResponse
+from pocketpaw_ee.cloud.billing.dto import (
+    CreateSubscriptionRequest,
+    CreateSubscriptionResponse,
+    CreateTopupRequest,
+    CreateTopupResponse,
+)
 from pocketpaw_ee.cloud.entitlements.dto import PlanCatalogResponse, plan_tier_to_dto
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
@@ -61,3 +69,24 @@ async def create_topup(
         amount_credits=body.amount_credits,
     )
     return CreateTopupResponse(checkout_url=result["checkout_url"])
+
+
+@router.post("/subscribe", response_model=CreateSubscriptionResponse)
+async def create_subscription(
+    body: CreateSubscriptionRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> CreateSubscriptionResponse:
+    """Subscribe the caller's workspace to ``plan_key`` — recurring checkout.
+
+    Returns the hosted-checkout url the buyer is redirected to. The plan is NOT
+    upgraded and credits are NOT granted here — both land when Dodo posts a
+    verified ``subscription.active`` to the public webhook; each renewal then
+    grants the tier's monthly allotment additively (unused credits roll over).
+    """
+    result = await billing_service.subscribe(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        plan_key=body.plan_key,
+    )
+    return CreateSubscriptionResponse(checkout_url=result["checkout_url"])

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -32,6 +32,14 @@
 # Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
 # Updated 2026-06-24 (security): enforce USD before granting; correct the
 #   bad-signature docstring (raises ``BadRequest`` → 400, not ``ValidationError``).
+# Updated 2026-06-24 (BC-7, the Subscription primitive): added ``subscribe`` (open
+#   a recurring checkout for a plan tier) and extended ``handle_webhook`` to route
+#   verified ``subscription.*`` deliveries. ``subscription.active`` /
+#   ``subscription.renewed`` grant the tier's monthly allotment ADDITIVELY (unused
+#   credits roll over) keyed on the per-renewal event id; ``subscription.active``
+#   also upgrades ``Workspace.plan``; ``subscription.cancelled`` reverts the plan
+#   to ``free`` WITHOUT clawing back granted credits. The Subscription doc tracks
+#   the gateway lifecycle alongside the per-renewal BC-1 grants.
 
 from __future__ import annotations
 
@@ -41,11 +49,19 @@ from pymongo.errors import DuplicateKeyError
 
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
-from pocketpaw_ee.cloud._core.realtime.events import BillingTopupCaptured
-from pocketpaw_ee.cloud.billing.domain import GatewayEvent
+from pocketpaw_ee.cloud._core.realtime.events import (
+    BillingSubscriptionGranted,
+    BillingTopupCaptured,
+)
+from pocketpaw_ee.cloud.billing import plans as plan_catalog
+from pocketpaw_ee.cloud.billing.domain import (
+    GatewayEvent,
+    SubscriptionEvent,
+)
 from pocketpaw_ee.cloud.billing.providers.base import IPaymentsProvider
 from pocketpaw_ee.cloud.credits import service as credits_service
 from pocketpaw_ee.cloud.models.payment import Payment
+from pocketpaw_ee.cloud.models.subscription import Subscription
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +69,16 @@ _GATEWAY = "dodo"
 # Only this event type grants credits. Other event families (payment.failed,
 # payment.processing, refunds, disputes, …) are acknowledged but never grant.
 _SUCCESS_EVENT = "payment.succeeded"
+
+# BC-7 subscription event families this service ACTS on. Each maps to a precise
+# money/plan action; any other subscription.* delivery (on_hold / paused /
+# failed / expired / plan_changed / updated) is acked but takes no action.
+_SUB_ACTIVE = "subscription.active"
+_SUB_RENEWED = "subscription.renewed"
+_SUB_CANCELLED = "subscription.cancelled"
+# The two grant-bearing events — each (with a fresh event id) grants the tier's
+# monthly allotment additively. active ALSO upgrades the workspace plan.
+_SUB_GRANT_EVENTS = frozenset({_SUB_ACTIVE, _SUB_RENEWED})
 
 
 def _default_provider() -> IPaymentsProvider:
@@ -107,6 +133,74 @@ async def create_topup(
 
 
 # ---------------------------------------------------------------------------
+# Subscriptions (BC-7)
+# ---------------------------------------------------------------------------
+
+
+def _dodo_product_for_plan(plan_key: str) -> str | None:
+    """Resolve the Dodo recurring-product id for ``plan_key``, or None.
+
+    The plan catalog (``billing.plans``) is the single source — it reads the
+    ``POCKETPAW_DODO_PLAN_PRODUCTS`` mapping off settings and exposes it as the
+    tier's ``dodo_product_id``. Going through the catalog (not settings directly)
+    keeps the product lookup co-located with the rest of the tier's billing facts
+    and degrades safely to None when nothing is configured.
+    """
+    tier = plan_catalog.get_plan(plan_key)
+    return tier.dodo_product_id if tier is not None else None
+
+
+async def subscribe(
+    workspace_id: str,
+    user_id: str,
+    plan_key: str,
+    *,
+    customer_email: str | None = None,
+    provider: IPaymentsProvider | None = None,
+) -> dict:
+    """Open a recurring subscription checkout for ``plan_key``; return its url.
+
+    Resolves the tier's Dodo recurring-product id from the plan catalog (driven by
+    the ``POCKETPAW_DODO_PLAN_PRODUCTS`` config mapping), calls the provider to
+    create the subscription with ``metadata={workspace_id, plan_key}`` so the
+    renewal webhook can route the per-cycle grant back to the right wallet at the
+    right tier, and returns ``{"checkout_url": ...}``. Credits are NOT granted and
+    the plan is NOT changed here — both land when Dodo posts a verified
+    ``subscription.active`` to the public webhook.
+    """
+    # Rule 6 — validate at entry.
+    if not workspace_id:
+        raise ValidationError("billing.invalid_workspace", "workspace_id is required")
+    if not plan_key:
+        raise ValidationError("billing.invalid_plan", "plan_key is required")
+
+    tier = plan_catalog.get_plan(plan_key)
+    if tier is None:
+        # An unknown / typo'd tier — never open a checkout for a plan that isn't
+        # in the catalog (the renewal grant would have no allotment to apply).
+        raise ValidationError("billing.unknown_plan", f"'{plan_key}' is not a known plan tier")
+    product_id = tier.dodo_product_id
+    if not product_id:
+        # The tier exists but no recurring product is configured for it. Fail
+        # loudly here (not silently) — POCKETPAW_DODO_PLAN_PRODUCTS is unset.
+        raise ValidationError(
+            "billing.plan_product_unconfigured",
+            f"No Dodo recurring product id is configured for plan '{plan_key}' "
+            "(POCKETPAW_DODO_PLAN_PRODUCTS).",
+        )
+
+    prov = provider or _default_provider()
+    checkout = await prov.create_subscription(
+        plan_key=plan_key,
+        product_id=product_id,
+        workspace_id=workspace_id,
+        customer_email=customer_email,
+        metadata={"workspace_id": workspace_id, "plan_key": plan_key, "user_id": user_id or ""},
+    )
+    return {"checkout_url": checkout.checkout_url}
+
+
+# ---------------------------------------------------------------------------
 # Webhook
 # ---------------------------------------------------------------------------
 
@@ -123,7 +217,11 @@ async def handle_webhook(
     (→ 400 via the cloud error handler) when the signature does not verify — the
     payload is NEVER trusted before then.
 
-    EXACTLY-ONCE: the grant keys on the webhook ``event_id`` (BC-1's unique
+    Routes by event family: a one-time ``payment.*`` delivery parses to a
+    ``GatewayEvent`` (top-up grant); a recurring ``subscription.*`` delivery
+    parses to a ``SubscriptionEvent`` (BC-7 renewal grant + plan change).
+
+    EXACTLY-ONCE: every grant keys on the webhook ``event_id`` (BC-1's unique
     ``(workspace, idempotency_key)`` index), so a replayed delivery re-grants
     nothing. We detect the replay (same balance before/after the grant) to avoid
     a spurious capture emit, and the ``Payment`` row's own unique index keeps the
@@ -133,7 +231,12 @@ async def handle_webhook(
 
     # SECURITY: signature is verified inside the provider BEFORE the body is
     # parsed. A bad signature raises BadRequest here → 400, no grant.
-    event: GatewayEvent = prov.verify_and_parse_webhook(payload=payload, headers=headers)
+    event = prov.verify_and_parse_webhook(payload=payload, headers=headers)
+
+    # Route by the normalized event shape. A recurring subscription delivery is a
+    # SubscriptionEvent (BC-7); everything else is the BC-2 one-time GatewayEvent.
+    if isinstance(event, SubscriptionEvent):
+        return await _handle_subscription_event(event)
 
     # Only a success event grants. Everything else (failed / processing / refund
     # / dispute) is acknowledged so the gateway stops retrying, but never grants.
@@ -240,7 +343,184 @@ async def _record_payment(event: GatewayEvent) -> None:
         return
 
 
+# ---------------------------------------------------------------------------
+# Subscription webhook handling (BC-7)
+# ---------------------------------------------------------------------------
+
+
+async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
+    """Act on a VERIFIED ``subscription.*`` webhook (signature already checked).
+
+    * ``subscription.active`` / ``subscription.renewed`` → grant the tier's
+      monthly allotment ADDITIVELY (unused credits roll over) keyed on the
+      per-renewal ``event_id``; ``active`` ALSO upgrades ``Workspace.plan``.
+    * ``subscription.cancelled`` → revert ``Workspace.plan`` to ``free`` WITHOUT
+      clawing back any granted credits.
+    * any other subscription.* delivery → acked, no action.
+
+    Returns ``{"ok": True, "granted": <bool>}`` (``granted`` is only ever True for
+    a grant-bearing event that actually applied, never a replay).
+    """
+    # Lazy import — keeps this service free of the heavy workspace.service import
+    # (Beanie) at module load, mirroring the entitlements resolver.
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    if not event.workspace_id:
+        # No routable workspace on the verified metadata — ack so Dodo stops
+        # retrying, but take no action (nothing to grant or upgrade).
+        logger.warning(
+            "billing.webhook: %s carried no workspace_id (event_id=%s) — ignoring",
+            event.type,
+            event.event_id,
+        )
+        return {"ok": True, "granted": False}
+
+    if event.type == _SUB_CANCELLED:
+        # Revert the entitlement to free. Do NOT claw back granted credits — the
+        # workspace keeps the rolled-over balance it already paid for.
+        ok = await workspace_service.set_workspace_plan(event.workspace_id, "free")
+        await _upsert_subscription(event, status="cancelled", plan_key="free")
+        logger.info(
+            "billing.webhook: subscription.cancelled for workspace=%s (event_id=%s) — "
+            "plan reverted to free=%s, credits NOT clawed back",
+            event.workspace_id,
+            event.event_id,
+            ok,
+        )
+        return {"ok": True, "granted": False}
+
+    if event.type not in _SUB_GRANT_EVENTS:
+        # on_hold / paused / failed / expired / plan_changed / updated — acked,
+        # no money/plan action in v1.
+        logger.info("billing.webhook: ignoring subscription event type=%s", event.type)
+        return {"ok": True, "granted": False}
+
+    # A grant-bearing event (active | renewed). Resolve the tier so we know the
+    # allotment to grant. A missing / unknown plan_key can't be granted against.
+    tier = plan_catalog.get_plan(event.plan_key)
+    if tier is None:
+        logger.warning(
+            "billing.webhook: %s carried unknown plan_key=%r (event_id=%s) — ignoring",
+            event.type,
+            event.plan_key,
+            event.event_id,
+        )
+        return {"ok": True, "granted": False}
+    if tier.monthly_credit_allotment <= 0:
+        # A zero-allotment tier (e.g. free) grants nothing — but still record the
+        # subscription / upgrade the plan on an active.
+        logger.info(
+            "billing.webhook: %s for zero-allotment plan=%s — no credit grant",
+            event.type,
+            tier.key,
+        )
+        applied = False
+    else:
+        # Grant the allotment ADDITIVELY (BC-1 grant is additive → rollover) keyed
+        # on the per-renewal event id. A replay of THIS event collides on BC-1's
+        # unique (workspace, idempotency_key) index and no-ops; each NEW month's
+        # renewal carries a fresh event id and grants again.
+        balance_before = await credits_service.balance(event.workspace_id)
+        new_balance = await credits_service.grant(
+            workspace=event.workspace_id,
+            amount=tier.monthly_credit_allotment,
+            cause="subscription_grant",
+            idempotency_key=event.event_id,
+            ref={
+                "gateway": _GATEWAY,
+                "event_id": event.event_id,
+                "plan_key": tier.key,
+                "subscription_id": event.subscription_id,
+            },
+        )
+        applied = new_balance == balance_before + tier.monthly_credit_allotment
+
+    # subscription.active upgrades the entitlement to the subscribed tier.
+    if event.type == _SUB_ACTIVE:
+        await workspace_service.set_workspace_plan(event.workspace_id, tier.key)
+
+    # Track the subscription lifecycle (active for both active + renewed).
+    await _upsert_subscription(event, status="active", plan_key=tier.key)
+
+    if applied:
+        # Rule 9 — emit only on a grant that actually applied (not a replay).
+        await emit(
+            BillingSubscriptionGranted(
+                data={
+                    "workspace_id": event.workspace_id,
+                    "gateway": _GATEWAY,
+                    "event_id": event.event_id,
+                    "plan_key": tier.key,
+                    "subscription_id": event.subscription_id,
+                    "amount_credits": tier.monthly_credit_allotment,
+                    "balance_after": new_balance,
+                }
+            )
+        )
+        logger.info(
+            "billing.webhook: %s granted %d credits to workspace=%s plan=%s (event_id=%s)",
+            event.type,
+            tier.monthly_credit_allotment,
+            event.workspace_id,
+            tier.key,
+            event.event_id,
+        )
+    else:
+        logger.info(
+            "billing.webhook: %s for workspace=%s (event_id=%s) — no new grant "
+            "(replay or zero-allotment)",
+            event.type,
+            event.workspace_id,
+            event.event_id,
+        )
+
+    return {"ok": True, "granted": applied}
+
+
+async def _upsert_subscription(event: SubscriptionEvent, *, status: str, plan_key: str) -> None:
+    """Upsert the human-facing ``Subscription`` record. Idempotent.
+
+    Keyed on the unique ``(gateway, gateway_subscription_id)`` index: a first
+    activation inserts, a renewal / cancellation of a known subscription updates
+    the existing row's status / plan. A missing ``subscription_id`` (the gateway
+    didn't carry one) is recorded with an empty id rather than crashing the
+    webhook — the BC-1 grant is the money guard, this row is only the audit trail.
+    """
+    existing = await Subscription.find_one(
+        Subscription.gateway == _GATEWAY,
+        Subscription.gateway_subscription_id == event.subscription_id,
+    )
+    if existing is not None:
+        existing.status = status
+        existing.plan_key = plan_key
+        if event.product_id:
+            existing.product_id = event.product_id
+        await existing.save()
+        return
+    doc = Subscription(
+        workspace=event.workspace_id,
+        gateway=_GATEWAY,
+        gateway_subscription_id=event.subscription_id,
+        plan_key=plan_key,
+        product_id=event.product_id or None,
+        status=status,
+    )
+    try:
+        await doc.insert()
+    except DuplicateKeyError:
+        # A racing delivery inserted it first — re-fetch and update instead.
+        existing = await Subscription.find_one(
+            Subscription.gateway == _GATEWAY,
+            Subscription.gateway_subscription_id == event.subscription_id,
+        )
+        if existing is not None:
+            existing.status = status
+            existing.plan_key = plan_key
+            await existing.save()
+
+
 __all__ = [
     "create_topup",
     "handle_webhook",
+    "subscribe",
 ]

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -25,7 +25,13 @@
 # SECURITY: the provider verifies the signature before this module trusts any
 # field. The webhook secret / API key are never logged.
 #
+# CURRENCY: the 1-credit==1-cent mapping is USD-only, so ``handle_webhook`` gates
+# the grant on ``currency == "USD"`` — a verified non-USD success event is acked
+# but never granted (it would otherwise credit 1:1 against the wrong denomination).
+#
 # Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
+# Updated 2026-06-24 (security): enforce USD before granting; correct the
+#   bad-signature docstring (raises ``BadRequest`` → 400, not ``ValidationError``).
 
 from __future__ import annotations
 
@@ -113,7 +119,7 @@ async def handle_webhook(
 ) -> dict:
     """Verify + parse a gateway webhook, granting credits on a success event.
 
-    Returns ``{"ok": True, "granted": <bool>}``. Raises ``ValidationError``
+    Returns ``{"ok": True, "granted": <bool>}``. Raises ``BadRequest``
     (→ 400 via the cloud error handler) when the signature does not verify — the
     payload is NEVER trusted before then.
 
@@ -126,7 +132,7 @@ async def handle_webhook(
     prov = provider or _default_provider()
 
     # SECURITY: signature is verified inside the provider BEFORE the body is
-    # parsed. A bad signature raises ValidationError here → 400, no grant.
+    # parsed. A bad signature raises BadRequest here → 400, no grant.
     event: GatewayEvent = prov.verify_and_parse_webhook(payload=payload, headers=headers)
 
     # Only a success event grants. Everything else (failed / processing / refund
@@ -146,6 +152,20 @@ async def handle_webhook(
     if event.amount_credits <= 0:
         logger.warning(
             "billing.webhook: payment.succeeded had non-positive amount (event_id=%s) — ignoring",
+            event.event_id,
+        )
+        return {"ok": True, "granted": False}
+    # USD-ONLY: the 1-credit==1-cent mapping holds only for USD. A verified
+    # non-USD charge would be credited 1:1 against the wrong denomination (a
+    # ¥750 charge wrongly granting 750 credits == $7.50). Until the gateway
+    # carries an FX-normalized amount, gate the grant on currency == USD; any
+    # other currency is acked (200) so Dodo stops retrying, but grants nothing.
+    if event.currency.upper() != "USD":
+        # Log the event id + currency only — never the amount (PII / money).
+        logger.warning(
+            "billing.webhook: payment.succeeded in non-USD currency=%s (event_id=%s) — "
+            "not granting (USD-only)",
+            event.currency,
             event.event_id,
         )
         return {"ok": True, "granted": False}

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -40,6 +40,13 @@
 #   also upgrades ``Workspace.plan``; ``subscription.cancelled`` reverts the plan
 #   to ``free`` WITHOUT clawing back granted credits. The Subscription doc tracks
 #   the gateway lifecycle alongside the per-renewal BC-1 grants.
+# Updated 2026-06-24 (B1 review fix): the capture-event emit (BillingTopupCaptured
+#   / BillingSubscriptionGranted) is now gated on ``credits.grant``'s ``created``
+#   flag, NOT the prior balance-delta heuristic (``new_balance == before +
+#   amount``). Under concurrency a racing grant could shift the balance so a
+#   genuine first grant looked like a replay (emit wrongly suppressed) or a replay
+#   looked genuine (spurious emit). ``grant`` now returns a ``GrantResult``; the
+#   created-flag is the authoritative "this grant actually applied" signal.
 # Updated 2026-06-24 (BC-9, per-site annual plan): the subscription webhook
 #   dispatch now FORKS on a ``site_id`` in the verified event metadata. A delivery
 #   WITH a ``site_id`` is a PER-SITE annual sub (each published site has its own
@@ -234,9 +241,9 @@ async def handle_webhook(
 
     EXACTLY-ONCE: every grant keys on the webhook ``event_id`` (BC-1's unique
     ``(workspace, idempotency_key)`` index), so a replayed delivery re-grants
-    nothing. We detect the replay (same balance before/after the grant) to avoid
-    a spurious capture emit, and the ``Payment`` row's own unique index keeps the
-    record single too.
+    nothing. We detect the replay via ``credits.grant``'s ``created`` flag
+    (False on a duplicate-key replay) to avoid a spurious capture emit, and the
+    ``Payment`` row's own unique index keeps the record single too.
     """
     prov = provider or _default_provider()
 
@@ -286,17 +293,19 @@ async def handle_webhook(
 
     # Grant EXACTLY ONCE — idempotency is keyed on the webhook event id. A replay
     # collides on BC-1's unique (workspace, idempotency_key) index and no-ops.
-    balance_before = await credits_service.balance(event.workspace_id)
-    new_balance = await credits_service.grant(
+    result = await credits_service.grant(
         workspace=event.workspace_id,
         amount=event.amount_credits,
         cause="top_up",
         idempotency_key=event.event_id,
         ref={"gateway": _GATEWAY, "event_id": event.event_id},
     )
-    # A genuine first grant moved the balance up by amount_credits; a replay
-    # returns the unchanged current balance.
-    applied = new_balance == balance_before + event.amount_credits
+    new_balance = result.balance
+    # A genuine first grant reports ``created=True``; a replay reports False. We
+    # gate the capture emit on this authoritative flag, NOT a balance delta — a
+    # delta heuristic mis-fires under concurrency (a racing grant could mask a
+    # genuine grant as a replay or vice versa).
+    applied = result.created
 
     # Record the payment (idempotently — the unique gateway+event_id index keeps
     # a replay from inserting a second row). The ledger entry is the money guard;
@@ -439,8 +448,7 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
         # on the per-renewal event id. A replay of THIS event collides on BC-1's
         # unique (workspace, idempotency_key) index and no-ops; each NEW month's
         # renewal carries a fresh event id and grants again.
-        balance_before = await credits_service.balance(event.workspace_id)
-        new_balance = await credits_service.grant(
+        result = await credits_service.grant(
             workspace=event.workspace_id,
             amount=tier.monthly_credit_allotment,
             cause="subscription_grant",
@@ -452,7 +460,11 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
                 "subscription_id": event.subscription_id,
             },
         )
-        applied = new_balance == balance_before + tier.monthly_credit_allotment
+        new_balance = result.balance
+        # Gate the grant emit on the authoritative created-flag (True on a real
+        # first grant, False on a duplicate-key replay), NOT a balance delta — the
+        # delta heuristic races under concurrency.
+        applied = result.created
 
     # subscription.active upgrades the entitlement to the subscribed tier.
     if event.type == _SUB_ACTIVE:
@@ -570,10 +582,26 @@ async def _upsert_subscription(event: SubscriptionEvent, *, status: str, plan_ke
 
     Keyed on the unique ``(gateway, gateway_subscription_id)`` index: a first
     activation inserts, a renewal / cancellation of a known subscription updates
-    the existing row's status / plan. A missing ``subscription_id`` (the gateway
-    didn't carry one) is recorded with an empty id rather than crashing the
-    webhook — the BC-1 grant is the money guard, this row is only the audit trail.
+    the existing row's status / plan.
+
+    B2 review fix — a missing / falsy ``subscription_id`` is SKIPPED (logged), not
+    recorded with an empty id. Two different workspaces whose verified events both
+    carry no subscription_id would otherwise collide on the unique
+    ``(gateway, "")`` key — the second delivery would overwrite the FIRST
+    workspace's audit row (cross-tenant corruption). The grant + plan change still
+    proceed in the caller (the BC-1 ledger is the money guard); only this
+    audit-trail row is skipped. The index is intentionally left unchanged.
     """
+    if not event.subscription_id:
+        logger.warning(
+            "billing.webhook: %s for workspace=%s carried no subscription_id "
+            "(event_id=%s) — skipping Subscription audit upsert (grant/plan still applied)",
+            event.type,
+            event.workspace_id,
+            event.event_id,
+        )
+        return
+
     existing = await Subscription.find_one(
         Subscription.gateway == _GATEWAY,
         Subscription.gateway_subscription_id == event.subscription_id,

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -40,10 +40,21 @@
 #   also upgrades ``Workspace.plan``; ``subscription.cancelled`` reverts the plan
 #   to ``free`` WITHOUT clawing back granted credits. The Subscription doc tracks
 #   the gateway lifecycle alongside the per-renewal BC-1 grants.
+# Updated 2026-06-24 (BC-9, per-site annual plan): the subscription webhook
+#   dispatch now FORKS on a ``site_id`` in the verified event metadata. A delivery
+#   WITH a ``site_id`` is a PER-SITE annual sub (each published site has its own
+#   plan) and routes to ``_handle_site_subscription_event``, which updates the
+#   SITE's ``subscription_status`` / ``annual_renewal_date`` (active/renewed →
+#   active; cancelled → cancelled) via the sites service — it NEVER grants
+#   workspace credits and NEVER changes ``Workspace.plan``. A delivery WITHOUT a
+#   ``site_id`` is the unchanged BC-7 workspace-plan path. Same verified-signature
+#   + idempotency guards apply (the per-site path is reached only AFTER
+#   ``verify_and_parse_webhook`` succeeds).
 
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
 
 from pymongo.errors import DuplicateKeyError
 
@@ -361,6 +372,14 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
     Returns ``{"ok": True, "granted": <bool>}`` (``granted`` is only ever True for
     a grant-bearing event that actually applied, never a replay).
     """
+    # BC-9: a PER-SITE annual sub carries a ``site_id`` on its metadata; a
+    # workspace-plan sub does not. Route a per-site delivery to the SITE (update
+    # its subscription_status / renewal date) instead of the workspace path (which
+    # grants credits / changes Workspace.plan). The site_id is the sole
+    # discriminator — everything below stays the unchanged BC-7 workspace path.
+    if event.site_id:
+        return await _handle_site_subscription_event(event)
+
     # Lazy import — keeps this service free of the heavy workspace.service import
     # (Beanie) at module load, mirroring the entitlements resolver.
     from pocketpaw_ee.cloud.workspace import service as workspace_service
@@ -475,6 +494,75 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
         )
 
     return {"ok": True, "granted": applied}
+
+
+async def _handle_site_subscription_event(event: SubscriptionEvent) -> dict:
+    """Act on a VERIFIED PER-SITE ``subscription.*`` webhook (BC-9).
+
+    A per-site annual sub (each published site has its OWN recurring plan) is
+    distinguished from a workspace-plan sub by the ``site_id`` on its metadata.
+    This path updates the SITE's lifecycle ONLY — it NEVER grants workspace
+    credits and NEVER changes ``Workspace.plan`` (the two grant/plan side effects
+    of the BC-7 workspace path). The site write is delegated to the sites service
+    (entity isolation — billing never imports the Site model):
+
+      * ``subscription.active`` / ``subscription.renewed`` → mark the site sub
+        ``active`` and advance its annual renewal date (one year out).
+      * ``subscription.cancelled`` → mark the site sub ``cancelled``.
+      * any other subscription.* delivery → acked, no action.
+
+    Returns ``{"ok": True, "granted": False}`` always — a per-site sub never
+    moves the workspace credit wallet, so ``granted`` is never True here.
+    """
+    # Lazy import — keeps billing free of an eager sites-service import at module
+    # load, mirroring the workspace-service lazy import in the BC-7 path.
+    from pocketpaw_ee.cloud._core.errors import NotFound
+    from pocketpaw_ee.sites import service as sites_service
+
+    if event.type == _SUB_CANCELLED:
+        status, renewal = "cancelled", None
+    elif event.type in _SUB_GRANT_EVENTS:
+        # active | renewed → the site sub is active; advance the annual renewal
+        # date one year from this verified event (the next charge cycle).
+        status, renewal = "active", datetime.now(UTC) + timedelta(days=365)
+    else:
+        # on_hold / paused / failed / expired / plan_changed / updated — acked,
+        # no site-state action in v1.
+        logger.info(
+            "billing.webhook: ignoring per-site subscription event type=%s (site=%s)",
+            event.type,
+            event.site_id,
+        )
+        return {"ok": True, "granted": False}
+
+    try:
+        await sites_service.mark_site_subscription(
+            workspace_id=event.workspace_id,
+            site_id=event.site_id,
+            status=status,
+            subscription_id=event.subscription_id or None,
+            annual_renewal_date=renewal,
+        )
+    except NotFound:
+        # A verified delivery for a site that doesn't exist for this workspace
+        # (deleted, or a stale/cross-tenant id) — ack (200) so Dodo stops
+        # retrying, but take no action. Nothing to update.
+        logger.warning(
+            "billing.webhook: per-site %s for unknown site=%s (event_id=%s) — ignoring",
+            event.type,
+            event.site_id,
+            event.event_id,
+        )
+        return {"ok": True, "granted": False}
+
+    logger.info(
+        "billing.webhook: per-site %s for site=%s → %s (event_id=%s)",
+        event.type,
+        event.site_id,
+        status,
+        event.event_id,
+    )
+    return {"ok": True, "granted": False}
 
 
 async def _upsert_subscription(event: SubscriptionEvent, *, status: str, plan_key: str) -> None:

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -1,0 +1,226 @@
+# ee/pocketpaw_ee/cloud/billing/service.py — the billing business logic
+# (BC-2, the Gateway primitive). Sole owner of writes to the ``Payment`` Beanie
+# document (entity isolation — only THIS module imports ``models.payment``).
+#
+# Module-level ``async def`` API (NOT a class, per EE cloud rule, mirroring
+# ``credits.service``). Public API:
+#   * ``create_topup``    — build a hosted-checkout url for a credit purchase via
+#                           the configured payment provider (Dodo in v1).
+#   * ``handle_webhook``  — verify + parse an inbound gateway webhook, and on a
+#                           ``payment.succeeded`` event grant credits EXACTLY ONCE
+#                           (BC-1's idempotent ``credits.grant`` keyed on the
+#                           webhook event id) and record a ``Payment`` row.
+#
+# EXACTLY-ONCE: the grant's idempotency is BC-1's job — ``credits.grant`` keys on
+# ``(workspace, idempotency_key=event_id)`` with a unique index, so a replayed
+# webhook is a no-op grant (balance unchanged, no re-emit). The ``Payment`` row's
+# own unique ``(gateway, gateway_event_id)`` index is a second, independent guard
+# so a replay never inserts a duplicate record. We grant FIRST (the money guard),
+# then upsert the record; a duplicate record insert is swallowed.
+#
+# Rule 9 — ``emit(BillingTopupCaptured(...))`` fires after a grant that ACTUALLY
+# applied (never on a replay no-op). Rule 10 — raise ``CloudError`` subclasses
+# (ValidationError / Forbidden), never HTTPException. Rule 6 — validate at entry.
+#
+# SECURITY: the provider verifies the signature before this module trusts any
+# field. The webhook secret / API key are never logged.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
+
+from __future__ import annotations
+
+import logging
+
+from pymongo.errors import DuplicateKeyError
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import BillingTopupCaptured
+from pocketpaw_ee.cloud.billing.domain import GatewayEvent
+from pocketpaw_ee.cloud.billing.providers.base import IPaymentsProvider
+from pocketpaw_ee.cloud.credits import service as credits_service
+from pocketpaw_ee.cloud.models.payment import Payment
+
+logger = logging.getLogger(__name__)
+
+_GATEWAY = "dodo"
+# Only this event type grants credits. Other event families (payment.failed,
+# payment.processing, refunds, disputes, …) are acknowledged but never grant.
+_SUCCESS_EVENT = "payment.succeeded"
+
+
+def _default_provider() -> IPaymentsProvider:
+    """Build the v1 provider (Dodo) from runtime settings.
+
+    Lazy so importing this module never constructs an SDK client. Callers may
+    inject their own provider (tests pass a mock) — this is only the default.
+    """
+    from pocketpaw.config import get_settings
+    from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+
+    return DodoProvider.from_settings(get_settings())
+
+
+# ---------------------------------------------------------------------------
+# Checkout
+# ---------------------------------------------------------------------------
+
+
+async def create_topup(
+    workspace_id: str,
+    user_id: str,
+    amount_credits: int,
+    *,
+    customer_email: str | None = None,
+    provider: IPaymentsProvider | None = None,
+) -> dict:
+    """Create a one-time top-up and return ``{"checkout_url": ...}``.
+
+    ``amount_credits`` is integer credits (1 credit == $0.01) and must be a
+    positive integer. ``workspace_id`` is stamped onto the gateway metadata so
+    the success webhook can route the grant back to the right wallet.
+    """
+    # Rule 6 — validate at entry.
+    if (
+        not isinstance(amount_credits, int)
+        or isinstance(amount_credits, bool)
+        or amount_credits <= 0
+    ):
+        raise ValidationError("billing.invalid_amount", "amount_credits must be a positive integer")
+    if not workspace_id:
+        raise ValidationError("billing.invalid_workspace", "workspace_id is required")
+
+    prov = provider or _default_provider()
+    checkout = await prov.create_one_time(
+        amount_credits=amount_credits,
+        workspace_id=workspace_id,
+        customer_email=customer_email,
+        metadata={"workspace_id": workspace_id, "user_id": user_id or ""},
+    )
+    return {"checkout_url": checkout.checkout_url}
+
+
+# ---------------------------------------------------------------------------
+# Webhook
+# ---------------------------------------------------------------------------
+
+
+async def handle_webhook(
+    *,
+    payload: bytes,
+    headers: dict[str, str],
+    provider: IPaymentsProvider | None = None,
+) -> dict:
+    """Verify + parse a gateway webhook, granting credits on a success event.
+
+    Returns ``{"ok": True, "granted": <bool>}``. Raises ``ValidationError``
+    (→ 400 via the cloud error handler) when the signature does not verify — the
+    payload is NEVER trusted before then.
+
+    EXACTLY-ONCE: the grant keys on the webhook ``event_id`` (BC-1's unique
+    ``(workspace, idempotency_key)`` index), so a replayed delivery re-grants
+    nothing. We detect the replay (same balance before/after the grant) to avoid
+    a spurious capture emit, and the ``Payment`` row's own unique index keeps the
+    record single too.
+    """
+    prov = provider or _default_provider()
+
+    # SECURITY: signature is verified inside the provider BEFORE the body is
+    # parsed. A bad signature raises ValidationError here → 400, no grant.
+    event: GatewayEvent = prov.verify_and_parse_webhook(payload=payload, headers=headers)
+
+    # Only a success event grants. Everything else (failed / processing / refund
+    # / dispute) is acknowledged so the gateway stops retrying, but never grants.
+    if event.type != _SUCCESS_EVENT:
+        logger.info("billing.webhook: ignoring non-success event type=%s", event.type)
+        return {"ok": True, "granted": False}
+
+    if not event.workspace_id:
+        # A success event with no workspace_id in metadata can't be routed. Ack
+        # it (200) so the gateway stops retrying, but record nothing.
+        logger.warning(
+            "billing.webhook: payment.succeeded carried no workspace_id (event_id=%s) — ignoring",
+            event.event_id,
+        )
+        return {"ok": True, "granted": False}
+    if event.amount_credits <= 0:
+        logger.warning(
+            "billing.webhook: payment.succeeded had non-positive amount (event_id=%s) — ignoring",
+            event.event_id,
+        )
+        return {"ok": True, "granted": False}
+
+    # Grant EXACTLY ONCE — idempotency is keyed on the webhook event id. A replay
+    # collides on BC-1's unique (workspace, idempotency_key) index and no-ops.
+    balance_before = await credits_service.balance(event.workspace_id)
+    new_balance = await credits_service.grant(
+        workspace=event.workspace_id,
+        amount=event.amount_credits,
+        cause="top_up",
+        idempotency_key=event.event_id,
+        ref={"gateway": _GATEWAY, "event_id": event.event_id},
+    )
+    # A genuine first grant moved the balance up by amount_credits; a replay
+    # returns the unchanged current balance.
+    applied = new_balance == balance_before + event.amount_credits
+
+    # Record the payment (idempotently — the unique gateway+event_id index keeps
+    # a replay from inserting a second row). The ledger entry is the money guard;
+    # this row is the human-facing payment record.
+    await _record_payment(event)
+
+    if applied:
+        # Rule 9 — emit only on a grant that actually applied (not a replay).
+        await emit(
+            BillingTopupCaptured(
+                data={
+                    "workspace_id": event.workspace_id,
+                    "gateway": _GATEWAY,
+                    "event_id": event.event_id,
+                    "amount_credits": event.amount_credits,
+                    "currency": event.currency,
+                    "balance_after": new_balance,
+                }
+            )
+        )
+        logger.info(
+            "billing.webhook: granted %d credits to workspace=%s (event_id=%s)",
+            event.amount_credits,
+            event.workspace_id,
+            event.event_id,
+        )
+    else:
+        logger.info(
+            "billing.webhook: replay of event_id=%s — grant was a no-op, balance unchanged",
+            event.event_id,
+        )
+
+    return {"ok": True, "granted": applied}
+
+
+async def _record_payment(event: GatewayEvent) -> None:
+    """Upsert the ``Payment`` record for a captured top-up. Idempotent.
+
+    A replayed webhook collides on the unique ``(gateway, gateway_event_id)``
+    index → ``DuplicateKeyError`` → we treat it as already recorded (no-op).
+    """
+    doc = Payment(
+        workspace=event.workspace_id,
+        gateway=_GATEWAY,
+        gateway_ref=str((event.raw.get("data") or {}).get("payment_id") or "") or None,
+        gateway_event_id=event.event_id,
+        amount_credits=event.amount_credits,
+        currency=event.currency or None,
+        status="succeeded",
+    )
+    try:
+        await doc.insert()
+    except DuplicateKeyError:
+        # Already recorded by a prior delivery of the same event — no-op.
+        return
+
+
+__all__ = [
+    "create_topup",
+    "handle_webhook",
+]

--- a/ee/pocketpaw_ee/cloud/billing/site_plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/site_plans.py
@@ -1,0 +1,138 @@
+# ee/pocketpaw_ee/cloud/billing/site_plans.py — the SITE-PLAN CATALOG: the
+# declarative view of the PER-SITE annual plan tiers (BC-9, the per-site plan
+# layer). The Webflow model — each PUBLISHED site carries its OWN recurring
+# ANNUAL plan on a tier, distinct from the workspace plan (``billing.plans``).
+#
+# This is the read-only catalog the per-site subscription flow (publish_pocket)
+# builds on. For each site tier it pairs:
+#   * ``annual_price_usd`` — the recurring annual price for the tier (USD,
+#     whole dollars). The intended sticker; the live charge runs through Dodo.
+#   * ``dodo_product_id`` — the Dodo recurring-product id for the tier, or None
+#     until config populates it (read from the ``POCKETPAW_DODO_SITE_PRODUCTS``
+#     mapping setting when configured). None v1 degrades gracefully — the publish
+#     records the intended tier WITHOUT a live charge.
+#   * ``cloudflare_features`` — the set of Cloudflare features a higher tier
+#     resells (BC-10 provisions these on publish). The base tier resells none.
+#
+# Read-only by design (mirrors ``billing.plans``): no DB, no writes, no emit.
+# ``list_site_plans`` / ``get_site_plan`` return frozen ``SitePlanTier`` value
+# objects built fresh from the catalog constants + config, so the catalog can
+# never drift.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-9): new module.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# The site-plan ladder. Each tier names its annual price + the Cloudflare
+# features it resells. Round, modest defaults — a real price sheet tunes them,
+# but the SHAPE (a growing ladder, base resells nothing) is the contract.
+#
+#   basic    — $0/yr    — the included tier; no resold Cloudflare features.
+#   pro      — $120/yr  — adds a custom domain + analytics.
+#   business — $480/yr  — adds the WAF + edge cache controls on top of pro.
+# ---------------------------------------------------------------------------
+_SITE_PLAN_ANNUAL_PRICE_USD: dict[str, int] = {
+    "basic": 0,
+    "pro": 120,
+    "business": 480,
+}
+
+# The Cloudflare features each tier resells (BC-10 provisions them on publish).
+# A higher tier is a superset of the one below it.
+_SITE_PLAN_CF_FEATURES: dict[str, frozenset[str]] = {
+    "basic": frozenset(),
+    "pro": frozenset({"custom_domain", "analytics"}),
+    "business": frozenset({"custom_domain", "analytics", "waf", "edge_cache"}),
+}
+
+# Order the catalog is listed in — the price ladder, cheapest first.
+_SITE_TIER_ORDER: tuple[str, ...] = ("basic", "pro", "business")
+
+# The base/floor site tier — a publish with no explicit tier resolves here.
+BASE_SITE_PLAN_KEY = "basic"
+
+
+@dataclass(frozen=True)
+class SitePlanTier:
+    """One row of the per-site plan catalog — the declarative view of a site tier.
+
+    ``key`` matches the ``Site.plan_tier`` string. ``annual_price_usd`` is the
+    recurring annual sticker (USD, whole dollars). ``dodo_product_id`` is the
+    recurring-product id, or None until config populates it. ``cloudflare_features``
+    is the set of Cloudflare features the tier resells (BC-10 provisions them).
+    """
+
+    key: str
+    annual_price_usd: int
+    dodo_product_id: str | None
+    cloudflare_features: frozenset[str]
+
+
+def _dodo_product_for(key: str) -> str | None:
+    """Resolve the Dodo recurring-product id for a site tier, or None.
+
+    Reads an optional ``POCKETPAW_DODO_SITE_PRODUCTS`` mapping
+    (``{tier_key: product_id}``) off settings when present. None is the correct
+    default in v1 — the per-site sub degrades to "record the tier, skip the live
+    charge" when no product is configured. Lazy ``get_settings`` import so building
+    the catalog never forces config load in a context that doesn't have it (e.g. a
+    unit test of ``list_site_plans``); any config error degrades safely to None
+    rather than breaking the read. Mirrors ``billing.plans._dodo_product_for``.
+    """
+    try:
+        from pocketpaw.config import get_settings
+
+        mapping = getattr(get_settings(), "dodo_site_products", None)
+    except Exception:
+        return None
+    if not isinstance(mapping, dict):
+        return None
+    val = mapping.get(key)
+    return val if isinstance(val, str) and val else None
+
+
+def _build(key: str) -> SitePlanTier:
+    """Construct a ``SitePlanTier`` for ``key`` from the catalog constants + config.
+
+    An unknown ``key`` yields a 0-price, no-feature tier — but callers go through
+    ``get_site_plan`` / ``list_site_plans``, which only ever pass known keys.
+    """
+    return SitePlanTier(
+        key=key,
+        annual_price_usd=_SITE_PLAN_ANNUAL_PRICE_USD.get(key, 0),
+        dodo_product_id=_dodo_product_for(key),
+        cloudflare_features=_SITE_PLAN_CF_FEATURES.get(key, frozenset()),
+    )
+
+
+def list_site_plans() -> list[SitePlanTier]:
+    """Return the full site-plan catalog, cheapest tier first.
+
+    Each ``SitePlanTier`` is built fresh from the catalog constants + config, so
+    the catalog always reflects the current configuration.
+    """
+    return [_build(key) for key in _SITE_TIER_ORDER]
+
+
+def get_site_plan(key: str | None) -> SitePlanTier | None:
+    """Resolve a single site tier by its ``key`` (the ``Site.plan_tier`` string).
+
+    Returns None for an unknown / missing key. Callers that need a guaranteed
+    floor map a None back to ``BASE_SITE_PLAN_KEY`` themselves — this function does
+    NOT silently substitute, so a typo in a lookup is visible rather than masked
+    (mirrors ``billing.plans.get_plan``).
+    """
+    if not key or key not in _SITE_PLAN_ANNUAL_PRICE_USD:
+        return None
+    return _build(key)
+
+
+__all__ = [
+    "BASE_SITE_PLAN_KEY",
+    "SitePlanTier",
+    "get_site_plan",
+    "list_site_plans",
+]

--- a/ee/pocketpaw_ee/cloud/billing/webhooks.py
+++ b/ee/pocketpaw_ee/cloud/billing/webhooks.py
@@ -1,0 +1,51 @@
+# ee/pocketpaw_ee/cloud/billing/webhooks.py — the PUBLIC inbound gateway webhook
+# (BC-2, the Gateway primitive).
+#
+# ``POST /billing/webhooks/dodo`` carries NO auth dependency — Dodo is the
+# caller. Trust is established by the Standard-Webhooks signature, verified
+# inside ``billing.service.handle_webhook`` (which delegates to the provider)
+# against the RAW request bytes BEFORE any field is trusted. This router is
+# mounted SEPARATELY from the licensed top-up router in ee/cloud/__init__.py so
+# no auth/license dependency ever attaches to it.
+#
+# On a verified ``payment.succeeded`` the service grants credits EXACTLY ONCE
+# (BC-1's idempotent grant, keyed on the webhook event id). A bad signature
+# raises ``ValidationError`` → 400 via the cloud error handler — no grant.
+#
+# SECURITY: read RAW bytes (the signature is over the exact bytes — never
+# re-serialize). Never log the secret or customer PII.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new module.
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request
+
+from pocketpaw_ee.cloud.billing import service as billing_service
+from pocketpaw_ee.cloud.billing.dto import WebhookAck
+
+logger = logging.getLogger(__name__)
+
+# NO license / auth dependency — the Standard-Webhooks signature is the trust
+# boundary. Mounted on its own in mount_cloud().
+router = APIRouter(prefix="/billing/webhooks", tags=["Billing"])
+
+
+@router.post("/dodo", response_model=WebhookAck)
+async def dodo_webhook(request: Request) -> WebhookAck:
+    """Ingest a Dodo Payments webhook.
+
+    Reads the RAW body + headers, verifies the Standard-Webhooks signature, and
+    on a ``payment.succeeded`` event grants the purchased credits to the
+    workspace named in the payment metadata — EXACTLY ONCE (a replay is a no-op).
+    Returns 200 with ``{ok, granted}``; a signature that does not verify raises
+    ``ValidationError`` → 400 (no grant).
+    """
+    raw = await request.body()
+    # Starlette headers are case-insensitive; hand the service a plain dict (the
+    # Standard-Webhooks verifier lowercases keys itself).
+    headers = dict(request.headers)
+    result = await billing_service.handle_webhook(payload=raw, headers=headers)
+    return WebhookAck(ok=bool(result.get("ok", True)), granted=bool(result.get("granted", False)))

--- a/ee/pocketpaw_ee/cloud/billing/webhooks.py
+++ b/ee/pocketpaw_ee/cloud/billing/webhooks.py
@@ -10,12 +10,14 @@
 #
 # On a verified ``payment.succeeded`` the service grants credits EXACTLY ONCE
 # (BC-1's idempotent grant, keyed on the webhook event id). A bad signature
-# raises ``ValidationError`` → 400 via the cloud error handler — no grant.
+# raises ``BadRequest`` → 400 via the cloud error handler — no grant.
 #
 # SECURITY: read RAW bytes (the signature is over the exact bytes — never
 # re-serialize). Never log the secret or customer PII.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new module.
+# Updated 2026-06-24 (security): correct the bad-signature docstring — the
+#   provider raises ``BadRequest`` (400), not ``ValidationError`` (422).
 
 from __future__ import annotations
 
@@ -41,7 +43,7 @@ async def dodo_webhook(request: Request) -> WebhookAck:
     on a ``payment.succeeded`` event grants the purchased credits to the
     workspace named in the payment metadata — EXACTLY ONCE (a replay is a no-op).
     Returns 200 with ``{ok, granted}``; a signature that does not verify raises
-    ``ValidationError`` → 400 (no grant).
+    ``BadRequest`` → 400 (no grant).
     """
     raw = await request.body()
     # Starlette headers are case-insensitive; hand the service a plain dict (the

--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -5,6 +5,15 @@ message, submitting a ``Run`` to the configured executor, and tailing the
 run's Redis Stream so durability sits underneath the wire shape the
 frontend already speaks.
 
+Changes: 2026-06-24 (BC-4, integration/billing-credits) — credit hard-block at
+run-start. This module is the SINGLE chokepoint that starts a new chat run
+(``create_run`` + executor submit), so the credit gate sits here, right after
+scope resolution and BEFORE any DB write. When ``settings.billing_enforced`` is
+on, a workspace at balance <= 0 gets 402 (``credits.insufficient``) and NO run /
+user message is persisted; in-flight runs (already past this point) are never
+affected. The flag is OFF by default so OSS / self-host (no ledger) are
+unaffected. See ``credits.service.check_balance``.
+
 Changes: 2026-06-18 (PERF-6, feat/sites-minimal-context) — window the history
 fed to the agent on the SITES EDIT/REFINE surface only. The sites builder got
 progressively slower per edit because ``load_history_for_scope`` loads the FULL
@@ -33,6 +42,7 @@ from typing import Any, Literal
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
+from pocketpaw.config import get_settings
 from pocketpaw_ee.cloud._core.errors import CloudError
 from pocketpaw_ee.cloud.chat.agent_schemas import CloudAgentChatRequest
 from pocketpaw_ee.cloud.chat.agent_service import (
@@ -132,6 +142,20 @@ async def post_agent_chat(
         ctx.intent = body.intent
     except InvalidScope:
         raise CloudError(400, "scope.invalid", "Invalid scope") from None
+
+    # BC-4 run-start hard-block. Sit the credit gate at the SINGLE run-start
+    # chokepoint — BEFORE any DB write (no user message, no ChatRunDoc) and
+    # BEFORE the executor submit — so a blocked run leaves no trace and
+    # IN-FLIGHT runs (already past this point) are never killed. Flag-gated:
+    # OFF by default (OSS / self-host run no ledger), ON for the cloud via
+    # ``POCKETPAW_BILLING_ENFORCED``. ``check_balance`` raises
+    # ``InsufficientCredits`` (402, credits.insufficient), which the CloudError
+    # handler maps to the wire — we never raise HTTPException here. Imported
+    # locally to keep the credits package off this hot module's import graph.
+    if get_settings().billing_enforced:
+        from pocketpaw_ee.cloud.credits import service as credits_service
+
+        await credits_service.check_balance(workspace_id)
 
     transport = get_stream_transport()
     # Resolve the surface-aware context preamble AFTER scope is resolved

--- a/ee/pocketpaw_ee/cloud/chat/runs/service.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/service.py
@@ -10,6 +10,12 @@ Changes:
   token-usage dict it assembles from the backend's ``token_usage`` event, so
   each finished run carries its real prompt / completion / cached token counts.
   ``None`` leaves the stored usage untouched (legacy callers / no-usage runs).
+- 2026-06-24 (B3 review fix — metering boundary) — added ``mark_billed(run_id)``.
+  The metering service (BC-3) previously wrote ``run_doc.billed=True`` +
+  ``run_doc.save()`` directly, a FOREIGN write across the chat.runs entity
+  boundary (EE Rule 2 — only this module touches ``ChatRunDoc``). ``bill_run`` now
+  calls ``mark_billed`` instead. Reading ``run_doc.usage`` in metering stays fine;
+  only the WRITE moves here, the owner of the document.
 """
 
 from __future__ import annotations
@@ -116,6 +122,16 @@ async def mark_terminal(
     if usage:
         doc.usage = usage
     doc.ended_at = _utcnow()
+    await doc.save()
+
+
+async def mark_billed(run_id: str) -> None:
+    """Flag a run as billed (BC-3). The owner of ``ChatRunDoc`` makes this write
+    so the metering service never writes a foreign entity's document (EE Rule 2).
+    Idempotent — re-flagging an already-billed run is harmless; the ledger key is
+    the real double-debit guard, this flag just keeps the sweeper bounded."""
+    doc = await get_run(run_id)
+    doc.billed = True
     await doc.save()
 
 

--- a/ee/pocketpaw_ee/cloud/chat/runs/worker.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/worker.py
@@ -19,6 +19,13 @@ multi-replica would interrupt sibling workers' in-flight runs), sweep any
 ``queued``/``running`` leftovers as ``interrupted``. LLM streams can't resume
 mid-generation; the partial already streamed remains visible, the user
 retries manually. HA deploys rely on the 10-minute heartbeat sweeper instead.
+
+Updated: 2026-06-24 (integration/billing-credits, BC-3) — the boot sweep now
+also runs the compute-cost metering sweep (``sweep_unbilled_runs``) so any
+terminal runs the prior worker left unbilled are charged on restart. The
+metering sweep is idempotent (billed flag + ``run:{run_id}`` ledger key), so it
+is safe even when the boot stale-run sweep is disabled — it just bills the
+already-terminal backlog.
 """
 
 from __future__ import annotations
@@ -38,6 +45,7 @@ from pocketpaw_ee.cloud.chat.runs.run_core import execute_run
 from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
 from pocketpaw_ee.cloud.jobs.domain import job_timeout_seconds
 from pocketpaw_ee.cloud.jobs.worker import execute_workspace_job
+from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
 from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
 
 logger = logging.getLogger(__name__)
@@ -82,6 +90,16 @@ async def _startup(ctx: dict[str, Any]) -> None:
             logger.info("worker boot: marked %d orphaned runs as interrupted", swept)
     except Exception:
         logger.exception("worker boot: stale-run sweep failed")
+    # BC-3 metering: bill any terminal runs the prior worker left unbilled (the
+    # boot sweep above just turned this boot's orphans terminal, and earlier
+    # finished runs may never have been billed). Own try so a metering failure
+    # can't abort worker startup.
+    try:
+        billed = await sweep_unbilled_runs()
+        if billed:
+            logger.info("worker boot: billed %d unbilled terminal runs", billed)
+    except Exception:
+        logger.exception("worker boot: compute-cost metering sweep failed")
 
 
 async def _shutdown(ctx: dict[str, Any]) -> None:

--- a/ee/pocketpaw_ee/cloud/credits/__init__.py
+++ b/ee/pocketpaw_ee/cloud/credits/__init__.py
@@ -1,0 +1,10 @@
+# ee/pocketpaw_ee/cloud/credits/__init__.py — Credits entity package marker.
+# Created 2026-06-23 (integration/billing-credits, BC-1): the credit ledger +
+# atomic balance (the Ledger primitive). The 4-file entity shape (domain / dto /
+# service / router) lives here. Plain marker — the router is imported explicitly
+# by ``ee.cloud.__init__:mount_cloud``, not eagerly here, so importing this
+# package never pulls FastAPI / Beanie.
+
+"""Credit ledger — workspace-scoped wallet with grant / debit / query."""
+
+from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/credits/domain.py
+++ b/ee/pocketpaw_ee/cloud/credits/domain.py
@@ -1,0 +1,36 @@
+# ee/pocketpaw_ee/cloud/credits/domain.py — frozen value objects for the
+# credit ledger entity (BC-1, the Ledger primitive).
+#
+# These are the plain, framework-free shapes the service hands back across the
+# entity boundary — never the Beanie documents themselves. Only
+# ``credits.service`` imports ``models.credit``; routers / DTOs / other entities
+# consume these domain objects (the same entity-isolation boundary the pockets
+# entity uses).
+#
+# Created 2026-06-23 (integration/billing-credits, BC-1): new entity.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class LedgerEntry:
+    """One immutable movement on a workspace's credit wallet.
+
+    Mirrors ``models.credit.CreditLedgerEntry`` with framework-free types.
+    ``amount_delta`` is signed; ``balance_after`` is the wallet balance once
+    this movement landed.
+    """
+
+    id: str
+    workspace_id: str
+    kind: str
+    amount_delta: int
+    balance_after: int
+    member_id: str | None
+    cause: str | None
+    ref: dict = field(default_factory=dict)
+    idempotency_key: str = ""
+    created_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/credits/domain.py
+++ b/ee/pocketpaw_ee/cloud/credits/domain.py
@@ -8,11 +8,37 @@
 # entity uses).
 #
 # Created 2026-06-23 (integration/billing-credits, BC-1): new entity.
+# Updated 2026-06-24 (B1 review fix): added ``GrantResult`` — ``grant`` now
+# reports whether the ledger entry was NEWLY created (``created=True``) vs a
+# duplicate-key replay (``created=False``), alongside the new balance. Billing's
+# webhook capture-event emit was previously gated on a balance-delta heuristic
+# (``new_balance == before + amount``) that mis-fires under concurrency: a racing
+# grant could make a genuine first grant look like a replay (suppressing the
+# capture emit) or a replay look genuine (a spurious emit). ``created`` is the
+# authoritative signal — set True only when the insert landed, False on
+# ``DuplicateKeyError``.
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+
+
+@dataclass(frozen=True)
+class GrantResult:
+    """The outcome of a ``credits.grant`` call.
+
+    ``balance`` is the wallet balance after the call. ``created`` is True only
+    when this call NEWLY inserted the ledger entry (a real grant applied); it is
+    False when the call collided on the unique ``(workspace, idempotency_key)``
+    index — i.e. a duplicate-key REPLAY of an already-applied grant (a no-op that
+    returns the current balance). Callers gate their "money moved" side effects
+    (e.g. billing's capture-event emit) on ``created``, never on a balance delta,
+    which is unreliable under concurrency.
+    """
+
+    balance: int
+    created: bool
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/credits/dto.py
+++ b/ee/pocketpaw_ee/cloud/credits/dto.py
@@ -1,0 +1,70 @@
+# ee/pocketpaw_ee/cloud/credits/dto.py — request/response schemas for the
+# credit ledger HTTP surface (BC-1, the Ledger primitive).
+#
+# Distinct Request / Response DTOs per the EE cloud rule 4. The read surface
+# (balance + history) is the only HTTP-exposed half in BC-1; grant / debit are
+# called in-process by the rest of the billing subsystem (top-ups, subscription
+# grants, compute spend), not from a public route.
+#
+# Created 2026-06-23 (integration/billing-credits, BC-1): new entity.
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from pocketpaw_ee.cloud.credits.domain import LedgerEntry
+
+
+class BalanceResponse(BaseModel):
+    """Current spendable balance for the caller's workspace.
+
+    ``balance_credits`` is integer credits (1 credit == $0.01).
+    """
+
+    workspace_id: str
+    balance_credits: int
+
+
+class LedgerEntryResponse(BaseModel):
+    """One movement on the wire — mirrors ``domain.LedgerEntry``."""
+
+    id: str
+    workspace_id: str
+    kind: str
+    amount_delta: int
+    balance_after: int
+    member_id: str | None = None
+    cause: str | None = None
+    ref: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str = ""
+    created_at: datetime | None = None
+
+
+class HistoryResponse(BaseModel):
+    """A page of ledger movements, newest first.
+
+    ``next_cursor`` is the id to pass back as ``cursor`` for the next page,
+    or ``None`` when the page is the last one.
+    """
+
+    entries: list[LedgerEntryResponse] = Field(default_factory=list)
+    next_cursor: str | None = None
+
+
+def ledger_entry_to_dto(entry: LedgerEntry) -> LedgerEntryResponse:
+    """Map a frozen ``domain.LedgerEntry`` to its wire DTO."""
+    return LedgerEntryResponse(
+        id=entry.id,
+        workspace_id=entry.workspace_id,
+        kind=entry.kind,
+        amount_delta=entry.amount_delta,
+        balance_after=entry.balance_after,
+        member_id=entry.member_id,
+        cause=entry.cause,
+        ref=dict(entry.ref),
+        idempotency_key=entry.idempotency_key,
+        created_at=entry.created_at,
+    )

--- a/ee/pocketpaw_ee/cloud/credits/router.py
+++ b/ee/pocketpaw_ee/cloud/credits/router.py
@@ -1,0 +1,60 @@
+# ee/pocketpaw_ee/cloud/credits/router.py — the credit ledger read surface
+# (BC-1, the Ledger primitive).
+#
+# Two read routes, both scoped to the caller's CURRENT workspace (resolved via
+# the standard ``current_workspace_id`` / ``current_user_id`` deps):
+#   * GET /credits/balance  — the current spendable balance.
+#   * GET /credits/history  — a page of ledger movements, newest first.
+#
+# THIN adapters per the "primitive = service + thin adapters" shape — all logic
+# lives in ``credits.service``. Grant / debit are NOT exposed here: they are
+# called in-process by the rest of the billing subsystem (top-ups, subscription
+# grants, compute spend), not from a public route. Mounted in ``mount_cloud()``.
+#
+# Created 2026-06-23 (integration/billing-credits, BC-1): new entity.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from pocketpaw_ee.cloud.credits import service as credits_service
+from pocketpaw_ee.cloud.credits.dto import (
+    BalanceResponse,
+    HistoryResponse,
+    ledger_entry_to_dto,
+)
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import current_workspace_id
+
+router = APIRouter(prefix="/credits", tags=["Credits"], dependencies=[Depends(require_license)])
+
+
+@router.get("/balance", response_model=BalanceResponse)
+async def get_credit_balance(
+    workspace_id: str = Depends(current_workspace_id),
+) -> BalanceResponse:
+    """Return the current spendable credit balance for the caller's workspace.
+
+    ``balance_credits`` is integer credits (1 credit == $0.01). A workspace
+    with no wallet yet reads back ``0``.
+    """
+    bal = await credits_service.balance(workspace_id)
+    return BalanceResponse(workspace_id=workspace_id, balance_credits=bal)
+
+
+@router.get("/history", response_model=HistoryResponse)
+async def get_credit_history(
+    workspace_id: str = Depends(current_workspace_id),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = Query(default=None),
+) -> HistoryResponse:
+    """Page the workspace's append-only credit ledger, newest first.
+
+    Pass the returned ``next_cursor`` back as ``cursor`` to fetch the next
+    (older) page; a ``null`` ``next_cursor`` marks the last page.
+    """
+    entries, next_cursor = await credits_service.history(workspace_id, limit=limit, cursor=cursor)
+    return HistoryResponse(
+        entries=[ledger_entry_to_dto(e) for e in entries],
+        next_cursor=next_cursor,
+    )

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -1,0 +1,378 @@
+# ee/pocketpaw_ee/cloud/credits/service.py — the credit ledger business logic
+# (BC-1, the Ledger primitive). Sole owner of writes to the ``CreditBalance``
+# and ``CreditLedgerEntry`` Beanie documents (entity isolation — only THIS
+# module imports ``models.credit``).
+#
+# Module-level ``async def`` API (NOT a class, per EE cloud rule). Public API:
+#   * ``grant``     — add credits, idempotent. Returns the new balance.
+#   * ``debit``     — remove credits, idempotent + atomic. Raises
+#                     ``InsufficientCredits`` (402) on over-debit, with ZERO
+#                     side effects. Returns the new balance.
+#   * ``balance``   — read the current spendable balance (tenant-scoped).
+#   * ``history``   — page the append-only ledger, newest first.
+#   * ``reconcile`` — recompute ``balance == sum(amount_delta)`` and repair the
+#                     CreditBalance doc if it drifted (covers a crash between
+#                     the ledger insert and the balance ``$inc``).
+#
+# ATOMICITY (verdict from grounding: NO Mongo transactions — single-node Mongo
+# has no replica set, so ``session.start_transaction`` is unavailable and used
+# nowhere). Movements are made atomic with single-document operators only:
+#
+#   1. Exactly-once guard — INSERT the ledger entry FIRST, stamped with the
+#      caller's ``idempotency_key``. The UNIQUE compound index on
+#      ``(workspace, idempotency_key)`` makes a retried movement collide on
+#      insert (``DuplicateKeyError`` / Mongo code 11000) → the movement was
+#      already applied → return the current balance (no-op, no re-apply,
+#      no second emit). This holds invariant (a): a duplicate key never
+#      double-applies.
+#
+#   2. Apply the effect with a conditional atomic ``$inc`` on the single
+#      CreditBalance doc (the ``find_one_and_update`` CAS idiom — copied from
+#      ``auth/service.py``'s claim_home_pocket_id and ``leads/service.py``'s
+#      _bump):
+#        * grant — unconditional ``$inc: +amount`` with ``upsert=True`` (creates
+#          the balance row at 0 then increments in one call).
+#        * debit — CONDITIONAL ``$inc: -amount`` filtered on
+#          ``balance_credits >= amount``. If it returns ``None`` the wallet had
+#          insufficient funds → we DELETE the ledger entry we inserted in step 1
+#          (rollback) and raise ``InsufficientCredits``. This holds invariant
+#          (b): a rejected over-debit leaves NO ledger entry and NO balance
+#          change, AND a later retry with the same key re-evaluates cleanly
+#          (the key is free again because the entry was deleted).
+#
+#   WHY insert-first then rollback-on-reject (not "insert only after a
+#   successful $inc"): the ledger entry IS the idempotency token. If we applied
+#   the $inc first and inserted the entry second, two concurrent calls with the
+#   same key could both pass the $inc before either inserted (double-spend), and
+#   the unique-key guard would only catch it AFTER the money already moved. By
+#   inserting first, the unique index serializes same-key callers before any
+#   balance moves; the conditional $inc serializes DIFFERENT-key debits against
+#   the funds check. The deletion on insufficient funds is the only compensating
+#   write, and it runs before the balance ever changed, so invariant (b) holds.
+#
+#   3. The new ``balance_after`` (returned by the atomic ``$inc``) is written
+#      back onto the ledger entry so the audit row is self-describing.
+#
+#   The only crash window is between the step-1 insert and the step-2 $inc: a
+#   committed ledger entry whose effect never landed on the balance.
+#   ``reconcile`` closes it — balance is defined as ``sum(amount_delta)`` over
+#   the committed ledger, so re-summing repairs any drift.
+#
+# Rule 9 — ``emit(CreditMovement(...))`` fires after each SUCCESSFUL grant /
+# debit (never on a no-op replay). Rule 10 — raise ``InsufficientCredits``
+# (CloudError), never HTTPException.
+#
+# Created 2026-06-23 (integration/billing-credits, BC-1): new entity.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from beanie import PydanticObjectId
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+from pocketpaw_ee.cloud._core.errors import InsufficientCredits, ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import CreditMovement
+from pocketpaw_ee.cloud.credits.domain import LedgerEntry
+from pocketpaw_ee.cloud.models.credit import CreditBalance, CreditLedgerEntry
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers
+# ---------------------------------------------------------------------------
+
+
+def _entry_to_domain(doc: CreditLedgerEntry) -> LedgerEntry:
+    return LedgerEntry(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        kind=doc.kind,
+        amount_delta=doc.amount_delta,
+        balance_after=doc.balance_after,
+        member_id=doc.member_id,
+        cause=doc.cause,
+        ref=dict(doc.ref or {}),
+        idempotency_key=doc.idempotency_key,
+        created_at=getattr(doc, "createdAt", None),
+    )
+
+
+async def _current_balance(workspace: str) -> int:
+    """Read the workspace's current balance, or 0 when no row exists yet."""
+    doc = await CreditBalance.find_one(CreditBalance.workspace == workspace)
+    return int(doc.balance_credits) if doc is not None else 0
+
+
+async def _emit_movement(entry: CreditLedgerEntry) -> None:
+    """Emit ``credits.movement`` after a successful grant / debit (rule 9)."""
+    await emit(
+        CreditMovement(
+            data={
+                "workspace_id": entry.workspace,
+                "kind": entry.kind,
+                "amount_delta": entry.amount_delta,
+                "balance_after": entry.balance_after,
+                "cause": entry.cause,
+                "idempotency_key": entry.idempotency_key,
+            }
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write API
+# ---------------------------------------------------------------------------
+
+
+async def grant(
+    workspace: str,
+    amount: int,
+    cause: str,
+    idempotency_key: str,
+    *,
+    member_id: str | None = None,
+    ref: dict | None = None,
+    kind: str = "grant",
+) -> int:
+    """Add ``amount`` credits to the workspace wallet. Idempotent.
+
+    Returns the new balance. A retried call with the same
+    ``(workspace, idempotency_key)`` is a no-op that returns the current
+    balance — the movement already applied.
+
+    ``kind`` defaults to ``"grant"``; pass ``"genesis"`` to seed a fresh
+    wallet's first credits (the ledger origin row).
+    """
+    # Rule 6 — validate at entry. Money-handling: an amount must be a positive
+    # integer (1 credit == $0.01) and the idempotency key must be present.
+    if not isinstance(amount, int) or isinstance(amount, bool) or amount <= 0:
+        raise ValidationError("credits.invalid_amount", "Grant amount must be a positive integer")
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+    if not idempotency_key:
+        raise ValidationError("credits.invalid_key", "idempotency_key is required")
+
+    # Step 1 — insert the ledger entry FIRST (the exactly-once guard).
+    entry = CreditLedgerEntry(
+        workspace=workspace,
+        kind=kind,
+        amount_delta=amount,
+        balance_after=0,  # stamped after the $inc returns the new balance
+        member_id=member_id,
+        cause=cause,
+        ref=dict(ref or {}),
+        idempotency_key=idempotency_key,
+    )
+    try:
+        await entry.insert()
+    except DuplicateKeyError:
+        # This movement was already applied — return the current balance.
+        return await _current_balance(workspace)
+
+    # Step 2 — apply the effect: unconditional $inc with upsert (creates the
+    # balance row at 0 then increments in one atomic call).
+    coll = CreditBalance.get_pymongo_collection()
+    updated = await coll.find_one_and_update(
+        {"workspace": workspace},
+        {
+            "$inc": {"balance_credits": amount},
+            "$setOnInsert": {"createdAt": datetime.now(UTC)},
+            "$currentDate": {"updatedAt": True},
+        },
+        upsert=True,
+        return_document=ReturnDocument.AFTER,
+    )
+    new_balance = int(updated["balance_credits"])
+
+    # Step 3 — write balance_after back onto the audit row.
+    entry.balance_after = new_balance
+    await entry.save()
+
+    await _emit_movement(entry)
+    return new_balance
+
+
+async def debit(
+    workspace: str,
+    amount: int,
+    cause: str,
+    idempotency_key: str,
+    *,
+    member_id: str | None = None,
+    ref: dict | None = None,
+    kind: str = "spend",
+) -> int:
+    """Remove ``amount`` credits from the workspace wallet. Atomic + idempotent.
+
+    Returns the new balance. Raises ``InsufficientCredits`` (402) when the
+    wallet holds fewer than ``amount`` credits — with ZERO side effects (no
+    ledger entry, no balance change). A retried call with the same
+    ``(workspace, idempotency_key)`` is a no-op that returns the current
+    balance.
+    """
+    # Rule 6 — validate at entry.
+    if not isinstance(amount, int) or isinstance(amount, bool) or amount <= 0:
+        raise ValidationError("credits.invalid_amount", "Debit amount must be a positive integer")
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+    if not idempotency_key:
+        raise ValidationError("credits.invalid_key", "idempotency_key is required")
+
+    # Step 1 — insert the ledger entry FIRST (the exactly-once guard). The delta
+    # is signed negative for a debit.
+    entry = CreditLedgerEntry(
+        workspace=workspace,
+        kind=kind,
+        amount_delta=-amount,
+        balance_after=0,  # stamped after the $inc returns the new balance
+        member_id=member_id,
+        cause=cause,
+        ref=dict(ref or {}),
+        idempotency_key=idempotency_key,
+    )
+    try:
+        await entry.insert()
+    except DuplicateKeyError:
+        # This movement was already applied — return the current balance.
+        return await _current_balance(workspace)
+
+    # Step 2 — apply the effect: CONDITIONAL $inc filtered on
+    # ``balance_credits >= amount`` so two racing debits can never both pass the
+    # funds check (compare-and-swap, not read-then-write). NO upsert — a wallet
+    # that doesn't exist yet has zero credits and cannot satisfy the filter.
+    coll = CreditBalance.get_pymongo_collection()
+    updated = await coll.find_one_and_update(
+        {"workspace": workspace, "balance_credits": {"$gte": amount}},
+        {"$inc": {"balance_credits": -amount}, "$currentDate": {"updatedAt": True}},
+        return_document=ReturnDocument.AFTER,
+    )
+    if updated is None:
+        # Insufficient funds. Roll back the ledger entry we inserted in step 1 so
+        # the rejected debit leaves NO trace (invariant b) and a retry with the
+        # same key can re-evaluate cleanly (the key is free again).
+        await entry.delete()
+        available = await _current_balance(workspace)
+        raise InsufficientCredits(amount, available)
+
+    new_balance = int(updated["balance_credits"])
+
+    # Step 3 — write balance_after back onto the audit row.
+    entry.balance_after = new_balance
+    await entry.save()
+
+    await _emit_movement(entry)
+    return new_balance
+
+
+# ---------------------------------------------------------------------------
+# Read API (Rule 7 — every read is tenant-filtered on ``workspace``)
+# ---------------------------------------------------------------------------
+
+
+async def balance(workspace: str) -> int:
+    """Return the workspace's current spendable balance (0 when no wallet)."""
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+    return await _current_balance(workspace)
+
+
+async def history(
+    workspace: str,
+    *,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> tuple[list[LedgerEntry], str | None]:
+    """Page the workspace's ledger, newest first.
+
+    Returns ``(entries, next_cursor)`` where ``next_cursor`` is the id to pass
+    as ``cursor`` for the following page, or ``None`` when this is the last
+    page. ``cursor`` is the last id from the previous page — only entries
+    OLDER than it are returned (id is a monotonic ObjectId, so ``_id < cursor``
+    is a stable "older than" predicate).
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+    limit = max(1, min(int(limit), 200))
+
+    query: dict[str, Any] = {"workspace": workspace}
+    if cursor:
+        try:
+            query["_id"] = {"$lt": PydanticObjectId(cursor)}
+        except Exception:
+            raise ValidationError("credits.invalid_cursor", "cursor is not a valid id") from None
+
+    # Fetch one extra to know whether a further page exists.
+    docs = await CreditLedgerEntry.find(query).sort("-_id").limit(limit + 1).to_list()
+    has_more = len(docs) > limit
+    page = docs[:limit]
+    next_cursor = str(page[-1].id) if (has_more and page) else None
+    return [_entry_to_domain(d) for d in page], next_cursor
+
+
+async def reconcile(workspace: str) -> int:
+    """Recompute the balance from the ledger and repair the CreditBalance doc.
+
+    Balance is DEFINED as ``sum(amount_delta)`` over the workspace's committed
+    ledger. This re-sums every entry and writes the result back onto the
+    CreditBalance doc when it has drifted (covers a crash between a ledger
+    insert and its balance ``$inc``). Returns the reconciled balance.
+
+    Idempotent: a wallet already in agreement is left untouched (and the call
+    still returns the correct balance).
+    """
+    if not workspace:
+        raise ValidationError("credits.invalid_workspace", "workspace is required")
+
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == workspace).to_list()
+    computed = sum(int(e.amount_delta) for e in entries)
+
+    coll = CreditBalance.get_pymongo_collection()
+    bal_doc = await CreditBalance.find_one(CreditBalance.workspace == workspace)
+    if bal_doc is None:
+        if computed == 0:
+            # No wallet and no movements — nothing to repair.
+            return 0
+        # A ledger exists but the balance row was lost — recreate it.
+        await coll.update_one(
+            {"workspace": workspace},
+            {
+                "$set": {"balance_credits": computed},
+                "$setOnInsert": {"createdAt": datetime.now(UTC)},
+                "$currentDate": {"updatedAt": True},
+            },
+            upsert=True,
+        )
+        logger.warning(
+            "credits.reconcile: workspace=%s had ledger sum=%d but no balance row; recreated",
+            workspace,
+            computed,
+        )
+        return computed
+
+    if int(bal_doc.balance_credits) != computed:
+        logger.warning(
+            "credits.reconcile: workspace=%s balance drifted (stored=%d, ledger=%d); repaired",
+            workspace,
+            int(bal_doc.balance_credits),
+            computed,
+        )
+        await coll.update_one(
+            {"workspace": workspace},
+            {"$set": {"balance_credits": computed}, "$currentDate": {"updatedAt": True}},
+        )
+    return computed
+
+
+__all__ = [
+    "balance",
+    "debit",
+    "grant",
+    "history",
+    "reconcile",
+]

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -4,7 +4,11 @@
 # module imports ``models.credit``).
 #
 # Module-level ``async def`` API (NOT a class, per EE cloud rule). Public API:
-#   * ``grant``     — add credits, idempotent. Returns the new balance.
+#   * ``grant``     — add credits, idempotent. Returns a ``GrantResult`` carrying
+#                     the new balance AND ``created`` (True on a real first grant,
+#                     False on a duplicate-key replay) so callers gate side
+#                     effects on the authoritative created-flag, not a balance
+#                     delta that races under concurrency.
 #   * ``debit``     — remove credits, idempotent + atomic. Raises
 #                     ``InsufficientCredits`` (402) on over-debit, with ZERO
 #                     side effects. Returns the new balance.
@@ -88,6 +92,13 @@
 # it BEFORE create_run/submit, but ONLY when ``settings.billing_enforced`` is on,
 # so OSS/self-host (flag default False) is unaffected and IN-FLIGHT runs are never
 # touched. Kept flag-free here so the check stays reusable.
+# Changed 2026-06-24 (B1 review fix): ``grant`` now returns a ``GrantResult``
+# (balance + ``created``) instead of a bare int. ``created`` is True only when the
+# ledger entry was NEWLY inserted, False on the ``DuplicateKeyError`` replay path.
+# Billing's webhook keyed its capture-event emit on a balance-delta heuristic
+# (``new_balance == before + amount``) that is wrong under concurrency — a racing
+# grant could suppress a genuine emit or fire a spurious one. The created-flag is
+# the authoritative replay signal; callers gate the emit on it.
 
 from __future__ import annotations
 
@@ -102,7 +113,7 @@ from pymongo.errors import DuplicateKeyError
 from pocketpaw_ee.cloud._core.errors import InsufficientCredits, ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import CreditMovement
-from pocketpaw_ee.cloud.credits.domain import LedgerEntry
+from pocketpaw_ee.cloud.credits.domain import GrantResult, LedgerEntry
 from pocketpaw_ee.cloud.models.credit import CreditBalance, CreditLedgerEntry
 
 logger = logging.getLogger(__name__)
@@ -164,12 +175,15 @@ async def grant(
     member_id: str | None = None,
     ref: dict | None = None,
     kind: str = "grant",
-) -> int:
+) -> GrantResult:
     """Add ``amount`` credits to the workspace wallet. Idempotent.
 
-    Returns the new balance. A retried call with the same
-    ``(workspace, idempotency_key)`` is a no-op that returns the current
-    balance — the movement already applied.
+    Returns a ``GrantResult`` of ``(balance, created)``. ``created`` is True when
+    this call NEWLY applied the grant; a retried call with the same
+    ``(workspace, idempotency_key)`` is a no-op that returns the current balance
+    with ``created=False`` — the movement already applied. Callers gate their
+    "money moved" side effects (e.g. a capture-event emit) on ``created``, never
+    on a balance delta, which is unreliable under concurrency.
 
     ``kind`` defaults to ``"grant"``; pass ``"genesis"`` to seed a fresh
     wallet's first credits (the ledger origin row).
@@ -201,8 +215,10 @@ async def grant(
     try:
         await entry.insert()
     except DuplicateKeyError:
-        # This movement was already applied — return the current balance.
-        return await _current_balance(workspace)
+        # This movement was already applied — return the current balance and
+        # signal a replay (created=False) so the caller suppresses any
+        # money-moved side effect (e.g. a capture-event emit).
+        return GrantResult(balance=await _current_balance(workspace), created=False)
 
     # Step 2 — apply the effect: unconditional $inc with upsert (creates the
     # balance row at 0 then increments in one atomic call).
@@ -226,7 +242,7 @@ async def grant(
     await entry.save()
 
     await _emit_movement(entry)
-    return new_balance
+    return GrantResult(balance=new_balance, created=True)
 
 
 async def debit(
@@ -404,6 +420,17 @@ async def history(
 async def reconcile(workspace: str) -> int:
     """Re-drive unapplied ledger entries, then repair the CreditBalance doc.
 
+    WARNING — MANUAL RECOVERY TOOL, RUN QUIESCENT ONLY (B4). This is an operator
+    repair path for the rare crash-window drift (a committed ledger entry whose
+    balance ``$inc`` never landed), NOT a hot-path routine. It re-drives unapplied
+    entries and re-sums the ledger in MULTIPLE non-atomic steps, so it MUST run
+    with writes to this workspace's wallet PAUSED (quiescent). A concurrent grant
+    or debit racing a reconcile can interleave with the re-drive / re-sum and
+    corrupt the balance. Do NOT call it on every request, do NOT wire it into the
+    grant/debit path, and do NOT "rebuild" it into an always-on reconciler —
+    grant/debit are already individually atomic + idempotent; reconcile only exists
+    to repair the crash-window phantom after the fact, under operator control.
+
     The balance is DEFINED as ``sum(amount_delta)`` over the entries whose effect
     actually LANDED (``applied is True``) — NOT over every committed row. A
     committed-but-unapplied entry is a PHANTOM: it survived the step-1 insert but
@@ -554,6 +581,7 @@ async def reconcile(workspace: str) -> int:
 
 
 __all__ = [
+    "GrantResult",
     "balance",
     "check_balance",
     "debit",

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -51,18 +51,34 @@
 #   write, and it runs before the balance ever changed, so invariant (b) holds.
 #
 #   3. The new ``balance_after`` (returned by the atomic ``$inc``) is written
-#      back onto the ledger entry so the audit row is self-describing.
+#      back onto the ledger entry, and ``applied`` is flipped to True, so the
+#      audit row is self-describing AND ``reconcile`` can tell a landed entry
+#      from a phantom.
 #
 #   The only crash window is between the step-1 insert and the step-2 $inc: a
-#   committed ledger entry whose effect never landed on the balance.
-#   ``reconcile`` closes it — balance is defined as ``sum(amount_delta)`` over
-#   the committed ledger, so re-summing repairs any drift.
+#   committed ledger entry whose effect never landed on the balance — i.e. one
+#   left at ``applied is False``. ``reconcile`` closes it by RE-DRIVING every
+#   unapplied entry (not by blindly summing the whole ledger, which would count
+#   the phantom as if it had applied).
 #
 # Rule 9 — ``emit(CreditMovement(...))`` fires after each SUCCESSFUL grant /
 # debit (never on a no-op replay). Rule 10 — raise ``InsufficientCredits``
 # (CloudError), never HTTPException.
 #
 # Created 2026-06-23 (integration/billing-credits, BC-1): new entity.
+# Changed 2026-06-24 (BC-1 reconcile fix): an adversarial review found
+# ``reconcile`` summed ``amount_delta`` over ALL committed entries with no notion
+# of whether each entry's $inc actually LANDED, so a phantom (committed but
+# unapplied) debit drove the balance to a fabricated value. Three changes close
+# it: (1) every entry now carries an ``applied`` flag flipped True only after its
+# $inc lands; (2) ``debit`` gains ``allow_negative`` — an unconditional debit for
+# metered compute spend (BC-3) that may drive the balance below zero (a completed
+# run is always billed); a strict debit is tagged ``conditional=True``; (3)
+# ``reconcile`` now RE-DRIVES every ``applied is False`` entry (re-applying grants
+# and allow_negative debits unconditionally, re-applying strict debits with the
+# $gte guard and VOIDING them if the funds aren't there) and then sums only the
+# applied entries. The balance is NEVER clamped to >= 0 — a legitimate negative
+# from metered overage is preserved.
 
 from __future__ import annotations
 
@@ -158,12 +174,16 @@ async def grant(
     if not idempotency_key:
         raise ValidationError("credits.invalid_key", "idempotency_key is required")
 
-    # Step 1 — insert the ledger entry FIRST (the exactly-once guard).
+    # Step 1 — insert the ledger entry FIRST (the exactly-once guard). It starts
+    # ``applied=False`` (the crash-window state) and ``conditional=False`` (a
+    # grant is always re-driven unconditionally).
     entry = CreditLedgerEntry(
         workspace=workspace,
         kind=kind,
         amount_delta=amount,
         balance_after=0,  # stamped after the $inc returns the new balance
+        applied=False,
+        conditional=False,
         member_id=member_id,
         cause=cause,
         ref=dict(ref or {}),
@@ -190,8 +210,10 @@ async def grant(
     )
     new_balance = int(updated["balance_credits"])
 
-    # Step 3 — write balance_after back onto the audit row.
+    # Step 3 — the $inc landed: stamp balance_after and mark the entry applied so
+    # reconcile counts it (and never re-drives it as a phantom).
     entry.balance_after = new_balance
+    entry.applied = True
     await entry.save()
 
     await _emit_movement(entry)
@@ -207,14 +229,28 @@ async def debit(
     member_id: str | None = None,
     ref: dict | None = None,
     kind: str = "spend",
+    allow_negative: bool = False,
 ) -> int:
     """Remove ``amount`` credits from the workspace wallet. Atomic + idempotent.
 
-    Returns the new balance. Raises ``InsufficientCredits`` (402) when the
-    wallet holds fewer than ``amount`` credits — with ZERO side effects (no
-    ledger entry, no balance change). A retried call with the same
-    ``(workspace, idempotency_key)`` is a no-op that returns the current
-    balance.
+    Returns the new balance. A retried call with the same
+    ``(workspace, idempotency_key)`` is a no-op that returns the current balance.
+
+    Two modes, selected by ``allow_negative``:
+
+    * ``allow_negative=False`` (STRICT, the default): a CONDITIONAL
+      ``$inc: -amount`` filtered on ``balance_credits >= amount``. If the wallet
+      holds fewer than ``amount`` credits the movement is REJECTED with ZERO side
+      effects (the inserted ledger entry is rolled back) and ``InsufficientCredits``
+      (402) is raised. The entry is tagged ``conditional=True`` so a crashed
+      phantom is re-driven with the same funds guard (and voided if the funds
+      aren't there).
+    * ``allow_negative=True``: an UNCONDITIONAL ``$inc: -amount`` that may drive
+      the balance to or below zero and NEVER raises ``InsufficientCredits``. This
+      is metered compute spend (BC-3): a completed run is always billed — the
+      spend already happened — so the overage is recorded as a legitimate
+      negative balance. The no-overdraft guarantee is enforced at run-start, not
+      here. The entry is tagged ``conditional=False``.
     """
     # Rule 6 — validate at entry.
     if not isinstance(amount, int) or isinstance(amount, bool) or amount <= 0:
@@ -225,12 +261,17 @@ async def debit(
         raise ValidationError("credits.invalid_key", "idempotency_key is required")
 
     # Step 1 — insert the ledger entry FIRST (the exactly-once guard). The delta
-    # is signed negative for a debit.
+    # is signed negative for a debit. It starts ``applied=False`` (the
+    # crash-window state); ``conditional`` records whether this is a STRICT debit
+    # (must reject on insufficient funds) so reconcile re-drives a phantom the
+    # right way.
     entry = CreditLedgerEntry(
         workspace=workspace,
         kind=kind,
         amount_delta=-amount,
         balance_after=0,  # stamped after the $inc returns the new balance
+        applied=False,
+        conditional=not allow_negative,
         member_id=member_id,
         cause=cause,
         ref=dict(ref or {}),
@@ -242,28 +283,46 @@ async def debit(
         # This movement was already applied — return the current balance.
         return await _current_balance(workspace)
 
-    # Step 2 — apply the effect: CONDITIONAL $inc filtered on
-    # ``balance_credits >= amount`` so two racing debits can never both pass the
-    # funds check (compare-and-swap, not read-then-write). NO upsert — a wallet
-    # that doesn't exist yet has zero credits and cannot satisfy the filter.
     coll = CreditBalance.get_pymongo_collection()
-    updated = await coll.find_one_and_update(
-        {"workspace": workspace, "balance_credits": {"$gte": amount}},
-        {"$inc": {"balance_credits": -amount}, "$currentDate": {"updatedAt": True}},
-        return_document=ReturnDocument.AFTER,
-    )
-    if updated is None:
-        # Insufficient funds. Roll back the ledger entry we inserted in step 1 so
-        # the rejected debit leaves NO trace (invariant b) and a retry with the
-        # same key can re-evaluate cleanly (the key is free again).
-        await entry.delete()
-        available = await _current_balance(workspace)
-        raise InsufficientCredits(amount, available)
+    if allow_negative:
+        # Step 2 (metered) — UNCONDITIONAL $inc: the balance may go to or below
+        # zero. Upsert so a never-seen wallet still records the spend (it lands
+        # at -amount, a legitimate negative). Never raises InsufficientCredits.
+        updated = await coll.find_one_and_update(
+            {"workspace": workspace},
+            {
+                "$inc": {"balance_credits": -amount},
+                "$setOnInsert": {"createdAt": datetime.now(UTC)},
+                "$currentDate": {"updatedAt": True},
+            },
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+    else:
+        # Step 2 (strict) — CONDITIONAL $inc filtered on
+        # ``balance_credits >= amount`` so two racing debits can never both pass
+        # the funds check (compare-and-swap, not read-then-write). NO upsert — a
+        # wallet that doesn't exist yet has zero credits and cannot satisfy the
+        # filter.
+        updated = await coll.find_one_and_update(
+            {"workspace": workspace, "balance_credits": {"$gte": amount}},
+            {"$inc": {"balance_credits": -amount}, "$currentDate": {"updatedAt": True}},
+            return_document=ReturnDocument.AFTER,
+        )
+        if updated is None:
+            # Insufficient funds. Roll back the ledger entry we inserted in step
+            # 1 so the rejected debit leaves NO trace (invariant b) and a retry
+            # with the same key can re-evaluate cleanly (the key is free again).
+            await entry.delete()
+            available = await _current_balance(workspace)
+            raise InsufficientCredits(amount, available)
 
     new_balance = int(updated["balance_credits"])
 
-    # Step 3 — write balance_after back onto the audit row.
+    # Step 3 — the $inc landed: stamp balance_after and mark the entry applied so
+    # reconcile counts it (and never re-drives it as a phantom).
     entry.balance_after = new_balance
+    entry.applied = True
     await entry.save()
 
     await _emit_movement(entry)
@@ -316,29 +375,125 @@ async def history(
 
 
 async def reconcile(workspace: str) -> int:
-    """Recompute the balance from the ledger and repair the CreditBalance doc.
+    """Re-drive unapplied ledger entries, then repair the CreditBalance doc.
 
-    Balance is DEFINED as ``sum(amount_delta)`` over the workspace's committed
-    ledger. This re-sums every entry and writes the result back onto the
-    CreditBalance doc when it has drifted (covers a crash between a ledger
-    insert and its balance ``$inc``). Returns the reconciled balance.
+    The balance is DEFINED as ``sum(amount_delta)`` over the entries whose effect
+    actually LANDED (``applied is True``) — NOT over every committed row. A
+    committed-but-unapplied entry is a PHANTOM: it survived the step-1 insert but
+    crashed before its balance ``$inc``, so summing it blind would invent a
+    balance the wallet never held (the review repro: grant 100 + a phantom debit
+    -1000 must not yield -950).
 
-    Idempotent: a wallet already in agreement is left untouched (and the call
-    still returns the correct balance).
+    This runs in two phases:
+
+    1. RE-DRIVE every ``applied is False`` entry, oldest first, applying its
+       effect for real:
+         * a STRICT debit (``conditional is True``) re-drives with the same
+           ``balance_credits >= amount`` conditional ``$inc``. If the funds aren't
+           there it was never authorized to land — the entry is VOIDED (deleted),
+           NOT counted, and NO negative is invented.
+         * a grant or ``allow_negative`` debit (``conditional is False``)
+           re-drives with an unconditional ``$inc`` (upserting the row).
+       Each successfully re-driven entry is stamped ``balance_after`` and marked
+       ``applied=True``.
+    2. Set ``balance_credits = sum(amount_delta)`` over the now-applied entries
+       and write it back when it has drifted. The result is NEVER clamped to
+       >= 0 — a legitimately negative balance (from ``allow_negative`` metered
+       overage) is preserved as-is.
+
+    Returns the reconciled balance. Idempotent: a wallet with no phantoms and a
+    balance already in agreement is left untouched.
     """
     if not workspace:
         raise ValidationError("credits.invalid_workspace", "workspace is required")
 
-    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == workspace).to_list()
-    computed = sum(int(e.amount_delta) for e in entries)
-
     coll = CreditBalance.get_pymongo_collection()
+
+    # Phase 1 — re-drive every unapplied (phantom) entry, oldest first so the
+    # conditional debit guards re-evaluate against the same balance order the
+    # original calls would have seen.
+    unapplied = (
+        await CreditLedgerEntry.find(
+            CreditLedgerEntry.workspace == workspace,
+            CreditLedgerEntry.applied == False,  # noqa: E712 — Beanie field equality, not `is`
+        )
+        .sort("+_id")
+        .to_list()
+    )
+    for entry in unapplied:
+        if entry.conditional:
+            # Strict debit: re-apply only if the funds are there. ``amount_delta``
+            # is negative, so the required balance is ``-amount_delta``.
+            required = -int(entry.amount_delta)
+            updated = await coll.find_one_and_update(
+                {"workspace": workspace, "balance_credits": {"$gte": required}},
+                {
+                    "$inc": {"balance_credits": int(entry.amount_delta)},
+                    "$currentDate": {"updatedAt": True},
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+            if updated is None:
+                # Never authorized to land — void it. Do NOT invent a negative.
+                logger.warning(
+                    "credits.reconcile: workspace=%s voiding unapplied strict debit "
+                    "(key=%s, delta=%d) — insufficient funds, never authorized",
+                    workspace,
+                    entry.idempotency_key,
+                    int(entry.amount_delta),
+                )
+                await entry.delete()
+                continue
+        else:
+            # Grant or allow_negative debit: unconditional $inc (upsert so a lost
+            # balance row is recreated). The balance may legitimately go negative.
+            updated = await coll.find_one_and_update(
+                {"workspace": workspace},
+                {
+                    "$inc": {"balance_credits": int(entry.amount_delta)},
+                    "$setOnInsert": {"createdAt": datetime.now(UTC)},
+                    "$currentDate": {"updatedAt": True},
+                },
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+
+        # The re-drive landed: stamp and mark applied.
+        entry.balance_after = int(updated["balance_credits"])
+        entry.applied = True
+        await entry.save()
+        logger.warning(
+            "credits.reconcile: workspace=%s re-drove unapplied entry (key=%s, delta=%d) "
+            "→ balance_after=%d",
+            workspace,
+            entry.idempotency_key,
+            int(entry.amount_delta),
+            entry.balance_after,
+        )
+
+    # Phase 2 — the canonical balance is the sum over the APPLIED entries.
+    applied_entries = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == workspace,
+        CreditLedgerEntry.applied == True,  # noqa: E712 — Beanie field equality, not `is`
+    ).to_list()
+    computed = sum(int(e.amount_delta) for e in applied_entries)
+
+    if computed < 0:
+        # Not an error — a metered allow_negative overage legitimately drives the
+        # balance below zero. Log it for visibility, but NEVER alter the value.
+        logger.warning(
+            "credits.reconcile: workspace=%s reconciled to a negative balance (%d) — "
+            "metered overage; preserving as-is",
+            workspace,
+            computed,
+        )
+
     bal_doc = await CreditBalance.find_one(CreditBalance.workspace == workspace)
     if bal_doc is None:
         if computed == 0:
-            # No wallet and no movements — nothing to repair.
+            # No wallet and no applied movements — nothing to repair.
             return 0
-        # A ledger exists but the balance row was lost — recreate it.
+        # Applied entries exist but the balance row was lost — recreate it.
         await coll.update_one(
             {"workspace": workspace},
             {
@@ -349,7 +504,8 @@ async def reconcile(workspace: str) -> int:
             upsert=True,
         )
         logger.warning(
-            "credits.reconcile: workspace=%s had ledger sum=%d but no balance row; recreated",
+            "credits.reconcile: workspace=%s had applied-ledger sum=%d but no balance row; "
+            "recreated",
             workspace,
             computed,
         )
@@ -357,7 +513,8 @@ async def reconcile(workspace: str) -> int:
 
     if int(bal_doc.balance_credits) != computed:
         logger.warning(
-            "credits.reconcile: workspace=%s balance drifted (stored=%d, ledger=%d); repaired",
+            "credits.reconcile: workspace=%s balance drifted (stored=%d, applied-ledger=%d); "
+            "repaired",
             workspace,
             int(bal_doc.balance_credits),
             computed,

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -9,6 +9,9 @@
 #                     ``InsufficientCredits`` (402) on over-debit, with ZERO
 #                     side effects. Returns the new balance.
 #   * ``balance``   — read the current spendable balance (tenant-scoped).
+#   * ``check_balance`` — raise ``InsufficientCredits`` when the wallet is
+#                     out of credits (balance <= 0). The pure, flag-free
+#                     assertion behind BC-4's run-start hard-block.
 #   * ``history``   — page the append-only ledger, newest first.
 #   * ``reconcile`` — recompute ``balance == sum(amount_delta)`` and repair the
 #                     CreditBalance doc if it drifted (covers a crash between
@@ -79,6 +82,12 @@
 # $gte guard and VOIDING them if the funds aren't there) and then sums only the
 # applied entries. The balance is NEVER clamped to >= 0 — a legitimate negative
 # from metered overage is preserved.
+# Changed 2026-06-24 (BC-4 run-start hard-block): added ``check_balance`` — a
+# pure, flag-free read that raises ``InsufficientCredits`` (402) when the wallet
+# is at or below zero. The chat run-start chokepoint (chat/agent_router.py) calls
+# it BEFORE create_run/submit, but ONLY when ``settings.billing_enforced`` is on,
+# so OSS/self-host (flag default False) is unaffected and IN-FLIGHT runs are never
+# touched. Kept flag-free here so the check stays reusable.
 
 from __future__ import annotations
 
@@ -341,6 +350,24 @@ async def balance(workspace: str) -> int:
     return await _current_balance(workspace)
 
 
+async def check_balance(workspace: str) -> None:
+    """Raise ``InsufficientCredits`` when the wallet is out of credits.
+
+    The run-start hard-block (BC-4): a workspace whose balance is ``<= 0`` may
+    not START a new chat run. A pure, reusable assertion — it carries NO flag
+    logic (the caller decides whether enforcement is on), so it stays usable by
+    any future gate (e.g. a pre-flight estimate check) without coupling to the
+    ``billing_enforced`` setting. A no-op for any positive balance; raises a 402
+    ``credits.insufficient`` (mapped by the CloudError handler) at zero or below.
+    The reported ``requested`` is 1 — the minimum a new run will consume — and
+    ``available`` is the clamped non-negative balance so the message reads
+    sensibly even on a metered-overage negative wallet.
+    """
+    bal = await balance(workspace)
+    if bal <= 0:
+        raise InsufficientCredits(1, max(bal, 0))
+
+
 async def history(
     workspace: str,
     *,
@@ -528,6 +555,7 @@ async def reconcile(workspace: str) -> int:
 
 __all__ = [
     "balance",
+    "check_balance",
     "debit",
     "grant",
     "history",

--- a/ee/pocketpaw_ee/cloud/entitlements/__init__.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/__init__.py
@@ -1,0 +1,19 @@
+# ee/pocketpaw_ee/cloud/entitlements/__init__.py — Entitlements entity package
+# marker (BC-6, the Entitlement primitive).
+#
+# The entitlements RESOLVER maps a workspace -> what it's entitled to (its plan,
+# the plan's feature set, and its monthly credit allotment) by reading the
+# workspace's CURRENT ``Workspace.plan`` and looking it up in the billing plan
+# catalog (``ee.cloud.billing.plans``). It is the read/declarative layer BC-7
+# (subscriptions) and BC-9 (per-site) build on. No event projection here —
+# entitlements derive from the existing ``Workspace.plan`` field.
+#
+# Plain marker — the router is imported explicitly by
+# ``ee.cloud.__init__:mount_cloud``, not eagerly here, so importing this package
+# never pulls FastAPI / Beanie.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-6): new entity.
+
+"""Entitlements — resolve a workspace to its plan, features, and allotment."""
+
+from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -1,0 +1,34 @@
+# ee/pocketpaw_ee/cloud/entitlements/domain.py — the frozen, framework-free
+# value object the entitlements resolver returns (BC-6, the Entitlement
+# primitive).
+#
+# ``Entitlements`` is the normalized "what is this workspace entitled to" shape:
+# its resolved plan key, the plan's feature set, and its monthly credit
+# allotment. It carries no framework type (no Beanie, no FastAPI) so the service
+# can build it and the DTO layer can map it without either reaching into the
+# other. It is derived from the EXISTING ``Workspace.plan`` field + the billing
+# plan catalog — there is no event projection here.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-6): new entity.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Entitlements:
+    """What a workspace is entitled to, resolved from its current plan.
+
+    ``plan`` is the resolved tier key (matches ``Workspace.plan`` /
+    ``PLAN_FEATURES`` — a workspace with no/unknown plan resolves to the base
+    ``free`` tier). ``features`` is that tier's feature set (the same set
+    ``PLAN_FEATURES`` and the policy gate use — one source of truth).
+    ``monthly_credit_allotment`` is integer credits (1 credit == $0.01) granted
+    per renewal for the tier.
+    """
+
+    workspace_id: str
+    plan: str
+    monthly_credit_allotment: int
+    features: frozenset[str] = field(default_factory=frozenset)

--- a/ee/pocketpaw_ee/cloud/entitlements/dto.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/dto.py
@@ -10,12 +10,18 @@
 # is not), so the response is stable and diff-friendly for clients.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-6): new entity.
+# Updated 2026-06-24 (BC-10): added ``SitePlanTierResponse`` / ``SitePlanCatalogResponse``
+#   for ``GET /billing/site-plans`` — the PER-SITE plan catalog (each tier ->
+#   annual price + the Cloudflare features it resells). ``cloudflare_features`` is a
+#   SORTED list (deterministic JSON, same rule as ``features`` above). The frontend
+#   (BC-11) reads this to render the publish tier picker.
 
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
 from pocketpaw_ee.cloud.billing.plans import PlanTier
+from pocketpaw_ee.cloud.billing.site_plans import SitePlanTier
 from pocketpaw_ee.cloud.entitlements.domain import Entitlements
 
 
@@ -68,4 +74,35 @@ def entitlements_to_dto(ent: Entitlements) -> EntitlementsResponse:
         plan=ent.plan,
         monthly_credit_allotment=ent.monthly_credit_allotment,
         features=sorted(ent.features),
+    )
+
+
+class SitePlanTierResponse(BaseModel):
+    """One row of the PER-SITE plan catalog on the wire — mirrors ``SitePlanTier``.
+
+    ``annual_price_usd`` is the recurring annual sticker (USD, whole dollars).
+    ``cloudflare_features`` is the SORTED list of Cloudflare features the tier
+    resells (deterministic JSON; BC-10 provisions these when a domain is added).
+    ``dodo_product_id`` is None until config populates it.
+    """
+
+    key: str
+    annual_price_usd: int
+    dodo_product_id: str | None = None
+    cloudflare_features: list[str] = Field(default_factory=list)
+
+
+class SitePlanCatalogResponse(BaseModel):
+    """The full per-site plan catalog — response of ``GET /billing/site-plans``."""
+
+    site_plans: list[SitePlanTierResponse] = Field(default_factory=list)
+
+
+def site_plan_tier_to_dto(tier: SitePlanTier) -> SitePlanTierResponse:
+    """Map a frozen ``site_plans.SitePlanTier`` to its wire DTO (features sorted)."""
+    return SitePlanTierResponse(
+        key=tier.key,
+        annual_price_usd=tier.annual_price_usd,
+        dodo_product_id=tier.dodo_product_id,
+        cloudflare_features=sorted(tier.cloudflare_features),
     )

--- a/ee/pocketpaw_ee/cloud/entitlements/dto.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/dto.py
@@ -1,0 +1,71 @@
+# ee/pocketpaw_ee/cloud/entitlements/dto.py — request/response schemas for the
+# entitlements + plan-catalog HTTP surface (BC-6, the Plan + Entitlement
+# primitives).
+#
+# Read-only surface, so there is no request DTO. ``PlanTierResponse`` mirrors a
+# ``billing.plans.PlanTier`` (one catalog row); ``PlanCatalogResponse`` wraps the
+# list for ``GET /billing/plans``. ``EntitlementsResponse`` mirrors
+# ``entitlements.domain.Entitlements`` for ``GET /entitlements``. ``features`` is
+# serialized as a SORTED list (a JSON array is deterministic on the wire; a set
+# is not), so the response is stable and diff-friendly for clients.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-6): new entity.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from pocketpaw_ee.cloud.billing.plans import PlanTier
+from pocketpaw_ee.cloud.entitlements.domain import Entitlements
+
+
+class PlanTierResponse(BaseModel):
+    """One row of the plan catalog on the wire — mirrors ``plans.PlanTier``.
+
+    ``monthly_credit_allotment`` is integer credits (1 credit == $0.01).
+    ``features`` is a sorted list (deterministic JSON). ``dodo_product_id`` is
+    None until BC-7 / config populates it.
+    """
+
+    key: str
+    monthly_credit_allotment: int
+    dodo_product_id: str | None = None
+    features: list[str] = Field(default_factory=list)
+
+
+class PlanCatalogResponse(BaseModel):
+    """The full plan catalog — response of ``GET /billing/plans``."""
+
+    plans: list[PlanTierResponse] = Field(default_factory=list)
+
+
+class EntitlementsResponse(BaseModel):
+    """A workspace's resolved entitlements — response of ``GET /entitlements``.
+
+    Mirrors ``entitlements.domain.Entitlements``. ``features`` is a sorted list.
+    """
+
+    workspace_id: str
+    plan: str
+    monthly_credit_allotment: int
+    features: list[str] = Field(default_factory=list)
+
+
+def plan_tier_to_dto(tier: PlanTier) -> PlanTierResponse:
+    """Map a frozen ``plans.PlanTier`` to its wire DTO (features sorted)."""
+    return PlanTierResponse(
+        key=tier.key,
+        monthly_credit_allotment=tier.monthly_credit_allotment,
+        dodo_product_id=tier.dodo_product_id,
+        features=sorted(tier.features),
+    )
+
+
+def entitlements_to_dto(ent: Entitlements) -> EntitlementsResponse:
+    """Map a frozen ``domain.Entitlements`` to its wire DTO (features sorted)."""
+    return EntitlementsResponse(
+        workspace_id=ent.workspace_id,
+        plan=ent.plan,
+        monthly_credit_allotment=ent.monthly_credit_allotment,
+        features=sorted(ent.features),
+    )

--- a/ee/pocketpaw_ee/cloud/entitlements/router.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/router.py
@@ -1,0 +1,39 @@
+# ee/pocketpaw_ee/cloud/entitlements/router.py — the entitlements read surface
+# (BC-6, the Entitlement primitive).
+#
+# One read route, scoped to the caller's CURRENT workspace (resolved via the
+# standard ``current_workspace_id`` dep):
+#   * GET /entitlements — the workspace's resolved entitlements (plan + features
+#     + monthly credit allotment).
+#
+# THIN adapter per the "primitive = service + thin adapters" shape — all logic
+# lives in ``entitlements.service`` (and the catalog in ``billing.plans``).
+# Mounted in ``mount_cloud()``. The plan CATALOG itself (GET /billing/plans) is a
+# tenant-independent read and lives on the billing router.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-6): new entity.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+from pocketpaw_ee.cloud.entitlements.dto import EntitlementsResponse, entitlements_to_dto
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import current_workspace_id
+
+router = APIRouter(tags=["Entitlements"], dependencies=[Depends(require_license)])
+
+
+@router.get("/entitlements", response_model=EntitlementsResponse)
+async def get_entitlements(
+    workspace_id: str = Depends(current_workspace_id),
+) -> EntitlementsResponse:
+    """Return the caller's workspace's resolved entitlements.
+
+    Derived from the workspace's CURRENT ``Workspace.plan``: the resolved plan
+    key, that tier's feature set, and its monthly credit allotment. A workspace
+    with no/unknown plan resolves to the ``free`` base tier.
+    """
+    ent = await entitlements_service.resolve_entitlements(workspace_id)
+    return entitlements_to_dto(ent)

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -1,0 +1,72 @@
+# ee/pocketpaw_ee/cloud/entitlements/service.py — the entitlements RESOLVER
+# (BC-6, the Entitlement primitive).
+#
+# Module-level ``async def`` API (NOT a class, per EE cloud rule, mirroring
+# ``credits.service`` / ``billing.service``). Public API:
+#   * ``resolve_entitlements(workspace_id)`` — read the workspace's CURRENT plan
+#     (``workspace.service.get_workspace_plan``), look it up in the billing plan
+#     catalog (``billing.plans``), and return an ``Entitlements`` (plan +
+#     features + monthly credit allotment).
+#
+# READ-ONLY: no writes, no emit (EE cloud rule 9 only fires on mutation; this
+# entity mutates nothing). Tenancy: ``get_workspace_plan`` resolves the plan from
+# the ONE ``Workspace`` document with that id and returns None for a missing /
+# soft-deleted / malformed id, so there is no cross-tenant read here — a caller
+# only ever sees the plan of the workspace it asked for.
+#
+# FALLBACK: a workspace with no plan, an unknown plan string, or a missing
+# workspace resolves to the ``free`` base tier (``plans.BASE_PLAN_KEY``) — never
+# a crash, never a silent upgrade to a paid tier. (Subscription EVENTS that
+# CHANGE the plan are BC-7's job; here entitlements derive from the existing
+# ``Workspace.plan`` field as it stands.)
+#
+# Created 2026-06-24 (integration/billing-credits, BC-6): new entity.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.billing import plans as plan_catalog
+from pocketpaw_ee.cloud.entitlements.domain import Entitlements
+
+
+async def resolve_entitlements(workspace_id: str) -> Entitlements:
+    """Resolve a workspace to its entitlements (plan + features + allotment).
+
+    Reads the workspace's CURRENT ``Workspace.plan`` and looks the tier up in the
+    billing plan catalog. A workspace with no/unknown plan (or one that doesn't
+    exist) resolves to the ``free`` base tier — never a crash, never a paid-tier
+    leak.
+    """
+    # Rule 6 — validate at entry.
+    if not workspace_id:
+        raise ValidationError("entitlements.invalid_workspace", "workspace_id is required")
+
+    # Lazy import keeps this module free of the heavy workspace.service import at
+    # module load (it pulls Beanie), mirroring how the plan-feature gate dep
+    # imports the workspace service inside the guard.
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    plan_key = await workspace_service.get_workspace_plan(workspace_id)
+
+    # None (missing/deleted/malformed id) OR a plan string not in the catalog
+    # (a stale/typo'd tier) both fall back to the base floor. ``get_plan``
+    # returns None for an unknown key, so this one branch covers both.
+    tier = plan_catalog.get_plan(plan_key)
+    if tier is None:
+        tier = plan_catalog.get_plan(plan_catalog.BASE_PLAN_KEY)
+        # The base tier is a static catalog entry; this is never None in
+        # practice, but guard so a future catalog edit can't NPE the resolver.
+        if tier is None:  # pragma: no cover - defensive; base tier always exists
+            return Entitlements(
+                workspace_id=workspace_id,
+                plan=plan_catalog.BASE_PLAN_KEY,
+                monthly_credit_allotment=0,
+                features=frozenset(),
+            )
+
+    return Entitlements(
+        workspace_id=workspace_id,
+        plan=tier.key,
+        monthly_credit_allotment=tier.monthly_credit_allotment,
+        features=tier.features,
+    )

--- a/ee/pocketpaw_ee/cloud/metering/__init__.py
+++ b/ee/pocketpaw_ee/cloud/metering/__init__.py
@@ -1,0 +1,13 @@
+# ee/pocketpaw_ee/cloud/metering/__init__.py — Metering entity package marker.
+# Created 2026-06-24 (integration/billing-credits, BC-3): the compute-cost meter
+# + rate card (the Meter + Price primitives). Every completed / terminal chat run
+# is billed by its real compute cost times a flat markup, converted to integer
+# credits and debited to the workspace wallet EXACTLY ONCE via a durable sweeper.
+# The 4-file entity shape (domain / dto / service / sweeper) lives here. Plain
+# marker — nothing is imported eagerly so importing this package never pulls
+# FastAPI / Beanie.
+
+"""Compute-cost metering — bills each terminal chat run's compute cost to the
+workspace wallet exactly once, surviving crashes via a durable sweeper."""
+
+from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/metering/domain.py
+++ b/ee/pocketpaw_ee/cloud/metering/domain.py
@@ -1,0 +1,67 @@
+# ee/pocketpaw_ee/cloud/metering/domain.py — frozen value objects for the
+# compute-cost metering entity (BC-3, the Meter + Price primitives).
+#
+# Pure-Python, framework-free shapes. The service hands these back across the
+# entity boundary instead of leaking the Beanie ``ChatRunDoc`` or raw dicts.
+#
+#   * ``RateCard`` — the declarative Price primitive: a flat USD-cost markup +
+#     the per-credit USD denomination. ``to_credits(cost_usd)`` is the rate-card
+#     conversion (round(cost_usd * markup / credit_usd)). Kept a dataclass so a
+#     tiered card (per-model / per-tier rates) can subclass or replace it later
+#     without touching the debit path.
+#   * ``ComputeCost`` — the Meter primitive's output: the resolved USD cost of a
+#     run plus the model it was attributed to and the source it came from
+#     (reported total_cost_usd vs. the pricing-table estimate vs. none).
+#
+# Created 2026-06-24 (integration/billing-credits, BC-3): new entity.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+# Where a run's resolved cost came from — for the bill ref + debug logging.
+CostSource = Literal["reported", "estimated", "none"]
+
+
+@dataclass(frozen=True)
+class RateCard:
+    """The compute-spend rate card (the Price primitive).
+
+    ``markup`` is the flat multiplier applied to a run's real USD compute cost;
+    ``credit_usd`` is the USD value of one credit (1 credit == $0.01). The
+    conversion to billable credits is ``round(cost_usd * markup / credit_usd)``
+    — with the defaults that is ``round(cost_usd * 250)``.
+
+    Declarative on purpose: a flat card is two numbers, but the shape leaves room
+    for a tiered card (e.g. per-model multipliers) without changing ``bill_run``.
+    """
+
+    markup: float
+    credit_usd: float
+
+    def to_credits(self, cost_usd: float) -> int:
+        """Convert a USD compute cost into integer credits via the rate card.
+
+        ``round`` (banker's rounding) is fine here — the amounts are tiny and the
+        markup absorbs sub-credit drift. A non-positive cost yields 0 credits (no
+        debit; the run is still marked billed so it isn't re-swept).
+        """
+        if cost_usd <= 0:
+            return 0
+        return round(cost_usd * self.markup / self.credit_usd)
+
+
+@dataclass(frozen=True)
+class ComputeCost:
+    """A run's resolved compute cost (the Meter primitive's output).
+
+    ``cost_usd`` is the authoritative USD cost; ``source`` records how it was
+    resolved (the backend's reported ``total_cost_usd``, the pricing-table
+    estimate, or none for an unknown model / empty usage). ``model`` is the model
+    the cost was attributed to (``None`` when usage carried no model).
+    """
+
+    cost_usd: float
+    source: CostSource
+    model: str | None

--- a/ee/pocketpaw_ee/cloud/metering/dto.py
+++ b/ee/pocketpaw_ee/cloud/metering/dto.py
@@ -1,0 +1,38 @@
+# ee/pocketpaw_ee/cloud/metering/dto.py — result schema for the compute-cost
+# metering entity (BC-3, the Meter + Price primitives).
+#
+# Metering is an internal system job (the sweeper drives it; there is no public
+# CRUD route in BC-3), so the only DTO is the BILL RESULT — what ``bill_run``
+# returns to the sweeper / a caller so it can log or assert on the outcome
+# without reaching back into the Beanie doc. Distinct from the domain
+# ``ComputeCost`` (the meter's intermediate output): this is the post-debit
+# outcome (credits charged, the resulting balance, whether a debit actually ran).
+#
+# Created 2026-06-24 (integration/billing-credits, BC-3): new entity.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class BillResult(BaseModel):
+    """The outcome of billing one run's compute cost.
+
+    ``credits_charged`` is the integer credits debited (0 when the cost rounded
+    to nothing or usage was empty — the run is still marked billed).
+    ``balance_after`` is the workspace wallet balance once the debit landed (may
+    be negative: a completed run is always billed, so an overage is recorded as a
+    legitimate negative). ``debited`` is False when ``credits_charged == 0`` and
+    no ledger movement was written.
+    """
+
+    run_id: str
+    workspace_id: str
+    cost_usd: float
+    credits_charged: int
+    balance_after: int
+    debited: bool
+    cost_source: str = Field(
+        description="How the cost was resolved: 'reported' | 'estimated' | 'none'.",
+    )
+    model: str | None = None

--- a/ee/pocketpaw_ee/cloud/metering/service.py
+++ b/ee/pocketpaw_ee/cloud/metering/service.py
@@ -1,0 +1,225 @@
+# ee/pocketpaw_ee/cloud/metering/service.py — the compute-cost metering business
+# logic (BC-3, the Meter + Price primitives). Reads a finished ``ChatRunDoc``'s
+# token-usage, resolves its real USD compute cost, converts that to integer
+# credits via the rate card, and debits the workspace wallet EXACTLY ONCE.
+#
+# Module-level ``async def`` API (NOT a class, per EE cloud rule, mirroring
+# ``credits.service`` / ``billing.service``). Public API:
+#   * ``resolve_cost(usage)``  — the Meter: a run's ``usage`` dict -> ``ComputeCost``
+#                                (USD). Reported ``total_cost_usd`` wins when > 0;
+#                                else the pricing-table estimate; else 0.0.
+#   * ``load_rate_card()``     — build the ``RateCard`` (the Price primitive) from
+#                                runtime settings (POCKETPAW_BILLING_MARKUP /
+#                                POCKETPAW_CREDIT_USD).
+#   * ``bill_run(run_doc)``    — compute credits and debit the wallet once, keyed
+#                                on ``run:{run_id}`` (BC-1's idempotency guard),
+#                                then flip ``run_doc.billed`` True. Returns a
+#                                ``BillResult``.
+#
+# COST AUTHORITY: the production backend runs keyless / OAuth, so it frequently
+# emits ``total_cost_usd = None`` or ``0`` even though tokens were consumed. The
+# AUTHORITATIVE fallback is ``src/pocketpaw/usage_tracker._estimate_cost`` over
+# the ``_PRICING`` table — the same table the runtime usage tracker bills against.
+# We therefore only trust a reported cost when it is strictly positive; otherwise
+# we re-derive from token counts.
+#
+# EXACTLY-ONCE: the debit's ``idempotency_key=f"run:{run_id}"`` + BC-1's unique
+# ``(workspace, idempotency_key)`` index means a re-bill (sweeper double-run,
+# crash between the debit and the ``billed`` flag write, two workers) is a no-op
+# at the ledger. The ``billed`` flag is the cheap filter that keeps each sweep
+# bounded; the ledger key is the real guard. ``allow_negative=True`` — a completed
+# run is always billed (the compute already happened), so an overage drives the
+# balance legitimately negative rather than being blocked here. Hard-blocking is a
+# separate concern at run START, not at bill time.
+#
+# Rule 10 — only ``CloudError`` subclasses propagate (none raised on the happy
+# path; an unknown-model run bills 0, it does not error). Rule 6 — the meter
+# tolerates a missing / malformed usage dict (treats it as no usage).
+#
+# Created 2026-06-24 (integration/billing-credits, BC-3): new entity.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw_ee.cloud.credits import service as credits_service
+from pocketpaw_ee.cloud.metering.domain import ComputeCost, RateCard
+from pocketpaw_ee.cloud.metering.dto import BillResult
+from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+logger = logging.getLogger(__name__)
+
+# Business cause stamped on the ledger movement (matches the credits tests'
+# convention and the dashboard's spend filter).
+_COMPUTE_SPEND_CAUSE = "compute_spend"
+
+
+def _int(value: Any) -> int:
+    """Coerce a usage count to a non-negative int, tolerating None / strings."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+# ---------------------------------------------------------------------------
+# The Meter — resolve a run's real USD compute cost from its usage dict.
+# ---------------------------------------------------------------------------
+
+
+def resolve_cost(usage: dict[str, Any] | None) -> ComputeCost:
+    """Resolve a run's ``usage`` dict to a USD compute cost (the Meter).
+
+    Resolution order:
+      1. ``usage["total_cost_usd"]`` IF present and strictly ``> 0`` (the backend
+         reported a real cost) -> source ``"reported"``.
+      2. ELSE ``usage_tracker._estimate_cost(model, input, output, cached)`` over
+         the authoritative ``_PRICING`` table -> source ``"estimated"`` (this is
+         the keyless / OAuth path where the backend reports no cost).
+      3. ELSE ``0.0`` -> source ``"none"`` (unknown model or empty usage); logged
+         at DEBUG so an operator can spot an unpriced model without log noise.
+    """
+    usage = usage or {}
+    model = usage.get("model") or None
+
+    reported = usage.get("total_cost_usd")
+    if isinstance(reported, (int, float)) and not isinstance(reported, bool) and reported > 0:
+        return ComputeCost(cost_usd=float(reported), source="reported", model=model)
+
+    # Fallback to the authoritative pricing table. Import lazily so importing the
+    # metering entity never drags the runtime usage_tracker into the cloud import
+    # graph at module load.
+    from pocketpaw.usage_tracker import _estimate_cost
+
+    input_tokens = _int(usage.get("input_tokens"))
+    output_tokens = _int(usage.get("output_tokens"))
+    cached_input_tokens = _int(usage.get("cached_input_tokens"))
+
+    estimated = None
+    if model is not None and (input_tokens or output_tokens or cached_input_tokens):
+        estimated = _estimate_cost(model, input_tokens, output_tokens, cached_input_tokens)
+
+    if estimated is not None and estimated > 0:
+        return ComputeCost(cost_usd=float(estimated), source="estimated", model=model)
+
+    logger.debug(
+        "metering.resolve_cost: no billable cost (model=%r, in=%d, out=%d, cached=%d, "
+        "reported=%r) — billing 0",
+        model,
+        input_tokens,
+        output_tokens,
+        cached_input_tokens,
+        reported,
+    )
+    return ComputeCost(cost_usd=0.0, source="none", model=model)
+
+
+# ---------------------------------------------------------------------------
+# The Price — the rate card from runtime settings.
+# ---------------------------------------------------------------------------
+
+
+def load_rate_card() -> RateCard:
+    """Build the rate card (the Price primitive) from runtime settings.
+
+    Reads ``POCKETPAW_BILLING_MARKUP`` (default 2.5) and ``POCKETPAW_CREDIT_USD``
+    (default 0.01). Lazy import so the metering entity has no import-time
+    dependency on the settings singleton.
+    """
+    from pocketpaw.config import get_settings
+
+    settings = get_settings()
+    return RateCard(markup=float(settings.billing_markup), credit_usd=float(settings.credit_usd))
+
+
+# ---------------------------------------------------------------------------
+# bill_run — debit the wallet for one run's compute, exactly once.
+# ---------------------------------------------------------------------------
+
+
+async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) -> BillResult:
+    """Bill ``run_doc``'s compute cost to its workspace wallet, exactly once.
+
+    Resolves the USD cost (the Meter), converts to credits via the rate card (the
+    Price), and debits the workspace wallet with ``allow_negative=True`` keyed on
+    ``run:{run_id}`` so a re-bill is a ledger no-op. When the cost rounds to 0
+    credits (empty usage / unknown model / sub-credit cost) NO debit is written —
+    but the run is STILL marked ``billed`` so the sweeper never re-visits it.
+
+    The ``billed`` flag is flipped True and saved AFTER the debit lands. A crash
+    between the debit and the flag write is harmless: the next sweep re-bills,
+    BC-1's ``run:{run_id}`` key makes that debit a no-op, and the flag is then set.
+
+    ``rate_card`` may be injected (tests / a future per-workspace card); it
+    defaults to the settings-derived card.
+    """
+    card = rate_card if rate_card is not None else load_rate_card()
+    cost = resolve_cost(run_doc.usage)
+    credits = card.to_credits(cost.cost_usd)
+
+    workspace = run_doc.workspace
+    run_id = run_doc.run_id
+
+    if credits > 0:
+        balance_after = await credits_service.debit(
+            workspace=workspace,
+            amount=credits,
+            cause=_COMPUTE_SPEND_CAUSE,
+            idempotency_key=f"run:{run_id}",
+            ref={
+                "run_id": run_id,
+                "cost_usd": cost.cost_usd,
+                "cost_source": cost.source,
+                "model": cost.model,
+            },
+            allow_negative=True,
+        )
+        debited = True
+        logger.info(
+            "metering.bill_run: run=%s workspace=%s billed %d credits "
+            "(cost_usd=%.6f, source=%s, model=%r) -> balance=%d",
+            run_id,
+            workspace,
+            credits,
+            cost.cost_usd,
+            cost.source,
+            cost.model,
+            balance_after,
+        )
+    else:
+        # Nothing to charge — still mark billed so the run isn't re-swept forever.
+        balance_after = await credits_service.balance(workspace)
+        debited = False
+        logger.debug(
+            "metering.bill_run: run=%s workspace=%s cost rounds to 0 credits "
+            "(cost_usd=%.6f, source=%s) — marking billed, no debit",
+            run_id,
+            workspace,
+            cost.cost_usd,
+            cost.source,
+        )
+
+    # Flip the flag last. Idempotent by construction — a racing flag write that
+    # loses is harmless because the ledger key already prevented a double debit.
+    run_doc.billed = True
+    await run_doc.save()
+
+    return BillResult(
+        run_id=run_id,
+        workspace_id=workspace,
+        cost_usd=cost.cost_usd,
+        credits_charged=credits,
+        balance_after=balance_after,
+        debited=debited,
+        cost_source=cost.source,
+        model=cost.model,
+    )
+
+
+__all__ = [
+    "bill_run",
+    "load_rate_card",
+    "resolve_cost",
+]

--- a/ee/pocketpaw_ee/cloud/metering/service.py
+++ b/ee/pocketpaw_ee/cloud/metering/service.py
@@ -13,8 +13,9 @@
 #                                POCKETPAW_CREDIT_USD).
 #   * ``bill_run(run_doc)``    — compute credits and debit the wallet once, keyed
 #                                on ``run:{run_id}`` (BC-1's idempotency guard),
-#                                then flip ``run_doc.billed`` True. Returns a
-#                                ``BillResult``.
+#                                then mark the run billed via
+#                                ``chat.runs.service.mark_billed`` (the doc's
+#                                owner). Returns a ``BillResult``.
 #
 # COST AUTHORITY: the production backend runs keyless / OAuth, so it frequently
 # emits ``total_cost_usd = None`` or ``0`` even though tokens were consumed. The
@@ -36,13 +37,22 @@
 # path; an unknown-model run bills 0, it does not error). Rule 6 — the meter
 # tolerates a missing / malformed usage dict (treats it as no usage).
 #
+# ENTITY BOUNDARY (EE Rule 2): metering READS ``run_doc.usage`` (a value read is
+# fine), but the ``billed`` flag WRITE belongs to the chat.runs entity (the sole
+# owner of ``ChatRunDoc``). ``bill_run`` calls ``chat.runs.service.mark_billed``
+# rather than mutating + saving the foreign document itself.
+#
 # Created 2026-06-24 (integration/billing-credits, BC-3): new entity.
+# Updated 2026-06-24 (B3 review fix): ``bill_run`` no longer does
+# ``run_doc.billed=True; run_doc.save()`` directly (a foreign cross-entity write).
+# It now delegates the flag write to ``chat.runs.service.mark_billed(run_id)``.
 
 from __future__ import annotations
 
 import logging
 from typing import Any
 
+from pocketpaw_ee.cloud.chat.runs import service as chat_runs_service
 from pocketpaw_ee.cloud.credits import service as credits_service
 from pocketpaw_ee.cloud.metering.domain import ComputeCost, RateCard
 from pocketpaw_ee.cloud.metering.dto import BillResult
@@ -148,9 +158,11 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
     credits (empty usage / unknown model / sub-credit cost) NO debit is written —
     but the run is STILL marked ``billed`` so the sweeper never re-visits it.
 
-    The ``billed`` flag is flipped True and saved AFTER the debit lands. A crash
-    between the debit and the flag write is harmless: the next sweep re-bills,
-    BC-1's ``run:{run_id}`` key makes that debit a no-op, and the flag is then set.
+    The ``billed`` flag is flipped True AFTER the debit lands, via
+    ``chat.runs.service.mark_billed`` (the chat.runs entity owns ChatRunDoc — EE
+    Rule 2; metering never writes the foreign doc). A crash between the debit and
+    the flag write is harmless: the next sweep re-bills, BC-1's ``run:{run_id}``
+    key makes that debit a no-op, and the flag is then set.
 
     ``rate_card`` may be injected (tests / a future per-workspace card); it
     defaults to the settings-derived card.
@@ -201,10 +213,11 @@ async def bill_run(run_doc: ChatRunDoc, *, rate_card: RateCard | None = None) ->
             cost.source,
         )
 
-    # Flip the flag last. Idempotent by construction — a racing flag write that
-    # loses is harmless because the ledger key already prevented a double debit.
-    run_doc.billed = True
-    await run_doc.save()
+    # Flip the flag last, through the chat.runs entity that OWNS ChatRunDoc (EE
+    # Rule 2 — metering never writes a foreign document). Idempotent by
+    # construction — a racing flag write that loses is harmless because the ledger
+    # key already prevented a double debit.
+    await chat_runs_service.mark_billed(run_id)
 
     return BillResult(
         run_id=run_id,

--- a/ee/pocketpaw_ee/cloud/metering/sweeper.py
+++ b/ee/pocketpaw_ee/cloud/metering/sweeper.py
@@ -1,0 +1,93 @@
+# ee/pocketpaw_ee/cloud/metering/sweeper.py — the durable compute-cost metering
+# sweep (BC-3, the Meter + Price primitives).
+#
+# Every TERMINAL chat run (completed AND the non-completed terminal states —
+# cancelled / interrupted / failed; a partial run consumed tokens too) that has
+# not yet been billed gets its compute cost charged to the workspace wallet
+# EXACTLY ONCE. This runs as a system job on the SAME schedule as the stale-run
+# sweeper (the in-process 5-minute heartbeat + the Tier 2 worker boot), so a
+# crash between a run finishing and its bill landing is recovered on the next
+# tick — bill-on-completion that survives process death.
+#
+# TENANT-AGNOSTIC by design: this is a system job that scans across workspaces,
+# but every debit is workspace-scoped because the workspace travels on the run
+# doc and ``bill_run`` debits ``run_doc.workspace``. There is no cross-tenant
+# read of a wallet — only the run's own workspace is touched.
+#
+# IDEMPOTENT BY CONSTRUCTION: the query filters on ``billed == False`` (the cheap
+# filter) and each ``bill_run`` debit is keyed on ``run:{run_id}`` against BC-1's
+# unique ledger index (the real guard). Running the sweep twice — or two workers
+# racing it — bills each run once: the second debit collides on the key and is a
+# no-op, and the ``billed`` flag short-circuits the run out of later sweeps.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-3): new entity.
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud.metering import service as metering_service
+from pocketpaw_ee.cloud.metering.domain import RateCard
+from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+logger = logging.getLogger(__name__)
+
+# Terminal states whose runs are billable. ``completed`` is the happy path; the
+# other three are non-completed terminals that still consumed tokens before they
+# stopped, so they are billed for whatever the backend reported.
+_TERMINAL_STATES = ["completed", "interrupted", "failed", "cancelled"]
+
+# Cap per tick so a long-outage backlog can't wedge the heartbeat (mirrors the
+# stale-run sweeper's batch limit). The next tick drains the next batch.
+_SWEEP_BATCH_LIMIT = 200
+
+
+async def sweep_unbilled_runs(
+    *,
+    batch_limit: int = _SWEEP_BATCH_LIMIT,
+    rate_card: RateCard | None = None,
+) -> int:
+    """Bill every unbilled terminal chat run's compute cost, exactly once.
+
+    Queries up to ``batch_limit`` runs in a terminal state where ``billed`` is
+    False, oldest first (so the backlog drains FIFO), and bills each via
+    ``metering.service.bill_run``. Returns the number of runs billed (including
+    those that billed 0 credits but were marked billed). A per-run failure is
+    logged and skipped — it stays unbilled and is retried next tick — so one bad
+    run never wedges the whole sweep.
+
+    ``rate_card`` is resolved ONCE for the whole batch (a single settings read)
+    and passed into each ``bill_run`` so a 200-run sweep doesn't re-read settings
+    200 times. Tests inject a card here to pin the rate.
+    """
+    unbilled = (
+        await ChatRunDoc.find(
+            {"status": {"$in": _TERMINAL_STATES}},
+            ChatRunDoc.billed == False,  # noqa: E712 — Beanie field equality, not `is`
+        )
+        .sort("+createdAt")
+        .limit(batch_limit)
+        .to_list()
+    )
+    if not unbilled:
+        return 0
+
+    card = rate_card if rate_card is not None else metering_service.load_rate_card()
+
+    billed = 0
+    for doc in unbilled:
+        try:
+            await metering_service.bill_run(doc, rate_card=card)
+            billed += 1
+        except Exception:
+            # Leave ``billed`` False so the next tick retries this run; the
+            # run:{run_id} key keeps any partial debit from double-applying.
+            logger.exception(
+                "sweep_unbilled_runs: failed to bill run %s (workspace=%s) — will retry",
+                doc.run_id,
+                doc.workspace,
+            )
+
+    if billed:
+        logger.info("sweep_unbilled_runs: billed %d terminal runs", billed)
+    return billed

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -48,6 +48,10 @@ lives in the ``pocketpaw_ee.versions`` package (its own entity), so it is
 imported lazily here — the same out-of-models discipline the belt/mandates docs
 use — to keep ``cloud.models`` from hard-importing the versions package. Only
 ``pocketpaw_ee.versions.service`` imports the doc class directly.
+Updated: 2026-06-24 (integration/billing-credits, BC-2) — added ``Payment``
+(the top-up payment record captured via a verified Dodo webhook) to the imports,
+``__all__``, and ``get_all_documents()`` so the ``billing_payments`` collection
+is wired into ``init_beanie``. Only ``ee.cloud.billing.service`` writes the doc.
 """
 
 from __future__ import annotations
@@ -96,6 +100,7 @@ from pocketpaw_ee.cloud.models.meeting import (
 from pocketpaw_ee.cloud.models.member_ingest_state import MemberIngestState
 from pocketpaw_ee.cloud.models.message import Attachment, Mention, Message, Reaction
 from pocketpaw_ee.cloud.models.notification import Notification, NotificationSource
+from pocketpaw_ee.cloud.models.payment import Payment
 from pocketpaw_ee.cloud.models.planner import PlanSession, PlanSessionAgentGap
 from pocketpaw_ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
 from pocketpaw_ee.cloud.models.pocket_backend import PocketBackendCredential
@@ -230,6 +235,7 @@ __all__ = [
     "Notification",
     "NotificationSource",
     "OAuthAccount",
+    "Payment",
     "PlanSession",
     "PlanSessionAgentGap",
     "Pocket",
@@ -282,6 +288,9 @@ def get_all_documents():
         # Only ``ee.cloud.credits.service`` writes these.
         CreditBalance,
         CreditLedgerEntry,
+        # Billing payments (BC-2) — top-up payment records captured via a
+        # gateway webhook. Only ``ee.cloud.billing.service`` writes this.
+        Payment,
         Invite,
         Group,
         InstinctApproval,

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -62,6 +62,7 @@ from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 from pocketpaw_ee.cloud.models.comment import Comment, CommentAuthor, CommentTarget
 from pocketpaw_ee.cloud.models.composio_connection import ComposioConnection
 from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+from pocketpaw_ee.cloud.models.credit import CreditBalance, CreditLedgerEntry
 from pocketpaw_ee.cloud.models.cycle import Cycle, CycleDailyPoint
 from pocketpaw_ee.cloud.models.fabric_ingest_state import (
     FabricIngestConfig,
@@ -198,6 +199,8 @@ __all__ = [
     "CommentAuthor",
     "CommentTarget",
     "ComposioConnection",
+    "CreditBalance",
+    "CreditLedgerEntry",
     "Cycle",
     "CycleDailyPoint",
     "FabricIngestConfig",
@@ -275,6 +278,10 @@ def get_all_documents():
         Workspace,
         WorkspaceConnector,
         ComposioConnection,
+        # Credit ledger (BC-1) — workspace-scoped wallet + append-only audit.
+        # Only ``ee.cloud.credits.service`` writes these.
+        CreditBalance,
+        CreditLedgerEntry,
         Invite,
         Group,
         InstinctApproval,

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -52,6 +52,11 @@ Updated: 2026-06-24 (integration/billing-credits, BC-2) — added ``Payment``
 (the top-up payment record captured via a verified Dodo webhook) to the imports,
 ``__all__``, and ``get_all_documents()`` so the ``billing_payments`` collection
 is wired into ``init_beanie``. Only ``ee.cloud.billing.service`` writes the doc.
+Updated: 2026-06-24 (integration/billing-credits, BC-7) — added ``Subscription``
+(the recurring plan subscription record captured via a verified Dodo
+``subscription.active`` webhook) to the imports, ``__all__``, and
+``get_all_documents()`` so the ``billing_subscriptions`` collection is wired into
+``init_beanie``. Only ``ee.cloud.billing.service`` writes the doc.
 """
 
 from __future__ import annotations
@@ -110,6 +115,7 @@ from pocketpaw_ee.cloud.models.sense_preference import WorkspaceSensePreference
 from pocketpaw_ee.cloud.models.session import Session
 from pocketpaw_ee.cloud.models.site import Site, SiteDomain
 from pocketpaw_ee.cloud.models.site_rate_counter import SiteRateCounter
+from pocketpaw_ee.cloud.models.subscription import Subscription
 from pocketpaw_ee.cloud.models.task import Task, TaskAssignee, TaskSource
 from pocketpaw_ee.cloud.models.task_attachment import TaskAttachment
 from pocketpaw_ee.cloud.models.task_event import TaskEvent
@@ -246,6 +252,7 @@ __all__ = [
     "Site",
     "SiteDomain",
     "SiteRateCounter",
+    "Subscription",
     "WorkspaceSensePreference",
     "Task",
     "TaskAssignee",
@@ -291,6 +298,10 @@ def get_all_documents():
         # Billing payments (BC-2) — top-up payment records captured via a
         # gateway webhook. Only ``ee.cloud.billing.service`` writes this.
         Payment,
+        # Billing subscriptions (BC-7) — recurring plan subscription records
+        # captured via verified ``subscription.*`` webhooks. Only
+        # ``ee.cloud.billing.service`` writes this.
+        Subscription,
         Invite,
         Group,
         InstinctApproval,

--- a/ee/pocketpaw_ee/cloud/models/chat_run.py
+++ b/ee/pocketpaw_ee/cloud/models/chat_run.py
@@ -9,6 +9,13 @@ Changes:
   the backend reported no usage (legacy / empty-text / pre-metering runs), so the
   field is a precondition for outcome-based (token-metered) pricing without
   changing any existing run lifecycle.
+- 2026-06-24 (integration/billing-credits, BC-3 — compute-cost metering) — added
+  the ``billed`` flag. The metering sweeper (``ee.cloud.metering.sweeper``) bills
+  every terminal run's compute cost to the workspace wallet EXACTLY ONCE and
+  flips ``billed`` True so the run is never re-swept. ``False`` for every run
+  until its cost is metered (the durable backlog the sweeper drains). The
+  exactly-once guarantee is doubly held — the ledger's ``run:{run_id}``
+  idempotency key is the real guard, this flag is the cheap "already done" filter.
 """
 
 from __future__ import annotations
@@ -48,6 +55,13 @@ class ChatRunDoc(Document):
     # empty-text runs unchanged. This is the durable metering sink that
     # outcome-based pricing reads off.
     usage: dict[str, Any] = Field(default_factory=dict)
+    # BC-3 compute-cost metering: True once this run's compute cost has been
+    # billed to the workspace wallet. The metering sweeper queries terminal runs
+    # where ``billed is False`` and bills each EXACTLY ONCE, then flips this so the
+    # run never re-bills. The ledger's ``run:{run_id}`` idempotency key is the real
+    # exactly-once guard; this flag is the cheap "skip already-billed" filter that
+    # keeps each sweep bounded.
+    billed: bool = False
     createdAt: datetime = Field(default_factory=_utcnow)
     started_at: datetime | None = None
     ended_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/models/credit.py
+++ b/ee/pocketpaw_ee/cloud/models/credit.py
@@ -1,0 +1,104 @@
+# ee/pocketpaw_ee/cloud/models/credit.py — the credit-wallet documents.
+#
+# Two Beanie documents back the workspace-scoped credit ledger (BC-1, the
+# Ledger primitive — the foundation the rest of the billing subsystem grants
+# and debits against):
+#
+#   * ``CreditBalance``     — one row per workspace, the current spendable
+#                             balance. Mutated only via the atomic single-doc
+#                             ``$inc`` CAS in ``credits.service`` (NO Mongo
+#                             transactions — single-node Mongo has no replica
+#                             set, so ``session.start_transaction`` is
+#                             unavailable). The unique ``workspace`` index keeps
+#                             it one row per tenant and lets the grant upsert
+#                             key on it.
+#   * ``CreditLedgerEntry`` — the append-only audit log. Every movement (genesis
+#                             / grant / spend / transfer) is one immutable row.
+#                             The UNIQUE compound index on
+#                             ``(workspace, idempotency_key)`` is the exactly-once
+#                             guard: a retried movement collides on insert
+#                             (DuplicateKeyError, Mongo code 11000) so the
+#                             service can no-op it.
+#
+# Credits are integers — 1 credit == $0.01 — so there is no float drift.
+#
+# Created 2026-06-23 (integration/billing-credits, BC-1): new entity. Both docs
+# are registered in ``cloud.models.__init__`` (``get_all_documents()`` +
+# ``__all__``) so ``init_beanie`` wires the ``credit_balances`` /
+# ``credit_ledger`` collections. Only ``cloud.credits.service`` imports these
+# doc classes (entity-isolation boundary, mirroring the pockets entity).
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class CreditBalance(TimestampedDocument):
+    """The current spendable credit balance for one workspace.
+
+    Exactly one row per workspace (the ``workspace`` index is UNIQUE). The
+    balance is mutated only by the atomic conditional ``$inc`` in
+    ``credits.service`` — a debit uses a ``{balance_credits: {$gte: amount}}``
+    filter so two racing debits can never both pass the funds check
+    (compare-and-swap, not read-then-write).
+    """
+
+    # UNIQUE — one balance row per workspace. The grant path upserts on this
+    # key; the debit path CAS-updates the matching row.
+    workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
+    # Integer credits; 1 credit == $0.01. Never negative — the debit CAS only
+    # decrements a row that already holds >= the debit amount.
+    balance_credits: int = 0
+
+    class Settings:
+        name = "credit_balances"
+
+
+class CreditLedgerEntry(TimestampedDocument):
+    """One immutable movement on a workspace's credit wallet (append-only).
+
+    Every grant / debit / genesis / transfer writes exactly one entry. The
+    entry is inserted FIRST, stamped with ``idempotency_key``; the UNIQUE
+    compound index on ``(workspace, idempotency_key)`` makes a duplicate
+    movement collide on insert (``DuplicateKeyError`` / Mongo code 11000) so
+    the service returns the current balance without re-applying.
+
+    ``amount_delta`` is signed (positive for grant/genesis, negative for
+    spend). ``balance_after`` is the wallet balance once this entry's effect
+    landed — stamped after the atomic ``$inc`` returns the new balance.
+    ``reconcile`` recomputes ``balance == sum(amount_delta)`` over these rows.
+    """
+
+    # Tenant scope. Indexed (non-unique) — many entries per workspace.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # One of: ``genesis`` | ``grant`` | ``spend`` | ``transfer``.
+    kind: str
+    # Signed delta this entry applied (e.g. +500 on a grant, -120 on a spend).
+    amount_delta: int
+    # Wallet balance once this entry's effect landed. Stamped after the $inc.
+    balance_after: int = 0
+    # The workspace member responsible, when known (None for system grants).
+    member_id: str | None = None
+    # Business reason, e.g. ``top_up`` | ``subscription_grant`` | ``promo`` |
+    # ``referral`` | ``compute_spend`` | ``genesis``.
+    cause: str | None = None
+    # Free-form provenance, e.g. ``{"run_id": ...}`` / ``{"event_id": ...}`` /
+    # ``{"cost_basis": ...}``. Default-empty so a movement always has a dict.
+    ref: dict = {}  # noqa: RUF012 — Beanie field default, not a shared mutable
+    # The caller-supplied exactly-once key. Unique per workspace.
+    idempotency_key: str
+
+    class Settings:
+        name = "credit_ledger"
+        indexes = [
+            # Exactly-once guard. A retried movement (same workspace + key)
+            # collides here on insert → DuplicateKeyError → the service no-ops.
+            IndexModel(
+                [("workspace", 1), ("idempotency_key", 1)],
+                unique=True,
+                name="uq_workspace_idempotency_key",
+            ),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/credit.py
+++ b/ee/pocketpaw_ee/cloud/models/credit.py
@@ -27,6 +27,16 @@
 # ``__all__``) so ``init_beanie`` wires the ``credit_balances`` /
 # ``credit_ledger`` collections. Only ``cloud.credits.service`` imports these
 # doc classes (entity-isolation boundary, mirroring the pockets entity).
+#
+# Changed 2026-06-24 (BC-1 reconcile fix): ``CreditLedgerEntry`` gains two
+# fields — ``applied`` (the balance ``$inc`` for this entry has landed) and
+# ``conditional`` (this is a STRICT debit that must reject on insufficient
+# funds). They let ``reconcile`` distinguish an entry whose effect landed from a
+# phantom (committed-but-unapplied) entry, and re-drive each phantom the right
+# way instead of blindly counting it. Also corrected the ``CreditBalance``
+# invariant: the balance MAY go slightly negative from metered compute overage
+# (BC-3) — the no-overdraft guarantee is enforced at run-start, not by clamping
+# the balance to >= 0 here.
 
 from __future__ import annotations
 
@@ -49,8 +59,13 @@ class CreditBalance(TimestampedDocument):
     # UNIQUE — one balance row per workspace. The grant path upserts on this
     # key; the debit path CAS-updates the matching row.
     workspace: Indexed(str, unique=True)  # type: ignore[valid-type]
-    # Integer credits; 1 credit == $0.01. Never negative — the debit CAS only
-    # decrements a row that already holds >= the debit amount.
+    # Integer credits; 1 credit == $0.01. Usually >= 0 — a STRICT debit CAS only
+    # decrements a row that already holds >= the debit amount. It MAY go slightly
+    # negative from a metered ``allow_negative`` compute-spend debit (BC-3): a
+    # completed run is always billed, the spend already happened, so the overage
+    # is recorded as a legitimate negative balance rather than dropped. The
+    # no-overdraft guarantee is enforced at run-start (a later task) — NOT by
+    # clamping this field to >= 0. Always integer; never a float.
     balance_credits: int = 0
 
     class Settings:
@@ -69,7 +84,20 @@ class CreditLedgerEntry(TimestampedDocument):
     ``amount_delta`` is signed (positive for grant/genesis, negative for
     spend). ``balance_after`` is the wallet balance once this entry's effect
     landed — stamped after the atomic ``$inc`` returns the new balance.
-    ``reconcile`` recomputes ``balance == sum(amount_delta)`` over these rows.
+    ``reconcile`` recomputes ``balance == sum(amount_delta)`` over the rows whose
+    effect actually landed (``applied is True``).
+
+    ``applied`` closes the crash window. An entry is inserted FIRST (the
+    idempotency guard), then the balance ``$inc`` runs; ``applied`` flips to True
+    ONLY after that ``$inc`` lands. A committed entry left at ``applied is False``
+    is a phantom — its effect never reached the balance — so ``reconcile`` must
+    re-drive it, not count it.
+
+    ``conditional`` records HOW to re-drive a phantom. True only for a STRICT
+    debit (one that must reject on insufficient funds): reconcile re-drives it
+    with the ``$gte`` conditional ``$inc`` and VOIDS it if the funds aren't there
+    (it was never authorized to land). False for grants and for ``allow_negative``
+    metered debits: reconcile re-drives those with an unconditional ``$inc``.
     """
 
     # Tenant scope. Indexed (non-unique) — many entries per workspace.
@@ -80,6 +108,16 @@ class CreditLedgerEntry(TimestampedDocument):
     amount_delta: int
     # Wallet balance once this entry's effect landed. Stamped after the $inc.
     balance_after: int = 0
+    # The balance $inc for this entry has LANDED. False is the crash-window
+    # state: the entry committed but its effect never reached the balance.
+    # ``reconcile`` re-drives every ``applied is False`` entry, then sums only the
+    # applied ones. Set True in the grant / debit success paths after the $inc.
+    applied: bool = False
+    # True only for a STRICT debit (must reject on insufficient funds). False for
+    # grants and ``allow_negative`` debits. Tells ``reconcile`` whether to re-drive
+    # a phantom with the conditional $gte $inc (and void it on insufficiency) or
+    # an unconditional $inc.
+    conditional: bool = False
     # The workspace member responsible, when known (None for system grants).
     member_id: str | None = None
     # Business reason, e.g. ``top_up`` | ``subscription_grant`` | ``promo`` |

--- a/ee/pocketpaw_ee/cloud/models/payment.py
+++ b/ee/pocketpaw_ee/cloud/models/payment.py
@@ -1,0 +1,64 @@
+# ee/pocketpaw_ee/cloud/models/payment.py — the Payment record document
+# (BC-2, the Gateway primitive).
+#
+# One row per captured (or in-flight) top-up payment, workspace-scoped. The
+# webhook handler upserts it on a verified ``payment.succeeded`` so the credit
+# grant has an auditable payment provenance alongside the BC-1 ledger entry. It
+# is NOT the idempotency authority — exactly-once is enforced by BC-1's unique
+# ``(workspace, idempotency_key)`` ledger index, keyed on the webhook event id —
+# this doc is the human-facing payment record. The UNIQUE compound index on
+# ``(gateway, gateway_event_id)`` keeps a replayed webhook from inserting a
+# second row.
+#
+# Only ``ee.cloud.billing.service`` writes this doc (entity-isolation boundary,
+# mirroring the credits/pockets entities). Registered in
+# ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``billing_payments`` collection.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new entity.
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class Payment(TimestampedDocument):
+    """A top-up payment captured through a gateway (Dodo in v1).
+
+    ``amount_credits`` is integer credits (1 credit == $0.01). ``status`` is
+    ``succeeded`` once a verified ``payment.succeeded`` webhook landed; the row
+    may be created in ``pending`` at top-up time in a later task. ``gateway`` +
+    ``gateway_event_id`` are unique together so a replayed webhook never inserts
+    a duplicate record.
+    """
+
+    # Tenant scope. Indexed (non-unique) — many payments per workspace.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The gateway that processed this payment, e.g. ``dodo``.
+    gateway: str
+    # The gateway's own payment reference (Dodo ``payment_id``), when known.
+    gateway_ref: str | None = None
+    # The webhook delivery id that captured this payment (Standard-Webhooks
+    # ``webhook-id``). The BC-1 grant's idempotency key. Part of the unique index.
+    gateway_event_id: str
+    # Integer credits granted by this payment; 1 credit == $0.01. Always integer.
+    amount_credits: int
+    # ISO currency the buyer was charged in (e.g. ``USD``), informational.
+    currency: str | None = None
+    # ``succeeded`` | ``failed`` | ``pending``.
+    status: str = "succeeded"
+
+    class Settings:
+        name = "billing_payments"
+        indexes = [
+            # A replayed webhook (same gateway + delivery id) collides here on
+            # insert → the service treats it as already-recorded.
+            IndexModel(
+                [("gateway", 1), ("gateway_event_id", 1)],
+                unique=True,
+                name="uq_gateway_event_id",
+            ),
+        ]

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -55,6 +55,20 @@
 # stored value on every re-publish so the binding target (and the data behind it)
 # is stable across deploys. "" for static sites (no D1 binding). Defaults "", so
 # pre-DS-2 rows and every static publish read empty — no migration.
+#
+# Updated 2026-06-24 (integration/billing-credits, BC-9 — per-site annual plan):
+# added the per-site billing fields a published site carries on its OWN recurring
+# annual plan (the Webflow model — each site has its own tier, not just the
+# workspace plan). ``plan_tier`` is the site-plan catalog key (basic | pro |
+# business — ``site_plans.SITE_PLAN_CATALOG``), ``subscription_id`` the Dodo
+# subscription this site's annual sub maps to, ``annual_renewal_date`` the next
+# renewal stamp the webhook updates, and ``subscription_status`` the lifecycle
+# (none | active | cancelled). ``service.publish_pocket`` stamps ``plan_tier`` +
+# ``subscription_id`` at publish; the per-site ``subscription.*`` webhook (routed
+# by a ``site_id`` on its metadata) advances ``subscription_status`` /
+# ``annual_renewal_date``. All default to backward-compatible values (None /
+# "none") so every pre-BC-9 row and every workspace-plan-only site reads as having
+# no per-site sub — no migration.
 
 from __future__ import annotations
 
@@ -99,6 +113,19 @@ class Site(TimestampedDocument):
     # Stable across re-publishes (publish reuses the stored value) so the D1
     # binding target — and the data behind it — never moves under a live site.
     d1_database_id: str = ""
+    # BC-9: per-site annual plan (the Webflow model — each published site has its
+    # OWN recurring annual plan on a tier, distinct from the workspace plan).
+    # ``plan_tier`` is the site-plan catalog key (basic | pro | business — see
+    # ``billing.site_plans``); None until a publish stamps one. ``subscription_id``
+    # is the Dodo subscription id for this site's annual sub (None when Dodo is
+    # unconfigured — the tier is recorded without a live charge in v1).
+    # ``annual_renewal_date`` is the next renewal stamp the per-site webhook
+    # updates; ``subscription_status`` tracks the lifecycle (none | active |
+    # cancelled). Defaults keep pre-BC-9 / workspace-plan-only sites at "no sub".
+    plan_tier: str | None = None
+    subscription_id: str | None = None
+    annual_renewal_date: datetime | None = None
+    subscription_status: str = "none"
     # PERF-2: a non-destructive tombstone for duplicate Site docs the pre-PERF-1
     # per-publish ObjectId minting left behind. The dedupe migration keeps ONE
     # canonical doc per (workspace, pocket_id) active and sets this True on the

--- a/ee/pocketpaw_ee/cloud/models/subscription.py
+++ b/ee/pocketpaw_ee/cloud/models/subscription.py
@@ -1,0 +1,66 @@
+# ee/pocketpaw_ee/cloud/models/subscription.py — the Subscription record document
+# (BC-7, the Subscription primitive).
+#
+# One row per workspace recurring subscription, workspace-scoped. The webhook
+# handler upserts it on a verified ``subscription.active`` (first activation) and
+# tracks its status across renewals / cancellation, so a workspace's billing
+# subscription has an auditable record alongside the per-renewal BC-1 grants. It
+# is NOT the idempotency authority for grants — exactly-once on the credit grant
+# is enforced by BC-1's unique ``(workspace, idempotency_key)`` ledger index, keyed
+# on the per-renewal webhook event id. This doc is the human-facing subscription
+# state. The UNIQUE index on ``(gateway, gateway_subscription_id)`` keeps one row
+# per gateway subscription (a replayed activation never inserts a second).
+#
+# Only ``ee.cloud.billing.service`` writes this doc (entity-isolation boundary,
+# mirroring the credits / payment entities). Registered in
+# ``cloud.models.__init__`` (``get_all_documents()`` + ``__all__``) so
+# ``init_beanie`` wires the ``billing_subscriptions`` collection.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-7): new entity.
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class Subscription(TimestampedDocument):
+    """A workspace's recurring plan subscription, captured through a gateway.
+
+    ``plan_key`` is the tier the workspace subscribed to (matches
+    ``Workspace.plan`` and the ``PLAN_FEATURES`` key). ``status`` tracks the
+    gateway lifecycle: ``active`` once a verified ``subscription.active`` landed,
+    ``cancelled`` after a ``subscription.cancelled``. ``gateway`` +
+    ``gateway_subscription_id`` are unique together so one row tracks one gateway
+    subscription across its renewals.
+    """
+
+    # Tenant scope. Indexed (non-unique) — a workspace may have historical rows.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The gateway that processed this subscription, e.g. ``dodo``.
+    gateway: str
+    # The gateway's own subscription id (Dodo ``subscription_id``). Part of the
+    # unique index so a replayed activation never inserts a duplicate row.
+    gateway_subscription_id: str
+    # The plan tier this subscription grants (team | business | enterprise).
+    plan_key: str
+    # The gateway recurring product id this subscription is for, when known.
+    product_id: str | None = None
+    # ``active`` once a verified subscription.active landed; ``cancelled`` after
+    # a subscription.cancelled. Renewals leave it ``active``.
+    status: str = "active"
+
+    class Settings:
+        name = "billing_subscriptions"
+        indexes = [
+            # One row per gateway subscription — a replayed activation (same
+            # gateway + subscription id) collides here on insert → the service
+            # updates the existing row instead of inserting a duplicate.
+            IndexModel(
+                [("gateway", 1), ("gateway_subscription_id", 1)],
+                unique=True,
+                name="uq_gateway_subscription_id",
+            ),
+        ]

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -19,6 +19,11 @@ Public API:
 - ``get_workspace_plan(workspace_id)`` — lightweight plan-tier lookup for
   the plan-feature gate dependency; returns "team" on any failure so the
   dep fails open on plan rather than crashing with a 500.
+- ``set_workspace_plan(workspace_id, plan)`` — set the workspace's plan
+  tier (BC-7). The billing subscription webhook is the only caller: a
+  verified ``subscription.active`` upgrades to the subscribed tier and a
+  ``subscription.cancelled`` reverts to ``free``. Returns True on a write,
+  False when the workspace is missing/soft-deleted.
 
 Changes: added get_workspace_plan helper for plan-feature gate dep; added
 slug_reason() (format + reserved + uniqueness) backing the live
@@ -1627,6 +1632,33 @@ async def get_workspace_plan(workspace_id: str) -> str | None:
     if doc is None or doc.deleted_at is not None:
         return None
     return doc.plan
+
+
+async def set_workspace_plan(workspace_id: str, plan: str) -> bool:
+    """Set a workspace's plan tier (BC-7 subscription lifecycle).
+
+    The ONLY caller is the billing subscription webhook: a verified
+    ``subscription.active`` upgrades the workspace to the subscribed tier, and a
+    ``subscription.cancelled`` reverts it to ``free``. Idempotent — writing the
+    same plan the workspace already holds is a harmless no-op write.
+
+    Returns True when the plan was written, False when the workspace is missing /
+    soft-deleted / has a malformed id (so the webhook can log-and-ack rather than
+    500 on an unroutable event). Does NOT touch credits — the per-renewal grant is
+    BC-1's job, keyed on the webhook event id; this only moves the entitlement.
+    """
+    if not plan:
+        raise ValidationError("workspace.invalid_plan", "plan is required")
+    try:
+        oid = PydanticObjectId(workspace_id)
+    except Exception:
+        return False
+    doc = await _WorkspaceDoc.get(oid)
+    if doc is None or doc.deleted_at is not None:
+        return False
+    doc.plan = plan
+    await doc.save()
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -91,6 +91,7 @@ _xproc_consumer_task: asyncio.Task[None] | None = None
 
 async def _sweeper_loop() -> None:
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
+    from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
 
     while True:
         try:
@@ -100,15 +101,30 @@ async def _sweeper_loop() -> None:
             raise
         except Exception:
             _run_sweeper_logger.exception("sweep_stale_runs tick failed")
+        # BC-3 metering: bill every newly-terminal run's compute cost on the same
+        # heartbeat. Kept in its own try so a metering failure can't suppress the
+        # stale-run sweep (or vice versa) on the next tick.
+        try:
+            await sweep_unbilled_runs()
+        except Exception:
+            _run_sweeper_logger.exception("sweep_unbilled_runs tick failed")
 
 
 async def start_run_sweeper() -> None:
-    """Sweep once on boot, then tick every 5 minutes until shutdown."""
+    """Sweep once on boot, then tick every 5 minutes until shutdown.
+
+    Boot runs both the stale-run sweep (interrupt orphaned runs) and the BC-3
+    compute-cost metering sweep (bill any terminal runs left unbilled by the
+    prior process); the 5-minute loop then ticks both.
+    """
     from pocketpaw_ee.cloud.chat.runs.sweeper import sweep_stale_runs
+    from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
 
     global _sweeper_task
     with suppress(Exception):
         await sweep_stale_runs()
+    with suppress(Exception):
+        await sweep_unbilled_runs()
     _sweeper_task = asyncio.create_task(_sweeper_loop())
 
 

--- a/ee/pocketpaw_ee/guards/abac.py
+++ b/ee/pocketpaw_ee/guards/abac.py
@@ -1,5 +1,11 @@
 # Attribute-based policy rules — plan gates, action-role mapping, tool whitelist.
 # Created: 2026-04-10
+# Updated: 2026-06-24 (integration/billing-credits, BC-6) — added a minimal
+#   ``free`` base tier to PLAN_FEATURES so the billing catalog and the
+#   entitlements resolver have an explicit floor to fall back to (a workspace
+#   with no/unknown plan resolves to ``free``). PLAN_FEATURES stays the single
+#   source of truth for which features a tier has; the billing catalog
+#   (``ee.cloud.billing.plans``) references it rather than duplicating it.
 
 from __future__ import annotations
 
@@ -16,6 +22,10 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 PLAN_FEATURES: dict[str, set[str]] = {
+    # The base/free floor — a workspace with no paid plan (or an unknown plan)
+    # resolves here. Deliberately minimal: the core canvas (pockets) and the
+    # ability to run sessions, nothing that costs the platform a paid upstream.
+    "free": {"pockets", "sessions"},
     "team": {"pockets", "sessions", "agents", "memory"},
     "business": {
         "pockets",

--- a/ee/pocketpaw_ee/sites/cloudflare_client.py
+++ b/ee/pocketpaw_ee/sites/cloudflare_client.py
@@ -34,6 +34,19 @@
 # supplied (a static site), it keeps the prior single-module upload byte-for-byte,
 # so the static path never regresses. The fail-closed + in-memory-token handling
 # is identical on both paths.
+# Updated 2026-06-24 (BC-10 — resell Cloudflare features by site-plan tier):
+# ``create_custom_hostname`` gained an optional ``features`` param (the
+# ``cloudflare_features`` set from the site's plan tier — e.g. ``{"waf",
+# "edge_cache", ...}``). When features are present, the custom-hostname request
+# carries the corresponding premium SSL/settings fields via ``_ssl_for_features``
+# (a pure feature-set → CF ``ssl`` payload map) plus a ``custom_metadata`` block
+# recording the resold feature set, so a HIGHER tier provisions paid security
+# (WAF / strict TLS / edge cache) at hostname-create time. When ``features`` is
+# None/empty (the BASE tier), the request is the prior basic
+# ``{"method": "http", "type": "dv"}`` ssl payload byte-for-byte, so a basic-tier
+# site never regresses. The mapping is intentionally MINIMAL + documented (a real
+# CF account tunes the exact toggles); the contract is "feature set in → those
+# CF fields out", asserted with a mocked transport.
 
 from __future__ import annotations
 
@@ -55,6 +68,51 @@ _MAIN_MODULE = "index.mjs"
 # date the generator bakes into the (otherwise-ignored-on-direct-API-upload)
 # wrangler.toml so the runtime semantics are identical to a wrangler deploy.
 _COMPATIBILITY_DATE = "2024-09-23"
+
+# BC-10: the basic (no-feature) custom-hostname SSL payload — the prior default,
+# kept byte-for-byte so a base-tier site never regresses.
+_BASIC_SSL: dict = {"method": "http", "type": "dv"}
+
+# BC-10: map a single resold feature → the custom-hostname ``ssl.settings`` fields
+# it provisions. A site's plan tier resolves to a SET of feature keys (from
+# ``billing.site_plans``); the union of these per-feature fragments becomes the
+# ``ssl.settings`` block on the create request. Intentionally MINIMAL — a real CF
+# account tunes the exact toggles; the contract is the feature → field mapping,
+# not the specific security values. Features not in this map (e.g. analytics,
+# custom_domain) provision NO ssl.settings field — they're recorded on
+# ``custom_metadata`` so the tier is still visible on the hostname.
+_FEATURE_SSL_SETTINGS: dict[str, dict] = {
+    # WAF / managed security: opt the hostname into strict TLS so the resold
+    # WAF rules sit behind a hardened handshake.
+    "waf": {"min_tls_version": "1.2", "tls_1_3": "on"},
+    # Edge cache controls: enable HTTP/2 + early-hints-friendly negotiation on
+    # the resold edge-cache tier.
+    "edge_cache": {"http2": "on"},
+}
+
+
+def _ssl_for_features(features: set[str] | None) -> dict:
+    """Build the custom-hostname ``ssl`` payload for a tier's resold features.
+
+    No features (base tier) → the prior basic ``{"method": "http", "type": "dv"}``
+    payload, unchanged. With features, the basic payload gains an ``ssl.settings``
+    block that is the UNION of every known feature's fragment (``_FEATURE_SSL_SETTINGS``)
+    plus a ``custom_metadata`` recording the full resold feature set (sorted, so the
+    wire payload is deterministic). A feature with no ssl fragment still lands on
+    ``custom_metadata`` — the tier is visible even when it provisions no toggle.
+    """
+    if not features:
+        return dict(_BASIC_SSL)
+    settings: dict = {}
+    for feat in features:
+        settings.update(_FEATURE_SSL_SETTINGS.get(feat, {}))
+    ssl: dict = dict(_BASIC_SSL)
+    if settings:
+        ssl["settings"] = settings
+    # Record the resold feature set on the hostname so the tier is auditable on
+    # the CF side (sorted → deterministic wire payload).
+    ssl["custom_metadata"] = {"resold_features": ",".join(sorted(features))}
+    return ssl
 
 
 def _map_status(cf_status: str, ssl_status: str) -> HostnameStatus:
@@ -155,12 +213,24 @@ class CloudflareClient:
         self._unwrap(resp)
         return True
 
-    async def create_custom_hostname(self, hostname: str) -> CustomHostname:
+    async def create_custom_hostname(
+        self, hostname: str, *, features: set[str] | None = None
+    ) -> CustomHostname:
+        """Register a Cloudflare-for-SaaS custom hostname, return its single CNAME.
+
+        ``features`` (BC-10) is the site plan tier's ``cloudflare_features`` set.
+        When present, the create request carries the premium ``ssl`` payload built
+        by ``_ssl_for_features`` (strict-TLS / HTTP-2 toggles for WAF / edge-cache
+        + a ``custom_metadata`` recording the resold set), so a HIGHER-tier site
+        provisions paid security at hostname-create time. When None/empty (the BASE
+        tier), the request is the prior basic DV ``ssl`` payload, unchanged — a
+        base-tier site never regresses.
+        """
         url = f"{_CF_API}/zones/{self._zone_id}/custom_hostnames"
         async with self._client() as client:
             resp = await client.post(
                 url,
-                json={"hostname": hostname, "ssl": {"method": "http", "type": "dv"}},
+                json={"hostname": hostname, "ssl": _ssl_for_features(features)},
             )
         result = self._unwrap(resp)
         return CustomHostname(

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -75,12 +75,18 @@
 #     is empty, but ``columns`` is still listed from the spec.
 # These are READ-ONLY views (no request DTO — the inputs are path params); the
 # data view never writes through this surface.
+# Updated 2026-06-24 (S2 review fix): ``DomainRequest.hostname`` now carries a
+# permissive DNS-hostname validator (label-dot-label, letters/digits/hyphens, no
+# leading/trailing/double dots, total length capped) so an obviously-malformed
+# host is rejected at the DTO (422) before it reaches Cloudflare. Kept permissive
+# — it accepts any real registrable hostname, it only blocks garbage.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class PublishRequest(BaseModel):
@@ -285,8 +291,33 @@ class SiteDataRowsResponse(BaseModel):
     rows: list[dict[str, Any]] = []
 
 
+# A permissive DNS hostname: one or more dot-separated labels, each 1-63 chars of
+# letters/digits/hyphens (not starting or ending with a hyphen), at least two
+# labels (a registrable name has a TLD). Case-insensitive. This is deliberately
+# loose — it accepts any real hostname and only rejects obvious garbage (spaces,
+# leading/trailing/double dots, illegal characters, empty labels).
+_HOSTNAME_RE = re.compile(
+    r"^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+)
+
+
 class DomainRequest(BaseModel):
     hostname: str
+
+    @field_validator("hostname")
+    @classmethod
+    def _validate_hostname(cls, v: str) -> str:
+        """Reject an obviously-malformed hostname before it reaches Cloudflare.
+
+        Permissive: any real registrable hostname passes; only garbage (spaces,
+        bad characters, leading/trailing/double dots, single-label names) fails.
+        The trailing-dot FQDN form is normalized away first so ``example.com.``
+        is accepted.
+        """
+        host = (v or "").strip().rstrip(".")
+        if not _HOSTNAME_RE.match(host):
+            raise ValueError("hostname is not a valid DNS hostname")
+        return host
 
 
 class DomainStatusResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -84,7 +84,12 @@ from pydantic import BaseModel
 
 
 class PublishRequest(BaseModel):
+    # ``site_plan_key`` (BC-10) is the OPTIONAL per-site plan tier the site is
+    # published on (basic | pro | business — see ``billing.site_plans``). Omitted
+    # defaults to the base tier in ``publish_pocket``; a higher tier resells its
+    # Cloudflare features when a custom domain is later added.
     pocket_id: str
+    site_plan_key: str | None = None
 
 
 class MakeEditableRequest(BaseModel):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -140,6 +140,7 @@ async def publish_site(
         workspace_id=ctx.workspace_id,
         user_id=ctx.user_id,
         pocket_id=body.pocket_id,
+        site_plan_key=body.site_plan_key,
     )
     return sites_service._to_response(doc)
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,12 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-24 (C1 review fix — _cf_client guard): ``_cf_client`` reads the
+# PAW_CF_* vars with ``os.environ.get`` and raises a ``ValidationError``
+# (CloudError → 422) when any is missing, instead of a raw ``KeyError`` (an
+# unhandled 500). ``add_domain`` calls it directly, so an unconfigured Cloudflare
+# now returns a clean "Cloudflare is not configured" error.
+#
 # Updated 2026-06-24 (BC-9 — per-site annual plan + publish entitlement gate):
 # ``publish_pocket`` gained ``site_plan_key`` (the per-site tier from
 # ``billing.site_plans``, defaulting to the base tier) and now — after a LIVE
@@ -550,15 +556,28 @@ def _default_allowed_origins() -> list[str]:
 
 
 def _cf_client():
-    """Build the real Cloudflare client from settings (env). Injected in tests."""
+    """Build the real Cloudflare client from settings (env). Injected in tests.
+
+    C1 review fix — reads the required vars with ``os.environ.get`` and raises a
+    ``ValidationError`` (CloudError → 422, mapped by the cloud error handler) when
+    any is missing, instead of a raw ``KeyError`` (which surfaces as an unhandled
+    500). ``add_domain`` calls this directly, so an unconfigured Cloudflare now
+    returns a clean "Cloudflare is not configured" error rather than a 500.
+    """
     import os
 
     from pocketpaw_ee.sites.cloudflare_client import CloudflareClient
 
+    account_id = os.environ.get("PAW_CF_ACCOUNT_ID")
+    api_token = os.environ.get("PAW_CF_API_TOKEN")
+    zone_id = os.environ.get("PAW_CF_ZONE_ID")
+    if not (account_id and api_token and zone_id):
+        raise ValidationError("sites.cloudflare_unconfigured", "Cloudflare is not configured")
+
     return CloudflareClient(
-        account_id=os.environ["PAW_CF_ACCOUNT_ID"],
-        api_token=os.environ["PAW_CF_API_TOKEN"],
-        zone_id=os.environ["PAW_CF_ZONE_ID"],
+        account_id=account_id,
+        api_token=api_token,
+        zone_id=zone_id,
         dispatch_namespace=os.environ.get("PAW_CF_DISPATCH_NAMESPACE", "paw-sites"),
     )
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,22 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-24 (BC-9 — per-site annual plan + publish entitlement gate):
+# ``publish_pocket`` gained ``site_plan_key`` (the per-site tier from
+# ``billing.site_plans``, defaulting to the base tier) and now — after a LIVE
+# publish persists the Site doc — stamps ``Site.plan_tier`` + ``Site.subscription_id``,
+# opens a PER-SITE annual Dodo subscription via BC-7's ``create_subscription`` with
+# ``metadata={workspace_id, site_id, plan_key}`` (the ``site_id`` is how the
+# renewal webhook tells a per-site sub from a workspace-plan sub), and emits
+# ``SitePublished``. When the site tier has no configured Dodo recurring product
+# (v1 default) the sub init DEGRADES gracefully — the tier is recorded without a
+# live charge, never crashing the publish. The publish ENTITLEMENT gate is the
+# existing ``require_sites_plan`` (the "fabric" plan feature) ``publish`` already
+# runs FIRST, before any Site insert — a workspace lacking it raises Forbidden and
+# no Site is created. New seam ``_billing_provider`` on ``publish_pocket`` injects
+# a mock subscription provider in tests. A PREVIEW publish skips all of BC-9 (it
+# never persists a Site doc).
+#
 # Updated 2026-06-20 (DS-3 — control-plane read of a dynamic site's D1 data):
 # added the operator data-view reads ``list_site_data_tables`` and
 # ``read_site_data_table`` (backing GET /sites/by-pocket/{pocket_id}/data and
@@ -952,6 +968,38 @@ async def _load(workspace_id: str, site_id: str) -> _SiteDoc:
     return doc
 
 
+async def mark_site_subscription(
+    *,
+    workspace_id: str,
+    site_id: str,
+    status: str,
+    subscription_id: str | None = None,
+    annual_renewal_date: datetime | None = None,
+) -> _SiteDoc | None:
+    """Advance a site's per-site annual subscription lifecycle (BC-9).
+
+    The entity-isolation write the billing webhook calls when a verified PER-SITE
+    ``subscription.*`` delivery (one carrying a ``site_id``) lands: billing owns
+    the Workspace / credits writes, the sites service owns the Site write, so the
+    per-site sub state is updated HERE, not by billing reaching into the Site
+    model. Sets ``subscription_status`` (active | cancelled), and on an
+    activation/renewal also advances ``annual_renewal_date``. Reuses the stored
+    ``subscription_id`` when the caller passes one (a renewal may re-confirm it).
+
+    Tenant-scoped on ``workspace`` via ``_load`` (a missing / cross-tenant /
+    malformed site id raises NotFound → the webhook acks without a write). Returns
+    the updated doc, or raises NotFound when the site does not exist for the
+    workspace (the caller — a verified webhook — treats that as nothing to do)."""
+    site = await _load(workspace_id, site_id)
+    site.subscription_status = status
+    if subscription_id:
+        site.subscription_id = subscription_id
+    if annual_renewal_date is not None:
+        site.annual_renewal_date = annual_renewal_date
+    await site.save()
+    return site
+
+
 async def _canonical_site_doc(workspace_id: str, pocket_id: str) -> _SiteDoc | None:
     """The ONE canonical Site doc for (workspace, pocket_id), or None (PERF-1).
 
@@ -1057,15 +1105,35 @@ async def publish_pocket(
     user_id: str,
     pocket_id: str,
     name: str = "",
+    site_plan_key: str | None = None,
     builder_origin: str | None = None,
     preview: bool = False,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
     _local_deploy: Callable[[str, str], str] | None = None,
+    _billing_provider: Any | None = None,
 ) -> _SiteDoc:
     """Publish a pocket as a site by id — the shared path for the REST router
     and the in-process MCP tool.
+
+    BC-9 (per-site annual plan — the Webflow model): a published site carries its
+    OWN recurring annual plan on a tier. ``site_plan_key`` selects the tier from
+    the site-plan catalog (``billing.site_plans``); it defaults to the base tier.
+    After a LIVE publish (not a preview) inserts the Site doc, this:
+      * GATES on the workspace's Sites entitlement (already enforced first via
+        ``publish`` → ``require_sites_plan`` — a workspace lacking it never reaches
+        the Site insert);
+      * stamps ``Site.plan_tier`` + ``Site.subscription_id`` for the tier;
+      * initiates a PER-SITE annual Dodo subscription (BC-7's ``create_subscription``)
+        with ``metadata={workspace_id, site_id, plan_key}`` — the ``site_id`` is how
+        the renewal webhook tells a per-site sub from a workspace-plan sub. When
+        Dodo is not configured (no recurring product for the site tier), this
+        DEGRADES gracefully: it records the intended tier without a live charge
+        (``subscription_id`` stays None), never crashing the publish;
+      * emits ``SitePublished`` ({workspace_id, site_id, pocket_id, owner,
+        plan_tier}).
+    A preview publish skips all of this (it never persists a Site doc).
 
     ``preview`` (Branch primitive — EDIT/arm path) is forwarded straight to
     ``publish``: ``True`` builds + smoke-gates + locally serves a DRAFT preview
@@ -1116,7 +1184,7 @@ async def publish_pocket(
     # backed by a per-tenant D1, so its deployed Worker gets a D1 binding.
     pattern = pocket.get("pattern")
 
-    return await publish(
+    doc = await publish(
         workspace_id=workspace_id,
         user_id=user_id,
         pocket_id=pocket_id,
@@ -1133,6 +1201,122 @@ async def publish_pocket(
         _bundle_reader=_bundle_reader,
         _local_deploy=_local_deploy,
     )
+
+    # BC-9: a PREVIEW publish never persists a Site doc, so there is no per-site
+    # plan to stamp / sub to open / event to emit — return the transient doc as-is.
+    if preview:
+        return doc
+
+    # A LIVE publish: stamp the per-site annual plan, open the per-site Dodo sub
+    # (degrading gracefully when Dodo is unconfigured), and emit SitePublished.
+    return await _apply_site_plan(
+        doc=doc,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        site_plan_key=site_plan_key,
+        provider=_billing_provider,
+    )
+
+
+async def _apply_site_plan(
+    *,
+    doc: _SiteDoc,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    site_plan_key: str | None,
+    provider: Any | None,
+) -> _SiteDoc:
+    """Stamp the per-site annual plan on a freshly published Site doc, open its
+    per-site Dodo subscription, and emit ``SitePublished`` (BC-9).
+
+    The site tier resolves from the site-plan catalog (``billing.site_plans``);
+    an unknown / missing key falls back to the base tier so a publish never fails
+    on a typo'd tier (the gate that matters — Sites entitlement — already ran in
+    ``publish``). The subscription is opened through BC-7's provider
+    (``create_subscription``) with ``metadata={workspace_id, site_id, plan_key}``;
+    the ``site_id`` is what the renewal webhook routes on to tell a per-site sub
+    from a workspace-plan sub. When the tier has no configured Dodo recurring
+    product (v1 default), this DEGRADES gracefully — it records the tier without a
+    live charge (``subscription_id`` stays None) and never crashes the publish.
+
+    Lazy imports (billing catalog / provider / emit) keep the sites service free
+    of an eager billing import at module load."""
+    from pocketpaw_ee.cloud._core.realtime.emit import emit
+    from pocketpaw_ee.cloud._core.realtime.events import SitePublished
+    from pocketpaw_ee.cloud.billing import site_plans
+
+    # Resolve the tier; fall back to the base tier for a None / unknown key so a
+    # publish is never blocked by a bad tier string (the entitlement gate is the
+    # one that matters and already ran).
+    tier = site_plans.get_site_plan(site_plan_key) or site_plans.get_site_plan(
+        site_plans.BASE_SITE_PLAN_KEY
+    )
+    plan_key = tier.key if tier is not None else site_plans.BASE_SITE_PLAN_KEY
+
+    site_id = str(doc.id)
+    subscription_id: str | None = None
+    # Open a PER-SITE annual Dodo subscription when the tier has a configured
+    # recurring product. metadata.site_id is the per-site discriminator the
+    # webhook routes on. No product configured (v1 default) → record the tier
+    # without a live charge; never crash the publish.
+    if tier is not None and tier.dodo_product_id:
+        try:
+            prov = provider or _default_billing_provider()
+            checkout = await prov.create_subscription(
+                plan_key=plan_key,
+                product_id=tier.dodo_product_id,
+                workspace_id=workspace_id,
+                customer_email=None,
+                metadata={
+                    "workspace_id": workspace_id,
+                    "site_id": site_id,
+                    "plan_key": plan_key,
+                },
+            )
+            subscription_id = checkout.subscription_id or None
+        except Exception:  # noqa: BLE001 — a billing hiccup must not undo the deploy
+            logger.warning(
+                "sites.publish: per-site subscription init failed for site %s "
+                "(tier=%s) — recording the tier without a live charge",
+                site_id,
+                plan_key,
+                exc_info=True,
+            )
+
+    # Stamp the per-site plan on the (already persisted) canonical Site doc.
+    doc.plan_tier = plan_key
+    doc.subscription_id = subscription_id
+    # A live sub starts pending until Dodo posts a verified subscription.active;
+    # an unconfigured (no-charge) tier has no live sub to activate, so it stays
+    # "none". The per-site webhook advances "pending" → "active".
+    doc.subscription_status = "pending" if subscription_id else "none"
+    await doc.save()
+
+    await emit(
+        SitePublished(
+            data={
+                "workspace_id": workspace_id,
+                "site_id": site_id,
+                "pocket_id": pocket_id,
+                "owner": user_id,
+                "plan_tier": plan_key,
+            }
+        )
+    )
+    return doc
+
+
+def _default_billing_provider() -> Any:
+    """Build the default payments provider (Dodo) for a per-site subscription.
+
+    Lazy so importing the sites service never constructs an SDK client; tests
+    inject their own provider via ``publish_pocket(_billing_provider=...)``."""
+    from pocketpaw.config import get_settings
+    from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+
+    return DodoProvider.from_settings(get_settings())
 
 
 def apply_edits(source: str, edits: list[dict[str, str]]) -> str:

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -17,6 +17,16 @@
 # a mock subscription provider in tests. A PREVIEW publish skips all of BC-9 (it
 # never persists a Site doc).
 #
+# Updated 2026-06-24 (BC-10 — resell Cloudflare features by site-plan tier):
+# ``add_domain`` now resolves the site's ``plan_tier`` → its
+# ``site_plans.get_site_plan(...).cloudflare_features`` and passes that set to
+# ``CloudflareClient.create_custom_hostname(hostname, features=...)``. So adding a
+# custom domain to a HIGHER-tier site provisions its resold Cloudflare paid
+# features (WAF / edge-cache / strict TLS) at hostname-create time; a base-tier
+# (or unset-tier) site resolves to an empty set and stays on the basic create
+# path, unchanged. ``site_plans`` is imported lazily inside ``add_domain``,
+# mirroring ``publish_pocket``.
+#
 # Updated 2026-06-20 (DS-3 — control-plane read of a dynamic site's D1 data):
 # added the operator data-view reads ``list_site_data_tables`` and
 # ``read_site_data_table`` (backing GET /sites/by-pocket/{pocket_id}/data and
@@ -1044,9 +1054,19 @@ async def add_domain(
 ) -> DomainStatusResponse:
     """Register a custom hostname with Cloudflare for SaaS and store it on the
     site. Returns the ONE CNAME the client pastes at their registrar."""
+    # BC-10: a higher site-plan tier resells Cloudflare paid features (WAF /
+    # edge-cache / strict TLS). Lazy import mirrors publish_pocket's site_plans
+    # use — keeps the billing catalog off the module-import path.
+    from pocketpaw_ee.cloud.billing import site_plans
+
     cf = _cloudflare or _cf_client()
     site = await _load(workspace_id, site_id)
-    ch = await cf.create_custom_hostname(hostname)
+    # Resolve the site's tier → its cloudflare_features and provision them on the
+    # custom hostname. A base-tier (or unknown) site resolves to an empty set, so
+    # create_custom_hostname stays on the basic path.
+    plan = site_plans.get_site_plan(site.plan_tier)
+    features = set(plan.cloudflare_features) if plan else set()
+    ch = await cf.create_custom_hostname(hostname, features=features)
     site.domains.append(
         _SiteDomainDoc(
             hostname=ch.hostname,

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -120,6 +120,17 @@ dependencies = [
     # ``OASIS_RECSYS_AVAILABLE`` in
     # ``ee/pocketpaw_ee/foresight/substrate/oasis/__init__.py``.
     "igraph>=0.11",
+    # --- Payments gateway (BC-2 — the Gateway primitive) ---
+    # Dodo is the only gateway for v1, behind the IPaymentsProvider abstraction
+    # in ee/pocketpaw_ee/cloud/billing/providers/ so Razorpay can drop in later.
+    # PINNED to 1.105.0: the supply-chain rule on this machine enforces a 7-day
+    # minimum release age. The newest dodopayments (1.105.1) was published
+    # 2026-06-18 (<7 days ago) so it is BLOCKED; 1.105.0 (released 2026-06-16)
+    # is the latest version that satisfies the age guard. The ``[webhooks]``
+    # extra pulls ``standardwebhooks<2,>=1.0.1`` (stable since 2024) — the
+    # Standard Webhooks HMAC-SHA256 verifier the inbound webhook route uses to
+    # prove a payload came from Dodo before any credits are granted.
+    "dodopayments[webhooks]==1.105.0",
 ]
 
 [project.optional-dependencies]

--- a/ee/uv.lock
+++ b/ee/uv.lock
@@ -925,6 +925,28 @@ wheels = [
 ]
 
 [[package]]
+name = "dodopayments"
+version = "1.105.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c3/7928365b52facda9f01c3e807f33a382cccf1e4da928ed213df9f578a41e/dodopayments-1.105.0.tar.gz", hash = "sha256:5aa1dcb229c3a3d200913b4e82a42b80757a7044e5457ca962c624f374636230", size = 273364, upload-time = "2026-06-16T22:59:50.637Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/f1/b36366ba09bb4bc962e851a305960813c11a7d4336e88c8c3bccde7b391d/dodopayments-1.105.0-py3-none-any.whl", hash = "sha256:ed3195e91c4a41a7d8023d04158598366773fa9139dc0d215e2cbd3bdfb0193c", size = 389251, upload-time = "2026-06-16T22:59:49.28Z" },
+]
+
+[package.optional-dependencies]
+webhooks = [
+    { name = "standardwebhooks" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3055,6 +3077,7 @@ dependencies = [
     { name = "composio-langgraph" },
     { name = "composio-openai-agents" },
     { name = "dnspython" },
+    { name = "dodopayments", extra = ["webhooks"] },
     { name = "fastapi-users", extra = ["beanie", "oauth"] },
     { name = "google-api-python-client" },
     { name = "google-auth" },
@@ -3096,6 +3119,7 @@ requires-dist = [
     { name = "composio-langgraph", specifier = ">=0.7.0" },
     { name = "composio-openai-agents", specifier = ">=0.7.0" },
     { name = "dnspython", specifier = ">=2.6.0" },
+    { name = "dodopayments", extras = ["webhooks"], specifier = "==1.105.0" },
     { name = "fastapi-users", extras = ["beanie", "oauth"], specifier = ">=13.0.0" },
     { name = "google-api-python-client", specifier = ">=2.100.0" },
     { name = "google-auth", specifier = ">=2.25.0" },
@@ -4213,6 +4237,20 @@ wheels = [
 ]
 
 [[package]]
+name = "standardwebhooks"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "python-dateutil" },
+    { name = "types-deprecated" },
+    { name = "types-python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/7d/04fc3aa177403472d3ddae90953d8f878dc5fd21ba29c02fc9e97e10703f/standardwebhooks-1.0.1.tar.gz", hash = "sha256:b557bb2e4b16ada179a517ec0fe6cbec5acf976c5619922bf29c457f89a451bd", size = 5103, upload-time = "2026-02-18T19:13:06.793Z" }
+
+[[package]]
 name = "starlette"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4352,12 +4390,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-deprecated"
+version = "1.3.1.20260520"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/86/8cc66b0a4d01826e64f86e0001b8755105d1b6052c654e2448a0e72750ee/types_deprecated-1.3.1.20260520.tar.gz", hash = "sha256:4d0d9e5521432d9ce88169fb8b793b45d70d8e8cc1a7ecd5a4465abbf83c9ab4", size = 8649, upload-time = "2026-05-20T05:55:57.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/27/e8fd41f0d41b964870d370e7fc78311193910fe9a15c7399ade4a4aeea58/types_deprecated-1.3.1.20260520-py3-none-any.whl", hash = "sha256:8af853b7ccd3b7685159f3ab2e3b6f7999b6cd7e425cda02749e32a42a96c7d6", size = 9105, upload-time = "2026-05-20T05:55:56.259Z" },
+]
+
+[[package]]
 name = "types-protobuf"
 version = "7.34.1.20260518"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/29/59/e2b13b499d15e6720150c4b1a8d91e31fcacf716b432397475b3151ff7e4/types_protobuf-7.34.1.20260518.tar.gz", hash = "sha256:28cfaded25889cb83ebfb63cfb0a43628f0b6f3785767bec17287dc6468795f2", size = 68936, upload-time = "2026-05-18T06:01:47.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/1f/ec5caf72c2e3b688ca3927e0979a04ddad19e1afc4bf1c199bd743e0f419/types_protobuf-7.34.1.20260518-py3-none-any.whl", hash = "sha256:a0a5337413347166439c0e07cbc26c6164d091401c6f01b1dfd8cdb966c4dd8f", size = 85992, upload-time = "2026-05-18T06:01:45.696Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/e8/c01bdf0d7c3659428c091fbd693177093639565bcbc86bc20098e6d37cc6/types_python_dateutil-2.9.0.20260518.tar.gz", hash = "sha256:51f02dc03b61c7f6a07df45797d4dfe8a1aa47f0b7db9ad89f6fd3a1a70e1b51", size = 17082, upload-time = "2026-05-18T06:05:24.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/22/169273273ca34e9ab0ae2f387ba72ed7e09faaaf834da01d6b89c2bea71a/types_python_dateutil-2.9.0.20260518-py3-none-any.whl", hash = "sha256:d6a9c5bd0de61460c8fdef8ab2b400f956a1a1075cce08d4e2b4434e478c50b8", size = 18431, upload-time = "2026-05-18T06:05:23.641Z" },
 ]
 
 [[package]]

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,12 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-24: Added ``dodo_plan_products`` (default {}, env
+    POCKETPAW_DODO_PLAN_PRODUCTS as a JSON object) — the BC-7 mapping of plan
+    tier key -> Dodo recurring product id. ``subscribe`` reads it to open a
+    recurring checkout; the subscription webhook reverses it (product_id ->
+    plan key) to know which tier renewed. A before-validator degrades a
+    malformed env string to {} so a typo can't crash settings load.
   - 2026-06-24: Added ``billing_enforced`` (default False, env
     POCKETPAW_BILLING_ENFORCED) — the BC-4 run-start hard-block flag. When
     True the cloud rejects STARTING a new chat run on a zero-or-negative
@@ -1430,6 +1436,19 @@ class Settings(BaseSettings):
             "denomination). Set via POCKETPAW_DODO_CREDIT_PRODUCT_ID."
         ),
     )
+    dodo_plan_products: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Mapping of plan tier key -> Dodo RECURRING product id (BC-7 "
+            "subscriptions). ``subscribe(plan_key)`` looks the product up here to "
+            "open a recurring checkout; the inbound subscription webhook reverses "
+            "the lookup (product_id -> plan key) to know which tier renewed (and "
+            "thus the monthly credit allotment from the plan catalog). Set via "
+            "POCKETPAW_DODO_PLAN_PRODUCTS as a JSON object, e.g. "
+            '{"team":"prod_team","business":"prod_biz"}. Default empty disables '
+            "subscriptions (subscribe raises a clear ValidationError)."
+        ),
+    )
 
     # Billing — compute-cost metering rate card (BC-3, the Meter + Price
     # primitives). A completed chat run is billed by its real compute cost times
@@ -1680,6 +1699,28 @@ class Settings(BaseSettings):
             "instead of a raw URL in the chat. Set False to disable if detection is brittle."
         ),
     )
+
+    @field_validator("dodo_plan_products", mode="before")
+    @classmethod
+    def _parse_dodo_plan_products(cls, v: object) -> object:
+        """Accept a JSON-object env string for the plan->product map.
+
+        pydantic-settings parses JSON for dict fields, but a hand-set
+        ``POCKETPAW_DODO_PLAN_PRODUCTS`` that isn't valid JSON (or isn't an
+        object) should degrade to an empty mapping — subscriptions then fail
+        loudly at ``subscribe`` time with a clear ``plan_unconfigured`` error
+        rather than crashing the entire settings load at boot. A dict passes
+        straight through.
+        """
+        if v is None or v == "":
+            return {}
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+            except ValueError:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return v
 
     @field_validator("composio_toolkits", mode="before")
     @classmethod

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1426,6 +1426,31 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Billing — compute-cost metering rate card (BC-3, the Meter + Price
+    # primitives). A completed chat run is billed by its real compute cost times
+    # a flat markup, converted from USD into integer credits. These two settings
+    # ARE the rate card: keeping them declarative (a flat multiplier + the credit
+    # denomination) leaves room for a tiered card later without changing the
+    # debit path. ``credits = round(cost_usd * markup / credit_usd)``.
+    billing_markup: float = Field(
+        default=2.5,
+        description=(
+            "Flat markup applied to a chat run's real compute cost before it is "
+            "billed to the workspace wallet (covers infra + margin). The metered "
+            "credit charge is round(cost_usd * billing_markup / credit_usd). Set "
+            "via POCKETPAW_BILLING_MARKUP."
+        ),
+    )
+    credit_usd: float = Field(
+        default=0.01,
+        description=(
+            "USD value of one credit (1 credit == $0.01 == 1 cent, the lowest "
+            "currency denomination — the same denomination Dodo top-ups use). "
+            "Divides the marked-up compute cost to yield integer credits. Set via "
+            "POCKETPAW_CREDIT_USD."
+        ),
+    )
+
     # Pocket data-source refresh — cost controls (RFC 04 M3).
     # A pocket source binding may declare an `interval` or `webhook` refresh
     # trigger. Both are AUTO-refresh: they re-run a source without a human in

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1385,6 +1385,47 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Billing — Dodo Payments gateway (BC-2, the Gateway primitive).
+    # The only payment gateway in v1; a provider abstraction
+    # (``ee.cloud.billing.providers``) keeps Razorpay et al. a later swap.
+    # All three are optional so a non-billing deployment boots fine; the Dodo
+    # provider raises a clear ValidationError when a billing call is made
+    # without the key configured.
+    dodo_payments_api_key: str | None = Field(
+        default=None,
+        description=(
+            "Dodo Payments API bearer token, used to authenticate the server-side "
+            "DodoPayments client when creating a one-time top-up checkout. Set via "
+            "POCKETPAW_DODO_PAYMENTS_API_KEY. None disables Dodo top-ups."
+        ),
+    )
+    dodo_environment: str = Field(
+        default="test_mode",
+        description=(
+            "Dodo Payments environment — 'test_mode' (default) or 'live_mode'. "
+            "Selects the API base URL the DodoPayments client targets. Set via "
+            "POCKETPAW_DODO_ENVIRONMENT."
+        ),
+    )
+    dodo_webhook_secret: str | None = Field(
+        default=None,
+        description=(
+            "Dodo Payments webhook signing secret (Standard Webhooks / 'whsec_…'). "
+            "Used to VERIFY the signature on every inbound /billing/webhooks/dodo "
+            "POST before the payload is trusted. Set via "
+            "POCKETPAW_DODO_WEBHOOK_SECRET. NEVER logged."
+        ),
+    )
+    dodo_credit_product_id: str | None = Field(
+        default=None,
+        description=(
+            "Dodo product id for the credits SKU. A one-time top-up adds this "
+            "product to the cart with a pay-what-you-want amount equal to the "
+            "purchased credits (1 credit == $0.01 == 1 cent, the currency's lowest "
+            "denomination). Set via POCKETPAW_DODO_CREDIT_PRODUCT_ID."
+        ),
+    )
+
     # Pocket data-source refresh — cost controls (RFC 04 M3).
     # A pocket source binding may declare an `interval` or `webhook` refresh
     # trigger. Both are AUTO-refresh: they re-run a source without a human in

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,11 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-06-24: Added ``billing_enforced`` (default False, env
+    POCKETPAW_BILLING_ENFORCED) — the BC-4 run-start hard-block flag. When
+    True the cloud rejects STARTING a new chat run on a zero-or-negative
+    credit balance with HTTP 402; in-flight runs are untouched. Off by
+    default so OSS / self-host stay unaffected.
   - 2026-06-18: Added the four layered/learning Instinct gate defaults —
     ``instinct_approval_level`` (default "ASK", dormant),
     ``instinct_auto_approve_threshold`` (0.9), ``instinct_dry_run_mode``
@@ -1448,6 +1453,17 @@ class Settings(BaseSettings):
             "currency denomination — the same denomination Dodo top-ups use). "
             "Divides the marked-up compute cost to yield integer credits. Set via "
             "POCKETPAW_CREDIT_USD."
+        ),
+    )
+    billing_enforced: bool = Field(
+        default=False,
+        description=(
+            "Run-start hard-block (BC-4). When True, STARTING a new chat run on a "
+            "workspace whose credit balance is <= 0 is rejected with HTTP 402 "
+            "(credits.insufficient) BEFORE any run row is written; in-flight runs "
+            "are never killed. Default False so OSS / self-host deployments (which "
+            "run no credit ledger) are unaffected; the cloud turns it on via "
+            "POCKETPAW_BILLING_ENFORCED."
         ),
     )
 

--- a/src/pocketpaw/credentials.py
+++ b/src/pocketpaw/credentials.py
@@ -1,6 +1,8 @@
 """Encrypted credential storage for PocketPaw.
 
 Changes:
+  - 2026-06-24: add dodo_payments_api_key + dodo_webhook_secret to SECRET_FIELDS
+    so they persist encrypted, never plaintext in config.json (BC-2 trust boundary).
   - 2026-04-10: v1 migration failure no longer crashes — logs warning, starts with empty store.
   - 2026-04-03: Hardened: Argon2id + AES-256-GCM, backup-safe migration, AEAD.
   - 2026-02-06: Initial implementation — Fernet encryption with machine-derived PBKDF2 key.
@@ -60,6 +62,8 @@ SECRET_FIELDS: frozenset[str] = frozenset(
         "litellm_api_key",
         "claude_code_oauth_token",
         "status_api_key",
+        "dodo_payments_api_key",
+        "dodo_webhook_secret",
     }
 )
 

--- a/tests/cloud/billing/test_dodo_webhook.py
+++ b/tests/cloud/billing/test_dodo_webhook.py
@@ -17,6 +17,9 @@
 # on the captured events.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-2): new test module.
+# Updated 2026-06-24 (security): add test_non_usd_event_does_not_grant (the
+#   USD-only grant guard) and test_dodo_secrets_are_in_secret_fields (the Dodo
+#   secrets are on the encrypted-persistence allowlist).
 
 from __future__ import annotations
 
@@ -337,6 +340,28 @@ async def test_success_event_without_workspace_id_does_not_grant(mongo_db):
     assert result == {"ok": True, "granted": False}
 
 
+async def test_non_usd_event_does_not_grant(mongo_db, recording_bus):
+    """A validly-signed payment.succeeded in a non-USD currency is acked (200)
+    but grants NOTHING — the 1-credit==1-cent mapping is USD-only, so crediting a
+    ¥750 charge 1:1 would wrongly grant 750 credits ($7.50). The USD-only guard
+    must short-circuit before the grant."""
+    body = _payment_succeeded_body(workspace_id=WS, total_amount=750, currency="JPY")
+    headers = _sign(body, msg_id="evt_jpy_1")
+
+    assert await credits.balance(WS) == 0
+    result = await billing.handle_webhook(
+        payload=body.encode(), headers=headers, provider=_provider()
+    )
+
+    # Acked but not granted — same shape as the other non-grant branches.
+    assert result == {"ok": True, "granted": False}
+    # Balance unchanged: NO credits granted for the non-USD charge.
+    assert await credits.balance(WS) == 0
+    # No Payment row and no capture event for a charge that never granted.
+    assert await Payment.find(Payment.workspace == WS).to_list() == []
+    assert [e for e in recording_bus.events if e.type == "billing.topup.captured"] == []
+
+
 # ---------------------------------------------------------------------------
 # Provider unit checks — verify_and_parse_webhook normalization + config guards.
 # ---------------------------------------------------------------------------
@@ -371,3 +396,18 @@ async def test_create_topup_product_unconfigured_raises(mongo_db):
     with pytest.raises(ValidationError) as exc:
         await billing.create_topup(workspace_id=WS, user_id="u1", amount_credits=100, provider=prov)
     assert exc.value.code == "billing.product_unconfigured"
+
+
+# ---------------------------------------------------------------------------
+# Secret-persistence guard — the Dodo API key and webhook signing secret MUST be
+# on the encrypted-persistence allowlist, or a dashboard-set value would be
+# written PLAINTEXT to ~/.pocketpaw/config.json (signing secret in plaintext == a
+# trust-boundary leak). This fast guard fails the build if either is dropped.
+# ---------------------------------------------------------------------------
+
+
+def test_dodo_secrets_are_in_secret_fields():
+    from pocketpaw.credentials import SECRET_FIELDS
+
+    assert "dodo_payments_api_key" in SECRET_FIELDS
+    assert "dodo_webhook_secret" in SECRET_FIELDS

--- a/tests/cloud/billing/test_dodo_webhook.py
+++ b/tests/cloud/billing/test_dodo_webhook.py
@@ -20,6 +20,9 @@
 # Updated 2026-06-24 (security): add test_non_usd_event_does_not_grant (the
 #   USD-only grant guard) and test_dodo_secrets_are_in_secret_fields (the Dodo
 #   secrets are on the encrypted-persistence allowlist).
+# Updated 2026-06-24 (S1 review fix): add test_topup_request_rejects_over_ceiling /
+#   _accepts_ceiling — CreateTopupRequest.amount_credits is capped at 1,000,000
+#   credits ($10,000); an over-ceiling amount is a 422 at the DTO.
 
 from __future__ import annotations
 
@@ -396,6 +399,35 @@ async def test_create_topup_product_unconfigured_raises(mongo_db):
     with pytest.raises(ValidationError) as exc:
         await billing.create_topup(workspace_id=WS, user_id="u1", amount_credits=100, provider=prov)
     assert exc.value.code == "billing.product_unconfigured"
+
+
+# ---------------------------------------------------------------------------
+# S1 review fix — the top-up amount has an upper ceiling (1,000,000 credits ==
+# $10,000). Over-ceiling is a 422 at the DTO before the service is reached.
+# ---------------------------------------------------------------------------
+
+
+def test_topup_request_rejects_over_ceiling():
+    from pocketpaw_ee.cloud.billing.dto import CreateTopupRequest
+    from pydantic import ValidationError as PydanticValidationError
+
+    with pytest.raises(PydanticValidationError):
+        CreateTopupRequest(amount_credits=1_000_001)  # one over the $10,000 cap
+
+
+def test_topup_request_accepts_ceiling_and_below():
+    from pocketpaw_ee.cloud.billing.dto import CreateTopupRequest
+
+    assert CreateTopupRequest(amount_credits=1_000_000).amount_credits == 1_000_000
+    assert CreateTopupRequest(amount_credits=1).amount_credits == 1
+
+
+def test_topup_request_still_rejects_non_positive():
+    from pocketpaw_ee.cloud.billing.dto import CreateTopupRequest
+    from pydantic import ValidationError as PydanticValidationError
+
+    with pytest.raises(PydanticValidationError):
+        CreateTopupRequest(amount_credits=0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/billing/test_dodo_webhook.py
+++ b/tests/cloud/billing/test_dodo_webhook.py
@@ -1,0 +1,373 @@
+# tests/cloud/billing/test_dodo_webhook.py — proves the BC-2 Gateway-primitive
+# contract: a verified Dodo ``payment.succeeded`` webhook grants the right
+# credits EXACTLY ONCE, a tampered/bad-signature webhook is rejected with no
+# grant, a non-success event never grants, and ``create_topup`` returns a hosted
+# checkout url (the Dodo client mocked).
+#
+# Signing uses the REAL ``standardwebhooks`` library so the verification path is
+# exercised end-to-end (no shortcut around the signature check). The dodopayments
+# CLIENT is mocked — ``create_topup`` patches ``AsyncDodoPayments`` on the dodo
+# provider module; the webhook path never touches the SDK client (verification is
+# pure ``standardwebhooks``).
+#
+# Uses the shared ``mongo_db`` fixture (mongomock-motor + Beanie over
+# ALL_DOCUMENTS) from tests/cloud/conftest.py, the same DB pattern the BC-1
+# ledger tests use. The autouse ``recording_bus`` installs a RecordingBus so the
+# service's ``emit(BillingTopupCaptured(...))`` never raises and tests can assert
+# on the captured events.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-2): new test module.
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import BadRequest, ValidationError
+from pocketpaw_ee.cloud.billing import service as billing
+from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.models.payment import Payment
+from standardwebhooks import Webhook
+
+WS = "ws_billing_test"
+# A valid Standard-Webhooks secret: ``whsec_`` + base64 of a 32-byte key.
+SECRET = "whsec_" + base64.b64encode(b"billing-test-secret-key-32bytes!").decode()
+PRODUCT_ID = "prod_credits_sku"
+
+
+def _provider() -> DodoProvider:
+    """A DodoProvider wired with the test webhook secret + product id.
+
+    The API key is set so ``create_one_time`` passes its pre-flight; the SDK
+    client is mocked per-test where checkout is exercised.
+    """
+    return DodoProvider(
+        api_key="dodo_test_key",
+        environment="test_mode",
+        webhook_secret=SECRET,
+        credit_product_id=PRODUCT_ID,
+    )
+
+
+def _sign(body: str, *, msg_id: str, ts: datetime | None = None) -> dict[str, str]:
+    """Produce valid Standard-Webhooks headers for ``body`` using ``SECRET``."""
+    ts = ts or datetime.now(UTC)
+    sig = Webhook(SECRET).sign(msg_id=msg_id, timestamp=ts, data=body)  # 'v1,<b64>'
+    return {
+        "webhook-id": msg_id,
+        "webhook-timestamp": str(int(ts.timestamp())),
+        "webhook-signature": sig,
+    }
+
+
+def _payment_succeeded_body(
+    *, workspace_id: str = WS, total_amount: int = 500, currency: str = "USD"
+) -> str:
+    """A Dodo ``payment.succeeded`` webhook body (the real envelope shape)."""
+    return json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": "payment.succeeded",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "payment_id": "pay_abc123",
+                "metadata": {"workspace_id": workspace_id},
+                "total_amount": total_amount,
+                "currency": currency,
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion 1 — a valid signed payment.succeeded grants the right credits to the
+# workspace named in the payment metadata.
+# ---------------------------------------------------------------------------
+
+
+async def test_valid_webhook_grants_credits(mongo_db):
+    body = _payment_succeeded_body(workspace_id=WS, total_amount=500)
+    headers = _sign(body, msg_id="evt_grant_1")
+
+    assert await credits.balance(WS) == 0
+    result = await billing.handle_webhook(
+        payload=body.encode(), headers=headers, provider=_provider()
+    )
+
+    assert result == {"ok": True, "granted": True}
+    # 500 cents -> 500 credits (1 credit == 1 cent).
+    assert await credits.balance(WS) == 500
+
+    # A Payment record was written for the capture.
+    payments = await Payment.find(Payment.workspace == WS).to_list()
+    assert len(payments) == 1
+    assert payments[0].gateway == "dodo"
+    assert payments[0].gateway_event_id == "evt_grant_1"
+    assert payments[0].amount_credits == 500
+    assert payments[0].status == "succeeded"
+
+
+async def test_valid_webhook_emits_capture_event(mongo_db, recording_bus):
+    body = _payment_succeeded_body(workspace_id=WS, total_amount=250)
+    headers = _sign(body, msg_id="evt_emit_1")
+
+    await billing.handle_webhook(payload=body.encode(), headers=headers, provider=_provider())
+
+    captured = [e for e in recording_bus.events if e.type == "billing.topup.captured"]
+    assert len(captured) == 1
+    data = captured[0].data
+    assert data["workspace_id"] == WS
+    assert data["gateway"] == "dodo"
+    assert data["event_id"] == "evt_emit_1"
+    assert data["amount_credits"] == 250
+
+
+# ---------------------------------------------------------------------------
+# Criterion 2 — a tampered payload / bad signature is REJECTED (400) with no
+# grant. ValidationError -> 400 via the cloud error handler.
+# ---------------------------------------------------------------------------
+
+
+async def test_tampered_payload_is_rejected_no_grant(mongo_db):
+    body = _payment_succeeded_body(workspace_id=WS, total_amount=500)
+    headers = _sign(body, msg_id="evt_tamper_1")
+
+    # Tamper with the body AFTER signing — the signature no longer matches.
+    tampered = body.replace('"total_amount": 500', '"total_amount": 999999').encode()
+
+    with pytest.raises(BadRequest) as exc:
+        await billing.handle_webhook(payload=tampered, headers=headers, provider=_provider())
+    assert exc.value.status_code == 400
+    assert exc.value.code == "billing.webhook_invalid_signature"
+
+    # No credits granted, no payment recorded.
+    assert await credits.balance(WS) == 0
+    assert await Payment.find(Payment.workspace == WS).to_list() == []
+
+
+async def test_wrong_secret_is_rejected_no_grant(mongo_db):
+    body = _payment_succeeded_body(workspace_id=WS, total_amount=500)
+    # Sign with a DIFFERENT secret than the provider verifies with.
+    other_secret = "whsec_" + base64.b64encode(b"a-totally-different-32byte-key!!!").decode()
+    ts = datetime.now(UTC)
+    bad_sig = Webhook(other_secret).sign(msg_id="evt_bad", timestamp=ts, data=body)
+    headers = {
+        "webhook-id": "evt_bad",
+        "webhook-timestamp": str(int(ts.timestamp())),
+        "webhook-signature": bad_sig,
+    }
+
+    with pytest.raises(BadRequest) as exc:
+        await billing.handle_webhook(payload=body.encode(), headers=headers, provider=_provider())
+    assert exc.value.status_code == 400
+    assert exc.value.code == "billing.webhook_invalid_signature"
+    assert await credits.balance(WS) == 0
+
+
+async def test_missing_signature_headers_rejected(mongo_db):
+    body = _payment_succeeded_body()
+    with pytest.raises(BadRequest) as exc:
+        await billing.handle_webhook(
+            payload=body.encode(),
+            headers={"content-type": "application/json"},
+            provider=_provider(),
+        )
+    assert exc.value.status_code == 400
+    assert exc.value.code == "billing.webhook_invalid_signature"
+    assert await credits.balance(WS) == 0
+
+
+async def test_stale_timestamp_rejected(mongo_db):
+    body = _payment_succeeded_body()
+    # 10 minutes old — outside Standard-Webhooks' 5-minute tolerance.
+    stale = datetime.now(UTC) - timedelta(minutes=10)
+    headers = _sign(body, msg_id="evt_stale", ts=stale)
+    with pytest.raises(BadRequest) as exc:
+        await billing.handle_webhook(payload=body.encode(), headers=headers, provider=_provider())
+    assert exc.value.status_code == 400
+    assert exc.value.code == "billing.webhook_invalid_signature"
+    assert await credits.balance(WS) == 0
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3 — grants EXACTLY ONCE; replay of the same event_id is a no-op
+# (balance unchanged, no second emit), via BC-1's unique idempotency key.
+# ---------------------------------------------------------------------------
+
+
+async def test_replay_same_event_id_is_noop(mongo_db, recording_bus):
+    body = _payment_succeeded_body(workspace_id=WS, total_amount=500)
+    headers = _sign(body, msg_id="evt_replay_1")
+
+    first = await billing.handle_webhook(
+        payload=body.encode(), headers=headers, provider=_provider()
+    )
+    assert first == {"ok": True, "granted": True}
+    assert await credits.balance(WS) == 500
+
+    # Re-deliver the SAME event (same webhook-id) — re-signed but identical id.
+    second = await billing.handle_webhook(
+        payload=body.encode(), headers=headers, provider=_provider()
+    )
+    assert second == {"ok": True, "granted": False}  # replay no-op
+    assert await credits.balance(WS) == 500  # unchanged — no double-grant
+
+    # Exactly one capture event emitted (the replay did not re-emit).
+    captured = [e for e in recording_bus.events if e.type == "billing.topup.captured"]
+    assert len(captured) == 1
+
+    # Exactly one Payment row (the replay's insert collided on the unique index).
+    payments = await Payment.find(Payment.workspace == WS).to_list()
+    assert len(payments) == 1
+
+
+async def test_replay_with_resigned_headers_still_noop(mongo_db):
+    """A replay re-signed with a fresh timestamp (valid signature) but the SAME
+    webhook-id still grants nothing — idempotency keys on the event id, not the
+    signature."""
+    body = _payment_succeeded_body(workspace_id=WS, total_amount=300)
+    h1 = _sign(body, msg_id="evt_dup_id", ts=datetime.now(UTC) - timedelta(minutes=1))
+    h2 = _sign(body, msg_id="evt_dup_id", ts=datetime.now(UTC))  # fresh sig, same id
+
+    await billing.handle_webhook(payload=body.encode(), headers=h1, provider=_provider())
+    assert await credits.balance(WS) == 300
+    res2 = await billing.handle_webhook(payload=body.encode(), headers=h2, provider=_provider())
+    assert res2["granted"] is False
+    assert await credits.balance(WS) == 300
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4 — create_topup returns a checkout url (Dodo client mocked).
+# ---------------------------------------------------------------------------
+
+
+async def test_create_topup_returns_checkout_url(mongo_db, monkeypatch):
+    # Mock the async DodoPayments client so no network call happens. The provider
+    # builds the client via ``AsyncDodoPayments`` imported on the dodo module.
+    fake_response = MagicMock()
+    fake_response.payment_link = "https://checkout.dodopayments.test/pay/abc123"
+    fake_response.payment_id = "pay_xyz789"
+
+    fake_client = MagicMock()
+    fake_client.payments.create = AsyncMock(return_value=fake_response)
+
+    import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
+
+    monkeypatch.setattr(dodo_mod, "AsyncDodoPayments", MagicMock(return_value=fake_client))
+
+    result = await billing.create_topup(
+        workspace_id=WS, user_id="u1", amount_credits=1000, provider=_provider()
+    )
+    assert result == {"checkout_url": "https://checkout.dodopayments.test/pay/abc123"}
+
+    # The Dodo client was called with the workspace_id on metadata and the
+    # pay-what-you-want amount on the cart (1000 credits == 1000 cents).
+    _, kwargs = fake_client.payments.create.call_args
+    assert kwargs["payment_link"] is True
+    assert kwargs["metadata"]["workspace_id"] == WS
+    assert kwargs["product_cart"][0]["product_id"] == PRODUCT_ID
+    assert kwargs["product_cart"][0]["amount"] == 1000
+
+
+async def test_create_topup_rejects_non_positive_amount(mongo_db):
+    with pytest.raises(ValidationError):
+        await billing.create_topup(
+            workspace_id=WS, user_id="u1", amount_credits=0, provider=_provider()
+        )
+    with pytest.raises(ValidationError):
+        await billing.create_topup(
+            workspace_id=WS, user_id="u1", amount_credits=-50, provider=_provider()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Criterion 5 — a non-success event (payment.failed) never grants.
+# ---------------------------------------------------------------------------
+
+
+async def test_payment_failed_event_does_not_grant(mongo_db, recording_bus):
+    body = json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": "payment.failed",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "payment_id": "pay_fail_1",
+                "metadata": {"workspace_id": WS},
+                "total_amount": 500,
+                "currency": "USD",
+            },
+        }
+    )
+    headers = _sign(body, msg_id="evt_failed_1")
+
+    result = await billing.handle_webhook(
+        payload=body.encode(), headers=headers, provider=_provider()
+    )
+    assert result == {"ok": True, "granted": False}
+    assert await credits.balance(WS) == 0
+    assert await Payment.find(Payment.workspace == WS).to_list() == []
+    assert [e for e in recording_bus.events if e.type == "billing.topup.captured"] == []
+
+
+async def test_success_event_without_workspace_id_does_not_grant(mongo_db):
+    """A verified success event whose metadata lacks workspace_id is acked (200)
+    but grants nothing — it can't be routed."""
+    body = json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": "payment.succeeded",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "payment_id": "pay_noroute",
+                "metadata": {},
+                "total_amount": 500,
+                "currency": "USD",
+            },
+        }
+    )
+    headers = _sign(body, msg_id="evt_noroute_1")
+    result = await billing.handle_webhook(
+        payload=body.encode(), headers=headers, provider=_provider()
+    )
+    assert result == {"ok": True, "granted": False}
+
+
+# ---------------------------------------------------------------------------
+# Provider unit checks — verify_and_parse_webhook normalization + config guards.
+# ---------------------------------------------------------------------------
+
+
+async def test_provider_parses_verified_event_fields():
+    body = _payment_succeeded_body(workspace_id="ws_parse", total_amount=750, currency="EUR")
+    headers = _sign(body, msg_id="evt_parse_1")
+    event = _provider().verify_and_parse_webhook(payload=body.encode(), headers=headers)
+    assert event.event_id == "evt_parse_1"  # from the webhook-id header
+    assert event.type == "payment.succeeded"
+    assert event.workspace_id == "ws_parse"
+    assert event.amount_credits == 750
+    assert event.currency == "EUR"
+
+
+async def test_provider_webhook_unconfigured_raises():
+    prov = DodoProvider(
+        api_key="k", environment="test_mode", webhook_secret=None, credit_product_id=PRODUCT_ID
+    )
+    body = _payment_succeeded_body()
+    headers = _sign(body, msg_id="evt_x")
+    with pytest.raises(ValidationError) as exc:
+        prov.verify_and_parse_webhook(payload=body.encode(), headers=headers)
+    assert exc.value.code == "billing.webhook_unconfigured"
+
+
+async def test_create_topup_product_unconfigured_raises(mongo_db):
+    prov = DodoProvider(
+        api_key="k", environment="test_mode", webhook_secret=SECRET, credit_product_id=None
+    )
+    with pytest.raises(ValidationError) as exc:
+        await billing.create_topup(workspace_id=WS, user_id="u1", amount_credits=100, provider=prov)
+    assert exc.value.code == "billing.product_unconfigured"

--- a/tests/cloud/billing/test_plans.py
+++ b/tests/cloud/billing/test_plans.py
@@ -1,0 +1,119 @@
+# tests/cloud/billing/test_plans.py — proves the BC-6 Plan-catalog contract:
+# the declarative plan catalog (``billing.plans``) and the ``GET /billing/plans``
+# read surface expose every tier with its monthly credit allotment + features +
+# Dodo product id, the features come STRAIGHT from ``PLAN_FEATURES`` (one source
+# of truth, no duplication), and ``get_plan`` resolves a known key / rejects an
+# unknown one.
+#
+# Pure-function + HTTP-layer tests — no DB. ``list_plans`` / ``get_plan`` are
+# synchronous catalog builders over ``PLAN_FEATURES``; the route is exercised
+# with a FastAPI ``TestClient`` and the ``require_license`` dep overridden (same
+# pattern as test_plan_feature_gate.py — no JWT, no Mongo).
+#
+# Created 2026-06-24 (integration/billing-credits, BC-6): new test module.
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud.billing import plans
+from pocketpaw_ee.cloud.billing.router import router as billing_router
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.guards.abac import PLAN_FEATURES
+
+EXPECTED_TIERS = {"free", "team", "business", "enterprise"}
+
+
+# ---------------------------------------------------------------------------
+# Catalog — list_plans / get_plan are the source-of-truth-respecting view.
+# ---------------------------------------------------------------------------
+
+
+def test_list_plans_covers_every_plan_features_tier():
+    """Every tier in PLAN_FEATURES shows up in the catalog (no tier dropped)."""
+    keys = {p.key for p in plans.list_plans()}
+    assert keys == set(PLAN_FEATURES.keys())
+    assert EXPECTED_TIERS <= keys
+
+
+def test_list_plans_features_match_plan_features_exactly():
+    """Catalog features are SOURCED FROM PLAN_FEATURES — never duplicated/drifted."""
+    for p in plans.list_plans():
+        assert set(p.features) == PLAN_FEATURES[p.key], p.key
+
+
+def test_list_plans_allotment_ladder_is_monotonic_and_free_is_zero():
+    """free grants nothing; each paid tier is a strict step up the credit ladder."""
+    by_key = {p.key: p for p in plans.list_plans()}
+    assert by_key["free"].monthly_credit_allotment == 0
+    assert (
+        by_key["free"].monthly_credit_allotment
+        < by_key["team"].monthly_credit_allotment
+        < by_key["business"].monthly_credit_allotment
+        < by_key["enterprise"].monthly_credit_allotment
+    )
+
+
+def test_list_plans_is_cheapest_first():
+    """The catalog is ordered cheapest tier first (the price ladder)."""
+    listed = [p.key for p in plans.list_plans()]
+    assert listed[:4] == ["free", "team", "business", "enterprise"]
+
+
+def test_dodo_product_id_is_none_until_bc7():
+    """No Dodo product id is wired yet — every tier reads back None in v1."""
+    assert all(p.dodo_product_id is None for p in plans.list_plans())
+
+
+def test_get_plan_resolves_a_known_key():
+    """get_plan returns the right tier for a known key, with matching features."""
+    biz = plans.get_plan("business")
+    assert biz is not None
+    assert biz.key == "business"
+    assert set(biz.features) == PLAN_FEATURES["business"]
+    assert biz.monthly_credit_allotment > 0
+
+
+@pytest.mark.parametrize("bad", ["nope", "", None, "FREE", "Team"])
+def test_get_plan_rejects_unknown_or_missing_key(bad):
+    """An unknown / empty / None / wrong-case key resolves to None (not a guess)."""
+    assert plans.get_plan(bad) is None
+
+
+def test_base_plan_key_is_a_real_catalog_entry():
+    """The declared base/floor tier exists in the catalog (resolver relies on it)."""
+    base = plans.get_plan(plans.BASE_PLAN_KEY)
+    assert base is not None
+    assert base.key == "free"
+    assert base.monthly_credit_allotment == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /billing/plans — the HTTP read surface.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def plans_client() -> TestClient:
+    """A TestClient over an app mounting the billing router, license waived."""
+    app = FastAPI()
+    app.include_router(billing_router)
+    app.dependency_overrides[require_license] = lambda: None
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_get_billing_plans_returns_the_catalog(plans_client):
+    """GET /billing/plans lists every tier with allotment + sorted features."""
+    resp = plans_client.get("/billing/plans")
+    assert resp.status_code == 200
+    body = resp.json()
+    rows = {row["key"]: row for row in body["plans"]}
+    assert set(rows.keys()) == set(PLAN_FEATURES.keys())
+
+    biz = rows["business"]
+    assert biz["monthly_credit_allotment"] == plans.get_plan("business").monthly_credit_allotment
+    # Features arrive as a sorted JSON array but carry the same SET as PLAN_FEATURES.
+    assert set(biz["features"]) == PLAN_FEATURES["business"]
+    assert biz["features"] == sorted(biz["features"])
+    assert biz["dodo_product_id"] is None

--- a/tests/cloud/billing/test_subscriptions.py
+++ b/tests/cloud/billing/test_subscriptions.py
@@ -1,0 +1,402 @@
+# tests/cloud/billing/test_subscriptions.py — proves the BC-7 Subscription-
+# primitive contract end-to-end:
+#   1. ``subscribe(ws, "business")`` opens a Dodo recurring checkout with the
+#      right product id + {workspace_id, plan_key} metadata, returning the hosted
+#      url (the SDK client mocked).
+#   2. a VERIFIED ``subscription.active`` grants the tier's monthly allotment AND
+#      upgrades ``Workspace.plan`` — entitlements then resolve to that tier.
+#   3. a VERIFIED ``subscription.renewed`` (a NEW event id) grants the allotment
+#      AGAIN, ADDITIVELY — proving ROLLOVER (balance == 2x allotment after
+#      active + renewed).
+#   4. a REPLAY of the same renewal event id is a no-op (balance unchanged).
+#   5. a VERIFIED ``subscription.cancelled`` reverts ``Workspace.plan`` to free
+#      WITHOUT clawing back the granted credits.
+#
+# Signing uses the REAL ``standardwebhooks`` library so the verification path is
+# exercised end-to-end (no shortcut around the signature check). The Dodo SDK
+# CLIENT is mocked only for the ``subscribe`` checkout call; the webhook path
+# never touches the SDK (verification is pure ``standardwebhooks``).
+#
+# Uses the shared ``mongo_db`` fixture (mongomock-motor + Beanie over
+# ALL_DOCUMENTS) from tests/cloud/conftest.py. Workspaces are inserted as REAL
+# ``Workspace`` docs so ``set_workspace_plan`` / ``get_workspace_plan`` (which
+# parse a PydanticObjectId) and the entitlements resolver run against live docs
+# — the credit wallet is keyed on the workspace id string the same way.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-7): new test module.
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pocketpaw_ee.cloud.billing import plans
+from pocketpaw_ee.cloud.billing import service as billing
+from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.entitlements import service as entitlements
+from pocketpaw_ee.cloud.models.subscription import Subscription
+from standardwebhooks import Webhook
+
+# A valid Standard-Webhooks secret: ``whsec_`` + base64 of a 32-byte key.
+SECRET = "whsec_" + base64.b64encode(b"billing-test-secret-key-32bytes!").decode()
+# The plan -> Dodo recurring product mapping the provider/service resolve against.
+PLAN_PRODUCTS = {"team": "prod_team_recurring", "business": "prod_business_recurring"}
+SUB_ID = "sub_dodo_abc123"
+
+
+def _provider() -> DodoProvider:
+    """A DodoProvider wired with the test webhook secret + plan->product map.
+
+    The API key is set so ``create_subscription`` passes its pre-flight; the SDK
+    client is mocked per-test where the checkout is exercised. ``plan_products``
+    feeds the webhook-parse reverse map (product_id -> plan_key fallback).
+    """
+    return DodoProvider(
+        api_key="dodo_test_key",
+        environment="test_mode",
+        webhook_secret=SECRET,
+        credit_product_id="prod_credits_sku",
+        plan_products=PLAN_PRODUCTS,
+    )
+
+
+@pytest.fixture
+def patch_plan_products(monkeypatch: pytest.MonkeyPatch):
+    """Point the plan catalog's product resolver at PLAN_PRODUCTS.
+
+    The catalog reads ``settings.dodo_plan_products`` to populate each tier's
+    ``dodo_product_id``; ``subscribe`` resolves the product through that. Patch
+    the catalog helper directly so the test doesn't depend on a real settings
+    load (and so ``get_plan('business').dodo_product_id`` is populated).
+    """
+    monkeypatch.setattr(plans, "_dodo_product_for", lambda key: PLAN_PRODUCTS.get(key))
+
+
+async def _make_workspace(plan: str = "free") -> str:
+    """Insert a real Workspace doc and return its id string (the wallet key)."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(name="Acme", slug=f"acme-{plan}", owner="u-owner", plan=plan)
+    await ws.insert()
+    return str(ws.id)
+
+
+def _sign(body: str, *, msg_id: str, ts: datetime | None = None) -> dict[str, str]:
+    """Produce valid Standard-Webhooks headers for ``body`` using ``SECRET``."""
+    ts = ts or datetime.now(UTC)
+    sig = Webhook(SECRET).sign(msg_id=msg_id, timestamp=ts, data=body)  # 'v1,<b64>'
+    return {
+        "webhook-id": msg_id,
+        "webhook-timestamp": str(int(ts.timestamp())),
+        "webhook-signature": sig,
+    }
+
+
+def _subscription_body(
+    *,
+    event_type: str,
+    workspace_id: str,
+    plan_key: str = "business",
+    product_id: str = "prod_business_recurring",
+    subscription_id: str = SUB_ID,
+) -> str:
+    """A Dodo ``subscription.*`` webhook body (the real envelope shape).
+
+    The buyer metadata lives at ``data.metadata`` (carrying workspace_id +
+    plan_key, as ``create_subscription`` stamps), the recurring product at
+    ``data.product_id``, and the subscription id at ``data.subscription_id``.
+    """
+    return json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": event_type,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "subscription_id": subscription_id,
+                "product_id": product_id,
+                "metadata": {"workspace_id": workspace_id, "plan_key": plan_key},
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion 1 — subscribe() opens a Dodo recurring checkout with the right
+# product id + {workspace_id, plan_key} metadata, returning the hosted url.
+# ---------------------------------------------------------------------------
+
+
+async def test_subscribe_creates_dodo_subscription_with_product_and_metadata(
+    mongo_db, monkeypatch, patch_plan_products
+):
+    ws = await _make_workspace(plan="free")
+
+    # Mock the async DodoPayments client so no network call happens.
+    fake_response = MagicMock()
+    fake_response.payment_link = "https://checkout.dodopayments.test/sub/abc123"
+    fake_response.subscription_id = SUB_ID
+
+    fake_client = MagicMock()
+    fake_client.subscriptions.create = AsyncMock(return_value=fake_response)
+
+    import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
+
+    monkeypatch.setattr(dodo_mod, "AsyncDodoPayments", MagicMock(return_value=fake_client))
+
+    result = await billing.subscribe(
+        workspace_id=ws, user_id="u1", plan_key="business", provider=_provider()
+    )
+    assert result == {"checkout_url": "https://checkout.dodopayments.test/sub/abc123"}
+
+    # The Dodo client was called with the business recurring product id and the
+    # workspace_id + plan_key on metadata (so the renewal webhook can route back).
+    _, kwargs = fake_client.subscriptions.create.call_args
+    assert kwargs["product_id"] == "prod_business_recurring"
+    assert kwargs["payment_link"] is True
+    assert kwargs["metadata"]["workspace_id"] == ws
+    assert kwargs["metadata"]["plan_key"] == "business"
+
+
+async def test_subscribe_rejects_unknown_plan(mongo_db, patch_plan_products):
+    ws = await _make_workspace()
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    with pytest.raises(ValidationError) as exc:
+        await billing.subscribe(
+            workspace_id=ws, user_id="u1", plan_key="platinum", provider=_provider()
+        )
+    assert exc.value.code == "billing.unknown_plan"
+
+
+async def test_subscribe_rejects_plan_with_no_product_configured(mongo_db, monkeypatch):
+    """A real tier with no Dodo product configured fails loudly (not silently)."""
+    # No plan->product mapping configured: dodo_product_id resolves to None.
+    monkeypatch.setattr(plans, "_dodo_product_for", lambda key: None)
+    ws = await _make_workspace()
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    with pytest.raises(ValidationError) as exc:
+        await billing.subscribe(
+            workspace_id=ws, user_id="u1", plan_key="business", provider=_provider()
+        )
+    assert exc.value.code == "billing.plan_product_unconfigured"
+
+
+# ---------------------------------------------------------------------------
+# Criterion 2 — a verified subscription.active grants the business allotment AND
+# upgrades Workspace.plan; entitlements then resolve to business.
+# ---------------------------------------------------------------------------
+
+
+async def test_active_grants_allotment_and_upgrades_plan(mongo_db):
+    ws = await _make_workspace(plan="free")
+    allotment = plans.get_plan("business").monthly_credit_allotment
+    assert allotment > 0
+
+    assert await credits.balance(ws) == 0
+
+    body = _subscription_body(event_type="subscription.active", workspace_id=ws)
+    headers = _sign(body, msg_id="evt_sub_active_1")
+    result = await billing.handle_webhook(
+        payload=body.encode(), headers=headers, provider=_provider()
+    )
+
+    assert result == {"ok": True, "granted": True}
+    # The business monthly allotment was granted to the wallet.
+    assert await credits.balance(ws) == allotment
+
+    # Workspace.plan was upgraded to business, so entitlements resolve to business.
+    ent = await entitlements.resolve_entitlements(ws)
+    assert ent.plan == "business"
+    assert ent.monthly_credit_allotment == allotment
+
+    # A Subscription record was written tracking the gateway lifecycle.
+    subs = await Subscription.find(Subscription.workspace == ws).to_list()
+    assert len(subs) == 1
+    assert subs[0].gateway == "dodo"
+    assert subs[0].gateway_subscription_id == SUB_ID
+    assert subs[0].plan_key == "business"
+    assert subs[0].status == "active"
+
+
+async def test_active_emits_subscription_granted_event(mongo_db, recording_bus):
+    ws = await _make_workspace(plan="free")
+    body = _subscription_body(event_type="subscription.active", workspace_id=ws)
+    headers = _sign(body, msg_id="evt_sub_active_emit")
+
+    await billing.handle_webhook(payload=body.encode(), headers=headers, provider=_provider())
+
+    captured = [e for e in recording_bus.events if e.type == "billing.subscription.granted"]
+    assert len(captured) == 1
+    data = captured[0].data
+    assert data["workspace_id"] == ws
+    assert data["plan_key"] == "business"
+    assert data["subscription_id"] == SUB_ID
+    assert data["amount_credits"] == plans.get_plan("business").monthly_credit_allotment
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3 — a verified subscription.renewed (NEW event id) grants the
+# allotment AGAIN additively. balance == 2x allotment after active + renewed
+# (ROLLOVER — unused credits carry forward, the grant is additive).
+# ---------------------------------------------------------------------------
+
+
+async def test_renewal_grants_additively_proving_rollover(mongo_db):
+    ws = await _make_workspace(plan="free")
+    allotment = plans.get_plan("business").monthly_credit_allotment
+
+    # Month 1 — activation grants once.
+    active_body = _subscription_body(event_type="subscription.active", workspace_id=ws)
+    await billing.handle_webhook(
+        payload=active_body.encode(),
+        headers=_sign(active_body, msg_id="evt_active_rollover"),
+        provider=_provider(),
+    )
+    assert await credits.balance(ws) == allotment
+
+    # Month 2 — a renewal with a FRESH event id grants the allotment AGAIN. None
+    # of month 1's credits were spent, so they ROLL OVER: balance == 2x allotment.
+    renewed_body = _subscription_body(event_type="subscription.renewed", workspace_id=ws)
+    result = await billing.handle_webhook(
+        payload=renewed_body.encode(),
+        headers=_sign(renewed_body, msg_id="evt_renewed_rollover"),  # NEW event id
+        provider=_provider(),
+    )
+
+    assert result == {"ok": True, "granted": True}
+    assert await credits.balance(ws) == 2 * allotment  # ROLLOVER proven
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4 — a replay of the SAME renewal event id is a no-op (balance
+# unchanged), via BC-1's unique (workspace, idempotency_key) index.
+# ---------------------------------------------------------------------------
+
+
+async def test_replay_same_renewal_event_id_is_noop(mongo_db, recording_bus):
+    ws = await _make_workspace(plan="free")
+    allotment = plans.get_plan("business").monthly_credit_allotment
+
+    # First activation grants.
+    active_body = _subscription_body(event_type="subscription.active", workspace_id=ws)
+    await billing.handle_webhook(
+        payload=active_body.encode(),
+        headers=_sign(active_body, msg_id="evt_active_replay"),
+        provider=_provider(),
+    )
+    assert await credits.balance(ws) == allotment
+
+    # A renewal grants again (fresh id) — balance is 2x.
+    renewed_body = _subscription_body(event_type="subscription.renewed", workspace_id=ws)
+    first = await billing.handle_webhook(
+        payload=renewed_body.encode(),
+        headers=_sign(renewed_body, msg_id="evt_renewed_dup_id"),
+        provider=_provider(),
+    )
+    assert first["granted"] is True
+    assert await credits.balance(ws) == 2 * allotment
+
+    # Re-deliver the SAME renewal (same webhook-id, re-signed) — a no-op grant.
+    second = await billing.handle_webhook(
+        payload=renewed_body.encode(),
+        headers=_sign(renewed_body, msg_id="evt_renewed_dup_id"),  # SAME id
+        provider=_provider(),
+    )
+    assert second == {"ok": True, "granted": False}  # replay no-op
+    assert await credits.balance(ws) == 2 * allotment  # unchanged — no triple-grant
+
+    # Exactly two grant events emitted (active + the one renewal; the replay did
+    # not re-emit).
+    captured = [e for e in recording_bus.events if e.type == "billing.subscription.granted"]
+    assert len(captured) == 2
+
+
+# ---------------------------------------------------------------------------
+# Criterion 5 — a verified subscription.cancelled reverts Workspace.plan to free
+# WITHOUT clawing back the granted credits.
+# ---------------------------------------------------------------------------
+
+
+async def test_cancellation_reverts_plan_without_clawing_back_credits(mongo_db):
+    ws = await _make_workspace(plan="free")
+    allotment = plans.get_plan("business").monthly_credit_allotment
+
+    # Activate: plan -> business, allotment granted.
+    active_body = _subscription_body(event_type="subscription.active", workspace_id=ws)
+    await billing.handle_webhook(
+        payload=active_body.encode(),
+        headers=_sign(active_body, msg_id="evt_active_cancel"),
+        provider=_provider(),
+    )
+    assert await credits.balance(ws) == allotment
+    assert (await entitlements.resolve_entitlements(ws)).plan == "business"
+
+    # Cancel: plan reverts to free; the granted credits are NOT clawed back.
+    cancel_body = _subscription_body(event_type="subscription.cancelled", workspace_id=ws)
+    result = await billing.handle_webhook(
+        payload=cancel_body.encode(),
+        headers=_sign(cancel_body, msg_id="evt_cancelled_1"),
+        provider=_provider(),
+    )
+
+    assert result == {"ok": True, "granted": False}  # cancellation never grants
+    # Plan reverted to free.
+    ent = await entitlements.resolve_entitlements(ws)
+    assert ent.plan == "free"
+    # Credits are PRESERVED — the workspace keeps what it paid for (no clawback).
+    assert await credits.balance(ws) == allotment
+
+    # The Subscription record reflects the cancelled status.
+    sub = await Subscription.find_one(
+        Subscription.gateway == "dodo", Subscription.gateway_subscription_id == SUB_ID
+    )
+    assert sub is not None
+    assert sub.status == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Provider-level checks — webhook parse normalizes a subscription.* delivery to
+# a SubscriptionEvent, and the product_id reverse-map fills a missing plan_key.
+# ---------------------------------------------------------------------------
+
+
+async def test_provider_parses_subscription_event_fields():
+    body = _subscription_body(
+        event_type="subscription.active", workspace_id="ws_parse", plan_key="team"
+    )
+    headers = _sign(body, msg_id="evt_parse_sub_1")
+    event = _provider().verify_and_parse_webhook(payload=body.encode(), headers=headers)
+    # A subscription delivery normalizes to a SubscriptionEvent, not a GatewayEvent.
+    from pocketpaw_ee.cloud.billing.domain import SubscriptionEvent
+
+    assert isinstance(event, SubscriptionEvent)
+    assert event.event_id == "evt_parse_sub_1"
+    assert event.type == "subscription.active"
+    assert event.workspace_id == "ws_parse"
+    assert event.plan_key == "team"
+    assert event.subscription_id == SUB_ID
+
+
+async def test_provider_reverse_maps_product_id_when_plan_key_missing():
+    """A subscription delivery whose metadata lacks plan_key still routes by the
+    recurring product id (reverse-mapped through the configured plan->product)."""
+    body = json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": "subscription.renewed",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "subscription_id": SUB_ID,
+                "product_id": "prod_business_recurring",
+                "metadata": {"workspace_id": "ws_rev"},  # NO plan_key
+            },
+        }
+    )
+    headers = _sign(body, msg_id="evt_reverse_1")
+    event = _provider().verify_and_parse_webhook(payload=body.encode(), headers=headers)
+    assert event.plan_key == "business"  # recovered from product_id reverse-map

--- a/tests/cloud/billing/test_subscriptions.py
+++ b/tests/cloud/billing/test_subscriptions.py
@@ -24,6 +24,12 @@
 # — the credit wallet is keyed on the workspace id string the same way.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-7): new test module.
+# Updated 2026-06-24 (B2 review fix): added
+#   test_empty_subscription_id_does_not_corrupt_cross_tenant — two workspaces whose
+#   verified active events both carry an EMPTY subscription_id must NOT collide on
+#   the unique (gateway, "") Subscription index. The fix SKIPS the audit upsert on
+#   a falsy subscription_id, so the second workspace never overwrites the first's
+#   row; the grant + plan change still apply for both.
 
 from __future__ import annotations
 
@@ -400,3 +406,54 @@ async def test_provider_reverse_maps_product_id_when_plan_key_missing():
     headers = _sign(body, msg_id="evt_reverse_1")
     event = _provider().verify_and_parse_webhook(payload=body.encode(), headers=headers)
     assert event.plan_key == "business"  # recovered from product_id reverse-map
+
+
+# ---------------------------------------------------------------------------
+# B2 review fix — an empty subscription_id must NOT collide two workspaces on the
+# unique (gateway, gateway_subscription_id) Subscription index. The fix skips the
+# audit upsert on a falsy subscription_id; the grant + plan change still apply.
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_subscription_id_does_not_corrupt_cross_tenant(mongo_db):
+    # Distinct starting plans → distinct workspace slugs (the helper derives the
+    # slug from the plan, and slug is uniquely indexed). Both are below business,
+    # so the active event upgrades each to business.
+    ws_a = await _make_workspace(plan="free")
+    ws_b = await _make_workspace(plan="team")
+    allotment = plans.get_plan("business").monthly_credit_allotment
+    assert allotment > 0
+
+    # Two DIFFERENT workspaces each get a verified active event carrying an EMPTY
+    # subscription_id (the gateway didn't send one). Before the fix the second
+    # would overwrite the first's Subscription row via the (dodo, "") unique key.
+    body_a = _subscription_body(
+        event_type="subscription.active", workspace_id=ws_a, subscription_id=""
+    )
+    res_a = await billing.handle_webhook(
+        payload=body_a.encode(),
+        headers=_sign(body_a, msg_id="evt_empty_sub_a"),
+        provider=_provider(),
+    )
+    body_b = _subscription_body(
+        event_type="subscription.active", workspace_id=ws_b, subscription_id=""
+    )
+    res_b = await billing.handle_webhook(
+        payload=body_b.encode(),
+        headers=_sign(body_b, msg_id="evt_empty_sub_b"),
+        provider=_provider(),
+    )
+
+    # The grant + plan change still happen for BOTH (the money path is unaffected).
+    assert res_a == {"ok": True, "granted": True}
+    assert res_b == {"ok": True, "granted": True}
+    assert await credits.balance(ws_a) == allotment
+    assert await credits.balance(ws_b) == allotment
+    assert (await entitlements.resolve_entitlements(ws_a)).plan == "business"
+    assert (await entitlements.resolve_entitlements(ws_b)).plan == "business"
+
+    # And NO Subscription audit row was written for either (the upsert is skipped
+    # on a falsy id), so there is no cross-tenant overwrite — workspace A's audit
+    # trail is never replaced by workspace B's.
+    subs = await Subscription.find().to_list()
+    assert subs == []

--- a/tests/cloud/credits/__init__.py
+++ b/tests/cloud/credits/__init__.py
@@ -1,0 +1,2 @@
+# tests/cloud/credits/__init__.py — package marker for the BC-1 credit ledger
+# test module. Created 2026-06-23 (integration/billing-credits).

--- a/tests/cloud/credits/test_enforcement.py
+++ b/tests/cloud/credits/test_enforcement.py
@@ -1,0 +1,254 @@
+# tests/cloud/credits/test_enforcement.py — BC-4 run-start hard-block.
+#
+# Proves the credit gate at the SINGLE chat run-start chokepoint
+# (chat/agent_router.py::post_agent_chat):
+#   1. billing_enforced=True + balance 0  -> POST returns 402 credits.insufficient
+#      and NO ChatRunDoc is created (the gate runs before create_run/submit).
+#   2. billing_enforced=True + balance > 0 -> the request proceeds past the gate.
+#   3. billing_enforced=False (default)   -> never gates, even at balance 0.
+#   4. credits.service.check_balance raises InsufficientCredits at balance <= 0
+#      and is a no-op at balance > 0 (unit level).
+#
+# Created 2026-06-24 (integration/billing-credits, BC-4).
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Router-test scaffolding (mirrors tests/cloud/test_agent_router.py so the POST
+# path runs without a real Redis transport / scope resolution).
+# ---------------------------------------------------------------------------
+
+
+def _fake_ctx() -> SimpleNamespace:
+    return SimpleNamespace(
+        kind=SimpleNamespace(value="session"),
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+        agent_ids_in_scope=["a1"],
+        pocket_tool_specs=[],
+        session_id=None,
+        pocket_id=None,
+        intent=None,
+    )
+
+
+async def _fake_resolve(**_):
+    return _fake_ctx()
+
+
+async def _fake_persist_user_message(_ctx, _body):
+    return "user_msg_id_1"
+
+
+async def _fake_load_history(_ctx, *, limit=50):  # noqa: ARG001
+    return []
+
+
+async def _fake_ensure_session(_ctx):
+    return "session_id_1"
+
+
+class _StubTransport:
+    """Emits one ``stream_end`` so the SSE generator closes without Redis."""
+
+    def __init__(self) -> None:
+        self.cancelled: list[str] = []
+
+    async def request_cancel(self, run_id: str) -> None:
+        self.cancelled.append(run_id)
+
+    def read_events(self, run_id: str, *, after: str = "0", block_ms: int = 15000) -> AsyncIterator:  # noqa: ARG002
+        async def _gen() -> AsyncIterator:
+            from pocketpaw_ee.cloud.chat.runs.transport import StreamEvent
+
+            yield StreamEvent(
+                entry_id="1-0",
+                event="stream_end",
+                data={"assistant_message_id": None, "usage": {}, "cancelled": False},
+            )
+
+        return _gen()
+
+
+def _enforce(monkeypatch, mod, *, on: bool) -> None:
+    """Point the router's ``get_settings`` at a stub carrying the flag."""
+    monkeypatch.setattr(mod, "get_settings", lambda: SimpleNamespace(billing_enforced=on))
+
+
+def _patch_run_internals(mod):
+    """Patch the side-effecting collaborators the POST path calls AFTER the gate.
+
+    Returns the context-manager bundle; the executor stub records submitted run
+    ids so a test can assert the run did (or did not) proceed past the gate.
+    """
+    submitted: list[str] = []
+
+    class _FakeExecutor:
+        async def submit(self, spec):
+            submitted.append(spec.run_id)
+
+    return submitted, _FakeExecutor
+
+
+# ---------------------------------------------------------------------------
+# 1 — enforced + balance 0 -> 402 and NO run/ChatRunDoc created.
+# ---------------------------------------------------------------------------
+
+
+async def test_enforced_zero_balance_blocks_with_402_and_creates_no_run(
+    cloud_app_client: AsyncClient,
+    mongo_db,  # noqa: ARG001 — forces Beanie init
+    monkeypatch,
+):
+    from pocketpaw_ee.cloud.chat import agent_router as mod
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    _enforce(monkeypatch, mod, on=True)
+    submitted, _FakeExecutor = _patch_run_internals(mod)
+    monkeypatch.setattr(mod, "get_executor", lambda: _FakeExecutor())
+    monkeypatch.setattr(mod, "get_stream_transport", lambda: _StubTransport())
+
+    # Workspace w1 has no wallet -> balance() returns 0 -> gate must fire.
+    with (
+        patch.object(mod, "resolve_scope_context", _fake_resolve),
+        patch.object(mod, "load_history_for_scope", _fake_load_history),
+        patch.object(mod, "_persist_user_message", _fake_persist_user_message),
+        patch.object(mod, "_ensure_scope_session", _fake_ensure_session),
+    ):
+        resp = await cloud_app_client.post(
+            "/cloud/chat/session/s1/agent",
+            json={"content": "hello", "client_message_id": "c1"},
+        )
+
+    assert resp.status_code == 402
+    assert resp.json()["error"]["code"] == "credits.insufficient"
+    # The gate ran before create_run / submit: no run reached the executor and
+    # no ChatRunDoc was written.
+    assert submitted == []
+    assert await ChatRunDoc.find_all().count() == 0
+
+
+# ---------------------------------------------------------------------------
+# 2 — enforced + balance > 0 -> proceeds past the gate (run created/submitted).
+# ---------------------------------------------------------------------------
+
+
+async def test_enforced_positive_balance_proceeds(
+    cloud_app_client: AsyncClient,
+    mongo_db,  # noqa: ARG001 — forces Beanie init so create_run can persist
+    monkeypatch,
+):
+    from pocketpaw_ee.cloud.chat import agent_router as mod
+    from pocketpaw_ee.cloud.credits import service as credits_service
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    # Fund the wallet so check_balance is a no-op.
+    await credits_service.grant("w1", 100, cause="test.seed", idempotency_key="seed-1")
+
+    _enforce(monkeypatch, mod, on=True)
+    submitted, _FakeExecutor = _patch_run_internals(mod)
+    monkeypatch.setattr(mod, "get_executor", lambda: _FakeExecutor())
+    monkeypatch.setattr(mod, "get_stream_transport", lambda: _StubTransport())
+
+    with (
+        patch.object(mod, "resolve_scope_context", _fake_resolve),
+        patch.object(mod, "load_history_for_scope", _fake_load_history),
+        patch.object(mod, "_persist_user_message", _fake_persist_user_message),
+        patch.object(mod, "_ensure_scope_session", _fake_ensure_session),
+    ):
+        resp = await cloud_app_client.post(
+            "/cloud/chat/session/s1/agent",
+            json={"content": "hello", "client_message_id": "c2"},
+        )
+
+    assert resp.status_code == 200
+    # Proceeded past the gate: a run was created and submitted to the executor.
+    assert len(submitted) == 1
+    assert await ChatRunDoc.find_all().count() == 1
+
+
+# ---------------------------------------------------------------------------
+# 3 — NOT enforced (default) -> never gates, even at balance 0.
+# ---------------------------------------------------------------------------
+
+
+async def test_not_enforced_never_gates_at_zero_balance(
+    cloud_app_client: AsyncClient,
+    mongo_db,  # noqa: ARG001 — forces Beanie init so create_run can persist
+    monkeypatch,
+):
+    from pocketpaw_ee.cloud.chat import agent_router as mod
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    # Default posture: flag OFF. Wallet is empty (balance 0) — must still proceed.
+    _enforce(monkeypatch, mod, on=False)
+    submitted, _FakeExecutor = _patch_run_internals(mod)
+    monkeypatch.setattr(mod, "get_executor", lambda: _FakeExecutor())
+    monkeypatch.setattr(mod, "get_stream_transport", lambda: _StubTransport())
+
+    with (
+        patch.object(mod, "resolve_scope_context", _fake_resolve),
+        patch.object(mod, "load_history_for_scope", _fake_load_history),
+        patch.object(mod, "_persist_user_message", _fake_persist_user_message),
+        patch.object(mod, "_ensure_scope_session", _fake_ensure_session),
+    ):
+        resp = await cloud_app_client.post(
+            "/cloud/chat/session/s1/agent",
+            json={"content": "hello", "client_message_id": "c3"},
+        )
+
+    assert resp.status_code == 200
+    assert len(submitted) == 1
+    assert await ChatRunDoc.find_all().count() == 1
+
+
+# ---------------------------------------------------------------------------
+# 4 — check_balance unit behaviour.
+# ---------------------------------------------------------------------------
+
+
+async def test_check_balance_raises_at_zero(mongo_db):  # noqa: ARG001 — Beanie init
+    from pocketpaw_ee.cloud._core.errors import InsufficientCredits
+    from pocketpaw_ee.cloud.credits import service as credits_service
+
+    # No wallet -> balance 0 -> raises 402 credits.insufficient.
+    with pytest.raises(InsufficientCredits) as exc:
+        await credits_service.check_balance("w-empty")
+    assert exc.value.status_code == 402
+    assert exc.value.code == "credits.insufficient"
+
+
+async def test_check_balance_raises_when_negative(mongo_db):  # noqa: ARG001 — Beanie init
+    from pocketpaw_ee.cloud._core.errors import InsufficientCredits
+    from pocketpaw_ee.cloud.credits import service as credits_service
+
+    # Drive the wallet negative via a metered (allow_negative) debit, then assert
+    # the gate still blocks at < 0.
+    await credits_service.grant("w-neg", 10, cause="seed", idempotency_key="g1")
+    await credits_service.debit(
+        "w-neg", 25, cause="overage", idempotency_key="d1", allow_negative=True
+    )
+    assert await credits_service.balance("w-neg") == -15
+    with pytest.raises(InsufficientCredits):
+        await credits_service.check_balance("w-neg")
+
+
+async def test_check_balance_noop_when_positive(mongo_db):  # noqa: ARG001 — Beanie init
+    from pocketpaw_ee.cloud.credits import service as credits_service
+
+    await credits_service.grant("w-funded", 5, cause="seed", idempotency_key="g1")
+    # No exception -> returns None.
+    assert await credits_service.check_balance("w-funded") is None

--- a/tests/cloud/credits/test_ledger.py
+++ b/tests/cloud/credits/test_ledger.py
@@ -35,8 +35,9 @@ WS = "ws_credit_test"
 
 
 async def test_grant_raises_balance(mongo_db):
-    new_balance = await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")
-    assert new_balance == 500
+    result = await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")
+    assert result.balance == 500
+    assert result.created is True
     assert await credits.balance(WS) == 500
 
     # A second, distinct grant accumulates.
@@ -100,8 +101,10 @@ async def test_over_debit_raises_and_has_no_side_effects(mongo_db):
 async def test_duplicate_idempotency_key_is_noop_for_grant(mongo_db):
     first = await credits.grant(WS, 400, cause="top_up", idempotency_key="dup")
     second = await credits.grant(WS, 400, cause="top_up", idempotency_key="dup")
-    assert first == 400
-    assert second == 400  # returns current balance, does NOT re-apply
+    assert first.balance == 400
+    assert first.created is True  # the first call NEWLY applied the grant
+    assert second.balance == 400  # returns current balance, does NOT re-apply
+    assert second.created is False  # B1 — the replay is detected via created, not a delta
     assert await credits.balance(WS) == 400
 
     # Exactly one ledger row for the key.
@@ -263,15 +266,21 @@ async def test_grant_emits_credit_movement(mongo_db, recording_bus):
 
 
 async def test_duplicate_replay_does_not_re_emit(mongo_db, recording_bus):
-    await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")
-    await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")  # replay
+    first = await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")
+    replay = await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")  # replay
+    # B1 — the replay reports created=False (the authoritative replay signal the
+    # billing webhook gates its capture emit on), and does NOT re-emit.
+    assert first.created is True
+    assert replay.created is False
+    assert replay.balance == 500  # current balance, not re-applied
     movements = [e for e in recording_bus.events if e.type == "credits.movement"]
     assert len(movements) == 1  # the no-op replay did not re-emit
 
 
 async def test_genesis_kind_seeds_wallet(mongo_db):
-    bal = await credits.grant(WS, 1000, cause="genesis", idempotency_key="gen", kind="genesis")
-    assert bal == 1000
+    result = await credits.grant(WS, 1000, cause="genesis", idempotency_key="gen", kind="genesis")
+    assert result.balance == 1000
+    assert result.created is True
     entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
     assert entries[0].kind == "genesis"
 

--- a/tests/cloud/credits/test_ledger.py
+++ b/tests/cloud/credits/test_ledger.py
@@ -1,0 +1,271 @@
+# tests/cloud/credits/test_ledger.py — proves the BC-1 credit ledger contract:
+# the atomic, idempotent grant / debit / balance / history / reconcile API and
+# its two money-handling invariants:
+#   (a) a duplicate idempotency_key never double-applies;
+#   (b) a rejected over-debit leaves NO ledger entry and NO balance change.
+#
+# Uses the shared ``mongo_db`` fixture (mongomock-motor + Beanie init over
+# ALL_DOCUMENTS) from tests/cloud/conftest.py — the same DB-fixture pattern the
+# chat-runs / home-pocket service tests use. The autouse ``recording_bus``
+# fixture installs a RecordingBus so the service's ``emit(CreditMovement(...))``
+# calls never raise.
+#
+# Created 2026-06-23 (integration/billing-credits, BC-1): new test module.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import InsufficientCredits, ValidationError
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.models.credit import CreditBalance, CreditLedgerEntry
+
+WS = "ws_credit_test"
+
+
+# ---------------------------------------------------------------------------
+# Criterion 1 — grant raises the balance; balance() reflects it.
+# ---------------------------------------------------------------------------
+
+
+async def test_grant_raises_balance(mongo_db):
+    new_balance = await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")
+    assert new_balance == 500
+    assert await credits.balance(WS) == 500
+
+    # A second, distinct grant accumulates.
+    await credits.grant(WS, 250, cause="promo", idempotency_key="g2")
+    assert await credits.balance(WS) == 750
+
+
+# ---------------------------------------------------------------------------
+# Criterion 2 — debit lowers the balance.
+# ---------------------------------------------------------------------------
+
+
+async def test_debit_lowers_balance(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="g1")
+    new_balance = await credits.debit(WS, 300, cause="compute_spend", idempotency_key="d1")
+    assert new_balance == 700
+    assert await credits.balance(WS) == 700
+
+    # The spend is recorded as a signed-negative ledger movement.
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
+    spend = [e for e in entries if e.idempotency_key == "d1"][0]
+    assert spend.amount_delta == -300
+    assert spend.balance_after == 700
+    assert spend.kind == "spend"
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3 — over-debit raises InsufficientCredits AND leaves ZERO side
+# effects (no balance change, no stray applied ledger entry).
+# ---------------------------------------------------------------------------
+
+
+async def test_over_debit_raises_and_has_no_side_effects(mongo_db):
+    await credits.grant(WS, 100, cause="top_up", idempotency_key="g1")
+
+    with pytest.raises(InsufficientCredits) as exc:
+        await credits.debit(WS, 250, cause="compute_spend", idempotency_key="d_over")
+    assert exc.value.status_code == 402
+    assert exc.value.code == "credits.insufficient"
+
+    # Balance unchanged.
+    assert await credits.balance(WS) == 100
+
+    # No ledger entry survives for the rejected debit (the insert was rolled
+    # back), and the genesis grant is the only movement.
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
+    assert all(e.idempotency_key != "d_over" for e in entries)
+    assert len(entries) == 1
+
+    # The freed key can be reused after a top-up — a retry re-evaluates cleanly.
+    await credits.grant(WS, 500, cause="top_up", idempotency_key="g2")
+    assert await credits.debit(WS, 250, cause="compute_spend", idempotency_key="d_over") == 350
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4 — a duplicate idempotency_key is a no-op (balance unchanged, no
+# second movement applied) for BOTH grant and debit.
+# ---------------------------------------------------------------------------
+
+
+async def test_duplicate_idempotency_key_is_noop_for_grant(mongo_db):
+    first = await credits.grant(WS, 400, cause="top_up", idempotency_key="dup")
+    second = await credits.grant(WS, 400, cause="top_up", idempotency_key="dup")
+    assert first == 400
+    assert second == 400  # returns current balance, does NOT re-apply
+    assert await credits.balance(WS) == 400
+
+    # Exactly one ledger row for the key.
+    rows = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "dup",
+    ).to_list()
+    assert len(rows) == 1
+
+
+async def test_duplicate_idempotency_key_is_noop_for_debit(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="g1")
+    first = await credits.debit(WS, 200, cause="compute_spend", idempotency_key="dup_d")
+    second = await credits.debit(WS, 200, cause="compute_spend", idempotency_key="dup_d")
+    assert first == 800
+    assert second == 800  # no double-spend
+    assert await credits.balance(WS) == 800
+
+    rows = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "dup_d",
+    ).to_list()
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Criterion 5 — two concurrent debits each for the full balance: exactly ONE
+# succeeds (no double-spend); the other raises InsufficientCredits; final
+# balance == 0.
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_full_debits_exactly_one_succeeds(mongo_db):
+    await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")
+
+    results = await asyncio.gather(
+        credits.debit(WS, 500, cause="compute_spend", idempotency_key="c1"),
+        credits.debit(WS, 500, cause="compute_spend", idempotency_key="c2"),
+        return_exceptions=True,
+    )
+
+    successes = [r for r in results if isinstance(r, int)]
+    failures = [r for r in results if isinstance(r, InsufficientCredits)]
+    assert len(successes) == 1, f"expected exactly one success, got {results!r}"
+    assert len(failures) == 1, f"expected exactly one InsufficientCredits, got {results!r}"
+    assert successes[0] == 0
+    assert await credits.balance(WS) == 0
+
+    # The loser left no applied ledger entry — only the grant + one spend remain.
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
+    spends = [e for e in entries if e.kind == "spend"]
+    assert len(spends) == 1
+
+
+# ---------------------------------------------------------------------------
+# Criterion 6 — reconcile() repairs a simulated drift.
+# ---------------------------------------------------------------------------
+
+
+async def test_reconcile_repairs_drift(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="g1")
+    await credits.debit(WS, 300, cause="compute_spend", idempotency_key="d1")
+    # Ledger sum: +1000 - 300 = 700.
+
+    # Simulate a crash that left the balance doc stale (e.g. a $inc that landed
+    # but a later mutation corrupted the cached balance).
+    coll = CreditBalance.get_pymongo_collection()
+    await coll.update_one({"workspace": WS}, {"$set": {"balance_credits": 999999}})
+    assert await credits.balance(WS) == 999999  # corrupted
+
+    repaired = await credits.reconcile(WS)
+    assert repaired == 700
+    assert await credits.balance(WS) == 700
+
+
+async def test_reconcile_recreates_lost_balance_row(mongo_db):
+    await credits.grant(WS, 800, cause="top_up", idempotency_key="g1")
+    # Simulate the crash window: a committed ledger entry whose balance row was
+    # lost entirely.
+    coll = CreditBalance.get_pymongo_collection()
+    await coll.delete_one({"workspace": WS})
+    assert await credits.balance(WS) == 0  # row gone → reads as 0
+
+    repaired = await credits.reconcile(WS)
+    assert repaired == 800
+    assert await credits.balance(WS) == 800
+
+
+async def test_reconcile_is_noop_when_in_agreement(mongo_db):
+    await credits.grant(WS, 600, cause="top_up", idempotency_key="g1")
+    assert await credits.reconcile(WS) == 600
+    assert await credits.balance(WS) == 600
+
+
+# ---------------------------------------------------------------------------
+# Extra coverage — tenant isolation, history paging, validation, emit.
+# ---------------------------------------------------------------------------
+
+
+async def test_balance_is_tenant_scoped(mongo_db):
+    await credits.grant("ws_a", 100, cause="top_up", idempotency_key="a1")
+    await credits.grant("ws_b", 250, cause="top_up", idempotency_key="b1")
+    assert await credits.balance("ws_a") == 100
+    assert await credits.balance("ws_b") == 250
+
+
+async def test_history_newest_first_and_pages(mongo_db):
+    for i in range(5):
+        await credits.grant(WS, 100, cause="top_up", idempotency_key=f"g{i}")
+
+    entries, next_cursor = await credits.history(WS, limit=2)
+    assert len(entries) == 2
+    assert next_cursor is not None
+    # Newest first — last grant (g4) leads.
+    assert entries[0].idempotency_key == "g4"
+    assert entries[1].idempotency_key == "g3"
+
+    page2, cursor2 = await credits.history(WS, limit=2, cursor=next_cursor)
+    assert [e.idempotency_key for e in page2] == ["g2", "g1"]
+    assert cursor2 is not None
+
+    page3, cursor3 = await credits.history(WS, limit=2, cursor=cursor2)
+    assert [e.idempotency_key for e in page3] == ["g0"]
+    assert cursor3 is None  # last page
+
+
+async def test_history_is_tenant_scoped(mongo_db):
+    await credits.grant("ws_a", 100, cause="top_up", idempotency_key="a1")
+    await credits.grant("ws_b", 100, cause="top_up", idempotency_key="b1")
+    entries, _ = await credits.history("ws_a")
+    assert len(entries) == 1
+    assert entries[0].workspace_id == "ws_a"
+
+
+async def test_grant_rejects_non_positive_amount(mongo_db):
+    with pytest.raises(ValidationError):
+        await credits.grant(WS, 0, cause="top_up", idempotency_key="z")
+    with pytest.raises(ValidationError):
+        await credits.grant(WS, -5, cause="top_up", idempotency_key="neg")
+
+
+async def test_debit_rejects_non_positive_amount(mongo_db):
+    await credits.grant(WS, 100, cause="top_up", idempotency_key="g1")
+    with pytest.raises(ValidationError):
+        await credits.debit(WS, 0, cause="compute_spend", idempotency_key="z")
+
+
+async def test_grant_emits_credit_movement(mongo_db, recording_bus):
+    await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")
+    movements = [e for e in recording_bus.events if e.type == "credits.movement"]
+    assert len(movements) == 1
+    data = movements[0].data
+    assert data["workspace_id"] == WS
+    assert data["kind"] == "grant"
+    assert data["amount_delta"] == 500
+    assert data["balance_after"] == 500
+    assert data["cause"] == "top_up"
+    assert data["idempotency_key"] == "g1"
+
+
+async def test_duplicate_replay_does_not_re_emit(mongo_db, recording_bus):
+    await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")
+    await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")  # replay
+    movements = [e for e in recording_bus.events if e.type == "credits.movement"]
+    assert len(movements) == 1  # the no-op replay did not re-emit
+
+
+async def test_genesis_kind_seeds_wallet(mongo_db):
+    bal = await credits.grant(WS, 1000, cause="genesis", idempotency_key="gen", kind="genesis")
+    assert bal == 1000
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
+    assert entries[0].kind == "genesis"

--- a/tests/cloud/credits/test_ledger.py
+++ b/tests/cloud/credits/test_ledger.py
@@ -11,6 +11,11 @@
 # calls never raise.
 #
 # Created 2026-06-23 (integration/billing-credits, BC-1): new test module.
+# Changed 2026-06-24 (BC-1 reconcile fix): added four tests covering the
+# applied/conditional fix — ``allow_negative`` metered debit driving the balance
+# below zero, reconcile re-driving an unapplied (phantom) grant, reconcile
+# re-driving-or-voiding an unapplied strict debit, and the exact review repro
+# proving reconcile never invents a balance from a phantom entry.
 
 from __future__ import annotations
 
@@ -269,3 +274,145 @@ async def test_genesis_kind_seeds_wallet(mongo_db):
     assert bal == 1000
     entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
     assert entries[0].kind == "genesis"
+
+
+# ---------------------------------------------------------------------------
+# BC-1 reconcile fix — applied/conditional semantics.
+# ---------------------------------------------------------------------------
+
+
+async def test_allow_negative_debit_can_go_below_zero(mongo_db):
+    """A metered ``allow_negative`` debit may drive the balance below zero (a
+    completed run is always billed); a STRICT debit of the same would reject."""
+    await credits.grant(WS, 100, cause="top_up", idempotency_key="g1")
+
+    new_balance = await credits.debit(
+        WS, 300, cause="compute_spend", idempotency_key="meter", allow_negative=True
+    )
+    assert new_balance == -200
+    assert await credits.balance(WS) == -200
+
+    # The spend row records the negative balance, is applied, and is NOT
+    # conditional (so reconcile re-drives it unconditionally).
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
+    spend = [e for e in entries if e.idempotency_key == "meter"][0]
+    assert spend.amount_delta == -300
+    assert spend.balance_after == -200
+    assert spend.applied is True
+    assert spend.conditional is False
+    assert spend.kind == "spend"
+
+    # A STRICT debit (the default) for the same amount on a negative wallet still
+    # rejects — the no-overdraft guard is intact for non-metered debits.
+    with pytest.raises(InsufficientCredits):
+        await credits.debit(WS, 300, cause="compute_spend", idempotency_key="strict")
+    assert await credits.balance(WS) == -200  # unchanged by the rejected strict debit
+
+
+async def test_reconcile_redrives_unapplied_grant(mongo_db):
+    """A phantom grant (entry committed, balance never inc'd) is re-driven by
+    reconcile: the grant applies and the balance becomes correct."""
+    # Real grant lands normally.
+    await credits.grant(WS, 500, cause="top_up", idempotency_key="g1")
+    assert await credits.balance(WS) == 500
+
+    # Simulate the crash window for a SECOND grant: insert the ledger entry but
+    # never run its balance $inc (applied stays False).
+    phantom = CreditLedgerEntry(
+        workspace=WS,
+        kind="grant",
+        amount_delta=250,
+        balance_after=0,
+        applied=False,
+        conditional=False,
+        cause="promo",
+        ref={},
+        idempotency_key="phantom_grant",
+    )
+    await phantom.insert()
+    assert await credits.balance(WS) == 500  # phantom not yet applied
+
+    repaired = await credits.reconcile(WS)
+    assert repaired == 750  # 500 + re-driven 250
+    assert await credits.balance(WS) == 750
+
+    reloaded = await CreditLedgerEntry.get(phantom.id)
+    assert reloaded.applied is True
+    assert reloaded.balance_after == 750
+
+
+async def test_reconcile_redrives_or_voids_unapplied_strict_debit(mongo_db):
+    """A phantom STRICT debit that exceeds funds is VOIDED by reconcile (no
+    negative invented); a phantom strict debit within funds is APPLIED."""
+    await credits.grant(WS, 100, cause="top_up", idempotency_key="g1")
+
+    # Phantom strict debit that EXCEEDS the balance — should be voided.
+    over = CreditLedgerEntry(
+        workspace=WS,
+        kind="spend",
+        amount_delta=-1000,
+        balance_after=0,
+        applied=False,
+        conditional=True,
+        cause="compute_spend",
+        ref={},
+        idempotency_key="phantom_over",
+    )
+    await over.insert()
+
+    repaired = await credits.reconcile(WS)
+    assert repaired == 100  # over-funds phantom voided, never counted
+    assert await credits.balance(WS) == 100
+    # The voided entry no longer exists.
+    assert await CreditLedgerEntry.get(over.id) is None
+
+    # Phantom strict debit WITHIN funds — should be applied.
+    within = CreditLedgerEntry(
+        workspace=WS,
+        kind="spend",
+        amount_delta=-40,
+        balance_after=0,
+        applied=False,
+        conditional=True,
+        cause="compute_spend",
+        ref={},
+        idempotency_key="phantom_within",
+    )
+    await within.insert()
+
+    repaired2 = await credits.reconcile(WS)
+    assert repaired2 == 60  # 100 - re-driven 40
+    assert await credits.balance(WS) == 60
+    reloaded = await CreditLedgerEntry.get(within.id)
+    assert reloaded.applied is True
+    assert reloaded.balance_after == 60
+
+
+async def test_reconcile_never_invents_balance_from_phantom(mongo_db):
+    """The exact review repro: grant 100 + a phantom (unapplied) conditional
+    debit -1000 must NOT persist -950. The over-funds strict phantom is voided,
+    so the balance stays 100."""
+    await credits.grant(WS, 100, cause="top_up", idempotency_key="g1")
+
+    # The phantom conditional debit that the old reconcile would have blindly
+    # summed (100 + -1000 = -900, or the review's -950 with a stale row).
+    phantom = CreditLedgerEntry(
+        workspace=WS,
+        kind="spend",
+        amount_delta=-1000,
+        balance_after=0,
+        applied=False,
+        conditional=True,
+        cause="compute_spend",
+        ref={},
+        idempotency_key="phantom_debit",
+    )
+    await phantom.insert()
+
+    repaired = await credits.reconcile(WS)
+    assert repaired == 100, "reconcile must not invent a balance from a phantom debit"
+    assert repaired != -950
+    assert repaired != -900
+    assert await credits.balance(WS) == 100
+    # The phantom strict debit was never authorized to land — voided, not counted.
+    assert await CreditLedgerEntry.get(phantom.id) is None

--- a/tests/cloud/entitlements/__init__.py
+++ b/tests/cloud/entitlements/__init__.py
@@ -1,0 +1,4 @@
+# tests/cloud/entitlements/__init__.py — test package marker for the BC-6
+# Entitlements entity (the Entitlement primitive).
+#
+# Created 2026-06-24 (integration/billing-credits, BC-6): new test package.

--- a/tests/cloud/entitlements/test_entitlements.py
+++ b/tests/cloud/entitlements/test_entitlements.py
@@ -1,0 +1,174 @@
+# tests/cloud/entitlements/test_entitlements.py — proves the BC-6 Entitlement-
+# primitive contract: ``resolve_entitlements(workspace_id)`` maps a workspace to
+# its plan + features + monthly credit allotment, derived from the EXISTING
+# ``Workspace.plan`` field via ``get_workspace_plan`` and the billing plan
+# catalog. Key invariants:
+#   (a) a ``plan="business"`` workspace resolves the business feature set + its
+#       allotment (features straight from PLAN_FEATURES);
+#   (b) a workspace with no / unknown plan, or one that doesn't exist, falls back
+#       to the ``free`` base tier — no crash, no paid-tier leak;
+#   (c) the resolver reads the plan of the asked-for workspace ONLY (a second
+#       tenant's plan never leaks across).
+#
+# Two layers: unit tests patch ``get_workspace_plan`` (no DB) to drive every plan
+# string; one DB-backed test inserts REAL ``Workspace`` docs (mongo_db fixture)
+# to prove the end-to-end read AND tenant isolation. The HTTP route is exercised
+# with a TestClient + overridden deps (license waived, workspace pinned).
+#
+# Created 2026-06-24 (integration/billing-credits, BC-6): new test module.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.entitlements import service as entitlements
+from pocketpaw_ee.cloud.entitlements.router import router as entitlements_router
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import current_workspace_id
+from pocketpaw_ee.guards.abac import PLAN_FEATURES
+
+WS = "ws_entitlements_test"
+
+
+@pytest.fixture
+def patch_plan(monkeypatch: pytest.MonkeyPatch):
+    """Patch get_workspace_plan to return a fixed plan string (or None)."""
+
+    def _patch(plan: str | None) -> None:
+        import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+        monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value=plan))
+
+    return _patch
+
+
+# ---------------------------------------------------------------------------
+# Criterion (a) — a business workspace resolves business features + allotment.
+# ---------------------------------------------------------------------------
+
+
+async def test_business_plan_resolves_business_features_and_allotment(patch_plan):
+    patch_plan("business")
+    ent = await entitlements.resolve_entitlements(WS)
+    assert ent.workspace_id == WS
+    assert ent.plan == "business"
+    assert set(ent.features) == PLAN_FEATURES["business"]
+    assert ent.monthly_credit_allotment > 0
+    # The catalog's business allotment is exactly what resolves.
+    from pocketpaw_ee.cloud.billing import plans
+
+    assert ent.monthly_credit_allotment == plans.get_plan("business").monthly_credit_allotment
+
+
+@pytest.mark.parametrize("plan", ["free", "team", "business", "enterprise"])
+async def test_every_known_plan_resolves_its_own_features(patch_plan, plan):
+    patch_plan(plan)
+    ent = await entitlements.resolve_entitlements(WS)
+    assert ent.plan == plan
+    assert set(ent.features) == PLAN_FEATURES[plan]
+
+
+# ---------------------------------------------------------------------------
+# Criterion (b) — no/unknown plan, or missing workspace, falls back to free.
+# ---------------------------------------------------------------------------
+
+
+async def test_unknown_plan_falls_back_to_free(patch_plan):
+    """A stale / typo'd plan string is NOT trusted — resolve to the free floor."""
+    patch_plan("legacy_gold_tier")
+    ent = await entitlements.resolve_entitlements(WS)
+    assert ent.plan == "free"
+    assert set(ent.features) == PLAN_FEATURES["free"]
+    assert ent.monthly_credit_allotment == 0
+
+
+async def test_missing_workspace_falls_back_to_free(patch_plan):
+    """get_workspace_plan returns None (missing/deleted/bad id) -> free, no crash."""
+    patch_plan(None)
+    ent = await entitlements.resolve_entitlements(WS)
+    assert ent.plan == "free"
+    assert ent.monthly_credit_allotment == 0
+    # Crucially, free must NOT carry any paid-tier feature.
+    assert "fabric" not in ent.features
+    assert "instinct" not in ent.features
+
+
+async def test_empty_workspace_id_is_rejected_at_entry():
+    """Rule 6 — an empty workspace_id raises ValidationError, not a silent free."""
+    with pytest.raises(ValidationError):
+        await entitlements.resolve_entitlements("")
+
+
+# ---------------------------------------------------------------------------
+# DB-backed — real Workspace docs prove end-to-end read + tenant isolation.
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_reads_real_workspace_plan_and_isolates_tenants(mongo_db):
+    """Two workspaces with different plans each resolve their OWN plan only."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    biz_ws = Workspace(name="Acme", slug="acme-biz", owner="u-owner", plan="business")
+    await biz_ws.insert()
+    free_ws = Workspace(name="Beta", slug="beta-free", owner="u-owner2", plan="free")
+    await free_ws.insert()
+
+    biz_ent = await entitlements.resolve_entitlements(str(biz_ws.id))
+    free_ent = await entitlements.resolve_entitlements(str(free_ws.id))
+
+    # Each resolves its OWN plan — no cross-tenant leak.
+    assert biz_ent.plan == "business"
+    assert set(biz_ent.features) == PLAN_FEATURES["business"]
+    assert free_ent.plan == "free"
+    assert set(free_ent.features) == PLAN_FEATURES["free"]
+    # The free tenant did NOT pick up the business tenant's paid features.
+    assert "fabric" not in free_ent.features
+
+
+async def test_resolve_for_nonexistent_id_is_free(mongo_db):
+    """A well-formed but nonexistent workspace id resolves to free (no crash)."""
+    from bson import ObjectId
+
+    ent = await entitlements.resolve_entitlements(str(ObjectId()))
+    assert ent.plan == "free"
+    assert ent.monthly_credit_allotment == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /entitlements — the HTTP read surface.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def entitlements_client() -> TestClient:
+    """TestClient over the entitlements router; license waived, workspace pinned."""
+    app = FastAPI()
+    app.include_router(entitlements_router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_workspace_id] = lambda: WS
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_get_entitlements_returns_resolved_entitlements(entitlements_client, patch_plan):
+    patch_plan("business")
+    resp = entitlements_client.get("/entitlements")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["workspace_id"] == WS
+    assert body["plan"] == "business"
+    assert set(body["features"]) == PLAN_FEATURES["business"]
+    assert body["features"] == sorted(body["features"])  # deterministic JSON
+    assert body["monthly_credit_allotment"] > 0
+
+
+def test_get_entitlements_unknown_plan_is_free(entitlements_client, patch_plan):
+    patch_plan(None)
+    resp = entitlements_client.get("/entitlements")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["plan"] == "free"
+    assert body["monthly_credit_allotment"] == 0

--- a/tests/cloud/metering/__init__.py
+++ b/tests/cloud/metering/__init__.py
@@ -1,0 +1,2 @@
+# tests/cloud/metering/__init__.py — package marker for the BC-3 compute-cost
+# metering test module. Created 2026-06-24 (integration/billing-credits).

--- a/tests/cloud/metering/test_compute_meter.py
+++ b/tests/cloud/metering/test_compute_meter.py
@@ -1,0 +1,279 @@
+# tests/cloud/metering/test_compute_meter.py — proves the BC-3 compute-cost
+# metering contract: every completed / terminal chat run debits its workspace
+# wallet by (real compute cost x markup) -> integer credits, EXACTLY ONCE, and
+# the sweep is idempotent + crash-safe.
+#
+# The five acceptance criteria:
+#   1. A completed run with usage.total_cost_usd = 0.04 -> debits round(0.04*250)
+#      = 10 credits; balance drops by 10; a ``compute_spend`` ledger row keyed
+#      ``run:{id}`` exists; the run is marked billed=True.
+#   2. A run with token counts but NO total_cost_usd falls back to the
+#      pricing-table estimate for a known model and debits the computed credits
+#      (> 0).
+#   3. Running the sweeper TWICE debits ONCE — balance changes once, one ledger
+#      row (idempotency: billed flag + run_id key).
+#   4. A terminal run with empty usage = {} debits 0 but is still marked
+#      billed=True (won't be re-swept).
+#   5. allow_negative: a run whose cost exceeds the wallet still bills fully and
+#      drives the balance negative (proving metered spend isn't blocked here).
+#
+# Uses the shared ``mongo_db`` fixture (mongomock-motor + Beanie over
+# ALL_DOCUMENTS) from tests/cloud/conftest.py — the same DB-fixture pattern the
+# credits / chat-runs tests use. The autouse ``recording_bus`` keeps the
+# credits service's ``emit(CreditMovement(...))`` from raising. A fixed
+# ``RateCard`` (markup 2.5, credit_usd 0.01) is injected so the rate never
+# depends on ambient settings.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-3): new test module.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.metering import service as metering
+from pocketpaw_ee.cloud.metering.domain import RateCard
+from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs
+from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+from pocketpaw_ee.cloud.models.credit import CreditLedgerEntry
+
+# Pin the rate card so the tests don't depend on ambient POCKETPAW_* settings.
+# With these values credits = round(cost_usd * 250).
+RATE = RateCard(markup=2.5, credit_usd=0.01)
+
+WS = "ws_metering_test"
+
+
+async def _make_run(
+    *,
+    run_id: str,
+    workspace: str = WS,
+    status: str = "completed",
+    usage: dict | None = None,
+    billed: bool = False,
+) -> ChatRunDoc:
+    """Insert a terminal ChatRunDoc carrying the given usage dict."""
+    doc = ChatRunDoc(
+        run_id=run_id,
+        workspace=workspace,
+        context_type="dm",
+        scope_id="scope-1",
+        session_key="sk-1",
+        user_id="u1",
+        agent_id="a1",
+        client_message_id=f"cmid-{run_id}",
+        user_message_id=f"umid-{run_id}",
+        status=status,  # type: ignore[arg-type]
+        usage=usage if usage is not None else {},
+        billed=billed,
+    )
+    await doc.insert()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Criterion 1 — reported total_cost_usd drives the debit; ledger + flag land.
+# ---------------------------------------------------------------------------
+
+
+async def test_reported_cost_debits_expected_credits(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    run = await _make_run(
+        run_id="run-1",
+        usage={"total_cost_usd": 0.04, "model": "claude-sonnet-4-20250514"},
+    )
+
+    result = await metering.bill_run(run, rate_card=RATE)
+
+    # round(0.04 * 250) == 10 credits.
+    assert result.credits_charged == 10
+    assert result.debited is True
+    assert await credits.balance(WS) == 990  # 1000 - 10
+
+    # A compute_spend ledger row keyed run:{id} exists, signed-negative.
+    entries = await CreditLedgerEntry.find(CreditLedgerEntry.workspace == WS).to_list()
+    spend = [e for e in entries if e.idempotency_key == "run:run-1"]
+    assert len(spend) == 1
+    assert spend[0].amount_delta == -10
+    assert spend[0].cause == "compute_spend"
+    assert spend[0].ref.get("run_id") == "run-1"
+
+    # The run is flipped billed.
+    reloaded = await ChatRunDoc.find_one(ChatRunDoc.run_id == "run-1")
+    assert reloaded is not None
+    assert reloaded.billed is True
+
+
+# ---------------------------------------------------------------------------
+# Criterion 2 — no reported cost -> fall back to the pricing-table estimate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("reported", [None, 0])
+async def test_estimate_fallback_when_no_reported_cost(mongo_db, reported):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    # gpt-4o is in _PRICING (input $2.5/1M, output $10/1M). 1000 in + 1000 out
+    # -> (1000*2.5 + 1000*10)/1e6 = 0.0125 USD -> round(0.0125 * 250) = 3.
+    usage = {
+        "input_tokens": 1000,
+        "output_tokens": 1000,
+        "model": "gpt-4o",
+    }
+    if reported is not None:
+        usage["total_cost_usd"] = reported
+    run = await _make_run(run_id=f"run-est-{reported}", usage=usage)
+
+    before = await credits.balance(WS)
+    result = await metering.bill_run(run, rate_card=RATE)
+
+    assert result.cost_source == "estimated"
+    assert result.credits_charged > 0
+    assert result.credits_charged == 3
+    assert await credits.balance(WS) == before - result.credits_charged
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3 — running the sweeper TWICE debits ONCE (idempotency).
+# ---------------------------------------------------------------------------
+
+
+async def test_sweep_twice_debits_once(mongo_db):
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    await _make_run(
+        run_id="run-sweep",
+        usage={"total_cost_usd": 0.04, "model": "gpt-4o"},
+    )
+
+    first = await sweep_unbilled_runs(rate_card=RATE)
+    assert first == 1
+    balance_after_first = await credits.balance(WS)
+    assert balance_after_first == 990  # 1000 - round(0.04*250)=10
+
+    # Second sweep: the run is now billed=True, so it isn't even re-queried.
+    second = await sweep_unbilled_runs(rate_card=RATE)
+    assert second == 0
+    assert await credits.balance(WS) == balance_after_first
+
+    # Exactly one compute_spend ledger row for this run.
+    spend = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "run:run-sweep",
+    ).to_list()
+    assert len(spend) == 1
+
+
+async def test_sweep_idempotent_even_if_flag_lost(mongo_db):
+    """Belt-and-braces: even if the billed flag is lost, the run_id key blocks a
+    second debit. Force ``billed`` back to False and re-sweep — the ledger key
+    makes the re-bill a no-op, so the balance never moves twice."""
+    await credits.grant(WS, 1000, cause="top_up", idempotency_key="seed")
+    run = await _make_run(
+        run_id="run-flagloss",
+        usage={"total_cost_usd": 0.04, "model": "gpt-4o"},
+    )
+
+    await sweep_unbilled_runs(rate_card=RATE)
+    balance_once = await credits.balance(WS)
+    assert balance_once == 990
+
+    # Simulate a lost flag write (crash between debit and save).
+    run.billed = False
+    await run.save()
+
+    swept = await sweep_unbilled_runs(rate_card=RATE)
+    assert swept == 1  # it was re-picked up...
+    assert await credits.balance(WS) == balance_once  # ...but the debit was a no-op
+
+    spend = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "run:run-flagloss",
+    ).to_list()
+    assert len(spend) == 1  # still exactly one ledger row
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4 — empty usage -> debit 0 but still mark billed.
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_usage_bills_zero_but_marks_billed(mongo_db):
+    await credits.grant(WS, 500, cause="top_up", idempotency_key="seed")
+    run = await _make_run(run_id="run-empty", status="failed", usage={})
+
+    result = await metering.bill_run(run, rate_card=RATE)
+
+    assert result.credits_charged == 0
+    assert result.debited is False
+    assert result.cost_source == "none"
+    assert await credits.balance(WS) == 500  # unchanged
+
+    # No ledger row for this run.
+    spend = await CreditLedgerEntry.find(
+        CreditLedgerEntry.workspace == WS,
+        CreditLedgerEntry.idempotency_key == "run:run-empty",
+    ).to_list()
+    assert len(spend) == 0
+
+    # But the run is marked billed so the sweep won't re-visit it.
+    reloaded = await ChatRunDoc.find_one(ChatRunDoc.run_id == "run-empty")
+    assert reloaded is not None
+    assert reloaded.billed is True
+
+    # And a sweep over an all-billed table is a no-op.
+    assert await sweep_unbilled_runs(rate_card=RATE) == 0
+
+
+# ---------------------------------------------------------------------------
+# Criterion 5 — allow_negative: a run costlier than the wallet bills fully and
+# drives the balance below zero (metered spend is never blocked here).
+# ---------------------------------------------------------------------------
+
+
+async def test_overage_drives_balance_negative(mongo_db):
+    # Tiny wallet: 5 credits.
+    await credits.grant(WS, 5, cause="top_up", idempotency_key="seed")
+    # cost 0.04 -> 10 credits, which exceeds the 5-credit wallet.
+    run = await _make_run(
+        run_id="run-overage",
+        usage={"total_cost_usd": 0.04, "model": "gpt-4o"},
+    )
+
+    result = await metering.bill_run(run, rate_card=RATE)
+
+    assert result.credits_charged == 10
+    assert result.debited is True
+    # 5 - 10 == -5: the overage is recorded as a legitimate negative balance.
+    assert result.balance_after == -5
+    assert await credits.balance(WS) < 0
+    assert await credits.balance(WS) == -5
+
+    reloaded = await ChatRunDoc.find_one(ChatRunDoc.run_id == "run-overage")
+    assert reloaded is not None
+    assert reloaded.billed is True
+
+
+# ---------------------------------------------------------------------------
+# Extra — the sweep bills the non-completed terminal states too (a cancelled /
+# interrupted / failed run consumed tokens), and skips non-terminal runs.
+# ---------------------------------------------------------------------------
+
+
+async def test_sweep_covers_terminal_states_and_skips_active(mongo_db):
+    await credits.grant(WS, 10_000, cause="top_up", idempotency_key="seed")
+    # Four billable terminals.
+    for i, status in enumerate(["completed", "cancelled", "interrupted", "failed"]):
+        await _make_run(
+            run_id=f"run-term-{i}",
+            status=status,
+            usage={"total_cost_usd": 0.04, "model": "gpt-4o"},
+        )
+    # Two non-terminal runs that must NOT be billed.
+    await _make_run(run_id="run-queued", status="queued", usage={"total_cost_usd": 0.04})
+    await _make_run(run_id="run-running", status="running", usage={"total_cost_usd": 0.04})
+
+    billed = await sweep_unbilled_runs(rate_card=RATE)
+    assert billed == 4  # only the four terminals
+
+    # The active runs stay unbilled.
+    for rid in ("run-queued", "run-running"):
+        doc = await ChatRunDoc.find_one(ChatRunDoc.run_id == rid)
+        assert doc is not None and doc.billed is False

--- a/tests/cloud/sites/test_cloudflare_tiers.py
+++ b/tests/cloud/sites/test_cloudflare_tiers.py
@@ -1,0 +1,260 @@
+# tests/cloud/sites/test_cloudflare_tiers.py — proves the BC-10 contract: resell
+# Cloudflare features by site-plan tier + expose the per-site plan catalog.
+#
+#   1. Adding a domain to a site whose plan_tier resells WAF/security features →
+#      add_domain resolves the tier's cloudflare_features and calls
+#      create_custom_hostname WITH that set.
+#   2. A BASIC-tier site (empty cloudflare_features) → create_custom_hostname is
+#      called WITHOUT premium settings (the unchanged basic ssl payload), proven
+#      end to end against the real CloudflareClient + a mocked transport.
+#   3. The tier → feature mapping is honored exactly (the features passed per tier
+#      match site_plans, and the CF request carries the premium ssl.settings only
+#      for tiers that resell them).
+#   4. GET /billing/site-plans returns the catalog tiers with their
+#      cloudflare_features.
+#
+# add_domain loads a REAL seeded Site doc (it owns Site writes), so the
+# tier-resolution criteria run against live Beanie with a fake CF client that
+# records the ``features`` kwarg. The wire-shape criterion (premium ssl in the CF
+# request body) drives the real CloudflareClient with an httpx.MockTransport, the
+# same no-network pattern as test_cloudflare_client.py. The HTTP catalog read uses
+# a FastAPI TestClient with require_license waived (same pattern as test_plans.py).
+#
+# Created 2026-06-24 (integration/billing-credits, BC-10): new test module.
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud.billing import site_plans
+from pocketpaw_ee.cloud.billing.router import router as billing_router
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.cloudflare_client import CloudflareClient
+from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus
+
+# ---------------------------------------------------------------------------
+# Test doubles.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingCF:
+    """Stand-in CloudflareClient that records the ``features`` kwarg add_domain
+    passes to create_custom_hostname (never touches the network)."""
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict] = []
+
+    async def create_custom_hostname(
+        self, hostname: str, *, features: set[str] | None = None
+    ) -> CustomHostname:
+        self.create_calls.append({"hostname": hostname, "features": features})
+        return CustomHostname(
+            id="ch_test",
+            hostname=hostname,
+            status=HostnameStatus.PENDING,
+            cname_target="zone_1.cdn.cloudflare.net",
+        )
+
+
+async def _seed_site(*, workspace_id: str, plan_tier: str | None) -> str:
+    """Insert a real Site doc on ``plan_tier`` and return its id string."""
+    doc = Site(
+        workspace=workspace_id,
+        pocket_id="pk_1",
+        owner="u1",
+        name="My Site",
+        plan_tier=plan_tier,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+# ---------------------------------------------------------------------------
+# Criterion 1 — a higher tier provisions its resold features.
+# ---------------------------------------------------------------------------
+
+
+async def test_add_domain_passes_business_tier_features(mongo_db):
+    """A business-tier site (resells WAF + edge_cache) → create_custom_hostname
+    is called WITH that feature set."""
+    ws = "ws_business"
+    site_id = await _seed_site(workspace_id=ws, plan_tier="business")
+    cf = _RecordingCF()
+
+    await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.example.com",
+        _cloudflare=cf,
+    )
+
+    assert len(cf.create_calls) == 1
+    passed = cf.create_calls[0]["features"]
+    expected = site_plans.get_site_plan("business").cloudflare_features
+    assert passed == set(expected)
+    # The premium security features ride along.
+    assert "waf" in passed
+    assert "edge_cache" in passed
+
+
+# ---------------------------------------------------------------------------
+# Criterion 2 — a basic tier provisions nothing premium (current behavior).
+# ---------------------------------------------------------------------------
+
+
+async def test_add_domain_basic_tier_passes_no_features(mongo_db):
+    """A basic-tier site resells no Cloudflare features → create_custom_hostname is
+    called with an EMPTY feature set (the basic path)."""
+    ws = "ws_basic"
+    site_id = await _seed_site(workspace_id=ws, plan_tier="basic")
+    cf = _RecordingCF()
+
+    await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.basic.com",
+        _cloudflare=cf,
+    )
+
+    assert cf.create_calls[0]["features"] == set()
+
+
+async def test_add_domain_unset_tier_passes_no_features(mongo_db):
+    """A site with no plan_tier (pre-BC-9 / workspace-plan-only) resolves to no
+    features — never an error, never premium provisioning."""
+    ws = "ws_none"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=None)
+    cf = _RecordingCF()
+
+    await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.none.com",
+        _cloudflare=cf,
+    )
+
+    assert cf.create_calls[0]["features"] == set()
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3 — the tier → feature mapping is honored exactly, end to end.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tier", ["basic", "pro", "business"])
+async def test_add_domain_honors_exact_tier_feature_mapping(mongo_db, tier):
+    """For every tier the features add_domain passes equal that tier's catalog
+    cloudflare_features — no more, no less."""
+    ws = f"ws_{tier}"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=tier)
+    cf = _RecordingCF()
+
+    await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname=f"www.{tier}.com",
+        _cloudflare=cf,
+    )
+
+    assert cf.create_calls[0]["features"] == set(site_plans.get_site_plan(tier).cloudflare_features)
+
+
+def _cf_client(handler) -> CloudflareClient:
+    return CloudflareClient(
+        account_id="acct_1",
+        api_token="tok_1",
+        zone_id="zone_1",
+        dispatch_namespace="paw-sites",
+        _transport=httpx.MockTransport(handler),
+    )
+
+
+def _hostname_ok_response(request: httpx.Request, seen: dict) -> httpx.Response:
+    import json
+
+    seen["body"] = json.loads(request.content)
+    return httpx.Response(
+        200,
+        json={
+            "success": True,
+            "result": {
+                "id": "ch_1",
+                "hostname": "www.example.com",
+                "status": "pending",
+                "ssl": {"status": "pending_validation"},
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_custom_hostname_premium_features_inject_ssl_settings():
+    """With premium features the CF request body carries an ``ssl.settings`` block
+    (strict TLS for waf, http2 for edge_cache) + records the resold feature set."""
+    seen: dict = {}
+    client = _cf_client(lambda req: _hostname_ok_response(req, seen))
+
+    await client.create_custom_hostname(
+        "www.example.com", features={"custom_domain", "analytics", "waf", "edge_cache"}
+    )
+
+    ssl = seen["body"]["ssl"]
+    # Base DV fields preserved.
+    assert ssl["method"] == "http"
+    assert ssl["type"] == "dv"
+    # Premium toggles for waf + edge_cache present.
+    assert ssl["settings"]["min_tls_version"] == "1.2"
+    assert ssl["settings"]["tls_1_3"] == "on"
+    assert ssl["settings"]["http2"] == "on"
+    # The resold set is recorded on the hostname (sorted, deterministic).
+    assert ssl["custom_metadata"]["resold_features"] == ("analytics,custom_domain,edge_cache,waf")
+
+
+@pytest.mark.asyncio
+async def test_create_custom_hostname_no_features_is_basic_unchanged():
+    """No features → the request body is the prior basic DV payload, byte-for-byte
+    (no ssl.settings, no custom_metadata) — the basic path never regresses."""
+    seen: dict = {}
+    client = _cf_client(lambda req: _hostname_ok_response(req, seen))
+
+    await client.create_custom_hostname("www.example.com")
+
+    assert seen["body"]["ssl"] == {"method": "http", "type": "dv"}
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4 — GET /billing/site-plans returns the catalog.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def site_plans_client() -> TestClient:
+    """A TestClient over an app mounting the billing router, license waived."""
+    app = FastAPI()
+    app.include_router(billing_router)
+    app.dependency_overrides[require_license] = lambda: None
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_get_billing_site_plans_returns_catalog_with_cf_features(site_plans_client):
+    resp = site_plans_client.get("/billing/site-plans")
+    assert resp.status_code == 200
+    body = resp.json()
+    rows = {row["key"]: row for row in body["site_plans"]}
+    assert set(rows.keys()) == {"basic", "pro", "business"}
+
+    # Each tier carries its annual price + sorted cloudflare_features.
+    assert rows["basic"]["annual_price_usd"] == 0
+    assert rows["basic"]["cloudflare_features"] == []
+    assert "custom_domain" in rows["pro"]["cloudflare_features"]
+    biz_features = rows["business"]["cloudflare_features"]
+    assert "waf" in biz_features
+    assert "edge_cache" in biz_features
+    # Features arrive as a SORTED JSON array (deterministic wire payload).
+    assert biz_features == sorted(biz_features)
+    # The catalog matches the source-of-truth site_plans exactly.
+    assert set(biz_features) == set(site_plans.get_site_plan("business").cloudflare_features)

--- a/tests/cloud/sites/test_review_fixes.py
+++ b/tests/cloud/sites/test_review_fixes.py
@@ -1,0 +1,108 @@
+# tests/cloud/sites/test_review_fixes.py — covers two Sites review fixes:
+#   * C1 — _cf_client() raises a CloudError (ValidationError, 422), NOT a raw
+#     KeyError (an unhandled 500), when a required PAW_CF_* env var is missing.
+#     add_domain calls _cf_client directly, so an unconfigured Cloudflare must
+#     surface a clean mapped error instead of crashing.
+#   * S2 — DomainRequest.hostname is validated with a permissive DNS-hostname
+#     pattern: real hostnames pass; obvious garbage (spaces, bad chars,
+#     single-label names, leading/trailing/double dots) is rejected at the DTO.
+#
+# Both checks are synchronous and DB-free — _cf_client only reads env, and
+# DomainRequest is a pure Pydantic model. No mongo fixture needed.
+#
+# Created 2026-06-24 (integration/billing-credits review fixes C1 + S2).
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError, ValidationError
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.dto import DomainRequest
+from pydantic import ValidationError as PydanticValidationError
+
+_CF_VARS = ("PAW_CF_ACCOUNT_ID", "PAW_CF_API_TOKEN", "PAW_CF_ZONE_ID")
+
+
+# ---------------------------------------------------------------------------
+# C1 — _cf_client() guards on a missing env var (CloudError, not KeyError).
+# ---------------------------------------------------------------------------
+
+
+def test_cf_client_missing_account_id_raises_cloud_error_not_keyerror(monkeypatch):
+    # All CF vars unset → _cf_client must raise a mapped CloudError, NOT KeyError.
+    for var in _CF_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    with pytest.raises(CloudError) as exc:
+        sites_service._cf_client()
+
+    # It is the 422 ValidationError carrying the "not configured" message — and it
+    # is a CloudError (so the cloud error handler maps it), never a raw KeyError.
+    assert isinstance(exc.value, ValidationError)
+    assert exc.value.status_code == 422
+    assert exc.value.code == "sites.cloudflare_unconfigured"
+    assert "Cloudflare is not configured" in exc.value.message
+
+
+def test_cf_client_partial_config_still_raises_cloud_error(monkeypatch):
+    # Account id present but token + zone missing → still a clean CloudError.
+    monkeypatch.setenv("PAW_CF_ACCOUNT_ID", "acct_123")
+    monkeypatch.delenv("PAW_CF_API_TOKEN", raising=False)
+    monkeypatch.delenv("PAW_CF_ZONE_ID", raising=False)
+
+    with pytest.raises(ValidationError) as exc:
+        sites_service._cf_client()
+    assert exc.value.code == "sites.cloudflare_unconfigured"
+
+
+def test_cf_client_does_not_raise_keyerror(monkeypatch):
+    # Explicitly assert the OLD failure mode (KeyError) no longer occurs.
+    for var in _CF_VARS:
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(CloudError):
+        sites_service._cf_client()  # must not be KeyError (which CloudError isn't)
+
+
+# ---------------------------------------------------------------------------
+# S2 — DomainRequest.hostname validation (permissive DNS hostname).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "example.com",
+        "www.example.com",
+        "sub.domain.example.co.uk",
+        "my-site.example.com",
+        "a.bc",
+        "EXAMPLE.COM",  # case-insensitive
+        "example.com.",  # trailing-dot FQDN form is normalized away
+    ],
+)
+def test_valid_hostnames_accepted(hostname):
+    req = DomainRequest(hostname=hostname)
+    # The trailing dot is normalized off; everything else round-trips.
+    assert req.hostname == hostname.rstrip(".")
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "",  # empty
+        "   ",  # whitespace
+        "localhost",  # single label (no TLD)
+        "example",  # single label
+        "exa mple.com",  # space
+        "-example.com",  # leading hyphen label
+        "example-.com",  # trailing hyphen label
+        "example..com",  # double dot / empty label
+        ".example.com",  # leading dot
+        "example.com/path",  # path / illegal char
+        "http://example.com",  # scheme / illegal chars
+        "exam$ple.com",  # illegal char
+    ],
+)
+def test_invalid_hostnames_rejected(hostname):
+    with pytest.raises(PydanticValidationError):
+        DomainRequest(hostname=hostname)

--- a/tests/cloud/sites/test_site_billing.py
+++ b/tests/cloud/sites/test_site_billing.py
@@ -1,0 +1,429 @@
+# tests/cloud/sites/test_site_billing.py — proves the BC-9 per-site annual plan +
+# publish entitlement gate contract:
+#
+#   1. ``list_site_plans()`` returns tiers with an annual price + cloudflare
+#      features; ``get_site_plan`` resolves a known key and rejects an unknown one.
+#   2. publish_pocket with a workspace that HAS the Sites entitlement → succeeds,
+#      stamps ``Site.plan_tier``, and emits ``SitePublished``.
+#   3. publish_pocket with a workspace LACKING the Sites entitlement → Forbidden,
+#      no Site doc created.
+#   4. a PER-SITE ``subscription.active`` webhook (metadata carries a ``site_id``)
+#      → updates the SITE's subscription_status to active, does NOT grant workspace
+#      credits, and does NOT change Workspace.plan.
+#
+# The Sites publish entitlement gate is the EXISTING ``require_sites_plan`` (the
+# "fabric" plan feature, business+), which ``publish`` runs FIRST — before any
+# Site insert. business HAS fabric; team does NOT, so the negative case is a real
+# end-to-end gate test (no patching of the gate). Real Workspace + Pocket docs are
+# seeded so the gate, the pocket read, and the per-site sub all run against live
+# Beanie. The Dodo subscription provider is injected (a mock) so no network call
+# happens; the webhook path signs with the REAL standardwebhooks library so the
+# per-site routing is exercised through the verified path.
+#
+# Created 2026-06-24 (integration/billing-credits, BC-9): new test module.
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud.billing import service as billing
+from pocketpaw_ee.cloud.billing import site_plans
+from pocketpaw_ee.cloud.billing.domain import SubscriptionCheckout
+from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+from pocketpaw_ee.cloud.credits import service as credits
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import service as sites_service
+from standardwebhooks import Webhook
+
+# A valid Standard-Webhooks secret: ``whsec_`` + base64 of a 32-byte key.
+SECRET = "whsec_" + base64.b64encode(b"site-billing-test-secret-32bytes!").decode()
+SITE_SUB_ID = "sub_site_dodo_xyz"
+
+
+class _FakeGenerator:
+    """Stand-in for the SvelteKit generator — never touches Bun/workerd."""
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakeCF:
+    """Stand-in Cloudflare client — records put_worker calls, never deploys."""
+
+    def __init__(self):
+        self.put_calls: list[str] = []
+
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        self.put_calls.append(script_name)
+        return True
+
+
+class _FakeBillingProvider:
+    """Injected per-site subscription provider — records the create_subscription
+    call and returns a fixed subscription id (no Dodo SDK / network)."""
+
+    def __init__(self, subscription_id: str = SITE_SUB_ID):
+        self.subscription_id = subscription_id
+        self.calls: list[dict] = []
+
+    async def create_subscription(
+        self, *, plan_key, product_id, workspace_id, customer_email, metadata
+    ) -> SubscriptionCheckout:
+        self.calls.append(
+            {
+                "plan_key": plan_key,
+                "product_id": product_id,
+                "workspace_id": workspace_id,
+                "metadata": dict(metadata),
+            }
+        )
+        return SubscriptionCheckout(
+            checkout_url="https://checkout.dodopayments.test/site/abc",
+            subscription_id=self.subscription_id,
+        )
+
+
+def _provider() -> DodoProvider:
+    """A DodoProvider wired with the test webhook secret (webhook path only)."""
+    return DodoProvider(
+        api_key="dodo_test_key",
+        environment="test_mode",
+        webhook_secret=SECRET,
+        credit_product_id="prod_credits_sku",
+        plan_products={},
+    )
+
+
+async def _make_workspace(plan: str) -> str:
+    """Insert a real Workspace doc at ``plan`` and return its id string."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(
+        name="Acme", slug=f"acme-{plan}-{datetime.now(UTC).timestamp()}", owner="u1", plan=plan
+    )
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _make_pocket(*, workspace_id: str, owner: str = "u1") -> str:
+    """Insert a real Pocket doc owned by ``owner`` and return its id string."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace_id,
+        name="My Landing",
+        owner=owner,
+        type="site",
+        pattern="landing",
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+def _sign(body: str, *, msg_id: str) -> dict[str, str]:
+    ts = datetime.now(UTC)
+    sig = Webhook(SECRET).sign(msg_id=msg_id, timestamp=ts, data=body)
+    return {
+        "webhook-id": msg_id,
+        "webhook-timestamp": str(int(ts.timestamp())),
+        "webhook-signature": sig,
+    }
+
+
+def _site_subscription_body(
+    *, event_type: str, workspace_id: str, site_id: str, plan_key: str = "pro"
+) -> str:
+    """A PER-SITE Dodo ``subscription.*`` webhook body — note ``site_id`` on the
+    metadata, the discriminator that routes this to the SITE path."""
+    return json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": event_type,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "subscription_id": SITE_SUB_ID,
+                "product_id": "prod_site_pro",
+                "metadata": {
+                    "workspace_id": workspace_id,
+                    "site_id": site_id,
+                    "plan_key": plan_key,
+                },
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion 1 — site-plan catalog.
+# ---------------------------------------------------------------------------
+
+
+def test_list_site_plans_returns_tiers_with_price_and_cf_features():
+    tiers = site_plans.list_site_plans()
+    keys = [t.key for t in tiers]
+    assert keys == ["basic", "pro", "business"]  # cheapest first
+
+    by_key = {t.key: t for t in tiers}
+    # Each tier carries an annual price (USD) + a cloudflare_features set.
+    assert by_key["basic"].annual_price_usd == 0
+    assert by_key["pro"].annual_price_usd > 0
+    assert isinstance(by_key["pro"].cloudflare_features, frozenset)
+    # Higher tiers resell more Cloudflare features (a growing ladder).
+    assert by_key["basic"].cloudflare_features == frozenset()
+    assert "custom_domain" in by_key["pro"].cloudflare_features
+    assert by_key["pro"].cloudflare_features <= by_key["business"].cloudflare_features
+
+
+def test_get_site_plan_resolves_and_rejects():
+    assert site_plans.get_site_plan("pro").key == "pro"
+    # An unknown / missing key resolves to None (not silently substituted).
+    assert site_plans.get_site_plan("platinum") is None
+    assert site_plans.get_site_plan(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Criterion 2 — publish with the Sites entitlement succeeds, stamps plan_tier,
+# emits SitePublished.
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_with_entitlement_stamps_plan_and_emits(mongo_db, recording_bus, monkeypatch):
+    # business HAS the "fabric" (Sites) feature → the gate passes.
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    # Configure a Dodo product for the "pro" site tier so the per-site sub fires.
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+    )
+    fake_provider = _FakeBillingProvider()
+
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=fake_provider,
+    )
+
+    # The site was stamped with its per-site tier + subscription id.
+    assert doc.plan_tier == "pro"
+    assert doc.subscription_id == SITE_SUB_ID
+    assert doc.subscription_status == "pending"
+
+    # The per-site Dodo sub was opened with the site_id on its metadata (the
+    # discriminator the renewal webhook routes on).
+    assert len(fake_provider.calls) == 1
+    call = fake_provider.calls[0]
+    assert call["plan_key"] == "pro"
+    assert call["product_id"] == "prod_site_pro"
+    assert call["metadata"]["site_id"] == str(doc.id)
+    assert call["metadata"]["workspace_id"] == ws
+
+    # The persisted doc reflects the stamp.
+    persisted = await Site.find_one(Site.id == doc.id)
+    assert persisted is not None
+    assert persisted.plan_tier == "pro"
+
+    # SitePublished was emitted with the per-site payload.
+    published = [e for e in recording_bus.events if e.type == "site.published"]
+    assert len(published) == 1
+    data = published[0].data
+    assert data["workspace_id"] == ws
+    assert data["site_id"] == str(doc.id)
+    assert data["pocket_id"] == pocket_id
+    assert data["owner"] == "u1"
+    assert data["plan_tier"] == "pro"
+
+
+async def test_publish_degrades_gracefully_when_dodo_unconfigured(mongo_db, recording_bus):
+    """With no Dodo product configured for the tier (v1 default), publish records
+    the intended tier WITHOUT a live charge — no subscription_id, no crash."""
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+        # No _billing_provider injected and no product configured → no live sub.
+    )
+
+    assert doc.plan_tier == "pro"
+    assert doc.subscription_id is None
+    assert doc.subscription_status == "none"
+    # The publish still emits SitePublished (the site IS published, just no charge).
+    assert any(e.type == "site.published" for e in recording_bus.events)
+
+
+async def test_publish_defaults_to_base_tier(mongo_db):
+    """An omitted site_plan_key falls back to the base tier."""
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+    assert doc.plan_tier == site_plans.BASE_SITE_PLAN_KEY
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3 — publish without the Sites entitlement is Forbidden, no Site.
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_without_entitlement_is_forbidden_and_creates_no_site(mongo_db):
+    from pocketpaw_ee.cloud._core.errors import Forbidden
+
+    # team does NOT have the "fabric" (Sites) feature → the gate denies.
+    ws = await _make_workspace(plan="team")
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    with pytest.raises(Forbidden) as exc:
+        await sites_service.publish_pocket(
+            workspace_id=ws,
+            user_id="u1",
+            pocket_id=pocket_id,
+            site_plan_key="pro",
+            _generator=_FakeGenerator(),
+            _cloudflare=_FakeCF(),
+            _bundle_reader=lambda d: b"x",
+        )
+    assert exc.value.code == "plan.feature_denied"
+
+    # No Site doc was created for the workspace.
+    sites = await Site.find(Site.workspace == ws).to_list()
+    assert sites == []
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4 — a per-site subscription.active webhook updates the SITE only.
+# ---------------------------------------------------------------------------
+
+
+async def test_per_site_active_webhook_updates_site_not_workspace(mongo_db, monkeypatch):
+    # Publish a site (business workspace, pro tier) so there's a Site doc to update.
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+    )
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=_FakeBillingProvider(),
+    )
+    site_id = str(doc.id)
+
+    # The workspace plan + credit balance BEFORE the webhook.
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    plan_before = await workspace_service.get_workspace_plan(ws)
+    assert await credits.balance(ws) == 0
+
+    # A verified PER-SITE subscription.active (metadata carries site_id).
+    body = _site_subscription_body(
+        event_type="subscription.active", workspace_id=ws, site_id=site_id
+    )
+    result = await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="evt_site_active_1"),
+        provider=_provider(),
+    )
+
+    # The per-site path never grants workspace credits.
+    assert result == {"ok": True, "granted": False}
+    assert await credits.balance(ws) == 0  # NO workspace credit grant
+
+    # The workspace plan is UNCHANGED (per-site subs don't touch Workspace.plan).
+    assert await workspace_service.get_workspace_plan(ws) == plan_before
+
+    # The SITE's subscription_status flipped to active + a renewal date was set.
+    updated = await Site.find_one(Site.id == doc.id)
+    assert updated is not None
+    assert updated.subscription_status == "active"
+    assert updated.annual_renewal_date is not None
+
+
+async def test_per_site_cancelled_webhook_marks_site_cancelled(mongo_db, monkeypatch):
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+    )
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=_FakeBillingProvider(),
+    )
+
+    cancel_body = _site_subscription_body(
+        event_type="subscription.cancelled", workspace_id=ws, site_id=str(doc.id)
+    )
+    result = await billing.handle_webhook(
+        payload=cancel_body.encode(),
+        headers=_sign(cancel_body, msg_id="evt_site_cancel_1"),
+        provider=_provider(),
+    )
+
+    assert result == {"ok": True, "granted": False}
+    updated = await Site.find_one(Site.id == doc.id)
+    assert updated.subscription_status == "cancelled"
+
+
+async def test_workspace_plan_sub_still_routes_to_workspace_path(mongo_db):
+    """A subscription delivery WITHOUT a site_id is the unchanged BC-7 workspace
+    path — it grants workspace credits / changes the plan, proving BC-9 routing
+    didn't break the workspace-plan sub."""
+    from pocketpaw_ee.cloud.billing import plans
+
+    ws = await _make_workspace(plan="free")
+    allotment = plans.get_plan("business").monthly_credit_allotment
+
+    body = json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": "subscription.active",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "subscription_id": "sub_ws_plan",
+                "product_id": "prod_business_recurring",
+                # NO site_id → workspace-plan path.
+                "metadata": {"workspace_id": ws, "plan_key": "business"},
+            },
+        }
+    )
+    result = await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="evt_ws_plan_active"),
+        provider=_provider(),
+    )
+    assert result == {"ok": True, "granted": True}  # workspace path DID grant
+    assert await credits.balance(ws) == allotment

--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -1,5 +1,10 @@
 # tests/ee/sites/conftest.py
 # Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+# Updated 2026-06-24 (BC-9): added an autouse ``_recording_bus_for_sites`` fixture.
+#   ``publish_pocket`` now emits ``SitePublished`` after a live publish, and
+#   ``emit()`` asserts a bus is initialised; this installs a recording bus for the
+#   whole sites tree (mirroring tests/cloud/conftest.py) so publish tests don't
+#   trip that guard.
 # Merged 2026-06-17 (fix/sites-plan-gate-asymmetry) — UNION of the PERF-2 Beanie
 # settings fixture and the plan-gate default-plan fixture (see below).
 #
@@ -64,6 +69,36 @@ async def _sites_beanie_settings() -> Any:
 
     await init_beanie(database=db, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
     yield
+
+
+@pytest.fixture(autouse=True)
+def _recording_bus_for_sites():
+    """Install a RecordingBus for every sites test (BC-9).
+
+    ``sites.service.publish_pocket`` now emits ``SitePublished`` after a live
+    publish, and ``emit()`` raises ``AssertionError`` when no bus is initialised
+    (a deliberate "forgot init_realtime" guard). The cloud test tree installs a
+    recording bus autouse via ``tests/cloud/conftest.py``; mirror it here so the
+    sites-tree publish tests don't trip that guard. A test that wants to assert on
+    emitted events can request this fixture by name to read ``bus.events``."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ee/sites/test_dentist_e2e.py
+++ b/tests/ee/sites/test_dentist_e2e.py
@@ -50,7 +50,7 @@ class _FakeCF:
     async def put_worker(self, *, script_name, bundle, bindings=None):
         return True
 
-    async def create_custom_hostname(self, hostname):
+    async def create_custom_hostname(self, hostname, *, features=None):
         return CustomHostname(
             id="ch_1",
             hostname=hostname,

--- a/tests/ee/sites/test_router.py
+++ b/tests/ee/sites/test_router.py
@@ -62,7 +62,7 @@ class _FakeCF:
     async def put_worker(self, *, script_name, bundle, bindings=None):
         return True
 
-    async def create_custom_hostname(self, hostname):
+    async def create_custom_hostname(self, hostname, *, features=None):
         return CustomHostname(
             id="ch_1",
             hostname=hostname,

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -73,7 +73,7 @@ class _FakeCF:
         self.put_bindings.append(bindings)
         return True
 
-    async def create_custom_hostname(self, hostname):
+    async def create_custom_hostname(self, hostname, *, features=None):
         return CustomHostname(
             id="ch_1",
             hostname=hostname,

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -3,6 +3,8 @@
 # Created: 2026-02-06
 # Tests: CredentialStore, config save/load separation, plaintext migration,
 #         file permissions, and log secret scrubbing.
+# Updated 2026-06-24: expected SECRET_FIELDS now includes the Dodo billing
+#         secrets (dodo_payments_api_key, dodo_webhook_secret).
 
 import json
 import logging
@@ -540,6 +542,8 @@ class TestSecretFieldsList:
             "litellm_api_key",
             "claude_code_oauth_token",
             "status_api_key",
+            "dodo_payments_api_key",
+            "dodo_webhook_secret",
         }
         assert SECRET_FIELDS == expected
 

--- a/uv.lock
+++ b/uv.lock
@@ -1272,6 +1272,28 @@ wheels = [
 ]
 
 [[package]]
+name = "dodopayments"
+version = "1.105.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c3/7928365b52facda9f01c3e807f33a382cccf1e4da928ed213df9f578a41e/dodopayments-1.105.0.tar.gz", hash = "sha256:5aa1dcb229c3a3d200913b4e82a42b80757a7044e5457ca962c624f374636230", size = 273364, upload-time = "2026-06-16T22:59:50.637Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/f1/b36366ba09bb4bc962e851a305960813c11a7d4336e88c8c3bccde7b391d/dodopayments-1.105.0-py3-none-any.whl", hash = "sha256:ed3195e91c4a41a7d8023d04158598366773fa9139dc0d215e2cbd3bdfb0193c", size = 389251, upload-time = "2026-06-16T22:59:49.28Z" },
+]
+
+[package.optional-dependencies]
+webhooks = [
+    { name = "standardwebhooks" },
+]
+
+[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -5054,6 +5076,7 @@ dependencies = [
     { name = "composio-langgraph" },
     { name = "composio-openai-agents" },
     { name = "dnspython" },
+    { name = "dodopayments", extra = ["webhooks"] },
     { name = "fastapi-users", extra = ["beanie", "oauth"] },
     { name = "google-api-python-client" },
     { name = "google-auth" },
@@ -5084,6 +5107,7 @@ requires-dist = [
     { name = "composio-langgraph", specifier = ">=0.7.0" },
     { name = "composio-openai-agents", specifier = ">=0.7.0" },
     { name = "dnspython", specifier = ">=2.6.0" },
+    { name = "dodopayments", extras = ["webhooks"], specifier = "==1.105.0" },
     { name = "fastapi-users", extras = ["beanie", "oauth"], specifier = ">=13.0.0" },
     { name = "google-api-python-client", specifier = ">=2.100.0" },
     { name = "google-auth", specifier = ">=2.25.0" },
@@ -6823,6 +6847,20 @@ wheels = [
 ]
 
 [[package]]
+name = "standardwebhooks"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "python-dateutil" },
+    { name = "types-deprecated" },
+    { name = "types-python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/7d/04fc3aa177403472d3ddae90953d8f878dc5fd21ba29c02fc9e97e10703f/standardwebhooks-1.0.1.tar.gz", hash = "sha256:b557bb2e4b16ada179a517ec0fe6cbec5acf976c5619922bf29c457f89a451bd", size = 5103, upload-time = "2026-02-18T19:13:06.793Z" }
+
+[[package]]
 name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7018,12 +7056,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-deprecated"
+version = "1.3.1.20260520"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/86/8cc66b0a4d01826e64f86e0001b8755105d1b6052c654e2448a0e72750ee/types_deprecated-1.3.1.20260520.tar.gz", hash = "sha256:4d0d9e5521432d9ce88169fb8b793b45d70d8e8cc1a7ecd5a4465abbf83c9ab4", size = 8649, upload-time = "2026-05-20T05:55:57.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/27/e8fd41f0d41b964870d370e7fc78311193910fe9a15c7399ade4a4aeea58/types_deprecated-1.3.1.20260520-py3-none-any.whl", hash = "sha256:8af853b7ccd3b7685159f3ab2e3b6f7999b6cd7e425cda02749e32a42a96c7d6", size = 9105, upload-time = "2026-05-20T05:55:56.259Z" },
+]
+
+[[package]]
 name = "types-protobuf"
 version = "7.34.1.20260403"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b3/c2e407ea36e0e4355c135127cee1b88a2cc9a2c92eafca50a360ab9f2708/types_protobuf-7.34.1.20260403.tar.gz", hash = "sha256:8d7881867888e667eb9563c08a916fccdc12bdb5f9f34c31d217cce876e36765", size = 68782, upload-time = "2026-04-03T04:18:09.428Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/95/24fb0f6fe37b41cf94f9b9912712645e17d8048d4becaf37c1607ddd8e32/types_protobuf-7.34.1.20260403-py3-none-any.whl", hash = "sha256:16d9bbca52ab0f306279958878567df2520f3f5579059419b0ce149a0ad1e332", size = 86011, upload-time = "2026-04-03T04:18:08.245Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/e8/c01bdf0d7c3659428c091fbd693177093639565bcbc86bc20098e6d37cc6/types_python_dateutil-2.9.0.20260518.tar.gz", hash = "sha256:51f02dc03b61c7f6a07df45797d4dfe8a1aa47f0b7db9ad89f6fd3a1a70e1b51", size = 17082, upload-time = "2026-05-18T06:05:24.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/22/169273273ca34e9ab0ae2f387ba72ed7e09faaaf834da01d6b89c2bea71a/types_python_dateutil-2.9.0.20260518-py3-none-any.whl", hash = "sha256:d6a9c5bd0de61460c8fdef8ab2b400f956a1a1075cce08d4e2b4434e478c50b8", size = 18431, upload-time = "2026-05-18T06:05:23.641Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this adds

A credit and billing system for the cloud backend, built from a small set of reusable primitives so a new pricing model becomes a configuration change rather than a new subsystem. Money moves through it three ways:

- **Prepaid wallet (pay-as-you-go).** Workspaces buy credits and spend them as they use the platform. A run's real compute cost, marked up, is debited after it finishes.
- **Workspace subscription plans.** A seat tier grants a monthly credit allotment that rolls over, and the plan sets what the workspace can do.
- **Per-site annual plans.** Publishing a Paw Site puts it on an annual plan tier; higher tiers resell Cloudflare security features.

## The primitives

- `credits/`: an append-only ledger plus a per-workspace balance. Balance changes are atomic and applied exactly once.
- `billing/`: the Dodo gateway (one-time top-ups and subscriptions), a signature-verified webhook handler, and the plan catalog.
- `metering/`: turns each finished run's cost into a credit debit, driven by a durable sweeper.
- `entitlements/`: resolves a workspace's plan into its features and allotment.
- `sites`: per-site plan tiers, the publish gate, and Cloudflare feature provisioning.

## Decisions worth knowing

- **Dodo only for now.** Stripe onboarding from India is impractical, and Dodo is a merchant of record. The gateway sits behind an interface so Razorpay can drop in later.
- **No multi-document transactions.** The deployment runs single-node Mongo with no replica set, so the ledger uses a conditional atomic `$inc` on a single balance document plus a unique idempotency index, with a reconcile pass for the crash window. This handles the Rule-11 money case without transactions.
- **Cost comes from the pricing table.** The production backend often runs keyless (OAuth), where the SDK reports no token cost, so the meter treats the pricing table as authoritative and uses the SDK figure only when it is present.
- **Enforcement is off by default.** A workspace at zero balance gets a 402 when it starts a new run, but only when `POCKETPAW_BILLING_ENFORCED` is set, so self-hosted installs are unaffected. Runs already in flight always finish.

## Testing

The billing smoke is green: 150 tests across credits, billing, metering, entitlements, sites, and credentials. A separate reviewer agent checked every money and security path against the diff. Those reviews caught and fixed three real bugs before this PR:

- a reconcile path that could persist a negative balance from a crash-window phantom entry,
- a webhook that credited non-USD payments at one credit per cent (a 100x over-credit risk for zero-decimal currencies),
- the Dodo API key and webhook signing secret being written to config in plaintext.

## Before going live

- Set the Dodo product IDs in config (`POCKETPAW_DODO_PLAN_PRODUCTS`, `POCKETPAW_DODO_SITE_PRODUCTS`, and the credits product). Subscriptions and top-ups degrade gracefully until then.
- `dodopayments` is pinned to 1.105.0 to respect the 7-day release-age rule. Bump it once a newer version ages in.
- The site-publish gate reuses the existing `fabric` plan feature instead of a new `site_publish` key. Switching to a dedicated key is a one-line change if you want non-fabric tiers to publish sites.
- The Cloudflare feature-to-setting mapping is deliberately minimal. A real account would tune the WAF ruleset.

Design notes live in `docs/design/drafts/2026-06-23-paw-os-billing-credits.md`.

Holding this for your review before merge, especially the money paths.
