### PR TITLE
fix(chat): run worker drops the authenticated workspace, breaking site creation

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -5,6 +5,16 @@ message, submitting a ``Run`` to the configured executor, and tailing the
 run's Redis Stream so durability sits underneath the wire shape the
 frontend already speaks.
 
+Changes: 2026-06-25 (fix/worker-trusts-spec-workspace) — ``post_agent_chat``
+threads the authenticated ``workspace_id`` into ``resolve_scope_context`` via
+``expected_workspace_id``, matching the run worker. The HTTP route already
+validates the workspace (the ``current_workspace_id`` dependency rejects an
+empty one with 400); passing it lets the resolver fall back to it when a scope
+doc's ``workspace`` field is empty and reject a scope whose non-empty doc
+workspace disagrees with the caller's (cross-tenant guard). Keeps the
+synchronous request path consistent with the worker that actually attaches the
+run identity.
+
 Changes: 2026-06-24 (BC-4, integration/billing-credits) — credit hard-block at
 run-start. This module is the SINGLE chokepoint that starts a new chat run
 (``create_run`` + executor submit), so the credit gate sits here, right after
@@ -136,8 +146,18 @@ async def post_agent_chat(
     workspace_id: str = Depends(current_workspace_id),
 ) -> StreamingResponse:
     try:
+        # Thread the authenticated workspace (fix/worker-trusts-spec-workspace).
+        # The HTTP route already validated it via ``current_workspace_id``; the
+        # resolver uses it the same way the worker does — fall back when the
+        # scope doc's ``workspace`` is empty, reject a scope whose non-empty doc
+        # workspace disagrees with the caller's (cross-tenant guard). Keeps the
+        # synchronous path consistent with the run worker.
         ctx = await resolve_scope_context(
-            scope=scope, scope_id=scope_id, user_id=user_id, agent_id_hint=body.agent_id
+            scope=scope,
+            scope_id=scope_id,
+            user_id=user_id,
+            agent_id_hint=body.agent_id,
+            expected_workspace_id=workspace_id,
         )
         ctx.intent = body.intent
     except InvalidScope:

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -124,6 +124,23 @@ type-gated. The renderer re-sanitizes even though ``summarize_ripple_spec``
 now sanitizes at the source (the get_pocket ``_summary`` path) — it never
 trusts a hand-built dict. Capped lists render honest "+N more" markers
 from the summarizer's new ``*_omitted`` counters.
