### PR TITLE
Charge-first per-site publishing (backend)

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -57,6 +57,16 @@
 #   ``site_id`` is the unchanged BC-7 workspace-plan path. Same verified-signature
 #   + idempotency guards apply (the per-site path is reached only AFTER
 #   ``verify_and_parse_webhook`` succeeds).
+# Updated 2026-06-24 (feat/charge-first-sites): the per-site ``subscription.active``
+#   delivery now drives CHARGE-FIRST ACTIVATION. A paid-tier site is published as
+#   PENDING (created but NOT deployed live); on the verified ``subscription.active``
+#   the per-site path calls ``sites_service.activate_site``, which runs the deferred
+#   deploy (generate + smoke-gate + Cloudflare/local deploy) and marks the sub
+#   active — so a paid site goes live ONLY after payment confirms. ``activate_site``
+#   is idempotent (an already-active/deployed site is a no-op), so a replayed
+#   ``active`` does not re-deploy. ``renewed`` just refreshes the renewal date (the
+#   site is already live), ``cancelled`` marks the site cancelled WITHOUT undeploying
+#   it in v1.
 
 from __future__ import annotations
 
@@ -509,18 +519,27 @@ async def _handle_subscription_event(event: SubscriptionEvent) -> dict:
 
 
 async def _handle_site_subscription_event(event: SubscriptionEvent) -> dict:
-    """Act on a VERIFIED PER-SITE ``subscription.*`` webhook (BC-9).
+    """Act on a VERIFIED PER-SITE ``subscription.*`` webhook (BC-9 + charge-first).
 
     A per-site annual sub (each published site has its OWN recurring plan) is
     distinguished from a workspace-plan sub by the ``site_id`` on its metadata.
     This path updates the SITE's lifecycle ONLY — it NEVER grants workspace
     credits and NEVER changes ``Workspace.plan`` (the two grant/plan side effects
-    of the BC-7 workspace path). The site write is delegated to the sites service
+    of the BC-7 workspace path). All site writes are delegated to the sites service
     (entity isolation — billing never imports the Site model):
 
-      * ``subscription.active`` / ``subscription.renewed`` → mark the site sub
-        ``active`` and advance its annual renewal date (one year out).
-      * ``subscription.cancelled`` → mark the site sub ``cancelled``.
+      * ``subscription.active`` → CHARGE-FIRST ACTIVATION. A paid-tier site was
+        published as PENDING (created but NOT deployed live) and is deployed + goes
+        live only now that payment is confirmed: ``sites_service.activate_site``
+        runs the deferred deploy (generate + smoke-gate + Cloudflare/local deploy)
+        and marks the sub active. It is idempotent — an already-active/deployed
+        site is a no-op, so a replayed delivery (or a renewal that arrives as
+        ``active``) does not re-deploy.
+      * ``subscription.renewed`` → the site is already live; just refresh the
+        renewal date (one year out) via ``mark_site_subscription`` — no re-deploy.
+      * ``subscription.cancelled`` → mark the site sub ``cancelled``. The live site
+        is NOT undeployed in v1 (a cancelled annual plan keeps serving until the
+        paid period would lapse; an undeploy/teardown is a follow-up).
       * any other subscription.* delivery → acked, no action.
 
     Returns ``{"ok": True, "granted": False}`` always — a per-site sub never
@@ -531,30 +550,44 @@ async def _handle_site_subscription_event(event: SubscriptionEvent) -> dict:
     from pocketpaw_ee.cloud._core.errors import NotFound
     from pocketpaw_ee.sites import service as sites_service
 
-    if event.type == _SUB_CANCELLED:
-        status, renewal = "cancelled", None
-    elif event.type in _SUB_GRANT_EVENTS:
-        # active | renewed → the site sub is active; advance the annual renewal
-        # date one year from this verified event (the next charge cycle).
-        status, renewal = "active", datetime.now(UTC) + timedelta(days=365)
-    else:
-        # on_hold / paused / failed / expired / plan_changed / updated — acked,
-        # no site-state action in v1.
-        logger.info(
-            "billing.webhook: ignoring per-site subscription event type=%s (site=%s)",
-            event.type,
-            event.site_id,
-        )
-        return {"ok": True, "granted": False}
-
     try:
-        await sites_service.mark_site_subscription(
-            workspace_id=event.workspace_id,
-            site_id=event.site_id,
-            status=status,
-            subscription_id=event.subscription_id or None,
-            annual_renewal_date=renewal,
-        )
+        if event.type == _SUB_ACTIVE:
+            # CHARGE-FIRST: payment confirmed → deploy the pending site live and
+            # mark the sub active. Idempotent for at-least-once delivery.
+            await sites_service.activate_site(
+                workspace_id=event.workspace_id,
+                site_id=event.site_id,
+            )
+            status = "active"
+        elif event.type == _SUB_RENEWED:
+            # Already live — just refresh the annual renewal date (no re-deploy).
+            await sites_service.mark_site_subscription(
+                workspace_id=event.workspace_id,
+                site_id=event.site_id,
+                status="active",
+                subscription_id=event.subscription_id or None,
+                annual_renewal_date=datetime.now(UTC) + timedelta(days=365),
+            )
+            status = "active"
+        elif event.type == _SUB_CANCELLED:
+            # Mark cancelled; do NOT undeploy the live site in v1.
+            await sites_service.mark_site_subscription(
+                workspace_id=event.workspace_id,
+                site_id=event.site_id,
+                status="cancelled",
+                subscription_id=event.subscription_id or None,
+                annual_renewal_date=None,
+            )
+            status = "cancelled"
+        else:
+            # on_hold / paused / failed / expired / plan_changed / updated — acked,
+            # no site-state action in v1.
+            logger.info(
+                "billing.webhook: ignoring per-site subscription event type=%s (site=%s)",
+                event.type,
+                event.site_id,
+            )
+            return {"ok": True, "granted": False}
     except NotFound:
         # A verified delivery for a site that doesn't exist for this workspace
         # (deleted, or a stale/cross-tenant id) — ack (200) so Dodo stops

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -69,6 +69,22 @@
 # ``annual_renewal_date``. All default to backward-compatible values (None /
 # "none") so every pre-BC-9 row and every workspace-plan-only site reads as having
 # no per-site sub — no migration.
+#
+# Updated 2026-06-24 (feat/charge-first-sites — charge-first per-site publishing):
+# a PAID-tier site is now created as PENDING and NOT deployed live until the
+# ``subscription.active`` webhook confirms payment. Two additions support that:
+#   * ``pending_deploy_inputs`` — the deploy inputs (rippleSpec / theme / engine /
+#     svelte source / pattern / builder_origin / name) captured at publish time so
+#     the webhook-time ``activate_site`` can run the deferred deploy WITHOUT
+#     re-reading the pocket (the webhook only carries workspace_id + site_id, and
+#     the pocket's draft may have moved on by activation time). Set ONLY for a
+#     pending paid publish; "" / empty for a free/live publish, and cleared once
+#     the site is activated. Default empty dict so every pre-charge-first row reads
+#     as having no pending deploy.
+#   * ``_checkout_url`` — a TRANSIENT pydantic PrivateAttr (NOT persisted to Mongo)
+#     the publish path stashes the Dodo checkout link on so the router can surface
+#     it on ``SiteResponse.checkout_url`` for a paid publish. None for a free
+#     publish. Private so it never round-trips through the DB.
 
 from __future__ import annotations
 
@@ -76,7 +92,7 @@ from datetime import datetime
 from typing import Any
 
 from beanie import Indexed
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
@@ -126,6 +142,17 @@ class Site(TimestampedDocument):
     subscription_id: str | None = None
     annual_renewal_date: datetime | None = None
     subscription_status: str = "none"
