### PR TITLE
feat(sites): Workers-for-Platforms dispatch worker + public site URLs

### DIFF
--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -120,6 +120,13 @@ POCKETPAW_LICENSE_KEY=
 # PAW_CF_* ones above). Set them alongside PAW_CF_ACCOUNT_ID for a workers deploy.
 # CLOUDFLARE_API_TOKEN=
 # CLOUDFLARE_ACCOUNT_ID=
+#
+# The base domain a published site is served at: a site is reachable at
+# https://<site_id>.<PAW_CF_SITES_DOMAIN> via the WfP dispatch worker
+# (ee/pocketpaw_ee/sites/cloudflare/dispatch-worker). When set, publish stamps the
+# site URL; when unset, publish still uploads the worker but the site has no public
+# URL (a warning is logged) until the domain is set and the dispatch worker deployed.
+# PAW_CF_SITES_DOMAIN=sites.hzd.interacly.com
 
 # ── Model Catalog — LiteLLM proxy (MCG-1) ──────────────────────────────────────
 # The catalog API (GET /api/v1/catalog/models[/{id}]) reads available models from

--- a/docs/runbooks/2026-06-26-cloudflare-sites-dispatch-setup.md
+++ b/docs/runbooks/2026-06-26-cloudflare-sites-dispatch-setup.md
@@ -1,0 +1,177 @@
+<!--
+2026-06-26-cloudflare-sites-dispatch-setup.md
+Created 2026-06-25 (feat/sites-cf-dispatch-worker): end-to-end runbook to take Paw
+Sites live on Cloudflare Workers for Platforms — provision the account/token/zone,
+create the dispatch namespace, deploy the dispatch worker, set up wildcard DNS +
+TLS, set the backend env, and smoke a publish.
+-->
+
+# Runbook — Cloudflare Paw Sites dispatch go-live
+
+Take Paw Sites from "publish uploads a worker that nobody can reach" to "a
+published site is live at `https://<site_id>.<PAW_CF_SITES_DOMAIN>`."
+
+This is the **serving layer**. Publishing already uploads each generated site as a
+**user worker** into the `paw-sites` Workers-for-Platforms (WfP) **dispatch
+namespace** (`cloudflare_client.put_worker`). But a user worker in a dispatch
+namespace is **not directly URL-addressable** — it only serves when a **dispatch
+worker** routes a request to it. This runbook stands up that dispatch worker and
+wires the URL.
+
+> Cross-reference: the workspace-level go-live draft
+> `docs/design/drafts/2026-06-20-cloudflare-deploy-activation.md` (in the
+> paw-workspace repo) covers activating the Cloudflare account + token + zone at the
+> deploy layer. This runbook is the sites-specific serving half and assumes that
+> account/token/zone work is either done here (steps 1–2) or already done there.
+
+## Prerequisites
+
+- A Cloudflare account on a **Workers Paid** plan (WfP dispatch namespaces require
+  it).
+- A zone in that account you can add DNS + certificates to (e.g. `interacly.com`).
+- `wrangler` installed via the dispatch worker's `package.json`
+  (`ee/pocketpaw_ee/sites/cloudflare/dispatch-worker`) — pinned to an aged version
+  for the supply-chain gate; do not bump to latest.
+- Backend deploy access (Coolify) to set env vars.
+
+Pick your **sites domain** now and use it consistently below. Two valid shapes:
+
+- **First-level** (simplest TLS): `PAW_CF_SITES_DOMAIN = sites-domain.com` where
+  that is a CF zone, so sites serve at `https://<id>.sites-domain.com` and Universal
+  SSL's `*.<zone>` cert covers them with no extra cert.
+- **Sub-subdomain**: `PAW_CF_SITES_DOMAIN = sites.hzd.interacly.com`, so sites serve
+  at `https://<id>.sites.hzd.interacly.com`. This is a **2-level-deep wildcard**
+  (`*.sites.<zone>`) and needs Total TLS or an Advanced Certificate (step 5b).
+
+The examples below use `sites.hzd.interacly.com` in the `interacly.com` zone —
+substitute your own.
+
+## 1. Provision account, token, zone
+
+1. Note the **Account ID** (Cloudflare dashboard → any domain → right sidebar).
+2. Create an **API token** with permissions:
+   - `Account → Workers Scripts → Edit` (deploy workers, manage dispatch
+     namespaces / user-worker uploads),
+   - `Zone → DNS → Edit` and `Zone → SSL and Certificates → Edit` for the sites
+     zone (custom hostnames + certs),
+   - scoped to the specific account + zone.
+3. Note the **Zone ID** of the sites zone.
+
+These become `PAW_CF_ACCOUNT_ID`, `PAW_CF_API_TOKEN`, `PAW_CF_ZONE_ID`.
+
+## 2. Create the dispatch namespace
+
+The backend uploads each site into the namespace named by
+`PAW_CF_DISPATCH_NAMESPACE` (default `paw-sites`). Create it once (idempotent):
+
+```bash
+cd ee/pocketpaw_ee/sites/cloudflare/dispatch-worker
+npm install
+npx wrangler dispatch-namespace create paw-sites
+npx wrangler dispatch-namespace list   # confirm paw-sites is listed
+```
+
+> The namespace name MUST match `PAW_CF_DISPATCH_NAMESPACE`. If you override that
+> env var, create + bind the namespace under the same name (also update the
+> `namespace` in `wrangler.jsonc`).
+
+## 3. Deploy the dispatch worker
+
+From the same directory. Set the route to the wildcard for your sites domain —
+either edit `wrangler.jsonc`:
+
+```jsonc
+"routes": [
+  { "pattern": "*.sites.hzd.interacly.com/*", "zone_name": "interacly.com" }
+]
+```
+
+…or pass it on deploy:
+
+```bash
+npx wrangler deploy --route '*.sites.hzd.interacly.com/*'
+```
+
+The `*.<domain>/*` wildcard route is the recommended WfP pattern — it works
+regardless of DNS proxy settings and has no per-route limit.
+
+## 4. Wildcard DNS
+
+Add a **wildcard DNS record** for the sites domain, **proxied (orange cloud)**, in
+the zone:
+
+```
+Type: AAAA   Name: *.sites.hzd.interacly.com   Content: 100::   Proxy: ON
+```
+
+(A placeholder target like `AAAA 100::` or `A 192.0.2.1` is fine — the worker
+route, not the origin, serves the request. The record only needs to exist and be
+proxied so the edge runs the worker.)
+
+## 5. TLS
+
+A published site is served over HTTPS, so the wildcard host must have a matching
+cert.
+
+- **5a. First-level domain** (`*.<zone>`): covered by **Universal SSL**
+  automatically. Nothing to do.
+- **5b. Sub-subdomain** (`*.sites.<zone>`, 2 levels deep): **NOT** covered by
+  Universal SSL. Either:
+  - enable **Total TLS** on the zone (SSL/TLS → Edge Certificates → Total TLS), or
+  - add an **Advanced Certificate** that includes `*.sites.<zone>`.
+
+  Without one of these, browsers get a TLS error even though the worker is live.
+
+## 6. Backend env
+
+Set these in the backend env (Coolify) so publish takes the real CF path AND
+stamps the public URL:
+
+```
+PAW_CF_ACCOUNT_ID=<account id>
+PAW_CF_API_TOKEN=<api token>
+PAW_CF_ZONE_ID=<zone id>
+PAW_CF_DISPATCH_NAMESPACE=paw-sites           # must match step 2
+PAW_CF_SITES_DOMAIN=sites.hzd.interacly.com   # the domain you routed + DNS'd
+```
+
+> `PAW_CF_SITES_DOMAIN` must ALSO be added to the canonical Coolify `.env.example`
+> in the paw-workspace repo (`deploy/coolify/`). The in-repo
+> `.env.enterprise.example` is updated alongside this change, but the deploy
+> template lives in the workspace repo and is out of scope for this repo's PR.
+
+Restart the backend so the new env is read.
+
+## 7. Smoke
+
+```bash
+# Route + worker live (no published site needed):
+curl -s https://anything.sites.hzd.interacly.com/__paw_health
+# expect: ok
+
+# Publish a site through the app, then hit its subdomain:
+curl -sI https://<24-hex-site-id>.sites.hzd.interacly.com/
+# expect: 200 + the rendered site HTML
+```
+
+The published Site doc's `url` should now read
+`https://<site_id>.sites.hzd.interacly.com`. Confirm in the dashboard (the site
+opens) or via the API (`GET /sites`).
+
+### Reading the codes
+
+| Code | Meaning |
+|------|---------|
+| `200 ok` on `/__paw_health` | route + dispatch worker are live |
+| `404 Not found` | label is not a 24-hex site id (probe / apex) |
+| `404 Site not found` | valid id, but no user worker in the namespace (unpublished / deleted) |
+| `502 Site error` | the user worker threw at runtime |
+| TLS error | step 5 cert does not cover the wildcard — fix the cert |
+
+## Follow-up — custom domains
+
+v1 is **subdomain routing only**. When a site connects its own custom hostname
+(`create_custom_hostname` / Cloudflare for SaaS), the inbound `hostname` is no
+longer `<site_id>.<domain>`, so the dispatch worker's leftmost-label trick 404s it.
+Custom domains need a `hostname → site_id` map in the dispatch worker — a routing
+KV populated at domain-connect time, or a backend lookup. Tracked as a follow-up.