+Changes: 2026-06-25 (fix/worker-trusts-spec-workspace) — ``resolve_scope_context``
+and the three resolvers gained ``expected_workspace_id``: the authenticated,
+route-validated workspace the run worker threads from ``spec.workspace_id``.
+The new ``_reconcile_workspace_id`` helper makes it tenant-safe: a NON-EMPTY
+doc ``workspace`` stays authoritative AND a disagreeing ``expected_workspace_id``
+raises ``Forbidden`` (the cross-tenant guard — the ``_get_pocket`` / ``_get_session``
+finders look up by ``_id`` alone, not tenant-scoped, so a spec for workspace B
+can load workspace A's doc); an EMPTY/missing doc workspace FALLS BACK to the
+trusted ``expected_workspace_id``. This fixes the worker throwing away the
+authenticated ``spec.workspace_id`` and re-deriving tenancy from a doc that can
+be empty — which blanked the identity contextvar and made the sites-create MCP
+tool raise "requires workspace and user context (call from a cloud chat
+session)". ``expected_workspace_id is None`` (legacy / non-worker callers)
+preserves today's doc-only behavior. Defense-in-depth: ``attach_agent_identity``
+now REJECTS an empty ``workspace_id`` / ``user_id`` (raises ``ValueError``)
+instead of binding ``""``, so any future caller that loses tenancy fails loudly
+at the seam, not deep inside an MCP tool.
 """
 
 from __future__ import annotations
@@ -151,7 +168,7 @@ from pocketpaw.ripple import (
     get_pocket_prompts,
 )
 from pocketpaw.ripple._pockets import _MCP_POCKET_BACKENDS
-from pocketpaw_ee.cloud.shared.errors import CloudError, NotFound
+from pocketpaw_ee.cloud.shared.errors import CloudError, Forbidden, NotFound
 from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceProfile
 
 logger = logging.getLogger(__name__)
@@ -205,7 +222,22 @@ def attach_agent_identity(
     is streaming through — used by ``create_pocket`` to link the active
     session to the freshly-created pocket. ``pocket_id`` is the room the chat
     is anchored to (when any) — read by the connector-execution MCP server to
-    scope ``list_connector_actions`` / ``connector_execute`` to this pocket."""
+    scope ``list_connector_actions`` / ``connector_execute`` to this pocket.
+
+    Defense-in-depth (fix/worker-trusts-spec-workspace): REJECT an empty
+    ``workspace_id`` / ``user_id`` instead of binding ``""`` to the contextvar.
+    A blank tenancy here silently propagated to every in-process MCP tool —
+    the sites-create tool surfaced it as "requires workspace and user context
+    (call from a cloud chat session)" deep inside the tool, far from the seam
+    that lost the id. Failing loudly at the bind makes any future caller that
+    drops tenancy break at the source instead. Every real caller (the SSE chat
+    path, the group/DM bridge, the in-process test harnesses) already passes
+    non-empty ids, so this is a guard, not a behavior change for them."""
+    if not workspace_id or not user_id:
+        raise ValueError(
+            "attach_agent_identity requires a non-empty workspace_id and user_id "
+            f"(got workspace_id={workspace_id!r}, user_id={user_id!r})"
+        )
     return (
         _active_workspace_id.set(workspace_id),
         _active_user_id.set(user_id),
@@ -730,16 +762,69 @@ async def _get_default_workspace_agent_id(workspace_id: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+def _reconcile_workspace_id(doc_workspace_id: str, expected_workspace_id: str | None) -> str:
+    """Resolve the AUTHORITATIVE workspace for a scope, given the workspace the
+    scope DOC carries and the ``expected_workspace_id`` the authenticated caller
+    asserts (the worker threads ``spec.workspace_id`` here — fix/worker-trusts-
+    spec-workspace).
+
+    Rules (tenant-safe by construction):
+
+    * Doc workspace NON-EMPTY:
+        - it stays AUTHORITATIVE, AND
+        - if ``expected_workspace_id`` is also non-empty and DISAGREES, raise a
+          ``Forbidden`` — never silently trust a mismatched caller assertion.
+          The scope finders look the doc up by ``_id`` alone (not tenant-scoped),
+          so a spec for workspace B CAN load workspace A's doc; this mismatch
+          check is the actual cross-tenant guard, not just belt-and-suspenders.
+    * Doc workspace EMPTY/missing (a legacy / partially-stamped doc):
+        - FALL BACK to the trusted ``expected_workspace_id`` when present. This
+          is the fix: the worker stops blanking tenancy when the doc's workspace
+          field is empty, and uses the authenticated id the HTTP route already
+          validated (the ``current_workspace_id`` dependency rejects an empty
+          workspace with 400 before the spec is ever built).
+        - ``""`` when neither is usable — the caller (``execute_run``) then
+          raises a clean error rather than attaching an empty identity.
+
+    ``expected_workspace_id is None`` (legacy / non-worker callers that don't
+    thread it) preserves today's behavior exactly: the doc workspace passes
+    through untouched.
+    """
+    doc_ws = (doc_workspace_id or "").strip()
+    expected = (expected_workspace_id or "").strip()
+    if doc_ws:
+        if expected and expected != doc_ws:
+            raise Forbidden(
+                "scope.workspace_mismatch",
+                "Scope belongs to a different workspace than the authenticated request",
+            )
+        return doc_ws
+    return expected
+
+
 async def resolve_scope_context(
-    *, scope: str, scope_id: str, user_id: str, agent_id_hint: str | None
+    *,
+    scope: str,
+    scope_id: str,
+    user_id: str,
+    agent_id_hint: str | None,
+    expected_workspace_id: str | None = None,
 ) -> ScopeContext:
     """Resolve a ``ScopeContext`` for a cloud agent chat request.
