### PR TITLE
feat(sites): ship the paw-sites generator toolchain into the enterprise image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,3 +55,13 @@ idocs
 # Logs
 *.log
 temp
+
+# Vendored Paw Sites publish toolchain (DEP-1/DEP-2). The `dist`/`build` patterns
+# above are root-anchored, so they do NOT exclude the nested deploy/paw-sites/dist
+# tree (verified) — but keep these explicit negations so a future `**/dist`-style
+# pattern can't silently strip the vendored generator + ripple tarball the
+# PAW_SITES_SOURCE=vendor / RIPPLE_SOURCE=vendor build COPYs from the context.
+!deploy/paw-sites
+!deploy/paw-sites/**
+!deploy/ripple
+!deploy/ripple/**

--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -57,3 +57,36 @@ POCKETPAW_LICENSE_KEY=
 # ── OPTIONAL: agent backend + tools ───────────────────────────────────────
 # POCKETPAW_AGENT_BACKEND=claude_agent_sdk
 # POCKETPAW_TOOL_PROFILE=coding
+
+# ── Paw Sites — publish toolchain (baked into the image; override only to tune) ─
+# A live Paw Site publish shells out to the bundled paw-sites generator + bun and
+# installs @ripple-ui/svelte. The image already bakes sensible defaults — these are
+# here for visibility / override, NOT required for a publish to work.
+#   PAW_SITES_GEN_CMD     — the generator invocation. UNSET by default: the
+#                           `paw-sites-gen` wrapper is on PATH. Set only to point at
+#                           an alternate build, e.g. "node /path/cli.js".
+# PAW_SITES_GEN_CMD=
+#   PAW_SITES_RIPPLE_DEP  — the npm source the generated site's @ripple-ui/svelte
+#                           dep is rewritten to before install. Baked to the bundled
+#                           tarball; override to pin a published registry version
+#                           once ripple is public.
+# PAW_SITES_RIPPLE_DEP=file:/opt/ripple-ui-svelte-0.5.0.tgz
+#   PAW_SITES_MOTION_DEP  — motion.dev version the generated site declares (ripple
+#                           lazy-loads it). Keep in lockstep with ripple's pin.
+# PAW_SITES_MOTION_DEP=^12.40.0
+#
+# Build-time source switch (NOT runtime env — pass as docker --build-arg; see
+# deploy/README-build.md). Internal CI / Coolify clones the private sibling repos:
+#   PAW_SITES_SOURCE=clone   RIPPLE_SOURCE=clone
+#   PAW_SITES_REPO=https://github.com/qbtrix/paw-sites.git   PAW_SITES_REF=main
+#   RIPPLE_REPO=https://github.com/qbtrix/ripple-iui.git     RIPPLE_REF=main
+
+# ── Paw Sites — Cloudflare deploy (REQUIRED only for a LIVE edge deploy) ───────
+# A publish takes the REAL Cloudflare Workers-for-Platforms path when ALL of these
+# are set; otherwise it DEGRADES to a local static-serve (dev only — the site is
+# served from the container at a localhost URL, not the edge). Leave unset for a
+# dev / smoke deploy; set the group to ship sites live to Cloudflare.
+# PAW_CF_ACCOUNT_ID=
+# PAW_CF_API_TOKEN=
+# PAW_CF_ZONE_ID=
+# PAW_CF_DISPATCH_NAMESPACE=paw-sites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,15 @@ jobs:
     #   COOLIFY_API_TOKEN   — a Coolify API token with deploy permission
     # While the secrets are unset the job warns and exits green, so dev CI
     # doesn't go red before the one-time Coolify setup is done.
+    #
+    # Paw Sites toolchain (feat/paw-sites-prod-deploy, DEP-4): Dockerfile.enterprise
+    # bundles bun + the paw-sites generator + the @ripple-ui/svelte tarball so a live
+    # publish works. The vendored trees (deploy/paw-sites/, deploy/ripple/) are
+    # gitignored, so they are NOT in Coolify's clone — the Coolify app's build config
+    # MUST set the CLONE source for both:
+    #     PAW_SITES_SOURCE=clone   RIPPLE_SOURCE=clone
+    # (Coolify owns the docker build; this job only fires the webhook, so the args
+    # live in Coolify's app settings, not here.) See deploy/README-build.md.
     name: Deploy to Coolify
     runs-on: ubuntu-latest
     needs: [lint, build, test-oss, test, import-linter]

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,16 @@ private.key
 *.bak
 
 output.txt
+
+# Vendored Paw Sites publish toolchain (DEP-1/DEP-2) — build artifacts staged into
+# the build context by scripts/vendor-paw-sites.sh + scripts/vendor-ripple-tarball.sh
+# for a PAW_SITES_SOURCE=vendor / RIPPLE_SOURCE=vendor Dockerfile.enterprise build.
+# The artifacts themselves are never committed (mirrors paw-enterprise's
+# /deploy/ripple/): internal CI / Coolify builds with the `clone` source instead.
+# But the DIRS must exist in EVERY checkout (incl. Coolify's clone) — the Dockerfile
+# COPYs them unconditionally before the vendor/clone branch — so a tracked .gitkeep
+# keeps each dir present while its contents stay ignored.
+/deploy/paw-sites/*
+!/deploy/paw-sites/.gitkeep
+/deploy/ripple/*
+!/deploy/ripple/.gitkeep

--- a/Dockerfile.enterprise
+++ b/Dockerfile.enterprise
@@ -12,6 +12,34 @@
 #   * non-root pocketpaw user, 0.0.0.0:8888 bind, healthcheck.
 #
 # Changes:
+#   - 2026-06-25 (feat/paw-sites-prod-deploy, DEP-1 + DEP-2): the Paw Sites publish
+#     path shells out to the paw-sites generator (`paw-sites-gen`) + `bun` at
+#     publish time, and a generated ripple-track site installs `@ripple-ui/svelte`.
+#     This image previously shipped NONE of that toolchain, so every publish 500'd.
+#     Now bundled:
+#       * `bun` — COPY'd from the pinned `oven/bun:1.2-debian` image (no curl|bash),
+#         on PATH in the runtime stage.
+#       * `paw-sites-gen` — built in a `paw-sites` stage (vendor prebuilt tree, or
+#         clone+build) and COPY'd to /opt/paw-sites, symlinked at
+#         /usr/local/bin/paw-sites-gen. The generator is pure-Node (stdlib + local
+#         modules), so dist/ + templates/ + package.json is all it needs (no
+#         node_modules); it runs via `node`.
+#       * `@ripple-ui/svelte` tarball — built+packed in a `ripple` stage (vendor
+#         prebuilt .tgz, or clone+build+pack) and COPY'd to
+#         /opt/ripple-ui-svelte-0.5.0.tgz. Baked into
+#         `PAW_SITES_RIPPLE_DEP=file:/opt/ripple-ui-svelte-0.5.0.tgz` so the publish
+#         path rewrites the generated site's dep to a resolvable source, plus
+#         `PAW_SITES_MOTION_DEP` in lockstep with ripple's motion pin.
+#     Both sibling repos live OUTSIDE the pocketpaw build context, so each has a
+#     vendor/clone source switch (mirrors paw-enterprise/deploy/Dockerfile):
+#       * PAW_SITES_SOURCE / RIPPLE_SOURCE = `vendor` (default) COPYs a prebuilt
+#         tree from the build context (deploy/paw-sites/, deploy/ripple/), produced
+#         by scripts/vendor-paw-sites.sh + scripts/vendor-ripple-tarball.sh.
+#       * = `clone` (internal CI / Coolify, which HAS repo access) clones
+#         PAW_SITES_REPO / RIPPLE_REPO and builds in-image. The vendored trees are
+#         gitignored artifacts, so Coolify (which clones pocketpaw dev) MUST pass
+#         `--build-arg PAW_SITES_SOURCE=clone --build-arg RIPPLE_SOURCE=clone`.
+#         See deploy/README-build.md.
 #   - 2026-06-10 (sov/w1a-deploy): Added an ENTRYPOINT
 #     (docker-entrypoint.enterprise.sh) that generates + persists a stable
 #     AUTH_SECRET on first run, so the production-posture auth gate (W0e) is
@@ -19,9 +47,15 @@
 #     CMD stays `pocketpaw` so the command is still overridable. Bundled the kb
 #     binary + POCKETPAW_KB_BIN, and the FSL enterprise layer.
 # Build:
+#   # Vendor the generator + ripple tarball into the build context first (once):
+#   scripts/vendor-paw-sites.sh && scripts/vendor-ripple-tarball.sh
 #   docker compose -f docker-compose.enterprise.yml build
 #   # or directly:
 #   docker build -f Dockerfile.enterprise -t pocketpaw-ee .
+#   # Internal CI / Coolify (has private-repo access — no vendoring needed):
+#   docker build -f Dockerfile.enterprise \
+#     --build-arg PAW_SITES_SOURCE=clone --build-arg RIPPLE_SOURCE=clone \
+#     -t pocketpaw-ee .
 
 # ---- kb-go binary stage ----
 # The cloud KB / member-ingest features shell out to the `kb` binary
@@ -42,6 +76,101 @@ FROM node:22.14.0-slim AS node
 # Pre-install CLI-based agent backends so they're cached in this layer
 RUN npm install -g @anthropic-ai/claude-code @openai/codex && \
     npm cache clean --force
+
+# ---- bun stage ----
+# Pin the bun image so the runtime stage can COPY a known bun binary (no
+# curl|bash). 1.2+ is required to parse the text-format bun.lock used by ripple +
+# generated sites (same pin as paw-enterprise/deploy/Dockerfile). The paw-sites /
+# ripple builder stages below FROM this image so their `bun install`/`bun run
+# build`/`bun pm pack` all use the same bun.
+FROM oven/bun:1.2-debian AS bun
+
+# ---- paw-sites generator stage ----
+# Build (or vendor) the paw-sites generator so /usr/local/bin/paw-sites-gen is on
+# PATH in the runtime image. paw-sites is a SIBLING repo OUTSIDE the build context,
+# so it has a vendor/clone source switch (mirrors the FE's RIPPLE_SOURCE):
+#   vendor (default) — COPY the prebuilt deploy/paw-sites/ tree from the build
+#                      context (produced by scripts/vendor-paw-sites.sh). PUBLIC
+#                      path: no private-repo access needed.
+#   clone            — git clone PAW_SITES_REPO@PAW_SITES_REF and build in-image.
+#                      INTERNAL path (CI / Coolify with repo access).
+# The output at /out is the minimal runtime tree: dist/ (the compiled generator,
+# pure Node stdlib + local modules — NO external runtime deps) + templates/ (read
+# at runtime as a sibling of dist/) + package.json.
+FROM bun AS paw-sites
+ARG PAW_SITES_SOURCE=vendor
+ARG PAW_SITES_REPO=https://github.com/qbtrix/paw-sites.git
+ARG PAW_SITES_REF=main
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+# COPY the build-context dir unconditionally (it always exists — a tracked
+# .gitkeep keeps it present even in Coolify's clone, where the vendored artifacts
+# are gitignored and absent). On vendor it carries the prebuilt tree; on clone it
+# carries only .gitkeep and the branch below rm's + re-clones over it.
+COPY deploy/paw-sites/ /build/paw-sites/
+RUN if [ "$PAW_SITES_SOURCE" = "clone" ]; then \
+      echo "PAW_SITES_SOURCE=clone — building generator from $PAW_SITES_REPO @ $PAW_SITES_REF" && \
+      rm -rf /build/paw-sites && \
+      ( git clone --depth=1 --branch "$PAW_SITES_REF" "$PAW_SITES_REPO" /build/paw-sites \
+        || ( git clone "$PAW_SITES_REPO" /build/paw-sites && cd /build/paw-sites && git checkout "$PAW_SITES_REF" ) ) && \
+      cd /build/paw-sites && bun install --frozen-lockfile && bun run build ; \
+    else \
+      echo "PAW_SITES_SOURCE=vendor — using prebuilt generator from build context" && \
+      test -f /build/paw-sites/dist/cli.js \
+        || ( echo "ERROR: deploy/paw-sites/dist not found. Run scripts/vendor-paw-sites.sh first." && exit 1 ) ; \
+    fi && \
+    mkdir -p /out && \
+    cp -R /build/paw-sites/dist /out/dist && \
+    cp -R /build/paw-sites/templates /out/templates && \
+    cp /build/paw-sites/package.json /out/package.json && \
+    test -d /out/templates || ( echo "ERROR: generator templates/ missing — runtime generate would fail." && exit 1 )
+
+# ---- ripple tarball stage ----
+# Produce the @ripple-ui/svelte npm tarball a generated ripple-track site installs
+# (its dep is rewritten to file:/opt/ripple-ui-svelte-0.5.0.tgz at publish time).
+# ripple is also a SIBLING repo outside the context, so the same vendor/clone
+# switch applies:
+#   vendor (default) — COPY the prebuilt deploy/ripple/ripple-ui-svelte-0.5.0.tgz
+#                      (produced by scripts/vendor-ripple-tarball.sh).
+#   clone            — git clone RIPPLE_REPO@RIPPLE_REF, build, and `bun pm pack`.
+# Either way the tarball lands at /out/ripple-ui-svelte-0.5.0.tgz.
+FROM bun AS ripple
+ARG RIPPLE_SOURCE=vendor
+ARG RIPPLE_REPO=https://github.com/qbtrix/ripple-iui.git
+ARG RIPPLE_REF=main
+# Must match scripts/vendor-ripple-tarball.sh + @ripple-ui/svelte@0.5.0.
+ARG RIPPLE_TARBALL=ripple-ui-svelte-0.5.0.tgz
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+RUN mkdir -p /out
+# COPY the build-context dir unconditionally (always present via a tracked
+# .gitkeep, even in Coolify's clone where the tarball is gitignored/absent). On
+# vendor it carries the prebuilt .tgz; on clone it carries only .gitkeep and the
+# branch below builds + packs a fresh tarball into /out instead.
+COPY deploy/ripple/ /build/ripple-vendor/
+RUN if [ "$RIPPLE_SOURCE" = "clone" ]; then \
+      echo "RIPPLE_SOURCE=clone — building + packing ripple from $RIPPLE_REPO @ $RIPPLE_REF" && \
+      ( git clone --depth=1 --branch "$RIPPLE_REF" "$RIPPLE_REPO" /build/ripple \
+        || ( git clone "$RIPPLE_REPO" /build/ripple && cd /build/ripple && git checkout "$RIPPLE_REF" ) ) && \
+      cd /build/ripple && bun install --frozen-lockfile && bun run build && \
+      bun pm pack --destination /out >/dev/null && \
+      packed="$(ls -1 /out/*.tgz | head -n1)" && \
+      [ "$(basename "$packed")" = "$RIPPLE_TARBALL" ] || mv "$packed" "/out/$RIPPLE_TARBALL" ; \
+    else \
+      echo "RIPPLE_SOURCE=vendor — using prebuilt ripple tarball from build context" && \
+      test -f "/build/ripple-vendor/$RIPPLE_TARBALL" \
+        || ( echo "ERROR: deploy/ripple/$RIPPLE_TARBALL not found. Run scripts/vendor-ripple-tarball.sh first." && exit 1 ) && \
+      cp "/build/ripple-vendor/$RIPPLE_TARBALL" "/out/$RIPPLE_TARBALL" ; \
+    fi && \
+    test -f "/out/$RIPPLE_TARBALL" || ( echo "ERROR: ripple tarball missing after stage." && exit 1 )
 
 # ---- Builder stage ----
 FROM python:3.12-slim AS builder
@@ -109,6 +238,27 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js /usr/local/bin/claude && \
     ln -s /usr/local/lib/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex
 
+# --- Paw Sites publish toolchain (DEP-1 + DEP-2) ---
+# bun: the Sites publish path runs `bun install` + `bun run build` on the generated
+# SvelteKit project. COPY the pinned bun binary (no curl|bash) so it's on PATH.
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+# paw-sites generator: the runtime tree (dist/ + templates/ + package.json). The
+# generator is pure Node (stdlib + local modules), so it needs NO node_modules.
+# Expose it as the `paw-sites-gen` bin the publish path execs by default
+# (PAW_SITES_GEN_CMD left unset). cli.js carries NO shebang, and the publish path
+# execs the bin directly (asyncio.create_subprocess_exec, no shell), so a bare
+# symlink would hit "exec format error". Instead install a tiny wrapper WITH a
+# shebang that execs Node on the real entry. Node resolves `import.meta.url`
+# through to /opt/paw-sites/dist/cli.js, so the generator's runtime
+# `join(dirname(import.meta.url), '..', 'templates')` correctly finds
+# /opt/paw-sites/templates.
+COPY --from=paw-sites /out /opt/paw-sites
+RUN printf '#!/bin/sh\nexec node /opt/paw-sites/dist/cli.js "$@"\n' > /usr/local/bin/paw-sites-gen && \
+    chmod 0755 /usr/local/bin/paw-sites-gen
+# ripple tarball: a generated ripple-track site installs @ripple-ui/svelte from the
+# `file:` spec baked into PAW_SITES_RIPPLE_DEP below.
+COPY --from=ripple /out/ripple-ui-svelte-0.5.0.tgz /opt/ripple-ui-svelte-0.5.0.tgz
+
 # Copy venv from builder
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
@@ -149,6 +299,17 @@ ENV POCKETPAW_ENV=production
 ENV POCKETPAW_KB_BIN=/usr/local/bin/kb
 # Agent-created files land here — bind-mount to access them on the host
 ENV POCKETPAW_FILE_JAIL_PATH=/home/pocketpaw/workspace
+
+# --- Paw Sites publish toolchain config (DEP-2) ---
+# A generated ripple-track site pins an unpublished @ripple-ui/svelte; the publish
+# path rewrites that dep to PAW_SITES_RIPPLE_DEP before `bun install`. Point it at
+# the bundled tarball so the install resolves with no registry / private-repo
+# access. PAW_SITES_MOTION_DEP must stay in LOCKSTEP with ripple's motion pin
+# (ripple/package.json -> "motion": "^12.40.0") — ripple lazy-loads motion via a
+# client-only dynamic import, so the generated site declares it directly.
+# PAW_SITES_GEN_CMD is deliberately UNSET: the `paw-sites-gen` wrapper is on PATH.
+ENV PAW_SITES_RIPPLE_DEP=file:/opt/ripple-ui-svelte-0.5.0.tgz
+ENV PAW_SITES_MOTION_DEP=^12.40.0
 
 EXPOSE 8888
 

--- a/Dockerfile.enterprise
+++ b/Dockerfile.enterprise
@@ -23,7 +23,11 @@
 #         clone+build) and COPY'd to /opt/paw-sites, symlinked at
 #         /usr/local/bin/paw-sites-gen. The generator is pure-Node (stdlib + local
 #         modules), so dist/ + templates/ + package.json is all it needs (no
-#         node_modules); it runs via `node`.
+#         node_modules); it runs via `node`. On the CLONE path its package.json pins
+#         @ripple-ui/svelte = "file:../ripple" (absent in that stage), so the stage
+#         rewrites that one dep to the 0.5.0 tarball the `ripple` stage builds before
+#         `bun install` — the generator never imports ripple (string literals only),
+#         so this just satisfies the installer.
 #       * `@ripple-ui/svelte` tarball — built+packed in a `ripple` stage (vendor
 #         prebuilt .tgz, or clone+build+pack) and COPY'd to
 #         /opt/ripple-ui-svelte-0.5.0.tgz. Baked into
@@ -85,53 +89,12 @@ RUN npm install -g @anthropic-ai/claude-code @openai/codex && \
 # build`/`bun pm pack` all use the same bun.
 FROM oven/bun:1.2-debian AS bun
 
-# ---- paw-sites generator stage ----
-# Build (or vendor) the paw-sites generator so /usr/local/bin/paw-sites-gen is on
-# PATH in the runtime image. paw-sites is a SIBLING repo OUTSIDE the build context,
-# so it has a vendor/clone source switch (mirrors the FE's RIPPLE_SOURCE):
-#   vendor (default) — COPY the prebuilt deploy/paw-sites/ tree from the build
-#                      context (produced by scripts/vendor-paw-sites.sh). PUBLIC
-#                      path: no private-repo access needed.
-#   clone            — git clone PAW_SITES_REPO@PAW_SITES_REF and build in-image.
-#                      INTERNAL path (CI / Coolify with repo access).
-# The output at /out is the minimal runtime tree: dist/ (the compiled generator,
-# pure Node stdlib + local modules — NO external runtime deps) + templates/ (read
-# at runtime as a sibling of dist/) + package.json.
-FROM bun AS paw-sites
-ARG PAW_SITES_SOURCE=vendor
-ARG PAW_SITES_REPO=https://github.com/qbtrix/paw-sites.git
-ARG PAW_SITES_REF=main
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /build
-# COPY the build-context dir unconditionally (it always exists — a tracked
-# .gitkeep keeps it present even in Coolify's clone, where the vendored artifacts
-# are gitignored and absent). On vendor it carries the prebuilt tree; on clone it
-# carries only .gitkeep and the branch below rm's + re-clones over it.
-COPY deploy/paw-sites/ /build/paw-sites/
-RUN if [ "$PAW_SITES_SOURCE" = "clone" ]; then \
-      echo "PAW_SITES_SOURCE=clone — building generator from $PAW_SITES_REPO @ $PAW_SITES_REF" && \
-      rm -rf /build/paw-sites && \
-      ( git clone --depth=1 --branch "$PAW_SITES_REF" "$PAW_SITES_REPO" /build/paw-sites \
-        || ( git clone "$PAW_SITES_REPO" /build/paw-sites && cd /build/paw-sites && git checkout "$PAW_SITES_REF" ) ) && \
-      cd /build/paw-sites && bun install --frozen-lockfile && bun run build ; \
-    else \
-      echo "PAW_SITES_SOURCE=vendor — using prebuilt generator from build context" && \
-      test -f /build/paw-sites/dist/cli.js \
-        || ( echo "ERROR: deploy/paw-sites/dist not found. Run scripts/vendor-paw-sites.sh first." && exit 1 ) ; \
-    fi && \
-    mkdir -p /out && \
-    cp -R /build/paw-sites/dist /out/dist && \
-    cp -R /build/paw-sites/templates /out/templates && \
-    cp /build/paw-sites/package.json /out/package.json && \
-    test -d /out/templates || ( echo "ERROR: generator templates/ missing — runtime generate would fail." && exit 1 )
-
 # ---- ripple tarball stage ----
 # Produce the @ripple-ui/svelte npm tarball a generated ripple-track site installs
 # (its dep is rewritten to file:/opt/ripple-ui-svelte-0.5.0.tgz at publish time).
+# Defined BEFORE the paw-sites stage because that stage COPYs --from=ripple (the
+# clone path installs the generator's @ripple-ui/svelte dep from this tarball) — a
+# COPY --from must reference an earlier-defined stage.
 # ripple is also a SIBLING repo outside the context, so the same vendor/clone
 # switch applies:
 #   vendor (default) — COPY the prebuilt deploy/ripple/ripple-ui-svelte-0.5.0.tgz
@@ -171,6 +134,69 @@ RUN if [ "$RIPPLE_SOURCE" = "clone" ]; then \
       cp "/build/ripple-vendor/$RIPPLE_TARBALL" "/out/$RIPPLE_TARBALL" ; \
     fi && \
     test -f "/out/$RIPPLE_TARBALL" || ( echo "ERROR: ripple tarball missing after stage." && exit 1 )
+
+# ---- paw-sites generator stage ----
+# Build (or vendor) the paw-sites generator so /usr/local/bin/paw-sites-gen is on
+# PATH in the runtime image. paw-sites is a SIBLING repo OUTSIDE the build context,
+# so it has a vendor/clone source switch (mirrors the FE's RIPPLE_SOURCE):
+#   vendor (default) — COPY the prebuilt deploy/paw-sites/ tree from the build
+#                      context (produced by scripts/vendor-paw-sites.sh). PUBLIC
+#                      path: no private-repo access needed.
+#   clone            — git clone PAW_SITES_REPO@PAW_SITES_REF and build in-image.
+#                      INTERNAL path (CI / Coolify with repo access).
+# The output at /out is the minimal runtime tree: dist/ (the compiled generator,
+# pure Node stdlib + local modules — NO external runtime deps) + templates/ (read
+# at runtime as a sibling of dist/) + package.json.
+FROM bun AS paw-sites
+ARG PAW_SITES_SOURCE=vendor
+ARG PAW_SITES_REPO=https://github.com/qbtrix/paw-sites.git
+ARG PAW_SITES_REF=main
+# Must match the `ripple` stage's tarball name (the clone path installs the
+# generator's @ripple-ui/svelte dep from it).
+ARG RIPPLE_TARBALL=ripple-ui-svelte-0.5.0.tgz
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# The generator's package.json pins @ripple-ui/svelte = "file:../ripple". On the
+# CLONE path ../ripple does NOT exist in this stage, so `bun install` can't resolve
+# that file: dep and fails. The generator only references @ripple-ui/svelte as
+# STRING LITERALS (an allowlist version const + template text it emits into
+# generated sites) — it has NO real import of it — so `tsc` does not need it
+# resolved; only `bun install` chokes. Fix: install the dep from the real 0.5.0
+# tarball the `ripple` stage already builds. COPY it in (a no-op cost on the vendor
+# path, which never touches it).
+COPY --from=ripple /out/${RIPPLE_TARBALL} /opt/${RIPPLE_TARBALL}
+
+WORKDIR /build
+# COPY the build-context dir unconditionally (it always exists — a tracked
+# .gitkeep keeps it present even in Coolify's clone, where the vendored artifacts
+# are gitignored and absent). On vendor it carries the prebuilt tree; on clone it
+# carries only .gitkeep and the branch below rm's + re-clones over it.
+COPY deploy/paw-sites/ /build/paw-sites/
+RUN if [ "$PAW_SITES_SOURCE" = "clone" ]; then \
+      echo "PAW_SITES_SOURCE=clone — building generator from $PAW_SITES_REPO @ $PAW_SITES_REF" && \
+      rm -rf /build/paw-sites && \
+      ( git clone --depth=1 --branch "$PAW_SITES_REF" "$PAW_SITES_REPO" /build/paw-sites \
+        || ( git clone "$PAW_SITES_REPO" /build/paw-sites && cd /build/paw-sites && git checkout "$PAW_SITES_REF" ) ) && \
+      cd /build/paw-sites && \
+      # Rewrite the unresolvable file:../ripple dep to the bundled 0.5.0 tarball so
+      # `bun install` resolves. Drop --frozen-lockfile (package.json now differs from
+      # the committed lock by exactly this one key). tsc doesn't need ripple, so this
+      # only satisfies the installer.
+      bun -e 'const f="package.json";const p=JSON.parse(require("fs").readFileSync(f));p.dependencies["@ripple-ui/svelte"]="file:/opt/'"$RIPPLE_TARBALL"'";require("fs").writeFileSync(f,JSON.stringify(p,null,2));' && \
+      bun install && bun run build ; \
+    else \
+      echo "PAW_SITES_SOURCE=vendor — using prebuilt generator from build context" && \
+      test -f /build/paw-sites/dist/cli.js \
+        || ( echo "ERROR: deploy/paw-sites/dist not found. Run scripts/vendor-paw-sites.sh first." && exit 1 ) ; \
+    fi && \
+    mkdir -p /out && \
+    cp -R /build/paw-sites/dist /out/dist && \
+    cp -R /build/paw-sites/templates /out/templates && \
+    cp /build/paw-sites/package.json /out/package.json && \
+    test -d /out/templates || ( echo "ERROR: generator templates/ missing — runtime generate would fail." && exit 1 )
 
 # ---- Builder stage ----
 FROM python:3.12-slim AS builder

--- a/deploy/README-build.md
+++ b/deploy/README-build.md
@@ -1,0 +1,108 @@
+<!--
+  deploy/README-build.md -- how to build the PocketPaw Enterprise image with the
+  Paw Sites publish toolchain bundled.
+  Created 2026-06-25 (feat/paw-sites-prod-deploy, DEP-4): documents the
+  vendor/clone source switch for the paw-sites generator + the @ripple-ui/svelte
+  tarball that Dockerfile.enterprise needs so a live `POST /sites/publish` works in
+  the deployed image (it previously 500'd — the image shipped no bun / generator /
+  ripple).
+-->
+
+# Building the PocketPaw Enterprise image (with Paw Sites publishing)
+
+`Dockerfile.enterprise` builds the sovereign per-tenant enterprise image. A live
+**Paw Site publish** shells out, at publish time, to:
+
+1. `paw-sites-gen build ...` — the site generator CLI,
+2. `bun install` + `bun run build` — on the generated SvelteKit project.
+
+The generated ripple-track site also installs `@ripple-ui/svelte`. So the runtime
+image must carry **bun**, the **paw-sites-gen** binary, and a resolvable
+**`@ripple-ui/svelte`** package. Both `paw-sites` and `ripple` are private SIBLING
+repos OUTSIDE the pocketpaw build context, so each has a `vendor` / `clone` source
+switch — the same pattern as `paw-enterprise/deploy/Dockerfile`.
+
+## 1. Build without private-repo access (vendored — the default)
+
+`PAW_SITES_SOURCE=vendor` (default) and `RIPPLE_SOURCE=vendor` (default) COPY
+prebuilt trees from the build context. Stage them once before building:
+
+```bash
+# Generator → deploy/paw-sites/ (dist/ + templates/ + package.json)
+scripts/vendor-paw-sites.sh
+# @ripple-ui/svelte tarball → deploy/ripple/ripple-ui-svelte-0.5.0.tgz
+scripts/vendor-ripple-tarball.sh
+```
+
+Both scripts vendor from the sibling `../paw-sites` / `../ripple` checkouts by
+default; override the source dir with `PAW_SITES_DIR=...` / `RIPPLE_DIR=...` (e.g. a
+CI-downloaded checkout). Then build:
+
+```bash
+docker build -f Dockerfile.enterprise -t pocketpaw-ee .
+# or: docker compose -f docker-compose.enterprise.yml build
+```
+
+`deploy/paw-sites/` and `deploy/ripple/` are gitignored build artifacts (mirroring
+the FE's `deploy/ripple/`) — distribute them as a released tarball / OCI layer to
+customers who don't have the private source.
+
+## 2. Internal CI / Coolify (clone — needs private-repo access)
+
+The Coolify app clones pocketpaw `dev` and builds `Dockerfile.enterprise`. The
+vendored trees are gitignored, so they are **not** in that clone — Coolify must
+build with the `clone` source, which clones + builds the sibling repos in-image.
+Set these two build args in the Coolify app's build configuration (Coolify owns the
+`docker build`; the CI `deploy-coolify` job only fires the deploy webhook):
+
+```
+PAW_SITES_SOURCE=clone
+RIPPLE_SOURCE=clone
+```
+
+Optionally pin the refs (defaults: repos below, ref `main`):
+
+```
+PAW_SITES_REPO=https://github.com/qbtrix/paw-sites.git
+PAW_SITES_REF=main
+RIPPLE_REPO=https://github.com/qbtrix/ripple-iui.git
+RIPPLE_REF=main
+```
+
+Equivalent direct build:
+
+```bash
+docker build -f Dockerfile.enterprise \
+  --build-arg PAW_SITES_SOURCE=clone \
+  --build-arg RIPPLE_SOURCE=clone \
+  -t pocketpaw-ee .
+```
+
+We default the Dockerfile to `vendor` (the local / released-build path) and put
+`clone` on Coolify rather than the reverse, because the clone path needs network +
+private-repo credentials at build time — a property the internal CI runner has and
+an air-gapped customer build does not.
+
+## 3. Why this is the lower-risk choice for Coolify
+
+The alternative — having the CI `deploy-coolify` job run the vendor scripts and
+commit/push the artifacts before the webhook — was rejected: it would commit large
+build artifacts to `dev`, and Coolify rebuilds from its own clone anyway, so the
+artifacts would have to be pushed to a branch Coolify sees. The `clone` source keeps
+the artifacts out of git entirely and lets Coolify build the exact pinned refs, at
+the cost of a longer first build (cached afterward).
+
+## 4. Runtime env (baked, overridable)
+
+The image bakes these so a publish resolves with no extra config (see
+`.env.enterprise.example` for the full list):
+
+- `PAW_SITES_RIPPLE_DEP=file:/opt/ripple-ui-svelte-0.5.0.tgz` — the bundled ripple
+  tarball the publish path rewrites the generated site's dep to.
+- `PAW_SITES_MOTION_DEP=^12.40.0` — kept in lockstep with ripple's motion pin.
+- `paw-sites-gen` is on `PATH` (a wrapper at `/usr/local/bin/paw-sites-gen` that
+  execs `node /opt/paw-sites/dist/cli.js`), so `PAW_SITES_GEN_CMD` stays unset.
+
+A LIVE Cloudflare deploy additionally needs the `PAW_CF_*` group (account id, API
+token, zone, dispatch namespace) — see `.env.enterprise.example`. Without them the
+publish degrades to the local static-serve path (dev only).

--- a/deploy/paw-sites/.gitkeep
+++ b/deploy/paw-sites/.gitkeep
@@ -1,0 +1,3 @@
+# Keep this dir present in every checkout so Dockerfile.enterprise can COPY it
+# even on the clone source path (Coolify). Vendored artifacts live here but are
+# gitignored — see scripts/vendor-paw-sites.sh + .gitignore.

--- a/deploy/ripple/.gitkeep
+++ b/deploy/ripple/.gitkeep
@@ -1,0 +1,3 @@
+# Keep this dir present in every checkout so Dockerfile.enterprise can COPY it
+# even on the clone source path (Coolify). The vendored ripple tarball lives here
+# but is gitignored — see scripts/vendor-ripple-tarball.sh + .gitignore.

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,18 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-06-25 (feat/paw-sites-prod-deploy, DEP-3 — graceful generator
+# failure): the publish path shells out to the paw-sites generator + bun, which in
+# a misconfigured deploy (an image missing the toolchain) raised a bare
+# FileNotFoundError / RuntimeError / SmokeGateFailed that escaped publish() as an
+# UNHANDLED 500 (the cloud error handler maps ONLY CloudError). New helper
+# ``_build_or_cloud_error`` wraps EVERY generator.build() call in the publish path
+# (the live build in ``_deploy_site_doc`` and the preview build in ``publish``) and
+# maps those build/install/smoke failures to ``Internal("sites.generator_failed")``
+# (a clean 5xx envelope with a reason), chaining the cause for logs. A CloudError
+# raised inside the build (an injected fake, the existing SmokeGateFailed-driven
+# rollback callers) is re-raised unchanged so its own status/code stand.
+#
 # Updated 2026-06-24 (feat/charge-first-sites — charge-first per-site publishing):
 # a PAID site tier (positive ``annual_price_usd`` AND a configured
 # ``dodo_product_id``) is now CHARGE-FIRST — published as PENDING and NOT deployed
@@ -371,7 +383,14 @@ from typing import Any
 from bson import ObjectId
 from bson.errors import InvalidId
 
-from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.errors import (
+    CloudError,
+    Forbidden,
+    Internal,
+    NotFound,
+    ValidationError,
+    with_cause,
+)
 from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
 from pocketpaw_ee.sites.domain import HostnameStatus
@@ -412,6 +431,66 @@ _SITES_PLAN_FEATURE = "fabric"
 
 def _default_bundle_reader(project_dir: str) -> bytes:
     return Path(project_dir, _WORKER_BUNDLE_REL).read_bytes()
+
+
+async def _build_or_cloud_error(
+    generator: GeneratorClient, *, map_smoke_gate: bool = True, **build_kwargs: Any
+) -> Any:
+    """Run ``generator.build(...)`` and map any build/install/smoke failure to a
+    ``CloudError`` so a publish never escapes as an UNHANDLED 500 (DEP-3).
+
+    The generator shells out to the paw-sites generator (paw-sites-gen) + bun. In a
+    misconfigured deploy (e.g. an image missing the toolchain — the bug this fix
+    addresses) ``build()`` raises a bare ``FileNotFoundError`` (no such binary on
+    PATH); on a non-zero generator step it raises ``RuntimeError``; a failed install
+    or the workerd SSR fail-gate raises ``SmokeGateFailed`` (a ``RuntimeError``
+    subclass). None of those are ``CloudError`` subclasses, so the cloud error
+    handler (which maps ONLY ``CloudError``) would let them surface as an opaque 500
+    with no machine-readable code. This maps them to ``Internal`` (``CloudError`` →
+    500 with code ``sites.generator_failed``) so the API returns a clean envelope
+    with a reason instead — and chains the cause for log context (the cause is never
+    leaked in the client envelope). ``CloudError`` raised inside the build is
+    re-raised unchanged so its own status/code/message stand.
+
+    ``map_smoke_gate`` (default True) controls whether ``SmokeGateFailed`` is mapped
+    too. The LIVE publish path (``_deploy_site_doc``) maps it — nothing downstream
+    catches it there, so it would escape as a 500. The PREVIEW/edit path passes
+    ``map_smoke_gate=False`` so ``SmokeGateFailed`` propagates RAW: the edit caller
+    (``edit_svelte_component``) catches it to roll the component source back to its
+    prior contents, a contract that must be preserved (mapping it to ``Internal``
+    would silently break that rollback)."""
+    from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+    try:
+        return await generator.build(**build_kwargs)
+    except CloudError:
+        # Already a clean envelope — let it stand (status/code/message preserved).
+        raise
+    except SmokeGateFailed as exc:
+        if not map_smoke_gate:
+            # Preview/edit path: let the caller's rollback-on-SmokeGateFailed run.
+            raise
+        logger.error("sites.publish: generator smoke gate failed", exc_info=True)
+        raise with_cause(
+            Internal(
+                "sites.generator_failed",
+                "Site generation failed — the publishing toolchain is unavailable "
+                "or the build did not complete. See server logs for details.",
+            ),
+            exc,
+        ) from exc
+    except (FileNotFoundError, RuntimeError, OSError) as exc:
+        # Missing toolchain / non-zero generator step → a real server-side infra
+        # failure, so a 5xx with a reason (not a 4xx — the request was well-formed).
+        logger.error("sites.publish: generator build failed", exc_info=True)
+        raise with_cause(
+            Internal(
+                "sites.generator_failed",
+                "Site generation failed — the publishing toolchain is unavailable "
+                "or the build did not complete. See server logs for details.",
+            ),
+            exc,
+        ) from exc
 
 
 def _preview_id(pocket_id: str) -> str:
@@ -868,7 +947,13 @@ async def publish(
     if preview:
         from pocketpaw_ee.sites import local_server
 
-        build = await generator.build(
+        # DEP-3: map a missing-toolchain / non-zero generator failure to a clean
+        # CloudError so the preview/edit/arm path never 500s opaquely either, BUT
+        # leave SmokeGateFailed RAW (map_smoke_gate=False) so edit_svelte_component's
+        # rollback-on-SmokeGateFailed contract is preserved on this preview path.
+        build = await _build_or_cloud_error(
+            generator,
+            map_smoke_gate=False,
             ripple_spec=ripple_spec,
             theme=theme,
             site_id=site_id,
@@ -987,7 +1072,13 @@ async def _deploy_site_doc(
     is deployed and no doc is flipped to deployed.
     """
     gen = generator or GeneratorClient()
-    build = await gen.build(
+    # DEP-3: map a generator/install/smoke failure (missing toolchain, non-zero
+    # build, SSR fail-gate) to a clean CloudError (sites.generator_failed → 5xx)
+    # instead of letting a bare FileNotFoundError / RuntimeError / SmokeGateFailed
+    # escape as an unhandled 500. A misconfigured image (no paw-sites-gen / bun on
+    # PATH) is the bug this guards.
+    build = await _build_or_cloud_error(
+        gen,
         ripple_spec=ripple_spec,
         theme=theme,
         site_id=site_id,

--- a/scripts/vendor-paw-sites.sh
+++ b/scripts/vendor-paw-sites.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/vendor-paw-sites.sh -- stage the prebuilt paw-sites GENERATOR into
+# deploy/paw-sites/ so Dockerfile.enterprise can build the enterprise image
+# WITHOUT clone access to the private paw-sites repo (the PAW_SITES_SOURCE=vendor
+# path, mirroring paw-enterprise/scripts/vendor-ripple.sh).
+#
+# Created 2026-06-25 (feat/paw-sites-prod-deploy, DEP-4). The Sites publish path
+# shells out to ``paw-sites-gen`` (the generator CLI) at publish time; the
+# enterprise image needs that binary on PATH. paw-sites is a SIBLING repo OUTSIDE
+# the pocketpaw build context, so a plain ``COPY ../paw-sites`` is impossible —
+# this script copies the minimal runtime tree (built ``dist/`` + ``templates/`` +
+# ``package.json``) into ``deploy/paw-sites/``, which the Dockerfile COPYs to
+# ``/opt/paw-sites`` and symlinks as ``/usr/local/bin/paw-sites-gen``.
+#
+# What the runtime tree needs (and why this minimal set is enough):
+#   * dist/        — the compiled generator (``tsc`` output; ``dist/cli.js`` is the
+#                    bin). Its own top-level imports are node: stdlib + local ./
+#                    modules ONLY — it has NO external runtime deps, so no
+#                    node_modules is shipped.
+#   * templates/   — the generator resolves these at RUNTIME via
+#                    ``join(dirname(import.meta.url), '..', 'templates')`` from
+#                    dist/, so templates/ MUST sit as a sibling of dist/ under
+#                    /opt/paw-sites. Omitting it breaks every generate.
+#   * package.json — carries the ``bin`` map + ``type: module``; harmless to ship.
+#
+# Source precedence:
+#   1. $PAW_SITES_DIR (explicit override) — e.g. a CI-downloaded checkout.
+#   2. ../paw-sites (sibling checkout) — the workspace dev layout. Its dist/ is a
+#      gitignored build artifact, so this script runs the build if dist is missing.
+#
+# Usage:
+#   scripts/vendor-paw-sites.sh                          # vendor from ../paw-sites
+#   PAW_SITES_DIR=/path/to/paw-sites scripts/vendor-paw-sites.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$HERE/deploy/paw-sites"
+SRC="${PAW_SITES_DIR:-$HERE/../paw-sites}"
+
+if [ ! -d "$SRC" ]; then
+  echo "ERROR: paw-sites source not found at '$SRC'." >&2
+  echo "Set PAW_SITES_DIR to a paw-sites checkout." >&2
+  exit 1
+fi
+
+# Build the generator's dist if it's absent (sibling checkout: dist/ is gitignored).
+if [ ! -f "$SRC/dist/cli.js" ]; then
+  echo "[vendor-paw-sites] dist/ missing in '$SRC' — building it"
+  ( cd "$SRC" && bun install --frozen-lockfile && bun run build )
+fi
+
+if [ ! -f "$SRC/dist/cli.js" ]; then
+  echo "ERROR: '$SRC/dist/cli.js' still missing after build." >&2
+  exit 1
+fi
+
+if [ ! -d "$SRC/templates" ]; then
+  echo "ERROR: '$SRC/templates' missing — the generator reads these at runtime." >&2
+  exit 1
+fi
+
+echo "[vendor-paw-sites] vendoring $SRC -> $DEST"
+rm -rf "$DEST"
+mkdir -p "$DEST"
+cp "$SRC/package.json" "$DEST/package.json"
+cp -R "$SRC/dist" "$DEST/dist"
+cp -R "$SRC/templates" "$DEST/templates"
+
+echo "[vendor-paw-sites] done. deploy/paw-sites/ is ready for a PAW_SITES_SOURCE=vendor build."

--- a/scripts/vendor-ripple-tarball.sh
+++ b/scripts/vendor-ripple-tarball.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# scripts/vendor-ripple-tarball.sh -- pack the built @ripple-ui/svelte package into
+# a resolvable npm TARBALL staged at deploy/ripple/ripple-ui-svelte-0.5.0.tgz, so
+# Dockerfile.enterprise can satisfy a generated Paw Site's @ripple-ui/svelte
+# dependency WITHOUT clone access to the private ripple repo (the
+# RIPPLE_SOURCE=vendor path).
+#
+# Created 2026-06-25 (feat/paw-sites-prod-deploy, DEP-2). A generated ripple-track
+# site pins @ripple-ui/svelte and, before ``bun install``, the Sites publish path
+# rewrites that dep to ``PAW_SITES_RIPPLE_DEP`` — baked in the image as
+# ``file:/opt/ripple-ui-svelte-0.5.0.tgz``. This script produces that tarball.
+#
+# Why a tarball (not a vendored dist tree like the FE): a generated site installs
+# @ripple-ui/svelte as a NORMAL dependency from a ``file:`` spec; a ``file:`` to a
+# packed .tgz is the resolvable, self-contained form bun installs cleanly. Packing
+# (``bun pm pack``) respects ripple's package.json ``files`` field, so the tarball
+# carries exactly the published surface (dist/ minus tests) + package.json.
+#
+# Source precedence:
+#   1. $RIPPLE_DIR (explicit override) — e.g. a CI-downloaded checkout.
+#   2. ../ripple (sibling checkout) — the workspace dev layout. Its dist/ is a
+#      gitignored build artifact, so this script builds it first if missing.
+#
+# Usage:
+#   scripts/vendor-ripple-tarball.sh                    # pack from ../ripple
+#   RIPPLE_DIR=/path/to/ripple scripts/vendor-ripple-tarball.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$HERE/deploy/ripple"
+SRC="${RIPPLE_DIR:-$HERE/../ripple}"
+# Must match the file the Dockerfile bakes into PAW_SITES_RIPPLE_DEP and the
+# version in ripple/package.json (@ripple-ui/svelte@0.5.0).
+TARBALL="ripple-ui-svelte-0.5.0.tgz"
+
+if [ ! -d "$SRC" ]; then
+  echo "ERROR: ripple source not found at '$SRC'." >&2
+  echo "Set RIPPLE_DIR to a ripple checkout." >&2
+  exit 1
+fi
+
+# Build ripple's dist if it's absent (sibling checkout: dist/ is gitignored).
+if [ ! -f "$SRC/dist/index.js" ]; then
+  echo "[vendor-ripple-tarball] dist/ missing in '$SRC' — building it"
+  ( cd "$SRC" && bun install --frozen-lockfile && bun run build )
+fi
+
+if [ ! -f "$SRC/dist/index.js" ]; then
+  echo "ERROR: '$SRC/dist/index.js' still missing after build." >&2
+  exit 1
+fi
+
+echo "[vendor-ripple-tarball] packing $SRC -> $DEST/$TARBALL"
+rm -rf "$DEST"
+mkdir -p "$DEST"
+# ``bun pm pack`` writes the .tgz into the package dir; --destination targets DEST.
+# The packed name is derived from name+version, so normalize to the expected file.
+( cd "$SRC" && bun pm pack --destination "$DEST" >/dev/null )
+
+# bun names the tarball "<scope>-<name>-<version>.tgz" (e.g.
+# ripple-ui-svelte-0.5.0.tgz). Normalize whatever was produced to the exact name
+# the Dockerfile/PAW_SITES_RIPPLE_DEP expects.
+produced="$(ls -1 "$DEST"/*.tgz 2>/dev/null | head -n1 || true)"
+if [ -z "$produced" ]; then
+  echo "ERROR: no .tgz produced by 'bun pm pack' in '$DEST'." >&2
+  exit 1
+fi
+if [ "$(basename "$produced")" != "$TARBALL" ]; then
+  mv "$produced" "$DEST/$TARBALL"
+fi
+
+echo "[vendor-ripple-tarball] done. $DEST/$TARBALL is ready for a RIPPLE_SOURCE=vendor build."

--- a/tests/ee/sites/test_publish_generator_failure.py
+++ b/tests/ee/sites/test_publish_generator_failure.py
@@ -1,0 +1,162 @@
+# tests/ee/sites/test_publish_generator_failure.py
+# Created: 2026-06-25 (feat/paw-sites-prod-deploy, DEP-3) — reproduce-first coverage
+# for the "publish path crashes with an unhandled 500 when the generator toolchain
+# is missing" bug.
+#
+# In the deployed enterprise image the publish path shells out to the paw-sites
+# generator (paw-sites-gen) + bun at build time. Before DEP-1/DEP-2 the image
+# shipped none of that toolchain, so generator.build() raised a bare
+# FileNotFoundError (no such binary on PATH) / RuntimeError (generator non-zero
+# exit) that escaped publish() as an UNHANDLED 500 — the cloud error handler only
+# maps CloudError subclasses, so anything else surfaces as an opaque 500 with no
+# machine-readable code.
+#
+# DEP-3 wraps the unconditional generator.build() call in the publish path so a
+# generator / install / smoke failure maps to a clean CloudError (Internal →
+# 500 with code "sites.generator_failed") instead. These tests assert that
+# mapping: point PAW_SITES_GEN_CMD at a non-existent binary (the real prod
+# failure) — or inject a runner that raises — and require a CloudError, NOT a raw
+# FileNotFoundError / RuntimeError / SmokeGateFailed.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+def _ripple_spec() -> dict:
+    return {"version": 1, "state": {}, "ui": {"type": "container"}}
+
+
+class TestPublishGeneratorFailureMapsToCloudError:
+    @pytest.mark.asyncio
+    async def test_missing_generator_binary_is_cloud_error_not_500(
+        self, beanie_test_db, monkeypatch
+    ) -> None:
+        """The exact prod failure: the generator binary is not on PATH. With the
+        REAL subprocess runner, generator.build() raises FileNotFoundError when it
+        tries to exec a non-existent ``paw-sites-gen``. The publish path must map
+        that to a CloudError (a clean 5xx envelope), NOT let it escape as an
+        unhandled 500."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud._core.errors import CloudError
+        from pocketpaw_ee.sites import service as sites_service
+
+        # Force LOCAL deploy mode (no Cloudflare creds) and point the generator at a
+        # binary that does not exist, so the REAL subprocess runner's exec fails with
+        # FileNotFoundError inside generator.build().
+        monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+        monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+        monkeypatch.setenv("PAW_SITES_GEN_CMD", "/nonexistent/paw-sites-gen-does-not-exist-xyz")
+        # Keep the per-pocket build dir off the real home.
+        monkeypatch.setenv("PAW_SITES_BUILD_DIR", "/tmp/paw-sites-test-build")
+
+        workspace_id = str(ObjectId())
+        user_id = str(ObjectId())
+        pocket_id = str(ObjectId())
+
+        with pytest.raises(CloudError) as ei:
+            await sites_service.publish(
+                workspace_id=workspace_id,
+                user_id=user_id,
+                pocket_id=pocket_id,
+                ripple_spec=_ripple_spec(),
+                theme={},
+                name="Acme",
+            )
+        # A real cloud envelope: a 5xx with a machine-readable code, never an
+        # unhandled 500 (which would NOT be a CloudError at all).
+        assert 500 <= ei.value.status_code < 600
+        assert ei.value.code == "sites.generator_failed"
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_from_generator_is_cloud_error(
+        self, beanie_test_db, monkeypatch
+    ) -> None:
+        """A generator that exits non-zero raises RuntimeError("generator failed:
+        ...") inside build(). The publish path must surface that as a CloudError,
+        not an unhandled 500. Injected via a fake generator so no subprocess runs."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud._core.errors import CloudError
+        from pocketpaw_ee.sites import service as sites_service
+
+        monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+        monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+        class _BoomGenerator:
+            async def build(self, **_kwargs):  # noqa: ANN003
+                raise RuntimeError("generator failed: boom from tsc")
+
+        with pytest.raises(CloudError) as ei:
+            await sites_service.publish(
+                workspace_id=str(ObjectId()),
+                user_id=str(ObjectId()),
+                pocket_id=str(ObjectId()),
+                ripple_spec=_ripple_spec(),
+                theme={},
+                name="Acme",
+                _generator=_BoomGenerator(),
+            )
+        assert 500 <= ei.value.status_code < 600
+        assert ei.value.code == "sites.generator_failed"
+
+    @pytest.mark.asyncio
+    async def test_smoke_gate_failure_is_cloud_error(self, beanie_test_db, monkeypatch) -> None:
+        """A SmokeGateFailed (the workerd SSR fail-gate, or a bun install/build
+        failure) is also an infra failure on the publish path — it must map to a
+        CloudError, not escape unhandled. Injected via a fake generator."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud._core.errors import CloudError
+        from pocketpaw_ee.sites import service as sites_service
+        from pocketpaw_ee.sites.generator_client import SmokeGateFailed
+
+        monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+        monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+        class _SmokeFailGenerator:
+            async def build(self, **_kwargs):  # noqa: ANN003
+                raise SmokeGateFailed("bun install failed (exit 1): ...")
+
+        with pytest.raises(CloudError) as ei:
+            await sites_service.publish(
+                workspace_id=str(ObjectId()),
+                user_id=str(ObjectId()),
+                pocket_id=str(ObjectId()),
+                ripple_spec=_ripple_spec(),
+                theme={},
+                name="Acme",
+                _generator=_SmokeFailGenerator(),
+            )
+        assert 500 <= ei.value.status_code < 600
+        assert ei.value.code == "sites.generator_failed"
+
+    @pytest.mark.asyncio
+    async def test_preview_build_failure_is_cloud_error(self, beanie_test_db, monkeypatch) -> None:
+        """The PREVIEW branch of publish() also builds (smoke=False) before serving
+        locally. A toolchain failure there must likewise map to a CloudError so the
+        edit/arm preview path never 500s opaquely either."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud._core.errors import CloudError
+        from pocketpaw_ee.sites import service as sites_service
+
+        monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+        monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+
+        class _BoomGenerator:
+            async def build(self, **_kwargs):  # noqa: ANN003
+                raise FileNotFoundError(2, "No such file or directory", "paw-sites-gen")
+
+        with pytest.raises(CloudError) as ei:
+            await sites_service.publish(
+                workspace_id=str(ObjectId()),
+                user_id=str(ObjectId()),
+                pocket_id=str(ObjectId()),
+                ripple_spec=_ripple_spec(),
+                theme={},
+                name="Acme",
+                preview=True,
+                _generator=_BoomGenerator(),
+            )
+        assert 500 <= ei.value.status_code < 600
+        assert ei.value.code == "sites.generator_failed"


### PR DESCRIPTION
## What this does

Site publishing shells out to the paw-sites generator (`paw-sites-gen` → `bun install` → `bun run build`) at publish time, but the deployed `pocketpaw-ee` image shipped none of that toolchain. So a real `POST /sites/publish` on the Coolify/Hetzner box 500s before it generates anything — and that's been true for all site publishing, not just the recent dynamic-svelte work. Everything we've tested runs locally, where `PAW_SITES_GEN_CMD` points at a hand-built `dist/cli.js`.

This adds the toolchain to `Dockerfile.enterprise`, mirroring the pattern the web frontend already uses for ripple (`paw-enterprise/deploy/Dockerfile`):

- **bun** — copied from the pinned `oven/bun:1.2-debian` image (no curl|bash).
- **paw-sites generator** — built in a stage (vendor a prebuilt tree, or clone+build) and put on PATH as `paw-sites-gen` (a shebang wrapper over `node dist/cli.js`, since the publish path execs the bin directly via `create_subprocess_exec`).
- **@ripple-ui/svelte tarball** — built and packed into the image; `PAW_SITES_RIPPLE_DEP` is baked to point a generated ripple site's install at it, with `PAW_SITES_MOTION_DEP` in lockstep.
- **graceful failure** — a generator/install/smoke failure now maps to a clean `CloudError` (5xx with a reason) instead of an unhandled 500. The preview/edit path keeps `SmokeGateFailed` raw so `edit_svelte_component`'s rollback still fires.

Both paw-sites and ripple are sibling repos outside the build context, so each has a `vendor` (default, prebuilt into `deploy/`) / `clone` (internal CI, has repo access) source switch. Coolify uses `clone`; the generator's `@ripple-ui/svelte = file:../ripple` dep is resolved from the built tarball on that path.

## How it was verified

- `_build_or_cloud_error` reproduce tests: 4 passed (missing binary / RuntimeError / SmokeGateFailed / preview path). Full sites suite: 260 passed.
- `docker build --check` clean. Built the `paw-sites` (vendor) and `ripple` stages green; confirmed the generator tree + tarball land and the `paw-sites-gen` wrapper resolves templates through `import.meta.url`.
- Clone path: the private paw-sites repo isn't reachable from the build env, so the clone branch's exact commands were run inside `oven/bun:1.2-debian` against the real source + a fresh tarball → `dist/cli.js` produced. The full in-Dockerfile clone build runs on Coolify.

## Known prerequisite — a separate, pre-existing image-build blocker

The full `Dockerfile.enterprise` build does not currently succeed on `dev`, for a reason this PR does not touch. The EE layer is installed with `pip install ./ee`, but the dependency tree only resolves under `uv`: `[tool.uv.sources]` pins a forked `camel-ai` that drops the `psutil<6` cap colliding with `livekit-agents` (psutil>=7), and pip ignores `[tool.uv.sources]`, so `pip install ./ee` hits a `ResolutionImpossible`. CI never builds this image (only the Coolify webhook does), so it isn't caught there. This PR's new stages build before that step and are independently verified. A working sites deploy needs that pip→uv fix too — flagging it for a separate decision.

## Deploy notes

- Coolify must build with `--build-arg PAW_SITES_SOURCE=clone --build-arg RIPPLE_SOURCE=clone` (the vendored trees are gitignored). See `deploy/README-build.md`.
- For live Cloudflare deploy, set `PAW_CF_*` in the Coolify env (documented in `.env.enterprise.example`); still gated on CF provisioning.

PRD: `docs/design/drafts/2026-06-25-paw-sites-prod-deploy.md`