--- a/ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/README.md
+++ b/ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/README.md
@@ -1,0 +1,139 @@
+<!--
+README.md — Paw Sites Workers-for-Platforms dispatch worker.
+Created 2026-06-25 (feat/sites-cf-dispatch-worker): deploy steps for the dynamic
+dispatch worker that makes published Paw Sites reachable.
+-->
+
+# Paw Sites — dispatch worker
+
+The serving half of Paw Sites on Cloudflare Workers for Platforms (WfP).
+
+## Why this exists
+
+Publishing a site uploads the generated site as a **user worker** into the
+`paw-sites` **dispatch namespace** (`cloudflare_client.put_worker`, called from
+`sites/service.py`). In Workers for Platforms, a user worker in a dispatch
+namespace is **not directly URL-addressable** — it only runs when a separate
+**Dynamic Dispatch Worker** routes a request to it via `env.DISPATCHER.get(name)`.
+This directory is that dispatch worker. Without it, every published site is
+unreachable (and `service.py` leaves the site `url=""`).
+
+## Routing model (v1 — subdomain per site)
+
+- A published site serves at `https://<site_id>.<PAW_CF_SITES_DOMAIN>`
+  (e.g. `https://<id>.sites.hzd.interacly.com`).
+- This worker runs on the route `*.<PAW_CF_SITES_DOMAIN>/*`, takes the **leftmost
+  hostname label** as the `site_id`, and dispatches
+  `env.DISPATCHER.get(siteId).fetch(request)`.
+- `site_id` is a Mongo ObjectId — 24 hex chars, a valid DNS label. The worker
+  validates the label against `^[a-f0-9]{24}$` and 404s anything else.
+- `GET /__paw_health` (and an apex / `www` host) returns `200 ok`, so the route
+  can be smoke-tested before any site exists.
+
+## Deploy
+
+All commands run from this directory
+(`ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/`).
+
+> Substitute your real `PAW_CF_SITES_DOMAIN` and zone everywhere
+> `sites.hzd.interacly.com` / `interacly.com` appear below.
+
+1. **Install** (pins an aged wrangler — see the supply-chain note below):
+
+   ```bash
+   npm install
+   ```
+
+2. **Create the dispatch namespace** (idempotent — skip if it already exists; a
+   re-run errors harmlessly):
+
+   ```bash
+   npx wrangler dispatch-namespace create paw-sites
+   # verify:
+   npx wrangler dispatch-namespace list
+   ```
+
+   This MUST be the same namespace the backend uploads sites into
+   (`PAW_CF_DISPATCH_NAMESPACE`, default `paw-sites`).
+
+3. **Set the route.** Either add a `routes` block to `wrangler.jsonc`:
+
+   ```jsonc
+   "routes": [
+     { "pattern": "*.sites.hzd.interacly.com/*", "zone_name": "interacly.com" }
+   ]
+   ```
+
+   …or pass it on the deploy:
+
+   ```bash
+   npx wrangler deploy --route '*.sites.hzd.interacly.com/*'
+   ```
+
+   The `*.<domain>/*` wildcard route is the recommended WfP pattern — it works
+   regardless of DNS proxy settings (orange-to-orange) and has no per-route limit.
+
+4. **Deploy:**
+
+   ```bash
+   npx wrangler deploy
+   # or: npm run deploy
+   ```
+
+5. **DNS — add a wildcard record** for the sites domain, **proxied (orange
+   cloud)**, in the zone:
+
+   ```
+   *.sites.hzd.interacly.com   →   (proxied; AAAA 100:: or A 192.0.2.1 placeholder)
+   ```
+
+   The worker route, not the DNS target, serves the request; the record just has
+   to exist and be proxied so the edge runs the worker.
+
+6. **TLS — important.** A **2-level-deep** wildcard like `*.sites.<zone>` is **NOT
+   covered by Universal SSL**, which only issues for `<zone>` and the first-level
+   `*.<zone>`. So the default cert will not match `*.sites.<zone>`. Pick one:
+
+   - **(a)** Make `PAW_CF_SITES_DOMAIN` a **first-level** subdomain of a CF zone
+     (i.e. use `*.<zone>` directly, so the site id is the first label under the
+     apex). This is covered by Universal SSL with no extra cert. **Simplest.**
+   - **(b)** Keep the deeper `*.sites.<zone>` wildcard and enable **Total TLS**
+     for the zone, or add an **Advanced Certificate** that covers
+     `*.sites.<zone>`. Without one of these, browsers get a TLS error even though
+     the worker is deployed.
+
+7. **Backend env.** Set `PAW_CF_SITES_DOMAIN` in the backend env (Coolify) to the
+   same domain you routed and DNS'd (e.g. `sites.hzd.interacly.com`). On the next
+   publish, `service.py` stamps the site `url` as
+   `https://<site_id>.<PAW_CF_SITES_DOMAIN>`. If it is unset, publish still works
+   but the site has no public URL (a warning is logged).
+
+## Smoke test
+
+```bash
+# the route + worker are live (no site needed):
+curl -s https://anything.sites.hzd.interacly.com/__paw_health   # -> ok
+
+# a published site (24-hex id) returns its rendered HTML:
+curl -sI https://<24-hex-site-id>.sites.hzd.interacly.com/
+```
+
+A 404 means the route matched but no user worker exists for that id (unpublished
+/ deleted). A 502 means the user worker threw at runtime.
+
+## Follow-up — custom-domain routing (NOT in v1)
+
+The leftmost-label trick only resolves the `*.<PAW_CF_SITES_DOMAIN>` subdomains.
+When a site connects its **own custom hostname** (via
+`cloudflare_client.create_custom_hostname` / Cloudflare for SaaS), the inbound
+`hostname` is no longer `<site_id>.<domain>`, so this worker would 404 it. Custom
+domains need the dispatch worker to map `hostname → site_id` — either a **routing
+KV** (`env.ROUTING_KV.get(hostname)`) populated at domain-connect time, or a
+backend lookup. v1 is **subdomain routing only**; the custom-hostname path is
+tracked as a follow-up.
+
+## Supply-chain note
+
+`wrangler` is pinned to `4.100.0` (not latest) so the version is past the
+workspace's 7-day minimum-release-age supply-chain gate. Bump it only to a version
+that has aged past the same threshold; do not run `npm install wrangler@latest`.