+
+    ``expected_workspace_id`` is the authoritative, authenticated workspace the
+    caller asserts (the run worker threads ``spec.workspace_id`` here). It is
+    used to (a) FALL BACK to trusted tenancy when the scope doc's ``workspace``
+    field is empty/missing and (b) REJECT a caller whose workspace DISAGREES
+    with a non-empty doc workspace (cross-tenant guard). Defaults to ``None`` —
+    legacy / non-worker callers keep today's doc-only behavior.
 
     Raises:
         InvalidScope: ``scope`` is not one of dm/group/pocket/session.
         NotFound: the group, pocket, or session doesn't exist.
-        CloudError: caller is not a member, no agent is in scope, or the
-            caller must disambiguate ``agent_id`` for a multi-agent group.
+        CloudError: caller is not a member, no agent is in scope, the caller
+            must disambiguate ``agent_id`` for a multi-agent group, or the
+            asserted workspace disagrees with the scope's (``Forbidden``).
     """
     try:
         kind = ScopeKind(scope)
@@ -747,19 +832,33 @@ async def resolve_scope_context(
         raise InvalidScope(scope) from e
 
     if kind is ScopeKind.POCKET:
-        return await _resolve_pocket(scope_id, user_id, agent_id_hint)
+        return await _resolve_pocket(scope_id, user_id, agent_id_hint, expected_workspace_id)
     if kind is ScopeKind.SESSION:
-        return await _resolve_session(scope_id, user_id, agent_id_hint)
-    return await _resolve_group_like(kind, scope_id, user_id, agent_id_hint)
+        return await _resolve_session(scope_id, user_id, agent_id_hint, expected_workspace_id)
+    return await _resolve_group_like(kind, scope_id, user_id, agent_id_hint, expected_workspace_id)
 
 
-async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | None) -> ScopeContext:
+async def _resolve_session(
+    scope_id: str,
+    user_id: str,
+    agent_id_hint: str | None,
+    expected_workspace_id: str | None = None,
+) -> ScopeContext:
     session = await _get_session(scope_id)
     if session is None or getattr(session, "deleted_at", None) is not None:
         raise NotFound("session", scope_id)
 
     if getattr(session, "owner", None) != user_id:
         raise CloudError(403, "session.forbidden", "Caller does not own this session")
+
+    # Trust the authenticated spec workspace when the doc's is empty; reject a
+    # spec that disagrees with a non-empty doc workspace (fix/worker-trusts-
+    # spec-workspace). Reconciled FIRST so the home-summary lookup and the
+    # returned ctx both use the authoritative id, and a cross-tenant mismatch
+    # raises before any further reads.
+    workspace_id = _reconcile_workspace_id(
+        str(getattr(session, "workspace", "")), expected_workspace_id
+    )
 
     # When the session lives inside a pocket, hydrate the pocket's tool specs
     # so a chat routed through ``session`` scope still gets the pocket-scoped
@@ -781,16 +880,13 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
             # active session id is honored). Surface the home pocket's
             # backend summary here too so the home agent inlines it whether
             # the chat routed through pocket or session scope.
-            backend_summary = await _home_backend_summary(
-                pocket_type, str(getattr(session, "workspace", "")), str(pocket_id)
-            )
+            backend_summary = await _home_backend_summary(pocket_type, workspace_id, str(pocket_id))
             # Pocket orientation for ALL pocket types — built from the doc
             # we already fetched, no extra read. Mirrors the pocket-scope
             # path so the agent sees the same <pocket-summary> block
             # whichever scope the frontend routed the chat through.
             pocket_summary = _pocket_summary_data(pocket)
 
-    workspace_id = str(getattr(session, "workspace", ""))
     target = agent_id_hint or getattr(session, "agent", None)
     if not target:
         # Sessions created via ``createPocketSession`` don't yet pin an agent
@@ -825,7 +921,11 @@ async def _resolve_session(scope_id: str, user_id: str, agent_id_hint: str | Non
 
 
 async def _resolve_group_like(
-    kind: ScopeKind, scope_id: str, user_id: str, agent_id_hint: str | None
+    kind: ScopeKind,
+    scope_id: str,
+    user_id: str,
+    agent_id_hint: str | None,
+    expected_workspace_id: str | None = None,
 ) -> ScopeContext:
     group = await _get_group(scope_id)
     if group is None:
@@ -851,7 +951,12 @@ async def _resolve_group_like(
 
     target = _pick_target_agent(agent_ids, agent_id_hint)
 
-    workspace_id = str(getattr(group, "workspace", ""))
+    # Trust the authenticated spec workspace when the doc's is empty; reject a
+    # spec that disagrees with a non-empty doc workspace (fix/worker-trusts-
+    # spec-workspace).
+    workspace_id = _reconcile_workspace_id(
+        str(getattr(group, "workspace", "")), expected_workspace_id
+    )
     # Orient the agent to the calling member (pp#1367) — pre-rendered capped
     # block, ``None`` when the member has no Person.
     about_member_block = await _resolve_about_member(workspace_id, user_id)
@@ -868,7 +973,12 @@ async def _resolve_group_like(
     )
 
 
-async def _resolve_pocket(scope_id: str, user_id: str, agent_id_hint: str | None) -> ScopeContext:
+async def _resolve_pocket(
+    scope_id: str,
+    user_id: str,
+    agent_id_hint: str | None,
+    expected_workspace_id: str | None = None,
+) -> ScopeContext:
     pocket = await _get_pocket(scope_id)
     if pocket is None:
         raise NotFound("pocket", scope_id)
@@ -883,7 +993,12 @@ async def _resolve_pocket(scope_id: str, user_id: str, agent_id_hint: str | None
     # For workspace/public we still require the caller be a workspace member;
     # the route-level dependency ``current_workspace_id`` already enforced that.
 
-    workspace_id = str(getattr(pocket, "workspace", ""))
+    # Trust the authenticated spec workspace when the doc's is empty; reject a
+    # spec that disagrees with a non-empty doc workspace (fix/worker-trusts-
+    # spec-workspace).
+    workspace_id = _reconcile_workspace_id(
+        str(getattr(pocket, "workspace", "")), expected_workspace_id
+    )
 
     agents = list(getattr(pocket, "agents", []) or [])
     agent_ids = [a if isinstance(a, str) else getattr(a, "id", None) for a in agents]

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,18 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-06-25 (fix/worker-trusts-spec-workspace) — ``execute_run`` now threads
+  the authenticated ``spec.workspace_id`` into ``resolve_scope_context`` via the
+  new ``expected_workspace_id`` kwarg, then raises a clean
+  ``CloudError("scope.no_workspace")`` if the resolved ``ctx.workspace_id`` is
+  STILL empty — instead of letting ``_drive_agent_loop`` attach an empty
+  identity. The worker used to re-derive tenancy from the scope doc alone and
+  discard the trusted, route-validated spec workspace; when the doc's
+  ``workspace`` field was empty the identity contextvar became ``""`` and the
+  sites-create MCP tool raised "requires workspace and user context (call from a
+  cloud chat session)". The resolver now falls back to the trusted spec
+  workspace (and rejects a spec that disagrees with a non-empty doc workspace —
+  the cross-tenant guard); this seam adds the loud, scope-specific failure.
 - 2026-06-13 (feat/claude-sdk-prewarm) — ``execute_run`` now fires
   ``_prewarm_session(ctx)`` as a fire-and-forget ``asyncio.create_task`` right
   after the entity-aware profile is resolved, so the agent's Claude CLI
@@ -120,6 +132,7 @@ from pocketpaw_ee.cloud.chat.agent_service import (
 from pocketpaw_ee.cloud.chat.runs import service as run_service
 from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
 from pocketpaw_ee.cloud.chat.runs.transport import get_stream_transport
+from pocketpaw_ee.cloud.shared.errors import CloudError
 from pocketpaw_ee.cloud.surface import (
     SurfaceKind,
     SurfaceMeta,
@@ -1049,12 +1062,33 @@ async def execute_run(spec: RunSpec) -> None:
     persistence purposes (no assistant message created).
     """
     transport = get_stream_transport()