+    # charge-first: the deploy inputs captured at publish time for a PENDING paid
+    # site, so the ``subscription.active`` webhook can run the deferred deploy
+    # without re-reading the pocket (the webhook carries only workspace_id +
+    # site_id, and the pocket's draft may have advanced by activation time). Keys:
+    # ripple_spec, theme, engine, source, pattern, builder_origin, name. Empty for
+    # a free/live publish; cleared once the site is activated.
+    pending_deploy_inputs: dict[str, Any] = Field(default_factory=dict)
+    # charge-first: TRANSIENT (NOT persisted) Dodo checkout link for a paid
+    # publish. The publish path stashes it here so the router can surface it on
+    # ``SiteResponse.checkout_url``; a PrivateAttr so it never serializes to Mongo.
+    _checkout_url: str | None = PrivateAttr(default=None)
     # PERF-2: a non-destructive tombstone for duplicate Site docs the pre-PERF-1
     # per-publish ObjectId minting left behind. The dedupe migration keeps ONE
     # canonical doc per (workspace, pocket_id) active and sets this True on the

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -75,6 +75,13 @@
 #     is empty, but ``columns`` is still listed from the spec.
 # These are READ-ONLY views (no request DTO — the inputs are path params); the
 # data view never writes through this surface.
+# Updated 2026-06-24 (feat/charge-first-sites): ``SiteResponse`` gains
+# ``checkout_url`` — the Dodo annual-checkout link a PAID-tier publish returns.
+# A paid publish defers the live deploy: it creates the site as PENDING
+# (deployed=False) and returns this link the caller redirects the buyer to; the
+# site deploys + goes live only when the ``subscription.active`` webhook confirms
+# payment. None for a free/base publish (which deploys immediately) and for any
+# non-publish response (default None, backward-compatible).
 # Updated 2026-06-24 (S2 review fix): ``DomainRequest.hostname`` now carries a
 # permissive DNS-hostname validator (label-dot-label, letters/digits/hyphens, no
 # leading/trailing/double dots, total length capped) so an obviously-malformed
@@ -126,6 +133,12 @@ class SiteResponse(BaseModel):
     # the pocket has no pattern or could not be resolved. Lets the frontend badge
     # dynamic sites in the gallery without a second fetch.
     pattern: str = ""