--- a/ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/package.json
+++ b/ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "paw-sites-dispatch",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Workers-for-Platforms dynamic dispatch worker for Paw Sites — routes *.<PAW_CF_SITES_DOMAIN> requests to the published user worker in the paw-sites namespace.",
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  },
+  "devDependencies": {
+    "wrangler": "4.100.0"
+  }
+}

--- a/ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/src/index.js
+++ b/ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/src/index.js
@@ -1,0 +1,73 @@
+// ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/src/index.js
+//
+// Created: 2026-06-25 (feat/sites-cf-dispatch-worker) — the Workers-for-Platforms
+// Dynamic Dispatch Worker for Paw Sites.
+//
+// WHY THIS EXISTS: publishing a Paw Site uploads the generated site as a USER
+// WORKER into the `paw-sites` WfP dispatch namespace (see
+// cloudflare_client.put_worker). In Workers for Platforms, user workers in a
+// dispatch namespace are NOT directly URL-addressable — they only run when a
+// separate dispatch worker routes a request to them via env.DISPATCHER.get(name).
+// This worker is that router. It runs on the route `*.<PAW_CF_SITES_DOMAIN>/*`,
+// reads the leftmost hostname label as the site id, and dispatches the request to
+// the matching user worker.
+//
+// ROUTING (subdomain-per-site, v1): a published site is served at
+// `https://<site_id>.<PAW_CF_SITES_DOMAIN>`. The site_id is a Mongo ObjectId (24
+// hex chars), which is a valid single DNS label. Custom-domain routing (a site
+// connecting its own hostname via Cloudflare-for-SaaS) is a FOLLOW-UP — the
+// leftmost-label trick only resolves the platform subdomains; a custom hostname
+// needs a hostname→site_id map (routing KV or a backend lookup). See README.md.
+//
+// SECURITY: these are AI-generated sites, so the namespace stays in UNTRUSTED mode
+// (the WfP default). This worker enables NO trusted-mode features and reads no
+// `request.cf`. DISPATCHER.get(name) throws synchronously when the script does not
+// exist in the namespace, so the get + the dispatched fetch are each wrapped to
+// fail closed (404 for an unknown site, 502 for a runtime error) rather than
+// surfacing a raw exception.
+
+// A site id is a Mongo ObjectId: exactly 24 hex characters. Validating the label
+// against this shape means a stray/probe subdomain never reaches DISPATCHER.get.
+const SITE_ID_RE = /^[a-f0-9]{24}$/i;
+
+export default {
+  async fetch(request, env, _ctx) {
+    const url = new URL(request.url);
+    const host = url.hostname;
+    const siteId = host.split(".")[0];
+
+    // Health affordance: a route smoke test hits `/__paw_health` (or the apex /
+    // `www` host with no site label) and gets a plain 200 so the wildcard route +
+    // worker can be verified live before any site exists.
+    if (url.pathname === "/__paw_health" || siteId === "" || siteId === "www") {
+      return new Response("ok", {
+        status: 200,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    // Reject anything that is not a site id BEFORE touching the dispatcher — a
+    // bare apex hit, a probe subdomain, or a malformed label is a 404, not a
+    // dispatch attempt.
+    if (!SITE_ID_RE.test(siteId)) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    // DISPATCHER.get throws synchronously when the script is not in the namespace
+    // (an unpublished / deleted site) — treat that as a 404.
+    let userWorker;
+    try {
+      userWorker = env.DISPATCHER.get(siteId);
+    } catch (_e) {
+      return new Response("Site not found", { status: 404 });
+    }
+
+    // The user worker runs untrusted; a throw here is a runtime failure inside the
+    // generated site, so fail closed with a 502 rather than leaking the exception.
+    try {
+      return await userWorker.fetch(request);
+    } catch (_e) {
+      return new Response("Site error", { status: 502 });
+    }
+  },
+};

--- a/ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/wrangler.jsonc
+++ b/ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/wrangler.jsonc
@@ -1,0 +1,23 @@
+{
+  // wrangler.jsonc — Paw Sites Workers-for-Platforms dispatch worker.
+  // Created 2026-06-25 (feat/sites-cf-dispatch-worker).
+  //
+  // The DISPATCHER binding resolves user workers in the `paw-sites` dispatch
+  // namespace (the same namespace cloudflare_client.put_worker uploads each
+  // published site into). The route is set at DEPLOY time (see README.md) because
+  // it embeds the real PAW_CF_SITES_DOMAIN + zone, which differ per environment —
+  // add a `routes` block here or pass `--route` on `wrangler deploy`.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "paw-sites-dispatch",
+  "main": "src/index.js",
+  "compatibility_date": "2026-06-01",
+  "dispatch_namespaces": [
+    {
+      "binding": "DISPATCHER",
+      "namespace": "paw-sites"
+    }
+  ]
+  // routes are set at deploy time (see README) — *.<PAW_CF_SITES_DOMAIN>/*
+  // e.g. add here once you substitute your real domain + zone:
+  // "routes": [{ "pattern": "*.sites.hzd.interacly.com/*", "zone_name": "interacly.com" }]
+}

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -68,6 +68,19 @@
 # ``_workers_deploy`` test-injection seam threads ``publish`` → ``_deploy_site_doc``
 # (mirrors ``_local_deploy``/``_cloudflare``). Billing/charge-first logic untouched.
 #
+# Updated 2026-06-25 (feat/sites-cf-dispatch-worker — wire the published URL for the
+# WfP serving layer): a user worker uploaded into the `paw-sites` dispatch namespace
+# is NOT directly URL-addressable in Workers for Platforms — it serves only when the
+# new Dynamic Dispatch Worker (ee/pocketpaw_ee/sites/cloudflare/dispatch-worker)
+# routes `<site_id>.<PAW_CF_SITES_DOMAIN>` to it. So the CF branch of
+# ``_deploy_site_doc`` now, AFTER ``put_worker`` succeeds, stamps the public URL as
+# ``https://{site_id}.{PAW_CF_SITES_DOMAIN}`` when ``PAW_CF_SITES_DOMAIN`` is set; if
+# it is unset it leaves ``url=""`` (the worker IS uploaded — the deploy succeeded —
+# it is just unreachable until the operator deploys the dispatch worker + sets the
+# domain) and logs a warning. The LOCAL branch is untouched. v1 is subdomain routing
+# only; a connected custom hostname needs a hostname→site_id map in the dispatch
+# worker (follow-up).
+#
 # Updated 2026-06-25 (feat/paw-sites-prod-deploy, DEP-3 — graceful generator
 # failure): the publish path shells out to the paw-sites generator + bun, which in
 # a misconfigured deploy (an image missing the toolchain) raised a bare
@@ -1383,6 +1396,25 @@ async def _deploy_site_doc(
             [{"type": "d1", "name": _D1_BINDING_NAME, "id": d1_database_id}] if is_dynamic else None
         )
         await cf.put_worker(script_name=site_id, bundle=bundle, bindings=bindings)
+        # CF-DISPATCH: the worker is now in the `paw-sites` dispatch namespace, but
+        # a user worker in a WfP dispatch namespace is NOT directly URL-addressable
+        # — it only serves when the dispatch worker
+        # (ee/pocketpaw_ee/sites/cloudflare/dispatch-worker) routes
+        # `<site_id>.<PAW_CF_SITES_DOMAIN>` to it. So the public URL is the
+        # per-site subdomain, NOT a *.workers.dev address. When PAW_CF_SITES_DOMAIN
+        # is configured, stamp it; when it is not, leave url="" (the deploy still
+        # succeeded — the worker is uploaded — it is just unreachable until the
+        # operator deploys the dispatch worker + sets the domain) and warn.
+        import os
+
+        domain = os.environ.get("PAW_CF_SITES_DOMAIN", "").strip()
+        if domain:
+            url = f"https://{site_id}.{domain}"
+        else:
+            logger.warning(
+                "PAW_CF_SITES_DOMAIN unset — published site has no public URL "
+                "(set it + deploy the dispatch worker)"
+            )
 
     # PERF-1: UPSERT ONE canonical Site doc per (workspace, pocket_id) keyed on the
     # stable ``_id`` (== site_id), rather than inserting a fresh row every publish.

--- a/tests/ee/sites/test_service.py
+++ b/tests/ee/sites/test_service.py
@@ -50,6 +50,13 @@
 # a DYNAMIC site in workers mode raises a clean ValidationError (Phase 2); and with
 # PAW_CF_DEPLOY_MODE UNSET the legacy local/wfp selection is preserved (an injected
 # CF client still wins → put_worker; no env creds + no CF → local deployer).
+#
+# Updated 2026-06-25 (feat/sites-cf-dispatch-worker — published URL wiring):
+# coverage that a CF-mode publish with PAW_CF_SITES_DOMAIN set stamps the Site
+# doc's url as https://<site_id>.<domain> (and persists it), and that with the
+# domain UNSET the CF path leaves url="" without crashing (the worker is still
+# uploaded — the deploy succeeded — it just has no public URL until the operator
+# sets the domain + deploys the dispatch worker).
 from __future__ import annotations
 
 import pytest
@@ -182,7 +189,63 @@ async def test_publish_injected_cf_takes_real_branch_even_without_creds(
         _local_deploy=boom,
     )
     assert cf.put_calls == [site.script_name]
-    assert site.url == ""  # CF path leaves url empty in v1
+    assert site.url == ""  # CF path leaves url empty when PAW_CF_SITES_DOMAIN unset
+
+
+@pytest.mark.asyncio
+async def test_publish_cf_stamps_subdomain_url_when_sites_domain_set(beanie_test_db, monkeypatch):
+    """CF-DISPATCH: a published site is served at https://<site_id>.<domain> via the
+    WfP dispatch worker (a user worker in a dispatch namespace is not directly
+    URL-addressable). With PAW_CF_SITES_DOMAIN set, the CF branch stamps that
+    per-site subdomain URL on the Site doc after put_worker, and it persists."""
+    monkeypatch.setenv("PAW_CF_SITES_DOMAIN", "sites.example.com")
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        _generator=gen,
+        _cloudflare=cf,  # injected CF → the REAL deploy branch
+        _bundle_reader=lambda d: b"export default {}",
+    )
+    expected = f"https://{site.id}.sites.example.com"
+    # The deploy still uploaded the worker into the namespace.
+    assert cf.put_calls == [site.script_name]
+    # The URL is the per-site subdomain the dispatch worker resolves.
+    assert site.url == expected
+    # And it is persisted on the canonical Site doc (re-read from the DB).
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    reloaded = await _SiteDoc.find_one({"_id": ObjectId(site.script_name), "workspace": "ws1"})
+    assert reloaded is not None
+    assert reloaded.url == expected
+
+
+@pytest.mark.asyncio
+async def test_publish_cf_leaves_url_empty_when_sites_domain_unset(beanie_test_db, monkeypatch):
+    """With PAW_CF_SITES_DOMAIN UNSET, the CF branch must not crash and must leave
+    url="" — the worker is still uploaded (the deploy succeeded) but the site has no
+    public URL until the operator sets the domain + deploys the dispatch worker."""
+    monkeypatch.delenv("PAW_CF_SITES_DOMAIN", raising=False)
+    gen, cf = _FakeGenerator(), _FakeCF()
+    site = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pk1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="x",
+        _generator=gen,
+        _cloudflare=cf,  # injected CF → the REAL deploy branch
+        _bundle_reader=lambda d: b"export default {}",
+    )
+    assert cf.put_calls == [site.script_name]  # the worker WAS uploaded
+    assert site.deployed is True  # the deploy succeeded
+    assert site.url == ""  # …but there is no public URL without the domain
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What this does

Published sites are uploaded as **user workers** into the `paw-sites` Workers-for-Platforms dispatch namespace — but in WfP, user workers aren't directly URL-addressable; they only run when a **dispatch worker** routes to them via `env.DISPATCHER.get(name)`. We had no dispatch worker, and the CF publish branch left the site `url=""`. So published sites were unreachable. This adds the serving layer.

- **Dispatch worker** (`ee/pocketpaw_ee/sites/cloudflare/dispatch-worker/`) — a dependency-free Worker bound to the `paw-sites` namespace, deployed on `*.<PAW_CF_SITES_DOMAIN>/*`. It reads the leftmost hostname label as the site id, validates it's a 24-hex ObjectId, and dispatches `env.DISPATCHER.get(siteId).fetch(request)`. Fails closed (404 unknown site, 502 runtime error); `/__paw_health` returns 200 for live route smoke-testing. Stays in WfP's untrusted mode (these are AI-generated sites).
- **URL wiring** (`service.py`) — the CF publish branch now sets `url = https://<site_id>.<PAW_CF_SITES_DOMAIN>` (was `""`). If `PAW_CF_SITES_DOMAIN` is unset it logs a warning and leaves the URL empty (no crash).
- **Runbook** — `docs/runbooks/2026-06-26-cloudflare-sites-dispatch-setup.md`: the full go-live — provision → create namespace → deploy this worker → wildcard DNS + the 2-level-wildcard TLS caveat → set the env → smoke a publish.

## Routing (v1 = subdomain-per-site)

`https://<site_id>.sites.<your-domain>`. **Custom-domain routing** (a site connecting its own hostname via Cloudflare-for-SaaS) is a follow-up: it needs a `hostname → site_id` map (a routing KV or a backend lookup), since the leftmost-label trick only resolves the platform subdomains.

## Tests

`tests/ee/sites/test_service.py`: CF publish with `PAW_CF_SITES_DOMAIN` set → the Site URL is the per-site subdomain; unset → empty URL + no crash, worker still uploaded. Full sites suite green (262 passed).

## Also needed (separate repo)

`PAW_CF_SITES_DOMAIN` must be added to the Coolify `.env.example` in paw-workspace `deploy/coolify/` (flagged in the runbook; can't be done from this repo).