+    # Thread the authenticated, route-validated workspace from the spec into
+    # scope resolution (fix/worker-trusts-spec-workspace). The HTTP route stamps
+    # ``spec.workspace_id`` from the ``current_workspace_id`` dependency (which
+    # rejects an empty workspace with 400), so it is the trusted tenancy. The
+    # resolver uses it to FALL BACK when the scope doc's ``workspace`` field is
+    # empty/missing and to REJECT a spec whose workspace disagrees with a
+    # non-empty doc workspace. Before this, the worker re-derived tenancy from
+    # the doc alone and a blank doc workspace blanked the whole identity — the
+    # sites-create MCP tool then raised "requires workspace and user context".
     ctx = await resolve_scope_context(
         scope=spec.context_type,
         scope_id=spec.scope_id,
         user_id=spec.user_id,
         agent_id_hint=spec.agent_id,
+        expected_workspace_id=spec.workspace_id,
     )
+    # Even with the spec fallback, a doc + spec that BOTH lack a usable workspace
+    # must fail cleanly here — never attach an empty identity downstream (the
+    # contextvar-reading MCP tools would surface a confusing error deep inside
+    # the tool instead of at this seam). ``attach_agent_identity`` also rejects
+    # empties as defense-in-depth; this gives a scope-specific code first.
+    if not ctx.workspace_id:
+        raise CloudError(
+            400,
+            "scope.no_workspace",
+            "Could not resolve a workspace for this run's scope",
+        )
     ctx.intent = spec.intent
 
     # Mirror agent_router._ensure_scope_session so _drive_agent_loop's