+    # charge-first: the Dodo annual-checkout link for a PAID-tier publish. A paid
+    # publish creates the site as PENDING (deployed=False) and returns this link
+    # the caller redirects the buyer to; the site deploys + goes live only after
+    # the ``subscription.active`` webhook confirms payment. None for a free/base
+    # publish (which deploys immediately) and for any non-publish response.
+    checkout_url: str | None = None
 
 
 class SitePreviewResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1702,16 +1702,19 @@ async def activate_site(
 
     inputs = doc.pending_deploy_inputs or {}
     if not inputs:
-        # No captured deploy inputs — cannot run the deferred deploy from the
-        # webhook. Advance the status so the lifecycle is consistent, but log the
-        # gap (a site that reached "active" with nothing to deploy is unexpected).
-        logger.warning(
+        # No captured deploy inputs — we cannot run the deferred deploy from the
+        # webhook (it carries no pocket scope). This is an unexpected/corrupt state:
+        # every charge-first pending site captures its inputs at publish, and they
+        # are only cleared on a SUCCESSFUL deploy. Do NOT advance to "active" — that
+        # would be a lie (active + deployed=False = a paid site that 404s). Leave it
+        # PENDING and log loudly so an operator investigates; the site never claims
+        # to be live without an actual deploy.
+        logger.error(
             "sites.activate: pending site %s has no captured deploy inputs — "
-            "marking active without a deploy (unexpected state)",
+            "leaving it PENDING (cannot deploy from the webhook); operator "
+            "intervention required",
             site_id,
         )
-        doc.subscription_status = "active"
-        await doc.save()
         return doc
 
     pocket_id = doc.pocket_id

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,34 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-24 (feat/charge-first-sites — charge-first per-site publishing):
+# a PAID site tier (positive ``annual_price_usd`` AND a configured
+# ``dodo_product_id``) is now CHARGE-FIRST — published as PENDING and NOT deployed
+# live until payment confirms; a FREE/base tier still deploys instantly.
+#   * Extracted ``_deploy_site_doc`` — the generate + smoke-gate + Cloudflare/local
+#     deploy + upsert-and-stamp-deployed half of ``publish``. ``publish`` (free
+#     path) calls it as before; the charge-first activation reuses it at webhook
+#     time. ``publish``'s preview branch is unchanged (it builds inline + returns a
+#     transient doc, no deploy).
+#   * ``publish_pocket`` resolves the per-site tier BEFORE deploy and branches:
+#     PAID + chargeable → ``_publish_pending_site`` (create a PENDING Site doc with
+#     ``deployed=False`` / ``subscription_status="pending"`` / ``plan_tier`` and the
+#     captured deploy inputs on ``Site.pending_deploy_inputs``, open the Dodo annual
+#     checkout, return the checkout_url — NO deploy); FREE/base → live publish as
+#     today, then ``_apply_site_plan`` stamps the tier. A "paid" tier whose Dodo
+#     product is UNCONFIGURED can't open a checkout, so it DEGRADES to an immediate
+#     live publish (never strands the user).
+#   * ``activate_site(site_id)`` — loads the PENDING site, runs ``_deploy_site_doc``
+#     from the stored ``pending_deploy_inputs`` (the webhook carries only
+#     workspace_id + site_id, and the pocket's draft may have advanced), marks the
+#     sub active, promotes the draft to published, and emits ``SitePublished``. The
+#     per-site ``subscription.active`` webhook calls it. Idempotent — an
+#     already-active/deployed site is a no-op.
+#   * The publish response carries ``checkout_url`` (``SiteResponse.checkout_url``):
+#     the Dodo link for a paid publish, None for a free publish. It rides the
+#     returned Site doc on a TRANSIENT ``_checkout_url`` PrivateAttr (never
+#     persisted); ``_to_response`` reads it via getattr.
+#
 # Updated 2026-06-24 (C1 review fix — _cf_client guard): ``_cf_client`` reads the
 # PAW_CF_* vars with ``os.environ.get`` and raises a ``ValidationError``
 # (CloudError → 422) when any is missing, instead of a raw ``KeyError`` (an
@@ -324,7 +352,7 @@ from __future__ import annotations
 import logging
 import secrets
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -665,6 +693,11 @@ def _to_response(doc: _SiteDoc, pattern: str = "") -> SiteResponse:
         # ...), resolved by the caller from Pocket.pattern (it lives on the pocket,
         # not the Site). "" when unset / unresolved so the gallery is empty-safe.
         pattern=pattern,
+        # charge-first: the Dodo checkout link a PAID-tier publish returns, read
+        # from the transient ``_checkout_url`` PrivateAttr (never persisted). None
+        # for a free/live publish and for any list/status read (those docs are
+        # loaded from Mongo, where the PrivateAttr defaults to None).
+        checkout_url=getattr(doc, "_checkout_url", None),
     )
 
 
@@ -740,7 +773,9 @@ async def publish(
     deploy); a CF-only preview build is still generated and smoke-gated but is not
     PUT into the dispatch namespace.
 
-    Deploy has two branches:
+    The generate + deploy + upsert half lives in ``_deploy_site_doc`` (extracted so
+    the charge-first webhook ``activate_site`` can run the SAME deferred deploy at
+    payment-confirm time). It has two branches:
       * REAL Cloudflare (default when creds are present, or when a CF client is
         injected): PUT the Worker bundle into the dispatch namespace.
       * LOCAL fake-deploy (no CF creds / PAW_SITES_LOCAL=1, and no injected CF
@@ -808,47 +843,35 @@ async def publish(
         if _existing is not None and _existing.signed_key:
             signed_key = _existing.signed_key
 
-    build = await generator.build(
-        ripple_spec=ripple_spec,
-        theme=theme,
-        site_id=site_id,
-        title=site_name,
-        capture_api_base=_capture_base(),
-        capture_signed_key=signed_key,
-        engine=engine,
-        source=source,
-        builder_origin=builder_origin,
-        # PERF-3: build into the STABLE per-pocket working dir so node_modules
-        # persists and `bun install` is cached across builds (preview AND publish),
-        # cutting the dominant per-edit cost. A fresh site_id is minted per publish,
-        # but a pocket's working dir is reused across its publishes/previews.
-        pocket_id=pocket_id,
-        # P0a (was PERF-4): ``smoke`` now toggles ONLY the workerd SSR FAIL-gate,
-        # NOT whether ``bun run build`` runs. ``bun run build`` (the static-output
-        # step) runs on BOTH preview and publish (``static_build`` defaults to True),
-        # because this site is SERVED via deploy_local and persist_site copies
-        # whatever the build leaves on disk — skipping it served a STALE anchorless
-        # build (the #1 bug: no hover edit-pill). A preview/edit/arm build
-        # (preview=True) skips only the SSR fail-gate (smoke=False) — it still BUILDS
-        # fresh + anchored output; a live publish (preview=False) keeps the SSR gate
-        # (smoke=True) so the gate + the rollback below are unchanged. A preview that
-        # would fail the SSR render is not blocked — the live publish still gates +
-        # rolls back, so a broken edit never reaches the live deploy.
-        smoke=not preview,
-    )
-
-    # PREVIEW MODE (Branch primitive — EDIT/arm path): the build above already ran
-    # the smoke gate (a broken edit is still caught BEFORE it can be served), but a
-    # preview must NOT take the edit live. Serve the built dir from localhost so the
-    # builder iframe can frame the working copy, then return a TRANSIENT Site-shaped
-    # object (NOT persisted, ``deployed=False``) carrying that preview URL. The
-    # pocket's draft version is left untouched (no promote → ``get_draft`` stays
-    # non-None, the ``published`` pointer does not move), so the draft is reviewable
-    # and ``request_publish_pocket`` can submit it. The canonical live Site doc and
-    # its URL are not claimed or overwritten — only an approved review (the real
-    # ``publish``, ``preview=False``) deploys live + promotes.
+    # PREVIEW MODE (Branch primitive — EDIT/arm path): build + smoke-gate + locally
+    # serve a DRAFT preview but do NOT take the edit live. The build runs the smoke
+    # gate (a broken edit is caught BEFORE it can be served), then we serve the built
+    # dir from localhost and return a TRANSIENT Site-shaped object (NOT persisted,
+    # ``deployed=False``) carrying that preview URL. The pocket's draft version is
+    # left untouched (no promote → ``get_draft`` stays non-None, the ``published``
+    # pointer does not move), so the draft is reviewable and ``request_publish_pocket``
+    # can submit it. The canonical live Site doc and its URL are not claimed or
+    # overwritten — only an approved review (the real ``publish``, ``preview=False``)
+    # deploys live + promotes.
     if preview:
         from pocketpaw_ee.sites import local_server
+
+        build = await generator.build(
+            ripple_spec=ripple_spec,
+            theme=theme,
+            site_id=site_id,
+            title=site_name,
+            capture_api_base=_capture_base(),
+            capture_signed_key=signed_key,
+            engine=engine,
+            source=source,
+            builder_origin=builder_origin,
+            pocket_id=pocket_id,
+            # A preview/edit/arm build skips only the SSR fail-gate (smoke=False); a
+            # live publish keeps it (see _deploy_site_doc). It still BUILDS fresh +
+            # anchored output either way.
+            smoke=False,
+        )
 
         # Serve at a STABLE per-pocket preview id (NOT the freshly-minted ObjectId)
         # so repeated preview builds overwrite the same dir and serve at the SAME
@@ -875,19 +898,101 @@ async def publish(
         )
 
     # BP-2 / #1345: promote the pocket's current draft version to ``published``
-    # BEFORE deploy. The build (which runs the smoke gate) has succeeded, so the
-    # version being published is known-good; the published pointer is the durable
-    # "this is what was published" record even if the deploy below fails
-    # (published != live — a failed deploy just leaves the Site doc un-persisted,
-    # so the pocket reads not-live while the published tag stands). The snapshot
-    # for the promote is the engine's content: the rippleSpec for a ripple site,
-    # the {path: contents} source map for a svelte site.
+    # BEFORE deploy. ``_deploy_site_doc`` runs the smoke gate, so the version being
+    # published is known-good; the published pointer is the durable "this is what
+    # was published" record even if the deploy below fails (published != live — a
+    # failed deploy just leaves the Site doc un-persisted, so the pocket reads
+    # not-live while the published tag stands). The snapshot for the promote is the
+    # engine's content: the rippleSpec for a ripple site, the {path: contents}
+    # source map for a svelte site.
     version_content: dict[str, Any] = (source if engine == "svelte" else ripple_spec) or {}
     await _promote_pocket_draft_to_published(
         pocket_id=pocket_id,
         workspace_id=workspace_id,
         author=user_id,
         content=version_content,
+    )
+
+    # Generate + deploy + upsert the live Site doc. Extracted into a reusable helper
+    # so the charge-first webhook (``activate_site``) can run the SAME deferred
+    # deploy at payment-confirm time. ``publish`` (free path) calls it now.
+    return await _deploy_site_doc(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        pocket_id=pocket_id,
+        site_id=site_id,
+        signed_key=signed_key,
+        site_name=site_name,
+        ripple_spec=ripple_spec,
+        theme=theme,
+        engine=engine,
+        source=source,
+        pattern=pattern,
+        builder_origin=builder_origin,
+        generator=generator,
+        cloudflare=_cloudflare,
+        bundle_reader=_bundle_reader,
+        local_deploy=_local_deploy,
+    )
+
+
+async def _deploy_site_doc(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    site_id: str,
+    signed_key: str,
+    site_name: str,
+    ripple_spec: dict[str, Any] | None,
+    theme: dict[str, Any],
+    engine: str = "ripple",
+    source: dict[str, str] | None = None,
+    pattern: str | None = None,
+    builder_origin: str | None = None,
+    generator: GeneratorClient | None = None,
+    cloudflare: Any | None = None,
+    bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
+    local_deploy: Callable[[str, str], str] | None = None,
+) -> _SiteDoc:
+    """Generate, smoke-gate, deploy, and UPSERT the LIVE canonical Site doc.
+
+    The deploy half of ``publish`` — extracted so the charge-first webhook
+    (``activate_site``) can run the SAME deferred deploy at payment-confirm time
+    using the inputs captured on the pending Site doc. It runs
+    ``generator.build`` (with the SSR smoke fail-gate ON — a broken site is
+    rejected before it deploys), deploys via the LOCAL static server or Cloudflare
+    Workers-for-Platforms, and upserts ONE canonical Site doc per (workspace,
+    pocket_id) keyed on the stable ``_id`` (== ``site_id``), flipping
+    ``deployed=True`` + stamping ``deployed_at``.
+
+    Identity (``site_id`` / ``signed_key`` / ``site_name``) is resolved by the
+    caller so the same values flow through a publish and a later activation (the
+    deploy folder / URL / CF worker / Site doc id stay stable). On an upsert it
+    PRESERVES domain/allowed_origins/signed_key and CLEARS any
+    ``pending_deploy_inputs`` (the site is now live, not pending). Raises
+    ``SmokeGateFailed`` (from generator_client) if the SSR render fails — nothing
+    is deployed and no doc is flipped to deployed.
+    """
+    gen = generator or GeneratorClient()
+    build = await gen.build(
+        ripple_spec=ripple_spec,
+        theme=theme,
+        site_id=site_id,
+        title=site_name,
+        capture_api_base=_capture_base(),
+        capture_signed_key=signed_key,
+        engine=engine,
+        source=source,
+        builder_origin=builder_origin,
+        # PERF-3: build into the STABLE per-pocket working dir so node_modules
+        # persists and `bun install` is cached across builds, cutting the dominant
+        # per-edit cost.
+        pocket_id=pocket_id,
+        # A live deploy keeps the SSR fail-gate (smoke=True) so the gate + the
+        # rollback in edit_svelte_component are unchanged — a broken edit never
+        # reaches the live deploy.
+        smoke=True,
     )
 
     # DS-2: a DYNAMIC site (pattern == "dynamic", or a spec carrying live
@@ -906,16 +1011,16 @@ async def publish(
 
     # Local mode only when the caller did NOT inject a CF client (tests inject a
     # fake CF and expect the real branch) AND the environment selects it.
-    use_local = _cloudflare is None and _local_mode()
+    use_local = cloudflare is None and _local_mode()
     url = ""
     if use_local:
         from pocketpaw_ee.sites import local_server
 
-        deploy = _local_deploy or local_server.deploy_local
+        deploy = local_deploy or local_server.deploy_local
         url = deploy(site_id, build.project_dir)
     else:
-        cf = _cloudflare or _cf_client()
-        bundle = _bundle_reader(build.project_dir)
+        cf = cloudflare or _cf_client()
+        bundle = bundle_reader(build.project_dir)
         # Only a dynamic site passes bindings; a static publish passes None so the
         # single-module upload path stays byte-for-byte unchanged (no regress).
         bindings = (
@@ -932,11 +1037,10 @@ async def publish(
     # re-publish; only a first insert seeds the defaults. ``signed_key`` is likewise
     # kept stable across re-publishes (the capture endpoint verifies against it).
     oid = ObjectId(site_id)
-    # P2b: this branch runs ONLY on a successful non-preview deploy (a preview
-    # returned earlier), so ``deployed`` flips True HERE — stamp the live-deploy
-    # time alongside it. A re-publish refreshes it (it is "last shipped", not
-    # "first shipped"). It is NOT set on a preview/edit build and NOT a plain
-    # updatedAt bump, so it stays a true "last deployed" marker.
+    # P2b: this runs ONLY on a successful deploy, so ``deployed`` flips True HERE —
+    # stamp the live-deploy time alongside it. A re-publish refreshes it (it is
+    # "last shipped", not "first shipped"). It is NOT a plain updatedAt bump, so it
+    # stays a true "last deployed" marker.
     now = datetime.now(UTC)
     doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
     if doc is None:
@@ -973,6 +1077,9 @@ async def publish(
         doc.deployed = True
         doc.deployed_at = now
         doc.url = url
+        # charge-first: a live deploy clears any captured pending inputs — the site
+        # is no longer pending payment, so the snapshot is no longer needed.
+        doc.pending_deploy_inputs = {}
         # DS-2: keep the D1 id in sync. For a dynamic site it is the (reused)
         # stable id; a static re-publish leaves it "" (no binding). We only ever
         # SET it for a dynamic publish — a publish that is no longer dynamic does
@@ -1223,6 +1330,71 @@ async def publish_pocket(
     # backed by a per-tenant D1, so its deployed Worker gets a D1 binding.
     pattern = pocket.get("pattern")
 
+    # charge-first: a PREVIEW publish never persists a Site doc and never bills, so
+    # it stays the unchanged Branch-primitive preview path — build + smoke-gate +
+    # locally serve a transient draft, no tier/sub/event.
+    if preview:
+        return await publish(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            ripple_spec=ripple_spec,
+            theme=theme,
+            engine=engine,
+            source=source,
+            pattern=pattern,
+            name=name or pocket.get("name", ""),
+            builder_origin=builder_origin,
+            preview=True,
+            _generator=_generator,
+            _cloudflare=_cloudflare,
+            _bundle_reader=_bundle_reader,
+            _local_deploy=_local_deploy,
+        )
+
+    # charge-first: resolve the per-site tier BEFORE deploy, then branch.
+    #   * a PAID tier (positive annual price AND a configured Dodo product) DEFERS
+    #     the live deploy — create the Site as PENDING, open the annual checkout,
+    #     return the checkout_url, and let the ``subscription.active`` webhook deploy
+    #     it live once payment is confirmed (``_publish_pending_site``).
+    #   * a FREE/base tier — OR a "paid" tier whose Dodo product is NOT configured
+    #     (a paid tier can't open a checkout, so don't strand the user) — publishes
+    #     LIVE immediately, exactly as before, then stamps the (free/degraded) tier.
+    from pocketpaw_ee.cloud.billing import site_plans
+
+    tier = site_plans.get_site_plan(site_plan_key) or site_plans.get_site_plan(
+        site_plans.BASE_SITE_PLAN_KEY
+    )
+    is_paid = tier is not None and tier.annual_price_usd > 0
+    dodo_configured = tier is not None and bool(tier.dodo_product_id)
+
+    if is_paid and not dodo_configured:
+        # A paid tier whose Dodo product is unconfigured can't open a checkout —
+        # fall back to publishing LIVE immediately so the user is never stranded.
+        logger.warning(
+            "sites.publish: paid tier %s has no configured Dodo product — publishing "
+            "live immediately (charge-first fallback, no checkout)",
+            tier.key if tier is not None else site_plan_key,
+        )
+
+    if is_paid and dodo_configured:
+        # PAID + chargeable → defer the deploy until subscription.active.
+        return await _publish_pending_site(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            ripple_spec=ripple_spec,
+            theme=theme,
+            engine=engine,
+            source=source,
+            pattern=pattern,
+            name=name or pocket.get("name", ""),
+            builder_origin=builder_origin,
+            tier=tier,
+            provider=_billing_provider,
+        )
+
+    # FREE/base (or paid-but-unconfigured fallback) → publish LIVE now.
     doc = await publish(
         workspace_id=workspace_id,
         user_id=user_id,
@@ -1234,20 +1406,16 @@ async def publish_pocket(
         pattern=pattern,
         name=name or pocket.get("name", ""),
         builder_origin=builder_origin,
-        preview=preview,
+        preview=False,
         _generator=_generator,
         _cloudflare=_cloudflare,
         _bundle_reader=_bundle_reader,
         _local_deploy=_local_deploy,
     )
 
-    # BC-9: a PREVIEW publish never persists a Site doc, so there is no per-site
-    # plan to stamp / sub to open / event to emit — return the transient doc as-is.
-    if preview:
-        return doc
-
-    # A LIVE publish: stamp the per-site annual plan, open the per-site Dodo sub
-    # (degrading gracefully when Dodo is unconfigured), and emit SitePublished.
+    # Stamp the per-site annual plan, open the per-site Dodo sub (degrading
+    # gracefully when Dodo is unconfigured), and emit SitePublished. No checkout_url
+    # on this path — the site is already live.
     return await _apply_site_plan(
         doc=doc,
         workspace_id=workspace_id,
@@ -1345,6 +1513,266 @@ async def _apply_site_plan(
         )
     )
     return doc
+
+
+async def _publish_pending_site(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    ripple_spec: dict[str, Any] | None,
+    theme: dict[str, Any],
+    engine: str,
+    source: dict[str, str] | None,
+    pattern: str | None,
+    name: str,
+    builder_origin: str | None,
+    tier: Any,
+    provider: Any | None,
+) -> _SiteDoc:
+    """Charge-first: create a PAID-tier site as PENDING and open its checkout,
+    WITHOUT deploying it live.
+
+    The paid-tier half of ``publish_pocket``. Rather than generate + deploy and
+    then bill, it:
+      1. resolves the STABLE per-(workspace, pocket) identity (the same ``site_id``
+         a live publish would use, and the existing signed_key when the pocket was
+         published before) so a later ``activate_site`` deploys at the same id/URL;
+      2. UPSERTS a PENDING canonical Site doc — ``deployed=False``,
+         ``subscription_status="pending"``, ``plan_tier=<tier>`` — and persists the
+         DEPLOY INPUTS (rippleSpec / theme / engine / source / pattern /
+         builder_origin / name) on ``pending_deploy_inputs`` so the webhook-time
+         activation can deploy WITHOUT re-reading the pocket (the webhook carries
+         only workspace_id + site_id, and the pocket's draft may have moved on);
+      3. opens the per-site annual Dodo subscription (the SAME ``create_subscription``
+         + ``metadata={workspace_id, site_id, plan_key}`` the live path uses) and
+         captures the checkout_url, which it stashes on the returned doc's transient
+         ``_checkout_url`` for the router to surface.
+
+    It does NOT run the generator, does NOT deploy, does NOT promote the pocket's
+    draft to published (the site is not live yet), and does NOT emit
+    ``SitePublished`` — all of that happens in ``activate_site`` when the
+    ``subscription.active`` webhook confirms payment. If opening the checkout fails
+    AFTER the pending doc is persisted, the pending doc stands (status="pending",
+    no checkout_url) so the operator can see the attempt and retry — the deploy is
+    never taken without payment.
+    """
+    site_name = (name or "").strip()
+    if not site_name:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        _pocket = await pockets_service.get(pocket_id, user_id)
+        site_name = (_pocket.get("name") or "").strip()
+    if not site_name:
+        site_name = "Untitled site"
+
+    oid = _live_object_id(workspace_id, pocket_id)
+    site_id = str(oid)
+    plan_key = tier.key
+
+    # Reuse the stored signed_key when the pocket was published before, so the
+    # eventual deploy bakes a key that matches the doc the capture endpoint
+    # verifies against; mint one for a first publish.
+    signed_key = f"site_key_{secrets.token_urlsafe(24)}"
+    existing = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if existing is not None and existing.signed_key:
+        signed_key = existing.signed_key
+
+    # The deploy inputs the webhook-time activation needs (the webhook carries only
+    # workspace_id + site_id). Stored on the pending doc so activation never re-reads
+    # the pocket (whose draft may have advanced).
+    pending_inputs: dict[str, Any] = {
+        "ripple_spec": ripple_spec,
+        "theme": theme,
+        "engine": engine,
+        "source": source,
+        "pattern": pattern,
+        "builder_origin": builder_origin,
+        "name": site_name,
+    }
+
+    if existing is None:
+        doc = _SiteDoc(
+            id=oid,
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            owner=user_id,
+            name=site_name,
+            script_name=site_id,
+            deployed=False,  # PENDING — not deployed until payment confirms
+            signed_key=signed_key,
+            url="",
+            builder_origin=builder_origin or "",
+            plan_tier=plan_key,
+            subscription_status="pending",
+            pending_deploy_inputs=pending_inputs,
+            allowed_origins=_default_allowed_origins(),
+            event_mapping=_DEFAULT_EVENT_MAPPING,
+        )
+        await doc.insert()
+    else:
+        # Re-publish of a pocket onto a paid tier: refresh the pending intent in
+        # place. A previously-live site is taken back to pending until the new
+        # annual sub confirms — but the deploy fields are LEFT as-is until the
+        # activation re-deploys (we don't tear down a live site before payment).
+        doc = existing
+        doc.owner = user_id
+        doc.name = site_name
+        doc.plan_tier = plan_key
+        doc.subscription_status = "pending"
+        doc.pending_deploy_inputs = pending_inputs
+        await doc.save()
+
+    # Open the per-site annual Dodo subscription and capture the checkout link the
+    # caller redirects the buyer to. A failure here leaves the pending doc standing
+    # (no checkout_url) — never deploy without payment.
+    checkout_url: str | None = None
+    subscription_id: str | None = None
+    try:
+        prov = provider or _default_billing_provider()
+        checkout = await prov.create_subscription(
+            plan_key=plan_key,
+            product_id=tier.dodo_product_id,
+            workspace_id=workspace_id,
+            customer_email=None,
+            metadata={
+                "workspace_id": workspace_id,
+                "site_id": site_id,
+                "plan_key": plan_key,
+            },
+        )
+        checkout_url = checkout.checkout_url or None
+        subscription_id = checkout.subscription_id or None
+    except Exception:  # noqa: BLE001 — a billing hiccup must not crash the publish
+        logger.warning(
+            "sites.publish: per-site checkout init failed for pending site %s "
+            "(tier=%s) — site stays pending, no checkout opened",
+            site_id,
+            plan_key,
+            exc_info=True,
+        )
+
+    if subscription_id is not None:
+        doc.subscription_id = subscription_id
+        await doc.save()
+
+    # Stash the checkout link on the transient PrivateAttr so the router can surface
+    # it on SiteResponse.checkout_url (never persisted).
+    doc._checkout_url = checkout_url
+    return doc
+
+
+async def activate_site(
+    *,
+    workspace_id: str,
+    site_id: str,
+    _generator: GeneratorClient | None = None,
+    _cloudflare: Any | None = None,
+    _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
+    _local_deploy: Callable[[str, str], str] | None = None,
+) -> _SiteDoc:
+    """Deploy + activate a PENDING charge-first site (charge-first activation).
+
+    Called from the per-site ``subscription.active`` webhook once payment is
+    confirmed. Loads the PENDING Site doc (tenant-scoped via ``_load`` — a missing /
+    cross-tenant id raises NotFound, which the webhook acks without a write), reads
+    the DEPLOY INPUTS captured on it at publish time (``pending_deploy_inputs``),
+    and runs the SAME deferred deploy a live publish would have (``_deploy_site_doc``
+    — generate + smoke-gate + deploy + upsert ``deployed=True`` + stamp
+    ``deployed_at``). It then marks ``subscription_status="active"``, promotes the
+    pocket's draft to published (the durable "this was published" record, mirroring
+    the live publish), and emits ``SitePublished``.
+
+    Idempotent for the webhook's at-least-once delivery: an already-active /
+    already-deployed site is returned unchanged (no re-deploy, no re-emit) — a
+    replayed or out-of-order ``subscription.active`` is a no-op.
+
+    If the pending doc carries NO ``pending_deploy_inputs`` (an unexpected state —
+    e.g. a site that was never a charge-first pending publish), it cannot be
+    deployed from the webhook; the status is still advanced to active and the doc
+    returned, and the gap is logged. ``_generator`` / ``_cloudflare`` / etc. are
+    injectable so the path is unit-testable without Bun / workerd / Cloudflare.
+    """
+    doc = await _load(workspace_id, site_id)
+
+    # Idempotent: an already-deployed+active site is a no-op (replayed / out-of-order
+    # delivery). We treat "deployed and active" as the terminal live state.
+    if doc.deployed and doc.subscription_status == "active":
+        return doc
+
+    inputs = doc.pending_deploy_inputs or {}
+    if not inputs:
+        # No captured deploy inputs — cannot run the deferred deploy from the
+        # webhook. Advance the status so the lifecycle is consistent, but log the
+        # gap (a site that reached "active" with nothing to deploy is unexpected).
+        logger.warning(
+            "sites.activate: pending site %s has no captured deploy inputs — "
+            "marking active without a deploy (unexpected state)",
+            site_id,
+        )
+        doc.subscription_status = "active"
+        await doc.save()
+        return doc
+
+    pocket_id = doc.pocket_id
+    # Deploy live using the inputs captured at publish time (NOT a fresh pocket read
+    # — the webhook has no pocket scope, and the pocket's draft may have advanced).
+    deployed = await _deploy_site_doc(
+        workspace_id=workspace_id,
+        user_id=doc.owner,
+        pocket_id=pocket_id,
+        site_id=site_id,
+        signed_key=doc.signed_key,
+        site_name=inputs.get("name") or doc.name,
+        ripple_spec=inputs.get("ripple_spec"),
+        theme=inputs.get("theme") or {},
+        engine=inputs.get("engine") or "ripple",
+        source=inputs.get("source"),
+        pattern=inputs.get("pattern"),
+        builder_origin=inputs.get("builder_origin"),
+        generator=_generator,
+        cloudflare=_cloudflare,
+        bundle_reader=_bundle_reader,
+        local_deploy=_local_deploy,
+    )
+
+    # The deploy flipped ``deployed=True`` and cleared pending_deploy_inputs; now
+    # mark the per-site sub active and advance the annual renewal date (one year out
+    # — the next charge cycle), mirroring the renewed path.
+    deployed.subscription_status = "active"
+    deployed.annual_renewal_date = datetime.now(UTC) + timedelta(days=365)
+    await deployed.save()
+
+    # Promote the pocket's draft to published — the durable "this was published"
+    # record, mirroring the live publish path (best-effort; versioning never gates
+    # the deploy/activation).
+    version_content: dict[str, Any] = (
+        inputs.get("source") if (inputs.get("engine") == "svelte") else inputs.get("ripple_spec")
+    ) or {}
+    await _promote_pocket_draft_to_published(
+        pocket_id=pocket_id,
+        workspace_id=workspace_id,
+        author=doc.owner,
+        content=version_content,
+    )
+
+    # Emit SitePublished now that the site is actually live (deferred from the
+    # pending publish — a charge-first site is "published" only once it deploys).
+    from pocketpaw_ee.cloud._core.realtime.emit import emit
+    from pocketpaw_ee.cloud._core.realtime.events import SitePublished
+
+    await emit(
+        SitePublished(
+            data={
+                "workspace_id": workspace_id,
+                "site_id": site_id,
+                "pocket_id": pocket_id,
+                "owner": doc.owner,
+                "plan_tier": deployed.plan_tier or "",
+            }
+        )
+    )
+    return deployed
 
 
 def _default_billing_provider() -> Any:
@@ -2418,6 +2846,7 @@ __all__ = [
     "apply_edits",
     "publish",
     "publish_pocket",
+    "activate_site",
     "preview_pocket",
     "pocket_status",
     "list_site_data_tables",

--- a/tests/cloud/sites/test_charge_first.py
+++ b/tests/cloud/sites/test_charge_first.py
@@ -1,0 +1,449 @@
+# tests/cloud/sites/test_charge_first.py — proves the charge-first per-site
+# publishing contract (feat/charge-first-sites): a PAID site tier is created as
+# PENDING and deployed live only after the subscription.active webhook confirms
+# payment; a FREE/base tier deploys immediately. The four acceptance criteria:
+#
+#   1. Paid-tier publish → returns a checkout_url, the Site is deployed=False +
+#      subscription_status="pending", and the deploy (generator/Cloudflare) was
+#      NOT invoked.
+#   2. subscription.active webhook (metadata site_id) for that pending site →
+#      activate_site runs the deploy (generator/Cloudflare invoked), the Site
+#      becomes deployed=True + subscription_status="active".
+#   3. Free/base-tier publish → deploys immediately (generator/Cloudflare invoked),
+#      deployed=True, checkout_url is None (proves no regression to the free path).
+#   4. Dodo-unconfigured paid tier → falls back to immediate live publish (the user
+#      is never stranded — no checkout to open, so deploy now).
+#
+# The generator / Cloudflare / Dodo provider are mocked exactly like the sibling
+# test_site_billing.py (never touches Bun/workerd/Dodo); the webhook path signs
+# with the REAL standardwebhooks library so the per-site activation routing runs
+# through the verified path. Real Workspace + Pocket docs are seeded so the plan
+# gate, the pocket read, and the per-site sub all run against live Beanie.
+#
+# Created 2026-06-24 (feat/charge-first-sites): new test module.
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.billing import service as billing
+from pocketpaw_ee.cloud.billing import site_plans
+from pocketpaw_ee.cloud.billing.domain import SubscriptionCheckout
+from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import service as sites_service
+from standardwebhooks import Webhook
+
+SECRET = "whsec_" + base64.b64encode(b"charge-first-test-secret-32bytes!").decode()
+SITE_SUB_ID = "sub_site_charge_first"
+CHECKOUT_URL = "https://checkout.dodopayments.test/site/charge-first"
+
+
+class _RecordingGenerator:
+    """Stand-in SvelteKit generator — records build calls, never touches Bun."""
+
+    def __init__(self):
+        self.build_calls: list[dict] = []
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.build_calls.append(dict(kw))
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _RecordingCF:
+    """Stand-in Cloudflare client — records put_worker calls, never deploys."""
+
+    def __init__(self):
+        self.put_calls: list[str] = []
+
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        self.put_calls.append(script_name)
+        return True
+
+
+class _RecordingBillingProvider:
+    """Injected per-site subscription provider — records create_subscription and
+    returns a fixed checkout url + subscription id (no Dodo SDK / network)."""
+
+    def __init__(self, subscription_id: str = SITE_SUB_ID, checkout_url: str = CHECKOUT_URL):
+        self.subscription_id = subscription_id
+        self.checkout_url = checkout_url
+        self.calls: list[dict] = []
+
+    async def create_subscription(
+        self, *, plan_key, product_id, workspace_id, customer_email, metadata
+    ) -> SubscriptionCheckout:
+        self.calls.append(
+            {
+                "plan_key": plan_key,
+                "product_id": product_id,
+                "workspace_id": workspace_id,
+                "metadata": dict(metadata),
+            }
+        )
+        return SubscriptionCheckout(
+            checkout_url=self.checkout_url,
+            subscription_id=self.subscription_id,
+        )
+
+
+def _provider() -> DodoProvider:
+    """A DodoProvider wired with the test webhook secret (webhook path only)."""
+    return DodoProvider(
+        api_key="dodo_test_key",
+        environment="test_mode",
+        webhook_secret=SECRET,
+        credit_product_id="prod_credits_sku",
+        plan_products={},
+    )
+
+
+async def _make_workspace(plan: str = "business") -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(
+        name="Acme", slug=f"acme-{plan}-{datetime.now(UTC).timestamp()}", owner="u1", plan=plan
+    )
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _make_pocket(*, workspace_id: str, owner: str = "u1") -> str:
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace_id,
+        name="My Landing",
+        owner=owner,
+        type="site",
+        pattern="landing",
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+def _sign(body: str, *, msg_id: str) -> dict[str, str]:
+    ts = datetime.now(UTC)
+    sig = Webhook(SECRET).sign(msg_id=msg_id, timestamp=ts, data=body)
+    return {
+        "webhook-id": msg_id,
+        "webhook-timestamp": str(int(ts.timestamp())),
+        "webhook-signature": sig,
+    }
+
+
+def _site_subscription_body(*, event_type: str, workspace_id: str, site_id: str) -> str:
+    """A PER-SITE Dodo subscription.* webhook body — note ``site_id`` on the
+    metadata, the discriminator that routes this to the SITE / activation path."""
+    return json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": event_type,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "subscription_id": SITE_SUB_ID,
+                "product_id": "prod_site_pro",
+                "metadata": {
+                    "workspace_id": workspace_id,
+                    "site_id": site_id,
+                    "plan_key": "pro",
+                },
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Criterion 1 — paid-tier publish defers the deploy + returns a checkout_url.
+# ---------------------------------------------------------------------------
+
+
+async def test_paid_publish_is_pending_and_returns_checkout_url(
+    mongo_db, recording_bus, monkeypatch
+):
+    # Configure a Dodo product for the "pro" site tier so it is a chargeable PAID
+    # tier (positive price + a product) → charge-first defers the deploy.
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+    )
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    gen = _RecordingGenerator()
+    cf = _RecordingCF()
+    provider = _RecordingBillingProvider()
+
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    # The site is PENDING — created but NOT deployed live.
+    assert doc.deployed is False
+    assert doc.subscription_status == "pending"
+    assert doc.plan_tier == "pro"
+    assert doc.subscription_id == SITE_SUB_ID
+
+    # The deploy was DEFERRED — neither the generator nor Cloudflare ran.
+    assert gen.build_calls == []
+    assert cf.put_calls == []
+
+    # The checkout link is returned: on the transient PrivateAttr AND surfaced on
+    # the SiteResponse (what the router returns to the caller).
+    assert doc._checkout_url == CHECKOUT_URL
+    resp = sites_service._to_response(doc)
+    assert resp.checkout_url == CHECKOUT_URL
+    assert resp.deployed is False
+
+    # The per-site sub was opened with the site_id on its metadata (the webhook
+    # discriminator) so subscription.active can route back to this site.
+    assert len(provider.calls) == 1
+    assert provider.calls[0]["metadata"]["site_id"] == str(doc.id)
+
+    # The deploy inputs were persisted so the webhook can deploy without re-reading
+    # the pocket.
+    persisted = await Site.find_one(Site.id == doc.id)
+    assert persisted is not None
+    assert persisted.deployed is False
+    assert persisted.subscription_status == "pending"
+    assert persisted.pending_deploy_inputs  # non-empty captured inputs
+
+    # SitePublished is DEFERRED to activation — not emitted while pending.
+    assert [e for e in recording_bus.events if e.type == "site.published"] == []
+
+
+# ---------------------------------------------------------------------------
+# Criterion 2 — subscription.active webhook deploys the pending site live.
+# ---------------------------------------------------------------------------
+
+
+async def test_active_webhook_deploys_pending_site(mongo_db, recording_bus, monkeypatch):
+    # PAID tier → pending publish (deploy deferred).
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+    )
+    # Force local deploy mode + fake the generator/local-server so the webhook-driven
+    # activation (which can't take injected seams) needs no Bun/workerd/Cloudflare.
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    activation_gen = _RecordingGenerator()
+    monkeypatch.setattr(sites_service, "GeneratorClient", lambda *a, **k: activation_gen)
+    from pocketpaw_ee.sites import local_server
+
+    deploy_calls: list[str] = []
+
+    def _fake_deploy_local(site_id, project_dir):
+        deploy_calls.append(site_id)
+        return f"http://local/{site_id}/"
+
+    monkeypatch.setattr(local_server, "deploy_local", _fake_deploy_local)
+
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_RecordingGenerator(),  # publish path generator (must NOT run)
+        _billing_provider=_RecordingBillingProvider(),
+    )
+    site_id = str(doc.id)
+    assert doc.deployed is False  # pending
+
+    # A verified PER-SITE subscription.active (metadata carries site_id).
+    body = _site_subscription_body(
+        event_type="subscription.active", workspace_id=ws, site_id=site_id
+    )
+    result = await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="evt_active_charge_first_1"),
+        provider=_provider(),
+    )
+    assert result == {"ok": True, "granted": False}
+
+    # The deploy RAN at activation — the generator built and the (local) deploy was
+    # invoked for this site.
+    assert len(activation_gen.build_calls) == 1
+    assert deploy_calls == [site_id]
+
+    # The SITE is now live + active + carries a renewal date, and the captured
+    # deploy inputs were cleared.
+    updated = await Site.find_one(Site.id == doc.id)
+    assert updated is not None
+    assert updated.deployed is True
+    assert updated.subscription_status == "active"
+    assert updated.annual_renewal_date is not None
+    assert updated.pending_deploy_inputs == {}
+
+    # SitePublished is emitted now that the site is actually live.
+    published = [e for e in recording_bus.events if e.type == "site.published"]
+    assert len(published) == 1
+    assert published[0].data["site_id"] == site_id
+
+
+async def test_active_webhook_is_idempotent(mongo_db, monkeypatch):
+    """A replayed subscription.active does not re-deploy an already-active site."""
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+    )
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    activation_gen = _RecordingGenerator()
+    monkeypatch.setattr(sites_service, "GeneratorClient", lambda *a, **k: activation_gen)
+    from pocketpaw_ee.sites import local_server
+
+    monkeypatch.setattr(
+        local_server, "deploy_local", lambda site_id, project_dir: f"http://local/{site_id}/"
+    )
+
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_RecordingGenerator(),
+        _billing_provider=_RecordingBillingProvider(),
+    )
+    site_id = str(doc.id)
+
+    body = _site_subscription_body(
+        event_type="subscription.active", workspace_id=ws, site_id=site_id
+    )
+    await billing.handle_webhook(
+        payload=body.encode(), headers=_sign(body, msg_id="evt_active_1"), provider=_provider()
+    )
+    assert len(activation_gen.build_calls) == 1  # deployed once
+
+    # A second active delivery (a replay / out-of-order) is a no-op — no re-deploy.
+    body2 = _site_subscription_body(
+        event_type="subscription.active", workspace_id=ws, site_id=site_id
+    )
+    await billing.handle_webhook(
+        payload=body2.encode(), headers=_sign(body2, msg_id="evt_active_2"), provider=_provider()
+    )
+    assert len(activation_gen.build_calls) == 1  # still 1 — not re-deployed
+
+
+async def test_activate_site_invokes_cloudflare(mongo_db, monkeypatch):
+    """Direct activate_site with an injected CF client proves the Cloudflare deploy
+    branch runs at activation (the CF-injected path the webhook can't reach)."""
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+    )
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_RecordingGenerator(),
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=_RecordingBillingProvider(),
+    )
+    site_id = str(doc.id)
+    assert doc.deployed is False
+
+    gen = _RecordingGenerator()
+    cf = _RecordingCF()
+    activated = await sites_service.activate_site(
+        workspace_id=ws,
+        site_id=site_id,
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+
+    # The Cloudflare put_worker ran at activation, at the stable site id.
+    assert gen.build_calls and cf.put_calls == [site_id]
+    assert activated.deployed is True
+    assert activated.subscription_status == "active"
+
+
+# ---------------------------------------------------------------------------
+# Criterion 3 — free/base-tier publish deploys immediately (no regression).
+# ---------------------------------------------------------------------------
+
+
+async def test_free_publish_deploys_immediately(mongo_db, recording_bus):
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    gen = _RecordingGenerator()
+    cf = _RecordingCF()
+
+    # No site_plan_key → base/free tier (basic, $0, no product).
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+
+    # Deployed LIVE immediately — generator + Cloudflare both ran.
+    assert doc.deployed is True
+    assert len(gen.build_calls) == 1
+    assert cf.put_calls == [str(doc.id)]
+    assert doc.plan_tier == site_plans.BASE_SITE_PLAN_KEY
+
+    # No checkout for a free publish.
+    assert getattr(doc, "_checkout_url", None) is None
+    resp = sites_service._to_response(doc)
+    assert resp.checkout_url is None
+    assert resp.deployed is True
+
+    # The free path emits SitePublished at publish time (the site is live now).
+    assert any(e.type == "site.published" for e in recording_bus.events)
+
+
+# ---------------------------------------------------------------------------
+# Criterion 4 — a paid tier with NO Dodo product falls back to live publish.
+# ---------------------------------------------------------------------------
+
+
+async def test_paid_tier_without_dodo_product_publishes_live(mongo_db):
+    """A "paid" tier (positive price) whose Dodo product is UNCONFIGURED can't open
+    a checkout, so charge-first degrades to an immediate live publish — the user is
+    never stranded with a pending, never-deployable site."""
+    # No _dodo_product_for monkeypatch → pro has a price but NO configured product.
+    assert site_plans.get_site_plan("pro").annual_price_usd > 0
+    assert site_plans.get_site_plan("pro").dodo_product_id is None
+
+    ws = await _make_workspace(plan="business")
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    gen = _RecordingGenerator()
+    cf = _RecordingCF()
+
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+    )
+
+    # Fell back to a LIVE publish — deployed now, no checkout, no live charge.
+    assert doc.deployed is True
+    assert len(gen.build_calls) == 1
+    assert cf.put_calls == [str(doc.id)]
+    assert doc.plan_tier == "pro"
+    assert doc.subscription_id is None  # no charge opened
+    assert getattr(doc, "_checkout_url", None) is None
+    assert sites_service._to_response(doc).checkout_url is None

--- a/tests/cloud/sites/test_site_billing.py
+++ b/tests/cloud/sites/test_site_billing.py
@@ -202,6 +202,7 @@ async def test_publish_with_entitlement_stamps_plan_and_emits(mongo_db, recordin
         site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
     )
     fake_provider = _FakeBillingProvider()
+    fake_cf = _FakeCF()
 
     doc = await sites_service.publish_pocket(
         workspace_id=ws,
@@ -209,15 +210,19 @@ async def test_publish_with_entitlement_stamps_plan_and_emits(mongo_db, recordin
         pocket_id=pocket_id,
         site_plan_key="pro",
         _generator=_FakeGenerator(),
-        _cloudflare=_FakeCF(),
+        _cloudflare=fake_cf,
         _bundle_reader=lambda d: b"x",
         _billing_provider=fake_provider,
     )
 
-    # The site was stamped with its per-site tier + subscription id.
+    # charge-first: a PAID tier (pro) is published as PENDING — stamped with its
+    # tier + subscription id, but NOT deployed live until subscription.active.
     assert doc.plan_tier == "pro"
     assert doc.subscription_id == SITE_SUB_ID
     assert doc.subscription_status == "pending"
+    assert doc.deployed is False
+    # The deploy was DEFERRED — the generator/Cloudflare were not invoked.
+    assert fake_cf.put_calls == []
 
     # The per-site Dodo sub was opened with the site_id on its metadata (the
     # discriminator the renewal webhook routes on).
@@ -228,20 +233,16 @@ async def test_publish_with_entitlement_stamps_plan_and_emits(mongo_db, recordin
     assert call["metadata"]["site_id"] == str(doc.id)
     assert call["metadata"]["workspace_id"] == ws
 
-    # The persisted doc reflects the stamp.
+    # The persisted doc reflects the pending stamp.
     persisted = await Site.find_one(Site.id == doc.id)
     assert persisted is not None
     assert persisted.plan_tier == "pro"
+    assert persisted.deployed is False
 
-    # SitePublished was emitted with the per-site payload.
+    # charge-first: SitePublished is DEFERRED to activation (the site is not live
+    # yet) — it is NOT emitted at publish time for a paid pending site.
     published = [e for e in recording_bus.events if e.type == "site.published"]
-    assert len(published) == 1
-    data = published[0].data
-    assert data["workspace_id"] == ws
-    assert data["site_id"] == str(doc.id)
-    assert data["pocket_id"] == pocket_id
-    assert data["owner"] == "u1"
-    assert data["plan_tier"] == "pro"
+    assert published == []
 
 
 async def test_publish_degrades_gracefully_when_dodo_unconfigured(mongo_db, recording_bus):
@@ -319,7 +320,18 @@ async def test_publish_without_entitlement_is_forbidden_and_creates_no_site(mong
 
 
 async def test_per_site_active_webhook_updates_site_not_workspace(mongo_db, monkeypatch):
-    # Publish a site (business workspace, pro tier) so there's a Site doc to update.
+    # charge-first: a paid (pro) publish creates a PENDING site; the
+    # subscription.active webhook deploys it live + marks the sub active. Force
+    # local deploy mode and fake the generator/local-server so the webhook-driven
+    # activation needs no Bun/workerd/Cloudflare.
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    monkeypatch.setattr(sites_service, "GeneratorClient", _FakeGenerator)
+    from pocketpaw_ee.sites import local_server
+
+    monkeypatch.setattr(
+        local_server, "deploy_local", lambda site_id, project_dir: f"http://local/{site_id}/"
+    )
+
     ws = await _make_workspace(plan="business")
     pocket_id = await _make_pocket(workspace_id=ws)
     monkeypatch.setattr(
@@ -331,11 +343,12 @@ async def test_per_site_active_webhook_updates_site_not_workspace(mongo_db, monk
         pocket_id=pocket_id,
         site_plan_key="pro",
         _generator=_FakeGenerator(),
-        _cloudflare=_FakeCF(),
-        _bundle_reader=lambda d: b"x",
         _billing_provider=_FakeBillingProvider(),
     )
     site_id = str(doc.id)
+    # Published PENDING — not yet deployed.
+    assert doc.deployed is False
+    assert doc.subscription_status == "pending"
 
     # The workspace plan + credit balance BEFORE the webhook.
     from pocketpaw_ee.cloud.workspace import service as workspace_service
@@ -360,9 +373,11 @@ async def test_per_site_active_webhook_updates_site_not_workspace(mongo_db, monk
     # The workspace plan is UNCHANGED (per-site subs don't touch Workspace.plan).
     assert await workspace_service.get_workspace_plan(ws) == plan_before
 
-    # The SITE's subscription_status flipped to active + a renewal date was set.
+    # charge-first: the SITE is now DEPLOYED live + its sub flipped to active + a
+    # renewal date was set.
     updated = await Site.find_one(Site.id == doc.id)
     assert updated is not None
+    assert updated.deployed is True
     assert updated.subscription_status == "active"
     assert updated.annual_renewal_date is not None
 


### PR DESCRIPTION
## What this adds

Charge-first publishing for per-site plans. A free or base-tier publish deploys the site immediately, as before. A paid-tier publish now charges before the site goes live: it creates the site as pending (not deployed), opens the Dodo annual checkout, and returns the checkout URL. The site deploys and goes live only when the verified `subscription.active` webhook confirms payment.

## How it works

- The deploy step was extracted from `publish()` into a reusable function, so it can run either at publish time (free tier) or at webhook time (paid tier).
- `publish_pocket()` branches on the resolved tier. Paid tier goes to `_publish_pending_site`: it upserts a pending Site doc, persists the deploy inputs on the doc (the webhook carries only `workspace_id` + `site_id`, and the pocket's draft may have moved on), opens the subscription, and returns the checkout URL. Free tier deploys live as today.
- `activate_site()` runs on the per-site `subscription.active` webhook: it deploys from the captured inputs and marks the site active. It is idempotent for at-least-once delivery and tenant-scoped (a missing or cross-tenant id raises `NotFound`).
- `SiteResponse` carries `checkout_url` (null for a free publish, the Dodo link for a paid one).

## The money invariant

A paid site never serves without a confirmed payment. An adversarial review confirmed this holds on every realistic path: the per-site webhook is reached only after the Standard-Webhooks signature is verified, activation is idempotent and tenant-scoped, and the free path is unchanged. A pending site has `deployed=False` and no Cloudflare worker, so it is not reachable until activation.

## Deliberate behavior worth your eye

- Re-publishing an already-live site onto a paid tier keeps the old site serving until the new subscription clears. We do not tear down a live site before payment.
- `subscription.cancelled` does not unpublish in v1. Lapse and teardown handling is a follow-up.
- A paid tier with no configured Dodo product falls back to an immediate live publish, so an operator misconfiguration never strands the user.
- A pending site that somehow has no captured deploy inputs stays pending and logs an error, rather than marking itself active without a deploy.

## Follow-ups from review (money-safe, not blocking)

- Cap the size of `pending_deploy_inputs` so a pathological spec cannot bloat the Site doc toward Mongo's per-doc limit.
- Persist the pending doc only after the checkout opens, so a checkout failure leaves no orphan pending row.

## Testing

90 tests across sites and billing, including the four charge-first cases (paid publish stays pending and returns a checkout URL with no deploy; the active webhook deploys the pending site; free publish deploys immediately; a Dodo-unconfigured paid tier falls back to live). Review verdict: ship.

Holding this for your review before merge.