--- a/tests/cloud/chat/test_execute_run_identity.py
+++ b/tests/cloud/chat/test_execute_run_identity.py
@@ -1,0 +1,221 @@
+# tests/cloud/chat/test_execute_run_identity.py
+#
+# Created: 2026-06-25 (fix/worker-trusts-spec-workspace) — reproduction +
+# regression guard for the cloud-chat-worker tenancy bug: a run that calls
+# create_landing_site / create_svelte_site failed on the deployed backend with
+# "requires workspace and user context (call from a cloud chat session)".
+#
+# Root cause: execute_run re-derives tenancy from the Mongo scope DOC via
+# resolve_scope_context and threw away the authenticated, non-empty
+# spec.workspace_id. When the doc's ``workspace`` field was empty/missing, the
+# resolved ScopeContext carried workspace_id="", attach_agent_identity .set() an
+# empty contextvar, and the in-process MCP tool's _identity() guard raised.
+#
+# These tests drive the REAL identity path — resolve_scope_context(...,
+# expected_workspace_id=spec.workspace_id) → attach_agent_identity(
+# workspace_id=ctx.workspace_id, ...) → current_workspace_id() — NOT the
+# scripts/test_svelte_create.py harness shortcut (which hardcodes the
+# workspace_id straight into attach_agent_identity and bypasses the resolver).
+# The fix must (1) fall back to the trusted spec workspace when the doc's is
+# empty, (2) reject a spec that DISAGREES with a non-empty doc workspace
+# (cross-tenant guard), and (3) make attach_agent_identity reject empty ids.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import (
+    attach_agent_identity,
+    current_user_id,
+    current_workspace_id,
+    detach_agent_identity,
+    resolve_scope_context,
+)
+from pocketpaw_ee.cloud.shared.errors import CloudError
+
+# The authoritative, authenticated tenancy the HTTP route stamps onto the
+# RunSpec (current_workspace_id dependency raises 400 if empty, so this is
+# always non-empty by the time the worker picks the spec up off Redis).
+SPEC_WORKSPACE = "w_trusted"
+SPEC_USER = "u_caller"
+
+
+def _session_doc(*, workspace: str) -> SimpleNamespace:
+    """A session scope doc with a controllable ``workspace`` field. The bug is
+    triggered when ``workspace`` is "" (or missing)."""
+    from pocketpaw_ee.cloud.models.session import Session
+
+    return Session.model_construct(
+        id="s_sites",
+        sessionId="ws_sites",
+        workspace=workspace,
+        owner=SPEC_USER,
+        agent="agent_pp",
+        pocket=None,
+        deleted_at=None,
+    )
+
+
+def _pocket_doc(*, workspace: str) -> SimpleNamespace:
+    """A pocket scope doc with a controllable ``workspace`` field."""
+    return SimpleNamespace(
+        id="p_site",
+        type="custom",
+        workspace=workspace,
+        owner=SPEC_USER,
+        team=[SPEC_USER],
+        agents=["agent_pp"],
+        tool_specs=[],
+        visibility="workspace",
+        shared_with=[],
+    )
+
+
+# ===========================================================================
+# RED — the bug. A scope doc with an EMPTY workspace, a spec carrying a valid
+# non-empty workspace_id: the active identity must end up populated FROM THE
+# TRUSTED SPEC, not blanked out from the doc.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_session_empty_doc_workspace_falls_back_to_spec():
+    """The decisive reproduction: a session doc whose ``workspace`` is empty,
+    resolved with the trusted spec workspace, must yield a ScopeContext whose
+    workspace_id is the spec's — so the MCP tool's identity guard passes."""
+    with patch(
+        "pocketpaw_ee.cloud.chat.agent_service._get_session",
+        AsyncMock(return_value=_session_doc(workspace="")),
+    ):
+        ctx = await resolve_scope_context(
+            scope="session",
+            scope_id="s_sites",
+            user_id=SPEC_USER,
+            agent_id_hint=None,
+            expected_workspace_id=SPEC_WORKSPACE,
+        )
+    assert ctx.workspace_id == SPEC_WORKSPACE
+
+    # And the contextvar the MCP tool reads ends up populated, not "".
+    tokens = attach_agent_identity(workspace_id=ctx.workspace_id, user_id=ctx.user_id)
+    try:
+        assert current_workspace_id() == SPEC_WORKSPACE
+        assert current_user_id() == SPEC_USER
+    finally:
+        detach_agent_identity(tokens)
+
+
+@pytest.mark.asyncio
+async def test_pocket_empty_doc_workspace_falls_back_to_spec():
+    """Same fallback for a pocket-scope doc with an empty workspace."""
+    with patch(
+        "pocketpaw_ee.cloud.chat.agent_service._get_pocket",
+        AsyncMock(return_value=_pocket_doc(workspace="")),
+    ):
+        ctx = await resolve_scope_context(
+            scope="pocket",
+            scope_id="p_site",
+            user_id=SPEC_USER,
+            agent_id_hint=None,
+            expected_workspace_id=SPEC_WORKSPACE,
+        )
+    assert ctx.workspace_id == SPEC_WORKSPACE
+
+
+# ===========================================================================
+# Tenancy safety — the spec must NOT be allowed to spoof a different workspace
+# than a doc that DOES carry one.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_session_doc_workspace_authoritative_when_present():
+    """A non-empty doc workspace stays authoritative when the spec AGREES."""
+    with patch(
+        "pocketpaw_ee.cloud.chat.agent_service._get_session",
+        AsyncMock(return_value=_session_doc(workspace=SPEC_WORKSPACE)),
+    ):
+        ctx = await resolve_scope_context(
+            scope="session",
+            scope_id="s_sites",
+            user_id=SPEC_USER,
+            agent_id_hint=None,
+            expected_workspace_id=SPEC_WORKSPACE,
+        )
+    assert ctx.workspace_id == SPEC_WORKSPACE
+
+
+@pytest.mark.asyncio
+async def test_session_spec_disagreeing_with_doc_raises():
+    """Cross-tenant guard: a spec whose workspace DISAGREES with a non-empty
+    doc workspace must raise, never silently trust the mismatched spec."""
+    with patch(
+        "pocketpaw_ee.cloud.chat.agent_service._get_session",
+        AsyncMock(return_value=_session_doc(workspace="w_real")),
+    ):
+        with pytest.raises(CloudError):
+            await resolve_scope_context(
+                scope="session",
+                scope_id="s_sites",
+                user_id=SPEC_USER,
+                agent_id_hint=None,
+                expected_workspace_id="w_attacker",
+            )
+
+
+@pytest.mark.asyncio
+async def test_pocket_spec_disagreeing_with_doc_raises():
+    with patch(
+        "pocketpaw_ee.cloud.chat.agent_service._get_pocket",
+        AsyncMock(return_value=_pocket_doc(workspace="w_real")),
+    ):
+        with pytest.raises(CloudError):
+            await resolve_scope_context(
+                scope="pocket",
+                scope_id="p_site",
+                user_id=SPEC_USER,
+                agent_id_hint=None,
+                expected_workspace_id="w_attacker",
+            )
+
+
+# ===========================================================================
+# Backward compatibility — callers that DON'T thread expected_workspace_id
+# (legacy / non-worker paths) keep today's behavior.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_no_expected_workspace_keeps_doc_workspace():
+    """Without expected_workspace_id the resolver behaves exactly as before:
+    the doc's workspace (here non-empty) is used unchanged."""
+    with patch(
+        "pocketpaw_ee.cloud.chat.agent_service._get_session",
+        AsyncMock(return_value=_session_doc(workspace="w_doc")),
+    ):
+        ctx = await resolve_scope_context(
+            scope="session",
+            scope_id="s_sites",
+            user_id=SPEC_USER,
+            agent_id_hint=None,
+        )
+    assert ctx.workspace_id == "w_doc"
+
+
+# ===========================================================================
+# Defense-in-depth — attach_agent_identity must REJECT empty tenancy so any
+# future caller that loses workspace/user fails loudly at the seam instead of
+# blanking the contextvar and surfacing deep inside an MCP tool.
+# ===========================================================================
+
+
+def test_attach_agent_identity_rejects_empty_workspace():
+    with pytest.raises(ValueError):
+        attach_agent_identity(workspace_id="", user_id=SPEC_USER)
+
+
+def test_attach_agent_identity_rejects_empty_user():
+    with pytest.raises(ValueError):
+        attach_agent_identity(workspace_id=SPEC_WORKSPACE, user_id="")


### PR DESCRIPTION
## The bug

Creating a site — or any cloud chat run that calls a workspace-scoped MCP tool — fails on the deployed backend with "requires workspace and user context (call from a cloud chat session)", even though the user is signed in and in a workspace.

The authenticated HTTP route builds the run with a validated, non-empty `workspace_id`. But `execute_run` (the worker that actually runs the agent) throws that away and re-derives the workspace from the Mongo scope document: `workspace_id = str(getattr(session, "workspace", ""))`. When that field is empty or missing, the identity contextvar is set to `""`, and the site-creation tool's guard fires.

It only surfaces through the real run path (the worker), which is why local runs — and the in-process test harness, which hardcodes the workspace and bypasses `execute_run` — never hit it.

## The fix

Make the worker trust the authenticated tenancy it was handed, without weakening tenant isolation:

- `execute_run` threads `spec.workspace_id` (the route-validated value) into `resolve_scope_context` as `expected_workspace_id`.
- A new `_reconcile_workspace_id` helper: a non-empty doc workspace stays authoritative, and if `expected_workspace_id` disagrees it raises `Forbidden` (a real cross-tenant guard — the scope lookups are by `_id`, not tenant-scoped); an empty doc workspace falls back to the trusted value.
- If identity is still empty after resolution, `execute_run` raises a clear `CloudError("scope.no_workspace")` instead of attaching an empty identity.
- `attach_agent_identity` now rejects empty `workspace_id`/`user_id` outright, so any future caller that loses tenancy fails loudly at the seam rather than deep inside a tool.

The same threading is applied to the synchronous route path so the request and the worker behave identically.

## Tests

`tests/cloud/chat/test_execute_run_identity.py` (8): empty-doc-workspace falls back to spec (the fix); doc workspace authoritative when present (no regression); spec disagreeing with the doc raises `Forbidden` (the cross-tenant guard); no-expected keeps legacy behavior; `attach_agent_identity` rejects empty. All green, and the wider chat / scope / sites suites pass (303 in the touched area). ruff clean; the OSS→EE import boundary holds.

## Note

This makes the worker robust regardless of *why* a doc's `workspace` is empty — normally it's a required field, so an empty one points to legacy data or a create path that didn't stamp it (worth a follow-up, but no longer load-bearing). The clearer errors (`scope.no_workspace`, `scope.workspace_mismatch`) are self-diagnosing if anything related recurs.
